### PR TITLE
fix(router): change the retrieve's payload to query

### DIFF
--- a/crates/router/src/routes/payments.rs
+++ b/crates/router/src/routes/payments.rs
@@ -93,12 +93,12 @@ pub async fn payments_retrieve(
     state: web::Data<AppState>,
     req: HttpRequest,
     path: web::Path<String>,
-    json_payload: web::Json<PaymentRetrieveBody>,
+    query_payload: web::Query<PaymentRetrieveBody>,
 ) -> HttpResponse {
     let payload = PaymentsRetrieveRequest {
         resource_id: PaymentIdType::PaymentIntentId(path.to_string()),
-        merchant_id: json_payload.merchant_id.clone(),
-        force_sync: json_payload.force_sync.unwrap_or(false),
+        merchant_id: query_payload.merchant_id.clone(),
+        force_sync: query_payload.force_sync.unwrap_or(false),
         param: None,
         connector: None,
     };


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
Change the deserialisation method from Json to Query in the payments retrieve function
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!-- Provide links to the files with corresponding changes -->


## Motivation and Context
Based on the requirements for the payments retrieve API to accept parameters instead of fields in the body
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
Tested the endpoint by sending proper query parameters & by sending no query params
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
