### PR TITLE
fix(scheduler): fix retry_count bug for getting schedule time

### DIFF
--- a/crates/router/src/types/api/payments.rs
+++ b/crates/router/src/types/api/payments.rs
@@ -179,7 +179,6 @@ impl Default for PaymentMethod {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-#[serde(untagged)]
 pub enum PaymentIdType {
     PaymentIntentId(String),
     ConnectorTransactionId(String),
@@ -668,5 +667,14 @@ mod payments_test {
         let _deserialized_pay_req: PaymentsRequest =
             serde_json::from_str(&serialized).expect("error de-serializing payments response");
         //assert_eq!(pay_req, deserialized_pay_req)
+    }
+
+    // Intended to test the serialization and deserialization of the enum PaymentIdType
+    #[test]
+    fn test_connector_id_type() {
+        let sample_1 = PaymentIdType::PaymentIntentId("test_234565430uolsjdnf48i0".to_string());
+        let s_sample_1 = serde_json::to_string(&sample_1).unwrap();
+        let ds_sample_1 = serde_json::from_str::<PaymentIdType>(&s_sample_1).unwrap();
+        assert_eq!(ds_sample_1, sample_1)
     }
 }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
The change in this PR targets 2 areas in the scheduler flow
- `get_sync_process_schedule_time`
- `execute_workflow` for `payment_sync` specifically while deserializing the tracking_data 
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!-- Provide links to the files with corresponding changes -->


## Motivation and Context
While performing manual sanity & load tests there were internal errors while deserializing the tracking data in consumer. After manual analysis the point of failure was narrowed down to the serialization of the payment_id/txn_id struct from tracking data.
Secondly, the scheduling time was always being fetched from the `frequency` vector instead of `starts_after`.
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
Manual sanity testing as well as unit tests
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [x] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
