### PR TITLE
feat(connector): add psync for authorizedotnet

### DIFF
--- a/crates/router/src/connector/authorizedotnet.rs
+++ b/crates/router/src/connector/authorizedotnet.rs
@@ -103,8 +103,10 @@ impl
         req: &types::PaymentsRouterSyncData,
     ) -> CustomResult<Option<String>, errors::ConnectorError> {
         let sync_request =
-            utils::Encode::<authorizedotnet::CreateSyncRequest>::convert_and_encode(req)
-                .change_context(errors::ConnectorError::RequestEncodingFailed)?;
+            utils::Encode::<authorizedotnet::AuthorizedotnetCreateSyncRequest>::convert_and_encode(
+                req,
+            )
+            .change_context(errors::ConnectorError::RequestEncodingFailed)?;
         Ok(Some(sync_request))
     }
 
@@ -135,8 +137,8 @@ impl
         let intermediate_response =
             bytes::Bytes::copy_from_slice(intermediate_response.0.as_bytes());
 
-        let response: authorizedotnet::SyncResponse = intermediate_response
-            .parse_struct("SyncResponse")
+        let response: authorizedotnet::AuthorizedotnetSyncResponse = intermediate_response
+            .parse_struct("AuthorizedotnetSyncResponse")
             .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
 
         types::RouterData::try_from(types::ResponseRouterData {
@@ -586,8 +588,10 @@ impl
         req: &types::RefundsRouterData<api::RSync>,
     ) -> CustomResult<Option<String>, errors::ConnectorError> {
         let sync_request =
-            utils::Encode::<authorizedotnet::CreateSyncRequest>::convert_and_encode(req)
-                .change_context(errors::ConnectorError::RequestEncodingFailed)?;
+            utils::Encode::<authorizedotnet::AuthorizedotnetCreateSyncRequest>::convert_and_encode(
+                req,
+            )
+            .change_context(errors::ConnectorError::RequestEncodingFailed)?;
         Ok(Some(sync_request))
     }
 
@@ -618,8 +622,8 @@ impl
         let intermediate_response =
             bytes::Bytes::copy_from_slice(intermediate_response.0.as_bytes());
 
-        let response: authorizedotnet::SyncResponse = intermediate_response
-            .parse_struct("SyncResponse")
+        let response: authorizedotnet::AuthorizedotnetSyncResponse = intermediate_response
+            .parse_struct("AuthorizedotnetSyncResponse")
             .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
 
         types::RouterData::try_from(types::ResponseRouterData {

--- a/crates/router/src/connector/authorizedotnet/transformers.rs
+++ b/crates/router/src/connector/authorizedotnet/transformers.rs
@@ -427,11 +427,11 @@ pub struct TransactionDetails {
 }
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct CreateSyncRequest {
+pub struct AuthorizedotnetCreateSyncRequest {
     get_transaction_details_request: TransactionDetails,
 }
 
-impl<F> TryFrom<&types::RefundsRouterData<F>> for CreateSyncRequest {
+impl<F> TryFrom<&types::RefundsRouterData<F>> for AuthorizedotnetCreateSyncRequest {
     type Error = error_stack::Report<errors::ConnectorError>;
 
     fn try_from(item: &types::RefundsRouterData<F>) -> Result<Self, Self::Error> {
@@ -441,7 +441,7 @@ impl<F> TryFrom<&types::RefundsRouterData<F>> for CreateSyncRequest {
             .map(|refund_response_data| refund_response_data.connector_refund_id.clone());
         let merchant_authentication = MerchantAuthentication::try_from(&item.connector_auth_type)?;
 
-        let payload = CreateSyncRequest {
+        let payload = AuthorizedotnetCreateSyncRequest {
             get_transaction_details_request: TransactionDetails {
                 merchant_authentication,
                 transaction_id,
@@ -451,7 +451,7 @@ impl<F> TryFrom<&types::RefundsRouterData<F>> for CreateSyncRequest {
     }
 }
 
-impl TryFrom<&types::PaymentsRouterSyncData> for CreateSyncRequest {
+impl TryFrom<&types::PaymentsRouterSyncData> for AuthorizedotnetCreateSyncRequest {
     type Error = error_stack::Report<errors::ConnectorError>;
 
     fn try_from(item: &types::PaymentsRouterSyncData) -> Result<Self, Self::Error> {
@@ -461,7 +461,7 @@ impl TryFrom<&types::PaymentsRouterSyncData> for CreateSyncRequest {
             .map(|payment_response_data| payment_response_data.connector_transaction_id.clone());
         let merchant_authentication = MerchantAuthentication::try_from(&item.connector_auth_type)?;
 
-        let payload = CreateSyncRequest {
+        let payload = AuthorizedotnetCreateSyncRequest {
             get_transaction_details_request: TransactionDetails {
                 merchant_authentication,
                 transaction_id,
@@ -493,7 +493,7 @@ pub struct SyncTransactionResponse {
 }
 
 #[derive(Debug, Deserialize)]
-pub struct SyncResponse {
+pub struct AuthorizedotnetSyncResponse {
     transaction: SyncTransactionResponse,
 }
 
@@ -522,13 +522,13 @@ impl From<SyncStatus> for enums::AttemptStatus {
     }
 }
 
-impl TryFrom<types::RefundsResponseRouterData<api::RSync, SyncResponse>>
+impl TryFrom<types::RefundsResponseRouterData<api::RSync, AuthorizedotnetSyncResponse>>
     for types::RefundsRouterData<api::RSync>
 {
     type Error = error_stack::Report<errors::ConnectorError>;
 
     fn try_from(
-        item: types::RefundsResponseRouterData<api::RSync, SyncResponse>,
+        item: types::RefundsResponseRouterData<api::RSync, AuthorizedotnetSyncResponse>,
     ) -> Result<Self, Self::Error> {
         let refund_status = enums::RefundStatus::from(item.response.transaction.transaction_status);
         Ok(types::RouterData {
@@ -541,13 +541,20 @@ impl TryFrom<types::RefundsResponseRouterData<api::RSync, SyncResponse>>
     }
 }
 
-impl<F, Req> TryFrom<types::ResponseRouterData<F, SyncResponse, Req, types::PaymentsResponseData>>
-    for types::RouterData<F, Req, types::PaymentsResponseData>
+impl<F, Req>
+    TryFrom<
+        types::ResponseRouterData<F, AuthorizedotnetSyncResponse, Req, types::PaymentsResponseData>,
+    > for types::RouterData<F, Req, types::PaymentsResponseData>
 {
     type Error = error_stack::Report<errors::ConnectorError>;
 
     fn try_from(
-        item: types::ResponseRouterData<F, SyncResponse, Req, types::PaymentsResponseData>,
+        item: types::ResponseRouterData<
+            F,
+            AuthorizedotnetSyncResponse,
+            Req,
+            types::PaymentsResponseData,
+        >,
     ) -> Result<Self, Self::Error> {
         let payment_status =
             enums::AttemptStatus::from(item.response.transaction.transaction_status);


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
Add the capability of payment sync for authorizedotnet connector. 


### Additional Changes

- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables


## Motivation and Context

This feature is required to be able to call authorizedotnet connector for syncing the payment status


## How did you test it?

Tested this manually by making a payment and then hit the payments retrieve endpoint
<img width="517" alt="Screenshot 2022-11-23 at 1 24 48 PM" src="https://user-images.githubusercontent.com/48803246/203495904-3cad9a02-18d2-4939-a585-4745513359ae.png">
<img width="588" alt="Screenshot 2022-11-23 at 2 42 42 PM" src="https://user-images.githubusercontent.com/48803246/203508875-1d2a5053-8d6f-4fae-af63-50b1ec1295a2.png">



## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
