### PR TITLE
feat(core): add server base_url in server config

### DIFF
--- a/crates/router/src/configs/defaults.toml
+++ b/crates/router/src/configs/defaults.toml
@@ -4,7 +4,7 @@
 port = 8080
 host = "127.0.0.1"
 request_body_limit = 16_384 # Post request body is limited to 16k.
-domain = "https://sandbox-router.juspay.io"
+base_url = "http://localhost:8080"
 
 [proxy]
 # http_url = ""

--- a/crates/router/src/configs/settings.rs
+++ b/crates/router/src/configs/settings.rs
@@ -62,7 +62,7 @@ pub struct Server {
     pub port: u16,
     pub host: String,
     pub request_body_limit: usize,
-    pub domain: String,
+    pub base_url: String,
 }
 
 #[derive(Debug, Deserialize, Clone)]

--- a/crates/router/src/core/payments/helpers.rs
+++ b/crates/router/src/core/payments/helpers.rs
@@ -291,32 +291,24 @@ fn validate_new_mandate_request(req: &api::PaymentsRequest) -> RouterResult<()> 
     Ok(())
 }
 
-pub fn create_server_url(server: &Server) -> String {
-    if server.host.eq("127.0.0.1") || server.host.eq("localhost") {
-        format!("http://{}:{}", server.host, server.port)
-    } else {
-        server.domain.to_owned()
-    }
-}
 pub fn create_startpay_url(
     server: &Server,
     payment_attempt: &storage::PaymentAttempt,
     payment_intent: &storage::PaymentIntent,
 ) -> String {
-    let server_url = create_server_url(server);
-
     format!(
         "{}/payments/start/{}/{}/{}",
-        server_url, payment_intent.payment_id, payment_intent.merchant_id, payment_attempt.txn_id
+        server.base_url,
+        payment_intent.payment_id,
+        payment_intent.merchant_id,
+        payment_attempt.txn_id
     )
 }
 
 pub fn create_redirect_url(server: &Server, payment_attempt: &storage::PaymentAttempt) -> String {
-    let server_url = create_server_url(server);
-
     format!(
         "{}/payments/{}/{}/response/{}",
-        server_url,
+        server.base_url,
         payment_attempt.payment_id,
         payment_attempt.merchant_id,
         payment_attempt.connector


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description

The url in the next action had 0.0.0.0 in the host instead of sandbox endpoint


### Additional Changes

- [ ] This PR modifies the database schema
- [x] This PR modifies application configuration/environment variables
   [defaults.toml](crates/router/src/configs/defaults.toml)


## Motivation and Context

We need to store the endpoint url which is the hosted sandbox/production url. This url will be used when we send url to the client redirecting to our site.


## How did you test it?

Did not test it yet. Need to test it in the sandbox.


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
