### PR TITLE
ci(CI-skip-ignored-files): specify OS matrix with single entry

### DIFF
--- a/.github/workflows/CI-skip-ignored-files.yml
+++ b/.github/workflows/CI-skip-ignored-files.yml
@@ -30,7 +30,11 @@ jobs:
 
   check-msrv:
     name: Check compilation on MSRV toolchain
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
     steps:
       - name: Skip compilation checks
         shell: bash
@@ -47,6 +51,10 @@ jobs:
   test:
     name: Run tests on stable toolchain
     runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
     steps:
       - name: Skip compilation checks
         shell: bash


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description

This PR fixes a minor derp introduced in #10. Turns out specifying `runs-on: ubuntu-latest` vs. specifying `runs-on: ${{ matrix.os }}` with a single `ubuntu-latest` entry causes GitHub to consider them as different jobs, and thus do not count towards required status checks.

### Additional Changes

- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!-- Provide links to the files with corresponding changes -->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

See #10.


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

N/A.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
