### PR TITLE
router:types: Add DeviceInformation type to get browser info

### DIFF
--- a/crates/router/src/types.rs
+++ b/crates/router/src/types.rs
@@ -111,6 +111,20 @@ pub struct RefundsRequestData {
     pub refund_amount: i32,
 }
 
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct DeviceInformation {
+    pub color_depth: u8,
+    pub java_enabled: bool,
+    pub java_script_enabled: bool,
+    pub language: String,
+    pub screen_height: u32,
+    pub screen_width: u32,
+    pub time_zone: i32,
+    pub ip_address: Option<std::net::IpAddr>,
+    pub accept_header: Option<String>,
+    pub user_agent: String,
+}
+
 #[derive(Debug, Clone)]
 pub struct RefundsResponseData {
     pub connector_refund_id: String,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->
Added DeviceInfo struct type for getting browser info from merchant.

### Additional Changes

- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!-- 
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
This is needed for 3DS2.0 integration which needs browser info to be sent.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
