### PR TITLE
payment_attempt: Add browser info column into payment attempt table

### DIFF
--- a/crates/router/src/db/payment_attempt.rs
+++ b/crates/router/src/db/payment_attempt.rs
@@ -199,6 +199,7 @@ mod storage {
                 amount_to_capture: payment_attempt.amount_to_capture,
                 cancellation_reason: payment_attempt.cancellation_reason.clone(),
                 mandate_id: payment_attempt.mandate_id.clone(),
+                browser_info: payment_attempt.browser_info.clone(),
             };
             // TODO: Add a proper error for serialization failure
             let redis_value = serde_json::to_string(&created_attempt)

--- a/crates/router/src/schema.rs
+++ b/crates/router/src/schema.rs
@@ -203,6 +203,7 @@ diesel::table! {
         cancellation_reason -> Nullable<Varchar>,
         amount_to_capture -> Nullable<Int4>,
         mandate_id -> Nullable<Varchar>,
+        browser_info -> Nullable<Jsonb>,
     }
 }
 

--- a/crates/router/src/types/storage/payment_attempt.rs
+++ b/crates/router/src/types/storage/payment_attempt.rs
@@ -35,6 +35,7 @@ pub struct PaymentAttempt {
     pub cancellation_reason: Option<String>,
     pub amount_to_capture: Option<i32>,
     pub mandate_id: Option<String>,
+    pub browser_info: Option<serde_json::Value>,
 }
 
 #[derive(Clone, Debug, Default, Insertable, router_derive::DebugAsDisplay)]
@@ -68,6 +69,7 @@ pub struct PaymentAttemptNew {
     pub cancellation_reason: Option<String>,
     pub amount_to_capture: Option<i32>,
     pub mandate_id: Option<String>,
+    pub browser_info: Option<serde_json::Value>,
 }
 
 #[derive(Clone, Debug)]

--- a/migrations/2022-11-24-095709_add_browser_info_to_payment_attempt/down.sql
+++ b/migrations/2022-11-24-095709_add_browser_info_to_payment_attempt/down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE payment_attempt
+DROP COLUMN browser_info;

--- a/migrations/2022-11-24-095709_add_browser_info_to_payment_attempt/up.sql
+++ b/migrations/2022-11-24-095709_add_browser_info_to_payment_attempt/up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE payment_attempt
+ADD COLUMN browser_info JSONB DEFAULT '{}'::JSONB;


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->
Added browser info column to payment attempt table. This is needed to persist the browser info we get from payment request.

### Additional Changes

- [x] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

[up.sql](https://github.com/juspay/orca/blob/10db53d832b544955d340c280f4e46dc3ba23960/migrations/2022-11-24-095709_add_browser_info_to_payment_attempt/up.sql)

<!-- 
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
This is required for persisting the browser info we get from payment request.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
