### PR TITLE
router: Get browser info from payment request

### DIFF
--- a/crates/router/src/core/payments/operations/payment_create.rs
+++ b/crates/router/src/core/payments/operations/payment_create.rs
@@ -26,7 +26,7 @@ use crate::{
             enums::{self, IntentStatus},
         },
     },
-    utils::OptionExt,
+    utils::{self, OptionExt},
 };
 #[derive(Debug, Clone, Copy, PaymentOperation)]
 #[operation(ops = "all", flow = "authorize")]
@@ -70,6 +70,15 @@ impl<F: Send + Clone> GetTracker<F, PaymentData<F>, api::PaymentsRequest> for Pa
         let billing_address =
             helpers::get_address_for_payment_request(db, request.billing.as_ref(), None).await?;
 
+        let browser_info = request
+            .device_info
+            .clone()
+            .map(|x| utils::Encode::<types::DeviceInformation>::encode_to_value(&x))
+            .transpose()
+            .change_context(errors::ApiErrorResponse::InvalidDataValue {
+                field_name: "device_info",
+            })?;
+
         payment_attempt = match db
             .insert_payment_attempt(Self::make_payment_attempt(
                 &payment_id,
@@ -78,6 +87,7 @@ impl<F: Send + Clone> GetTracker<F, PaymentData<F>, api::PaymentsRequest> for Pa
                 money,
                 payment_method_type,
                 request,
+                browser_info,
             ))
             .await
         {
@@ -287,6 +297,7 @@ impl PaymentCreate {
         money: (i32, enums::Currency),
         payment_method: Option<enums::PaymentMethodType>,
         request: &api::PaymentsRequest,
+        device_info: Option<serde_json::Value>,
     ) -> storage::PaymentAttemptNew {
         let created_at @ modified_at @ last_synced = Some(crate::utils::date_time::now());
         let status =
@@ -308,6 +319,7 @@ impl PaymentCreate {
             modified_at,
             last_synced,
             authentication_type: request.authentication_type,
+            browser_info: device_info,
             ..storage::PaymentAttemptNew::default()
         }
     }

--- a/crates/router/src/core/payments/transformers.rs
+++ b/crates/router/src/core/payments/transformers.rs
@@ -255,6 +255,14 @@ impl<F: Clone> TryFrom<PaymentData<F>> for types::PaymentsRequestData {
     type Error = error_stack::Report<errors::ApiErrorResponse>;
 
     fn try_from(payment_data: PaymentData<F>) -> Result<Self, Self::Error> {
+        let browser_info: Option<types::DeviceInformation> = payment_data
+            .payment_attempt
+            .browser_info
+            .map(|b| b.parse_value("DeviceInformation"))
+            .transpose()
+            .change_context(errors::ApiErrorResponse::InvalidDataValue {
+                field_name: "browser_info",
+            })?;
         Ok(Self {
             payment_method_data: {
                 let payment_method_type = payment_data
@@ -276,6 +284,7 @@ impl<F: Clone> TryFrom<PaymentData<F>> for types::PaymentsRequestData {
             confirm: payment_data.payment_attempt.confirm,
             statement_descriptor_suffix: payment_data.payment_intent.statement_descriptor_suffix,
             capture_method: payment_data.payment_attempt.capture_method,
+            device_info: browser_info,
         })
     }
 }

--- a/crates/router/src/types.rs
+++ b/crates/router/src/types.rs
@@ -75,6 +75,7 @@ pub struct PaymentsRequestData {
     pub mandate_id: Option<String>,
     pub off_session: Option<bool>,
     pub setup_mandate_details: Option<payments::MandateData>,
+    pub device_info: Option<DeviceInformation>,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/router/src/types/api/payments.rs
+++ b/crates/router/src/types/api/payments.rs
@@ -50,6 +50,7 @@ pub struct PaymentsRequest {
     pub payment_token: Option<i32>,
     pub shipping: Option<Address>,
     pub billing: Option<Address>,
+    pub device_info: Option<types::DeviceInformation>,
     pub statement_descriptor_name: Option<String>,
     pub statement_descriptor_suffix: Option<String>,
     pub metadata: Option<serde_json::Value>,

--- a/crates/router/tests/connectors/aci.rs
+++ b/crates/router/tests/connectors/aci.rs
@@ -46,6 +46,7 @@ fn construct_payment_router_data() -> types::PaymentsRouterData {
             off_session: None,
             setup_mandate_details: None,
             capture_method: None,
+            device_info: None,
         },
         response: None,
         payment_method_id: None,

--- a/crates/router/tests/connectors/authorizedotnet.rs
+++ b/crates/router/tests/connectors/authorizedotnet.rs
@@ -46,6 +46,7 @@ fn construct_payment_router_data() -> types::PaymentsRouterData {
             off_session: None,
             setup_mandate_details: None,
             capture_method: None,
+            device_info: None,
         },
         payment_method_id: None,
         response: None,

--- a/crates/router/tests/connectors/checkout.rs
+++ b/crates/router/tests/connectors/checkout.rs
@@ -42,6 +42,7 @@ fn construct_payment_router_data() -> types::PaymentsRouterData {
             off_session: None,
             setup_mandate_details: None,
             capture_method: None,
+            device_info: None,
         },
         response: None,
         payment_method_id: None,

--- a/crates/router/tests/payments.rs
+++ b/crates/router/tests/payments.rs
@@ -326,6 +326,7 @@ async fn payments_create_core() {
         mandate_id: None,
         off_session: None,
         client_secret: None,
+        device_info: None,
     };
 
     let expected_response = api::PaymentsResponse {
@@ -484,6 +485,7 @@ async fn payments_create_core_adyen_no_redirect() {
         mandate_id: None,
         off_session: None,
         client_secret: None,
+        device_info: None,
     };
 
     let expected_response = services::BachResponse::Json(api::PaymentsResponse {

--- a/crates/router/tests/payments2.rs
+++ b/crates/router/tests/payments2.rs
@@ -91,6 +91,7 @@ async fn payments_create_core() {
         mandate_id: None,
         off_session: None,
         client_secret: None,
+        device_info: None,
     };
 
     let expected_response = api::PaymentsResponse {
@@ -252,6 +253,7 @@ async fn payments_create_core_adyen_no_redirect() {
         off_session: None,
         mandate_id: None,
         client_secret: None,
+        device_info: None,
     };
 
     let expected_response = services::BachResponse::Json(api::PaymentsResponse {


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->
Add browser info to PaymentRequest to get it from merchants.

### Additional Changes

- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!-- 
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
Added browser info field to payment request for getting it from merchants.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
