### PR TITLE
fix(loadtest): rename `[database]` to `[master_database]` in config file

### DIFF
--- a/loadtest/config/Development.toml
+++ b/loadtest/config/Development.toml
@@ -7,7 +7,7 @@ enabled = false
 [log.telemetry]
 enabled = true
 
-[database]
+[master_database]
 username = "postgres"
 password = "postgres"
 host = "db"


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->
This is an extension to #4; fixes one instance of `[database]` in `loadtest/config/Development.toml` which seems to have been left out during the refactor. 


### Additional Changes

- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!-- 
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->
N/A

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
I was trying to run loadtests and the `router` service was unable to connect to the database; this turned out to be the cause.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Ran `docker compose up -d` in `loadtest` directory.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt`
- [ ] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
