### PR TITLE
fix: Save browser info as null

### DIFF
--- a/migrations/2022-11-24-095709_add_browser_info_to_payment_attempt/up.sql
+++ b/migrations/2022-11-24-095709_add_browser_info_to_payment_attempt/up.sql
@@ -1,2 +1,2 @@
 ALTER TABLE payment_attempt
-ADD COLUMN browser_info JSONB DEFAULT '{}'::JSONB;
+ADD COLUMN browser_info JSONB DEFAULT NULL;


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->
Since we were saving browser_info as empty json in the database it was failing during deserialization. So save it as NULL instead

### Additional Changes

- [x] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!-- 
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
Since we were saving browser_info as empty json in the database it was failing during deserialization. So save it as NULL instead

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Successful payment request with browser_info being null.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
