### PR TITLE
fix(migrations): added unique index on merchant_id and connector_name in merchant_connector_account

### DIFF
--- a/migrations/2022-11-30-084736_update-index-in-mca/down.sql
+++ b/migrations/2022-11-30-084736_update-index-in-mca/down.sql
@@ -1,4 +1,1 @@
--- This file should undo anything in `up.sql`
 DROP INDEX merchant_connector_account_merchant_id_connector_name_index;
-CREATE INDEX merchant_connector_account_connector_type_index ON merchant_connector_account (connector_type);
-CREATE INDEX merchant_connector_account_merchant_id_index ON merchant_connector_account (merchant_id);

--- a/migrations/2022-11-30-084736_update-index-in-mca/up.sql
+++ b/migrations/2022-11-30-084736_update-index-in-mca/up.sql
@@ -1,3 +1,1 @@
-DROP INDEX merchant_connector_account_connector_type_index;
-DROP INDEX merchant_connector_account_merchant_id_index;
 CREATE UNIQUE INDEX merchant_connector_account_merchant_id_connector_name_index ON merchant_connector_account (merchant_id, connector_name);


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [x] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!-- 
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
Multiple records were created in merchant_connector_account table with the same merchant_id and connector_name. This is not a good practice, for a given merchant_id and connector_name single record should be created in DB.
<img width="955" alt="image" src="https://user-images.githubusercontent.com/68317979/204757803-a8a6156d-15ed-4042-bb66-27bd8a31ed8c.png">



## How did you test it?
Already tests for payment connector create API. Now on multiple creates on the same merchant_connector_account with same merchant_id and connector_name "duplicate_request" error is thrown. 


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt`
- [ ] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [x] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
