### PR TITLE
fix: Update browser info on payment confirmation

### DIFF
--- a/crates/router/src/types/storage/payment_attempt.rs
+++ b/crates/router/src/types/storage/payment_attempt.rs
@@ -87,6 +87,7 @@ pub enum PaymentAttemptUpdate {
     ConfirmUpdate {
         status: enums::AttemptStatus,
         payment_method: Option<enums::PaymentMethodType>,
+        browser_info: Option<serde_json::Value>,
     },
     VoidUpdate {
         status: enums::AttemptStatus,
@@ -124,6 +125,7 @@ pub(super) struct PaymentAttemptUpdateInternal {
     modified_at: Option<PrimitiveDateTime>,
     redirect: Option<bool>,
     mandate_id: Option<String>,
+    browser_info: Option<serde_json::Value>,
 }
 
 impl PaymentAttemptUpdate {
@@ -142,6 +144,7 @@ impl PaymentAttemptUpdate {
             payment_method_id: pa_update
                 .payment_method_id
                 .unwrap_or(source.payment_method_id),
+            browser_info: pa_update.browser_info,
             modified_at: common_utils::date_time::now(),
             ..source
         }
@@ -178,10 +181,12 @@ impl From<PaymentAttemptUpdate> for PaymentAttemptUpdateInternal {
             PaymentAttemptUpdate::ConfirmUpdate {
                 status,
                 payment_method,
+                browser_info,
             } => Self {
                 status: Some(status),
                 payment_method,
                 modified_at: Some(common_utils::date_time::now()),
+                browser_info,
                 ..Default::default()
             },
             PaymentAttemptUpdate::VoidUpdate {


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->
So whenever we created a payment intent without confirmation, and send confirm request on the same payment id with browser info it wouldn't update it in DB.

### Additional Changes

- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!-- 
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
Bugfix of browserinfo not getting updated when you send it in confirmation request.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Send a payment create request with `confirm=false` and `browser_info=null`. And send payment confirmation code with actual `browser_info`.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
