### PR TITLE
fix: mandate_type change & unittests

### DIFF
--- a/crates/api_models/src/payment_methods.rs
+++ b/crates/api_models/src/payment_methods.rs
@@ -95,7 +95,11 @@ impl<'de> serde::Deserialize<'de> for ListPaymentMethodRequest {
                 while let Some(key) = map.next_key()? {
                     match key {
                         "client_secret" => {
-                            output.client_secret = Some(map.next_value()?);
+                            set_or_reject_duplicate(
+                                &mut output.client_secret,
+                                "client_secret",
+                                map.next_value()?,
+                            )?;
                         }
                         "accepted_countries" => match output.accepted_countries.as_mut() {
                             Some(inner) => inner.push(map.next_value()?),
@@ -110,13 +114,25 @@ impl<'de> serde::Deserialize<'de> for ListPaymentMethodRequest {
                             }
                         },
                         "amount" => {
-                            output.amount = Some(map.next_value()?);
+                            set_or_reject_duplicate(
+                                &mut output.amount,
+                                "amount",
+                                map.next_value()?,
+                            )?;
                         }
                         "recurring_enabled" => {
-                            output.recurring_enabled = Some(map.next_value()?);
+                            set_or_reject_duplicate(
+                                &mut output.recurring_enabled,
+                                "recurring_enabled",
+                                map.next_value()?,
+                            )?;
                         }
                         "installment_payment_enabled" => {
-                            output.installment_payment_enabled = Some(map.next_value()?);
+                            set_or_reject_duplicate(
+                                &mut output.installment_payment_enabled,
+                                "installment_payment_enabled",
+                                map.next_value()?,
+                            )?;
                         }
                         _ => {}
                     }
@@ -127,6 +143,21 @@ impl<'de> serde::Deserialize<'de> for ListPaymentMethodRequest {
         }
 
         deserializer.deserialize_identifier(FieldVisitor)
+    }
+}
+
+// Try to set the provided value to the data otherwise throw an error
+fn set_or_reject_duplicate<T, E: de::Error>(
+    data: &mut Option<T>,
+    name: &'static str,
+    value: T,
+) -> Result<(), E> {
+    match data {
+        Some(_inner) => Err(de::Error::duplicate_field(name)),
+        None => {
+            *data = Some(value);
+            Ok(())
+        }
     }
 }
 

--- a/crates/api_models/src/payments.rs
+++ b/crates/api_models/src/payments.rs
@@ -148,6 +148,7 @@ pub struct MandateAmountData {
 }
 
 #[derive(Eq, PartialEq, Debug, serde::Deserialize, serde::Serialize, Clone)]
+#[serde(rename_all = "snake_case")]
 pub enum MandateType {
     SingleUse(MandateAmountData),
     MultiUse(Option<MandateAmountData>),
@@ -835,5 +836,19 @@ mod amount {
         D: de::Deserializer<'de>,
     {
         deserializer.deserialize_option(OptionalAmountVisitor)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_mandate_type() {
+        let mandate_type = MandateType::default();
+        assert_eq!(
+            serde_json::to_string(&mandate_type).unwrap(),
+            r#"{"multi_use":null}"#
+        )
     }
 }

--- a/crates/router/src/routes/payment_methods.rs
+++ b/crates/router/src/routes/payment_methods.rs
@@ -142,3 +142,30 @@ pub async fn payment_method_delete_api(
     )
     .await
 }
+
+#[cfg(test)]
+mod tests {
+    use api_models::payment_methods::ListPaymentMethodRequest;
+
+    use super::*;
+
+    #[test]
+    fn test_custom_list_deserialization() {
+        let dummy_data = "amount=120&recurring_enabled=true&installment_payment_enabled=true&accepted_countries=US&accepted_countries=IN";
+        let de_query: web::Query<payment_methods::ListPaymentMethodRequest> =
+            web::Query::from_query(dummy_data).unwrap();
+        let de_struct = de_query.into_inner();
+        assert_eq!(
+            de_struct.accepted_countries,
+            Some(vec!["US".to_string(), "IN".to_string()])
+        )
+    }
+
+    #[test]
+    fn test_custom_list_deserialization_multi_amount() {
+        let dummy_data = "amount=120&recurring_enabled=true&amount=1000";
+        let de_query: Result<web::Query<ListPaymentMethodRequest>, _> =
+            web::Query::from_query(dummy_data);
+        assert!(de_query.is_err())
+    }
+}


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Enhancement

## Description
This PR includes 2 small but specific changes
1. Having mandate_type as `snake_case`
2. Rejecting duplicates in query parsing of list api
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!-- 
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
4. `crates/router/src/configs`
5. `loadtest/config`
-->


## Motivation and Context
Post discussion with @bernard-eugine the non-vector fields should not allow duplicates and must throw parsing error. Also, while verifying the the mandate_data field, the mandate_type must be in `snake_case` similar to stripe
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
included unit tests for the same
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [x] I added unit tests for my changes where possible