### PR TITLE
ci: remove explicitly provided cache key

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -98,8 +98,6 @@ jobs:
           toolchain: 1.64
 
       - uses: Swatinem/rust-cache@v2.2.0
-        with:
-          key: cargo-cache-${{ hashFiles('**/Cargo.lock', '**/Cargo.toml') }}-${{ matrix.os }}-msrv
 
       - name: Install cargo-hack
         uses: baptiste0928/cargo-install@v1.3.0
@@ -169,8 +167,6 @@ jobs:
       #     crate: cargo-nextest
 
       - uses: Swatinem/rust-cache@v2.2.0
-        with:
-          key: cargo-cache-${{ hashFiles('**/Cargo.lock', '**/Cargo.toml') }}-${{ matrix.os }}-stable
 
       # - name: Setup Embark Studios lint rules
       #   shell: bash


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->
This PR removes the explicitly provided cache key for the `rust-cache` action.

`tokio` uses the action [without any explicit cache key](https://github.com/tokio-rs/tokio/blob/81b50e946fe2f6b30de5e61356ab7cae560956a9/.github/workflows/ci.yml#L82), so we'll follow the same.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
Hopefully, this enables proper restoration of dependency cache in CI checks.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Haven't been able to, "I hope it works" (TM).

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt`
- [ ] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
