### PR TITLE
ci: run tests on PRs with `S-awaiting-merge` label

### DIFF
--- a/.github/workflows/CI-skip-ignored-files.yml
+++ b/.github/workflows/CI-skip-ignored-files.yml
@@ -10,16 +10,12 @@ on:
       - "ready_for_review"
       - "reopened"
       - "synchronize"
-    paths:
-      - "config/**"
-      - "contrib/**"
-      - "docs/**"
-      - "monitoring/**"
-      - "openapi/**"
-      - "postman/**"
-      - "*.md"
-      - "LICENSE"
-      - "NOTICE"
+    paths-ignore:
+      - ".github/workflows/**"
+      - "crates/**"
+      - "examples/**"
+      - "Cargo.lock"
+      - "Cargo.toml"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -4,16 +4,12 @@ on:
   push:
     branches:
       - main
-    paths-ignore:
-      - "config/**"
-      - "contrib/**"
-      - "docs/**"
-      - "monitoring/**"
-      - "openapi/**"
-      - "postman/**"
-      - "*.md"
-      - "LICENSE"
-      - "NOTICE"
+    paths:
+      - ".github/workflows/**"
+      - "crates/**"
+      - "examples/**"
+      - "Cargo.lock"
+      - "Cargo.toml"
 
   pull_request:
     types:
@@ -22,16 +18,12 @@ on:
       - "ready_for_review"
       - "reopened"
       - "synchronize"
-    paths-ignore:
-      - "config/**"
-      - "contrib/**"
-      - "docs/**"
-      - "monitoring/**"
-      - "openapi/**"
-      - "postman/**"
-      - "*.md"
-      - "LICENSE"
-      - "NOTICE"
+    paths:
+      - ".github/workflows/**"
+      - "crates/**"
+      - "examples/**"
+      - "Cargo.lock"
+      - "Cargo.toml"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->
This PR updates the CI workflow to run tests when PRs are labeled `S-awaiting-merge`. This could either be when the PR is opened, reopened, marked ready for review (from a draft PR), assigned a label, or synchronized with the base branch.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
We often have people opening WIP PRs which unnecessarily use CI resources with no fruitful results. This change is a hopeful attempt to prevent that.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Haven't tested it, "I hope it works" (TM). :crossed_fingers:

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt`
- [ ] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable