### PR TITLE
ci: allow tests to run on push to `main` branch

### DIFF
--- a/.github/workflows/CI-skip-ignored-files.yml
+++ b/.github/workflows/CI-skip-ignored-files.yml
@@ -3,6 +3,16 @@
 name: CI
 
 on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - ".github/workflows/**"
+      - "crates/**"
+      - "examples/**"
+      - "Cargo.lock"
+      - "Cargo.toml"
+
   pull_request:
     types:
       - "labeled"
@@ -24,7 +34,7 @@ concurrency:
 jobs:
   formatting:
     name: Check formatting
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'S-awaiting-merge') }}
+    if: ${{ github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'S-awaiting-merge') }}
     runs-on: ubuntu-latest
     steps:
       - name: Skip formatting
@@ -33,7 +43,7 @@ jobs:
 
   check-msrv:
     name: Check compilation on MSRV toolchain
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'S-awaiting-merge') }}
+    if: ${{ github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'S-awaiting-merge') }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -46,7 +56,7 @@ jobs:
 
   # cargo-deny:
   #   name: Run cargo-deny
-  #   if: ${{ contains(github.event.pull_request.labels.*.name, 'S-awaiting-merge') }}
+  #   if: ${{ github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'S-awaiting-merge') }}
   #   runs-on: ubuntu-latest
   #   steps:
   #     - name: Skip cargo-deny
@@ -55,7 +65,7 @@ jobs:
 
   test:
     name: Run tests on stable toolchain
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'S-awaiting-merge') }}
+    if: ${{ github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'S-awaiting-merge') }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -54,7 +54,7 @@ env:
 jobs:
   formatting:
     name: Check formatting
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'S-awaiting-merge') }}
+    if: ${{ github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'S-awaiting-merge') }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -72,7 +72,7 @@ jobs:
 
   check-msrv:
     name: Check compilation on MSRV toolchain
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'S-awaiting-merge') }}
+    if: ${{ github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'S-awaiting-merge') }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: true
@@ -110,7 +110,7 @@ jobs:
 
   # cargo-deny:
   #   name: Run cargo-deny
-  #   if: ${{ contains(github.event.pull_request.labels.*.name, 'S-awaiting-merge') }}
+  #   if: ${{ github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'S-awaiting-merge') }}
   #   runs-on: ubuntu-latest
   #   strategy:
   #     matrix:
@@ -132,7 +132,7 @@ jobs:
 
   test:
     name: Run tests on stable toolchain
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'S-awaiting-merge') }}
+    if: ${{ github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'S-awaiting-merge') }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->
This PR fixes a minor mistake in #166 where I forgot to allow tests on the `main` branch.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
N/A

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
N/A

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt`
- [ ] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
