### PR TITLE
fix(router): make customer id mandatory when confirming payments

### DIFF
--- a/crates/router/src/core/payments/helpers.rs
+++ b/crates/router/src/core/payments/helpers.rs
@@ -617,6 +617,17 @@ pub async fn get_customer_from_details(
     }
 }
 
+pub fn validate_customer_id_given(customer_id: &Option<String>) -> RouterResult<()> {
+    if customer_id.is_none() {
+        Err(errors::ApiErrorResponse::InvalidRequestData {
+            message: "'customer_id' is a mandatory field that was not provided".to_string(),
+        })
+        .into_report()
+    } else {
+        Ok(())
+    }
+}
+
 pub async fn get_connector_default(
     merchant_account: &storage::MerchantAccount,
     state: &AppState,

--- a/crates/router/src/core/payments/operations/payment_confirm.rs
+++ b/crates/router/src/core/payments/operations/payment_confirm.rs
@@ -356,6 +356,8 @@ impl<F: Send + Clone> ValidateRequest<F, api::PaymentsRequest> for PaymentConfir
                 expected_format: "merchant_id from merchant account".to_string(),
             })?;
 
+        helpers::validate_customer_id_given(&request.customer_id)?;
+
         helpers::validate_pm_or_token_given(&request.payment_token, &request.payment_method_data)?;
 
         let mandate_type = helpers::validate_mandate(request)?;

--- a/crates/router/src/core/payments/operations/payment_create.rs
+++ b/crates/router/src/core/payments/operations/payment_create.rs
@@ -394,6 +394,7 @@ impl<F: Send + Clone> ValidateRequest<F, api::PaymentsRequest> for PaymentCreate
                 &request.payment_token,
                 &request.payment_method_data,
             )?;
+            helpers::validate_customer_id_given(&request.customer_id)?;
         }
 
         let request_merchant_id = request.merchant_id.as_deref();

--- a/crates/router/src/core/payments/operations/payment_update.rs
+++ b/crates/router/src/core/payments/operations/payment_update.rs
@@ -364,6 +364,7 @@ impl<F: Send + Clone> ValidateRequest<F, api::PaymentsRequest> for PaymentUpdate
                 &request.payment_token,
                 &request.payment_method_data,
             )?;
+            helpers::validate_customer_id_given(&request.customer_id)?;
         }
 
         let request_merchant_id = request.merchant_id.as_deref();


### PR DESCRIPTION
## Type of Change
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
Make `customer_id` mandatory when confirming a payment. This is either when the customer calls `PaymentConfirm` or calls either `PaymentCreate` or `PaymentUpdate` with `confirm: true`. The changes involve addition of proper validations in all of the aforementioned operations to enforce this.

### Additional Changes
None.

## Motivation and Context
`customer_id` is required when confirming the payment.

## How did you test it?
Local testing with stripe payments.

Following is `PaymentCreate` with `confirm: true` but no customer ID given.
<img width="624" alt="image" src="https://user-images.githubusercontent.com/47862918/208895588-85de7096-68a4-4975-8126-5a1f3974ea51.png">

`PaymentUpdate` with no customer ID
<img width="624" alt="image" src="https://user-images.githubusercontent.com/47862918/208895705-ed678b5c-13ba-4c02-9637-569596df8ffd.png">

`PaymentConfirm` with no customer ID
<img width="624" alt="image" src="https://user-images.githubusercontent.com/47862918/208895781-43030d06-4a3b-4248-b513-f3ebd6625b58.png">


## Checklist

- [x] I formatted the code `cargo +nightly fmt`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
