### PR TITLE
feat(middleware): return request ID in response header

### DIFF
--- a/crates/router/src/lib.rs
+++ b/crates/router/src/lib.rs
@@ -34,6 +34,7 @@ pub(crate) mod macros;
 pub mod routes;
 pub mod scheduler;
 
+mod middleware;
 pub mod services;
 pub mod types;
 pub mod utils;
@@ -94,6 +95,7 @@ pub fn mk_app(
 
     let mut server_app = actix_web::App::new()
         .app_data(json_cfg)
+        .wrap(middleware::RequestId)
         .wrap(router_env::tracing_actix_web::TracingLogger::default())
         .wrap(ErrorHandlers::new().handler(
             StatusCode::NOT_FOUND,

--- a/crates/router/src/middleware.rs
+++ b/crates/router/src/middleware.rs
@@ -1,0 +1,61 @@
+/// Middleware to include request ID in response header.
+pub(crate) struct RequestId;
+
+impl<S, B> actix_web::dev::Transform<S, actix_web::dev::ServiceRequest> for RequestId
+where
+    S: actix_web::dev::Service<
+        actix_web::dev::ServiceRequest,
+        Response = actix_web::dev::ServiceResponse<B>,
+        Error = actix_web::Error,
+    >,
+    S::Future: 'static,
+    B: 'static,
+{
+    type Response = actix_web::dev::ServiceResponse<B>;
+    type Error = actix_web::Error;
+    type Transform = RequestIdMiddleware<S>;
+    type InitError = ();
+    type Future = std::future::Ready<Result<Self::Transform, Self::InitError>>;
+
+    fn new_transform(&self, service: S) -> Self::Future {
+        std::future::ready(Ok(RequestIdMiddleware { service }))
+    }
+}
+
+pub(crate) struct RequestIdMiddleware<S> {
+    service: S,
+}
+
+impl<S, B> actix_web::dev::Service<actix_web::dev::ServiceRequest> for RequestIdMiddleware<S>
+where
+    S: actix_web::dev::Service<
+        actix_web::dev::ServiceRequest,
+        Response = actix_web::dev::ServiceResponse<B>,
+        Error = actix_web::Error,
+    >,
+    S::Future: 'static,
+    B: 'static,
+{
+    type Response = actix_web::dev::ServiceResponse<B>;
+    type Error = actix_web::Error;
+    type Future = futures::future::LocalBoxFuture<'static, Result<Self::Response, Self::Error>>;
+
+    actix_web::dev::forward_ready!(service);
+
+    fn call(&self, req: actix_web::dev::ServiceRequest) -> Self::Future {
+        let mut req = req;
+        let request_id_fut = req.extract::<router_env::tracing_actix_web::RequestId>();
+        let response_fut = self.service.call(req);
+
+        Box::pin(async move {
+            let request_id = request_id_fut.await?;
+            let mut response = response_fut.await?;
+            response.headers_mut().append(
+                http::header::HeaderName::from_static("x-request-id"),
+                http::HeaderValue::from_str(&request_id.as_hyphenated().to_string())?,
+            );
+
+            Ok(response)
+        })
+    }
+}


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->
This PR provides a new middleware to include the request ID in the `x-request-id` response header.

The implementation follows the simple middleware implementation described on the [`actix-web` docs](https://actix.rs/docs/middleware) for the most part.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
Including a request ID in the response helps debug the complete process that occurred during the entire request-response cycle for that specific request.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
```bash
$ curl -i http://localhost:8080/health
HTTP/1.1 200 OK
content-length: 14
access-control-allow-credentials: true
x-request-id: d5533217-3b51-4c5c-8043-eddb90cfa4f2
vary: Origin, Access-Control-Request-Method, Access-Control-Request-Headers
access-control-expose-headers: x-request-id
date: Wed, 21 Dec 2022 21:04:42 GMT

health is good
```

I've also verified from the logs that the request ID being logged there is indeed the same value.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
