### PR TITLE
fix(router): updating amount_captured in payment_intent

### DIFF
--- a/crates/router/src/connector/stripe/transformers.rs
+++ b/crates/router/src/connector/stripe/transformers.rs
@@ -399,6 +399,7 @@ impl<F, T>
                 redirection_data,
                 mandate_reference,
             }),
+            amount_captured: Some(item.response.amount_received),
             ..item.data
         })
     }

--- a/crates/router/src/core/payments/operations/payment_response.rs
+++ b/crates/router/src/core/payments/operations/payment_response.rs
@@ -260,7 +260,7 @@ async fn payment_response_update_tracker<F: Clone, T>(
         Ok(_) => storage::PaymentIntentUpdate::ResponseUpdate {
             status: router_data.status.foreign_into(),
             return_url: router_data.return_url,
-            amount_captured: None,
+            amount_captured: router_data.amount_captured,
         },
     };
 

--- a/crates/router/src/core/payments/transformers.rs
+++ b/crates/router/src/core/payments/transformers.rs
@@ -96,6 +96,7 @@ where
         connector_meta_data: merchant_connector_account.metadata,
         request: T::try_from(payment_data.clone())?,
         response: response.map_or_else(|| Err(types::ErrorResponse::default()), Ok),
+        amount_captured: payment_data.payment_intent.amount_captured,
     };
 
     Ok(router_data)

--- a/crates/router/src/core/utils.rs
+++ b/crates/router/src/core/utils.rs
@@ -74,7 +74,7 @@ pub async fn construct_refund_router_data<'a, F>(
         address: PaymentAddress::default(),
         auth_type: payment_attempt.authentication_type.unwrap_or_default(),
         connector_meta_data: None,
-
+        amount_captured: payment_intent.amount_captured,
         request: types::RefundsData {
             refund_id: refund.refund_id.clone(),
             payment_method_data,

--- a/crates/router/src/types.rs
+++ b/crates/router/src/types.rs
@@ -76,6 +76,7 @@ pub struct RouterData<Flow, Request, Response> {
     pub address: PaymentAddress,
     pub auth_type: storage_enums::AuthenticationType,
     pub connector_meta_data: Option<serde_json::Value>,
+    pub amount_captured: Option<i64>,
 
     /// Contains flow-specific data required to construct a request and send it to the connector.
     pub request: Request,

--- a/crates/router/tests/connectors/aci.rs
+++ b/crates/router/tests/connectors/aci.rs
@@ -54,6 +54,7 @@ fn construct_payment_router_data() -> types::PaymentsAuthorizeRouterData {
         payment_method_id: None,
         address: PaymentAddress::default(),
         connector_meta_data: None,
+        amount_captured: None,
     }
 }
 
@@ -93,6 +94,7 @@ fn construct_refund_router_data<F>() -> types::RefundsRouterData<F> {
         response: Err(types::ErrorResponse::default()),
         address: PaymentAddress::default(),
         connector_meta_data: None,
+        amount_captured: None,
     }
 }
 

--- a/crates/router/tests/connectors/authorizedotnet.rs
+++ b/crates/router/tests/connectors/authorizedotnet.rs
@@ -54,6 +54,7 @@ fn construct_payment_router_data() -> types::PaymentsAuthorizeRouterData {
         response: Err(types::ErrorResponse::default()),
         address: PaymentAddress::default(),
         connector_meta_data: None,
+        amount_captured: None,
     }
 }
 
@@ -92,6 +93,7 @@ fn construct_refund_router_data<F>() -> types::RefundsRouterData<F> {
         response: Err(types::ErrorResponse::default()),
         payment_method_id: None,
         address: PaymentAddress::default(),
+        amount_captured: None,
     }
 }
 

--- a/crates/router/tests/connectors/checkout.rs
+++ b/crates/router/tests/connectors/checkout.rs
@@ -51,6 +51,7 @@ fn construct_payment_router_data() -> types::PaymentsAuthorizeRouterData {
         payment_method_id: None,
         address: PaymentAddress::default(),
         connector_meta_data: None,
+        amount_captured: None,
     }
 }
 
@@ -89,6 +90,7 @@ fn construct_refund_router_data<F>() -> types::RefundsRouterData<F> {
         response: Err(types::ErrorResponse::default()),
         payment_method_id: None,
         address: PaymentAddress::default(),
+        amount_captured: None,
     }
 }
 

--- a/crates/router/tests/connectors/utils.rs
+++ b/crates/router/tests/connectors/utils.rs
@@ -188,5 +188,6 @@ fn generate_data<Flow, Req: From<Req>, Res>(
         payment_method_id: None,
         address: PaymentAddress::default(),
         connector_meta_data: None,
+        amount_captured: None,
     }
 }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->
 Update amount_captured field in payment_intent.

### Additional Changes

- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!-- 
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
Gives the merchant info about how much amount was received during the payment.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Manually

In case of automatic capture, amount_received variable is updated.
<img width="1037" alt="image" src="https://user-images.githubusercontent.com/68317979/209635691-2930de2c-f45a-4fa7-9ae3-aa761d53e1e9.png">

In case of manual capture
<img width="772" alt="image" src="https://user-images.githubusercontent.com/68317979/209635810-5c9df2ce-3f44-4176-a0e8-f60309ab5e2b.png">

<img width="846" alt="image" src="https://user-images.githubusercontent.com/68317979/209636011-2a47a984-1bfa-48e0-83a4-0d240de8f4cd.png">


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [x] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
