### PR TITLE
fix: payment connector retrieve null metadata 

### DIFF
--- a/crates/router/src/core/admin.rs
+++ b/crates/router/src/core/admin.rs
@@ -1,4 +1,3 @@
-use api_models::admin;
 use error_stack::{report, ResultExt};
 use uuid::Uuid;
 
@@ -358,10 +357,7 @@ pub async fn retrieve_payment_connector(
             error.to_not_found_response(errors::ApiErrorResponse::MerchantConnectorAccountNotFound)
         })?;
 
-    let mut response: admin::PaymentConnectorCreate = mca.clone().foreign_try_into()?;
-    response.metadata = mca.metadata;
-
-    Ok(service_api::BachResponse::Json(response))
+    Ok(service_api::BachResponse::Json(mca.foreign_try_into()?))
 }
 
 pub async fn list_payment_connectors(

--- a/crates/router/src/types/transformers.rs
+++ b/crates/router/src/types/transformers.rs
@@ -347,7 +347,7 @@ impl TryFrom<F<storage::MerchantConnectorAccount>>
             )),
             test_mode: merchant_ca.test_mode,
             disabled: merchant_ca.disabled,
-            metadata: None,
+            metadata: merchant_ca.metadata,
             payment_methods_enabled,
         }
         .into())


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix

## Description
<!-- Describe your changes in detail -->
Metadata was showing null for payment connector retrieve call.


### Additional Changes

- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!-- 
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
Metadata with some value in payment connector create but was null for retrieve call.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Manual

<img width="1247" alt="Screenshot 2022-12-27 at 1 48 43 PM" src="https://user-images.githubusercontent.com/59434228/209639408-7ebf2211-984d-480d-abf1-25adad5bba69.png">


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
