### PR TITLE
fix: use non force sync workflow when payment in terminal state

### DIFF
--- a/crates/router/src/core/payments/helpers.rs
+++ b/crates/router/src/core/payments/helpers.rs
@@ -994,13 +994,16 @@ pub(crate) fn validate_amount_to_capture(
     )
 }
 
-pub fn can_call_connector(status: storage_enums::IntentStatus) -> bool {
-    matches!(
+pub fn can_call_connector(status: &storage_enums::AttemptStatus) -> bool {
+    !matches!(
         status,
-        storage_enums::IntentStatus::Failed
-            | storage_enums::IntentStatus::Processing
-            | storage_enums::IntentStatus::Succeeded
-            | storage_enums::IntentStatus::RequiresCustomerAction
+        storage_enums::AttemptStatus::Charged
+            | storage_enums::AttemptStatus::AutoRefunded
+            | storage_enums::AttemptStatus::Voided
+            | storage_enums::AttemptStatus::CodInitiated
+            | storage_enums::AttemptStatus::Authorized
+            | storage_enums::AttemptStatus::Started
+            | storage_enums::AttemptStatus::Failure
     )
 }
 


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix


## Description
This change fixes the issue where, the payments route throws wrong error message, when performing payment sync for payments with terminal status.
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!-- 
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
N/A
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<img width="1110" alt="Screenshot 2022-12-27 at 3 07 01 PM" src="https://user-images.githubusercontent.com/51093026/209646153-1a90381c-fe24-4815-9bf0-b977fe705173.png">

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
