### PR TITLE
refactor: use http post method for sessions endponint

### DIFF
--- a/crates/router/src/routes/app.rs
+++ b/crates/router/src/routes/app.rs
@@ -60,7 +60,7 @@ impl Payments {
             .service(web::resource("").route(web::post().to(payments_create)))
             .service(web::resource("/list").route(web::get().to(payments_list)))
             .service(
-                web::resource("/session_tokens").route(web::get().to(payments_connector_session)),
+                web::resource("/session_tokens").route(web::post().to(payments_connector_session)),
             )
             .service(
                 web::resource("/{payment_id}")


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Refactoring

## Description
This PR includes changes to make the sessions endpoint http method as POST instead of GET.



## Motivation and Context
Using GET method data cannot be sent using the browser, so it is converted to POST so that client secret and payment id can be sent. In future there will be additional fields to be sent in the body of sessions endpoint.


## How did you test it?
<img width="1196" alt="Screenshot 2023-01-03 at 11 51 06 AM" src="https://user-images.githubusercontent.com/48803246/210308521-e901a1f4-120a-46b1-8cd4-50497b05eaf1.png">




## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
