### PR TITLE
fix: Use hsetnx for setting ephemeral key

### DIFF
--- a/crates/redis_interface/src/commands.rs
+++ b/crates/redis_interface/src/commands.rs
@@ -251,15 +251,18 @@ impl super::RedisConnectionPool {
         &self,
         kv: &[(&str, V)],
         field: &str,
-    ) -> CustomResult<HsetnxReply, errors::RedisError>
+    ) -> CustomResult<Vec<HsetnxReply>, errors::RedisError>
     where
         V: serde::Serialize + Debug,
     {
+        let mut hsetnx: Vec<HsetnxReply> = Vec::with_capacity(kv.len());
         for (key, val) in kv {
-            self.serialize_and_set_hash_field_if_not_exist(key, field, val)
-                .await?;
+            hsetnx.push(
+                self.serialize_and_set_hash_field_if_not_exist(key, field, val)
+                    .await?,
+            );
         }
-        Ok(HsetnxReply::KeySet)
+        Ok(hsetnx)
     }
 
     #[instrument(level = "DEBUG", skip(self))]


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->
This fixes the Internal server error while trying to set ephemeral key on sanbox.

### Additional Changes

- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!-- 
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
So apparently when you are trying to use the `MSET` command in Redis, which is used to set multiple keys to multiple values in a single atomic operation. But on a setup where there are 2 or more redis clusters if the keys are being set on different clusters redis throws error.



## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
