### PR TITLE
fix: populate payment_token in response

### DIFF
--- a/crates/router/src/core/payments/transformers.rs
+++ b/crates/router/src/core/payments/transformers.rs
@@ -140,7 +140,6 @@ where
             payment_data.address,
             server,
             payment_data.connector_response.authentication_data,
-            payment_data.token,
             operation,
         )
     }
@@ -230,7 +229,6 @@ pub fn payments_to_payments_response<R, Op>(
     address: PaymentAddress,
     server: &Server,
     redirection_data: Option<serde_json::Value>,
-    payment_token: Option<String>,
     operation: Op,
 ) -> RouterResponse<api::PaymentsResponse>
 where
@@ -311,7 +309,7 @@ where
                             payment_method_data.map(api::PaymentMethodDataResponse::from),
                             auth_flow == services::AuthFlow::Merchant,
                         )
-                        .set_payment_token(payment_token)
+                        .set_payment_token(payment_attempt.payment_token)
                         .set_error_message(payment_attempt.error_message)
                         .set_shipping(address.shipping)
                         .set_billing(address.billing)
@@ -374,6 +372,7 @@ where
             shipping: address.shipping,
             billing: address.billing,
             cancellation_reason: payment_attempt.cancellation_reason,
+            payment_token: payment_attempt.payment_token,
             ..Default::default()
         }),
     })

--- a/crates/storage_models/src/payment_attempt.rs
+++ b/crates/storage_models/src/payment_attempt.rs
@@ -36,8 +36,8 @@ pub struct PaymentAttempt {
     pub amount_to_capture: Option<i64>,
     pub mandate_id: Option<String>,
     pub browser_info: Option<serde_json::Value>,
-    pub payment_token: Option<String>,
     pub error_code: Option<String>,
+    pub payment_token: Option<String>,
 }
 
 #[derive(


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix

## Description
Issue while populating the payment_token in `status` and `cancel` response
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!-- 
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
The bug fix spree
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<img width="1028" alt="Screenshot 2023-01-04 at 7 28 03 PM" src="https://user-images.githubusercontent.com/51093026/210570854-77b85f11-edaa-4dca-9cb2-6bb059c5de6c.png">

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code