### PR TITLE
refactor(routes/sessions): use pub key auth

### DIFF
--- a/crates/router/src/routes/payments.rs
+++ b/crates/router/src/routes/payments.rs
@@ -262,12 +262,12 @@ pub async fn payments_connector_session(
                 merchant_account,
                 payments::PaymentSession,
                 payload,
-                api::AuthFlow::Merchant,
+                api::AuthFlow::Client,
                 None,
                 payments::CallConnectorAction::Trigger,
             )
         },
-        api::MerchantAuthentication::ApiKey,
+        api::MerchantAuthentication::PublishableKey,
     )
     .await
 }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Refactoring

## Description
This PR will make the sessions endpoint to authenticate using publishable key instead of api key. 

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
Since this endpoint will be called by the SDK, using api key auth might cause leakage of api key on the client side.


## How did you test it?
![Screenshot 2023-01-05 at 3 26 39 PM](https://user-images.githubusercontent.com/48803246/210752441-8ac5a43c-c4a1-405f-995a-9d8353dc0ea4.png)



## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
