### PR TITLE
fix: fixing tempo & histogram without using custom dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,7 +91,7 @@ dependencies = [
  "rand",
  "sha1",
  "smallvec",
- "tracing 0.1.36",
+ "tracing",
  "zstd",
 ]
 
@@ -115,7 +115,7 @@ dependencies = [
  "http",
  "regex",
  "serde",
- "tracing 0.1.36",
+ "tracing",
 ]
 
 [[package]]
@@ -144,7 +144,7 @@ dependencies = [
  "num_cpus",
  "socket2",
  "tokio",
- "tracing 0.1.36",
+ "tracing",
 ]
 
 [[package]]
@@ -454,7 +454,7 @@ dependencies = [
  "time",
  "tokio",
  "tower",
- "tracing 0.1.36",
+ "tracing",
  "zeroize",
 ]
 
@@ -469,7 +469,7 @@ dependencies = [
  "aws-types",
  "http",
  "regex",
- "tracing 0.1.36",
+ "tracing",
 ]
 
 [[package]]
@@ -487,7 +487,7 @@ dependencies = [
  "lazy_static",
  "percent-encoding",
  "pin-project-lite",
- "tracing 0.1.36",
+ "tracing",
 ]
 
 [[package]]
@@ -566,7 +566,7 @@ dependencies = [
  "aws-smithy-http",
  "aws-types",
  "http",
- "tracing 0.1.36",
+ "tracing",
 ]
 
 [[package]]
@@ -584,7 +584,7 @@ dependencies = [
  "regex",
  "ring",
  "time",
- "tracing 0.1.36",
+ "tracing",
 ]
 
 [[package]]
@@ -619,7 +619,7 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tower",
- "tracing 0.1.36",
+ "tracing",
 ]
 
 [[package]]
@@ -640,7 +640,7 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-util 0.7.4",
- "tracing 0.1.36",
+ "tracing",
 ]
 
 [[package]]
@@ -655,7 +655,7 @@ dependencies = [
  "http-body",
  "pin-project-lite",
  "tower",
- "tracing 0.1.36",
+ "tracing",
 ]
 
 [[package]]
@@ -710,7 +710,7 @@ dependencies = [
  "aws-smithy-types",
  "http",
  "rustc_version",
- "tracing 0.1.36",
+ "tracing",
  "zeroize",
 ]
 
@@ -1325,7 +1325,7 @@ dependencies = [
  "tokio-native-tls",
  "tokio-stream",
  "tokio-util 0.6.10",
- "tracing 0.1.36",
+ "tracing",
  "tracing-futures",
  "url",
 ]
@@ -1555,7 +1555,7 @@ dependencies = [
  "slab",
  "tokio",
  "tokio-util 0.7.4",
- "tracing 0.1.36",
+ "tracing",
 ]
 
 [[package]]
@@ -1666,7 +1666,7 @@ dependencies = [
  "socket2",
  "tokio",
  "tower-service",
- "tracing 0.1.36",
+ "tracing",
  "want",
 ]
 
@@ -2168,29 +2168,20 @@ name = "opentelemetry"
 version = "0.18.0"
 source = "git+https://github.com/open-telemetry/opentelemetry-rust?rev=44b90202fd744598db8b0ace5b8f0bad7ec45658#44b90202fd744598db8b0ace5b8f0bad7ec45658"
 dependencies = [
- "opentelemetry_api 0.18.0 (git+https://github.com/open-telemetry/opentelemetry-rust?rev=44b90202fd744598db8b0ace5b8f0bad7ec45658)",
- "opentelemetry_sdk 0.18.0 (git+https://github.com/open-telemetry/opentelemetry-rust?rev=44b90202fd744598db8b0ace5b8f0bad7ec45658)",
-]
-
-[[package]]
-name = "opentelemetry"
-version = "0.18.0"
-source = "git+https://github.com/jarnura/opentelemetry-rust?rev=a82056696ca3d26960458269a894e5cf15056ad8#a82056696ca3d26960458269a894e5cf15056ad8"
-dependencies = [
- "opentelemetry_api 0.18.0 (git+https://github.com/jarnura/opentelemetry-rust?rev=a82056696ca3d26960458269a894e5cf15056ad8)",
- "opentelemetry_sdk 0.18.0 (git+https://github.com/jarnura/opentelemetry-rust?rev=a82056696ca3d26960458269a894e5cf15056ad8)",
+ "opentelemetry_api",
+ "opentelemetry_sdk",
 ]
 
 [[package]]
 name = "opentelemetry-otlp"
 version = "0.11.0"
-source = "git+https://github.com/jarnura/opentelemetry-rust?rev=a82056696ca3d26960458269a894e5cf15056ad8#a82056696ca3d26960458269a894e5cf15056ad8"
+source = "git+https://github.com/open-telemetry/opentelemetry-rust?rev=44b90202fd744598db8b0ace5b8f0bad7ec45658#44b90202fd744598db8b0ace5b8f0bad7ec45658"
 dependencies = [
  "async-trait",
  "futures",
  "futures-util",
  "http",
- "opentelemetry 0.18.0 (git+https://github.com/jarnura/opentelemetry-rust?rev=a82056696ca3d26960458269a894e5cf15056ad8)",
+ "opentelemetry",
  "opentelemetry-proto",
  "prost",
  "thiserror",
@@ -2201,11 +2192,11 @@ dependencies = [
 [[package]]
 name = "opentelemetry-proto"
 version = "0.1.0"
-source = "git+https://github.com/jarnura/opentelemetry-rust?rev=a82056696ca3d26960458269a894e5cf15056ad8#a82056696ca3d26960458269a894e5cf15056ad8"
+source = "git+https://github.com/open-telemetry/opentelemetry-rust?rev=44b90202fd744598db8b0ace5b8f0bad7ec45658#44b90202fd744598db8b0ace5b8f0bad7ec45658"
 dependencies = [
  "futures",
  "futures-util",
- "opentelemetry 0.18.0 (git+https://github.com/jarnura/opentelemetry-rust?rev=a82056696ca3d26960458269a894e5cf15056ad8)",
+ "opentelemetry",
  "prost",
  "tonic",
 ]
@@ -2226,21 +2217,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "opentelemetry_api"
-version = "0.18.0"
-source = "git+https://github.com/jarnura/opentelemetry-rust?rev=a82056696ca3d26960458269a894e5cf15056ad8#a82056696ca3d26960458269a894e5cf15056ad8"
-dependencies = [
- "fnv",
- "futures-channel",
- "futures-util",
- "indexmap",
- "js-sys",
- "once_cell",
- "pin-project-lite",
- "thiserror",
-]
-
-[[package]]
 name = "opentelemetry_sdk"
 version = "0.18.0"
 source = "git+https://github.com/open-telemetry/opentelemetry-rust?rev=44b90202fd744598db8b0ace5b8f0bad7ec45658#44b90202fd744598db8b0ace5b8f0bad7ec45658"
@@ -2253,26 +2229,7 @@ dependencies = [
  "futures-executor",
  "futures-util",
  "once_cell",
- "opentelemetry_api 0.18.0 (git+https://github.com/open-telemetry/opentelemetry-rust?rev=44b90202fd744598db8b0ace5b8f0bad7ec45658)",
- "percent-encoding",
- "rand",
- "thiserror",
-]
-
-[[package]]
-name = "opentelemetry_sdk"
-version = "0.18.0"
-source = "git+https://github.com/jarnura/opentelemetry-rust?rev=a82056696ca3d26960458269a894e5cf15056ad8#a82056696ca3d26960458269a894e5cf15056ad8"
-dependencies = [
- "async-trait",
- "crossbeam-channel",
- "dashmap",
- "fnv",
- "futures-channel",
- "futures-executor",
- "futures-util",
- "once_cell",
- "opentelemetry_api 0.18.0 (git+https://github.com/jarnura/opentelemetry-rust?rev=a82056696ca3d26960458269a894e5cf15056ad8)",
+ "opentelemetry_api",
  "percent-encoding",
  "rand",
  "thiserror",
@@ -2848,7 +2805,7 @@ dependencies = [
  "config",
  "gethostname",
  "once_cell",
- "opentelemetry 0.18.0 (git+https://github.com/jarnura/opentelemetry-rust?rev=a82056696ca3d26960458269a894e5cf15056ad8)",
+ "opentelemetry",
  "opentelemetry-otlp",
  "rustc-hash",
  "serde",
@@ -2857,12 +2814,12 @@ dependencies = [
  "strum",
  "time",
  "tokio",
- "tracing 0.2.0",
+ "tracing",
  "tracing-actix-web",
  "tracing-appender",
- "tracing-attributes 0.1.22",
- "tracing-opentelemetry 0.16.0",
- "tracing-subscriber 0.3.0",
+ "tracing-attributes",
+ "tracing-opentelemetry",
+ "tracing-subscriber",
  "vergen",
 ]
 
@@ -3496,7 +3453,7 @@ dependencies = [
  "futures-sink",
  "pin-project-lite",
  "tokio",
- "tracing 0.1.36",
+ "tracing",
 ]
 
 [[package]]
@@ -3536,7 +3493,7 @@ dependencies = [
  "tower",
  "tower-layer",
  "tower-service",
- "tracing 0.1.36",
+ "tracing",
  "tracing-futures",
 ]
 
@@ -3557,7 +3514,7 @@ dependencies = [
  "tokio-util 0.7.4",
  "tower-layer",
  "tower-service",
- "tracing 0.1.36",
+ "tracing",
 ]
 
 [[package]]
@@ -3600,19 +3557,8 @@ dependencies = [
  "cfg-if",
  "log",
  "pin-project-lite",
- "tracing-attributes 0.1.22",
- "tracing-core 0.1.30",
-]
-
-[[package]]
-name = "tracing"
-version = "0.2.0"
-source = "git+https://github.com/jarnura/tracing?rev=16d277227f60788750528e4f4cc1db4f36b0869f#16d277227f60788750528e4f4cc1db4f36b0869f"
-dependencies = [
- "cfg-if",
- "pin-project-lite",
- "tracing-attributes 0.2.0",
- "tracing-core 0.2.0",
+ "tracing-attributes",
+ "tracing-core",
 ]
 
 [[package]]
@@ -3622,22 +3568,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d725b8fa6ef307b3f4856913523337de45c47cc79271bafd7acfb39559e3a2da"
 dependencies = [
  "actix-web",
- "opentelemetry 0.18.0 (git+https://github.com/open-telemetry/opentelemetry-rust?rev=44b90202fd744598db8b0ace5b8f0bad7ec45658)",
+ "opentelemetry",
  "pin-project",
- "tracing 0.1.36",
- "tracing-opentelemetry 0.18.0",
+ "tracing",
+ "tracing-opentelemetry",
  "uuid",
 ]
 
 [[package]]
 name = "tracing-appender"
-version = "0.2.0"
-source = "git+https://github.com/jarnura/tracing?rev=16d277227f60788750528e4f4cc1db4f36b0869f#16d277227f60788750528e4f4cc1db4f36b0869f"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09d48f71a791638519505cefafe162606f706c25592e4bde4d97600c0195312e"
 dependencies = [
  "crossbeam-channel",
- "thiserror",
  "time",
- "tracing-subscriber 0.3.0",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -3645,16 +3591,6 @@ name = "tracing-attributes"
 version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11c75893af559bc8e10716548bdef5cb2b983f8e637db9d0e15126b61b484ee2"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "tracing-attributes"
-version = "0.2.0"
-source = "git+https://github.com/jarnura/tracing?rev=16d277227f60788750528e4f4cc1db4f36b0869f#16d277227f60788750528e4f4cc1db4f36b0869f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3672,21 +3608,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-core"
-version = "0.2.0"
-source = "git+https://github.com/jarnura/tracing?rev=16d277227f60788750528e4f4cc1db4f36b0869f#16d277227f60788750528e4f4cc1db4f36b0869f"
-dependencies = [
- "once_cell",
-]
-
-[[package]]
 name = "tracing-futures"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
 dependencies = [
  "pin-project",
- "tracing 0.1.36",
+ "tracing",
 ]
 
 [[package]]
@@ -3697,31 +3625,7 @@ checksum = "78ddad33d2d10b1ed7eb9d1f518a5674713876e97e5bb9b7345a7984fbb4f922"
 dependencies = [
  "lazy_static",
  "log",
- "tracing-core 0.1.30",
-]
-
-[[package]]
-name = "tracing-log"
-version = "0.2.0"
-source = "git+https://github.com/jarnura/tracing?rev=16d277227f60788750528e4f4cc1db4f36b0869f#16d277227f60788750528e4f4cc1db4f36b0869f"
-dependencies = [
- "log",
- "once_cell",
- "tracing-core 0.2.0",
-]
-
-[[package]]
-name = "tracing-opentelemetry"
-version = "0.16.0"
-source = "git+https://github.com/jarnura/tracing?rev=16d277227f60788750528e4f4cc1db4f36b0869f#16d277227f60788750528e4f4cc1db4f36b0869f"
-dependencies = [
- "async-trait",
- "once_cell",
- "opentelemetry 0.18.0 (git+https://github.com/jarnura/opentelemetry-rust?rev=a82056696ca3d26960458269a894e5cf15056ad8)",
- "tracing 0.2.0",
- "tracing-core 0.2.0",
- "tracing-log 0.2.0",
- "tracing-subscriber 0.3.0",
+ "tracing-core",
 ]
 
 [[package]]
@@ -3731,26 +3635,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21ebb87a95ea13271332df069020513ab70bdb5637ca42d6e492dc3bbbad48de"
 dependencies = [
  "once_cell",
- "opentelemetry 0.18.0 (git+https://github.com/open-telemetry/opentelemetry-rust?rev=44b90202fd744598db8b0ace5b8f0bad7ec45658)",
- "tracing 0.1.36",
- "tracing-core 0.1.30",
- "tracing-log 0.1.3",
- "tracing-subscriber 0.3.16",
+ "opentelemetry",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber",
 ]
 
 [[package]]
 name = "tracing-serde"
-version = "0.2.0"
-source = "git+https://github.com/jarnura/tracing?rev=16d277227f60788750528e4f4cc1db4f36b0869f#16d277227f60788750528e4f4cc1db4f36b0869f"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
 dependencies = [
  "serde",
- "tracing-core 0.2.0",
+ "tracing-core",
 ]
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.0"
-source = "git+https://github.com/jarnura/tracing?rev=16d277227f60788750528e4f4cc1db4f36b0869f#16d277227f60788750528e4f4cc1db4f36b0869f"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6176eae26dd70d0c919749377897b54a9276bd7061339665dd68777926b5a70"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -3761,21 +3667,10 @@ dependencies = [
  "sharded-slab",
  "smallvec",
  "thread_local",
- "tracing 0.2.0",
- "tracing-core 0.2.0",
- "tracing-log 0.2.0",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
  "tracing-serde",
-]
-
-[[package]]
-name = "tracing-subscriber"
-version = "0.3.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6176eae26dd70d0c919749377897b54a9276bd7061339665dd68777926b5a70"
-dependencies = [
- "sharded-slab",
- "thread_local",
- "tracing-core 0.1.30",
 ]
 
 [[package]]

--- a/crates/router_env/Cargo.toml
+++ b/crates/router_env/Cargo.toml
@@ -12,8 +12,8 @@ build = "src/build.rs"
 config = { version = "0.13.3", features = ["toml"] }
 gethostname = "0.4.1"
 once_cell = "1.16.0"
-opentelemetry = { git = "https://github.com/jarnura/opentelemetry-rust", rev = "a82056696ca3d26960458269a894e5cf15056ad8",  features = ["rt-tokio-current-thread", "metrics"] }
-opentelemetry-otlp = { git = "https://github.com/jarnura/opentelemetry-rust", rev = "a82056696ca3d26960458269a894e5cf15056ad8", features = ["metrics"] }
+opentelemetry = { git = "https://github.com/open-telemetry/opentelemetry-rust/", rev = "44b90202fd744598db8b0ace5b8f0bad7ec45658",  features = ["rt-tokio-current-thread", "metrics"] }
+opentelemetry-otlp = { git = "https://github.com/open-telemetry/opentelemetry-rust/", rev = "44b90202fd744598db8b0ace5b8f0bad7ec45658", features = ["metrics"] }
 rustc-hash = "1.1"
 serde = { version = "1.0.149", features = ["derive"] }
 serde_json = "1.0.89"
@@ -21,12 +21,12 @@ serde_path_to_error = "0.1.8"
 strum = { version = "0.24.1", features = ["derive"] }
 time = { version = "0.3.17", default-features = false, features = ["formatting"] }
 tokio = { version = "1.23.0" }
-tracing = { git = "https://github.com/jarnura/tracing", rev = "16d277227f60788750528e4f4cc1db4f36b0869f" }
+tracing = { version = "0.1.36" }
 tracing-actix-web = { version = "0.6.1", features = ["opentelemetry_0_18"], optional = true }
-tracing-appender = { git = "https://github.com/jarnura/tracing", rev = "16d277227f60788750528e4f4cc1db4f36b0869f" }
+tracing-appender = { version = "0.2.2" }
 tracing-attributes = "=0.1.22"
-tracing-subscriber = { git = "https://github.com/jarnura/tracing", rev = "16d277227f60788750528e4f4cc1db4f36b0869f", default-features = true, features = ["json", "env-filter", "registry"] }
-tracing-opentelemetry = { git = "https://github.com/jarnura/tracing", rev = "16d277227f60788750528e4f4cc1db4f36b0869f" }
+tracing-subscriber = { version = "0.3.15", default-features = true, features = ["json", "env-filter", "registry"] }
+tracing-opentelemetry = { version = "0.18.0" }
 vergen = { version = "7.4.3", optional = true }
 
 [dev-dependencies]

--- a/crates/router_env/src/logger/formatter.rs
+++ b/crates/router_env/src/logger/formatter.rs
@@ -13,12 +13,12 @@ use serde::ser::{SerializeMap, Serializer};
 use serde_json::Value;
 // use time::format_description::well_known::Rfc3339;
 use time::format_description::well_known::Iso8601;
-use tracing::{Collect, Event, Id, Metadata};
+use tracing::{Event, Id, Metadata, Subscriber};
 use tracing_subscriber::{
     fmt::MakeWriter,
+    layer::Context,
     registry::{LookupSpan, SpanRef},
-    subscribe::Context,
-    Subscribe,
+    Layer,
 };
 
 use crate::Storage;
@@ -184,7 +184,7 @@ where
         message: &str,
     ) -> Result<(), std::io::Error>
     where
-        S: Collect + for<'a> LookupSpan<'a>,
+        S: Subscriber + for<'a> LookupSpan<'a>,
     {
         let is_extra = |s: &str| !IMPLICIT_KEYS.contains(s);
         let is_extra_implicit = |s: &str| is_extra(s) && EXTRA_IMPLICIT_KEYS.contains(s);
@@ -278,7 +278,7 @@ where
         ty: RecordType,
     ) -> Result<Vec<u8>, std::io::Error>
     where
-        S: Collect + for<'a> LookupSpan<'a>,
+        S: Subscriber + for<'a> LookupSpan<'a>,
     {
         let mut buffer = Vec::new();
         let mut serializer = serde_json::Serializer::new(&mut buffer);
@@ -305,7 +305,7 @@ where
         event: &Event<'_>,
     ) -> std::io::Result<Vec<u8>>
     where
-        S: Collect + for<'a> LookupSpan<'a>,
+        S: Subscriber + for<'a> LookupSpan<'a>,
     {
         let mut buffer = Vec::new();
         let mut serializer = serde_json::Serializer::new(&mut buffer);
@@ -338,7 +338,7 @@ where
 
     fn span_message<S>(span: &SpanRef<'_, S>, ty: RecordType) -> String
     where
-        S: Collect + for<'a> LookupSpan<'a>,
+        S: Subscriber + for<'a> LookupSpan<'a>,
     {
         format!("[{} - {}]", span.metadata().name().to_uppercase(), ty)
     }
@@ -355,7 +355,7 @@ where
         storage: &Storage<'_>,
     ) -> String
     where
-        S: Collect + for<'a> LookupSpan<'a>,
+        S: Subscriber + for<'a> LookupSpan<'a>,
     {
         // Get value of ket "message" or "target" if does not exist.
         let mut message = storage
@@ -382,9 +382,9 @@ where
 }
 
 #[allow(clippy::expect_used)]
-impl<S, W> Subscribe<S> for FormattingLayer<W>
+impl<S, W> Layer<S> for FormattingLayer<W>
 where
-    S: Collect + for<'a> LookupSpan<'a>,
+    S: Subscriber + for<'a> LookupSpan<'a>,
     W: for<'a> MakeWriter<'a> + 'static,
 {
     fn on_event(&self, event: &Event<'_>, ctx: Context<'_, S>) {

--- a/crates/router_env/src/logger/setup.rs
+++ b/crates/router_env/src/logger/setup.rs
@@ -16,9 +16,7 @@ use opentelemetry::{
 };
 use opentelemetry_otlp::WithExportConfig;
 use tracing_appender::non_blocking::WorkerGuard;
-use tracing_subscriber::{
-    filter, fmt, subscribe::CollectExt, util::SubscriberInitExt, EnvFilter, Subscribe,
-};
+use tracing_subscriber::{filter, fmt, prelude::*, util::SubscriberInitExt, EnvFilter, Layer};
 
 use crate::{config, FormattingLayer, Level, StorageSubscription};
 
@@ -73,9 +71,7 @@ pub fn setup<Str: AsRef<str>>(
     };
 
     let telemetry_layer = match telemetry {
-        Some(Ok(ref tracer)) => {
-            Some(tracing_opentelemetry::subscriber().with_tracer(tracer.clone()))
-        }
+        Some(Ok(ref tracer)) => Some(tracing_opentelemetry::layer().with_tracer(tracer.clone())),
         _ => None,
     };
 
@@ -102,7 +98,7 @@ pub fn setup<Str: AsRef<str>>(
 
         match conf.console.log_format {
             config::LogFormat::Default => {
-                let logging_layer = fmt::subscriber()
+                let logging_layer = fmt::layer()
                     .with_timer(fmt::time::time())
                     .with_span_events(fmt::format::FmtSpan::ACTIVE)
                     .pretty()

--- a/crates/router_env/src/logger/storage.rs
+++ b/crates/router_env/src/logger/storage.rs
@@ -7,9 +7,9 @@ use std::{collections::HashMap, fmt, time::Instant};
 use tracing::{
     field::{Field, Visit},
     span::{Attributes, Record},
-    Collect, Id,
+    Id, Subscriber,
 };
-use tracing_subscriber::{subscribe::Context, Subscribe};
+use tracing_subscriber::{layer::Context, Layer};
 
 /// Storage to store key value pairs of spans.
 #[derive(Clone, Debug)]
@@ -89,7 +89,7 @@ impl Visit for Storage<'_> {
 }
 
 #[allow(clippy::expect_used)]
-impl<S: Collect + for<'a> tracing_subscriber::registry::LookupSpan<'a>> Subscribe<S>
+impl<S: Subscriber + for<'a> tracing_subscriber::registry::LookupSpan<'a>> Layer<S>
     for StorageSubscription
 {
     /// On new span.


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] New feature
- [x] Enhancement


## Description

INFO: Raising with with base set to `fix_traces`, while merging please change the base to `main`

This is an extension to the PR #201
This removes some of the custom dependencies with `tracing` and `opentelemetry`
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!-- 
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
Performance Monitoring
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<img width="1149" alt="Screenshot 2023-01-05 at 7 43 30 PM" src="https://user-images.githubusercontent.com/51093026/210800184-a44cf59a-8844-47d9-8163-2e1b29656808.png">

<img width="1704" alt="Screenshot 2023-01-05 at 7 43 46 PM" src="https://user-images.githubusercontent.com/51093026/210800245-b038b7a2-9fdb-423f-adae-8e08238a7f30.png">

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code