### PR TITLE
feat(compatiblity): added field to accept 3ds or no_3ds in request body

### DIFF
--- a/crates/router/src/compatibility/stripe/payment_intents/types.rs
+++ b/crates/router/src/compatibility/stripe/payment_intents/types.rs
@@ -189,9 +189,7 @@ impl TryFrom<StripePaymentIntentRequest> for payments::PaymentsRequest {
                     request_three_d_secure,
                 } = pmo;
 
-                request_three_d_secure
-                    .unwrap_or_else(Request3DS::default)
-                    .foreign_into()
+                request_three_d_secure.foreign_into()
             }),
             ..Self::default()
         })
@@ -391,9 +389,9 @@ pub enum Request3DS {
     Any,
 }
 
-impl From<Foreign<Request3DS>> for Foreign<api_models::enums::AuthenticationType> {
-    fn from(item: Foreign<Request3DS>) -> Self {
-        Self(match item.0 {
+impl From<Foreign<Option<Request3DS>>> for Foreign<api_models::enums::AuthenticationType> {
+    fn from(item: Foreign<Option<Request3DS>>) -> Self {
+        Self(match item.0.unwrap_or_default() {
             Request3DS::Automatic => api_models::enums::AuthenticationType::NoThreeDs,
             Request3DS::Any => api_models::enums::AuthenticationType::ThreeDs,
         })


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->
added field to accept 3ds or no_3ds in request body

### Additional Changes

- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!-- 
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
added field to accept 3ds or no_3ds in request body

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Manually , tested on postman. 
<img width="857" alt="image" src="https://user-images.githubusercontent.com/68317979/210957076-f91761e7-38a3-45ae-a1ad-711e189b25d4.png">


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [x] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
