### PR TITLE
feat(session_token): serialize with camelCase for gpay token

### DIFF
--- a/crates/api_models/src/payments.rs
+++ b/crates/api_models/src/payments.rs
@@ -744,18 +744,21 @@ pub struct PaymentsSessionRequest {
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all(serialize = "camelCase"))]
 pub struct GpayAllowedMethodsParameters {
     pub allowed_auth_methods: Vec<String>,
     pub allowed_card_networks: Vec<String>,
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all(serialize = "camelCase"))]
 pub struct GpayTokenParameters {
     pub gateway: String,
     pub gateway_merchant_id: String,
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all(serialize = "camelCase"))]
 pub struct GpayTokenizationSpecification {
     #[serde(rename = "type")]
     pub token_specification_type: String,
@@ -763,6 +766,7 @@ pub struct GpayTokenizationSpecification {
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all(serialize = "camelCase"))]
 pub struct GpayAllowedPaymentMethods {
     #[serde(rename = "type")]
     pub payment_method_type: String,
@@ -771,6 +775,7 @@ pub struct GpayAllowedPaymentMethods {
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all(serialize = "camelCase"))]
 pub struct GpayTransactionInfo {
     pub country_code: String,
     pub currency_code: String,
@@ -779,11 +784,13 @@ pub struct GpayTransactionInfo {
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all(serialize = "camelCase"))]
 pub struct GpayMerchantInfo {
     pub merchant_name: String,
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all(serialize = "camelCase"))]
 pub struct GpayMetadata {
     pub merchant_info: GpayMerchantInfo,
     pub allowed_payment_methods: Vec<GpayAllowedPaymentMethods>,
@@ -799,7 +806,9 @@ pub struct GpaySessionTokenData {
 #[serde(rename_all = "lowercase")]
 pub enum SessionToken {
     Gpay {
-        allowed_payment_methods: Vec<GpayAllowedPaymentMethods>,
+        #[serde(flatten)]
+        gpay_token: GpayMetadata,
+        #[serde(rename(serialize = "transactionInfo"))]
         transaction_info: GpayTransactionInfo,
     },
     Klarna {

--- a/crates/router/src/core/payments/flows/session_flow.rs
+++ b/crates/router/src/core/payments/flows/session_flow.rs
@@ -87,7 +87,7 @@ fn create_gpay_session_token(
     let response_router_data = types::PaymentsSessionRouterData {
         response: Ok(types::PaymentsResponseData::SessionResponse {
             session_token: payment_types::SessionToken::Gpay {
-                allowed_payment_methods: gpay_data.gpay.allowed_payment_methods,
+                gpay_token: gpay_data.gpay,
                 transaction_info,
             },
         }),


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->


- [x] Refactoring

## Description
<!-- Describe your changes in detail -->
Send the google pay session token ( taken from metadata ), in camelCase since google pay is expecting it in camelCase.

<!-- 
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
Refactoring request from the frontend team


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
![Screenshot 2023-01-09 at 3 26 36 PM](https://user-images.githubusercontent.com/48803246/211281999-51943c39-5826-4d54-a471-208efdad944e.png)


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
