### PR TITLE
feat(core): add access token connector auth type

### DIFF
--- a/crates/common_utils/src/lib.rs
+++ b/crates/common_utils/src/lib.rs
@@ -27,6 +27,11 @@ pub mod date_time {
     pub fn convert_to_pdt(offset_time: OffsetDateTime) -> PrimitiveDateTime {
         PrimitiveDateTime::new(offset_time.date(), offset_time.time())
     }
+
+    /// Get the current time in unix timestamp format
+    pub fn now_unix_timestamp() -> i64 {
+        OffsetDateTime::now_utc().unix_timestamp()
+    }
 }
 
 /// Generate a nanoid with the given prefix and length

--- a/crates/router/src/connector/braintree.rs
+++ b/crates/router/src/connector/braintree.rs
@@ -276,7 +276,7 @@ impl
         data: &types::PaymentsSyncRouterData,
         res: types::Response,
     ) -> CustomResult<types::PaymentsSyncRouterData, errors::ConnectorError> {
-        logger::debug!(payment_sync_response=?res);
+        logger::debug!(payment_sync_response_braintree=?res);
         let response: braintree::BraintreePaymentsResponse = res
             .response
             .parse_struct("Braintree PaymentsResponse")
@@ -365,11 +365,11 @@ impl
         data: &types::PaymentsAuthorizeRouterData,
         res: types::Response,
     ) -> CustomResult<types::PaymentsAuthorizeRouterData, errors::ConnectorError> {
+        logger::debug!(braintreepayments_create_response=?res);
         let response: braintree::BraintreePaymentsResponse = res
             .response
             .parse_struct("Braintree PaymentsResponse")
             .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
-        logger::debug!(braintreepayments_create_response=?response);
         types::ResponseRouterData {
             response,
             data: data.clone(),

--- a/crates/router/src/connector/braintree/transformers.rs
+++ b/crates/router/src/connector/braintree/transformers.rs
@@ -85,7 +85,7 @@ impl TryFrom<&types::PaymentsAuthorizeRouterData> for BraintreePaymentsRequest {
     fn try_from(item: &types::PaymentsAuthorizeRouterData) -> Result<Self, Self::Error> {
         let submit_for_settlement = matches!(
             item.request.capture_method,
-            Some(enums::CaptureMethod::Automatic)
+            Some(enums::CaptureMethod::Automatic) | None
         );
 
         let amount = item.request.amount.to_string();

--- a/crates/router/src/connector/braintree/transformers.rs
+++ b/crates/router/src/connector/braintree/transformers.rs
@@ -85,7 +85,7 @@ impl TryFrom<&types::PaymentsAuthorizeRouterData> for BraintreePaymentsRequest {
     fn try_from(item: &types::PaymentsAuthorizeRouterData) -> Result<Self, Self::Error> {
         let submit_for_settlement = matches!(
             item.request.capture_method,
-            Some(enums::CaptureMethod::Automatic) | None
+            Some(enums::CaptureMethod::Automatic)
         );
 
         let amount = item.request.amount.to_string();

--- a/crates/router/src/core/payments/transformers.rs
+++ b/crates/router/src/core/payments/transformers.rs
@@ -11,7 +11,7 @@ use crate::{
         payments::{self, helpers},
     },
     routes::AppState,
-    services::{self, refresh_connector_access_token, RedirectForm},
+    services::{self, RedirectForm},
     types::{
         self, api,
         storage::{self, enums},
@@ -59,7 +59,7 @@ where
 
         let _token = match access_token {
             Some(token) => token,
-            None => refresh_connector_access_token(state, connector_id.to_string())
+            None => services::refresh_connector_access_token(state, connector_id.to_string())
                 .await
                 .change_context(errors::ApiErrorResponse::InternalServerError)?,
         };

--- a/crates/router/src/core/payments/transformers.rs
+++ b/crates/router/src/core/payments/transformers.rs
@@ -1,6 +1,6 @@
 use std::{fmt::Debug, marker::PhantomData};
 
-use error_stack::{FutureExt, ResultExt};
+use error_stack::ResultExt;
 use router_env::{instrument, tracing};
 
 use super::{flows::Feature, PaymentAddress, PaymentData};
@@ -50,14 +50,14 @@ where
         .parse_value("ConnectorAuthType")
         .change_context(errors::ApiErrorResponse::InternalServerError)?;
 
-    let auth_type = if let types::ConnectorAuthType::AccessToken { api_key, id, .. } = &auth_type {
+    let auth_type = if let types::ConnectorAuthType::AccessToken { .. } = &auth_type {
         let db = &*state.store;
         let access_token = db
             .get_access_token(&merchant_account.merchant_id, connector_id)
             .await
             .change_context(errors::ApiErrorResponse::InternalServerError)?;
 
-        let token = match access_token {
+        let _token = match access_token {
             Some(token) => token,
             None => refresh_connector_access_token(state, connector_id.to_string())
                 .await

--- a/crates/router/src/db.rs
+++ b/crates/router/src/db.rs
@@ -44,6 +44,7 @@ pub trait StorageInterface:
     + events::EventInterface
     + merchant_account::MerchantAccountInterface
     + merchant_connector_account::MerchantConnectorAccountInterface
+    + merchant_connector_account::ConnectorAccessToken
     + locker_mock_up::LockerMockUpInterface
     + payment_intent::PaymentIntentInterface
     + payment_method::PaymentMethodInterface

--- a/crates/router/src/db/merchant_connector_account.rs
+++ b/crates/router/src/db/merchant_connector_account.rs
@@ -28,17 +28,17 @@ pub trait ConnectorAccessToken {
 impl ConnectorAccessToken for Store {
     async fn get_access_token(
         &self,
-        merchant_id: &str,
-        connector: &str,
+        _merchant_id: &str,
+        _connector: &str,
     ) -> CustomResult<Option<String>, errors::StorageError> {
-        Ok(Some("TODO".to_string()))
+        Ok(None)
     }
 
     async fn set_access_token_with_expiry(
         &self,
-        merchant_id: &str,
-        connector: &str,
-        expiry: u64,
+        _merchant_id: &str,
+        _connector: &str,
+        _expiry: u64,
     ) -> CustomResult<(), errors::StorageError> {
         Ok(())
     }
@@ -48,17 +48,17 @@ impl ConnectorAccessToken for Store {
 impl ConnectorAccessToken for MockDb {
     async fn get_access_token(
         &self,
-        merchant_id: &str,
-        connector: &str,
+        _merchant_id: &str,
+        _connector: &str,
     ) -> CustomResult<Option<String>, errors::StorageError> {
-        Ok(Some("TODO".to_string()))
+        Ok(None)
     }
 
     async fn set_access_token_with_expiry(
         &self,
-        merchant_id: &str,
-        connector: &str,
-        expiry: u64,
+        _merchant_id: &str,
+        _connector: &str,
+        _expiry: u64,
     ) -> CustomResult<(), errors::StorageError> {
         Ok(())
     }

--- a/crates/router/src/db/merchant_connector_account.rs
+++ b/crates/router/src/db/merchant_connector_account.rs
@@ -9,6 +9,62 @@ use crate::{
 };
 
 #[async_trait::async_trait]
+pub trait ConnectorAccessToken {
+    async fn get_access_token(
+        &self,
+        merchant_id: &str,
+        connector: &str,
+    ) -> CustomResult<Option<String>, errors::StorageError>;
+
+    async fn set_access_token_with_expiry(
+        &self,
+        merchant_id: &str,
+        connector: &str,
+        expiry: u64,
+    ) -> CustomResult<(), errors::StorageError>;
+}
+
+#[async_trait::async_trait]
+impl ConnectorAccessToken for Store {
+    async fn get_access_token(
+        &self,
+        merchant_id: &str,
+        connector: &str,
+    ) -> CustomResult<Option<String>, errors::StorageError> {
+        Ok(Some("TODO".to_string()))
+    }
+
+    async fn set_access_token_with_expiry(
+        &self,
+        merchant_id: &str,
+        connector: &str,
+        expiry: u64,
+    ) -> CustomResult<(), errors::StorageError> {
+        Ok(())
+    }
+}
+
+#[async_trait::async_trait]
+impl ConnectorAccessToken for MockDb {
+    async fn get_access_token(
+        &self,
+        merchant_id: &str,
+        connector: &str,
+    ) -> CustomResult<Option<String>, errors::StorageError> {
+        Ok(Some("TODO".to_string()))
+    }
+
+    async fn set_access_token_with_expiry(
+        &self,
+        merchant_id: &str,
+        connector: &str,
+        expiry: u64,
+    ) -> CustomResult<(), errors::StorageError> {
+        Ok(())
+    }
+}
+
+#[async_trait::async_trait]
 pub trait MerchantConnectorAccountInterface {
     async fn find_merchant_connector_account_by_merchant_id_connector(
         &self,

--- a/crates/router/src/services/api.rs
+++ b/crates/router/src/services/api.rs
@@ -764,8 +764,8 @@ pub fn build_redirection_form(form: &RedirectForm) -> maud::Markup {
     }
 }
 
-pub async fn refresh_connector_access_token<'a>(
-    _state: &'a AppState,
+pub async fn refresh_connector_access_token(
+    _state: &AppState,
     _connector_name: String,
 ) -> CustomResult<String, errors::ConnectorError> {
     Ok(String::new())

--- a/crates/router/src/services/api.rs
+++ b/crates/router/src/services/api.rs
@@ -22,9 +22,8 @@ use crate::{
         payments,
     },
     db::StorageInterface,
-    headers, logger,
+    logger,
     routes::AppState,
-    services,
     types::{
         self, api,
         storage::{self, enums},
@@ -766,29 +765,10 @@ pub fn build_redirection_form(form: &RedirectForm) -> maud::Markup {
 }
 
 pub async fn refresh_connector_access_token<'a>(
-    state: &'a AppState,
-    connector_name: String,
+    _state: &'a AppState,
+    _connector_name: String,
 ) -> CustomResult<String, errors::ConnectorError> {
-    let headers = vec![(
-        headers::CONTENT_TYPE.to_string(),
-        "application/json".to_string(),
-    )];
-
-    let body = "{}".to_string();
-
-    let request = services::RequestBuilder::new()
-        .method(services::Method::Post)
-        .url("https://apis.sandbox.globalpay.com/ucp/accesstoken")
-        .headers(headers)
-        .body(Some(body))
-        .build();
-
-    // Acquire a lock on the resource ( merchant_account+connector ) to prevent the accesstoken to
-    // be refreshed by another request.
-    let response = send_request(state, request).await;
-
-    // release lock, all others waiting should get the value -> how to do this?
-    Ok("access_token".to_string())
+    todo!()
 }
 
 #[cfg(test)]

--- a/crates/router/src/services/api.rs
+++ b/crates/router/src/services/api.rs
@@ -768,7 +768,7 @@ pub async fn refresh_connector_access_token<'a>(
     _state: &'a AppState,
     _connector_name: String,
 ) -> CustomResult<String, errors::ConnectorError> {
-    todo!()
+    Ok(String::new())
 }
 
 #[cfg(test)]

--- a/crates/router/src/types.rs
+++ b/crates/router/src/types.rs
@@ -260,6 +260,14 @@ pub enum ConnectorAuthType {
         key1: String,
         api_secret: String,
     },
+    AccessToken {
+        api_key: String,
+        id: String,
+        #[serde(skip_deserializing)]
+        expires_at: i64, // Store as unix timestamp
+        #[serde(skip_deserializing)]
+        access_token: Option<String>,
+    },
     #[default]
     NoKey,
 }

--- a/crates/router/src/types.rs
+++ b/crates/router/src/types.rs
@@ -264,8 +264,6 @@ pub enum ConnectorAuthType {
         api_key: String,
         id: String,
         #[serde(skip_deserializing)]
-        expires_at: i64, // Store as unix timestamp
-        #[serde(skip_deserializing)]
         access_token: Option<String>,
     },
     #[default]


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] New feature

## Description
<!-- Describe your changes in detail -->
This PR will add support for refreshing the access token for supported connectors. Connector integration should be provided for supported connectors.


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
For some connectors there is a requirement to get a time constrained access token which must be used for each request. This access token must be refreshed when it expires. This PR provides an interface for this feature. 
A pseudo code of the interface
```rust
let access_token = get_access_token_from_redis()
if let Some(token) = access_token {
    token = refresh_access_token()
    store_access_token_in_db_with_expiry(token)
}
```
Access token connector auth type is 
```rust
AccessToken {
        api_key: String,
        id: String,
        #[serde(skip_deserializing)]
        access_token: Option<String>,
    }
```

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Not testable, will test by integrating with one of the connectors

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
