### PR TITLE
docs(github): add `--all` flag to rustfmt command in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -47,7 +47,7 @@ Or did you test this change manually (provide relevant screenshots)?
 ## Checklist
 <!-- Put an `x` in the boxes that apply -->
 
-- [ ] I formatted the code `cargo +nightly fmt --all --check`
+- [ ] I formatted the code `cargo +nightly fmt --all`
 - [ ] I addressed lints thrown by `cargo clippy`
 - [ ] I reviewed submitted code
 - [ ] I added unit tests for my changes where possible

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -47,7 +47,7 @@ Or did you test this change manually (provide relevant screenshots)?
 ## Checklist
 <!-- Put an `x` in the boxes that apply -->
 
-- [ ] I formatted the code `cargo +nightly fmt`
+- [ ] I formatted the code `cargo +nightly fmt --all --check`
 - [ ] I addressed lints thrown by `cargo clippy`
 - [ ] I reviewed submitted code
 - [ ] I added unit tests for my changes where possible


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [X] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->
Refactor code formatting command in PR template as build pipeline fails with the existing command for some scenario.

### Additional Changes

- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!-- 
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
Refactor formatting command to avoid unwanted formatting errors during build pipeline

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
NA

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [X] I formatted the code `cargo +nightly fmt`
- [ ] I addressed lints thrown by `cargo clippy`
- [X] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
