### PR TITLE
fix(gpay): send merchant info field

### DIFF
--- a/crates/api_models/src/payments.rs
+++ b/crates/api_models/src/payments.rs
@@ -819,7 +819,7 @@ pub struct GpayMetadata {
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct GpaySessionTokenData {
-    pub gpay: GpayMetadata,
+    pub data: GpayMetadata,
 }
 
 #[derive(Debug, Clone, serde::Serialize)]

--- a/crates/api_models/src/payments.rs
+++ b/crates/api_models/src/payments.rs
@@ -827,7 +827,8 @@ pub struct GpaySessionTokenData {
 #[serde(rename_all = "lowercase")]
 pub enum SessionToken {
     Gpay {
-        allowed_payment_methods: Vec<GpayAllowedPaymentMethods>,
+        #[serde(flatten)]
+        data: GpayMetadata,
         transaction_info: GpayTransactionInfo,
     },
     Klarna {

--- a/crates/router/src/core/payments/flows/session_flow.rs
+++ b/crates/router/src/core/payments/flows/session_flow.rs
@@ -84,7 +84,7 @@ fn create_gpay_session_token(
     let response_router_data = types::PaymentsSessionRouterData {
         response: Ok(types::PaymentsResponseData::SessionResponse {
             session_token: payment_types::SessionToken::Gpay {
-                allowed_payment_methods: gpay_data.gpay.allowed_payment_methods,
+                data: gpay_data.gpay,
                 transaction_info,
             },
         }),

--- a/crates/router/src/core/payments/flows/session_flow.rs
+++ b/crates/router/src/core/payments/flows/session_flow.rs
@@ -84,7 +84,7 @@ fn create_gpay_session_token(
     let response_router_data = types::PaymentsSessionRouterData {
         response: Ok(types::PaymentsResponseData::SessionResponse {
             session_token: payment_types::SessionToken::Gpay {
-                data: gpay_data.gpay,
+                data: gpay_data.data,
                 transaction_info,
             },
         }),


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix

## Description
<!-- Describe your changes in detail -->
This PR will fix missing merchant info when fetching the session token for gpay.


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
This change is required because without merchant info field in the session token, the google pay sdk cannot be initialized.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Fetch session token for google pay
![Screenshot 2023-01-12 at 1 05 00 PM](https://user-images.githubusercontent.com/48803246/212005666-636a303b-2033-41bb-8ae9-83267de0eca0.png)


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
