### PR TITLE
fix: Fix error code being null in response

### DIFF
--- a/crates/router/src/core/payments/transformers.rs
+++ b/crates/router/src/core/payments/transformers.rs
@@ -210,7 +210,7 @@ where
                 .payment_method_data
                 .map(api::PaymentMethodDataResponse::from),
             payment_token: data.token,
-            error_code: None,
+            error_code: data.payment_attempt.error_code,
             error_message: data.payment_attempt.error_message,
         }))
     }
@@ -315,6 +315,7 @@ where
                         )
                         .set_payment_token(payment_attempt.payment_token)
                         .set_error_message(payment_attempt.error_message)
+                        .set_error_code(payment_attempt.error_code)
                         .set_shipping(address.shipping)
                         .set_billing(address.billing)
                         .to_owned()


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->
Fixed error code being null in payments response

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
Fixed error code being null in payments response


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
<img width="1340" alt="image" src="https://user-images.githubusercontent.com/43412619/212061289-9e78323f-0892-4046-b523-05229412b767.png">



## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
