### PR TITLE
fix(connector): pass error message to response body instead of changing the context for required field validation

### DIFF
--- a/crates/router/src/connector/globalpay.rs
+++ b/crates/router/src/connector/globalpay.rs
@@ -147,8 +147,10 @@ impl ConnectorIntegration<api::Void, types::PaymentsCancelData, types::PaymentsR
         &self,
         req: &types::PaymentsCancelRouterData,
     ) -> CustomResult<Option<String>, errors::ConnectorError> {
-        let globalpay_req = utils::Encode::<GlobalpayPaymentsRequest>::convert_and_encode(req)
-            .change_context(errors::ConnectorError::RequestEncodingFailed)?;
+        let req_obj = GlobalpayPaymentsRequest::try_from(req)?;
+        let globalpay_req =
+            utils::Encode::<GlobalpayPaymentsRequest>::encode_to_string_of_json(&req_obj)
+                .change_context(errors::ConnectorError::RequestEncodingFailed)?;
         Ok(Some(globalpay_req))
     }
 
@@ -282,8 +284,10 @@ impl ConnectorIntegration<api::Capture, types::PaymentsCaptureData, types::Payme
         &self,
         req: &types::PaymentsCaptureRouterData,
     ) -> CustomResult<Option<String>, errors::ConnectorError> {
-        let globalpay_req = utils::Encode::<GlobalpayPaymentsRequest>::convert_and_encode(req)
-            .change_context(errors::ConnectorError::RequestEncodingFailed)?;
+        let req_obj = GlobalpayPaymentsRequest::try_from(req)?;
+        let globalpay_req =
+            utils::Encode::<GlobalpayPaymentsRequest>::encode_to_string_of_json(&req_obj)
+                .change_context(errors::ConnectorError::RequestEncodingFailed)?;
         Ok(Some(globalpay_req))
     }
 
@@ -367,8 +371,10 @@ impl ConnectorIntegration<api::Authorize, types::PaymentsAuthorizeData, types::P
         &self,
         req: &types::PaymentsAuthorizeRouterData,
     ) -> CustomResult<Option<String>, errors::ConnectorError> {
-        let globalpay_req = utils::Encode::<GlobalpayPaymentsRequest>::convert_and_encode(req)
-            .change_context(errors::ConnectorError::RequestEncodingFailed)?;
+        let req_obj = GlobalpayPaymentsRequest::try_from(req)?;
+        let globalpay_req =
+            utils::Encode::<GlobalpayPaymentsRequest>::encode_to_string_of_json(&req_obj)
+                .change_context(errors::ConnectorError::RequestEncodingFailed)?;
         Ok(Some(globalpay_req))
     }
 

--- a/crates/router/src/core/errors/utils.rs
+++ b/crates/router/src/core/errors/utils.rs
@@ -84,7 +84,7 @@ impl ConnectorErrorExt for error_stack::Report<errors::ConnectorError> {
                 Some(serde_json::json!(reason))
             }
             errors::ConnectorError::MissingRequiredField { field_name } => {
-                Some(serde_json::json!({"missing_field": field_name}))
+                Some(serde_json::json!({ "missing_field": field_name }))
             }
             _ => None,
         };

--- a/crates/router/src/core/errors/utils.rs
+++ b/crates/router/src/core/errors/utils.rs
@@ -83,6 +83,9 @@ impl ConnectorErrorExt for error_stack::Report<errors::ConnectorError> {
             errors::ConnectorError::RequestEncodingFailedWithReason(reason) => {
                 Some(serde_json::json!(reason))
             }
+            errors::ConnectorError::MissingRequiredField { field_name } => {
+                Some(serde_json::json!({"missing_field": field_name}))
+            }
             _ => None,
         };
         self.change_context(errors::ApiErrorResponse::PaymentAuthorizationFailed { data })


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->
Required field validation is done in connector side and appropriate error message is also getting printed but this message is not being shown in the response body. this fix will help passing the error message for required field validation 

### Additional Changes

- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!-- 
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
Pass error message to response body instead of changing the context

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
<img width="1088" alt="Screenshot 2023-01-12 at 8 51 02 PM" src="https://user-images.githubusercontent.com/20727598/212106673-983ddce5-cd00-4745-936e-ffc435971f14.png">


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
