### PR TITLE
feat(storage_models): impl generic filter order and add function in payment_attempt to get latest based on created_at

### DIFF
--- a/crates/storage_models/src/query/generics.rs
+++ b/crates/storage_models/src/query/generics.rs
@@ -12,7 +12,7 @@ use diesel::{
         QueryId, UpdateStatement,
     },
     query_dsl::{
-        methods::{FilterDsl, FindDsl, LimitDsl},
+        methods::{FilterDsl, FindDsl, LimitDsl, OrderDsl},
         LoadQuery, RunQueryDsl,
     },
     result::Error as DieselError,

--- a/crates/storage_models/src/query/generics.rs
+++ b/crates/storage_models/src/query/generics.rs
@@ -23,6 +23,8 @@ use router_env::{instrument, logger, tracing};
 
 use crate::{errors, PgPooledConn, StorageResult};
 
+const DEFAULT_LIMIT: i64 = 100;
+
 #[instrument(level = "DEBUG", skip_all)]
 pub(super) async fn generic_insert<T, V, R>(conn: &PgPooledConn, values: V) -> StorageResult<R>
 where
@@ -378,7 +380,7 @@ where
     let query = <T as HasTable>::table()
         .filter(predicate)
         .order(expr)
-        .limit(limit.unwrap_or(100));
+        .limit(limit.unwrap_or(DEFAULT_LIMIT));
 
     logger::debug!(query = %debug_query::<Pg, _>(&query).to_string());
 
@@ -386,7 +388,7 @@ where
         .get_results_async(conn)
         .await
         .into_report()
-        .change_context(errors::DatabaseError::NotFound)
+        .change_context(errors::DatabaseError::Others)
         .attach_printable_lazy(|| "Error filtering records by predicate and order")
 }
 

--- a/crates/storage_models/src/query/payment_attempt.rs
+++ b/crates/storage_models/src/query/payment_attempt.rs
@@ -61,6 +61,23 @@ impl PaymentAttempt {
     }
 
     #[instrument(skip(conn))]
+    pub async fn find_latest_by_payment_id_merchant_id(
+        conn: &PgPooledConn,
+        payment_id: &str,
+        merchant_id: &str,
+    ) -> StorageResult<Vec<Self>> {
+        generics::generic_filter_order::<<Self as HasTable>::Table, _, _, _>(
+            conn,
+            dsl::merchant_id
+                .eq(merchant_id.to_owned())
+                .and(dsl::payment_id.eq(payment_id.to_owned())),
+            Some(1),
+            dsl::created_at.desc(),
+        )
+        .await
+    }
+
+    #[instrument(skip(conn))]
     pub async fn find_optional_by_payment_id_merchant_id(
         conn: &PgPooledConn,
         payment_id: &str,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->
In order to have multiple payment_attempts for a single payment_intent we need a function to fetch the latest payment attempt. 

### Additional Changes

- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!-- 
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Checked if it compiles.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [x] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
