### PR TITLE
build(deps): use utoipa crate upstream URL as git dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -293,15 +293,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "android_system_properties"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "ansi_term"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -958,19 +949,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "chrono"
-version = "0.4.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b0a3d9ed01224b22057780a37bb8c5dbfe1be8ba48678e7bf57ec4b385411f"
-dependencies = [
- "iana-time-zone",
- "num-integer",
- "num-traits",
- "serde",
- "winapi",
-]
-
-[[package]]
 name = "clap"
 version = "2.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -979,20 +957,10 @@ dependencies = [
  "ansi_term",
  "atty",
  "bitflags",
- "strsim 0.8.0",
+ "strsim",
  "textwrap",
  "unicode-width",
  "vec_map",
-]
-
-[[package]]
-name = "codespan-reporting"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
-dependencies = [
- "termcolor",
- "unicode-width",
 ]
 
 [[package]]
@@ -1137,85 +1105,6 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
-]
-
-[[package]]
-name = "cxx"
-version = "1.0.85"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5add3fc1717409d029b20c5b6903fc0c0b02fa6741d820054f4a2efa5e5816fd"
-dependencies = [
- "cc",
- "cxxbridge-flags",
- "cxxbridge-macro",
- "link-cplusplus",
-]
-
-[[package]]
-name = "cxx-build"
-version = "1.0.85"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4c87959ba14bc6fbc61df77c3fcfe180fc32b93538c4f1031dd802ccb5f2ff0"
-dependencies = [
- "cc",
- "codespan-reporting",
- "once_cell",
- "proc-macro2",
- "quote",
- "scratch",
- "syn",
-]
-
-[[package]]
-name = "cxxbridge-flags"
-version = "1.0.85"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69a3e162fde4e594ed2b07d0f83c6c67b745e7f28ce58c6df5e6b6bef99dfb59"
-
-[[package]]
-name = "cxxbridge-macro"
-version = "1.0.85"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e7e2adeb6a0d4a282e581096b06e1791532b7d576dcde5ccd9382acf55db8e6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "darling"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0dd3cd20dc6b5a876612a6e5accfe7f3dd883db6d07acfbf14c128f61550dfa"
-dependencies = [
- "darling_core",
- "darling_macro",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a784d2ccaf7c98501746bf0be29b2022ba41fd62a2e622af997a03e9f972859f"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim 0.10.0",
- "syn",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7618812407e9402654622dd402b0a89dff9ba93badd6540781526117b92aab7e"
-dependencies = [
- "darling_core",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -1971,36 +1860,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "iana-time-zone"
-version = "0.1.53"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64c122667b287044802d6ce17ee2ddf13207ed924c712de9a66a5814d5b64765"
-dependencies = [
- "android_system_properties",
- "core-foundation-sys",
- "iana-time-zone-haiku",
- "js-sys",
- "wasm-bindgen",
- "winapi",
-]
-
-[[package]]
-name = "iana-time-zone-haiku"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0703ae284fc167426161c2e3f1da3ea71d94b21bedbcc9494e92b28e334e3dca"
-dependencies = [
- "cxx",
- "cxx-build",
-]
-
-[[package]]
-name = "ident_case"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
-
-[[package]]
 name = "idna"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2180,15 +2039,6 @@ dependencies = [
  "libc",
  "pkg-config",
  "vcpkg",
-]
-
-[[package]]
-name = "link-cplusplus"
-version = "1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecd207c9c713c34f95a097a5b029ac2ce6010530c7b49d7fea24d977dede04f5"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -3334,12 +3184,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
-name = "scratch"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddccb15bcce173023b3fedd9436f882a0739b8dfb45e4f6b6002bee5929f61b2"
-
-[[package]]
 name = "sct"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3451,34 +3295,6 @@ dependencies = [
  "itoa 1.0.4",
  "ryu",
  "serde",
-]
-
-[[package]]
-name = "serde_with"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25bf4a5a814902cd1014dbccfa4d4560fb8432c779471e96e035602519f82eef"
-dependencies = [
- "base64 0.13.1",
- "chrono",
- "hex",
- "indexmap",
- "serde",
- "serde_json",
- "serde_with_macros",
- "time",
-]
-
-[[package]]
-name = "serde_with_macros"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3452b4c0f6c1e357f73fdb87cd1efabaa12acf328c7a528e252893baeb3f4aa"
-dependencies = [
- "darling",
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -3638,12 +3454,6 @@ name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "strsim"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "structopt"
@@ -4237,19 +4047,18 @@ checksum = "e8db7427f936968176eaa7cdf81b7f98b980b18495ec28f1b5791ac3bfe3eea9"
 [[package]]
 name = "utoipa"
 version = "2.4.2"
-source = "git+https://github.com/SanchithHegde/utoipa?branch=retain-property-order#4ca5604f94484c7a5a7852972c9b6e68f33a871e"
+source = "git+https://github.com/juhaku/utoipa?rev=2a5c09d953f14dc78af655bbcfd016ce9a71baa0#2a5c09d953f14dc78af655bbcfd016ce9a71baa0"
 dependencies = [
  "indexmap",
  "serde",
  "serde_json",
- "serde_with",
  "utoipa-gen",
 ]
 
 [[package]]
 name = "utoipa-gen"
 version = "2.4.2"
-source = "git+https://github.com/SanchithHegde/utoipa?branch=retain-property-order#4ca5604f94484c7a5a7852972c9b6e68f33a871e"
+source = "git+https://github.com/juhaku/utoipa?rev=2a5c09d953f14dc78af655bbcfd016ce9a71baa0#2a5c09d953f14dc78af655bbcfd016ce9a71baa0"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",

--- a/crates/api_models/Cargo.toml
+++ b/crates/api_models/Cargo.toml
@@ -13,7 +13,7 @@ serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.91"
 strum = { version = "0.24.1", features = ["derive"] }
 time = { version = "0.3.17", features = ["serde", "serde-well-known", "std"] }
-utoipa = { git = "https://github.com/SanchithHegde/utoipa", branch = "retain-property-order" }
+utoipa = { git = "https://github.com/juhaku/utoipa", rev = "2a5c09d953f14dc78af655bbcfd016ce9a71baa0", features = ["preserve_order"] }
 
 # First party crates
 common_utils = { version = "0.1.0", path = "../common_utils" }

--- a/crates/api_models/Cargo.toml
+++ b/crates/api_models/Cargo.toml
@@ -13,6 +13,7 @@ serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.91"
 strum = { version = "0.24.1", features = ["derive"] }
 time = { version = "0.3.17", features = ["serde", "serde-well-known", "std"] }
+# Switch to the crates.io release of `utoipa` when the `preserve_order` feature is available in the release
 utoipa = { git = "https://github.com/juhaku/utoipa", rev = "2a5c09d953f14dc78af655bbcfd016ce9a71baa0", features = ["preserve_order"] }
 
 # First party crates

--- a/crates/api_models/src/admin.rs
+++ b/crates/api_models/src/admin.rs
@@ -65,6 +65,9 @@ pub struct CreateMerchantAccount {
     /// API key that will be used for server side API access
     #[schema(example = "AH3423bkjbkjdsfbkj")]
     pub publishable_key: Option<String>,
+
+    /// An identifier for the vault used to store payment method information.
+    #[schema(example = "locker_abc123")]
     pub locker_id: Option<String>,
 }
 

--- a/crates/router/Cargo.toml
+++ b/crates/router/Cargo.toml
@@ -66,6 +66,7 @@ thiserror = "1.0.38"
 time = { version = "0.3.17", features = ["serde", "serde-well-known", "std"] }
 tokio = { version = "1.24.1", features = ["macros", "rt-multi-thread"] }
 url = { version = "2.3.1", features = ["serde"] }
+# Switch to the crates.io release of `utoipa` when the `preserve_order` feature is available in the release
 utoipa = { git = "https://github.com/juhaku/utoipa", rev = "2a5c09d953f14dc78af655bbcfd016ce9a71baa0", features = ["preserve_order"] }
 uuid = { version = "1.2.2", features = ["serde", "v4"] }
 

--- a/crates/router/Cargo.toml
+++ b/crates/router/Cargo.toml
@@ -66,7 +66,7 @@ thiserror = "1.0.38"
 time = { version = "0.3.17", features = ["serde", "serde-well-known", "std"] }
 tokio = { version = "1.24.1", features = ["macros", "rt-multi-thread"] }
 url = { version = "2.3.1", features = ["serde"] }
-utoipa = { git = "https://github.com/SanchithHegde/utoipa", branch = "retain-property-order" }
+utoipa = { git = "https://github.com/juhaku/utoipa", rev = "2a5c09d953f14dc78af655bbcfd016ce9a71baa0", features = ["preserve_order"] }
 uuid = { version = "1.2.2", features = ["serde", "v4"] }
 
 # First party crates

--- a/openapi/generated.json
+++ b/openapi/generated.json
@@ -236,6 +236,11 @@
             "type": "string",
             "description": "API key that will be used for server side API access",
             "example": "AH3423bkjbkjdsfbkj"
+          },
+          "locker_id": {
+            "type": "string",
+            "description": "An identifier for the vault used to store payment method information.",
+            "example": "locker_abc123"
           }
         }
       },
@@ -593,6 +598,11 @@
             "type": "string",
             "description": "API key that will be used for server side API access",
             "example": "AH3423bkjbkjdsfbkj"
+          },
+          "locker_id": {
+            "type": "string",
+            "description": "An identifier for the vault used to store payment method information.",
+            "example": "locker_abc123"
           }
         }
       },


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [x] Dependency updates

## Description
<!-- Describe your changes in detail -->
This PR updates the repository URL for the `utoipa` crate to use the upstream repository URL instead of my fork.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
Since juhaku/utoipa#436 was merged, my fork is no longer required. However, since it could take some time for the next release of the crate, we'll be using it as a git dependency.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Regenerated the OpenAPI spec file, there are no changes in property order of the schemas.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
