### PR TITLE
fix: changes in olap oltp separation

### DIFF
--- a/crates/router/src/lib.rs
+++ b/crates/router/src/lib.rs
@@ -78,7 +78,8 @@ pub fn mk_olap_app(
         .service(routes::Refunds::olap_server(state.clone()))
         .service(routes::Payouts::olap_server(state.clone()))
         .service(routes::MerchantAccount::olap_server(state.clone()))
-        .service(routes::MerchantConnectorAccount::olap_server(state.clone()));
+        .service(routes::MerchantConnectorAccount::olap_server(state.clone()))
+        .service(routes::Mandates::olap_server(state.clone()));
 
     #[cfg(feature = "stripe")]
     {
@@ -163,7 +164,9 @@ pub fn mk_oltp_app(
         .service(routes::Payouts::oltp_server(state.clone()))
         .service(routes::PaymentMethods::oltp_server(state.clone()))
         .service(routes::EphemeralKey::oltp_server(state.clone()))
-        .service(routes::Webhooks::oltp_server(state.clone()));
+        .service(routes::Webhooks::oltp_server(state.clone()))
+        .service(routes::MerchantConnectorAccount::oltp_server(state.clone()))
+        .service(routes::Mandates::oltp_server(state.clone()));
 
     #[cfg(feature = "stripe")]
     {

--- a/crates/router/src/routes/app.rs
+++ b/crates/router/src/routes/app.rs
@@ -211,13 +211,18 @@ impl MerchantConnectorAccount {
                     .route(web::get().to(payment_connector_list)),
             )
             .service(
-                web::resource("/payment_methods").route(web::get().to(list_payment_method_api)),
-            )
-            .service(
                 web::resource("/{merchant_id}/connectors/{merchant_connector_id}")
                     .route(web::get().to(payment_connector_retrieve))
                     .route(web::post().to(payment_connector_update))
                     .route(web::delete().to(payment_connector_delete)),
+            )
+    }
+
+    pub fn oltp_server(state: AppState) -> Scope {
+        web::scope("/account")
+            .app_data(web::Data::new(state))
+            .service(
+                web::resource("/payment_methods").route(web::get().to(list_payment_method_api)),
             )
     }
 }
@@ -236,6 +241,7 @@ impl EphemeralKey {
 pub struct Mandates;
 
 impl Mandates {
+    #[cfg(feature = "olap")]
     pub fn olap_server(state: AppState) -> Scope {
         web::scope("/mandates")
             .app_data(web::Data::new(state))


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->
> List of payment method api is moved to OLTP instead of OLAP
> Add feature gates to mandate OLAP which was missing
> Add mandate services in OLAP and OLTP while making the server app.

### Additional Changes

- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!-- 
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
Change in OLAP and OLTP separation

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
