### PR TITLE
refactor(api_models): add `created_at` and `updated_at` fields in `RefundResponse`

### DIFF
--- a/crates/api_models/src/refunds.rs
+++ b/crates/api_models/src/refunds.rs
@@ -76,6 +76,10 @@ pub struct RefundResponse {
     #[schema(value_type = Option<Object>)]
     pub metadata: Option<serde_json::Value>,
     pub error_message: Option<String>,
+    #[serde(with = "common_utils::custom_serde::iso8601::option")]
+    pub created_at: Option<PrimitiveDateTime>,
+    #[serde(with = "common_utils::custom_serde::iso8601::option")]
+    pub updated_at: Option<PrimitiveDateTime>,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]

--- a/crates/router/src/core/refunds.rs
+++ b/crates/router/src/core/refunds.rs
@@ -506,33 +506,6 @@ pub async fn refund_list(
     ))
 }
 
-impl<F> TryFrom<types::RefundsRouterData<F>> for refunds::RefundResponse {
-    type Error = error_stack::Report<errors::ApiErrorResponse>;
-
-    fn try_from(data: types::RefundsRouterData<F>) -> RouterResult<Self> {
-        let refund_id = data.request.refund_id.to_string();
-        let response = data.response;
-
-        let (status, error_message) = match response {
-            Ok(response) => (response.refund_status.foreign_into(), None),
-            Err(error_response) => (api::RefundStatus::Pending, Some(error_response.message)),
-        };
-
-        Ok(Self {
-            payment_id: data.payment_id,
-            refund_id,
-            amount: data.request.amount / 100,
-            currency: data.request.currency.to_string(),
-            reason: data.request.reason,
-            status,
-            metadata: None,
-            error_message,
-            created_at: None,
-            updated_at: None,
-        })
-    }
-}
-
 impl From<Foreign<storage::Refund>> for Foreign<api::RefundResponse> {
     fn from(refund: Foreign<storage::Refund>) -> Self {
         let refund = refund.0;

--- a/crates/router/src/core/refunds.rs
+++ b/crates/router/src/core/refunds.rs
@@ -527,6 +527,8 @@ impl<F> TryFrom<types::RefundsRouterData<F>> for refunds::RefundResponse {
             status,
             metadata: None,
             error_message,
+            created_at: None,
+            updated_at: None,
         })
     }
 }
@@ -543,6 +545,8 @@ impl From<Foreign<storage::Refund>> for Foreign<api::RefundResponse> {
             status: refund.refund_status.foreign_into(),
             metadata: refund.metadata,
             error_message: refund.refund_error_message,
+            created_at: Some(refund.created_at),
+            updated_at: Some(refund.updated_at),
         }
         .into()
     }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Refactoring

## Description
<!-- Describe your changes in detail -->
Add field `created_at` and `updated_at` in refunds response.


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
The field helps to track when the refund was created and updated, and display them if necessary.


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
![Screenshot 2023-01-16 at 5 51 24 PM](https://user-images.githubusercontent.com/48803246/212677192-094f6581-e56a-4b9f-931f-8bfd490e9bc2.png)




## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
