### PR TITLE
docs: fix broken link to contributing guidelines

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,7 +4,6 @@ docs/ @juspay/orca-maintainers
 *.md @juspay/orca-maintainers
 LICENSE @juspay/orca-maintainers
 NOTICE @juspay/orca-maintainers
-contrib/ @juspay/orca-maintainers
 .github/ @juspay/orca-maintainers
 .gitignore @juspay/orca-maintainers
 Makefile @juspay/orca-maintainers

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -89,7 +89,7 @@ body:
     attributes:
       label: Have you read the Contributing Guidelines?
       options:
-        - label: I have read the [Contributing Guidelines](https://github.com/juspay/hyperswitch/blob/main/contrib/CONTRIBUTING.md)
+        - label: I have read the [Contributing Guidelines](https://github.com/juspay/hyperswitch/blob/main/docs/CONTRIBUTING.md)
           required: true
 
   - type: dropdown

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -42,7 +42,7 @@ body:
     attributes:
       label: Have you read the Contributing Guidelines?
       options:
-        - label: I have read the [Contributing Guidelines](https://github.com/juspay/hyperswitch/blob/main/contrib/CONTRIBUTING.md)
+        - label: I have read the [Contributing Guidelines](https://github.com/juspay/hyperswitch/blob/main/docs/CONTRIBUTING.md)
           required: true
 
   - type: dropdown

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ It was born from our struggle to understand and integrate various payment option
 This project is created and currently maintained by [Juspay](https://juspay.io/juspay-router).
 
 We welcome contributions from the open source community.
-Please read through our [contributing guidelines](contrib/CONTRIBUTING.md).
+Please read through our [contributing guidelines](/docs/CONTRIBUTING.md).
 Included are directions for opening issues, coding standards, and notes on development.
 
 Important note for Rust developers: We aim for contributions from the community across a broad range of tracks.


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [x] Documentation

## Description
<!-- Describe your changes in detail -->
This PR fixes broken links to the contributing guidelines.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
N/A

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
N/A

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
