### PR TITLE
refactor(storage_models): made generic queries public

### DIFF
--- a/crates/storage_models/src/query/generics.rs
+++ b/crates/storage_models/src/query/generics.rs
@@ -24,7 +24,7 @@ use router_env::{instrument, logger, tracing};
 use crate::{errors, PgPooledConn, StorageResult};
 
 #[instrument(level = "DEBUG", skip_all)]
-pub(super) async fn generic_insert<T, V, R>(conn: &PgPooledConn, values: V) -> StorageResult<R>
+pub async fn generic_insert<T, V, R>(conn: &PgPooledConn, values: V) -> StorageResult<R>
 where
     T: HasTable<Table = T> + Table + 'static,
     V: Debug + Insertable<T>,
@@ -53,7 +53,7 @@ where
 }
 
 #[instrument(level = "DEBUG", skip_all)]
-pub(super) async fn generic_update<T, V, P>(
+pub async fn generic_update<T, V, P>(
     conn: &PgPooledConn,
     predicate: P,
     values: V,
@@ -82,7 +82,7 @@ where
 }
 
 #[instrument(level = "DEBUG", skip_all)]
-pub(super) async fn generic_update_with_results<T, V, P, R>(
+pub async fn generic_update_with_results<T, V, P, R>(
     conn: &PgPooledConn,
     predicate: P,
     values: V,
@@ -112,7 +112,7 @@ where
 }
 
 #[instrument(level = "DEBUG", skip_all)]
-pub(super) async fn generic_update_by_id<T, V, Pk, R>(
+pub async fn generic_update_by_id<T, V, Pk, R>(
     conn: &PgPooledConn,
     id: Pk,
     values: V,
@@ -160,7 +160,7 @@ where
 }
 
 #[instrument(level = "DEBUG", skip_all)]
-pub(super) async fn generic_delete<T, P>(conn: &PgPooledConn, predicate: P) -> StorageResult<bool>
+pub async fn generic_delete<T, P>(conn: &PgPooledConn, predicate: P) -> StorageResult<bool>
 where
     T: FilterDsl<P> + HasTable<Table = T> + Table + 'static,
     <T as FilterDsl<P>>::Output: IntoUpdateTarget,
@@ -191,7 +191,7 @@ where
 }
 
 #[instrument(level = "DEBUG", skip_all)]
-pub(super) async fn generic_delete_one_with_result<T, P, R>(
+pub async fn generic_delete_one_with_result<T, P, R>(
     conn: &PgPooledConn,
     predicate: P,
 ) -> StorageResult<R>
@@ -247,7 +247,7 @@ where
 }
 
 #[instrument(level = "DEBUG", skip_all)]
-pub(super) async fn generic_find_by_id<T, Pk, R>(conn: &PgPooledConn, id: Pk) -> StorageResult<R>
+pub async fn generic_find_by_id<T, Pk, R>(conn: &PgPooledConn, id: Pk) -> StorageResult<R>
 where
     T: FindDsl<Pk> + HasTable<Table = T> + LimitDsl + Table + 'static,
     <T as FindDsl<Pk>>::Output: QueryFragment<Pg> + RunQueryDsl<PgConnection> + Send + 'static,
@@ -260,7 +260,7 @@ where
 }
 
 #[instrument(level = "DEBUG", skip_all)]
-pub(super) async fn generic_find_by_id_optional<T, Pk, R>(
+pub async fn generic_find_by_id_optional<T, Pk, R>(
     conn: &PgPooledConn,
     id: Pk,
 ) -> StorageResult<Option<R>>
@@ -302,7 +302,7 @@ where
 }
 
 #[instrument(level = "DEBUG", skip_all)]
-pub(super) async fn generic_find_one<T, P, R>(conn: &PgPooledConn, predicate: P) -> StorageResult<R>
+pub async fn generic_find_one<T, P, R>(conn: &PgPooledConn, predicate: P) -> StorageResult<R>
 where
     T: FilterDsl<P> + HasTable<Table = T> + Table + 'static,
     <T as FilterDsl<P>>::Output:
@@ -313,7 +313,7 @@ where
 }
 
 #[instrument(level = "DEBUG", skip_all)]
-pub(super) async fn generic_find_one_optional<T, P, R>(
+pub async fn generic_find_one_optional<T, P, R>(
     conn: &PgPooledConn,
     predicate: P,
 ) -> StorageResult<Option<R>>
@@ -327,7 +327,7 @@ where
 }
 
 #[instrument(level = "DEBUG", skip_all)]
-pub(super) async fn generic_filter<T, P, R>(
+pub async fn generic_filter<T, P, R>(
     conn: &PgPooledConn,
     predicate: P,
     limit: Option<i64>,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [X] Refactoring
- [ ] Dependency updates

## Description
Changed generic DB queries visibility from `pub(super)` to `pub`.
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!-- 
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
Generic queries need to be used by other repos.
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [X] I formatted the code `cargo +nightly fmt --all`
- [X] I addressed lints thrown by `cargo clippy`
- [X] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
