### PR TITLE
refactor(router): make utilities public

### DIFF
--- a/crates/router/src/core/admin.rs
+++ b/crates/router/src/core/admin.rs
@@ -16,7 +16,7 @@ use crate::{
 };
 
 #[inline]
-fn create_merchant_api_key() -> String {
+pub fn create_merchant_api_key() -> String {
     let id = Uuid::new_v4().simple();
     match env::which() {
         Env::Development => format!("dev_{id}"),

--- a/crates/router/src/core/errors.rs
+++ b/crates/router/src/core/errors.rs
@@ -1,6 +1,6 @@
-pub(crate) mod api_error_response;
-pub(crate) mod error_handlers;
-pub(crate) mod utils;
+pub mod api_error_response;
+pub mod error_handlers;
+pub mod utils;
 
 use std::fmt::Display;
 
@@ -12,8 +12,10 @@ pub use redis_interface::errors::RedisError;
 use router_env::opentelemetry::metrics::MetricsError;
 use storage_models::errors as storage_errors;
 
-pub use self::api_error_response::ApiErrorResponse;
-pub(crate) use self::utils::{ConnectorErrorExt, StorageErrorExt};
+pub use self::{
+    api_error_response::ApiErrorResponse,
+    utils::{ConnectorErrorExt, StorageErrorExt},
+};
 use crate::services;
 pub type RouterResult<T> = CustomResult<T, ApiErrorResponse>;
 pub type RouterResponse<T> = CustomResult<services::ApplicationResponse<T>, ApiErrorResponse>;

--- a/crates/router/src/core/errors/utils.rs
+++ b/crates/router/src/core/errors/utils.rs
@@ -1,6 +1,6 @@
 use crate::{core::errors, logger};
 
-pub(crate) trait StorageErrorExt {
+pub trait StorageErrorExt {
     fn to_not_found_response(
         self,
         not_found_response: errors::ApiErrorResponse,
@@ -40,7 +40,7 @@ impl StorageErrorExt for error_stack::Report<errors::StorageError> {
     }
 }
 
-pub(crate) trait ConnectorErrorExt {
+pub trait ConnectorErrorExt {
     fn to_refund_failed_response(self) -> error_stack::Report<errors::ApiErrorResponse>;
     fn to_payment_failed_response(self) -> error_stack::Report<errors::ApiErrorResponse>;
     fn to_verify_failed_response(self) -> error_stack::Report<errors::ApiErrorResponse>;
@@ -115,7 +115,7 @@ impl ConnectorErrorExt for error_stack::Report<errors::ConnectorError> {
     }
 }
 
-pub(crate) trait RedisErrorExt {
+pub trait RedisErrorExt {
     fn to_redis_failed_response(self, key: &str) -> error_stack::Report<errors::StorageError>;
 }
 

--- a/crates/router/src/utils.rs
+++ b/crates/router/src/utils.rs
@@ -1,11 +1,11 @@
-pub(crate) mod custom_serde;
-pub(crate) mod db_utils;
-mod ext_traits;
+pub mod custom_serde;
+pub mod db_utils;
+pub mod ext_traits;
 
 #[cfg(feature = "kv_store")]
-pub(crate) mod storage_partitioning;
+pub mod storage_partitioning;
 
-pub(crate) use common_utils::{
+pub use common_utils::{
     crypto,
     ext_traits::{ByteSliceExt, BytesExt, Encode, StringExt, ValueExt},
     fp_utils::when,
@@ -15,7 +15,7 @@ use error_stack::{IntoReport, ResultExt};
 use nanoid::nanoid;
 use serde::de::DeserializeOwned;
 
-pub(crate) use self::ext_traits::{OptionExt, ValidateCall};
+pub use self::ext_traits::{OptionExt, ValidateCall};
 use crate::{
     consts,
     core::errors::{self, RouterResult},

--- a/crates/router/src/utils/ext_traits.rs
+++ b/crates/router/src/utils/ext_traits.rs
@@ -6,7 +6,7 @@ use crate::{
     utils::when,
 };
 
-pub(crate) trait OptionExt<T> {
+pub trait OptionExt<T> {
     fn check_value_present(&self, field_name: &str) -> RouterResult<()>;
 
     fn get_required_value(self, field_name: &str) -> RouterResult<T>;


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->
Make `router` utils and error utils public.

### Additional Changes
None
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!-- 
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
Usage of router-centric utilities in external crates.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Manual, compiler-guided.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
