### PR TITLE
fix: Use setup future usage for saving card

### DIFF
--- a/crates/api_models/src/enums.rs
+++ b/crates/api_models/src/enums.rs
@@ -552,6 +552,7 @@ pub enum RoutableConnectors {
     Globalpay,
     Klarna,
     Payu,
+    Rapyd,
     Shift4,
     Stripe,
     Worldline,

--- a/crates/router/src/core/mandate.rs
+++ b/crates/router/src/core/mandate.rs
@@ -183,6 +183,15 @@ where
                             )
                         })?;
                 };
+            } else if resp.request.get_setup_future_usage().is_some() {
+                helpers::call_payment_method(
+                    state,
+                    merchant_account,
+                    Some(&resp.request.get_payment_method_data()),
+                    Some(resp.payment_method),
+                    maybe_customer,
+                )
+                .await?;
             }
         }
     }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
In case its not a mandate transaction , check for `setup_future_usage` flag to save a card


### Additional Changes

- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!-- 
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
