### PR TITLE
feat: Add redirect url to pm list

### DIFF
--- a/crates/api_models/src/payment_methods.rs
+++ b/crates/api_models/src/payment_methods.rs
@@ -168,8 +168,14 @@ fn set_or_reject_duplicate<T, E: de::Error>(
     }
 }
 
-#[derive(Eq, PartialEq, Hash, Debug, serde::Deserialize)]
+#[derive(Debug, serde::Serialize)]
 pub struct ListPaymentMethodResponse {
+    pub redirect_url: Option<String>,
+    pub payment_methods: collections::HashSet<ListPaymentMethod>,
+}
+
+#[derive(Eq, PartialEq, Hash, Debug, serde::Deserialize)]
+pub struct ListPaymentMethod {
     pub payment_method: api_enums::PaymentMethodType,
     pub payment_method_types: Option<Vec<api_enums::PaymentMethodSubType>>,
     pub payment_method_issuers: Option<Vec<String>>,
@@ -188,13 +194,13 @@ pub struct ListPaymentMethodResponse {
 /// Currently if the payment method is Wallet or Paylater the relevant fields are `payment_method`
 /// and `payment_method_issuers`. Otherwise only consider
 /// `payment_method`,`payment_method_issuers`,`payment_method_types`,`payment_schemes` fields.
-impl serde::Serialize for ListPaymentMethodResponse {
+impl serde::Serialize for ListPaymentMethod {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
         use serde::ser::SerializeStruct;
-        let mut state = serializer.serialize_struct("ListPaymentMethodResponse", 4)?;
+        let mut state = serializer.serialize_struct("ListPaymentMethod", 4)?;
         state.serialize_field("payment_method", &self.payment_method)?;
         match self.payment_method {
             api_enums::PaymentMethodType::Wallet | api_enums::PaymentMethodType::PayLater => {
@@ -212,7 +218,7 @@ impl serde::Serialize for ListPaymentMethodResponse {
 
 #[derive(Debug, serde::Serialize)]
 pub struct ListCustomerPaymentMethodsResponse {
-    pub enabled_payment_methods: collections::HashSet<ListPaymentMethodResponse>,
+    pub enabled_payment_methods: collections::HashSet<ListPaymentMethod>,
     pub customer_payment_methods: Vec<CustomerPaymentMethod>,
 }
 

--- a/crates/api_models/src/payment_methods.rs
+++ b/crates/api_models/src/payment_methods.rs
@@ -1,4 +1,4 @@
-use std::collections;
+use std::collections::HashSet;
 
 use common_utils::pii;
 use serde::de;
@@ -171,7 +171,7 @@ fn set_or_reject_duplicate<T, E: de::Error>(
 #[derive(Debug, serde::Serialize)]
 pub struct ListPaymentMethodResponse {
     pub redirect_url: Option<String>,
-    pub payment_methods: collections::HashSet<ListPaymentMethod>,
+    pub payment_methods: HashSet<ListPaymentMethod>,
 }
 
 #[derive(Eq, PartialEq, Hash, Debug, serde::Deserialize)]
@@ -218,7 +218,7 @@ impl serde::Serialize for ListPaymentMethod {
 
 #[derive(Debug, serde::Serialize)]
 pub struct ListCustomerPaymentMethodsResponse {
-    pub enabled_payment_methods: collections::HashSet<ListPaymentMethod>,
+    pub enabled_payment_methods: HashSet<ListPaymentMethod>,
     pub customer_payment_methods: Vec<CustomerPaymentMethod>,
 }
 

--- a/crates/router/src/core/payment_methods/cards.rs
+++ b/crates/router/src/core/payment_methods/cards.rs
@@ -1,4 +1,4 @@
-use std::collections;
+use std::collections::HashSet;
 
 use common_utils::{consts, ext_traits::AsyncExt, generate_id};
 use error_stack::{report, ResultExt};
@@ -383,7 +383,7 @@ pub async fn list_payment_methods(
             error.to_not_found_response(errors::ApiErrorResponse::MerchantAccountNotFound)
         })?;
 
-    let mut response: collections::HashSet<api::ListPaymentMethod> = collections::HashSet::new();
+    let mut response: HashSet<api::ListPaymentMethod> = HashSet::new();
     for mca in all_mcas {
         let payment_methods = match mca.payment_methods_enabled {
             Some(pm) => pm,
@@ -415,7 +415,7 @@ pub async fn list_payment_methods(
 async fn filter_payment_methods(
     payment_methods: Vec<serde_json::Value>,
     req: &mut api::ListPaymentMethodRequest,
-    resp: &mut collections::HashSet<api::ListPaymentMethod>,
+    resp: &mut HashSet<api::ListPaymentMethod>,
     payment_intent: Option<&storage::PaymentIntent>,
     payment_attempt: Option<&storage::PaymentAttempt>,
     address: Option<&storage::Address>,
@@ -474,8 +474,8 @@ fn filter_accepted_enum_based<T: Eq + std::hash::Hash + Clone>(
 ) -> (Option<Vec<T>>, Option<Vec<T>>, bool) {
     match (left, right) {
         (Some(ref l), Some(ref r)) => {
-            let a: collections::HashSet<&T> = collections::HashSet::from_iter(l.iter());
-            let b: collections::HashSet<&T> = collections::HashSet::from_iter(r.iter());
+            let a: HashSet<&T> = HashSet::from_iter(l.iter());
+            let b: HashSet<&T> = HashSet::from_iter(r.iter());
 
             let y: Vec<T> = a.intersection(&b).map(|&i| i.to_owned()).collect();
             (Some(y), Some(r.to_vec()), true)
@@ -578,8 +578,7 @@ pub async fn list_customer_payment_method(
             error.to_not_found_response(errors::ApiErrorResponse::MerchantAccountNotFound)
         })?;
 
-    let mut enabled_methods: collections::HashSet<api::ListPaymentMethod> =
-        collections::HashSet::new();
+    let mut enabled_methods: HashSet<api::ListPaymentMethod> = HashSet::new();
     for mca in all_mcas {
         let payment_methods = match mca.payment_methods_enabled {
             Some(pm) => pm,

--- a/crates/router/src/types/api/payment_methods.rs
+++ b/crates/router/src/types/api/payment_methods.rs
@@ -4,9 +4,9 @@ pub use api_models::payment_methods::{
     CardDetail, CardDetailFromLocker, CreatePaymentMethod, CustomerPaymentMethod,
     DeletePaymentMethodResponse, DeleteTokenizeByDateRequest, DeleteTokenizeByTokenRequest,
     GetTokenizePayloadRequest, GetTokenizePayloadResponse, ListCustomerPaymentMethodsResponse,
-    ListPaymentMethodRequest, ListPaymentMethodResponse, PaymentMethodId, PaymentMethodResponse,
-    TokenizePayloadEncrypted, TokenizePayloadRequest, TokenizedCardValue1, TokenizedCardValue2,
-    TokenizedWalletValue1, TokenizedWalletValue2, UpdatePaymentMethod,
+    ListPaymentMethod, ListPaymentMethodRequest, ListPaymentMethodResponse, PaymentMethodId,
+    PaymentMethodResponse, TokenizePayloadEncrypted, TokenizePayloadRequest, TokenizedCardValue1,
+    TokenizedCardValue2, TokenizedWalletValue1, TokenizedWalletValue2, UpdatePaymentMethod,
 };
 use error_stack::report;
 use literally::hmap;


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->
- [x] Enhancement

## Description
<!-- Describe your changes in detail -->
List payment methods needs to have redirect url in it for sdk to fallback incase of any failure.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
N/A

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Manual

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
