### PR TITLE
fix: don't update payment on requires_capture

### DIFF
--- a/crates/router/src/core/payments/operations/payment_update.rs
+++ b/crates/router/src/core/payments/operations/payment_update.rs
@@ -180,7 +180,7 @@ impl<F: Send + Clone> GetTracker<F, PaymentData<F>, api::PaymentsRequest> for Pa
                 Err(report!(errors::ApiErrorResponse::PreconditionFailed {
                     message: format!(
                         "You cannot update this Payment because the status of this payment is {}",
-                        payment_intent.status.to_string()
+                        payment_intent.status
                     )
                 }))
             }

--- a/crates/router/src/core/payments/operations/payment_update.rs
+++ b/crates/router/src/core/payments/operations/payment_update.rs
@@ -174,11 +174,14 @@ impl<F: Send + Clone> GetTracker<F, PaymentData<F>, api::PaymentsRequest> for Pa
             };
 
         match payment_intent.status {
-            enums::IntentStatus::Succeeded | enums::IntentStatus::Failed => {
+            enums::IntentStatus::Succeeded
+            | enums::IntentStatus::Failed
+            | enums::IntentStatus::RequiresCapture => {
                 Err(report!(errors::ApiErrorResponse::PreconditionFailed {
-                    message:
-                        "You cannot update this Payment because it has already succeeded/failed."
-                            .into()
+                    message: format!(
+                        "You cannot update this Payment because the status of this payment is {}",
+                        payment_intent.status.to_string()
+                    )
                 }))
             }
             _ => Ok((


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix

## Description
<!-- Describe your changes in detail -->
Don't update payment intent in case of requires_capture status.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
Merchant shouldn't be able to update the payment intent once the amount is already blocked for the payment method.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
<img width="1346" alt="image" src="https://user-images.githubusercontent.com/43412619/213156589-553780c7-8623-4a2d-9f5f-8a3b33fcf3e1.png">


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
