### PR TITLE
build(deps): migrate to `clap` from `structopt`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -293,15 +293,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "anyhow"
 version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -950,17 +941,36 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "2.34.0"
+version = "4.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+checksum = "4ec7a4128863c188deefe750ac1d1dfe66c236909f845af04beed823638dc1b2"
 dependencies = [
- "ansi_term",
- "atty",
  "bitflags",
- "strsim",
- "textwrap",
- "unicode-width",
- "vec_map",
+ "clap_derive",
+ "clap_lex",
+ "once_cell",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "684a277d672e91966334af371f1a7b5833f9aa00b07c84e92fbce95e00208ce8"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "783fe232adfca04f90f56201b26d79682d4cd2625e0bc7290b95123afe558ade"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -1223,6 +1233,7 @@ version = "0.1.0"
 dependencies = [
  "async-bb8-diesel",
  "bb8",
+ "clap",
  "common_utils",
  "config",
  "diesel",
@@ -1233,7 +1244,6 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "storage_models",
- "structopt",
  "thiserror",
  "tokio",
 ]
@@ -1675,15 +1685,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
  "ahash",
-]
-
-[[package]]
-name = "heck"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
 ]
 
 [[package]]
@@ -2428,6 +2429,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_str_bytes"
+version = "6.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
+
+[[package]]
 name = "outref"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2991,6 +2998,7 @@ dependencies = [
  "base64 0.21.0",
  "bb8",
  "bytes",
+ "clap",
  "common_utils",
  "config",
  "crc32fast",
@@ -3028,7 +3036,6 @@ dependencies = [
  "serde_urlencoded",
  "serial_test",
  "storage_models",
- "structopt",
  "strum",
  "thiserror",
  "time",
@@ -3452,36 +3459,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "strsim"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "structopt"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
-dependencies = [
- "clap",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
-dependencies = [
- "heck 0.3.3",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "strum"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3496,7 +3473,7 @@ version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
 dependencies = [
- "heck 0.4.0",
+ "heck",
  "proc-macro2",
  "quote",
  "rustversion",
@@ -3571,15 +3548,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
-]
-
-[[package]]
-name = "textwrap"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
 ]
 
 [[package]]
@@ -4011,18 +3979,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-segmentation"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fdbf052a0783de01e944a6ce7a8cb939e295b1e7be835a1112c3b9a7f047a5a"
-
-[[package]]
-name = "unicode-width"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
-
-[[package]]
 name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4089,12 +4045,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "vergen"

--- a/crates/drainer/Cargo.toml
+++ b/crates/drainer/Cargo.toml
@@ -10,13 +10,13 @@ license = "Apache-2.0"
 [dependencies]
 async-bb8-diesel = { git = "https://github.com/juspay/async-bb8-diesel", rev = "9a71d142726dbc33f41c1fd935ddaa79841c7be5" }
 bb8 = "0.8"
+clap = { version = "4.1.1", default-features = false, features = ["std", "derive", "help", "usage"] }
 config = { version = "0.13.3", features = ["toml"] }
 diesel = { version = "2.0.2", features = ["postgres", "serde_json", "time"] }
 error-stack = "0.2.4"
 serde = "1.0.152"
 serde_json = "1.0.91"
 serde_path_to_error = "0.1.9"
-structopt = "0.3.26"
 thiserror = "1.0.38"
 tokio = { version = "1.24.1", features = ["macros", "rt-multi-thread"] }
 

--- a/crates/drainer/src/main.rs
+++ b/crates/drainer/src/main.rs
@@ -1,10 +1,9 @@
 use drainer::{errors::DrainerResult, services, settings, start_drainer};
-use structopt::StructOpt;
 
 #[tokio::main]
 async fn main() -> DrainerResult<()> {
     // Get configuration
-    let cmd_line = settings::CmdLineConf::from_args();
+    let cmd_line = <settings::CmdLineConf as clap::Parser>::parse();
 
     #[allow(clippy::expect_used)]
     let conf = settings::Settings::with_config_path(cmd_line.config_path)

--- a/crates/drainer/src/settings.rs
+++ b/crates/drainer/src/settings.rs
@@ -6,16 +6,15 @@ use redis_interface as redis;
 pub use router_env::config::{Log, LogConsole, LogFile, LogTelemetry};
 use router_env::{env, logger};
 use serde::Deserialize;
-use structopt::StructOpt;
 
 use crate::errors;
 
-#[derive(StructOpt, Default)]
-#[structopt(version = router_env::version!())]
+#[derive(clap::Parser, Default)]
+#[command(version = router_env::version!())]
 pub struct CmdLineConf {
     /// Config file.
     /// Application will look for "config/config.toml" if this option isn't specified.
-    #[structopt(short = "f", long, parse(from_os_str))]
+    #[arg(short = 'f', long, value_name = "FILE")]
     pub config_path: Option<PathBuf>,
 }
 

--- a/crates/router/Cargo.toml
+++ b/crates/router/Cargo.toml
@@ -33,6 +33,7 @@ aws-sdk-kms = { version = "0.22.0", optional = true }
 base64 = "0.21.0"
 bb8 = "0.8"
 bytes = "1.3.0"
+clap = { version = "4.1.1", default-features = false, features = ["std", "derive", "help", "usage"] }
 config = { version = "0.13.3", features = ["toml"] }
 crc32fast = "1.3.2"
 diesel = { version = "2.0.2", features = ["postgres", "serde_json", "time"] }
@@ -62,7 +63,6 @@ serde_json = "1.0.91"
 serde_path_to_error = "0.1.9"
 serde_qs = { version = "0.11.0", optional = true }
 serde_urlencoded = "0.7.1"
-structopt = "0.3.26"
 strum = { version = "0.24.1", features = ["derive"] }
 thiserror = "1.0.38"
 time = { version = "0.3.17", features = ["serde", "serde-well-known", "std"] }

--- a/crates/router/src/bin/router.rs
+++ b/crates/router/src/bin/router.rs
@@ -3,12 +3,11 @@ use router::{
     core::errors::{ApplicationError, ApplicationResult},
     logger,
 };
-use structopt::StructOpt;
 
 #[actix_web::main]
 async fn main() -> ApplicationResult<()> {
     // get commandline config before initializing config
-    let cmd_line = CmdLineConf::from_args();
+    let cmd_line = <CmdLineConf as clap::Parser>::parse();
     if let Some(Subcommand::GenerateOpenapiSpec) = cmd_line.subcommand {
         let file_path = "openapi/generated.json";
         #[allow(clippy::expect_used)]

--- a/crates/router/src/bin/scheduler.rs
+++ b/crates/router/src/bin/scheduler.rs
@@ -6,7 +6,6 @@ use router::{
     core::errors::{self, CustomResult},
     logger, routes, scheduler,
 };
-use structopt::StructOpt;
 
 const SCHEDULER_FLOW: &str = "SCHEDULER_FLOW";
 
@@ -14,7 +13,7 @@ const SCHEDULER_FLOW: &str = "SCHEDULER_FLOW";
 async fn main() -> CustomResult<(), errors::ProcessTrackerError> {
     // console_subscriber::init();
 
-    let cmd_line = CmdLineConf::from_args();
+    let cmd_line = <CmdLineConf as clap::Parser>::parse();
 
     #[allow(clippy::expect_used)]
     let conf = Settings::with_config_path(cmd_line.config_path)

--- a/crates/router/src/configs/settings.rs
+++ b/crates/router/src/configs/settings.rs
@@ -5,26 +5,25 @@ use config::{Environment, File};
 use redis_interface::RedisSettings;
 pub use router_env::config::{Log, LogConsole, LogFile, LogTelemetry};
 use serde::Deserialize;
-use structopt::StructOpt;
 
 use crate::{
     core::errors::{ApplicationError, ApplicationResult},
     env::{self, logger, Env},
 };
 
-#[derive(StructOpt, Default)]
-#[structopt(version = router_env::version!())]
+#[derive(clap::Parser, Default)]
+#[command(version = router_env::version!())]
 pub struct CmdLineConf {
     /// Config file.
     /// Application will look for "config/config.toml" if this option isn't specified.
-    #[structopt(short = "f", long, parse(from_os_str))]
+    #[arg(short = 'f', long, value_name = "FILE")]
     pub config_path: Option<PathBuf>,
 
-    #[structopt(subcommand)]
+    #[command(subcommand)]
     pub subcommand: Option<Subcommand>,
 }
 
-#[derive(StructOpt)]
+#[derive(clap::Parser)]
 pub enum Subcommand {
     /// Generate the OpenAPI specification file from code.
     GenerateOpenapiSpec,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [x] Dependency updates

## Description
<!-- Describe your changes in detail -->
This PR migrates from the `structopt` crate to the `clap` crate for parsing CLI arguments.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
I was setting up `cargo-deny`. One of the advisory checks failed stating that `ansi_term` (a dependency of `structopt`) is unmaintained ([`RUSTSEC-2021-0139`](https://rustsec.org/advisories/RUSTSEC-2021-0139.html)) and one of the suggested dependency migrations is to migrate to a newer version of `clap`.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Checked the help messages generated by both versions, they are similar.

**Help message generated by `structopt`:**

```text
router 0.2.0-8ad5b37-2023-01-18T11:17:16Z

USAGE:
    router [OPTIONS] [SUBCOMMAND]

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information

OPTIONS:
    -f, --config-path <config-path>    Config file. Application will look for "config/config.toml" if this option isn't
                                       specified

SUBCOMMANDS:
    generate-openapi-spec    Generate the OpenAPI specification file from code
    help                     Prints this message or the help of the given subcommand(s)
```

**Help message generated by `clap`:**

```text
Usage: router [OPTIONS] [COMMAND]

Commands:
  generate-openapi-spec  Generate the OpenAPI specification file from code
  help                   Print this message or the help of the given subcommand(s)

Options:
  -f, --config-path <FILE>  Config file. Application will look for "config/config.toml" if this option isn't specified
  -h, --help                Print help
  -V, --version             Print version
```

Also, I've confirmed that the `-f`, `-h` and `-V` flags work as expected.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
