### PR TITLE
fix(redis_interface): add missing `#[serde(default)]` annotation to `RedisSettings`

### DIFF
--- a/crates/redis_interface/src/types.rs
+++ b/crates/redis_interface/src/types.rs
@@ -9,6 +9,7 @@ use error_stack::IntoReport;
 use crate::errors;
 
 #[derive(Debug, serde::Deserialize, Clone)]
+#[serde(default)]
 pub struct RedisSettings {
     pub host: String,
     pub port: u16,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->
This PR fixes a mistake in my previous PR #352 where I missed out adding a `#[serde(default)]` annotation to the `RedisSettings` struct.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
Bug fix.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Specified a subset of redis settings and started `router`. The application now runs without panicking.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
