### PR TITLE
feat: add connector error

### DIFF
--- a/connector-template/mod.rs
+++ b/connector-template/mod.rs
@@ -123,7 +123,7 @@ impl
 
     fn get_error_response(
         &self,
-        _res: Bytes,
+        _res: types::Response,
     ) -> CustomResult<ErrorResponse, errors::ConnectorError> {
         self.build_error_response(res)
     }
@@ -220,7 +220,7 @@ impl
 
     fn get_error_response(
         &self,
-        _res: Bytes,
+        _res: types::Response,
     ) -> CustomResult<ErrorResponse, errors::ConnectorError> {
         self.build_error_response(res)
     }
@@ -299,7 +299,7 @@ impl
         .change_context(errors::ConnectorError::ResponseHandlingFailed)
     }
 
-    fn get_error_response(&self, res: Bytes) -> CustomResult<ErrorResponse,errors::ConnectorError> {
+    fn get_error_response(&self, res: types::Response) -> CustomResult<ErrorResponse,errors::ConnectorError> {
         self.build_error_response(res)
     }
 }
@@ -357,7 +357,7 @@ impl
         .change_context(errors::ConnectorError::ResponseHandlingFailed)
     }
 
-    fn get_error_response(&self, res: Bytes) -> CustomResult<ErrorResponse,errors::ConnectorError> {
+    fn get_error_response(&self, res: types::Response) -> CustomResult<ErrorResponse,errors::ConnectorError> {
         self.build_error_response(res)
     }
 }
@@ -407,7 +407,7 @@ impl
         .change_context(errors::ConnectorError::ResponseHandlingFailed)
     }
 
-    fn get_error_response(&self, res: Bytes) -> CustomResult<ErrorResponse,errors::ConnectorError> {
+    fn get_error_response(&self, res: types::Response) -> CustomResult<ErrorResponse,errors::ConnectorError> {
         self.build_error_response(res)
     }
 }

--- a/crates/router/src/compatibility/stripe/errors.rs
+++ b/crates/router/src/compatibility/stripe/errors.rs
@@ -359,6 +359,7 @@ impl From<errors::ApiErrorResponse> for StripeErrorCode {
             errors::ApiErrorResponse::RefundFailed { data } => Self::RefundFailed, // Nothing at stripe to map
 
             errors::ApiErrorResponse::InternalServerError => Self::InternalServerError, // not a stripe code
+            errors::ApiErrorResponse::ExternalConnectorError { .. } => Self::InternalServerError,
             errors::ApiErrorResponse::IncorrectConnectorNameGiven => Self::InternalServerError,
             errors::ApiErrorResponse::MandateActive => Self::MandateActive, //not a stripe code
             errors::ApiErrorResponse::CustomerRedacted => Self::CustomerRedacted, //not a stripe code

--- a/crates/router/src/connector/aci.rs
+++ b/crates/router/src/connector/aci.rs
@@ -2,7 +2,6 @@ mod result_codes;
 mod transformers;
 use std::fmt::Debug;
 
-use bytes::Bytes;
 use error_stack::{IntoReport, ResultExt};
 use transformers as aci;
 
@@ -167,11 +166,12 @@ impl
 
     fn get_error_response(
         &self,
-        res: Bytes,
+        res: types::Response,
     ) -> CustomResult<types::ErrorResponse, errors::ConnectorError> {
-        let response: aci::AciPaymentsResponse = res
-            .parse_struct("AciPaymentsResponse")
-            .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
+        let response: aci::AciPaymentsResponse =
+            res.response
+                .parse_struct("AciPaymentsResponse")
+                .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
         Ok(types::ErrorResponse {
             code: response.result.code,
             message: response.result.description,
@@ -183,6 +183,7 @@ impl
                     )
                 })
             }),
+            status_code: res.status_code,
         })
     }
 }
@@ -277,12 +278,14 @@ impl
 
     fn get_error_response(
         &self,
-        res: Bytes,
+        res: types::Response,
     ) -> CustomResult<types::ErrorResponse, errors::ConnectorError> {
-        let response: aci::AciPaymentsResponse = res
-            .parse_struct("AciPaymentsResponse")
-            .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
+        let response: aci::AciPaymentsResponse =
+            res.response
+                .parse_struct("AciPaymentsResponse")
+                .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
         Ok(types::ErrorResponse {
+            status_code: res.status_code,
             code: response.result.code,
             message: response.result.description,
             reason: response.result.parameter_errors.and_then(|errors| {
@@ -376,12 +379,14 @@ impl
 
     fn get_error_response(
         &self,
-        res: Bytes,
+        res: types::Response,
     ) -> CustomResult<types::ErrorResponse, errors::ConnectorError> {
-        let response: aci::AciPaymentsResponse = res
-            .parse_struct("AciPaymentsResponse")
-            .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
+        let response: aci::AciPaymentsResponse =
+            res.response
+                .parse_struct("AciPaymentsResponse")
+                .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
         Ok(types::ErrorResponse {
+            status_code: res.status_code,
             code: response.result.code,
             message: response.result.description,
             reason: response.result.parameter_errors.and_then(|errors| {
@@ -483,12 +488,14 @@ impl services::ConnectorIntegration<api::Execute, types::RefundsData, types::Ref
     }
     fn get_error_response(
         &self,
-        res: Bytes,
+        res: types::Response,
     ) -> CustomResult<types::ErrorResponse, errors::ConnectorError> {
         let response: aci::AciRefundResponse = res
+            .response
             .parse_struct("AciRefundResponse")
             .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
         Ok(types::ErrorResponse {
+            status_code: res.status_code,
             code: response.result.code,
             message: response.result.description,
             reason: response.result.parameter_errors.and_then(|errors| {

--- a/crates/router/src/connector/adyen.rs
+++ b/crates/router/src/connector/adyen.rs
@@ -3,7 +3,6 @@ mod transformers;
 use std::fmt::Debug;
 
 use base64::Engine;
-use bytes::Bytes;
 use error_stack::{IntoReport, ResultExt};
 use router_env::{instrument, tracing};
 
@@ -156,12 +155,14 @@ impl
     }
     fn get_error_response(
         &self,
-        res: Bytes,
+        res: types::Response,
     ) -> CustomResult<types::ErrorResponse, errors::ConnectorError> {
         let response: adyen::ErrorResponse = res
+            .response
             .parse_struct("adyen::ErrorResponse")
             .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
         Ok(types::ErrorResponse {
+            status_code: res.status_code,
             code: response.error_code,
             message: response.message,
             reason: None,
@@ -288,12 +289,14 @@ impl
 
     fn get_error_response(
         &self,
-        res: Bytes,
+        res: types::Response,
     ) -> CustomResult<types::ErrorResponse, errors::ConnectorError> {
         let response: adyen::ErrorResponse = res
+            .response
             .parse_struct("ErrorResponse")
             .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
         Ok(types::ErrorResponse {
+            status_code: res.status_code,
             code: response.error_code,
             message: response.message,
             reason: None,
@@ -397,12 +400,14 @@ impl
 
     fn get_error_response(
         &self,
-        res: Bytes,
+        res: types::Response,
     ) -> CustomResult<types::ErrorResponse, errors::ConnectorError> {
         let response: adyen::ErrorResponse = res
+            .response
             .parse_struct("ErrorResponse")
             .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
         Ok(types::ErrorResponse {
+            status_code: res.status_code,
             code: response.error_code,
             message: response.message,
             reason: None,
@@ -490,13 +495,15 @@ impl
 
     fn get_error_response(
         &self,
-        res: Bytes,
+        res: types::Response,
     ) -> CustomResult<types::ErrorResponse, errors::ConnectorError> {
         let response: adyen::ErrorResponse = res
+            .response
             .parse_struct("ErrorResponse")
             .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
         logger::info!(response=?res);
         Ok(types::ErrorResponse {
+            status_code: res.status_code,
             code: response.error_code,
             message: response.message,
             reason: None,
@@ -588,13 +595,15 @@ impl services::ConnectorIntegration<api::Execute, types::RefundsData, types::Ref
 
     fn get_error_response(
         &self,
-        res: Bytes,
+        res: types::Response,
     ) -> CustomResult<types::ErrorResponse, errors::ConnectorError> {
         let response: adyen::ErrorResponse = res
+            .response
             .parse_struct("ErrorResponse")
             .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
         logger::info!(response=?res);
         Ok(types::ErrorResponse {
+            status_code: res.status_code,
             code: response.error_code,
             message: response.message,
             reason: None,

--- a/crates/router/src/connector/adyen/transformers.rs
+++ b/crates/router/src/connector/adyen/transformers.rs
@@ -466,6 +466,7 @@ impl TryFrom<types::PaymentsCancelResponseRouterData<AdyenCancelResponse>>
 pub fn get_adyen_response(
     response: AdyenResponse,
     is_capture_manual: bool,
+    status_code: u16,
 ) -> errors::CustomResult<
     (
         storage_enums::AttemptStatus,
@@ -494,6 +495,7 @@ pub fn get_adyen_response(
                 .refusal_reason
                 .unwrap_or_else(|| consts::NO_ERROR_MESSAGE.to_string()),
             reason: None,
+            status_code,
         })
     } else {
         None
@@ -511,6 +513,7 @@ pub fn get_adyen_response(
 
 pub fn get_redirection_response(
     response: AdyenRedirectionResponse,
+    status_code: u16,
 ) -> errors::CustomResult<
     (
         storage_enums::AttemptStatus,
@@ -530,6 +533,7 @@ pub fn get_redirection_response(
                 .refusal_reason
                 .unwrap_or_else(|| consts::NO_ERROR_MESSAGE.to_string()),
             reason: None,
+            status_code,
         })
     } else {
         None
@@ -585,10 +589,10 @@ impl<F, Req>
         let is_manual_capture = items.1;
         let (status, error, payment_response_data) = match item.response {
             AdyenPaymentResponse::AdyenResponse(response) => {
-                get_adyen_response(response, is_manual_capture)?
+                get_adyen_response(response, is_manual_capture, item.http_code)?
             }
             AdyenPaymentResponse::AdyenRedirectResponse(response) => {
-                get_redirection_response(response)?
+                get_redirection_response(response, item.http_code)?
             }
         };
 

--- a/crates/router/src/connector/applepay.rs
+++ b/crates/router/src/connector/applepay.rs
@@ -2,7 +2,6 @@ mod transformers;
 
 use std::fmt::Debug;
 
-use bytes::Bytes;
 use common_utils::ext_traits::ValueExt;
 use error_stack::{IntoReport, ResultExt};
 
@@ -160,12 +159,14 @@ impl
 
     fn get_error_response(
         &self,
-        res: Bytes,
+        res: types::Response,
     ) -> CustomResult<types::ErrorResponse, errors::ConnectorError> {
         let response: applepay::ErrorResponse = res
+            .response
             .parse_struct("ErrorResponse")
             .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
         Ok(types::ErrorResponse {
+            status_code: res.status_code,
             code: response.status_code,
             message: response.status_message,
             reason: None,

--- a/crates/router/src/connector/authorizedotnet/transformers.rs
+++ b/crates/router/src/connector/authorizedotnet/transformers.rs
@@ -301,6 +301,7 @@ impl<F, T>
                     code: error.error_code,
                     message: error.error_text,
                     reason: None,
+                    status_code: item.http_code,
                 })
             });
 
@@ -431,6 +432,7 @@ impl<F> TryFrom<types::RefundsResponseRouterData<F, AuthorizedotnetRefundRespons
                 code: error.error_code.clone(),
                 message: error.error_text.clone(),
                 reason: None,
+                status_code: item.http_code,
             })
         });
 

--- a/crates/router/src/connector/braintree.rs
+++ b/crates/router/src/connector/braintree.rs
@@ -2,7 +2,6 @@ mod transformers;
 
 use std::fmt::Debug;
 
-use bytes::Bytes;
 use error_stack::ResultExt;
 
 use self::transformers as braintree;
@@ -119,13 +118,15 @@ impl
 
     fn get_error_response(
         &self,
-        res: Bytes,
+        res: types::Response,
     ) -> CustomResult<types::ErrorResponse, errors::ConnectorError> {
         let response: braintree::ErrorResponse = res
+            .response
             .parse_struct("Error Response")
             .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
 
         Ok(types::ErrorResponse {
+            status_code: res.status_code,
             code: consts::NO_ERROR_CODE.to_string(),
             message: response.api_error_response.message,
             reason: None,
@@ -251,13 +252,15 @@ impl
 
     fn get_error_response(
         &self,
-        res: Bytes,
+        res: types::Response,
     ) -> CustomResult<types::ErrorResponse, errors::ConnectorError> {
         let response: braintree::ErrorResponse = res
+            .response
             .parse_struct("Braintree Error Response")
             .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
 
         Ok(types::ErrorResponse {
+            status_code: res.status_code,
             code: consts::NO_ERROR_CODE.to_string(),
             message: response.api_error_response.message,
             reason: None,
@@ -381,14 +384,16 @@ impl
 
     fn get_error_response(
         &self,
-        res: Bytes,
+        res: types::Response,
     ) -> CustomResult<types::ErrorResponse, errors::ConnectorError> {
         logger::debug!(braintreepayments_create_response=?res);
 
         let response: braintree::ErrorResponse = res
+            .response
             .parse_struct("Braintree ErrorResponse")
             .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
         Ok(types::ErrorResponse {
+            status_code: res.status_code,
             code: consts::NO_ERROR_CODE.to_string(),
             message: response.api_error_response.message,
             reason: None,
@@ -458,13 +463,15 @@ impl
 
     fn get_error_response(
         &self,
-        res: Bytes,
+        res: types::Response,
     ) -> CustomResult<types::ErrorResponse, errors::ConnectorError> {
         let response: braintree::ErrorResponse = res
+            .response
             .parse_struct("Braintree ErrorResponse")
             .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
 
         Ok(types::ErrorResponse {
+            status_code: res.status_code,
             code: consts::NO_ERROR_CODE.to_string(),
             message: response.api_error_response.message,
             reason: None,
@@ -590,7 +597,7 @@ impl services::ConnectorIntegration<api::Execute, types::RefundsData, types::Ref
 
     fn get_error_response(
         &self,
-        _res: Bytes,
+        _res: types::Response,
     ) -> CustomResult<types::ErrorResponse, errors::ConnectorError> {
         Err(errors::ConnectorError::NotImplemented("braintree".to_string()).into())
     }
@@ -622,7 +629,7 @@ impl services::ConnectorIntegration<api::RSync, types::RefundsData, types::Refun
 
     fn get_error_response(
         &self,
-        _res: Bytes,
+        _res: types::Response,
     ) -> CustomResult<types::ErrorResponse, errors::ConnectorError> {
         Err(errors::ConnectorError::NotImplemented("braintree".to_string()).into())
     }

--- a/crates/router/src/connector/checkout.rs
+++ b/crates/router/src/connector/checkout.rs
@@ -4,7 +4,6 @@ mod transformers;
 
 use std::fmt::Debug;
 
-use bytes::Bytes;
 use error_stack::{IntoReport, ResultExt};
 
 use self::transformers as checkout;
@@ -162,12 +161,14 @@ impl
 
     fn get_error_response(
         &self,
-        res: Bytes,
+        res: types::Response,
     ) -> CustomResult<types::ErrorResponse, errors::ConnectorError> {
         let response: checkout::ErrorResponse = res
+            .response
             .parse_struct("ErrorResponse")
             .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
         Ok(types::ErrorResponse {
+            status_code: res.status_code,
             code: response
                 .error_codes
                 .unwrap_or_else(|| vec![consts::NO_ERROR_CODE.to_string()])
@@ -259,12 +260,14 @@ impl
 
     fn get_error_response(
         &self,
-        res: Bytes,
+        res: types::Response,
     ) -> CustomResult<types::ErrorResponse, errors::ConnectorError> {
         let response: checkout::ErrorResponse = res
+            .response
             .parse_struct("ErrorResponse")
             .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
         Ok(types::ErrorResponse {
+            status_code: res.status_code,
             code: response
                 .error_codes
                 .unwrap_or_else(|| vec![consts::NO_ERROR_CODE.to_string()])
@@ -361,12 +364,14 @@ impl
 
     fn get_error_response(
         &self,
-        res: Bytes,
+        res: types::Response,
     ) -> CustomResult<types::ErrorResponse, errors::ConnectorError> {
         let response: checkout::ErrorResponse = res
+            .response
             .parse_struct("ErrorResponse")
             .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
         Ok(types::ErrorResponse {
+            status_code: res.status_code,
             code: response
                 .error_codes
                 .unwrap_or_else(|| vec![consts::NO_ERROR_CODE.to_string()])
@@ -459,12 +464,14 @@ impl
 
     fn get_error_response(
         &self,
-        res: Bytes,
+        res: types::Response,
     ) -> CustomResult<types::ErrorResponse, errors::ConnectorError> {
         let response: checkout::ErrorResponse = res
+            .response
             .parse_struct("ErrorResponse")
             .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
         Ok(types::ErrorResponse {
+            status_code: res.status_code,
             code: response
                 .error_codes
                 .unwrap_or_else(|| vec![consts::NO_ERROR_CODE.to_string()])
@@ -568,12 +575,14 @@ impl services::ConnectorIntegration<api::Execute, types::RefundsData, types::Ref
 
     fn get_error_response(
         &self,
-        res: Bytes,
+        res: types::Response,
     ) -> CustomResult<types::ErrorResponse, errors::ConnectorError> {
         let response: checkout::ErrorResponse = res
+            .response
             .parse_struct("ErrorResponse")
             .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
         Ok(types::ErrorResponse {
+            status_code: res.status_code,
             code: response
                 .error_codes
                 .unwrap_or_else(|| vec![consts::NO_ERROR_CODE.to_string()])
@@ -667,12 +676,14 @@ impl services::ConnectorIntegration<api::RSync, types::RefundsData, types::Refun
 
     fn get_error_response(
         &self,
-        res: Bytes,
+        res: types::Response,
     ) -> CustomResult<types::ErrorResponse, errors::ConnectorError> {
         let response: checkout::ErrorResponse = res
+            .response
             .parse_struct("ErrorResponse")
             .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
         Ok(types::ErrorResponse {
+            status_code: res.status_code,
             code: response
                 .error_codes
                 .unwrap_or_else(|| vec![consts::NO_ERROR_CODE.to_string()])

--- a/crates/router/src/connector/cybersource.rs
+++ b/crates/router/src/connector/cybersource.rs
@@ -3,7 +3,6 @@ mod transformers;
 use std::fmt::Debug;
 
 use base64::Engine;
-use bytes::Bytes;
 use error_stack::{IntoReport, ResultExt};
 use ring::{digest, hmac};
 use time::OffsetDateTime;
@@ -87,12 +86,14 @@ impl ConnectorCommon for Cybersource {
 
     fn build_error_response(
         &self,
-        res: Bytes,
+        res: types::Response,
     ) -> CustomResult<types::ErrorResponse, errors::ConnectorError> {
         let response: cybersource::ErrorResponse = res
+            .response
             .parse_struct("Cybersource ErrorResponse")
             .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
         Ok(types::ErrorResponse {
+            status_code: res.status_code,
             code: consts::NO_ERROR_CODE.to_string(),
             message: response.details.to_string(),
             reason: None,
@@ -256,7 +257,7 @@ impl ConnectorIntegration<api::Capture, types::PaymentsCaptureData, types::Payme
     }
     fn get_error_response(
         &self,
-        res: Bytes,
+        res: types::Response,
     ) -> CustomResult<types::ErrorResponse, errors::ConnectorError> {
         self.build_error_response(res)
     }
@@ -337,7 +338,7 @@ impl ConnectorIntegration<api::PSync, types::PaymentsSyncData, types::PaymentsRe
     }
     fn get_error_response(
         &self,
-        res: Bytes,
+        res: types::Response,
     ) -> CustomResult<types::ErrorResponse, errors::ConnectorError> {
         self.build_error_response(res)
     }
@@ -422,7 +423,7 @@ impl ConnectorIntegration<api::Authorize, types::PaymentsAuthorizeData, types::P
 
     fn get_error_response(
         &self,
-        res: Bytes,
+        res: types::Response,
     ) -> CustomResult<types::ErrorResponse, errors::ConnectorError> {
         self.build_error_response(res)
     }
@@ -499,7 +500,7 @@ impl ConnectorIntegration<api::Void, types::PaymentsCancelData, types::PaymentsR
 
     fn get_error_response(
         &self,
-        res: Bytes,
+        res: types::Response,
     ) -> CustomResult<types::ErrorResponse, errors::ConnectorError> {
         self.build_error_response(res)
     }
@@ -585,7 +586,7 @@ impl ConnectorIntegration<api::Execute, types::RefundsData, types::RefundsRespon
     }
     fn get_error_response(
         &self,
-        res: Bytes,
+        res: types::Response,
     ) -> CustomResult<types::ErrorResponse, errors::ConnectorError> {
         self.build_error_response(res)
     }
@@ -653,7 +654,7 @@ impl ConnectorIntegration<api::RSync, types::RefundsData, types::RefundsResponse
     }
     fn get_error_response(
         &self,
-        res: Bytes,
+        res: types::Response,
     ) -> CustomResult<types::ErrorResponse, errors::ConnectorError> {
         self.build_error_response(res)
     }

--- a/crates/router/src/connector/cybersource/transformers.rs
+++ b/crates/router/src/connector/cybersource/transformers.rs
@@ -300,6 +300,7 @@ impl<F, T>
                     code: consts::NO_ERROR_CODE.to_string(),
                     message: error.message,
                     reason: Some(error.reason),
+                    status_code: item.http_code,
                 }),
                 _ => Ok(types::PaymentsResponseData::TransactionResponse {
                     resource_id: types::ResponseId::ConnectorTransactionId(item.response.id),

--- a/crates/router/src/connector/fiserv.rs
+++ b/crates/router/src/connector/fiserv.rs
@@ -3,7 +3,6 @@ mod transformers;
 use std::fmt::Debug;
 
 use base64::Engine;
-use bytes::Bytes;
 use error_stack::ResultExt;
 use ring::hmac;
 use time::OffsetDateTime;
@@ -200,9 +199,10 @@ impl
 
     fn get_error_response(
         &self,
-        res: Bytes,
+        res: types::Response,
     ) -> CustomResult<types::ErrorResponse, errors::ConnectorError> {
         let response: fiserv::ErrorResponse = res
+            .response
             .parse_struct("Fiserv ErrorResponse")
             .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
 
@@ -223,6 +223,7 @@ impl
         };
 
         Ok(types::ErrorResponse {
+            status_code: res.status_code,
             code: consts::NO_ERROR_CODE.to_string(),
             message,
             reason: None,
@@ -347,9 +348,10 @@ impl
 
     fn get_error_response(
         &self,
-        res: Bytes,
+        res: types::Response,
     ) -> CustomResult<types::ErrorResponse, errors::ConnectorError> {
         let response: fiserv::ErrorResponse = res
+            .response
             .parse_struct("Fiserv ErrorResponse")
             .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
 
@@ -369,6 +371,7 @@ impl
             (None, None) => consts::NO_ERROR_MESSAGE.to_string(),
         };
         Ok(types::ErrorResponse {
+            status_code: res.status_code,
             code: consts::NO_ERROR_CODE.to_string(),
             message,
             reason: None,

--- a/crates/router/src/connector/globalpay.rs
+++ b/crates/router/src/connector/globalpay.rs
@@ -4,7 +4,6 @@ mod transformers;
 
 use std::fmt::Debug;
 
-use bytes::Bytes;
 use error_stack::{IntoReport, ResultExt};
 
 use self::{
@@ -22,7 +21,7 @@ use crate::{
     types::{
         self,
         api::{self, ConnectorCommon, ConnectorCommonExt},
-        ErrorResponse, Response,
+        ErrorResponse,
     },
     utils::{self, BytesExt},
 };
@@ -77,13 +76,15 @@ impl ConnectorCommon for Globalpay {
 
     fn build_error_response(
         &self,
-        res: Bytes,
+        res: types::Response,
     ) -> CustomResult<ErrorResponse, errors::ConnectorError> {
         let response: globalpay::GlobalpayErrorResponse = res
+            .response
             .parse_struct("Globalpay ErrorResponse")
             .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
 
         Ok(ErrorResponse {
+            status_code: res.status_code,
             code: response.error_code,
             message: response.detailed_error_description,
             reason: None,
@@ -157,7 +158,7 @@ impl ConnectorIntegration<api::Void, types::PaymentsCancelData, types::PaymentsR
     fn handle_response(
         &self,
         data: &types::PaymentsCancelRouterData,
-        res: Response,
+        res: types::Response,
     ) -> CustomResult<types::PaymentsCancelRouterData, errors::ConnectorError> {
         let response: GlobalpayPaymentsResponse = res
             .response
@@ -175,7 +176,7 @@ impl ConnectorIntegration<api::Void, types::PaymentsCancelData, types::PaymentsR
 
     fn get_error_response(
         &self,
-        res: Bytes,
+        res: types::Response,
     ) -> CustomResult<ErrorResponse, errors::ConnectorError> {
         self.build_error_response(res)
     }
@@ -228,7 +229,7 @@ impl ConnectorIntegration<api::PSync, types::PaymentsSyncData, types::PaymentsRe
 
     fn get_error_response(
         &self,
-        res: Bytes,
+        res: types::Response,
     ) -> CustomResult<ErrorResponse, errors::ConnectorError> {
         self.build_error_response(res)
     }
@@ -236,7 +237,7 @@ impl ConnectorIntegration<api::PSync, types::PaymentsSyncData, types::PaymentsRe
     fn handle_response(
         &self,
         data: &types::PaymentsSyncRouterData,
-        res: Response,
+        res: types::Response,
     ) -> CustomResult<types::PaymentsSyncRouterData, errors::ConnectorError> {
         logger::debug!(payment_sync_response=?res);
         let response: GlobalpayPaymentsResponse = res
@@ -311,7 +312,7 @@ impl ConnectorIntegration<api::Capture, types::PaymentsCaptureData, types::Payme
     fn handle_response(
         &self,
         data: &types::PaymentsCaptureRouterData,
-        res: Response,
+        res: types::Response,
     ) -> CustomResult<types::PaymentsCaptureRouterData, errors::ConnectorError> {
         let response: GlobalpayPaymentsResponse = res
             .response
@@ -329,7 +330,7 @@ impl ConnectorIntegration<api::Capture, types::PaymentsCaptureData, types::Payme
 
     fn get_error_response(
         &self,
-        res: Bytes,
+        res: types::Response,
     ) -> CustomResult<ErrorResponse, errors::ConnectorError> {
         self.build_error_response(res)
     }
@@ -400,7 +401,7 @@ impl ConnectorIntegration<api::Authorize, types::PaymentsAuthorizeData, types::P
     fn handle_response(
         &self,
         data: &types::PaymentsAuthorizeRouterData,
-        res: Response,
+        res: types::Response,
     ) -> CustomResult<types::PaymentsAuthorizeRouterData, errors::ConnectorError> {
         let response: GlobalpayPaymentsResponse = res
             .response
@@ -418,7 +419,7 @@ impl ConnectorIntegration<api::Authorize, types::PaymentsAuthorizeData, types::P
 
     fn get_error_response(
         &self,
-        res: Bytes,
+        res: types::Response,
     ) -> CustomResult<ErrorResponse, errors::ConnectorError> {
         self.build_error_response(res)
     }
@@ -484,7 +485,7 @@ impl ConnectorIntegration<api::Execute, types::RefundsData, types::RefundsRespon
     fn handle_response(
         &self,
         data: &types::RefundsRouterData<api::Execute>,
-        res: Response,
+        res: types::Response,
     ) -> CustomResult<types::RefundsRouterData<api::Execute>, errors::ConnectorError> {
         logger::debug!(target: "router::connector::globalpay", response=?res);
         let response: GlobalpayPaymentsResponse = res
@@ -502,7 +503,7 @@ impl ConnectorIntegration<api::Execute, types::RefundsData, types::RefundsRespon
 
     fn get_error_response(
         &self,
-        res: Bytes,
+        res: types::Response,
     ) -> CustomResult<ErrorResponse, errors::ConnectorError> {
         self.build_error_response(res)
     }
@@ -553,7 +554,7 @@ impl ConnectorIntegration<api::RSync, types::RefundsData, types::RefundsResponse
     fn handle_response(
         &self,
         data: &types::RefundSyncRouterData,
-        res: Response,
+        res: types::Response,
     ) -> CustomResult<types::RefundSyncRouterData, errors::ConnectorError> {
         logger::debug!(target: "router::connector::globalpay", response=?res);
         let response: GlobalpayPaymentsResponse = res
@@ -571,7 +572,7 @@ impl ConnectorIntegration<api::RSync, types::RefundsData, types::RefundsResponse
 
     fn get_error_response(
         &self,
-        res: Bytes,
+        res: types::Response,
     ) -> CustomResult<ErrorResponse, errors::ConnectorError> {
         self.build_error_response(res)
     }

--- a/crates/router/src/connector/klarna.rs
+++ b/crates/router/src/connector/klarna.rs
@@ -2,7 +2,6 @@ mod transformers;
 use std::fmt::Debug;
 
 use api_models::payments as api_payments;
-use bytes::Bytes;
 use error_stack::{IntoReport, ResultExt};
 use transformers as klarna;
 
@@ -141,13 +140,15 @@ impl
 
     fn get_error_response(
         &self,
-        res: Bytes,
+        res: types::Response,
     ) -> CustomResult<types::ErrorResponse, errors::ConnectorError> {
         logger::debug!(klarna_session_error_logs=?res);
         let response: klarna::KlarnaErrorResponse = res
+            .response
             .parse_struct("KlarnaErrorResponse")
             .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
         Ok(types::ErrorResponse {
+            status_code: res.status_code,
             code: response.error_code,
             message: response.error_messages.join(" & "),
             reason: None,
@@ -284,13 +285,15 @@ impl
 
     fn get_error_response(
         &self,
-        res: Bytes,
+        res: types::Response,
     ) -> CustomResult<types::ErrorResponse, errors::ConnectorError> {
         logger::debug!(klarna_error_response=?res);
         let response: klarna::KlarnaErrorResponse = res
+            .response
             .parse_struct("KlarnaErrorResponse")
             .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
         Ok(types::ErrorResponse {
+            status_code: res.status_code,
             code: response.error_code,
             message: response.error_messages.join(" & "),
             reason: None,

--- a/crates/router/src/connector/payu.rs
+++ b/crates/router/src/connector/payu.rs
@@ -2,7 +2,6 @@ mod transformers;
 
 use std::fmt::Debug;
 
-use bytes::Bytes;
 use error_stack::{IntoReport, ResultExt};
 use transformers as payu;
 
@@ -16,7 +15,7 @@ use crate::{
     types::{
         self,
         api::{self, ConnectorCommon, ConnectorCommonExt},
-        ErrorResponse, Response,
+        ErrorResponse,
     },
     utils::{self, BytesExt},
 };
@@ -67,13 +66,15 @@ impl ConnectorCommon for Payu {
     }
     fn build_error_response(
         &self,
-        res: Bytes,
+        res: types::Response,
     ) -> CustomResult<ErrorResponse, errors::ConnectorError> {
         let response: payu::PayuErrorResponse = res
+            .response
             .parse_struct("Payu ErrorResponse")
             .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
 
         Ok(ErrorResponse {
+            status_code: res.status_code,
             code: response.status.status_code,
             message: response.status.status_desc,
             reason: response.status.code_literal,
@@ -142,7 +143,7 @@ impl
     fn handle_response(
         &self,
         data: &types::PaymentsCancelRouterData,
-        res: Response,
+        res: types::Response,
     ) -> CustomResult<types::PaymentsCancelRouterData, errors::ConnectorError> {
         let response: payu::PayuPaymentsCancelResponse = res
             .response
@@ -158,7 +159,7 @@ impl
     }
     fn get_error_response(
         &self,
-        res: Bytes,
+        res: types::Response,
     ) -> CustomResult<ErrorResponse, errors::ConnectorError> {
         self.build_error_response(res)
     }
@@ -216,7 +217,7 @@ impl
     fn handle_response(
         &self,
         data: &types::PaymentsSyncRouterData,
-        res: Response,
+        res: types::Response,
     ) -> CustomResult<types::PaymentsSyncRouterData, errors::ConnectorError> {
         logger::debug!(target: "router::connector::payu", response=?res);
         let response: payu::PayuPaymentsSyncResponse = res
@@ -234,7 +235,7 @@ impl
 
     fn get_error_response(
         &self,
-        res: Bytes,
+        res: types::Response,
     ) -> CustomResult<ErrorResponse, errors::ConnectorError> {
         self.build_error_response(res)
     }
@@ -303,7 +304,7 @@ impl
     fn handle_response(
         &self,
         data: &types::PaymentsCaptureRouterData,
-        res: Response,
+        res: types::Response,
     ) -> CustomResult<types::PaymentsCaptureRouterData, errors::ConnectorError> {
         let response: payu::PayuPaymentsCaptureResponse = res
             .response
@@ -320,7 +321,7 @@ impl
 
     fn get_error_response(
         &self,
-        res: Bytes,
+        res: types::Response,
     ) -> CustomResult<ErrorResponse, errors::ConnectorError> {
         self.build_error_response(res)
     }
@@ -402,7 +403,7 @@ impl
     fn handle_response(
         &self,
         data: &types::PaymentsAuthorizeRouterData,
-        res: Response,
+        res: types::Response,
     ) -> CustomResult<types::PaymentsAuthorizeRouterData, errors::ConnectorError> {
         let response: payu::PayuPaymentsResponse = res
             .response
@@ -420,7 +421,7 @@ impl
 
     fn get_error_response(
         &self,
-        res: Bytes,
+        res: types::Response,
     ) -> CustomResult<ErrorResponse, errors::ConnectorError> {
         self.build_error_response(res)
     }
@@ -487,7 +488,7 @@ impl services::ConnectorIntegration<api::Execute, types::RefundsData, types::Ref
     fn handle_response(
         &self,
         data: &types::RefundsRouterData<api::Execute>,
-        res: Response,
+        res: types::Response,
     ) -> CustomResult<types::RefundsRouterData<api::Execute>, errors::ConnectorError> {
         logger::debug!(target: "router::connector::payu", response=?res);
         let response: payu::RefundResponse = res
@@ -505,7 +506,7 @@ impl services::ConnectorIntegration<api::Execute, types::RefundsData, types::Ref
 
     fn get_error_response(
         &self,
-        res: Bytes,
+        res: types::Response,
     ) -> CustomResult<ErrorResponse, errors::ConnectorError> {
         self.build_error_response(res)
     }
@@ -557,7 +558,7 @@ impl services::ConnectorIntegration<api::RSync, types::RefundsData, types::Refun
     fn handle_response(
         &self,
         data: &types::RefundSyncRouterData,
-        res: Response,
+        res: types::Response,
     ) -> CustomResult<types::RefundSyncRouterData, errors::ConnectorError> {
         logger::debug!(target: "router::connector::payu", response=?res);
         let response: payu::RefundSyncResponse =
@@ -575,7 +576,7 @@ impl services::ConnectorIntegration<api::RSync, types::RefundsData, types::Refun
 
     fn get_error_response(
         &self,
-        res: Bytes,
+        res: types::Response,
     ) -> CustomResult<ErrorResponse, errors::ConnectorError> {
         self.build_error_response(res)
     }

--- a/crates/router/src/connector/rapyd.rs
+++ b/crates/router/src/connector/rapyd.rs
@@ -2,7 +2,6 @@ mod transformers;
 use std::fmt::Debug;
 
 use base64::Engine;
-use bytes::Bytes;
 use common_utils::date_time;
 use error_stack::{IntoReport, ResultExt};
 use rand::distributions::{Alphanumeric, DistString};
@@ -20,7 +19,7 @@ use crate::{
     types::{
         self,
         api::{self, ConnectorCommon},
-        ErrorResponse, Response,
+        ErrorResponse,
     },
     utils::{self, BytesExt},
 };
@@ -155,7 +154,7 @@ impl
     fn handle_response(
         &self,
         data: &types::PaymentsAuthorizeRouterData,
-        res: Response,
+        res: types::Response,
     ) -> CustomResult<types::PaymentsAuthorizeRouterData, errors::ConnectorError> {
         let response: rapyd::RapydPaymentsResponse = res
             .response
@@ -173,12 +172,14 @@ impl
 
     fn get_error_response(
         &self,
-        res: Bytes,
+        res: types::Response,
     ) -> CustomResult<ErrorResponse, errors::ConnectorError> {
         let response: rapyd::RapydPaymentsResponse = res
+            .response
             .parse_struct("Rapyd ErrorResponse")
             .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
         Ok(ErrorResponse {
+            status_code: res.status_code,
             code: response.status.error_code,
             message: response.status.status,
             reason: response.status.message,
@@ -265,7 +266,7 @@ impl
     fn handle_response(
         &self,
         data: &types::PaymentsCancelRouterData,
-        res: Response,
+        res: types::Response,
     ) -> CustomResult<types::PaymentsCancelRouterData, errors::ConnectorError> {
         let response: rapyd::RapydPaymentsResponse = res
             .response
@@ -283,12 +284,14 @@ impl
 
     fn get_error_response(
         &self,
-        res: Bytes,
+        res: types::Response,
     ) -> CustomResult<ErrorResponse, errors::ConnectorError> {
         let response: rapyd::RapydPaymentsResponse = res
+            .response
             .parse_struct("Rapyd ErrorResponse")
             .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
         Ok(ErrorResponse {
+            status_code: res.status_code,
             code: response.status.error_code,
             message: response.status.status,
             reason: response.status.message,
@@ -331,7 +334,7 @@ impl
 
     fn get_error_response(
         &self,
-        _res: Bytes,
+        _res: types::Response,
     ) -> CustomResult<ErrorResponse, errors::ConnectorError> {
         Err(errors::ConnectorError::NotImplemented("PSync".to_string()).into())
     }
@@ -339,7 +342,7 @@ impl
     fn handle_response(
         &self,
         _data: &types::PaymentsSyncRouterData,
-        _res: Response,
+        _res: types::Response,
     ) -> CustomResult<types::PaymentsSyncRouterData, errors::ConnectorError> {
         Err(errors::ConnectorError::NotImplemented("PSync".to_string()).into())
     }
@@ -416,7 +419,7 @@ impl
     fn handle_response(
         &self,
         data: &types::PaymentsCaptureRouterData,
-        res: Response,
+        res: types::Response,
     ) -> CustomResult<types::PaymentsCaptureRouterData, errors::ConnectorError> {
         let response: rapyd::RapydPaymentsResponse = res
             .response
@@ -445,12 +448,14 @@ impl
 
     fn get_error_response(
         &self,
-        res: Bytes,
+        res: types::Response,
     ) -> CustomResult<ErrorResponse, errors::ConnectorError> {
         let response: rapyd::RapydPaymentsResponse = res
+            .response
             .parse_struct("Rapyd ErrorResponse")
             .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
         Ok(ErrorResponse {
+            status_code: res.status_code,
             code: response.status.error_code,
             message: response.status.status,
             reason: response.status.message,
@@ -541,7 +546,7 @@ impl services::ConnectorIntegration<api::Execute, types::RefundsData, types::Ref
     fn handle_response(
         &self,
         data: &types::RefundsRouterData<api::Execute>,
-        res: Response,
+        res: types::Response,
     ) -> CustomResult<types::RefundsRouterData<api::Execute>, errors::ConnectorError> {
         logger::debug!(target: "router::connector::rapyd", response=?res);
         let response: rapyd::RefundResponse = res
@@ -559,12 +564,14 @@ impl services::ConnectorIntegration<api::Execute, types::RefundsData, types::Ref
 
     fn get_error_response(
         &self,
-        res: Bytes,
+        res: types::Response,
     ) -> CustomResult<ErrorResponse, errors::ConnectorError> {
         let response: rapyd::RapydPaymentsResponse = res
+            .response
             .parse_struct("Rapyd ErrorResponse")
             .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
         Ok(ErrorResponse {
+            status_code: res.status_code,
             code: response.status.error_code,
             message: response.status.status,
             reason: response.status.message,
@@ -598,7 +605,7 @@ impl services::ConnectorIntegration<api::RSync, types::RefundsData, types::Refun
     fn handle_response(
         &self,
         data: &types::RefundSyncRouterData,
-        res: Response,
+        res: types::Response,
     ) -> CustomResult<types::RefundSyncRouterData, errors::ConnectorError> {
         logger::debug!(target: "router::connector::rapyd", response=?res);
         let response: rapyd::RefundResponse = res
@@ -616,7 +623,7 @@ impl services::ConnectorIntegration<api::RSync, types::RefundsData, types::Refun
 
     fn get_error_response(
         &self,
-        _res: Bytes,
+        _res: types::Response,
     ) -> CustomResult<ErrorResponse, errors::ConnectorError> {
         Err(errors::ConnectorError::NotImplemented("RSync".to_string()).into())
     }

--- a/crates/router/src/connector/rapyd/transformers.rs
+++ b/crates/router/src/connector/rapyd/transformers.rs
@@ -219,6 +219,7 @@ impl TryFrom<types::PaymentsResponseRouterData<RapydPaymentsResponse>>
                     enums::AttemptStatus::Failure,
                     Err(types::ErrorResponse {
                         code: item.response.status.error_code,
+                        status_code: item.http_code,
                         message: item.response.status.status,
                         reason: item.response.status.message,
                     }),
@@ -228,6 +229,7 @@ impl TryFrom<types::PaymentsResponseRouterData<RapydPaymentsResponse>>
                 enums::AttemptStatus::Failure,
                 Err(types::ErrorResponse {
                     code: item.response.status.error_code,
+                    status_code: item.http_code,
                     message: item.response.status.status,
                     reason: item.response.status.message,
                 }),
@@ -236,6 +238,7 @@ impl TryFrom<types::PaymentsResponseRouterData<RapydPaymentsResponse>>
                 enums::AttemptStatus::Failure,
                 Err(types::ErrorResponse {
                     code: item.response.status.error_code,
+                    status_code: item.http_code,
                     message: item.response.status.status,
                     reason: item.response.status.message,
                 }),
@@ -397,6 +400,7 @@ impl TryFrom<types::PaymentsCaptureResponseRouterData<RapydPaymentsResponse>>
                         code: item.response.status.error_code,
                         message: item.response.status.status,
                         reason: item.response.status.message,
+                        status_code: item.http_code,
                     }),
                 ),
             },
@@ -406,6 +410,7 @@ impl TryFrom<types::PaymentsCaptureResponseRouterData<RapydPaymentsResponse>>
                     code: item.response.status.error_code,
                     message: item.response.status.status,
                     reason: item.response.status.message,
+                    status_code: item.http_code,
                 }),
             ),
             _ => (
@@ -414,6 +419,7 @@ impl TryFrom<types::PaymentsCaptureResponseRouterData<RapydPaymentsResponse>>
                     code: item.response.status.error_code,
                     message: item.response.status.status,
                     reason: item.response.status.message,
+                    status_code: item.http_code,
                 }),
             ),
         };
@@ -449,6 +455,7 @@ impl TryFrom<types::PaymentsCancelResponseRouterData<RapydPaymentsResponse>>
                     enums::AttemptStatus::Failure,
                     Err(types::ErrorResponse {
                         code: item.response.status.error_code,
+                        status_code: item.http_code,
                         message: item.response.status.status,
                         reason: item.response.status.message,
                     }),
@@ -458,6 +465,7 @@ impl TryFrom<types::PaymentsCancelResponseRouterData<RapydPaymentsResponse>>
                 enums::AttemptStatus::Failure,
                 Err(types::ErrorResponse {
                     code: item.response.status.error_code,
+                    status_code: item.http_code,
                     message: item.response.status.status,
                     reason: item.response.status.message,
                 }),
@@ -466,6 +474,7 @@ impl TryFrom<types::PaymentsCancelResponseRouterData<RapydPaymentsResponse>>
                 enums::AttemptStatus::Failure,
                 Err(types::ErrorResponse {
                     code: item.response.status.error_code,
+                    status_code: item.http_code,
                     message: item.response.status.status,
                     reason: item.response.status.message,
                 }),

--- a/crates/router/src/connector/shift4.rs
+++ b/crates/router/src/connector/shift4.rs
@@ -2,7 +2,6 @@ mod transformers;
 
 use std::fmt::Debug;
 
-use bytes::Bytes;
 use common_utils::ext_traits::ByteSliceExt;
 use error_stack::ResultExt;
 use transformers as shift4;
@@ -19,7 +18,7 @@ use crate::{
     types::{
         self,
         api::{self, ConnectorCommon, ConnectorCommonExt},
-        ErrorResponse, Response,
+        ErrorResponse,
     },
     utils::{self, BytesExt},
 };
@@ -76,13 +75,15 @@ impl ConnectorCommon for Shift4 {
 
     fn build_error_response(
         &self,
-        res: Bytes,
+        res: types::Response,
     ) -> CustomResult<ErrorResponse, errors::ConnectorError> {
         let response: shift4::ErrorResponse = res
+            .response
             .parse_struct("Shift4 ErrorResponse")
             .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
 
         Ok(ErrorResponse {
+            status_code: res.status_code,
             code: response
                 .error
                 .code
@@ -157,7 +158,7 @@ impl ConnectorIntegration<api::PSync, types::PaymentsSyncData, types::PaymentsRe
 
     fn get_error_response(
         &self,
-        res: Bytes,
+        res: types::Response,
     ) -> CustomResult<ErrorResponse, errors::ConnectorError> {
         self.build_error_response(res)
     }
@@ -165,7 +166,7 @@ impl ConnectorIntegration<api::PSync, types::PaymentsSyncData, types::PaymentsRe
     fn handle_response(
         &self,
         data: &types::PaymentsSyncRouterData,
-        res: Response,
+        res: types::Response,
     ) -> CustomResult<types::PaymentsSyncRouterData, errors::ConnectorError> {
         logger::debug!(payment_sync_response=?res);
         let response: shift4::Shift4PaymentsResponse = res
@@ -217,7 +218,7 @@ impl ConnectorIntegration<api::Capture, types::PaymentsCaptureData, types::Payme
     fn handle_response(
         &self,
         data: &types::PaymentsCaptureRouterData,
-        res: Response,
+        res: types::Response,
     ) -> CustomResult<types::PaymentsCaptureRouterData, errors::ConnectorError> {
         let response: shift4::Shift4PaymentsResponse = res
             .response
@@ -248,7 +249,7 @@ impl ConnectorIntegration<api::Capture, types::PaymentsCaptureData, types::Payme
 
     fn get_error_response(
         &self,
-        res: Bytes,
+        res: types::Response,
     ) -> CustomResult<ErrorResponse, errors::ConnectorError> {
         self.build_error_response(res)
     }
@@ -317,7 +318,7 @@ impl ConnectorIntegration<api::Authorize, types::PaymentsAuthorizeData, types::P
     fn handle_response(
         &self,
         data: &types::PaymentsAuthorizeRouterData,
-        res: Response,
+        res: types::Response,
     ) -> CustomResult<types::PaymentsAuthorizeRouterData, errors::ConnectorError> {
         let response: shift4::Shift4PaymentsResponse = res
             .response
@@ -335,7 +336,7 @@ impl ConnectorIntegration<api::Authorize, types::PaymentsAuthorizeData, types::P
 
     fn get_error_response(
         &self,
-        res: Bytes,
+        res: types::Response,
     ) -> CustomResult<ErrorResponse, errors::ConnectorError> {
         self.build_error_response(res)
     }
@@ -394,7 +395,7 @@ impl ConnectorIntegration<api::Execute, types::RefundsData, types::RefundsRespon
     fn handle_response(
         &self,
         data: &types::RefundsRouterData<api::Execute>,
-        res: Response,
+        res: types::Response,
     ) -> CustomResult<types::RefundsRouterData<api::Execute>, errors::ConnectorError> {
         logger::debug!(target: "router::connector::shift4", response=?res);
         let response: shift4::RefundResponse = res
@@ -412,7 +413,7 @@ impl ConnectorIntegration<api::Execute, types::RefundsData, types::RefundsRespon
 
     fn get_error_response(
         &self,
-        res: Bytes,
+        res: types::Response,
     ) -> CustomResult<ErrorResponse, errors::ConnectorError> {
         self.build_error_response(res)
     }
@@ -457,7 +458,7 @@ impl ConnectorIntegration<api::RSync, types::RefundsData, types::RefundsResponse
     fn handle_response(
         &self,
         data: &types::RefundSyncRouterData,
-        res: Response,
+        res: types::Response,
     ) -> CustomResult<types::RefundSyncRouterData, errors::ConnectorError> {
         logger::debug!(target: "router::connector::shift4", response=?res);
         let response: shift4::RefundResponse =
@@ -475,7 +476,7 @@ impl ConnectorIntegration<api::RSync, types::RefundsData, types::RefundsResponse
 
     fn get_error_response(
         &self,
-        res: Bytes,
+        res: types::Response,
     ) -> CustomResult<ErrorResponse, errors::ConnectorError> {
         self.build_error_response(res)
     }

--- a/crates/router/src/connector/stripe.rs
+++ b/crates/router/src/connector/stripe.rs
@@ -2,7 +2,6 @@ mod transformers;
 
 use std::{collections::HashMap, fmt::Debug};
 
-use bytes::Bytes;
 use error_stack::{IntoReport, ResultExt};
 use router_env::{instrument, tracing};
 
@@ -164,13 +163,15 @@ impl
 
     fn get_error_response(
         &self,
-        res: Bytes,
+        res: types::Response,
     ) -> CustomResult<types::ErrorResponse, errors::ConnectorError> {
         let response: stripe::ErrorResponse = res
+            .response
             .parse_struct("ErrorResponse")
             .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
 
         Ok(types::ErrorResponse {
+            status_code: res.status_code,
             code: response
                 .error
                 .code
@@ -263,13 +264,15 @@ impl
 
     fn get_error_response(
         &self,
-        res: Bytes,
+        res: types::Response,
     ) -> CustomResult<types::ErrorResponse, errors::ConnectorError> {
         let response: stripe::ErrorResponse = res
+            .response
             .parse_struct("ErrorResponse")
             .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
 
         Ok(types::ErrorResponse {
+            status_code: res.status_code,
             code: response
                 .error
                 .code
@@ -373,12 +376,14 @@ impl
 
     fn get_error_response(
         &self,
-        res: Bytes,
+        res: types::Response,
     ) -> CustomResult<types::ErrorResponse, errors::ConnectorError> {
         let response: stripe::ErrorResponse = res
+            .response
             .parse_struct("ErrorResponse")
             .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
         Ok(types::ErrorResponse {
+            status_code: res.status_code,
             code: response
                 .error
                 .code
@@ -478,12 +483,14 @@ impl
 
     fn get_error_response(
         &self,
-        res: Bytes,
+        res: types::Response,
     ) -> CustomResult<types::ErrorResponse, errors::ConnectorError> {
         let response: stripe::ErrorResponse = res
+            .response
             .parse_struct("ErrorResponse")
             .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
         Ok(types::ErrorResponse {
+            status_code: res.status_code,
             code: response
                 .error
                 .code
@@ -603,12 +610,14 @@ impl
 
     fn get_error_response(
         &self,
-        res: Bytes,
+        res: types::Response,
     ) -> CustomResult<types::ErrorResponse, errors::ConnectorError> {
         let response: stripe::ErrorResponse = res
+            .response
             .parse_struct("ErrorResponse")
             .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
         Ok(types::ErrorResponse {
+            status_code: res.status_code,
             code: response
                 .error
                 .code
@@ -705,12 +714,14 @@ impl services::ConnectorIntegration<api::Execute, types::RefundsData, types::Ref
 
     fn get_error_response(
         &self,
-        res: Bytes,
+        res: types::Response,
     ) -> CustomResult<types::ErrorResponse, errors::ConnectorError> {
         let response: stripe::ErrorResponse = res
+            .response
             .parse_struct("ErrorResponse")
             .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
         Ok(types::ErrorResponse {
+            status_code: res.status_code,
             code: response
                 .error
                 .code
@@ -805,12 +816,14 @@ impl services::ConnectorIntegration<api::RSync, types::RefundsData, types::Refun
 
     fn get_error_response(
         &self,
-        res: Bytes,
+        res: types::Response,
     ) -> CustomResult<types::ErrorResponse, errors::ConnectorError> {
         let response: stripe::ErrorResponse = res
+            .response
             .parse_struct("ErrorResponse")
             .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
         Ok(types::ErrorResponse {
+            status_code: res.status_code,
             code: response
                 .error
                 .code

--- a/crates/router/src/connector/worldpay.rs
+++ b/crates/router/src/connector/worldpay.rs
@@ -4,7 +4,6 @@ mod transformers;
 
 use std::fmt::Debug;
 
-use bytes::Bytes;
 use error_stack::{IntoReport, ResultExt};
 use storage_models::enums;
 use transformers as worldpay;
@@ -73,12 +72,14 @@ impl ConnectorCommon for Worldpay {
 
     fn build_error_response(
         &self,
-        res: Bytes,
+        res: Response,
     ) -> CustomResult<ErrorResponse, errors::ConnectorError> {
         let response: WorldpayErrorResponse = res
+            .response
             .parse_struct("WorldpayErrorResponse")
             .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
         Ok(ErrorResponse {
+            status_code: res.status_code,
             code: response.error_name,
             message: response.message,
             reason: None,
@@ -172,7 +173,7 @@ impl ConnectorIntegration<api::Void, types::PaymentsCancelData, types::PaymentsR
 
     fn get_error_response(
         &self,
-        res: Bytes,
+        res: Response,
     ) -> CustomResult<ErrorResponse, errors::ConnectorError> {
         self.build_error_response(res)
     }
@@ -228,7 +229,7 @@ impl ConnectorIntegration<api::PSync, types::PaymentsSyncData, types::PaymentsRe
 
     fn get_error_response(
         &self,
-        res: Bytes,
+        res: Response,
     ) -> CustomResult<ErrorResponse, errors::ConnectorError> {
         self.build_error_response(res)
     }
@@ -332,7 +333,7 @@ impl ConnectorIntegration<api::Capture, types::PaymentsCaptureData, types::Payme
 
     fn get_error_response(
         &self,
-        res: Bytes,
+        res: Response,
     ) -> CustomResult<ErrorResponse, errors::ConnectorError> {
         self.build_error_response(res)
     }
@@ -421,7 +422,7 @@ impl ConnectorIntegration<api::Authorize, types::PaymentsAuthorizeData, types::P
 
     fn get_error_response(
         &self,
-        res: Bytes,
+        res: Response,
     ) -> CustomResult<ErrorResponse, errors::ConnectorError> {
         self.build_error_response(res)
     }
@@ -510,7 +511,7 @@ impl ConnectorIntegration<api::Execute, types::RefundsData, types::RefundsRespon
 
     fn get_error_response(
         &self,
-        res: Bytes,
+        res: Response,
     ) -> CustomResult<ErrorResponse, errors::ConnectorError> {
         self.build_error_response(res)
     }
@@ -576,7 +577,7 @@ impl ConnectorIntegration<api::RSync, types::RefundsData, types::RefundsResponse
 
     fn get_error_response(
         &self,
-        res: Bytes,
+        res: Response,
     ) -> CustomResult<ErrorResponse, errors::ConnectorError> {
         self.build_error_response(res)
     }

--- a/crates/router/src/core/errors/api_error_response.rs
+++ b/crates/router/src/core/errors/api_error_response.rs
@@ -11,6 +11,7 @@ pub enum ErrorType {
     ServerNotAvailable,
     DuplicateRequest,
     ValidationError,
+    ConnectorError,
 }
 
 #[allow(dead_code)]
@@ -134,6 +135,8 @@ pub enum ApiErrorResponse {
     MandateValidationFailed { reason: String },
     #[error(error_type = ErrorType::ServerNotAvailable, code = "IR_00", message = "This API is under development and will be made available soon.")]
     NotImplemented,
+    #[error(error_type = ErrorType::ConnectorError, code = "RE_00", message = "{message}")]
+    ExternalConnectorError { message: String, status_code: u16 },
 }
 
 impl ::core::fmt::Display for ApiErrorResponse {
@@ -154,6 +157,9 @@ impl actix_web::ResponseError for ApiErrorResponse {
             Self::Unauthorized | Self::InvalidEphermeralKey | Self::InvalidJwtToken => {
                 StatusCode::UNAUTHORIZED
             } // 401
+            Self::ExternalConnectorError { status_code, .. } => {
+                StatusCode::from_u16(*status_code).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR)
+            }
             Self::InvalidRequestUrl => StatusCode::NOT_FOUND, // 404
             Self::InvalidHttpMethod => StatusCode::METHOD_NOT_ALLOWED, // 405
             Self::MissingRequiredField { .. } | Self::InvalidDataValue { .. } => {

--- a/crates/router/src/core/errors/api_error_response.rs
+++ b/crates/router/src/core/errors/api_error_response.rs
@@ -135,7 +135,7 @@ pub enum ApiErrorResponse {
     MandateValidationFailed { reason: String },
     #[error(error_type = ErrorType::ServerNotAvailable, code = "IR_00", message = "This API is under development and will be made available soon.")]
     NotImplemented,
-    #[error(error_type = ErrorType::ConnectorError, code = "RE_00", message = "{message}")]
+    #[error(error_type = ErrorType::ConnectorError, code = "RE_00", message = "{message}", ignore = "status_code")]
     ExternalConnectorError { message: String, status_code: u16 },
 }
 

--- a/crates/router/src/core/payments/operations/payment_response.rs
+++ b/crates/router/src/core/payments/operations/payment_response.rs
@@ -275,5 +275,12 @@ async fn payment_response_update_tracker<F: Clone, T>(
         .await
         .map_err(|error| error.to_not_found_response(errors::ApiErrorResponse::PaymentNotFound))?;
 
+    router_data.response.map_err(|error_response| {
+        errors::ApiErrorResponse::ExternalConnectorError {
+            message: error_response.message,
+            status_code: 500,
+        }
+    })?;
+
     Ok(payment_data)
 }

--- a/crates/router/src/services/api.rs
+++ b/crates/router/src/services/api.rs
@@ -4,7 +4,6 @@ pub(crate) mod request;
 use std::{collections::HashMap, fmt::Debug, future::Future, str, time::Instant};
 
 use actix_web::{body, HttpRequest, HttpResponse, Responder};
-use bytes::Bytes;
 use error_stack::{report, IntoReport, Report, ResultExt};
 use masking::ExposeOptionInterface;
 use router_env::{instrument, tracing, Tag};
@@ -101,7 +100,7 @@ pub trait ConnectorIntegration<T, Req, Resp>: ConnectorIntegrationAny<T, Req, Re
 
     fn get_error_response(
         &self,
-        _res: Bytes,
+        _res: types::Response,
     ) -> CustomResult<ErrorResponse, errors::ConnectorError> {
         Ok(ErrorResponse::get_not_implemented())
     }
@@ -164,8 +163,7 @@ where
                             let response = match body {
                                 Ok(body) => connector_integration.handle_response(req, body)?,
                                 Err(body) => {
-                                    let error =
-                                        connector_integration.get_error_response(body.response)?;
+                                    let error = connector_integration.get_error_response(body)?;
                                     router_data.response = Err(error);
 
                                     router_data

--- a/crates/router/src/types.rs
+++ b/crates/router/src/types.rs
@@ -287,6 +287,7 @@ pub struct ErrorResponse {
     pub code: String,
     pub message: String,
     pub reason: Option<String>,
+    pub status_code: u16,
 }
 
 impl ErrorResponse {
@@ -295,6 +296,7 @@ impl ErrorResponse {
             code: errors::ApiErrorResponse::NotImplemented.error_code(),
             message: errors::ApiErrorResponse::NotImplemented.error_message(),
             reason: None,
+            status_code: http::StatusCode::INTERNAL_SERVER_ERROR.as_u16(),
         }
     }
 }
@@ -305,6 +307,10 @@ impl From<errors::ApiErrorResponse> for ErrorResponse {
             code: error.error_code(),
             message: error.error_message(),
             reason: None,
+            status_code: match error {
+                errors::ApiErrorResponse::ExternalConnectorError { status_code, .. } => status_code,
+                _ => 500,
+            },
         }
     }
 }

--- a/crates/router/src/types/api.rs
+++ b/crates/router/src/types/api.rs
@@ -9,7 +9,6 @@ pub mod webhooks;
 
 use std::{fmt::Debug, str::FromStr};
 
-use bytes::Bytes;
 use error_stack::{report, IntoReport, ResultExt};
 
 pub use self::{admin::*, customers::*, payment_methods::*, payments::*, refunds::*, webhooks::*};
@@ -49,9 +48,10 @@ pub trait ConnectorCommon {
     /// common error response for a connector if it is same in all case
     fn build_error_response(
         &self,
-        _res: Bytes,
+        res: types::Response,
     ) -> CustomResult<ErrorResponse, errors::ConnectorError> {
         Ok(ErrorResponse {
+            status_code: res.status_code,
             code: consts::NO_ERROR_CODE.to_string(),
             message: consts::NO_ERROR_MESSAGE.to_string(),
             reason: None,

--- a/crates/router_derive/src/macros/api_error.rs
+++ b/crates/router_derive/src/macros/api_error.rs
@@ -189,7 +189,8 @@ fn implement_serialize(
         // Safety: Missing attributes are already checked before this function is called.
         #[allow(clippy::unwrap_used)]
         let error_message = properties.message.as_ref().unwrap();
-        let msg_unused_fields = get_unused_fields(&variant.fields, &error_message.value());
+        let msg_unused_fields =
+            get_unused_fields(&variant.fields, &error_message.value(), &properties.ignore);
 
         // Safety: Missing attributes are already checked before this function is called.
         #[allow(clippy::unwrap_used)]

--- a/crates/router_derive/src/macros/api_error/helpers.rs
+++ b/crates/router_derive/src/macros/api_error/helpers.rs
@@ -14,6 +14,7 @@ mod keyword {
     custom_keyword!(error_type);
     custom_keyword!(code);
     custom_keyword!(message);
+    custom_keyword!(ignore);
 }
 
 enum EnumMeta {
@@ -107,6 +108,10 @@ enum VariantMeta {
         keyword: keyword::message,
         value: LitStr,
     },
+    Ignore {
+        keyword: keyword::ignore,
+        value: LitStr,
+    },
 }
 
 impl Parse for VariantMeta {
@@ -127,6 +132,11 @@ impl Parse for VariantMeta {
             let _: Token![=] = input.parse()?;
             let value = input.parse()?;
             Ok(Self::Message { keyword, value })
+        } else if lookahead.peek(keyword::ignore) {
+            let keyword = input.parse()?;
+            let _: Token![=] = input.parse()?;
+            let value = input.parse()?;
+            Ok(Self::Ignore { keyword, value })
         } else {
             Err(lookahead.error())
         }
@@ -139,6 +149,7 @@ impl Spanned for VariantMeta {
             Self::ErrorType { keyword, .. } => keyword.span,
             Self::Code { keyword, .. } => keyword.span,
             Self::Message { keyword, .. } => keyword.span,
+            Self::Ignore { keyword, .. } => keyword.span,
         }
     }
 }
@@ -163,6 +174,7 @@ pub(super) struct ErrorVariantProperties {
     pub error_type: Option<TypePath>,
     pub code: Option<LitStr>,
     pub message: Option<LitStr>,
+    pub ignore: std::collections::HashSet<String>,
 }
 
 impl HasErrorVariantProperties for Variant {
@@ -172,6 +184,7 @@ impl HasErrorVariantProperties for Variant {
         let mut error_type_keyword = None;
         let mut code_keyword = None;
         let mut message_keyword = None;
+        let mut ignore_keyword = None;
         for meta in self.get_metadata()? {
             match meta {
                 VariantMeta::ErrorType { keyword, value } => {
@@ -197,6 +210,18 @@ impl HasErrorVariantProperties for Variant {
 
                     message_keyword = Some(keyword);
                     output.message = Some(value);
+                }
+                VariantMeta::Ignore { keyword, value } => {
+                    if let Some(first_keyword) = ignore_keyword {
+                        return Err(occurrence_error(first_keyword, keyword, "ignore"));
+                    }
+                    ignore_keyword = Some(keyword);
+                    output.ignore = value
+                        .value()
+                        .replace(' ', "")
+                        .split(',')
+                        .map(ToString::to_string)
+                        .collect();
                 }
             }
         }
@@ -227,11 +252,25 @@ pub(super) fn check_missing_attributes(
 }
 
 /// Get all the fields not used in the error message.
-pub(super) fn get_unused_fields(fields: &Fields, message: &str) -> Vec<Field> {
+pub(super) fn get_unused_fields(
+    fields: &Fields,
+    message: &str,
+    ignore: &std::collections::HashSet<String>,
+) -> Vec<Field> {
     let fields = match fields {
         syn::Fields::Unit => Vec::new(),
         syn::Fields::Unnamed(_) => Vec::new(),
-        syn::Fields::Named(fields) => fields.named.iter().cloned().collect(),
+        syn::Fields::Named(fields) => fields
+            .named
+            .iter()
+            .filter(|field| {
+                field
+                    .ident
+                    .as_ref()
+                    .map_or(true, |idn| ignore.contains(&idn.to_string()))
+            })
+            .cloned()
+            .collect(),
     };
 
     fields
@@ -245,3 +284,8 @@ pub(super) fn get_unused_fields(fields: &Fields, message: &str) -> Vec<Field> {
         .cloned()
         .collect()
 }
+
+// fn allow_field(ident: &Ident) -> bool {
+//     // This will allow fields with underscore at the end to be hidden during serialization
+//     !ident.to_string().ends_with("_")
+// }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
This PR introduces `ExternalConnectorError` into `ApiErrorResponse` which allows for status code propagation and providing error when a payment is failed

If a payment is failed from the connector side, an error in the standard error format will be displayed with 
<img width="1022" alt="Screenshot 2023-01-19 at 12 41 17 AM" src="https://user-images.githubusercontent.com/51093026/213272660-6dfc9e7b-0bca-469d-864f-d6985896804c.png">

Here, the error is in the format
```rust
errors::ApiErrorResponse::ExternalConnectorError {
 	message: "card details verification failed".to_string(),
    status_code: 500,
}
```
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!-- 
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
