### PR TITLE
refactor(stripe): use bearer explictly when calling connectors

### DIFF
--- a/crates/router/src/connector/checkout.rs
+++ b/crates/router/src/connector/checkout.rs
@@ -42,7 +42,10 @@ impl ConnectorCommon for Checkout {
         let auth: checkout::CheckoutAuthType = auth_type
             .try_into()
             .change_context(errors::ConnectorError::FailedToObtainAuthType)?;
-        Ok(vec![(headers::AUTHORIZATION.to_string(), auth.api_key)])
+        Ok(vec![(
+            headers::AUTHORIZATION.to_string(),
+            format!("Bearer {}", auth.api_key),
+        )])
     }
 
     fn base_url<'a>(&self, connectors: &'a settings::Connectors) -> &'a str {
@@ -363,6 +366,7 @@ impl
         &self,
         res: Bytes,
     ) -> CustomResult<types::ErrorResponse, errors::ConnectorError> {
+        logger::debug!(checkout_error_response=?res);
         let response: checkout::ErrorResponse = res
             .parse_struct("ErrorResponse")
             .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;

--- a/crates/router/src/connector/stripe.rs
+++ b/crates/router/src/connector/stripe.rs
@@ -47,7 +47,10 @@ impl ConnectorCommon for Stripe {
         let auth: stripe::StripeAuthType = auth_type
             .try_into()
             .change_context(errors::ConnectorError::FailedToObtainAuthType)?;
-        Ok(vec![(headers::AUTHORIZATION.to_string(), auth.api_key)])
+        Ok(vec![(
+            headers::AUTHORIZATION.to_string(),
+            format!("Bearer {}", auth.api_key),
+        )])
     }
 }
 


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Refactoring

## Description
<!-- Describe your changes in detail -->
This PR will refactor `stripe` and `checkout` request to send the token as `Bearer` instead of asking merchant to add the token type while creating the token.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
Instead of requesting the merchant to provide this information for a connector, since we have all information of how to send a request to connector, it is better if this is done in the code.


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
- Create a connector account with just the api key, without token type ( Bearer or Basic added )
![Screenshot 2023-01-19 at 11 33 15 AM](https://user-images.githubusercontent.com/48803246/213367582-7caf954b-6d2c-4f0b-9e4f-eccbb36d6a8e.png)

- Create a payment
![Screenshot 2023-01-19 at 11 35 04 AM](https://user-images.githubusercontent.com/48803246/213367848-83bd81fd-c16e-4f23-a103-e4e06244e113.png)


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
