### PR TITLE
fix(router): fix incorrect order of routing_algorithm and metadata fields in db models

### DIFF
--- a/crates/storage_models/src/merchant_account.rs
+++ b/crates/storage_models/src/merchant_account.rs
@@ -21,8 +21,8 @@ pub struct MerchantAccount {
     pub publishable_key: Option<String>,
     pub storage_scheme: storage_enums::MerchantStorageScheme,
     pub locker_id: Option<String>,
-    pub metadata: Option<serde_json::Value>,
     pub routing_algorithm: Option<serde_json::Value>,
+    pub metadata: Option<serde_json::Value>,
 }
 
 #[derive(Clone, Debug, Default, Insertable, router_derive::DebugAsDisplay)]
@@ -41,8 +41,8 @@ pub struct MerchantAccountNew {
     pub redirect_to_merchant_with_http_post: Option<bool>,
     pub publishable_key: Option<String>,
     pub locker_id: Option<String>,
-    pub metadata: Option<serde_json::Value>,
     pub routing_algorithm: Option<serde_json::Value>,
+    pub metadata: Option<serde_json::Value>,
 }
 
 #[derive(Debug)]
@@ -61,8 +61,8 @@ pub enum MerchantAccountUpdate {
         redirect_to_merchant_with_http_post: Option<bool>,
         publishable_key: Option<String>,
         locker_id: Option<String>,
-        metadata: Option<serde_json::Value>,
         routing_algorithm: Option<serde_json::Value>,
+        metadata: Option<serde_json::Value>,
     },
 }
 
@@ -82,8 +82,8 @@ pub struct MerchantAccountUpdateInternal {
     redirect_to_merchant_with_http_post: Option<bool>,
     publishable_key: Option<String>,
     locker_id: Option<String>,
-    metadata: Option<serde_json::Value>,
     routing_algorithm: Option<serde_json::Value>,
+    metadata: Option<serde_json::Value>,
 }
 
 impl From<MerchantAccountUpdate> for MerchantAccountUpdateInternal {

--- a/crates/storage_models/src/schema.rs
+++ b/crates/storage_models/src/schema.rs
@@ -158,8 +158,8 @@ diesel::table! {
         publishable_key -> Nullable<Varchar>,
         storage_scheme -> MerchantStorageScheme,
         locker_id -> Nullable<Varchar>,
-        metadata -> Nullable<Jsonb>,
         routing_algorithm -> Nullable<Json>,
+        metadata -> Nullable<Jsonb>,
     }
 }
 


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
Running the latest migrations causes the `routing_algorithm` and `metadata` fields to go out of order in `schema.rs` w.r.t the DB models. This PR fixes that.


### Additional Changes
- [x] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!-- 
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->
- [schema.rs](https://github.com/juspay/hyperswitch/blob/d776c0a9f18f29207109dc454918f70f32453607/crates/storage_models/src/schema.rs)
- [merchant_account.rs](https://github.com/juspay/hyperswitch/blob/d776c0a9f18f29207109dc454918f70f32453607/crates/storage_models/src/merchant_account.rs)

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
The field ordering in `schema.rs` table definition and the actual db type should be identical.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
compiler-guided + stripe payments. Earlier it used to error out.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
