### PR TITLE
fix(aci,braintree,rapyd,stripe): URL encode request params instead of JSON

### DIFF
--- a/crates/router/src/connector/aci.rs
+++ b/crates/router/src/connector/aci.rs
@@ -228,11 +228,9 @@ impl
         &self,
         req: &types::PaymentsAuthorizeRouterData,
     ) -> CustomResult<Option<String>, errors::ConnectorError> {
-        let connector_req = aci::AciPaymentsRequest::try_from(req)?;
         // encode only for for urlencoded things.
-        let aci_req =
-            utils::Encode::<aci::AciPaymentsRequest>::encode_to_string_of_json(&connector_req)
-                .change_context(errors::ConnectorError::RequestEncodingFailed)?;
+        let aci_req = utils::Encode::<aci::AciPaymentsRequest>::convert_and_url_encode(req)
+            .change_context(errors::ConnectorError::RequestEncodingFailed)?;
         logger::debug!(aci_payment_logs=?aci_req);
         Ok(Some(aci_req))
     }
@@ -343,10 +341,8 @@ impl
         &self,
         req: &types::PaymentsCancelRouterData,
     ) -> CustomResult<Option<String>, errors::ConnectorError> {
-        let connector_req = aci::AciCancelRequest::try_from(req)?;
-        let aci_req =
-            utils::Encode::<aci::AciCancelRequest>::encode_to_string_of_json(&connector_req)
-                .change_context(errors::ConnectorError::RequestEncodingFailed)?;
+        let aci_req = utils::Encode::<aci::AciCancelRequest>::convert_and_url_encode(req)
+            .change_context(errors::ConnectorError::RequestEncodingFailed)?;
         Ok(Some(aci_req))
     }
     fn build_request(
@@ -450,8 +446,7 @@ impl services::ConnectorIntegration<api::Execute, types::RefundsData, types::Ref
         &self,
         req: &types::RefundsRouterData<api::Execute>,
     ) -> CustomResult<Option<String>, errors::ConnectorError> {
-        let connector_req = aci::AciRefundRequest::try_from(req)?;
-        let body = utils::Encode::<aci::AciRefundRequest>::encode_to_string_of_json(&connector_req)
+        let body = utils::Encode::<aci::AciRefundRequest>::convert_and_url_encode(req)
             .change_context(errors::ConnectorError::RequestEncodingFailed)?;
         Ok(Some(body))
     }

--- a/crates/router/src/connector/braintree.rs
+++ b/crates/router/src/connector/braintree.rs
@@ -137,12 +137,9 @@ impl
         &self,
         req: &types::PaymentsSessionRouterData,
     ) -> CustomResult<Option<String>, errors::ConnectorError> {
-        let connector_req = braintree::BraintreeSessionRequest::try_from(req)?;
         let braintree_session_request =
-            utils::Encode::<braintree::BraintreeSessionRequest>::encode_to_string_of_json(
-                &connector_req,
-            )
-            .change_context(errors::ConnectorError::RequestEncodingFailed)?;
+            utils::Encode::<braintree::BraintreeSessionRequest>::convert_and_url_encode(req)
+                .change_context(errors::ConnectorError::RequestEncodingFailed)?;
 
         logger::debug!(?braintree_session_request);
         Ok(Some(braintree_session_request))
@@ -360,12 +357,9 @@ impl
         &self,
         req: &types::PaymentsAuthorizeRouterData,
     ) -> CustomResult<Option<String>, errors::ConnectorError> {
-        let connector_req = braintree::BraintreePaymentsRequest::try_from(req)?;
         let braintree_req =
-            utils::Encode::<braintree::BraintreePaymentsRequest>::encode_to_string_of_json(
-                &connector_req,
-            )
-            .change_context(errors::ConnectorError::RequestEncodingFailed)?;
+            utils::Encode::<braintree::BraintreePaymentsRequest>::convert_and_url_encode(req)
+                .change_context(errors::ConnectorError::RequestEncodingFailed)?;
         Ok(Some(braintree_req))
     }
 
@@ -560,12 +554,9 @@ impl services::ConnectorIntegration<api::Execute, types::RefundsData, types::Ref
         &self,
         req: &types::RefundsRouterData<api::Execute>,
     ) -> CustomResult<Option<String>, errors::ConnectorError> {
-        let connector_req = braintree::BraintreeRefundRequest::try_from(req)?;
         let braintree_req =
-            utils::Encode::<braintree::BraintreeRefundRequest>::encode_to_string_of_json(
-                &connector_req,
-            )
-            .change_context(errors::ConnectorError::RequestEncodingFailed)?;
+            utils::Encode::<braintree::BraintreeRefundRequest>::convert_and_url_encode(req)
+                .change_context(errors::ConnectorError::RequestEncodingFailed)?;
         Ok(Some(braintree_req))
     }
 

--- a/crates/router/src/connector/rapyd.rs
+++ b/crates/router/src/connector/rapyd.rs
@@ -146,10 +146,8 @@ impl
         &self,
         req: &types::PaymentsAuthorizeRouterData,
     ) -> CustomResult<Option<String>, errors::ConnectorError> {
-        let connector_req = rapyd::RapydPaymentsRequest::try_from(req)?;
-        let rapyd_req =
-            utils::Encode::<rapyd::RapydPaymentsRequest>::encode_to_string_of_json(&connector_req)
-                .change_context(errors::ConnectorError::RequestEncodingFailed)?;
+        let rapyd_req = utils::Encode::<rapyd::RapydPaymentsRequest>::convert_and_url_encode(req)
+            .change_context(errors::ConnectorError::RequestEncodingFailed)?;
         Ok(Some(rapyd_req))
     }
 
@@ -377,10 +375,8 @@ impl
         &self,
         req: &types::PaymentsCaptureRouterData,
     ) -> CustomResult<Option<String>, errors::ConnectorError> {
-        let connector_req = rapyd::CaptureRequest::try_from(req)?;
-        let rapyd_req =
-            utils::Encode::<rapyd::CaptureRequest>::encode_to_string_of_json(&connector_req)
-                .change_context(errors::ConnectorError::RequestEncodingFailed)?;
+        let rapyd_req = utils::Encode::<rapyd::CaptureRequest>::convert_and_url_encode(req)
+            .change_context(errors::ConnectorError::RequestEncodingFailed)?;
         Ok(Some(rapyd_req))
     }
 

--- a/crates/router/src/connector/stripe.rs
+++ b/crates/router/src/connector/stripe.rs
@@ -121,10 +121,8 @@ impl
         &self,
         req: &types::PaymentsCaptureRouterData,
     ) -> CustomResult<Option<String>, errors::ConnectorError> {
-        let connector_req = stripe::CaptureRequest::try_from(req)?;
-        let stripe_req =
-            utils::Encode::<stripe::CaptureRequest>::encode_to_string_of_json(&connector_req)
-                .change_context(errors::ConnectorError::RequestEncodingFailed)?;
+        let stripe_req = utils::Encode::<stripe::CaptureRequest>::convert_and_url_encode(req)
+            .change_context(errors::ConnectorError::RequestEncodingFailed)?;
         Ok(Some(stripe_req))
     }
 
@@ -335,10 +333,8 @@ impl
         &self,
         req: &types::PaymentsAuthorizeRouterData,
     ) -> CustomResult<Option<String>, errors::ConnectorError> {
-        let connector_req = stripe::PaymentIntentRequest::try_from(req)?;
-        let stripe_req =
-            utils::Encode::<stripe::PaymentIntentRequest>::encode_to_string_of_json(&connector_req)
-                .change_context(errors::ConnectorError::RequestEncodingFailed)?;
+        let stripe_req = utils::Encode::<stripe::PaymentIntentRequest>::convert_and_url_encode(req)
+            .change_context(errors::ConnectorError::RequestEncodingFailed)?;
         Ok(Some(stripe_req))
     }
 
@@ -449,12 +445,10 @@ impl
         &self,
         req: &types::PaymentsCancelRouterData,
     ) -> CustomResult<Option<String>, errors::ConnectorError> {
-        let connector_req = stripe::CancelRequest::try_from(req)?;
-        let stripe_req =
-            utils::Encode::<stripe::CancelRequest>::encode_to_string_of_json(&connector_req)
-                .change_context(errors::ConnectorError::RequestEncodingFailedWithReason(
-                    "Invalid cancellation reason".to_string(),
-                ))?;
+        let stripe_req = utils::Encode::<stripe::CancelRequest>::convert_and_url_encode(req)
+            .change_context(errors::ConnectorError::RequestEncodingFailedWithReason(
+                "Invalid cancellation reason".to_string(),
+            ))?;
         Ok(Some(stripe_req))
     }
 
@@ -566,10 +560,8 @@ impl
         &self,
         req: &types::RouterData<api::Verify, types::VerifyRequestData, types::PaymentsResponseData>,
     ) -> CustomResult<Option<String>, errors::ConnectorError> {
-        let connector_req = stripe::SetupIntentRequest::try_from(req)?;
-        let stripe_req =
-            utils::Encode::<stripe::SetupIntentRequest>::encode_to_string_of_json(&connector_req)
-                .change_context(errors::ConnectorError::RequestEncodingFailed)?;
+        let stripe_req = utils::Encode::<stripe::SetupIntentRequest>::convert_and_url_encode(req)
+            .change_context(errors::ConnectorError::RequestEncodingFailed)?;
         Ok(Some(stripe_req))
     }
 
@@ -682,10 +674,8 @@ impl services::ConnectorIntegration<api::Execute, types::RefundsData, types::Ref
         &self,
         req: &types::RefundsRouterData<api::Execute>,
     ) -> CustomResult<Option<String>, errors::ConnectorError> {
-        let connector_req = stripe::RefundRequest::try_from(req)?;
-        let stripe_req =
-            utils::Encode::<stripe::RefundRequest>::encode_to_string_of_json(&connector_req)
-                .change_context(errors::ConnectorError::RequestEncodingFailed)?;
+        let stripe_req = utils::Encode::<stripe::RefundRequest>::convert_and_url_encode(req)
+            .change_context(errors::ConnectorError::RequestEncodingFailed)?;
         Ok(Some(stripe_req))
     }
 


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
For connector aci, Braintree, rapyd, stripe request encoding should be done using "convert_and_url_encode".


### Additional Changes

- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!-- 
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
Fix for connector requests url encoding.


## How did you test it?
No tests available.


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
