### PR TITLE
fix(checkout): status mapping for payment

### DIFF
--- a/crates/router/src/connector/checkout.rs
+++ b/crates/router/src/connector/checkout.rs
@@ -279,6 +279,7 @@ impl
         &self,
         res: types::Response,
     ) -> CustomResult<types::ErrorResponse, errors::ConnectorError> {
+        logger::debug!(raw_response=?res);
         let response: checkout::ErrorResponse = res
             .response
             .parse_struct("ErrorResponse")
@@ -368,11 +369,11 @@ impl
         data: &types::PaymentsAuthorizeRouterData,
         res: types::Response,
     ) -> CustomResult<types::PaymentsAuthorizeRouterData, errors::ConnectorError> {
+        logger::debug!(payments_create_response=?res);
         let response: checkout::PaymentsResponse = res
             .response
             .parse_struct("PaymentIntentResponse")
             .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
-        logger::debug!(payments_create_response=?response);
         types::RouterData::try_from(types::ResponseRouterData {
             response,
             data: data.clone(),
@@ -470,12 +471,13 @@ impl
         data: &types::PaymentsCancelRouterData,
         res: types::Response,
     ) -> CustomResult<types::PaymentsCancelRouterData, errors::ConnectorError> {
+        logger::debug!(payments_create_response=?res);
+
         let mut response: checkout::PaymentVoidResponse = res
             .response
             .parse_struct("PaymentVoidResponse")
             .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
         response.status = res.status_code;
-        logger::debug!(payments_create_response=?response);
         types::RouterData::try_from(types::ResponseRouterData {
             response,
             data: data.clone(),

--- a/crates/router/src/connector/checkout.rs
+++ b/crates/router/src/connector/checkout.rs
@@ -471,7 +471,7 @@ impl
         data: &types::PaymentsCancelRouterData,
         res: types::Response,
     ) -> CustomResult<types::PaymentsCancelRouterData, errors::ConnectorError> {
-        logger::debug!(payments_create_response=?res);
+        logger::debug!(payments_cancel_response=?res);
 
         let mut response: checkout::PaymentVoidResponse = res
             .response

--- a/crates/router/src/connector/checkout/transformers.rs
+++ b/crates/router/src/connector/checkout/transformers.rs
@@ -140,6 +140,34 @@ pub enum CheckoutPaymentStatus {
     Captured,
 }
 
+impl From<transformers::Foreign<(CheckoutPaymentStatus, Option<enums::CaptureMethod>)>>
+    for transformers::Foreign<enums::AttemptStatus>
+{
+    fn from(
+        item: transformers::Foreign<(CheckoutPaymentStatus, Option<enums::CaptureMethod>)>,
+    ) -> Self {
+        let item = item.0;
+        let status = item.0;
+        let capture_method = item.1;
+        match status {
+            CheckoutPaymentStatus::Authorized => {
+                if capture_method == Some(enums::CaptureMethod::Automatic)
+                    || capture_method.is_none()
+                {
+                    enums::AttemptStatus::Charged
+                } else {
+                    enums::AttemptStatus::Authorized
+                }
+            }
+            CheckoutPaymentStatus::Captured => enums::AttemptStatus::Charged,
+            CheckoutPaymentStatus::Declined => enums::AttemptStatus::Failure,
+            CheckoutPaymentStatus::Pending => enums::AttemptStatus::AuthenticationPending,
+            CheckoutPaymentStatus::CardVerified => enums::AttemptStatus::Pending,
+        }
+        .into()
+    }
+}
+
 impl From<transformers::Foreign<(CheckoutPaymentStatus, Balances)>>
     for transformers::Foreign<enums::AttemptStatus>
 {
@@ -215,7 +243,7 @@ impl TryFrom<types::PaymentsResponseRouterData<PaymentsResponse>>
         Ok(Self {
             status: enums::AttemptStatus::foreign_from((
                 item.response.status,
-                item.response.balances,
+                item.data.request.capture_method,
             )),
             response: Ok(types::PaymentsResponseData::TransactionResponse {
                 resource_id: types::ResponseId::ConnectorTransactionId(item.response.id),

--- a/crates/router/src/connector/checkout/transformers.rs
+++ b/crates/router/src/connector/checkout/transformers.rs
@@ -147,8 +147,7 @@ impl From<transformers::Foreign<(CheckoutPaymentStatus, Option<enums::CaptureMet
         item: transformers::Foreign<(CheckoutPaymentStatus, Option<enums::CaptureMethod>)>,
     ) -> Self {
         let item = item.0;
-        let status = item.0;
-        let capture_method = item.1;
+        let (status, capture_method) = item;
         match status {
             CheckoutPaymentStatus::Authorized => {
                 if capture_method == Some(enums::CaptureMethod::Automatic)


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix

## Description
<!-- Describe your changes in detail -->
This fixes checkout getting `requires_capture` error even after an automatic capture payment.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
Checkout getting `requires_capture` status even in automatic capture because when you make a payment with automatic capture in checkout it will be authorized first and captured few seconds later. So in balances the `amount_to_capture` will not be 0 when we get the response.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
<img width="1337" alt="image" src="https://user-images.githubusercontent.com/43412619/213797465-75a0117a-0050-43d3-aa1c-2c4b0fac82cd.png">


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code