### PR TITLE
feat: add post get tracker for `call_connector`

### DIFF
--- a/crates/common_utils/src/ext_traits.rs
+++ b/crates/common_utils/src/ext_traits.rs
@@ -303,7 +303,7 @@ pub trait AsyncExt<A, B> {
 }
 
 #[async_trait::async_trait]
-impl<A: Send, B, E: Send> AsyncExt<A, B> for Result<A, E> {
+impl<A: Send + Sync, B, E: Send> AsyncExt<A, B> for Result<A, E> {
     type WrappedSelf<T> = Result<T, E>;
     async fn async_and_then<F, Fut>(self, func: F) -> Self::WrappedSelf<B>
     where
@@ -329,7 +329,7 @@ impl<A: Send, B, E: Send> AsyncExt<A, B> for Result<A, E> {
 }
 
 #[async_trait::async_trait]
-impl<A: Send, B> AsyncExt<A, B> for Option<A> {
+impl<A: Send + Sync, B> AsyncExt<A, B> for Option<A> {
     type WrappedSelf<T> = Option<T>;
     async fn async_and_then<F, Fut>(self, func: F) -> Self::WrappedSelf<B>
     where

--- a/crates/common_utils/src/ext_traits.rs
+++ b/crates/common_utils/src/ext_traits.rs
@@ -303,7 +303,7 @@ pub trait AsyncExt<A, B> {
 }
 
 #[async_trait::async_trait]
-impl<A: Send + Sync, B, E: Send> AsyncExt<A, B> for Result<A, E> {
+impl<A: Send, B, E: Send> AsyncExt<A, B> for Result<A, E> {
     type WrappedSelf<T> = Result<T, E>;
     async fn async_and_then<F, Fut>(self, func: F) -> Self::WrappedSelf<B>
     where
@@ -329,7 +329,7 @@ impl<A: Send + Sync, B, E: Send> AsyncExt<A, B> for Result<A, E> {
 }
 
 #[async_trait::async_trait]
-impl<A: Send + Sync, B> AsyncExt<A, B> for Option<A> {
+impl<A: Send, B> AsyncExt<A, B> for Option<A> {
     type WrappedSelf<T> = Option<T>;
     async fn async_and_then<F, Fut>(self, func: F) -> Self::WrappedSelf<B>
     where

--- a/crates/router/src/core/payments/operations.rs
+++ b/crates/router/src/core/payments/operations.rs
@@ -62,6 +62,13 @@ pub trait Operation<F: Clone, T>: Send + std::fmt::Debug {
             format!("post connector update tracker not found for {self:?}")
         })
     }
+
+    fn to_post_get_tracker(
+        &self,
+    ) -> RouterResult<&(dyn PostGetTracker<F, PaymentData<F>, T> + Send + Sync)> {
+        Err(report!(errors::ApiErrorResponse::InternalServerError))
+            .attach_printable_lazy(|| format!("post connector get tracker not found for {self:?}"))
+    }
 }
 
 pub struct ValidateResult<'a> {
@@ -155,6 +162,20 @@ pub trait PostUpdateTracker<F, D, R>: Send {
     ) -> RouterResult<D>
     where
         F: 'b + Send;
+}
+
+#[async_trait]
+pub trait PostGetTracker<F, D, R>: Send + Sync {
+    async fn get_tracker<'b>(
+        &'b self,
+        db: &dyn StorageInterface,
+        payment_id: &api::PaymentIdType,
+        payment_data: D,
+        response: &types::RouterData<F, R, PaymentsResponseData>,
+        storage_scheme: enums::MerchantStorageScheme,
+    ) -> RouterResult<(BoxedOperation<'b, F, R>, D)>
+    where
+        F: 'b + Send + Sync;
 }
 
 #[async_trait]

--- a/crates/router/src/core/payments/operations/payment_response.rs
+++ b/crates/router/src/core/payments/operations/payment_response.rs
@@ -2,7 +2,7 @@ use async_trait::async_trait;
 use error_stack::ResultExt;
 use router_derive;
 
-use super::{Operation, PostUpdateTracker};
+use super::{BoxedOperation, Operation, PostGetTracker, PostUpdateTracker};
 use crate::{
     core::{
         errors::{self, RouterResult, StorageErrorExt},
@@ -20,7 +20,7 @@ use crate::{
 
 #[derive(Debug, Clone, Copy, router_derive::PaymentOperation)]
 #[operation(
-    ops = "post_tracker",
+    ops = "post_update_tracker,post_get_tracker",
     flow = "syncdata,authorizedata,canceldata,capturedata,verifydata,sessiondata"
 )]
 pub struct PaymentResponse;
@@ -52,6 +52,25 @@ impl<F: Clone> PostUpdateTracker<F, PaymentData<F>, types::PaymentsAuthorizeData
             .await
     }
 }
+#[async_trait]
+impl<F: Clone> PostGetTracker<F, PaymentData<F>, types::PaymentsAuthorizeData> for PaymentResponse {
+    async fn get_tracker<'b>(
+        &'b self,
+        _db: &dyn StorageInterface,
+        _payment_id: &api::PaymentIdType,
+        payment_data: PaymentData<F>,
+        _response: &types::RouterData<F, types::PaymentsAuthorizeData, types::PaymentsResponseData>,
+        _storage_scheme: enums::MerchantStorageScheme,
+    ) -> RouterResult<(
+        BoxedOperation<'b, F, types::PaymentsAuthorizeData>,
+        PaymentData<F>,
+    )>
+    where
+        F: 'b + Send + Sync,
+    {
+        Ok((Box::new(self), payment_data))
+    }
+}
 
 #[async_trait]
 impl<F: Clone> PostUpdateTracker<F, PaymentData<F>, types::PaymentsSyncData> for PaymentResponse {
@@ -68,6 +87,26 @@ impl<F: Clone> PostUpdateTracker<F, PaymentData<F>, types::PaymentsSyncData> for
     {
         payment_response_update_tracker(db, payment_id, payment_data, response, storage_scheme)
             .await
+    }
+}
+
+#[async_trait]
+impl<F: Clone> PostGetTracker<F, PaymentData<F>, types::PaymentsSyncData> for PaymentResponse {
+    async fn get_tracker<'b>(
+        &'b self,
+        _db: &dyn StorageInterface,
+        _payment_id: &api::PaymentIdType,
+        payment_data: PaymentData<F>,
+        _response: &types::RouterData<F, types::PaymentsSyncData, types::PaymentsResponseData>,
+        _storage_scheme: enums::MerchantStorageScheme,
+    ) -> RouterResult<(
+        BoxedOperation<'b, F, types::PaymentsSyncData>,
+        PaymentData<F>,
+    )>
+    where
+        F: 'b + Send + Sync,
+    {
+        Ok((Box::new(self), payment_data))
     }
 }
 
@@ -92,6 +131,26 @@ impl<F: Clone> PostUpdateTracker<F, PaymentData<F>, types::PaymentsSessionData>
 }
 
 #[async_trait]
+impl<F: Clone> PostGetTracker<F, PaymentData<F>, types::PaymentsSessionData> for PaymentResponse {
+    async fn get_tracker<'b>(
+        &'b self,
+        _db: &dyn StorageInterface,
+        _payment_id: &api::PaymentIdType,
+        payment_data: PaymentData<F>,
+        _response: &types::RouterData<F, types::PaymentsSessionData, types::PaymentsResponseData>,
+        _storage_scheme: enums::MerchantStorageScheme,
+    ) -> RouterResult<(
+        BoxedOperation<'b, F, types::PaymentsSessionData>,
+        PaymentData<F>,
+    )>
+    where
+        F: 'b + Send + Sync,
+    {
+        Ok((Box::new(self), payment_data))
+    }
+}
+
+#[async_trait]
 impl<F: Clone> PostUpdateTracker<F, PaymentData<F>, types::PaymentsCaptureData>
     for PaymentResponse
 {
@@ -110,7 +169,25 @@ impl<F: Clone> PostUpdateTracker<F, PaymentData<F>, types::PaymentsCaptureData>
             .await
     }
 }
-
+#[async_trait]
+impl<F: Clone> PostGetTracker<F, PaymentData<F>, types::PaymentsCaptureData> for PaymentResponse {
+    async fn get_tracker<'b>(
+        &'b self,
+        _db: &dyn StorageInterface,
+        _payment_id: &api::PaymentIdType,
+        payment_data: PaymentData<F>,
+        _response: &types::RouterData<F, types::PaymentsCaptureData, types::PaymentsResponseData>,
+        _storage_scheme: enums::MerchantStorageScheme,
+    ) -> RouterResult<(
+        BoxedOperation<'b, F, types::PaymentsCaptureData>,
+        PaymentData<F>,
+    )>
+    where
+        F: 'b + Send + Sync,
+    {
+        Ok((Box::new(self), payment_data))
+    }
+}
 #[async_trait]
 impl<F: Clone> PostUpdateTracker<F, PaymentData<F>, types::PaymentsCancelData> for PaymentResponse {
     async fn update_tracker<'b>(
@@ -129,7 +206,25 @@ impl<F: Clone> PostUpdateTracker<F, PaymentData<F>, types::PaymentsCancelData> f
             .await
     }
 }
-
+#[async_trait]
+impl<F: Clone> PostGetTracker<F, PaymentData<F>, types::PaymentsCancelData> for PaymentResponse {
+    async fn get_tracker<'b>(
+        &'b self,
+        _db: &dyn StorageInterface,
+        _payment_id: &api::PaymentIdType,
+        payment_data: PaymentData<F>,
+        _response: &types::RouterData<F, types::PaymentsCancelData, types::PaymentsResponseData>,
+        _storage_scheme: enums::MerchantStorageScheme,
+    ) -> RouterResult<(
+        BoxedOperation<'b, F, types::PaymentsCancelData>,
+        PaymentData<F>,
+    )>
+    where
+        F: 'b + Send + Sync,
+    {
+        Ok((Box::new(self), payment_data))
+    }
+}
 #[async_trait]
 impl<F: Clone> PostUpdateTracker<F, PaymentData<F>, types::VerifyRequestData> for PaymentResponse {
     async fn update_tracker<'b>(
@@ -153,7 +248,25 @@ impl<F: Clone> PostUpdateTracker<F, PaymentData<F>, types::VerifyRequestData> fo
             .await
     }
 }
-
+#[async_trait]
+impl<F: Clone> PostGetTracker<F, PaymentData<F>, types::VerifyRequestData> for PaymentResponse {
+    async fn get_tracker<'b>(
+        &'b self,
+        _db: &dyn StorageInterface,
+        _payment_id: &api::PaymentIdType,
+        payment_data: PaymentData<F>,
+        _response: &types::RouterData<F, types::VerifyRequestData, types::PaymentsResponseData>,
+        _storage_scheme: enums::MerchantStorageScheme,
+    ) -> RouterResult<(
+        BoxedOperation<'b, F, types::VerifyRequestData>,
+        PaymentData<F>,
+    )>
+    where
+        F: 'b + Send + Sync,
+    {
+        Ok((Box::new(self), payment_data))
+    }
+}
 async fn payment_response_update_tracker<F: Clone, T>(
     db: &dyn StorageInterface,
     _payment_id: &api::PaymentIdType,

--- a/crates/router/src/db.rs
+++ b/crates/router/src/db.rs
@@ -18,9 +18,11 @@ pub mod reverse_lookup;
 
 use std::sync::Arc;
 
+use common_utils::errors::CustomResult;
+use error_stack::report;
 use futures::lock::Mutex;
 
-use crate::{services::Store, types::storage};
+use crate::{core::errors, services::Store, types::storage};
 
 #[derive(PartialEq, Eq)]
 pub enum StorageImpl {
@@ -53,8 +55,32 @@ pub trait StorageInterface:
     + connector_response::ConnectorResponseInterface
     + reverse_lookup::ReverseLookupInterface
     + 'static
+    + InternalLoader
 {
     async fn close(&mut self) {}
+}
+
+pub trait InternalLoader {
+    fn get_store(&self) -> CustomResult<&Store, errors::StorageError> {
+        Err(report!(errors::StorageError::DatabaseError(report!(
+            storage_models::errors::DatabaseError::Others
+        ))))
+    }
+    fn get_mock_db(&self) -> CustomResult<&MockDb, errors::StorageError> {
+        Err(report!(errors::StorageError::MockDbError))
+    }
+}
+
+impl InternalLoader for Store {
+    fn get_store(&self) -> CustomResult<&Store, errors::StorageError> {
+        Ok(self)
+    }
+}
+
+impl InternalLoader for MockDb {
+    fn get_mock_db(&self) -> CustomResult<&MockDb, errors::StorageError> {
+        Ok(self)
+    }
 }
 
 #[async_trait::async_trait]
@@ -112,7 +138,7 @@ pub async fn get_and_deserialize_key<T>(
     db: &dyn StorageInterface,
     key: &str,
     type_name: &str,
-) -> common_utils::errors::CustomResult<T, redis_interface::errors::RedisError>
+) -> CustomResult<T, errors::RedisError>
 where
     T: serde::de::DeserializeOwned,
 {


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description

This change adds an empty implementation of `PostGetTracker` that is to be executed just before the `PostupdateTracker`. This can be used if a need of performing a request from an external resource arises, (i.e. database)
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!-- 
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
