### PR TITLE
fix: move `connector_refund_id` to request

### DIFF
--- a/crates/router/src/connector/authorizedotnet/transformers.rs
+++ b/crates/router/src/connector/authorizedotnet/transformers.rs
@@ -466,13 +466,18 @@ impl<F> TryFrom<&types::RefundsRouterData<F>> for AuthorizedotnetCreateSyncReque
     type Error = error_stack::Report<errors::ConnectorError>;
 
     fn try_from(item: &types::RefundsRouterData<F>) -> Result<Self, Self::Error> {
-        let transaction_id = item.request.connector_refund_id.clone();
+        let transaction_id = item
+            .request
+            .connector_refund_id
+            .clone()
+            .get_required_value("connector_refund_id")
+            .change_context(errors::ConnectorError::MissingConnectorRefundID)?;
         let merchant_authentication = MerchantAuthentication::try_from(&item.connector_auth_type)?;
 
         let payload = Self {
             get_transaction_details_request: TransactionDetails {
                 merchant_authentication,
-                transaction_id,
+                transaction_id: Some(transaction_id),
             },
         };
         Ok(payload)

--- a/crates/router/src/connector/authorizedotnet/transformers.rs
+++ b/crates/router/src/connector/authorizedotnet/transformers.rs
@@ -466,11 +466,7 @@ impl<F> TryFrom<&types::RefundsRouterData<F>> for AuthorizedotnetCreateSyncReque
     type Error = error_stack::Report<errors::ConnectorError>;
 
     fn try_from(item: &types::RefundsRouterData<F>) -> Result<Self, Self::Error> {
-        let transaction_id = item
-            .response
-            .as_ref()
-            .map(|refund_response_data| refund_response_data.connector_refund_id.clone())
-            .ok();
+        let transaction_id = item.request.connector_refund_id.clone();
         let merchant_authentication = MerchantAuthentication::try_from(&item.connector_auth_type)?;
 
         let payload = Self {

--- a/crates/router/src/connector/checkout.rs
+++ b/crates/router/src/connector/checkout.rs
@@ -673,12 +673,11 @@ impl services::ConnectorIntegration<api::RSync, types::RefundsData, types::Refun
         res: types::Response,
     ) -> CustomResult<types::RefundsRouterData<api::RSync>, errors::ConnectorError> {
         let refund_action_id = data
-            .response
+            .request
+            .connector_refund_id
             .clone()
-            .ok()
-            .get_required_value("response")
-            .change_context(errors::ConnectorError::ResponseDeserializationFailed)?
-            .connector_refund_id;
+            .get_required_value("connector_refund_id")
+            .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
 
         let response: Vec<checkout::ActionResponse> = res
             .response

--- a/crates/router/src/connector/shift4.rs
+++ b/crates/router/src/connector/shift4.rs
@@ -445,12 +445,11 @@ impl ConnectorIntegration<api::RSync, types::RefundsData, types::RefundsResponse
         connectors: &settings::Connectors,
     ) -> CustomResult<String, errors::ConnectorError> {
         let refund_id = req
-            .response
+            .request
+            .connector_refund_id
             .clone()
-            .ok()
-            .get_required_value("response")
-            .change_context(errors::ConnectorError::ResponseDeserializationFailed)?
-            .connector_refund_id;
+            .get_required_value("connector_refund_id")
+            .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
         Ok(format!(
             "{}refunds/{}",
             self.base_url(connectors),

--- a/crates/router/src/connector/stripe.rs
+++ b/crates/router/src/connector/stripe.rs
@@ -779,13 +779,11 @@ impl services::ConnectorIntegration<api::RSync, types::RefundsData, types::Refun
         connectors: &settings::Connectors,
     ) -> CustomResult<String, errors::ConnectorError> {
         let id = req
-            .response
-            .as_ref()
-            .ok()
-            .get_required_value("response")
-            .change_context(errors::ConnectorError::FailedToObtainIntegrationUrl)?
+            .request
             .connector_refund_id
-            .clone();
+            .clone()
+            .get_required_value("connector_refund_id")
+            .change_context(errors::ConnectorError::FailedToObtainIntegrationUrl)?;
         Ok(format!("{}v1/refunds/{}", self.base_url(connectors), id))
     }
 

--- a/crates/router/src/connector/worldline.rs
+++ b/crates/router/src/connector/worldline.rs
@@ -601,13 +601,11 @@ impl ConnectorIntegration<api::RSync, types::RefundsData, types::RefundsResponse
         connectors: &Connectors,
     ) -> CustomResult<String, errors::ConnectorError> {
         let refund_id = req
-            .response
-            .as_ref()
-            .ok()
-            .get_required_value("response")
-            .change_context(errors::ConnectorError::FailedToObtainIntegrationUrl)?
+            .request
             .connector_refund_id
-            .clone();
+            .clone()
+            .get_required_value("connector_refund_id")
+            .change_context(errors::ConnectorError::FailedToObtainIntegrationUrl)?;
         let base_url = self.base_url(connectors);
         let auth: worldline::AuthType = worldline::AuthType::try_from(&req.connector_auth_type)?;
         let merchant_account_id = auth.merchant_account_id;

--- a/crates/router/src/core/errors.rs
+++ b/crates/router/src/core/errors.rs
@@ -237,6 +237,8 @@ pub enum ConnectorError {
     NotImplemented(String),
     #[error("Missing connector transaction ID")]
     MissingConnectorTransactionID,
+    #[error("Missing connector refund ID")]
+    MissingConnectorRefundID,
     #[error("Webhooks not implemented for this connector")]
     WebhooksNotImplemented,
     #[error("Failed to decode webhook event body")]

--- a/crates/router/src/core/refunds.rs
+++ b/crates/router/src/core/refunds.rs
@@ -295,9 +295,11 @@ pub async fn sync_refund_with_gateway(
 
     logger::debug!(refund_retrieve_router_data=?router_data);
 
-    match add_access_token_result.access_token_result {
-        Ok(access_token) => router_data.access_token = access_token,
-        Err(connector_error) => router_data.response = Err(connector_error),
+    if add_access_token_result.connector_supports_access_token {
+        match add_access_token_result.access_token_result {
+            Ok(access_token) => router_data.access_token = access_token,
+            Err(connector_error) => router_data.response = Err(connector_error),
+        }
     }
 
     let router_data_res = if !(add_access_token_result.connector_supports_access_token

--- a/crates/router/src/core/utils.rs
+++ b/crates/router/src/core/utils.rs
@@ -74,6 +74,7 @@ pub async fn construct_refund_router_data<'a, F>(
             amount,
             connector_metadata: payment_attempt.connector_metadata.clone(),
             reason: refund.refund_reason.clone(),
+            connector_refund_id: refund.connector_refund_id.clone(),
         },
 
         response: Ok(types::RefundsResponseData {

--- a/crates/router/src/types.rs
+++ b/crates/router/src/types.rs
@@ -217,6 +217,8 @@ impl ResponseId {
 pub struct RefundsData {
     pub refund_id: String,
     pub connector_transaction_id: String,
+
+    pub connector_refund_id: Option<String>,
     pub currency: storage_enums::Currency,
     /// Amount for the payment against which this refund is issued
     pub amount: i64,

--- a/crates/router/tests/connectors/aci.rs
+++ b/crates/router/tests/connectors/aci.rs
@@ -87,6 +87,7 @@ fn construct_refund_router_data<F>() -> types::RefundsRouterData<F> {
             refund_amount: 100,
             connector_metadata: None,
             reason: None,
+            connector_refund_id: None,
         },
         payment_method_id: None,
         response: Err(types::ErrorResponse::default()),

--- a/crates/router/tests/connectors/authorizedotnet.rs
+++ b/crates/router/tests/connectors/authorizedotnet.rs
@@ -87,6 +87,7 @@ fn construct_refund_router_data<F>() -> types::RefundsRouterData<F> {
             refund_amount: 1,
             connector_metadata: None,
             reason: None,
+            connector_refund_id: None,
         },
         response: Err(types::ErrorResponse::default()),
         payment_method_id: None,

--- a/crates/router/tests/connectors/checkout.rs
+++ b/crates/router/tests/connectors/checkout.rs
@@ -84,6 +84,7 @@ fn construct_refund_router_data<F>() -> types::RefundsRouterData<F> {
             refund_amount: 10,
             connector_metadata: None,
             reason: None,
+            connector_refund_id: None,
         },
         response: Err(types::ErrorResponse::default()),
         payment_method_id: None,

--- a/crates/router/tests/connectors/utils.rs
+++ b/crates/router/tests/connectors/utils.rs
@@ -121,6 +121,7 @@ pub trait ConnectorActions: Connector {
                 refund_amount: 100,
                 connector_metadata: None,
                 reason: None,
+                connector_refund_id: None,
             }),
             payment_info,
         );
@@ -143,6 +144,7 @@ pub trait ConnectorActions: Connector {
                 refund_amount: 100,
                 connector_metadata: None,
                 reason: None,
+                connector_refund_id: None,
             }),
             payment_info,
         );
@@ -307,6 +309,7 @@ impl Default for PaymentRefundType {
             refund_amount: 100,
             connector_metadata: None,
             reason: None,
+            connector_refund_id: None,
         };
         Self(data)
     }


### PR DESCRIPTION


## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description

This change will move the `connector_refund_id` into request while also making the updation of router_data for `access_token` step in refund sync optional for connectors that doesn't support it.

This change resolves a bug where the refund sync was failing for every connector which doesn't have access token
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!-- 
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
This is an sample of refund with connector that needs access_token (i.e. braintree):
<img width="640" alt="Screenshot 2023-01-21 at 9 19 25 PM" src="https://user-images.githubusercontent.com/51093026/213874993-611c6702-80e0-43cf-a15e-41ce1a65e6b6.png">

This the sample output of refund sync for connector that doesn't need access_token (i.e. stripe):
<img width="668" alt="Screenshot 2023-01-21 at 9 21 44 PM" src="https://user-images.githubusercontent.com/51093026/213875087-b144d33c-1c4c-47b1-b3ca-c6415a60ab04.png">

Here both the calls provide identical result as expected with refund sync

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
