### PR TITLE
fix(router): fix refund error code diesel field ordering

### DIFF
--- a/crates/storage_models/src/refund.rs
+++ b/crates/storage_models/src/refund.rs
@@ -25,7 +25,6 @@ pub struct Refund {
     pub refund_status: storage_enums::RefundStatus,
     pub sent_to_gateway: bool,
     pub refund_error_message: Option<String>,
-    pub refund_error_code: Option<String>,
     pub metadata: Option<serde_json::Value>,
     pub refund_arn: Option<String>,
     pub created_at: PrimitiveDateTime,
@@ -33,6 +32,7 @@ pub struct Refund {
     pub description: Option<String>,
     pub attempt_id: String,
     pub refund_reason: Option<String>,
+    pub refund_error_code: Option<String>,
 }
 
 #[derive(
@@ -104,10 +104,10 @@ pub struct RefundUpdateInternal {
     refund_status: Option<storage_enums::RefundStatus>,
     sent_to_gateway: Option<bool>,
     refund_error_message: Option<String>,
-    refund_error_code: Option<String>,
     refund_arn: Option<String>,
     metadata: Option<serde_json::Value>,
     refund_reason: Option<String>,
+    refund_error_code: Option<String>,
 }
 
 impl From<RefundUpdate> for RefundUpdateInternal {

--- a/crates/storage_models/src/schema.rs
+++ b/crates/storage_models/src/schema.rs
@@ -322,7 +322,6 @@ diesel::table! {
         refund_status -> RefundStatus,
         sent_to_gateway -> Bool,
         refund_error_message -> Nullable<Text>,
-        refund_error_code -> Nullable<Varchar>,
         metadata -> Nullable<Json>,
         refund_arn -> Nullable<Varchar>,
         created_at -> Timestamp,
@@ -330,6 +329,7 @@ diesel::table! {
         description -> Nullable<Varchar>,
         attempt_id -> Varchar,
         refund_reason -> Nullable<Varchar>,
+        refund_error_code -> Nullable<Text>,
     }
 }
 


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->
With the latest migration adding a `refund_error_code` field, the ordering of the fields in `schema.rs` was not the same as in the storage model. This PR fixes that.

### Additional Changes

- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!-- 
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
Diesel expects the field ordering of the `schema.rs` table definition and the storage model to be identical.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
compiler-guided.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
