### PR TITLE
fix: payment_method_id not populated

### DIFF
--- a/crates/router/src/core/payment_methods/cards.rs
+++ b/crates/router/src/core/payment_methods/cards.rs
@@ -280,8 +280,8 @@ pub async fn mock_delete_card<'a>(
         .await
         .change_context(errors::VaultError::FetchCardFailed)?;
     Ok(payment_methods::DeleteCardResponse {
-        card_id: locker_mock_up.card_id,
-        external_id: locker_mock_up.external_id,
+        card_id: Some(locker_mock_up.card_id),
+        external_id: Some(locker_mock_up.external_id),
         card_isin: None,
         status: "SUCCESS".to_string(),
     })

--- a/crates/router/src/core/payment_methods/transformers.rs
+++ b/crates/router/src/core/payment_methods/transformers.rs
@@ -57,8 +57,8 @@ pub struct GetCardResponse {
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DeleteCardResponse {
-    pub card_id: String,
-    pub external_id: String,
+    pub card_id: Option<String>,
+    pub external_id: Option<String>,
     pub card_isin: Option<Secret<String>>,
     pub status: String,
 }

--- a/crates/router/src/core/payment_methods/vault.rs
+++ b/crates/router/src/core/payment_methods/vault.rs
@@ -91,7 +91,7 @@ impl Vaultable for api::CCard {
 
         let supp_data = SupplementaryVaultData {
             customer_id: value2.customer_id,
-            payment_method_id: None,
+            payment_method_id: value2.payment_method_id,
         };
 
         Ok((card, supp_data))


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
After the card detail are fetched from basilisk, payment_method_id is not set, modified DeleteCardResponse from legacy locker getting parsing error


### Additional Changes

- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!-- 
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
we can test it on sbx only


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
