### PR TITLE
fix(connector): fix globalpay error handling

### DIFF
--- a/crates/router/src/connector/cybersource/transformers.rs
+++ b/crates/router/src/connector/cybersource/transformers.rs
@@ -226,7 +226,7 @@ impl TryFrom<&types::ConnectorAuthType> for CybersourceAuthType {
     }
 }
 #[derive(Debug, Default, Clone, Deserialize, Eq, PartialEq)]
-#[serde(rename_all = "UPPERCASE")]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum CybersourcePaymentStatus {
     Authorized,
     Succeeded,
@@ -235,6 +235,7 @@ pub enum CybersourcePaymentStatus {
     Reversed,
     Pending,
     Declined,
+    AuthorizedPendingReview,
     Transmitted,
     #[default]
     Processing,
@@ -243,7 +244,7 @@ pub enum CybersourcePaymentStatus {
 impl From<CybersourcePaymentStatus> for enums::AttemptStatus {
     fn from(item: CybersourcePaymentStatus) -> Self {
         match item {
-            CybersourcePaymentStatus::Authorized => Self::Authorized,
+            CybersourcePaymentStatus::Authorized | CybersourcePaymentStatus::AuthorizedPendingReview => Self::Authorized,
             CybersourcePaymentStatus::Succeeded | CybersourcePaymentStatus::Transmitted => {
                 Self::Charged
             }

--- a/crates/router/src/connector/cybersource/transformers.rs
+++ b/crates/router/src/connector/cybersource/transformers.rs
@@ -244,7 +244,8 @@ pub enum CybersourcePaymentStatus {
 impl From<CybersourcePaymentStatus> for enums::AttemptStatus {
     fn from(item: CybersourcePaymentStatus) -> Self {
         match item {
-            CybersourcePaymentStatus::Authorized | CybersourcePaymentStatus::AuthorizedPendingReview => Self::Authorized,
+            CybersourcePaymentStatus::Authorized
+            | CybersourcePaymentStatus::AuthorizedPendingReview => Self::Authorized,
             CybersourcePaymentStatus::Succeeded | CybersourcePaymentStatus::Transmitted => {
                 Self::Charged
             }

--- a/crates/router/src/connector/globalpay/response.rs
+++ b/crates/router/src/connector/globalpay/response.rs
@@ -344,7 +344,7 @@ pub enum FingerprintPresenceIndicator {
 }
 
 /// Indicates where a transaction is in its lifecycle.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum GlobalpayPaymentStatus {
     /// A Transaction has been successfully authorized and captured. The funding

--- a/crates/router/src/connector/globalpay/response.rs
+++ b/crates/router/src/connector/globalpay/response.rs
@@ -344,7 +344,7 @@ pub enum FingerprintPresenceIndicator {
 }
 
 /// Indicates where a transaction is in its lifecycle.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum GlobalpayPaymentStatus {
     /// A Transaction has been successfully authorized and captured. The funding

--- a/crates/router/src/connector/globalpay/transformers.rs
+++ b/crates/router/src/connector/globalpay/transformers.rs
@@ -185,7 +185,7 @@ impl<F, T>
             types::PaymentsResponseData,
         >,
     ) -> Result<Self, Self::Error> {
-        let status = enums::AttemptStatus::from(item.response.status.clone());
+        let status = enums::AttemptStatus::from(item.response.status);
         Ok(Self {
             status,
             response: get_payment_response(status, item.response),

--- a/crates/router/src/connector/globalpay/transformers.rs
+++ b/crates/router/src/connector/globalpay/transformers.rs
@@ -158,7 +158,7 @@ fn get_payment_response(
             message: response
                 .payment_method
                 .and_then(|pm| pm.message)
-                .unwrap_or("".to_string()),
+                .unwrap_or_default(),
             ..Default::default()
         }),
         _ => Ok(types::PaymentsResponseData::TransactionResponse {

--- a/crates/router/src/connector/globalpay/transformers.rs
+++ b/crates/router/src/connector/globalpay/transformers.rs
@@ -149,10 +149,16 @@ impl From<GlobalpayPaymentStatus> for enums::RefundStatus {
     }
 }
 
-fn get_payment_response(status : enums::AttemptStatus, response : GlobalpayPaymentsResponse) -> Result<types::PaymentsResponseData, ErrorResponse>{
+fn get_payment_response(
+    status: enums::AttemptStatus,
+    response: GlobalpayPaymentsResponse,
+) -> Result<types::PaymentsResponseData, ErrorResponse> {
     match status {
         enums::AttemptStatus::Failure => Err(ErrorResponse {
-            message: response.payment_method.and_then(|pm| pm.message).map_or("".to_string(), |f| f),
+            message: response
+                .payment_method
+                .and_then(|pm| pm.message)
+                .map_or("".to_string(), |f| f),
             ..Default::default()
         }),
         _ => Ok(types::PaymentsResponseData::TransactionResponse {
@@ -161,7 +167,7 @@ fn get_payment_response(status : enums::AttemptStatus, response : GlobalpayPayme
             redirect: false,
             mandate_reference: None,
             connector_metadata: None,
-        })
+        }),
     }
 }
 

--- a/crates/router/src/connector/globalpay/transformers.rs
+++ b/crates/router/src/connector/globalpay/transformers.rs
@@ -158,7 +158,7 @@ fn get_payment_response(
             message: response
                 .payment_method
                 .and_then(|pm| pm.message)
-                .map_or("".to_string(), |f| f),
+                .unwrap_or("".to_string()),
             ..Default::default()
         }),
         _ => Ok(types::PaymentsResponseData::TransactionResponse {

--- a/crates/router/src/connector/globalpay/transformers.rs
+++ b/crates/router/src/connector/globalpay/transformers.rs
@@ -9,8 +9,9 @@ use super::{
 };
 use crate::{
     connector::utils::{self, CardData, PaymentsRequestData},
+    consts,
     core::errors,
-    types::{self, api, storage::enums, ErrorResponse}, consts,
+    types::{self, api, storage::enums, ErrorResponse},
 };
 
 impl TryFrom<&types::PaymentsAuthorizeRouterData> for GlobalpayPaymentsRequest {

--- a/crates/router/src/connector/globalpay/transformers.rs
+++ b/crates/router/src/connector/globalpay/transformers.rs
@@ -10,7 +10,7 @@ use super::{
 use crate::{
     connector::utils::{self, CardData, PaymentsRequestData},
     core::errors,
-    types::{self, api, storage::enums, ErrorResponse},
+    types::{self, api, storage::enums, ErrorResponse}, consts,
 };
 
 impl TryFrom<&types::PaymentsAuthorizeRouterData> for GlobalpayPaymentsRequest {
@@ -158,7 +158,7 @@ fn get_payment_response(
             message: response
                 .payment_method
                 .and_then(|pm| pm.message)
-                .unwrap_or_default(),
+                .unwrap_or_else(|| consts::NO_ERROR_MESSAGE.to_string()),
             ..Default::default()
         }),
         _ => Ok(types::PaymentsResponseData::TransactionResponse {

--- a/crates/router/src/connector/globalpay/transformers.rs
+++ b/crates/router/src/connector/globalpay/transformers.rs
@@ -10,7 +10,7 @@ use super::{
 use crate::{
     connector::utils::{self, CardData, PaymentsRequestData},
     core::errors,
-    types::{self, api, storage::enums},
+    types::{self, api, storage::enums, ErrorResponse},
 };
 
 impl TryFrom<&types::PaymentsAuthorizeRouterData> for GlobalpayPaymentsRequest {
@@ -149,6 +149,22 @@ impl From<GlobalpayPaymentStatus> for enums::RefundStatus {
     }
 }
 
+fn get_payment_response(status : enums::AttemptStatus, response : GlobalpayPaymentsResponse) -> Result<types::PaymentsResponseData, ErrorResponse>{
+    match status {
+        enums::AttemptStatus::Failure => Err(ErrorResponse {
+            message: response.payment_method.and_then(|pm| pm.message).map_or("".to_string(), |f| f),
+            ..Default::default()
+        }),
+        _ => Ok(types::PaymentsResponseData::TransactionResponse {
+            resource_id: types::ResponseId::ConnectorTransactionId(response.id),
+            redirection_data: None,
+            redirect: false,
+            mandate_reference: None,
+            connector_metadata: None,
+        })
+    }
+}
+
 impl<F, T>
     TryFrom<types::ResponseRouterData<F, GlobalpayPaymentsResponse, T, types::PaymentsResponseData>>
     for types::RouterData<F, T, types::PaymentsResponseData>
@@ -162,15 +178,10 @@ impl<F, T>
             types::PaymentsResponseData,
         >,
     ) -> Result<Self, Self::Error> {
+        let status = enums::AttemptStatus::from(item.response.status.clone());
         Ok(Self {
-            status: enums::AttemptStatus::from(item.response.status),
-            response: Ok(types::PaymentsResponseData::TransactionResponse {
-                resource_id: types::ResponseId::ConnectorTransactionId(item.response.id),
-                redirection_data: None,
-                redirect: false,
-                mandate_reference: None,
-                connector_metadata: None,
-            }),
+            status,
+            response: get_payment_response(status, item.response),
             ..item.data
         })
     }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->
Globalpay throw error message for failure transaction if it has the message.

### Additional Changes

- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!-- 
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
Previously for failure transactions only the `failed` status is shown, now adding the reason for failure also to the response

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Ran unit tests in local


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [X] I formatted the code `cargo +nightly fmt --all`
- [X] I addressed lints thrown by `cargo clippy`
- [X] I reviewed submitted code
