### PR TITLE
chore: address Rust 1.67 clippy lints

### DIFF
--- a/crates/common_utils/src/ext_traits.rs
+++ b/crates/common_utils/src/ext_traits.rs
@@ -87,7 +87,7 @@ where
         serde_json::to_string(&P::try_from(self).change_context(errors::ParsingError)?)
             .into_report()
             .change_context(errors::ParsingError)
-            .attach_printable_lazy(|| format!("Unable to convert {:?} to a request", self))
+            .attach_printable_lazy(|| format!("Unable to convert {self:?} to a request"))
     }
 
     fn convert_and_url_encode(&'e self) -> CustomResult<String, errors::ParsingError>
@@ -99,7 +99,7 @@ where
         serde_urlencoded::to_string(&P::try_from(self).change_context(errors::ParsingError)?)
             .into_report()
             .change_context(errors::ParsingError)
-            .attach_printable_lazy(|| format!("Unable to convert {:?} to a request", self))
+            .attach_printable_lazy(|| format!("Unable to convert {self:?} to a request"))
     }
 
     // Check without two functions can we combine this
@@ -110,7 +110,7 @@ where
         serde_urlencoded::to_string(self)
             .into_report()
             .change_context(errors::ParsingError)
-            .attach_printable_lazy(|| format!("Unable to convert {:?} to a request", self))
+            .attach_printable_lazy(|| format!("Unable to convert {self:?} to a request"))
     }
 
     fn encode_to_string_of_json(&'e self) -> CustomResult<String, errors::ParsingError>
@@ -120,7 +120,7 @@ where
         serde_json::to_string(self)
             .into_report()
             .change_context(errors::ParsingError)
-            .attach_printable_lazy(|| format!("Unable to convert {:?} to a request", self))
+            .attach_printable_lazy(|| format!("Unable to convert {self:?} to a request"))
     }
 
     fn encode_to_value(&'e self) -> CustomResult<serde_json::Value, errors::ParsingError>
@@ -130,7 +130,7 @@ where
         serde_json::to_value(self)
             .into_report()
             .change_context(errors::ParsingError)
-            .attach_printable_lazy(|| format!("Unable to convert {:?} to a value", self))
+            .attach_printable_lazy(|| format!("Unable to convert {self:?} to a value"))
     }
 
     fn encode_to_vec(&'e self) -> CustomResult<Vec<u8>, errors::ParsingError>
@@ -140,7 +140,7 @@ where
         serde_json::to_vec(self)
             .into_report()
             .change_context(errors::ParsingError)
-            .attach_printable_lazy(|| format!("Unable to convert {:?} to a value", self))
+            .attach_printable_lazy(|| format!("Unable to convert {self:?} to a value"))
     }
 }
 

--- a/crates/common_utils/src/pii.rs
+++ b/crates/common_utils/src/pii.rs
@@ -143,13 +143,13 @@ mod pii_masking_strategy_tests {
     #[test]
     fn test_valid_card_number_masking() {
         let secret: Secret<String, CardNumber> = Secret::new("1234567890987654".to_string());
-        assert_eq!("123456**********", format!("{:?}", secret));
+        assert_eq!("123456**********", format!("{secret:?}"));
     }
 
     #[test]
     fn test_invalid_card_number_masking() {
         let secret: Secret<String, CardNumber> = Secret::new("1234567890".to_string());
-        assert_eq!("123456****", format!("{:?}", secret));
+        assert_eq!("123456****", format!("{secret:?}"));
     }
 
     /*
@@ -172,34 +172,34 @@ mod pii_masking_strategy_tests {
     #[test]
     fn test_valid_email_masking() {
         let secret: Secret<String, Email> = Secret::new("myemail@gmail.com".to_string());
-        assert_eq!("*******@gmail.com", format!("{:?}", secret));
+        assert_eq!("*******@gmail.com", format!("{secret:?}"));
     }
 
     #[test]
     fn test_invalid_email_masking() {
         let secret: Secret<String, Email> = Secret::new("myemailgmail.com".to_string());
-        assert_eq!("*** alloc::string::String ***", format!("{:?}", secret));
+        assert_eq!("*** alloc::string::String ***", format!("{secret:?}"));
 
         let secret: Secret<String, Email> = Secret::new("myemail@gmail@com".to_string());
-        assert_eq!("*** alloc::string::String ***", format!("{:?}", secret));
+        assert_eq!("*** alloc::string::String ***", format!("{secret:?}"));
     }
 
     #[test]
     fn test_valid_ip_addr_masking() {
         let secret: Secret<String, IpAddress> = Secret::new("123.23.1.78".to_string());
-        assert_eq!("123.**.**.**", format!("{:?}", secret));
+        assert_eq!("123.**.**.**", format!("{secret:?}"));
     }
 
     #[test]
     fn test_invalid_ip_addr_masking() {
         let secret: Secret<String, IpAddress> = Secret::new("123.4.56".to_string());
-        assert_eq!("*** alloc::string::String ***", format!("{:?}", secret));
+        assert_eq!("*** alloc::string::String ***", format!("{secret:?}"));
 
         let secret: Secret<String, IpAddress> = Secret::new("123.4567.12.4".to_string());
-        assert_eq!("*** alloc::string::String ***", format!("{:?}", secret));
+        assert_eq!("*** alloc::string::String ***", format!("{secret:?}"));
 
         let secret: Secret<String, IpAddress> = Secret::new("123..4.56".to_string());
-        assert_eq!("*** alloc::string::String ***", format!("{:?}", secret));
+        assert_eq!("*** alloc::string::String ***", format!("{secret:?}"));
     }
 
     #[test]
@@ -208,7 +208,7 @@ mod pii_masking_strategy_tests {
             Secret::new("pay_uszFB2QGe9MmLY65ojhT_secret_tLjTz9tAQxUVEFqfmOIP".to_string());
         assert_eq!(
             "pay_uszFB2QGe9MmLY65ojhT_***************************",
-            format!("{:?}", secret)
+            format!("{secret:?}")
         );
     }
 
@@ -216,6 +216,6 @@ mod pii_masking_strategy_tests {
     fn test_invalid_client_secret_masking() {
         let secret: Secret<String, IpAddress> =
             Secret::new("pay_uszFB2QGe9MmLY65ojhT_secret".to_string());
-        assert_eq!("*** alloc::string::String ***", format!("{:?}", secret));
+        assert_eq!("*** alloc::string::String ***", format!("{secret:?}"));
     }
 }

--- a/crates/drainer/src/utils.rs
+++ b/crates/drainer/src/utils.rs
@@ -111,5 +111,5 @@ pub(crate) fn get_stream_key_flag(store: Arc<services::Store>, stream_index: u8)
 }
 
 pub(crate) fn get_drainer_stream_name(store: Arc<services::Store>, stream_index: u8) -> String {
-    store.drainer_stream(format!("shard_{}", stream_index).as_str())
+    store.drainer_stream(format!("shard_{stream_index}").as_str())
 }

--- a/crates/masking/tests/basic.rs
+++ b/crates/masking/tests/basic.rs
@@ -40,7 +40,7 @@ fn basic() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 
     // format
 
-    let got = format!("{:?}", composite);
+    let got = format!("{composite:?}");
     let exp = "Composite { secret_number: *** basic::basic::AccountNumber ***, not_secret: \"not secret\" }";
     assert_eq!(got, exp);
 
@@ -87,7 +87,7 @@ fn without_serialize() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 
     // format
 
-    let got = format!("{:?}", composite);
+    let got = format!("{composite:?}");
     let exp = "Composite { secret_number: *** basic::without_serialize::AccountNumber ***, not_secret: \"not secret\" }";
     assert_eq!(got, exp);
 
@@ -129,7 +129,7 @@ fn for_string() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 
     // format
 
-    let got = format!("{:?}", composite);
+    let got = format!("{composite:?}");
     let exp =
         "Composite { secret_number: *** alloc::string::String ***, not_secret: \"not secret\" }";
     assert_eq!(got, exp);

--- a/crates/router/src/connector/cybersource.rs
+++ b/crates/router/src/connector/cybersource.rs
@@ -153,7 +153,7 @@ where
             ("Signature".to_string(), signature),
         ];
         if matches!(http_method, services::Method::Post | services::Method::Put) {
-            headers.push(("Digest".to_string(), format!("SHA-256={}", sha256)));
+            headers.push(("Digest".to_string(), format!("SHA-256={sha256}")));
         }
         Ok(headers)
     }

--- a/crates/router/src/core/admin.rs
+++ b/crates/router/src/core/admin.rs
@@ -417,8 +417,7 @@ pub async fn update_payment_connector(
         .change_context(errors::ApiErrorResponse::InternalServerError)
         .attach_printable_lazy(|| {
             format!(
-                "Failed while updating MerchantConnectorAccount: id: {}",
-                merchant_connector_id
+                "Failed while updating MerchantConnectorAccount: id: {merchant_connector_id}"
             )
         })?;
 

--- a/crates/router/src/core/admin.rs
+++ b/crates/router/src/core/admin.rs
@@ -416,9 +416,7 @@ pub async fn update_payment_connector(
         .await
         .change_context(errors::ApiErrorResponse::InternalServerError)
         .attach_printable_lazy(|| {
-            format!(
-                "Failed while updating MerchantConnectorAccount: id: {merchant_connector_id}"
-            )
+            format!("Failed while updating MerchantConnectorAccount: id: {merchant_connector_id}")
         })?;
 
     let updated_pm_enabled = updated_mca.payment_methods_enabled.map(|pm| {

--- a/crates/router/src/core/customers.rs
+++ b/crates/router/src/core/customers.rs
@@ -77,9 +77,7 @@ pub async fn create_customer(
                     .await
                     .change_context(errors::ApiErrorResponse::InternalServerError)
                     .attach_printable_lazy(|| {
-                        format!(
-                            "Failed while fetching Customer, customer_id: {customer_id}"
-                        )
+                        format!("Failed while fetching Customer, customer_id: {customer_id}")
                     })?
             } else {
                 Err(error

--- a/crates/router/src/core/customers.rs
+++ b/crates/router/src/core/customers.rs
@@ -78,8 +78,7 @@ pub async fn create_customer(
                     .change_context(errors::ApiErrorResponse::InternalServerError)
                     .attach_printable_lazy(|| {
                         format!(
-                            "Failed while fetching Customer, customer_id: {}",
-                            customer_id
+                            "Failed while fetching Customer, customer_id: {customer_id}"
                         )
                     })?
             } else {

--- a/crates/router/src/core/payment_methods/transformers.rs
+++ b/crates/router/src/core/payment_methods/transformers.rs
@@ -72,7 +72,7 @@ pub fn mk_add_card_request(
     merchant_id: &str,
 ) -> CustomResult<services::Request, errors::VaultError> {
     let customer_id = if cfg!(feature = "sandbox") {
-        format!("{}::{}", customer_id, merchant_id)
+        format!("{customer_id}::{merchant_id}")
     } else {
         customer_id.to_owned()
     };

--- a/crates/router/src/core/payments.rs
+++ b/crates/router/src/core/payments.rs
@@ -239,7 +239,7 @@ where
 }
 
 fn is_start_pay<Op: Debug>(operation: &Op) -> bool {
-    format!("{:?}", operation).eq("PaymentStart")
+    format!("{operation:?}").eq("PaymentStart")
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -562,7 +562,7 @@ pub fn should_call_connector<Op: Debug, F: Clone>(
     operation: &Op,
     payment_data: &PaymentData<F>,
 ) -> bool {
-    match format!("{:?}", operation).as_str() {
+    match format!("{operation:?}").as_str() {
         "PaymentConfirm" => true,
         "PaymentStart" => {
             !matches!(

--- a/crates/router/src/core/payments/flows/session_flow.rs
+++ b/crates/router/src/core/payments/flows/session_flow.rs
@@ -74,8 +74,7 @@ fn create_gpay_session_token(
         .parse_value::<payment_types::GpaySessionTokenData>("GpaySessionTokenData")
         .change_context(errors::ConnectorError::NoConnectorMetaData)
         .attach_printable(format!(
-            "cannot parse gpay metadata from the given value {:?}",
-            connector_metadata
+            "cannot parse gpay metadata from the given value {connector_metadata:?}"
         ))
         .change_context(errors::ApiErrorResponse::InvalidDataFormat {
             field_name: "connector_metadata".to_string(),

--- a/crates/router/src/core/payments/helpers.rs
+++ b/crates/router/src/core/payments/helpers.rs
@@ -230,8 +230,7 @@ pub fn validate_request_amount_and_amount_to_capture(
                     utils::when(!amount_to_capture.le(&amount_inner.get()), || {
                         Err(report!(errors::ApiErrorResponse::PreconditionFailed {
                             message: format!(
-                            "amount_to_capture is greater than amount capture_amount: {:?} request_amount: {:?}",
-                            amount_to_capture, amount
+                            "amount_to_capture is greater than amount capture_amount: {amount_to_capture:?} request_amount: {amount:?}"
                         )
                         }))
                     })
@@ -1054,9 +1053,9 @@ pub fn make_url_with_signature(
     })
 }
 
-pub fn hmac_sha256_sorted_query_params<'a>(
+pub fn hmac_sha256_sorted_query_params(
     params: &mut [(Cow<'_, str>, Cow<'_, str>)],
-    key: &'a str,
+    key: &str,
 ) -> RouterResult<String> {
     params.sort();
     let final_string = params
@@ -1077,7 +1076,7 @@ pub fn hmac_sha256_sorted_query_params<'a>(
 }
 
 pub fn check_if_operation_confirm<Op: std::fmt::Debug>(operations: Op) -> bool {
-    format!("{:?}", operations) == "PaymentConfirm"
+    format!("{operations:?}") == "PaymentConfirm"
 }
 
 pub fn generate_mandate(

--- a/crates/router/src/core/payments/operations/payment_method_validate.rs
+++ b/crates/router/src/core/payments/operations/payment_method_validate.rs
@@ -298,7 +298,7 @@ impl PaymentMethodValidate {
         let status = helpers::payment_intent_status_fsm(&request.payment_method_data, Some(true));
 
         let client_secret =
-            utils::generate_id(consts::ID_LENGTH, format!("{}_secret", payment_id).as_str());
+            utils::generate_id(consts::ID_LENGTH, format!("{payment_id}_secret").as_str());
         storage::PaymentIntentNew {
             payment_id: payment_id.to_string(),
             merchant_id: merchant_id.to_string(),

--- a/crates/router/src/core/refunds.rs
+++ b/crates/router/src/core/refunds.rs
@@ -384,9 +384,7 @@ pub async fn refund_update_core(
         )
         .await
         .change_context(errors::ApiErrorResponse::InternalServerError)
-        .attach_printable_lazy(|| {
-            format!("Unable to update refund with refund_id: {refund_id}")
-        })?;
+        .attach_printable_lazy(|| format!("Unable to update refund with refund_id: {refund_id}"))?;
 
     Ok(services::ApplicationResponse::Json(response.foreign_into()))
 }

--- a/crates/router/src/core/refunds.rs
+++ b/crates/router/src/core/refunds.rs
@@ -385,7 +385,7 @@ pub async fn refund_update_core(
         .await
         .change_context(errors::ApiErrorResponse::InternalServerError)
         .attach_printable_lazy(|| {
-            format!("Unable to update refund with refund_id: {}", refund_id)
+            format!("Unable to update refund with refund_id: {refund_id}")
         })?;
 
     Ok(services::ApplicationResponse::Json(response.foreign_into()))
@@ -693,7 +693,7 @@ pub async fn sync_refund_with_gateway_workflow(
             let id = refund_tracker.id.clone();
             refund_tracker
                 .clone()
-                .finish_with_status(&*state.store, format!("COMPLETED_BY_PT_{}", id))
+                .finish_with_status(&*state.store, format!("COMPLETED_BY_PT_{id}"))
                 .await?
         }
         _ => {
@@ -806,7 +806,7 @@ pub async fn trigger_refund_execute_workflow(
             let id = refund_tracker.id.clone();
             refund_tracker
                 .clone()
-                .finish_with_status(db, format!("COMPLETED_BY_PT_{}", id))
+                .finish_with_status(db, format!("COMPLETED_BY_PT_{id}"))
                 .await?;
         }
     };
@@ -916,7 +916,7 @@ pub async fn get_refund_sync_process_schedule_time(
     let redis_mapping: errors::CustomResult<process_data::ConnectorPTMapping, errors::RedisError> =
         db::get_and_deserialize_key(
             db,
-            &format!("pt_mapping_refund_sync_{}", connector),
+            &format!("pt_mapping_refund_sync_{connector}"),
             "ConnectorPTMapping",
         )
         .await;

--- a/crates/router/src/core/webhooks/utils.rs
+++ b/crates/router/src/core/webhooks/utils.rs
@@ -13,7 +13,7 @@ pub async fn lookup_webhook_event(
     merchant_id: &str,
     event: &api::IncomingWebhookEvent,
 ) -> bool {
-    let redis_key = format!("whconf_{}_{}", merchant_id, connector_id);
+    let redis_key = format!("whconf_{merchant_id}_{connector_id}");
     let webhook_config: api::MerchantWebhookConfig =
         get_and_deserialize_key(db, &redis_key, "MerchantWebhookConfig")
             .await

--- a/crates/router/src/db/ephemeral_key.rs
+++ b/crates/router/src/db/ephemeral_key.rs
@@ -88,7 +88,7 @@ mod storage {
             &self,
             key: &str,
         ) -> CustomResult<EphemeralKey, errors::StorageError> {
-            let key = format!("epkey_{}", key);
+            let key = format!("epkey_{key}");
             self.redis_conn
                 .get_hash_field_and_deserialize(&key, "ephkey", "EphemeralKey")
                 .await

--- a/crates/router/src/db/payment_attempt.rs
+++ b/crates/router/src/db/payment_attempt.rs
@@ -392,7 +392,7 @@ mod storage {
                         .await
                     {
                         Ok(HsetnxReply::KeyNotSet) => Err(errors::StorageError::DuplicateValue(
-                            format!("Payment Attempt already exists for payment_id: {}", key),
+                            format!("Payment Attempt already exists for payment_id: {key}"),
                         ))
                         .into_report(),
                         Ok(HsetnxReply::KeySet) => {
@@ -544,7 +544,7 @@ mod storage {
                 }
 
                 enums::MerchantStorageScheme::RedisKv => {
-                    let key = format!("{}_{}", merchant_id, payment_id);
+                    let key = format!("{merchant_id}_{payment_id}");
                     let lookup = self
                         .get_lookup_by_lookup_id(&key)
                         .await
@@ -619,8 +619,7 @@ mod storage {
             .and_then(|attempt| match attempt.status {
                 enums::AttemptStatus::Charged => Ok(attempt),
                 _ => Err(errors::StorageError::ValueNotFound(format!(
-                    "Successful payment attempt does not exist for {}_{}",
-                    payment_id, merchant_id
+                    "Successful payment attempt does not exist for {payment_id}_{merchant_id}"
                 )))
                 .into_report(),
             })

--- a/crates/router/src/db/payment_intent.rs
+++ b/crates/router/src/db/payment_intent.rs
@@ -220,7 +220,7 @@ mod storage {
                 }
 
                 enums::MerchantStorageScheme::RedisKv => {
-                    let key = format!("{}_{}", merchant_id, payment_id);
+                    let key = format!("{merchant_id}_{payment_id}");
                     self.redis_conn
                         .get_hash_field_and_deserialize::<PaymentIntent>(
                             &key,
@@ -230,7 +230,7 @@ mod storage {
                         .await
                         .map_err(|error| match error.current_context() {
                             errors::RedisError::NotFound => errors::StorageError::ValueNotFound(
-                                format!("Payment Intent does not exist for {}", key),
+                                format!("Payment Intent does not exist for {key}"),
                             )
                             .into(),
                             _ => error.change_context(errors::StorageError::KVError),

--- a/crates/router/src/db/refund.rs
+++ b/crates/router/src/db/refund.rs
@@ -235,7 +235,7 @@ mod storage {
                     .into_report()
                 }
                 enums::MerchantStorageScheme::RedisKv => {
-                    let lookup_id = format!("{}_{}", merchant_id, internal_reference_id);
+                    let lookup_id = format!("{merchant_id}_{internal_reference_id}");
                     let lookup = self
                         .get_lookup_by_lookup_id(&lookup_id)
                         .await
@@ -560,7 +560,7 @@ mod storage {
                     .into_report()
                 }
                 enums::MerchantStorageScheme::RedisKv => {
-                    let key = format!("{}_{}", merchant_id, payment_id);
+                    let key = format!("{merchant_id}_{payment_id}");
                     let lookup = self
                         .get_lookup_by_lookup_id(&key)
                         .await

--- a/crates/router/src/scheduler/types/batch.rs
+++ b/crates/router/src/scheduler/types/batch.rs
@@ -107,7 +107,7 @@ impl ProcessTrackerBatch {
             .into_report()
             .change_context(errors::ParsingError)
             .attach_printable_lazy(|| {
-                format!("Unable to parse trackers from JSON string: {:?}", trackers)
+                format!("Unable to parse trackers from JSON string: {trackers:?}")
             })
             .change_context(errors::ProcessTrackerError::DeserializationFailed)?;
 

--- a/crates/router/src/scheduler/workflows/payment_sync.rs
+++ b/crates/router/src/scheduler/workflows/payment_sync.rs
@@ -96,12 +96,7 @@ pub async fn get_sync_process_schedule_time(
     retry_count: i32,
 ) -> Result<Option<time::PrimitiveDateTime>, errors::ProcessTrackerError> {
     let redis_mapping: errors::CustomResult<process_data::ConnectorPTMapping, errors::RedisError> =
-        get_and_deserialize_key(
-            db,
-            &format!("pt_mapping_{connector}"),
-            "ConnectorPTMapping",
-        )
-        .await;
+        get_and_deserialize_key(db, &format!("pt_mapping_{connector}"), "ConnectorPTMapping").await;
     let mapping = match redis_mapping {
         Ok(x) => x,
         Err(err) => {

--- a/crates/router/src/scheduler/workflows/payment_sync.rs
+++ b/crates/router/src/scheduler/workflows/payment_sync.rs
@@ -58,7 +58,7 @@ impl ProcessTrackerWorkflow for PaymentsSyncWorkflow {
             status if terminal_status.contains(status) => {
                 let id = process.id.clone();
                 process
-                    .finish_with_status(db, format!("COMPLETED_BY_PT_{}", id))
+                    .finish_with_status(db, format!("COMPLETED_BY_PT_{id}"))
                     .await?
             }
             _ => {
@@ -98,7 +98,7 @@ pub async fn get_sync_process_schedule_time(
     let redis_mapping: errors::CustomResult<process_data::ConnectorPTMapping, errors::RedisError> =
         get_and_deserialize_key(
             db,
-            &format!("pt_mapping_{}", connector),
+            &format!("pt_mapping_{connector}"),
             "ConnectorPTMapping",
         )
         .await;

--- a/crates/router/src/types/storage/payment_attempt.rs
+++ b/crates/router/src/types/storage/payment_attempt.rs
@@ -41,7 +41,7 @@ mod tests {
             .insert_payment_attempt(payment_attempt, enums::MerchantStorageScheme::PostgresOnly)
             .await
             .unwrap();
-        eprintln!("{:?}", response);
+        eprintln!("{response:?}");
 
         assert_eq!(response.payment_id, payment_id.clone());
     }
@@ -82,7 +82,7 @@ mod tests {
             .await
             .unwrap();
 
-        eprintln!("{:?}", response);
+        eprintln!("{response:?}");
 
         assert_eq!(response.payment_id, payment_id);
     }

--- a/crates/router/src/utils/ext_traits.rs
+++ b/crates/router/src/utils/ext_traits.rs
@@ -93,7 +93,7 @@ pub(crate) fn merge_json_values(a: &mut serde_json::Value, b: &serde_json::Value
     use serde_json::Value;
 
     match (a, b) {
-        (&mut Value::Object(ref mut a), &Value::Object(ref b)) => {
+        (&mut Value::Object(ref mut a), Value::Object(b)) => {
             for (k, v) in b {
                 merge_json_values(a.entry(k.clone()).or_insert(Value::Null), v);
             }

--- a/crates/router/tests/customers.rs
+++ b/crates/router/tests/customers.rs
@@ -38,40 +38,40 @@ async fn customer_success() {
         .await
         .unwrap();
     response_body = response.body().await;
-    println!("customer-create: {:?} : {:?}", response, response_body);
+    println!("customer-create: {response:?} : {response_body:?}");
     assert_eq!(response.status(), awc::http::StatusCode::OK);
 
     // retrieve customer
     response = client
-        .get(format!("http://127.0.0.1:8080/customers/{}", customer_id))
+        .get(format!("http://127.0.0.1:8080/customers/{customer_id}"))
         .insert_header(api_key)
         .send()
         .await
         .unwrap();
     response_body = response.body().await;
-    println!("customer-retrieve: {:?} =:= {:?}", response, response_body);
+    println!("customer-retrieve: {response:?} =:= {response_body:?}");
     assert_eq!(response.status(), awc::http::StatusCode::OK);
 
     // update customer
     response = client
-        .post(format!("http://127.0.0.1:8080/customers/{}", customer_id))
+        .post(format!("http://127.0.0.1:8080/customers/{customer_id}"))
         .insert_header(api_key)
         .send_json(&update_request)
         .await
         .unwrap();
     response_body = response.body().await;
-    println!("customer-update: {:?} =:= {:?}", response, response_body);
+    println!("customer-update: {response:?} =:= {response_body:?}");
     assert_eq!(response.status(), awc::http::StatusCode::OK);
 
     // delete customer
     response = client
-        .delete(format!("http://127.0.0.1:8080/customers/{}", customer_id))
+        .delete(format!("http://127.0.0.1:8080/customers/{customer_id}"))
         .insert_header(api_key)
         .send()
         .await
         .unwrap();
     response_body = response.body().await;
-    println!("customer-delete : {:?} =:= {:?}", response, response_body);
+    println!("customer-delete : {response:?} =:= {response_body:?}");
     assert_eq!(response.status(), awc::http::StatusCode::OK);
 }
 
@@ -100,7 +100,7 @@ async fn customer_failure() {
         .await
         .unwrap();
     response_body = response.body().await;
-    println!("{:?} : {:?}", response, response_body);
+    println!("{response:?} : {response_body:?}");
     assert_eq!(
         response.status(),
         awc::http::StatusCode::UNPROCESSABLE_ENTITY
@@ -108,24 +108,24 @@ async fn customer_failure() {
 
     // retrieve a customer with customer id which is not in DB
     response = client
-        .post(format!("http://127.0.0.1:8080/customers/{}", customer_id))
+        .post(format!("http://127.0.0.1:8080/customers/{customer_id}"))
         .insert_header(api_key)
         .send()
         .await
         .unwrap();
     response_body = response.body().await;
-    println!("{:?} : {:?}", response, response_body);
+    println!("{response:?} : {response_body:?}");
     assert_eq!(response.status(), awc::http::StatusCode::BAD_REQUEST);
 
     // update customer id with customer id which is not in DB
     response = client
-        .post(format!("http://127.0.0.1:8080/customers/{}", customer_id))
+        .post(format!("http://127.0.0.1:8080/customers/{customer_id}"))
         .insert_header(api_key)
         .send_json(&request)
         .await
         .unwrap();
     response_body = response.body().await;
-    println!("{:?} : {:?}", response, response_body);
+    println!("{response:?} : {response_body:?}");
     assert_eq!(
         response.status(),
         awc::http::StatusCode::UNPROCESSABLE_ENTITY
@@ -133,13 +133,13 @@ async fn customer_failure() {
 
     // delete a customer with customer id which is not in DB
     response = client
-        .delete(format!("http://127.0.0.1:8080/customers/{}", customer_id))
+        .delete(format!("http://127.0.0.1:8080/customers/{customer_id}"))
         .insert_header(api_key)
         .send()
         .await
         .unwrap();
     response_body = response.body().await;
-    println!("{:?} : {:?}", response, response_body);
+    println!("{response:?} : {response_body:?}");
     assert_eq!(response.status(), awc::http::StatusCode::BAD_REQUEST);
 
     // email validation for customer update
@@ -152,20 +152,20 @@ async fn customer_failure() {
         .await
         .unwrap();
     response_body = response.body().await;
-    println!("{:?} : {:?}", response, response_body);
+    println!("{response:?} : {response_body:?}");
     assert_eq!(response.status(), awc::http::StatusCode::OK);
 
     request = serde_json::json!({
         "email": "abch"
     });
     response = client
-        .post(format!("http://127.0.0.1:8080/customers/{}", customer_id))
+        .post(format!("http://127.0.0.1:8080/customers/{customer_id}"))
         .insert_header(api_key)
         .send_json(&request)
         .await
         .unwrap();
     response_body = response.body().await;
-    println!("{:?} : {:?}", response, response_body);
+    println!("{response:?} : {response_body:?}");
     assert_eq!(
         response.status(),
         awc::http::StatusCode::UNPROCESSABLE_ENTITY
@@ -176,13 +176,13 @@ async fn customer_failure() {
         "email": "abch"
     });
     response = client
-        .post(format!("http://127.0.0.1:8080/customers/{}", customer_id))
+        .post(format!("http://127.0.0.1:8080/customers/{customer_id}"))
         .insert_header(api_key)
         .send_json(&request)
         .await
         .unwrap();
     response_body = response.body().await;
-    println!("{:?} : {:?}", response, response_body);
+    println!("{response:?} : {response_body:?}");
     assert_eq!(
         response.status(),
         awc::http::StatusCode::UNPROCESSABLE_ENTITY

--- a/crates/router/tests/payments.rs
+++ b/crates/router/tests/payments.rs
@@ -63,7 +63,7 @@ async fn payments_create_stripe() {
         .await
         .unwrap();
     let create_response_body = create_response.body().await;
-    println!("{:?} : {:?}", create_response, create_response_body);
+    println!("{create_response:?} : {create_response_body:?}");
     assert_eq!(create_response.status(), awc::http::StatusCode::OK);
 
     let mut retrieve_response = client
@@ -73,7 +73,7 @@ async fn payments_create_stripe() {
         .await
         .unwrap();
     let retrieve_response_body = retrieve_response.body().await;
-    println!("{:?} =:= {:?}", retrieve_response, retrieve_response_body);
+    println!("{retrieve_response:?} =:= {retrieve_response_body:?}");
     assert_eq!(retrieve_response.status(), awc::http::StatusCode::OK);
 
     let mut refund_response = client
@@ -84,7 +84,7 @@ async fn payments_create_stripe() {
         .unwrap();
 
     let refund_response_body = refund_response.body().await;
-    println!("{:?} =:= {:?}", refund_response, refund_response_body);
+    println!("{refund_response:?} =:= {refund_response_body:?}");
     assert_eq!(refund_response.status(), awc::http::StatusCode::OK);
 }
 
@@ -132,7 +132,7 @@ async fn payments_create_adyen() {
         .await
         .unwrap();
     let create_response_body = create_response.body().await;
-    println!("{:?} : {:?}", create_response, create_response_body);
+    println!("{create_response:?} : {create_response_body:?}");
     assert_eq!(create_response.status(), awc::http::StatusCode::OK);
 
     let mut retrieve_response = client
@@ -142,7 +142,7 @@ async fn payments_create_adyen() {
         .await
         .unwrap();
     let retrieve_response_body = retrieve_response.body().await;
-    println!("{:?} =:= {:?}", retrieve_response, retrieve_response_body);
+    println!("{retrieve_response:?} =:= {retrieve_response_body:?}");
     assert_eq!(retrieve_response.status(), awc::http::StatusCode::OK);
 
     let mut refund_response = client
@@ -153,7 +153,7 @@ async fn payments_create_adyen() {
         .unwrap();
 
     let refund_response_body = refund_response.body().await;
-    println!("{:?} =:= {:?}", refund_response, refund_response_body);
+    println!("{refund_response:?} =:= {refund_response_body:?}");
     assert_eq!(refund_response.status(), awc::http::StatusCode::OK);
 }
 
@@ -197,7 +197,7 @@ async fn payments_create_fail() {
         .await
         .unwrap();
     let invalid_response_body = invalid_response.body().await;
-    println!("{:?} : {:?}", invalid_response, invalid_response_body);
+    println!("{invalid_response:?} : {invalid_response_body:?}");
     assert_eq!(
         invalid_response.status(),
         awc::http::StatusCode::BAD_REQUEST
@@ -210,7 +210,7 @@ async fn payments_create_fail() {
         .await
         .unwrap();
     let api_key_response_body = api_key_response.body().await;
-    println!("{:?} =:= {:?}", api_key_response, api_key_response_body);
+    println!("{api_key_response:?} =:= {api_key_response_body:?}");
     assert_eq!(
         api_key_response.status(),
         awc::http::StatusCode::UNAUTHORIZED
@@ -230,13 +230,13 @@ async fn payments_todo() {
 
     for endpoint in get_endpoints {
         response = client
-            .get(format!("http://127.0.0.1:8080/payments/{}", endpoint))
+            .get(format!("http://127.0.0.1:8080/payments/{endpoint}"))
             .insert_header(("API-KEY", "MySecretApiKey"))
             .send()
             .await
             .unwrap();
         response_body = response.body().await;
-        println!("{} =:= {:?} : {:?}", endpoint, response, response_body);
+        println!("{endpoint} =:= {response:?} : {response_body:?}");
         assert_eq!(response.status(), awc::http::StatusCode::OK);
     }
 
@@ -264,7 +264,7 @@ fn connector_list() {
 
     let newlist: types::ConnectorsList = serde_json::from_str(&json).unwrap();
 
-    println!("{:#?}", newlist);
+    println!("{newlist:#?}");
     assert_eq!(true, true);
 }
 

--- a/crates/router/tests/payments2.rs
+++ b/crates/router/tests/payments2.rs
@@ -24,7 +24,7 @@ fn connector_list() {
 
     let newlist: router::types::ConnectorsList = serde_json::from_str(&json).unwrap();
 
-    println!("{:#?}", newlist);
+    println!("{newlist:#?}");
     assert_eq!(true, true);
 }
 

--- a/crates/router/tests/payouts.rs
+++ b/crates/router/tests/payouts.rs
@@ -14,23 +14,23 @@ async fn payouts_todo() {
 
     for endpoint in get_endpoints {
         response = client
-            .get(format!("http://127.0.0.1:8080/payouts/{}", endpoint))
+            .get(format!("http://127.0.0.1:8080/payouts/{endpoint}"))
             .send()
             .await
             .unwrap();
         response_body = response.body().await;
-        println!("{} =:= {:?} : {:?}", endpoint, response, response_body);
+        println!("{endpoint} =:= {response:?} : {response_body:?}");
         assert_eq!(response.status(), awc::http::StatusCode::OK);
     }
 
     for endpoint in post_endpoints {
         response = client
-            .post(format!("http://127.0.0.1:8080/payouts/{}", endpoint))
+            .post(format!("http://127.0.0.1:8080/payouts/{endpoint}"))
             .send()
             .await
             .unwrap();
         response_body = response.body().await;
-        println!("{} =:= {:?} : {:?}", endpoint, response, response_body);
+        println!("{endpoint} =:= {response:?} : {response_body:?}");
         assert_eq!(response.status(), awc::http::StatusCode::OK);
     }
 }

--- a/crates/router/tests/refunds.rs
+++ b/crates/router/tests/refunds.rs
@@ -49,23 +49,23 @@ async fn refunds_todo() {
 
     for endpoint in get_endpoints {
         response = client
-            .get(format!("http://127.0.0.1:8080/refunds/{}", endpoint))
+            .get(format!("http://127.0.0.1:8080/refunds/{endpoint}"))
             .send()
             .await
             .unwrap();
         response_body = response.body().await;
-        println!("{} =:= {:?} : {:?}", endpoint, response, response_body);
+        println!("{endpoint} =:= {response:?} : {response_body:?}");
         assert_eq!(response.status(), awc::http::StatusCode::OK);
     }
 
     for endpoint in post_endpoints {
         response = client
-            .post(format!("http://127.0.0.1:8080/refunds/{}", endpoint))
+            .post(format!("http://127.0.0.1:8080/refunds/{endpoint}"))
             .send()
             .await
             .unwrap();
         response_body = response.body().await;
-        println!("{} =:= {:?} : {:?}", endpoint, response, response_body);
+        println!("{endpoint} =:= {response:?} : {response_body:?}");
         assert_eq!(response.status(), awc::http::StatusCode::OK);
     }
 }

--- a/crates/router_derive/src/lib.rs
+++ b/crates/router_derive/src/lib.rs
@@ -160,7 +160,7 @@ pub fn setter(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     // pub fn set_n(&mut self,n: u32)
     let build_methods = fields.iter().map(|f| {
         let name = f.ident.as_ref().unwrap();
-        let method_name = format!("set_{}", name);
+        let method_name = format!("set_{name}");
         let method_ident = syn::Ident::new(&method_name, name.span());
         let ty = &f.ty;
         if check_if_auth_based_attr_is_present(f, "auth_based") {

--- a/crates/router_derive/src/macros/helpers.rs
+++ b/crates/router_derive/src/macros/helpers.rs
@@ -13,7 +13,7 @@ pub(super) fn occurrence_error<T: ToTokens>(
 ) -> syn::Error {
     let mut error = syn::Error::new_spanned(
         second_keyword,
-        format!("Found multiple occurrences of error({})", attr),
+        format!("Found multiple occurrences of error({attr})"),
     );
     error.combine(syn::Error::new_spanned(first_keyword, "first one here"));
     error

--- a/crates/router_env/src/logger/formatter.rs
+++ b/crates/router_env/src/logger/formatter.rs
@@ -106,7 +106,7 @@ impl fmt::Display for RecordType {
             Self::ExitSpan => "END",
             Self::Event => "EVENT",
         };
-        write!(f, "{}", repr)
+        write!(f, "{repr}")
     }
 }
 

--- a/crates/router_env/src/logger/setup.rs
+++ b/crates/router_env/src/logger/setup.rs
@@ -156,6 +156,6 @@ fn setup_metrics() -> Option<BasicController> {
         .with_period(Duration::from_secs(3))
         .with_timeout(Duration::from_secs(10))
         .build()
-        .map_err(|err| eprintln!("Failed to Setup Metrics with {:?}", err))
+        .map_err(|err| eprintln!("Failed to Setup Metrics with {err:?}"))
         .ok()
 }

--- a/crates/router_env/src/logger/storage.rs
+++ b/crates/router_env/src/logger/storage.rs
@@ -78,11 +78,11 @@ impl Visit for Storage<'_> {
             name if name.starts_with("log.") => (),
             name if name.starts_with("r#") => {
                 self.values
-                    .insert(&name[2..], serde_json::Value::from(format!("{:?}", value)));
+                    .insert(&name[2..], serde_json::Value::from(format!("{value:?}")));
             }
             name => {
                 self.values
-                    .insert(name, serde_json::Value::from(format!("{:?}", value)));
+                    .insert(name, serde_json::Value::from(format!("{value:?}")));
             }
         };
     }

--- a/crates/storage_models/src/query/generics.rs
+++ b/crates/storage_models/src/query/generics.rs
@@ -34,7 +34,7 @@ where
         AsQuery + LoadQuery<'static, PgConnection, R> + Send,
     R: Send + 'static,
 {
-    let debug_values = format!("{:?}", values);
+    let debug_values = format!("{values:?}");
 
     let query = diesel::insert_into(<T as HasTable>::table()).values(values);
     logger::debug!(query = %debug_query::<Pg, _>(&query).to_string());
@@ -49,7 +49,7 @@ where
             _ => Err(err).change_context(errors::DatabaseError::Others),
         },
     }
-    .attach_printable_lazy(|| format!("Error while inserting {}", debug_values))
+    .attach_printable_lazy(|| format!("Error while inserting {debug_values}"))
 }
 
 #[instrument(level = "DEBUG", skip_all)]
@@ -68,7 +68,7 @@ where
         <V as AsChangeset>::Changeset,
     >: AsQuery + QueryFragment<Pg> + QueryId + Send + 'static,
 {
-    let debug_values = format!("{:?}", values);
+    let debug_values = format!("{values:?}");
 
     let query = diesel::update(<T as HasTable>::table().filter(predicate)).set(values);
     logger::debug!(query = %debug_query::<Pg, _>(&query).to_string());
@@ -78,7 +78,7 @@ where
         .await
         .into_report()
         .change_context(errors::DatabaseError::Others)
-        .attach_printable_lazy(|| format!("Error while updating {}", debug_values))
+        .attach_printable_lazy(|| format!("Error while updating {debug_values}"))
 }
 
 #[instrument(level = "DEBUG", skip_all)]
@@ -98,7 +98,7 @@ where
     >: AsQuery + LoadQuery<'static, PgConnection, R> + QueryFragment<Pg> + Send,
     R: Send + 'static,
 {
-    let debug_values = format!("{:?}", values);
+    let debug_values = format!("{values:?}");
 
     let query = diesel::update(<T as HasTable>::table().filter(predicate)).set(values);
     logger::debug!(query = %debug_query::<Pg, _>(&query).to_string());
@@ -108,7 +108,7 @@ where
         .await
         .into_report()
         .change_context(errors::DatabaseError::Others)
-        .attach_printable_lazy(|| format!("Error while updating {}", debug_values))
+        .attach_printable_lazy(|| format!("Error while updating {debug_values}"))
 }
 
 #[instrument(level = "DEBUG", skip_all)]
@@ -138,7 +138,7 @@ where
     <V as AsChangeset>::Changeset: Clone,
     <<<T as FindDsl<Pk>>::Output as HasTable>::Table as QuerySource>::FromClause: Clone,
 {
-    let debug_values = format!("{:?}", values);
+    let debug_values = format!("{values:?}");
 
     let query = diesel::update(<T as HasTable>::table().find(id.to_owned())).set(values);
 
@@ -152,10 +152,10 @@ where
         }
         Err(ConnectionError::Query(DieselError::NotFound)) => {
             Err(report!(errors::DatabaseError::NotFound))
-                .attach_printable_lazy(|| format!("Error while updating by ID {}", debug_values))
+                .attach_printable_lazy(|| format!("Error while updating by ID {debug_values}"))
         }
         _ => Err(report!(errors::DatabaseError::Others))
-            .attach_printable_lazy(|| format!("Error while updating by ID {}", debug_values)),
+            .attach_printable_lazy(|| format!("Error while updating by ID {debug_values}")),
     }
 }
 
@@ -243,7 +243,7 @@ where
             _ => Err(err).change_context(errors::DatabaseError::Others),
         },
     }
-    .attach_printable_lazy(|| format!("Error finding record by primary key: {:?}", id))
+    .attach_printable_lazy(|| format!("Error finding record by primary key: {id:?}"))
 }
 
 #[instrument(level = "DEBUG", skip_all)]


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->
This PR addresses new clippy lints stabilized in Rust 1.67.

Most of them were just instances of [`clippy::uninlined_format_args`](https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args).

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
N/A

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
N/A

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
