### PR TITLE
fix: add disable env flag for consumer

### DIFF
--- a/config/Development.toml
+++ b/config/Development.toml
@@ -42,8 +42,22 @@ locker_decryption_key1 = ""
 locker_decryption_key2 = ""
 
 [connectors.supported]
-wallets = ["klarna","braintree","applepay"]
-cards = ["stripe","adyen","authorizedotnet","checkout","braintree","aci","shift4","cybersource", "worldpay", "globalpay", "fiserv", "payu", "worldline"]
+wallets = ["klarna", "braintree", "applepay"]
+cards = [
+    "stripe",
+    "adyen",
+    "authorizedotnet",
+    "checkout",
+    "braintree",
+    "aci",
+    "shift4",
+    "cybersource",
+    "worldpay",
+    "globalpay",
+    "fiserv",
+    "payu",
+    "worldline",
+]
 
 [refund]
 max_attempts = 10
@@ -102,4 +116,7 @@ base_url = "https://eu.sandbox.api-ingenico.com/"
 
 [scheduler]
 stream = "SCHEDULER_STREAM"
+
+[scheduler.consumer]
+disabled = false
 consumer_group = "SCHEDULER_GROUP"

--- a/config/Development.toml
+++ b/config/Development.toml
@@ -42,22 +42,8 @@ locker_decryption_key1 = ""
 locker_decryption_key2 = ""
 
 [connectors.supported]
-wallets = ["klarna", "braintree", "applepay"]
-cards = [
-    "stripe",
-    "adyen",
-    "authorizedotnet",
-    "checkout",
-    "braintree",
-    "aci",
-    "shift4",
-    "cybersource",
-    "worldpay",
-    "globalpay",
-    "fiserv",
-    "payu",
-    "worldline",
-]
+wallets = ["klarna","braintree","applepay"]
+cards = ["stripe","adyen","authorizedotnet","checkout","braintree","aci","shift4","cybersource", "worldpay", "globalpay", "fiserv", "payu", "worldline"]
 
 [refund]
 max_attempts = 10

--- a/config/config.example.toml
+++ b/config/config.example.toml
@@ -166,7 +166,10 @@ cards = [
 # It defines the the streams/queues name and configuration as well as event selection variables
 [scheduler]
 stream = "SCHEDULER_STREAM"
+
+[scheduler.consumer]
 consumer_group = "SCHEDULER_GROUP"
+disabled = false                   # This flag decides if the consumer should actively consume task
 
 [scheduler.producer]
 upper_fetch_limit = 0             # Upper limit for fetching entries from the redis queue (in seconds)

--- a/crates/router/src/configs/defaults.rs
+++ b/crates/router/src/configs/defaults.rs
@@ -82,8 +82,8 @@ impl Default for super::settings::SchedulerSettings {
     fn default() -> Self {
         Self {
             stream: "SCHEDULER_STREAM".into(),
-            consumer_group: "SCHEDULER_GROUP".into(),
             producer: super::settings::ProducerSettings::default(),
+            consumer: super::settings::ConsumerSettings::default(),
         }
     }
 }
@@ -96,6 +96,15 @@ impl Default for super::settings::ProducerSettings {
             lock_key: "PRODUCER_LOCKING_KEY".into(),
             lock_ttl: 160,
             batch_size: 200,
+        }
+    }
+}
+
+impl Default for super::settings::ConsumerSettings {
+    fn default() -> Self {
+        Self {
+            disabled: false,
+            consumer_group: "SCHEDULER_GROUP".into(),
         }
     }
 }

--- a/crates/router/src/configs/settings.rs
+++ b/crates/router/src/configs/settings.rs
@@ -163,8 +163,8 @@ pub struct ConnectorParams {
 #[serde(default)]
 pub struct SchedulerSettings {
     pub stream: String,
-    pub consumer_group: String,
     pub producer: ProducerSettings,
+    pub consumer: ConsumerSettings,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -176,6 +176,13 @@ pub struct ProducerSettings {
     pub lock_key: String,
     pub lock_ttl: i64,
     pub batch_size: usize,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct ConsumerSettings {
+    pub disabled: bool,
+    pub consumer_group: String,
 }
 
 #[cfg(feature = "kv_store")]

--- a/crates/router/src/configs/validations.rs
+++ b/crates/router/src/configs/validations.rs
@@ -152,7 +152,7 @@ impl super::settings::SchedulerSettings {
             ))
         })?;
 
-        when(self.consumer_group.is_default_or_empty(), || {
+        when(self.consumer.consumer_group.is_default_or_empty(), || {
             Err(ApplicationError::InvalidConfigurationValueError(
                 "scheduler consumer group must not be empty".into(),
             ))

--- a/crates/router/src/scheduler/consumer.rs
+++ b/crates/router/src/scheduler/consumer.rs
@@ -71,6 +71,12 @@ pub async fn start_consumer(
         match rx.try_recv() {
             Err(oneshot::error::TryRecvError::Empty) => {
                 interval.tick().await;
+
+                // A guard from env to disable the consumer
+                if settings.consumer.disabled {
+                    continue;
+                }
+
                 tokio::task::spawn(pt_utils::consumer_operation_handler(
                     state.clone(),
                     options.clone(),
@@ -112,7 +118,7 @@ pub async fn consumer_operations(
     settings: &settings::SchedulerSettings,
 ) -> CustomResult<(), errors::ProcessTrackerError> {
     let stream_name = settings.stream.clone();
-    let group_name = settings.consumer_group.clone();
+    let group_name = settings.consumer.consumer_group.clone();
     let consumer_name = format!("consumer_{}", Uuid::new_v4());
 
     let group_created = &mut state

--- a/crates/router/src/scheduler/utils.rs
+++ b/crates/router/src/scheduler/utils.rs
@@ -156,7 +156,7 @@ pub fn divide_into_batches(
         .fold(Vec::new(), |mut batches, item| {
             let batch = ProcessTrackerBatch {
                 id: batch_id.clone(),
-                group_name: conf.consumer_group.clone(),
+                group_name: conf.consumer.consumer_group.clone(),
                 stream_name: conf.stream.clone(),
                 connection_name: String::new(),
                 created_time: batch_creation_time,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description

This change introduces 2 changes in the configuration in the `[scheduler]` section

```diff
[scheduler]
stream = "SCHEDULER_STREAM"
- consumer_group = "SCHEDULER_GROUP"
+ [scheduler.consumer]
+ consumer_group = "SCHEDULER_GROUP"
+ disabled = false 
```
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema
- [x] This PR modifies application configuration/environment variables

<!-- 
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
