### PR TITLE
fix(refund): fix failing refund update with KV storage backend

### DIFF
--- a/crates/storage_models/src/query/refund.rs
+++ b/crates/storage_models/src/query/refund.rs
@@ -19,9 +19,16 @@ impl RefundNew {
 impl Refund {
     #[instrument(skip(conn))]
     pub async fn update(self, conn: &PgPooledConn, refund: RefundUpdate) -> StorageResult<Self> {
-        match generics::generic_update_by_id::<<Self as HasTable>::Table, _, _, _>(
+        match generics::generic_update_with_unique_predicate_get_result::<
+            <Self as HasTable>::Table,
+            _,
+            _,
+            _,
+        >(
             conn,
-            self.id,
+            dsl::refund_id
+                .eq(self.refund_id.to_owned())
+                .and(dsl::merchant_id.eq(self.merchant_id.to_owned())),
             RefundUpdateInternal::from(refund),
         )
         .await


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->
Update of refund was happening with the serial `id` primary key field, but in the KV flow we won't know the serial id and thus the update would fail. This PR solves that by updating based on `(merchant_id, refund_id)`.

### Additional Changes

- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!-- 
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Manual
![image](https://user-images.githubusercontent.com/68317979/216337030-d1e19e4d-cf86-4b70-823e-f704f8229fdb.png)

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [x] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
