### PR TITLE
feat: Added update cache for admin table

### DIFF
--- a/crates/router/src/db/merchant_account.rs
+++ b/crates/router/src/db/merchant_account.rs
@@ -90,11 +90,24 @@ impl MerchantAccountInterface for Store {
         this: storage::MerchantAccount,
         merchant_account: storage::MerchantAccountUpdate,
     ) -> CustomResult<storage::MerchantAccount, errors::StorageError> {
-        let conn = pg_connection(&self.master_pool).await;
-        this.update(&conn, merchant_account)
-            .await
-            .map_err(Into::into)
-            .into_report()
+        let merchant_id = this.merchant_id.clone();
+        let update_func = || async {
+            let conn = pg_connection(&self.master_pool).await;
+            this.update(&conn, merchant_account)
+                .await
+                .map_err(Into::into)
+                .into_report()
+        };
+
+        #[cfg(not(feature = "accounts_cache"))]
+        {
+            update_func().await
+        }
+
+        #[cfg(feature = "accounts_cache")]
+        {
+            super::cache::redact_cache(self, &merchant_id, update_func).await
+        }
     }
 
     async fn update_specific_fields_in_merchant(
@@ -102,11 +115,27 @@ impl MerchantAccountInterface for Store {
         merchant_id: &str,
         merchant_account: storage::MerchantAccountUpdate,
     ) -> CustomResult<storage::MerchantAccount, errors::StorageError> {
-        let conn = pg_connection(&self.master_pool).await;
-        storage::MerchantAccount::update_with_specific_fields(&conn, merchant_id, merchant_account)
+        let update_func = || async {
+            let conn = pg_connection(&self.master_pool).await;
+            storage::MerchantAccount::update_with_specific_fields(
+                &conn,
+                merchant_id,
+                merchant_account,
+            )
             .await
             .map_err(Into::into)
             .into_report()
+        };
+
+        #[cfg(not(feature = "accounts_cache"))]
+        {
+            update_func().await
+        }
+
+        #[cfg(feature = "accounts_cache")]
+        {
+            super::cache::redact_cache(self, merchant_id, update_func).await
+        }
     }
 
     async fn find_merchant_account_by_api_key(
@@ -135,11 +164,23 @@ impl MerchantAccountInterface for Store {
         &self,
         merchant_id: &str,
     ) -> CustomResult<bool, errors::StorageError> {
-        let conn = pg_connection(&self.master_pool).await;
-        storage::MerchantAccount::delete_by_merchant_id(&conn, merchant_id)
-            .await
-            .map_err(Into::into)
-            .into_report()
+        let delete_func = || async {
+            let conn = pg_connection(&self.master_pool).await;
+            storage::MerchantAccount::delete_by_merchant_id(&conn, merchant_id)
+                .await
+                .map_err(Into::into)
+                .into_report()
+        };
+
+        #[cfg(not(feature = "accounts_cache"))]
+        {
+            delete_func().await
+        }
+
+        #[cfg(feature = "accounts_cache")]
+        {
+            super::cache::redact_cache(self, merchant_id, delete_func).await
+        }
     }
 }
 


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->
- [x] New feature

## Description
<!-- Describe your changes in detail -->
Added cached update for admin table.


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
Added cached update for merchant account. This will only do cached update if `accounts_cache` feature is enabled.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code