### PR TITLE
refactor: use unique id for merchant_conenctor_id instead of int

### DIFF
--- a/crates/api_models/src/admin.rs
+++ b/crates/api_models/src/admin.rs
@@ -228,7 +228,7 @@ pub struct MerchantId {
 #[derive(Default, Debug, Deserialize, ToSchema, Serialize)]
 pub struct MerchantConnectorId {
     pub merchant_id: String,
-    pub merchant_connector_id: i32,
+    pub merchant_connector_id: String,
 }
 
 /// Create a new Payment Connector for the merchant account. The connector could be a payment processor / facilitator / acquirer or specialized services like Fraud / Accounting etc."
@@ -242,8 +242,8 @@ pub struct PaymentConnectorCreate {
     #[schema(example = "stripe")]
     pub connector_name: String,
     /// Unique ID of the connector
-    #[schema(example = 42)]
-    pub merchant_connector_id: Option<i32>,
+    #[schema(example = "mca_5apGeP94tMts6rg3U3kR")]
+    pub merchant_connector_id: Option<String>,
     /// Account details of the Connector. You can specify up to 50 keys, with key names up to 40 characters long and values up to 500 characters long. Useful for storing additional, structured information on an object.
     #[schema(value_type = Option<Object>,example = json!({ "auth_type": "HeaderKey","api_key": "Basic MyVerySecretApiKey" }))]
     pub connector_account_details: Option<Secret<serde_json::Value>>,
@@ -334,8 +334,8 @@ pub struct DeleteMcaResponse {
     #[schema(max_length = 255, example = "y3oqhf46pyzuxjbcn2giaqnb44")]
     pub merchant_id: String,
     /// Unique ID of the connector
-    #[schema(example = 42)]
-    pub merchant_connector_id: i32,
+    #[schema(example = "mca_5apGeP94tMts6rg3U3kR")]
+    pub merchant_connector_id: String,
     /// If the connector is deleted or not
     #[schema(example = false)]
     pub deleted: bool,

--- a/crates/router/src/core/admin.rs
+++ b/crates/router/src/core/admin.rs
@@ -3,6 +3,7 @@ use error_stack::{report, FutureExt, ResultExt};
 use uuid::Uuid;
 
 use crate::{
+    consts,
     core::errors::{self, RouterResponse, RouterResult, StorageErrorExt},
     db::StorageInterface,
     env::{self, Env},
@@ -285,7 +286,7 @@ pub async fn create_payment_connector(
         merchant_id: Some(merchant_id.to_string()),
         connector_type: Some(req.connector_type.foreign_into()),
         connector_name: Some(req.connector_name),
-        merchant_connector_id: None,
+        merchant_connector_id: utils::generate_id(consts::ID_LENGTH, "mca"),
         connector_account_details: req.connector_account_details,
         payment_methods_enabled,
         test_mode: req.test_mode,
@@ -307,7 +308,7 @@ pub async fn create_payment_connector(
 pub async fn retrieve_payment_connector(
     store: &dyn StorageInterface,
     merchant_id: String,
-    merchant_connector_id: i32,
+    merchant_connector_id: String,
 ) -> RouterResponse<api::PaymentConnectorCreate> {
     let _merchant_account = store
         .find_merchant_account_by_merchant_id(&merchant_id)
@@ -362,7 +363,7 @@ pub async fn list_payment_connectors(
 pub async fn update_payment_connector(
     db: &dyn StorageInterface,
     merchant_id: &str,
-    merchant_connector_id: i32,
+    merchant_connector_id: &str,
     req: api::PaymentConnectorCreate,
 ) -> RouterResponse<api::PaymentConnectorCreate> {
     let _merchant_account = db
@@ -395,7 +396,7 @@ pub async fn update_payment_connector(
         merchant_id: Some(merchant_id.to_string()),
         connector_type: Some(req.connector_type.foreign_into()),
         connector_name: Some(req.connector_name),
-        merchant_connector_id: Some(merchant_connector_id),
+        merchant_connector_id: Some(merchant_connector_id.to_string()),
         connector_account_details: req.connector_account_details,
         payment_methods_enabled,
         test_mode: req.test_mode,
@@ -438,7 +439,7 @@ pub async fn update_payment_connector(
 pub async fn delete_payment_connector(
     db: &dyn StorageInterface,
     merchant_id: String,
-    merchant_connector_id: i32,
+    merchant_connector_id: String,
 ) -> RouterResponse<api::DeleteMcaResponse> {
     let _merchant_account = db
         .find_merchant_account_by_merchant_id(&merchant_id)

--- a/crates/router/src/core/admin.rs
+++ b/crates/router/src/core/admin.rs
@@ -376,7 +376,7 @@ pub async fn update_payment_connector(
     let mca = db
         .find_by_merchant_connector_account_merchant_id_merchant_connector_id(
             merchant_id,
-            &merchant_connector_id,
+            merchant_connector_id,
         )
         .await
         .map_err(|error| {

--- a/crates/router/src/db/merchant_connector_account.rs
+++ b/crates/router/src/db/merchant_connector_account.rs
@@ -110,7 +110,7 @@ pub trait MerchantConnectorAccountInterface {
     async fn find_by_merchant_connector_account_merchant_id_merchant_connector_id(
         &self,
         merchant_id: &str,
-        merchant_connector_id: &i32,
+        merchant_connector_id: &str,
     ) -> CustomResult<storage::MerchantConnectorAccount, errors::StorageError>;
 
     async fn find_merchant_connector_account_by_merchant_id_list(
@@ -127,7 +127,7 @@ pub trait MerchantConnectorAccountInterface {
     async fn delete_merchant_connector_account_by_merchant_id_merchant_connector_id(
         &self,
         merchant_id: &str,
-        merchant_connector_id: &i32,
+        merchant_connector_id: &str,
     ) -> CustomResult<bool, errors::StorageError>;
 }
 
@@ -152,7 +152,7 @@ impl MerchantConnectorAccountInterface for Store {
     async fn find_by_merchant_connector_account_merchant_id_merchant_connector_id(
         &self,
         merchant_id: &str,
-        merchant_connector_id: &i32,
+        merchant_connector_id: &str,
     ) -> CustomResult<storage::MerchantConnectorAccount, errors::StorageError> {
         let conn = pg_connection(&self.master_pool).await;
         storage::MerchantConnectorAccount::find_by_merchant_id_merchant_connector_id(
@@ -199,7 +199,7 @@ impl MerchantConnectorAccountInterface for Store {
     async fn delete_merchant_connector_account_by_merchant_id_merchant_connector_id(
         &self,
         merchant_id: &str,
-        merchant_connector_id: &i32,
+        merchant_connector_id: &str,
     ) -> CustomResult<bool, errors::StorageError> {
         let conn = pg_connection(&self.master_pool).await;
         storage::MerchantConnectorAccount::delete_by_merchant_id_merchant_connector_id(
@@ -236,7 +236,7 @@ impl MerchantConnectorAccountInterface for MockDb {
     async fn find_by_merchant_connector_account_merchant_id_merchant_connector_id(
         &self,
         _merchant_id: &str,
-        _merchant_connector_id: &i32,
+        _merchant_connector_id: &str,
     ) -> CustomResult<storage::MerchantConnectorAccount, errors::StorageError> {
         // [#172]: Implement function for `MockDb`
         Err(errors::StorageError::MockDbError)?
@@ -256,7 +256,7 @@ impl MerchantConnectorAccountInterface for MockDb {
             connector_account_details: t.connector_account_details.unwrap_or_default().expose(),
             test_mode: t.test_mode,
             disabled: t.disabled,
-            merchant_connector_id: t.merchant_connector_id.unwrap_or_default(),
+            merchant_connector_id: t.merchant_connector_id,
             payment_methods_enabled: t.payment_methods_enabled,
             metadata: t.metadata,
             connector_type: t
@@ -287,7 +287,7 @@ impl MerchantConnectorAccountInterface for MockDb {
     async fn delete_merchant_connector_account_by_merchant_id_merchant_connector_id(
         &self,
         _merchant_id: &str,
-        _merchant_connector_id: &i32,
+        _merchant_connector_id: &str,
     ) -> CustomResult<bool, errors::StorageError> {
         // [#172]: Implement function for `MockDb`
         Err(errors::StorageError::MockDbError)?

--- a/crates/router/src/routes/admin.rs
+++ b/crates/router/src/routes/admin.rs
@@ -200,7 +200,7 @@ pub async fn payment_connector_create(
 pub async fn payment_connector_retrieve(
     state: web::Data<AppState>,
     req: HttpRequest,
-    path: web::Path<(String, i32)>,
+    path: web::Path<(String, String)>,
 ) -> HttpResponse {
     let (merchant_id, merchant_connector_id) = path.into_inner();
     let payload = web::Json(admin::MerchantConnectorId {
@@ -279,7 +279,7 @@ pub async fn payment_connector_list(
 pub async fn payment_connector_update(
     state: web::Data<AppState>,
     req: HttpRequest,
-    path: web::Path<(String, i32)>,
+    path: web::Path<(String, String)>,
     json_payload: web::Json<admin::PaymentConnectorCreate>,
 ) -> HttpResponse {
     let (merchant_id, merchant_connector_id) = path.into_inner();
@@ -288,7 +288,7 @@ pub async fn payment_connector_update(
         &req,
         json_payload.into_inner(),
         |state, _, req| {
-            update_payment_connector(&*state.store, &merchant_id, merchant_connector_id, req)
+            update_payment_connector(&*state.store, &merchant_id, &merchant_connector_id, req)
         },
         &auth::AdminApiAuth,
     )
@@ -318,7 +318,7 @@ pub async fn payment_connector_update(
 pub async fn payment_connector_delete(
     state: web::Data<AppState>,
     req: HttpRequest,
-    path: web::Path<(String, i32)>,
+    path: web::Path<(String, String)>,
 ) -> HttpResponse {
     let (merchant_id, merchant_connector_id) = path.into_inner();
     let payload = web::Json(admin::MerchantConnectorId {

--- a/crates/storage_models/src/merchant_connector_account.rs
+++ b/crates/storage_models/src/merchant_connector_account.rs
@@ -12,7 +12,7 @@ pub struct MerchantConnectorAccount {
     pub connector_account_details: serde_json::Value,
     pub test_mode: Option<bool>,
     pub disabled: Option<bool>,
-    pub merchant_connector_id: i32,
+    pub merchant_connector_id: String,
     #[diesel(deserialize_as = super::OptionalDieselArray<serde_json::Value>)]
     pub payment_methods_enabled: Option<Vec<serde_json::Value>>,
     pub connector_type: storage_enums::ConnectorType,
@@ -28,7 +28,7 @@ pub struct MerchantConnectorAccountNew {
     pub connector_account_details: Option<Secret<serde_json::Value>>,
     pub test_mode: Option<bool>,
     pub disabled: Option<bool>,
-    pub merchant_connector_id: Option<i32>,
+    pub merchant_connector_id: String,
     pub payment_methods_enabled: Option<Vec<serde_json::Value>>,
     pub metadata: Option<serde_json::Value>,
 }
@@ -42,7 +42,7 @@ pub enum MerchantConnectorAccountUpdate {
         connector_account_details: Option<Secret<serde_json::Value>>,
         test_mode: Option<bool>,
         disabled: Option<bool>,
-        merchant_connector_id: Option<i32>,
+        merchant_connector_id: Option<String>,
         payment_methods_enabled: Option<Vec<serde_json::Value>>,
         metadata: Option<serde_json::Value>,
     },
@@ -56,7 +56,7 @@ pub struct MerchantConnectorAccountUpdateInternal {
     connector_account_details: Option<Secret<serde_json::Value>>,
     test_mode: Option<bool>,
     disabled: Option<bool>,
-    merchant_connector_id: Option<i32>,
+    merchant_connector_id: Option<String>,
     payment_methods_enabled: Option<Vec<serde_json::Value>>,
     metadata: Option<serde_json::Value>,
 }

--- a/crates/storage_models/src/query/merchant_connector_account.rs
+++ b/crates/storage_models/src/query/merchant_connector_account.rs
@@ -44,7 +44,7 @@ impl MerchantConnectorAccount {
     pub async fn delete_by_merchant_id_merchant_connector_id(
         conn: &PgPooledConn,
         merchant_id: &str,
-        merchant_connector_id: &i32,
+        merchant_connector_id: &str,
     ) -> StorageResult<bool> {
         generics::generic_delete::<<Self as HasTable>::Table, _>(
             conn,
@@ -74,7 +74,7 @@ impl MerchantConnectorAccount {
     pub async fn find_by_merchant_id_merchant_connector_id(
         conn: &PgPooledConn,
         merchant_id: &str,
-        merchant_connector_id: &i32,
+        merchant_connector_id: &str,
     ) -> StorageResult<Self> {
         generics::generic_find_one::<<Self as HasTable>::Table, _, _>(
             conn,

--- a/crates/storage_models/src/schema.rs
+++ b/crates/storage_models/src/schema.rs
@@ -174,7 +174,7 @@ diesel::table! {
         connector_account_details -> Json,
         test_mode -> Nullable<Bool>,
         disabled -> Nullable<Bool>,
-        merchant_connector_id -> Int4,
+        merchant_connector_id -> Varchar,
         payment_methods_enabled -> Nullable<Array<Nullable<Json>>>,
         connector_type -> ConnectorType,
         metadata -> Nullable<Jsonb>,

--- a/migrations/2023-02-07-070512_change_merchant_connector_id_data_type/down.sql
+++ b/migrations/2023-02-07-070512_change_merchant_connector_id_data_type/down.sql
@@ -1,0 +1,10 @@
+CREATE SEQUENCE IF NOT EXISTS merchant_connector_id_seq OWNED BY merchant_connector_account.merchant_connector_id;
+
+UPDATE merchant_connector_account
+SET merchant_connector_id = id;
+
+ALTER TABLE merchant_connector_account
+ALTER COLUMN merchant_connector_id TYPE INTEGER USING (trim(merchant_connector_id)::integer);
+
+ALTER TABLE merchant_connector_account 
+ALTER COLUMN merchant_connector_id SET DEFAULT nextval('merchant_connector_id_seq');

--- a/migrations/2023-02-07-070512_change_merchant_connector_id_data_type/up.sql
+++ b/migrations/2023-02-07-070512_change_merchant_connector_id_data_type/up.sql
@@ -1,0 +1,6 @@
+ALTER TABLE merchant_connector_account
+ALTER COLUMN merchant_connector_id TYPE VARCHAR(128) USING merchant_connector_id::varchar;
+
+
+ALTER TABLE merchant_connector_account
+ALTER COLUMN merchant_connector_id DROP DEFAULT;


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->
- [x] Refactoring

## Description
<!-- Describe your changes in detail -->
Change the `merchant_connector_id` data type to use unique id.

### Additional Changes

- [x] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!-- 
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
Since we want to implement KV for Merchant connector account table we need to have a unique id as key for the table.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
<img width="676" alt="image" src="https://user-images.githubusercontent.com/43412619/217210075-48902f09-f3a2-4eee-9b43-a979b0eda027.png">


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code