### PR TITLE
feat: add tick interval to drainer

### DIFF
--- a/config/config.example.toml
+++ b/config/config.example.toml
@@ -187,5 +187,5 @@ batch_size = 200 # Specifies the batch size the producer will push under a singl
 stream_name = "DRAINER_STREAM" # Specifies the stream name to be used by the drainer
 num_partitions = 64            # Specifies the number of partitions the stream will be divided into
 max_read_count = 100           # Specifies the maximum number of entries that would be read from redis stream in one call
-shutdown_interval = 1000       # Specifies how much time to wait, while waiting for threads to complete execution
-loop_interval = 500            # Specifies how much time to wait after checking all the possible streams in completed
+shutdown_interval = 1000       # Specifies how much time to wait, while waiting for threads to complete execution (in milliseconds)
+loop_interval = 500            # Specifies how much time to wait after checking all the possible streams in completed (in milliseconds)

--- a/config/config.example.toml
+++ b/config/config.example.toml
@@ -188,3 +188,4 @@ stream_name = "DRAINER_STREAM" # Specifies the stream name to be used by the dra
 num_partitions = 64            # Specifies the number of partitions the stream will be divided into
 max_read_count = 100           # Specifies the maximum number of entries that would be read from redis stream in one call
 shutdown_interval = 1000       # Specifies how much time to wait, while waiting for threads to complete execution
+loop_interval = 500            # Specifies how much time to wait after checking all the possible streams in completed

--- a/crates/drainer/src/main.rs
+++ b/crates/drainer/src/main.rs
@@ -19,6 +19,7 @@ async fn main() -> DrainerResult<()> {
     let number_of_streams = store.config.drainer_num_partitions;
     let max_read_count = conf.drainer.max_read_count;
     let shutdown_intervals = conf.drainer.shutdown_interval;
+    let loop_interval = conf.drainer.loop_interval;
 
     let _guard = logger::setup(&conf.log).change_context(errors::DrainerError::MetricsError)?;
 
@@ -29,6 +30,7 @@ async fn main() -> DrainerResult<()> {
         number_of_streams,
         max_read_count,
         shutdown_intervals,
+        loop_interval,
     )
     .await?;
 

--- a/crates/drainer/src/settings.rs
+++ b/crates/drainer/src/settings.rs
@@ -45,6 +45,7 @@ pub struct DrainerSettings {
     pub num_partitions: u8,
     pub max_read_count: u64,
     pub shutdown_interval: u32, // in milliseconds
+    pub loop_interval: u32,     // in milliseconds
 }
 
 impl Default for Database {
@@ -67,6 +68,7 @@ impl Default for DrainerSettings {
             num_partitions: 64,
             max_read_count: 100,
             shutdown_interval: 1000, // in milliseconds
+            loop_interval: 500,      // in milliseconds
         }
     }
 }

--- a/crates/drainer/src/utils.rs
+++ b/crates/drainer/src/utils.rs
@@ -124,8 +124,13 @@ pub fn parse_stream_entries<'a>(
 
 // Here the output is in the format (stream_index, jobs_picked),
 // similar to the first argument of the function
-pub fn increment_stream_index((index, jobs_picked): (u8, u8), total_streams: u8) -> (u8, u8) {
+pub async fn increment_stream_index(
+    (index, jobs_picked): (u8, u8),
+    total_streams: u8,
+    interval: &mut tokio::time::Interval,
+) -> (u8, u8) {
     if index == total_streams - 1 {
+        interval.tick().await;
         match jobs_picked {
             0 => metrics::CYCLES_COMPLETED_UNSUCCESSFULLY.add(&metrics::CONTEXT, 1, &[]),
             _ => metrics::CYCLES_COMPLETED_SUCCESSFULLY.add(&metrics::CONTEXT, 1, &[]),

--- a/crates/router/src/configs/defaults.rs
+++ b/crates/router/src/configs/defaults.rs
@@ -116,6 +116,8 @@ impl Default for super::settings::DrainerSettings {
             stream_name: "DRAINER_STREAM".into(),
             num_partitions: 64,
             max_read_count: 100,
+            shutdown_interval: 1000,
+            loop_interval: 500,
         }
     }
 }

--- a/crates/router/src/configs/settings.rs
+++ b/crates/router/src/configs/settings.rs
@@ -194,6 +194,8 @@ pub struct DrainerSettings {
     pub stream_name: String,
     pub num_partitions: u8,
     pub max_read_count: u64,
+    pub shutdown_interval: u32, // in milliseconds
+    pub loop_interval: u32,     // in milliseconds
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description

This change will add sleep interval to drainer once a cycle is completed
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema
- [x] This PR modifies application configuration/environment variables


```
[drainer]
loop_interval: 500, // in milliseconds
```
<!-- 
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
