### PR TITLE
fix(core): use guard for access token result

### DIFF
--- a/crates/router/src/core/payments.rs
+++ b/crates/router/src/core/payments.rs
@@ -356,9 +356,11 @@ where
         .add_access_token(state, &connector, merchant_account)
         .await?;
 
-    match add_access_token_result.access_token_result {
-        Ok(access_token) => router_data.access_token = access_token,
-        Err(connector_error) => router_data.response = Err(connector_error),
+    if add_access_token_result.connector_supports_access_token {
+        match add_access_token_result.access_token_result {
+            Ok(access_token) => router_data.access_token = access_token,
+            Err(connector_error) => router_data.response = Err(connector_error),
+        }
     }
 
     let router_data_res = if !(add_access_token_result.connector_supports_access_token

--- a/crates/router/src/core/payments.rs
+++ b/crates/router/src/core/payments.rs
@@ -356,12 +356,10 @@ where
         .add_access_token(state, &connector, merchant_account)
         .await?;
 
-    if add_access_token_result.connector_supports_access_token {
-        match add_access_token_result.access_token_result {
-            Ok(access_token) => router_data.access_token = access_token,
-            Err(connector_error) => router_data.response = Err(connector_error),
-        }
-    }
+    access_token::update_router_data_with_access_token_result(
+        &add_access_token_result,
+        &mut router_data,
+    );
 
     let router_data_res = if !(add_access_token_result.connector_supports_access_token
         && router_data.access_token.is_none())

--- a/crates/router/src/core/payments.rs
+++ b/crates/router/src/core/payments.rs
@@ -359,6 +359,7 @@ where
     access_token::update_router_data_with_access_token_result(
         &add_access_token_result,
         &mut router_data,
+        &call_connector_action,
     );
 
     let router_data_res = if !(add_access_token_result.connector_supports_access_token

--- a/crates/router/src/core/payments/access_token.rs
+++ b/crates/router/src/core/payments/access_token.rs
@@ -48,6 +48,18 @@ pub fn router_data_type_conversion<F1, F2, Req1, Req2, Res1, Res2>(
     }
 }
 
+pub fn update_router_data_with_access_token_result<F, Req, Res>(
+    add_access_token_result: &types::AddAccessTokenResult,
+    router_data: &mut types::RouterData<F, Req, Res>,
+) {
+    if add_access_token_result.connector_supports_access_token {
+        match add_access_token_result.access_token_result.as_ref() {
+            Ok(access_token) => router_data.access_token = access_token.clone(),
+            Err(connector_error) => router_data.response = Err(connector_error.clone()),
+        }
+    }
+}
+
 pub async fn add_access_token<
     F: Clone + 'static,
     Req: Debug + Clone + 'static,

--- a/crates/router/src/core/payments/access_token.rs
+++ b/crates/router/src/core/payments/access_token.rs
@@ -51,8 +51,18 @@ pub fn router_data_type_conversion<F1, F2, Req1, Req2, Res1, Res2>(
 pub fn update_router_data_with_access_token_result<F, Req, Res>(
     add_access_token_result: &types::AddAccessTokenResult,
     router_data: &mut types::RouterData<F, Req, Res>,
+    call_connector_action: &payments::CallConnectorAction,
 ) {
-    if add_access_token_result.connector_supports_access_token {
+    // Update router data with access token or error only if it will be calling connector
+    let should_update_router_data = matches!(
+        (
+            add_access_token_result.connector_supports_access_token,
+            call_connector_action
+        ),
+        (true, payments::CallConnectorAction::Trigger)
+    );
+
+    if should_update_router_data {
         match add_access_token_result.access_token_result.as_ref() {
             Ok(access_token) => router_data.access_token = access_token.clone(),
             Err(connector_error) => router_data.response = Err(connector_error.clone()),

--- a/crates/router/src/core/refunds.rs
+++ b/crates/router/src/core/refunds.rs
@@ -131,10 +131,10 @@ pub async fn trigger_refund_to_gateway(
 
     logger::debug!(refund_router_data=?router_data);
 
-    match add_access_token_result.access_token_result {
-        Ok(access_token) => router_data.access_token = access_token,
-        Err(connector_error) => router_data.response = Err(connector_error),
-    }
+    access_token::update_router_data_with_access_token_result(
+        &add_access_token_result,
+        &mut router_data,
+    );
 
     let router_data_res = if !(add_access_token_result.connector_supports_access_token
         && router_data.access_token.is_none())
@@ -295,12 +295,10 @@ pub async fn sync_refund_with_gateway(
 
     logger::debug!(refund_retrieve_router_data=?router_data);
 
-    if add_access_token_result.connector_supports_access_token {
-        match add_access_token_result.access_token_result {
-            Ok(access_token) => router_data.access_token = access_token,
-            Err(connector_error) => router_data.response = Err(connector_error),
-        }
-    }
+    access_token::update_router_data_with_access_token_result(
+        &add_access_token_result,
+        &mut router_data,
+    );
 
     let router_data_res = if !(add_access_token_result.connector_supports_access_token
         && router_data.access_token.is_none())

--- a/crates/router/src/core/refunds.rs
+++ b/crates/router/src/core/refunds.rs
@@ -134,6 +134,7 @@ pub async fn trigger_refund_to_gateway(
     access_token::update_router_data_with_access_token_result(
         &add_access_token_result,
         &mut router_data,
+        &payments::CallConnectorAction::Trigger,
     );
 
     let router_data_res = if !(add_access_token_result.connector_supports_access_token
@@ -298,6 +299,7 @@ pub async fn sync_refund_with_gateway(
     access_token::update_router_data_with_access_token_result(
         &add_access_token_result,
         &mut router_data,
+        &payments::CallConnectorAction::Trigger,
     );
 
     let router_data_res = if !(add_access_token_result.connector_supports_access_token


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix

## Description
<!-- Describe your changes in detail -->
Klarna redirect payments were failing because of default error that was present in router data, which was populated by access token result.


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
- Create payment
![Screenshot 2023-02-08 at 12 44 21 PM](https://user-images.githubusercontent.com/48803246/217459987-6d111dc4-e8d8-493f-88c6-1a9d153117fd.png)
- Successful redirection
![Screenshot 2023-02-08 at 12 44 36 PM](https://user-images.githubusercontent.com/48803246/217460052-db0359d3-efb4-4576-920a-3e88ca83ad7f.png)


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
