### PR TITLE
refactor: Pass country and currency as json format in MCA

### DIFF
--- a/crates/api_models/src/admin.rs
+++ b/crates/api_models/src/admin.rs
@@ -269,14 +269,16 @@ pub struct PaymentConnectorCreate {
                 "Discover",
                 "Discover"
             ],
-            "accepted_currencies": [
-                "AED",
-                "AED"
-            ],
-            "accepted_countries": [
-                "in",
-                "us"
-            ],
+            "accepted_currencies": {
+                "enable_all":false,
+                "disable_only": ["INR", "CAD", "AED","JPY"],
+                "enable_only": ["EUR","USD"]
+            },
+            "accepted_countries": {
+                "enable_all":false,
+                "disable_only": ["FR", "DE","IN"],
+                "enable_only": ["UK","AU"]
+            },
             "minimum_amount": 1,
             "maximum_amount": 68607706,
             "recurring_enabled": true,
@@ -305,11 +307,23 @@ pub struct PaymentMethods {
     #[schema(example = json!(["MASTER","VISA","DINERS"]))]
     pub payment_schemes: Option<Vec<String>>,
     /// List of currencies accepted or has the processing capabilities of the processor
-    #[schema(value_type = Option<Vec<Currency>>,example = json!(["USD","EUR","AED"]))]
-    pub accepted_currencies: Option<Vec<api_enums::Currency>>,
+    #[schema(example = json!(
+        {
+        "enable_all":false,
+        "disable_only": ["INR", "CAD", "AED","JPY"],
+        "enable_only": ["EUR","USD"]
+        }
+    ))]
+    pub accepted_currencies: Option<AcceptedCurrencies>,
     ///  List of Countries accepted or has the processing capabilities of the processor
-    #[schema(example = json!(["US","IN"]))]
-    pub accepted_countries: Option<Vec<String>>,
+    #[schema(example = json!(
+        {
+            "enable_all":false,
+            "disable_only": ["FR", "DE","IN"],
+            "enable_only": ["UK","AU"]
+        }
+    ))]
+    pub accepted_countries: Option<AcceptedCountries>,
     /// Minimum amount supported by the processor. To be represented in the lowest denomination of the target currency (For example, for USD it should be in cents)
     #[schema(example = 1)]
     pub minimum_amount: Option<i32>,
@@ -326,6 +340,30 @@ pub struct PaymentMethods {
     /// Type of payment experience enabled with the connector
     #[schema(value_type = Option<Vec<PaymentExperience>>,example = json!(["redirect_to_url"]))]
     pub payment_experience: Option<Vec<payment_methods::PaymentExperience>>,
+}
+
+/// List of enabled and disabled currencies
+#[derive(Eq, PartialEq, Hash, Debug, Clone, serde::Serialize, Deserialize, ToSchema)]
+#[serde(deny_unknown_fields)]
+pub struct AcceptedCurrencies {
+    /// True in case all currencies are supported
+    pub enable_all: bool,
+    /// List of disabled currencies, provide in case only few of currencies are not supported
+    pub disable_only: Option<Vec<api_enums::Currency>>,
+    /// List of enable currencies, provide in case only few of currencies are supported
+    pub enable_only: Option<Vec<api_enums::Currency>>,
+}
+
+/// List of enabled and disabled countries
+#[derive(Eq, PartialEq, Hash, Debug, Clone, serde::Serialize, Deserialize, ToSchema)]
+#[serde(deny_unknown_fields)]
+pub struct AcceptedCountries {
+    /// True in case all countries are supported
+    pub enable_all: bool,
+    /// List of disabled countries, provide in case only few of countries are not supported
+    pub disable_only: Option<Vec<String>>,
+    /// List of enable countries, provide in case only few of countries are supported
+    pub enable_only: Option<Vec<String>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]

--- a/crates/api_models/src/payment_methods.rs
+++ b/crates/api_models/src/payment_methods.rs
@@ -168,24 +168,12 @@ pub struct ListPaymentMethodRequest {
     pub client_secret: Option<String>,
 
     /// The two-letter ISO currency code
-    #[schema(example = json!(
-        {
-            "enable_all":false,
-            "disable_only": ["FR", "DE","IN"],
-            "enable_only": ["UK","AU"]
-        }
-    ))]
-    pub accepted_countries: Option<admin::AcceptedCountries>,
+    #[schema(example = json!(["US", "UK", "IN"]))]
+    pub accepted_countries: Option<Vec<String>>,
 
     /// The three-letter ISO currency code
-    #[schema(example = json!(
-        {
-        "enable_all":false,
-        "disable_only": ["INR", "CAD", "AED","JPY"],
-        "enable_only": ["EUR","USD"]
-        }
-    ))]
-    pub accepted_currencies: Option<admin::AcceptedCurrencies>,
+    #[schema(value_type = Option<Vec<Currency>>,example = json!(["USD", "EUR"]))]
+    pub accepted_currencies: Option<Vec<api_enums::Currency>>,
 
     /// Filter by amount
     #[schema(example = 60)]
@@ -229,18 +217,18 @@ impl<'de> serde::Deserialize<'de> for ListPaymentMethodRequest {
                                 map.next_value()?,
                             )?;
                         }
-                        // "accepted_countries" => match output.accepted_countries.as_mut() {
-                        //     Some(inner) => inner.push(map.next_value()?),
-                        //     None => {
-                        //         output.accepted_countries = Some(vec![map.next_value()?]);
-                        //     }
-                        // },
-                        // "accepted_currencies" => match output.accepted_currencies.as_mut() {
-                        //     Some(inner) => inner.push(map.next_value()?),
-                        //     None => {
-                        //         output.accepted_currencies = Some(vec![map.next_value()?]);
-                        //     }
-                        // },
+                        "accepted_countries" => match output.accepted_countries.as_mut() {
+                            Some(inner) => inner.push(map.next_value()?),
+                            None => {
+                                output.accepted_countries = Some(vec![map.next_value()?]);
+                            }
+                        },
+                        "accepted_currencies" => match output.accepted_currencies.as_mut() {
+                            Some(inner) => inner.push(map.next_value()?),
+                            None => {
+                                output.accepted_currencies = Some(vec![map.next_value()?]);
+                            }
+                        },
                         "amount" => {
                             set_or_reject_duplicate(
                                 &mut output.amount,

--- a/crates/api_models/src/payment_methods.rs
+++ b/crates/api_models/src/payment_methods.rs
@@ -377,8 +377,6 @@ impl serde::Serialize for ListPaymentMethod {
         let mut state = serializer.serialize_struct("ListPaymentMethod", 4)?;
         state.serialize_field("payment_method", &self.payment_method)?;
         state.serialize_field("payment_experience", &self.payment_experience)?;
-        state.serialize_field("accepted_currencies", &self.accepted_currencies)?;
-        state.serialize_field("accepted_countries", &self.accepted_countries)?;
         match self.payment_method {
             api_enums::PaymentMethodType::Wallet | api_enums::PaymentMethodType::PayLater => {
                 state.serialize_field("payment_method_issuers", &self.payment_method_issuers)?;

--- a/crates/router/src/core/admin.rs
+++ b/crates/router/src/core/admin.rs
@@ -1,4 +1,4 @@
-use common_utils::ext_traits::ValueExt;
+use common_utils::{ext_traits::ValueExt, fp_utils::when};
 use error_stack::{report, FutureExt, ResultExt};
 use uuid::Uuid;
 
@@ -240,6 +240,38 @@ async fn validate_merchant_id<S: Into<String>>(
             error.to_not_found_response(errors::ApiErrorResponse::MerchantAccountNotFound)
         })
 }
+
+fn validate_pm_enabled(pm: &api::PaymentMethods) -> RouterResult<()> {
+    if let Some(ac) = pm.accepted_countries.to_owned() {
+        when(ac.enable_all && ac.enable_only.is_some(), || {
+            Err(errors::ApiErrorResponse::PreconditionFailed {
+                message: "In case all countries are enabled,provide the disable_only country"
+                    .to_string(),
+            })
+        })?;
+        when(!ac.enable_all && ac.disable_only.is_some(), || {
+            Err(errors::ApiErrorResponse::PreconditionFailed {
+                message: "In case enable_all is false, provide the enable_only country".to_string(),
+            })
+        })?;
+    };
+    if let Some(ac) = pm.accepted_currencies.to_owned() {
+        when(ac.enable_all && ac.enable_only.is_some(), || {
+            Err(errors::ApiErrorResponse::PreconditionFailed {
+                message: "In case all currencies are enabled, provide the disable_only currency"
+                    .to_string(),
+            })
+        })?;
+        when(!ac.enable_all && ac.disable_only.is_some(), || {
+            Err(errors::ApiErrorResponse::PreconditionFailed {
+                message: "In case enable_all is false, provide the enable_only currency"
+                    .to_string(),
+            })
+        })?;
+    };
+    Ok(())
+}
+
 // Payment Connector API -  Every merchant and connector can have an instance of (merchant <> connector)
 //                          with unique merchant_connector_id for Create Operation
 
@@ -260,6 +292,7 @@ pub async fn create_payment_connector(
     let payment_methods_enabled = match req.payment_methods_enabled {
         Some(val) => {
             for pm in val.into_iter() {
+                validate_pm_enabled(&pm)?;
                 let pm_value = utils::Encode::<api::PaymentMethods>::encode_to_value(&pm)
                     .change_context(errors::ApiErrorResponse::InternalServerError)
                     .attach_printable(
@@ -387,6 +420,9 @@ pub async fn update_payment_connector(
         pm_enabled
             .iter()
             .flat_map(|payment_method| {
+                validate_pm_enabled(payment_method)
+                    .change_context(errors::ParsingError)
+                    .attach_printable("Validation for accepted country and currency failed")?;
                 utils::Encode::<api::PaymentMethods>::encode_to_value(payment_method)
             })
             .collect::<Vec<serde_json::Value>>()

--- a/crates/router/src/core/payment_methods/cards.rs
+++ b/crates/router/src/core/payment_methods/cards.rs
@@ -1,6 +1,6 @@
 use std::collections::HashSet;
 
-use api_models::admin::{AcceptedCountries, AcceptedCurrencies};
+use api_models::{admin, enums as api_enums};
 use common_utils::{consts, ext_traits::AsyncExt, generate_id};
 use error_stack::{report, ResultExt};
 use router_env::{instrument, tracing};
@@ -436,89 +436,19 @@ async fn filter_payment_methods(
                     payment_method_object.accepted_countries,
                     req.accepted_countries,
                     filter,
-                ) = match (
+                ) = filter_pm_country_based(
                     &payment_method_object.accepted_countries,
                     &req.accepted_countries,
-                ) {
-                    (None, None) => (None, None, true),
-                    (None, Some(req_accepted_countries)) => {
-                        (None, Some(req_accepted_countries.to_owned()), false)
-                    }
-                    (Some(accepted_countries), None) => {
-                        (Some(accepted_countries.to_owned()), None, true)
-                    }
-                    (Some(accepted_countries), Some(req_accepted_countries)) => {
-                        if accepted_countries.enable_all {
-                            (
-                                Some(req_accepted_countries.to_owned()),
-                                Some(req_accepted_countries.to_owned()),
-                                true,
-                            )
-                        } else {
-                            let enable_only = filter_accepted_enum_based(
-                                &accepted_countries.enable_only,
-                                &req_accepted_countries.enable_only,
-                            );
-                            let disable_only = filter_accepted_enum_based(
-                                &accepted_countries.disable_only,
-                                &req_accepted_countries.disable_only,
-                            );
-                            (
-                                Some(AcceptedCountries {
-                                    enable_all: false,
-                                    disable_only,
-                                    enable_only,
-                                }),
-                                Some(req_accepted_countries.to_owned()),
-                                true,
-                            )
-                        }
-                    }
-                };
+                );
                 let filter2;
                 (
                     payment_method_object.accepted_currencies,
                     req.accepted_currencies,
                     filter2,
-                ) = match (
+                ) = filter_pm_currencies_based(
                     &payment_method_object.accepted_currencies,
                     &req.accepted_currencies,
-                ) {
-                    (None, None) => (None, None, true),
-                    (None, Some(req_accepted_countries)) => {
-                        (None, Some(req_accepted_countries.to_owned()), false)
-                    }
-                    (Some(accepted_currencies), None) => {
-                        (Some(accepted_currencies.to_owned()), None, true)
-                    }
-                    (Some(accepted_currencies), Some(req_accepted_currencies)) => {
-                        if accepted_currencies.enable_all {
-                            (
-                                Some(req_accepted_currencies.to_owned()),
-                                Some(req_accepted_currencies.to_owned()),
-                                true,
-                            )
-                        } else {
-                            let enable_only = filter_accepted_enum_based(
-                                &accepted_currencies.enable_only,
-                                &req_accepted_currencies.enable_only,
-                            );
-                            let disable_only = filter_accepted_enum_based(
-                                &accepted_currencies.disable_only,
-                                &req_accepted_currencies.disable_only,
-                            );
-                            (
-                                Some(AcceptedCurrencies {
-                                    enable_all: false,
-                                    disable_only,
-                                    enable_only,
-                                }),
-                                Some(req_accepted_currencies.to_owned()),
-                                true,
-                            )
-                        }
-                    }
-                };
+                );
                 let filter3 = if let Some(payment_intent) = payment_intent {
                     filter_payment_country_based(&payment_method_object, address).await?
                         && filter_payment_currency_based(payment_intent, &payment_method_object)
@@ -538,6 +468,72 @@ async fn filter_payment_methods(
     Ok(())
 }
 
+fn filter_pm_country_based(
+    accepted_countries: &Option<admin::AcceptedCountries>,
+    right: &Option<Vec<String>>,
+) -> (Option<admin::AcceptedCountries>, Option<Vec<String>>, bool) {
+    match (accepted_countries, right) {
+        (None, None) => (None, None, true),
+        (None, Some(ref r)) => (None, Some(r.to_vec()), false),
+        (Some(l), None) => (Some(l.to_owned()), None, true),
+        (Some(l), Some(ref r)) => {
+            if l.enable_all {
+                (Some(l.to_owned()), Some(r.to_vec()), true)
+            } else {
+                let enable_only = if l.enable_only.is_some() {
+                    filter_accepted_enum_based(&l.enable_only, &Some(r.to_owned()))
+                } else {
+                    filter_disabled_enum_based(&l.disable_only, &Some(r.to_owned()))
+                };
+                (
+                    Some(admin::AcceptedCountries {
+                        enable_all: false,
+                        enable_only,
+                        disable_only: None,
+                    }),
+                    Some(r.to_vec()),
+                    true,
+                )
+            }
+        }
+    }
+}
+
+fn filter_pm_currencies_based(
+    accepted_currency: &Option<admin::AcceptedCurrencies>,
+    right: &Option<Vec<api_enums::Currency>>,
+) -> (
+    Option<admin::AcceptedCurrencies>,
+    Option<Vec<api_enums::Currency>>,
+    bool,
+) {
+    match (accepted_currency, right) {
+        (None, None) => (None, None, true),
+        (None, Some(ref r)) => (None, Some(r.to_vec()), false),
+        (Some(l), None) => (Some(l.to_owned()), None, true),
+        (Some(l), Some(ref r)) => {
+            if l.enable_all {
+                (Some(l.to_owned()), Some(r.to_vec()), true)
+            } else {
+                let enable_only = if l.enable_only.is_some() {
+                    filter_accepted_enum_based(&l.enable_only, &Some(r.to_owned()))
+                } else {
+                    filter_disabled_enum_based(&l.disable_only, &Some(r.to_owned()))
+                };
+                (
+                    Some(admin::AcceptedCurrencies {
+                        enable_all: false,
+                        enable_only,
+                        disable_only: None,
+                    }),
+                    Some(r.to_vec()),
+                    true,
+                )
+            }
+        }
+    }
+}
+
 fn filter_accepted_enum_based<T: Eq + std::hash::Hash + Clone>(
     left: &Option<Vec<T>>,
     right: &Option<Vec<T>>,
@@ -551,6 +547,25 @@ fn filter_accepted_enum_based<T: Eq + std::hash::Hash + Clone>(
             Some(y)
         }
         (Some(ref l), None) => Some(l.to_vec()),
+        (_, _) => None,
+    }
+}
+
+fn filter_disabled_enum_based<T: Eq + std::hash::Hash + Clone>(
+    left: &Option<Vec<T>>,
+    right: &Option<Vec<T>>,
+) -> Option<Vec<T>> {
+    match (left, right) {
+        (Some(ref l), Some(ref r)) => {
+            let mut enabled = Vec::new();
+            for element in r {
+                if !l.contains(element) {
+                    enabled.push(element.to_owned());
+                }
+            }
+            Some(enabled)
+        }
+        (None, Some(r)) => Some(r.to_vec()),
         (_, _) => None,
     }
 }

--- a/crates/router/src/core/payment_methods/cards.rs
+++ b/crates/router/src/core/payment_methods/cards.rs
@@ -470,9 +470,9 @@ async fn filter_payment_methods(
 
 fn filter_pm_country_based(
     accepted_countries: &Option<admin::AcceptedCountries>,
-    right: &Option<Vec<String>>,
+    req_country_list: &Option<Vec<String>>,
 ) -> (Option<admin::AcceptedCountries>, Option<Vec<String>>, bool) {
-    match (accepted_countries, right) {
+    match (accepted_countries, req_country_list) {
         (None, None) => (None, None, true),
         (None, Some(ref r)) => (None, Some(r.to_vec()), false),
         (Some(l), None) => (Some(l.to_owned()), None, true),
@@ -497,13 +497,13 @@ fn filter_pm_country_based(
 
 fn filter_pm_currencies_based(
     accepted_currency: &Option<admin::AcceptedCurrencies>,
-    right: &Option<Vec<api_enums::Currency>>,
+    req_currency_list: &Option<Vec<api_enums::Currency>>,
 ) -> (
     Option<admin::AcceptedCurrencies>,
     Option<Vec<api_enums::Currency>>,
     bool,
 ) {
-    match (accepted_currency, right) {
+    match (accepted_currency, req_currency_list) {
         (None, None) => (None, None, true),
         (None, Some(ref r)) => (None, Some(r.to_vec()), false),
         (Some(l), None) => (Some(l.to_owned()), None, true),
@@ -602,13 +602,14 @@ async fn filter_payment_country_based(
 ) -> errors::CustomResult<bool, errors::ApiErrorResponse> {
     Ok(address.map_or(true, |address| {
         address.country.as_ref().map_or(true, |country| {
-            pm.accepted_countries.clone().map_or(true, |ac| {
+            pm.accepted_countries.as_ref().map_or(true, |ac| {
                 if ac.enable_all {
-                    ac.disable_only.map_or(true, |disable_countries| {
+                    ac.disable_only.as_ref().map_or(true, |disable_countries| {
                         disable_countries.contains(country)
                     })
                 } else {
                     ac.enable_only
+                        .as_ref()
                         .map_or(false, |enable_countries| enable_countries.contains(country))
                 }
             })
@@ -621,13 +622,13 @@ fn filter_payment_currency_based(
     pm: &api::ListPaymentMethod,
 ) -> bool {
     payment_intent.currency.map_or(true, |currency| {
-        pm.accepted_currencies.clone().map_or(true, |ac| {
+        pm.accepted_currencies.as_ref().map_or(true, |ac| {
             if ac.enable_all {
-                ac.disable_only.map_or(true, |disable_currencies| {
+                ac.disable_only.as_ref().map_or(true, |disable_currencies| {
                     disable_currencies.contains(&currency.foreign_into())
                 })
             } else {
-                ac.enable_only.map_or(false, |enable_currencies| {
+                ac.enable_only.as_ref().map_or(false, |enable_currencies| {
                     enable_currencies.contains(&currency.foreign_into())
                 })
             }

--- a/crates/router/src/routes/payment_methods.rs
+++ b/crates/router/src/routes/payment_methods.rs
@@ -268,14 +268,11 @@ mod tests {
 
     #[test]
     fn test_custom_list_deserialization() {
-        let dummy_data = "amount=120&recurring_enabled=true&installment_payment_enabled=true&accepted_countries=US&accepted_countries=IN";
+        let dummy_data = "amount=120&recurring_enabled=true&installment_payment_enabled=true";
         let de_query: web::Query<ListPaymentMethodRequest> =
             web::Query::from_query(dummy_data).unwrap();
         let de_struct = de_query.into_inner();
-        assert_eq!(
-            de_struct.accepted_countries,
-            Some(vec!["US".to_string(), "IN".to_string()])
-        )
+        assert_eq!(de_struct.installment_payment_enabled, Some(true))
     }
 
     #[test]


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates

## Description
Supported country and currency , the size exceed the allowed request size, refactoring how these field are passed in the MCA and in the List PM api


### Additional Changes

- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!-- 
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
Changing the format of the fields
{
"enable_all": false,
"disable_only": ["INR" ],
"enable_only": ["EUR"]
}


## How did you test it?
Testing with passing filters in list pm


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
