### PR TITLE
fix: don't call connector if connector transaction id doesn't exist

### DIFF
--- a/crates/router/src/core/payments/helpers.rs
+++ b/crates/router/src/core/payments/helpers.rs
@@ -848,7 +848,7 @@ pub(crate) fn validate_payment_method_fields_present(
     Ok(())
 }
 
-pub fn can_call_connector(
+pub fn check_force_psync_precondition(
     status: &storage_enums::AttemptStatus,
     connector_transaction_id: &Option<String>,
 ) -> bool {

--- a/crates/router/src/core/payments/helpers.rs
+++ b/crates/router/src/core/payments/helpers.rs
@@ -848,7 +848,10 @@ pub(crate) fn validate_payment_method_fields_present(
     Ok(())
 }
 
-pub fn can_call_connector(status: &storage_enums::AttemptStatus) -> bool {
+pub fn can_call_connector(
+    status: &storage_enums::AttemptStatus,
+    connector_transaction_id: &Option<String>,
+) -> bool {
     !matches!(
         status,
         storage_enums::AttemptStatus::Charged
@@ -858,7 +861,7 @@ pub fn can_call_connector(status: &storage_enums::AttemptStatus) -> bool {
             | storage_enums::AttemptStatus::Authorized
             | storage_enums::AttemptStatus::Started
             | storage_enums::AttemptStatus::Failure
-    )
+    ) && connector_transaction_id.is_some()
 }
 
 pub fn append_option<T, U, F, V>(func: F, option1: Option<T>, option2: Option<U>) -> Option<V>

--- a/crates/router/src/core/payments/operations/payment_status.rs
+++ b/crates/router/src/core/payments/operations/payment_status.rs
@@ -263,7 +263,7 @@ async fn get_tracker_for_sync<
             payment_method_data: None,
             force_sync: Some(
                 request.force_sync
-                    && helpers::can_call_connector(
+                    && helpers::check_force_psync_precondition(
                         &payment_attempt.status,
                         &payment_attempt.connector_transaction_id,
                     ),

--- a/crates/router/src/core/payments/operations/payment_status.rs
+++ b/crates/router/src/core/payments/operations/payment_status.rs
@@ -262,7 +262,11 @@ async fn get_tracker_for_sync<
             confirm: Some(request.force_sync),
             payment_method_data: None,
             force_sync: Some(
-                request.force_sync && helpers::can_call_connector(&payment_attempt.status),
+                request.force_sync
+                    && helpers::can_call_connector(
+                        &payment_attempt.status,
+                        &payment_attempt.connector_transaction_id,
+                    ),
             ),
             payment_attempt,
             refunds,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
In the case where we do not have the connector transaction id of a connector force_sync should not fail, rather we need it not to call the connector it this case.
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!-- 
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
