### PR TITLE
refactor: send full payment object for payment sync

### DIFF
--- a/crates/router/src/core/payments/operations/payment_response.rs
+++ b/crates/router/src/core/payments/operations/payment_response.rs
@@ -48,8 +48,28 @@ impl<F: Clone> PostUpdateTracker<F, PaymentData<F>, types::PaymentsAuthorizeData
             .mandate_id
             .or_else(|| router_data.request.mandate_id.clone());
 
-        payment_response_update_tracker(db, payment_id, payment_data, router_data, storage_scheme)
-            .await
+        let router_response = router_data.response.clone();
+        let connector = router_data.connector.clone();
+
+        payment_data = payment_response_update_tracker(
+            db,
+            payment_id,
+            payment_data,
+            router_data,
+            storage_scheme,
+        )
+        .await?;
+
+        router_response.clone().map_err(|error_response| {
+            errors::ApiErrorResponse::ExternalConnectorError {
+                message: error_response.message,
+                code: error_response.code,
+                status_code: error_response.status_code,
+                connector,
+            }
+        })?;
+
+        Ok(payment_data)
     }
 }
 
@@ -60,13 +80,13 @@ impl<F: Clone> PostUpdateTracker<F, PaymentData<F>, types::PaymentsSyncData> for
         db: &dyn StorageInterface,
         payment_id: &api::PaymentIdType,
         payment_data: PaymentData<F>,
-        response: types::RouterData<F, types::PaymentsSyncData, types::PaymentsResponseData>,
+        router_data: types::RouterData<F, types::PaymentsSyncData, types::PaymentsResponseData>,
         storage_scheme: enums::MerchantStorageScheme,
     ) -> RouterResult<PaymentData<F>>
     where
         F: 'b + Send,
     {
-        payment_response_update_tracker(db, payment_id, payment_data, response, storage_scheme)
+        payment_response_update_tracker(db, payment_id, payment_data, router_data, storage_scheme)
             .await
     }
 }
@@ -79,15 +99,35 @@ impl<F: Clone> PostUpdateTracker<F, PaymentData<F>, types::PaymentsSessionData>
         &'b self,
         db: &dyn StorageInterface,
         payment_id: &api::PaymentIdType,
-        payment_data: PaymentData<F>,
-        response: types::RouterData<F, types::PaymentsSessionData, types::PaymentsResponseData>,
+        mut payment_data: PaymentData<F>,
+        router_data: types::RouterData<F, types::PaymentsSessionData, types::PaymentsResponseData>,
         storage_scheme: enums::MerchantStorageScheme,
     ) -> RouterResult<PaymentData<F>>
     where
         F: 'b + Send,
     {
-        payment_response_update_tracker(db, payment_id, payment_data, response, storage_scheme)
-            .await
+        let router_response = router_data.response.clone();
+        let connector = router_data.connector.clone();
+
+        payment_data = payment_response_update_tracker(
+            db,
+            payment_id,
+            payment_data,
+            router_data,
+            storage_scheme,
+        )
+        .await?;
+
+        router_response.clone().map_err(|error_response| {
+            errors::ApiErrorResponse::ExternalConnectorError {
+                message: error_response.message,
+                code: error_response.code,
+                status_code: error_response.status_code,
+                connector,
+            }
+        })?;
+
+        Ok(payment_data)
     }
 }
 
@@ -99,15 +139,35 @@ impl<F: Clone> PostUpdateTracker<F, PaymentData<F>, types::PaymentsCaptureData>
         &'b self,
         db: &dyn StorageInterface,
         payment_id: &api::PaymentIdType,
-        payment_data: PaymentData<F>,
-        response: types::RouterData<F, types::PaymentsCaptureData, types::PaymentsResponseData>,
+        mut payment_data: PaymentData<F>,
+        router_data: types::RouterData<F, types::PaymentsCaptureData, types::PaymentsResponseData>,
         storage_scheme: enums::MerchantStorageScheme,
     ) -> RouterResult<PaymentData<F>>
     where
         F: 'b + Send,
     {
-        payment_response_update_tracker(db, payment_id, payment_data, response, storage_scheme)
-            .await
+        let router_response = router_data.response.clone();
+        let connector = router_data.connector.clone();
+
+        payment_data = payment_response_update_tracker(
+            db,
+            payment_id,
+            payment_data,
+            router_data,
+            storage_scheme,
+        )
+        .await?;
+
+        router_response.clone().map_err(|error_response| {
+            errors::ApiErrorResponse::ExternalConnectorError {
+                message: error_response.message,
+                code: error_response.code,
+                status_code: error_response.status_code,
+                connector,
+            }
+        })?;
+
+        Ok(payment_data)
     }
 }
 
@@ -117,16 +177,36 @@ impl<F: Clone> PostUpdateTracker<F, PaymentData<F>, types::PaymentsCancelData> f
         &'b self,
         db: &dyn StorageInterface,
         payment_id: &api::PaymentIdType,
-        payment_data: PaymentData<F>,
-        response: types::RouterData<F, types::PaymentsCancelData, types::PaymentsResponseData>,
+        mut payment_data: PaymentData<F>,
+        router_data: types::RouterData<F, types::PaymentsCancelData, types::PaymentsResponseData>,
 
         storage_scheme: enums::MerchantStorageScheme,
     ) -> RouterResult<PaymentData<F>>
     where
         F: 'b + Send,
     {
-        payment_response_update_tracker(db, payment_id, payment_data, response, storage_scheme)
-            .await
+        let router_response = router_data.response.clone();
+        let connector = router_data.connector.clone();
+
+        payment_data = payment_response_update_tracker(
+            db,
+            payment_id,
+            payment_data,
+            router_data,
+            storage_scheme,
+        )
+        .await?;
+
+        router_response.clone().map_err(|error_response| {
+            errors::ApiErrorResponse::ExternalConnectorError {
+                message: error_response.message,
+                code: error_response.code,
+                status_code: error_response.status_code,
+                connector,
+            }
+        })?;
+
+        Ok(payment_data)
     }
 }
 
@@ -149,8 +229,28 @@ impl<F: Clone> PostUpdateTracker<F, PaymentData<F>, types::VerifyRequestData> fo
             // .map(api_models::payments::MandateIds::new)
         });
 
-        payment_response_update_tracker(db, payment_id, payment_data, router_data, storage_scheme)
-            .await
+        let router_response = router_data.response.clone();
+        let connector = router_data.connector.clone();
+
+        payment_data = payment_response_update_tracker(
+            db,
+            payment_id,
+            payment_data,
+            router_data,
+            storage_scheme,
+        )
+        .await?;
+
+        router_response.clone().map_err(|error_response| {
+            errors::ApiErrorResponse::ExternalConnectorError {
+                message: error_response.message,
+                code: error_response.code,
+                status_code: error_response.status_code,
+                connector,
+            }
+        })?;
+
+        Ok(payment_data)
     }
 }
 
@@ -161,7 +261,6 @@ async fn payment_response_update_tracker<F: Clone, T>(
     router_data: types::RouterData<F, T, types::PaymentsResponseData>,
     storage_scheme: enums::MerchantStorageScheme,
 ) -> RouterResult<PaymentData<F>> {
-    let connector = router_data.connector.clone();
     let (payment_attempt_update, connector_response_update) = match router_data.response.clone() {
         Err(err) => (
             Some(storage::PaymentAttemptUpdate::ErrorUpdate {
@@ -262,7 +361,7 @@ async fn payment_response_update_tracker<F: Clone, T>(
         },
         Ok(_) => storage::PaymentIntentUpdate::ResponseUpdate {
             status: router_data.status.foreign_into(),
-            return_url: router_data.return_url,
+            return_url: router_data.return_url.clone(),
             amount_captured: router_data.amount_captured,
         },
     };
@@ -275,15 +374,6 @@ async fn payment_response_update_tracker<F: Clone, T>(
         )
         .await
         .map_err(|error| error.to_not_found_response(errors::ApiErrorResponse::PaymentNotFound))?;
-
-    router_data.response.map_err(|error_response| {
-        errors::ApiErrorResponse::ExternalConnectorError {
-            message: error_response.message,
-            code: error_response.code,
-            status_code: error_response.status_code,
-            connector,
-        }
-    })?;
 
     Ok(payment_data)
 }

--- a/crates/router/src/core/payments/operations/payment_response.rs
+++ b/crates/router/src/core/payments/operations/payment_response.rs
@@ -60,7 +60,7 @@ impl<F: Clone> PostUpdateTracker<F, PaymentData<F>, types::PaymentsAuthorizeData
         )
         .await?;
 
-        router_response.clone().map_err(|error_response| {
+        router_response.map_err(|error_response| {
             errors::ApiErrorResponse::ExternalConnectorError {
                 message: error_response.message,
                 code: error_response.code,
@@ -118,7 +118,7 @@ impl<F: Clone> PostUpdateTracker<F, PaymentData<F>, types::PaymentsSessionData>
         )
         .await?;
 
-        router_response.clone().map_err(|error_response| {
+        router_response.map_err(|error_response| {
             errors::ApiErrorResponse::ExternalConnectorError {
                 message: error_response.message,
                 code: error_response.code,
@@ -158,7 +158,7 @@ impl<F: Clone> PostUpdateTracker<F, PaymentData<F>, types::PaymentsCaptureData>
         )
         .await?;
 
-        router_response.clone().map_err(|error_response| {
+        router_response.map_err(|error_response| {
             errors::ApiErrorResponse::ExternalConnectorError {
                 message: error_response.message,
                 code: error_response.code,
@@ -197,7 +197,7 @@ impl<F: Clone> PostUpdateTracker<F, PaymentData<F>, types::PaymentsCancelData> f
         )
         .await?;
 
-        router_response.clone().map_err(|error_response| {
+        router_response.map_err(|error_response| {
             errors::ApiErrorResponse::ExternalConnectorError {
                 message: error_response.message,
                 code: error_response.code,
@@ -241,7 +241,7 @@ impl<F: Clone> PostUpdateTracker<F, PaymentData<F>, types::VerifyRequestData> fo
         )
         .await?;
 
-        router_response.clone().map_err(|error_response| {
+        router_response.map_err(|error_response| {
             errors::ApiErrorResponse::ExternalConnectorError {
                 message: error_response.message,
                 code: error_response.code,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Refactoring

## Description
<!-- Describe your changes in detail -->
Send the full body during a payment sync call when calling connector.


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
When calling a connector during a psync call, if there is a connector error, then payments sync call would send the shorter version. 

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
