### PR TITLE
refactor: Throw 500 error on database connection error instead of panic

### DIFF
--- a/config/Development.toml
+++ b/config/Development.toml
@@ -25,6 +25,7 @@ host = "localhost"
 port = 5432
 dbname = "hyperswitch_db"
 pool_size = 5
+connection_timeout = 10
 
 [proxy]
 

--- a/config/config.example.toml
+++ b/config/config.example.toml
@@ -25,6 +25,7 @@ host = "localhost"        # DB Host
 port = 5432               # DB Port
 dbname = "hyperswitch_db" # Name of Database
 pool_size = 5             # Number of connections to keep open
+connection_timeout = 10   # Timeout for database connection in seconds
 
 # Replica SQL data store credentials
 [replica_database]
@@ -34,6 +35,7 @@ host = "localhost"        # DB Host
 port = 5432               # DB Port
 dbname = "hyperswitch_db" # Name of Database
 pool_size = 5             # Number of connections to keep open
+connection_timeout = 10   # Timeout for database connection in seconds
 
 # Redis credentials
 [redis]

--- a/crates/router/src/configs/defaults.rs
+++ b/crates/router/src/configs/defaults.rs
@@ -20,6 +20,7 @@ impl Default for super::settings::Database {
             port: 5432,
             dbname: String::new(),
             pool_size: 5,
+            connection_timeout: 10,
         }
     }
 }

--- a/crates/router/src/configs/settings.rs
+++ b/crates/router/src/configs/settings.rs
@@ -123,6 +123,7 @@ pub struct Database {
     pub port: u16,
     pub dbname: String,
     pub pool_size: u32,
+    pub connection_timeout: u64,
 }
 
 #[derive(Debug, Deserialize, Clone)]

--- a/crates/router/src/connection.rs
+++ b/crates/router/src/connection.rs
@@ -1,8 +1,9 @@
 use async_bb8_diesel::{AsyncConnection, ConnectionError};
 use bb8::{CustomizeConnection, PooledConnection};
 use diesel::PgConnection;
+use error_stack::{IntoReport, ResultExt};
 
-use crate::configs::settings::Database;
+use crate::{configs::settings::Database, errors};
 
 pub type PgPool = bb8::Pool<async_bb8_diesel::ConnectionManager<PgConnection>>;
 
@@ -42,7 +43,9 @@ pub async fn diesel_make_pg_pool(database: &Database, test_transaction: bool) ->
         database.username, database.password, database.host, database.port, database.dbname
     );
     let manager = async_bb8_diesel::ConnectionManager::<PgConnection>::new(database_url);
-    let mut pool = bb8::Pool::builder().max_size(database.pool_size);
+    let mut pool = bb8::Pool::builder()
+        .max_size(database.pool_size)
+        .connection_timeout(std::time::Duration::from_secs(database.connection_timeout));
 
     if test_transaction {
         pool = pool.connection_customizer(Box::new(TestTransaction));
@@ -56,8 +59,12 @@ pub async fn diesel_make_pg_pool(database: &Database, test_transaction: bool) ->
 #[allow(clippy::expect_used)]
 pub async fn pg_connection(
     pool: &PgPool,
-) -> PooledConnection<'_, async_bb8_diesel::ConnectionManager<PgConnection>> {
+) -> errors::CustomResult<
+    PooledConnection<'_, async_bb8_diesel::ConnectionManager<PgConnection>>,
+    errors::StorageError,
+> {
     pool.get()
         .await
-        .expect("Couldn't retrieve PostgreSQL connection")
+        .into_report()
+        .change_context(errors::StorageError::DatabaseConnectionError)
 }

--- a/crates/router/src/connection.rs
+++ b/crates/router/src/connection.rs
@@ -56,7 +56,6 @@ pub async fn diesel_make_pg_pool(database: &Database, test_transaction: bool) ->
         .expect("Failed to create PostgreSQL connection pool")
 }
 
-#[allow(clippy::expect_used)]
 pub async fn pg_connection(
     pool: &PgPool,
 ) -> errors::CustomResult<

--- a/crates/router/src/core/errors.rs
+++ b/crates/router/src/core/errors.rs
@@ -59,6 +59,8 @@ pub enum StorageError {
         entity: &'static str,
         key: Option<String>,
     },
+    #[error("Timed out while trying to connect to the database")]
+    DatabaseConnectionError,
     #[error("KV error")]
     KVError,
     #[error("Serialization failure")]

--- a/crates/router/src/db/address.rs
+++ b/crates/router/src/db/address.rs
@@ -39,7 +39,7 @@ impl AddressInterface for Store {
         &self,
         address_id: &str,
     ) -> CustomResult<storage::Address, errors::StorageError> {
-        let conn = pg_connection(&self.master_pool).await;
+        let conn = pg_connection(&self.master_pool).await?;
         storage::Address::find_by_address_id(&conn, address_id)
             .await
             .map_err(Into::into)
@@ -51,7 +51,7 @@ impl AddressInterface for Store {
         address_id: String,
         address: storage::AddressUpdate,
     ) -> CustomResult<storage::Address, errors::StorageError> {
-        let conn = pg_connection(&self.master_pool).await;
+        let conn = pg_connection(&self.master_pool).await?;
         storage::Address::update_by_address_id(&conn, address_id, address)
             .await
             .map_err(Into::into)
@@ -62,7 +62,7 @@ impl AddressInterface for Store {
         &self,
         address: storage::AddressNew,
     ) -> CustomResult<storage::Address, errors::StorageError> {
-        let conn = pg_connection(&self.master_pool).await;
+        let conn = pg_connection(&self.master_pool).await?;
         address
             .insert(&conn)
             .await
@@ -76,7 +76,7 @@ impl AddressInterface for Store {
         merchant_id: &str,
         address: storage::AddressUpdate,
     ) -> CustomResult<Vec<storage::Address>, errors::StorageError> {
-        let conn = pg_connection(&self.master_pool).await;
+        let conn = pg_connection(&self.master_pool).await?;
         storage::Address::update_by_merchant_id_customer_id(
             &conn,
             customer_id,

--- a/crates/router/src/db/configs.rs
+++ b/crates/router/src/db/configs.rs
@@ -45,7 +45,7 @@ impl ConfigInterface for Store {
         &self,
         config: storage::ConfigNew,
     ) -> CustomResult<storage::Config, errors::StorageError> {
-        let conn = pg_connection(&self.master_pool).await;
+        let conn = pg_connection(&self.master_pool).await?;
         config.insert(&conn).await.map_err(Into::into).into_report()
     }
 
@@ -53,7 +53,7 @@ impl ConfigInterface for Store {
         &self,
         key: &str,
     ) -> CustomResult<storage::Config, errors::StorageError> {
-        let conn = pg_connection(&self.master_pool).await;
+        let conn = pg_connection(&self.master_pool).await?;
         storage::Config::find_by_key(&conn, key)
             .await
             .map_err(Into::into)
@@ -65,7 +65,7 @@ impl ConfigInterface for Store {
         key: &str,
         config_update: storage::ConfigUpdate,
     ) -> CustomResult<storage::Config, errors::StorageError> {
-        let conn = pg_connection(&self.master_pool).await;
+        let conn = pg_connection(&self.master_pool).await?;
         storage::Config::update_by_key(&conn, key, config_update)
             .await
             .map_err(Into::into)
@@ -91,7 +91,7 @@ impl ConfigInterface for Store {
     }
 
     async fn delete_config_by_key(&self, key: &str) -> CustomResult<bool, errors::StorageError> {
-        let conn = pg_connection(&self.master_pool).await;
+        let conn = pg_connection(&self.master_pool).await?;
         storage::Config::delete_by_key(&conn, key)
             .await
             .map_err(Into::into)

--- a/crates/router/src/db/connector_response.rs
+++ b/crates/router/src/db/connector_response.rs
@@ -38,7 +38,7 @@ impl ConnectorResponseInterface for Store {
         connector_response: storage::ConnectorResponseNew,
         _storage_scheme: enums::MerchantStorageScheme,
     ) -> CustomResult<storage::ConnectorResponse, errors::StorageError> {
-        let conn = pg_connection(&self.master_pool).await;
+        let conn = pg_connection(&self.master_pool).await?;
         connector_response
             .insert(&conn)
             .await
@@ -53,7 +53,7 @@ impl ConnectorResponseInterface for Store {
         attempt_id: &str,
         _storage_scheme: enums::MerchantStorageScheme,
     ) -> CustomResult<storage::ConnectorResponse, errors::StorageError> {
-        let conn = pg_connection(&self.master_pool).await;
+        let conn = pg_connection(&self.master_pool).await?;
         storage::ConnectorResponse::find_by_payment_id_merchant_id_attempt_id(
             &conn,
             payment_id,
@@ -71,7 +71,7 @@ impl ConnectorResponseInterface for Store {
         connector_response_update: storage::ConnectorResponseUpdate,
         _storage_scheme: enums::MerchantStorageScheme,
     ) -> CustomResult<storage::ConnectorResponse, errors::StorageError> {
-        let conn = pg_connection(&self.master_pool).await;
+        let conn = pg_connection(&self.master_pool).await?;
         this.update(&conn, connector_response_update)
             .await
             .map_err(Into::into)

--- a/crates/router/src/db/customers.rs
+++ b/crates/router/src/db/customers.rs
@@ -50,7 +50,7 @@ impl CustomerInterface for Store {
         customer_id: &str,
         merchant_id: &str,
     ) -> CustomResult<Option<storage::Customer>, errors::StorageError> {
-        let conn = pg_connection(&self.master_pool).await;
+        let conn = pg_connection(&self.master_pool).await?;
         let maybe_customer = storage::Customer::find_optional_by_customer_id_merchant_id(
             &conn,
             customer_id,
@@ -75,7 +75,7 @@ impl CustomerInterface for Store {
         merchant_id: String,
         customer: storage::CustomerUpdate,
     ) -> CustomResult<storage::Customer, errors::StorageError> {
-        let conn = pg_connection(&self.master_pool).await;
+        let conn = pg_connection(&self.master_pool).await?;
         storage::Customer::update_by_customer_id_merchant_id(
             &conn,
             customer_id,
@@ -92,7 +92,7 @@ impl CustomerInterface for Store {
         customer_id: &str,
         merchant_id: &str,
     ) -> CustomResult<storage::Customer, errors::StorageError> {
-        let conn = pg_connection(&self.master_pool).await;
+        let conn = pg_connection(&self.master_pool).await?;
         let customer =
             storage::Customer::find_by_customer_id_merchant_id(&conn, customer_id, merchant_id)
                 .await
@@ -108,7 +108,7 @@ impl CustomerInterface for Store {
         &self,
         customer_data: storage::CustomerNew,
     ) -> CustomResult<storage::Customer, errors::StorageError> {
-        let conn = pg_connection(&self.master_pool).await;
+        let conn = pg_connection(&self.master_pool).await?;
         customer_data
             .insert(&conn)
             .await
@@ -121,7 +121,7 @@ impl CustomerInterface for Store {
         customer_id: &str,
         merchant_id: &str,
     ) -> CustomResult<bool, errors::StorageError> {
-        let conn = pg_connection(&self.master_pool).await;
+        let conn = pg_connection(&self.master_pool).await?;
         storage::Customer::delete_by_customer_id_merchant_id(&conn, customer_id, merchant_id)
             .await
             .map_err(Into::into)

--- a/crates/router/src/db/events.rs
+++ b/crates/router/src/db/events.rs
@@ -21,7 +21,7 @@ impl EventInterface for Store {
         &self,
         event: storage::EventNew,
     ) -> CustomResult<storage::Event, errors::StorageError> {
-        let conn = pg_connection(&self.master_pool).await;
+        let conn = pg_connection(&self.master_pool).await?;
         event.insert(&conn).await.map_err(Into::into).into_report()
     }
 }

--- a/crates/router/src/db/locker_mock_up.rs
+++ b/crates/router/src/db/locker_mock_up.rs
@@ -31,7 +31,7 @@ impl LockerMockUpInterface for Store {
         &self,
         card_id: &str,
     ) -> CustomResult<storage::LockerMockUp, errors::StorageError> {
-        let conn = pg_connection(&self.master_pool).await;
+        let conn = pg_connection(&self.master_pool).await?;
         storage::LockerMockUp::find_by_card_id(&conn, card_id)
             .await
             .map_err(Into::into)
@@ -42,7 +42,7 @@ impl LockerMockUpInterface for Store {
         &self,
         new: storage::LockerMockUpNew,
     ) -> CustomResult<storage::LockerMockUp, errors::StorageError> {
-        let conn = pg_connection(&self.master_pool).await;
+        let conn = pg_connection(&self.master_pool).await?;
         new.insert(&conn).await.map_err(Into::into).into_report()
     }
 
@@ -50,7 +50,7 @@ impl LockerMockUpInterface for Store {
         &self,
         card_id: &str,
     ) -> CustomResult<storage::LockerMockUp, errors::StorageError> {
-        let conn = pg_connection(&self.master_pool).await;
+        let conn = pg_connection(&self.master_pool).await?;
         storage::LockerMockUp::delete_by_card_id(&conn, card_id)
             .await
             .map_err(Into::into)

--- a/crates/router/src/db/mandate.rs
+++ b/crates/router/src/db/mandate.rs
@@ -41,7 +41,7 @@ impl MandateInterface for Store {
         merchant_id: &str,
         mandate_id: &str,
     ) -> CustomResult<storage::Mandate, errors::StorageError> {
-        let conn = pg_connection(&self.master_pool).await;
+        let conn = pg_connection(&self.master_pool).await?;
         storage::Mandate::find_by_merchant_id_mandate_id(&conn, merchant_id, mandate_id)
             .await
             .map_err(Into::into)
@@ -53,7 +53,7 @@ impl MandateInterface for Store {
         merchant_id: &str,
         customer_id: &str,
     ) -> CustomResult<Vec<storage::Mandate>, errors::StorageError> {
-        let conn = pg_connection(&self.master_pool).await;
+        let conn = pg_connection(&self.master_pool).await?;
         storage::Mandate::find_by_merchant_id_customer_id(&conn, merchant_id, customer_id)
             .await
             .map_err(Into::into)
@@ -66,7 +66,7 @@ impl MandateInterface for Store {
         mandate_id: &str,
         mandate: storage::MandateUpdate,
     ) -> CustomResult<storage::Mandate, errors::StorageError> {
-        let conn = pg_connection(&self.master_pool).await;
+        let conn = pg_connection(&self.master_pool).await?;
         storage::Mandate::update_by_merchant_id_mandate_id(&conn, merchant_id, mandate_id, mandate)
             .await
             .map_err(Into::into)
@@ -77,7 +77,7 @@ impl MandateInterface for Store {
         &self,
         mandate: storage::MandateNew,
     ) -> CustomResult<storage::Mandate, errors::StorageError> {
-        let conn = pg_connection(&self.master_pool).await;
+        let conn = pg_connection(&self.master_pool).await?;
         mandate
             .insert(&conn)
             .await

--- a/crates/router/src/db/merchant_account.rs
+++ b/crates/router/src/db/merchant_account.rs
@@ -54,7 +54,7 @@ impl MerchantAccountInterface for Store {
         &self,
         merchant_account: storage::MerchantAccountNew,
     ) -> CustomResult<storage::MerchantAccount, errors::StorageError> {
-        let conn = pg_connection(&self.master_pool).await;
+        let conn = pg_connection(&self.master_pool).await?;
         merchant_account
             .insert(&conn)
             .await
@@ -67,7 +67,7 @@ impl MerchantAccountInterface for Store {
         merchant_id: &str,
     ) -> CustomResult<storage::MerchantAccount, errors::StorageError> {
         let fetch_func = || async {
-            let conn = pg_connection(&self.master_pool).await;
+            let conn = pg_connection(&self.master_pool).await?;
             storage::MerchantAccount::find_by_merchant_id(&conn, merchant_id)
                 .await
                 .map_err(Into::into)
@@ -92,7 +92,7 @@ impl MerchantAccountInterface for Store {
     ) -> CustomResult<storage::MerchantAccount, errors::StorageError> {
         let _merchant_id = this.merchant_id.clone();
         let update_func = || async {
-            let conn = pg_connection(&self.master_pool).await;
+            let conn = pg_connection(&self.master_pool).await?;
             this.update(&conn, merchant_account)
                 .await
                 .map_err(Into::into)
@@ -116,7 +116,7 @@ impl MerchantAccountInterface for Store {
         merchant_account: storage::MerchantAccountUpdate,
     ) -> CustomResult<storage::MerchantAccount, errors::StorageError> {
         let update_func = || async {
-            let conn = pg_connection(&self.master_pool).await;
+            let conn = pg_connection(&self.master_pool).await?;
             storage::MerchantAccount::update_with_specific_fields(
                 &conn,
                 merchant_id,
@@ -142,7 +142,7 @@ impl MerchantAccountInterface for Store {
         &self,
         api_key: &str,
     ) -> CustomResult<storage::MerchantAccount, errors::StorageError> {
-        let conn = pg_connection(&self.master_pool).await;
+        let conn = pg_connection(&self.master_pool).await?;
         storage::MerchantAccount::find_by_api_key(&conn, api_key)
             .await
             .map_err(Into::into)
@@ -153,7 +153,7 @@ impl MerchantAccountInterface for Store {
         &self,
         publishable_key: &str,
     ) -> CustomResult<storage::MerchantAccount, errors::StorageError> {
-        let conn = pg_connection(&self.master_pool).await;
+        let conn = pg_connection(&self.master_pool).await?;
         storage::MerchantAccount::find_by_publishable_key(&conn, publishable_key)
             .await
             .map_err(Into::into)
@@ -165,7 +165,7 @@ impl MerchantAccountInterface for Store {
         merchant_id: &str,
     ) -> CustomResult<bool, errors::StorageError> {
         let delete_func = || async {
-            let conn = pg_connection(&self.master_pool).await;
+            let conn = pg_connection(&self.master_pool).await?;
             storage::MerchantAccount::delete_by_merchant_id(&conn, merchant_id)
                 .await
                 .map_err(Into::into)

--- a/crates/router/src/db/merchant_connector_account.rs
+++ b/crates/router/src/db/merchant_connector_account.rs
@@ -138,7 +138,7 @@ impl MerchantConnectorAccountInterface for Store {
         merchant_id: &str,
         connector: &str,
     ) -> CustomResult<storage::MerchantConnectorAccount, errors::StorageError> {
-        let conn = pg_connection(&self.master_pool).await;
+        let conn = pg_connection(&self.master_pool).await?;
         storage::MerchantConnectorAccount::find_by_merchant_id_connector(
             &conn,
             merchant_id,
@@ -154,7 +154,7 @@ impl MerchantConnectorAccountInterface for Store {
         merchant_id: &str,
         merchant_connector_id: &str,
     ) -> CustomResult<storage::MerchantConnectorAccount, errors::StorageError> {
-        let conn = pg_connection(&self.master_pool).await;
+        let conn = pg_connection(&self.master_pool).await?;
         storage::MerchantConnectorAccount::find_by_merchant_id_merchant_connector_id(
             &conn,
             merchant_id,
@@ -169,7 +169,7 @@ impl MerchantConnectorAccountInterface for Store {
         &self,
         t: storage::MerchantConnectorAccountNew,
     ) -> CustomResult<storage::MerchantConnectorAccount, errors::StorageError> {
-        let conn = pg_connection(&self.master_pool).await;
+        let conn = pg_connection(&self.master_pool).await?;
         t.insert(&conn).await.map_err(Into::into).into_report()
     }
 
@@ -177,7 +177,7 @@ impl MerchantConnectorAccountInterface for Store {
         &self,
         merchant_id: &str,
     ) -> CustomResult<Vec<storage::MerchantConnectorAccount>, errors::StorageError> {
-        let conn = pg_connection(&self.master_pool).await;
+        let conn = pg_connection(&self.master_pool).await?;
         storage::MerchantConnectorAccount::find_by_merchant_id(&conn, merchant_id)
             .await
             .map_err(Into::into)
@@ -189,7 +189,7 @@ impl MerchantConnectorAccountInterface for Store {
         this: storage::MerchantConnectorAccount,
         merchant_connector_account: storage::MerchantConnectorAccountUpdate,
     ) -> CustomResult<storage::MerchantConnectorAccount, errors::StorageError> {
-        let conn = pg_connection(&self.master_pool).await;
+        let conn = pg_connection(&self.master_pool).await?;
         this.update(&conn, merchant_connector_account)
             .await
             .map_err(Into::into)
@@ -201,7 +201,7 @@ impl MerchantConnectorAccountInterface for Store {
         merchant_id: &str,
         merchant_connector_id: &str,
     ) -> CustomResult<bool, errors::StorageError> {
-        let conn = pg_connection(&self.master_pool).await;
+        let conn = pg_connection(&self.master_pool).await?;
         storage::MerchantConnectorAccount::delete_by_merchant_id_merchant_connector_id(
             &conn,
             merchant_id,

--- a/crates/router/src/db/payment_attempt.rs
+++ b/crates/router/src/db/payment_attempt.rs
@@ -75,7 +75,7 @@ mod storage {
             payment_attempt: PaymentAttemptNew,
             _storage_scheme: enums::MerchantStorageScheme,
         ) -> CustomResult<PaymentAttempt, errors::StorageError> {
-            let conn = pg_connection(&self.master_pool).await;
+            let conn = pg_connection(&self.master_pool).await?;
             payment_attempt
                 .insert(&conn)
                 .await
@@ -89,7 +89,7 @@ mod storage {
             payment_attempt: PaymentAttemptUpdate,
             _storage_scheme: enums::MerchantStorageScheme,
         ) -> CustomResult<PaymentAttempt, errors::StorageError> {
-            let conn = pg_connection(&self.master_pool).await;
+            let conn = pg_connection(&self.master_pool).await?;
             this.update(&conn, payment_attempt)
                 .await
                 .map_err(Into::into)
@@ -102,7 +102,7 @@ mod storage {
             merchant_id: &str,
             _storage_scheme: enums::MerchantStorageScheme,
         ) -> CustomResult<PaymentAttempt, errors::StorageError> {
-            let conn = pg_connection(&self.master_pool).await;
+            let conn = pg_connection(&self.master_pool).await?;
             PaymentAttempt::find_by_payment_id_merchant_id(&conn, payment_id, merchant_id)
                 .await
                 .map_err(Into::into)
@@ -116,7 +116,7 @@ mod storage {
             merchant_id: &str,
             _storage_scheme: enums::MerchantStorageScheme,
         ) -> CustomResult<PaymentAttempt, errors::StorageError> {
-            let conn = pg_connection(&self.master_pool).await;
+            let conn = pg_connection(&self.master_pool).await?;
             PaymentAttempt::find_by_connector_transaction_id_payment_id_merchant_id(
                 &conn,
                 connector_transaction_id,
@@ -134,7 +134,7 @@ mod storage {
             merchant_id: &str,
             _storage_scheme: enums::MerchantStorageScheme,
         ) -> CustomResult<PaymentAttempt, errors::StorageError> {
-            let conn = pg_connection(&self.master_pool).await;
+            let conn = pg_connection(&self.master_pool).await?;
             PaymentAttempt::find_last_successful_attempt_by_payment_id_merchant_id(
                 &conn,
                 payment_id,
@@ -151,7 +151,7 @@ mod storage {
             connector_txn_id: &str,
             _storage_scheme: enums::MerchantStorageScheme,
         ) -> CustomResult<PaymentAttempt, errors::StorageError> {
-            let conn = pg_connection(&self.master_pool).await;
+            let conn = pg_connection(&self.master_pool).await?;
             PaymentAttempt::find_by_merchant_id_connector_txn_id(
                 &conn,
                 merchant_id,
@@ -168,7 +168,7 @@ mod storage {
             attempt_id: &str,
             _storage_scheme: enums::MerchantStorageScheme,
         ) -> CustomResult<PaymentAttempt, errors::StorageError> {
-            let conn = pg_connection(&self.master_pool).await;
+            let conn = pg_connection(&self.master_pool).await?;
 
             PaymentAttempt::find_by_merchant_id_attempt_id(&conn, merchant_id, attempt_id)
                 .await
@@ -336,7 +336,7 @@ mod storage {
         ) -> CustomResult<PaymentAttempt, errors::StorageError> {
             match storage_scheme {
                 enums::MerchantStorageScheme::PostgresOnly => {
-                    let conn = pg_connection(&self.master_pool).await;
+                    let conn = pg_connection(&self.master_pool).await?;
                     payment_attempt
                         .insert(&conn)
                         .await
@@ -397,7 +397,7 @@ mod storage {
                         })
                         .into_report(),
                         Ok(HsetnxReply::KeySet) => {
-                            let conn = pg_connection(&self.master_pool).await;
+                            let conn = pg_connection(&self.master_pool).await?;
 
                             //Reverse lookup for attempt_id
                             ReverseLookupNew {
@@ -445,7 +445,7 @@ mod storage {
         ) -> CustomResult<PaymentAttempt, errors::StorageError> {
             match storage_scheme {
                 enums::MerchantStorageScheme::PostgresOnly => {
-                    let conn = pg_connection(&self.master_pool).await;
+                    let conn = pg_connection(&self.master_pool).await?;
                     this.update(&conn, payment_attempt)
                         .await
                         .map_err(Into::into)
@@ -468,7 +468,7 @@ mod storage {
                         .map(|_| updated_attempt)
                         .change_context(errors::StorageError::KVError)?;
 
-                    let conn = pg_connection(&self.master_pool).await;
+                    let conn = pg_connection(&self.master_pool).await?;
                     // Reverse lookup for connector_transaction_id
                     if let (None, Some(connector_transaction_id)) = (
                         old_connector_transaction_id,
@@ -520,7 +520,7 @@ mod storage {
             storage_scheme: enums::MerchantStorageScheme,
         ) -> CustomResult<PaymentAttempt, errors::StorageError> {
             let database_call = || async {
-                let conn = pg_connection(&self.master_pool).await;
+                let conn = pg_connection(&self.master_pool).await?;
                 PaymentAttempt::find_by_payment_id_merchant_id(&conn, payment_id, merchant_id)
                     .await
                     .map_err(Into::into)
@@ -558,7 +558,7 @@ mod storage {
             storage_scheme: enums::MerchantStorageScheme,
         ) -> CustomResult<PaymentAttempt, errors::StorageError> {
             let database_call = || async {
-                let conn = pg_connection(&self.master_pool).await;
+                let conn = pg_connection(&self.master_pool).await?;
                 PaymentAttempt::find_by_connector_transaction_id_payment_id_merchant_id(
                     &conn,
                     connector_transaction_id,
@@ -622,7 +622,7 @@ mod storage {
             storage_scheme: enums::MerchantStorageScheme,
         ) -> CustomResult<PaymentAttempt, errors::StorageError> {
             let database_call = || async {
-                let conn = pg_connection(&self.master_pool).await;
+                let conn = pg_connection(&self.master_pool).await?;
                 PaymentAttempt::find_by_merchant_id_connector_txn_id(
                     &conn,
                     merchant_id,
@@ -664,7 +664,7 @@ mod storage {
             storage_scheme: enums::MerchantStorageScheme,
         ) -> CustomResult<PaymentAttempt, errors::StorageError> {
             let database_call = || async {
-                let conn = pg_connection(&self.master_pool).await;
+                let conn = pg_connection(&self.master_pool).await?;
                 PaymentAttempt::find_by_merchant_id_attempt_id(&conn, merchant_id, attempt_id)
                     .await
                     .map_err(Into::into)

--- a/crates/router/src/db/payment_intent.rs
+++ b/crates/router/src/db/payment_intent.rs
@@ -63,7 +63,7 @@ mod storage {
         ) -> CustomResult<PaymentIntent, errors::StorageError> {
             match storage_scheme {
                 enums::MerchantStorageScheme::PostgresOnly => {
-                    let conn = pg_connection(&self.master_pool).await;
+                    let conn = pg_connection(&self.master_pool).await?;
                     new.insert(&conn).await.map_err(Into::into).into_report()
                 }
 
@@ -134,7 +134,7 @@ mod storage {
         ) -> CustomResult<PaymentIntent, errors::StorageError> {
             match storage_scheme {
                 enums::MerchantStorageScheme::PostgresOnly => {
-                    let conn = pg_connection(&self.master_pool).await;
+                    let conn = pg_connection(&self.master_pool).await?;
                     this.update(&conn, payment_intent)
                         .await
                         .map_err(Into::into)
@@ -189,7 +189,7 @@ mod storage {
             storage_scheme: enums::MerchantStorageScheme,
         ) -> CustomResult<PaymentIntent, errors::StorageError> {
             let database_call = || async {
-                let conn = pg_connection(&self.master_pool).await;
+                let conn = pg_connection(&self.master_pool).await?;
                 PaymentIntent::find_by_payment_id_merchant_id(&conn, payment_id, merchant_id)
                     .await
                     .map_err(Into::into)
@@ -219,7 +219,7 @@ mod storage {
         ) -> CustomResult<Vec<PaymentIntent>, errors::StorageError> {
             match storage_scheme {
                 enums::MerchantStorageScheme::PostgresOnly => {
-                    let conn = pg_connection(&self.replica_pool).await;
+                    let conn = pg_connection(&self.replica_pool).await?;
                     PaymentIntent::filter_by_constraints(&conn, merchant_id, pc)
                         .await
                         .map_err(Into::into)
@@ -253,7 +253,7 @@ mod storage {
             new: PaymentIntentNew,
             _storage_scheme: enums::MerchantStorageScheme,
         ) -> CustomResult<PaymentIntent, errors::StorageError> {
-            let conn = pg_connection(&self.master_pool).await;
+            let conn = pg_connection(&self.master_pool).await?;
             new.insert(&conn).await.map_err(Into::into).into_report()
         }
 
@@ -263,7 +263,7 @@ mod storage {
             payment_intent: PaymentIntentUpdate,
             _storage_scheme: enums::MerchantStorageScheme,
         ) -> CustomResult<PaymentIntent, errors::StorageError> {
-            let conn = pg_connection(&self.master_pool).await;
+            let conn = pg_connection(&self.master_pool).await?;
             this.update(&conn, payment_intent)
                 .await
                 .map_err(Into::into)
@@ -276,7 +276,7 @@ mod storage {
             merchant_id: &str,
             _storage_scheme: enums::MerchantStorageScheme,
         ) -> CustomResult<PaymentIntent, errors::StorageError> {
-            let conn = pg_connection(&self.master_pool).await;
+            let conn = pg_connection(&self.master_pool).await?;
             PaymentIntent::find_by_payment_id_merchant_id(&conn, payment_id, merchant_id)
                 .await
                 .map_err(Into::into)
@@ -290,7 +290,7 @@ mod storage {
             pc: &api::PaymentListConstraints,
             _storage_scheme: enums::MerchantStorageScheme,
         ) -> CustomResult<Vec<PaymentIntent>, errors::StorageError> {
-            let conn = pg_connection(&self.replica_pool).await;
+            let conn = pg_connection(&self.replica_pool).await?;
             PaymentIntent::filter_by_constraints(&conn, merchant_id, pc)
                 .await
                 .map_err(Into::into)

--- a/crates/router/src/db/payment_method.rs
+++ b/crates/router/src/db/payment_method.rs
@@ -38,7 +38,7 @@ impl PaymentMethodInterface for Store {
         &self,
         payment_method_id: &str,
     ) -> CustomResult<storage::PaymentMethod, errors::StorageError> {
-        let conn = pg_connection(&self.master_pool).await;
+        let conn = pg_connection(&self.master_pool).await?;
         storage::PaymentMethod::find_by_payment_method_id(&conn, payment_method_id)
             .await
             .map_err(Into::into)
@@ -49,7 +49,7 @@ impl PaymentMethodInterface for Store {
         &self,
         m: storage::PaymentMethodNew,
     ) -> CustomResult<storage::PaymentMethod, errors::StorageError> {
-        let conn = pg_connection(&self.master_pool).await;
+        let conn = pg_connection(&self.master_pool).await?;
         m.insert(&conn).await.map_err(Into::into).into_report()
     }
 
@@ -58,7 +58,7 @@ impl PaymentMethodInterface for Store {
         customer_id: &str,
         merchant_id: &str,
     ) -> CustomResult<Vec<storage::PaymentMethod>, errors::StorageError> {
-        let conn = pg_connection(&self.master_pool).await;
+        let conn = pg_connection(&self.master_pool).await?;
         storage::PaymentMethod::find_by_customer_id_merchant_id(&conn, customer_id, merchant_id)
             .await
             .map_err(Into::into)
@@ -70,7 +70,7 @@ impl PaymentMethodInterface for Store {
         merchant_id: &str,
         payment_method_id: &str,
     ) -> CustomResult<storage::PaymentMethod, errors::StorageError> {
-        let conn = pg_connection(&self.master_pool).await;
+        let conn = pg_connection(&self.master_pool).await?;
         storage::PaymentMethod::delete_by_merchant_id_payment_method_id(
             &conn,
             merchant_id,

--- a/crates/router/src/db/process_tracker.rs
+++ b/crates/router/src/db/process_tracker.rs
@@ -58,7 +58,7 @@ impl ProcessTrackerInterface for Store {
         &self,
         id: &str,
     ) -> CustomResult<Option<storage::ProcessTracker>, errors::StorageError> {
-        let conn = pg_connection(&self.master_pool).await;
+        let conn = pg_connection(&self.master_pool).await?;
         storage::ProcessTracker::find_process_by_id(&conn, id)
             .await
             .map_err(Into::into)
@@ -70,7 +70,7 @@ impl ProcessTrackerInterface for Store {
         ids: Vec<String>,
         schedule_time: PrimitiveDateTime,
     ) -> CustomResult<usize, errors::StorageError> {
-        let conn = pg_connection(&self.master_pool).await;
+        let conn = pg_connection(&self.master_pool).await?;
         storage::ProcessTracker::reinitialize_limbo_processes(&conn, ids, schedule_time)
             .await
             .map_err(Into::into)
@@ -84,7 +84,7 @@ impl ProcessTrackerInterface for Store {
         status: enums::ProcessTrackerStatus,
         limit: Option<i64>,
     ) -> CustomResult<Vec<storage::ProcessTracker>, errors::StorageError> {
-        let conn = pg_connection(&self.master_pool).await;
+        let conn = pg_connection(&self.master_pool).await?;
         storage::ProcessTracker::find_processes_by_time_status(
             &conn,
             time_lower_limit,
@@ -101,7 +101,7 @@ impl ProcessTrackerInterface for Store {
         &self,
         new: storage::ProcessTrackerNew,
     ) -> CustomResult<storage::ProcessTracker, errors::StorageError> {
-        let conn = pg_connection(&self.master_pool).await;
+        let conn = pg_connection(&self.master_pool).await?;
         new.insert_process(&conn)
             .await
             .map_err(Into::into)
@@ -113,7 +113,7 @@ impl ProcessTrackerInterface for Store {
         this: storage::ProcessTracker,
         process: storage::ProcessTrackerUpdate,
     ) -> CustomResult<storage::ProcessTracker, errors::StorageError> {
-        let conn = pg_connection(&self.master_pool).await;
+        let conn = pg_connection(&self.master_pool).await?;
         this.update(&conn, process)
             .await
             .map_err(Into::into)
@@ -125,7 +125,7 @@ impl ProcessTrackerInterface for Store {
         this: storage::ProcessTracker,
         process: storage::ProcessTrackerUpdate,
     ) -> CustomResult<storage::ProcessTracker, errors::StorageError> {
-        let conn = pg_connection(&self.master_pool).await;
+        let conn = pg_connection(&self.master_pool).await?;
         this.update(&conn, process)
             .await
             .map_err(Into::into)
@@ -137,7 +137,7 @@ impl ProcessTrackerInterface for Store {
         task_ids: Vec<String>,
         task_update: storage::ProcessTrackerUpdate,
     ) -> CustomResult<usize, errors::StorageError> {
-        let conn = pg_connection(&self.master_pool).await;
+        let conn = pg_connection(&self.master_pool).await?;
         storage::ProcessTracker::update_process_status_by_ids(&conn, task_ids, task_update)
             .await
             .map_err(Into::into)

--- a/crates/router/src/db/refund.rs
+++ b/crates/router/src/db/refund.rs
@@ -86,7 +86,7 @@ mod storage {
             merchant_id: &str,
             _storage_scheme: enums::MerchantStorageScheme,
         ) -> CustomResult<storage_types::Refund, errors::StorageError> {
-            let conn = pg_connection(&self.master_pool).await;
+            let conn = pg_connection(&self.master_pool).await?;
             storage_types::Refund::find_by_internal_reference_id_merchant_id(
                 &conn,
                 internal_reference_id,
@@ -102,7 +102,7 @@ mod storage {
             new: storage_types::RefundNew,
             _storage_scheme: enums::MerchantStorageScheme,
         ) -> CustomResult<storage_types::Refund, errors::StorageError> {
-            let conn = pg_connection(&self.master_pool).await;
+            let conn = pg_connection(&self.master_pool).await?;
             new.insert(&conn).await.map_err(Into::into).into_report()
         }
 
@@ -112,7 +112,7 @@ mod storage {
             connector_transaction_id: &str,
             _storage_scheme: enums::MerchantStorageScheme,
         ) -> CustomResult<Vec<storage_types::Refund>, errors::StorageError> {
-            let conn = pg_connection(&self.master_pool).await;
+            let conn = pg_connection(&self.master_pool).await?;
             storage_types::Refund::find_by_merchant_id_connector_transaction_id(
                 &conn,
                 merchant_id,
@@ -129,7 +129,7 @@ mod storage {
             refund: storage_types::RefundUpdate,
             _storage_scheme: enums::MerchantStorageScheme,
         ) -> CustomResult<storage_types::Refund, errors::StorageError> {
-            let conn = pg_connection(&self.master_pool).await;
+            let conn = pg_connection(&self.master_pool).await?;
             this.update(&conn, refund)
                 .await
                 .map_err(Into::into)
@@ -142,7 +142,7 @@ mod storage {
             refund_id: &str,
             _storage_scheme: enums::MerchantStorageScheme,
         ) -> CustomResult<storage_types::Refund, errors::StorageError> {
-            let conn = pg_connection(&self.master_pool).await;
+            let conn = pg_connection(&self.master_pool).await?;
             storage_types::Refund::find_by_merchant_id_refund_id(&conn, merchant_id, refund_id)
                 .await
                 .map_err(Into::into)
@@ -166,7 +166,7 @@ mod storage {
             merchant_id: &str,
             _storage_scheme: enums::MerchantStorageScheme,
         ) -> CustomResult<Vec<storage_types::Refund>, errors::StorageError> {
-            let conn = pg_connection(&self.master_pool).await;
+            let conn = pg_connection(&self.master_pool).await?;
             storage_types::Refund::find_by_payment_id_merchant_id(&conn, payment_id, merchant_id)
                 .await
                 .map_err(Into::into)
@@ -181,7 +181,7 @@ mod storage {
             _storage_scheme: enums::MerchantStorageScheme,
             limit: i64,
         ) -> CustomResult<Vec<storage_models::refund::Refund>, errors::StorageError> {
-            let conn = pg_connection(&self.replica_pool).await;
+            let conn = pg_connection(&self.replica_pool).await?;
             <storage_models::refund::Refund as storage_types::RefundDbExt>::filter_by_constraints(
                 &conn,
                 merchant_id,
@@ -220,7 +220,7 @@ mod storage {
             storage_scheme: enums::MerchantStorageScheme,
         ) -> CustomResult<storage_types::Refund, errors::StorageError> {
             let database_call = || async {
-                let conn = pg_connection(&self.master_pool).await;
+                let conn = pg_connection(&self.master_pool).await?;
                 storage_types::Refund::find_by_internal_reference_id_merchant_id(
                     &conn,
                     internal_reference_id,
@@ -261,7 +261,7 @@ mod storage {
         ) -> CustomResult<storage_types::Refund, errors::StorageError> {
             match storage_scheme {
                 enums::MerchantStorageScheme::PostgresOnly => {
-                    let conn = pg_connection(&self.master_pool).await;
+                    let conn = pg_connection(&self.master_pool).await?;
                     new.insert(&conn).await.map_err(Into::into).into_report()
                 }
                 enums::MerchantStorageScheme::RedisKv => {
@@ -310,7 +310,7 @@ mod storage {
                         })
                         .into_report(),
                         Ok(HsetnxReply::KeySet) => {
-                            let conn = pg_connection(&self.master_pool).await;
+                            let conn = pg_connection(&self.master_pool).await?;
 
                             let reverse_lookups = vec![
                                 storage_types::ReverseLookupNew {
@@ -368,7 +368,7 @@ mod storage {
         ) -> CustomResult<Vec<storage_types::Refund>, errors::StorageError> {
             match storage_scheme {
                 enums::MerchantStorageScheme::PostgresOnly => {
-                    let conn = pg_connection(&self.master_pool).await;
+                    let conn = pg_connection(&self.master_pool).await?;
                     storage_types::Refund::find_by_merchant_id_connector_transaction_id(
                         &conn,
                         merchant_id,
@@ -407,7 +407,7 @@ mod storage {
         ) -> CustomResult<storage_types::Refund, errors::StorageError> {
             match storage_scheme {
                 enums::MerchantStorageScheme::PostgresOnly => {
-                    let conn = pg_connection(&self.master_pool).await;
+                    let conn = pg_connection(&self.master_pool).await?;
                     this.update(&conn, refund)
                         .await
                         .map_err(Into::into)
@@ -466,7 +466,7 @@ mod storage {
             storage_scheme: enums::MerchantStorageScheme,
         ) -> CustomResult<storage_types::Refund, errors::StorageError> {
             let database_call = || async {
-                let conn = pg_connection(&self.master_pool).await;
+                let conn = pg_connection(&self.master_pool).await?;
                 storage_types::Refund::find_by_merchant_id_refund_id(&conn, merchant_id, refund_id)
                     .await
                     .map_err(Into::into)
@@ -515,7 +515,7 @@ mod storage {
         ) -> CustomResult<Vec<storage_types::Refund>, errors::StorageError> {
             match storage_scheme {
                 enums::MerchantStorageScheme::PostgresOnly => {
-                    let conn = pg_connection(&self.master_pool).await;
+                    let conn = pg_connection(&self.master_pool).await?;
                     storage_types::Refund::find_by_payment_id_merchant_id(
                         &conn,
                         payment_id,
@@ -553,7 +553,7 @@ mod storage {
         ) -> CustomResult<Vec<storage_models::refund::Refund>, errors::StorageError> {
             match storage_scheme {
                 enums::MerchantStorageScheme::PostgresOnly => {
-                    let conn = pg_connection(&self.replica_pool).await;
+                    let conn = pg_connection(&self.replica_pool).await?;
                     <storage_models::refund::Refund as storage_types::RefundDbExt>::filter_by_constraints(&conn, merchant_id, refund_details, limit)
                         .await
                         .map_err(Into::into)

--- a/crates/router/src/db/reverse_lookup.rs
+++ b/crates/router/src/db/reverse_lookup.rs
@@ -1,3 +1,4 @@
+use error_stack::ResultExt;
 use storage_models::{errors, StorageResult};
 
 use super::{MockDb, Store};
@@ -15,12 +16,16 @@ pub trait ReverseLookupInterface {
 #[async_trait::async_trait]
 impl ReverseLookupInterface for Store {
     async fn insert_reverse_lookup(&self, new: ReverseLookupNew) -> StorageResult<ReverseLookup> {
-        let conn = pg_connection(&self.master_pool).await;
+        let conn = pg_connection(&self.master_pool)
+            .await
+            .change_context(errors::DatabaseError::DatabaseConnectionError)?;
         new.insert(&conn).await
     }
 
     async fn get_lookup_by_lookup_id(&self, id: &str) -> StorageResult<ReverseLookup> {
-        let conn = pg_connection(&self.master_pool).await;
+        let conn = pg_connection(&self.master_pool)
+            .await
+            .change_context(errors::DatabaseError::DatabaseConnectionError)?;
         ReverseLookup::find_by_lookup_id(id, &conn).await
     }
 }

--- a/loadtest/config/Development.toml
+++ b/loadtest/config/Development.toml
@@ -14,6 +14,7 @@ host = "db"
 port = 5432
 dbname = "loadtest_router"
 pool_size = 20
+connection_timeout = 10
 
 [server]
 host = "0.0.0.0"


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->
- [x] Refactoring

## Description
<!-- Describe your changes in detail -->
Do not panic while getting db connection. Instead of that just throw 500 error. This PR also makes connection timeout in Database configurable.

### Additional Changes

- [x] This PR modifies application configuration/environment variables

<!-- 
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
When database goes down we don't want our application panic and stop actix workers since restarting it has much overhead. So instead just 500 error.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Start the application and bring down the database and try to make a payment. Throws 500 error.
<img width="1298" alt="image" src="https://user-images.githubusercontent.com/43412619/217778275-018d0a95-f4f7-46e7-b18b-5cf1bf7bef76.png">

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code