### PR TITLE
fix: throw 500 error when redis goes down

### DIFF
--- a/crates/redis_interface/src/lib.rs
+++ b/crates/redis_interface/src/lib.rs
@@ -21,8 +21,12 @@ pub mod commands;
 pub mod errors;
 pub mod types;
 
+use std::sync::{atomic, Arc};
+
 use common_utils::errors::CustomResult;
 use error_stack::{IntoReport, ResultExt};
+use fred::interfaces::ClientLike;
+use futures::StreamExt;
 use router_env::logger;
 
 pub use self::{commands::*, types::*};
@@ -31,6 +35,7 @@ pub struct RedisConnectionPool {
     pub pool: fred::pool::RedisPool,
     config: RedisConfig,
     join_handles: Vec<fred::types::ConnectHandle>,
+    pub is_redis_available: Arc<atomic::AtomicBool>,
 }
 
 impl RedisConnectionPool {
@@ -62,6 +67,7 @@ impl RedisConnectionPool {
             config.version = fred::types::RespVersion::RESP3;
         }
         config.tracing = true;
+        config.blocking = fred::types::Blocking::Error;
         let policy = fred::types::ReconnectPolicy::new_constant(
             conf.reconnect_max_attempts,
             conf.reconnect_delay,
@@ -82,6 +88,7 @@ impl RedisConnectionPool {
             pool,
             config,
             join_handles,
+            is_redis_available: Arc::new(atomic::AtomicBool::new(true)),
         })
     }
 
@@ -94,6 +101,19 @@ impl RedisConnectionPool {
                 Err(error) => logger::error!(%error),
             };
         }
+    }
+    pub async fn on_error(&self) {
+        self.pool
+            .on_error()
+            .for_each(|err| {
+                logger::error!("{err:?}");
+                if self.pool.state() == fred::types::ClientState::Disconnected {
+                    self.is_redis_available
+                        .store(false, atomic::Ordering::SeqCst);
+                }
+                futures::future::ready(())
+            })
+            .await;
     }
 }
 

--- a/crates/router/src/core/errors.rs
+++ b/crates/router/src/core/errors.rs
@@ -69,6 +69,14 @@ pub enum StorageError {
     CustomerRedacted,
     #[error("Deserialization failure")]
     DeserializationFailed,
+    #[error("Received Error RedisError: {0}")]
+    ERedisError(error_stack::Report<RedisError>),
+}
+
+impl From<error_stack::Report<RedisError>> for StorageError {
+    fn from(err: error_stack::Report<RedisError>) -> Self {
+        Self::ERedisError(err)
+    }
 }
 
 impl From<error_stack::Report<storage_errors::DatabaseError>> for StorageError {

--- a/crates/router/src/db/ephemeral_key.rs
+++ b/crates/router/src/db/ephemeral_key.rs
@@ -56,7 +56,8 @@ mod storage {
             };
 
             match self
-                .redis_conn
+                .redis_conn()
+                .map_err(Into::<errors::StorageError>::into)?
                 .serialize_and_set_multiple_hash_field_if_not_exist(
                     &[(&secret_key, &created_ek), (&id_key, &created_ek)],
                     "ephkey",
@@ -72,11 +73,13 @@ mod storage {
                 }
                 Ok(_) => {
                     let expire_at = expires.assume_utc().unix_timestamp();
-                    self.redis_conn
+                    self.redis_conn()
+                        .map_err(Into::<errors::StorageError>::into)?
                         .set_expire_at(&secret_key, expire_at)
                         .await
                         .change_context(errors::StorageError::KVError)?;
-                    self.redis_conn
+                    self.redis_conn()
+                        .map_err(Into::<errors::StorageError>::into)?
                         .set_expire_at(&id_key, expire_at)
                         .await
                         .change_context(errors::StorageError::KVError)?;
@@ -90,7 +93,8 @@ mod storage {
             key: &str,
         ) -> CustomResult<EphemeralKey, errors::StorageError> {
             let key = format!("epkey_{key}");
-            self.redis_conn
+            self.redis_conn()
+                .map_err(Into::<errors::StorageError>::into)?
                 .get_hash_field_and_deserialize(&key, "ephkey", "EphemeralKey")
                 .await
                 .change_context(errors::StorageError::KVError)
@@ -101,12 +105,14 @@ mod storage {
         ) -> CustomResult<EphemeralKey, errors::StorageError> {
             let ek = self.get_ephemeral_key(id).await?;
 
-            self.redis_conn
+            self.redis_conn()
+                .map_err(Into::<errors::StorageError>::into)?
                 .delete_key(&format!("epkey_{}", &ek.id))
                 .await
                 .change_context(errors::StorageError::KVError)?;
 
-            self.redis_conn
+            self.redis_conn()
+                .map_err(Into::<errors::StorageError>::into)?
                 .delete_key(&format!("epkey_{}", &ek.secret))
                 .await
                 .change_context(errors::StorageError::KVError)?;

--- a/crates/router/src/db/payment_attempt.rs
+++ b/crates/router/src/db/payment_attempt.rs
@@ -387,7 +387,8 @@ mod storage {
 
                     let field = format!("pa_{}", created_attempt.attempt_id);
                     match self
-                        .redis_conn
+                        .redis_conn()
+                        .map_err(Into::<errors::StorageError>::into)?
                         .serialize_and_set_hash_field_if_not_exist(&key, &field, &created_attempt)
                         .await
                     {
@@ -462,7 +463,8 @@ mod storage {
                         .change_context(errors::StorageError::KVError)?;
                     let field = format!("pa_{}", updated_attempt.attempt_id);
                     let updated_attempt = self
-                        .redis_conn
+                        .redis_conn()
+                        .map_err(Into::<errors::StorageError>::into)?
                         .set_hash_fields(&key, (&field, &redis_value))
                         .await
                         .map(|_| updated_attempt)
@@ -538,11 +540,13 @@ mod storage {
                         .into_report()?;
 
                     db_utils::try_redis_get_else_try_database_get(
-                        self.redis_conn.get_hash_field_and_deserialize(
-                            &lookup.pk_id,
-                            &lookup.sk_id,
-                            "PaymentAttempt",
-                        ),
+                        self.redis_conn()
+                            .map_err(Into::<errors::StorageError>::into)?
+                            .get_hash_field_and_deserialize(
+                                &lookup.pk_id,
+                                &lookup.sk_id,
+                                "PaymentAttempt",
+                            ),
                         database_call,
                     )
                     .await
@@ -582,11 +586,9 @@ mod storage {
                     let key = &lookup.pk_id;
 
                     db_utils::try_redis_get_else_try_database_get(
-                        self.redis_conn.get_hash_field_and_deserialize(
-                            key,
-                            &lookup.sk_id,
-                            "PaymentAttempt",
-                        ),
+                        self.redis_conn()
+                            .map_err(Into::<errors::StorageError>::into)?
+                            .get_hash_field_and_deserialize(key, &lookup.sk_id, "PaymentAttempt"),
                         database_call,
                     )
                     .await
@@ -645,11 +647,9 @@ mod storage {
 
                     let key = &lookup.pk_id;
                     db_utils::try_redis_get_else_try_database_get(
-                        self.redis_conn.get_hash_field_and_deserialize(
-                            key,
-                            &lookup.sk_id,
-                            "PaymentAttempt",
-                        ),
+                        self.redis_conn()
+                            .map_err(Into::<errors::StorageError>::into)?
+                            .get_hash_field_and_deserialize(key, &lookup.sk_id, "PaymentAttempt"),
                         database_call,
                     )
                     .await
@@ -682,11 +682,9 @@ mod storage {
                         .into_report()?;
                     let key = &lookup.pk_id;
                     db_utils::try_redis_get_else_try_database_get(
-                        self.redis_conn.get_hash_field_and_deserialize(
-                            key,
-                            &lookup.sk_id,
-                            "PaymentAttempt",
-                        ),
+                        self.redis_conn()
+                            .map_err(Into::<errors::StorageError>::into)?
+                            .get_hash_field_and_deserialize(key, &lookup.sk_id, "PaymentAttempt"),
                         database_call,
                     )
                     .await

--- a/crates/router/src/db/payment_intent.rs
+++ b/crates/router/src/db/payment_intent.rs
@@ -95,7 +95,8 @@ mod storage {
                     };
 
                     match self
-                        .redis_conn
+                        .redis_conn()
+                        .map_err(Into::<errors::StorageError>::into)?
                         .serialize_and_set_hash_field_if_not_exist(&key, "pi", &created_intent)
                         .await
                     {
@@ -152,7 +153,8 @@ mod storage {
                             .change_context(errors::StorageError::SerializationFailed)?;
 
                     let updated_intent = self
-                        .redis_conn
+                        .redis_conn()
+                        .map_err(Into::<errors::StorageError>::into)?
                         .set_hash_fields(&key, ("pi", &redis_value))
                         .await
                         .map(|_| updated_intent)
@@ -201,7 +203,8 @@ mod storage {
                 enums::MerchantStorageScheme::RedisKv => {
                     let key = format!("{merchant_id}_{payment_id}");
                     db_utils::try_redis_get_else_try_database_get(
-                        self.redis_conn
+                        self.redis_conn()
+                            .map_err(Into::<errors::StorageError>::into)?
                             .get_hash_field_and_deserialize(&key, "pi", "PaymentIntent"),
                         database_call,
                     )

--- a/crates/router/src/db/refund.rs
+++ b/crates/router/src/db/refund.rs
@@ -242,11 +242,9 @@ mod storage {
 
                     let key = &lookup.pk_id;
                     db_utils::try_redis_get_else_try_database_get(
-                        self.redis_conn.get_hash_field_and_deserialize(
-                            key,
-                            &lookup.sk_id,
-                            "Refund",
-                        ),
+                        self.redis_conn()
+                            .map_err(Into::<errors::StorageError>::into)?
+                            .get_hash_field_and_deserialize(key, &lookup.sk_id, "Refund"),
                         database_call,
                     )
                     .await
@@ -300,7 +298,8 @@ mod storage {
                         &created_refund.attempt_id, &created_refund.refund_id
                     );
                     match self
-                        .redis_conn
+                        .redis_conn()
+                        .map_err(Into::<errors::StorageError>::into)?
                         .serialize_and_set_hash_field_if_not_exist(&key, &field, &created_refund)
                         .await
                     {
@@ -391,7 +390,8 @@ mod storage {
 
                     let pattern = db_utils::generate_hscan_pattern_for_refund(&lookup.sk_id);
 
-                    self.redis_conn
+                    self.redis_conn()
+                        .map_err(Into::<errors::StorageError>::into)?
                         .hscan_and_deserialize(key, &pattern, None)
                         .await
                         .change_context(errors::StorageError::KVError)
@@ -433,7 +433,8 @@ mod storage {
                         )
                         .change_context(errors::StorageError::SerializationFailed)?;
 
-                    self.redis_conn
+                    self.redis_conn()
+                        .map_err(Into::<errors::StorageError>::into)?
                         .set_hash_fields(&lookup.pk_id, (field, redis_value))
                         .await
                         .change_context(errors::StorageError::KVError)?;
@@ -484,11 +485,9 @@ mod storage {
 
                     let key = &lookup.pk_id;
                     db_utils::try_redis_get_else_try_database_get(
-                        self.redis_conn.get_hash_field_and_deserialize(
-                            key,
-                            &lookup.sk_id,
-                            "Refund",
-                        ),
+                        self.redis_conn()
+                            .map_err(Into::<errors::StorageError>::into)?
+                            .get_hash_field_and_deserialize(key, &lookup.sk_id, "Refund"),
                         database_call,
                     )
                     .await
@@ -535,7 +534,8 @@ mod storage {
 
                     let pattern = db_utils::generate_hscan_pattern_for_refund(&lookup.sk_id);
 
-                    self.redis_conn
+                    self.redis_conn()
+                        .map_err(Into::<errors::StorageError>::into)?
                         .hscan_and_deserialize(&key, &pattern, None)
                         .await
                         .change_context(errors::StorageError::KVError)

--- a/crates/router/src/scheduler/producer.rs
+++ b/crates/router/src/scheduler/producer.rs
@@ -62,20 +62,16 @@ pub async fn run_producer_flow(
     op: &SchedulerOptions,
     settings: &SchedulerSettings,
 ) -> CustomResult<(), errors::ProcessTrackerError> {
-    lock_acquire_release::<_, _, error_stack::Report<errors::ProcessTrackerError>>(
-        state,
-        settings,
-        move || async {
-            let tasks = fetch_producer_tasks(&*state.store, op, settings).await?;
-            debug!("Producer count of tasks {}", tasks.len());
+    lock_acquire_release::<_, _>(state, settings, move || async {
+        let tasks = fetch_producer_tasks(&*state.store, op, settings).await?;
+        debug!("Producer count of tasks {}", tasks.len());
 
-            // [#268]: Allow task based segregation of tasks
+        // [#268]: Allow task based segregation of tasks
 
-            divide_and_append_tasks(state, SchedulerFlow::Producer, tasks, settings).await?;
+        divide_and_append_tasks(state, SchedulerFlow::Producer, tasks, settings).await?;
 
-            Ok(())
-        },
-    )
+        Ok(())
+    })
     .await?;
 
     Ok(())

--- a/crates/router/src/services.rs
+++ b/crates/router/src/services.rs
@@ -3,10 +3,15 @@ pub mod authentication;
 pub mod encryption;
 pub mod logger;
 
-use std::sync::Arc;
+use std::sync::{atomic, Arc};
+
+use redis_interface::errors::RedisError;
 
 pub use self::{api::*, encryption::*};
-use crate::connection::{diesel_make_pg_pool, PgPool};
+use crate::{
+    connection::{diesel_make_pg_pool, PgPool},
+    core::errors,
+};
 
 #[derive(Clone)]
 pub struct Store {
@@ -27,11 +32,18 @@ pub(crate) struct StoreConfig {
 
 impl Store {
     pub async fn new(config: &crate::configs::settings::Settings, test_transaction: bool) -> Self {
+        let redis_conn = Arc::new(crate::connection::redis_connection(config).await);
+        let redis_clone = redis_conn.clone();
+
+        tokio::spawn(async move {
+            redis_clone.on_error().await;
+        });
+
         Self {
             master_pool: diesel_make_pg_pool(&config.master_database, test_transaction).await,
             #[cfg(feature = "olap")]
             replica_pool: diesel_make_pg_pool(&config.replica_database, test_transaction).await,
-            redis_conn: Arc::new(crate::connection::redis_connection(config).await),
+            redis_conn,
             #[cfg(feature = "kv_store")]
             config: StoreConfig {
                 drainer_stream_name: config.drainer.stream_name.clone(),
@@ -44,6 +56,20 @@ impl Store {
     pub fn get_drainer_stream_name(&self, shard_key: &str) -> String {
         // Example: {shard_5}_drainer_stream
         format!("{{{}}}_{}", shard_key, self.config.drainer_stream_name,)
+    }
+
+    pub fn redis_conn(
+        &self,
+    ) -> errors::CustomResult<Arc<redis_interface::RedisConnectionPool>, RedisError> {
+        if self
+            .redis_conn
+            .is_redis_available
+            .load(atomic::Ordering::SeqCst)
+        {
+            Ok(self.redis_conn.clone())
+        } else {
+            Err(RedisError::RedisConnectionError.into())
+        }
     }
 
     #[cfg(feature = "kv_store")]


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->
- [x] Enhancement

## Description
<!-- Describe your changes in detail -->
Created a global flag to check if redis is available or not if it's not available send 500 error to all reamaining requests.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
Currently if redis goes down currently after `reconnect_attempts` reached fred will currently close the client and block the whole application. 

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or 
did you test this change manually (provide relevant screenshots)?
-->
Manual
<img width="1714" alt="Screenshot 2023-02-10 at 6 10 18 PM" src="https://user-images.githubusercontent.com/43412619/218101223-dd07382d-1e39-4e29-864d-3ff71408a850.png">
<img width="1346" alt="Screenshot 2023-02-10 at 6 10 31 PM" src="https://user-images.githubusercontent.com/43412619/218101276-24f2c259-d0f2-4967-90c6-f3ce8d783f82.png">


## Checklist
<!-- Put an `x` in the boxes that apply -->
- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code