### PR TITLE
refactor(middleware): change visibility to `pub`

### DIFF
--- a/crates/router/src/lib.rs
+++ b/crates/router/src/lib.rs
@@ -15,7 +15,7 @@ pub(crate) mod macros;
 pub mod routes;
 pub mod scheduler;
 
-mod middleware;
+pub mod middleware;
 #[cfg(feature = "openapi")]
 pub mod openapi;
 pub mod services;

--- a/crates/router/src/middleware.rs
+++ b/crates/router/src/middleware.rs
@@ -1,5 +1,5 @@
 /// Middleware to include request ID in response header.
-pub(crate) struct RequestId;
+pub struct RequestId;
 
 impl<S, B> actix_web::dev::Transform<S, actix_web::dev::ServiceRequest> for RequestId
 where
@@ -22,7 +22,7 @@ where
     }
 }
 
-pub(crate) struct RequestIdMiddleware<S> {
+pub struct RequestIdMiddleware<S> {
     service: S,
 }
 


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->
This PR changes the visibility of the `router::middleware` module to be public.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
This should help sharing middleware code across multiple services.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
N/A

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
