### PR TITLE
fix: allow errors with status code 200 to pass

### DIFF
--- a/crates/router/src/core/payments/operations/payment_response.rs
+++ b/crates/router/src/core/payments/operations/payment_response.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use common_utils::fp_utils;
 use error_stack::ResultExt;
 use router_derive;
 
@@ -60,13 +61,15 @@ impl<F: Clone> PostUpdateTracker<F, PaymentData<F>, types::PaymentsAuthorizeData
         )
         .await?;
 
-        router_response.map_err(|error_response| {
-            errors::ApiErrorResponse::ExternalConnectorError {
-                message: error_response.message,
-                code: error_response.code,
-                status_code: error_response.status_code,
-                connector,
-            }
+        router_response.map(|_| ()).or_else(|error_response| {
+            fp_utils::when((200..300).contains(&error_response.status_code), || {
+                Err(errors::ApiErrorResponse::ExternalConnectorError {
+                    code: error_response.code,
+                    message: error_response.message,
+                    connector,
+                    status_code: error_response.status_code,
+                })
+            })
         })?;
 
         Ok(payment_data)

--- a/crates/router/src/core/payments/operations/payment_response.rs
+++ b/crates/router/src/core/payments/operations/payment_response.rs
@@ -62,7 +62,7 @@ impl<F: Clone> PostUpdateTracker<F, PaymentData<F>, types::PaymentsAuthorizeData
         .await?;
 
         router_response.map(|_| ()).or_else(|error_response| {
-            fp_utils::when((200..300).contains(&error_response.status_code), || {
+            fp_utils::when(!(200..300).contains(&error_response.status_code), || {
                 Err(errors::ApiErrorResponse::ExternalConnectorError {
                     code: error_response.code,
                     message: error_response.message,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description

This will allow connectors with status code 2xx to pass through. While any error with a status code other than 2xx will be converted into router error
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!-- 
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<img width="1089" alt="Screenshot 2023-02-16 at 6 51 36 PM" src="https://user-images.githubusercontent.com/51093026/219376118-e4bc2c7f-a2f6-48a8-aad3-00d9155bafa5.png">


<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
