### PR TITLE
ehnahce(braintree): create basic auth for braintree

### DIFF
--- a/crates/router/src/connector/braintree.rs
+++ b/crates/router/src/connector/braintree.rs
@@ -39,7 +39,7 @@ impl ConnectorCommon for Braintree {
         let auth: braintree::BraintreeAuthType = auth_type
             .try_into()
             .change_context(errors::ConnectorError::FailedToObtainAuthType)?;
-        Ok(vec![(headers::AUTHORIZATION.to_string(), auth.api_key)])
+        Ok(vec![(headers::AUTHORIZATION.to_string(), auth.auth_header)])
     }
 }
 
@@ -103,7 +103,7 @@ impl
         Ok(format!(
             "{}/merchants/{}/client_token",
             self.base_url(connectors),
-            auth_type.merchant_account,
+            auth_type.merchant_id,
         ))
     }
 
@@ -131,6 +131,7 @@ impl
         &self,
         res: types::Response,
     ) -> CustomResult<types::ErrorResponse, errors::ConnectorError> {
+        logger::debug!(braintree_payments_error_response=?res);
         let response: braintree::ErrorResponse = res
             .response
             .parse_struct("Error Response")
@@ -241,7 +242,7 @@ impl
         Ok(format!(
             "{}/merchants/{}/transactions/{}",
             self.base_url(connectors),
-            auth_type.merchant_account,
+            auth_type.merchant_id,
             connector_payment_id
         ))
     }
@@ -341,7 +342,7 @@ impl
         Ok(format!(
             "{}merchants/{}/transactions",
             self.base_url(connectors),
-            auth_type.merchant_account
+            auth_type.merchant_id
         ))
     }
 
@@ -452,7 +453,7 @@ impl
         Ok(format!(
             "{}merchants/{}/transactions/{}/void",
             self.base_url(connectors),
-            auth_type.merchant_account,
+            auth_type.merchant_id,
             req.request.connector_transaction_id
         ))
     }
@@ -556,7 +557,7 @@ impl services::ConnectorIntegration<api::Execute, types::RefundsData, types::Ref
         Ok(format!(
             "{}merchants/{}/transactions/{}",
             self.base_url(connectors),
-            auth_type.merchant_account,
+            auth_type.merchant_id,
             connector_payment_id
         ))
     }

--- a/crates/router/src/connector/braintree/transformers.rs
+++ b/crates/router/src/connector/braintree/transformers.rs
@@ -1,7 +1,9 @@
+use base64::Engine;
 use error_stack::ResultExt;
 use serde::{Deserialize, Serialize};
 
 use crate::{
+    consts,
     core::errors,
     pii::PeekInterface,
     types::{self, api, storage::enums},
@@ -135,17 +137,24 @@ impl TryFrom<&types::PaymentsAuthorizeRouterData> for BraintreePaymentsRequest {
 }
 
 pub struct BraintreeAuthType {
-    pub(super) api_key: String,
-    pub(super) merchant_account: String,
+    pub(super) auth_header: String,
+    pub(super) merchant_id: String,
 }
 
 impl TryFrom<&types::ConnectorAuthType> for BraintreeAuthType {
     type Error = error_stack::Report<errors::ConnectorError>;
     fn try_from(item: &types::ConnectorAuthType) -> Result<Self, Self::Error> {
-        if let types::ConnectorAuthType::BodyKey { api_key, key1 } = item {
+        if let types::ConnectorAuthType::SignatureKey {
+            api_key: public_key,
+            key1: merchant_id,
+            api_secret: private_key,
+        } = item
+        {
+            let auth_key = format!("{}:{}", public_key, private_key);
+            let auth_header = format!("Basic {}", consts::BASE64_ENGINE.encode(auth_key));
             Ok(Self {
-                api_key: api_key.to_string(),
-                merchant_account: key1.to_string(),
+                auth_header,
+                merchant_id: merchant_id.to_owned(),
             })
         } else {
             Err(errors::ConnectorError::FailedToObtainAuthType)?

--- a/crates/router/src/connector/braintree/transformers.rs
+++ b/crates/router/src/connector/braintree/transformers.rs
@@ -150,7 +150,7 @@ impl TryFrom<&types::ConnectorAuthType> for BraintreeAuthType {
             api_secret: private_key,
         } = item
         {
-            let auth_key = format!("{}:{}", public_key, private_key);
+            let auth_key = format!("{public_key}:{private_key}");
             let auth_header = format!("Basic {}", consts::BASE64_ENGINE.encode(auth_key));
             Ok(Self {
                 auth_header,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Enhancement

## Description
<!-- Describe your changes in detail -->
Allow for api keys to be passed when creating braintree connector account instead of base64 encoded string.



## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
This change will ease creating braintree connector.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
- Create braintree connector account
```json
{
"connector_account_details": {
       "auth_type": "SignatureKey",
        "api_key": <public_key>,
        "key1": <merchant_id>,
        "api_secret": <private_key>
    },
}
- Create a 
<img width="558" alt="Screenshot 2023-02-16 at 4 38 54 PM" src="https://user-images.githubusercontent.com/48803246/219348994-21a60d92-16f5-4323-98cb-6f5e75ba4849.png">
payment 


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
