### PR TITLE
fix(router): allow setup future usage to be updated in payment update and confirm requests

### DIFF
--- a/crates/router/src/core/payments/operations/payment_confirm.rs
+++ b/crates/router/src/core/payments/operations/payment_confirm.rs
@@ -58,6 +58,11 @@ impl<F: Send + Clone> GetTracker<F, PaymentData<F>, api::PaymentsRequest> for Pa
                 error.to_not_found_response(errors::ApiErrorResponse::PaymentNotFound)
             })?;
 
+        payment_intent.setup_future_usage = request
+            .setup_future_usage
+            .map(ForeignInto::foreign_into)
+            .or(payment_intent.setup_future_usage);
+
         helpers::validate_payment_status_against_not_allowed_statuses(
             &payment_intent.status,
             &[
@@ -325,6 +330,7 @@ impl<F: Clone> UpdateTracker<F, PaymentData<F>, api::PaymentsRequest> for Paymen
 
         let customer_id = customer.map(|c| c.customer_id);
         let return_url = payment_data.payment_intent.return_url.clone();
+        let setup_future_usage = payment_data.payment_intent.setup_future_usage;
 
         payment_data.payment_intent = db
             .update_payment_intent(
@@ -332,6 +338,7 @@ impl<F: Clone> UpdateTracker<F, PaymentData<F>, api::PaymentsRequest> for Paymen
                 storage::PaymentIntentUpdate::Update {
                     amount: payment_data.amount.into(),
                     currency: payment_data.currency,
+                    setup_future_usage,
                     status: intent_status,
                     customer_id,
                     shipping_address_id: shipping_address,

--- a/crates/storage_models/src/payment_intent.rs
+++ b/crates/storage_models/src/payment_intent.rs
@@ -95,6 +95,7 @@ pub enum PaymentIntentUpdate {
     Update {
         amount: i64,
         currency: storage_enums::Currency,
+        setup_future_usage: Option<storage_enums::FutureUsage>,
         status: storage_enums::IntentStatus,
         customer_id: Option<String>,
         shipping_address_id: Option<String>,
@@ -158,6 +159,7 @@ impl From<PaymentIntentUpdate> for PaymentIntentUpdateInternal {
             PaymentIntentUpdate::Update {
                 amount,
                 currency,
+                setup_future_usage,
                 status,
                 customer_id,
                 shipping_address_id,
@@ -167,6 +169,7 @@ impl From<PaymentIntentUpdate> for PaymentIntentUpdateInternal {
                 amount: Some(amount),
                 currency: Some(currency),
                 status: Some(status),
+                setup_future_usage,
                 customer_id,
                 client_secret: make_client_secret_null_if_success(Some(status)),
                 shipping_address_id,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->
Allow the `setup_future_usage` associated with the payment intent to be updated in Payment Update and Confirm APIs.

### Additional Changes
None
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!-- 
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Local, compiler-guided, stripe payments.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
