### PR TITLE
refactor(compatibility): add additional fields to stripe payment and refund response types

### DIFF
--- a/crates/router/src/compatibility/stripe/payment_intents/types.rs
+++ b/crates/router/src/compatibility/stripe/payment_intents/types.rs
@@ -278,6 +278,7 @@ pub struct StripePaymentIntentResponse {
     pub refunds: Option<Vec<refunds::RefundResponse>>,
     pub mandate_id: Option<String>,
     pub metadata: Option<Value>,
+    pub charges: Charges,
 }
 
 impl From<payments::PaymentsResponse> for StripePaymentIntentResponse {
@@ -296,9 +297,32 @@ impl From<payments::PaymentsResponse> for StripePaymentIntentResponse {
             refunds: resp.refunds,
             mandate_id: resp.mandate_id,
             metadata: resp.metadata,
+            charges: Charges::new(),
         }
     }
 }
+
+#[derive(Default, Eq, PartialEq, Serialize)]
+pub struct Charges {
+    object: &'static str,
+    data: Vec<String>,
+    has_more: bool,
+    total_count: i32,
+    url: String
+}
+
+impl Charges {
+    fn new() -> Self {
+        Self {
+            object: "list",
+            data: vec![],
+            has_more: false,
+            total_count: 0,
+            url: "abc".to_string(),
+        }
+    }
+}
+
 #[derive(Clone, Debug, serde::Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct StripePaymentListConstraints {

--- a/crates/router/src/compatibility/stripe/payment_intents/types.rs
+++ b/crates/router/src/compatibility/stripe/payment_intents/types.rs
@@ -308,7 +308,7 @@ pub struct Charges {
     data: Vec<String>,
     has_more: bool,
     total_count: i32,
-    url: String
+    url: String,
 }
 
 impl Charges {

--- a/crates/router/src/compatibility/stripe/refunds/types.rs
+++ b/crates/router/src/compatibility/stripe/refunds/types.rs
@@ -24,7 +24,7 @@ pub struct StripeCreateRefundResponse {
     pub currency: String,
     pub payment_intent: String,
     pub status: StripeRefundStatus,
-    pub created: i64,
+    pub created: u32,
     pub metadata: serde_json::Value,
 }
 
@@ -82,7 +82,7 @@ impl TryFrom<refunds::RefundResponse> for StripeCreateRefundResponse {
                 .ok_or(errors::ApiErrorResponse::InternalServerError)
                 .into_report()
                 .attach_printable("`created_at` not available got Refund")?
-                .unix_timestamp(),
+                .microsecond(),
             metadata: res.metadata.unwrap_or(serde_json::json!({})),
         })
     }

--- a/crates/router/src/compatibility/stripe/refunds/types.rs
+++ b/crates/router/src/compatibility/stripe/refunds/types.rs
@@ -1,8 +1,9 @@
 use std::{convert::From, default::Default};
 
+use error_stack::{IntoReport, ResultExt};
 use serde::{Deserialize, Serialize};
 
-use crate::types::api::refunds;
+use crate::{core::errors, types::api::refunds};
 
 #[derive(Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub struct StripeCreateRefundRequest {
@@ -23,6 +24,8 @@ pub struct StripeCreateRefundResponse {
     pub currency: String,
     pub payment_intent: String,
     pub status: StripeRefundStatus,
+    pub created: i64,
+    pub metadata: serde_json::Value,
 }
 
 #[derive(Clone, Serialize, Deserialize, Eq, PartialEq)]
@@ -65,14 +68,22 @@ impl From<refunds::RefundStatus> for StripeRefundStatus {
     }
 }
 
-impl From<refunds::RefundResponse> for StripeCreateRefundResponse {
-    fn from(res: refunds::RefundResponse) -> Self {
-        Self {
+impl TryFrom<refunds::RefundResponse> for StripeCreateRefundResponse {
+    type Error = error_stack::Report<errors::ApiErrorResponse>;
+    fn try_from(res: refunds::RefundResponse) -> Result<Self, Self::Error> {
+        Ok(Self {
             id: res.refund_id,
             amount: res.amount,
             currency: res.currency.to_ascii_lowercase(),
             payment_intent: res.payment_id,
             status: res.status.into(),
-        }
+            created: res
+                .created_at
+                .ok_or(errors::ApiErrorResponse::InternalServerError)
+                .into_report()
+                .attach_printable("`created_at` not available got Refund")?
+                .unix_timestamp(),
+            metadata: res.metadata.unwrap_or(serde_json::json!({})),
+        })
     }
 }

--- a/crates/router/src/compatibility/wrap.rs
+++ b/crates/router/src/compatibility/wrap.rs
@@ -23,7 +23,7 @@ where
     F: Fn(&'b A, U, T) -> Fut,
     Fut: Future<Output = RouterResult<api::ApplicationResponse<Q>>>,
     Q: Serialize + std::fmt::Debug + 'a,
-    S: From<Q> + Serialize,
+    S: TryFrom<Q> + Serialize,
     E: Serialize + error_stack::Context + actix_web::ResponseError + Clone,
     errors::ApiErrorResponse: ErrorSwitch<E>,
     T: std::fmt::Debug,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->
Add additional fields to stripe payment and refund response types

### Additional Changes

- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!-- 
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Manual
![image](https://user-images.githubusercontent.com/68317979/220067246-665bce6b-dadf-440c-b1e4-ce8a55c34482.png)


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [x] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
