### PR TITLE
fix: add currency in verify request data

### DIFF
--- a/crates/router/src/core/payments/transformers.rs
+++ b/crates/router/src/core/payments/transformers.rs
@@ -523,6 +523,7 @@ impl<F: Clone> TryFrom<PaymentData<F>> for types::VerifyRequestData {
 
     fn try_from(payment_data: PaymentData<F>) -> Result<Self, Self::Error> {
         Ok(Self {
+            currency: payment_data.currency,
             confirm: true,
             payment_method_data: payment_data
                 .payment_method_data

--- a/crates/router/src/types.rs
+++ b/crates/router/src/types.rs
@@ -151,6 +151,7 @@ pub struct PaymentsSessionData {
 
 #[derive(Debug, Clone)]
 pub struct VerifyRequestData {
+    pub currency: storage_enums::Currency,
     pub payment_method_data: payments::PaymentMethod,
     pub confirm: bool,
     pub statement_descriptor_suffix: Option<String>,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description

Passing currency in the `VerifyRequestData`, for some connectors they require to send currency even in the case of `0` amount payment.
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!-- 
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
