### PR TITLE
refactor: add better log to parse struct

### DIFF
--- a/crates/common_utils/src/ext_traits.rs
+++ b/crates/common_utils/src/ext_traits.rs
@@ -157,7 +157,7 @@ pub trait BytesExt<T> {
 }
 
 impl<T> BytesExt<T> for bytes::Bytes {
-    fn parse_struct<'de>(&'de self, type_name: &str) -> CustomResult<T, errors::ParsingError>
+    fn parse_struct<'de>(&'de self, _type_name: &str) -> CustomResult<T, errors::ParsingError>
     where
         T: Deserialize<'de>,
     {
@@ -166,7 +166,10 @@ impl<T> BytesExt<T> for bytes::Bytes {
         serde_json::from_slice::<T>(self.chunk())
             .into_report()
             .change_context(errors::ParsingError)
-            .attach_printable_lazy(|| format!("Unable to parse {type_name} from bytes"))
+            .attach_printable_lazy(|| {
+                let variable_type = std::any::type_name::<T>();
+                format!("Unable to parse {variable_type} from bytes {self:?}")
+            })
     }
 }
 


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Enhancement

## Description
<!-- Describe your changes in detail -->
Provide details on why parsing the struct failed by logging the raw bytes along with the type name which was intended to be converted to.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
There were many cases where the response handling was failing because of deserialization problem. This will ease up debugging by providing relevant information.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Create a payment ( or any request where it is sure that it will fail ) and check the logs.
Example of a checkout connector.
<img width="1721" alt="Screenshot 2023-02-20 at 5 45 16 PM" src="https://user-images.githubusercontent.com/48803246/220103981-fa23c7c4-7d98-4a84-ac52-b2f4dc976388.png">



## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
