### PR TITLE
fix: add zero-padded formatting for error code

### DIFF
--- a/crates/api_models/src/errors/types.rs
+++ b/crates/api_models/src/errors/types.rs
@@ -48,7 +48,7 @@ impl<'a> From<&'a ApiErrorResponse> for ErrorResponse<'a> {
         let error_info = value.get_internal_error();
         let error_type = value.error_type();
         Self {
-            code: format!("{}_{}", error_info.sub_code, error_info.error_identifier),
+            code: format!("{}_{:02}", error_info.sub_code, error_info.error_identifier),
             message: Cow::Borrowed(value.get_internal_error().error_message.as_str()),
             error_type,
             extra: &error_info.extra,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description

Adding zero-padding for the error codes, ie. `HE_0` → `HE_00`
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!-- 
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
