### PR TITLE
feat(core): add api locking interface POC

### DIFF
--- a/crates/redis_interface/src/commands.rs
+++ b/crates/redis_interface/src/commands.rs
@@ -149,6 +149,30 @@ impl super::RedisConnectionPool {
     }
 
     #[instrument(level = "DEBUG", skip(self))]
+    pub async fn set_key_with_expiry_if_not_exist<V>(
+        &self,
+        key: &str,
+        value: V,
+        seconds: i64,
+    ) -> CustomResult<SetnxReply, errors::RedisError>
+    where
+        V: TryInto<RedisValue> + Debug,
+        V::Error: Into<fred::error::RedisError>,
+    {
+        self.pool
+            .set(
+                key,
+                value,
+                Some(Expiration::EX(seconds)),
+                Some(SetOptions::NX),
+                false,
+            )
+            .await
+            .into_report()
+            .change_context(errors::RedisError::SetFailed)
+    }
+
+    #[instrument(level = "DEBUG", skip(self))]
     pub async fn set_key_if_not_exist<V>(
         &self,
         key: &str,

--- a/crates/router/src/core.rs
+++ b/crates/router/src/core.rs
@@ -3,6 +3,7 @@ pub mod api_keys;
 pub mod configs;
 pub mod customers;
 pub mod errors;
+pub mod locking;
 pub mod mandate;
 pub mod payment_methods;
 pub mod payments;

--- a/crates/router/src/core/locking.rs
+++ b/crates/router/src/core/locking.rs
@@ -1,0 +1,164 @@
+use actix_web::rt::time as actix_time;
+use error_stack::{IntoReport, ResultExt};
+use redis_interface as redis;
+use router_env::logger;
+
+use super::errors::{self, RouterResult};
+use crate::routes;
+
+// pr: should there be 2 enums AcquireLockStatus and ReleaseLockStatus ?
+pub enum LockStatus {
+    Acquired,
+    AlreadyLocked,
+    NotEnabled,
+    AcquireFailedRetriesExhausted,
+    Released,
+    ReleaseFailedRetriesExhausted,
+}
+
+pub enum ActionOnWaitTimeout {}
+
+pub struct LockingInput {
+    pub unique_locking_key: String,
+    pub api_identifier: String,
+    pub action_on_wait_timeout: ActionOnWaitTimeout,
+    pub merchant_id: String,
+}
+
+pub async fn get_key_and_lock_resource(
+    state: &routes::AppState,
+    locking_input: LockingInput,
+    _should_retry: bool,
+) -> RouterResult<LockStatus> {
+    let api_identifier = locking_input.api_identifier.as_str();
+
+    let is_locking_enabled_for_merchant = true;
+    let is_locking_enabled_on_api = true;
+
+    // let get_expiry_time = get_expiry_time_from_redis_based_on_connector_pmd_pm();
+    if is_locking_enabled_for_merchant && is_locking_enabled_on_api {
+        let expiry_in_seconds = 100; // get it from redis
+        let delay_between_retries_in_seconds = 10; // get it from redis
+        let retries = 1; // get from redis based on should_retry, if not present in redis default 1?
+        let locking_key = locking_input.unique_locking_key;
+        lock_resource(
+            state,
+            locking_key,
+            expiry_in_seconds,
+            retries,
+            delay_between_retries_in_seconds,
+            api_identifier,
+        )
+        .await
+    } else {
+        logger::info!(
+            "Resource Locking not Enabled for merchant_id: {} and api: {}",
+            locking_input.merchant_id,
+            api_identifier.to_owned()
+        );
+        Ok(LockStatus::NotEnabled)
+    }
+}
+
+pub async fn lock_resource(
+    state: &routes::AppState,
+    locking_key: String,
+    expiry_in_seconds: u64,
+    retries: i32,
+    delay_between_retries_in_seconds: i64,
+    _api_identifier: &str,
+) -> RouterResult<LockStatus> {
+    let redis_key_for_lock = get_redis_key_for_locks(locking_key);
+    let redis_value_for_lock = true; // should get session id or request_id as we need info of who acquired the lock.
+    acquire_lock_on_resource_in_redis(
+        state,
+        redis_key_for_lock.as_str(),
+        redis_value_for_lock,
+        expiry_in_seconds,
+        delay_between_retries_in_seconds,
+        retries,
+    )
+    .await
+}
+
+#[inline]
+fn get_redis_key_for_locks(a: String) -> String {
+    format!("SYNCHRONIZED_LOCK_{}", a)
+}
+
+pub async fn acquire_lock_on_resource_in_redis(
+    state: &routes::AppState,
+    key: &str,
+    value: bool,
+    expiry_in_seconds: u64,
+    _delay_between_retries_in_seconds: i64,
+    mut retries: i32,
+) -> RouterResult<LockStatus> {
+    let redis_conn = state
+        .store
+        .clone()
+        .get_store()
+        .change_context(errors::ApiErrorResponse::InternalServerError)?
+        .redis_conn()
+        .change_context(errors::ApiErrorResponse::InternalServerError)?;
+
+    while retries != 0 {
+        // pr: should these be named as tries instead of retries
+        retries -= 1;
+
+        let is_lock_acquired = redis_conn
+            .set_key_with_expiry_if_not_exist(
+                key,
+                value,
+                expiry_in_seconds
+                    .try_into()
+                    .into_report()
+                    .change_context(errors::ApiErrorResponse::InternalServerError)?, // todo:  throw an appropriate error
+            )
+            .await;
+
+        match is_lock_acquired {
+            Ok(redis::SetnxReply::KeySet) => {
+                // (addAquiredLockInfoToState redisKey >>= logLockAcquired)
+                return Ok(LockStatus::Acquired);
+            }
+            Ok(redis::SetnxReply::KeyNotSet) => {
+                logger::error!("Lock not acquired, retrying");
+                actix_time::sleep(tokio::time::Duration::from_millis(expiry_in_seconds * 1000))
+                    .await;
+            }
+            Err(error) => {
+                logger::error!(error=%error.current_context(), "Error while locking");
+                actix_time::sleep(tokio::time::Duration::from_millis(expiry_in_seconds * 1000))
+                    .await;
+            }
+        }
+    }
+
+    Ok(LockStatus::AcquireFailedRetriesExhausted)
+}
+
+pub async fn release_lock(
+    state: &routes::AppState,
+    mut retries: i32,
+    key: &str,
+) -> RouterResult<LockStatus> {
+    let redis_conn = state
+        .store
+        .clone()
+        .get_store()
+        .change_context(errors::ApiErrorResponse::InternalServerError)?
+        .redis_conn()
+        .change_context(errors::ApiErrorResponse::InternalServerError)?;
+    while retries != 0 {
+        retries -= 1;
+
+        match redis_conn.delete_key(key).await {
+            Ok(_) => return Ok(LockStatus::Released),
+            Err(error) => {
+                logger::error!(error=%error.current_context(), "Error while locking");
+            }
+        }
+    }
+    Ok(LockStatus::ReleaseFailedRetriesExhausted)
+}

--- a/crates/router/src/db.rs
+++ b/crates/router/src/db.rs
@@ -20,9 +20,11 @@ pub mod reverse_lookup;
 
 use std::sync::Arc;
 
+use common_utils::errors::CustomResult;
+use error_stack::report;
 use futures::lock::Mutex;
 
-use crate::{services::Store, types::storage};
+use crate::{core::errors, services::Store, types::storage};
 
 #[derive(PartialEq, Eq)]
 pub enum StorageImpl {
@@ -56,8 +58,32 @@ pub trait StorageInterface:
     + refund::RefundInterface
     + reverse_lookup::ReverseLookupInterface
     + 'static
+    + InternalLoader
 {
     async fn close(&mut self) {}
+}
+
+pub trait InternalLoader {
+    fn get_store(&self) -> CustomResult<&Store, errors::StorageError> {
+        Err(report!(errors::StorageError::DatabaseError(report!(
+            storage_models::errors::DatabaseError::Others
+        ))))
+    }
+    fn get_mock_db(&self) -> CustomResult<&MockDb, errors::StorageError> {
+        Err(report!(errors::StorageError::MockDbError))
+    }
+}
+
+impl InternalLoader for Store {
+    fn get_store(&self) -> CustomResult<&Store, errors::StorageError> {
+        Ok(self)
+    }
+}
+
+impl InternalLoader for MockDb {
+    fn get_mock_db(&self) -> CustomResult<&MockDb, errors::StorageError> {
+        Ok(self)
+    }
 }
 
 #[async_trait::async_trait]
@@ -115,7 +141,7 @@ pub async fn get_and_deserialize_key<T>(
     db: &dyn StorageInterface,
     key: &str,
     type_name: &str,
-) -> common_utils::errors::CustomResult<T, redis_interface::errors::RedisError>
+) -> CustomResult<T, errors::RedisError>
 where
     T: serde::de::DeserializeOwned,
 {


### PR DESCRIPTION
WIP

## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->
This PR contains the functions used for API locking. 

### Additional Changes

- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!-- 
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
Api locking is required to prevent threads from modifying the same resource simultaneously. 


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
