### PR TITLE
refactor(connector): remove `peek()` on PII info

### DIFF
--- a/crates/masking/src/secret.rs
+++ b/crates/masking/src/secret.rs
@@ -59,6 +59,28 @@ where
             masking_strategy: PhantomData,
         }
     }
+
+    /// Zip 2 secrets with the same masking strategy into one
+    pub fn zip<OtherSecretValue>(
+        self,
+        other: Secret<OtherSecretValue, MaskingStrategy>,
+    ) -> Secret<(SecretValue, OtherSecretValue), MaskingStrategy>
+    where
+        MaskingStrategy: Strategy<OtherSecretValue> + Strategy<(SecretValue, OtherSecretValue)>,
+    {
+        (self.inner_secret, other.inner_secret).into()
+    }
+
+    /// consume self and modify the inner value
+    pub fn map<OtherSecretValue>(
+        self,
+        f: impl FnOnce(SecretValue) -> OtherSecretValue,
+    ) -> Secret<OtherSecretValue, MaskingStrategy>
+    where
+        MaskingStrategy: Strategy<OtherSecretValue>,
+    {
+        f(self.inner_secret).into()
+    }
 }
 
 impl<SecretValue, MaskingStrategy> PeekInterface<SecretValue>

--- a/crates/router/src/connector/authorizedotnet/transformers.rs
+++ b/crates/router/src/connector/authorizedotnet/transformers.rs
@@ -5,7 +5,6 @@ use serde::{Deserialize, Serialize};
 use crate::{
     connector::utils::RefundsRequestData,
     core::errors,
-    pii::PeekInterface,
     types::{self, api, storage::enums},
     utils::OptionExt,
 };
@@ -71,12 +70,14 @@ impl From<api_models::payments::PaymentMethod> for PaymentDetails {
     fn from(value: api_models::payments::PaymentMethod) -> Self {
         match value {
             api::PaymentMethod::Card(ref ccard) => {
-                let expiry_month = ccard.card_exp_month.peek().clone();
-                let expiry_year = ccard.card_exp_year.peek().clone();
-
                 Self::CreditCard(CreditCardDetails {
                     card_number: ccard.card_number.clone(),
-                    expiration_date: format!("{expiry_year}-{expiry_month}").into(),
+                    // expiration_date: format!("{expiry_year}-{expiry_month}").into(),
+                    expiration_date: ccard
+                        .card_exp_month
+                        .clone()
+                        .zip(ccard.card_exp_year.clone())
+                        .map(|(expiry_month, expiry_year)| format!("{expiry_year}-{expiry_month}")),
                     card_code: Some(ccard.card_cvc.clone()),
                 })
             }

--- a/crates/router/src/connector/braintree/transformers.rs
+++ b/crates/router/src/connector/braintree/transformers.rs
@@ -1,12 +1,12 @@
 use api_models::payments;
 use base64::Engine;
 use error_stack::ResultExt;
+use masking::Secret;
 use serde::{Deserialize, Serialize};
 
 use crate::{
     consts,
     core::errors,
-    pii::PeekInterface,
     types::{self, api, storage::enums},
     utils::OptionExt,
 };
@@ -79,10 +79,10 @@ pub struct Card {
 #[derive(Default, Debug, Serialize, Eq, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct CardDetails {
-    number: String,
-    expiration_month: String,
-    expiration_year: String,
-    cvv: String,
+    number: Secret<String, common_utils::pii::CardNumber>,
+    expiration_month: Secret<String>,
+    expiration_year: Secret<String>,
+    cvv: Secret<String>,
 }
 
 impl TryFrom<&types::PaymentsAuthorizeRouterData> for BraintreePaymentsRequest {
@@ -100,13 +100,13 @@ impl TryFrom<&types::PaymentsAuthorizeRouterData> for BraintreePaymentsRequest {
         };
         let kind = "sale".to_string();
 
-        let payment_method_data_type = match item.request.payment_method_data {
-            api::PaymentMethod::Card(ref ccard) => Ok(PaymentMethodType::CreditCard(Card {
+        let payment_method_data_type = match item.request.payment_method_data.clone() {
+            api::PaymentMethod::Card(ccard) => Ok(PaymentMethodType::CreditCard(Card {
                 credit_card: CardDetails {
-                    number: ccard.card_number.peek().clone(),
-                    expiration_month: ccard.card_exp_month.peek().clone(),
-                    expiration_year: ccard.card_exp_year.peek().clone(),
-                    cvv: ccard.card_cvc.peek().clone(),
+                    number: ccard.card_number,
+                    expiration_month: ccard.card_exp_month,
+                    expiration_year: ccard.card_exp_year,
+                    cvv: ccard.card_cvc,
                 },
             })),
             api::PaymentMethod::Wallet(ref wallet_data) => {

--- a/crates/router/src/connector/cybersource/transformers.rs
+++ b/crates/router/src/connector/cybersource/transformers.rs
@@ -107,8 +107,8 @@ fn build_bill_to(
 impl TryFrom<&types::PaymentsAuthorizeRouterData> for CybersourcePaymentsRequest {
     type Error = error_stack::Report<errors::ConnectorError>;
     fn try_from(item: &types::PaymentsAuthorizeRouterData) -> Result<Self, Self::Error> {
-        match item.request.payment_method_data {
-            api::PaymentMethod::Card(ref ccard) => {
+        match item.request.payment_method_data.clone() {
+            api::PaymentMethod::Card(ccard) => {
                 let phone = item.get_billing_phone()?;
                 let phone_number = phone.get_number()?;
                 let country_code = phone.get_country_code()?;

--- a/crates/router/src/connector/cybersource/transformers.rs
+++ b/crates/router/src/connector/cybersource/transformers.rs
@@ -41,10 +41,10 @@ pub struct PaymentInformation {
 #[derive(Default, Debug, Serialize, Eq, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct Card {
-    number: String,
-    expiration_month: String,
-    expiration_year: String,
-    security_code: String,
+    number: Secret<String, pii::CardNumber>,
+    expiration_month: Secret<String>,
+    expiration_year: Secret<String>,
+    security_code: Secret<String>,
 }
 
 #[derive(Default, Debug, Serialize, Eq, PartialEq)]
@@ -131,10 +131,10 @@ impl TryFrom<&types::PaymentsAuthorizeRouterData> for CybersourcePaymentsRequest
 
                 let payment_information = PaymentInformation {
                     card: Card {
-                        number: ccard.card_number.peek().clone(),
-                        expiration_month: ccard.card_exp_month.peek().clone(),
-                        expiration_year: ccard.card_exp_year.peek().clone(),
-                        security_code: ccard.card_cvc.peek().clone(),
+                        number: ccard.card_number,
+                        expiration_month: ccard.card_exp_month,
+                        expiration_year: ccard.card_exp_year,
+                        security_code: ccard.card_cvc,
                     },
                 };
 

--- a/crates/router/src/connector/globalpay.rs
+++ b/crates/router/src/connector/globalpay.rs
@@ -596,12 +596,11 @@ impl ConnectorIntegration<api::Execute, types::RefundsData, types::RefundsRespon
             .response
             .parse_struct("globalpay RefundResponse")
             .change_context(errors::ConnectorError::RequestEncodingFailed)?;
-        types::ResponseRouterData {
+        types::RouterData::try_from(types::ResponseRouterData {
             response,
             data: data.clone(),
             http_code: res.status_code,
-        }
-        .try_into()
+        })
         .change_context(errors::ConnectorError::ResponseHandlingFailed)
     }
 

--- a/crates/router/src/connector/globalpay/requests.rs
+++ b/crates/router/src/connector/globalpay/requests.rs
@@ -1,3 +1,5 @@
+use common_utils::pii;
+use masking::Secret;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Default, Serialize)]
@@ -298,18 +300,18 @@ pub struct Card {
     /// did not work as expected.
     pub chip_condition: Option<ChipCondition>,
     /// The numeric value printed on the physical card.
-    pub cvv: String,
+    pub cvv: Secret<String>,
     /// Card Verification Value Indicator sent by the Merchant indicating the CVV
     /// availability.
     pub cvv_indicator: CvvIndicator,
     /// The 2 digit expiry date month of the card.
-    pub expiry_month: String,
+    pub expiry_month: Secret<String>,
     /// The 2 digit expiry date year of the card.
-    pub expiry_year: String,
+    pub expiry_year: Secret<String>,
     /// Indicates whether the card is a debit or credit card.
     pub funding: Option<Funding>,
     /// The the card account number used to authorize the transaction. Also known as PAN.
-    pub number: String,
+    pub number: Secret<String, pii::CardNumber>,
     /// Contains the pin block info, relating to the pin code the Payer entered.
     pub pin_block: Option<String>,
     /// The full card tag data for an EMV/chip card transaction.

--- a/crates/router/src/connector/globalpay/transformers.rs
+++ b/crates/router/src/connector/globalpay/transformers.rs
@@ -8,7 +8,7 @@ use super::{
     response::{GlobalpayPaymentStatus, GlobalpayPaymentsResponse, GlobalpayRefreshTokenResponse},
 };
 use crate::{
-    connector::utils::{self, CardData, PaymentsRequestData},
+    connector::utils::{self, PaymentsRequestData, CardData},
     consts,
     core::errors,
     types::{self, api, storage::enums, ErrorResponse},
@@ -27,6 +27,7 @@ impl TryFrom<&types::PaymentsAuthorizeRouterData> for GlobalpayPaymentsRequest {
             .map(|o| o.to_string())
             .ok_or_else(utils::missing_field_err("connector_meta.account_name"))?;
         let card = item.get_card()?;
+        let expiry_year = card.get_card_expiry_year_2_digit();
         Ok(Self {
             account_name,
             amount: Some(item.request.amount.to_string()),
@@ -39,10 +40,10 @@ impl TryFrom<&types::PaymentsAuthorizeRouterData> for GlobalpayPaymentsRequest {
             }),
             payment_method: requests::PaymentMethod {
                 card: Some(requests::Card {
-                    number: card.get_card_number(),
-                    expiry_month: card.get_card_expiry_month(),
-                    expiry_year: card.get_card_expiry_year_2_digit(),
-                    cvv: card.get_card_cvc(),
+                    number: card.card_number,
+                    expiry_month: card.card_exp_month,
+                    expiry_year,
+                    cvv: card.card_cvc,
                     ..Default::default()
                 }),
                 ..Default::default()

--- a/crates/router/src/connector/globalpay/transformers.rs
+++ b/crates/router/src/connector/globalpay/transformers.rs
@@ -8,7 +8,7 @@ use super::{
     response::{GlobalpayPaymentStatus, GlobalpayPaymentsResponse, GlobalpayRefreshTokenResponse},
 };
 use crate::{
-    connector::utils::{self, PaymentsRequestData, CardData},
+    connector::utils::{self, CardData, PaymentsRequestData},
     consts,
     core::errors,
     types::{self, api, storage::enums, ErrorResponse},

--- a/crates/router/src/connector/utils.rs
+++ b/crates/router/src/connector/utils.rs
@@ -94,29 +94,14 @@ impl PaymentsRequestData for types::PaymentsAuthorizeRouterData {
 }
 
 pub trait CardData {
-    fn get_card_number(&self) -> String;
-    fn get_card_expiry_month(&self) -> String;
-    fn get_card_expiry_year(&self) -> String;
-    fn get_card_expiry_year_2_digit(&self) -> String;
-    fn get_card_cvc(&self) -> String;
+    fn get_card_expiry_year_2_digit(&self) -> Secret<String>;
 }
 
 impl CardData for api::Card {
-    fn get_card_number(&self) -> String {
-        self.card_number.peek().clone()
-    }
-    fn get_card_expiry_month(&self) -> String {
-        self.card_exp_month.peek().clone()
-    }
-    fn get_card_expiry_year(&self) -> String {
-        self.card_exp_year.peek().clone()
-    }
-    fn get_card_expiry_year_2_digit(&self) -> String {
-        let year = self.card_exp_year.peek().clone();
-        year[year.len() - 2..].to_string()
-    }
-    fn get_card_cvc(&self) -> String {
-        self.card_cvc.peek().clone()
+    fn get_card_expiry_year_2_digit(&self) -> Secret<String> {
+        let binding = self.card_exp_year.clone();
+        let year = binding.peek();
+        Secret::new(year[year.len() - 2..].to_string())
     }
 }
 pub trait PhoneDetailsData {

--- a/crates/router/src/connector/worldpay/requests.rs
+++ b/crates/router/src/connector/worldpay/requests.rs
@@ -1,3 +1,5 @@
+use common_utils::pii;
+use masking::Secret;
 use serde::{Deserialize, Serialize};
 #[derive(Clone, Debug, PartialEq, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -148,10 +150,10 @@ pub struct CardPayment {
     pub card_holder_name: Option<String>,
     pub card_expiry_date: CardExpiryDate,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub cvc: Option<String>,
+    pub cvc: Option<Secret<String>>,
     #[serde(rename = "type")]
     pub payment_type: PaymentType,
-    pub card_number: String,
+    pub card_number: Secret<String, pii::CardNumber>,
 }
 
 #[derive(Clone, Debug, PartialEq, Default, Serialize, Deserialize)]
@@ -174,8 +176,8 @@ pub struct WalletPayment {
 
 #[derive(Clone, Debug, PartialEq, Default, Serialize, Deserialize)]
 pub struct CardExpiryDate {
-    pub month: u8,
-    pub year: u16,
+    pub month: Secret<String>,
+    pub year: Secret<String>,
 }
 
 #[derive(Clone, Debug, PartialEq, Default, Serialize, Deserialize)]

--- a/crates/router/src/connector/worldpay/transformers.rs
+++ b/crates/router/src/connector/worldpay/transformers.rs
@@ -1,8 +1,5 @@
-use std::str::FromStr;
-
 use common_utils::errors::CustomResult;
 use error_stack::ResultExt;
-use masking::PeekInterface;
 use storage_models::enums;
 
 use super::{requests::*, response::*};
@@ -12,30 +9,16 @@ use crate::{
     utils::OptionExt,
 };
 
-fn parse_int<T: FromStr>(
-    val: masking::Secret<String, masking::WithType>,
-) -> CustomResult<T, errors::ConnectorError>
-where
-    <T as FromStr>::Err: Sync,
-{
-    let res = val.peek().parse::<T>();
-    if let Ok(val) = res {
-        Ok(val)
-    } else {
-        Err(errors::ConnectorError::RequestEncodingFailed)?
-    }
-}
-
 fn fetch_payment_instrument(
     payment_method: api::PaymentMethod,
 ) -> CustomResult<PaymentInstrument, errors::ConnectorError> {
     match payment_method {
         api::PaymentMethod::Card(card) => Ok(PaymentInstrument::Card(CardPayment {
             card_expiry_date: CardExpiryDate {
-                month: parse_int::<u8>(card.card_exp_month)?,
-                year: parse_int::<u16>(card.card_exp_year)?,
+                month: card.card_exp_month,
+                year: card.card_exp_year,
             },
-            card_number: card.card_number.peek().to_string(),
+            card_number: card.card_number,
             ..CardPayment::default()
         })),
         api::PaymentMethod::Wallet(wallet) => match wallet.issuer_name {

--- a/crates/router/src/core/errors/api_error_response.rs
+++ b/crates/router/src/core/errors/api_error_response.rs
@@ -88,6 +88,7 @@ pub enum ApiErrorResponse {
         message: String,
         connector: String,
         status_code: u16,
+        reason: Option<String>,
     },
     #[error(error_type = ErrorType::ProcessingError, code = "CE_01", message = "Payment failed during authorization with connector. Retry payment")]
     PaymentAuthorizationFailed { data: Option<serde_json::Value> },
@@ -340,8 +341,9 @@ impl common_utils::errors::ErrorSwitch<api_models::errors::types::ApiErrorRespon
                 code,
                 message,
                 connector,
+                reason,
                 status_code,
-            } => AER::ConnectorError(ApiError::new("CE", 0, format!("{code}: {message}"), Some(Extra {connector: Some(connector.clone()), ..Default::default()})), StatusCode::from_u16(*status_code).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR)),
+            } => AER::ConnectorError(ApiError::new("CE", 0, format!("{code}: {message}"), Some(Extra {connector: Some(connector.clone()), reason: reason.clone(), ..Default::default()})), StatusCode::from_u16(*status_code).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR)),
             Self::PaymentAuthorizationFailed { data } => {
                 AER::BadRequest(ApiError::new("CE", 1, "Payment failed during authorization with connector. Retry payment", Some(Extra { data: data.clone(), ..Default::default()})))
             }

--- a/crates/router/src/core/payments/operations/payment_response.rs
+++ b/crates/router/src/core/payments/operations/payment_response.rs
@@ -68,6 +68,7 @@ impl<F: Clone> PostUpdateTracker<F, PaymentData<F>, types::PaymentsAuthorizeData
                     message: error_response.message,
                     connector,
                     status_code: error_response.status_code,
+                    reason: error_response.reason,
                 })
             })
         })?;
@@ -126,6 +127,7 @@ impl<F: Clone> PostUpdateTracker<F, PaymentData<F>, types::PaymentsSessionData>
                 message: error_response.message,
                 code: error_response.code,
                 status_code: error_response.status_code,
+                reason: error_response.reason,
                 connector,
             }
         })?;
@@ -166,6 +168,7 @@ impl<F: Clone> PostUpdateTracker<F, PaymentData<F>, types::PaymentsCaptureData>
                 message: error_response.message,
                 code: error_response.code,
                 status_code: error_response.status_code,
+                reason: error_response.reason,
                 connector,
             }
         })?;
@@ -205,6 +208,7 @@ impl<F: Clone> PostUpdateTracker<F, PaymentData<F>, types::PaymentsCancelData> f
                 message: error_response.message,
                 code: error_response.code,
                 status_code: error_response.status_code,
+                reason: error_response.reason,
                 connector,
             }
         })?;
@@ -249,6 +253,7 @@ impl<F: Clone> PostUpdateTracker<F, PaymentData<F>, types::VerifyRequestData> fo
                 message: error_response.message,
                 code: error_response.code,
                 status_code: error_response.status_code,
+                reason: error_response.reason,
                 connector,
             }
         })?;

--- a/crates/router/tests/connectors/globalpay.rs
+++ b/crates/router/tests/connectors/globalpay.rs
@@ -1,5 +1,3 @@
-use std::{thread::sleep, time::Duration};
-
 use masking::Secret;
 use router::types::{
     self,
@@ -99,7 +97,10 @@ async fn should_capture_already_authorized_payment() {
 #[actix_web::test]
 async fn should_sync_payment() {
     let connector = Globalpay {};
-    let authorize_response = connector.authorize_payment(None, get_default_payment_info()).await.unwrap();
+    let authorize_response = connector
+        .authorize_payment(None, get_default_payment_info())
+        .await
+        .unwrap();
     let txn_id = utils::get_connector_transaction_id(authorize_response.response);
     let response = connector
         .psync_retry_till_status_matches(

--- a/crates/router/tests/connectors/globalpay.rs
+++ b/crates/router/tests/connectors/globalpay.rs
@@ -54,6 +54,10 @@ fn get_default_payment_info() -> Option<PaymentInfo> {
             }),
             ..Default::default()
         }),
+        access_token: Some(types::AccessToken {
+            token: "<access_token>".to_string(),
+            expires: 18600,
+        }),
         ..Default::default()
     })
 }
@@ -95,12 +99,8 @@ async fn should_capture_already_authorized_payment() {
 #[actix_web::test]
 async fn should_sync_payment() {
     let connector = Globalpay {};
-    let authorize_response = connector
-        .authorize_payment(None, get_default_payment_info())
-        .await
-        .unwrap();
+    let authorize_response = connector.authorize_payment(None, get_default_payment_info()).await.unwrap();
     let txn_id = utils::get_connector_transaction_id(authorize_response.response);
-    sleep(Duration::from_secs(5)); // to avoid 404 error as globalpay takes some time to process the new transaction
     let response = connector
         .psync_retry_till_status_matches(
             enums::AttemptStatus::Authorized,
@@ -111,7 +111,7 @@ async fn should_sync_payment() {
                 encoded_data: None,
                 capture_method: None,
             }),
-            None,
+            get_default_payment_info(),
         )
         .await
         .unwrap();


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [X] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->
Closes #308 

### Additional Changes

- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!-- 
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
In connectors when mapping the PII information while building the request we are mapping as plain text(String), it is not recommended as it can be logged. so removing those logs from connector code. 

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [X] I formatted the code `cargo +nightly fmt --all`
- [X] I addressed lints thrown by `cargo clippy`
- [X] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
