### PR TITLE
feat(connector): [Bluesnap] add authorize, capture, void, refund, psync, rsync and Webhooks support 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1038,6 +1038,7 @@ dependencies = [
  "futures",
  "hex",
  "masking",
+ "md5",
  "nanoid",
  "once_cell",
  "proptest",
@@ -2180,6 +2181,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "md5"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 
 [[package]]
 name = "memchr"

--- a/config/Development.toml
+++ b/config/Development.toml
@@ -48,6 +48,7 @@ cards = [
     "aci",
     "adyen",
     "authorizedotnet",
+    "bluesnap",
     "braintree",
     "checkout",
     "cybersource",
@@ -118,6 +119,9 @@ base_url = "https://apis.sandbox.globalpay.com/ucp/"
 
 [connectors.worldline]
 base_url = "https://eu.sandbox.api-ingenico.com/"
+
+[connectors.bluesnap]
+base_url = "https://sandbox.bluesnap.com/"
 
 [connectors.nuvei]
 base_url = "https://ppp-test.nuvei.com/"

--- a/config/config.example.toml
+++ b/config/config.example.toml
@@ -153,6 +153,9 @@ base_url = "https://try.access.worldpay.com/"
 [connectors.globalpay]
 base_url = "https://apis.sandbox.globalpay.com/ucp/"
 
+[connectors.bluesnap]
+base_url = "https://sandbox.bluesnap.com/"
+
 [connectors.nuvei]
 base_url = "https://ppp-test.nuvei.com/"
 

--- a/config/docker_compose.toml
+++ b/config/docker_compose.toml
@@ -105,6 +105,9 @@ base_url = "https://try.access.worldpay.com/"
 [connectors.globalpay]
 base_url = "https://apis.sandbox.globalpay.com/ucp/"
 
+[connectors.bluesnap]
+base_url = "https://sandbox.bluesnap.com/"
+
 [connectors.nuvei]
 base_url = "https://ppp-test.nuvei.com/"
 
@@ -113,6 +116,7 @@ wallets = ["klarna", "braintree", "applepay"]
 cards = [
     "adyen",
     "authorizedotnet",
+    "bluesnap",
     "braintree",
     "checkout",
     "cybersource",

--- a/crates/api_models/src/enums.rs
+++ b/crates/api_models/src/enums.rs
@@ -514,6 +514,7 @@ pub enum Connector {
     Adyen,
     Applepay,
     Authorizedotnet,
+    Bluesnap,
     Braintree,
     Checkout,
     Cybersource,

--- a/crates/common_utils/Cargo.toml
+++ b/crates/common_utils/Cargo.toml
@@ -26,6 +26,7 @@ signal-hook = "0.3.14"
 tokio = { version = "1.25.0", features = ["macros", "rt-multi-thread"] }
 thiserror = "1.0.38"
 time = { version = "0.3.17", features = ["serde", "serde-well-known", "std"] }
+md5 = "0.7.0"
 
 # First party crates
 masking = { version = "0.1.0", path = "../masking" }

--- a/crates/common_utils/src/crypto.rs
+++ b/crates/common_utils/src/crypto.rs
@@ -1,5 +1,6 @@
 //! Utilities for cryptographic algorithms
 use error_stack::{IntoReport, ResultExt};
+use md5;
 use ring::{aead, hmac};
 
 use crate::errors::{self, CustomResult};
@@ -235,6 +236,30 @@ impl GenerateDigest for Sha512 {
         Ok(digest.as_ref().to_vec())
     }
 }
+/// MD5 hash function
+#[derive(Debug)]
+pub struct Md5;
+
+impl GenerateDigest for Md5 {
+    fn generate_digest(&self, message: &[u8]) -> CustomResult<Vec<u8>, errors::CryptoError> {
+        let digest = md5::compute(message);
+        Ok(digest.as_ref().to_vec())
+    }
+}
+
+impl VerifySignature for Md5 {
+    fn verify_signature(
+        &self,
+        _secret: &[u8],
+        signature: &[u8],
+        msg: &[u8],
+    ) -> CustomResult<bool, errors::CryptoError> {
+        let hashed_digest = Self
+            .generate_digest(msg)
+            .change_context(errors::CryptoError::SignatureVerificationFailed)?;
+        Ok(hashed_digest == signature)
+    }
+}
 
 impl GenerateDigest for Sha256 {
     fn generate_digest(&self, message: &[u8]) -> CustomResult<Vec<u8>, errors::CryptoError> {
@@ -267,6 +292,7 @@ pub fn generate_cryptographically_secure_random_bytes<const N: usize>() -> [u8; 
 mod crypto_tests {
     #![allow(clippy::expect_used)]
     use super::{DecodeMessage, EncodeMessage, SignMessage, VerifySignature};
+    use crate::crypto::GenerateDigest;
 
     #[test]
     fn test_hmac_sha256_sign_message() {
@@ -397,5 +423,40 @@ mod crypto_tests {
         let err_decoded = algorithm.decode_message(&wrong_secret, &message);
 
         assert!(err_decoded.is_err());
+    }
+
+    #[test]
+    fn test_md5_digest() {
+        let message = "abcdefghijklmnopqrstuvwxyz".as_bytes();
+        assert_eq!(
+            format!(
+                "{}",
+                hex::encode(super::Md5.generate_digest(message).expect("Digest"))
+            ),
+            "c3fcd3d76192e4007dfb496cca67e13b"
+        );
+    }
+
+    #[test]
+    fn test_md5_verify_signature() {
+        let right_signature =
+            hex::decode("c3fcd3d76192e4007dfb496cca67e13b").expect("signature decoding");
+        let wrong_signature =
+            hex::decode("d5550730377011948f12cc28889bee590d2a5434d6f54b87562f2dbc2657823f")
+                .expect("Wrong signature decoding");
+        let secret = "".as_bytes();
+        let data = "abcdefghijklmnopqrstuvwxyz".as_bytes();
+
+        let right_verified = super::Md5
+            .verify_signature(secret, &right_signature, data)
+            .expect("Right signature verification result");
+
+        assert!(right_verified);
+
+        let wrong_verified = super::Md5
+            .verify_signature(secret, &wrong_signature, data)
+            .expect("Wrong signature verification result");
+
+        assert!(!wrong_verified);
     }
 }

--- a/crates/router/src/configs/settings.rs
+++ b/crates/router/src/configs/settings.rs
@@ -139,6 +139,7 @@ pub struct Connectors {
     pub adyen: ConnectorParams,
     pub applepay: ConnectorParams,
     pub authorizedotnet: ConnectorParams,
+    pub bluesnap: ConnectorParams,
     pub braintree: ConnectorParams,
     pub checkout: ConnectorParams,
     pub cybersource: ConnectorParams,

--- a/crates/router/src/connector.rs
+++ b/crates/router/src/connector.rs
@@ -2,6 +2,7 @@ pub mod aci;
 pub mod adyen;
 pub mod applepay;
 pub mod authorizedotnet;
+pub mod bluesnap;
 pub mod braintree;
 pub mod checkout;
 pub mod cybersource;
@@ -19,7 +20,7 @@ pub mod worldpay;
 
 pub use self::{
     aci::Aci, adyen::Adyen, applepay::Applepay, authorizedotnet::Authorizedotnet,
-    braintree::Braintree, checkout::Checkout, cybersource::Cybersource, fiserv::Fiserv,
-    globalpay::Globalpay, klarna::Klarna, nuvei::Nuvei, payu::Payu, rapyd::Rapyd, shift4::Shift4,
-    stripe::Stripe, worldline::Worldline, worldpay::Worldpay,
+    bluesnap::Bluesnap, braintree::Braintree, checkout::Checkout, cybersource::Cybersource,
+    fiserv::Fiserv, globalpay::Globalpay, klarna::Klarna, nuvei::Nuvei, payu::Payu, rapyd::Rapyd,
+    shift4::Shift4, stripe::Stripe, worldline::Worldline, worldpay::Worldpay,
 };

--- a/crates/router/src/connector/bluesnap.rs
+++ b/crates/router/src/connector/bluesnap.rs
@@ -1,0 +1,741 @@
+mod transformers;
+
+use std::fmt::Debug;
+
+use base64::Engine;
+use common_utils::crypto;
+use error_stack::{IntoReport, ResultExt};
+use transformers as bluesnap;
+
+use crate::{
+    configs::settings,
+    consts,
+    core::{
+        errors::{self, CustomResult},
+        payments,
+    },
+    db::StorageInterface,
+    headers, logger,
+    services::{self, ConnectorIntegration},
+    types::{
+        self,
+        api::{self, ConnectorCommon, ConnectorCommonExt},
+        ErrorResponse, Response,
+    },
+    utils::{self, BytesExt},
+};
+
+#[derive(Debug, Clone)]
+pub struct Bluesnap;
+
+impl<Flow, Request, Response> ConnectorCommonExt<Flow, Request, Response> for Bluesnap
+where
+    Self: ConnectorIntegration<Flow, Request, Response>,
+{
+    fn build_headers(
+        &self,
+        req: &types::RouterData<Flow, Request, Response>,
+        _connectors: &settings::Connectors,
+    ) -> CustomResult<Vec<(String, String)>, errors::ConnectorError> {
+        let mut header = self.get_auth_header(&req.connector_auth_type)?;
+        header.push((
+            headers::CONTENT_TYPE.to_string(),
+            self.get_content_type().to_string(),
+        ));
+        Ok(header)
+    }
+}
+
+impl ConnectorCommon for Bluesnap {
+    fn id(&self) -> &'static str {
+        "bluesnap"
+    }
+
+    fn common_get_content_type(&self) -> &'static str {
+        "application/json"
+    }
+
+    fn base_url<'a>(&self, connectors: &'a settings::Connectors) -> &'a str {
+        connectors.bluesnap.base_url.as_ref()
+    }
+
+    fn get_auth_header(
+        &self,
+        auth_type: &types::ConnectorAuthType,
+    ) -> CustomResult<Vec<(String, String)>, errors::ConnectorError> {
+        let auth: bluesnap::BluesnapAuthType = auth_type
+            .try_into()
+            .change_context(errors::ConnectorError::FailedToObtainAuthType)?;
+        let encoded_api_key =
+            consts::BASE64_ENGINE.encode(format!("{}:{}", auth.key1, auth.api_key));
+        Ok(vec![(
+            headers::AUTHORIZATION.to_string(),
+            format!("Basic {}", encoded_api_key),
+        )])
+    }
+
+    fn build_error_response(
+        &self,
+        res: Response,
+    ) -> CustomResult<ErrorResponse, errors::ConnectorError> {
+        logger::debug!(bluesnap_error_response=?res);
+        let response: bluesnap::BluesnapErrorResponse = res
+            .response
+            .parse_struct("BluesnapErrorResponse")
+            .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
+        Ok(ErrorResponse {
+            status_code: res.status_code,
+            code: match response.message.first() {
+                Some(first_error) => first_error.code.clone(),
+                _ => consts::NO_ERROR_CODE.to_string(),
+            },
+            message: match response.message.first() {
+                Some(first_error) => first_error.description.clone(),
+                _ => consts::NO_ERROR_MESSAGE.to_string(),
+            },
+            reason: None,
+        })
+    }
+}
+
+impl api::Payment for Bluesnap {}
+
+impl api::PreVerify for Bluesnap {}
+impl ConnectorIntegration<api::Verify, types::VerifyRequestData, types::PaymentsResponseData>
+    for Bluesnap
+{
+}
+
+impl api::PaymentVoid for Bluesnap {}
+
+impl ConnectorIntegration<api::Void, types::PaymentsCancelData, types::PaymentsResponseData>
+    for Bluesnap
+{
+    fn get_headers(
+        &self,
+        req: &types::PaymentsCancelRouterData,
+        connectors: &settings::Connectors,
+    ) -> CustomResult<Vec<(String, String)>, errors::ConnectorError> {
+        self.build_headers(req, connectors)
+    }
+
+    fn get_content_type(&self) -> &'static str {
+        self.common_get_content_type()
+    }
+
+    fn get_url(
+        &self,
+        _req: &types::PaymentsCancelRouterData,
+        connectors: &settings::Connectors,
+    ) -> CustomResult<String, errors::ConnectorError> {
+        Ok(format!(
+            "{}{}",
+            self.base_url(connectors),
+            "services/2/transactions"
+        ))
+    }
+
+    fn get_request_body(
+        &self,
+        req: &types::PaymentsCancelRouterData,
+    ) -> CustomResult<Option<String>, errors::ConnectorError> {
+        let connector_req = bluesnap::BluesnapVoidRequest::try_from(req)?;
+        let bluesnap_req =
+            utils::Encode::<bluesnap::BluesnapVoidRequest>::encode_to_string_of_json(
+                &connector_req,
+            )
+            .change_context(errors::ConnectorError::RequestEncodingFailed)?;
+        Ok(Some(bluesnap_req))
+    }
+
+    fn build_request(
+        &self,
+        req: &types::PaymentsCancelRouterData,
+        connectors: &settings::Connectors,
+    ) -> CustomResult<Option<services::Request>, errors::ConnectorError> {
+        let request = services::RequestBuilder::new()
+            .method(services::Method::Put)
+            .url(&types::PaymentsVoidType::get_url(self, req, connectors)?)
+            .headers(types::PaymentsVoidType::get_headers(self, req, connectors)?)
+            .body(types::PaymentsVoidType::get_request_body(self, req)?)
+            .build();
+        Ok(Some(request))
+    }
+
+    fn handle_response(
+        &self,
+        data: &types::PaymentsCancelRouterData,
+        res: Response,
+    ) -> CustomResult<types::PaymentsCancelRouterData, errors::ConnectorError> {
+        let response: bluesnap::BluesnapPaymentsResponse = res
+            .response
+            .parse_struct("BluesnapPaymentsResponse")
+            .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
+        types::RouterData::try_from(types::ResponseRouterData {
+            response,
+            data: data.clone(),
+            http_code: res.status_code,
+        })
+        .change_context(errors::ConnectorError::ResponseHandlingFailed)
+    }
+
+    fn get_error_response(
+        &self,
+        res: Response,
+    ) -> CustomResult<ErrorResponse, errors::ConnectorError> {
+        self.build_error_response(res)
+    }
+}
+
+impl api::ConnectorAccessToken for Bluesnap {}
+
+impl ConnectorIntegration<api::AccessTokenAuth, types::AccessTokenRequestData, types::AccessToken>
+    for Bluesnap
+{
+}
+
+impl api::PaymentSync for Bluesnap {}
+impl ConnectorIntegration<api::PSync, types::PaymentsSyncData, types::PaymentsResponseData>
+    for Bluesnap
+{
+    fn get_headers(
+        &self,
+        req: &types::PaymentsSyncRouterData,
+        connectors: &settings::Connectors,
+    ) -> CustomResult<Vec<(String, String)>, errors::ConnectorError> {
+        self.build_headers(req, connectors)
+    }
+
+    fn get_content_type(&self) -> &'static str {
+        self.common_get_content_type()
+    }
+
+    fn get_url(
+        &self,
+        req: &types::PaymentsSyncRouterData,
+        connectors: &settings::Connectors,
+    ) -> CustomResult<String, errors::ConnectorError> {
+        let connector_payment_id = req
+            .request
+            .connector_transaction_id
+            .get_connector_transaction_id()
+            .change_context(errors::ConnectorError::MissingConnectorTransactionID)?;
+        Ok(format!(
+            "{}{}{}",
+            self.base_url(connectors),
+            "services/2/transactions/",
+            connector_payment_id
+        ))
+    }
+
+    fn build_request(
+        &self,
+        req: &types::PaymentsSyncRouterData,
+        connectors: &settings::Connectors,
+    ) -> CustomResult<Option<services::Request>, errors::ConnectorError> {
+        Ok(Some(
+            services::RequestBuilder::new()
+                .method(services::Method::Get)
+                .url(&types::PaymentsSyncType::get_url(self, req, connectors)?)
+                .headers(types::PaymentsSyncType::get_headers(self, req, connectors)?)
+                .build(),
+        ))
+    }
+
+    fn get_error_response(
+        &self,
+        res: Response,
+    ) -> CustomResult<ErrorResponse, errors::ConnectorError> {
+        self.build_error_response(res)
+    }
+
+    fn handle_response(
+        &self,
+        data: &types::PaymentsSyncRouterData,
+        res: Response,
+    ) -> CustomResult<types::PaymentsSyncRouterData, errors::ConnectorError> {
+        let response: bluesnap::BluesnapPaymentsResponse = res
+            .response
+            .parse_struct("bluesnap BluesnapPaymentsResponse")
+            .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
+        types::ResponseRouterData {
+            response,
+            data: data.clone(),
+            http_code: res.status_code,
+        }
+        .try_into()
+        .change_context(errors::ConnectorError::ResponseHandlingFailed)
+    }
+}
+
+impl api::PaymentCapture for Bluesnap {}
+impl ConnectorIntegration<api::Capture, types::PaymentsCaptureData, types::PaymentsResponseData>
+    for Bluesnap
+{
+    fn get_headers(
+        &self,
+        req: &types::PaymentsCaptureRouterData,
+        connectors: &settings::Connectors,
+    ) -> CustomResult<Vec<(String, String)>, errors::ConnectorError> {
+        self.build_headers(req, connectors)
+    }
+
+    fn get_content_type(&self) -> &'static str {
+        self.common_get_content_type()
+    }
+
+    fn get_url(
+        &self,
+        _req: &types::PaymentsCaptureRouterData,
+        connectors: &settings::Connectors,
+    ) -> CustomResult<String, errors::ConnectorError> {
+        Ok(format!(
+            "{}{}",
+            self.base_url(connectors),
+            "services/2/transactions"
+        ))
+    }
+
+    fn get_request_body(
+        &self,
+        req: &types::PaymentsCaptureRouterData,
+    ) -> CustomResult<Option<String>, errors::ConnectorError> {
+        let connector_req = bluesnap::BluesnapCaptureRequest::try_from(req)?;
+        let bluesnap_req =
+            utils::Encode::<bluesnap::BluesnapCaptureRequest>::encode_to_string_of_json(
+                &connector_req,
+            )
+            .change_context(errors::ConnectorError::RequestEncodingFailed)?;
+        Ok(Some(bluesnap_req))
+    }
+
+    fn build_request(
+        &self,
+        req: &types::PaymentsCaptureRouterData,
+        connectors: &settings::Connectors,
+    ) -> CustomResult<Option<services::Request>, errors::ConnectorError> {
+        let request = services::RequestBuilder::new()
+            .method(services::Method::Put)
+            .url(&types::PaymentsCaptureType::get_url(self, req, connectors)?)
+            .headers(types::PaymentsCaptureType::get_headers(
+                self, req, connectors,
+            )?)
+            .body(types::PaymentsCaptureType::get_request_body(self, req)?)
+            .build();
+        Ok(Some(request))
+    }
+
+    fn handle_response(
+        &self,
+        data: &types::PaymentsCaptureRouterData,
+        res: Response,
+    ) -> CustomResult<types::PaymentsCaptureRouterData, errors::ConnectorError> {
+        let response: bluesnap::BluesnapPaymentsResponse = res
+            .response
+            .parse_struct("Bluesnap BluesnapPaymentsResponse")
+            .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
+        types::ResponseRouterData {
+            response,
+            data: data.clone(),
+            http_code: res.status_code,
+        }
+        .try_into()
+        .change_context(errors::ConnectorError::ResponseHandlingFailed)
+    }
+
+    fn get_error_response(
+        &self,
+        res: Response,
+    ) -> CustomResult<ErrorResponse, errors::ConnectorError> {
+        let response: String = res
+            .response
+            .parse_struct("ErrorResponse")
+            .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
+        logger::debug!(bluesnap_error_response=?res);
+
+        Ok(ErrorResponse {
+            status_code: res.status_code,
+            code: consts::NO_ERROR_CODE.to_string(),
+            message: response,
+            reason: None,
+        })
+    }
+}
+
+impl api::PaymentSession for Bluesnap {}
+
+impl ConnectorIntegration<api::Session, types::PaymentsSessionData, types::PaymentsResponseData>
+    for Bluesnap
+{
+    //TODO: implement sessions flow
+}
+
+impl api::PaymentAuthorize for Bluesnap {}
+
+impl ConnectorIntegration<api::Authorize, types::PaymentsAuthorizeData, types::PaymentsResponseData>
+    for Bluesnap
+{
+    fn get_headers(
+        &self,
+        req: &types::PaymentsAuthorizeRouterData,
+        connectors: &settings::Connectors,
+    ) -> CustomResult<Vec<(String, String)>, errors::ConnectorError> {
+        self.build_headers(req, connectors)
+    }
+
+    fn get_content_type(&self) -> &'static str {
+        self.common_get_content_type()
+    }
+
+    fn get_url(
+        &self,
+        _req: &types::PaymentsAuthorizeRouterData,
+        connectors: &settings::Connectors,
+    ) -> CustomResult<String, errors::ConnectorError> {
+        Ok(format!(
+            "{}{}",
+            self.base_url(connectors),
+            "services/2/transactions"
+        ))
+    }
+
+    fn get_request_body(
+        &self,
+        req: &types::PaymentsAuthorizeRouterData,
+    ) -> CustomResult<Option<String>, errors::ConnectorError> {
+        let connector_req = bluesnap::BluesnapPaymentsRequest::try_from(req)?;
+        let bluesnap_req =
+            utils::Encode::<bluesnap::BluesnapPaymentsRequest>::encode_to_string_of_json(
+                &connector_req,
+            )
+            .change_context(errors::ConnectorError::RequestEncodingFailed)?;
+        Ok(Some(bluesnap_req))
+    }
+
+    fn build_request(
+        &self,
+        req: &types::PaymentsAuthorizeRouterData,
+        connectors: &settings::Connectors,
+    ) -> CustomResult<Option<services::Request>, errors::ConnectorError> {
+        Ok(Some(
+            services::RequestBuilder::new()
+                .method(services::Method::Post)
+                .url(&types::PaymentsAuthorizeType::get_url(
+                    self, req, connectors,
+                )?)
+                .headers(types::PaymentsAuthorizeType::get_headers(
+                    self, req, connectors,
+                )?)
+                .body(types::PaymentsAuthorizeType::get_request_body(self, req)?)
+                .build(),
+        ))
+    }
+
+    fn handle_response(
+        &self,
+        data: &types::PaymentsAuthorizeRouterData,
+        res: Response,
+    ) -> CustomResult<types::PaymentsAuthorizeRouterData, errors::ConnectorError> {
+        let response: bluesnap::BluesnapPaymentsResponse = res
+            .response
+            .parse_struct("bluesnap BluesnapPaymentsResponse")
+            .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
+        types::ResponseRouterData {
+            response,
+            data: data.clone(),
+            http_code: res.status_code,
+        }
+        .try_into()
+        .change_context(errors::ConnectorError::ResponseHandlingFailed)
+    }
+
+    fn get_error_response(
+        &self,
+        res: Response,
+    ) -> CustomResult<ErrorResponse, errors::ConnectorError> {
+        self.build_error_response(res)
+    }
+}
+
+impl api::Refund for Bluesnap {}
+impl api::RefundExecute for Bluesnap {}
+impl api::RefundSync for Bluesnap {}
+
+impl ConnectorIntegration<api::Execute, types::RefundsData, types::RefundsResponseData>
+    for Bluesnap
+{
+    fn get_headers(
+        &self,
+        req: &types::RefundsRouterData<api::Execute>,
+        connectors: &settings::Connectors,
+    ) -> CustomResult<Vec<(String, String)>, errors::ConnectorError> {
+        self.build_headers(req, connectors)
+    }
+
+    fn get_content_type(&self) -> &'static str {
+        self.common_get_content_type()
+    }
+
+    fn get_url(
+        &self,
+        req: &types::RefundsRouterData<api::Execute>,
+        connectors: &settings::Connectors,
+    ) -> CustomResult<String, errors::ConnectorError> {
+        Ok(format!(
+            "{}{}{}",
+            self.base_url(connectors),
+            "services/2/transactions/refund/",
+            req.request.connector_transaction_id
+        ))
+    }
+
+    fn get_request_body(
+        &self,
+        req: &types::RefundsRouterData<api::Execute>,
+    ) -> CustomResult<Option<String>, errors::ConnectorError> {
+        let connector_req = bluesnap::BluesnapRefundRequest::try_from(req)?;
+        let bluesnap_req =
+            utils::Encode::<bluesnap::BluesnapRefundRequest>::encode_to_string_of_json(
+                &connector_req,
+            )
+            .change_context(errors::ConnectorError::RequestEncodingFailed)?;
+        Ok(Some(bluesnap_req))
+    }
+
+    fn build_request(
+        &self,
+        req: &types::RefundsRouterData<api::Execute>,
+        connectors: &settings::Connectors,
+    ) -> CustomResult<Option<services::Request>, errors::ConnectorError> {
+        let request = services::RequestBuilder::new()
+            .method(services::Method::Post)
+            .url(&types::RefundExecuteType::get_url(self, req, connectors)?)
+            .headers(types::RefundExecuteType::get_headers(
+                self, req, connectors,
+            )?)
+            .body(types::RefundExecuteType::get_request_body(self, req)?)
+            .build();
+        Ok(Some(request))
+    }
+
+    fn handle_response(
+        &self,
+        data: &types::RefundsRouterData<api::Execute>,
+        res: Response,
+    ) -> CustomResult<types::RefundsRouterData<api::Execute>, errors::ConnectorError> {
+        let response: bluesnap::RefundResponse = res
+            .response
+            .parse_struct("bluesnap RefundResponse")
+            .change_context(errors::ConnectorError::RequestEncodingFailed)?;
+        types::ResponseRouterData {
+            response,
+            data: data.clone(),
+            http_code: res.status_code,
+        }
+        .try_into()
+        .change_context(errors::ConnectorError::ResponseHandlingFailed)
+    }
+
+    fn get_error_response(
+        &self,
+        res: Response,
+    ) -> CustomResult<ErrorResponse, errors::ConnectorError> {
+        self.build_error_response(res)
+    }
+}
+
+impl ConnectorIntegration<api::RSync, types::RefundsData, types::RefundsResponseData> for Bluesnap {
+    fn get_headers(
+        &self,
+        req: &types::RefundSyncRouterData,
+        connectors: &settings::Connectors,
+    ) -> CustomResult<Vec<(String, String)>, errors::ConnectorError> {
+        self.build_headers(req, connectors)
+    }
+
+    fn get_content_type(&self) -> &'static str {
+        self.common_get_content_type()
+    }
+
+    fn get_url(
+        &self,
+        req: &types::RefundSyncRouterData,
+        connectors: &settings::Connectors,
+    ) -> CustomResult<String, errors::ConnectorError> {
+        Ok(format!(
+            "{}{}{}",
+            self.base_url(connectors),
+            "services/2/transactions/",
+            req.request
+                .connector_refund_id
+                .as_deref()
+                .ok_or(errors::ConnectorError::MissingConnectorRefundID)?
+        ))
+    }
+
+    fn build_request(
+        &self,
+        req: &types::RefundsRouterData<api::RSync>,
+        connectors: &settings::Connectors,
+    ) -> CustomResult<Option<services::Request>, errors::ConnectorError> {
+        Ok(Some(
+            services::RequestBuilder::new()
+                .method(services::Method::Get)
+                .url(&types::RefundSyncType::get_url(self, req, connectors)?)
+                .headers(types::RefundSyncType::get_headers(self, req, connectors)?)
+                .build(),
+        ))
+    }
+
+    fn handle_response(
+        &self,
+        data: &types::RefundSyncRouterData,
+        res: Response,
+    ) -> CustomResult<types::RefundSyncRouterData, errors::ConnectorError> {
+        let response: bluesnap::BluesnapPaymentsResponse = res
+            .response
+            .parse_struct("bluesnap BluesnapPaymentsResponse")
+            .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
+        types::ResponseRouterData {
+            response,
+            data: data.clone(),
+            http_code: res.status_code,
+        }
+        .try_into()
+        .change_context(errors::ConnectorError::ResponseHandlingFailed)
+    }
+
+    fn get_error_response(
+        &self,
+        res: Response,
+    ) -> CustomResult<ErrorResponse, errors::ConnectorError> {
+        self.build_error_response(res)
+    }
+}
+
+#[async_trait::async_trait]
+impl api::IncomingWebhook for Bluesnap {
+    fn get_webhook_source_verification_algorithm(
+        &self,
+        _headers: &actix_web::http::header::HeaderMap,
+        _body: &[u8],
+    ) -> CustomResult<Box<dyn crypto::VerifySignature + Send>, errors::ConnectorError> {
+        Ok(Box::new(crypto::Md5))
+    }
+
+    fn get_webhook_source_verification_signature(
+        &self,
+        _headers: &actix_web::http::header::HeaderMap,
+        body: &[u8],
+    ) -> CustomResult<Vec<u8>, errors::ConnectorError> {
+        let webhook_body: bluesnap::BluesnapWebhookBody = serde_urlencoded::from_bytes(body)
+            .into_report()
+            .change_context(errors::ConnectorError::WebhookSignatureNotFound)?;
+        let signature = webhook_body.auth_key;
+        hex::decode(signature)
+            .into_report()
+            .change_context(errors::ConnectorError::WebhookSignatureNotFound)
+    }
+    fn get_webhook_source_verification_message(
+        &self,
+        _headers: &actix_web::http::header::HeaderMap,
+        body: &[u8],
+        _merchant_id: &str,
+        _secret: &[u8],
+    ) -> CustomResult<Vec<u8>, errors::ConnectorError> {
+        let webhook_body: bluesnap::BluesnapWebhookBody = serde_urlencoded::from_bytes(body)
+            .into_report()
+            .change_context(errors::ConnectorError::WebhookSignatureNotFound)?;
+        let msg = webhook_body.reference_number + &webhook_body.contract_id;
+        Ok(msg.into_bytes())
+    }
+
+    async fn get_webhook_source_verification_merchant_secret(
+        &self,
+        db: &dyn StorageInterface,
+        merchant_id: &str,
+    ) -> CustomResult<Vec<u8>, errors::ConnectorError> {
+        let key = format!("whsec_verification_{}_{}", self.id(), merchant_id);
+        let secret = db
+            .find_config_by_key(&key)
+            .await
+            .change_context(errors::ConnectorError::WebhookVerificationSecretNotFound)?;
+
+        Ok(secret.config.into_bytes())
+    }
+
+    async fn verify_webhook_source(
+        &self,
+        db: &dyn StorageInterface,
+        headers: &actix_web::http::header::HeaderMap,
+        body: &[u8],
+        merchant_id: &str,
+    ) -> CustomResult<bool, errors::ConnectorError> {
+        let algorithm = self
+            .get_webhook_source_verification_algorithm(headers, body)
+            .change_context(errors::ConnectorError::WebhookSourceVerificationFailed)?;
+
+        let signature = self
+            .get_webhook_source_verification_signature(headers, body)
+            .change_context(errors::ConnectorError::WebhookSourceVerificationFailed)?;
+        let mut secret = self
+            .get_webhook_source_verification_merchant_secret(db, merchant_id)
+            .await
+            .change_context(errors::ConnectorError::WebhookSourceVerificationFailed)?;
+        let mut message = self
+            .get_webhook_source_verification_message(headers, body, merchant_id, &secret)
+            .change_context(errors::ConnectorError::WebhookSourceVerificationFailed)?;
+        message.append(&mut secret);
+        algorithm
+            .verify_signature(&secret, &signature, &message)
+            .change_context(errors::ConnectorError::WebhookSourceVerificationFailed)
+    }
+
+    fn get_webhook_object_reference_id(
+        &self,
+        body: &[u8],
+    ) -> CustomResult<String, errors::ConnectorError> {
+        let webhook_body: bluesnap::BluesnapWebhookBody = serde_urlencoded::from_bytes(body)
+            .into_report()
+            .change_context(errors::ConnectorError::WebhookSignatureNotFound)?;
+        Ok(webhook_body.reference_number)
+    }
+
+    fn get_webhook_event_type(
+        &self,
+        body: &[u8],
+    ) -> CustomResult<api::IncomingWebhookEvent, errors::ConnectorError> {
+        let details: bluesnap::BluesnapWebhookObjectEventType = serde_urlencoded::from_bytes(body)
+            .into_report()
+            .change_context(errors::ConnectorError::WebhookEventTypeNotFound)?;
+
+        Ok(match details.transaction_type.as_str() {
+            "DECLINE" | "CC_CHARGE_FAILED" => api::IncomingWebhookEvent::PaymentIntentFailure,
+            "CHARGE" => api::IncomingWebhookEvent::PaymentIntentSuccess,
+            _ => Err(errors::ConnectorError::WebhookEventTypeNotFound).into_report()?,
+        })
+    }
+
+    fn get_webhook_resource_object(
+        &self,
+        body: &[u8],
+    ) -> CustomResult<serde_json::Value, errors::ConnectorError> {
+        let details: bluesnap::BluesnapWebhookObjectResource = serde_urlencoded::from_bytes(body)
+            .into_report()
+            .change_context(errors::ConnectorError::WebhookEventTypeNotFound)?;
+        let res_json =
+            utils::Encode::<transformers::BluesnapWebhookObjectResource>::encode_to_value(&details)
+                .change_context(errors::ConnectorError::WebhookResourceObjectNotFound)?;
+
+        Ok(res_json)
+    }
+}
+
+impl services::ConnectorRedirectResponse for Bluesnap {
+    fn get_flow_type(
+        &self,
+        _query_params: &str,
+    ) -> CustomResult<payments::CallConnectorAction, errors::ConnectorError> {
+        Ok(payments::CallConnectorAction::Trigger)
+    }
+}

--- a/crates/router/src/connector/bluesnap.rs
+++ b/crates/router/src/connector/bluesnap.rs
@@ -619,20 +619,19 @@ impl ConnectorIntegration<api::RSync, types::RefundsData, types::RefundsResponse
 impl api::IncomingWebhook for Bluesnap {
     fn get_webhook_source_verification_algorithm(
         &self,
-        _headers: &actix_web::http::header::HeaderMap,
-        _body: &[u8],
+        _request: &api::IncomingWebhookRequestDetails<'_>,
     ) -> CustomResult<Box<dyn crypto::VerifySignature + Send>, errors::ConnectorError> {
         Ok(Box::new(crypto::Md5))
     }
 
     fn get_webhook_source_verification_signature(
         &self,
-        _headers: &actix_web::http::header::HeaderMap,
-        body: &[u8],
+        request: &api::IncomingWebhookRequestDetails<'_>,
     ) -> CustomResult<Vec<u8>, errors::ConnectorError> {
-        let webhook_body: bluesnap::BluesnapWebhookBody = serde_urlencoded::from_bytes(body)
-            .into_report()
-            .change_context(errors::ConnectorError::WebhookSignatureNotFound)?;
+        let webhook_body: bluesnap::BluesnapWebhookBody =
+            serde_urlencoded::from_bytes(request.body)
+                .into_report()
+                .change_context(errors::ConnectorError::WebhookSignatureNotFound)?;
         let signature = webhook_body.auth_key;
         hex::decode(signature)
             .into_report()
@@ -640,14 +639,14 @@ impl api::IncomingWebhook for Bluesnap {
     }
     fn get_webhook_source_verification_message(
         &self,
-        _headers: &actix_web::http::header::HeaderMap,
-        body: &[u8],
+        request: &api::IncomingWebhookRequestDetails<'_>,
         _merchant_id: &str,
         _secret: &[u8],
     ) -> CustomResult<Vec<u8>, errors::ConnectorError> {
-        let webhook_body: bluesnap::BluesnapWebhookBody = serde_urlencoded::from_bytes(body)
-            .into_report()
-            .change_context(errors::ConnectorError::WebhookSignatureNotFound)?;
+        let webhook_body: bluesnap::BluesnapWebhookBody =
+            serde_urlencoded::from_bytes(request.body)
+                .into_report()
+                .change_context(errors::ConnectorError::WebhookSignatureNotFound)?;
         let msg = webhook_body.reference_number + &webhook_body.contract_id;
         Ok(msg.into_bytes())
     }
@@ -669,23 +668,22 @@ impl api::IncomingWebhook for Bluesnap {
     async fn verify_webhook_source(
         &self,
         db: &dyn StorageInterface,
-        headers: &actix_web::http::header::HeaderMap,
-        body: &[u8],
+        request: &api::IncomingWebhookRequestDetails<'_>,
         merchant_id: &str,
     ) -> CustomResult<bool, errors::ConnectorError> {
         let algorithm = self
-            .get_webhook_source_verification_algorithm(headers, body)
+            .get_webhook_source_verification_algorithm(request)
             .change_context(errors::ConnectorError::WebhookSourceVerificationFailed)?;
 
         let signature = self
-            .get_webhook_source_verification_signature(headers, body)
+            .get_webhook_source_verification_signature(request)
             .change_context(errors::ConnectorError::WebhookSourceVerificationFailed)?;
         let mut secret = self
             .get_webhook_source_verification_merchant_secret(db, merchant_id)
             .await
             .change_context(errors::ConnectorError::WebhookSourceVerificationFailed)?;
         let mut message = self
-            .get_webhook_source_verification_message(headers, body, merchant_id, &secret)
+            .get_webhook_source_verification_message(request, merchant_id, &secret)
             .change_context(errors::ConnectorError::WebhookSourceVerificationFailed)?;
         message.append(&mut secret);
         algorithm
@@ -695,21 +693,23 @@ impl api::IncomingWebhook for Bluesnap {
 
     fn get_webhook_object_reference_id(
         &self,
-        body: &[u8],
+        request: &api::IncomingWebhookRequestDetails<'_>,
     ) -> CustomResult<String, errors::ConnectorError> {
-        let webhook_body: bluesnap::BluesnapWebhookBody = serde_urlencoded::from_bytes(body)
-            .into_report()
-            .change_context(errors::ConnectorError::WebhookSignatureNotFound)?;
+        let webhook_body: bluesnap::BluesnapWebhookBody =
+            serde_urlencoded::from_bytes(request.body)
+                .into_report()
+                .change_context(errors::ConnectorError::WebhookSignatureNotFound)?;
         Ok(webhook_body.reference_number)
     }
 
     fn get_webhook_event_type(
         &self,
-        body: &[u8],
+        request: &api::IncomingWebhookRequestDetails<'_>,
     ) -> CustomResult<api::IncomingWebhookEvent, errors::ConnectorError> {
-        let details: bluesnap::BluesnapWebhookObjectEventType = serde_urlencoded::from_bytes(body)
-            .into_report()
-            .change_context(errors::ConnectorError::WebhookEventTypeNotFound)?;
+        let details: bluesnap::BluesnapWebhookObjectEventType =
+            serde_urlencoded::from_bytes(request.body)
+                .into_report()
+                .change_context(errors::ConnectorError::WebhookEventTypeNotFound)?;
 
         Ok(match details.transaction_type.as_str() {
             "DECLINE" | "CC_CHARGE_FAILED" => api::IncomingWebhookEvent::PaymentIntentFailure,
@@ -720,11 +720,12 @@ impl api::IncomingWebhook for Bluesnap {
 
     fn get_webhook_resource_object(
         &self,
-        body: &[u8],
+        request: &api::IncomingWebhookRequestDetails<'_>,
     ) -> CustomResult<serde_json::Value, errors::ConnectorError> {
-        let details: bluesnap::BluesnapWebhookObjectResource = serde_urlencoded::from_bytes(body)
-            .into_report()
-            .change_context(errors::ConnectorError::WebhookEventTypeNotFound)?;
+        let details: bluesnap::BluesnapWebhookObjectResource =
+            serde_urlencoded::from_bytes(request.body)
+                .into_report()
+                .change_context(errors::ConnectorError::WebhookEventTypeNotFound)?;
         let res_json =
             utils::Encode::<transformers::BluesnapWebhookObjectResource>::encode_to_value(&details)
                 .change_context(errors::ConnectorError::WebhookResourceObjectNotFound)?;

--- a/crates/router/src/connector/bluesnap/transformers.rs
+++ b/crates/router/src/connector/bluesnap/transformers.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     core::errors,
-    pii::{self, PeekInterface, Secret},
+    pii::{self, Secret},
     types::{
         self, api,
         storage::enums,
@@ -31,9 +31,9 @@ pub enum PaymentMethodDetails {
 #[serde(rename_all = "camelCase")]
 pub struct Card {
     card_number: Secret<String, pii::CardNumber>,
-    expiration_month: String,
-    expiration_year: String,
-    security_code: String,
+    expiration_month: Secret<String>,
+    expiration_year: Secret<String>,
+    security_code: Secret<String>,
 }
 
 impl TryFrom<&types::PaymentsAuthorizeRouterData> for BluesnapPaymentsRequest {
@@ -45,13 +45,13 @@ impl TryFrom<&types::PaymentsAuthorizeRouterData> for BluesnapPaymentsRequest {
         };
         let payment_method = match item.request.payment_method_data.clone() {
             api::PaymentMethod::Card(ccard) => Ok(PaymentMethodDetails::CreditCard(Card {
-                card_number: ccard.card_number.clone(),
-                expiration_month: ccard.card_exp_month.peek().clone(),
-                expiration_year: ccard.card_exp_year.peek().clone(),
-                security_code: ccard.card_cvc.peek().clone(),
+                card_number: ccard.card_number,
+                expiration_month: ccard.card_exp_month.clone(),
+                expiration_year: ccard.card_exp_year.clone(),
+                security_code: ccard.card_cvc,
             })),
             _ => Err(errors::ConnectorError::NotImplemented(
-                "Unknown payment method".to_string(),
+                "payment method".to_string(),
             )),
         }?;
         Ok(Self {

--- a/crates/router/src/connector/bluesnap/transformers.rs
+++ b/crates/router/src/connector/bluesnap/transformers.rs
@@ -1,0 +1,333 @@
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    core::errors,
+    pii::{self, PeekInterface, Secret},
+    types::{
+        self, api,
+        storage::enums,
+        transformers::{self, ForeignTryFrom},
+    },
+};
+
+#[derive(Debug, Serialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct BluesnapPaymentsRequest {
+    amount: i64,
+    #[serde(flatten)]
+    payment_method: PaymentMethodDetails,
+    currency: enums::Currency,
+    soft_descriptor: Option<String>,
+    card_transaction_type: BluesnapTxnType,
+}
+
+#[derive(Debug, Serialize, Eq, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub enum PaymentMethodDetails {
+    CreditCard(Card),
+}
+
+#[derive(Default, Debug, Serialize, Eq, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct Card {
+    card_number: Secret<String, pii::CardNumber>,
+    expiration_month: String,
+    expiration_year: String,
+    security_code: String,
+}
+
+impl TryFrom<&types::PaymentsAuthorizeRouterData> for BluesnapPaymentsRequest {
+    type Error = error_stack::Report<errors::ConnectorError>;
+    fn try_from(item: &types::PaymentsAuthorizeRouterData) -> Result<Self, Self::Error> {
+        let auth_mode = match item.request.capture_method {
+            Some(enums::CaptureMethod::Manual) => BluesnapTxnType::AuthOnly,
+            _ => BluesnapTxnType::AuthCapture,
+        };
+        let payment_method = match item.request.payment_method_data.clone() {
+            api::PaymentMethod::Card(ccard) => Ok(PaymentMethodDetails::CreditCard(Card {
+                card_number: ccard.card_number.clone(),
+                expiration_month: ccard.card_exp_month.peek().clone(),
+                expiration_year: ccard.card_exp_year.peek().clone(),
+                security_code: ccard.card_cvc.peek().clone(),
+            })),
+            _ => Err(errors::ConnectorError::NotImplemented(
+                "Unknown payment method".to_string(),
+            )),
+        }?;
+        Ok(Self {
+            amount: item.request.amount,
+            payment_method,
+            currency: item.request.currency,
+            soft_descriptor: item.description.clone(),
+            card_transaction_type: auth_mode,
+        })
+    }
+}
+
+#[derive(Debug, Serialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct BluesnapVoidRequest {
+    card_transaction_type: BluesnapTxnType,
+    transaction_id: String,
+}
+
+impl TryFrom<&types::PaymentsCancelRouterData> for BluesnapVoidRequest {
+    type Error = error_stack::Report<errors::ConnectorError>;
+    fn try_from(item: &types::PaymentsCancelRouterData) -> Result<Self, Self::Error> {
+        let card_transaction_type = BluesnapTxnType::AuthReversal;
+        let transaction_id = item.request.connector_transaction_id.to_string();
+        Ok(Self {
+            card_transaction_type,
+            transaction_id,
+        })
+    }
+}
+
+#[derive(Debug, Serialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct BluesnapCaptureRequest {
+    card_transaction_type: BluesnapTxnType,
+    transaction_id: String,
+    amount: Option<i64>,
+}
+
+impl TryFrom<&types::PaymentsCaptureRouterData> for BluesnapCaptureRequest {
+    type Error = error_stack::Report<errors::ConnectorError>;
+    fn try_from(item: &types::PaymentsCaptureRouterData) -> Result<Self, Self::Error> {
+        let card_transaction_type = BluesnapTxnType::Capture;
+        let transaction_id = item.request.connector_transaction_id.to_string();
+        Ok(Self {
+            card_transaction_type,
+            transaction_id,
+            amount: item.request.amount_to_capture,
+        })
+    }
+}
+
+// Auth Struct
+pub struct BluesnapAuthType {
+    pub(super) api_key: String,
+    pub(super) key1: String,
+}
+
+impl TryFrom<&types::ConnectorAuthType> for BluesnapAuthType {
+    type Error = error_stack::Report<errors::ConnectorError>;
+    fn try_from(auth_type: &types::ConnectorAuthType) -> Result<Self, Self::Error> {
+        if let types::ConnectorAuthType::BodyKey { api_key, key1 } = auth_type {
+            Ok(Self {
+                api_key: api_key.to_string(),
+                key1: key1.to_string(),
+            })
+        } else {
+            Err(errors::ConnectorError::FailedToObtainAuthType.into())
+        }
+    }
+}
+// PaymentsResponse
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum BluesnapTxnType {
+    AuthOnly,
+    AuthCapture,
+    AuthReversal,
+    Capture,
+    Refund,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum BluesnapProcessingStatus {
+    #[serde(alias = "success")]
+    Success,
+    #[default]
+    #[serde(alias = "pending")]
+    Pending,
+    #[serde(alias = "fail")]
+    Fail,
+    #[serde(alias = "pending_merchant_review")]
+    PendingMerchantReview,
+}
+
+impl TryFrom<transformers::Foreign<(BluesnapTxnType, BluesnapProcessingStatus)>>
+    for transformers::Foreign<enums::AttemptStatus>
+{
+    type Error = error_stack::Report<errors::ConnectorError>;
+    fn try_from(
+        item: transformers::Foreign<(BluesnapTxnType, BluesnapProcessingStatus)>,
+    ) -> Result<Self, Self::Error> {
+        let item = item.0;
+        let (item_txn_status, item_processing_status) = item;
+        Ok(match item_processing_status {
+            BluesnapProcessingStatus::Success => match item_txn_status {
+                BluesnapTxnType::AuthOnly => enums::AttemptStatus::Authorized,
+                BluesnapTxnType::AuthReversal => enums::AttemptStatus::Voided,
+                BluesnapTxnType::AuthCapture | BluesnapTxnType::Capture => {
+                    enums::AttemptStatus::Charged
+                }
+                BluesnapTxnType::Refund => enums::AttemptStatus::Charged,
+            },
+            BluesnapProcessingStatus::Pending | BluesnapProcessingStatus::PendingMerchantReview => {
+                enums::AttemptStatus::Pending
+            }
+            BluesnapProcessingStatus::Fail => enums::AttemptStatus::Failure,
+        }
+        .into())
+    }
+}
+
+impl From<BluesnapProcessingStatus> for enums::RefundStatus {
+    fn from(item: BluesnapProcessingStatus) -> Self {
+        match item {
+            BluesnapProcessingStatus::Success => Self::Success,
+            BluesnapProcessingStatus::Pending => Self::Pending,
+            BluesnapProcessingStatus::PendingMerchantReview => Self::ManualReview,
+            BluesnapProcessingStatus::Fail => Self::Failure,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct BluesnapPaymentsResponse {
+    processing_info: ProcessingInfoResponse,
+    transaction_id: String,
+    card_transaction_type: BluesnapTxnType,
+}
+
+#[derive(Default, Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct Refund {
+    refund_transaction_id: String,
+    amount: String,
+}
+
+#[derive(Default, Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct ProcessingInfoResponse {
+    processing_status: BluesnapProcessingStatus,
+    authorization_code: Option<String>,
+    network_transaction_id: Option<String>,
+}
+
+impl<F, T>
+    TryFrom<types::ResponseRouterData<F, BluesnapPaymentsResponse, T, types::PaymentsResponseData>>
+    for types::RouterData<F, T, types::PaymentsResponseData>
+{
+    type Error = error_stack::Report<errors::ConnectorError>;
+    fn try_from(
+        item: types::ResponseRouterData<
+            F,
+            BluesnapPaymentsResponse,
+            T,
+            types::PaymentsResponseData,
+        >,
+    ) -> Result<Self, Self::Error> {
+        Ok(Self {
+            status: enums::AttemptStatus::foreign_try_from((
+                item.response.card_transaction_type,
+                item.response.processing_info.processing_status,
+            ))?,
+            response: Ok(types::PaymentsResponseData::TransactionResponse {
+                resource_id: types::ResponseId::ConnectorTransactionId(
+                    item.response.transaction_id,
+                ),
+                redirection_data: None,
+                redirect: false,
+                mandate_reference: None,
+                connector_metadata: None,
+            }),
+            ..item.data
+        })
+    }
+}
+
+#[derive(Default, Debug, Eq, PartialEq, Serialize)]
+pub struct BluesnapRefundRequest {
+    amount: Option<i64>,
+    reason: Option<String>,
+}
+
+impl<F> TryFrom<&types::RefundsRouterData<F>> for BluesnapRefundRequest {
+    type Error = error_stack::Report<errors::ConnectorError>;
+    fn try_from(item: &types::RefundsRouterData<F>) -> Result<Self, Self::Error> {
+        Ok(Self {
+            reason: item.request.reason.clone(),
+            amount: Some(item.request.refund_amount),
+        })
+    }
+}
+
+#[derive(Default, Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RefundResponse {
+    refund_transaction_id: i32,
+}
+
+impl TryFrom<types::RefundsResponseRouterData<api::RSync, BluesnapPaymentsResponse>>
+    for types::RefundsRouterData<api::RSync>
+{
+    type Error = error_stack::Report<errors::ConnectorError>;
+    fn try_from(
+        item: types::RefundsResponseRouterData<api::RSync, BluesnapPaymentsResponse>,
+    ) -> Result<Self, Self::Error> {
+        Ok(Self {
+            response: Ok(types::RefundsResponseData {
+                connector_refund_id: item.response.transaction_id.clone(),
+                refund_status: enums::RefundStatus::from(
+                    item.response.processing_info.processing_status,
+                ),
+            }),
+            ..item.data
+        })
+    }
+}
+
+impl TryFrom<types::RefundsResponseRouterData<api::Execute, RefundResponse>>
+    for types::RefundsRouterData<api::Execute>
+{
+    type Error = error_stack::Report<errors::ConnectorError>;
+    fn try_from(
+        item: types::RefundsResponseRouterData<api::Execute, RefundResponse>,
+    ) -> Result<Self, Self::Error> {
+        Ok(Self {
+            response: Ok(types::RefundsResponseData {
+                connector_refund_id: item.response.refund_transaction_id.to_string(),
+                refund_status: enums::RefundStatus::Pending,
+            }),
+            ..item.data
+        })
+    }
+}
+#[derive(Debug, Clone, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct BluesnapWebhookBody {
+    pub auth_key: String,
+    pub contract_id: String,
+    pub reference_number: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BluesnapWebhookObjectEventType {
+    pub transaction_type: String,
+}
+#[derive(Default, Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct BluesnapWebhookObjectResource {
+    pub auth_key: String,
+    pub contract_id: String,
+    pub reference_number: String,
+}
+
+#[derive(Default, Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct ErrorDetails {
+    pub code: String,
+    pub description: String,
+}
+
+#[derive(Default, Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct BluesnapErrorResponse {
+    pub message: Vec<ErrorDetails>,
+}

--- a/crates/router/src/types.rs
+++ b/crates/router/src/types.rs
@@ -394,7 +394,7 @@ impl Default for ErrorResponse {
 
 impl From<&&mut PaymentsAuthorizeRouterData> for PaymentsAuthorizeSessionTokenRouterData {
     fn from(data: &&mut PaymentsAuthorizeRouterData) -> Self {
-        PaymentsAuthorizeSessionTokenRouterData {
+        Self {
             flow: PhantomData,
             request: AuthorizeSessionTokenData {
                 amount_to_capture: data.amount_captured,

--- a/crates/router/src/types/api.rs
+++ b/crates/router/src/types/api.rs
@@ -164,6 +164,7 @@ impl ConnectorData {
             "adyen" => Ok(Box::new(&connector::Adyen)),
             "applepay" => Ok(Box::new(&connector::Applepay)),
             "authorizedotnet" => Ok(Box::new(&connector::Authorizedotnet)),
+            "bluesnap" => Ok(Box::new(&connector::Bluesnap)),
             "braintree" => Ok(Box::new(&connector::Braintree)),
             "checkout" => Ok(Box::new(&connector::Checkout)),
             "cybersource" => Ok(Box::new(&connector::Cybersource)),

--- a/crates/router/tests/connectors/bluesnap.rs
+++ b/crates/router/tests/connectors/bluesnap.rs
@@ -1,0 +1,540 @@
+use masking::Secret;
+use router::types::{self, api, storage::enums, ConnectorAuthType};
+
+use crate::{
+    connector_auth,
+    utils::{self, ConnectorActions},
+};
+
+#[derive(Clone, Copy)]
+struct BluesnapTest;
+impl ConnectorActions for BluesnapTest {}
+static CONNECTOR: BluesnapTest = BluesnapTest {};
+impl utils::Connector for BluesnapTest {
+    fn get_data(&self) -> types::api::ConnectorData {
+        use router::connector::Bluesnap;
+        types::api::ConnectorData {
+            connector: Box::new(&Bluesnap),
+            connector_name: types::Connector::Bluesnap,
+            get_token: types::api::GetToken::Connector,
+        }
+    }
+
+    fn get_auth_token(&self) -> ConnectorAuthType {
+        types::ConnectorAuthType::from(
+            connector_auth::ConnectorAuthentication::new()
+                .bluesnap
+                .expect("Missing connector authentication configuration"),
+        )
+    }
+
+    fn get_name(&self) -> String {
+        "bluesnap".to_string()
+    }
+}
+
+// Cards Positive Tests
+// Creates a payment using the manual capture flow (Non 3DS).
+// passed
+#[serial_test::serial]
+#[actix_web::test]
+async fn should_only_authorize_payment() {
+    let response = CONNECTOR
+        .authorize_payment(None, None)
+        .await
+        .expect("Authorize payment response");
+    assert_eq!(response.status, enums::AttemptStatus::Authorized);
+}
+
+// Captures a payment using the manual capture flow (Non 3DS).
+// passed
+#[serial_test::serial]
+#[actix_web::test]
+async fn should_capture_authorized_payment() {
+    let response = CONNECTOR
+        .authorize_and_capture_payment(None, None, None)
+        .await
+        .expect("Capture payment response");
+    assert_eq!(response.status, enums::AttemptStatus::Charged);
+}
+
+// Partially captures a payment using the manual capture flow (Non 3DS).
+// passed
+#[serial_test::serial]
+#[actix_web::test]
+async fn should_partially_capture_authorized_payment() {
+    let response = CONNECTOR
+        .authorize_and_capture_payment(
+            None,
+            Some(types::PaymentsCaptureData {
+                amount_to_capture: Some(50),
+                ..utils::PaymentCaptureType::default().0
+            }),
+            None,
+        )
+        .await
+        .expect("Capture payment response");
+    assert_eq!(response.status, enums::AttemptStatus::Charged);
+}
+
+// Synchronizes a payment using the manual capture flow (Non 3DS).
+// passed
+#[serial_test::serial]
+#[actix_web::test]
+async fn should_sync_authorized_payment() {
+    let authorize_response = CONNECTOR
+        .authorize_payment(None, None)
+        .await
+        .expect("Authorize payment response");
+    let txn_id = utils::get_connector_transaction_id(authorize_response.response);
+    let response = CONNECTOR
+        .psync_retry_till_status_matches(
+            enums::AttemptStatus::Authorized,
+            Some(types::PaymentsSyncData {
+                connector_transaction_id: router::types::ResponseId::ConnectorTransactionId(
+                    txn_id.unwrap(),
+                ),
+                encoded_data: None,
+                capture_method: None,
+            }),
+            None,
+        )
+        .await
+        .expect("PSync response");
+    assert_eq!(response.status, enums::AttemptStatus::Authorized,);
+}
+
+// Voids a payment using the manual capture flow (Non 3DS).
+// passed
+#[serial_test::serial]
+#[actix_web::test]
+async fn should_void_authorized_payment() {
+    let response = CONNECTOR
+        .authorize_and_void_payment(
+            None,
+            Some(types::PaymentsCancelData {
+                connector_transaction_id: String::from(""),
+                cancellation_reason: Some("requested_by_customer".to_string()),
+                ..Default::default()
+            }),
+            None,
+        )
+        .await
+        .expect("Void payment response");
+    assert_eq!(response.status, enums::AttemptStatus::Voided);
+}
+
+// Refunds a payment using the manual capture flow (Non 3DS).
+// passed
+#[serial_test::serial]
+#[actix_web::test]
+async fn should_refund_manually_captured_payment() {
+    let response = CONNECTOR
+        .capture_payment_and_refund(None, None, None, None)
+        .await
+        .unwrap();
+    let rsync_response = CONNECTOR
+        .rsync_retry_till_status_matches(
+            enums::RefundStatus::Success,
+            response.response.unwrap().connector_refund_id,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        rsync_response.response.unwrap().refund_status,
+        enums::RefundStatus::Success,
+    );
+}
+
+// Partially refunds a payment using the manual capture flow (Non 3DS).
+// passed
+#[serial_test::serial]
+#[actix_web::test]
+async fn should_partially_refund_manually_captured_payment() {
+    let response = CONNECTOR
+        .capture_payment_and_refund(
+            None,
+            None,
+            Some(types::RefundsData {
+                refund_amount: 50,
+                ..utils::PaymentRefundType::default().0
+            }),
+            None,
+        )
+        .await
+        .unwrap();
+    let rsync_response = CONNECTOR
+        .rsync_retry_till_status_matches(
+            enums::RefundStatus::Success,
+            response.response.unwrap().connector_refund_id,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        rsync_response.response.unwrap().refund_status,
+        enums::RefundStatus::Success,
+    );
+}
+
+// Synchronizes a refund using the manual capture flow (Non 3DS).
+// Passed
+#[serial_test::serial]
+#[actix_web::test]
+async fn should_sync_manually_captured_refund() {
+    let refund_response = CONNECTOR
+        .capture_payment_and_refund(None, None, None, None)
+        .await
+        .unwrap();
+    let response = CONNECTOR
+        .rsync_retry_till_status_matches(
+            enums::RefundStatus::Success,
+            refund_response.response.unwrap().connector_refund_id,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        response.response.unwrap().refund_status,
+        enums::RefundStatus::Success,
+    );
+}
+
+// Creates a payment using the automatic capture flow (Non 3DS).
+// passed
+#[serial_test::serial]
+#[actix_web::test]
+async fn should_make_payment() {
+    let authorize_response = CONNECTOR.make_payment(None, None).await.unwrap();
+    assert_eq!(authorize_response.status, enums::AttemptStatus::Charged);
+}
+
+// Synchronizes a payment using the automatic capture flow (Non 3DS).
+// passed
+#[serial_test::serial]
+#[actix_web::test]
+async fn should_sync_auto_captured_payment() {
+    let authorize_response = CONNECTOR.make_payment(None, None).await.unwrap();
+    assert_eq!(authorize_response.status, enums::AttemptStatus::Charged);
+    let txn_id = utils::get_connector_transaction_id(authorize_response.response);
+    assert_ne!(txn_id, None, "Empty connector transaction id");
+    let response = CONNECTOR
+        .psync_retry_till_status_matches(
+            enums::AttemptStatus::Charged,
+            Some(types::PaymentsSyncData {
+                connector_transaction_id: router::types::ResponseId::ConnectorTransactionId(
+                    txn_id.unwrap(),
+                ),
+                encoded_data: None,
+                capture_method: None,
+            }),
+            None,
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status, enums::AttemptStatus::Charged,);
+}
+
+// Refunds a payment using the automatic capture flow (Non 3DS).
+// passed
+#[serial_test::serial]
+#[actix_web::test]
+async fn should_refund_auto_captured_payment() {
+    let response = CONNECTOR
+        .make_payment_and_refund(None, None, None)
+        .await
+        .unwrap();
+    let rsync_response = CONNECTOR
+        .rsync_retry_till_status_matches(
+            enums::RefundStatus::Success,
+            response.response.unwrap().connector_refund_id,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        rsync_response.response.unwrap().refund_status,
+        enums::RefundStatus::Success,
+    );
+}
+
+// Partially refunds a payment using the automatic capture flow (Non 3DS).
+// passed
+#[serial_test::serial]
+#[actix_web::test]
+async fn should_partially_refund_succeeded_payment() {
+    let refund_response = CONNECTOR
+        .make_payment_and_refund(
+            None,
+            Some(types::RefundsData {
+                refund_amount: 50,
+                ..utils::PaymentRefundType::default().0
+            }),
+            None,
+        )
+        .await
+        .unwrap();
+    let rsync_response = CONNECTOR
+        .rsync_retry_till_status_matches(
+            enums::RefundStatus::Success,
+            refund_response.response.unwrap().connector_refund_id,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        rsync_response.response.unwrap().refund_status,
+        enums::RefundStatus::Success,
+    );
+}
+
+// Creates multiple refunds against a payment using the automatic capture flow (Non 3DS).
+// passed
+#[serial_test::serial]
+#[actix_web::test]
+async fn should_refund_succeeded_payment_multiple_times() {
+    let authorize_response = CONNECTOR.make_payment(None, None).await.unwrap();
+    assert_eq!(authorize_response.status, enums::AttemptStatus::Charged);
+    let transaction_id = utils::get_connector_transaction_id(authorize_response.response).unwrap();
+    for _x in 0..2 {
+        tokio::time::sleep(std::time::Duration::from_secs(5)).await; // to avoid 404 error
+        let refund_response = CONNECTOR
+            .refund_payment(
+                transaction_id.clone(),
+                Some(types::RefundsData {
+                    refund_amount: 50,
+                    ..utils::PaymentRefundType::default().0
+                }),
+                None,
+            )
+            .await
+            .unwrap();
+        let rsync_response = CONNECTOR
+            .rsync_retry_till_status_matches(
+                enums::RefundStatus::Success,
+                refund_response.response.unwrap().connector_refund_id,
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            rsync_response.response.unwrap().refund_status,
+            enums::RefundStatus::Success,
+        );
+    }
+}
+
+// Synchronizes a refund using the automatic capture flow (Non 3DS).
+// passed
+#[serial_test::serial]
+#[actix_web::test]
+async fn should_sync_refund() {
+    let refund_response = CONNECTOR
+        .make_payment_and_refund(None, None, None)
+        .await
+        .unwrap();
+    let response = CONNECTOR
+        .rsync_retry_till_status_matches(
+            enums::RefundStatus::Success,
+            refund_response.response.unwrap().connector_refund_id,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        response.response.unwrap().refund_status,
+        enums::RefundStatus::Success,
+    );
+}
+
+// Cards Negative scenerios
+// Creates a payment with incorrect card number.
+// passed
+#[serial_test::serial]
+#[actix_web::test]
+async fn should_fail_payment_for_incorrect_card_number() {
+    let response = CONNECTOR
+        .make_payment(
+            Some(types::PaymentsAuthorizeData {
+                payment_method_data: types::api::PaymentMethod::Card(api::Card {
+                    card_number: Secret::new("1234567891011".to_string()),
+                    ..utils::CCardType::default().0
+                }),
+                ..utils::PaymentAuthorizeType::default().0
+            }),
+            None,
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        response.response.unwrap_err().message,
+        "Order creation failure due to problematic input.".to_string(),
+    );
+}
+
+// Creates a payment with empty card number.
+// passed
+#[serial_test::serial]
+#[actix_web::test]
+async fn should_fail_payment_for_empty_card_number() {
+    let response = CONNECTOR
+        .make_payment(
+            Some(types::PaymentsAuthorizeData {
+                payment_method_data: types::api::PaymentMethod::Card(api::Card {
+                    card_number: Secret::new(String::from("")),
+                    ..utils::CCardType::default().0
+                }),
+                ..utils::PaymentAuthorizeType::default().0
+            }),
+            None,
+        )
+        .await
+        .unwrap();
+    let x = response.response.unwrap_err();
+    assert_eq!(
+        x.message,
+        "Order creation failure due to problematic input.",
+    );
+}
+
+// Creates a payment with incorrect CVC.
+// passed
+#[serial_test::serial]
+#[actix_web::test]
+async fn should_fail_payment_for_incorrect_cvc() {
+    let response = CONNECTOR
+        .make_payment(
+            Some(types::PaymentsAuthorizeData {
+                payment_method_data: types::api::PaymentMethod::Card(api::Card {
+                    card_cvc: Secret::new("12345".to_string()),
+                    ..utils::CCardType::default().0
+                }),
+                ..utils::PaymentAuthorizeType::default().0
+            }),
+            None,
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        response.response.unwrap_err().message,
+        "Order creation failure due to problematic input.".to_string(),
+    );
+}
+
+// Creates a payment with incorrect expiry month.
+// passed
+#[serial_test::serial]
+#[actix_web::test]
+async fn should_fail_payment_for_invalid_exp_month() {
+    let response = CONNECTOR
+        .make_payment(
+            Some(types::PaymentsAuthorizeData {
+                payment_method_data: types::api::PaymentMethod::Card(api::Card {
+                    card_exp_month: Secret::new("20".to_string()),
+                    ..utils::CCardType::default().0
+                }),
+                ..utils::PaymentAuthorizeType::default().0
+            }),
+            None,
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        response.response.unwrap_err().message,
+        "Order creation failure due to problematic input.".to_string(),
+    );
+}
+
+// Creates a payment with incorrect expiry year.
+// passed
+#[serial_test::serial]
+#[actix_web::test]
+async fn should_fail_payment_for_incorrect_expiry_year() {
+    let response = CONNECTOR
+        .make_payment(
+            Some(types::PaymentsAuthorizeData {
+                payment_method_data: types::api::PaymentMethod::Card(api::Card {
+                    card_exp_year: Secret::new("2000".to_string()),
+                    ..utils::CCardType::default().0
+                }),
+                ..utils::PaymentAuthorizeType::default().0
+            }),
+            None,
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        response.response.unwrap_err().message,
+        "Order creation failure due to problematic input.".to_string(),
+    );
+}
+
+// Voids a payment using automatic capture flow (Non 3DS).
+// passed
+#[serial_test::serial]
+#[actix_web::test]
+async fn should_fail_void_payment_for_auto_capture() {
+    let authorize_response = CONNECTOR.make_payment(None, None).await.unwrap();
+    assert_eq!(authorize_response.status, enums::AttemptStatus::Charged);
+    let txn_id = utils::get_connector_transaction_id(authorize_response.response);
+    assert_ne!(txn_id, None, "Empty connector transaction id");
+    let void_response = CONNECTOR
+        .void_payment(txn_id.unwrap(), None, None)
+        .await
+        .unwrap();
+    assert_eq!(
+        void_response.response.unwrap_err().message,
+        "Transaction AUTH_REVERSAL failed. Transaction has already been captured."
+    );
+}
+
+// Captures a payment using invalid connector payment id.
+// passed
+#[serial_test::serial]
+#[actix_web::test]
+async fn should_fail_capture_for_invalid_payment() {
+    let capture_response = CONNECTOR
+        .capture_payment("123456789".to_string(), None, None)
+        .await
+        .unwrap();
+
+    capture_response
+        .response
+        .unwrap_err()
+        .message
+        .contains("is not authorized to view transaction");
+}
+
+// Refunds a payment with refund amount higher than payment amount.
+// passed
+#[serial_test::serial]
+#[actix_web::test]
+async fn should_fail_for_refund_amount_higher_than_payment_amount() {
+    let response = CONNECTOR
+        .make_payment_and_refund(
+            None,
+            Some(types::RefundsData {
+                refund_amount: 150,
+                ..utils::PaymentRefundType::default().0
+            }),
+            None,
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        response.response.unwrap_err().message,
+        "Refund amount cannot be more than the refundable order amount.",
+    );
+}
+
+// Connector dependent test cases goes here
+
+// [#478]: add unit tests for non 3DS, wallets & webhooks in connector tests

--- a/crates/router/tests/connectors/bluesnap.rs
+++ b/crates/router/tests/connectors/bluesnap.rs
@@ -35,7 +35,7 @@ impl utils::Connector for BluesnapTest {
 
 // Cards Positive Tests
 // Creates a payment using the manual capture flow (Non 3DS).
-// passed
+
 #[serial_test::serial]
 #[actix_web::test]
 async fn should_only_authorize_payment() {
@@ -47,7 +47,7 @@ async fn should_only_authorize_payment() {
 }
 
 // Captures a payment using the manual capture flow (Non 3DS).
-// passed
+
 #[serial_test::serial]
 #[actix_web::test]
 async fn should_capture_authorized_payment() {
@@ -59,7 +59,7 @@ async fn should_capture_authorized_payment() {
 }
 
 // Partially captures a payment using the manual capture flow (Non 3DS).
-// passed
+
 #[serial_test::serial]
 #[actix_web::test]
 async fn should_partially_capture_authorized_payment() {
@@ -78,7 +78,7 @@ async fn should_partially_capture_authorized_payment() {
 }
 
 // Synchronizes a payment using the manual capture flow (Non 3DS).
-// passed
+
 #[serial_test::serial]
 #[actix_web::test]
 async fn should_sync_authorized_payment() {
@@ -105,7 +105,7 @@ async fn should_sync_authorized_payment() {
 }
 
 // Voids a payment using the manual capture flow (Non 3DS).
-// passed
+
 #[serial_test::serial]
 #[actix_web::test]
 async fn should_void_authorized_payment() {
@@ -125,7 +125,7 @@ async fn should_void_authorized_payment() {
 }
 
 // Refunds a payment using the manual capture flow (Non 3DS).
-// passed
+
 #[serial_test::serial]
 #[actix_web::test]
 async fn should_refund_manually_captured_payment() {
@@ -149,7 +149,7 @@ async fn should_refund_manually_captured_payment() {
 }
 
 // Partially refunds a payment using the manual capture flow (Non 3DS).
-// passed
+
 #[serial_test::serial]
 #[actix_web::test]
 async fn should_partially_refund_manually_captured_payment() {
@@ -181,7 +181,7 @@ async fn should_partially_refund_manually_captured_payment() {
 }
 
 // Synchronizes a refund using the manual capture flow (Non 3DS).
-// Passed
+
 #[serial_test::serial]
 #[actix_web::test]
 async fn should_sync_manually_captured_refund() {
@@ -205,7 +205,7 @@ async fn should_sync_manually_captured_refund() {
 }
 
 // Creates a payment using the automatic capture flow (Non 3DS).
-// passed
+
 #[serial_test::serial]
 #[actix_web::test]
 async fn should_make_payment() {
@@ -214,7 +214,7 @@ async fn should_make_payment() {
 }
 
 // Synchronizes a payment using the automatic capture flow (Non 3DS).
-// passed
+
 #[serial_test::serial]
 #[actix_web::test]
 async fn should_sync_auto_captured_payment() {
@@ -240,7 +240,7 @@ async fn should_sync_auto_captured_payment() {
 }
 
 // Refunds a payment using the automatic capture flow (Non 3DS).
-// passed
+
 #[serial_test::serial]
 #[actix_web::test]
 async fn should_refund_auto_captured_payment() {
@@ -264,7 +264,7 @@ async fn should_refund_auto_captured_payment() {
 }
 
 // Partially refunds a payment using the automatic capture flow (Non 3DS).
-// passed
+
 #[serial_test::serial]
 #[actix_web::test]
 async fn should_partially_refund_succeeded_payment() {
@@ -295,7 +295,7 @@ async fn should_partially_refund_succeeded_payment() {
 }
 
 // Creates multiple refunds against a payment using the automatic capture flow (Non 3DS).
-// passed
+
 #[serial_test::serial]
 #[actix_web::test]
 async fn should_refund_succeeded_payment_multiple_times() {
@@ -332,7 +332,7 @@ async fn should_refund_succeeded_payment_multiple_times() {
 }
 
 // Synchronizes a refund using the automatic capture flow (Non 3DS).
-// passed
+
 #[serial_test::serial]
 #[actix_web::test]
 async fn should_sync_refund() {
@@ -357,7 +357,7 @@ async fn should_sync_refund() {
 
 // Cards Negative scenerios
 // Creates a payment with incorrect card number.
-// passed
+
 #[serial_test::serial]
 #[actix_web::test]
 async fn should_fail_payment_for_incorrect_card_number() {
@@ -381,7 +381,7 @@ async fn should_fail_payment_for_incorrect_card_number() {
 }
 
 // Creates a payment with empty card number.
-// passed
+
 #[serial_test::serial]
 #[actix_web::test]
 async fn should_fail_payment_for_empty_card_number() {
@@ -406,7 +406,7 @@ async fn should_fail_payment_for_empty_card_number() {
 }
 
 // Creates a payment with incorrect CVC.
-// passed
+
 #[serial_test::serial]
 #[actix_web::test]
 async fn should_fail_payment_for_incorrect_cvc() {
@@ -430,7 +430,7 @@ async fn should_fail_payment_for_incorrect_cvc() {
 }
 
 // Creates a payment with incorrect expiry month.
-// passed
+
 #[serial_test::serial]
 #[actix_web::test]
 async fn should_fail_payment_for_invalid_exp_month() {
@@ -454,7 +454,7 @@ async fn should_fail_payment_for_invalid_exp_month() {
 }
 
 // Creates a payment with incorrect expiry year.
-// passed
+
 #[serial_test::serial]
 #[actix_web::test]
 async fn should_fail_payment_for_incorrect_expiry_year() {
@@ -478,7 +478,7 @@ async fn should_fail_payment_for_incorrect_expiry_year() {
 }
 
 // Voids a payment using automatic capture flow (Non 3DS).
-// passed
+
 #[serial_test::serial]
 #[actix_web::test]
 async fn should_fail_void_payment_for_auto_capture() {
@@ -497,7 +497,7 @@ async fn should_fail_void_payment_for_auto_capture() {
 }
 
 // Captures a payment using invalid connector payment id.
-// passed
+
 #[serial_test::serial]
 #[actix_web::test]
 async fn should_fail_capture_for_invalid_payment() {
@@ -514,7 +514,7 @@ async fn should_fail_capture_for_invalid_payment() {
 }
 
 // Refunds a payment with refund amount higher than payment amount.
-// passed
+
 #[serial_test::serial]
 #[actix_web::test]
 async fn should_fail_for_refund_amount_higher_than_payment_amount() {

--- a/crates/router/tests/connectors/connector_auth.rs
+++ b/crates/router/tests/connectors/connector_auth.rs
@@ -6,6 +6,7 @@ pub(crate) struct ConnectorAuthentication {
     pub aci: Option<BodyKey>,
     pub adyen: Option<BodyKey>,
     pub authorizedotnet: Option<BodyKey>,
+    pub bluesnap: Option<BodyKey>,
     pub checkout: Option<BodyKey>,
     pub cybersource: Option<SignatureKey>,
     pub fiserv: Option<SignatureKey>,

--- a/crates/router/tests/connectors/main.rs
+++ b/crates/router/tests/connectors/main.rs
@@ -3,6 +3,7 @@
 mod aci;
 mod adyen;
 mod authorizedotnet;
+mod bluesnap;
 mod checkout;
 mod connector_auth;
 mod cybersource;

--- a/loadtest/config/Development.toml
+++ b/loadtest/config/Development.toml
@@ -85,6 +85,9 @@ base_url = "https://apple-pay-gateway.apple.com/"
 [connectors.klarna]
 base_url = "https://api-na.playground.klarna.com/"
 
+[connectors.bluesnap]
+base_url = "https://sandbox.bluesnap.com/"
+
 [connectors.nuvei]
 base_url = "https://ppp-test.nuvei.com/"
 
@@ -94,6 +97,7 @@ cards = [
     "aci",
     "adyen",
     "authorizedotnet",
+    "bluesnap",
     "braintree",
     "checkout",
     "cybersource",


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [X] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
Updating support for [Bluesnap](https://developers.bluesnap.com/v8976-JSON/reference/bluesnap-payment-api-json) payment gateway
Payment Method: card
Supported payment flows

- [Authorize](https://developers.bluesnap.com/v8976-JSON/reference/auth-capture)
- [Capture](https://developers.bluesnap.com/v8976-JSON/reference/capture)
- [PSync](https://developers.bluesnap.com/v8976-JSON/reference/retrieve)
- [Refund](https://developers.bluesnap.com/v8976-JSON/reference/refund)
- [Cancel](https://developers.bluesnap.com/v8976-JSON/reference/auth-reversal)
-  [RSync](https://developers.bluesnap.com/v8976-JSON/reference/retrieve)
- [Webhooks](https://support.bluesnap.com/docs/about-ipns)



### Additional Changes

- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!-- 
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
<img width="985" alt="Screenshot 2023-02-22 at 3 34 03 PM" src="https://user-images.githubusercontent.com/55536657/220620974-22002dac-79f2-4b98-a5fc-48b998cada0c.png">



## Checklist
<!-- Put an `x` in the boxes that apply -->

- [X] I formatted the code `cargo +nightly fmt --all`
- [X] I addressed lints thrown by `cargo clippy`
- [X] I reviewed submitted code
- [X] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
