### PR TITLE
chore: adding build only sandbox feature to reduce build time

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -105,7 +105,7 @@ jobs:
 
       - name: Test compilation
         shell: bash
-        run: cargo hack check --workspace --each-feature --no-dev-deps
+        run: cargo hack check --features="sandbox" --ignore-unknown-features 
 
   # cargo-deny:
   #   name: Run cargo-deny
@@ -183,7 +183,7 @@ jobs:
 
       - name: Test compilation
         shell: bash
-        run: cargo hack check --workspace --each-feature --no-dev-deps
+        run: cargo hack check --features="sandbox" --ignore-unknown-features 
 
       # - name: Run tests
       #   shell: bash


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->

Adding build only the sandbox feature in CI-CD


### Additional Changes

- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!-- 
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

Build taking more time in CI-CD, even for small changes.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
