### PR TITLE
fix(compatibility): map stripe country_code to payment_request country code

### DIFF
--- a/crates/router/src/compatibility/stripe/payment_intents/types.rs
+++ b/crates/router/src/compatibility/stripe/payment_intents/types.rs
@@ -24,11 +24,12 @@ pub struct StripeBillingDetails {
 impl From<StripeBillingDetails> for payments::Address {
     fn from(details: StripeBillingDetails) -> Self {
         Self {
-            address: details.address,
             phone: Some(payments::PhoneDetails {
                 number: details.phone,
-                country_code: None,
+                country_code: details.address.as_ref().and_then(|a| a.country.clone()),
             }),
+
+            address: details.address,
         }
     }
 }
@@ -104,11 +105,11 @@ pub struct Shipping {
 impl From<Shipping> for payments::Address {
     fn from(details: Shipping) -> Self {
         Self {
-            address: details.address,
             phone: Some(payments::PhoneDetails {
                 number: details.phone,
-                country_code: None,
+                country_code: details.address.as_ref().and_then(|a| a.country.clone()),
             }),
+            address: details.address,
         }
     }
 }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->
The country in billing details of stripe compatibility is  mapped to country_code in address of payments request .

### Additional Changes

- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!-- 
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
