### PR TITLE
bugfix(refunds): skip validate refunds for card

### DIFF
--- a/crates/router/src/core/refunds/validator.rs
+++ b/crates/router/src/core/refunds/validator.rs
@@ -1,5 +1,5 @@
 use common_utils::ext_traits::StringExt;
-use error_stack::{report, ResultExt};
+use error_stack::{report, IntoReport, ResultExt};
 use router_env::{instrument, tracing};
 use time::PrimitiveDateTime;
 
@@ -148,27 +148,39 @@ pub fn validate_for_valid_refunds(
         .get_required_value("connector")?
         .parse_enum("connector")
         .change_context(errors::ApiErrorResponse::IncorrectConnectorNameGiven)?;
-    let payment_method_type = payment_attempt
-        .payment_method_type
-        .clone()
-        .get_required_value("payment_method_type")?;
 
-    utils::when(
-        matches!(
-            (connector, payment_method_type),
-            (
-                api_models::enums::Connector::Braintree,
-                storage_models::enums::PaymentMethodType::Paypal
-            ) | (
-                api_models::enums::Connector::Klarna,
-                storage_models::enums::PaymentMethodType::Klarna
+    let payment_method = payment_attempt
+        .payment_method
+        .as_ref()
+        .get_required_value("payment_method")?;
+
+    match payment_method {
+        storage_models::enums::PaymentMethod::PayLater
+        | storage_models::enums::PaymentMethod::Wallet => {
+            let payment_method_type = payment_attempt
+                .payment_method_type
+                .clone()
+                .get_required_value("payment_method_type")?;
+
+            utils::when(
+                matches!(
+                    (connector, payment_method_type),
+                    (
+                        api_models::enums::Connector::Braintree,
+                        storage_models::enums::PaymentMethodType::Paypal,
+                    ) | (
+                        api_models::enums::Connector::Klarna,
+                        storage_models::enums::PaymentMethodType::Klarna
+                    )
+                ),
+                || {
+                    Err(errors::ApiErrorResponse::RefundNotPossible {
+                        connector: connector.to_string(),
+                    })
+                },
             )
-        ),
-        || {
-            Err(errors::ApiErrorResponse::RefundNotPossible {
-                connector: connector.to_string(),
-            })
-        },
-    )?;
-    Ok(())
+            .into_report()
+        }
+        _ => Ok(()),
+    }
 }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix

## Description
<!-- Describe your changes in detail -->
Check the validate refunds only if payment method is wallet or pay_later. for other payment_methods skip this validation.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
Make refunds easy and accessible to all.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
