### PR TITLE
bugfix: populate failed status and add bank_redirect

### DIFF
--- a/crates/api_models/src/enums.rs
+++ b/crates/api_models/src/enums.rs
@@ -427,6 +427,7 @@ pub enum PaymentMethod {
     Card,
     PayLater,
     Wallet,
+    BankRedirect,
 }
 
 #[derive(

--- a/crates/router/src/connector/adyen/transformers.rs
+++ b/crates/router/src/connector/adyen/transformers.rs
@@ -1,5 +1,5 @@
 use base64::Engine;
-use error_stack::ResultExt;
+use error_stack::{IntoReport, ResultExt};
 use masking::PeekInterface;
 use reqwest::Url;
 use serde::{Deserialize, Serialize};
@@ -337,6 +337,11 @@ impl TryFrom<&types::PaymentsAuthorizeRouterData> for AdyenPaymentRequest {
                 get_paylater_specific_payment_data(item)
             }
             storage_models::enums::PaymentMethod::Wallet => get_wallet_specific_payment_data(item),
+            _ => Err(errors::ConnectorError::NotSupported {
+                payment_method: item.payment_method.to_string(),
+                connector: "adyen",
+            })
+            .into_report()?,
         }
     }
 }

--- a/crates/router/src/core/payments/operations/payment_response.rs
+++ b/crates/router/src/core/payments/operations/payment_response.rs
@@ -273,7 +273,7 @@ async fn payment_response_update_tracker<F: Clone, T>(
         Err(err) => (
             Some(storage::PaymentAttemptUpdate::ErrorUpdate {
                 connector: Some(router_data.connector.clone()),
-                status: router_data.status.foreign_into(),
+                status: storage::enums::AttemptStatus::Failure,
                 error_message: Some(err.message),
                 error_code: Some(err.code),
             }),
@@ -364,7 +364,7 @@ async fn payment_response_update_tracker<F: Clone, T>(
 
     let payment_intent_update = match router_data.response {
         Err(_) => storage::PaymentIntentUpdate::PGStatusUpdate {
-            status: router_data.status.foreign_into(),
+            status: enums::IntentStatus::Failed,
         },
         Ok(_) => storage::PaymentIntentUpdate::ResponseUpdate {
             status: router_data.status.foreign_into(),

--- a/crates/storage_models/src/enums.rs
+++ b/crates/storage_models/src/enums.rs
@@ -431,6 +431,7 @@ pub enum PaymentMethod {
     Card,
     PayLater,
     Wallet,
+    BankRedirect,
 }
 
 #[derive(


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix

## Description
<!-- Describe your changes in detail -->
- Map all responses with error to failed
- Add bank redirect enum variant


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Manual

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
