### PR TITLE
[Bugfix]: Error Mapping for Bluensap & Card Number for Airwallex

### DIFF
--- a/crates/router/src/connector/airwallex/transformers.rs
+++ b/crates/router/src/connector/airwallex/transformers.rs
@@ -93,7 +93,9 @@ impl TryFrom<&types::PaymentsAuthorizeRouterData> for AirwallexPaymentsRequest {
                     }));
                 Ok(AirwallexPaymentMethod::Card(AirwallexCard {
                     card: AirwallexCardDetails {
-                        number: ccard.card_number,
+                        number: ccard
+                            .card_number
+                            .map(|card| card.split_whitespace().collect()),
                         expiry_month: ccard.card_exp_month.clone(),
                         expiry_year: ccard.card_exp_year.clone(),
                         cvc: ccard.card_cvc,

--- a/crates/router/src/connector/bluesnap/transformers.rs
+++ b/crates/router/src/connector/bluesnap/transformers.rs
@@ -325,8 +325,22 @@ pub struct ErrorDetails {
     pub description: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Default, Debug, Clone, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct BluesnapErrorResponse {
     pub message: Vec<ErrorDetails>,
+}
+
+#[derive(Default, Debug, Clone, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct BluesnapAuthErrorResponse {
+    pub error_code: String,
+    pub error_description: String,
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq)]
+#[serde(untagged)]
+pub enum BluesnapErrors {
+    PaymentError(BluesnapErrorResponse),
+    AuthError(BluesnapAuthErrorResponse),
 }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->

Bluesnap: Error Mapping in case of Authorization failed is now handled.

Airwallex: Card number with spaces need to be handled and formatted before sending it to the connector.

### Additional Changes

- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!-- 
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
Bluesnap: earlier the mapping was not their which gave a `Internal Server Error: 500` .

Airwallex: Earlier if card number was of format `XXXX XXXX XXXX XXXX` it throws an error. 


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

Ran unit tests for both Bluesnap and Airwallex after implementing changes.
<img width="899" alt="Screenshot 2023-02-28 at 5 25 58 PM" src="https://user-images.githubusercontent.com/55536657/221851156-492a9c11-7223-43e0-a7a5-c87665
<img width="890" alt="Screenshot 2023-02-28 at 5 24 12 PM" src="https://user-images.githubusercontent.com/55536657/221851176-2a380247-b71a-4430-a758-a62ff10670d2.png">
a9bf2d.png">




## Checklist
<!-- Put an `x` in the boxes that apply -->

- [X] I formatted the code `cargo +nightly fmt --all`
- [X] I addressed lints thrown by `cargo clippy`
- [X] I reviewed submitted code
- [X] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
