### PR TITLE
fix(connector): fix wordline tests and visa card issuer support

### DIFF
--- a/crates/router/src/connector/utils.rs
+++ b/crates/router/src/connector/utils.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+use common_utils::pii;
 use error_stack::{report, IntoReport, ResultExt};
 use masking::Secret;
 use once_cell::sync::Lazy;
@@ -212,7 +213,11 @@ impl CardData for api::Card {
         Secret::new(year[year.len() - 2..].to_string())
     }
     fn get_card_issuer(&self) -> Result<CardIssuer, Error> {
-        get_card_issuer(self.card_number.peek().clone().as_str())
+        let card: Secret<String, pii::CardNumber> = self
+            .card_number
+            .clone()
+            .map(|card| card.split_whitespace().collect());
+        get_card_issuer(card.peek().clone().as_str())
     }
 }
 

--- a/crates/router/src/connector/worldline/transformers.rs
+++ b/crates/router/src/connector/worldline/transformers.rs
@@ -127,6 +127,7 @@ impl TryFrom<utils::CardIssuer> for Gateway {
             utils::CardIssuer::AmericanExpress => Ok(Self::Amex),
             utils::CardIssuer::Master => Ok(Self::MasterCard),
             utils::CardIssuer::Discover => Ok(Self::Discover),
+            utils::CardIssuer::Visa => Ok(Self::Visa),
             _ => Err(errors::ConnectorError::NotSupported {
                 payment_method: format!("{issuer}"),
                 connector: "worldline",

--- a/crates/router/tests/connectors/worldline.rs
+++ b/crates/router/tests/connectors/worldline.rs
@@ -98,7 +98,7 @@ async fn should_requires_manual_authorization() {
         enums::CaptureMethod::Manual,
     );
     let response = WorldlineTest {}
-        .make_payment(authorize_data, WorldlineTest::get_payment_info())
+        .authorize_payment(authorize_data, WorldlineTest::get_payment_info())
         .await;
     assert_eq!(response.unwrap().status, enums::AttemptStatus::Authorized);
 }
@@ -133,7 +133,10 @@ async fn should_throw_not_implemented_for_unsupported_issuer() {
         .await;
     assert_eq!(
         *response.unwrap_err().current_context(),
-        errors::ConnectorError::NotImplemented(String::from("Payment Method"))
+        errors::ConnectorError::NotSupported {
+            payment_method: "Maestro".to_string(),
+            connector: "worldline"
+        }
     )
 }
 
@@ -195,7 +198,7 @@ async fn should_sync_manual_auth_payment() {
         enums::CaptureMethod::Manual,
     );
     let response = connector
-        .make_payment(authorize_data, WorldlineTest::get_payment_info())
+        .authorize_payment(authorize_data, WorldlineTest::get_payment_info())
         .await
         .unwrap();
     assert_eq!(response.status, enums::AttemptStatus::Authorized);
@@ -261,7 +264,7 @@ async fn should_capture_authorized_payment() {
         enums::CaptureMethod::Manual,
     );
     let response = connector
-        .make_payment(authorize_data, WorldlineTest::get_payment_info())
+        .authorize_payment(authorize_data, WorldlineTest::get_payment_info())
         .await
         .unwrap();
     assert_eq!(response.status, enums::AttemptStatus::Authorized);
@@ -300,7 +303,7 @@ async fn should_cancel_unauthorized_payment() {
         enums::CaptureMethod::Manual,
     );
     let response = connector
-        .make_payment(authorize_data, WorldlineTest::get_payment_info())
+        .authorize_payment(authorize_data, WorldlineTest::get_payment_info())
         .await
         .unwrap();
     assert_eq!(response.status, enums::AttemptStatus::Authorized);
@@ -360,7 +363,7 @@ async fn should_fail_refund_with_invalid_payment_status() {
         enums::CaptureMethod::Manual,
     );
     let response = connector
-        .make_payment(authorize_data, WorldlineTest::get_payment_info())
+        .authorize_payment(authorize_data, WorldlineTest::get_payment_info())
         .await
         .unwrap();
     assert_eq!(response.status, enums::AttemptStatus::Authorized);


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
Unit test fix, Visa card issuer support for Worldline


### Additional Changes

- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!-- 
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
![Screenshot 2023-02-28 at 5 43 19 PM](https://user-images.githubusercontent.com/20727986/221852871-1bffa48f-a1fd-4cf2-9058-9016dfbd7c49.png)




## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
