### PR TITLE
bugfix(adyen): adyen psync fail fix

### DIFF
--- a/crates/router/src/core/payments/operations/payment_status.rs
+++ b/crates/router/src/core/payments/operations/payment_status.rs
@@ -243,6 +243,8 @@ async fn get_tracker_for_sync<
             )
         })?;
 
+    let contains_encoded_data = connector_response.encoded_data.is_some();
+
     Ok((
         Box::new(operation),
         PaymentData {
@@ -263,10 +265,10 @@ async fn get_tracker_for_sync<
             payment_method_data: None,
             force_sync: Some(
                 request.force_sync
-                    && helpers::check_force_psync_precondition(
+                    && (helpers::check_force_psync_precondition(
                         &payment_attempt.status,
                         &payment_attempt.connector_transaction_id,
-                    ),
+                    ) || contains_encoded_data),
             ),
             payment_attempt,
             refunds,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix

## Description
<!-- Describe your changes in detail -->
Fixed adyen redirects because of failed psync.

<!-- 
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Manual, confirmed with 3 colleagues.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
