### PR TITLE
feat(list): global filter mapping for payment methods via card network

### DIFF
--- a/config/config.example.toml
+++ b/config/config.example.toml
@@ -216,5 +216,5 @@ loop_interval = 500            # Specifies how much time to wait after checking 
 #           ^--- This can be any connector (can be multiple)
 paypal = { currency = "USD,INR", country = "US" }
 # ^                       ^------- comma-separated values
-# ^------------------------------- any valid payment method type (can be multiple)
+# ^------------------------------- any valid payment method type (can be multiple) (for cards this should be card_network)
 # If either currency or country isn't provided then, all possible values are accepted

--- a/crates/common_utils/Cargo.toml
+++ b/crates/common_utils/Cargo.toml
@@ -34,4 +34,4 @@ router_env = { version = "0.1.0", path = "../router_env", features = ["log_extra
 
 [dev-dependencies]
 fake = "2.5.0"
-proptest = "1.0.0"
+proptest = "1.1.0"

--- a/crates/router/src/configs/settings.rs
+++ b/crates/router/src/configs/settings.rs
@@ -78,9 +78,14 @@ pub struct ConnectorFilters(pub HashMap<String, PaymentMethodFilters>);
 
 #[derive(Debug, Deserialize, Clone, Default)]
 #[serde(transparent)]
-pub struct PaymentMethodFilters(
-    pub HashMap<api_models::enums::PaymentMethodType, CurrencyCountryFilter>,
-);
+pub struct PaymentMethodFilters(pub HashMap<PaymentMethodFilterKey, CurrencyCountryFilter>);
+
+#[derive(Debug, Deserialize, Clone, PartialEq, Eq, Hash)]
+#[serde(untagged)]
+pub enum PaymentMethodFilterKey {
+    PaymentMethodType(api_models::enums::PaymentMethodType),
+    CardNetwork(api_models::enums::CardNetwork),
+}
 
 #[derive(Debug, Deserialize, Clone, Default)]
 #[serde(default)]

--- a/crates/router/src/core/payment_methods/cards.rs
+++ b/crates/router/src/core/payment_methods/cards.rs
@@ -759,7 +759,7 @@ async fn filter_payment_methods(
                         &connector,
                         &payment_method_object.payment_method_type,
                         &mut payment_method_object.card_networks,
-                        address.and_then(|inner| inner.country.clone()),
+                        &address.and_then(|inner| inner.country.clone()),
                         payment_attempt
                             .and_then(|value| value.currency)
                             .map(|value| value.foreign_into()),
@@ -788,7 +788,7 @@ fn filter_pm_based_on_config<'a>(
     connector: &'a str,
     payment_method_type: &'a api_enums::PaymentMethodType,
     card_network: &mut Option<Vec<api_enums::CardNetwork>>,
-    country: Option<String>,
+    country: &Option<String>,
     currency: Option<api_enums::Currency>,
 ) -> bool {
     config
@@ -796,7 +796,7 @@ fn filter_pm_based_on_config<'a>(
         .get(connector)
         .and_then(|inner| match payment_method_type {
             api_enums::PaymentMethodType::Credit | api_enums::PaymentMethodType::Debit => {
-                card_network_filter(country.clone(), currency, card_network, inner);
+                card_network_filter(country, currency, card_network, inner);
                 None
             }
             payment_method_type => inner
@@ -810,7 +810,7 @@ fn filter_pm_based_on_config<'a>(
 }
 
 fn card_network_filter(
-    country: Option<String>,
+    country: &Option<String>,
     currency: Option<api_enums::Currency>,
     card_network: &mut Option<Vec<api_enums::CardNetwork>>,
     payment_method_filters: &settings::PaymentMethodFilters,
@@ -823,7 +823,7 @@ fn card_network_filter(
                 payment_method_filters
                     .0
                     .get(&key)
-                    .map(|value| global_country_currency_filter(value, country.clone(), currency))
+                    .map(|value| global_country_currency_filter(value, country, currency))
                     .unwrap_or(true)
             })
             .cloned()
@@ -834,14 +834,14 @@ fn card_network_filter(
 
 fn global_country_currency_filter(
     item: &settings::CurrencyCountryFilter,
-    country: Option<String>,
+    country: &Option<String>,
     currency: Option<api_enums::Currency>,
 ) -> bool {
     let country_condition = item
         .country
         .as_ref()
-        .zip(country)
-        .map(|(lhs, rhs)| lhs.contains(&rhs));
+        .zip(country.as_ref())
+        .map(|(lhs, rhs)| lhs.contains(rhs));
     let currency_condition = item
         .currency
         .as_ref()


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
In an earlier PR #689, we added a global filter mapping for `<connector>.<payment_method_type>`, but according to the new requirements, the various card networks will also have the similar filters. This PR addes support for `<connector>.<card_network>` in the configuration. @bernard-eugine is compiling the list for this configuration changes
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!-- 
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
