### PR TITLE
fix(connector): convert cents to dollar before sending to connector

### DIFF
--- a/crates/router/src/connector/airwallex/transformers.rs
+++ b/crates/router/src/connector/airwallex/transformers.rs
@@ -158,8 +158,8 @@ impl TryFrom<&types::PaymentsCaptureRouterData> for AirwallexPaymentsCaptureRequ
             request_id: Uuid::new_v4().to_string(),
             amount: match item.request.amount_to_capture {
                 Some(_a) => Some(item.request.get_amount_to_capture_in_dollars()?),
-                _ => None
-            }
+                _ => None,
+            },
         })
     }
 }

--- a/crates/router/src/connector/airwallex/transformers.rs
+++ b/crates/router/src/connector/airwallex/transformers.rs
@@ -156,7 +156,10 @@ impl TryFrom<&types::PaymentsCaptureRouterData> for AirwallexPaymentsCaptureRequ
     fn try_from(item: &types::PaymentsCaptureRouterData) -> Result<Self, Self::Error> {
         Ok(Self {
             request_id: Uuid::new_v4().to_string(),
-            amount: Some(item.request.get_amount_to_capture_in_dollars()?),
+            amount: match item.request.amount_to_capture {
+                Some(_a) => Some(item.request.get_amount_to_capture_in_dollars()?),
+                _ => None
+            }
         })
     }
 }

--- a/crates/router/src/connector/airwallex/transformers.rs
+++ b/crates/router/src/connector/airwallex/transformers.rs
@@ -29,7 +29,7 @@ impl TryFrom<&types::PaymentsAuthorizeSessionTokenRouterData> for AirwallexInten
     ) -> Result<Self, Self::Error> {
         Ok(Self {
             request_id: Uuid::new_v4().to_string(),
-            amount: item.request.get_amount_in_dollars(),
+            amount: item.request.get_amount_in_dollars()?,
             currency: item.request.currency,
             merchant_order_id: item.payment_id.clone(),
         })
@@ -156,7 +156,7 @@ impl TryFrom<&types::PaymentsCaptureRouterData> for AirwallexPaymentsCaptureRequ
     fn try_from(item: &types::PaymentsCaptureRouterData) -> Result<Self, Self::Error> {
         Ok(Self {
             request_id: Uuid::new_v4().to_string(),
-            amount: item.request.get_amount_to_capture_in_dollars(),
+            amount: Some(item.request.get_amount_to_capture_in_dollars()?),
         })
     }
 }
@@ -287,11 +287,11 @@ pub struct AirwallexRefundRequest {
 }
 
 impl<F> TryFrom<&types::RefundsRouterData<F>> for AirwallexRefundRequest {
-    type Error = error_stack::Report<errors::ParsingError>;
+    type Error = error_stack::Report<errors::ConnectorError>;
     fn try_from(item: &types::RefundsRouterData<F>) -> Result<Self, Self::Error> {
         Ok(Self {
             request_id: Uuid::new_v4().to_string(),
-            amount: Some(item.request.get_refund_amount_in_dollars()),
+            amount: Some(item.request.get_refund_amount_in_dollars()?),
             reason: item.request.reason.clone(),
             payment_intent_id: item.request.connector_transaction_id.clone(),
         })

--- a/crates/router/src/connector/applepay/transformers.rs
+++ b/crates/router/src/connector/applepay/transformers.rs
@@ -3,7 +3,7 @@ use common_utils::ext_traits::ValueExt;
 use error_stack::ResultExt;
 use masking::{Deserialize, Serialize};
 
-use crate::{connector::utils::PaymentsSessionRequestData, core::errors, types, utils::OptionExt};
+use crate::{connector::utils, core::errors, types, utils::OptionExt};
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -134,7 +134,10 @@ impl<F>
         let amount_info = AmountInfo {
             label: metadata.payment_request_data.label,
             label_type: "final".to_string(),
-            amount: item.data.request.get_amount_in_dollars()?,
+            amount: utils::to_currency_base_unit(
+                item.data.request.amount,
+                item.data.request.currency,
+            )?,
         };
 
         let payment_request = PaymentRequest {

--- a/crates/router/src/connector/applepay/transformers.rs
+++ b/crates/router/src/connector/applepay/transformers.rs
@@ -134,7 +134,7 @@ impl<F>
         let amount_info = AmountInfo {
             label: metadata.payment_request_data.label,
             label_type: "final".to_string(),
-            amount: item.data.request.get_amount_in_dollars(),
+            amount: item.data.request.get_amount_in_dollars()?,
         };
 
         let payment_request = PaymentRequest {

--- a/crates/router/src/connector/applepay/transformers.rs
+++ b/crates/router/src/connector/applepay/transformers.rs
@@ -3,7 +3,7 @@ use common_utils::ext_traits::ValueExt;
 use error_stack::ResultExt;
 use masking::{Deserialize, Serialize};
 
-use crate::{core::errors, types, utils::OptionExt};
+use crate::{connector::utils::PaymentsSessionRequestData, core::errors, types, utils::OptionExt};
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -134,7 +134,7 @@ impl<F>
         let amount_info = AmountInfo {
             label: metadata.payment_request_data.label,
             label_type: "final".to_string(),
-            amount: (item.data.request.amount / 100).to_string(),
+            amount: item.data.request.get_amount_in_dollars(),
         };
 
         let payment_request = PaymentRequest {

--- a/crates/router/src/connector/bluesnap/transformers.rs
+++ b/crates/router/src/connector/bluesnap/transformers.rs
@@ -102,7 +102,7 @@ impl TryFrom<&types::PaymentsCaptureRouterData> for BluesnapCaptureRequest {
             transaction_id,
             amount: match item.request.amount_to_capture {
                 Some(_a) => Some(item.request.get_amount_to_capture_in_dollars()?),
-                _ => None
+                _ => None,
             },
         })
     }

--- a/crates/router/src/connector/bluesnap/transformers.rs
+++ b/crates/router/src/connector/bluesnap/transformers.rs
@@ -100,7 +100,10 @@ impl TryFrom<&types::PaymentsCaptureRouterData> for BluesnapCaptureRequest {
         Ok(Self {
             card_transaction_type,
             transaction_id,
-            amount: Some(item.request.get_amount_to_capture_in_dollars()?),
+            amount: match item.request.amount_to_capture {
+                Some(_a) => Some(item.request.get_amount_to_capture_in_dollars()?),
+                _ => None
+            },
         })
     }
 }

--- a/crates/router/src/connector/bluesnap/transformers.rs
+++ b/crates/router/src/connector/bluesnap/transformers.rs
@@ -57,7 +57,7 @@ impl TryFrom<&types::PaymentsAuthorizeRouterData> for BluesnapPaymentsRequest {
             )),
         }?;
         Ok(Self {
-            amount: item.request.get_amount_in_dollars(),
+            amount: item.request.get_amount_in_dollars()?,
             payment_method,
             currency: item.request.currency,
             card_transaction_type: auth_mode,
@@ -100,7 +100,7 @@ impl TryFrom<&types::PaymentsCaptureRouterData> for BluesnapCaptureRequest {
         Ok(Self {
             card_transaction_type,
             transaction_id,
-            amount: item.request.get_amount_to_capture_in_dollars(),
+            amount: Some(item.request.get_amount_to_capture_in_dollars()?),
         })
     }
 }
@@ -252,7 +252,7 @@ impl<F> TryFrom<&types::RefundsRouterData<F>> for BluesnapRefundRequest {
     fn try_from(item: &types::RefundsRouterData<F>) -> Result<Self, Self::Error> {
         Ok(Self {
             reason: item.request.reason.clone(),
-            amount: Some(item.request.get_refund_amount_in_dollars()),
+            amount: Some(item.request.get_refund_amount_in_dollars()?),
         })
     }
 }

--- a/crates/router/src/connector/braintree/transformers.rs
+++ b/crates/router/src/connector/braintree/transformers.rs
@@ -92,7 +92,7 @@ impl TryFrom<&types::PaymentsAuthorizeRouterData> for BraintreePaymentsRequest {
             Some(enums::CaptureMethod::Automatic) | None
         );
 
-        let amount = item.request.get_amount_in_dollars();
+        let amount = item.request.get_amount_in_dollars()?;
         let device_data = DeviceData {};
         let options = PaymentOptions {
             submit_for_settlement,

--- a/crates/router/src/connector/braintree/transformers.rs
+++ b/crates/router/src/connector/braintree/transformers.rs
@@ -4,6 +4,7 @@ use masking::Secret;
 use serde::{Deserialize, Serialize};
 
 use crate::{
+    connector::utils::PaymentsAuthorizeRequestData,
     consts,
     core::errors,
     types::{self, api, storage::enums},
@@ -91,7 +92,7 @@ impl TryFrom<&types::PaymentsAuthorizeRouterData> for BraintreePaymentsRequest {
             Some(enums::CaptureMethod::Automatic) | None
         );
 
-        let amount = item.request.amount.to_string();
+        let amount = item.request.get_amount_in_dollars();
         let device_data = DeviceData {};
         let options = PaymentOptions {
             submit_for_settlement,

--- a/crates/router/src/connector/braintree/transformers.rs
+++ b/crates/router/src/connector/braintree/transformers.rs
@@ -4,7 +4,7 @@ use masking::Secret;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    connector::utils::PaymentsAuthorizeRequestData,
+    connector::utils,
     consts,
     core::errors,
     types::{self, api, storage::enums},
@@ -92,7 +92,7 @@ impl TryFrom<&types::PaymentsAuthorizeRouterData> for BraintreePaymentsRequest {
             Some(enums::CaptureMethod::Automatic) | None
         );
 
-        let amount = item.request.get_amount_in_dollars()?;
+        let amount = utils::to_currency_base_unit(item.request.amount, item.request.currency)?;
         let device_data = DeviceData {};
         let options = PaymentOptions {
             submit_for_settlement,

--- a/crates/router/src/connector/utils.rs
+++ b/crates/router/src/connector/utils.rs
@@ -158,6 +158,32 @@ impl PaymentsSessionRequestData for types::PaymentsSessionData {
     }
 }
 
+pub trait PaymentsAuthorizeSessionTokenRequestData {
+    //By default amount will be in cents, this method will convert the amount to dollars. Eg: 991 cents to 9.91 dollars
+    fn get_amount_in_dollars(&self) -> String;
+}
+
+impl PaymentsAuthorizeSessionTokenRequestData for types::AuthorizeSessionTokenData {
+    fn get_amount_in_dollars(&self) -> String {
+        #[allow(clippy::as_conversions)]
+        (self.amount as f32 / 100.0).to_string()
+    }
+}
+
+pub trait PaymentsCaptureRequestData {
+    //By default amount will be in cents, this method will convert the amount to capture to dollars. Eg: 991 cents to 9.91 dollars
+    fn get_amount_to_capture_in_dollars(&self) -> Option<String>;
+}
+
+impl PaymentsCaptureRequestData for types::PaymentsCaptureData {
+    fn get_amount_to_capture_in_dollars(&self) -> Option<String> {
+        #[allow(clippy::as_conversions)]
+        (self
+            .amount_to_capture
+            .map(|a| (a as f32 / 100.0).to_string()))
+    }
+}
+
 pub trait PaymentsSyncRequestData {
     fn is_auto_capture(&self) -> bool;
 }
@@ -184,6 +210,9 @@ impl PaymentsCancelRequestData for PaymentsCancelData {
 
 pub trait RefundsRequestData {
     fn get_connector_refund_id(&self) -> Result<String, Error>;
+
+    //By default amount will be in cents, this method will convert the amount to refund to dollars. Eg: 991 cents to 9.91 dollars
+    fn get_refund_amount_in_dollars(&self) -> String;
 }
 
 impl RefundsRequestData for types::RefundsData {
@@ -192,6 +221,10 @@ impl RefundsRequestData for types::RefundsData {
             .clone()
             .get_required_value("connector_refund_id")
             .change_context(errors::ConnectorError::MissingConnectorTransactionID)
+    }
+    fn get_refund_amount_in_dollars(&self) -> String {
+        #[allow(clippy::as_conversions)]
+        (self.refund_amount as f32 / 100.0).to_string()
     }
 }
 

--- a/crates/router/src/connector/utils.rs
+++ b/crates/router/src/connector/utils.rs
@@ -136,7 +136,7 @@ pub trait PaymentsAuthorizeRequestData {
     fn get_amount_in_dollars(&self) -> Result<String, error_stack::Report<errors::ConnectorError>>;
 }
 
-fn to_2_decimal_currency(
+fn to_two_decimal_currency(
     amount: i64,
     currency: storage_models::enums::Currency,
 ) -> Result<String, error_stack::Report<errors::ConnectorError>> {
@@ -160,7 +160,7 @@ impl PaymentsAuthorizeRequestData for types::PaymentsAuthorizeData {
         self.capture_method == Some(storage_models::enums::CaptureMethod::Automatic)
     }
     fn get_amount_in_dollars(&self) -> Result<String, error_stack::Report<errors::ConnectorError>> {
-        to_2_decimal_currency(self.amount, self.currency)
+        to_two_decimal_currency(self.amount, self.currency)
     }
 }
 
@@ -171,7 +171,7 @@ pub trait PaymentsSessionRequestData {
 
 impl PaymentsSessionRequestData for types::PaymentsSessionData {
     fn get_amount_in_dollars(&self) -> Result<String, error_stack::Report<errors::ConnectorError>> {
-        to_2_decimal_currency(self.amount, self.currency)
+        to_two_decimal_currency(self.amount, self.currency)
     }
 }
 
@@ -182,7 +182,7 @@ pub trait PaymentsAuthorizeSessionTokenRequestData {
 
 impl PaymentsAuthorizeSessionTokenRequestData for types::AuthorizeSessionTokenData {
     fn get_amount_in_dollars(&self) -> Result<String, error_stack::Report<errors::ConnectorError>> {
-        to_2_decimal_currency(self.amount, self.currency)
+        to_two_decimal_currency(self.amount, self.currency)
     }
 }
 
@@ -198,7 +198,7 @@ impl PaymentsCaptureRequestData for types::PaymentsCaptureData {
         &self,
     ) -> Result<String, error_stack::Report<errors::ConnectorError>> {
         match self.amount_to_capture {
-            Some(_a) => to_2_decimal_currency(self.amount, self.currency),
+            Some(_a) => to_two_decimal_currency(self.amount, self.currency),
             _ => Err(errors::ConnectorError::MissingRequiredField {
                 field_name: "amount_to_capture",
             }
@@ -250,7 +250,7 @@ impl RefundsRequestData for types::RefundsData {
     fn get_refund_amount_in_dollars(
         &self,
     ) -> Result<String, error_stack::Report<errors::ConnectorError>> {
-        to_2_decimal_currency(self.refund_amount, self.currency)
+        to_two_decimal_currency(self.refund_amount, self.currency)
     }
 }
 

--- a/crates/router/src/connector/utils.rs
+++ b/crates/router/src/connector/utils.rs
@@ -132,11 +132,29 @@ impl PaymentsRequestData for types::PaymentsAuthorizeRouterData {
 
 pub trait PaymentsAuthorizeRequestData {
     fn is_auto_capture(&self) -> bool;
+    //currently amount will be in cents, this method will convert the amount to dollars Eg: 991 cents to 9.91 dollars
+    fn get_amount_in_dollars(&self) -> String;
 }
 
 impl PaymentsAuthorizeRequestData for types::PaymentsAuthorizeData {
     fn is_auto_capture(&self) -> bool {
         self.capture_method == Some(storage_models::enums::CaptureMethod::Automatic)
+    }
+    fn get_amount_in_dollars(&self) -> String {
+        #[allow(clippy::as_conversions)]
+        (self.amount as f32 / 100.0).to_string()
+    }
+}
+
+pub trait PaymentsSessionRequestData {
+    //By default amount will be in cents, this method will convert the amount to dollars. Eg: 991 cents to 9.91 dollars
+    fn get_amount_in_dollars(&self) -> String;
+}
+
+impl PaymentsSessionRequestData for types::PaymentsSessionData {
+    fn get_amount_in_dollars(&self) -> String {
+        #[allow(clippy::as_conversions)]
+        (self.amount as f32 / 100.0).to_string()
     }
 }
 


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->
Added few functions in connector utils to convert and parse incoming amount in cents to dollar value before sending it to the connector.

### Additional Changes

- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!-- 
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
Certain Connectors don't take cents as input, we need to parse the incoming `amount` which is in cents to the dollar value.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

Ran the possible cases in postman also verified running unit tests wherever applicable

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [X] I formatted the code `cargo +nightly fmt --all`
- [X] I addressed lints thrown by `cargo clippy`
- [X] I reviewed submitted code
- [X] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
