### PR TITLE
fix: Populate amount_captured in case of success

### DIFF
--- a/crates/router/src/core/payments/operations/payment_response.rs
+++ b/crates/router/src/core/payments/operations/payment_response.rs
@@ -362,6 +362,13 @@ async fn payment_response_update_tracker<F: Clone, T>(
         None => payment_data.connector_response,
     };
 
+    let amount_captured = router_data.amount_captured.or_else(|| {
+        if router_data.status == enums::AttemptStatus::Charged {
+            Some(payment_data.payment_intent.amount)
+        } else {
+            None
+        }
+    });
     let payment_intent_update = match router_data.response {
         Err(_) => storage::PaymentIntentUpdate::PGStatusUpdate {
             status: enums::IntentStatus::Failed,
@@ -369,7 +376,7 @@ async fn payment_response_update_tracker<F: Clone, T>(
         Ok(_) => storage::PaymentIntentUpdate::ResponseUpdate {
             status: router_data.status.foreign_into(),
             return_url: router_data.return_url.clone(),
-            amount_captured: router_data.amount_captured,
+            amount_captured,
         },
     };
 


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->
- [x] Bugfix

## Description
<!-- Describe your changes in detail -->
Populate amount captured from amount if the status is succeeded.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
We are getting amount received as none in because many connectors aren't populating it.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Manual

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code