### PR TITLE
feat(session_token): create session token only if pmt is enabled

### DIFF
--- a/crates/router/src/core/payments/operations/payment_session.rs
+++ b/crates/router/src/core/payments/operations/payment_session.rs
@@ -1,5 +1,6 @@
 use std::{collections::HashSet, marker::PhantomData};
 
+use api_models::admin::PaymentMethodsEnabled;
 use async_trait::async_trait;
 use common_utils::ext_traits::ValueExt;
 use error_stack::ResultExt;
@@ -13,7 +14,7 @@ use crate::{
         payments::{self, helpers, operations, PaymentData},
     },
     db::StorageInterface,
-    pii,
+    logger, pii,
     pii::Secret,
     routes::AppState,
     types::{
@@ -224,11 +225,6 @@ impl<F: Send + Clone> ValidateRequest<F, api::PaymentsSessionRequest> for Paymen
     }
 }
 
-#[derive(serde::Deserialize, Default)]
-pub struct PaymentMethodEnabled {
-    payment_method: String,
-}
-
 #[async_trait]
 impl<F: Clone + Send, Op: Send + Sync + Operation<F, api::PaymentsSessionRequest>>
     Domain<F, api::PaymentsSessionRequest> for Op
@@ -294,17 +290,46 @@ where
             .change_context(errors::ApiErrorResponse::InternalServerError)
             .attach_printable("Database error when querying for merchant connector accounts")?;
 
-        let normal_connector_names = connector_accounts
+        let normal_connector_names: HashSet<String> = connector_accounts
             .iter()
             .filter(|connector_account| {
-                supported_connectors.contains(&connector_account.connector_name)
+                // let is_supported = supported_connectors.contains(&connector_account.connector_name);
+
+                connector_account
+                    .payment_methods_enabled
+                    .clone()
+                    .unwrap_or_default()
+                    .iter()
+                    .any(|payment_method| {
+                        let parsed_payment_method_result: Result<
+                            PaymentMethodsEnabled,
+                            error_stack::Report<errors::ParsingError>,
+                        > = payment_method.clone().parse_value("payment_method");
+
+                        match parsed_payment_method_result {
+                            Ok(parsed_payment_method) => parsed_payment_method
+                                .payment_method_types
+                                .map(|payment_method_types| {
+                                    payment_method_types.iter().any(|payment_method_type| {
+                                        matches!(
+                                        payment_method_type.payment_experience,
+                                        Some(api_models::enums::PaymentExperience::InvokeSdkClient)
+                                    )
+                                    })
+                                })
+                                .unwrap_or(false),
+                            Err(parsing_error) => {
+                                logger::debug!(session_token_parsing_error=?parsing_error);
+                                false
+                            }
+                        }
+                    })
             })
             .map(|filtered_connector| filtered_connector.connector_name.clone())
-            .collect::<HashSet<String>>();
+            .collect();
 
-        // Parse the payment methods enabled to check if the merchant has enabled gpay ( wallet )
-        // through that connector. This parsing from serde_json::Value to payment method is costly and has to be done for every connector
-        // for sure looks like an area of optimization
+        // Parse the payment methods enabled to check if the merchant has enabled googlepay ( wallet ) using that connector.
+        // A single connector can support creating session token from metadata as well as by calling the connector.
         let session_token_from_metadata_connectors = connector_accounts
             .iter()
             .filter(|connector_account| {
@@ -314,12 +339,28 @@ where
                     .unwrap_or_default()
                     .iter()
                     .any(|payment_method| {
-                        let parsed_payment_method: PaymentMethodEnabled = payment_method
-                            .clone()
-                            .parse_value("payment_method")
-                            .unwrap_or_default();
+                        let parsed_payment_method_result: Result<
+                            PaymentMethodsEnabled,
+                            error_stack::Report<errors::ParsingError>,
+                        > = payment_method.clone().parse_value("payment_method");
 
-                        parsed_payment_method.payment_method == "wallet"
+                        match parsed_payment_method_result {
+                            Ok(parsed_payment_method) => parsed_payment_method
+                                .payment_method_types
+                                .map(|payment_method_types| {
+                                    payment_method_types.iter().any(|payment_method_type| {
+                                        matches!(
+                                            payment_method_type.payment_method_type,
+                                            api_models::enums::PaymentMethodType::GooglePay
+                                        )
+                                    })
+                                })
+                                .unwrap_or(false),
+                            Err(parsing_error) => {
+                                logger::debug!(session_token_parsing_error=?parsing_error);
+                                false
+                            }
+                        }
                     })
             })
             .map(|filtered_connector| filtered_connector.connector_name.clone())

--- a/crates/router/src/core/payments/operations/payment_session.rs
+++ b/crates/router/src/core/payments/operations/payment_session.rs
@@ -293,8 +293,6 @@ where
         let normal_connector_names: HashSet<String> = connector_accounts
             .iter()
             .filter(|connector_account| {
-                // let is_supported = supported_connectors.contains(&connector_account.connector_name);
-
                 connector_account
                     .payment_methods_enabled
                     .clone()


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] New feature

## Description
<!-- Describe your changes in detail -->
Create session token only if it is enabled by the merchant. This involves parsing the payment methods enabled field for each merchant connector account and checking if `invoke_sdk_client` payment_experience for that particular payment_method_type  is enabled. 



## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
Since the calls to `payment_methods_list` and `session_tokens` will be made in parallel, if the merchant has not enabled particular wallet then it wont be reflected in payment methods list, but this check is not there in session token creation. This PR adds that functionality.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Manual.
- Create a connector account without enabling the wallet, and call session token -> token will not be created.
- Update the connector account and enable the wallet, and call session token -> token will be created.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
