### PR TITLE
refactor(api_keys): remove key ID prefix from plaintext API keys

### DIFF
--- a/crates/router/src/core/api_keys.rs
+++ b/crates/router/src/core/api_keys.rs
@@ -55,11 +55,12 @@ pub struct HashedApiKey(String);
 impl PlaintextApiKey {
     pub const HASH_KEY_LEN: usize = 32;
 
-    const PREFIX_LEN: usize = 8;
+    const PREFIX_LEN: usize = 12;
 
     pub fn new(length: usize) -> Self {
+        let env = router_env::env::prefix_for_env();
         let key = common_utils::crypto::generate_cryptographically_secure_random_string(length);
-        Self(key.into())
+        Self(format!("{env}_{key}").into())
     }
 
     pub fn new_key_id() -> String {

--- a/crates/router/src/types/transformers.rs
+++ b/crates/router/src/types/transformers.rs
@@ -392,15 +392,11 @@ impl
 
         let (api_key, plaintext_api_key) = item;
         Self {
-            key_id: api_key.key_id.clone(),
+            key_id: api_key.key_id,
             merchant_id: api_key.merchant_id,
             name: api_key.name,
             description: api_key.description,
-            api_key: StrongSecret::from(format!(
-                "{}-{}",
-                api_key.key_id,
-                plaintext_api_key.peek().to_owned()
-            )),
+            api_key: StrongSecret::from(plaintext_api_key.peek().to_owned()),
             created: api_key.created_at,
             expiration: api_key.expires_at.into(),
         }
@@ -410,14 +406,13 @@ impl
 impl ForeignFrom<storage_models::api_keys::ApiKey>
     for api_models::api_keys::RetrieveApiKeyResponse
 {
-    fn foreign_from(item: storage_models::api_keys::ApiKey) -> Self {
-        let api_key = item;
+    fn foreign_from(api_key: storage_models::api_keys::ApiKey) -> Self {
         Self {
-            key_id: api_key.key_id.clone(),
+            key_id: api_key.key_id,
             merchant_id: api_key.merchant_id,
             name: api_key.name,
             description: api_key.description,
-            prefix: format!("{}-{}", api_key.key_id, api_key.prefix).into(),
+            prefix: api_key.prefix.into(),
             created: api_key.created_at,
             expiration: api_key.expires_at.into(),
         }
@@ -427,8 +422,7 @@ impl ForeignFrom<storage_models::api_keys::ApiKey>
 impl ForeignFrom<api_models::api_keys::UpdateApiKeyRequest>
     for storage_models::api_keys::ApiKeyUpdate
 {
-    fn foreign_from(item: api_models::api_keys::UpdateApiKeyRequest) -> Self {
-        let api_key = item;
+    fn foreign_from(api_key: api_models::api_keys::UpdateApiKeyRequest) -> Self {
         Self::Update {
             name: api_key.name,
             description: api_key.description,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->
This PR removes the key ID prefix included in the plaintext API keys returned on creating a new API key. The key ID no longer needs to be sent by the user now that #639 makes it easier to identify the API key record in the database table.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
This change would also simplify our merchant authentication flow and migration of API keys from the merchant account table to the API keys table.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

1. Both the `key_id` and the plaintext `api_key` fields now contain the environment prefix for easier identification of the environment with which the keys can be used:

   ```shell
   $ curl --location 'http://localhost:8080/api_keys/merchant_123' \
   --header 'Content-Type: application/json' \
   --header 'Accept: application/json' \
   --header 'api-key: MyVerySecretAdminApiKey' \
   --data '{
     "name": "API Key 1",
     "description": null,
     "expiration": "2023-09-23T01:02:03.000Z"
   }'
   {
     "key_id": "dev_9leW4wj63JYqZ6KFWVT6",
     "merchant_id": "merchant_123",
     "name": "API Key 1",
     "description": null,
     "api_key": "dev_My64CharLongApiKey",
     "created": "2023-03-02T10:16:41.606Z",
     "expiration": "2023-09-23T01:02:03.000Z"
   }
   ```

2. The key prefix returned in the retrieve API key response now returns 12 characters instead of the 8 characters being returned earlier.

   ```shell
   $ curl --location 'http://localhost:8080/api_keys/merchant_123/dev_9leW4wj63JYqZ6KFWVT6' \
   --header 'Content-Type: application/json' \
   --header 'Accept: application/json' \
   --header 'api-key: MyVerySecretAdminApiKey'
   {
     "key_id": "dev_9leW4wj63JYqZ6KFWVT6",
     "merchant_id": "merchant_123",
     "name": "API Key 1",
     "description": null,
     "prefix": "dev_9leW4wj6",
     "created": "2023-03-02T10:16:41.606Z",
     "expiration": "2023-09-23T01:02:03.000Z"
   }
   ```

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable

---

~Marking as this as draft as this is blocked by #639.~
