### PR TITLE
enhance(stripe): send statement descriptor to stripe

### DIFF
--- a/crates/api_models/src/customers.rs
+++ b/crates/api_models/src/customers.rs
@@ -33,7 +33,7 @@ pub struct CustomerRequest {
     #[schema(value_type = Option<Object>,example = json!({
     "city": "Bangalore",
     "country": "IN",
-    "line1": "Juspay router",
+    "line1": "Hyperswitch router",
     "line2": "Koramangala",
     "line3": "Stallion",
     "state": "Karnataka",
@@ -73,7 +73,7 @@ pub struct CustomerResponse {
     #[schema(value_type = Option<Object>,example = json!({
     "city": "Bangalore",
     "country": "IN",
-    "line1": "Juspay router",
+    "line1": "Hyperswitch router",
     "line2": "Koramangala",
     "line3": "Stallion",
     "state": "Karnataka",

--- a/crates/api_models/src/payments.rs
+++ b/crates/api_models/src/payments.rs
@@ -154,8 +154,8 @@ pub struct PaymentsRequest {
     pub billing: Option<Address>,
 
     /// For non-card charges, you can use this value as the complete description that appears on your customers’ statements. Must contain at least one letter, maximum 22 characters.
-    #[schema(max_length = 255, example = "Juspay Router")]
-    pub statement_descriptor_name: Option<String>,
+    #[schema(max_length = 255, example = "Hyperswitch Router")]
+    pub statement_descriptor: Option<String>,
 
     /// Provides information about a card payment that customers see on their statements. Concatenated with the prefix (shortened descriptor) or statement descriptor that’s set on the account to form the complete statement descriptor. Maximum 22 characters for the concatenated descriptor.
     #[schema(max_length = 255, example = "Payment for shoes purchase")]
@@ -861,8 +861,8 @@ pub struct PaymentsResponse {
     #[schema(value_type = Option<AuthenticationType>, example = "no_three_ds", default = "three_ds")]
     pub authentication_type: Option<api_enums::AuthenticationType>,
     /// For non-card charges, you can use this value as the complete description that appears on your customers’ statements. Must contain at least one letter, maximum 22 characters.
-    #[schema(max_length = 255, example = "Juspay Router")]
-    pub statement_descriptor_name: Option<String>,
+    #[schema(max_length = 255, example = "Hyperswitch Router")]
+    pub statement_descriptor: Option<String>,
     /// Provides information about a card payment that customers see on their statements. Concatenated with the prefix (shortened descriptor) or statement descriptor that’s set on the account to form the complete statement descriptor. Maximum 255 characters for the concatenated descriptor.
     #[schema(max_length = 255, example = "Payment for shoes purchase")]
     pub statement_descriptor_suffix: Option<String>,

--- a/crates/router/src/compatibility/stripe/payment_intents/types.rs
+++ b/crates/router/src/compatibility/stripe/payment_intents/types.rs
@@ -181,7 +181,7 @@ impl TryFrom<StripePaymentIntentRequest> for payments::PaymentsRequest {
                 .billing_details
                 .as_ref()
                 .map(|b| payments::Address::from(b.to_owned())),
-            statement_descriptor_name: item.statement_descriptor,
+            statement_descriptor: item.statement_descriptor,
             statement_descriptor_suffix: item.statement_descriptor_suffix,
             metadata: item.metadata,
             client_secret: item.client_secret.map(|s| s.peek().clone()),
@@ -336,7 +336,7 @@ impl From<payments::PaymentsResponse> for StripePaymentIntentResponse {
             name: resp.name,
             phone: resp.phone,
             authentication_type: resp.authentication_type,
-            statement_descriptor_name: resp.statement_descriptor_name,
+            statement_descriptor_name: resp.statement_descriptor,
             statement_descriptor_suffix: resp.statement_descriptor_suffix,
             next_action: into_stripe_next_action(resp.next_action, resp.return_url),
             cancellation_reason: resp.cancellation_reason,

--- a/crates/router/src/compatibility/stripe/setup_intents/types.rs
+++ b/crates/router/src/compatibility/stripe/setup_intents/types.rs
@@ -159,7 +159,7 @@ impl From<StripeSetupIntentRequest> for payments::PaymentsRequest {
                 .billing_details
                 .as_ref()
                 .map(|b| payments::Address::from(b.to_owned())),
-            statement_descriptor_name: item.statement_descriptor,
+            statement_descriptor: item.statement_descriptor,
             statement_descriptor_suffix: item.statement_descriptor_suffix,
             metadata: item.metadata,
             client_secret: item.client_secret.map(|s| s.peek().clone()),

--- a/crates/router/src/connector/stripe/transformers.rs
+++ b/crates/router/src/connector/stripe/transformers.rs
@@ -33,10 +33,6 @@ impl TryFrom<&types::ConnectorAuthType> for StripeAuthType {
     }
 }
 
-// Stripe Types Definition
-// PAYMENT
-// PaymentIntentRequest
-
 #[derive(Debug, Default, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum StripeCaptureMethod {
@@ -72,6 +68,7 @@ pub struct PaymentIntentRequest {
     pub amount: i64, //amount in cents, hence passed as integer
     pub currency: String,
     pub statement_descriptor_suffix: Option<String>,
+    pub statement_descriptor: Option<String>,
     #[serde(rename = "metadata[order_id]")]
     pub metadata_order_id: String,
     #[serde(rename = "metadata[txn_id]")]
@@ -626,6 +623,7 @@ impl TryFrom<&types::PaymentsAuthorizeRouterData> for PaymentIntentRequest {
             amount: item.request.amount, //hopefully we don't loose some cents here
             currency: item.request.currency.to_string(), //we need to copy the value and not transfer ownership
             statement_descriptor_suffix: item.request.statement_descriptor_suffix.clone(),
+            statement_descriptor: item.request.statement_descriptor.clone(),
             metadata_order_id,
             metadata_txn_id,
             metadata_txn_uuid,
@@ -671,8 +669,6 @@ impl TryFrom<&types::VerifyRouterData> for SetupIntentRequest {
         })
     }
 }
-
-// PaymentIntentResponse
 
 #[derive(Clone, Debug, Default, Eq, PartialEq, Deserialize, Serialize)]
 pub struct StripeMetadata {

--- a/crates/router/src/core/payment_methods/transformers.rs
+++ b/crates/router/src/core/payment_methods/transformers.rs
@@ -83,7 +83,7 @@ pub fn mk_add_card_request(
         card_exp_year: card.card_exp_year.clone(),
         merchant_id: locker_id,
         email_address: Some("dummy@gmail.com".to_string().into()), //
-        name_on_card: Some("juspay".to_string().into()),           // [#256]
+        name_on_card: Some("John Doe".to_string().into()),         // [#256]
         nickname: Some("router".to_string()),                      //
     };
     let body = utils::Encode::<AddCardRequest<'_>>::encode(&add_card_req)

--- a/crates/router/src/core/payments/operations/payment_create.rs
+++ b/crates/router/src/core/payments/operations/payment_create.rs
@@ -500,7 +500,7 @@ impl PaymentCreate {
             return_url: request.return_url.as_ref().map(|a| a.to_string()),
             shipping_address_id,
             billing_address_id,
-            statement_descriptor_name: request.statement_descriptor_name.clone(),
+            statement_descriptor_name: request.statement_descriptor.clone(),
             statement_descriptor_suffix: request.statement_descriptor_suffix.clone(),
             metadata,
             ..storage::PaymentIntentNew::default()

--- a/crates/router/src/core/payments/transformers.rs
+++ b/crates/router/src/core/payments/transformers.rs
@@ -324,7 +324,7 @@ where
                                 .authentication_type
                                 .map(ForeignInto::foreign_into),
                         )
-                        .set_statement_descriptor_name(payment_intent.statement_descriptor_name)
+                        .set_statement_descriptor(payment_intent.statement_descriptor_name)
                         .set_statement_descriptor_suffix(payment_intent.statement_descriptor_suffix)
                         .set_setup_future_usage(
                             payment_intent
@@ -432,6 +432,7 @@ impl<F: Clone> TryFrom<PaymentData<F>> for types::PaymentsAuthorizeData {
             setup_mandate_details: payment_data.setup_mandate.clone(),
             confirm: payment_data.payment_attempt.confirm,
             statement_descriptor_suffix: payment_data.payment_intent.statement_descriptor_suffix,
+            statement_descriptor: payment_data.payment_intent.statement_descriptor_name,
             capture_method: payment_data.payment_attempt.capture_method,
             amount: payment_data.amount.into(),
             currency: payment_data.currency,

--- a/crates/router/src/types.rs
+++ b/crates/router/src/types.rs
@@ -116,6 +116,7 @@ pub struct PaymentsAuthorizeData {
     pub currency: storage_enums::Currency,
     pub confirm: bool,
     pub statement_descriptor_suffix: Option<String>,
+    pub statement_descriptor: Option<String>,
     pub capture_method: Option<storage_enums::CaptureMethod>,
     // Mandates
     pub setup_future_usage: Option<storage_enums::FutureUsage>,

--- a/crates/router/tests/connectors/aci.rs
+++ b/crates/router/tests/connectors/aci.rs
@@ -44,6 +44,7 @@ fn construct_payment_router_data() -> types::PaymentsAuthorizeRouterData {
             }),
             confirm: true,
             statement_descriptor_suffix: None,
+            statement_descriptor: None,
             setup_future_usage: None,
             mandate_id: None,
             off_session: None,

--- a/crates/router/tests/connectors/adyen.rs
+++ b/crates/router/tests/connectors/adyen.rs
@@ -72,6 +72,7 @@ impl AdyenTest {
             }),
             confirm: true,
             statement_descriptor_suffix: None,
+            statement_descriptor: None,
             setup_future_usage: None,
             mandate_id: None,
             off_session: None,

--- a/crates/router/tests/connectors/authorizedotnet.rs
+++ b/crates/router/tests/connectors/authorizedotnet.rs
@@ -44,6 +44,7 @@ fn construct_payment_router_data() -> types::PaymentsAuthorizeRouterData {
             }),
             confirm: true,
             statement_descriptor_suffix: None,
+            statement_descriptor: None,
             setup_future_usage: None,
             mandate_id: None,
             off_session: None,

--- a/crates/router/tests/connectors/checkout.rs
+++ b/crates/router/tests/connectors/checkout.rs
@@ -41,6 +41,7 @@ fn construct_payment_router_data() -> types::PaymentsAuthorizeRouterData {
             }),
             confirm: true,
             statement_descriptor_suffix: None,
+            statement_descriptor: None,
             setup_future_usage: None,
             mandate_id: None,
             off_session: None,

--- a/crates/router/tests/connectors/utils.rs
+++ b/crates/router/tests/connectors/utils.rs
@@ -475,6 +475,7 @@ impl Default for PaymentAuthorizeType {
             currency: enums::Currency::USD,
             confirm: true,
             statement_descriptor_suffix: None,
+            statement_descriptor: None,
             capture_method: None,
             setup_future_usage: None,
             mandate_id: None,

--- a/crates/router/tests/connectors/worldline.rs
+++ b/crates/router/tests/connectors/worldline.rs
@@ -74,6 +74,7 @@ impl WorldlineTest {
             }),
             confirm: true,
             statement_descriptor_suffix: None,
+            statement_descriptor: None,
             setup_future_usage: None,
             mandate_id: None,
             off_session: None,

--- a/crates/router/tests/payments.rs
+++ b/crates/router/tests/payments.rs
@@ -317,7 +317,7 @@ async fn payments_create_core() {
             address: None,
             phone: None,
         }),
-        statement_descriptor_name: Some("Juspay".to_string()),
+        statement_descriptor: Some("Juspay".to_string()),
         statement_descriptor_suffix: Some("Router".to_string()),
         ..Default::default()
     };
@@ -463,7 +463,7 @@ async fn payments_create_core_adyen_no_redirect() {
             address: None,
             phone: None,
         }),
-        statement_descriptor_name: Some("Juspay".to_string()),
+        statement_descriptor: Some("Juspay".to_string()),
         statement_descriptor_suffix: Some("Router".to_string()),
         ..Default::default()
     };

--- a/crates/router/tests/payments.rs
+++ b/crates/router/tests/payments.rs
@@ -317,8 +317,8 @@ async fn payments_create_core() {
             address: None,
             phone: None,
         }),
-        statement_descriptor: Some("Juspay".to_string()),
-        statement_descriptor_suffix: Some("Router".to_string()),
+        statement_descriptor: Some("Hyperswtich".to_string()),
+        statement_descriptor_suffix: Some("Hyperswitch".to_string()),
         ..Default::default()
     };
 

--- a/crates/router/tests/payments2.rs
+++ b/crates/router/tests/payments2.rs
@@ -77,7 +77,7 @@ async fn payments_create_core() {
             address: None,
             phone: None,
         }),
-        statement_descriptor_name: Some("Juspay".to_string()),
+        statement_descriptor: Some("Juspay".to_string()),
         statement_descriptor_suffix: Some("Router".to_string()),
         ..<_>::default()
     };
@@ -229,7 +229,7 @@ async fn payments_create_core_adyen_no_redirect() {
             address: None,
             phone: None,
         }),
-        statement_descriptor_name: Some("Juspay".to_string()),
+        statement_descriptor: Some("Juspay".to_string()),
         statement_descriptor_suffix: Some("Router".to_string()),
         ..Default::default()
     };

--- a/crates/router/tests/payments2.rs
+++ b/crates/router/tests/payments2.rs
@@ -77,8 +77,8 @@ async fn payments_create_core() {
             address: None,
             phone: None,
         }),
-        statement_descriptor: Some("Juspay".to_string()),
-        statement_descriptor_suffix: Some("Router".to_string()),
+        statement_descriptor: Some("Hyperswitch".to_string()),
+        statement_descriptor_suffix: Some("Hyperswitch".to_string()),
         ..<_>::default()
     };
 

--- a/crates/router/tests/utils.rs
+++ b/crates/router/tests/utils.rs
@@ -250,8 +250,8 @@ fn mk_payment(amount: i64, amount_to_capture: i32) -> Value {
           "card_cvc": "123"
         }
       },
-      "statement_descriptor_name": "Juspay",
-      "statement_descriptor_suffix": "Router",
+      "statement_descriptor_name": "Hyperswitch",
+      "statement_descriptor_suffix": "Hyperswitch",
       "metadata": {
         "udf1": "value1",
         "new_customer": "true",

--- a/openapi/generated.json
+++ b/openapi/generated.json
@@ -4397,10 +4397,10 @@
           "billing": {
             "$ref": "#/components/schemas/Address"
           },
-          "statement_descriptor_name": {
+          "statement_descriptor": {
             "type": "string",
             "description": "For non-card charges, you can use this value as the complete description that appears on your customers’ statements. Must contain at least one letter, maximum 22 characters.",
-            "example": "Juspay Router",
+            "example": "Hyperswitch Router",
             "maxLength": 255
           },
           "statement_descriptor_suffix": {
@@ -4593,10 +4593,10 @@
           "authentication_type": {
             "$ref": "#/components/schemas/AuthenticationType"
           },
-          "statement_descriptor_name": {
+          "statement_descriptor": {
             "type": "string",
             "description": "For non-card charges, you can use this value as the complete description that appears on your customers’ statements. Must contain at least one letter, maximum 22 characters.",
-            "example": "Juspay Router",
+            "example": "Hyperswitch Router",
             "maxLength": 255
           },
           "statement_descriptor_suffix": {

--- a/postman/portman-config.json
+++ b/postman/portman-config.json
@@ -432,7 +432,7 @@
                                         },
                                         {
                                             "key": "address.line1",
-                                            "value": "Juspay router"
+                                            "value": "Hyperswitch router"
                                         },
                                         {
                                             "key": "address.line2",
@@ -523,7 +523,7 @@
                                         },
                                         {
                                             "key": "address.line1",
-                                            "value": "Juspay router"
+                                            "value": "Hyperswitch router"
                                         },
                                         {
                                             "key": "address.line2",
@@ -928,7 +928,7 @@
                                         },
                                         {
                                             "key": "address.line1",
-                                            "value": "Juspay router"
+                                            "value": "Hyperswitch router"
                                         },
                                         {
                                             "key": "address.line2",


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Enhancement

## Description
<!-- Describe your changes in detail -->
- Pass statement descriptor field to stripe.
- Replace Juspay with hyperswitch in docs


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Create a payment with both `statement_descriptor` and `statement_descriptor_suffix` and check the same in stripe dashboard.
![Screenshot 2023-03-03 at 12 15 28 PM](https://user-images.githubusercontent.com/48803246/222650470-61acda78-81ad-474d-a6f6-aa596d6352d2.png)


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
