### PR TITLE
refactor: rename statement descriptor to statement descriptor name

### DIFF
--- a/crates/api_models/src/payments.rs
+++ b/crates/api_models/src/payments.rs
@@ -155,7 +155,7 @@ pub struct PaymentsRequest {
 
     /// For non-card charges, you can use this value as the complete description that appears on your customers’ statements. Must contain at least one letter, maximum 22 characters.
     #[schema(max_length = 255, example = "Hyperswitch Router")]
-    pub statement_descriptor: Option<String>,
+    pub statement_descriptor_name: Option<String>,
 
     /// Provides information about a card payment that customers see on their statements. Concatenated with the prefix (shortened descriptor) or statement descriptor that’s set on the account to form the complete statement descriptor. Maximum 22 characters for the concatenated descriptor.
     #[schema(max_length = 255, example = "Payment for shoes purchase")]
@@ -862,7 +862,7 @@ pub struct PaymentsResponse {
     pub authentication_type: Option<api_enums::AuthenticationType>,
     /// For non-card charges, you can use this value as the complete description that appears on your customers’ statements. Must contain at least one letter, maximum 22 characters.
     #[schema(max_length = 255, example = "Hyperswitch Router")]
-    pub statement_descriptor: Option<String>,
+    pub statement_descriptor_name: Option<String>,
     /// Provides information about a card payment that customers see on their statements. Concatenated with the prefix (shortened descriptor) or statement descriptor that’s set on the account to form the complete statement descriptor. Maximum 255 characters for the concatenated descriptor.
     #[schema(max_length = 255, example = "Payment for shoes purchase")]
     pub statement_descriptor_suffix: Option<String>,

--- a/crates/router/src/compatibility/stripe/payment_intents/types.rs
+++ b/crates/router/src/compatibility/stripe/payment_intents/types.rs
@@ -181,7 +181,7 @@ impl TryFrom<StripePaymentIntentRequest> for payments::PaymentsRequest {
                 .billing_details
                 .as_ref()
                 .map(|b| payments::Address::from(b.to_owned())),
-            statement_descriptor: item.statement_descriptor,
+            statement_descriptor_name: item.statement_descriptor,
             statement_descriptor_suffix: item.statement_descriptor_suffix,
             metadata: item.metadata,
             client_secret: item.client_secret.map(|s| s.peek().clone()),
@@ -336,7 +336,7 @@ impl From<payments::PaymentsResponse> for StripePaymentIntentResponse {
             name: resp.name,
             phone: resp.phone,
             authentication_type: resp.authentication_type,
-            statement_descriptor_name: resp.statement_descriptor,
+            statement_descriptor_name: resp.statement_descriptor_name,
             statement_descriptor_suffix: resp.statement_descriptor_suffix,
             next_action: into_stripe_next_action(resp.next_action, resp.return_url),
             cancellation_reason: resp.cancellation_reason,

--- a/crates/router/src/compatibility/stripe/setup_intents/types.rs
+++ b/crates/router/src/compatibility/stripe/setup_intents/types.rs
@@ -159,7 +159,7 @@ impl From<StripeSetupIntentRequest> for payments::PaymentsRequest {
                 .billing_details
                 .as_ref()
                 .map(|b| payments::Address::from(b.to_owned())),
-            statement_descriptor: item.statement_descriptor,
+            statement_descriptor_name: item.statement_descriptor,
             statement_descriptor_suffix: item.statement_descriptor_suffix,
             metadata: item.metadata,
             client_secret: item.client_secret.map(|s| s.peek().clone()),

--- a/crates/router/src/core/payments/operations/payment_create.rs
+++ b/crates/router/src/core/payments/operations/payment_create.rs
@@ -500,7 +500,7 @@ impl PaymentCreate {
             return_url: request.return_url.as_ref().map(|a| a.to_string()),
             shipping_address_id,
             billing_address_id,
-            statement_descriptor_name: request.statement_descriptor.clone(),
+            statement_descriptor_name: request.statement_descriptor_name.clone(),
             statement_descriptor_suffix: request.statement_descriptor_suffix.clone(),
             metadata,
             ..storage::PaymentIntentNew::default()

--- a/crates/router/src/core/payments/transformers.rs
+++ b/crates/router/src/core/payments/transformers.rs
@@ -324,7 +324,7 @@ where
                                 .authentication_type
                                 .map(ForeignInto::foreign_into),
                         )
-                        .set_statement_descriptor(payment_intent.statement_descriptor_name)
+                        .set_statement_descriptor_name(payment_intent.statement_descriptor_name)
                         .set_statement_descriptor_suffix(payment_intent.statement_descriptor_suffix)
                         .set_setup_future_usage(
                             payment_intent

--- a/crates/router/tests/payments.rs
+++ b/crates/router/tests/payments.rs
@@ -317,7 +317,7 @@ async fn payments_create_core() {
             address: None,
             phone: None,
         }),
-        statement_descriptor: Some("Hyperswtich".to_string()),
+        statement_descriptor_name: Some("Hyperswtich".to_string()),
         statement_descriptor_suffix: Some("Hyperswitch".to_string()),
         ..Default::default()
     };
@@ -463,7 +463,7 @@ async fn payments_create_core_adyen_no_redirect() {
             address: None,
             phone: None,
         }),
-        statement_descriptor: Some("Juspay".to_string()),
+        statement_descriptor_name: Some("Juspay".to_string()),
         statement_descriptor_suffix: Some("Router".to_string()),
         ..Default::default()
     };

--- a/crates/router/tests/payments2.rs
+++ b/crates/router/tests/payments2.rs
@@ -77,7 +77,7 @@ async fn payments_create_core() {
             address: None,
             phone: None,
         }),
-        statement_descriptor: Some("Hyperswitch".to_string()),
+        statement_descriptor_name: Some("Hyperswitch".to_string()),
         statement_descriptor_suffix: Some("Hyperswitch".to_string()),
         ..<_>::default()
     };
@@ -229,7 +229,7 @@ async fn payments_create_core_adyen_no_redirect() {
             address: None,
             phone: None,
         }),
-        statement_descriptor: Some("Juspay".to_string()),
+        statement_descriptor_name: Some("Juspay".to_string()),
         statement_descriptor_suffix: Some("Router".to_string()),
         ..Default::default()
     };


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Refactoring

## Description
<!-- Describe your changes in detail -->
Renaming the field in `PaymentsRequest` and `PaymentsResponse` back to statement_descriptor_name.



## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
This field was renamed in #707.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
- Create a payment
```json
{
"description": "Its my first payment request",
    "statement_descriptor_suffix": "Suffix",
    "statement_descriptor_name": "Statement Descriptor"
}
```
- Check stripe dashboard 
<img width="581" alt="Screenshot 2023-03-03 at 10 16 08 PM" src="https://user-images.githubusercontent.com/48803246/222778201-2cc6a713-f224-4ea3-9d15-c4a0f272a9dd.png">


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
