### PR TITLE
refactor(authentication): authenticate merchant by API keys from API keys table

### DIFF
--- a/crates/router/src/core/api_keys.rs
+++ b/crates/router/src/core/api_keys.rs
@@ -165,7 +165,7 @@ pub async fn retrieve_api_key(
     key_id: &str,
 ) -> RouterResponse<api::RetrieveApiKeyResponse> {
     let api_key = store
-        .find_api_key_optional(key_id)
+        .find_api_key_by_key_id_optional(key_id)
         .await
         .change_context(errors::ApiErrorResponse::InternalServerError) // If retrieve failed
         .attach_printable("Failed to retrieve new API key")?

--- a/crates/router/src/core/errors.rs
+++ b/crates/router/src/core/errors.rs
@@ -414,11 +414,3 @@ pub enum WebhooksFlowError {
     #[error("Resource not found")]
     ResourceNotFound,
 }
-
-#[derive(Debug, thiserror::Error)]
-pub enum ApiKeyError {
-    #[error("Failed to read API key hash from hexadecimal string")]
-    FailedToReadHashFromHex,
-    #[error("Failed to verify provided API key hash against stored API key hash")]
-    HashVerificationFailed,
-}

--- a/crates/router/src/db/api_keys.rs
+++ b/crates/router/src/db/api_keys.rs
@@ -27,6 +27,11 @@ pub trait ApiKeyInterface {
         key_id: &str,
     ) -> CustomResult<Option<storage::ApiKey>, errors::StorageError>;
 
+    async fn find_api_key_by_hash_optional(
+        &self,
+        hashed_api_key: storage::HashedApiKey,
+    ) -> CustomResult<Option<storage::ApiKey>, errors::StorageError>;
+
     async fn list_api_keys_by_merchant_id(
         &self,
         merchant_id: &str,
@@ -80,6 +85,17 @@ impl ApiKeyInterface for Store {
             .into_report()
     }
 
+    async fn find_api_key_by_hash_optional(
+        &self,
+        hashed_api_key: storage::HashedApiKey,
+    ) -> CustomResult<Option<storage::ApiKey>, errors::StorageError> {
+        let conn = pg_connection(&self.master_pool).await?;
+        storage::ApiKey::find_optional_by_hashed_api_key(&conn, hashed_api_key)
+            .await
+            .map_err(Into::into)
+            .into_report()
+    }
+
     async fn list_api_keys_by_merchant_id(
         &self,
         merchant_id: &str,
@@ -121,6 +137,14 @@ impl ApiKeyInterface for MockDb {
     async fn find_api_key_by_key_id_optional(
         &self,
         _key_id: &str,
+    ) -> CustomResult<Option<storage::ApiKey>, errors::StorageError> {
+        // [#172]: Implement function for `MockDb`
+        Err(errors::StorageError::MockDbError)?
+    }
+
+    async fn find_api_key_by_hash_optional(
+        &self,
+        _hashed_api_key: storage::HashedApiKey,
     ) -> CustomResult<Option<storage::ApiKey>, errors::StorageError> {
         // [#172]: Implement function for `MockDb`
         Err(errors::StorageError::MockDbError)?

--- a/crates/router/src/db/api_keys.rs
+++ b/crates/router/src/db/api_keys.rs
@@ -22,7 +22,7 @@ pub trait ApiKeyInterface {
 
     async fn revoke_api_key(&self, key_id: &str) -> CustomResult<bool, errors::StorageError>;
 
-    async fn find_api_key_optional(
+    async fn find_api_key_by_key_id_optional(
         &self,
         key_id: &str,
     ) -> CustomResult<Option<storage::ApiKey>, errors::StorageError>;
@@ -69,7 +69,7 @@ impl ApiKeyInterface for Store {
             .into_report()
     }
 
-    async fn find_api_key_optional(
+    async fn find_api_key_by_key_id_optional(
         &self,
         key_id: &str,
     ) -> CustomResult<Option<storage::ApiKey>, errors::StorageError> {
@@ -118,7 +118,7 @@ impl ApiKeyInterface for MockDb {
         Err(errors::StorageError::MockDbError)?
     }
 
-    async fn find_api_key_optional(
+    async fn find_api_key_by_key_id_optional(
         &self,
         _key_id: &str,
     ) -> CustomResult<Option<storage::ApiKey>, errors::StorageError> {

--- a/crates/router/src/routes/metrics.rs
+++ b/crates/router/src/routes/metrics.rs
@@ -5,11 +5,12 @@ use router_env::opentelemetry::{
     Context,
 };
 
+use crate::create_counter;
+
 pub static CONTEXT: Lazy<Context> = Lazy::new(Context::current);
 static GLOBAL_METER: Lazy<Meter> = Lazy::new(|| global::meter("ROUTER_API"));
 
-pub(crate) static HEALTH_METRIC: Lazy<Counter<u64>> =
-    Lazy::new(|| GLOBAL_METER.u64_counter("HEALTH_API").init());
-
-pub(crate) static KV_MISS: Lazy<Counter<u64>> =
-    Lazy::new(|| GLOBAL_METER.u64_counter("KV_MISS").init());
+create_counter!(HEALTH_METRIC, GLOBAL_METER); // No. of health API hits
+create_counter!(KV_MISS, GLOBAL_METER); // No. of KV misses
+#[cfg(feature = "kms")]
+create_counter!(AWS_KMS_FAILURES, GLOBAL_METER); // No. of AWS KMS API failures

--- a/crates/router/src/scheduler/metrics.rs
+++ b/crates/router/src/scheduler/metrics.rs
@@ -11,6 +11,7 @@ static PT_METER: Lazy<Meter> = Lazy::new(|| global::meter("PROCESS_TRACKER"));
 pub(crate) static CONSUMER_STATS: Lazy<Histogram<f64>> =
     Lazy::new(|| PT_METER.f64_histogram("CONSUMER_OPS").init());
 
+#[macro_export]
 macro_rules! create_counter {
     ($name:ident, $meter:ident) => {
         pub(crate) static $name: Lazy<Counter<u64>> =

--- a/crates/storage_models/src/api_keys.rs
+++ b/crates/storage_models/src/api_keys.rs
@@ -81,6 +81,12 @@ impl From<ApiKeyUpdate> for ApiKeyUpdateInternal {
 #[diesel(sql_type = diesel::sql_types::Text)]
 pub struct HashedApiKey(String);
 
+impl HashedApiKey {
+    pub fn into_inner(self) -> String {
+        self.0
+    }
+}
+
 impl From<String> for HashedApiKey {
     fn from(hashed_api_key: String) -> Self {
         Self(hashed_api_key)

--- a/crates/storage_models/src/query/api_keys.rs
+++ b/crates/storage_models/src/query/api_keys.rs
@@ -3,7 +3,7 @@ use router_env::{instrument, tracing};
 
 use super::generics;
 use crate::{
-    api_keys::{ApiKey, ApiKeyNew, ApiKeyUpdate, ApiKeyUpdateInternal},
+    api_keys::{ApiKey, ApiKeyNew, ApiKeyUpdate, ApiKeyUpdateInternal, HashedApiKey},
     errors,
     schema::api_keys::dsl,
     PgPooledConn, StorageResult,
@@ -61,6 +61,18 @@ impl ApiKey {
         generics::generic_find_by_id_optional::<<Self as HasTable>::Table, _, _>(
             conn,
             key_id.to_owned(),
+        )
+        .await
+    }
+
+    #[instrument(skip(conn))]
+    pub async fn find_optional_by_hashed_api_key(
+        conn: &PgPooledConn,
+        hashed_api_key: HashedApiKey,
+    ) -> StorageResult<Option<Self>> {
+        generics::generic_find_one_optional::<<Self as HasTable>::Table, _, _>(
+            conn,
+            dsl::hashed_api_key.eq(hashed_api_key),
         )
         .await
     }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->
This PR updates the API key authentication code to use the API keys from the API keys table instead of the merchant account table. I'll be taking up the deprecation of the `api_key` field from the merchant account table in a separate PR.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
This is an extension of PRs #511, #639 and #705, thus completely addressing #501.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Manually. After I made the change, I created a new merchant account and API key, and tested out creating customers and payments. Things worked as expected.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable

---

~Marking as this as draft as this is blocked by #639 and #705 being merged to `main` branch.~