### PR TITLE
fix(errors): use `Debug` impl instead of `Display` for error types wrapping `error_stack::Report`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -305,9 +305,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.68"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cb2f989d18dd141ab8ae82f64d1a8cdd37e0840f73a406896cf5e99502fab61"
+checksum = "224afbd727c3d6e4b90103ece64b8d1b67fbb1973b1046c2281eed3f3803f800"
 
 [[package]]
 name = "api_models"
@@ -1482,12 +1482,11 @@ dependencies = [
 
 [[package]]
 name = "error-stack"
-version = "0.2.4"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "859d224e04b2d93d974c08e375dac9b8d1a513846e44c6666450a57b1ed963f9"
+checksum = "5f00447f331c7f726db5b8532ebc9163519eed03c6d7c8b73c90b3ff5646ac85"
 dependencies = [
  "anyhow",
- "owo-colors",
  "rustc_version",
 ]
 
@@ -2099,12 +2098,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30e22bd8629359895450b59ea7a776c850561b96a3b1d31321c1949d9e6c9146"
 
 [[package]]
-name = "is_ci"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616cde7c720bb2bb5824a224687d8f77bfd38922027f01d825cd7453be5099fb"
-
-[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2663,15 +2656,6 @@ name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
-
-[[package]]
-name = "owo-colors"
-version = "3.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
-dependencies = [
- "supports-color",
-]
 
 [[package]]
 name = "parking"
@@ -3845,16 +3829,6 @@ name = "subtle"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
-
-[[package]]
-name = "supports-color"
-version = "1.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ba6faf2ca7ee42fdd458f4347ae0a9bd6bcc445ad7cb57ad82b383f18870d6f"
-dependencies = [
- "atty",
- "is_ci",
-]
 
 [[package]]
 name = "syn"

--- a/crates/api_models/Cargo.toml
+++ b/crates/api_models/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 actix-web = "4.3.0"
-error-stack = "0.2.4"
+error-stack = "0.3.1"
 frunk = "0.4.1"
 frunk_core = "0.4.1"
 mime = "0.3.16"

--- a/crates/common_utils/Cargo.toml
+++ b/crates/common_utils/Cargo.toml
@@ -10,7 +10,7 @@ license = "Apache-2.0"
 [dependencies]
 async-trait = "0.1.63"
 bytes = "1.3.0"
-error-stack = "0.2.4"
+error-stack = "0.3.1"
 futures = "0.3.25"
 hex = "0.4.3"
 nanoid = "0.4.0"

--- a/crates/drainer/Cargo.toml
+++ b/crates/drainer/Cargo.toml
@@ -13,7 +13,7 @@ bb8 = "0.8"
 clap = { version = "4.1.4", default-features = false, features = ["std", "derive", "help", "usage"] }
 config = { version = "0.13.3", features = ["toml"] }
 diesel = { version = "2.0.3", features = ["postgres", "serde_json", "time", "64-column-tables"] }
-error-stack = "0.2.4"
+error-stack = "0.3.1"
 once_cell = "1.17.0"
 serde = "1.0.152"
 serde_json = "1.0.91"

--- a/crates/drainer/src/errors.rs
+++ b/crates/drainer/src/errors.rs
@@ -5,7 +5,7 @@ use thiserror::Error;
 pub enum DrainerError {
     #[error("Error in parsing config : {0}")]
     ConfigParsingError(String),
-    #[error("Error during redis operation : {0}")]
+    #[error("Error during redis operation : {0:?}")]
     RedisError(error_stack::Report<redis::errors::RedisError>),
     #[error("Application configuration error: {0}")]
     ConfigurationError(config::ConfigError),

--- a/crates/redis_interface/Cargo.toml
+++ b/crates/redis_interface/Cargo.toml
@@ -9,7 +9,7 @@ license = "Apache-2.0"
 
 [dependencies]
 async-trait = "0.1.63"
-error-stack = "0.2.4"
+error-stack = "0.3.1"
 fred = { version = "5.2.0", features = ["metrics", "partial-tracing"] }
 futures = "0.3"
 serde = { version = "1.0.152", features = ["derive"] }

--- a/crates/router/Cargo.toml
+++ b/crates/router/Cargo.toml
@@ -42,7 +42,7 @@ crc32fast = "1.3.2"
 diesel = { version = "2.0.3", features = ["postgres", "serde_json", "time", "64-column-tables"] }
 dyn-clone = "1.0.10"
 encoding_rs = "0.8.31"
-error-stack = "0.2.4"
+error-stack = "0.3.1"
 frunk = "0.4.1"
 frunk_core = "0.4.1"
 futures = "0.3.25"

--- a/crates/router/src/core/errors.rs
+++ b/crates/router/src/core/errors.rs
@@ -50,7 +50,7 @@ macro_rules! impl_error_type {
 
 #[derive(Debug, thiserror::Error)]
 pub enum StorageError {
-    #[error("DatabaseError: {0}")]
+    #[error("DatabaseError: {0:?}")]
     DatabaseError(error_stack::Report<storage_errors::DatabaseError>),
     #[error("ValueNotFound: {0}")]
     ValueNotFound(String),
@@ -71,7 +71,7 @@ pub enum StorageError {
     CustomerRedacted,
     #[error("Deserialization failure")]
     DeserializationFailed,
-    #[error("Received Error RedisError: {0}")]
+    #[error("RedisError: {0:?}")]
     RedisError(error_stack::Report<RedisError>),
 }
 

--- a/crates/router/src/core/errors.rs
+++ b/crates/router/src/core/errors.rs
@@ -72,12 +72,12 @@ pub enum StorageError {
     #[error("Deserialization failure")]
     DeserializationFailed,
     #[error("Received Error RedisError: {0}")]
-    ERedisError(error_stack::Report<RedisError>),
+    RedisError(error_stack::Report<RedisError>),
 }
 
 impl From<error_stack::Report<RedisError>> for StorageError {
     fn from(err: error_stack::Report<RedisError>) -> Self {
-        Self::ERedisError(err)
+        Self::RedisError(err)
     }
 }
 

--- a/crates/storage_models/Cargo.toml
+++ b/crates/storage_models/Cargo.toml
@@ -13,7 +13,7 @@ kv_store = []
 async-bb8-diesel = { git = "https://github.com/juspay/async-bb8-diesel", rev = "9a71d142726dbc33f41c1fd935ddaa79841c7be5" }
 async-trait = "0.1.63"
 diesel = { version = "2.0.3", features = ["postgres", "serde_json", "time", "64-column-tables"] }
-error-stack = "0.2.4"
+error-stack = "0.3.1"
 frunk = "0.4.1"
 frunk_core = "0.4.1"
 hex = "0.4.3"


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->
This PR uses the `Debug` implementation instead of `Display` implementation for printing error types which wrap around `error_stack::Report`.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
Fixes #626.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

<details>
<summary>Scenario 1: Column missing from database table</summary>
<pre>
  2023-03-05T11:48:49.205284Z ERROR router::services::api: error: {"error":{"type":"api","message":"Something went wrong","code":"HE_00"}}
├╴at crates/router/src/services/api.rs:448:42
│
├─▶ {"error":{"type":"server_not_available","code":"HE_00","message":"Something went wrong"}}
│   ├╴at crates/router/src/core/api_keys.rs:120:10
│   ╰╴Failed to insert new API key
│
╰─▶ DatabaseError: An unknown error occurred
    ├╴at ~/hyperswitch/crates/storage_models/src/query/generics.rs:50:27
    ├╴Error while inserting ApiKeyNew { key_id: "dev_3CxVj7hy75r84j6v4HsU", merchant_id: "merchant_123", name: "API Key 1", description: None, hash_key: *** alloc::string::String ***, hashed_api_key: HashedApiKey("42d0fdaea3608f58139bde111dcaf215c5058dab74f8f3596621894a29513fae"), prefix: "x5DGYYL3", created_at: 2023-03-05 11:48:49.19647, expires_at: Some(2023-09-23 1:02:03.0), last_used: None }
    │
    ╰─▶ Failed to issue a query: column "hash_key" of relation "api_keys" does not exist
        ╰╴at ~/hyperswitch/crates/storage_models/src/query/generics.rs:43:46
    ╰╴at crates/router/src/db/api_keys.rs:49:14
    at crates/router/src/services/api.rs:527
    in router::services::api::server_wrap with request_method: "POST", request_url_path: "/api_keys/merchant_123"
    in router::routes::api_keys::api_key_create with flow: ApiKeyCreate
</pre>
</details>

<details>
<summary>Scenario 2: Insufficient permissions for user</summary>
<pre>
  2023-03-05T12:09:37.071652Z ERROR router::services::api: error: {"error":{"type":"api","message":"Something went wrong","code":"HE_00"}}
├╴at crates/router/src/services/api.rs:448:42
│
├─▶ {"error":{"type":"server_not_available","code":"HE_00","message":"Something went wrong"}}
│   ├╴at crates/router/src/core/api_keys.rs:120:10
│   ╰╴Failed to insert new API key
│
╰─▶ DatabaseError: An unknown error occurred
    ├╴at ~/hyperswitch/crates/storage_models/src/query/generics.rs:50:27
    ├╴Error while inserting ApiKeyNew { key_id: "dev_Tj9uQaFQe4khL5D5Umsa", merchant_id: "merchant_123", name: "API Key 1", description: None, hash_key: *** alloc::string::String ***, hashed_api_key: HashedApiKey("c00d96fa1bbec8229166174129a6ef9aa30846e11556583e7f817c33b16eda34"), prefix: "I1GBh5Kj", created_at: 2023-03-05 12:09:37.0637, expires_at: Some(2023-09-23 1:02:03.0), last_used: None }
    │
    ╰─▶ Failed to issue a query: permission denied for table api_keys
        ╰╴at ~/hyperswitch/crates/storage_models/src/query/generics.rs:43:46
    ╰╴at crates/router/src/db/api_keys.rs:49:14
    at crates/router/src/services/api.rs:527
    in router::services::api::server_wrap with request_method: "POST", request_url_path: "/api_keys/merchant_123"
    in router::routes::api_keys::api_key_create with flow: ApiKeyCreate
</pre>
</details>

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
