### PR TITLE
feat: cache reverse lookup fetches on redis

### DIFF
--- a/crates/router/src/db/cache.rs
+++ b/crates/router/src/db/cache.rs
@@ -42,7 +42,6 @@ pub async fn redact_cache<T, F, Fut>(
     fun: F,
 ) -> CustomResult<T, errors::StorageError>
 where
-    T: serde::Serialize + serde::de::DeserializeOwned + std::fmt::Debug,
     F: FnOnce() -> Fut + Send,
     Fut: futures::Future<Output = CustomResult<T, errors::StorageError>> + Send,
 {

--- a/crates/router/src/db/payment_attempt.rs
+++ b/crates/router/src/db/payment_attempt.rs
@@ -535,11 +535,7 @@ mod storage {
                 enums::MerchantStorageScheme::RedisKv => {
                     // [#439]: get the attempt_id from payment_intent
                     let key = format!("{merchant_id}_{payment_id}");
-                    let lookup = self
-                        .get_lookup_by_lookup_id(&key)
-                        .await
-                        .map_err(Into::<errors::StorageError>::into)
-                        .into_report()?;
+                    let lookup = self.get_lookup_by_lookup_id(&key).await?;
 
                     db_utils::try_redis_get_else_try_database_get(
                         self.redis_conn()
@@ -580,11 +576,7 @@ mod storage {
                 enums::MerchantStorageScheme::RedisKv => {
                     // We assume that PaymentAttempt <=> PaymentIntent is a one-to-one relation for now
                     let lookup_id = format!("{merchant_id}_{connector_transaction_id}");
-                    let lookup = self
-                        .get_lookup_by_lookup_id(&lookup_id)
-                        .await
-                        .map_err(Into::<errors::StorageError>::into)
-                        .into_report()?;
+                    let lookup = self.get_lookup_by_lookup_id(&lookup_id).await?;
                     let key = &lookup.pk_id;
 
                     db_utils::try_redis_get_else_try_database_get(
@@ -641,11 +633,7 @@ mod storage {
 
                 enums::MerchantStorageScheme::RedisKv => {
                     let lookup_id = format!("{merchant_id}_{connector_txn_id}");
-                    let lookup = self
-                        .get_lookup_by_lookup_id(&lookup_id)
-                        .await
-                        .map_err(Into::<errors::StorageError>::into)
-                        .into_report()?;
+                    let lookup = self.get_lookup_by_lookup_id(&lookup_id).await?;
 
                     let key = &lookup.pk_id;
                     db_utils::try_redis_get_else_try_database_get(
@@ -677,11 +665,7 @@ mod storage {
 
                 enums::MerchantStorageScheme::RedisKv => {
                     let lookup_id = format!("{merchant_id}_{attempt_id}");
-                    let lookup = self
-                        .get_lookup_by_lookup_id(&lookup_id)
-                        .await
-                        .map_err(Into::<errors::StorageError>::into)
-                        .into_report()?;
+                    let lookup = self.get_lookup_by_lookup_id(&lookup_id).await?;
                     let key = &lookup.pk_id;
                     db_utils::try_redis_get_else_try_database_get(
                         self.redis_conn()

--- a/crates/router/src/db/refund.rs
+++ b/crates/router/src/db/refund.rs
@@ -261,11 +261,7 @@ mod storage {
                 enums::MerchantStorageScheme::PostgresOnly => database_call().await,
                 enums::MerchantStorageScheme::RedisKv => {
                     let lookup_id = format!("{merchant_id}_{internal_reference_id}");
-                    let lookup = self
-                        .get_lookup_by_lookup_id(&lookup_id)
-                        .await
-                        .map_err(Into::<errors::StorageError>::into)
-                        .into_report()?;
+                    let lookup = self.get_lookup_by_lookup_id(&lookup_id).await?;
 
                     let key = &lookup.pk_id;
                     db_utils::try_redis_get_else_try_database_get(
@@ -461,11 +457,7 @@ mod storage {
                     let updated_refund = refund.clone().apply_changeset(this.clone());
                     // Check for database presence as well Maybe use a read replica here ?
 
-                    let lookup = self
-                        .get_lookup_by_lookup_id(&key)
-                        .await
-                        .map_err(Into::<errors::StorageError>::into)
-                        .into_report()?;
+                    let lookup = self.get_lookup_by_lookup_id(&key).await?;
 
                     let field = &lookup.sk_id;
 
@@ -519,11 +511,7 @@ mod storage {
                 enums::MerchantStorageScheme::PostgresOnly => database_call().await,
                 enums::MerchantStorageScheme::RedisKv => {
                     let lookup_id = format!("{merchant_id}_{refund_id}");
-                    let lookup = self
-                        .get_lookup_by_lookup_id(&lookup_id)
-                        .await
-                        .map_err(Into::<errors::StorageError>::into)
-                        .into_report()?;
+                    let lookup = self.get_lookup_by_lookup_id(&lookup_id).await?;
 
                     let key = &lookup.pk_id;
                     db_utils::try_redis_get_else_try_database_get(
@@ -560,11 +548,7 @@ mod storage {
                 enums::MerchantStorageScheme::PostgresOnly => database_call().await,
                 enums::MerchantStorageScheme::RedisKv => {
                     let lookup_id = format!("{merchant_id}_{connector_refund_id}_{connector}");
-                    let lookup = self
-                        .get_lookup_by_lookup_id(&lookup_id)
-                        .await
-                        .map_err(Into::<errors::StorageError>::into)
-                        .into_report()?;
+                    let lookup = self.get_lookup_by_lookup_id(&lookup_id).await?;
 
                     let key = &lookup.pk_id;
                     db_utils::try_redis_get_else_try_database_get(
@@ -609,11 +593,7 @@ mod storage {
                 }
                 enums::MerchantStorageScheme::RedisKv => {
                     let key = format!("{merchant_id}_{payment_id}");
-                    let lookup = self
-                        .get_lookup_by_lookup_id(&key)
-                        .await
-                        .map_err(Into::<errors::StorageError>::into)
-                        .into_report()?;
+                    let lookup = self.get_lookup_by_lookup_id(&key).await?;
 
                     let pattern = db_utils::generate_hscan_pattern_for_refund(&lookup.sk_id);
 

--- a/crates/router/src/db/reverse_lookup.rs
+++ b/crates/router/src/db/reverse_lookup.rs
@@ -1,41 +1,61 @@
-use error_stack::ResultExt;
-use storage_models::{errors, StorageResult};
+use error_stack::IntoReport;
 
-use super::{MockDb, Store};
+use super::{cache, MockDb, Store};
 use crate::{
     connection::pg_connection,
+    errors::{self, CustomResult},
     types::storage::reverse_lookup::{ReverseLookup, ReverseLookupNew},
 };
 
 #[async_trait::async_trait]
 pub trait ReverseLookupInterface {
-    async fn insert_reverse_lookup(&self, _new: ReverseLookupNew) -> StorageResult<ReverseLookup>;
-    async fn get_lookup_by_lookup_id(&self, _id: &str) -> StorageResult<ReverseLookup>;
+    async fn insert_reverse_lookup(
+        &self,
+        _new: ReverseLookupNew,
+    ) -> CustomResult<ReverseLookup, errors::StorageError>;
+    async fn get_lookup_by_lookup_id(
+        &self,
+        _id: &str,
+    ) -> CustomResult<ReverseLookup, errors::StorageError>;
 }
 
 #[async_trait::async_trait]
 impl ReverseLookupInterface for Store {
-    async fn insert_reverse_lookup(&self, new: ReverseLookupNew) -> StorageResult<ReverseLookup> {
-        let conn = pg_connection(&self.master_pool)
-            .await
-            .change_context(errors::DatabaseError::DatabaseConnectionError)?;
-        new.insert(&conn).await
+    async fn insert_reverse_lookup(
+        &self,
+        new: ReverseLookupNew,
+    ) -> CustomResult<ReverseLookup, errors::StorageError> {
+        let conn = pg_connection(&self.master_pool).await?;
+        new.insert(&conn).await.map_err(Into::into).into_report()
     }
 
-    async fn get_lookup_by_lookup_id(&self, id: &str) -> StorageResult<ReverseLookup> {
-        let conn = pg_connection(&self.master_pool)
-            .await
-            .change_context(errors::DatabaseError::DatabaseConnectionError)?;
-        ReverseLookup::find_by_lookup_id(id, &conn).await
+    async fn get_lookup_by_lookup_id(
+        &self,
+        id: &str,
+    ) -> CustomResult<ReverseLookup, errors::StorageError> {
+        let database_call = || async {
+            let conn = pg_connection(&self.master_pool).await?;
+            ReverseLookup::find_by_lookup_id(id, &conn)
+                .await
+                .map_err(Into::into)
+                .into_report()
+        };
+        cache::get_or_populate_cache(self, id, database_call).await
     }
 }
 
 #[async_trait::async_trait]
 impl ReverseLookupInterface for MockDb {
-    async fn insert_reverse_lookup(&self, _new: ReverseLookupNew) -> StorageResult<ReverseLookup> {
-        Err(errors::DatabaseError::NotFound.into())
+    async fn insert_reverse_lookup(
+        &self,
+        _new: ReverseLookupNew,
+    ) -> CustomResult<ReverseLookup, errors::StorageError> {
+        Err(errors::StorageError::MockDbError.into())
     }
-    async fn get_lookup_by_lookup_id(&self, _id: &str) -> StorageResult<ReverseLookup> {
-        Err(errors::DatabaseError::NotFound.into())
+    async fn get_lookup_by_lookup_id(
+        &self,
+        _id: &str,
+    ) -> CustomResult<ReverseLookup, errors::StorageError> {
+        Err(errors::StorageError::MockDbError.into())
     }
 }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->
- [x] Enhancement

## Description
<!-- Describe your changes in detail -->
This adds cached fetches for reverse lookup table.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
Since all the calls to reverse lookup table goes to the DB. Moved the fetch calls to redis cache to reduce the latency.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Manual

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code