### PR TITLE
fix(kms): log KMS SDK errors using the `Debug` impl

### DIFF
--- a/crates/router/src/services/kms.rs
+++ b/crates/router/src/services/kms.rs
@@ -10,7 +10,7 @@ mod aws_kms {
     use error_stack::{report, IntoReport, ResultExt};
 
     use super::*;
-    use crate::consts;
+    use crate::{consts, logger};
 
     impl KeyHandler {
         // Fetching KMS decrypted key
@@ -38,6 +38,10 @@ mod aws_kms {
                 .ciphertext_blob(blob)
                 .send()
                 .await
+                .map_err(|error| {
+                    logger::error!(kms_sdk_error=?error, "Failed to KMS decrypt data");
+                    error
+                })
                 .into_report()
                 .change_context(errors::EncryptionError)
                 .attach_printable("Error decrypting kms encrypted data")?;


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->
This PR fixes a bug with KMS errors not being logged with detailed information as to what exactly failed. 

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
This should ease debugging of errors originating from the AWS KMS SDK.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Manually, deployed a test build on sandbox environment.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
