### PR TITLE
feat(connector): add webhook support for worldline connector

### DIFF
--- a/crates/common_utils/src/ext_traits.rs
+++ b/crates/common_utils/src/ext_traits.rs
@@ -176,17 +176,17 @@ impl<T> BytesExt<T> for bytes::Bytes {
 ///
 /// Extending functionalities of `[u8]` for performing parsing
 ///
-pub trait ByteSliceExt<T> {
+pub trait ByteSliceExt {
     ///
     /// Convert `[u8]` into type `<T>` by using `serde::Deserialize`
     ///
-    fn parse_struct<'de>(&'de self, type_name: &str) -> CustomResult<T, errors::ParsingError>
+    fn parse_struct<'de, T>(&'de self, type_name: &str) -> CustomResult<T, errors::ParsingError>
     where
         T: Deserialize<'de>;
 }
 
-impl<T> ByteSliceExt<T> for [u8] {
-    fn parse_struct<'de>(&'de self, type_name: &str) -> CustomResult<T, errors::ParsingError>
+impl ByteSliceExt for [u8] {
+    fn parse_struct<'de, T>(&'de self, type_name: &str) -> CustomResult<T, errors::ParsingError>
     where
         T: Deserialize<'de>,
     {

--- a/crates/router/src/connector/worldline/transformers.rs
+++ b/crates/router/src/connector/worldline/transformers.rs
@@ -297,6 +297,7 @@ pub enum PaymentStatus {
     CaptureRequested,
     #[default]
     Processing,
+    Created,
 }
 
 impl ForeignFrom<(PaymentStatus, enums::CaptureMethod)> for enums::AttemptStatus {
@@ -316,6 +317,7 @@ impl ForeignFrom<(PaymentStatus, enums::CaptureMethod)> for enums::AttemptStatus
                 }
             }
             PaymentStatus::PendingApproval => Self::Authorized,
+            PaymentStatus::Created => Self::Started,
             _ => Self::Pending,
         }
     }
@@ -326,8 +328,8 @@ impl ForeignFrom<(PaymentStatus, enums::CaptureMethod)> for enums::AttemptStatus
 /// To keep this try_from logic generic in case of AUTHORIZE, SYNC and CAPTURE flows capture_method will be set from RouterData request.
 #[derive(Default, Debug, Clone, Deserialize, PartialEq)]
 pub struct Payment {
-    id: String,
-    status: PaymentStatus,
+    pub id: String,
+    pub status: PaymentStatus,
     #[serde(skip_deserializing)]
     pub capture_method: enums::CaptureMethod,
 }
@@ -485,4 +487,29 @@ pub struct Error {
 pub struct ErrorResponse {
     pub error_id: Option<String>,
     pub errors: Vec<Error>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WebhookBody {
+    pub api_version: String,
+    pub id: String,
+    pub created: String,
+    pub merchant_id: String,
+    #[serde(rename = "type")]
+    pub event_type: WebhookEvent,
+    pub payment: Option<serde_json::Value>,
+    pub refund: Option<serde_json::Value>,
+    pub payout: Option<serde_json::Value>,
+    pub token: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Deserialize)]
+pub enum WebhookEvent {
+    #[serde(rename = "payment.rejected")]
+    Rejected,
+    #[serde(rename = "payment.rejected_capture")]
+    RejectedCapture,
+    #[serde(rename = "payment.paid")]
+    Paid,
 }

--- a/crates/router/src/connector/worldline/transformers.rs
+++ b/crates/router/src/connector/worldline/transformers.rs
@@ -493,7 +493,7 @@ pub struct ErrorResponse {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct WebhookBody {
-    pub api_version: String,
+    pub api_version: Option<String>,
     pub id: String,
     pub created: String,
     pub merchant_id: String,

--- a/crates/router/src/connector/worldline/transformers.rs
+++ b/crates/router/src/connector/worldline/transformers.rs
@@ -308,7 +308,8 @@ impl ForeignFrom<(PaymentStatus, enums::CaptureMethod)> for enums::AttemptStatus
             | PaymentStatus::Paid
             | PaymentStatus::ChargebackNotification => Self::Charged,
             PaymentStatus::Cancelled => Self::Voided,
-            PaymentStatus::Rejected | PaymentStatus::RejectedCapture => Self::Failure,
+            PaymentStatus::Rejected => Self::Failure,
+            PaymentStatus::RejectedCapture => Self::CaptureFailed,
             PaymentStatus::CaptureRequested => {
                 if capture_method == enums::CaptureMethod::Automatic {
                     Self::Pending

--- a/crates/router/src/core/errors.rs
+++ b/crates/router/src/core/errors.rs
@@ -281,6 +281,8 @@ pub enum ConnectorError {
     WebhookEventTypeNotFound,
     #[error("Incoming webhook event resource object not found")]
     WebhookResourceObjectNotFound,
+    #[error("Could not respond to the incoming webhook event")]
+    WebhookResponseEncodingFailed,
     #[error("Invalid Date/time format")]
     InvalidDateFormat,
     #[error("Invalid Data format")]

--- a/crates/router/src/core/webhooks.rs
+++ b/crates/router/src/core/webhooks.rs
@@ -298,16 +298,6 @@ pub async fn webhooks_core<W: api::OutgoingWebhookType>(
         body: &body,
     };
 
-    let source_verified = connector
-        .verify_webhook_source(
-            &*state.store,
-            &request_details,
-            &merchant_account.merchant_id,
-        )
-        .await
-        .change_context(errors::ApiErrorResponse::InternalServerError)
-        .attach_printable("There was an issue in incoming webhook source verification")?;
-
     let decoded_body = connector
         .decode_webhook_body(
             &*state.store,
@@ -325,63 +315,78 @@ pub async fn webhooks_core<W: api::OutgoingWebhookType>(
         .change_context(errors::ApiErrorResponse::InternalServerError)
         .attach_printable("Could not find event type in incoming webhook body")?;
 
-    let process_webhook_further = utils::lookup_webhook_event(
-        &*state.store,
-        connector_name,
-        &merchant_account.merchant_id,
-        &event_type,
-    )
-    .await;
-
-    if process_webhook_further {
-        let object_ref_id = connector
-            .get_webhook_object_reference_id(&request_details)
+    if !matches!(
+        event_type,
+        api_models::webhooks::IncomingWebhookEvent::EndpointVerification
+    ) {
+        let source_verified = connector
+            .verify_webhook_source(
+                &*state.store,
+                &request_details,
+                &merchant_account.merchant_id,
+            )
+            .await
             .change_context(errors::ApiErrorResponse::InternalServerError)
-            .attach_printable("Could not find object reference id in incoming webhook body")?;
+            .attach_printable("There was an issue in incoming webhook source verification")?;
 
-        let event_object = connector
-            .get_webhook_resource_object(&request_details)
-            .change_context(errors::ApiErrorResponse::InternalServerError)
-            .attach_printable("Could not find resource object in incoming webhook body")?;
+        let process_webhook_further = utils::lookup_webhook_event(
+            &*state.store,
+            connector_name,
+            &merchant_account.merchant_id,
+            &event_type,
+        )
+        .await;
 
-        let webhook_details = api::IncomingWebhookDetails {
-            object_reference_id: object_ref_id,
-            resource_object: Encode::<serde_json::Value>::encode_to_vec(&event_object)
+        if process_webhook_further {
+            let object_ref_id = connector
+                .get_webhook_object_reference_id(&request_details)
                 .change_context(errors::ApiErrorResponse::InternalServerError)
-                .attach_printable(
-                    "There was an issue when encoding the incoming webhook body to bytes",
-                )?,
-        };
+                .attach_printable("Could not find object reference id in incoming webhook body")?;
 
-        let flow_type: api::WebhookFlow = event_type.to_owned().into();
-        match flow_type {
-            api::WebhookFlow::Payment => payments_incoming_webhook_flow::<W>(
-                state.clone(),
-                merchant_account,
-                webhook_details,
-                source_verified,
-            )
-            .await
-            .change_context(errors::ApiErrorResponse::InternalServerError)
-            .attach_printable("Incoming webhook flow for payments failed")?,
+            let event_object = connector
+                .get_webhook_resource_object(&request_details)
+                .change_context(errors::ApiErrorResponse::InternalServerError)
+                .attach_printable("Could not find resource object in incoming webhook body")?;
 
-            api::WebhookFlow::Refund => refunds_incoming_webhook_flow::<W>(
-                state.clone(),
-                merchant_account,
-                webhook_details,
-                connector_name,
-                source_verified,
-                event_type,
-            )
-            .await
-            .change_context(errors::ApiErrorResponse::InternalServerError)
-            .attach_printable("Incoming webhook flow for refunds failed")?,
+            let webhook_details = api::IncomingWebhookDetails {
+                object_reference_id: object_ref_id,
+                resource_object: Encode::<serde_json::Value>::encode_to_vec(&event_object)
+                    .change_context(errors::ApiErrorResponse::InternalServerError)
+                    .attach_printable(
+                        "There was an issue when encoding the incoming webhook body to bytes",
+                    )?,
+            };
 
-            api::WebhookFlow::ReturnResponse => {}
+            let flow_type: api::WebhookFlow = event_type.to_owned().into();
+            match flow_type {
+                api::WebhookFlow::Payment => payments_incoming_webhook_flow::<W>(
+                    state.clone(),
+                    merchant_account,
+                    webhook_details,
+                    source_verified,
+                )
+                .await
+                .change_context(errors::ApiErrorResponse::InternalServerError)
+                .attach_printable("Incoming webhook flow for payments failed")?,
 
-            _ => Err(errors::ApiErrorResponse::InternalServerError)
-                .into_report()
-                .attach_printable("Unsupported Flow Type received in incoming webhooks")?,
+                api::WebhookFlow::Refund => refunds_incoming_webhook_flow::<W>(
+                    state.clone(),
+                    merchant_account,
+                    webhook_details,
+                    connector_name,
+                    source_verified,
+                    event_type,
+                )
+                .await
+                .change_context(errors::ApiErrorResponse::InternalServerError)
+                .attach_printable("Incoming webhook flow for refunds failed")?,
+
+                api::WebhookFlow::ReturnResponse => {}
+
+                _ => Err(errors::ApiErrorResponse::InternalServerError)
+                    .into_report()
+                    .attach_printable("Unsupported Flow Type received in incoming webhooks")?,
+            }
         }
     }
 

--- a/crates/router/src/core/webhooks/utils.rs
+++ b/crates/router/src/core/webhooks/utils.rs
@@ -4,7 +4,10 @@ use crate::{
 };
 
 fn default_webhook_config() -> api::MerchantWebhookConfig {
-    std::collections::HashSet::from([api::IncomingWebhookEvent::PaymentIntentSuccess])
+    std::collections::HashSet::from([
+        api::IncomingWebhookEvent::PaymentIntentSuccess,
+        api::IncomingWebhookEvent::EndpointVerification,
+    ])
 }
 
 pub async fn lookup_webhook_event(

--- a/crates/router/src/core/webhooks/utils.rs
+++ b/crates/router/src/core/webhooks/utils.rs
@@ -4,10 +4,7 @@ use crate::{
 };
 
 fn default_webhook_config() -> api::MerchantWebhookConfig {
-    std::collections::HashSet::from([
-        api::IncomingWebhookEvent::PaymentIntentSuccess,
-        api::IncomingWebhookEvent::EndpointVerification,
-    ])
+    std::collections::HashSet::from([api::IncomingWebhookEvent::PaymentIntentSuccess])
 }
 
 pub async fn lookup_webhook_event(


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
Webhook integration for Worldline connector


### Additional Changes

- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!-- 
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
Webhook integration for Worldline connector


## How did you test it?
Manual testing


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
