### PR TITLE
ci(release): specify `fetch-depth` for code checkout and use official Docker GitHub actions

### DIFF
--- a/.github/workflows/auto-release-tag.yml
+++ b/.github/workflows/auto-release-tag.yml
@@ -11,6 +11,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Build router Docker image
         run: docker build . --file Dockerfile --tag juspaydotin/orca:${{ github.ref_name }} --build-arg BINARY=router
@@ -24,7 +26,7 @@ jobs:
       - name: Build drainer Docker image
         run: docker build . --file Dockerfile --tag juspaydotin/orca:drainer-${{ github.ref_name }} --build-arg BINARY=drainer
 
-      - name: Docker Login      
+      - name: Docker Login
         env:
           DOCKER_USER: ${{secrets.DOCKERHUB_USER}}
           DOCKER_TOKEN: ${{secrets.DOCKERHUB_PASSWD}}

--- a/.github/workflows/auto-release-tag.yml
+++ b/.github/workflows/auto-release-tag.yml
@@ -14,32 +14,46 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Build router Docker image
-        run: docker build . --file Dockerfile --tag juspaydotin/orca:${{ github.ref_name }} --build-arg BINARY=router
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKERHUB_PASSWD }}
 
-      - name: Build consumer Docker image
-        run: docker build . --file Dockerfile --tag juspaydotin/orca-consumer:${{ github.ref_name }} --build-arg BINARY=scheduler --build-arg SCHEDULER_FLOW=Consumer
+      - name: Build and push router Docker image
+        uses: docker/build-push-action@v4
+        with:
+          build-args: |
+            BINARY=router
+          context: .
+          push: true
+          tags: juspaydotin/orca:${{ github.ref_name }}
 
-      - name: Build producer Docker image
-        run: docker build . --file Dockerfile --tag juspaydotin/orca-producer:${{ github.ref_name }} --build-arg BINARY=scheduler --build-arg SCHEDULER_FLOW=Producer
+      - name: Build and push consumer Docker image
+        uses: docker/build-push-action@v4
+        with:
+          build-args: |
+            BINARY=scheduler
+            SCHEDULER_FLOW=Consumer
+          context: .
+          push: true
+          tags: juspaydotin/orca-consumer:${{ github.ref_name }}
 
-      - name: Build drainer Docker image
-        run: docker build . --file Dockerfile --tag juspaydotin/orca:drainer-${{ github.ref_name }} --build-arg BINARY=drainer
+      - name: Build and push producer Docker image
+        uses: docker/build-push-action@v4
+        with:
+          build-args: |
+            BINARY=scheduler
+            SCHEDULER_FLOW=Producer
+          context: .
+          push: true
+          tags: juspaydotin/orca-producer:${{ github.ref_name }}
 
-      - name: Docker Login
-        env:
-          DOCKER_USER: ${{secrets.DOCKERHUB_USER}}
-          DOCKER_TOKEN: ${{secrets.DOCKERHUB_PASSWD}}
-        run: docker login -u $DOCKER_USER -p $DOCKER_TOKEN
-
-      - name: Push router Docker image
-        run: docker push juspaydotin/orca:${{ github.ref_name }}
-
-      - name: Push consumer Docker image
-        run: docker push juspaydotin/orca-consumer:${{ github.ref_name }}
-
-      - name: Push producer Docker image
-        run: docker push juspaydotin/orca-producer:${{ github.ref_name }}
-
-      - name: Push drainer Docker image
-        run: docker push juspaydotin/orca:drainer-${{ github.ref_name }}
+      - name: Build and push drainer Docker image
+        uses: docker/build-push-action@v4
+        with:
+          build-args: |
+            BINARY=drainer
+          context: .
+          push: true
+          tags: juspaydotin/orca:drainer-${{ github.ref_name }}

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -11,32 +11,46 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Build router Docker image
-        run: docker build . --file Dockerfile --tag juspaydotin/orca:${{ github.sha }} --build-arg BINARY=router
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKERHUB_PASSWD }}
 
-      - name: Build consumer Docker image
-        run: docker build . --file Dockerfile --tag juspaydotin/orca-consumer:${{ github.sha }} --build-arg BINARY=scheduler --build-arg SCHEDULER_FLOW=Consumer
+      - name: Build and push router Docker image
+        uses: docker/build-push-action@v4
+        with:
+          build-args: |
+            BINARY=router
+          context: .
+          push: true
+          tags: juspaydotin/orca:${{ github.sha }}
 
-      - name: Build producer Docker image
-        run: docker build . --file Dockerfile --tag juspaydotin/orca-producer:${{ github.sha }} --build-arg BINARY=scheduler --build-arg SCHEDULER_FLOW=Producer
+      - name: Build and push consumer Docker image
+        uses: docker/build-push-action@v4
+        with:
+          build-args: |
+            BINARY=scheduler
+            SCHEDULER_FLOW=Consumer
+          context: .
+          push: true
+          tags: juspaydotin/orca-consumer:${{ github.sha }}
 
-      - name: Build drainer Docker image
-        run: docker build . --file Dockerfile --tag juspaydotin/orca:drainer-${{ github.sha }} --build-arg BINARY=drainer
+      - name: Build and push producer Docker image
+        uses: docker/build-push-action@v4
+        with:
+          build-args: |
+            BINARY=scheduler
+            SCHEDULER_FLOW=Producer
+          context: .
+          push: true
+          tags: juspaydotin/orca-producer:${{ github.sha }}
 
-      - name: Docker Login
-        env:
-          DOCKER_USER: ${{secrets.DOCKERHUB_USER}}
-          DOCKER_TOKEN: ${{secrets.DOCKERHUB_PASSWD}}
-        run: docker login -u $DOCKER_USER -p $DOCKER_TOKEN
-
-      - name: Push router Docker image
-        run: docker push juspaydotin/orca:${{ github.sha }}
-
-      - name: Push consumer Docker image
-        run: docker push juspaydotin/orca-consumer:${{ github.sha }}
-
-      - name: Push producer Docker image
-        run: docker push juspaydotin/orca-producer:${{ github.sha }}
-
-      - name: Push drainer Docker image
-        run: docker push juspaydotin/orca:drainer-${{ github.sha }}
+      - name: Build and push drainer Docker image
+        uses: docker/build-push-action@v4
+        with:
+          build-args: |
+            BINARY=drainer
+          context: .
+          push: true
+          tags: juspaydotin/orca:drainer-${{ github.sha }}

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -1,7 +1,6 @@
 name: Release branch manually
 
-on:
-  workflow_dispatch
+on: workflow_dispatch
 
 jobs:
   build:
@@ -9,6 +8,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Build router Docker image
         run: docker build . --file Dockerfile --tag juspaydotin/orca:${{ github.sha }} --build-arg BINARY=router
@@ -22,7 +23,7 @@ jobs:
       - name: Build drainer Docker image
         run: docker build . --file Dockerfile --tag juspaydotin/orca:drainer-${{ github.sha }} --build-arg BINARY=drainer
 
-      - name: Docker Login      
+      - name: Docker Login
         env:
           DOCKER_USER: ${{secrets.DOCKERHUB_USER}}
           DOCKER_TOKEN: ${{secrets.DOCKERHUB_PASSWD}}


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->
This PR fixes an issue with release builds not having the correct values for `VERGEN_GIT_*` environment variables. The fix is to clone the complete git history instead of just the latest commit. Additionally, this also updates the release workflows to use the official Docker GitHub actions for building and pushing Docker images.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
This should help us better identify the exact builds running in sandbox and production environments.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Created a manual build, found no `VERGEN_*` related warnings.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
