### PR TITLE
feat: Add HSTS headers to response

### DIFF
--- a/crates/api_models/src/errors/actix.rs
+++ b/crates/api_models/src/errors/actix.rs
@@ -25,6 +25,7 @@ impl actix_web::ResponseError for ApiErrorResponse {
 
         actix_web::HttpResponseBuilder::new(self.status_code())
             .insert_header((header::CONTENT_TYPE, mime::APPLICATION_JSON))
+            .insert_header((header::STRICT_TRANSPORT_SECURITY, "max-age=31536000"))
             .insert_header((header::VIA, "Juspay_Router"))
             .body(self.to_string())
     }

--- a/crates/router/src/compatibility/stripe/errors.rs
+++ b/crates/router/src/compatibility/stripe/errors.rs
@@ -518,8 +518,11 @@ impl actix_web::ResponseError for StripeErrorCode {
     fn error_response(&self) -> actix_web::HttpResponse {
         use actix_web::http::header;
 
+        use crate::consts;
+
         actix_web::HttpResponseBuilder::new(self.status_code())
             .insert_header((header::CONTENT_TYPE, mime::APPLICATION_JSON))
+            .insert_header((header::STRICT_TRANSPORT_SECURITY, consts::HSTS_HEADER_VALUE))
             .insert_header((header::VIA, "Juspay_Router"))
             .body(self.to_string())
     }

--- a/crates/router/src/consts.rs
+++ b/crates/router/src/consts.rs
@@ -24,3 +24,6 @@ pub(crate) const BASE64_ENGINE_URL_SAFE: base64::engine::GeneralPurpose =
 
 pub(crate) const API_KEY_LENGTH: usize = 64;
 pub(crate) const PUB_SUB_CHANNEL: &str = "hyperswitch_invalidate";
+
+/// Max age of 1 year in seconds. Which is `60*60*24*365`
+pub(crate) const HSTS_HEADER_VALUE: &str = "max-age=31536000";

--- a/crates/router/src/core/errors.rs
+++ b/crates/router/src/core/errors.rs
@@ -16,7 +16,7 @@ pub use self::{
     api_error_response::ApiErrorResponse,
     utils::{ConnectorErrorExt, StorageErrorExt},
 };
-use crate::services;
+use crate::{headers, services};
 pub type RouterResult<T> = CustomResult<T, ApiErrorResponse>;
 pub type RouterResponse<T> = CustomResult<services::ApplicationResponse<T>, ApiErrorResponse>;
 
@@ -154,7 +154,8 @@ impl From<ConfigError> for ApplicationError {
 
 fn error_response<T: Display>(err: &T) -> actix_web::HttpResponse {
     actix_web::HttpResponse::BadRequest()
-        .append_header(("Via", "Juspay_Router"))
+        .append_header((headers::HSTS, 31536000))
+        .append_header((headers::VIA, "Juspay_Router"))
         .content_type("application/json")
         .body(format!(r#"{{ "error": {{ "message": "{err}" }} }}"#))
 }

--- a/crates/router/src/core/errors.rs
+++ b/crates/router/src/core/errors.rs
@@ -16,7 +16,7 @@ pub use self::{
     api_error_response::ApiErrorResponse,
     utils::{ConnectorErrorExt, StorageErrorExt},
 };
-use crate::{headers, services};
+use crate::services;
 pub type RouterResult<T> = CustomResult<T, ApiErrorResponse>;
 pub type RouterResponse<T> = CustomResult<services::ApplicationResponse<T>, ApiErrorResponse>;
 
@@ -153,9 +153,13 @@ impl From<ConfigError> for ApplicationError {
 }
 
 fn error_response<T: Display>(err: &T) -> actix_web::HttpResponse {
+    use actix_web::http::header;
+
+    use crate::consts;
+
     actix_web::HttpResponse::BadRequest()
-        .append_header((headers::HSTS, 31536000))
-        .append_header((headers::VIA, "Juspay_Router"))
+        .append_header((header::STRICT_TRANSPORT_SECURITY, consts::HSTS_HEADER_VALUE))
+        .append_header((header::VIA, "Juspay_Router"))
         .content_type("application/json")
         .body(format!(r#"{{ "error": {{ "message": "{err}" }} }}"#))
 }

--- a/crates/router/src/core/errors/api_error_response.rs
+++ b/crates/router/src/core/errors/api_error_response.rs
@@ -253,8 +253,11 @@ impl actix_web::ResponseError for ApiErrorResponse {
     fn error_response(&self) -> actix_web::HttpResponse {
         use actix_web::http::header;
 
+        use crate::consts;
+
         actix_web::HttpResponseBuilder::new(self.status_code())
             .insert_header((header::CONTENT_TYPE, mime::APPLICATION_JSON))
+            .insert_header((header::STRICT_TRANSPORT_SECURITY, consts::HSTS_HEADER_VALUE))
             .insert_header((header::VIA, "Juspay_Router"))
             .body(self.to_string())
     }

--- a/crates/router/src/lib.rs
+++ b/crates/router/src/lib.rs
@@ -54,6 +54,8 @@ pub mod headers {
     pub const X_TRANS_KEY: &str = "X-Trans-Key";
     pub const X_VERSION: &str = "X-Version";
     pub const X_DATE: &str = "X-Date";
+    pub const HSTS: &str = "Strict-Transport-Security";
+    pub const VIA: &str = "Via";
 }
 
 pub mod pii {

--- a/crates/router/src/lib.rs
+++ b/crates/router/src/lib.rs
@@ -54,8 +54,6 @@ pub mod headers {
     pub const X_TRANS_KEY: &str = "X-Trans-Key";
     pub const X_VERSION: &str = "X-Version";
     pub const X_DATE: &str = "X-Date";
-    pub const HSTS: &str = "Strict-Transport-Security";
-    pub const VIA: &str = "Via";
 }
 
 pub mod pii {

--- a/crates/router/src/services/api.rs
+++ b/crates/router/src/services/api.rs
@@ -25,15 +25,10 @@ use crate::{
         payments,
     },
     db::StorageInterface,
-    logger,
+    headers, logger,
     routes::{app::AppStateInfo, AppState},
     services::authentication as auth,
-    types::{
-        self,
-        api::{self},
-        storage::{self},
-        ErrorResponse,
-    },
+    types::{self, api, storage, ErrorResponse},
 };
 
 pub type BoxedConnectorIntegration<'a, T, Req, Resp> =
@@ -542,19 +537,24 @@ pub async fn authenticate_by_api_key(
 pub fn http_response_json<T: body::MessageBody + 'static>(response: T) -> HttpResponse {
     HttpResponse::Ok()
         .content_type("application/json")
-        .append_header(("Via", "Juspay_router"))
+        .append_header((headers::VIA, "Juspay_router"))
+        .append_header((headers::HSTS, 31536000))
         .body(response)
 }
 
 pub fn http_response_plaintext<T: body::MessageBody + 'static>(res: T) -> HttpResponse {
     HttpResponse::Ok()
         .content_type("text/plain")
-        .append_header(("Via", "Juspay_router"))
+        .append_header((headers::VIA, "Juspay_router"))
+        .append_header((headers::HSTS, 31536000))
         .body(res)
 }
 
 pub fn http_response_ok() -> HttpResponse {
-    HttpResponse::Ok().finish()
+    HttpResponse::Ok()
+        .append_header((headers::VIA, "Juspay_router"))
+        .append_header((headers::HSTS, 31536000))
+        .finish()
 }
 
 pub fn http_redirect_response<T: body::MessageBody + 'static>(
@@ -563,11 +563,12 @@ pub fn http_redirect_response<T: body::MessageBody + 'static>(
 ) -> HttpResponse {
     HttpResponse::Ok()
         .content_type("application/json")
-        .append_header(("Via", "Juspay_router"))
+        .append_header((headers::VIA, "Juspay_router"))
         .append_header((
             "Location",
             redirection_response.return_url_with_query_params,
         ))
+        .append_header((headers::HSTS, 31536000))
         .status(http::StatusCode::FOUND)
         .body(response)
 }
@@ -575,7 +576,8 @@ pub fn http_redirect_response<T: body::MessageBody + 'static>(
 pub fn http_response_err<T: body::MessageBody + 'static>(response: T) -> HttpResponse {
     HttpResponse::BadRequest()
         .content_type("application/json")
-        .append_header(("Via", "Juspay_router"))
+        .append_header((headers::VIA, "Juspay_router"))
+        .append_header((headers::HSTS, 31536000))
         .body(response)
 }
 

--- a/crates/router/src/services/api.rs
+++ b/crates/router/src/services/api.rs
@@ -9,7 +9,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use actix_web::{body, HttpRequest, HttpResponse, Responder};
+use actix_web::{body, http::header, HttpRequest, HttpResponse, Responder};
 use common_utils::errors::ReportSwitchExt;
 use error_stack::{report, IntoReport, Report, ResultExt};
 use masking::ExposeOptionInterface;
@@ -20,12 +20,13 @@ use self::request::{ContentType, HeaderExt, RequestBuilderExt};
 pub use self::request::{Method, Request, RequestBuilder};
 use crate::{
     configs::settings::Connectors,
+    consts,
     core::{
         errors::{self, CustomResult, RouterResult},
         payments,
     },
     db::StorageInterface,
-    headers, logger,
+    logger,
     routes::{app::AppStateInfo, AppState},
     services::authentication as auth,
     types::{self, api, storage, ErrorResponse},
@@ -537,23 +538,23 @@ pub async fn authenticate_by_api_key(
 pub fn http_response_json<T: body::MessageBody + 'static>(response: T) -> HttpResponse {
     HttpResponse::Ok()
         .content_type("application/json")
-        .append_header((headers::VIA, "Juspay_router"))
-        .append_header((headers::HSTS, 31536000))
+        .append_header((header::VIA, "Juspay_router"))
+        .append_header((header::STRICT_TRANSPORT_SECURITY, consts::HSTS_HEADER_VALUE))
         .body(response)
 }
 
 pub fn http_response_plaintext<T: body::MessageBody + 'static>(res: T) -> HttpResponse {
     HttpResponse::Ok()
         .content_type("text/plain")
-        .append_header((headers::VIA, "Juspay_router"))
-        .append_header((headers::HSTS, 31536000))
+        .append_header((header::VIA, "Juspay_router"))
+        .append_header((header::STRICT_TRANSPORT_SECURITY, consts::HSTS_HEADER_VALUE))
         .body(res)
 }
 
 pub fn http_response_ok() -> HttpResponse {
     HttpResponse::Ok()
-        .append_header((headers::VIA, "Juspay_router"))
-        .append_header((headers::HSTS, 31536000))
+        .append_header((header::VIA, "Juspay_router"))
+        .append_header((header::STRICT_TRANSPORT_SECURITY, consts::HSTS_HEADER_VALUE))
         .finish()
 }
 
@@ -563,12 +564,12 @@ pub fn http_redirect_response<T: body::MessageBody + 'static>(
 ) -> HttpResponse {
     HttpResponse::Ok()
         .content_type("application/json")
-        .append_header((headers::VIA, "Juspay_router"))
+        .append_header((header::VIA, "Juspay_router"))
         .append_header((
             "Location",
             redirection_response.return_url_with_query_params,
         ))
-        .append_header((headers::HSTS, 31536000))
+        .append_header((header::STRICT_TRANSPORT_SECURITY, consts::HSTS_HEADER_VALUE))
         .status(http::StatusCode::FOUND)
         .body(response)
 }
@@ -576,8 +577,8 @@ pub fn http_redirect_response<T: body::MessageBody + 'static>(
 pub fn http_response_err<T: body::MessageBody + 'static>(response: T) -> HttpResponse {
     HttpResponse::BadRequest()
         .content_type("application/json")
-        .append_header((headers::VIA, "Juspay_router"))
-        .append_header((headers::HSTS, 31536000))
+        .append_header((header::VIA, "Juspay_router"))
+        .append_header((header::STRICT_TRANSPORT_SECURITY, consts::HSTS_HEADER_VALUE))
         .body(response)
 }
 

--- a/crates/router/src/utils.rs
+++ b/crates/router/src/utils.rs
@@ -57,8 +57,11 @@ pub mod error_parser {
         fn error_response(&self) -> actix_web::HttpResponse<actix_web::body::BoxBody> {
             use actix_web::http::header;
 
+            use crate::consts;
+
             actix_web::HttpResponseBuilder::new(StatusCode::BAD_REQUEST)
                 .insert_header((header::CONTENT_TYPE, mime::APPLICATION_JSON))
+                .insert_header((header::STRICT_TRANSPORT_SECURITY, consts::HSTS_HEADER_VALUE))
                 .insert_header((header::VIA, "Juspay_Router"))
                 .body(self.to_string())
         }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->
- [x] Enhancement

## Description
<!-- Describe your changes in detail -->
Added HSTS header for responses.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
This header informs browsers that the site should only be accessed using HTTPS.
For reference: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
<img width="1349" alt="image" src="https://user-images.githubusercontent.com/43412619/224010842-f619bbb0-3a5c-4d8d-b36b-9cdf3e60df4e.png">


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code