### PR TITLE
chore: address Rust 1.68 clippy lints

### DIFF
--- a/crates/router/src/scheduler/utils.rs
+++ b/crates/router/src/scheduler/utils.rs
@@ -345,13 +345,14 @@ where
     let lock_val = "LOCKED";
     let ttl = settings.producer.lock_ttl;
 
-    let result = if state
+    if state
         .store
         .acquire_pt_lock(tag, lock_key, lock_val, ttl)
         .await
         .change_context(errors::ProcessTrackerError::ERedisError(
             errors::RedisError::RedisConnectionError.into(),
-        ))? {
+        ))?
+    {
         let result = callback().await;
         state
             .store
@@ -361,8 +362,7 @@ where
         result
     } else {
         Ok(())
-    };
-    result
+    }
 }
 
 pub(crate) async fn signal_handler(


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->
This PR addresses a clippy lint stabilized in Rust 1.68.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
N/A

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
N/A

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
