### PR TITLE
refactor(client): remove dependence on `ROUTER_HTTP_PROXY` and `ROUTER_HTTPS_PROXY` env vars

### DIFF
--- a/crates/router/src/services/api/client.rs
+++ b/crates/router/src/services/api/client.rs
@@ -8,9 +8,6 @@ use crate::{
     core::errors::{self, CustomResult},
 };
 
-const HTTP_PROXY: &str = "ROUTER_HTTP_PROXY";
-const HTTPS_PROXY: &str = "ROUTER_HTTPS_PROXY";
-
 static PLAIN_CLIENT: OnceCell<reqwest::Client> = OnceCell::new();
 static HTTPS_PROXY_CLIENT: OnceCell<reqwest::Client> = OnceCell::new();
 static HTTP_PROXY_CLIENT: OnceCell<reqwest::Client> = OnceCell::new();
@@ -22,15 +19,9 @@ enum ProxyType {
 
 impl ProxyType {
     fn get_proxy_url(&self, proxy: &Proxy) -> Option<String> {
-        use std::env::var;
-
         match self {
-            Self::Http => var(HTTP_PROXY)
-                .or_else(|_| proxy.http_url.clone().ok_or(()))
-                .ok(),
-            Self::Https => var(HTTPS_PROXY)
-                .or_else(|_| proxy.https_url.clone().ok_or(()))
-                .ok(),
+            Self::Http => proxy.http_url.clone(),
+            Self::Https => proxy.https_url.clone(),
         }
     }
 }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->
This PR removes the dependence on `ROUTER_HTTP_PROXY` and `ROUTER_HTTPS_PROXY` environment variables, as having multiple ways to set a proxy makes it harder to inspect if requests are being proxied or not. The recommended way to set proxy will be to set `ROUTER__PROXY__HTTP_URL` and `ROUTER__PROXY__HTTPS_URL` instead, respectively.

### Additional Changes

- [ ] This PR modifies the database schema
- [x] This PR modifies application configuration/environment variables

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
Better debugging of HTTP client behavior.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Manually.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
