### PR TITLE
enhance(core): replace string with enum for country

### DIFF
--- a/crates/api_models/src/enums.rs
+++ b/crates/api_models/src/enums.rs
@@ -248,6 +248,31 @@ pub enum Currency {
     ZAR,
 }
 
+#[allow(clippy::upper_case_acronyms)]
+#[derive(
+    Clone,
+    Debug,
+    Eq,
+    Default,
+    Hash,
+    PartialEq,
+    serde::Deserialize,
+    serde::Serialize,
+    strum::Display,
+    strum::EnumString,
+    frunk::LabelledGeneric,
+)]
+#[rustfmt::skip]
+pub enum Country {
+    AL,DZ,AS,AO,AG,AR,AU,AT,AZ,BH,BY,BE,BR,BG,CA,CL,CO,HR,CZ,DK,DO,EG,
+    EE,FI,FR,DE,GR,HK,HU,IN,ID,IE,IL,IT,JP,JO,KZ,KE,KW,LV,LB,LT,LU,MY,
+    MX,NL,NZ,NO,OM,PK,PA,PE,PH,PL,PT,QA,RO,RU,SA,SG,SK,ZA,ES,LK,SE,CH,
+    TW,TH,TR,UA,AE,GB,UY,VN,CN,MO,AM,CY,FO,GE,GL,GG,IS,IM,JE,LI,MT,
+    MD,MC,ME,SM,RS,SI,CR,PS,UM,
+    #[default]
+    US
+}
+
 #[derive(
     Clone,
     Copy,

--- a/crates/api_models/src/payments.rs
+++ b/crates/api_models/src/payments.rs
@@ -495,7 +495,7 @@ pub enum BankRedirectData {
     Sofort {
         /// The country for bank payment
         #[schema(example = "US")]
-        country: String,
+        country: api_enums::Country,
 
         /// The preferred language
         #[schema(example = "en")]
@@ -677,7 +677,7 @@ pub struct AddressDetails {
 
     /// The two-letter ISO country code for the address
     #[schema(max_length = 2, min_length = 2, example = "US")]
-    pub country: Option<String>,
+    pub country: Option<api_enums::Country>,
 
     /// The first line of the address
     #[schema(value_type = Option<String>, max_length = 200, example = "123, King Street")]
@@ -1237,7 +1237,7 @@ pub struct GpayAllowedPaymentMethods {
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, ToSchema)]
 pub struct GpayTransactionInfo {
     /// The country code
-    pub country_code: String,
+    pub country_code: api_enums::Country,
     /// The currency code
     pub currency_code: String,
     /// The total price status (ex: 'FINAL')
@@ -1343,7 +1343,7 @@ pub struct ApplePaySessionResponse {
 #[derive(Debug, Clone, serde::Serialize, ToSchema, serde::Deserialize)]
 pub struct ApplePayPaymentRequest {
     /// The code for country
-    pub country_code: String,
+    pub country_code: api_enums::Country,
     /// The code for currency
     pub currency_code: String,
     /// Represents the total for the payment.

--- a/crates/router/src/compatibility/stripe/payment_intents/types.rs
+++ b/crates/router/src/compatibility/stripe/payment_intents/types.rs
@@ -25,7 +25,9 @@ impl From<StripeBillingDetails> for payments::Address {
         Self {
             phone: Some(payments::PhoneDetails {
                 number: details.phone,
-                country_code: details.address.as_ref().and_then(|a| a.country.clone()),
+                country_code: details.address.as_ref().and_then(|address| {
+                    address.country.as_ref().map(|country| country.to_string())
+                }),
             }),
 
             address: details.address,
@@ -107,7 +109,9 @@ impl From<Shipping> for payments::Address {
         Self {
             phone: Some(payments::PhoneDetails {
                 number: details.phone,
-                country_code: details.address.as_ref().and_then(|a| a.country.clone()),
+                country_code: details.address.as_ref().and_then(|address| {
+                    address.country.as_ref().map(|country| country.to_string())
+                }),
             }),
             address: details.address,
         }

--- a/crates/router/src/connector/adyen/transformers.rs
+++ b/crates/router/src/connector/adyen/transformers.rs
@@ -58,7 +58,7 @@ pub struct ShopperName {
 #[serde(rename_all = "camelCase")]
 pub struct Address {
     city: Option<String>,
-    country: Option<String>,
+    country: Option<api_enums::Country>,
     house_number_or_name: Option<Secret<String>>,
     postal_code: Option<Secret<String>>,
     state_or_province: Option<Secret<String>>,
@@ -95,7 +95,7 @@ pub struct AdyenPaymentRequest<'a> {
     telephone_number: Option<Secret<String>>,
     billing_address: Option<Address>,
     delivery_address: Option<Address>,
-    country_code: Option<String>,
+    country_code: Option<api_enums::Country>,
     line_items: Option<Vec<LineItem>>,
 }
 
@@ -547,13 +547,13 @@ fn get_shopper_name(item: &types::PaymentsAuthorizeRouterData) -> Option<Shopper
     })
 }
 
-fn get_country_code(item: &types::PaymentsAuthorizeRouterData) -> Option<String> {
-    let address = item
-        .address
-        .billing
-        .as_ref()
-        .and_then(|billing| billing.address.as_ref());
-    address.and_then(|address| address.country.clone())
+fn get_country_code(item: &types::PaymentsAuthorizeRouterData) -> Option<api_enums::Country> {
+    item.address.billing.as_ref().and_then(|billing| {
+        billing
+            .address
+            .as_ref()
+            .and_then(|address| address.country.clone())
+    })
 }
 
 fn get_payment_method_data<'a>(
@@ -683,7 +683,7 @@ fn get_card_specific_payment_data<'a>(
 
 fn get_sofort_extra_details(
     item: &types::PaymentsAuthorizeRouterData,
-) -> (Option<String>, Option<String>) {
+) -> (Option<String>, Option<api_enums::Country>) {
     match item.request.payment_method_data {
         api_models::payments::PaymentMethodData::BankRedirect(ref b) => {
             if let api_models::payments::BankRedirectData::Sofort {
@@ -693,7 +693,7 @@ fn get_sofort_extra_details(
             {
                 (
                     Some(preferred_language.to_string()),
-                    Some(country.to_string()),
+                    Some(country.to_owned()),
                 )
             } else {
                 (None, None)

--- a/crates/router/src/connector/applepay/transformers.rs
+++ b/crates/router/src/connector/applepay/transformers.rs
@@ -64,7 +64,7 @@ pub struct SessionRequest {
 #[serde(rename_all = "snake_case")]
 pub struct PaymentRequest {
     pub apple_pay_merchant_id: String,
-    pub country_code: String,
+    pub country_code: api_models::enums::Country,
     pub currency_code: String,
     pub total: AmountInfo,
     pub merchant_capabilities: Vec<String>,

--- a/crates/router/src/connector/cybersource/transformers.rs
+++ b/crates/router/src/connector/cybersource/transformers.rs
@@ -8,7 +8,11 @@ use crate::{
     consts,
     core::errors,
     pii::PeekInterface,
-    types::{self, api, storage::enums},
+    types::{
+        self,
+        api::{self, enums as api_enums},
+        storage::enums,
+    },
 };
 
 #[derive(Default, Debug, Serialize, Eq, PartialEq)]
@@ -76,7 +80,7 @@ pub struct BillTo {
     locality: String,
     administrative_area: Secret<String>,
     postal_code: Secret<String>,
-    country: String,
+    country: api_enums::Country,
     email: Secret<String, pii::Email>,
     phone_number: Secret<String>,
 }

--- a/crates/router/src/connector/globalpay/requests.rs
+++ b/crates/router/src/connector/globalpay/requests.rs
@@ -27,7 +27,7 @@ pub struct GlobalpayPaymentsRequest {
     /// related currency.
     pub convenience_amount: Option<String>,
     /// The country in ISO-3166-1(alpha-2 code) format.
-    pub country: String,
+    pub country: api_models::enums::Country,
     /// The currency of the amount in ISO-4217(alpha-3)
     pub currency: String,
     pub currency_conversion: Option<CurrencyConversion>,

--- a/crates/router/src/connector/multisafepay/transformers.rs
+++ b/crates/router/src/connector/multisafepay/transformers.rs
@@ -132,7 +132,7 @@ pub struct DeliveryObject {
     house_number: Secret<String>,
     zip_code: Secret<String>,
     city: String,
-    country: String,
+    country: api_models::enums::Country,
 }
 
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]

--- a/crates/router/src/connector/stripe/transformers.rs
+++ b/crates/router/src/connector/stripe/transformers.rs
@@ -148,7 +148,7 @@ pub enum BankSpecificData {
         #[serde(rename = "payment_method_options[sofort][preferred_language]")]
         preferred_language: String,
         #[serde(rename = "payment_method_data[sofort][country]")]
-        country: String,
+        country: api_enums::Country,
     },
 }
 
@@ -1080,7 +1080,7 @@ pub struct StripeShippingAddress {
     #[serde(rename = "shipping[address][city]")]
     pub city: Option<String>,
     #[serde(rename = "shipping[address][country]")]
-    pub country: Option<String>,
+    pub country: Option<api_enums::Country>,
     #[serde(rename = "shipping[address][line1]")]
     pub line1: Option<Secret<String>>,
     #[serde(rename = "shipping[address][line2]")]

--- a/crates/router/src/connector/utils.rs
+++ b/crates/router/src/connector/utils.rs
@@ -41,7 +41,7 @@ impl AccessTokenRequestInfo for types::RefreshTokenRouterData {
 
 pub trait RouterData {
     fn get_billing(&self) -> Result<&api::Address, Error>;
-    fn get_billing_country(&self) -> Result<String, Error>;
+    fn get_billing_country(&self) -> Result<api_models::enums::Country, Error>;
     fn get_billing_phone(&self) -> Result<&api::PhoneDetails, Error>;
     fn get_description(&self) -> Result<String, Error>;
     fn get_billing_address(&self) -> Result<&api::AddressDetails, Error>;
@@ -61,7 +61,7 @@ impl<Flow, Request, Response> RouterData for types::RouterData<Flow, Request, Re
             .ok_or_else(missing_field_err("billing"))
     }
 
-    fn get_billing_country(&self) -> Result<String, Error> {
+    fn get_billing_country(&self) -> Result<api_models::enums::Country, Error> {
         self.address
             .billing
             .as_ref()
@@ -260,7 +260,7 @@ pub trait AddressDetailsData {
     fn get_city(&self) -> Result<&String, Error>;
     fn get_line2(&self) -> Result<&Secret<String>, Error>;
     fn get_zip(&self) -> Result<&Secret<String>, Error>;
-    fn get_country(&self) -> Result<&String, Error>;
+    fn get_country(&self) -> Result<&api_models::enums::Country, Error>;
 }
 
 impl AddressDetailsData for api::AddressDetails {
@@ -300,7 +300,7 @@ impl AddressDetailsData for api::AddressDetails {
             .ok_or_else(missing_field_err("address.zip"))
     }
 
-    fn get_country(&self) -> Result<&String, Error> {
+    fn get_country(&self) -> Result<&api_models::enums::Country, Error> {
         self.country
             .as_ref()
             .ok_or_else(missing_field_err("address.country"))

--- a/crates/router/src/connector/worldline/transformers.rs
+++ b/crates/router/src/connector/worldline/transformers.rs
@@ -49,7 +49,7 @@ pub struct Order {
 #[serde(rename_all = "camelCase")]
 pub struct BillingAddress {
     pub city: Option<String>,
-    pub country_code: Option<String>,
+    pub country_code: Option<api_enums::Country>,
     pub house_number: Option<String>,
     pub state: Option<Secret<String>>,
     pub state_code: Option<String>,
@@ -84,7 +84,7 @@ pub struct Name {
 #[serde(rename_all = "camelCase")]
 pub struct Shipping {
     pub city: Option<String>,
-    pub country_code: Option<String>,
+    pub country_code: Option<api_enums::Country>,
     pub house_number: Option<String>,
     pub name: Option<Name>,
     pub state: Option<Secret<String>>,

--- a/crates/router/src/core/customers.rs
+++ b/crates/router/src/core/customers.rs
@@ -15,6 +15,7 @@ use crate::{
     types::{
         api::customers::{self, CustomerRequestExt},
         storage::{self, enums},
+        transformers::ForeignFrom,
     },
 };
 
@@ -39,7 +40,7 @@ pub async fn create_customer(
             .change_context(errors::ApiErrorResponse::AddressNotFound)?;
         db.insert_address(storage::AddressNew {
             city: customer_address.city,
-            country: customer_address.country,
+            country: customer_address.country.map(ForeignFrom::foreign_from),
             line1: customer_address.line1,
             line2: customer_address.line2,
             line3: customer_address.line3,
@@ -165,7 +166,7 @@ pub async fn delete_customer(
 
     let update_address = storage::AddressUpdate::Update {
         city: Some(REDACTED.to_string()),
-        country: Some(REDACTED.to_string()),
+        country: None,
         line1: Some(REDACTED.to_string().into()),
         line2: Some(REDACTED.to_string().into()),
         line3: Some(REDACTED.to_string().into()),
@@ -243,7 +244,7 @@ pub async fn update_customer(
             .change_context(errors::ApiErrorResponse::AddressNotFound)?;
         let update_address = storage::AddressUpdate::Update {
             city: customer_address.city,
-            country: customer_address.country,
+            country: customer_address.country.map(ForeignFrom::foreign_from),
             line1: customer_address.line1,
             line2: customer_address.line2,
             line3: customer_address.line3,

--- a/crates/router/src/core/payment_methods/cards.rs
+++ b/crates/router/src/core/payment_methods/cards.rs
@@ -759,7 +759,7 @@ async fn filter_payment_methods(
                         &connector,
                         &payment_method_object.payment_method_type,
                         &mut payment_method_object.card_networks,
-                        &address.and_then(|inner| inner.country.clone()),
+                        &address.and_then(|inner| inner.country.map(|country| country.to_string())),
                         payment_attempt
                             .and_then(|value| value.currency)
                             .map(|value| value.foreign_into()),
@@ -1026,12 +1026,12 @@ async fn filter_payment_country_based(
         address.country.as_ref().map_or(true, |country| {
             pm.accepted_countries.as_ref().map_or(true, |ac| {
                 if ac.accept_type == "enable_only" {
-                    ac.list
-                        .as_ref()
-                        .map_or(false, |enable_countries| enable_countries.contains(country))
+                    ac.list.as_ref().map_or(false, |enable_countries| {
+                        enable_countries.contains(&country.to_string())
+                    })
                 } else {
                     ac.list.as_ref().map_or(true, |disable_countries| {
-                        !disable_countries.contains(country)
+                        !disable_countries.contains(&country.to_string())
                     })
                 }
             })

--- a/crates/router/src/core/payments/flows/session_flow.rs
+++ b/crates/router/src/core/payments/flows/session_flow.rs
@@ -83,7 +83,7 @@ fn create_gpay_session_token(
 
     let session_data = router_data.request.clone();
     let transaction_info = payment_types::GpayTransactionInfo {
-        country_code: session_data.country.unwrap_or_else(|| "US".to_string()),
+        country_code: session_data.country.unwrap_or_default(),
         currency_code: router_data.request.currency.to_string(),
         total_price_status: "Final".to_string(),
         total_price: router_data.request.amount,

--- a/crates/router/src/core/payments/transformers.rs
+++ b/crates/router/src/core/payments/transformers.rs
@@ -519,11 +519,9 @@ impl<F: Clone> TryFrom<PaymentData<F>> for types::PaymentsSessionData {
         Ok(Self {
             amount: payment_data.amount.into(),
             currency: payment_data.currency,
-            country: payment_data
-                .address
-                .billing
-                .and_then(|billing_address| billing_address.address.map(|address| address.country))
-                .flatten(),
+            country: payment_data.address.billing.and_then(|billing_address| {
+                billing_address.address.and_then(|address| address.country)
+            }),
             order_details,
         })
     }

--- a/crates/router/src/types.rs
+++ b/crates/router/src/types.rs
@@ -165,7 +165,7 @@ pub struct PaymentsCancelData {
 pub struct PaymentsSessionData {
     pub amount: i64,
     pub currency: storage_enums::Currency,
-    pub country: Option<String>,
+    pub country: Option<api::enums::Country>,
     pub order_details: Option<api_models::payments::OrderDetails>,
 }
 

--- a/crates/router/src/types/transformers.rs
+++ b/crates/router/src/types/transformers.rs
@@ -246,9 +246,22 @@ impl ForeignFrom<api_enums::Currency> for storage_enums::Currency {
         frunk::labelled_convert_from(currency)
     }
 }
+
 impl ForeignFrom<storage_enums::Currency> for api_enums::Currency {
     fn foreign_from(currency: storage_enums::Currency) -> Self {
         frunk::labelled_convert_from(currency)
+    }
+}
+
+impl ForeignFrom<storage_enums::Country> for api_enums::Country {
+    fn foreign_from(country: storage_enums::Country) -> Self {
+        frunk::labelled_convert_from(country)
+    }
+}
+
+impl ForeignFrom<api_enums::Country> for storage_enums::Country {
+    fn foreign_from(country: api_enums::Country) -> Self {
+        frunk::labelled_convert_from(country)
     }
 }
 
@@ -257,7 +270,10 @@ impl<'a> ForeignFrom<&'a api_types::Address> for storage::AddressUpdate {
         let address = address;
         Self::Update {
             city: address.address.as_ref().and_then(|a| a.city.clone()),
-            country: address.address.as_ref().and_then(|a| a.country.clone()),
+            country: address
+                .address
+                .as_ref()
+                .and_then(|a| a.country.clone().map(ForeignFrom::foreign_from)),
             line1: address.address.as_ref().and_then(|a| a.line1.clone()),
             line2: address.address.as_ref().and_then(|a| a.line2.clone()),
             line3: address.address.as_ref().and_then(|a| a.line3.clone()),
@@ -296,7 +312,7 @@ impl<'a> ForeignFrom<&'a storage::Address> for api_types::Address {
         Self {
             address: Some(api_types::AddressDetails {
                 city: address.city.clone(),
-                country: address.country.clone(),
+                country: address.country.map(ForeignFrom::foreign_from),
                 line1: address.line1.clone(),
                 line2: address.line2.clone(),
                 line3: address.line3.clone(),
@@ -361,7 +377,7 @@ impl ForeignFrom<api_models::payments::AddressDetails> for storage_models::addre
         let address = item;
         Self {
             city: address.city,
-            country: address.country,
+            country: address.country.map(ForeignFrom::foreign_from),
             line1: address.line1,
             line2: address.line2,
             line3: address.line3,

--- a/crates/router/tests/connectors/adyen.rs
+++ b/crates/router/tests/connectors/adyen.rs
@@ -39,7 +39,7 @@ impl AdyenTest {
             address: Some(PaymentAddress {
                 billing: Some(Address {
                     address: Some(AddressDetails {
-                        country: Some("US".to_string()),
+                        country: Some(api_models::enums::Country::US),
                         ..Default::default()
                     }),
                     phone: None,

--- a/crates/router/tests/connectors/cybersource.rs
+++ b/crates/router/tests/connectors/cybersource.rs
@@ -42,7 +42,7 @@ fn get_default_payment_info() -> Option<utils::PaymentInfo> {
                     line2: Some(Secret::new("line2".to_string())),
                     city: Some("city".to_string()),
                     zip: Some(Secret::new("zip".to_string())),
-                    country: Some("IN".to_string()),
+                    country: Some(api_models::enums::Country::IN),
                     ..Default::default()
                 }),
                 phone: Some(api::PhoneDetails {

--- a/crates/router/tests/connectors/dlocal.rs
+++ b/crates/router/tests/connectors/dlocal.rs
@@ -445,7 +445,7 @@ pub fn get_payment_info() -> PaymentInfo {
                 phone: None,
                 address: Some(api::AddressDetails {
                     city: None,
-                    country: Some("PA".to_string()),
+                    country: Some(api_models::enums::Country::PA),
                     line1: None,
                     line2: None,
                     line3: None,

--- a/crates/router/tests/connectors/globalpay.rs
+++ b/crates/router/tests/connectors/globalpay.rs
@@ -45,7 +45,7 @@ fn get_default_payment_info() -> Option<PaymentInfo> {
         address: Some(types::PaymentAddress {
             billing: Some(api::Address {
                 address: Some(api::AddressDetails {
-                    country: Some("US".to_string()),
+                    country: Some(api_models::enums::Country::US),
                     ..Default::default()
                 }),
                 phone: None,

--- a/crates/router/tests/connectors/worldline.rs
+++ b/crates/router/tests/connectors/worldline.rs
@@ -42,7 +42,7 @@ impl WorldlineTest {
             address: Some(PaymentAddress {
                 billing: Some(Address {
                     address: Some(AddressDetails {
-                        country: Some("US".to_string()),
+                        country: Some(api_models::enums::Country::US),
                         ..Default::default()
                     }),
                     phone: None,

--- a/crates/storage_models/src/address.rs
+++ b/crates/storage_models/src/address.rs
@@ -4,6 +4,7 @@ use masking::Secret;
 use serde::{Deserialize, Serialize};
 use time::{OffsetDateTime, PrimitiveDateTime};
 
+use crate::enums;
 use crate::schema::address;
 
 #[derive(Clone, Debug, Deserialize, Serialize, Insertable, router_derive::DebugAsDisplay)]
@@ -12,7 +13,7 @@ use crate::schema::address;
 pub struct AddressNew {
     pub address_id: String,
     pub city: Option<String>,
-    pub country: Option<String>,
+    pub country: Option<enums::Country>,
     pub line1: Option<Secret<String>>,
     pub line2: Option<Secret<String>>,
     pub line3: Option<Secret<String>>,
@@ -34,7 +35,7 @@ pub struct Address {
     #[serde(skip_serializing)]
     pub address_id: String,
     pub city: Option<String>,
-    pub country: Option<String>,
+    pub country: Option<enums::Country>,
     pub line1: Option<Secret<String>>,
     pub line2: Option<Secret<String>>,
     pub line3: Option<Secret<String>>,
@@ -58,7 +59,7 @@ pub struct Address {
 pub enum AddressUpdate {
     Update {
         city: Option<String>,
-        country: Option<String>,
+        country: Option<enums::Country>,
         line1: Option<Secret<String>>,
         line2: Option<Secret<String>>,
         line3: Option<Secret<String>>,
@@ -75,7 +76,7 @@ pub enum AddressUpdate {
 #[diesel(table_name = address)]
 pub struct AddressUpdateInternal {
     city: Option<String>,
-    country: Option<String>,
+    country: Option<enums::Country>,
     line1: Option<Secret<String>>,
     line2: Option<Secret<String>>,
     line3: Option<Secret<String>>,

--- a/crates/storage_models/src/enums.rs
+++ b/crates/storage_models/src/enums.rs
@@ -256,6 +256,33 @@ pub enum Currency {
     ZAR,
 }
 
+#[allow(clippy::upper_case_acronyms)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Default,
+    Hash,
+    PartialEq,
+    serde::Deserialize,
+    serde::Serialize,
+    strum::Display,
+    strum::EnumString,
+    frunk::LabelledGeneric,
+)]
+#[router_derive::diesel_enum(storage_type = "text")]
+#[rustfmt::skip]
+pub enum Country {
+    AL,DZ,AS,AO,AG,AR,AU,AT,AZ,BH,BY,BE,BR,BG,CA,CL,CO,HR,CZ,DK,DO,EG,
+    EE,FI,FR,DE,GR,HK,HU,IN,ID,IE,IL,IT,JP,JO,KZ,KE,KW,LV,LB,LT,LU,MY,
+    MX,NL,NZ,NO,OM,PK,PA,PE,PH,PL,PT,QA,RO,RU,SA,SG,SK,ZA,ES,LK,SE,CH,
+    TW,TH,TR,UA,AE,GB,UY,VN,CN,MO,AM,CY,FO,GE,GL,GG,IS,IM,JE,LI,MT,
+    MD,MC,ME,SM,RS,SI,CR,PS,UM,
+    #[default]
+    US
+}
+
 #[derive(
     Clone,
     Copy,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Enhancement

## Description
<!-- Describe your changes in detail -->
Use enums for country instead of accepting arbitrary string.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
Accepting string for country does not have any type restriction.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Create a payment with billing country as `US` via stripe.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
