### PR TITLE
feat: populate fields from payment attempt in payment list

### DIFF
--- a/crates/router/src/core/payments.rs
+++ b/crates/router/src/core/payments.rs
@@ -631,7 +631,8 @@ pub async fn list_payments(
                 .find_payment_attempt_by_payment_id_merchant_id(
                     &pi.payment_id,
                     merchant_id,
-                    merchant.storage_scheme,
+                    // since OLAP doesn't have KV. Force to get the data from PSQL.
+                    storage_enums::MerchantStorageScheme::PostgresOnly,
                 )
                 .await
                 .ok()?;

--- a/crates/router/src/core/payments.rs
+++ b/crates/router/src/core/payments.rs
@@ -609,9 +609,13 @@ pub async fn list_payments(
     merchant: storage::MerchantAccount,
     constraints: api::PaymentListConstraints,
 ) -> RouterResponse<api::PaymentListResponse> {
+    use futures::stream::StreamExt;
+
+    use crate::types::transformers::ForeignFrom;
+
     helpers::validate_payment_list_request(&constraints)?;
     let merchant_id = &merchant.merchant_id;
-    let payment_intent =
+    let payment_intents =
         helpers::filter_by_constraints(db, &constraints, merchant_id, merchant.storage_scheme)
             .await
             .map_err(|err| {
@@ -621,10 +625,23 @@ pub async fn list_payments(
                 )
             })?;
 
-    let data: Vec<api::PaymentsResponse> = payment_intent
-        .into_iter()
-        .map(types::transformers::ForeignInto::foreign_into)
-        .collect();
+    let pi = futures::stream::iter(payment_intents)
+        .filter_map(|pi| async {
+            let pa = db
+                .find_payment_attempt_by_payment_id_merchant_id(
+                    &pi.payment_id,
+                    merchant_id,
+                    merchant.storage_scheme,
+                )
+                .await
+                .ok()?;
+            Some((pi, pa))
+        })
+        .collect::<Vec<(storage::PaymentIntent, storage::PaymentAttempt)>>()
+        .await;
+
+    let data: Vec<api::PaymentsResponse> = pi.into_iter().map(ForeignFrom::foreign_from).collect();
+
     Ok(services::ApplicationResponse::Json(
         api::PaymentListResponse {
             size: data.len(),

--- a/crates/router/src/core/payments/transformers.rs
+++ b/crates/router/src/core/payments/transformers.rs
@@ -15,7 +15,7 @@ use crate::{
     types::{
         self, api,
         storage::{self, enums},
-        transformers::ForeignInto,
+        transformers::{ForeignFrom, ForeignInto},
     },
     utils::{OptionExt, ValueExt},
 };
@@ -391,6 +391,30 @@ where
             ..Default::default()
         }),
     })
+}
+
+impl ForeignFrom<(storage::PaymentIntent, storage::PaymentAttempt)> for api::PaymentsResponse {
+    fn foreign_from(item: (storage::PaymentIntent, storage::PaymentAttempt)) -> Self {
+        let pi = item.0;
+        let pa = item.1;
+        Self {
+            payment_id: Some(pi.payment_id),
+            merchant_id: Some(pi.merchant_id),
+            status: pi.status.foreign_into(),
+            amount: pi.amount,
+            amount_capturable: pi.amount_captured,
+            client_secret: pi.client_secret.map(|s| s.into()),
+            created: Some(pi.created_at),
+            currency: pi.currency.map(|c| c.to_string()).unwrap_or_default(),
+            description: pi.description,
+            metadata: pi.metadata,
+            customer_id: pi.customer_id,
+            connector: pa.connector,
+            payment_method: pa.payment_method.map(ForeignInto::foreign_into),
+            payment_method_type: pa.payment_method_type.map(ForeignInto::foreign_into),
+            ..Default::default()
+        }
+    }
 }
 
 impl<F: Clone> TryFrom<PaymentData<F>> for types::PaymentsAuthorizeData {

--- a/crates/router/src/types/api/payments.rs
+++ b/crates/router/src/types/api/payments.rs
@@ -16,10 +16,7 @@ use time::PrimitiveDateTime;
 use crate::{
     core::errors,
     services::api,
-    types::{
-        self, api as api_types, storage,
-        transformers::{ForeignFrom, ForeignInto},
-    },
+    types::{self, api as api_types},
 };
 
 pub(crate) trait PaymentsRequestExt {
@@ -110,26 +107,6 @@ impl MandateValidationFieldsExt for MandateValidationFields {
             (None, None) => None,
             (_, Some(_)) => Some(MandateTxnType::RecurringMandateTxn),
             (Some(_), _) => Some(MandateTxnType::NewMandateTxn),
-        }
-    }
-}
-
-impl ForeignFrom<storage::PaymentIntent> for PaymentsResponse {
-    fn foreign_from(item: storage::PaymentIntent) -> Self {
-        let item = item;
-        Self {
-            payment_id: Some(item.payment_id),
-            merchant_id: Some(item.merchant_id),
-            status: item.status.foreign_into(),
-            amount: item.amount,
-            amount_capturable: item.amount_captured,
-            client_secret: item.client_secret.map(|s| s.into()),
-            created: Some(item.created_at),
-            currency: item.currency.map(|c| c.to_string()).unwrap_or_default(),
-            description: item.description,
-            metadata: item.metadata,
-            customer_id: item.customer_id,
-            ..Default::default()
         }
     }
 }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->
- [x] Enhancement

## Description
<!-- Describe your changes in detail -->
Populate some fields from payment attempt table in Paymentlist response.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
Populate necessary fields which we show in the dashboard from payment attempt.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Manual

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code