### PR TITLE
refactor: Add service_name to get and delete request

### DIFF
--- a/crates/api_models/src/payment_methods.rs
+++ b/crates/api_models/src/payment_methods.rs
@@ -545,12 +545,14 @@ pub struct TokenizePayloadRequest {
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub struct GetTokenizePayloadRequest {
     pub lookup_key: String,
+    pub service_name: String,
     pub get_value2: bool,
 }
 
 #[derive(Debug, serde::Serialize)]
 pub struct DeleteTokenizeByTokenRequest {
     pub lookup_key: String,
+    pub service_name: String,
 }
 
 #[derive(Debug, serde::Serialize)] // Blocked: Yet to be implemented by `basilisk`

--- a/crates/router/src/core/payment_methods/vault.rs
+++ b/crates/router/src/core/payment_methods/vault.rs
@@ -447,6 +447,7 @@ pub async fn get_tokenized_data(
     let payload_to_be_encrypted = api::GetTokenizePayloadRequest {
         lookup_key: lookup_key.to_string(),
         get_value2: should_get_value2,
+        service_name: VAULT_SERVICE_NAME.to_string(),
     };
     let payload = serde_json::to_string(&payload_to_be_encrypted)
         .map_err(|_x| errors::ApiErrorResponse::InternalServerError)?;
@@ -502,6 +503,7 @@ pub async fn delete_tokenized_data(
 ) -> RouterResult<String> {
     let payload_to_be_encrypted = api::DeleteTokenizeByTokenRequest {
         lookup_key: lookup_key.to_string(),
+        service_name: VAULT_SERVICE_NAME.to_string(),
     };
     let payload = serde_json::to_string(&payload_to_be_encrypted)
         .map_err(|_x| errors::ApiErrorResponse::InternalServerError)?;


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Refactoring

## Description
service_name is passed as mandatory request in all the api of basilisk-v3


### Additional Changes

- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!-- 
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
Needs to be tested in sbx/prod


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
