### PR TITLE
feat: generic in memory cache interface

### DIFF
--- a/crates/redis_interface/src/lib.rs
+++ b/crates/redis_interface/src/lib.rs
@@ -25,18 +25,19 @@ use std::sync::{atomic, Arc};
 
 use common_utils::errors::CustomResult;
 use error_stack::{IntoReport, ResultExt};
-use fred::interfaces::{ClientLike, PubsubInterface};
+use fred::interfaces::ClientLike;
 use futures::StreamExt;
 use router_env::logger;
 
 pub use self::{commands::*, types::*};
+pub use fred::interfaces::PubsubInterface;
 
 pub struct RedisConnectionPool {
     pub pool: fred::pool::RedisPool,
     config: RedisConfig,
     join_handles: Vec<fred::types::ConnectHandle>,
-    subscriber: RedisClient,
-    publisher: RedisClient,
+    pub subscriber: RedisClient,
+    pub publisher: RedisClient,
     pub is_redis_available: Arc<atomic::AtomicBool>,
 }
 
@@ -150,44 +151,6 @@ impl RedisConnectionPool {
                 futures::future::ready(())
             })
             .await;
-    }
-}
-
-#[async_trait::async_trait]
-pub trait PubSubInterface {
-    async fn subscribe(&self, channel: &str) -> CustomResult<usize, errors::RedisError>;
-    async fn publish(&self, channel: &str, key: &str) -> CustomResult<usize, errors::RedisError>;
-    async fn on_message(&self) -> CustomResult<(), errors::RedisError>;
-}
-
-#[async_trait::async_trait]
-impl PubSubInterface for RedisConnectionPool {
-    #[inline]
-    async fn subscribe(&self, channel: &str) -> CustomResult<usize, errors::RedisError> {
-        self.subscriber
-            .subscribe(channel)
-            .await
-            .into_report()
-            .change_context(errors::RedisError::SubscribeError)
-    }
-    #[inline]
-    async fn publish(&self, channel: &str, key: &str) -> CustomResult<usize, errors::RedisError> {
-        self.publisher
-            .publish(channel, key)
-            .await
-            .into_report()
-            .change_context(errors::RedisError::SubscribeError)
-    }
-    #[inline]
-    async fn on_message(&self) -> CustomResult<(), errors::RedisError> {
-        let mut message = self.subscriber.on_message();
-        while let Some((_, key)) = message.next().await {
-            let key = key
-                .as_string()
-                .ok_or::<errors::RedisError>(errors::RedisError::DeleteFailed)?;
-            self.delete_key(&key).await?;
-        }
-        Ok(())
     }
 }
 

--- a/crates/router/src/cache.rs
+++ b/crates/router/src/cache.rs
@@ -1,7 +1,11 @@
-use std::any::Any;
+use std::{any::Any, sync::Arc};
 
 use dyn_clone::DynClone;
 use moka::future::Cache as MokaCache;
+use once_cell::sync::Lazy;
+
+/// Config Cache with time_to_live as 30 mins and time_to_idle as 10 mins.
+pub static CONFIG_CACHE: Lazy<Cache> = Lazy::new(|| Cache::new(30 * 60, 10 * 60));
 
 /// Trait which defines the behaviour of types that's gonna be stored in Cache
 pub trait Cacheable: Any + Send + Sync + DynClone {
@@ -20,11 +24,11 @@ where
 dyn_clone::clone_trait_object!(Cacheable);
 
 pub struct Cache {
-    inner: MokaCache<String, Box<dyn Cacheable>>,
+    inner: MokaCache<String, Arc<dyn Cacheable>>,
 }
 
 impl std::ops::Deref for Cache {
-    type Target = MokaCache<String, Box<dyn Cacheable>>;
+    type Target = MokaCache<String, Arc<dyn Cacheable>>;
     fn deref(&self) -> &Self::Target {
         &self.inner
     }
@@ -45,7 +49,11 @@ impl Cache {
         }
     }
 
-    pub fn get_val<T: Clone + Any>(&self, key: &str) -> Option<T> {
+    pub async fn push<T: Cacheable>(&self, key: String, val: T) {
+        self.insert(key, Arc::new(val)).await;
+    }
+
+    pub fn get_val<T: Clone + Cacheable>(&self, key: &str) -> Option<T> {
         let val = self.get(key)?;
         (*val).as_any().downcast_ref::<T>().cloned()
     }
@@ -58,9 +66,7 @@ mod cache_tests {
     #[tokio::test]
     async fn construct_and_get_cache() {
         let cache = Cache::new(1800, 1800);
-        cache
-            .insert("key".to_string(), Box::new("val".to_string()))
-            .await;
+        cache.push("key".to_string(), "val".to_string()).await;
         assert_eq!(cache.get_val::<String>("key"), Some(String::from("val")));
     }
 }

--- a/crates/router/src/db/cache.rs
+++ b/crates/router/src/db/cache.rs
@@ -1,7 +1,11 @@
 use error_stack::ResultExt;
 
 use super::Store;
-use crate::core::errors::{self, CustomResult};
+use crate::{
+    consts,
+    core::errors::{self, CustomResult},
+    services::PubSubInterface,
+};
 
 pub async fn get_or_populate_cache<T, F, Fut>(
     store: &Store,
@@ -49,7 +53,7 @@ where
     store
         .redis_conn()
         .map_err(Into::<errors::StorageError>::into)?
-        .delete_key(key)
+        .publish(consts::PUB_SUB_CHANNEL, key)
         .await
         .change_context(errors::StorageError::KVError)?;
     Ok(data)

--- a/crates/router/src/services.rs
+++ b/crates/router/src/services.rs
@@ -6,15 +6,74 @@ pub mod logger;
 
 use std::sync::{atomic, Arc};
 
-use redis_interface::{errors::RedisError, PubSubInterface};
+use error_stack::{IntoReport, ResultExt};
+use futures::StreamExt;
+use redis_interface::errors as redis_errors;
 
 pub use self::{api::*, encryption::*};
 use crate::{
     async_spawn,
+    cache::CONFIG_CACHE,
     connection::{diesel_make_pg_pool, PgPool},
     consts,
     core::errors,
 };
+
+use redis_interface::PubsubInterface;
+
+#[async_trait::async_trait]
+pub trait PubSubInterface {
+    async fn subscribe(
+        &self,
+        channel: &str,
+    ) -> errors::CustomResult<usize, redis_errors::RedisError>;
+    async fn publish(
+        &self,
+        channel: &str,
+        key: &str,
+    ) -> errors::CustomResult<usize, redis_errors::RedisError>;
+    async fn on_message(&self) -> errors::CustomResult<(), redis_errors::RedisError>;
+}
+
+#[async_trait::async_trait]
+impl PubSubInterface for redis_interface::RedisConnectionPool {
+    #[inline]
+    async fn subscribe(
+        &self,
+        channel: &str,
+    ) -> errors::CustomResult<usize, redis_errors::RedisError> {
+        self.subscriber
+            .subscribe(channel)
+            .await
+            .into_report()
+            .change_context(redis_errors::RedisError::SubscribeError)
+    }
+    #[inline]
+    async fn publish(
+        &self,
+        channel: &str,
+        key: &str,
+    ) -> errors::CustomResult<usize, redis_errors::RedisError> {
+        self.publisher
+            .publish(channel, key)
+            .await
+            .into_report()
+            .change_context(redis_errors::RedisError::SubscribeError)
+    }
+    #[inline]
+    async fn on_message(&self) -> errors::CustomResult<(), redis_errors::RedisError> {
+        let mut message = self.subscriber.on_message();
+        while let Some((_, key)) = message.next().await {
+            let key = key
+                .as_string()
+                .ok_or::<redis_errors::RedisError>(redis_errors::RedisError::DeleteFailed)?;
+
+            self.delete_key(&key).await?;
+            CONFIG_CACHE.invalidate(&key).await;
+        }
+        Ok(())
+    }
+}
 
 #[derive(Clone)]
 pub struct Store {
@@ -73,7 +132,8 @@ impl Store {
 
     pub fn redis_conn(
         &self,
-    ) -> errors::CustomResult<Arc<redis_interface::RedisConnectionPool>, RedisError> {
+    ) -> errors::CustomResult<Arc<redis_interface::RedisConnectionPool>, redis_errors::RedisError>
+    {
         if self
             .redis_conn
             .is_redis_available
@@ -81,7 +141,7 @@ impl Store {
         {
             Ok(self.redis_conn.clone())
         } else {
-            Err(RedisError::RedisConnectionError.into())
+            Err(redis_errors::RedisError::RedisConnectionError.into())
         }
     }
 
@@ -94,8 +154,6 @@ impl Store {
     where
         T: crate::utils::storage_partitioning::KvStorePartition,
     {
-        use error_stack::ResultExt;
-
         let shard_key = T::shard_key(partition_key, self.config.drainer_num_partitions);
         let stream_name = self.get_drainer_stream_name(&shard_key);
         self.redis_conn


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->
- [x] Enhancement

## Description
<!-- Describe your changes in detail -->
This PR adds in memory cache support to the config table, the config in memory cache is a static with time to live as 30 mins and time to idle as 30 mins. On a normal get operation it checks if the data is in in memory cache and returns if exists. Otherwise it goes to db and gets the cache and inserts it into both redis and in memory.

Also switched to Arc for the value type in cache interface since moka clones the inner value on every get cloning an Arc is much more cheaper than cloning a Box.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
This is lower the latency of fetch in config table.


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
<img width="1331" alt="image" src="https://user-images.githubusercontent.com/43412619/225310102-bb84f741-5000-4b36-89a3-cf11d5117ec5.png">


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code