### PR TITLE
bugfix: card_fingerprint not sent by basilisk_hs

### DIFF
--- a/crates/router/src/core/payment_methods/cards.rs
+++ b/crates/router/src/core/payment_methods/cards.rs
@@ -1619,11 +1619,6 @@ impl BasiliskCardSupport {
             .clone()
             .expose_option()
             .unwrap_or_default();
-        let card_fingerprint = card
-            .card_fingerprint
-            .clone()
-            .expose_option()
-            .get_required_value("card_fingerprint")?;
         let value1 = payment_methods::mk_card_value1(
             card_number,
             card_exp_year,
@@ -1637,7 +1632,7 @@ impl BasiliskCardSupport {
         .attach_printable("Error getting Value1 for locker")?;
         let value2 = payment_methods::mk_card_value2(
             None,
-            Some(card_fingerprint),
+            None,
             None,
             Some(pm.customer_id.to_string()),
             Some(pm.payment_method_id.to_string()),


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
Card Fingerprint is not sent by basilisk_hs , so we made the fingerprints optional, while creating payment method entry fingerprint was fetched as a required field


### Additional Changes

- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!-- 
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
to be tested on prod/sbx


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
