### PR TITLE
refactor(metrics): use macros for constructing counter and histogram metrics

### DIFF
--- a/crates/drainer/src/metrics.rs
+++ b/crates/drainer/src/metrics.rs
@@ -1,59 +1,18 @@
-use once_cell::sync::Lazy;
 pub use router_env::opentelemetry::KeyValue;
-use router_env::opentelemetry::{
-    global,
-    metrics::{Counter, Histogram, Meter},
-    Context,
-};
+use router_env::{counter_metric, global_meter, histogram_metric, metrics_context};
 
-pub(crate) static CONTEXT: Lazy<Context> = Lazy::new(Context::current);
-static DRAINER_METER: Lazy<Meter> = Lazy::new(|| global::meter("DRAINER"));
+metrics_context!(CONTEXT);
+global_meter!(DRAINER_METER, "DRAINER");
 
-// Time in (ms) milliseconds
-pub(crate) static QUERY_EXECUTION_TIME: Lazy<Histogram<f64>> =
-    Lazy::new(|| DRAINER_METER.f64_histogram("QUERY_EXECUTION_TIME").init());
+counter_metric!(JOBS_PICKED_PER_STREAM, DRAINER_METER);
+counter_metric!(CYCLES_COMPLETED_SUCCESSFULLY, DRAINER_METER);
+counter_metric!(CYCLES_COMPLETED_UNSUCCESSFULLY, DRAINER_METER);
+counter_metric!(ERRORS_WHILE_QUERY_EXECUTION, DRAINER_METER);
+counter_metric!(SUCCESSFUL_QUERY_EXECUTION, DRAINER_METER);
+counter_metric!(SHUTDOWN_SIGNAL_RECEIVED, DRAINER_METER);
+counter_metric!(SUCCESSFUL_SHUTDOWN, DRAINER_METER);
 
-pub(crate) static JOBS_PICKED_PER_STREAM: Lazy<Counter<u64>> =
-    Lazy::new(|| DRAINER_METER.u64_counter("JOBS_PICKED_PER_CYCLE").init());
-
-pub(crate) static CYCLES_COMPLETED_SUCCESSFULLY: Lazy<Counter<u64>> = Lazy::new(|| {
-    DRAINER_METER
-        .u64_counter("CYCLES_COMPLETED_SUCCESSFULLY")
-        .init()
-});
-
-pub(crate) static CYCLES_COMPLETED_UNSUCCESSFULLY: Lazy<Counter<u64>> = Lazy::new(|| {
-    DRAINER_METER
-        .u64_counter("CYCLES_COMPLETED_UNSUCCESSFULLY")
-        .init()
-});
-
-pub(crate) static ERRORS_WHILE_QUERY_EXECUTION: Lazy<Counter<u64>> = Lazy::new(|| {
-    DRAINER_METER
-        .u64_counter("ERRORS_WHILE_QUERY_EXECUTION")
-        .init()
-});
-
-pub(crate) static SUCCESSFUL_QUERY_EXECUTION: Lazy<Counter<u64>> = Lazy::new(|| {
-    DRAINER_METER
-        .u64_counter("SUCCESSFUL_QUERY_EXECUTION")
-        .init()
-});
-
-// Time in (ms) milliseconds
-pub(crate) static REDIS_STREAM_READ_TIME: Lazy<Histogram<f64>> =
-    Lazy::new(|| DRAINER_METER.f64_histogram("REDIS_STREAM_READ_TIME").init());
-
-// Time in (ms) milliseconds
-pub(crate) static REDIS_STREAM_TRIM_TIME: Lazy<Histogram<f64>> =
-    Lazy::new(|| DRAINER_METER.f64_histogram("REDIS_STREAM_TRIM_TIME").init());
-
-pub(crate) static SHUTDOWN_SIGNAL_RECEIVED: Lazy<Counter<u64>> =
-    Lazy::new(|| DRAINER_METER.u64_counter("SHUTDOWN_SIGNAL_RECEIVED").init());
-
-pub(crate) static SUCCESSFUL_SHUTDOWN: Lazy<Counter<u64>> =
-    Lazy::new(|| DRAINER_METER.u64_counter("SUCCESSFUL_SHUTDOWN").init());
-
-// Time in (ms) milliseconds
-pub(crate) static CLEANUP_TIME: Lazy<Histogram<f64>> =
-    Lazy::new(|| DRAINER_METER.f64_histogram("CLEANUP_TIME").init());
+histogram_metric!(QUERY_EXECUTION_TIME, DRAINER_METER); // Time in (ms) milliseconds
+histogram_metric!(REDIS_STREAM_READ_TIME, DRAINER_METER); // Time in (ms) milliseconds
+histogram_metric!(REDIS_STREAM_TRIM_TIME, DRAINER_METER); // Time in (ms) milliseconds
+histogram_metric!(CLEANUP_TIME, DRAINER_METER); // Time in (ms) milliseconds

--- a/crates/router/src/routes/metrics.rs
+++ b/crates/router/src/routes/metrics.rs
@@ -1,16 +1,9 @@
-use once_cell::sync::Lazy;
-use router_env::opentelemetry::{
-    global,
-    metrics::{Counter, Meter},
-    Context,
-};
+use router_env::{counter_metric, global_meter, metrics_context};
 
-use crate::create_counter;
+metrics_context!(CONTEXT);
+global_meter!(GLOBAL_METER, "ROUTER_API");
 
-pub static CONTEXT: Lazy<Context> = Lazy::new(Context::current);
-static GLOBAL_METER: Lazy<Meter> = Lazy::new(|| global::meter("ROUTER_API"));
-
-create_counter!(HEALTH_METRIC, GLOBAL_METER); // No. of health API hits
-create_counter!(KV_MISS, GLOBAL_METER); // No. of KV misses
+counter_metric!(HEALTH_METRIC, GLOBAL_METER); // No. of health API hits
+counter_metric!(KV_MISS, GLOBAL_METER); // No. of KV misses
 #[cfg(feature = "kms")]
-create_counter!(AWS_KMS_FAILURES, GLOBAL_METER); // No. of AWS KMS API failures
+counter_metric!(AWS_KMS_FAILURES, GLOBAL_METER); // No. of AWS KMS API failures

--- a/crates/router/src/scheduler/metrics.rs
+++ b/crates/router/src/scheduler/metrics.rs
@@ -1,32 +1,18 @@
-use once_cell::sync::Lazy;
-use router_env::opentelemetry::{
-    global,
-    metrics::{Counter, Histogram, Meter},
-    Context,
-};
+use router_env::{counter_metric, global_meter, histogram_metric, metrics_context};
 
-pub(crate) static CONTEXT: Lazy<Context> = Lazy::new(Context::current);
-static PT_METER: Lazy<Meter> = Lazy::new(|| global::meter("PROCESS_TRACKER"));
+metrics_context!(CONTEXT);
+global_meter!(PT_METER, "PROCESS_TRACKER");
 
-pub(crate) static CONSUMER_STATS: Lazy<Histogram<f64>> =
-    Lazy::new(|| PT_METER.f64_histogram("CONSUMER_OPS").init());
+histogram_metric!(CONSUMER_STATS, PT_METER, "CONSUMER_OPS");
 
-#[macro_export]
-macro_rules! create_counter {
-    ($name:ident, $meter:ident) => {
-        pub(crate) static $name: Lazy<Counter<u64>> =
-            Lazy::new(|| $meter.u64_counter(stringify!($name)).init());
-    };
-}
-
-create_counter!(PAYMENT_COUNT, PT_METER); // No. of payments created
-create_counter!(TASKS_ADDED_COUNT, PT_METER); // Tasks added to process tracker
-create_counter!(TASKS_PICKED_COUNT, PT_METER); // Tasks picked by
-create_counter!(BATCHES_CREATED, PT_METER); // Batches added to stream
-create_counter!(BATCHES_CONSUMED, PT_METER); // Batches consumed by consumer
-create_counter!(TASK_CONSUMED, PT_METER); // Tasks consumed by consumer
-create_counter!(TASK_PROCESSED, PT_METER); // Tasks completed processing
-create_counter!(TASK_FINISHED, PT_METER); // Tasks finished
-create_counter!(TASK_RETRIED, PT_METER); // Tasks added for retries
-create_counter!(TOKENIZED_DATA_COUNT, PT_METER); // Tokenized data added
-create_counter!(RETRIED_DELETE_DATA_COUNT, PT_METER); // Tokenized data retried
+counter_metric!(PAYMENT_COUNT, PT_METER); // No. of payments created
+counter_metric!(TASKS_ADDED_COUNT, PT_METER); // Tasks added to process tracker
+counter_metric!(TASKS_PICKED_COUNT, PT_METER); // Tasks picked by
+counter_metric!(BATCHES_CREATED, PT_METER); // Batches added to stream
+counter_metric!(BATCHES_CONSUMED, PT_METER); // Batches consumed by consumer
+counter_metric!(TASK_CONSUMED, PT_METER); // Tasks consumed by consumer
+counter_metric!(TASK_PROCESSED, PT_METER); // Tasks completed processing
+counter_metric!(TASK_FINISHED, PT_METER); // Tasks finished
+counter_metric!(TASK_RETRIED, PT_METER); // Tasks added for retries
+counter_metric!(TOKENIZED_DATA_COUNT, PT_METER); // Tokenized data added
+counter_metric!(RETRIED_DELETE_DATA_COUNT, PT_METER); // Tokenized data retried

--- a/crates/router_env/src/lib.rs
+++ b/crates/router_env/src/lib.rs
@@ -9,6 +9,7 @@
 
 pub mod env;
 pub mod logger;
+pub mod metrics;
 /// `cargo` build instructions generation for obtaining information about the application
 /// environment.
 #[cfg(feature = "vergen")]

--- a/crates/router_env/src/metrics.rs
+++ b/crates/router_env/src/metrics.rs
@@ -1,0 +1,65 @@
+//! Utilities to easily create opentelemetry contexts, meters and metrics.
+
+/// Create a metrics [`Context`][Context] with the specified name.
+///
+/// [Context]: opentelemetry::Context
+#[macro_export]
+macro_rules! metrics_context {
+    ($name:ident) => {
+        pub(crate) static $name: once_cell::sync::Lazy<$crate::opentelemetry::Context> =
+            once_cell::sync::Lazy::new($crate::opentelemetry::Context::current);
+    };
+}
+
+/// Create a global [`Meter`][Meter] with the specified name and and an optional description.
+///
+/// [Meter]: opentelemetry::metrics::Meter
+#[macro_export]
+macro_rules! global_meter {
+    ($name:ident) => {
+        static $name: once_cell::sync::Lazy<$crate::opentelemetry::metrics::Meter> =
+            once_cell::sync::Lazy::new(|| $crate::opentelemetry::global::meter(stringify!($name)));
+    };
+    ($name:ident, $description:literal) => {
+        static $name: once_cell::sync::Lazy<$crate::opentelemetry::metrics::Meter> =
+            once_cell::sync::Lazy::new(|| $crate::opentelemetry::global::meter($description));
+    };
+}
+
+/// Create a [`Counter`][Counter] metric with the specified name and an optional description,
+/// associated with the specified meter. Note that the meter must be to a valid [`Meter`][Meter].
+///
+/// [Counter]: opentelemetry::metrics::Counter
+/// [Meter]: opentelemetry::metrics::Meter
+#[macro_export]
+macro_rules! counter_metric {
+    ($name:ident, $meter:ident) => {
+        pub(crate) static $name: once_cell::sync::Lazy<
+            $crate::opentelemetry::metrics::Counter<u64>,
+        > = once_cell::sync::Lazy::new(|| $meter.u64_counter(stringify!($name)).init());
+    };
+    ($name:ident, $meter:ident, description:literal) => {
+        pub(crate) static $name: once_cell::sync::Lazy<
+            $crate::opentelemetry::metrics::Counter<u64>,
+        > = once_cell::sync::Lazy::new(|| $meter.u64_counter($description).init());
+    };
+}
+
+/// Create a [`Histogram`][Histogram] metric with the specified name and an optional description,
+/// associated with the specified meter. Note that the meter must be to a valid [`Meter`][Meter].
+///
+/// [Histogram]: opentelemetry::metrics::Histogram
+/// [Meter]: opentelemetry::metrics::Meter
+#[macro_export]
+macro_rules! histogram_metric {
+    ($name:ident, $meter:ident) => {
+        pub(crate) static $name: once_cell::sync::Lazy<
+            $crate::opentelemetry::metrics::Histogram<f64>,
+        > = once_cell::sync::Lazy::new(|| $meter.f64_histogram(stringify!($name)).init());
+    };
+    ($name:ident, $meter:ident, $description:literal) => {
+        pub(crate) static $name: once_cell::sync::Lazy<
+            $crate::opentelemetry::metrics::Histogram<f64>,
+        > = once_cell::sync::Lazy::new(|| $meter.f64_histogram($description).init());
+    };
+}


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->
This PR refactors the construction of `Counter` and `Histogram` metrics to use macros. Furthermore, these macros have been added to the `router_env` crate, since it anyway re-exports types from the `opentelemetry` crate.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
This would reduce a lot of repetitive code involved with the construction of metrics.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
N/A

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
