### PR TITLE
fix(docker-compose): remove port for hyperswitch-server-init in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,7 +85,7 @@ services:
 
   migration_runner:
     image: rust:1.65
-    command: "bash -c 'cargo install diesel_cli && diesel migration --database-url postgres://db_user:db_pass@pg:5432/hyperswitch_db run'"
+    command: "bash -c 'cargo install diesel_cli --no-default-features --features \"postgres\" && diesel migration --database-url postgres://db_user:db_pass@pg:5432/hyperswitch_db run'"
     working_dir: /app
     networks:
       - router_net

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -96,8 +96,6 @@ services:
     image: rust:1.65
     command: cargo build --bin router
     working_dir: /app
-    ports:
-      - "8080:8080"
     networks:
       - router_net
     volumes:


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
"hyperswitch-server-init" container doesn't requires port config


### Additional Changes

- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!-- 
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
"hyperswitch-server-init" and "hyperswitch-server" containers are trying to run in the same port, due to which "hyperswitch-server" is not getting started. However we don't need to provide port for "hyperswitch-server-init" as it is only for build.


## How did you test it?
Running docker in local machine
