### PR TITLE
feat(connector): Add support to provide connector_payment_meta for capture and void request

### DIFF
--- a/crates/router/src/core/payments/transformers.rs
+++ b/crates/router/src/core/payments/transformers.rs
@@ -508,6 +508,7 @@ impl<F: Clone> TryFrom<PaymentData<F>> for types::PaymentsCaptureData {
                 .connector_transaction_id
                 .ok_or(errors::ApiErrorResponse::MerchantConnectorAccountNotFound)?,
             amount: payment_data.amount.into(),
+            connector_meta: payment_data.payment_attempt.connector_metadata,
         })
     }
 }
@@ -526,6 +527,7 @@ impl<F: Clone> TryFrom<PaymentData<F>> for types::PaymentsCancelData {
                     field_name: "connector_transaction_id",
                 })?,
             cancellation_reason: payment_data.payment_attempt.cancellation_reason,
+            connector_meta: payment_data.payment_attempt.connector_metadata,
         })
     }
 }

--- a/crates/router/src/types.rs
+++ b/crates/router/src/types.rs
@@ -147,12 +147,13 @@ pub struct PaymentsAuthorizeData {
     pub payment_method_type: Option<storage_enums::PaymentMethodType>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct PaymentsCaptureData {
     pub amount_to_capture: Option<i64>,
     pub currency: storage_enums::Currency,
     pub connector_transaction_id: String,
     pub amount: i64,
+    pub connector_meta: Option<serde_json::Value>,
 }
 
 #[derive(Debug, Clone)]
@@ -197,6 +198,7 @@ pub struct PaymentsCancelData {
     pub currency: Option<storage_enums::Currency>,
     pub connector_transaction_id: String,
     pub cancellation_reason: Option<String>,
+    pub connector_meta: Option<serde_json::Value>,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/router/tests/connectors/adyen.rs
+++ b/crates/router/tests/connectors/adyen.rs
@@ -168,10 +168,9 @@ async fn should_void_authorized_payment() {
                 enums::CaptureMethod::Manual,
             ),
             Some(types::PaymentsCancelData {
-                amount: None,
-                currency: None,
                 connector_transaction_id: String::from(""),
                 cancellation_reason: Some("requested_by_customer".to_string()),
+                ..Default::default()
             }),
             AdyenTest::get_payment_info(),
         )

--- a/crates/router/tests/connectors/airwallex.rs
+++ b/crates/router/tests/connectors/airwallex.rs
@@ -141,10 +141,9 @@ async fn should_void_authorized_payment() {
         .authorize_and_void_payment(
             payment_method_details(),
             Some(types::PaymentsCancelData {
-                amount: None,
-                currency: None,
                 connector_transaction_id: String::from(""),
                 cancellation_reason: Some("requested_by_customer".to_string()),
+                ..Default::default()
             }),
             get_default_payment_info(),
         )

--- a/crates/router/tests/connectors/utils.rs
+++ b/crates/router/tests/connectors/utils.rs
@@ -504,6 +504,7 @@ impl Default for PaymentCaptureType {
             currency: enums::Currency::USD,
             connector_transaction_id: "".to_string(),
             amount: 100,
+            ..Default::default()
         })
     }
 }

--- a/loadtest/config/Development.toml
+++ b/loadtest/config/Development.toml
@@ -81,9 +81,6 @@ worldpay.base_url = "https://try.access.worldpay.com/"
 trustpay.base_url = "https://test-tpgw.trustpay.eu/"
 trustpay.base_url_bank_redirects = "https://aapi.trustpay.eu/"
 
-[connectors.mollie]
-base_url = "https://api.mollie.com/v2/"
-
 [connectors.supported]
 wallets = ["klarna", "braintree", "applepay"]
 cards = [

--- a/scripts/add_connector.sh
+++ b/scripts/add_connector.sh
@@ -51,11 +51,11 @@ sed -i'' -e "s|pub mod $prvc;|pub mod $prvc;\npub mod ${pg};|" $conn.rs
 sed -i'' -e "s/};/${pg}::${pgc},\n};/" $conn.rs 
 sed -i'' -e "s|\"$prvc\" \(.*\)|\"$prvc\" \1\n\t\t\t\"${pg}\" => Ok(Box::new(\&connector::${pgc})),|" $src/types/api.rs
 sed -i'' -e "s/pub $prvc: \(.*\)/pub $prvc: \1\n\tpub ${pg}: ConnectorParams,/" $src/configs/settings.rs
-sed -i'' -e "s/$prvc.base_url \(.*\)/$prvc.base_url \1\n${pg}.base_url = \"$base_url\"/" config/Development.toml config/docker_compose.toml config/config.example.toml loadtest/config/Development.toml
+sed -i'' -e "s|$prvc.base_url \(.*\)|$prvc.base_url \1\n${pg}.base_url = \"$base_url\"|" config/Development.toml config/docker_compose.toml config/config.example.toml loadtest/config/Development.toml
 sed  -r -i'' -e "s/\"$prvc\",/\"$prvc\",\n    \"${pg}\",/" config/Development.toml config/docker_compose.toml config/config.example.toml loadtest/config/Development.toml
 sed -i'' -e "s/Dummy,/Dummy,\n\t${pgc},/" crates/api_models/src/enums.rs
 sed -i'' -e "s/pub enum RoutableConnectors {/pub enum RoutableConnectors {\n\t${pgc},/" crates/api_models/src/enums.rs
-sed -i'' -e "s/    connector::$prvcc,/    connector::$prvcc,\n\tconnector::${pgc},/" $src/core/payments/flows.rs
+sed -i'' -e "s/^default_imp_for_\(.*\)/default_imp_for_\1\n\tconnector::${pgc},/" $src/core/payments/flows.rs
 
 # remove temporary files created in above step
 rm $conn.rs-e $src/types/api.rs-e $src/configs/settings.rs-e config/Development.toml-e config/docker_compose.toml-e config/config.example.toml-e loadtest/config/Development.toml-e crates/api_models/src/enums.rs-e $src/core/payments/flows.rs-e


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [X] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->
1. Adding support to provide meta_data for capture and void request also
2. Bug fixes in add_connector script

### Additional Changes

- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!-- 
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
Previously when a detail from payment authorize response is needed in any of the payment flow we only add it in the `connector_meta` of payment_attempt table, but it was only used in PaymentSync, now we are enabling the Capture and Void flows to make use of connector_meta from payment_attempt. 

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Ran basic sanity cases locally

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [X] I formatted the code `cargo +nightly fmt --all`
- [X] I addressed lints thrown by `cargo clippy`
- [X] I reviewed submitted code
