### PR TITLE
fix: process delete response from basilisk-v3 as plaintext instead of JWE

### DIFF
--- a/crates/router/src/core/payment_methods/vault.rs
+++ b/crates/router/src/core/payment_methods/vault.rs
@@ -584,7 +584,7 @@ pub async fn delete_tokenized_data(
     let payload = serde_json::to_string(&payload_to_be_encrypted)
         .map_err(|_x| errors::ApiErrorResponse::InternalServerError)?;
 
-    let (public_key, private_key) = get_locker_jwe_keys(&state.conf.jwekey, &state.conf.kms)
+    let (public_key, _private_key) = get_locker_jwe_keys(&state.conf.jwekey, &state.conf.kms)
         .await
         .change_context(errors::ApiErrorResponse::InternalServerError)
         .attach_printable("Error getting Encryption key")?;
@@ -609,31 +609,11 @@ pub async fn delete_tokenized_data(
         .change_context(errors::ApiErrorResponse::InternalServerError)?;
     match response {
         Ok(r) => {
-            let resp: api::TokenizePayloadEncrypted = r
-                .response
-                .parse_struct("TokenizePayloadEncrypted")
+            let delete_response = std::str::from_utf8(&r.response)
+                .into_report()
                 .change_context(errors::ApiErrorResponse::InternalServerError)
-                .attach_printable("Decoding Failed for TokenizePayloadEncrypted")?;
-            let alg = jwe::RSA_OAEP_256;
-            let decrypted_payload = services::decrypt_jwe(
-                &resp.payload,
-                get_key_id(&state.conf.jwekey),
-                &resp.key_id,
-                private_key,
-                alg,
-            )
-            .await
-            .change_context(errors::ApiErrorResponse::InternalServerError)
-            .attach_printable(
-                "DeleteTokenizedApi: Decrypt Jwe failed for TokenizePayloadEncrypted",
-            )?;
-            let delete_response = decrypted_payload
-                .parse_struct("Delete")
-                .change_context(errors::ApiErrorResponse::InternalServerError)
-                .attach_printable(
-                    "Error getting TokenizePayloadEncrypted from tokenize response",
-                )?;
-            Ok(delete_response)
+                .attach_printable("Decoding Failed for basilisk delete response")?;
+            Ok(delete_response.to_string())
         }
         Err(err) => Err(errors::ApiErrorResponse::InternalServerError)
             .into_report()


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
Response of temp card delete api is sent as a plaintext instead of jwe encrypted payload


### Additional Changes

- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!-- 
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
Do a confirm call, card from basilisk-v3 should be deleted and response is parsed successfully in router


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
