### PR TITLE
feat(router_env): making metric flow as a trait for extensibility

### DIFF
--- a/crates/router/src/routes/metrics/request.rs
+++ b/crates/router/src/routes/metrics/request.rs
@@ -1,6 +1,9 @@
 use super::utils as metric_utils;
 
-pub async fn record_request_time_metric<F, R>(future: F, flow: router_env::Flow) -> R
+pub async fn record_request_time_metric<F, R>(
+    future: F,
+    flow: impl router_env::types::FlowMetric,
+) -> R
 where
     F: futures::Future<Output = R>,
 {

--- a/crates/router/src/services/api.rs
+++ b/crates/router/src/services/api.rs
@@ -522,7 +522,7 @@ where
     fields(request_method, request_url_path)
 )]
 pub async fn server_wrap<'a, 'b, A, T, U, Q, F, Fut, E>(
-    flow: router_env::Flow,
+    flow: impl router_env::types::FlowMetric,
     state: &'b A,
     request: &'a HttpRequest,
     payload: T,

--- a/crates/router_env/src/logger/types.rs
+++ b/crates/router_env/src/logger/types.rs
@@ -164,6 +164,12 @@ pub enum Flow {
     ApiKeyList,
 }
 
+///
+/// Trait for providing generic behaviour to flow metric
+///
+pub trait FlowMetric: ToString + std::fmt::Debug {}
+impl FlowMetric for Flow {}
+
 /// Category of log event.
 #[derive(Debug)]
 pub enum Category {


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description

This makes addition of third-party flows possible in case of extending the router with an external flow dependency
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!-- 
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
