### PR TITLE
fix(connector): [Airwallex] Change Session Token to Init Payment

### DIFF
--- a/crates/router/src/connector/airwallex/transformers.rs
+++ b/crates/router/src/connector/airwallex/transformers.rs
@@ -20,11 +20,9 @@ pub struct AirwallexIntentRequest {
     //ID created in merchant's order system that corresponds to this PaymentIntent.
     merchant_order_id: String,
 }
-impl TryFrom<&types::PaymentsAuthorizeSessionTokenRouterData> for AirwallexIntentRequest {
+impl TryFrom<&types::PaymentsInitRouterData> for AirwallexIntentRequest {
     type Error = error_stack::Report<errors::ConnectorError>;
-    fn try_from(
-        item: &types::PaymentsAuthorizeSessionTokenRouterData,
-    ) -> Result<Self, Self::Error> {
+    fn try_from(item: &types::PaymentsInitRouterData) -> Result<Self, Self::Error> {
         Ok(Self {
             request_id: Uuid::new_v4().to_string(),
             amount: utils::to_currency_base_unit(item.request.amount, item.request.currency)?,
@@ -390,6 +388,5 @@ pub struct AirwallexWebhookObjectResource {
 pub struct AirwallexErrorResponse {
     pub code: String,
     pub message: String,
-    pub details: Option<Vec<String>>,
     pub source: Option<String>,
 }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [X] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->

Change the `pretask` in the `Authorize` flow to `InitPayment` which is currently implemented via `SessionToken`.

### Additional Changes

- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!-- 
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

To initiate a payment in Airwallex's Server we need to first call their `create` API endpoint.
This was implemented using `SessionToken` flow in the code which is not correct as it does not involve any session token, But is a `InitPayment` flow which call the connector and records the basic payment details before authorise call or actual payment call is made to their servers.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

All the unit tests for airwallex passed, the `refunds` test were `ignored` as they are not supported by the connector.
Also manual testing for the basic cases is done using postman.


![Screenshot 2023-03-23 at 5 45 31 PM](https://user-images.githubusercontent.com/55536657/227200896-5e83f0bb-f04d-4546-8fde-9de3036dc14f.png)

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [X] I formatted the code `cargo +nightly fmt --all`
- [X] I addressed lints thrown by `cargo clippy`
- [X] I reviewed submitted code
- [X] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
