### PR TITLE
refactor(api_models): enhance accepted countries/currencies types

### DIFF
--- a/crates/api_models/src/admin.rs
+++ b/crates/api_models/src/admin.rs
@@ -360,28 +360,30 @@ pub struct PaymentMethodsEnabled {
     pub payment_method_types: Option<Vec<payment_methods::RequestPaymentMethodTypes>>,
 }
 
-/// List of enabled and disabled currencies, empty in case all currencies are enabled
-#[derive(Eq, PartialEq, Hash, Debug, Clone, serde::Serialize, Deserialize, ToSchema)]
-#[serde(deny_unknown_fields)]
-pub struct AcceptedCurrencies {
-    /// type of accepted currencies (disable_only, enable_only)
-    #[serde(rename = "type")]
-    pub accept_type: String,
-    /// List of currencies of the provided type
-    #[schema(value_type = Option<Vec<Currency>>,example = json!(["USD", "EUR"]))]
-    pub list: Option<Vec<api_enums::Currency>>,
+#[derive(PartialEq, Eq, Hash, Debug, Clone, serde::Serialize, Deserialize, ToSchema)]
+#[serde(
+    deny_unknown_fields,
+    tag = "type",
+    content = "list",
+    rename_all = "snake_case"
+)]
+pub enum AcceptedCurrencies {
+    SpecificAccepted(Vec<api_enums::Currency>),
+    SpecificDenied(Vec<api_enums::Currency>),
+    AllAccepted,
 }
 
-/// List of enabled and disabled countries, empty in case all countries are enabled
-#[derive(Eq, PartialEq, Hash, Debug, Clone, serde::Serialize, Deserialize, ToSchema)]
-#[serde(deny_unknown_fields)]
-pub struct AcceptedCountries {
-    /// Type of accepted countries (disable_only, enable_only)
-    #[serde(rename = "type")]
-    pub accept_type: String,
-    /// List of countries of the provided type
-    #[schema(example = json!(["FR", "DE","IN"]))]
-    pub list: Option<Vec<String>>,
+#[derive(PartialEq, Eq, Hash, Debug, Clone, serde::Serialize, Deserialize, ToSchema)]
+#[serde(
+    deny_unknown_fields,
+    tag = "type",
+    content = "list",
+    rename_all = "snake_case"
+)]
+pub enum AcceptedCountries {
+    SpecificAccepted(Vec<String>),
+    SpecificDenied(Vec<String>),
+    AllAccepted,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]

--- a/crates/api_models/src/admin.rs
+++ b/crates/api_models/src/admin.rs
@@ -368,8 +368,8 @@ pub struct PaymentMethodsEnabled {
     rename_all = "snake_case"
 )]
 pub enum AcceptedCurrencies {
-    SpecificAccepted(Vec<api_enums::Currency>),
-    SpecificDenied(Vec<api_enums::Currency>),
+    EnableOnly(Vec<api_enums::Currency>),
+    DisableOnly(Vec<api_enums::Currency>),
     AllAccepted,
 }
 
@@ -381,8 +381,8 @@ pub enum AcceptedCurrencies {
     rename_all = "snake_case"
 )]
 pub enum AcceptedCountries {
-    SpecificAccepted(Vec<String>),
-    SpecificDenied(Vec<String>),
+    EnableOnly(Vec<String>),
+    DisableOnly(Vec<String>),
     AllAccepted,
 }
 

--- a/crates/api_models/src/enums.rs
+++ b/crates/api_models/src/enums.rs
@@ -137,6 +137,7 @@ pub enum ConnectorType {
     serde::Serialize,
     strum::Display,
     strum::EnumString,
+    strum::EnumIter,
     ToSchema,
     frunk::LabelledGeneric,
 )]

--- a/crates/api_models/src/payment_methods.rs
+++ b/crates/api_models/src/payment_methods.rs
@@ -241,9 +241,8 @@ pub struct RequestPaymentMethodTypes {
     /// List of currencies accepted or has the processing capabilities of the processor
     #[schema(example = json!(
         {
-        "enable_all":false,
-        "disable_only": ["INR", "CAD", "AED","JPY"],
-        "enable_only": ["EUR","USD"]
+            "type": "specific_accepted",
+            "list": ["USD", "INR"]
         }
     ))]
     pub accepted_currencies: Option<admin::AcceptedCurrencies>,
@@ -251,9 +250,8 @@ pub struct RequestPaymentMethodTypes {
     ///  List of Countries accepted or has the processing capabilities of the processor
     #[schema(example = json!(
         {
-            "enable_all":false,
-            "disable_only": ["FR", "DE","IN"],
-            "enable_only": ["UK","AU"]
+            "type": "specific_accepted",
+            "list": ["UK", "AU"]
         }
     ))]
     pub accepted_countries: Option<admin::AcceptedCountries>,

--- a/crates/router/src/core/payment_methods/cards.rs
+++ b/crates/router/src/core/payment_methods/cards.rs
@@ -1238,21 +1238,21 @@ fn filter_pm_country_based(
     match (accepted_countries, req_country_list) {
         (None, None) => (None, None, true),
         (None, Some(ref r)) => (
-            Some(admin::AcceptedCountries::SpecificAccepted(r.to_vec())),
+            Some(admin::AcceptedCountries::EnableOnly(r.to_vec())),
             Some(r.to_vec()),
             true,
         ),
         (Some(l), None) => (Some(l.to_owned()), None, true),
         (Some(l), Some(ref r)) => {
             let updated = match l {
-                admin::AcceptedCountries::SpecificAccepted(acc) => {
+                admin::AcceptedCountries::EnableOnly(acc) => {
                     filter_accepted_enum_based(&Some(acc.clone()), &Some(r.to_owned()))
-                        .map(admin::AcceptedCountries::SpecificAccepted)
+                        .map(admin::AcceptedCountries::EnableOnly)
                 }
 
-                admin::AcceptedCountries::SpecificDenied(den) => {
+                admin::AcceptedCountries::DisableOnly(den) => {
                     filter_disabled_enum_based(&Some(den.clone()), &Some(r.to_owned()))
-                        .map(admin::AcceptedCountries::SpecificDenied)
+                        .map(admin::AcceptedCountries::DisableOnly)
                 }
 
                 admin::AcceptedCountries::AllAccepted => {
@@ -1276,21 +1276,21 @@ fn filter_pm_currencies_based(
     match (accepted_currency, req_currency_list) {
         (None, None) => (None, None, true),
         (None, Some(ref r)) => (
-            Some(admin::AcceptedCurrencies::SpecificAccepted(r.to_vec())),
+            Some(admin::AcceptedCurrencies::EnableOnly(r.to_vec())),
             Some(r.to_vec()),
             true,
         ),
         (Some(l), None) => (Some(l.to_owned()), None, true),
         (Some(l), Some(ref r)) => {
             let updated = match l {
-                admin::AcceptedCurrencies::SpecificAccepted(acc) => {
+                admin::AcceptedCurrencies::EnableOnly(acc) => {
                     filter_accepted_enum_based(&Some(acc.clone()), &Some(r.to_owned()))
-                        .map(admin::AcceptedCurrencies::SpecificAccepted)
+                        .map(admin::AcceptedCurrencies::EnableOnly)
                 }
 
-                admin::AcceptedCurrencies::SpecificDenied(den) => {
+                admin::AcceptedCurrencies::DisableOnly(den) => {
                     filter_disabled_enum_based(&Some(den.clone()), &Some(r.to_owned()))
-                        .map(admin::AcceptedCurrencies::SpecificDenied)
+                        .map(admin::AcceptedCurrencies::DisableOnly)
                 }
 
                 admin::AcceptedCurrencies::AllAccepted => {
@@ -1388,8 +1388,8 @@ async fn filter_payment_country_based(
     Ok(address.map_or(true, |address| {
         address.country.as_ref().map_or(true, |country| {
             pm.accepted_countries.as_ref().map_or(true, |ac| match ac {
-                admin::AcceptedCountries::SpecificAccepted(acc) => acc.contains(country),
-                admin::AcceptedCountries::SpecificDenied(den) => !den.contains(country),
+                admin::AcceptedCountries::EnableOnly(acc) => acc.contains(country),
+                admin::AcceptedCountries::DisableOnly(den) => !den.contains(country),
                 admin::AcceptedCountries::AllAccepted => true,
             })
         })
@@ -1402,10 +1402,10 @@ fn filter_payment_currency_based(
 ) -> bool {
     payment_intent.currency.map_or(true, |currency| {
         pm.accepted_currencies.as_ref().map_or(true, |ac| match ac {
-            admin::AcceptedCurrencies::SpecificAccepted(acc) => {
+            admin::AcceptedCurrencies::EnableOnly(acc) => {
                 acc.contains(&currency.foreign_into())
             }
-            admin::AcceptedCurrencies::SpecificDenied(den) => {
+            admin::AcceptedCurrencies::DisableOnly(den) => {
                 !den.contains(&currency.foreign_into())
             }
             admin::AcceptedCurrencies::AllAccepted => true,

--- a/crates/router/src/core/payment_methods/cards.rs
+++ b/crates/router/src/core/payment_methods/cards.rs
@@ -1402,12 +1402,8 @@ fn filter_payment_currency_based(
 ) -> bool {
     payment_intent.currency.map_or(true, |currency| {
         pm.accepted_currencies.as_ref().map_or(true, |ac| match ac {
-            admin::AcceptedCurrencies::EnableOnly(acc) => {
-                acc.contains(&currency.foreign_into())
-            }
-            admin::AcceptedCurrencies::DisableOnly(den) => {
-                !den.contains(&currency.foreign_into())
-            }
+            admin::AcceptedCurrencies::EnableOnly(acc) => acc.contains(&currency.foreign_into()),
+            admin::AcceptedCurrencies::DisableOnly(den) => !den.contains(&currency.foreign_into()),
             admin::AcceptedCurrencies::AllAccepted => true,
         })
     })

--- a/crates/router/src/core/payment_methods/cards.rs
+++ b/crates/router/src/core/payment_methods/cards.rs
@@ -1238,28 +1238,29 @@ fn filter_pm_country_based(
     match (accepted_countries, req_country_list) {
         (None, None) => (None, None, true),
         (None, Some(ref r)) => (
-            Some(admin::AcceptedCountries {
-                accept_type: "enable_only".to_owned(),
-                list: Some(r.to_vec()),
-            }),
+            Some(admin::AcceptedCountries::SpecificAccepted(r.to_vec())),
             Some(r.to_vec()),
             true,
         ),
         (Some(l), None) => (Some(l.to_owned()), None, true),
         (Some(l), Some(ref r)) => {
-            let list = if l.accept_type == "enable_only" {
-                filter_accepted_enum_based(&l.list, &Some(r.to_owned()))
-            } else {
-                filter_disabled_enum_based(&l.list, &Some(r.to_owned()))
+            let updated = match l {
+                admin::AcceptedCountries::SpecificAccepted(acc) => {
+                    filter_accepted_enum_based(&Some(acc.clone()), &Some(r.to_owned()))
+                        .map(admin::AcceptedCountries::SpecificAccepted)
+                }
+
+                admin::AcceptedCountries::SpecificDenied(den) => {
+                    filter_disabled_enum_based(&Some(den.clone()), &Some(r.to_owned()))
+                        .map(admin::AcceptedCountries::SpecificDenied)
+                }
+
+                admin::AcceptedCountries::AllAccepted => {
+                    Some(admin::AcceptedCountries::AllAccepted)
+                }
             };
-            (
-                Some(admin::AcceptedCountries {
-                    accept_type: l.accept_type.to_owned(),
-                    list,
-                }),
-                Some(r.to_vec()),
-                true,
-            )
+
+            (updated, Some(r.to_vec()), true)
         }
     }
 }
@@ -1275,28 +1276,29 @@ fn filter_pm_currencies_based(
     match (accepted_currency, req_currency_list) {
         (None, None) => (None, None, true),
         (None, Some(ref r)) => (
-            Some(admin::AcceptedCurrencies {
-                accept_type: "enable_only".to_owned(),
-                list: Some(r.to_vec()),
-            }),
+            Some(admin::AcceptedCurrencies::SpecificAccepted(r.to_vec())),
             Some(r.to_vec()),
             true,
         ),
         (Some(l), None) => (Some(l.to_owned()), None, true),
         (Some(l), Some(ref r)) => {
-            let list = if l.accept_type == "enable_only" {
-                filter_accepted_enum_based(&l.list, &Some(r.to_owned()))
-            } else {
-                filter_disabled_enum_based(&l.list, &Some(r.to_owned()))
+            let updated = match l {
+                admin::AcceptedCurrencies::SpecificAccepted(acc) => {
+                    filter_accepted_enum_based(&Some(acc.clone()), &Some(r.to_owned()))
+                        .map(admin::AcceptedCurrencies::SpecificAccepted)
+                }
+
+                admin::AcceptedCurrencies::SpecificDenied(den) => {
+                    filter_disabled_enum_based(&Some(den.clone()), &Some(r.to_owned()))
+                        .map(admin::AcceptedCurrencies::SpecificDenied)
+                }
+
+                admin::AcceptedCurrencies::AllAccepted => {
+                    Some(admin::AcceptedCurrencies::AllAccepted)
+                }
             };
-            (
-                Some(admin::AcceptedCurrencies {
-                    accept_type: l.accept_type.to_owned(),
-                    list,
-                }),
-                Some(r.to_vec()),
-                true,
-            )
+
+            (updated, Some(r.to_vec()), true)
         }
     }
 }
@@ -1385,16 +1387,10 @@ async fn filter_payment_country_based(
 ) -> errors::CustomResult<bool, errors::ApiErrorResponse> {
     Ok(address.map_or(true, |address| {
         address.country.as_ref().map_or(true, |country| {
-            pm.accepted_countries.as_ref().map_or(true, |ac| {
-                if ac.accept_type == "enable_only" {
-                    ac.list
-                        .as_ref()
-                        .map_or(false, |enable_countries| enable_countries.contains(country))
-                } else {
-                    ac.list.as_ref().map_or(true, |disable_countries| {
-                        !disable_countries.contains(country)
-                    })
-                }
+            pm.accepted_countries.as_ref().map_or(true, |ac| match ac {
+                admin::AcceptedCountries::SpecificAccepted(acc) => acc.contains(country),
+                admin::AcceptedCountries::SpecificDenied(den) => !den.contains(country),
+                admin::AcceptedCountries::AllAccepted => true,
             })
         })
     }))
@@ -1405,16 +1401,14 @@ fn filter_payment_currency_based(
     pm: &RequestPaymentMethodTypes,
 ) -> bool {
     payment_intent.currency.map_or(true, |currency| {
-        pm.accepted_currencies.as_ref().map_or(true, |ac| {
-            if ac.accept_type == "enable_only" {
-                ac.list.as_ref().map_or(false, |enable_currencies| {
-                    enable_currencies.contains(&currency.foreign_into())
-                })
-            } else {
-                ac.list.as_ref().map_or(true, |disable_currencies| {
-                    !disable_currencies.contains(&currency.foreign_into())
-                })
+        pm.accepted_currencies.as_ref().map_or(true, |ac| match ac {
+            admin::AcceptedCurrencies::SpecificAccepted(acc) => {
+                acc.contains(&currency.foreign_into())
             }
+            admin::AcceptedCurrencies::SpecificDenied(den) => {
+                !den.contains(&currency.foreign_into())
+            }
+            admin::AcceptedCurrencies::AllAccepted => true,
         })
     })
 }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->
This PR makes the `accepted_currencies` and `accepted_countries` field types in `MCA` as enums. Earlier, we had an explicit tagged data structure where the tag itself was a `String` so it could be anything. This change rectifies this issue by converting the types from explicitly tagged structs to serde tagged enums.

### Additional Changes
None
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!-- 
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
Using serde tagged enums allows better expression of data types with `variants`.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Manual, compiler-guided.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
