### PR TITLE
fix(cads_info): add extra columns to cards_info struct

### DIFF
--- a/crates/storage_models/src/cards_info.rs
+++ b/crates/storage_models/src/cards_info.rs
@@ -1,4 +1,5 @@
 use diesel::{Identifiable, Queryable};
+use time::PrimitiveDateTime;
 
 use crate::schema::cards_info;
 
@@ -14,4 +15,7 @@ pub struct CardInfo {
     pub bank_code_id: Option<String>,
     pub bank_code: Option<String>,
     pub country_code: Option<String>,
+    pub date_created: PrimitiveDateTime,
+    pub last_updated: Option<PrimitiveDateTime>,
+    pub last_updated_provider: Option<String>,
 }

--- a/crates/storage_models/src/schema.rs
+++ b/crates/storage_models/src/schema.rs
@@ -56,6 +56,9 @@ diesel::table! {
         bank_code_id -> Nullable<Varchar>,
         bank_code -> Nullable<Varchar>,
         country_code -> Nullable<Varchar>,
+        date_created -> Timestamp,
+        last_updated -> Nullable<Timestamp>,
+        last_updated_provider -> Nullable<Text>,
     }
 }
 


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix

## Description
<!-- Describe your changes in detail -->
There are some columns in `cards_info` table which will be used and updated by the crawlers. These columns are added in the migration. But when migrations are run, the columns are added to `schema.rs`. Since these fields are not in the `CardInfo` struct in `storage_models` the code will not compile. This PR adds those columns to the struct.



## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
Make the code compile.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
<img width="1222" alt="Screenshot 2023-03-29 at 4 29 40 PM" src="https://user-images.githubusercontent.com/48803246/228513374-b7176488-753c-493a-afbf-99466ffd7284.png">


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
