### PR TITLE
deps(api_models): put the errors module behind a feature flag

### DIFF
--- a/crates/api_models/Cargo.toml
+++ b/crates/api_models/Cargo.toml
@@ -4,14 +4,19 @@ version = "0.1.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[features]
+errors = [
+    "dep:actix-web",
+    "dep:reqwest",
+]
 
 [dependencies]
-actix-web = "4.3.1"
+actix-web = { version = "4.3.1", optional = true }
 error-stack = "0.3.1"
 frunk = "0.4.1"
 frunk_core = "0.4.1"
 mime = "0.3.16"
-reqwest = "0.11.14"
+reqwest = { version = "0.11.14", optional = true }
 serde = { version = "1.0.155", features = ["derive"] }
 serde_json = "1.0.94"
 strum = { version = "0.24.1", features = ["derive"] }

--- a/crates/api_models/src/lib.rs
+++ b/crates/api_models/src/lib.rs
@@ -6,6 +6,7 @@ pub mod cards_info;
 pub mod customers;
 pub mod disputes;
 pub mod enums;
+#[cfg(feature = "errors")]
 pub mod errors;
 pub mod files;
 pub mod mandates;

--- a/crates/api_models/src/webhooks.rs
+++ b/crates/api_models/src/webhooks.rs
@@ -50,14 +50,6 @@ impl From<IncomingWebhookEvent> for WebhookFlow {
     }
 }
 
-pub struct IncomingWebhookRequestDetails<'a> {
-    pub method: actix_web::http::Method,
-    pub headers: &'a actix_web::http::header::HeaderMap,
-    pub body: &'a [u8],
-    pub query_params: String,
-    pub query_params_json: &'a [u8],
-}
-
 pub type MerchantWebhookConfig = std::collections::HashSet<IncomingWebhookEvent>;
 
 pub enum RefundIdType {

--- a/crates/router/Cargo.toml
+++ b/crates/router/Cargo.toml
@@ -79,7 +79,7 @@ utoipa-swagger-ui = { version = "3.1.0", features = ["actix-web"] }
 uuid = { version = "1.3.0", features = ["serde", "v4"] }
 
 # First party crates
-api_models = { version = "0.1.0", path = "../api_models" }
+api_models = { version = "0.1.0", path = "../api_models", features = ["errors"] }
 common_utils = { version = "0.1.0", path = "../common_utils" }
 external_services = { version = "0.1.0", path = "../external_services" }
 masking = { version = "0.1.0", path = "../masking" }

--- a/crates/router/src/connector/adyen.rs
+++ b/crates/router/src/connector/adyen.rs
@@ -783,7 +783,7 @@ impl api::IncomingWebhook for Adyen {
 
     fn get_dispute_details(
         &self,
-        request: &api_models::webhooks::IncomingWebhookRequestDetails<'_>,
+        request: &api::IncomingWebhookRequestDetails<'_>,
     ) -> CustomResult<api::disputes::DisputePayload, errors::ConnectorError> {
         let notif = get_webhook_object_from_body(request.body)
             .change_context(errors::ConnectorError::WebhookBodyDecodingFailed)?;

--- a/crates/router/src/connector/trustpay.rs
+++ b/crates/router/src/connector/trustpay.rs
@@ -722,7 +722,7 @@ impl api::IncomingWebhook for Trustpay {
 
     fn get_dispute_details(
         &self,
-        request: &api_models::webhooks::IncomingWebhookRequestDetails<'_>,
+        request: &api::IncomingWebhookRequestDetails<'_>,
     ) -> CustomResult<api::disputes::DisputePayload, errors::ConnectorError> {
         let trustpay_response: trustpay::TrustpayWebhookResponse = request
             .body

--- a/crates/router/src/core/webhooks.rs
+++ b/crates/router/src/core/webhooks.rs
@@ -301,7 +301,7 @@ async fn disputes_incoming_webhook_flow<W: api::OutgoingWebhookType>(
     webhook_details: api::IncomingWebhookDetails,
     source_verified: bool,
     connector: &(dyn api::Connector + Sync),
-    request_details: &api_models::webhooks::IncomingWebhookRequestDetails<'_>,
+    request_details: &api::IncomingWebhookRequestDetails<'_>,
     event_type: api_models::webhooks::IncomingWebhookEvent,
 ) -> CustomResult<(), errors::WebhooksFlowError> {
     metrics::INCOMING_DISPUTE_WEBHOOK_METRIC.add(&metrics::CONTEXT, 1, &[]);
@@ -497,7 +497,7 @@ pub async fn webhooks_core<W: api::OutgoingWebhookType>(
         .change_context(errors::ApiErrorResponse::InternalServerError)
         .attach_printable("There was an error in parsing the query params")?;
 
-    let mut request_details = api_models::webhooks::IncomingWebhookRequestDetails {
+    let mut request_details = api::IncomingWebhookRequestDetails {
         method: req.method().clone(),
         headers: req.headers(),
         query_params: req.query_string().to_string(),

--- a/crates/router/src/types/api/webhooks.rs
+++ b/crates/router/src/types/api/webhooks.rs
@@ -1,7 +1,6 @@
 pub use api_models::webhooks::{
-    IncomingWebhookDetails, IncomingWebhookEvent, IncomingWebhookRequestDetails,
-    MerchantWebhookConfig, ObjectReferenceId, OutgoingWebhook, OutgoingWebhookContent,
-    OutgoingWebhookType, WebhookFlow,
+    IncomingWebhookDetails, IncomingWebhookEvent, MerchantWebhookConfig, ObjectReferenceId,
+    OutgoingWebhook, OutgoingWebhookContent, OutgoingWebhookType, WebhookFlow,
 };
 use error_stack::ResultExt;
 
@@ -12,6 +11,14 @@ use crate::{
     services,
     utils::crypto,
 };
+
+pub struct IncomingWebhookRequestDetails<'a> {
+    pub method: actix_web::http::Method,
+    pub headers: &'a actix_web::http::header::HeaderMap,
+    pub body: &'a [u8],
+    pub query_params: String,
+    pub query_params_json: &'a [u8],
+}
 
 #[async_trait::async_trait]
 pub trait IncomingWebhook: ConnectorCommon + Sync {


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [x] Dependency updates

## Description
<!-- Describe your changes in detail -->
This PR puts the `errors` module in `api_models` behind a feature flag and makes actix-web and related dependencies optional.

### Additional Changes
None
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!-- 
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
Required to make async/tokio related features in `api_models` opt-in.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
cargo build

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
