### PR TITLE
feat(middleware): add middleware to attach default response headers

### DIFF
--- a/crates/api_models/src/errors/actix.rs
+++ b/crates/api_models/src/errors/actix.rs
@@ -25,8 +25,6 @@ impl actix_web::ResponseError for ApiErrorResponse {
 
         actix_web::HttpResponseBuilder::new(self.status_code())
             .insert_header((header::CONTENT_TYPE, mime::APPLICATION_JSON))
-            .insert_header((header::STRICT_TRANSPORT_SECURITY, "max-age=31536000"))
-            .insert_header((header::VIA, "Juspay_Router"))
             .body(self.to_string())
     }
 }

--- a/crates/router/src/compatibility/stripe/errors.rs
+++ b/crates/router/src/compatibility/stripe/errors.rs
@@ -522,12 +522,8 @@ impl actix_web::ResponseError for StripeErrorCode {
     fn error_response(&self) -> actix_web::HttpResponse {
         use actix_web::http::header;
 
-        use crate::consts;
-
         actix_web::HttpResponseBuilder::new(self.status_code())
             .insert_header((header::CONTENT_TYPE, mime::APPLICATION_JSON))
-            .insert_header((header::STRICT_TRANSPORT_SECURITY, consts::HSTS_HEADER_VALUE))
-            .insert_header((header::VIA, "Juspay_Router"))
             .body(self.to_string())
     }
 }

--- a/crates/router/src/consts.rs
+++ b/crates/router/src/consts.rs
@@ -24,6 +24,3 @@ pub(crate) const BASE64_ENGINE_URL_SAFE: base64::engine::GeneralPurpose =
 
 pub(crate) const API_KEY_LENGTH: usize = 64;
 pub(crate) const PUB_SUB_CHANNEL: &str = "hyperswitch_invalidate";
-
-/// Max age of 1 year in seconds. Which is `60*60*24*365`
-pub(crate) const HSTS_HEADER_VALUE: &str = "max-age=31536000";

--- a/crates/router/src/core/errors.rs
+++ b/crates/router/src/core/errors.rs
@@ -153,14 +153,8 @@ impl From<ConfigError> for ApplicationError {
 }
 
 fn error_response<T: Display>(err: &T) -> actix_web::HttpResponse {
-    use actix_web::http::header;
-
-    use crate::consts;
-
     actix_web::HttpResponse::BadRequest()
-        .append_header((header::STRICT_TRANSPORT_SECURITY, consts::HSTS_HEADER_VALUE))
-        .append_header((header::VIA, "Juspay_Router"))
-        .content_type("application/json")
+        .content_type(mime::APPLICATION_JSON)
         .body(format!(r#"{{ "error": {{ "message": "{err}" }} }}"#))
 }
 

--- a/crates/router/src/core/errors/api_error_response.rs
+++ b/crates/router/src/core/errors/api_error_response.rs
@@ -263,12 +263,8 @@ impl actix_web::ResponseError for ApiErrorResponse {
     fn error_response(&self) -> actix_web::HttpResponse {
         use actix_web::http::header;
 
-        use crate::consts;
-
         actix_web::HttpResponseBuilder::new(self.status_code())
             .insert_header((header::CONTENT_TYPE, mime::APPLICATION_JSON))
-            .insert_header((header::STRICT_TRANSPORT_SECURITY, consts::HSTS_HEADER_VALUE))
-            .insert_header((header::VIA, "Juspay_Router"))
             .body(self.to_string())
     }
 }

--- a/crates/router/src/lib.rs
+++ b/crates/router/src/lib.rs
@@ -168,6 +168,7 @@ pub fn get_application_builder(
     actix_web::App::new()
         .app_data(json_cfg)
         .wrap(middleware::RequestId)
+        .wrap(middleware::default_response_headers())
         .wrap(router_env::tracing_actix_web::TracingLogger::default())
         .wrap(ErrorHandlers::new().handler(
             StatusCode::NOT_FOUND,

--- a/crates/router/src/middleware.rs
+++ b/crates/router/src/middleware.rs
@@ -59,3 +59,14 @@ where
         })
     }
 }
+
+/// Middleware for attaching default response headers. Headers with the same key already set in a
+/// response will not be overwritten.
+pub fn default_response_headers() -> actix_web::middleware::DefaultHeaders {
+    use actix_web::http::header;
+
+    actix_web::middleware::DefaultHeaders::new()
+        // Max age of 1 year in seconds, equal to `60 * 60 * 24 * 365` seconds.
+        .add((header::STRICT_TRANSPORT_SECURITY, "max-age=31536000"))
+        .add((header::VIA, "HyperSwitch"))
+}

--- a/crates/router/src/services/api.rs
+++ b/crates/router/src/services/api.rs
@@ -9,7 +9,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use actix_web::{body, http::header, HttpRequest, HttpResponse, Responder};
+use actix_web::{body, HttpRequest, HttpResponse, Responder};
 use common_utils::errors::ReportSwitchExt;
 use error_stack::{report, IntoReport, Report, ResultExt};
 use masking::ExposeOptionInterface;
@@ -20,7 +20,6 @@ use self::request::{ContentType, HeaderExt, RequestBuilderExt};
 pub use self::request::{Method, Request, RequestBuilder};
 use crate::{
     configs::settings::Connectors,
-    consts,
     core::{
         errors::{self, CustomResult},
         payments,
@@ -604,25 +603,16 @@ where
 
 pub fn http_response_json<T: body::MessageBody + 'static>(response: T) -> HttpResponse {
     HttpResponse::Ok()
-        .content_type("application/json")
-        .append_header((header::VIA, "Juspay_router"))
-        .append_header((header::STRICT_TRANSPORT_SECURITY, consts::HSTS_HEADER_VALUE))
+        .content_type(mime::APPLICATION_JSON)
         .body(response)
 }
 
 pub fn http_response_plaintext<T: body::MessageBody + 'static>(res: T) -> HttpResponse {
-    HttpResponse::Ok()
-        .content_type("text/plain")
-        .append_header((header::VIA, "Juspay_router"))
-        .append_header((header::STRICT_TRANSPORT_SECURITY, consts::HSTS_HEADER_VALUE))
-        .body(res)
+    HttpResponse::Ok().content_type(mime::TEXT_PLAIN).body(res)
 }
 
 pub fn http_response_ok() -> HttpResponse {
-    HttpResponse::Ok()
-        .append_header((header::VIA, "Juspay_router"))
-        .append_header((header::STRICT_TRANSPORT_SECURITY, consts::HSTS_HEADER_VALUE))
-        .finish()
+    HttpResponse::Ok().finish()
 }
 
 pub fn http_redirect_response<T: body::MessageBody + 'static>(
@@ -630,22 +620,18 @@ pub fn http_redirect_response<T: body::MessageBody + 'static>(
     redirection_response: api::RedirectionResponse,
 ) -> HttpResponse {
     HttpResponse::Ok()
-        .content_type("application/json")
-        .append_header((header::VIA, "Juspay_router"))
+        .content_type(mime::APPLICATION_JSON)
         .append_header((
             "Location",
             redirection_response.return_url_with_query_params,
         ))
-        .append_header((header::STRICT_TRANSPORT_SECURITY, consts::HSTS_HEADER_VALUE))
         .status(http::StatusCode::FOUND)
         .body(response)
 }
 
 pub fn http_response_err<T: body::MessageBody + 'static>(response: T) -> HttpResponse {
     HttpResponse::BadRequest()
-        .content_type("application/json")
-        .append_header((header::VIA, "Juspay_router"))
-        .append_header((header::STRICT_TRANSPORT_SECURITY, consts::HSTS_HEADER_VALUE))
+        .content_type(mime::APPLICATION_JSON)
         .body(response)
 }
 

--- a/crates/router/src/utils.rs
+++ b/crates/router/src/utils.rs
@@ -51,18 +51,14 @@ pub mod error_parser {
 
     impl ResponseError for CustomJsonError {
         fn status_code(&self) -> StatusCode {
-            StatusCode::INTERNAL_SERVER_ERROR
+            StatusCode::BAD_REQUEST
         }
 
         fn error_response(&self) -> actix_web::HttpResponse<actix_web::body::BoxBody> {
             use actix_web::http::header;
 
-            use crate::consts;
-
-            actix_web::HttpResponseBuilder::new(StatusCode::BAD_REQUEST)
+            actix_web::HttpResponseBuilder::new(self.status_code())
                 .insert_header((header::CONTENT_TYPE, mime::APPLICATION_JSON))
-                .insert_header((header::STRICT_TRANSPORT_SECURITY, consts::HSTS_HEADER_VALUE))
-                .insert_header((header::VIA, "Juspay_Router"))
                 .body(self.to_string())
         }
     }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->
This PR adds makes use of `actix_web::middleware::DefaultHeaders` middleware to attach default response headers.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
This should reduce duplication of the same set of response headers being added everywhere a response is returned.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
```shell
$ curl -X GET -I http://localhost:8080/health
HTTP/1.1 200 OK
content-length: 14
strict-transport-security: max-age=31536000
access-control-expose-headers: x-request-id, via, strict-transport-security
access-control-allow-credentials: true
x-request-id: d6af9e6c-f8a8-4fa2-91a1-f435e6c77b1e
via: HyperSwitch
vary: Origin, Access-Control-Request-Method, Access-Control-Request-Headers
date: Sat, 01 Apr 2023 11:01:06 GMT
```

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
