### PR TITLE
deps(common_utils): put the async ext trait behind a feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5042,13 +5042,13 @@ dependencies = [
 
 [[package]]
 name = "wiremock"
-version = "0.5.17"
+version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12316b50eb725e22b2f6b9c4cbede5b7b89984274d113a7440c86e5c3fc6f99b"
+checksum = "bd7b0b5b253ebc0240d6aac6dd671c495c467420577bf634d3064ae7e6fa2b4c"
 dependencies = [
  "assert-json-diff",
  "async-trait",
- "base64 0.13.1",
+ "base64 0.21.0",
  "deadpool",
  "futures",
  "futures-timer",

--- a/crates/common_utils/Cargo.toml
+++ b/crates/common_utils/Cargo.toml
@@ -16,14 +16,15 @@ signals = [
     "dep:futures"
 ]
 async_ext = [
-    "dep:futures"
+    "dep:futures",
+    "dep:async-trait"
 ]
 logs = [
     "dep:router_env"
 ]
 
 [dependencies]
-async-trait = "0.1.66"
+async-trait = { version = "0.1.66", optional = true }
 bytes = "1.4.0"
 error-stack = "0.3.1"
 futures = { version = "0.3.27", optional = true }

--- a/crates/common_utils/Cargo.toml
+++ b/crates/common_utils/Cargo.toml
@@ -12,7 +12,11 @@ signals = [
     "dep:signal-hook-tokio",
     "dep:signal-hook",
     "dep:tokio",
-    "dep:router_env"
+    "dep:router_env",
+    "dep:futures"
+]
+async_ext = [
+    "dep:futures"
 ]
 logs = [
     "dep:router_env"
@@ -22,7 +26,7 @@ logs = [
 async-trait = "0.1.66"
 bytes = "1.4.0"
 error-stack = "0.3.1"
-futures = "0.3.27"
+futures = { version = "0.3.27", optional = true }
 hex = "0.4.3"
 nanoid = "0.4.0"
 once_cell = "1.17.1"

--- a/crates/common_utils/src/ext_traits.rs
+++ b/crates/common_utils/src/ext_traits.rs
@@ -287,7 +287,7 @@ impl<T> StringExt<T> for String {
 /// Extending functionalities of Wrapper types for idiomatic
 ///
 #[cfg(feature = "async_ext")]
-#[async_trait::async_trait]
+#[cfg_attr(feature = "async_ext", async_trait::async_trait)]
 pub trait AsyncExt<A, B> {
     /// Output type of the map function
     type WrappedSelf<T>;
@@ -309,7 +309,7 @@ pub trait AsyncExt<A, B> {
 }
 
 #[cfg(feature = "async_ext")]
-#[async_trait::async_trait]
+#[cfg_attr(feature = "async_ext", async_trait::async_trait)]
 impl<A: Send, B, E: Send> AsyncExt<A, B> for Result<A, E> {
     type WrappedSelf<T> = Result<T, E>;
     async fn async_and_then<F, Fut>(self, func: F) -> Self::WrappedSelf<B>
@@ -336,7 +336,7 @@ impl<A: Send, B, E: Send> AsyncExt<A, B> for Result<A, E> {
 }
 
 #[cfg(feature = "async_ext")]
-#[async_trait::async_trait]
+#[cfg_attr(feature = "async_ext", async_trait::async_trait)]
 impl<A: Send, B> AsyncExt<A, B> for Option<A> {
     type WrappedSelf<T> = Option<T>;
     async fn async_and_then<F, Fut>(self, func: F) -> Self::WrappedSelf<B>

--- a/crates/common_utils/src/ext_traits.rs
+++ b/crates/common_utils/src/ext_traits.rs
@@ -286,6 +286,7 @@ impl<T> StringExt<T> for String {
 ///
 /// Extending functionalities of Wrapper types for idiomatic
 ///
+#[cfg(feature = "async_ext")]
 #[async_trait::async_trait]
 pub trait AsyncExt<A, B> {
     /// Output type of the map function
@@ -307,6 +308,7 @@ pub trait AsyncExt<A, B> {
         Fut: futures::Future<Output = Self::WrappedSelf<B>> + Send;
 }
 
+#[cfg(feature = "async_ext")]
 #[async_trait::async_trait]
 impl<A: Send, B, E: Send> AsyncExt<A, B> for Result<A, E> {
     type WrappedSelf<T> = Result<T, E>;
@@ -333,6 +335,7 @@ impl<A: Send, B, E: Send> AsyncExt<A, B> for Result<A, E> {
     }
 }
 
+#[cfg(feature = "async_ext")]
 #[async_trait::async_trait]
 impl<A: Send, B> AsyncExt<A, B> for Option<A> {
     type WrappedSelf<T> = Option<T>;

--- a/crates/common_utils/src/lib.rs
+++ b/crates/common_utils/src/lib.rs
@@ -17,12 +17,12 @@ pub mod validation;
 pub mod date_time {
     use std::num::NonZeroU8;
 
+    #[cfg(feature = "async_ext")]
+    use time::Instant;
     use time::{
         format_description::well_known::iso8601::{Config, EncodedConfig, Iso8601, TimePrecision},
         OffsetDateTime, PrimitiveDateTime,
     };
-    #[cfg(feature = "async_ext")]
-    use time::Instant;
     /// Struct to represent milliseconds in time sensitive data fields
     #[derive(Debug)]
     pub struct Milliseconds(i32);

--- a/crates/common_utils/src/lib.rs
+++ b/crates/common_utils/src/lib.rs
@@ -19,8 +19,10 @@ pub mod date_time {
 
     use time::{
         format_description::well_known::iso8601::{Config, EncodedConfig, Iso8601, TimePrecision},
-        Instant, OffsetDateTime, PrimitiveDateTime,
+        OffsetDateTime, PrimitiveDateTime,
     };
+    #[cfg(feature = "async_ext")]
+    use time::Instant;
     /// Struct to represent milliseconds in time sensitive data fields
     #[derive(Debug)]
     pub struct Milliseconds(i32);
@@ -42,6 +44,7 @@ pub mod date_time {
     }
 
     /// Calculate execution time for a async block in milliseconds
+    #[cfg(feature = "async_ext")]
     pub async fn time_it<T, Fut: futures::Future<Output = T>, F: FnOnce() -> Fut>(
         block: F,
     ) -> (T, f64) {

--- a/crates/redis_interface/Cargo.toml
+++ b/crates/redis_interface/Cargo.toml
@@ -16,7 +16,7 @@ serde = { version = "1.0.155", features = ["derive"] }
 thiserror = "1.0.39"
 
 # First party crates
-common_utils = { version = "0.1.0", path = "../common_utils" }
+common_utils = { version = "0.1.0", path = "../common_utils", features = ["async_ext"] }
 router_env = { version = "0.1.0", path = "../router_env", features = ["log_extra_implicit_fields", "log_custom_entries_to_extra"] }
 
 [dev-dependencies]

--- a/crates/router/Cargo.toml
+++ b/crates/router/Cargo.toml
@@ -80,7 +80,7 @@ uuid = { version = "1.3.0", features = ["serde", "v4"] }
 
 # First party crates
 api_models = { version = "0.1.0", path = "../api_models", features = ["errors"] }
-common_utils = { version = "0.1.0", path = "../common_utils", features = ["signals"] }
+common_utils = { version = "0.1.0", path = "../common_utils", features = ["signals", "async_ext"] }
 external_services = { version = "0.1.0", path = "../external_services" }
 masking = { version = "0.1.0", path = "../masking" }
 redis_interface = { version = "0.1.0", path = "../redis_interface" }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [x] Dependency updates

## Description
<!-- Describe your changes in detail -->
This PR puts the `AsyncExt` trait and certain async functions in the `common_utils` crate behind a feature flag.

### Additional Changes
None
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!-- 
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
Required to make the `api_models` crate free of any async-relate dependencies.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
cargo build + cargo hack

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
