### PR TITLE
refactor(scheduler): remove scheduler options & adding graceful shutdown to producer

### DIFF
--- a/config/config.example.toml
+++ b/config/config.example.toml
@@ -169,6 +169,8 @@ cards = [
 # It defines the the streams/queues name and configuration as well as event selection variables
 [scheduler]
 stream = "SCHEDULER_STREAM"
+graceful_shutdown_interval = 60000 # Specifies how much time to wait while re-attempting shutdown for a service (in milliseconds)
+loop_interval = 5000               # Specifies how much time to wait before starting the defined behaviour of producer or consumer (in milliseconds)
 
 [scheduler.consumer]
 consumer_group = "SCHEDULER_GROUP"

--- a/crates/router/src/bin/scheduler.rs
+++ b/crates/router/src/bin/scheduler.rs
@@ -38,28 +38,6 @@ async fn start_scheduler(
 ) -> CustomResult<(), errors::ProcessTrackerError> {
     use std::str::FromStr;
 
-    let options = scheduler::SchedulerOptions {
-        looper_interval: scheduler::Milliseconds {
-            milliseconds: 5_000,
-        },
-        db_name: "".to_string(),
-        cache_name: "".to_string(),
-        schema_name: "".to_string(),
-        cache_expiry: scheduler::Milliseconds {
-            milliseconds: 30_000_000,
-        },
-        runners: vec![],
-        fetch_limit: 30,
-        fetch_limit_product_factor: 1,
-        query_order: "".to_string(),
-        readiness: scheduler::options::ReadinessOptions {
-            is_ready: true,
-            graceful_termination_duration: scheduler::Milliseconds {
-                milliseconds: 60_000,
-            },
-        },
-    };
-
     #[allow(clippy::expect_used)]
     let flow = std::env::var(SCHEDULER_FLOW).expect("SCHEDULER_FLOW environment variable not set");
     #[allow(clippy::expect_used)]
@@ -71,6 +49,5 @@ async fn start_scheduler(
         .scheduler
         .clone()
         .ok_or(errors::ProcessTrackerError::ConfigurationError)?;
-    scheduler::start_process_tracker(state, Arc::new(options), flow, Arc::new(scheduler_settings))
-        .await
+    scheduler::start_process_tracker(state, flow, Arc::new(scheduler_settings)).await
 }

--- a/crates/router/src/configs/defaults.rs
+++ b/crates/router/src/configs/defaults.rs
@@ -89,6 +89,8 @@ impl Default for super::settings::SchedulerSettings {
             stream: "SCHEDULER_STREAM".into(),
             producer: super::settings::ProducerSettings::default(),
             consumer: super::settings::ConsumerSettings::default(),
+            graceful_shutdown_interval: 60000,
+            loop_interval: 5000,
         }
     }
 }

--- a/crates/router/src/configs/settings.rs
+++ b/crates/router/src/configs/settings.rs
@@ -293,6 +293,8 @@ pub struct SchedulerSettings {
     pub stream: String,
     pub producer: ProducerSettings,
     pub consumer: ConsumerSettings,
+    pub loop_interval: u64,
+    pub graceful_shutdown_interval: u64,
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/crates/router/src/scheduler.rs
+++ b/crates/router/src/scheduler.rs
@@ -19,17 +19,12 @@ use crate::{
 
 pub async fn start_process_tracker(
     state: &AppState,
-    options: Arc<SchedulerOptions>,
     scheduler_flow: SchedulerFlow,
     scheduler_settings: Arc<SchedulerSettings>,
 ) -> CustomResult<(), errors::ProcessTrackerError> {
     match scheduler_flow {
-        SchedulerFlow::Producer => {
-            producer::start_producer(state, Arc::clone(&options), scheduler_settings).await?
-        }
-        SchedulerFlow::Consumer => {
-            consumer::start_consumer(state, Arc::clone(&options), scheduler_settings).await?
-        }
+        SchedulerFlow::Producer => producer::start_producer(state, scheduler_settings).await?,
+        SchedulerFlow::Consumer => consumer::start_consumer(state, scheduler_settings).await?,
         SchedulerFlow::Cleaner => {
             error!("This flow has not been implemented yet!");
         }

--- a/crates/router/src/scheduler/utils.rs
+++ b/crates/router/src/scheduler/utils.rs
@@ -243,7 +243,6 @@ pub fn get_time_from_delta(delta: Option<i32>) -> Option<time::PrimitiveDateTime
 
 pub async fn consumer_operation_handler<E>(
     state: AppState,
-    options: sync::Arc<super::SchedulerOptions>,
     settings: sync::Arc<SchedulerSettings>,
     error_handler_fun: E,
     consumer_operation_counter: sync::Arc<atomic::AtomicU64>,
@@ -254,7 +253,7 @@ pub async fn consumer_operation_handler<E>(
     consumer_operation_counter.fetch_add(1, atomic::Ordering::Release);
     let start_time = std_time::Instant::now();
 
-    match consumer::consumer_operations(&state, &options, &settings).await {
+    match consumer::consumer_operations(&state, &settings).await {
         Ok(_) => (),
         Err(err) => error_handler_fun(err),
     }


### PR DESCRIPTION


## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description

Moving scheduler options to config and adding graceful shutdown to producer
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema
- [x] This PR modifies application configuration/environment variables

```diff
[scheduler]
+ graceful_shutdown_interval = 60000 # Specifies how much time to wait while re-attempting shutdown for a service (in milliseconds)
+ loop_interval = 5000               # Specifies how much time to wait before starting the defined behaviour of producer or consumer (in milliseconds)
```

<!-- 
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context

Providing more configuration for production releases, and removing hard coded values
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
