### PR TITLE
fix: Add locker sign keyid in env

### DIFF
--- a/config/config.example.toml
+++ b/config/config.example.toml
@@ -88,6 +88,7 @@ host = ""                      # Locker host
 mock_locker = true             # Emulate a locker locally using Postgres
 basilisk_host = ""             # Basilisk host
 locker_setup = "legacy_locker" # With locker to use while in the deployed environment (eg. legacy_locker, basilisk_locker)
+locker_signing_key_id = "1"    # Key_id to sign basilisk hs locker
 
 [jwekey] # 4 priv/pub key pair
 locker_key_identifier1 = "" # key identifier for key rotation , should be same as basilisk

--- a/crates/router/src/configs/defaults.rs
+++ b/crates/router/src/configs/defaults.rs
@@ -44,6 +44,7 @@ impl Default for super::settings::Locker {
             mock_locker: true,
             basilisk_host: "localhost".into(),
             locker_setup: super::settings::LockerSetup::LegacyLocker,
+            locker_signing_key_id: "1".into(),
         }
     }
 }

--- a/crates/router/src/configs/settings.rs
+++ b/crates/router/src/configs/settings.rs
@@ -167,6 +167,7 @@ pub struct Locker {
     pub mock_locker: bool,
     pub basilisk_host: String,
     pub locker_setup: LockerSetup,
+    pub locker_signing_key_id: String,
 }
 
 #[derive(Debug, Deserialize, Clone, Default)]

--- a/crates/router/src/core/payment_methods/vault.rs
+++ b/crates/router/src/core/payment_methods/vault.rs
@@ -484,8 +484,10 @@ pub async fn create_tokenize(
             let alg = jwe::RSA_OAEP_256;
             let decrypted_payload = services::decrypt_jwe(
                 &resp.payload,
-                get_key_id(&state.conf.jwekey),
-                &resp.key_id,
+                services::KeyIdCheck::RequestResponseKeyId((
+                    get_key_id(&state.conf.jwekey),
+                    &resp.key_id,
+                )),
                 private_key,
                 alg,
             )
@@ -557,8 +559,10 @@ pub async fn get_tokenized_data(
             let alg = jwe::RSA_OAEP_256;
             let decrypted_payload = services::decrypt_jwe(
                 &resp.payload,
-                get_key_id(&state.conf.jwekey),
-                &resp.key_id,
+                services::KeyIdCheck::RequestResponseKeyId((
+                    get_key_id(&state.conf.jwekey),
+                    &resp.key_id,
+                )),
                 private_key,
                 alg,
             )

--- a/crates/router/src/services/encryption.rs
+++ b/crates/router/src/services/encryption.rs
@@ -138,13 +138,24 @@ pub async fn encrypt_jwe(
         .attach_printable("Error getting jwt string")
 }
 
+pub enum KeyIdCheck<'a> {
+    RequestResponseKeyId((&'a str, &'a str)),
+    SkipKeyIdCheck,
+}
+
 pub async fn decrypt_jwe(
     jwt: &str,
-    key_id: &str,
-    resp_key_id: &str,
+    key_ids: KeyIdCheck<'_>,
     private_key: String,
     alg: jwe::alg::rsaes::RsaesJweAlgorithm,
 ) -> CustomResult<String, errors::EncryptionError> {
+    if let KeyIdCheck::RequestResponseKeyId((req_key_id, resp_key_id)) = key_ids {
+        utils::when(req_key_id.ne(resp_key_id), || {
+            Err(report!(errors::EncryptionError).attach_printable("Missing ciphertext blob"))
+                .attach_printable("key_id mismatch, Error authenticating response")
+        })?;
+    }
+
     let decrypter = alg
         .decrypter_from_pem(private_key)
         .into_report()
@@ -155,10 +166,6 @@ pub async fn decrypt_jwe(
         .into_report()
         .change_context(errors::EncryptionError)
         .attach_printable("Error getting Decrypted jwe")?;
-    utils::when(resp_key_id.ne(key_id), || {
-        Err(report!(errors::EncryptionError).attach_printable("Missing ciphertext blob"))
-            .attach_printable("key_id mismatch, Error authenticating response")
-    })?;
 
     String::from_utf8(dst_payload)
         .into_report()
@@ -245,8 +252,7 @@ mod tests {
         let alg = jwe::RSA_OAEP_256;
         let payload = decrypt_jwe(
             &jwt,
-            &conf.jwekey.locker_key_identifier1,
-            &conf.jwekey.locker_key_identifier1,
+            KeyIdCheck::SkipKeyIdCheck,
             conf.jwekey.locker_decryption_key1.to_owned(),
             alg,
         )

--- a/crates/router/src/services/encryption.rs
+++ b/crates/router/src/services/encryption.rs
@@ -151,8 +151,8 @@ pub async fn decrypt_jwe(
 ) -> CustomResult<String, errors::EncryptionError> {
     if let KeyIdCheck::RequestResponseKeyId((req_key_id, resp_key_id)) = key_ids {
         utils::when(req_key_id.ne(resp_key_id), || {
-            Err(report!(errors::EncryptionError).attach_printable("Missing ciphertext blob"))
-                .attach_printable("key_id mismatch, Error authenticating response")
+            Err(report!(errors::EncryptionError)
+                .attach_printable("key_id mismatch, Error authenticating response"))
         })?;
     }
 


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->

Add locker sign keyid in environment for locker.

Added default value for locker_signing_key_id as 1.


### Additional Changes

- [ ] This PR modifies the database schema
- [x] This PR modifies application configuration/environment variables

<!-- 
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->

Use `ROUTER__LOCKER__LOCKER_SIGNING_KEY_ID` to change the value.


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

Previously the locker sign keyid was hard coded in the application. 


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

This can only be tested in environment.


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [x] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
