### PR TITLE
refactor(router_env): improve logging setup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1069,6 +1069,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "cargo_metadata"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eee4243f1f26fc7a42710e7439c149e2b10b05472f88090acce52632f231a73a"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2485,15 +2499,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "matchers"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
-dependencies = [
- "regex-automata",
-]
-
-[[package]]
 name = "matchit"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2770,7 +2775,7 @@ dependencies = [
 [[package]]
 name = "opentelemetry"
 version = "0.18.0"
-source = "git+https://github.com/open-telemetry/opentelemetry-rust?rev=44b90202fd744598db8b0ace5b8f0bad7ec45658#44b90202fd744598db8b0ace5b8f0bad7ec45658"
+source = "git+https://github.com/open-telemetry/opentelemetry-rust/?rev=44b90202fd744598db8b0ace5b8f0bad7ec45658#44b90202fd744598db8b0ace5b8f0bad7ec45658"
 dependencies = [
  "opentelemetry_api",
  "opentelemetry_sdk",
@@ -2779,7 +2784,7 @@ dependencies = [
 [[package]]
 name = "opentelemetry-otlp"
 version = "0.11.0"
-source = "git+https://github.com/open-telemetry/opentelemetry-rust?rev=44b90202fd744598db8b0ace5b8f0bad7ec45658#44b90202fd744598db8b0ace5b8f0bad7ec45658"
+source = "git+https://github.com/open-telemetry/opentelemetry-rust/?rev=44b90202fd744598db8b0ace5b8f0bad7ec45658#44b90202fd744598db8b0ace5b8f0bad7ec45658"
 dependencies = [
  "async-trait",
  "futures",
@@ -2796,7 +2801,7 @@ dependencies = [
 [[package]]
 name = "opentelemetry-proto"
 version = "0.1.0"
-source = "git+https://github.com/open-telemetry/opentelemetry-rust?rev=44b90202fd744598db8b0ace5b8f0bad7ec45658#44b90202fd744598db8b0ace5b8f0bad7ec45658"
+source = "git+https://github.com/open-telemetry/opentelemetry-rust/?rev=44b90202fd744598db8b0ace5b8f0bad7ec45658#44b90202fd744598db8b0ace5b8f0bad7ec45658"
 dependencies = [
  "futures",
  "futures-util",
@@ -2808,7 +2813,7 @@ dependencies = [
 [[package]]
 name = "opentelemetry_api"
 version = "0.18.0"
-source = "git+https://github.com/open-telemetry/opentelemetry-rust?rev=44b90202fd744598db8b0ace5b8f0bad7ec45658#44b90202fd744598db8b0ace5b8f0bad7ec45658"
+source = "git+https://github.com/open-telemetry/opentelemetry-rust/?rev=44b90202fd744598db8b0ace5b8f0bad7ec45658#44b90202fd744598db8b0ace5b8f0bad7ec45658"
 dependencies = [
  "fnv",
  "futures-channel",
@@ -2823,7 +2828,7 @@ dependencies = [
 [[package]]
 name = "opentelemetry_sdk"
 version = "0.18.0"
-source = "git+https://github.com/open-telemetry/opentelemetry-rust?rev=44b90202fd744598db8b0ace5b8f0bad7ec45658#44b90202fd744598db8b0ace5b8f0bad7ec45658"
+source = "git+https://github.com/open-telemetry/opentelemetry-rust/?rev=44b90202fd744598db8b0ace5b8f0bad7ec45658#44b90202fd744598db8b0ace5b8f0bad7ec45658"
 dependencies = [
  "async-trait",
  "crossbeam-channel",
@@ -3365,15 +3370,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex-automata"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
-dependencies = [
- "regex-syntax",
-]
-
-[[package]]
 name = "regex-syntax"
 version = "0.6.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3540,6 +3536,7 @@ dependencies = [
 name = "router_env"
 version = "0.1.0"
 dependencies = [
+ "cargo_metadata 0.15.4",
  "config",
  "gethostname",
  "once_cell",
@@ -4013,7 +4010,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16d23b015676c90a0f01c197bfdc786c20342c73a0afdda9025adb0bc42940a8"
 dependencies = [
  "bytecount",
- "cargo_metadata",
+ "cargo_metadata 0.14.2",
  "error-chain",
  "glob",
  "pulldown-cmark",
@@ -4555,16 +4552,12 @@ version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6176eae26dd70d0c919749377897b54a9276bd7061339665dd68777926b5a70"
 dependencies = [
- "matchers",
  "nu-ansi-term",
- "once_cell",
- "regex",
  "serde",
  "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
- "tracing",
  "tracing-core",
  "tracing-log",
  "tracing-serde",

--- a/crates/drainer/src/env.rs
+++ b/crates/drainer/src/env.rs
@@ -5,24 +5,10 @@ pub mod logger {
     #[doc(inline)]
     pub use router_env::{log, logger::*};
 
-    ///
     /// Setup logging sub-system
-    ///
-    ///
     pub fn setup(
         conf: &config::Log,
     ) -> error_stack::Result<TelemetryGuard, router_env::opentelemetry::metrics::MetricsError> {
-        Ok(router_env::setup(
-            conf,
-            "drainer",
-            vec![
-                "drainer",
-                "common_utils",
-                "external_services",
-                "redis_interface",
-                "router_env",
-                "storage_models",
-            ],
-        )?)
+        Ok(router_env::setup(conf, router_env::service_name!(), [])?)
     }
 }

--- a/crates/router/src/env.rs
+++ b/crates/router/src/env.rs
@@ -4,29 +4,12 @@ pub mod logger {
     #[doc(inline)]
     pub use router_env::{log, logger::*};
 
-    ///
-    /// Setup logging sub-system.
-    ///
-    // TODO (prom-monitoring): Ideally tracing/opentelementry structs shouldn't be pushed out.
+    // TODO (prom-monitoring): Ideally tracing/opentelemetry structs shouldn't be pushed out.
     // Return a custom error type instead of `opentelemetry::metrics::MetricsError`.
+    /// Setup logging sub-system.
     pub fn setup(
         conf: &config::Log,
     ) -> Result<TelemetryGuard, router_env::opentelemetry::metrics::MetricsError> {
-        router_env::setup(
-            conf,
-            "router",
-            vec![
-                "router",
-                "actix_server",
-                "api_models",
-                "common_utils",
-                "external_services",
-                "masking",
-                "redis_interface",
-                "router_derive",
-                "router_env",
-                "storage_models",
-            ],
-        )
+        router_env::setup(conf, router_env::service_name!(), ["actix_server"])
     }
 }

--- a/crates/router_env/Cargo.toml
+++ b/crates/router_env/Cargo.toml
@@ -6,13 +6,12 @@ edition = "2021"
 rust-version = "1.65"
 readme = "README.md"
 license = "Apache-2.0"
-build = "src/build.rs"
 
 [dependencies]
 config = { version = "0.13.3", features = ["toml"] }
 gethostname = "0.4.1"
 once_cell = "1.17.1"
-opentelemetry = { git = "https://github.com/open-telemetry/opentelemetry-rust/", rev = "44b90202fd744598db8b0ace5b8f0bad7ec45658",  features = ["rt-tokio-current-thread", "metrics"] }
+opentelemetry = { git = "https://github.com/open-telemetry/opentelemetry-rust/", rev = "44b90202fd744598db8b0ace5b8f0bad7ec45658", features = ["rt-tokio-current-thread", "metrics"] }
 opentelemetry-otlp = { git = "https://github.com/open-telemetry/opentelemetry-rust/", rev = "44b90202fd744598db8b0ace5b8f0bad7ec45658", features = ["metrics"] }
 rustc-hash = "1.1"
 serde = { version = "1.0.155", features = ["derive"] }
@@ -26,13 +25,14 @@ tracing-actix-web = { version = "0.7.2", features = ["opentelemetry_0_18"], opti
 tracing-appender = { version = "0.2.2" }
 tracing-attributes = "=0.1.22"
 tracing-opentelemetry = { version = "0.18.0" }
-tracing-subscriber = { version = "0.3.16", default-features = true, features = ["json", "env-filter", "registry"] }
+tracing-subscriber = { version = "0.3.16", default-features = true, features = ["json", "registry"] }
 vergen = { version = "8.0.0-beta.9", optional = true, features = ["cargo", "git", "git2", "rustc"] }
 
 [dev-dependencies]
 tokio = { version = "1.26.0", features = ["macros", "rt-multi-thread"] }
 
 [build-dependencies]
+cargo_metadata = "0.15.4"
 vergen = { version = "8.0.0-beta.9", features = ["cargo", "git", "git2", "rustc"], optional = true }
 
 [features]

--- a/crates/router_env/build.rs
+++ b/crates/router_env/build.rs
@@ -1,0 +1,24 @@
+include!("src/vergen.rs");
+
+fn main() {
+    generate_cargo_instructions();
+
+    #[allow(clippy::expect_used)] // Safety: panicking in build scripts is okay for us
+    let metadata = cargo_metadata::MetadataCommand::new()
+        .exec()
+        .expect("Failed to obtain cargo metadata");
+    let workspace_members = metadata
+        .workspace_members
+        .iter()
+        .map(|package_id| {
+            #[allow(clippy::expect_used)] // Safety: panicking in build scripts is okay for us
+            package_id
+                .repr
+                .split_once(' ')
+                .expect("Unknown cargo metadata package ID format")
+                .0
+        })
+        .collect::<Vec<_>>()
+        .join(",");
+    println!("cargo:rustc-env=CARGO_WORKSPACE_MEMBERS={workspace_members}",);
+}

--- a/crates/router_env/src/build.rs
+++ b/crates/router_env/src/build.rs
@@ -1,5 +1,0 @@
-include!("vergen.rs");
-
-fn main() {
-    generate_cargo_instructions();
-}

--- a/crates/router_env/src/env.rs
+++ b/crates/router_env/src/env.rs
@@ -1,21 +1,16 @@
-//!
-//! Current environment related stuff.
-//!
+//! Information about the current environment.
 
 use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
 use strum::{Display, EnumString};
 
-/// Parent dir where Cargo.toml is stored
+/// Parent directory where `Cargo.toml` is stored.
 pub const CARGO_MANIFEST_DIR: &str = "CARGO_MANIFEST_DIR";
-/// Env variable that sets Development/Production env
+/// Environment variable that sets Development/Sandbox/Production environment.
 pub const RUN_ENV: &str = "RUN_ENV";
 
-///
 /// Current environment.
-///
-
 #[derive(Debug, Default, Deserialize, Serialize, Clone, Copy, Display, EnumString)]
 pub enum Env {
     /// Development environment.
@@ -47,32 +42,10 @@ pub fn prefix_for_env() -> &'static str {
     }
 }
 
-///
-/// Base path to look for config and logs directories.
-/// Application expects to find `./config/` and `./logs/` relative this directories.
-///
-/// Using workspace and splitting into monolith into crates introduce introduce extra level of complexity.
-/// We can't rely on current working directory anymore because there are several ways of running applications.
-///
-/// Developer can run application from root of repository:
-/// ```bash
-/// cargo run
-/// ```
-///
-/// Alternatively, developer can run from directory of crate:
-/// ```bash
-/// cd crates/router
-/// cargo run
-/// ```
-///
-/// Config and log files are located at root. No matter application is run it should work properly.
-/// `router_log::env::workspace_path` takes care of the problem returning path tho workspace relative which should other paths be calculated.
-///
-
+/// Path to the root directory of the cargo workspace.
+/// It is recommended that this be used by the application as the base path to build other paths
+/// such as configuration and logs directories.
 pub fn workspace_path() -> PathBuf {
-    // for (key, value) in std::env::vars() {
-    //     println!("{key} : {value}");
-    // }
     if let Ok(manifest_dir) = std::env::var(CARGO_MANIFEST_DIR) {
         let mut path = PathBuf::from(manifest_dir);
         path.pop();
@@ -105,10 +78,9 @@ macro_rules! version {
     };
 }
 
+/// A string uniquely identifying the application build.
 ///
-/// A string uniquely identify build of the service.
-///
-/// Consists of combination of
+/// Consists of a combination of:
 /// - Version defined in the crate file
 /// - Timestamp of commit
 /// - Hash of the commit
@@ -116,8 +88,6 @@ macro_rules! version {
 /// - Target triple
 ///
 /// Example: `0.1.0-f5f383e-2022-09-04T11:39:37Z-1.63.0-x86_64-unknown-linux-gnu`
-///
-
 #[cfg(feature = "vergen")]
 #[macro_export]
 macro_rules! build {
@@ -138,11 +108,9 @@ macro_rules! build {
     };
 }
 
+/// Short hash of the current commit.
 ///
-/// Full hash of the current commit.
-///
-/// Example: `f5f383ee7e36214d60ce3c6353b57db03ff0ceb1`.
-///
+/// Example: `f5f383e`.
 #[cfg(feature = "vergen")]
 #[macro_export]
 macro_rules! commit {
@@ -151,13 +119,11 @@ macro_rules! commit {
     };
 }
 
-// ///
 // /// Information about the platform on which service was built, including:
 // /// - Information about OS
 // /// - Information about CPU
 // ///
 // /// Example: ``.
-// ///
 // #[macro_export]
 // macro_rules! platform {
 //     (
@@ -170,12 +136,9 @@ macro_rules! commit {
 //     };
 // }
 
-///
 /// Service name deduced from name of the crate.
 ///
 /// Example: `router`.
-///
-
 #[macro_export]
 macro_rules! service_name {
     () => {
@@ -183,12 +146,9 @@ macro_rules! service_name {
     };
 }
 
-///
 /// Build profile, either debug or release.
 ///
 /// Example: `release`.
-///
-
 #[macro_export]
 macro_rules! profile {
     () => {

--- a/crates/router_env/src/env.rs
+++ b/crates/router_env/src/env.rs
@@ -17,8 +17,11 @@ pub mod vars {
     /// Directory of config TOML files. Default is `config`.
     pub const CONFIG_DIR: &str = "CONFIG_DIR";
 
-    /// Environment variable that sets the log level.
-    pub const RUST_LOG: &str = "RUST_LOG";
+    /// Environment variable that sets the console logging level.
+    pub const RUST_CONSOLE_LOG: &str = "RUST_CONSOLE_LOG";
+
+    /// Environment variable that sets the file logging level.
+    pub const RUST_FILE_LOG: &str = "RUST_FILE_LOG";
 
     /// Target to which the OpenTelemetry exporter is going to send signals.
     pub const OTEL_EXPORTER_OTLP_ENDPOINT: &str = opentelemetry_otlp::OTEL_EXPORTER_OTLP_ENDPOINT;

--- a/crates/router_env/src/env.rs
+++ b/crates/router_env/src/env.rs
@@ -5,10 +5,27 @@ use std::path::PathBuf;
 use serde::{Deserialize, Serialize};
 use strum::{Display, EnumString};
 
-/// Parent directory where `Cargo.toml` is stored.
-pub const CARGO_MANIFEST_DIR: &str = "CARGO_MANIFEST_DIR";
-/// Environment variable that sets Development/Sandbox/Production environment.
-pub const RUN_ENV: &str = "RUN_ENV";
+/// Environment variables accessed by the application. This module aims to be the source of truth
+/// containing all environment variable that the application accesses.
+pub mod vars {
+    /// Parent directory where `Cargo.toml` is stored.
+    pub const CARGO_MANIFEST_DIR: &str = "CARGO_MANIFEST_DIR";
+
+    /// Environment variable that sets Development/Sandbox/Production environment.
+    pub const RUN_ENV: &str = "RUN_ENV";
+
+    /// Directory of config TOML files. Default is `config`.
+    pub const CONFIG_DIR: &str = "CONFIG_DIR";
+
+    /// Environment variable that sets the log level.
+    pub const RUST_LOG: &str = "RUST_LOG";
+
+    /// Target to which the OpenTelemetry exporter is going to send signals.
+    pub const OTEL_EXPORTER_OTLP_ENDPOINT: &str = opentelemetry_otlp::OTEL_EXPORTER_OTLP_ENDPOINT;
+
+    /// Max waiting time for the OpenTelemetry backend to process each signal batch.
+    pub const OTEL_EXPORTER_OTLP_TIMEOUT: &str = opentelemetry_otlp::OTEL_EXPORTER_OTLP_TIMEOUT;
+}
 
 /// Current environment.
 #[derive(Debug, Default, Deserialize, Serialize, Clone, Copy, Display, EnumString)]
@@ -29,7 +46,7 @@ pub fn which() -> Env {
     #[cfg(not(debug_assertions))]
     let default_env = Env::Production;
 
-    std::env::var(RUN_ENV).map_or_else(|_| default_env, |v| v.parse().unwrap_or(default_env))
+    std::env::var(vars::RUN_ENV).map_or_else(|_| default_env, |v| v.parse().unwrap_or(default_env))
 }
 
 /// Three letter (lowercase) prefix corresponding to the current environment.
@@ -46,7 +63,7 @@ pub fn prefix_for_env() -> &'static str {
 /// It is recommended that this be used by the application as the base path to build other paths
 /// such as configuration and logs directories.
 pub fn workspace_path() -> PathBuf {
-    if let Ok(manifest_dir) = std::env::var(CARGO_MANIFEST_DIR) {
+    if let Ok(manifest_dir) = std::env::var(vars::CARGO_MANIFEST_DIR) {
         let mut path = PathBuf::from(manifest_dir);
         path.pop();
         path.pop();

--- a/crates/router_env/src/logger/config.rs
+++ b/crates/router_env/src/logger/config.rs
@@ -42,7 +42,7 @@ pub struct LogFile {
 }
 
 /// Describes the level of verbosity of a span or event.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct Level(pub(super) tracing::Level);
 
 impl Level {

--- a/crates/router_env/src/logger/config.rs
+++ b/crates/router_env/src/logger/config.rs
@@ -6,9 +6,6 @@ use std::path::PathBuf;
 
 use serde::Deserialize;
 
-/// Directory of config toml files. Default is config
-pub const CONFIG_DIR: &str = "CONFIG_DIR";
-
 /// Config settings.
 #[derive(Debug, Deserialize, Clone)]
 pub struct Config {
@@ -158,7 +155,8 @@ impl Config {
         if let Some(explicit_config_path_val) = explicit_config_path {
             config_path.push(explicit_config_path_val);
         } else {
-            let config_directory = std::env::var(CONFIG_DIR).unwrap_or_else(|_| "config".into());
+            let config_directory =
+                std::env::var(crate::env::vars::CONFIG_DIR).unwrap_or_else(|_| "config".into());
             let config_file_name = match environment {
                 "Production" => "Production.toml",
                 "Sandbox" => "Sandbox.toml",

--- a/crates/router_env/src/logger/setup.rs
+++ b/crates/router_env/src/logger/setup.rs
@@ -1,8 +1,7 @@
 //! Setup logging subsystem.
 
-use std::{str::FromStr, time::Duration};
+use std::{collections::HashSet, str::FromStr, time::Duration};
 
-use once_cell::sync::Lazy;
 use opentelemetry::{
     global, runtime,
     sdk::{
@@ -11,123 +10,99 @@ use opentelemetry::{
         propagation::TraceContextPropagator,
         trace, Resource,
     },
+    trace::TraceError,
     KeyValue,
 };
-use opentelemetry_otlp::WithExportConfig;
+use opentelemetry_otlp::{TonicExporterBuilder, WithExportConfig};
 use tracing_appender::non_blocking::WorkerGuard;
-use tracing_subscriber::{filter, fmt, prelude::*, util::SubscriberInitExt, EnvFilter, Layer};
+use tracing_subscriber::{filter::Targets, fmt, prelude::*, util::SubscriberInitExt, Layer};
 
-use crate::{config, FormattingLayer, Level, StorageSubscription};
+use crate::{config, FormattingLayer, StorageSubscription};
 
-/// TelemetryGuard which helps with
+/// Contains guards necessary for logging and metrics collection.
 #[derive(Debug)]
 pub struct TelemetryGuard {
     _log_guards: Vec<WorkerGuard>,
-    _metric_controller: Option<BasicController>,
+    _metrics_controller: Option<BasicController>,
 }
 
-///
-/// Setup logging sub-system specifying.
-/// Expects config and list of names of crates to watch.
-///
-pub fn setup<Str: AsRef<str>>(
-    conf: &config::Log,
-    service_name: &str,
-    crates_to_watch: Vec<Str>,
+/// Setup logging sub-system specifying the logging configuration, service (binary) name, and a
+/// list of external crates for which a more verbose logging must be enabled. All crates within the
+/// current cargo workspace are automatically considered for verbose logging.
+pub fn setup(
+    config: &config::Log,
+    service_name: &'static str,
+    crates_to_filter: impl AsRef<[&'static str]>,
 ) -> Result<TelemetryGuard, opentelemetry::metrics::MetricsError> {
     let mut guards = Vec::new();
 
-    global::set_text_map_propagator(TraceContextPropagator::new());
-
-    let telemetry = if conf.telemetry.enabled {
-        let trace_config = trace::config()
-            .with_sampler(trace::Sampler::TraceIdRatioBased(
-                conf.telemetry.sampling_rate.unwrap_or(1.0),
-            ))
-            .with_resource(Resource::new(vec![KeyValue::new("service.name", "router")]));
-
-        let endpoint = std::env::var(crate::env::vars::OTEL_EXPORTER_OTLP_ENDPOINT).ok();
-        let timeout = std::env::var(crate::env::vars::OTEL_EXPORTER_OTLP_TIMEOUT)
-            .ok()
-            .and_then(|s| u64::from_str(&s).ok());
-
-        let mut exporter_builder = opentelemetry_otlp::new_exporter().tonic();
-        if let Some(endpoint) = endpoint {
-            exporter_builder = exporter_builder.with_endpoint(endpoint);
-        }
-        if let Some(timeout) = timeout {
-            exporter_builder = exporter_builder.with_timeout(Duration::from_secs(timeout));
-        }
-
-        let tracer = opentelemetry_otlp::new_pipeline()
-            .tracing()
-            .with_exporter(exporter_builder)
-            .with_trace_config(trace_config)
-            .install_simple();
-
-        Some(tracer)
+    // Setup OpenTelemetry traces and metrics
+    let (telemetry_tracer, _metrics_controller) = if config.telemetry.enabled {
+        global::set_text_map_propagator(TraceContextPropagator::new());
+        (
+            setup_tracing_pipeline(service_name, config.telemetry.sampling_rate),
+            setup_metrics_pipeline(),
+        )
     } else {
-        None
+        (None, None)
     };
-
-    let file_writer = if conf.file.enabled {
-        let mut path: PathBuf = conf.file.path.clone().into();
-        path.push(crate::env::workspace_path());
-        path.push(&conf.file.path);
-        // println!("{:?} + {:?}", &path, &conf.file.file_name);
-        let file_appender = tracing_appender::rolling::hourly(&path, &conf.file.file_name);
-        let (file_writer, guard) = tracing_appender::non_blocking(file_appender);
-        guards.push(guard);
-
-        let file_filter = filter::Targets::new().with_default(conf.file.level.into_level());
-        let file_layer = FormattingLayer::new(service_name, file_writer).with_filter(file_filter);
-        Some(file_layer)
-    } else {
-        None
-    };
-
-    let telemetry_layer = match telemetry {
+    let telemetry_layer = match telemetry_tracer {
         Some(Ok(ref tracer)) => Some(tracing_opentelemetry::layer().with_tracer(tracer.clone())),
         _ => None,
     };
 
-    // Use 'RUST_LOG' environment variable will override the config settings
+    // Setup file logging
+    let file_writer = if config.file.enabled {
+        let mut path = crate::env::workspace_path();
+        // Using an absolute path for file log path would replace workspace path with absolute path,
+        // which is the intended behavior for us.
+        path.push(&config.file.path);
+
+        let file_appender = tracing_appender::rolling::hourly(&path, &config.file.file_name);
+        let (file_writer, guard) = tracing_appender::non_blocking(file_appender);
+        guards.push(guard);
+
+        let file_filter = get_target_filter(
+            crate::env::vars::RUST_FILE_LOG,
+            config::Level(tracing::Level::WARN),
+            config.file.level,
+            &crates_to_filter,
+        );
+
+        Some(FormattingLayer::new(service_name, file_writer).with_filter(file_filter))
+    } else {
+        None
+    };
+
     let subscriber = tracing_subscriber::registry()
         .with(telemetry_layer)
         .with(StorageSubscription)
-        .with(file_writer)
-        .with(
-            EnvFilter::builder()
-                .with_default_directive(Level::TRACE.into())
-                .with_env_var(crate::env::vars::RUST_LOG)
-                .from_env_lossy(),
-        );
+        .with(file_writer);
 
-    if conf.console.enabled {
+    // Setup console logging
+    if config.console.enabled {
         let (console_writer, guard) = tracing_appender::non_blocking(std::io::stdout());
         guards.push(guard);
 
-        let level = conf.console.level.into_level();
-        let mut console_filter = filter::Targets::new().with_default(Level::WARN);
-        for acrate in crates_to_watch {
-            console_filter = console_filter.with_target(acrate.as_ref(), level);
-        }
+        let console_filter = get_target_filter(
+            crate::env::vars::RUST_CONSOLE_LOG,
+            config::Level(tracing::Level::WARN),
+            config.console.level,
+            &crates_to_filter,
+        );
 
-        match conf.console.log_format {
+        match config.console.log_format {
             config::LogFormat::Default => {
                 let logging_layer = fmt::layer()
                     .with_timer(fmt::time::time())
-                    .with_span_events(fmt::format::FmtSpan::NONE)
                     .pretty()
-                    .with_writer(console_writer);
-
-                subscriber
-                    .with(logging_layer.with_filter(console_filter))
-                    .init();
+                    .with_writer(console_writer)
+                    .with_filter(console_filter);
+                subscriber.with(logging_layer).init();
             }
             config::LogFormat::Json => {
-                let logging_layer = FormattingLayer::new(service_name, console_writer);
-
+                let logging_layer =
+                    FormattingLayer::new(service_name, console_writer).with_filter(console_filter);
                 subscriber.with(logging_layer).init();
             }
         }
@@ -135,29 +110,20 @@ pub fn setup<Str: AsRef<str>>(
         subscriber.init();
     };
 
-    if let Some(Err(err)) = telemetry {
+    if let Some(Err(err)) = telemetry_tracer {
         tracing::error!("Failed to create an opentelemetry_otlp tracer: {err}");
+        eprintln!("Failed to create an opentelemetry_otlp tracer: {err}");
     }
 
-    // Returning the WorkerGuard for logs to be printed until it is dropped
+    // Returning the TelemetryGuard for logs to be printed and metrics to be collected until it is
+    // dropped
     Ok(TelemetryGuard {
         _log_guards: guards,
-        _metric_controller: setup_metrics(),
+        _metrics_controller,
     })
 }
 
-static HISTOGRAM_BUCKETS: Lazy<[f64; 15]> = Lazy::new(|| {
-    let mut init = 0.01;
-    let mut buckets: [f64; 15] = [0.0; 15];
-
-    for bucket in &mut buckets {
-        init *= 2.0;
-        *bucket = init;
-    }
-    buckets
-});
-
-fn setup_metrics() -> Option<BasicController> {
+fn get_opentelemetry_exporter() -> TonicExporterBuilder {
     let endpoint = std::env::var(crate::env::vars::OTEL_EXPORTER_OTLP_ENDPOINT).ok();
     let timeout = std::env::var(crate::env::vars::OTEL_EXPORTER_OTLP_TIMEOUT)
         .ok()
@@ -171,16 +137,87 @@ fn setup_metrics() -> Option<BasicController> {
         exporter_builder = exporter_builder.with_timeout(Duration::from_secs(timeout));
     }
 
+    exporter_builder
+}
+
+fn setup_tracing_pipeline(
+    service_name: &'static str,
+    sampling_rate: Option<f64>,
+) -> Option<Result<trace::Tracer, TraceError>> {
+    let trace_config = trace::config()
+        .with_sampler(trace::Sampler::TraceIdRatioBased(
+            sampling_rate.unwrap_or(1.0),
+        ))
+        .with_resource(Resource::new(vec![KeyValue::new(
+            "service.name",
+            service_name,
+        )]));
+
+    let tracer = opentelemetry_otlp::new_pipeline()
+        .tracing()
+        .with_exporter(get_opentelemetry_exporter())
+        .with_trace_config(trace_config)
+        .install_simple();
+
+    Some(tracer)
+}
+
+fn setup_metrics_pipeline() -> Option<BasicController> {
+    let histogram_buckets = {
+        let mut init = 0.01;
+        let mut buckets: [f64; 15] = [0.0; 15];
+
+        for bucket in &mut buckets {
+            init *= 2.0;
+            *bucket = init;
+        }
+        buckets
+    };
+
     opentelemetry_otlp::new_pipeline()
         .metrics(
-            simple::histogram(*HISTOGRAM_BUCKETS),
+            simple::histogram(histogram_buckets),
             cumulative_temporality_selector(),
+            // This would have to be updated if a different web framework is used
             runtime::TokioCurrentThread,
         )
-        .with_exporter(exporter_builder)
+        .with_exporter(get_opentelemetry_exporter())
         .with_period(Duration::from_secs(3))
         .with_timeout(Duration::from_secs(10))
         .build()
-        .map_err(|err| eprintln!("Failed to Setup Metrics with {err:?}"))
+        .map_err(|err| eprintln!("Failed to setup metrics pipeline: {err:?}"))
         .ok()
+}
+
+fn get_target_filter(
+    env_var: &'static str,
+    default_log_level: config::Level,
+    filter_log_level: config::Level,
+    crates_to_filter: impl AsRef<[&'static str]>,
+) -> Targets {
+    std::env::var(env_var)
+        .ok()
+        .and_then(|filter| {
+            // Try to create target filter from specified environment variable, if set
+            Targets::from_str(&filter)
+                .map_err(|error| {
+                    eprintln!("Invalid target filtering directive for `{env_var}`: {error}")
+                })
+                .ok()
+        })
+        .unwrap_or_else(|| {
+            // Construct a default target filter otherwise
+            let mut workspace_members = std::env!("CARGO_WORKSPACE_MEMBERS")
+                .split(',')
+                .collect::<HashSet<_>>();
+            workspace_members.extend(crates_to_filter.as_ref());
+
+            Targets::new()
+                .with_default(default_log_level.into_level())
+                .with_targets(
+                    workspace_members
+                        .drain()
+                        .zip(std::iter::repeat(filter_log_level.into_level())),
+                )
+        })
 }

--- a/crates/router_env/tests/logger.rs
+++ b/crates/router_env/tests/logger.rs
@@ -12,12 +12,7 @@ fn logger() -> &'static TelemetryGuard {
     INSTANCE.get_or_init(|| {
         let config = env::Config::new().unwrap();
 
-        env::logger::setup(
-            &config.log,
-            env::service_name!(),
-            vec![env::service_name!()],
-        )
-        .unwrap()
+        env::logger::setup(&config.log, env::service_name!(), []).unwrap()
     })
 }
 


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->
This PR improves the module responsible for setting up the logging system. It includes the following changes:

- Makes the implicitly accessed environment variables explicit. They all now reside in the `router_env::env::vars` module.
- Extracts the OpenTelemetry tracing pipeline setup to a different function.
- Makes the OpenTelemetry metrics pipeline setup conditional, it is now run only if `log.telemetry.enabled` is `true`.
- Simplifies the file path construction for file logging.
- Build script now sets the `CARGO_WORKSPACE_MEMBERS` environment variable with a comma-separated list of all crates in the current cargo workspace. This is used to enable verbose logging for all workspace members by default.
- Uses `Targets` only for filtering crates/targets to log and removes usages of `EnvFilter` for filtering.
- Uses `RUST_FILE_LOG` and `RUST_CONSOLE_LOG` environment variables to override `Targets` directives for file and console logging respectively, instead of `RUST_LOG`.

### Additional Changes

- [ ] This PR modifies the database schema
- [x] This PR modifies application configuration/environment variables

<!-- 
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->
The `RUST_LOG` environment variable is no longer accessed by the application, the `ROUTER__LOG__CONSOLE__LEVEL` or `ROUTER__LOG__FILE__LEVEL` environment variable should be used to set the logging level instead, and if advanced target filtering is required, the `RUST_CONSOLE_LOG` or `RUST_FILE_LOG` environment variables must be used instead.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
My initial motivation was to allow overriding the `Targets` filtering directive at runtime, so that better debugging is possible at runtime, if required. Since I had anyway ventured into the rabbit hole, I ended up refactoring parts of it.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Manually.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
