### PR TITLE
feat(process_tracker): changing runner selection to dyn dispatch

### DIFF
--- a/crates/router/src/scheduler.rs
+++ b/crates/router/src/scheduler.rs
@@ -24,7 +24,9 @@ pub async fn start_process_tracker(
 ) -> CustomResult<(), errors::ProcessTrackerError> {
     match scheduler_flow {
         SchedulerFlow::Producer => producer::start_producer(state, scheduler_settings).await?,
-        SchedulerFlow::Consumer => consumer::start_consumer(state, scheduler_settings).await?,
+        SchedulerFlow::Consumer => {
+            consumer::start_consumer(state, scheduler_settings, workflows::runner_from_task).await?
+        }
         SchedulerFlow::Cleaner => {
             error!("This flow has not been implemented yet!");
         }

--- a/crates/router/src/scheduler/consumer.rs
+++ b/crates/router/src/scheduler/consumer.rs
@@ -36,6 +36,7 @@ pub fn valid_business_statuses() -> Vec<&'static str> {
 pub async fn start_consumer(
     state: &AppState,
     settings: sync::Arc<settings::SchedulerSettings>,
+    workflow_selector: workflows::WorkflowSelectorFn,
 ) -> CustomResult<(), errors::ProcessTrackerError> {
     use std::time::Duration;
 
@@ -78,6 +79,7 @@ pub async fn start_consumer(
                         logger::error!(%err);
                     },
                     sync::Arc::clone(&consumer_operation_counter),
+                    workflow_selector,
                 ));
             }
             Ok(()) | Err(oneshot::error::TryRecvError::Closed) => {
@@ -108,6 +110,12 @@ pub async fn start_consumer(
 pub async fn consumer_operations(
     state: &AppState,
     settings: &settings::SchedulerSettings,
+    workflow_selector: impl Fn(
+        &storage::ProcessTracker,
+    ) -> Result<
+        Option<Box<dyn ProcessTrackerWorkflow>>,
+        errors::ProcessTrackerError,
+    >,
 ) -> CustomResult<(), errors::ProcessTrackerError> {
     let stream_name = settings.stream.clone();
     let group_name = settings.consumer.consumer_group.clone();
@@ -135,7 +143,9 @@ pub async fn consumer_operations(
         pt_utils::add_histogram_metrics(&pickup_time, task, &stream_name);
 
         metrics::TASK_CONSUMED.add(&metrics::CONTEXT, 1, &[]);
-        let runner = pt_utils::runner_from_task(task)?;
+        // let runner = workflows::runner_from_task(task)?
+        //     .ok_or(errors::ProcessTrackerError::UnexpectedFlow)?;
+        let runner = workflow_selector(task)?.ok_or(errors::ProcessTrackerError::UnexpectedFlow)?;
         handler.push(tokio::task::spawn(start_workflow(
             state.clone(),
             task.clone(),
@@ -190,21 +200,22 @@ pub async fn fetch_consumer_tasks(
 }
 
 // Accept flow_options if required
-#[instrument(skip(state), fields(workflow_id))]
+#[instrument(skip(state, runner), fields(workflow_id))]
 pub async fn start_workflow(
     state: AppState,
     process: storage::ProcessTracker,
     _pickup_time: PrimitiveDateTime,
-    runner: workflows::PTRunner,
+    runner: Box<dyn ProcessTrackerWorkflow>,
 ) {
     tracing::Span::current().record("workflow_id", Uuid::new_v4().to_string());
-    workflows::perform_workflow_execution(&state, process, runner).await
+    run_executor(&state, process, runner).await
+    // workflows::perform_workflow_execution(&state, process, runner).await
 }
 
-pub async fn run_executor<'a>(
-    state: &'a AppState,
+pub async fn run_executor(
+    state: &AppState,
     process: storage::ProcessTracker,
-    operation: &(impl ProcessTrackerWorkflow + Send + Sync),
+    operation: Box<dyn ProcessTrackerWorkflow>,
 ) {
     let output = operation.execute_workflow(state, process.clone()).await;
     match output {

--- a/crates/router/src/scheduler/utils.rs
+++ b/crates/router/src/scheduler/utils.rs
@@ -19,7 +19,6 @@ use crate::{
         self,
         enums::{self, ProcessTrackerStatus},
     },
-    utils::{OptionExt, StringExt},
 };
 
 pub async fn divide_and_append_tasks(
@@ -246,6 +245,12 @@ pub async fn consumer_operation_handler<E>(
     settings: sync::Arc<SchedulerSettings>,
     error_handler_fun: E,
     consumer_operation_counter: sync::Arc<atomic::AtomicU64>,
+    workflow_selector: impl Fn(
+            &storage::ProcessTracker,
+        ) -> Result<
+            Option<Box<dyn workflows::ProcessTrackerWorkflow>>,
+            errors::ProcessTrackerError,
+        > + Send,
 ) where
     // Error handler function
     E: FnOnce(error_stack::Report<errors::ProcessTrackerError>),
@@ -253,7 +258,7 @@ pub async fn consumer_operation_handler<E>(
     consumer_operation_counter.fetch_add(1, atomic::Ordering::Release);
     let start_time = std_time::Instant::now();
 
-    match consumer::consumer_operations(&state, &settings).await {
+    match consumer::consumer_operations(&state, &settings, workflow_selector).await {
         Ok(_) => (),
         Err(err) => error_handler_fun(err),
     }
@@ -263,14 +268,6 @@ pub async fn consumer_operation_handler<E>(
 
     let current_count = consumer_operation_counter.fetch_sub(1, atomic::Ordering::Release);
     logger::info!("Current tasks being executed: {}", current_count);
-}
-
-pub fn runner_from_task(
-    task: &storage::ProcessTracker,
-) -> Result<workflows::PTRunner, errors::ProcessTrackerError> {
-    let runner = task.runner.clone().get_required_value("runner")?;
-
-    Ok(runner.parse_enum("PTRunner")?)
 }
 
 pub fn add_histogram_metrics(

--- a/crates/router/src/scheduler/workflows.rs
+++ b/crates/router/src/scheduler/workflows.rs
@@ -1,9 +1,13 @@
 use async_trait::async_trait;
-use router_env::{instrument, tracing};
 use serde::{Deserialize, Serialize};
 use strum::EnumString;
 
-use crate::{core::errors, routes::AppState, scheduler::consumer, types::storage};
+use crate::{
+    core::errors,
+    routes::AppState,
+    types::storage,
+    utils::{OptionExt, StringExt},
+};
 pub mod payment_sync;
 pub mod refund_router;
 pub mod tokenized_data;
@@ -23,17 +27,19 @@ macro_rules! runners {
             pub struct $body;
         } )*
 
-        #[instrument(skip(state))]
-        pub async fn perform_workflow_execution<'a>(state: &AppState, process: storage::ProcessTracker, runner: PTRunner)
-        where
-        {
-            match runner {
-                $( PTRunner::$body => {
-                    let flow = &$body;
-                    consumer::run_executor(state, process, flow).await
 
+        pub fn runner_from_task(task: &storage::ProcessTracker) -> Result<Option<Box<dyn ProcessTrackerWorkflow>>, errors::ProcessTrackerError> {
+            let runner = task.runner.clone().get_required_value("runner")?;
+            let runner: Option<PTRunner> = runner.parse_enum("PTRunner").ok();
+            Ok(match runner {
+                $( Some( PTRunner::$body ) => {
+                    Some(Box::new($body))
                 } ,)*
-            }
+                None => {
+                    None
+                }
+            })
+
         }
     };
 }
@@ -48,6 +54,11 @@ runners! {
     RefundWorkflowRouter,
     DeleteTokenizeDataWorkflow
 }
+
+pub type WorkflowSelectorFn =
+    fn(
+        &storage::ProcessTracker,
+    ) -> Result<Option<Box<dyn ProcessTrackerWorkflow>>, errors::ProcessTrackerError>;
 
 #[async_trait]
 pub trait ProcessTrackerWorkflow: Send + Sync {


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
This PR contains the following changes:
- it introduces dynamic dispatch to runner selection and execution
- It moves the function that yields the runner to the start of the run consumer function

<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!-- 
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context

This will provide a easier way to replace the runner in case if need to expand this by importing this into a separate crate.
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
