### PR TITLE
refactor(core): changed connector authtype to connect specific

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2758,7 +2758,7 @@ dependencies = [
 [[package]]
 name = "opentelemetry"
 version = "0.18.0"
-source = "git+https://github.com/open-telemetry/opentelemetry-rust/?rev=44b90202fd744598db8b0ace5b8f0bad7ec45658#44b90202fd744598db8b0ace5b8f0bad7ec45658"
+source = "git+https://github.com/open-telemetry/opentelemetry-rust?rev=44b90202fd744598db8b0ace5b8f0bad7ec45658#44b90202fd744598db8b0ace5b8f0bad7ec45658"
 dependencies = [
  "opentelemetry_api",
  "opentelemetry_sdk",
@@ -2767,7 +2767,7 @@ dependencies = [
 [[package]]
 name = "opentelemetry-otlp"
 version = "0.11.0"
-source = "git+https://github.com/open-telemetry/opentelemetry-rust/?rev=44b90202fd744598db8b0ace5b8f0bad7ec45658#44b90202fd744598db8b0ace5b8f0bad7ec45658"
+source = "git+https://github.com/open-telemetry/opentelemetry-rust?rev=44b90202fd744598db8b0ace5b8f0bad7ec45658#44b90202fd744598db8b0ace5b8f0bad7ec45658"
 dependencies = [
  "async-trait",
  "futures",
@@ -2784,7 +2784,7 @@ dependencies = [
 [[package]]
 name = "opentelemetry-proto"
 version = "0.1.0"
-source = "git+https://github.com/open-telemetry/opentelemetry-rust/?rev=44b90202fd744598db8b0ace5b8f0bad7ec45658#44b90202fd744598db8b0ace5b8f0bad7ec45658"
+source = "git+https://github.com/open-telemetry/opentelemetry-rust?rev=44b90202fd744598db8b0ace5b8f0bad7ec45658#44b90202fd744598db8b0ace5b8f0bad7ec45658"
 dependencies = [
  "futures",
  "futures-util",
@@ -2796,7 +2796,7 @@ dependencies = [
 [[package]]
 name = "opentelemetry_api"
 version = "0.18.0"
-source = "git+https://github.com/open-telemetry/opentelemetry-rust/?rev=44b90202fd744598db8b0ace5b8f0bad7ec45658#44b90202fd744598db8b0ace5b8f0bad7ec45658"
+source = "git+https://github.com/open-telemetry/opentelemetry-rust?rev=44b90202fd744598db8b0ace5b8f0bad7ec45658#44b90202fd744598db8b0ace5b8f0bad7ec45658"
 dependencies = [
  "fnv",
  "futures-channel",
@@ -2811,7 +2811,7 @@ dependencies = [
 [[package]]
 name = "opentelemetry_sdk"
 version = "0.18.0"
-source = "git+https://github.com/open-telemetry/opentelemetry-rust/?rev=44b90202fd744598db8b0ace5b8f0bad7ec45658#44b90202fd744598db8b0ace5b8f0bad7ec45658"
+source = "git+https://github.com/open-telemetry/opentelemetry-rust?rev=44b90202fd744598db8b0ace5b8f0bad7ec45658#44b90202fd744598db8b0ace5b8f0bad7ec45658"
 dependencies = [
  "async-trait",
  "crossbeam-channel",
@@ -3431,6 +3431,7 @@ dependencies = [
  "blake3",
  "bytes",
  "clap",
+ "common_enums",
  "common_utils",
  "config",
  "crc32fast",

--- a/connector-template/mod.rs
+++ b/connector-template/mod.rs
@@ -78,7 +78,7 @@ impl ConnectorCommon for {{project-name | downcase | pascal_case}} {
         connectors.{{project-name}}.base_url.as_ref()
     }
 
-    fn get_auth_header(&self, auth_type:&types::ConnectorAuthType)-> CustomResult<Vec<(String,String)>,errors::ConnectorError> {
+    fn get_auth_header(&self, auth_type:&common_enums::ConnectorAuthType)-> CustomResult<Vec<(String,String)>,errors::ConnectorError> {
         let auth =  {{project-name | downcase}}::{{project-name | downcase | pascal_case}}AuthType::try_from(auth_type)
             .change_context(errors::ConnectorError::FailedToObtainAuthType)?;
         Ok(vec![(headers::AUTHORIZATION.to_string(), auth.api_key)])

--- a/connector-template/test.rs
+++ b/connector-template/test.rs
@@ -19,8 +19,8 @@ impl utils::Connector for {{project-name | downcase | pascal_case}}Test {
         }
     }
 
-    fn get_auth_token(&self) -> types::ConnectorAuthType {
-        types::ConnectorAuthType::from(
+    fn get_auth_token(&self) -> common_enums::ConnectorAuthType {
+        common_enums::ConnectorAuthType::from(
             connector_auth::ConnectorAuthentication::new()
                 .{{project-name | downcase}}
                 .expect("Missing connector authentication configuration"),

--- a/connector-template/transformers.rs
+++ b/connector-template/transformers.rs
@@ -48,11 +48,11 @@ pub struct {{project-name | downcase | pascal_case}}AuthType {
     pub(super) api_key: String
 }
 
-impl TryFrom<&types::ConnectorAuthType> for {{project-name | downcase | pascal_case}}AuthType  {
+impl TryFrom<&common_enums::ConnectorAuthType> for {{project-name | downcase | pascal_case}}AuthType  {
     type Error = error_stack::Report<errors::ConnectorError>;
-    fn try_from(auth_type: &types::ConnectorAuthType) -> Result<Self, Self::Error> {
+    fn try_from(auth_type: &common_enums::ConnectorAuthType) -> Result<Self, Self::Error> {
         match auth_type {
-            types::ConnectorAuthType::HeaderKey { api_key } => Ok(Self {
+            common_enums::ConnectorAuthType::HeaderKey { api_key } => Ok(Self {
                 api_key: api_key.to_string(),
             }),
             _ => Err(errors::ConnectorError::FailedToObtainAuthType.into()),

--- a/crates/api_models/src/admin.rs
+++ b/crates/api_models/src/admin.rs
@@ -1,3 +1,4 @@
+use common_enums::ConnectorAuthType;
 use common_utils::pii;
 use masking::{Secret, StrongSecret};
 use serde::{Deserialize, Serialize};
@@ -319,8 +320,8 @@ pub struct MerchantConnectorCreate {
     #[schema(value_type = ConnectorType, example = "payment_processor")]
     pub connector_type: api_enums::ConnectorType,
     /// Name of the Connector
-    #[schema(example = "stripe")]
-    pub connector_name: String,
+    // #[schema(example = "stripe")]
+    // pub connector_name: String,
     // /// Connector label for specific country and Business
     #[serde(skip_deserializing)]
     #[schema(example = "stripe_US_travel")]
@@ -329,9 +330,13 @@ pub struct MerchantConnectorCreate {
     /// Unique ID of the connector
     #[schema(example = "mca_5apGeP94tMts6rg3U3kR")]
     pub merchant_connector_id: Option<String>,
-    /// Account details of the Connector. You can specify up to 50 keys, with key names up to 40 characters long and values up to 500 characters long. Useful for storing additional, structured information on an object.
-    #[schema(value_type = Option<Object>,example = json!({ "auth_type": "HeaderKey","api_key": "Basic MyVerySecretApiKey" }))]
-    pub connector_account_details: Option<pii::SecretSerdeValue>,
+    // /// Account details of the Connector. You can specify up to 50 keys, with key names up to 40 characters long and values up to 500 characters long. Useful for storing additional, structured information on an object.
+    // #[schema(value_type = Option<Object>,example = json!({ "auth_type": "HeaderKey","api_key": "Basic MyVerySecretApiKey" }))]
+    // pub connector_account_details: Option<pii::SecretSerdeValue>,
+    #[schema(value_type = Option<Object>,example = json!({ "api_key": "Basic MyVerySecretApiKey" }))]
+    #[serde(flatten)]
+    pub connector_info: ConnectorAuthType,
+
     /// A boolean value to indicate if the connector is in Test mode. By default, its value is false.
     #[schema(default = false, example = false)]
     pub test_mode: Option<bool>,

--- a/crates/common_enums/src/connector_auth.rs
+++ b/crates/common_enums/src/connector_auth.rs
@@ -1,0 +1,217 @@
+use serde::{Deserialize, Serialize};
+
+//connector specific types
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct AciAuthType {
+    pub api_key: String,
+    pub entity_id: String,
+}
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct AdyenAuthType {
+    pub adyen_api_key: String,
+    pub adyen_account_id: String,
+}
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct AirwallexAuthType {
+    pub app_id: String,
+    pub key1: String
+}
+//applepay not sure it will work
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
+pub struct AuthorizedotnetAuthType {
+    pub api_login_id: String,
+    pub transaction_key: String,
+}
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct BamboraAuthType {
+    pub passcode: String,
+    pub merchant_id: String,
+}
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct BluesnapAuthType {
+    pub username: String,
+    pub password: String,
+}
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct BraintreeAuthType {
+    pub public_key: String,
+    pub merchant_id: String,
+    pub private_key: String,
+}
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct CheckoutAuthType {
+    pub checkout_api_key: String,
+    pub processing_channel_id: String,
+}
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct CoinbaseAuthType {
+    pub api_key: String,
+}
+//TODO:need to check  
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct CybersourceAuthType{
+    pub api_key: String,
+    pub merchant_account: String,
+    pub api_secret: String,
+}
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct DlocalAuthType {
+    pub x_login: String,
+    pub x_trans_key: String,
+    pub secret: String,
+}
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct FiservAuthType {
+    pub api_key: String,
+    pub merchant_id: String,
+    pub api_secret: String,
+}
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct ForteAuthType {
+    pub api_key: String,
+}
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct GlobalpayAuthType {
+    pub globalpay_app_id: String,
+    pub globalpay_app_key: String,
+}
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct KlarnaAuthType {
+    pub klarna_api_key: String,
+}
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct MollieAuthType {
+    pub api_key: String,
+}
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct MultisafepayAuthType {
+    pub api_key: String,
+}
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct NexinetsAuthType {
+    pub api_key: String,
+}
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct NuveiAuthType {
+    pub merchant_id: String,
+    pub merchant_site_id: String,
+    pub merchant_secret: String,
+}
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct OpennodeAuthType {
+    pub api_key: String,
+}
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct PayeezyAuthType {
+    pub api_key: String,
+    pub api_secret: String,
+    pub merchant_token: String,
+}
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct PaypalAuthType {
+    pub api_key: String,
+    pub api_secret: String,
+}
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct PayuAuthType{
+    pub api_key: String,
+    pub merchant_pos_id: String,
+}
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct RapydAuthType {
+    pub api_secret: String,
+    pub secret_key: String,
+}
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct Shift4AuthType {
+    pub shift4_api_key: String,
+}
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct StripeAuthType {
+    pub stripe_api_key: String,
+}
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct TrustpayAuthType {
+    pub api_key: String,
+    pub project_id: String,
+    pub secret_key: String,
+}
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct WorldlineAuthType {
+    pub api_key: String,
+    pub api_secret: String,
+    pub merchant_account_id: String,
+}
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct WorldpayAuthType {
+    pub username: String,
+    pub password: String,
+}
+
+#[derive(Debug, Default, serde::Serialize, Clone, serde::Deserialize, strum::Display)]
+#[serde(rename_all = "snake_case")]
+#[serde(tag = "connector_name", content = "connector_account_details")]
+pub enum ConnectorAuthType {
+    #[strum(serialize = "aci")]
+    Aci(AciAuthType),
+    #[strum(serialize = "adyen")]
+    Adyen(AdyenAuthType),
+    #[strum(serialize = "airwallex")]
+    Airwallex(AirwallexAuthType),
+    //applepay not sure it will work
+    #[strum(serialize = "authorizedotnet")]
+    Authorizedotnet(AuthorizedotnetAuthType),
+    #[strum(serialize = "bambora")]
+    Bambora(BamboraAuthType),
+    #[strum(serialize = "bluesnap")]
+    Bluesnap(BluesnapAuthType),
+    #[strum(serialize = "braintree")]
+    Braintree(BraintreeAuthType),
+    #[strum(serialize = "checkout")]
+    Checkout(CheckoutAuthType),
+    #[strum(serialize = "coinbase")]
+    Coinbase(CoinbaseAuthType),
+    //TODO:need to check  
+    #[strum(serialize = "cybersource")]
+    Cybersource(CybersourceAuthType),
+    #[strum(serialize = "dlocal")]
+    Dlocal(DlocalAuthType),
+    #[strum(serialize = "fiserv")]
+    Fiserv(FiservAuthType),
+    #[strum(serialize = "forte")]
+    Forte(ForteAuthType),
+    #[strum(serialize = "globalpay")]
+    Globalpay(GlobalpayAuthType),
+    #[strum(serialize = "klarna")]
+    Klarna(KlarnaAuthType),
+    #[strum(serialize = "mollie")]
+    Mollie(MollieAuthType),
+    #[strum(serialize = "multisafepay")]
+    Multisafepay(MultisafepayAuthType),
+    #[strum(serialize = "nexinets")]
+    Nexinets(NexinetsAuthType),
+    #[strum(serialize = "nuvei")]
+    Nuvei(NuveiAuthType),
+    #[strum(serialize = "opennode")]
+    Opennode(OpennodeAuthType),
+    #[strum(serialize = "payeezy")]
+    Payeezy(PayeezyAuthType),
+    #[strum(serialize = "paypal")]
+    Paypal(PaypalAuthType),
+    #[strum(serialize = "payu")]
+    Payu(PayuAuthType),
+    #[strum(serialize = "rapyd")]
+    Rapyd(RapydAuthType),
+    #[strum(serialize = "shift4")]
+    Shift4(Shift4AuthType),
+    #[strum(serialize = "stripe")]
+    Stripe(StripeAuthType),
+    #[strum(serialize = "trustPay")]
+    TrustPay(TrustpayAuthType),
+    #[strum(serialize = "worldline")]
+    Worldline(WorldlineAuthType),
+    #[strum(serialize = "worldpay")]
+    Worldpay(WorldpayAuthType),
+    #[default]
+    NoKey,
+}

--- a/crates/common_enums/src/enums.rs
+++ b/crates/common_enums/src/enums.rs
@@ -2623,3 +2623,157 @@ mod tests {
         assert!(result.is_err());
     }
 }
+
+#[derive(Default, serde::Serialize, Debug, Clone, serde::Deserialize, strum::Display)]
+#[serde(rename_all = "snake_case")]
+#[serde(tag = "connector_name", content = "connector_account_details")]
+pub enum ConnectorAuthType {
+    #[strum(serialize = "aci")]
+    Aci {
+        api_key: String,
+        entity_id: String,
+    },
+    #[strum(serialize = "adyen")]
+    Adyen {
+        adyen_api_key: String,
+        adyen_account_id: String,
+    },
+    #[strum(serialize = "airwallex")]
+    Airwallex {
+        app_id: String,
+        key1: String
+    },
+    //applepay not sure it will work
+    #[strum(serialize = "authorizedotnet")]
+    Authorizedotnet {
+        api_login_id: String,
+        transaction_key: String,
+    },
+    #[strum(serialize = "bambora")]
+    Bambora {
+        passcode: String,
+        merchant_id: String,
+    },
+    #[strum(serialize = "bluesnap")]
+    Bluesnap {
+        username: String,
+        password: String,
+    },
+    #[strum(serialize = "braintree")]
+    Braintree {
+        public_key: String,
+        merchant_id: String,
+        private_key: String,
+    },
+    #[strum(serialize = "checkout")]
+    Checkout {
+        checkout_api_key: String,
+        processing_channel_id: String,
+    },
+    #[strum(serialize = "coinbase")]
+    Coinbase {
+        api_key: String,
+    },
+    //TODO:need to check  
+    #[strum(serialize = "cybersource")]
+    Cybersource {
+        key: String,
+        merchant_account: String,
+        api_secret: String,
+    },
+    #[strum(serialize = "dlocal")]
+    Dlocal {
+        x_login: String,
+        x_trans_key: String,
+        secret: String,
+    },
+    #[strum(serialize = "fiserv")]
+    Fiserv {
+        api_key: String,
+        merchant_id: String,
+        api_secret: String,
+    },
+    #[strum(serialize = "forte")]
+    Forte {
+        api_key: String,
+    },
+    #[strum(serialize = "globalpay")]
+    Globalpay {
+        globalpay_app_id: String,
+        globalpay_app_key: String,
+    },
+    #[strum(serialize = "klarna")]
+    Klarna {
+        klarna_api_key: String,
+    },
+    #[strum(serialize = "mollie")]
+    Mollie {
+        api_key: String,
+    },
+    #[strum(serialize = "multisafepay")]
+    Multisafepay {
+        api_key: String,
+    },
+    #[strum(serialize = "nexinets")]
+    Nexinets {
+        api_key: String,
+    },
+    #[strum(serialize = "nuvei")]
+    Nuvei {
+        merchant_id: String,
+        merchant_site_id: String,
+        merchant_secret: String,
+    },
+    #[strum(serialize = "opennode")]
+    Opennode {
+        api_key: String,
+    },
+    #[strum(serialize = "payeezy")]
+    Payeezy {
+        api_key: String,
+        api_secret: String,
+        merchant_token: String,
+    },
+    #[strum(serialize = "paypal")]
+    Paypal {
+        api_key: String,
+        api_secret: String,
+    },
+    #[strum(serialize = "payu")]
+    Payu {
+        api_key: String,
+        merchant_pos_id: String,
+    },
+    #[strum(serialize = "rapyd")]
+    Rapyd {
+        api_secret: String,
+        secret_key: String,
+    },
+    #[strum(serialize = "shift4")]
+    Shift4 {
+        shift4_api_key: String,
+    },
+    #[strum(serialize = "stripe")]
+    Stripe {
+        stripe_api_key: String,
+    },
+    #[strum(serialize = "trustPay")]
+    TrustPay {
+        api_key: String,
+        project_id: String,
+        secret_key: String,
+    },
+    #[strum(serialize = "worldline")]
+    Worldline {
+        api_key: String,
+        api_secret: String,
+        merchant_account_id: String,
+    },
+    #[strum(serialize = "worldpay")]
+    Worldpay {
+        username: String,
+        password: String,
+    },
+    #[default]
+    NoKey,
+}

--- a/crates/common_enums/src/enums.rs
+++ b/crates/common_enums/src/enums.rs
@@ -2624,156 +2624,156 @@ mod tests {
     }
 }
 
-#[derive(Default, serde::Serialize, Debug, Clone, serde::Deserialize, strum::Display)]
-#[serde(rename_all = "snake_case")]
-#[serde(tag = "connector_name", content = "connector_account_details")]
-pub enum ConnectorAuthType {
-    #[strum(serialize = "aci")]
-    Aci {
-        api_key: String,
-        entity_id: String,
-    },
-    #[strum(serialize = "adyen")]
-    Adyen {
-        adyen_api_key: String,
-        adyen_account_id: String,
-    },
-    #[strum(serialize = "airwallex")]
-    Airwallex {
-        app_id: String,
-        key1: String
-    },
-    //applepay not sure it will work
-    #[strum(serialize = "authorizedotnet")]
-    Authorizedotnet {
-        api_login_id: String,
-        transaction_key: String,
-    },
-    #[strum(serialize = "bambora")]
-    Bambora {
-        passcode: String,
-        merchant_id: String,
-    },
-    #[strum(serialize = "bluesnap")]
-    Bluesnap {
-        username: String,
-        password: String,
-    },
-    #[strum(serialize = "braintree")]
-    Braintree {
-        public_key: String,
-        merchant_id: String,
-        private_key: String,
-    },
-    #[strum(serialize = "checkout")]
-    Checkout {
-        checkout_api_key: String,
-        processing_channel_id: String,
-    },
-    #[strum(serialize = "coinbase")]
-    Coinbase {
-        api_key: String,
-    },
-    //TODO:need to check  
-    #[strum(serialize = "cybersource")]
-    Cybersource {
-        key: String,
-        merchant_account: String,
-        api_secret: String,
-    },
-    #[strum(serialize = "dlocal")]
-    Dlocal {
-        x_login: String,
-        x_trans_key: String,
-        secret: String,
-    },
-    #[strum(serialize = "fiserv")]
-    Fiserv {
-        api_key: String,
-        merchant_id: String,
-        api_secret: String,
-    },
-    #[strum(serialize = "forte")]
-    Forte {
-        api_key: String,
-    },
-    #[strum(serialize = "globalpay")]
-    Globalpay {
-        globalpay_app_id: String,
-        globalpay_app_key: String,
-    },
-    #[strum(serialize = "klarna")]
-    Klarna {
-        klarna_api_key: String,
-    },
-    #[strum(serialize = "mollie")]
-    Mollie {
-        api_key: String,
-    },
-    #[strum(serialize = "multisafepay")]
-    Multisafepay {
-        api_key: String,
-    },
-    #[strum(serialize = "nexinets")]
-    Nexinets {
-        api_key: String,
-    },
-    #[strum(serialize = "nuvei")]
-    Nuvei {
-        merchant_id: String,
-        merchant_site_id: String,
-        merchant_secret: String,
-    },
-    #[strum(serialize = "opennode")]
-    Opennode {
-        api_key: String,
-    },
-    #[strum(serialize = "payeezy")]
-    Payeezy {
-        api_key: String,
-        api_secret: String,
-        merchant_token: String,
-    },
-    #[strum(serialize = "paypal")]
-    Paypal {
-        api_key: String,
-        api_secret: String,
-    },
-    #[strum(serialize = "payu")]
-    Payu {
-        api_key: String,
-        merchant_pos_id: String,
-    },
-    #[strum(serialize = "rapyd")]
-    Rapyd {
-        api_secret: String,
-        secret_key: String,
-    },
-    #[strum(serialize = "shift4")]
-    Shift4 {
-        shift4_api_key: String,
-    },
-    #[strum(serialize = "stripe")]
-    Stripe {
-        stripe_api_key: String,
-    },
-    #[strum(serialize = "trustPay")]
-    TrustPay {
-        api_key: String,
-        project_id: String,
-        secret_key: String,
-    },
-    #[strum(serialize = "worldline")]
-    Worldline {
-        api_key: String,
-        api_secret: String,
-        merchant_account_id: String,
-    },
-    #[strum(serialize = "worldpay")]
-    Worldpay {
-        username: String,
-        password: String,
-    },
-    #[default]
-    NoKey,
-}
+// #[derive(Default, serde::Serialize, Debug, Clone, serde::Deserialize, strum::Display)]
+// #[serde(rename_all = "snake_case")]
+// #[serde(tag = "connector_name", content = "connector_account_details")]
+// pub enum ConnectorAuthType {
+//     #[strum(serialize = "aci")]
+//     Aci {
+//         api_key: String,
+//         entity_id: String,
+//     },
+//     #[strum(serialize = "adyen")]
+//     Adyen {
+//         adyen_api_key: String,
+//         adyen_account_id: String,
+//     },
+//     #[strum(serialize = "airwallex")]
+//     Airwallex {
+//         app_id: String,
+//         key1: String
+//     },
+//     //applepay not sure it will work
+//     #[strum(serialize = "authorizedotnet")]
+//     Authorizedotnet {
+//         api_login_id: String,
+//         transaction_key: String,
+//     },
+//     #[strum(serialize = "bambora")]
+//     Bambora {
+//         passcode: String,
+//         merchant_id: String,
+//     },
+//     #[strum(serialize = "bluesnap")]
+//     Bluesnap {
+//         username: String,
+//         password: String,
+//     },
+//     #[strum(serialize = "braintree")]
+//     Braintree {
+//         public_key: String,
+//         merchant_id: String,
+//         private_key: String,
+//     },
+//     #[strum(serialize = "checkout")]
+//     Checkout {
+//         checkout_api_key: String,
+//         processing_channel_id: String,
+//     },
+//     #[strum(serialize = "coinbase")]
+//     Coinbase {
+//         api_key: String,
+//     },
+//     //TODO:need to check  
+//     #[strum(serialize = "cybersource")]
+//     Cybersource {
+//         key: String,
+//         merchant_account: String,
+//         api_secret: String,
+//     },
+//     #[strum(serialize = "dlocal")]
+//     Dlocal {
+//         x_login: String,
+//         x_trans_key: String,
+//         secret: String,
+//     },
+//     #[strum(serialize = "fiserv")]
+//     Fiserv {
+//         api_key: String,
+//         merchant_id: String,
+//         api_secret: String,
+//     },
+//     #[strum(serialize = "forte")]
+//     Forte {
+//         api_key: String,
+//     },
+//     #[strum(serialize = "globalpay")]
+//     Globalpay {
+//         globalpay_app_id: String,
+//         globalpay_app_key: String,
+//     },
+//     #[strum(serialize = "klarna")]
+//     Klarna {
+//         klarna_api_key: String,
+//     },
+//     #[strum(serialize = "mollie")]
+//     Mollie {
+//         api_key: String,
+//     },
+//     #[strum(serialize = "multisafepay")]
+//     Multisafepay {
+//         api_key: String,
+//     },
+//     #[strum(serialize = "nexinets")]
+//     Nexinets {
+//         api_key: String,
+//     },
+//     #[strum(serialize = "nuvei")]
+//     Nuvei {
+//         merchant_id: String,
+//         merchant_site_id: String,
+//         merchant_secret: String,
+//     },
+//     #[strum(serialize = "opennode")]
+//     Opennode {
+//         api_key: String,
+//     },
+//     #[strum(serialize = "payeezy")]
+//     Payeezy {
+//         api_key: String,
+//         api_secret: String,
+//         merchant_token: String,
+//     },
+//     #[strum(serialize = "paypal")]
+//     Paypal {
+//         api_key: String,
+//         api_secret: String,
+//     },
+//     #[strum(serialize = "payu")]
+//     Payu {
+//         api_key: String,
+//         merchant_pos_id: String,
+//     },
+//     #[strum(serialize = "rapyd")]
+//     Rapyd {
+//         api_secret: String,
+//         secret_key: String,
+//     },
+//     #[strum(serialize = "shift4")]
+//     Shift4 {
+//         shift4_api_key: String,
+//     },
+//     #[strum(serialize = "stripe")]
+//     Stripe {
+//         stripe_api_key: String,
+//     },
+//     #[strum(serialize = "trustPay")]
+//     TrustPay {
+//         api_key: String,
+//         project_id: String,
+//         secret_key: String,
+//     },
+//     #[strum(serialize = "worldline")]
+//     Worldline {
+//         api_key: String,
+//         api_secret: String,
+//         merchant_account_id: String,
+//     },
+//     #[strum(serialize = "worldpay")]
+//     Worldpay {
+//         username: String,
+//         password: String,
+//     },
+//     #[default]
+//     NoKey,
+// }

--- a/crates/common_enums/src/lib.rs
+++ b/crates/common_enums/src/lib.rs
@@ -1,2 +1,4 @@
 pub mod enums;
 pub use enums::*;
+pub mod connector_auth;
+pub use connector_auth::*;

--- a/crates/router/Cargo.toml
+++ b/crates/router/Cargo.toml
@@ -82,6 +82,7 @@ uuid = { version = "1.3.0", features = ["serde", "v4"] }
 # First party crates
 api_models = { version = "0.1.0", path = "../api_models", features = ["errors"] }
 common_utils = { version = "0.1.0", path = "../common_utils", features = ["signals", "async_ext"] }
+common_enums = {path = "../common_enums"}
 external_services = { version = "0.1.0", path = "../external_services" }
 masking = { version = "0.1.0", path = "../masking" }
 redis_interface = { version = "0.1.0", path = "../redis_interface" }

--- a/crates/router/src/connector/aci.rs
+++ b/crates/router/src/connector/aci.rs
@@ -34,7 +34,7 @@ impl ConnectorCommon for Aci {
 
     fn get_auth_header(
         &self,
-        auth_type: &types::ConnectorAuthType,
+        auth_type: &common_enums::ConnectorAuthType,
     ) -> CustomResult<Vec<(String, String)>, errors::ConnectorError> {
         let auth: aci::AciAuthType = auth_type
             .try_into()

--- a/crates/router/src/connector/aci.rs
+++ b/crates/router/src/connector/aci.rs
@@ -11,7 +11,7 @@ use crate::{
     headers, services,
     types::{
         self,
-        api::{self, ConnectorCommon},
+        api::{self, ConnectorCommon}, transformers::{ForeignTryInto, ForeignTryFrom},
     },
     utils::{self, BytesExt},
 };
@@ -36,8 +36,8 @@ impl ConnectorCommon for Aci {
         &self,
         auth_type: &common_enums::ConnectorAuthType,
     ) -> CustomResult<Vec<(String, String)>, errors::ConnectorError> {
-        let auth: aci::AciAuthType = auth_type
-            .try_into()
+        let auth: common_enums::AciAuthType = auth_type
+            .foreign_try_into()
             .change_context(errors::ConnectorError::FailedToObtainAuthType)?;
         Ok(vec![(headers::AUTHORIZATION.to_string(), auth.api_key)])
     }
@@ -132,7 +132,7 @@ impl
         req: &types::PaymentsSyncRouterData,
         connectors: &settings::Connectors,
     ) -> CustomResult<String, errors::ConnectorError> {
-        let auth = aci::AciAuthType::try_from(&req.connector_auth_type)?;
+        let auth = common_enums::AciAuthType::foreign_try_from(&req.connector_auth_type)?;
         Ok(format!(
             "{}{}{}{}{}",
             self.base_url(connectors),

--- a/crates/router/src/connector/aci/transformers.rs
+++ b/crates/router/src/connector/aci/transformers.rs
@@ -15,13 +15,13 @@ pub struct AciAuthType {
     pub entity_id: String,
 }
 
-impl TryFrom<&types::ConnectorAuthType> for AciAuthType {
+impl TryFrom<&common_enums::ConnectorAuthType> for AciAuthType {
     type Error = error_stack::Report<errors::ConnectorError>;
-    fn try_from(item: &types::ConnectorAuthType) -> Result<Self, Self::Error> {
-        if let types::ConnectorAuthType::BodyKey { api_key, key1 } = item {
+    fn try_from(item: &common_enums::ConnectorAuthType) -> Result<Self, Self::Error> {
+        if let common_enums::ConnectorAuthType::Aci { api_key, entity_id } = item {
             Ok(Self {
                 api_key: api_key.to_string(),
-                entity_id: key1.to_string(),
+                entity_id: entity_id.to_string(),
             })
         } else {
             Err(errors::ConnectorError::FailedToObtainAuthType)?

--- a/crates/router/src/connector/adyen.rs
+++ b/crates/router/src/connector/adyen.rs
@@ -18,7 +18,7 @@ use crate::{
     types::{
         self,
         api::{self, ConnectorCommon},
-        transformers::ForeignFrom,
+        transformers::{ForeignFrom, ForeignTryFrom},
     },
     utils::{self, crypto, ByteSliceExt, BytesExt, OptionExt},
 };
@@ -35,9 +35,9 @@ impl ConnectorCommon for Adyen {
         &self,
         auth_type: &common_enums::ConnectorAuthType,
     ) -> CustomResult<Vec<(String, String)>, errors::ConnectorError> {
-        let auth = adyen::AdyenAuthType::try_from(auth_type)
+        let auth = common_enums::AdyenAuthType::foreign_try_from(auth_type)
             .change_context(errors::ConnectorError::FailedToObtainAuthType)?;
-        Ok(vec![(headers::X_API_KEY.to_string(), auth.api_key)])
+        Ok(vec![(headers::X_API_KEY.to_string(), auth.adyen_api_key)])
     }
 
     fn base_url<'a>(&self, connectors: &'a settings::Connectors) -> &'a str {

--- a/crates/router/src/connector/adyen.rs
+++ b/crates/router/src/connector/adyen.rs
@@ -33,7 +33,7 @@ impl ConnectorCommon for Adyen {
 
     fn get_auth_header(
         &self,
-        auth_type: &types::ConnectorAuthType,
+        auth_type: &common_enums::ConnectorAuthType,
     ) -> CustomResult<Vec<(String, String)>, errors::ConnectorError> {
         let auth = adyen::AdyenAuthType::try_from(auth_type)
             .change_context(errors::ConnectorError::FailedToObtainAuthType)?;

--- a/crates/router/src/connector/adyen/transformers.rs
+++ b/crates/router/src/connector/adyen/transformers.rs
@@ -404,13 +404,13 @@ impl<'a> TryFrom<&api_enums::BankNames> for AdyenTestBankNames<'a> {
     }
 }
 
-impl TryFrom<&types::ConnectorAuthType> for AdyenAuthType {
+impl TryFrom<&common_enums::ConnectorAuthType> for AdyenAuthType {
     type Error = error_stack::Report<errors::ConnectorError>;
-    fn try_from(auth_type: &types::ConnectorAuthType) -> Result<Self, Self::Error> {
-        if let types::ConnectorAuthType::BodyKey { api_key, key1 } = auth_type {
+    fn try_from(auth_type: &common_enums::ConnectorAuthType) -> Result<Self, Self::Error> {
+        if let common_enums::ConnectorAuthType::Adyen { adyen_api_key, adyen_account_id } = auth_type {
             Ok(Self {
-                api_key: api_key.to_string(),
-                merchant_account: key1.to_string(),
+                api_key: adyen_api_key.to_string(),
+                merchant_account: adyen_account_id.to_string(),
             })
         } else {
             Err(errors::ConnectorError::FailedToObtainAuthType)?

--- a/crates/router/src/connector/authorizedotnet/transformers.rs
+++ b/crates/router/src/connector/authorizedotnet/transformers.rs
@@ -25,14 +25,14 @@ struct MerchantAuthentication {
     transaction_key: String,
 }
 
-impl TryFrom<&types::ConnectorAuthType> for MerchantAuthentication {
+impl TryFrom<&common_enums::ConnectorAuthType> for MerchantAuthentication {
     type Error = error_stack::Report<errors::ConnectorError>;
 
-    fn try_from(auth_type: &types::ConnectorAuthType) -> Result<Self, Self::Error> {
-        if let types::ConnectorAuthType::BodyKey { api_key, key1 } = auth_type {
+    fn try_from(auth_type: &common_enums::ConnectorAuthType) -> Result<Self, Self::Error> {
+        if let common_enums::ConnectorAuthType::Authorizedotnet { api_login_id, transaction_key } = auth_type {
             Ok(Self {
-                name: api_key.clone(),
-                transaction_key: key1.clone(),
+                name: api_login_id.clone(),
+                transaction_key: transaction_key.clone(),
             })
         } else {
             Err(errors::ConnectorError::FailedToObtainAuthType)?

--- a/crates/router/src/connector/bambora.rs
+++ b/crates/router/src/connector/bambora.rs
@@ -57,7 +57,7 @@ impl ConnectorCommon for Bambora {
 
     fn get_auth_header(
         &self,
-        auth_type: &types::ConnectorAuthType,
+        auth_type: &common_enums::ConnectorAuthType,
     ) -> CustomResult<Vec<(String, String)>, errors::ConnectorError> {
         let auth: bambora::BamboraAuthType = auth_type
             .try_into()

--- a/crates/router/src/connector/bambora/transformers.rs
+++ b/crates/router/src/connector/bambora/transformers.rs
@@ -91,11 +91,11 @@ pub struct BamboraAuthType {
     pub(super) api_key: String,
 }
 
-impl TryFrom<&types::ConnectorAuthType> for BamboraAuthType {
+impl TryFrom<&common_enums::ConnectorAuthType> for BamboraAuthType {
     type Error = error_stack::Report<errors::ConnectorError>;
-    fn try_from(auth_type: &types::ConnectorAuthType) -> Result<Self, Self::Error> {
-        if let types::ConnectorAuthType::BodyKey { api_key, key1 } = auth_type {
-            let auth_key = format!("{key1}:{api_key}");
+    fn try_from(auth_type: &common_enums::ConnectorAuthType) -> Result<Self, Self::Error> {
+        if let common_enums::ConnectorAuthType::Bambora { passcode, merchant_id } = auth_type {
+            let auth_key = format!("{merchant_id}:{passcode}");
             let auth_header = format!("Passcode {}", consts::BASE64_ENGINE.encode(auth_key));
             Ok(Self {
                 api_key: auth_header,

--- a/crates/router/src/connector/bambora/transformers.rs
+++ b/crates/router/src/connector/bambora/transformers.rs
@@ -94,8 +94,8 @@ pub struct BamboraAuthType {
 impl TryFrom<&common_enums::ConnectorAuthType> for BamboraAuthType {
     type Error = error_stack::Report<errors::ConnectorError>;
     fn try_from(auth_type: &common_enums::ConnectorAuthType) -> Result<Self, Self::Error> {
-        if let common_enums::ConnectorAuthType::Bambora { passcode, merchant_id } = auth_type {
-            let auth_key = format!("{merchant_id}:{passcode}");
+        if let common_enums::ConnectorAuthType::Bambora (connector_auth) = auth_type {
+            let auth_key = format!("{0}:{1}",connector_auth.merchant_id, connector_auth.passcode);
             let auth_header = format!("Passcode {}", consts::BASE64_ENGINE.encode(auth_key));
             Ok(Self {
                 api_key: auth_header,

--- a/crates/router/src/connector/bluesnap.rs
+++ b/crates/router/src/connector/bluesnap.rs
@@ -18,7 +18,7 @@ use crate::{
     types::{
         self,
         api::{self, ConnectorCommon, ConnectorCommonExt},
-        ErrorResponse, Response,
+        ErrorResponse, Response, transformers::ForeignTryInto,
     },
     utils::{self, BytesExt},
 };
@@ -61,8 +61,8 @@ impl ConnectorCommon for Bluesnap {
         &self,
         auth_type: &common_enums::ConnectorAuthType,
     ) -> CustomResult<Vec<(String, String)>, errors::ConnectorError> {
-        let auth: bluesnap::BluesnapAuthType = auth_type
-            .try_into()
+        let auth: common_enums::BluesnapAuthType = auth_type
+            .foreign_try_into()
             .change_context(errors::ConnectorError::FailedToObtainAuthType)?;
         let encoded_api_key =
             consts::BASE64_ENGINE.encode(format!("{}:{}", auth.username, auth.password));

--- a/crates/router/src/connector/bluesnap.rs
+++ b/crates/router/src/connector/bluesnap.rs
@@ -59,13 +59,13 @@ impl ConnectorCommon for Bluesnap {
 
     fn get_auth_header(
         &self,
-        auth_type: &types::ConnectorAuthType,
+        auth_type: &common_enums::ConnectorAuthType,
     ) -> CustomResult<Vec<(String, String)>, errors::ConnectorError> {
         let auth: bluesnap::BluesnapAuthType = auth_type
             .try_into()
             .change_context(errors::ConnectorError::FailedToObtainAuthType)?;
         let encoded_api_key =
-            consts::BASE64_ENGINE.encode(format!("{}:{}", auth.key1, auth.api_key));
+            consts::BASE64_ENGINE.encode(format!("{}:{}", auth.username, auth.password));
         Ok(vec![(
             headers::AUTHORIZATION.to_string(),
             format!("Basic {encoded_api_key}"),

--- a/crates/router/src/connector/bluesnap/transformers.rs
+++ b/crates/router/src/connector/bluesnap/transformers.rs
@@ -101,20 +101,11 @@ impl TryFrom<&types::PaymentsCaptureRouterData> for BluesnapCaptureRequest {
     }
 }
 
-// Auth Struct
-pub struct BluesnapAuthType {
-    pub(super) password: String,
-    pub(super) username: String,
-}
-
-impl TryFrom<&common_enums::ConnectorAuthType> for BluesnapAuthType {
+impl ForeignTryFrom<&common_enums::ConnectorAuthType> for common_enums::BluesnapAuthType {
     type Error = error_stack::Report<errors::ConnectorError>;
-    fn try_from(auth_type: &common_enums::ConnectorAuthType) -> Result<Self, Self::Error> {
-        if let common_enums::ConnectorAuthType::Bluesnap { password, username } = auth_type {
-            Ok(Self {
-                password: password.to_string(),
-                username: username.to_string(),
-            })
+    fn foreign_try_from(auth_type: &common_enums::ConnectorAuthType) -> Result<Self, Self::Error> {
+        if let common_enums::ConnectorAuthType::Bluesnap (connector_auth)  = auth_type {
+            Ok(connector_auth.clone())
         } else {
             Err(errors::ConnectorError::FailedToObtainAuthType.into())
         }

--- a/crates/router/src/connector/bluesnap/transformers.rs
+++ b/crates/router/src/connector/bluesnap/transformers.rs
@@ -103,17 +103,17 @@ impl TryFrom<&types::PaymentsCaptureRouterData> for BluesnapCaptureRequest {
 
 // Auth Struct
 pub struct BluesnapAuthType {
-    pub(super) api_key: String,
-    pub(super) key1: String,
+    pub(super) password: String,
+    pub(super) username: String,
 }
 
-impl TryFrom<&types::ConnectorAuthType> for BluesnapAuthType {
+impl TryFrom<&common_enums::ConnectorAuthType> for BluesnapAuthType {
     type Error = error_stack::Report<errors::ConnectorError>;
-    fn try_from(auth_type: &types::ConnectorAuthType) -> Result<Self, Self::Error> {
-        if let types::ConnectorAuthType::BodyKey { api_key, key1 } = auth_type {
+    fn try_from(auth_type: &common_enums::ConnectorAuthType) -> Result<Self, Self::Error> {
+        if let common_enums::ConnectorAuthType::Bluesnap { password, username } = auth_type {
             Ok(Self {
-                api_key: api_key.to_string(),
-                key1: key1.to_string(),
+                password: password.to_string(),
+                username: username.to_string(),
             })
         } else {
             Err(errors::ConnectorError::FailedToObtainAuthType.into())

--- a/crates/router/src/connector/braintree.rs
+++ b/crates/router/src/connector/braintree.rs
@@ -31,7 +31,7 @@ impl ConnectorCommon for Braintree {
 
     fn get_auth_header(
         &self,
-        auth_type: &types::ConnectorAuthType,
+        auth_type: &common_enums::ConnectorAuthType,
     ) -> CustomResult<Vec<(String, String)>, errors::ConnectorError> {
         let auth: braintree::BraintreeAuthType = auth_type
             .try_into()

--- a/crates/router/src/connector/braintree/transformers.rs
+++ b/crates/router/src/connector/braintree/transformers.rs
@@ -141,13 +141,13 @@ pub struct BraintreeAuthType {
     pub(super) merchant_id: String,
 }
 
-impl TryFrom<&types::ConnectorAuthType> for BraintreeAuthType {
+impl TryFrom<&common_enums::ConnectorAuthType> for BraintreeAuthType {
     type Error = error_stack::Report<errors::ConnectorError>;
-    fn try_from(item: &types::ConnectorAuthType) -> Result<Self, Self::Error> {
-        if let types::ConnectorAuthType::SignatureKey {
-            api_key: public_key,
-            key1: merchant_id,
-            api_secret: private_key,
+    fn try_from(item: &common_enums::ConnectorAuthType) -> Result<Self, Self::Error> {
+        if let common_enums::ConnectorAuthType::Braintree {
+            public_key,
+            merchant_id,
+            private_key,
         } = item
         {
             let auth_key = format!("{public_key}:{private_key}");

--- a/crates/router/src/connector/braintree/transformers.rs
+++ b/crates/router/src/connector/braintree/transformers.rs
@@ -144,17 +144,13 @@ pub struct BraintreeAuthType {
 impl TryFrom<&common_enums::ConnectorAuthType> for BraintreeAuthType {
     type Error = error_stack::Report<errors::ConnectorError>;
     fn try_from(item: &common_enums::ConnectorAuthType) -> Result<Self, Self::Error> {
-        if let common_enums::ConnectorAuthType::Braintree {
-            public_key,
-            merchant_id,
-            private_key,
-        } = item
+        if let common_enums::ConnectorAuthType::Braintree (connector_auth) = item
         {
-            let auth_key = format!("{public_key}:{private_key}");
+            let auth_key = format!("{0}:{1}", connector_auth.public_key, connector_auth.private_key);
             let auth_header = format!("Basic {}", consts::BASE64_ENGINE.encode(auth_key));
             Ok(Self {
                 auth_header,
-                merchant_id: merchant_id.to_owned(),
+                merchant_id: connector_auth.merchant_id.to_owned(),
             })
         } else {
             Err(errors::ConnectorError::FailedToObtainAuthType)?

--- a/crates/router/src/connector/checkout.rs
+++ b/crates/router/src/connector/checkout.rs
@@ -18,7 +18,7 @@ use crate::{
     headers, services,
     types::{
         self,
-        api::{self, ConnectorCommon},
+        api::{self, ConnectorCommon}, transformers::ForeignTryInto,
     },
     utils::{self, BytesExt},
 };
@@ -39,12 +39,12 @@ impl ConnectorCommon for Checkout {
         &self,
         auth_type: &common_enums::ConnectorAuthType,
     ) -> CustomResult<Vec<(String, String)>, errors::ConnectorError> {
-        let auth: checkout::CheckoutAuthType = auth_type
-            .try_into()
+        let auth: common_enums::CheckoutAuthType = auth_type
+            .foreign_try_into()
             .change_context(errors::ConnectorError::FailedToObtainAuthType)?;
         Ok(vec![(
             headers::AUTHORIZATION.to_string(),
-            format!("Bearer {}", auth.api_key),
+            format!("Bearer {}", auth.checkout_api_key),
         )])
     }
 

--- a/crates/router/src/connector/checkout.rs
+++ b/crates/router/src/connector/checkout.rs
@@ -37,7 +37,7 @@ impl ConnectorCommon for Checkout {
 
     fn get_auth_header(
         &self,
-        auth_type: &types::ConnectorAuthType,
+        auth_type: &common_enums::ConnectorAuthType,
     ) -> CustomResult<Vec<(String, String)>, errors::ConnectorError> {
         let auth: checkout::CheckoutAuthType = auth_type
             .try_into()

--- a/crates/router/src/connector/checkout/transformers.rs
+++ b/crates/router/src/connector/checkout/transformers.rs
@@ -52,13 +52,13 @@ pub struct CheckoutThreeDS {
     force_3ds: bool,
 }
 
-impl TryFrom<&types::ConnectorAuthType> for CheckoutAuthType {
+impl TryFrom<&common_enums::ConnectorAuthType> for CheckoutAuthType {
     type Error = error_stack::Report<errors::ConnectorError>;
-    fn try_from(auth_type: &types::ConnectorAuthType) -> Result<Self, Self::Error> {
-        if let types::ConnectorAuthType::BodyKey { api_key, key1 } = auth_type {
+    fn try_from(auth_type: &common_enums::ConnectorAuthType) -> Result<Self, Self::Error> {
+        if let common_enums::ConnectorAuthType::Checkout { checkout_api_key, processing_channel_id } = auth_type {
             Ok(Self {
-                api_key: api_key.to_string(),
-                processing_channel_id: key1.to_string(),
+                api_key: checkout_api_key.to_string(),
+                processing_channel_id: processing_channel_id.to_string(),
             })
         } else {
             Err(errors::ConnectorError::FailedToObtainAuthType.into())

--- a/crates/router/src/connector/coinbase.rs
+++ b/crates/router/src/connector/coinbase.rs
@@ -5,6 +5,7 @@ use std::fmt::Debug;
 use common_utils::{crypto, ext_traits::ByteSliceExt};
 use error_stack::{IntoReport, ResultExt};
 use transformers as coinbase;
+use crate::types::transformers::ForeignTryFrom;
 
 use self::coinbase::CoinbaseWebhookDetails;
 use super::utils;
@@ -76,7 +77,7 @@ impl ConnectorCommon for Coinbase {
         &self,
         auth_type: &common_enums::ConnectorAuthType,
     ) -> CustomResult<Vec<(String, String)>, errors::ConnectorError> {
-        let auth: coinbase::CoinbaseAuthType = coinbase::CoinbaseAuthType::try_from(auth_type)
+        let auth: common_enums::CoinbaseAuthType = common_enums::CoinbaseAuthType::foreign_try_from(auth_type)
             .change_context(errors::ConnectorError::FailedToObtainAuthType)?;
         Ok(vec![(headers::X_CC_API_KEY.to_string(), auth.api_key)])
     }

--- a/crates/router/src/connector/coinbase.rs
+++ b/crates/router/src/connector/coinbase.rs
@@ -74,7 +74,7 @@ impl ConnectorCommon for Coinbase {
 
     fn get_auth_header(
         &self,
-        auth_type: &types::ConnectorAuthType,
+        auth_type: &common_enums::ConnectorAuthType,
     ) -> CustomResult<Vec<(String, String)>, errors::ConnectorError> {
         let auth: coinbase::CoinbaseAuthType = coinbase::CoinbaseAuthType::try_from(auth_type)
             .change_context(errors::ConnectorError::FailedToObtainAuthType)?;

--- a/crates/router/src/connector/coinbase/transformers.rs
+++ b/crates/router/src/connector/coinbase/transformers.rs
@@ -7,7 +7,7 @@ use crate::{
     core::errors,
     pii::Secret,
     services,
-    types::{self, api, storage::enums},
+    types::{self, api, storage::enums, transformers::ForeignTryFrom},
 };
 
 #[derive(Debug, Default, Eq, PartialEq, Serialize)]
@@ -39,18 +39,11 @@ impl TryFrom<&types::PaymentsAuthorizeRouterData> for CoinbasePaymentsRequest {
     }
 }
 
-// Auth Struct
-pub struct CoinbaseAuthType {
-    pub(super) api_key: String,
-}
-
-impl TryFrom<&common_enums::ConnectorAuthType> for CoinbaseAuthType {
+impl ForeignTryFrom<&common_enums::ConnectorAuthType> for common_enums::CoinbaseAuthType {
     type Error = error_stack::Report<errors::ConnectorError>;
-    fn try_from(_auth_type: &common_enums::ConnectorAuthType) -> Result<Self, Self::Error> {
-        if let common_enums::ConnectorAuthType::Coinbase { api_key } = _auth_type {
-            Ok(Self {
-                api_key: api_key.to_string(),
-            })
+    fn foreign_try_from(_auth_type: &common_enums::ConnectorAuthType) -> Result<Self, Self::Error> {
+        if let common_enums::ConnectorAuthType::Coinbase(coinbase_auth) = _auth_type {
+            Ok(coinbase_auth.clone())
         } else {
             Err(errors::ConnectorError::FailedToObtainAuthType.into())
         }

--- a/crates/router/src/connector/coinbase/transformers.rs
+++ b/crates/router/src/connector/coinbase/transformers.rs
@@ -44,10 +44,10 @@ pub struct CoinbaseAuthType {
     pub(super) api_key: String,
 }
 
-impl TryFrom<&types::ConnectorAuthType> for CoinbaseAuthType {
+impl TryFrom<&common_enums::ConnectorAuthType> for CoinbaseAuthType {
     type Error = error_stack::Report<errors::ConnectorError>;
-    fn try_from(_auth_type: &types::ConnectorAuthType) -> Result<Self, Self::Error> {
-        if let types::ConnectorAuthType::HeaderKey { api_key } = _auth_type {
+    fn try_from(_auth_type: &common_enums::ConnectorAuthType) -> Result<Self, Self::Error> {
+        if let common_enums::ConnectorAuthType::Coinbase { api_key } = _auth_type {
             Ok(Self {
                 api_key: api_key.to_string(),
             })

--- a/crates/router/src/connector/cybersource.rs
+++ b/crates/router/src/connector/cybersource.rs
@@ -18,7 +18,7 @@ use crate::{
     services::{self, ConnectorIntegration},
     types::{
         self,
-        api::{self, ConnectorCommon, ConnectorCommonExt},
+        api::{self, ConnectorCommon, ConnectorCommonExt}, transformers::ForeignTryFrom,
     },
     utils::{self, BytesExt},
 };
@@ -34,14 +34,14 @@ impl Cybersource {
 
     pub fn generate_signature(
         &self,
-        auth: cybersource::CybersourceAuthType,
+        auth: common_enums::CybersourceAuthType,
         host: String,
         resource: &str,
         payload: &String,
         date: OffsetDateTime,
         http_method: services::Method,
     ) -> CustomResult<String, errors::ConnectorError> {
-        let cybersource::CybersourceAuthType {
+        let common_enums::CybersourceAuthType {
             api_key,
             merchant_account,
             api_secret,
@@ -124,7 +124,7 @@ where
     ) -> CustomResult<Vec<(String, String)>, errors::ConnectorError> {
         let date = OffsetDateTime::now_utc();
         let cybersource_req = self.get_request_body(req)?;
-        let auth = cybersource::CybersourceAuthType::try_from(&req.connector_auth_type)?;
+        let auth = common_enums::CybersourceAuthType::foreign_try_from(&req.connector_auth_type)?;
         let merchant_account = auth.merchant_account.clone();
         let base_url = connectors.cybersource.base_url.as_str();
         let cybersource_host = Url::parse(base_url)

--- a/crates/router/src/connector/cybersource/transformers.rs
+++ b/crates/router/src/connector/cybersource/transformers.rs
@@ -206,18 +206,18 @@ pub struct CybersourceAuthType {
     pub(super) api_secret: String,
 }
 
-impl TryFrom<&types::ConnectorAuthType> for CybersourceAuthType {
+impl TryFrom<&common_enums::ConnectorAuthType> for CybersourceAuthType {
     type Error = error_stack::Report<errors::ConnectorError>;
-    fn try_from(auth_type: &types::ConnectorAuthType) -> Result<Self, Self::Error> {
-        if let types::ConnectorAuthType::SignatureKey {
-            api_key,
-            key1,
+    fn try_from(auth_type: &common_enums::ConnectorAuthType) -> Result<Self, Self::Error> {
+        if let common_enums::ConnectorAuthType::Cybersource {
+            key,
+            merchant_account,
             api_secret,
         } = auth_type
         {
             Ok(Self {
-                api_key: api_key.to_string(),
-                merchant_account: key1.to_string(),
+                api_key: key.to_string(),
+                merchant_account: merchant_account.to_string(),
                 api_secret: api_secret.to_string(),
             })
         } else {

--- a/crates/router/src/connector/cybersource/transformers.rs
+++ b/crates/router/src/connector/cybersource/transformers.rs
@@ -11,7 +11,7 @@ use crate::{
     types::{
         self,
         api::{self, enums as api_enums},
-        storage::enums,
+        storage::enums, transformers::ForeignTryFrom,
     },
 };
 
@@ -200,26 +200,12 @@ impl TryFrom<&types::RefundExecuteRouterData> for CybersourcePaymentsRequest {
     }
 }
 
-pub struct CybersourceAuthType {
-    pub(super) api_key: String,
-    pub(super) merchant_account: String,
-    pub(super) api_secret: String,
-}
-
-impl TryFrom<&common_enums::ConnectorAuthType> for CybersourceAuthType {
+impl ForeignTryFrom<&common_enums::ConnectorAuthType> for common_enums::CybersourceAuthType {
     type Error = error_stack::Report<errors::ConnectorError>;
-    fn try_from(auth_type: &common_enums::ConnectorAuthType) -> Result<Self, Self::Error> {
-        if let common_enums::ConnectorAuthType::Cybersource {
-            key,
-            merchant_account,
-            api_secret,
-        } = auth_type
+    fn foreign_try_from(auth_type: &common_enums::ConnectorAuthType) -> Result<Self, Self::Error> {
+        if let common_enums::ConnectorAuthType::Cybersource (connector_auth) = auth_type
         {
-            Ok(Self {
-                api_key: key.to_string(),
-                merchant_account: merchant_account.to_string(),
-                api_secret: api_secret.to_string(),
-            })
+            Ok(connector_auth.clone())
         } else {
             Err(errors::ConnectorError::FailedToObtainAuthType)?
         }

--- a/crates/router/src/connector/dlocal.rs
+++ b/crates/router/src/connector/dlocal.rs
@@ -18,7 +18,7 @@ use crate::{
     types::{
         self,
         api::{self, ConnectorCommon, ConnectorCommonExt},
-        ErrorResponse, Response,
+        ErrorResponse, Response, transformers::ForeignTryFrom,
     },
     utils::{self, BytesExt},
 };
@@ -57,7 +57,7 @@ where
             .into_report()
             .change_context(errors::ConnectorError::RequestEncodingFailed)?;
 
-        let auth = dlocal::DlocalAuthType::try_from(&req.connector_auth_type)?;
+        let auth = common_enums::DlocalAuthType::foreign_try_from(&req.connector_auth_type)?;
         let sign_req: String = format!("{}{}{}", auth.x_login, date, dlocal_req);
         let authz = crypto::HmacSha256::sign_message(
             &crypto::HmacSha256,

--- a/crates/router/src/connector/dlocal/transformers.rs
+++ b/crates/router/src/connector/dlocal/transformers.rs
@@ -194,19 +194,19 @@ pub struct DlocalAuthType {
     pub(super) secret: String,
 }
 
-impl TryFrom<&types::ConnectorAuthType> for DlocalAuthType {
+impl TryFrom<&common_enums::ConnectorAuthType> for DlocalAuthType {
     type Error = error_stack::Report<errors::ConnectorError>;
-    fn try_from(auth_type: &types::ConnectorAuthType) -> Result<Self, Self::Error> {
-        if let types::ConnectorAuthType::SignatureKey {
-            api_key,
-            key1,
-            api_secret,
+    fn try_from(auth_type: &common_enums::ConnectorAuthType) -> Result<Self, Self::Error> {
+        if let common_enums::ConnectorAuthType::Dlocal {
+            x_login,
+            x_trans_key,
+            secret,
         } = auth_type
         {
             Ok(Self {
-                x_login: api_key.to_string(),
-                x_trans_key: key1.to_string(),
-                secret: api_secret.to_string(),
+                x_login: x_login.to_string(),
+                x_trans_key: x_trans_key.to_string(),
+                secret: secret.to_string(),
             })
         } else {
             Err(errors::ConnectorError::FailedToObtainAuthType.into())

--- a/crates/router/src/connector/dlocal/transformers.rs
+++ b/crates/router/src/connector/dlocal/transformers.rs
@@ -9,7 +9,7 @@ use crate::{
     connector::utils::{AddressDetailsData, RouterData},
     core::errors,
     services,
-    types::{self, api, storage::enums},
+    types::{self, api, storage::enums, transformers::ForeignTryFrom},
 };
 
 #[derive(Debug, Default, Eq, PartialEq, Serialize)]
@@ -187,27 +187,13 @@ impl TryFrom<&types::PaymentsCaptureRouterData> for DlocalPaymentsCaptureRequest
         })
     }
 }
-// Auth Struct
-pub struct DlocalAuthType {
-    pub(super) x_login: String,
-    pub(super) x_trans_key: String,
-    pub(super) secret: String,
-}
 
-impl TryFrom<&common_enums::ConnectorAuthType> for DlocalAuthType {
+impl ForeignTryFrom<&common_enums::ConnectorAuthType> for common_enums::DlocalAuthType {
     type Error = error_stack::Report<errors::ConnectorError>;
-    fn try_from(auth_type: &common_enums::ConnectorAuthType) -> Result<Self, Self::Error> {
-        if let common_enums::ConnectorAuthType::Dlocal {
-            x_login,
-            x_trans_key,
-            secret,
-        } = auth_type
+    fn foreign_try_from(auth_type: &common_enums::ConnectorAuthType) -> Result<Self, Self::Error> {
+        if let common_enums::ConnectorAuthType::Dlocal (connector_auth) = auth_type
         {
-            Ok(Self {
-                x_login: x_login.to_string(),
-                x_trans_key: x_trans_key.to_string(),
-                secret: secret.to_string(),
-            })
+            Ok(connector_auth.clone())
         } else {
             Err(errors::ConnectorError::FailedToObtainAuthType.into())
         }

--- a/crates/router/src/connector/fiserv.rs
+++ b/crates/router/src/connector/fiserv.rs
@@ -98,7 +98,7 @@ impl ConnectorCommon for Fiserv {
     }
     fn get_auth_header(
         &self,
-        auth_type: &types::ConnectorAuthType,
+        auth_type: &common_enums::ConnectorAuthType,
     ) -> CustomResult<Vec<(String, String)>, errors::ConnectorError> {
         let auth: fiserv::FiservAuthType = auth_type
             .try_into()

--- a/crates/router/src/connector/fiserv/transformers.rs
+++ b/crates/router/src/connector/fiserv/transformers.rs
@@ -164,18 +164,18 @@ pub struct FiservAuthType {
     pub(super) api_secret: String,
 }
 
-impl TryFrom<&types::ConnectorAuthType> for FiservAuthType {
+impl TryFrom<&common_enums::ConnectorAuthType> for FiservAuthType {
     type Error = error_stack::Report<errors::ConnectorError>;
-    fn try_from(auth_type: &types::ConnectorAuthType) -> Result<Self, Self::Error> {
-        if let types::ConnectorAuthType::SignatureKey {
+    fn try_from(auth_type: &common_enums::ConnectorAuthType) -> Result<Self, Self::Error> {
+        if let common_enums::ConnectorAuthType::Fiserv {
             api_key,
-            key1,
+            merchant_id,
             api_secret,
         } = auth_type
         {
             Ok(Self {
                 api_key: api_key.to_string(),
-                merchant_account: key1.to_string(),
+                merchant_account: merchant_id.to_string(),
                 api_secret: api_secret.to_string(),
             })
         } else {

--- a/crates/router/src/connector/forte.rs
+++ b/crates/router/src/connector/forte.rs
@@ -13,7 +13,7 @@ use crate::{
     types::{
         self,
         api::{self, ConnectorCommon, ConnectorCommonExt},
-        ErrorResponse, Response,
+        ErrorResponse, Response, transformers::ForeignTryFrom,
     },
     utils::{self, BytesExt},
 };
@@ -79,7 +79,7 @@ impl ConnectorCommon for Forte {
         &self,
         auth_type: &common_enums::ConnectorAuthType,
     ) -> CustomResult<Vec<(String, String)>, errors::ConnectorError> {
-        let auth = forte::ForteAuthType::try_from(auth_type)
+        let auth = common_enums::ForteAuthType::foreign_try_from(auth_type)
             .change_context(errors::ConnectorError::FailedToObtainAuthType)?;
         Ok(vec![(headers::AUTHORIZATION.to_string(), auth.api_key)])
     }

--- a/crates/router/src/connector/forte.rs
+++ b/crates/router/src/connector/forte.rs
@@ -77,7 +77,7 @@ impl ConnectorCommon for Forte {
 
     fn get_auth_header(
         &self,
-        auth_type: &types::ConnectorAuthType,
+        auth_type: &common_enums::ConnectorAuthType,
     ) -> CustomResult<Vec<(String, String)>, errors::ConnectorError> {
         let auth = forte::ForteAuthType::try_from(auth_type)
             .change_context(errors::ConnectorError::FailedToObtainAuthType)?;

--- a/crates/router/src/connector/forte/transformers.rs
+++ b/crates/router/src/connector/forte/transformers.rs
@@ -51,11 +51,11 @@ pub struct ForteAuthType {
     pub(super) api_key: String,
 }
 
-impl TryFrom<&types::ConnectorAuthType> for ForteAuthType {
+impl TryFrom<&common_enums::ConnectorAuthType> for ForteAuthType {
     type Error = error_stack::Report<errors::ConnectorError>;
-    fn try_from(auth_type: &types::ConnectorAuthType) -> Result<Self, Self::Error> {
+    fn try_from(auth_type: &common_enums::ConnectorAuthType) -> Result<Self, Self::Error> {
         match auth_type {
-            types::ConnectorAuthType::HeaderKey { api_key } => Ok(Self {
+            common_enums::ConnectorAuthType::Forte { api_key } => Ok(Self {
                 api_key: api_key.to_string(),
             }),
             _ => Err(errors::ConnectorError::FailedToObtainAuthType.into()),

--- a/crates/router/src/connector/globalpay.rs
+++ b/crates/router/src/connector/globalpay.rs
@@ -78,7 +78,7 @@ impl ConnectorCommon for Globalpay {
 
     fn get_auth_header(
         &self,
-        _auth_type: &types::ConnectorAuthType,
+        _auth_type: &common_enums::ConnectorAuthType,
     ) -> CustomResult<Vec<(String, String)>, errors::ConnectorError> {
         Ok(vec![])
     }

--- a/crates/router/src/connector/globalpay/transformers.rs
+++ b/crates/router/src/connector/globalpay/transformers.rs
@@ -106,13 +106,13 @@ pub struct GlobalpayAuthType {
     pub key: String,
 }
 
-impl TryFrom<&types::ConnectorAuthType> for GlobalpayAuthType {
+impl TryFrom<&common_enums::ConnectorAuthType> for GlobalpayAuthType {
     type Error = error_stack::Report<errors::ConnectorError>;
-    fn try_from(auth_type: &types::ConnectorAuthType) -> Result<Self, Self::Error> {
+    fn try_from(auth_type: &common_enums::ConnectorAuthType) -> Result<Self, Self::Error> {
         match auth_type {
-            types::ConnectorAuthType::BodyKey { api_key, key1 } => Ok(Self {
-                app_id: key1.to_string(),
-                key: api_key.to_string(),
+            common_enums::ConnectorAuthType::Globalpay { globalpay_app_key, globalpay_app_id } => Ok(Self {
+                app_id: globalpay_app_id.to_string(),
+                key: globalpay_app_key.to_string(),
             }),
             _ => Err(errors::ConnectorError::FailedToObtainAuthType.into()),
         }

--- a/crates/router/src/connector/klarna.rs
+++ b/crates/router/src/connector/klarna.rs
@@ -37,7 +37,7 @@ impl ConnectorCommon for Klarna {
 
     fn get_auth_header(
         &self,
-        auth_type: &types::ConnectorAuthType,
+        auth_type: &common_enums::ConnectorAuthType,
     ) -> CustomResult<Vec<(String, String)>, errors::ConnectorError> {
         let auth: klarna::KlarnaAuthType = auth_type
             .try_into()

--- a/crates/router/src/connector/klarna.rs
+++ b/crates/router/src/connector/klarna.rs
@@ -14,7 +14,7 @@ use crate::{
     types::{
         self,
         api::{self, ConnectorCommon},
-        storage::enums as storage_enums,
+        storage::enums as storage_enums, transformers::ForeignTryInto,
     },
     utils::{self, BytesExt},
 };
@@ -39,10 +39,10 @@ impl ConnectorCommon for Klarna {
         &self,
         auth_type: &common_enums::ConnectorAuthType,
     ) -> CustomResult<Vec<(String, String)>, errors::ConnectorError> {
-        let auth: klarna::KlarnaAuthType = auth_type
-            .try_into()
+        let auth: common_enums::KlarnaAuthType = auth_type
+            .foreign_try_into()
             .change_context(errors::ConnectorError::FailedToObtainAuthType)?;
-        Ok(vec![(headers::AUTHORIZATION.to_string(), auth.basic_token)])
+        Ok(vec![(headers::AUTHORIZATION.to_string(), auth.klarna_api_key)])
     }
 }
 

--- a/crates/router/src/connector/klarna/transformers.rs
+++ b/crates/router/src/connector/klarna/transformers.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     core::errors,
-    types::{self, storage::enums},
+    types::{self, storage::enums, transformers::ForeignTryFrom},
 };
 
 #[derive(Default, Debug, Serialize)]
@@ -143,17 +143,11 @@ pub enum KlarnaSessionIntent {
     BuyAndTokenize,
 }
 
-pub struct KlarnaAuthType {
-    pub basic_token: String,
-}
-
-impl TryFrom<&common_enums::ConnectorAuthType> for KlarnaAuthType {
+impl ForeignTryFrom<&common_enums::ConnectorAuthType> for common_enums::KlarnaAuthType {
     type Error = error_stack::Report<errors::ConnectorError>;
-    fn try_from(auth_type: &common_enums::ConnectorAuthType) -> Result<Self, Self::Error> {
-        if let common_enums::ConnectorAuthType::Klarna { klarna_api_key } = auth_type {
-            Ok(Self {
-                basic_token: klarna_api_key.to_string(),
-            })
+    fn foreign_try_from(auth_type: &common_enums::ConnectorAuthType) -> Result<Self, Self::Error> {
+        if let common_enums::ConnectorAuthType::Klarna (connector_auth) = auth_type {
+            Ok(connector_auth.clone())
         } else {
             Err(errors::ConnectorError::FailedToObtainAuthType.into())
         }

--- a/crates/router/src/connector/klarna/transformers.rs
+++ b/crates/router/src/connector/klarna/transformers.rs
@@ -147,12 +147,12 @@ pub struct KlarnaAuthType {
     pub basic_token: String,
 }
 
-impl TryFrom<&types::ConnectorAuthType> for KlarnaAuthType {
+impl TryFrom<&common_enums::ConnectorAuthType> for KlarnaAuthType {
     type Error = error_stack::Report<errors::ConnectorError>;
-    fn try_from(auth_type: &types::ConnectorAuthType) -> Result<Self, Self::Error> {
-        if let types::ConnectorAuthType::HeaderKey { api_key } = auth_type {
+    fn try_from(auth_type: &common_enums::ConnectorAuthType) -> Result<Self, Self::Error> {
+        if let common_enums::ConnectorAuthType::Klarna { klarna_api_key } = auth_type {
             Ok(Self {
-                basic_token: api_key.to_string(),
+                basic_token: klarna_api_key.to_string(),
             })
         } else {
             Err(errors::ConnectorError::FailedToObtainAuthType.into())

--- a/crates/router/src/connector/mollie.rs
+++ b/crates/router/src/connector/mollie.rs
@@ -16,7 +16,7 @@ use crate::{
     types::{
         self,
         api::{self, ConnectorCommon, ConnectorCommonExt},
-        ErrorResponse, Response,
+        ErrorResponse, Response, transformers::ForeignTryInto,
     },
     utils::{self, BytesExt},
 };
@@ -64,8 +64,8 @@ impl ConnectorCommon for Mollie {
         &self,
         auth_type: &common_enums::ConnectorAuthType,
     ) -> CustomResult<Vec<(String, String)>, errors::ConnectorError> {
-        let auth: mollie::MollieAuthType = auth_type
-            .try_into()
+        let auth: common_enums::MollieAuthType = auth_type
+            .foreign_try_into()
             .change_context(errors::ConnectorError::FailedToObtainAuthType)?;
         Ok(vec![(
             headers::AUTHORIZATION.to_string(),

--- a/crates/router/src/connector/mollie.rs
+++ b/crates/router/src/connector/mollie.rs
@@ -62,7 +62,7 @@ impl ConnectorCommon for Mollie {
 
     fn get_auth_header(
         &self,
-        auth_type: &types::ConnectorAuthType,
+        auth_type: &common_enums::ConnectorAuthType,
     ) -> CustomResult<Vec<(String, String)>, errors::ConnectorError> {
         let auth: mollie::MollieAuthType = auth_type
             .try_into()

--- a/crates/router/src/connector/mollie/transformers.rs
+++ b/crates/router/src/connector/mollie/transformers.rs
@@ -300,10 +300,10 @@ pub struct MollieAuthType {
     pub(super) api_key: String,
 }
 
-impl TryFrom<&types::ConnectorAuthType> for MollieAuthType {
+impl TryFrom<&common_enums::ConnectorAuthType> for MollieAuthType {
     type Error = Error;
-    fn try_from(auth_type: &types::ConnectorAuthType) -> Result<Self, Self::Error> {
-        if let types::ConnectorAuthType::HeaderKey { api_key } = auth_type {
+    fn try_from(auth_type: &common_enums::ConnectorAuthType) -> Result<Self, Self::Error> {
+        if let common_enums::ConnectorAuthType::Mollie { api_key } = auth_type {
             Ok(Self {
                 api_key: api_key.to_string(),
             })

--- a/crates/router/src/connector/multisafepay.rs
+++ b/crates/router/src/connector/multisafepay.rs
@@ -49,7 +49,7 @@ impl ConnectorCommon for Multisafepay {
 
     fn get_auth_header(
         &self,
-        auth_type: &types::ConnectorAuthType,
+        auth_type: &common_enums::ConnectorAuthType,
     ) -> CustomResult<Vec<(String, String)>, errors::ConnectorError> {
         let auth: multisafepay::MultisafepayAuthType = auth_type
             .try_into()

--- a/crates/router/src/connector/multisafepay.rs
+++ b/crates/router/src/connector/multisafepay.rs
@@ -13,7 +13,7 @@ use crate::{
     types::{
         self,
         api::{self, ConnectorCommon, ConnectorCommonExt},
-        ErrorResponse, Response,
+        ErrorResponse, Response, transformers::{ForeignTryInto, ForeignTryFrom},
     },
     utils::{self, BytesExt},
 };
@@ -51,8 +51,8 @@ impl ConnectorCommon for Multisafepay {
         &self,
         auth_type: &common_enums::ConnectorAuthType,
     ) -> CustomResult<Vec<(String, String)>, errors::ConnectorError> {
-        let auth: multisafepay::MultisafepayAuthType = auth_type
-            .try_into()
+        let auth: common_enums::MultisafepayAuthType = auth_type
+            .foreign_try_into()
             .change_context(errors::ConnectorError::FailedToObtainAuthType)?;
         Ok(vec![(headers::AUTHORIZATION.to_string(), auth.api_key)])
     }
@@ -130,7 +130,7 @@ impl ConnectorIntegration<api::PSync, types::PaymentsSyncData, types::PaymentsRe
         connectors: &settings::Connectors,
     ) -> CustomResult<String, errors::ConnectorError> {
         let url = self.base_url(connectors);
-        let api_key = multisafepay::MultisafepayAuthType::try_from(&req.connector_auth_type)
+        let api_key = common_enums::MultisafepayAuthType::foreign_try_from(&req.connector_auth_type)
             .change_context(errors::ConnectorError::FailedToObtainAuthType)?
             .api_key;
         let ord_id = req.payment_id.clone();
@@ -214,7 +214,7 @@ impl ConnectorIntegration<api::Authorize, types::PaymentsAuthorizeData, types::P
         connectors: &settings::Connectors,
     ) -> CustomResult<String, errors::ConnectorError> {
         let url = self.base_url(connectors);
-        let api_key = multisafepay::MultisafepayAuthType::try_from(&req.connector_auth_type)
+        let api_key = common_enums::MultisafepayAuthType::foreign_try_from(&req.connector_auth_type)
             .change_context(errors::ConnectorError::FailedToObtainAuthType)?
             .api_key;
         Ok(format!("{url}v1/json/orders?api_key={api_key}"))
@@ -304,7 +304,7 @@ impl ConnectorIntegration<api::Execute, types::RefundsData, types::RefundsRespon
         connectors: &settings::Connectors,
     ) -> CustomResult<String, errors::ConnectorError> {
         let url = self.base_url(connectors);
-        let api_key = multisafepay::MultisafepayAuthType::try_from(&req.connector_auth_type)
+        let api_key = common_enums::MultisafepayAuthType::foreign_try_from(&req.connector_auth_type)
             .change_context(errors::ConnectorError::FailedToObtainAuthType)?
             .api_key;
         let ord_id = req.payment_id.clone();
@@ -387,7 +387,7 @@ impl ConnectorIntegration<api::RSync, types::RefundsData, types::RefundsResponse
         connectors: &settings::Connectors,
     ) -> CustomResult<String, errors::ConnectorError> {
         let url = self.base_url(connectors);
-        let api_key = multisafepay::MultisafepayAuthType::try_from(&req.connector_auth_type)
+        let api_key = common_enums::MultisafepayAuthType::foreign_try_from(&req.connector_auth_type)
             .change_context(errors::ConnectorError::FailedToObtainAuthType)?
             .api_key;
         let ord_id = req.payment_id.clone();

--- a/crates/router/src/connector/multisafepay/transformers.rs
+++ b/crates/router/src/connector/multisafepay/transformers.rs
@@ -360,10 +360,10 @@ pub struct MultisafepayAuthType {
     pub(super) api_key: String,
 }
 
-impl TryFrom<&types::ConnectorAuthType> for MultisafepayAuthType {
+impl TryFrom<&common_enums::ConnectorAuthType> for MultisafepayAuthType {
     type Error = error_stack::Report<errors::ConnectorError>;
-    fn try_from(auth_type: &types::ConnectorAuthType) -> Result<Self, Self::Error> {
-        if let types::ConnectorAuthType::HeaderKey { api_key } = auth_type {
+    fn try_from(auth_type: &common_enums::ConnectorAuthType) -> Result<Self, Self::Error> {
+        if let common_enums::ConnectorAuthType::Multisafepay { api_key } = auth_type {
             Ok(Self {
                 api_key: api_key.to_string(),
             })

--- a/crates/router/src/connector/multisafepay/transformers.rs
+++ b/crates/router/src/connector/multisafepay/transformers.rs
@@ -8,7 +8,7 @@ use crate::{
     core::errors,
     pii::{self, Secret},
     services,
-    types::{self, api, storage::enums},
+    types::{self, api, storage::enums, transformers::ForeignTryFrom},
 };
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Deserialize, Serialize)]
@@ -355,18 +355,11 @@ impl TryFrom<&types::PaymentsAuthorizeRouterData> for MultisafepayPaymentsReques
     }
 }
 
-// Auth Struct
-pub struct MultisafepayAuthType {
-    pub(super) api_key: String,
-}
-
-impl TryFrom<&common_enums::ConnectorAuthType> for MultisafepayAuthType {
+impl ForeignTryFrom<&common_enums::ConnectorAuthType> for common_enums::MultisafepayAuthType {
     type Error = error_stack::Report<errors::ConnectorError>;
-    fn try_from(auth_type: &common_enums::ConnectorAuthType) -> Result<Self, Self::Error> {
-        if let common_enums::ConnectorAuthType::Multisafepay { api_key } = auth_type {
-            Ok(Self {
-                api_key: api_key.to_string(),
-            })
+    fn foreign_try_from(auth_type: &common_enums::ConnectorAuthType) -> Result<Self, Self::Error> {
+        if let common_enums::ConnectorAuthType::Multisafepay (connector_auth) = auth_type {
+            Ok(connector_auth.clone())
         } else {
             Err(errors::ConnectorError::FailedToObtainAuthType.into())
         }

--- a/crates/router/src/connector/nexinets.rs
+++ b/crates/router/src/connector/nexinets.rs
@@ -67,7 +67,7 @@ impl ConnectorCommon for Nexinets {
 
     fn get_auth_header(
         &self,
-        auth_type: &types::ConnectorAuthType,
+        auth_type: &common_enums::ConnectorAuthType,
     ) -> CustomResult<Vec<(String, String)>, errors::ConnectorError> {
         let auth = nexinets::NexinetsAuthType::try_from(auth_type)
             .change_context(errors::ConnectorError::FailedToObtainAuthType)?;

--- a/crates/router/src/connector/nexinets.rs
+++ b/crates/router/src/connector/nexinets.rs
@@ -13,7 +13,7 @@ use crate::{
     types::{
         self,
         api::{self, ConnectorCommon, ConnectorCommonExt},
-        ErrorResponse, Response,
+        ErrorResponse, Response, transformers::ForeignTryFrom,
     },
     utils::{self, BytesExt},
 };
@@ -69,7 +69,7 @@ impl ConnectorCommon for Nexinets {
         &self,
         auth_type: &common_enums::ConnectorAuthType,
     ) -> CustomResult<Vec<(String, String)>, errors::ConnectorError> {
-        let auth = nexinets::NexinetsAuthType::try_from(auth_type)
+        let auth = common_enums::NexinetsAuthType::foreign_try_from(auth_type)
             .change_context(errors::ConnectorError::FailedToObtainAuthType)?;
         Ok(vec![(headers::AUTHORIZATION.to_string(), auth.api_key)])
     }

--- a/crates/router/src/connector/nexinets/transformers.rs
+++ b/crates/router/src/connector/nexinets/transformers.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     connector::utils::PaymentsAuthorizeRequestData,
     core::errors,
-    types::{self, api, storage::enums},
+    types::{self, api, storage::enums, transformers::ForeignTryFrom},
 };
 
 #[derive(Default, Debug, Serialize, Eq, PartialEq)]
@@ -46,18 +46,12 @@ impl TryFrom<&types::PaymentsAuthorizeRouterData> for NexinetsPaymentsRequest {
     }
 }
 
-// Auth Struct
-pub struct NexinetsAuthType {
-    pub(super) api_key: String,
-}
-
-impl TryFrom<&common_enums::ConnectorAuthType> for NexinetsAuthType {
+impl ForeignTryFrom<&common_enums::ConnectorAuthType> for common_enums::NexinetsAuthType {
     type Error = error_stack::Report<errors::ConnectorError>;
-    fn try_from(auth_type: &common_enums::ConnectorAuthType) -> Result<Self, Self::Error> {
+    fn foreign_try_from(auth_type: &common_enums::ConnectorAuthType) -> Result<Self, Self::Error> {
         match auth_type {
-            common_enums::ConnectorAuthType::Nexinets { api_key } => Ok(Self {
-                api_key: api_key.to_string(),
-            }),
+            common_enums::ConnectorAuthType::Nexinets (connector_auth)=> 
+            Ok(connector_auth.clone()),
             _ => Err(errors::ConnectorError::FailedToObtainAuthType.into()),
         }
     }

--- a/crates/router/src/connector/nexinets/transformers.rs
+++ b/crates/router/src/connector/nexinets/transformers.rs
@@ -51,11 +51,11 @@ pub struct NexinetsAuthType {
     pub(super) api_key: String,
 }
 
-impl TryFrom<&types::ConnectorAuthType> for NexinetsAuthType {
+impl TryFrom<&common_enums::ConnectorAuthType> for NexinetsAuthType {
     type Error = error_stack::Report<errors::ConnectorError>;
-    fn try_from(auth_type: &types::ConnectorAuthType) -> Result<Self, Self::Error> {
+    fn try_from(auth_type: &common_enums::ConnectorAuthType) -> Result<Self, Self::Error> {
         match auth_type {
-            types::ConnectorAuthType::HeaderKey { api_key } => Ok(Self {
+            common_enums::ConnectorAuthType::Nexinets { api_key } => Ok(Self {
                 api_key: api_key.to_string(),
             }),
             _ => Err(errors::ConnectorError::FailedToObtainAuthType.into()),

--- a/crates/router/src/connector/nuvei.rs
+++ b/crates/router/src/connector/nuvei.rs
@@ -64,7 +64,7 @@ impl ConnectorCommon for Nuvei {
 
     fn get_auth_header(
         &self,
-        _auth_type: &types::ConnectorAuthType,
+        _auth_type: &common_enums::ConnectorAuthType,
     ) -> CustomResult<Vec<(String, String)>, errors::ConnectorError> {
         Ok(vec![])
     }

--- a/crates/router/src/connector/nuvei/transformers.rs
+++ b/crates/router/src/connector/nuvei/transformers.rs
@@ -692,7 +692,7 @@ pub struct NuveiPaymentRequestData {
     pub currency: String,
     pub related_transaction_id: Option<String>,
     pub client_request_id: String,
-    pub connector_auth_type: types::ConnectorAuthType,
+    pub connector_auth_type: common_enums::ConnectorAuthType,
     pub session_token: String,
     pub capture_method: Option<storage_models::enums::CaptureMethod>,
 }
@@ -755,19 +755,19 @@ pub struct NuveiAuthType {
     pub(super) merchant_secret: String,
 }
 
-impl TryFrom<&types::ConnectorAuthType> for NuveiAuthType {
+impl TryFrom<&common_enums::ConnectorAuthType> for NuveiAuthType {
     type Error = error_stack::Report<errors::ConnectorError>;
-    fn try_from(auth_type: &types::ConnectorAuthType) -> Result<Self, Self::Error> {
-        if let types::ConnectorAuthType::SignatureKey {
-            api_key,
-            key1,
-            api_secret,
+    fn try_from(auth_type: &common_enums::ConnectorAuthType) -> Result<Self, Self::Error> {
+        if let common_enums::ConnectorAuthType::Nuvei {
+            merchant_id,
+            merchant_site_id,
+            merchant_secret,
         } = auth_type
         {
             Ok(Self {
-                merchant_id: api_key.to_string(),
-                merchant_site_id: key1.to_string(),
-                merchant_secret: api_secret.to_string(),
+                merchant_id: merchant_id.to_string(),
+                merchant_site_id: merchant_site_id.to_string(),
+                merchant_secret: merchant_secret.to_string(),
             })
         } else {
             Err(errors::ConnectorError::FailedToObtainAuthType)?

--- a/crates/router/src/connector/opennode.rs
+++ b/crates/router/src/connector/opennode.rs
@@ -76,7 +76,7 @@ impl ConnectorCommon for Opennode {
 
     fn get_auth_header(
         &self,
-        auth_type: &types::ConnectorAuthType,
+        auth_type: &common_enums::ConnectorAuthType,
     ) -> CustomResult<Vec<(String, String)>, errors::ConnectorError> {
         let auth = opennode::OpennodeAuthType::try_from(auth_type)
             .change_context(errors::ConnectorError::FailedToObtainAuthType)?;

--- a/crates/router/src/connector/opennode.rs
+++ b/crates/router/src/connector/opennode.rs
@@ -15,7 +15,7 @@ use crate::{
     types::{
         self,
         api::{self, ConnectorCommon, ConnectorCommonExt},
-        ErrorResponse, Response,
+        ErrorResponse, Response, transformers::ForeignTryFrom,
     },
     utils::{BytesExt, Encode},
 };
@@ -78,7 +78,7 @@ impl ConnectorCommon for Opennode {
         &self,
         auth_type: &common_enums::ConnectorAuthType,
     ) -> CustomResult<Vec<(String, String)>, errors::ConnectorError> {
-        let auth = opennode::OpennodeAuthType::try_from(auth_type)
+        let auth = common_enums::OpennodeAuthType::foreign_try_from(auth_type)
             .change_context(errors::ConnectorError::FailedToObtainAuthType)?;
         Ok(vec![(headers::AUTHORIZATION.to_string(), auth.api_key)])
     }

--- a/crates/router/src/connector/opennode/transformers.rs
+++ b/crates/router/src/connector/opennode/transformers.rs
@@ -33,11 +33,11 @@ pub struct OpennodeAuthType {
     pub(super) api_key: String,
 }
 
-impl TryFrom<&types::ConnectorAuthType> for OpennodeAuthType {
+impl TryFrom<&common_enums::ConnectorAuthType> for OpennodeAuthType {
     type Error = error_stack::Report<errors::ConnectorError>;
-    fn try_from(auth_type: &types::ConnectorAuthType) -> Result<Self, Self::Error> {
+    fn try_from(auth_type: &common_enums::ConnectorAuthType) -> Result<Self, Self::Error> {
         match auth_type {
-            types::ConnectorAuthType::HeaderKey { api_key } => Ok(Self {
+            common_enums::ConnectorAuthType::Opennode { api_key } => Ok(Self {
                 api_key: api_key.to_string(),
             }),
             _ => Err(errors::ConnectorError::FailedToObtainAuthType.into()),

--- a/crates/router/src/connector/opennode/transformers.rs
+++ b/crates/router/src/connector/opennode/transformers.rs
@@ -6,7 +6,7 @@ use crate::{
     connector::utils::{PaymentsAuthorizeRequestData, RouterData},
     core::errors,
     services,
-    types::{self, api, storage::enums},
+    types::{self, api, storage::enums, transformers::ForeignTryFrom},
 };
 
 //TODO: Fill the struct with respective fields
@@ -27,20 +27,13 @@ impl TryFrom<&types::PaymentsAuthorizeRouterData> for OpennodePaymentsRequest {
     }
 }
 
-//TODO: Fill the struct with respective fields
-// Auth Struct
-pub struct OpennodeAuthType {
-    pub(super) api_key: String,
-}
-
-impl TryFrom<&common_enums::ConnectorAuthType> for OpennodeAuthType {
+impl ForeignTryFrom<&common_enums::ConnectorAuthType> for common_enums::OpennodeAuthType {
     type Error = error_stack::Report<errors::ConnectorError>;
-    fn try_from(auth_type: &common_enums::ConnectorAuthType) -> Result<Self, Self::Error> {
-        match auth_type {
-            common_enums::ConnectorAuthType::Opennode { api_key } => Ok(Self {
-                api_key: api_key.to_string(),
-            }),
-            _ => Err(errors::ConnectorError::FailedToObtainAuthType.into()),
+    fn foreign_try_from(auth_type: &common_enums::ConnectorAuthType) -> Result<Self, Self::Error> {
+        if let common_enums::ConnectorAuthType::Opennode(connector_auth) = auth_type {
+            Ok(connector_auth.clone())
+        } else {
+            Err(errors::ConnectorError::FailedToObtainAuthType)?
         }
     }
 }

--- a/crates/router/src/connector/payeezy.rs
+++ b/crates/router/src/connector/payeezy.rs
@@ -17,7 +17,7 @@ use crate::{
     types::{
         self,
         api::{self, ConnectorCommon, ConnectorCommonExt},
-        ErrorResponse, Response,
+        ErrorResponse, Response, transformers::ForeignTryFrom,
     },
     utils::{self, BytesExt},
 };
@@ -34,7 +34,7 @@ where
         req: &types::RouterData<Flow, Request, Response>,
         _connectors: &settings::Connectors,
     ) -> CustomResult<Vec<(String, String)>, errors::ConnectorError> {
-        let auth = payeezy::PayeezyAuthType::try_from(&req.connector_auth_type)?;
+        let auth = common_enums::PayeezyAuthType::foreign_try_from(&req.connector_auth_type)?;
         let option_request_payload = self.get_request_body(req)?;
         let request_payload = option_request_payload.map_or("{}".to_string(), |s| s);
         let timestamp = std::time::SystemTime::now()

--- a/crates/router/src/connector/payeezy/transformers.rs
+++ b/crates/router/src/connector/payeezy/transformers.rs
@@ -7,7 +7,7 @@ use crate::{
     connector::utils::{self, CardData},
     core::errors,
     pii::{self},
-    types::{self, api, storage::enums, transformers::ForeignFrom},
+    types::{self, api, storage::enums, transformers::{ForeignFrom, ForeignTryFrom}},
 };
 
 #[derive(Serialize, Debug)]
@@ -196,27 +196,12 @@ fn get_payment_method_data(
     }
 }
 
-// Auth Struct
-pub struct PayeezyAuthType {
-    pub(super) api_key: String,
-    pub(super) api_secret: String,
-    pub(super) merchant_token: String,
-}
-
-impl TryFrom<&common_enums::ConnectorAuthType> for PayeezyAuthType {
+impl ForeignTryFrom<&common_enums::ConnectorAuthType> for common_enums::PayeezyAuthType {
     type Error = error_stack::Report<errors::ConnectorError>;
-    fn try_from(item: &common_enums::ConnectorAuthType) -> Result<Self, Self::Error> {
-        if let common_enums::ConnectorAuthType::Payeezy {
-            api_key,
-            api_secret,
-            merchant_token,
-        } = item
+    fn foreign_try_from(item: &common_enums::ConnectorAuthType) -> Result<Self, Self::Error> {
+        if let common_enums::ConnectorAuthType::Payeezy (connector_auth) = item
         {
-            Ok(Self {
-                api_key: api_key.to_string(),
-                api_secret: api_secret.to_string(),
-                merchant_token: merchant_token.to_string(),
-            })
+            Ok(connector_auth.clone())
         } else {
             Err(errors::ConnectorError::FailedToObtainAuthType.into())
         }

--- a/crates/router/src/connector/payeezy/transformers.rs
+++ b/crates/router/src/connector/payeezy/transformers.rs
@@ -203,19 +203,19 @@ pub struct PayeezyAuthType {
     pub(super) merchant_token: String,
 }
 
-impl TryFrom<&types::ConnectorAuthType> for PayeezyAuthType {
+impl TryFrom<&common_enums::ConnectorAuthType> for PayeezyAuthType {
     type Error = error_stack::Report<errors::ConnectorError>;
-    fn try_from(item: &types::ConnectorAuthType) -> Result<Self, Self::Error> {
-        if let types::ConnectorAuthType::SignatureKey {
+    fn try_from(item: &common_enums::ConnectorAuthType) -> Result<Self, Self::Error> {
+        if let common_enums::ConnectorAuthType::Payeezy {
             api_key,
-            key1,
             api_secret,
+            merchant_token,
         } = item
         {
             Ok(Self {
                 api_key: api_key.to_string(),
                 api_secret: api_secret.to_string(),
-                merchant_token: key1.to_string(),
+                merchant_token: merchant_token.to_string(),
             })
         } else {
             Err(errors::ConnectorError::FailedToObtainAuthType.into())

--- a/crates/router/src/connector/paypal.rs
+++ b/crates/router/src/connector/paypal.rs
@@ -141,7 +141,7 @@ impl ConnectorCommon for Paypal {
 
     fn get_auth_header(
         &self,
-        auth_type: &types::ConnectorAuthType,
+        auth_type: &common_enums::ConnectorAuthType,
     ) -> CustomResult<Vec<(String, String)>, errors::ConnectorError> {
         let auth: paypal::PaypalAuthType = auth_type
             .try_into()
@@ -218,7 +218,7 @@ impl ConnectorIntegration<api::AccessTokenAuth, types::AccessTokenRequestData, t
             .try_into()
             .change_context(errors::ConnectorError::FailedToObtainAuthType)?;
 
-        let auth_id = format!("{}:{}", auth.key1, auth.api_key);
+        let auth_id = format!("{}:{}", auth.api_secret, auth.api_key);
         let auth_val = format!("Basic {}", consts::BASE64_ENGINE.encode(auth_id));
 
         Ok(vec![

--- a/crates/router/src/connector/paypal.rs
+++ b/crates/router/src/connector/paypal.rs
@@ -19,7 +19,7 @@ use crate::{
     types::{
         self,
         api::{self, CompleteAuthorize, ConnectorCommon, ConnectorCommonExt},
-        ErrorResponse, Response,
+        ErrorResponse, Response, transformers::ForeignTryInto,
     },
     utils::{self, BytesExt},
 };
@@ -143,8 +143,8 @@ impl ConnectorCommon for Paypal {
         &self,
         auth_type: &common_enums::ConnectorAuthType,
     ) -> CustomResult<Vec<(String, String)>, errors::ConnectorError> {
-        let auth: paypal::PaypalAuthType = auth_type
-            .try_into()
+        let auth: common_enums::PaypalAuthType = auth_type
+            .foreign_try_into()
             .change_context(errors::ConnectorError::FailedToObtainAuthType)?;
         Ok(vec![(headers::AUTHORIZATION.to_string(), auth.api_key)])
     }
@@ -214,8 +214,8 @@ impl ConnectorIntegration<api::AccessTokenAuth, types::AccessTokenRequestData, t
         req: &types::RefreshTokenRouterData,
         _connectors: &settings::Connectors,
     ) -> CustomResult<Vec<(String, String)>, errors::ConnectorError> {
-        let auth: paypal::PaypalAuthType = (&req.connector_auth_type)
-            .try_into()
+        let auth: common_enums::PaypalAuthType = (&req.connector_auth_type)
+            .foreign_try_into()
             .change_context(errors::ConnectorError::FailedToObtainAuthType)?;
 
         let auth_id = format!("{}:{}", auth.api_secret, auth.api_key);

--- a/crates/router/src/connector/paypal/transformers.rs
+++ b/crates/router/src/connector/paypal/transformers.rs
@@ -9,7 +9,7 @@ use crate::{
     },
     core::errors,
     pii,
-    types::{self, api, storage::enums as storage_enums, transformers::ForeignFrom},
+    types::{self, api, storage::enums as storage_enums, transformers::{ForeignFrom, ForeignTryFrom}},
 };
 
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
@@ -157,20 +157,12 @@ impl<F, T> TryFrom<types::ResponseRouterData<F, PaypalAuthUpdateResponse, T, typ
     }
 }
 
-#[derive(Debug)]
-pub struct PaypalAuthType {
-    pub(super) api_key: String,
-    pub(super) api_secret: String,
-}
-
-impl TryFrom<&common_enums::ConnectorAuthType> for PaypalAuthType {
+impl ForeignTryFrom<&common_enums::ConnectorAuthType> for common_enums::PaypalAuthType {
     type Error = error_stack::Report<errors::ConnectorError>;
-    fn try_from(auth_type: &common_enums::ConnectorAuthType) -> Result<Self, Self::Error> {
+    fn foreign_try_from(auth_type: &common_enums::ConnectorAuthType) -> Result<Self, Self::Error> {
         match auth_type {
-            common_enums::ConnectorAuthType::Paypal { api_key, api_secret } => Ok(Self {
-                api_key: api_key.to_string(),
-                api_secret: api_secret.to_string(),
-            }),
+            common_enums::ConnectorAuthType::Paypal (connector_auth) => 
+            Ok(connector_auth.clone()),
             _ => Err(errors::ConnectorError::FailedToObtainAuthType)?,
         }
     }

--- a/crates/router/src/connector/paypal/transformers.rs
+++ b/crates/router/src/connector/paypal/transformers.rs
@@ -160,16 +160,16 @@ impl<F, T> TryFrom<types::ResponseRouterData<F, PaypalAuthUpdateResponse, T, typ
 #[derive(Debug)]
 pub struct PaypalAuthType {
     pub(super) api_key: String,
-    pub(super) key1: String,
+    pub(super) api_secret: String,
 }
 
-impl TryFrom<&types::ConnectorAuthType> for PaypalAuthType {
+impl TryFrom<&common_enums::ConnectorAuthType> for PaypalAuthType {
     type Error = error_stack::Report<errors::ConnectorError>;
-    fn try_from(auth_type: &types::ConnectorAuthType) -> Result<Self, Self::Error> {
+    fn try_from(auth_type: &common_enums::ConnectorAuthType) -> Result<Self, Self::Error> {
         match auth_type {
-            types::ConnectorAuthType::BodyKey { api_key, key1 } => Ok(Self {
+            common_enums::ConnectorAuthType::Paypal { api_key, api_secret } => Ok(Self {
                 api_key: api_key.to_string(),
-                key1: key1.to_string(),
+                api_secret: api_secret.to_string(),
             }),
             _ => Err(errors::ConnectorError::FailedToObtainAuthType)?,
         }

--- a/crates/router/src/connector/payu.rs
+++ b/crates/router/src/connector/payu.rs
@@ -64,7 +64,7 @@ impl ConnectorCommon for Payu {
 
     fn get_auth_header(
         &self,
-        auth_type: &types::ConnectorAuthType,
+        auth_type: &common_enums::ConnectorAuthType,
     ) -> CustomResult<Vec<(String, String)>, errors::ConnectorError> {
         let auth: payu::PayuAuthType = auth_type
             .try_into()

--- a/crates/router/src/connector/payu.rs
+++ b/crates/router/src/connector/payu.rs
@@ -13,7 +13,7 @@ use crate::{
     types::{
         self,
         api::{self, ConnectorCommon, ConnectorCommonExt},
-        ErrorResponse,
+        ErrorResponse, transformers::ForeignTryInto,
     },
     utils::{self, BytesExt},
 };
@@ -66,8 +66,8 @@ impl ConnectorCommon for Payu {
         &self,
         auth_type: &common_enums::ConnectorAuthType,
     ) -> CustomResult<Vec<(String, String)>, errors::ConnectorError> {
-        let auth: payu::PayuAuthType = auth_type
-            .try_into()
+        let auth: common_enums::PayuAuthType = auth_type
+            .foreign_try_into()
             .change_context(errors::ConnectorError::FailedToObtainAuthType)?;
         Ok(vec![(headers::AUTHORIZATION.to_string(), auth.api_key)])
     }

--- a/crates/router/src/connector/payu/transformers.rs
+++ b/crates/router/src/connector/payu/transformers.rs
@@ -135,13 +135,13 @@ pub struct PayuAuthType {
     pub(super) merchant_pos_id: String,
 }
 
-impl TryFrom<&types::ConnectorAuthType> for PayuAuthType {
+impl TryFrom<&common_enums::ConnectorAuthType> for PayuAuthType {
     type Error = error_stack::Report<errors::ConnectorError>;
-    fn try_from(auth_type: &types::ConnectorAuthType) -> Result<Self, Self::Error> {
+    fn try_from(auth_type: &common_enums::ConnectorAuthType) -> Result<Self, Self::Error> {
         match auth_type {
-            types::ConnectorAuthType::BodyKey { api_key, key1 } => Ok(Self {
+            common_enums::ConnectorAuthType::Payu { api_key, merchant_pos_id } => Ok(Self {
                 api_key: api_key.to_string(),
-                merchant_pos_id: key1.to_string(),
+                merchant_pos_id: merchant_pos_id.to_string(),
             }),
             _ => Err(errors::ConnectorError::FailedToObtainAuthType)?,
         }

--- a/crates/router/src/connector/rapyd.rs
+++ b/crates/router/src/connector/rapyd.rs
@@ -65,7 +65,7 @@ impl ConnectorCommon for Rapyd {
 
     fn get_auth_header(
         &self,
-        _auth_type: &types::ConnectorAuthType,
+        _auth_type: &common_enums::ConnectorAuthType,
     ) -> CustomResult<Vec<(String, String)>, errors::ConnectorError> {
         Ok(vec![])
     }

--- a/crates/router/src/connector/rapyd/transformers.rs
+++ b/crates/router/src/connector/rapyd/transformers.rs
@@ -7,7 +7,7 @@ use crate::{
     core::errors,
     pii::{self, Secret},
     services,
-    types::{self, api, storage::enums, transformers::ForeignFrom},
+    types::{self, api, storage::enums, transformers::{ForeignFrom, ForeignTryFrom}},
     utils::OptionExt,
 };
 
@@ -135,20 +135,11 @@ impl TryFrom<&types::PaymentsAuthorizeRouterData> for RapydPaymentsRequest {
     }
 }
 
-#[derive(Debug, Deserialize)]
-pub struct RapydAuthType {
-    pub access_key: String,
-    pub secret_key: String,
-}
-
-impl TryFrom<&common_enums::ConnectorAuthType> for RapydAuthType {
+impl ForeignTryFrom<&common_enums::ConnectorAuthType> for common_enums::RapydAuthType {
     type Error = error_stack::Report<errors::ConnectorError>;
-    fn try_from(auth_type: &common_enums::ConnectorAuthType) -> Result<Self, Self::Error> {
-        if let common_enums::ConnectorAuthType::Rapyd { api_secret, secret_key } = auth_type {
-            Ok(Self {
-                access_key: api_secret.to_string(),
-                secret_key: secret_key.to_string(),
-            })
+    fn foreign_try_from(auth_type: &common_enums::ConnectorAuthType) -> Result<Self, Self::Error> {
+        if let common_enums::ConnectorAuthType::Rapyd (connector_auth) = auth_type {
+            Ok(connector_auth.clone())
         } else {
             Err(errors::ConnectorError::FailedToObtainAuthType)?
         }

--- a/crates/router/src/connector/rapyd/transformers.rs
+++ b/crates/router/src/connector/rapyd/transformers.rs
@@ -141,13 +141,13 @@ pub struct RapydAuthType {
     pub secret_key: String,
 }
 
-impl TryFrom<&types::ConnectorAuthType> for RapydAuthType {
+impl TryFrom<&common_enums::ConnectorAuthType> for RapydAuthType {
     type Error = error_stack::Report<errors::ConnectorError>;
-    fn try_from(auth_type: &types::ConnectorAuthType) -> Result<Self, Self::Error> {
-        if let types::ConnectorAuthType::BodyKey { api_key, key1 } = auth_type {
+    fn try_from(auth_type: &common_enums::ConnectorAuthType) -> Result<Self, Self::Error> {
+        if let common_enums::ConnectorAuthType::Rapyd { api_secret, secret_key } = auth_type {
             Ok(Self {
-                access_key: api_key.to_string(),
-                secret_key: key1.to_string(),
+                access_key: api_secret.to_string(),
+                secret_key: secret_key.to_string(),
             })
         } else {
             Err(errors::ConnectorError::FailedToObtainAuthType)?

--- a/crates/router/src/connector/shift4.rs
+++ b/crates/router/src/connector/shift4.rs
@@ -66,7 +66,7 @@ impl ConnectorCommon for Shift4 {
 
     fn get_auth_header(
         &self,
-        auth_type: &types::ConnectorAuthType,
+        auth_type: &common_enums::ConnectorAuthType,
     ) -> CustomResult<Vec<(String, String)>, errors::ConnectorError> {
         let auth: shift4::Shift4AuthType = auth_type
             .try_into()

--- a/crates/router/src/connector/shift4.rs
+++ b/crates/router/src/connector/shift4.rs
@@ -19,7 +19,7 @@ use crate::{
     types::{
         self,
         api::{self, ConnectorCommon, ConnectorCommonExt},
-        ErrorResponse,
+        ErrorResponse, transformers::ForeignTryInto,
     },
     utils::{self, BytesExt},
 };
@@ -68,10 +68,10 @@ impl ConnectorCommon for Shift4 {
         &self,
         auth_type: &common_enums::ConnectorAuthType,
     ) -> CustomResult<Vec<(String, String)>, errors::ConnectorError> {
-        let auth: shift4::Shift4AuthType = auth_type
-            .try_into()
+        let auth: common_enums::Shift4AuthType = auth_type
+            .foreign_try_into()
             .change_context(errors::ConnectorError::FailedToObtainAuthType)?;
-        Ok(vec![(headers::AUTHORIZATION.to_string(), auth.api_key)])
+        Ok(vec![(headers::AUTHORIZATION.to_string(), auth.shift4_api_key)])
     }
 
     fn build_error_response(

--- a/crates/router/src/connector/shift4/transformers.rs
+++ b/crates/router/src/connector/shift4/transformers.rs
@@ -271,12 +271,12 @@ pub struct Shift4AuthType {
     pub(super) api_key: String,
 }
 
-impl TryFrom<&types::ConnectorAuthType> for Shift4AuthType {
+impl TryFrom<&common_enums::ConnectorAuthType> for Shift4AuthType {
     type Error = Error;
-    fn try_from(item: &types::ConnectorAuthType) -> Result<Self, Self::Error> {
-        if let types::ConnectorAuthType::HeaderKey { api_key } = item {
+    fn try_from(item: &common_enums::ConnectorAuthType) -> Result<Self, Self::Error> {
+        if let common_enums::ConnectorAuthType::Shift4 { shift4_api_key } = item {
             Ok(Self {
-                api_key: api_key.to_string(),
+                api_key: shift4_api_key.to_string(),
             })
         } else {
             Err(errors::ConnectorError::FailedToObtainAuthType)?

--- a/crates/router/src/connector/shift4/transformers.rs
+++ b/crates/router/src/connector/shift4/transformers.rs
@@ -12,7 +12,7 @@ use crate::{
     },
     core::errors,
     pii, services,
-    types::{self, api, storage::enums, transformers::ForeignFrom},
+    types::{self, api, storage::enums, transformers::{ForeignFrom, ForeignTryFrom}},
 };
 
 type Error = error_stack::Report<errors::ConnectorError>;
@@ -266,18 +266,11 @@ fn get_address_details(address_details: Option<&payments::AddressDetails>) -> Op
     })
 }
 
-// Auth Struct
-pub struct Shift4AuthType {
-    pub(super) api_key: String,
-}
-
-impl TryFrom<&common_enums::ConnectorAuthType> for Shift4AuthType {
+impl ForeignTryFrom<&common_enums::ConnectorAuthType> for common_enums::Shift4AuthType {
     type Error = Error;
-    fn try_from(item: &common_enums::ConnectorAuthType) -> Result<Self, Self::Error> {
-        if let common_enums::ConnectorAuthType::Shift4 { shift4_api_key } = item {
-            Ok(Self {
-                api_key: shift4_api_key.to_string(),
-            })
+    fn foreign_try_from(item: &common_enums::ConnectorAuthType) -> Result<Self, Self::Error> {
+        if let common_enums::ConnectorAuthType::Shift4 (connector_auth) = item {
+            Ok(connector_auth.clone())
         } else {
             Err(errors::ConnectorError::FailedToObtainAuthType)?
         }

--- a/crates/router/src/connector/stripe.rs
+++ b/crates/router/src/connector/stripe.rs
@@ -43,7 +43,7 @@ impl ConnectorCommon for Stripe {
 
     fn get_auth_header(
         &self,
-        auth_type: &types::ConnectorAuthType,
+        auth_type: &common_enums::ConnectorAuthType,
     ) -> CustomResult<Vec<(String, String)>, errors::ConnectorError> {
         let auth: stripe::StripeAuthType = auth_type
             .try_into()

--- a/crates/router/src/connector/stripe.rs
+++ b/crates/router/src/connector/stripe.rs
@@ -19,7 +19,7 @@ use crate::{
     headers, services,
     types::{
         self,
-        api::{self, ConnectorCommon},
+        api::{self, ConnectorCommon}, transformers::ForeignTryInto,
     },
     utils::{self, crypto, ByteSliceExt, BytesExt},
 };
@@ -45,12 +45,12 @@ impl ConnectorCommon for Stripe {
         &self,
         auth_type: &common_enums::ConnectorAuthType,
     ) -> CustomResult<Vec<(String, String)>, errors::ConnectorError> {
-        let auth: stripe::StripeAuthType = auth_type
-            .try_into()
+        let auth: common_enums::StripeAuthType = auth_type
+            .foreign_try_into()
             .change_context(errors::ConnectorError::FailedToObtainAuthType)?;
         Ok(vec![(
             headers::AUTHORIZATION.to_string(),
-            format!("Bearer {}", auth.api_key),
+            format!("Bearer {}", auth.stripe_api_key),
         )])
     }
 }

--- a/crates/router/src/connector/stripe/transformers.rs
+++ b/crates/router/src/connector/stripe/transformers.rs
@@ -12,21 +12,15 @@ use crate::{
     core::errors,
     pii::{self, ExposeOptionInterface, Secret},
     services,
-    types::{self, api, storage::enums},
+    types::{self, api, storage::enums, transformers::{ForeignFrom, ForeignTryFrom}},
     utils::OptionExt,
 };
 
-pub struct StripeAuthType {
-    pub(super) api_key: String,
-}
-
-impl TryFrom<&common_enums::ConnectorAuthType> for StripeAuthType {
+impl ForeignTryFrom<&common_enums::ConnectorAuthType> for common_enums::StripeAuthType {
     type Error = error_stack::Report<errors::ConnectorError>;
-    fn try_from(item: &common_enums::ConnectorAuthType) -> Result<Self, Self::Error> {
-        if let common_enums::ConnectorAuthType::Stripe { stripe_api_key } = item {
-            Ok(Self {
-                api_key: stripe_api_key.to_string(),
-            })
+    fn foreign_try_from(item: &common_enums::ConnectorAuthType) -> Result<Self, Self::Error> {
+        if let common_enums::ConnectorAuthType::Stripe (connector_auth) = item {
+            Ok(connector_auth.clone())
         } else {
             Err(errors::ConnectorError::FailedToObtainAuthType.into())
         }

--- a/crates/router/src/connector/stripe/transformers.rs
+++ b/crates/router/src/connector/stripe/transformers.rs
@@ -20,12 +20,12 @@ pub struct StripeAuthType {
     pub(super) api_key: String,
 }
 
-impl TryFrom<&types::ConnectorAuthType> for StripeAuthType {
+impl TryFrom<&common_enums::ConnectorAuthType> for StripeAuthType {
     type Error = error_stack::Report<errors::ConnectorError>;
-    fn try_from(item: &types::ConnectorAuthType) -> Result<Self, Self::Error> {
-        if let types::ConnectorAuthType::HeaderKey { api_key } = item {
+    fn try_from(item: &common_enums::ConnectorAuthType) -> Result<Self, Self::Error> {
+        if let common_enums::ConnectorAuthType::Stripe { stripe_api_key } = item {
             Ok(Self {
-                api_key: api_key.to_string(),
+                api_key: stripe_api_key.to_string(),
             })
         } else {
             Err(errors::ConnectorError::FailedToObtainAuthType.into())

--- a/crates/router/src/connector/trustpay.rs
+++ b/crates/router/src/connector/trustpay.rs
@@ -82,7 +82,7 @@ impl ConnectorCommon for Trustpay {
 
     fn get_auth_header(
         &self,
-        auth_type: &types::ConnectorAuthType,
+        auth_type: &common_enums::ConnectorAuthType,
     ) -> CustomResult<Vec<(String, String)>, errors::ConnectorError> {
         let auth = trustpay::TrustpayAuthType::try_from(auth_type)
             .change_context(errors::ConnectorError::FailedToObtainAuthType)?;

--- a/crates/router/src/connector/trustpay.rs
+++ b/crates/router/src/connector/trustpay.rs
@@ -20,7 +20,7 @@ use crate::{
     types::{
         self,
         api::{self, ConnectorCommon, ConnectorCommonExt},
-        ErrorResponse, Response,
+        ErrorResponse, Response, transformers::ForeignTryFrom,
     },
     utils::{self, BytesExt},
 };
@@ -84,7 +84,7 @@ impl ConnectorCommon for Trustpay {
         &self,
         auth_type: &common_enums::ConnectorAuthType,
     ) -> CustomResult<Vec<(String, String)>, errors::ConnectorError> {
-        let auth = trustpay::TrustpayAuthType::try_from(auth_type)
+        let auth = common_enums::TrustpayAuthType::foreign_try_from(auth_type)
             .change_context(errors::ConnectorError::FailedToObtainAuthType)?;
         Ok(vec![(headers::X_API_KEY.to_string(), auth.api_key)])
     }
@@ -162,7 +162,7 @@ impl ConnectorIntegration<api::AccessTokenAuth, types::AccessTokenRequestData, t
         req: &types::RefreshTokenRouterData,
         _connectors: &settings::Connectors,
     ) -> CustomResult<Vec<(String, String)>, errors::ConnectorError> {
-        let auth = trustpay::TrustpayAuthType::try_from(&req.connector_auth_type)
+        let auth = common_enums::TrustpayAuthType::foreign_try_from(&req.connector_auth_type)
             .change_context(errors::ConnectorError::FailedToObtainAuthType)?;
         let auth_value = format!(
             "Basic {}",

--- a/crates/router/src/connector/trustpay/transformers.rs
+++ b/crates/router/src/connector/trustpay/transformers.rs
@@ -24,19 +24,19 @@ pub struct TrustpayAuthType {
     pub(super) secret_key: String,
 }
 
-impl TryFrom<&types::ConnectorAuthType> for TrustpayAuthType {
+impl TryFrom<&common_enums::ConnectorAuthType> for TrustpayAuthType {
     type Error = error_stack::Report<errors::ConnectorError>;
-    fn try_from(auth_type: &types::ConnectorAuthType) -> Result<Self, Self::Error> {
-        if let types::ConnectorAuthType::SignatureKey {
+    fn try_from(auth_type: &common_enums::ConnectorAuthType) -> Result<Self, Self::Error> {
+        if let common_enums::ConnectorAuthType::TrustPay {
             api_key,
-            key1,
-            api_secret,
+            project_id,
+            secret_key,
         } = auth_type
         {
             Ok(Self {
                 api_key: api_key.to_string(),
-                project_id: key1.to_string(),
-                secret_key: api_secret.to_string(),
+                project_id: project_id.to_string(),
+                secret_key: secret_key.to_string(),
             })
         } else {
             Err(errors::ConnectorError::FailedToObtainAuthType.into())

--- a/crates/router/src/connector/worldline.rs
+++ b/crates/router/src/connector/worldline.rs
@@ -22,7 +22,7 @@ use crate::{
     types::{
         self,
         api::{self, ConnectorCommon, ConnectorCommonExt},
-        ErrorResponse,
+        ErrorResponse, transformers::ForeignTryFrom,
     },
     utils::{self, crypto, BytesExt, OptionExt},
 };
@@ -33,7 +33,7 @@ pub struct Worldline;
 impl Worldline {
     pub fn generate_authorization_token(
         &self,
-        auth: worldline::AuthType,
+        auth: common_enums::WorldlineAuthType,
         http_method: &services::Method,
         content_type: &str,
         date: &str,
@@ -46,7 +46,7 @@ impl Worldline {
             date.trim(),
             endpoint.trim()
         );
-        let worldline::AuthType {
+        let common_enums::WorldlineAuthType {
             api_key,
             api_secret,
             ..
@@ -83,7 +83,7 @@ where
         let url = Self::get_url(self, req, connectors)?;
         let endpoint = url.replace(base_url, "");
         let http_method = Self::get_http_method(self);
-        let auth = worldline::AuthType::try_from(&req.connector_auth_type)?;
+        let auth = common_enums::WorldlineAuthType::foreign_try_from(&req.connector_auth_type)?;
         let date = Self::get_current_date_time()?;
         let content_type = Self::get_content_type(self);
         let signed_data: String =
@@ -174,7 +174,7 @@ impl ConnectorIntegration<api::Void, types::PaymentsCancelData, types::PaymentsR
         connectors: &Connectors,
     ) -> CustomResult<String, errors::ConnectorError> {
         let base_url = self.base_url(connectors);
-        let auth: worldline::AuthType = worldline::AuthType::try_from(&req.connector_auth_type)?;
+        let auth: common_enums::WorldlineAuthType = common_enums::WorldlineAuthType::foreign_try_from(&req.connector_auth_type)?;
         let merchant_account_id = auth.merchant_account_id;
         let payment_id: &str = req.request.connector_transaction_id.as_ref();
         Ok(format!(
@@ -254,7 +254,7 @@ impl ConnectorIntegration<api::PSync, types::PaymentsSyncData, types::PaymentsRe
             .get_connector_transaction_id()
             .change_context(errors::ConnectorError::MissingConnectorTransactionID)?;
         let base_url = self.base_url(connectors);
-        let auth = worldline::AuthType::try_from(&req.connector_auth_type)?;
+        let auth = common_enums::WorldlineAuthType::foreign_try_from(&req.connector_auth_type)?;
         let merchant_account_id = auth.merchant_account_id;
         Ok(format!(
             "{base_url}v1/{merchant_account_id}/payments/{payment_id}"
@@ -330,7 +330,7 @@ impl ConnectorIntegration<api::Capture, types::PaymentsCaptureData, types::Payme
     ) -> CustomResult<String, errors::ConnectorError> {
         let payment_id = req.request.connector_transaction_id.clone();
         let base_url = self.base_url(connectors);
-        let auth = worldline::AuthType::try_from(&req.connector_auth_type)?;
+        let auth = common_enums::WorldlineAuthType::foreign_try_from(&req.connector_auth_type)?;
         let merchant_account_id = auth.merchant_account_id;
         Ok(format!(
             "{base_url}v1/{merchant_account_id}/payments/{payment_id}/approve"
@@ -444,7 +444,7 @@ impl ConnectorIntegration<api::Authorize, types::PaymentsAuthorizeData, types::P
         connectors: &Connectors,
     ) -> CustomResult<String, errors::ConnectorError> {
         let base_url = self.base_url(connectors);
-        let auth = worldline::AuthType::try_from(&req.connector_auth_type)?;
+        let auth = common_enums::WorldlineAuthType::foreign_try_from(&req.connector_auth_type)?;
         let merchant_account_id = auth.merchant_account_id;
         Ok(format!("{base_url}v1/{merchant_account_id}/payments"))
     }
@@ -533,7 +533,7 @@ impl ConnectorIntegration<api::Execute, types::RefundsData, types::RefundsRespon
     ) -> CustomResult<String, errors::ConnectorError> {
         let payment_id = req.request.connector_transaction_id.clone();
         let base_url = self.base_url(connectors);
-        let auth = worldline::AuthType::try_from(&req.connector_auth_type)?;
+        let auth = common_enums::WorldlineAuthType::foreign_try_from(&req.connector_auth_type)?;
         let merchant_account_id = auth.merchant_account_id;
         Ok(format!(
             "{base_url}v1/{merchant_account_id}/payments/{payment_id}/refund"
@@ -623,7 +623,7 @@ impl ConnectorIntegration<api::RSync, types::RefundsData, types::RefundsResponse
     ) -> CustomResult<String, errors::ConnectorError> {
         let refund_id = req.request.get_connector_refund_id()?;
         let base_url = self.base_url(connectors);
-        let auth: worldline::AuthType = worldline::AuthType::try_from(&req.connector_auth_type)?;
+        let auth: common_enums::WorldlineAuthType = common_enums::WorldlineAuthType::foreign_try_from(&req.connector_auth_type)?;
         let merchant_account_id = auth.merchant_account_id;
         Ok(format!(
             "{base_url}v1/{merchant_account_id}/refunds/{refund_id}/"

--- a/crates/router/src/connector/worldline/transformers.rs
+++ b/crates/router/src/connector/worldline/transformers.rs
@@ -10,7 +10,7 @@ use crate::{
         self,
         api::{self, enums as api_enums},
         storage::enums,
-        transformers::ForeignFrom,
+        transformers::{ForeignFrom, ForeignTryFrom},
     },
 };
 
@@ -258,26 +258,12 @@ impl From<api_models::AddressDetails> for Shipping {
     }
 }
 
-pub struct AuthType {
-    pub api_key: String,
-    pub api_secret: String,
-    pub merchant_account_id: String,
-}
-
-impl TryFrom<&common_enums::ConnectorAuthType> for AuthType {
+impl ForeignTryFrom<&common_enums::ConnectorAuthType> for common_enums::WorldlineAuthType {
     type Error = error_stack::Report<errors::ConnectorError>;
-    fn try_from(auth_type: &common_enums::ConnectorAuthType) -> Result<Self, Self::Error> {
-        if let common_enums::ConnectorAuthType::Worldline {
-            api_key,
-            merchant_account_id,
-            api_secret,
-        } = auth_type
+    fn foreign_try_from(auth_type: &common_enums::ConnectorAuthType) -> Result<Self, Self::Error> {
+        if let common_enums::ConnectorAuthType::Worldline (connector_auth) = auth_type
         {
-            Ok(Self {
-                api_key: api_key.to_string(),
-                api_secret: api_secret.to_string(),
-                merchant_account_id: merchant_account_id.to_string(),
-            })
+            Ok(connector_auth.clone())
         } else {
             Err(errors::ConnectorError::FailedToObtainAuthType)?
         }

--- a/crates/router/src/connector/worldline/transformers.rs
+++ b/crates/router/src/connector/worldline/transformers.rs
@@ -264,19 +264,19 @@ pub struct AuthType {
     pub merchant_account_id: String,
 }
 
-impl TryFrom<&types::ConnectorAuthType> for AuthType {
+impl TryFrom<&common_enums::ConnectorAuthType> for AuthType {
     type Error = error_stack::Report<errors::ConnectorError>;
-    fn try_from(auth_type: &types::ConnectorAuthType) -> Result<Self, Self::Error> {
-        if let types::ConnectorAuthType::SignatureKey {
+    fn try_from(auth_type: &common_enums::ConnectorAuthType) -> Result<Self, Self::Error> {
+        if let common_enums::ConnectorAuthType::Worldline {
             api_key,
-            key1,
+            merchant_account_id,
             api_secret,
         } = auth_type
         {
             Ok(Self {
                 api_key: api_key.to_string(),
                 api_secret: api_secret.to_string(),
-                merchant_account_id: key1.to_string(),
+                merchant_account_id: merchant_account_id.to_string(),
             })
         } else {
             Err(errors::ConnectorError::FailedToObtainAuthType)?

--- a/crates/router/src/connector/worldpay.rs
+++ b/crates/router/src/connector/worldpay.rs
@@ -62,7 +62,7 @@ impl ConnectorCommon for Worldpay {
 
     fn get_auth_header(
         &self,
-        auth_type: &types::ConnectorAuthType,
+        auth_type: &common_enums::ConnectorAuthType,
     ) -> CustomResult<Vec<(String, String)>, errors::ConnectorError> {
         let auth: worldpay::WorldpayAuthType = auth_type
             .try_into()

--- a/crates/router/src/connector/worldpay/transformers.rs
+++ b/crates/router/src/connector/worldpay/transformers.rs
@@ -91,12 +91,12 @@ pub struct WorldpayAuthType {
     pub(super) api_key: String,
 }
 
-impl TryFrom<&types::ConnectorAuthType> for WorldpayAuthType {
+impl TryFrom<&common_enums::ConnectorAuthType> for WorldpayAuthType {
     type Error = error_stack::Report<errors::ConnectorError>;
-    fn try_from(auth_type: &types::ConnectorAuthType) -> Result<Self, Self::Error> {
+    fn try_from(auth_type: &common_enums::ConnectorAuthType) -> Result<Self, Self::Error> {
         match auth_type {
-            types::ConnectorAuthType::BodyKey { api_key, key1 } => {
-                let auth_key = format!("{key1}:{api_key}");
+            common_enums::ConnectorAuthType::Worldpay { password, username } => {
+                let auth_key = format!("{username}:{password}");
                 let auth_header = format!("Basic {}", consts::BASE64_ENGINE.encode(auth_key));
                 Ok(Self {
                     api_key: auth_header,

--- a/crates/router/src/connector/worldpay/transformers.rs
+++ b/crates/router/src/connector/worldpay/transformers.rs
@@ -95,8 +95,8 @@ impl TryFrom<&common_enums::ConnectorAuthType> for WorldpayAuthType {
     type Error = error_stack::Report<errors::ConnectorError>;
     fn try_from(auth_type: &common_enums::ConnectorAuthType) -> Result<Self, Self::Error> {
         match auth_type {
-            common_enums::ConnectorAuthType::Worldpay { password, username } => {
-                let auth_key = format!("{username}:{password}");
+            common_enums::ConnectorAuthType::Worldpay (connector_auth) => {
+                let auth_key = format!("{0}:{1}", connector_auth.username, connector_auth.password);
                 let auth_header = format!("Basic {}", consts::BASE64_ENGINE.encode(auth_key));
                 Ok(Self {
                     api_key: auth_header,

--- a/crates/router/src/core/payments/transformers.rs
+++ b/crates/router/src/core/payments/transformers.rs
@@ -52,7 +52,7 @@ where
     )
     .await?;
 
-    let auth_type: types::ConnectorAuthType = merchant_connector_account
+    let auth_type: common_enums::ConnectorAuthType = merchant_connector_account
         .get_connector_account_details()
         .parse_value("ConnectorAuthType")
         .change_context(errors::ApiErrorResponse::InternalServerError)

--- a/crates/router/src/core/utils.rs
+++ b/crates/router/src/core/utils.rs
@@ -46,7 +46,7 @@ pub async fn construct_refund_router_data<'a, F>(
     )
     .await?;
 
-    let auth_type: types::ConnectorAuthType = merchant_connector_account
+    let auth_type: common_enums::ConnectorAuthType = merchant_connector_account
         .get_connector_account_details()
         .parse_value("ConnectorAuthType")
         .change_context(errors::ApiErrorResponse::InternalServerError)?;

--- a/crates/router/src/routes/admin.rs
+++ b/crates/router/src/routes/admin.rs
@@ -182,7 +182,7 @@ pub async fn payment_connector_create(
         &req,
         json_payload.into_inner(),
         |state, _, req| create_payment_connector(&*state.store, req, &merchant_id),
-        &auth::AdminApiAuth,
+        &auth::AdminApiAuth, 
     )
     .await
 }

--- a/crates/router/src/types.rs
+++ b/crates/router/src/types.rs
@@ -13,6 +13,7 @@ pub mod transformers;
 use std::marker::PhantomData;
 
 pub use api_models::enums::Connector;
+use common_enums::ConnectorAuthType;
 use common_utils::{pii, pii::Email};
 use error_stack::{IntoReport, ResultExt};
 
@@ -367,25 +368,26 @@ pub struct ResponseRouterData<Flow, R, Request, Response> {
     pub http_code: u16,
 }
 
+//TODO: ANJI
 // Different patterns of authentication.
-#[derive(Default, Debug, Clone, serde::Deserialize)]
-#[serde(tag = "auth_type")]
-pub enum ConnectorAuthType {
-    HeaderKey {
-        api_key: String,
-    },
-    BodyKey {
-        api_key: String,
-        key1: String,
-    },
-    SignatureKey {
-        api_key: String,
-        key1: String,
-        api_secret: String,
-    },
-    #[default]
-    NoKey,
-}
+// #[derive(Default, Debug, Clone, serde::Deserialize)]
+// #[serde(tag = "auth_type")]
+// pub enum ConnectorAuthType {
+//     HeaderKey {
+//         api_key: String,
+//     },
+//     BodyKey {
+//         api_key: String,
+//         key1: String,
+//     },
+//     SignatureKey {
+//         api_key: String,
+//         key1: String,
+//         api_secret: String,
+//     },
+//     #[default]
+//     NoKey,
+// }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct ConnectorsList {
@@ -427,18 +429,22 @@ impl TryFrom<ConnectorAuthType> for AccessTokenRequestData {
     type Error = errors::ApiErrorResponse;
     fn try_from(connector_auth: ConnectorAuthType) -> Result<Self, Self::Error> {
         match connector_auth {
-            ConnectorAuthType::HeaderKey { api_key } => Ok(Self {
-                app_id: api_key,
-                id: None,
-            }),
-            ConnectorAuthType::BodyKey { api_key, key1 } => Ok(Self {
-                app_id: api_key,
+            ConnectorAuthType::Airwallex { app_id, key1 } => Ok(Self {
+                app_id: app_id,
                 id: Some(key1),
             }),
-            ConnectorAuthType::SignatureKey { api_key, key1, .. } => Ok(Self {
-                app_id: api_key,
-                id: Some(key1),
-            }),
+            // ConnectorAuthType::HeaderKey { api_key } => Ok(Self {
+            //     app_id: api_key,
+            //     id: None,
+            // }),
+            // ConnectorAuthType::BodyKey { api_key, key1 } => Ok(Self {
+            //     app_id: api_key,
+            //     id: Some(key1),
+            // }),
+            // ConnectorAuthType::SignatureKey { api_key, key1, .. } => Ok(Self {
+            //     app_id: api_key,
+            //     id: Some(key1),
+            // }),
             _ => Err(errors::ApiErrorResponse::InvalidDataValue {
                 field_name: "connector_account_details",
             }),

--- a/crates/router/src/types.rs
+++ b/crates/router/src/types.rs
@@ -429,9 +429,9 @@ impl TryFrom<ConnectorAuthType> for AccessTokenRequestData {
     type Error = errors::ApiErrorResponse;
     fn try_from(connector_auth: ConnectorAuthType) -> Result<Self, Self::Error> {
         match connector_auth {
-            ConnectorAuthType::Airwallex { app_id, key1 } => Ok(Self {
-                app_id: app_id,
-                id: Some(key1),
+            common_enums::ConnectorAuthType::Airwallex(_auth) => Ok(Self {
+                app_id: _auth.app_id,
+                id: Some(_auth.key1),
             }),
             // ConnectorAuthType::HeaderKey { api_key } => Ok(Self {
             //     app_id: api_key,

--- a/crates/router/src/types/api.rs
+++ b/crates/router/src/types/api.rs
@@ -51,7 +51,7 @@ pub trait ConnectorCommon {
     /// HTTP header used for authorization.
     fn get_auth_header(
         &self,
-        _auth_type: &types::ConnectorAuthType,
+        _auth_type: &common_enums::ConnectorAuthType,
     ) -> CustomResult<Vec<(String, String)>, errors::ConnectorError> {
         Ok(Vec::new())
     }

--- a/crates/router/tests/connectors/adyen.rs
+++ b/crates/router/tests/connectors/adyen.rs
@@ -20,8 +20,8 @@ impl utils::Connector for AdyenTest {
         }
     }
 
-    fn get_auth_token(&self) -> types::ConnectorAuthType {
-        types::ConnectorAuthType::from(
+    fn get_auth_token(&self) -> common_enums::ConnectorAuthType {
+        common_enums::ConnectorAuthType::from(
             connector_auth::ConnectorAuthentication::new()
                 .adyen
                 .expect("Missing connector authentication configuration"),

--- a/crates/router/tests/connectors/airwallex.rs
+++ b/crates/router/tests/connectors/airwallex.rs
@@ -37,7 +37,7 @@ impl Connector for AirwallexTest {
 
 fn get_access_token() -> Option<AccessToken> {
     match CONNECTOR.get_auth_token() {
-        common_enums::ConnectorAuthType::Airwallex { app_id, key1 } => Some(AccessToken {
+        common_enums::AirwallexAuthType { app_id, key1 } => Some(AccessToken {
             token: app_id,
             expires: key1.parse::<i64>().unwrap(),
         }),

--- a/crates/router/tests/connectors/airwallex.rs
+++ b/crates/router/tests/connectors/airwallex.rs
@@ -22,8 +22,8 @@ impl Connector for AirwallexTest {
         }
     }
 
-    fn get_auth_token(&self) -> types::ConnectorAuthType {
-        types::ConnectorAuthType::from(
+    fn get_auth_token(&self) -> common_enums::ConnectorAuthType {
+        common_enums::ConnectorAuthType::from(
             connector_auth::ConnectorAuthentication::new()
                 .airwallex
                 .expect("Missing connector authentication configuration"),
@@ -37,8 +37,8 @@ impl Connector for AirwallexTest {
 
 fn get_access_token() -> Option<AccessToken> {
     match CONNECTOR.get_auth_token() {
-        types::ConnectorAuthType::BodyKey { api_key, key1 } => Some(AccessToken {
-            token: api_key,
+        common_enums::ConnectorAuthType::Airwallex { app_id, key1 } => Some(AccessToken {
+            token: app_id,
             expires: key1.parse::<i64>().unwrap(),
         }),
         _ => None,

--- a/crates/router/tests/connectors/bambora.rs
+++ b/crates/router/tests/connectors/bambora.rs
@@ -20,8 +20,8 @@ impl utils::Connector for BamboraTest {
         }
     }
 
-    fn get_auth_token(&self) -> types::ConnectorAuthType {
-        types::ConnectorAuthType::from(
+    fn get_auth_token(&self) -> common_enums::ConnectorAuthType {
+        common_enums::ConnectorAuthType::from(
             connector_auth::ConnectorAuthentication::new()
                 .bambora
                 .expect("Missing connector authentication configuration"),

--- a/crates/router/tests/connectors/bluesnap.rs
+++ b/crates/router/tests/connectors/bluesnap.rs
@@ -1,5 +1,6 @@
 use masking::Secret;
-use router::types::{self, api, storage::enums, ConnectorAuthType};
+use router::types::{self, api, storage::enums};
+use common_enums::ConnectorAuthType;
 
 use crate::{
     connector_auth,
@@ -21,7 +22,7 @@ impl utils::Connector for BluesnapTest {
     }
 
     fn get_auth_token(&self) -> ConnectorAuthType {
-        types::ConnectorAuthType::from(
+        common_enums::ConnectorAuthType::from(
             connector_auth::ConnectorAuthentication::new()
                 .bluesnap
                 .expect("Missing connector authentication configuration"),

--- a/crates/router/tests/connectors/checkout.rs
+++ b/crates/router/tests/connectors/checkout.rs
@@ -236,10 +236,7 @@ async fn test_checkout_payment_failure() {
         types::PaymentsResponseData,
     > = connector.connector.get_connector_integration();
     let mut request = construct_payment_router_data();
-    request.connector_auth_type = types::ConnectorAuthType::BodyKey {
-        api_key: "".to_string(),
-        key1: "".to_string(),
-    };
+    request.connector_auth_type = common_enums::ConnectorAuthType::Checkout { checkout_api_key: "".to_string(), processing_channel_id: "".to_string() };
     let response = services::api::execute_connector_processing_step(
         &state,
         connector_integration,

--- a/crates/router/tests/connectors/checkout.rs
+++ b/crates/router/tests/connectors/checkout.rs
@@ -236,7 +236,7 @@ async fn test_checkout_payment_failure() {
         types::PaymentsResponseData,
     > = connector.connector.get_connector_integration();
     let mut request = construct_payment_router_data();
-    request.connector_auth_type = common_enums::ConnectorAuthType::Checkout { checkout_api_key: "".to_string(), processing_channel_id: "".to_string() };
+    request.connector_auth_type = common_enums::CheckoutAuthType { checkout_api_key: "".to_string(), processing_channel_id: "".to_string() };
     let response = services::api::execute_connector_processing_step(
         &state,
         connector_integration,

--- a/crates/router/tests/connectors/coinbase.rs
+++ b/crates/router/tests/connectors/coinbase.rs
@@ -19,8 +19,8 @@ impl utils::Connector for CoinbaseTest {
         }
     }
 
-    fn get_auth_token(&self) -> types::ConnectorAuthType {
-        types::ConnectorAuthType::from(
+    fn get_auth_token(&self) -> common_enums::ConnectorAuthType {
+        common_enums::ConnectorAuthType::from(
             connector_auth::ConnectorAuthentication::new()
                 .coinbase
                 .expect("Missing connector authentication configuration"),

--- a/crates/router/tests/connectors/connector_auth.rs
+++ b/crates/router/tests/connectors/connector_auth.rs
@@ -1,37 +1,37 @@
 use std::env;
 
-use router::types::ConnectorAuthType;
+use common_enums::ConnectorAuthType;
 use serde::Deserialize;
 
 #[derive(Debug, Deserialize, Clone)]
 pub(crate) struct ConnectorAuthentication {
-    pub aci: Option<BodyKey>,
-    pub adyen: Option<BodyKey>,
-    pub airwallex: Option<BodyKey>,
-    pub authorizedotnet: Option<BodyKey>,
-    pub bambora: Option<BodyKey>,
-    pub bluesnap: Option<BodyKey>,
-    pub checkout: Option<BodyKey>,
-    pub coinbase: Option<HeaderKey>,
-    pub cybersource: Option<SignatureKey>,
-    pub dlocal: Option<SignatureKey>,
-    pub fiserv: Option<SignatureKey>,
-    pub forte: Option<HeaderKey>,
-    pub globalpay: Option<HeaderKey>,
-    pub mollie: Option<HeaderKey>,
-    pub multisafepay: Option<HeaderKey>,
-    pub nexinets: Option<HeaderKey>,
-    pub nuvei: Option<SignatureKey>,
-    pub opennode: Option<HeaderKey>,
-    pub payeezy: Option<SignatureKey>,
-    pub paypal: Option<BodyKey>,
-    pub payu: Option<BodyKey>,
-    pub rapyd: Option<BodyKey>,
-    pub shift4: Option<HeaderKey>,
-    pub stripe: Option<HeaderKey>,
-    pub worldpay: Option<BodyKey>,
-    pub worldline: Option<SignatureKey>,
-    pub trustpay: Option<SignatureKey>,
+    pub aci: Option<Aci>,
+    pub adyen: Option<Adyen>,
+    pub airwallex: Option<Airwallex>,
+    pub authorizedotnet: Option<Authorizedotnet>,
+    pub bambora: Option<Bambora>,
+    pub bluesnap: Option<Bluesnap>,
+    pub checkout: Option<Checkout>,
+    pub coinbase: Option<Coinbase>,
+    pub cybersource: Option<Cybersource>,
+    pub dlocal: Option<Dlocal>,
+    pub fiserv: Option<Fiserv>,
+    pub forte: Option<Forte>,
+    pub globalpay: Option<Globalpay>,
+    pub mollie: Option<Mollie>,
+    pub multisafepay: Option<Multisafepay>,
+    pub nexinets: Option<Nexinets>,
+    pub nuvei: Option<Nuvei>,
+    pub opennode: Option<Opennode>,
+    pub payeezy: Option<Payeezy>,
+    pub paypal: Option<Paypal>,
+    pub payu: Option<Payu>,
+    pub rapyd: Option<Rapyd>,
+    pub shift4: Option<Shift4>,
+    pub stripe: Option<Stripe>,
+    pub worldpay: Option<Worldpay>,
+    pub worldline: Option<Worldline>,
+    pub trustpay: Option<TrustPay>,
 }
 
 impl ConnectorAuthentication {
@@ -46,47 +46,383 @@ impl ConnectorAuthentication {
     }
 }
 
-#[derive(Debug, Deserialize, Clone)]
-pub(crate) struct HeaderKey {
-    pub api_key: String,
-}
 
-impl From<HeaderKey> for ConnectorAuthType {
-    fn from(key: HeaderKey) -> Self {
-        Self::HeaderKey {
+//-------
+impl From<Aci> for ConnectorAuthType {
+    fn from(key: Aci) -> Self {
+        Self::Aci {
+            api_key: key.api_key,
+            entity_id: key.entity_id,
+        }
+    }
+}
+impl From<Adyen> for ConnectorAuthType {
+    fn from(key: Adyen) -> Self {
+        Self::Adyen {
+            adyen_api_key: key.adyen_api_key,
+            adyen_account_id: key.adyen_account_id,
+        }
+    }
+}
+impl From<Airwallex> for ConnectorAuthType {
+    fn from(key: Airwallex) -> Self {
+        Self::Airwallex {
+            app_id: key.app_id,
+            key1: key.key1
+        }
+    }
+}
+impl From<Authorizedotnet> for ConnectorAuthType {
+    fn from(key: Authorizedotnet) -> Self {
+        Self::Authorizedotnet {
+            api_login_id: key.api_login_id,
+            transaction_key: key.transaction_key,
+        }
+    }
+}
+impl From<Bambora> for ConnectorAuthType {
+    fn from(key: Bambora) -> Self {
+        Self::Bambora {
+            passcode: key.passcode,
+            merchant_id: key.merchant_id,
+        }
+    }
+}
+impl From<Bluesnap> for ConnectorAuthType {
+    fn from(key: Bluesnap) -> Self {
+        Self::Bluesnap {
+            username: key.username,
+            password: key.password,
+        }
+    }
+}
+impl From<Braintree> for ConnectorAuthType {
+    fn from(key: Braintree) -> Self {
+        Self::Braintree {
+            public_key: key.public_key,
+            merchant_id: key.merchant_id,
+            private_key: key.private_key,
+        }
+    }
+}
+impl From<Checkout> for ConnectorAuthType {
+    fn from(key: Checkout) -> Self {
+        Self::Checkout {
+            checkout_api_key: key.checkout_api_key,
+            processing_channel_id: key.processing_channel_id,
+        }
+    }
+}
+impl From<Coinbase> for ConnectorAuthType {
+    fn from(key: Coinbase) -> Self {
+        Self::Coinbase {
             api_key: key.api_key,
         }
     }
 }
-
-#[derive(Debug, Deserialize, Clone)]
-pub(crate) struct BodyKey {
-    pub api_key: String,
-    pub key1: String,
-}
-
-impl From<BodyKey> for ConnectorAuthType {
-    fn from(key: BodyKey) -> Self {
-        Self::BodyKey {
-            api_key: key.api_key,
-            key1: key.key1,
-        }
-    }
-}
-
-#[derive(Debug, Deserialize, Clone)]
-pub(crate) struct SignatureKey {
-    pub api_key: String,
-    pub key1: String,
-    pub api_secret: String,
-}
-
-impl From<SignatureKey> for ConnectorAuthType {
-    fn from(key: SignatureKey) -> Self {
-        Self::SignatureKey {
-            api_key: key.api_key,
-            key1: key.key1,
+impl From<Cybersource> for ConnectorAuthType {
+    fn from(key: Cybersource) -> Self {
+        Self::Cybersource {
+            key: key.key,
+            merchant_account: key.merchant_account,
             api_secret: key.api_secret,
         }
     }
+}
+
+impl From<Dlocal> for ConnectorAuthType {
+    fn from(key: Dlocal) -> Self {
+        Self::Dlocal {
+            x_login: key.x_login,
+            x_trans_key: key.x_trans_key,
+            secret: key.secret,
+        }
+    }
+}
+impl From<Fiserv> for ConnectorAuthType {
+    fn from(key: Fiserv) -> Self {
+        Self::Fiserv {
+            api_key: key.api_key,
+            merchant_id: key.merchant_id,
+            api_secret: key.api_secret,
+        }
+    }
+}
+impl From<Forte> for ConnectorAuthType {
+    fn from(key: Forte) -> Self {
+        Self::Forte {
+            api_key: key.api_key,
+        }
+    }
+}
+impl From<Globalpay> for ConnectorAuthType {
+    fn from(key: Globalpay) -> Self {
+        Self::Globalpay {
+            globalpay_app_id: key.globalpay_app_id,
+            globalpay_app_key: key.globalpay_app_key,
+        }
+    }
+}
+impl From<Klarna> for ConnectorAuthType {
+    fn from(key: Klarna) -> Self {
+        Self::Klarna {
+            klarna_api_key: key.klarna_api_key,
+        }
+    }
+}
+impl From<Mollie> for ConnectorAuthType {
+    fn from(key: Mollie) -> Self {
+        Self::Mollie {
+            api_key: key.api_key,
+        }
+    }
+}
+impl From<Multisafepay> for ConnectorAuthType {
+    fn from(key: Multisafepay) -> Self {
+        Self::Multisafepay {
+            api_key: key.api_key,
+        }
+    }
+}
+impl From<Nexinets> for ConnectorAuthType {
+    fn from(key: Nexinets) -> Self {
+        Self::Nexinets {
+            api_key: key.api_key,
+        }
+    }
+}
+impl From<Nuvei> for ConnectorAuthType {
+    fn from(key: Nuvei) -> Self {
+        Self::Nuvei {
+            merchant_id: key.merchant_id,
+            merchant_site_id: key.merchant_site_id,
+            merchant_secret: key.merchant_secret,
+        }
+    }
+}
+impl From<Opennode> for ConnectorAuthType {
+    fn from(key: Opennode) -> Self {
+        Self::Opennode {
+            api_key: key.api_key,
+        }
+    }
+}
+impl From<Payeezy> for ConnectorAuthType {
+    fn from(key: Payeezy) -> Self {
+        Self::Payeezy {
+            api_key: key.api_key,
+            api_secret: key.api_secret,
+            merchant_token: key.merchant_token,
+        }
+    }
+}
+impl From<Paypal> for ConnectorAuthType {
+    fn from(key: Paypal) -> Self {
+        Self::Paypal {
+            api_key: key.api_key,
+            api_secret: key.api_secret,
+        }
+    }
+}
+impl From<Payu> for ConnectorAuthType {
+    fn from(key: Payu) -> Self {
+        Self::Payu {
+            api_key: key.api_key,
+            merchant_pos_id: key.merchant_pos_id,
+        }
+    }
+}
+impl From<Rapyd> for ConnectorAuthType {
+    fn from(key: Rapyd) -> Self {
+        Self::Rapyd {
+            api_secret: key.api_secret,
+            secret_key: key.secret_key,
+        }
+    }
+}
+impl From<Shift4> for ConnectorAuthType {
+    fn from(key: Shift4) -> Self {
+        Self::Shift4 {
+            shift4_api_key: key.shift4_api_key,
+        }
+    }
+}
+impl From<Stripe> for ConnectorAuthType {
+    fn from(key: Stripe) -> Self {
+        Self::Stripe {
+            stripe_api_key: key.stripe_api_key,
+        }
+    }
+}
+impl From<TrustPay> for ConnectorAuthType {
+    fn from(key: TrustPay) -> Self {
+        Self::TrustPay {
+            api_key: key.api_key,
+            project_id: key.project_id,
+            secret_key: key.secret_key,
+        }
+    }
+}
+impl From<Worldline> for ConnectorAuthType {
+    fn from(key: Worldline) -> Self {
+        Self::Worldline {
+            api_key: key.api_key,
+            api_secret: key.api_secret,
+            merchant_account_id: key.merchant_account_id,
+        }
+    }
+}
+impl From<Worldpay> for ConnectorAuthType {
+    fn from(key: Worldpay) -> Self {
+        Self::Worldpay {
+            username: key.username,
+            password: key.password,
+        }
+    }
+}
+#[derive(Debug, Deserialize, Clone)]
+pub(crate) struct Aci {
+    pub api_key: String,
+    pub entity_id: String,
+}
+#[derive(Debug, Deserialize, Clone)]
+pub(crate) struct Adyen {
+    pub adyen_api_key: String,
+    pub adyen_account_id: String,
+}
+#[derive(Debug, Deserialize, Clone)]
+pub(crate) struct Airwallex {
+    pub app_id: String,
+    pub key1: String
+}
+//applepay not sure it will work
+#[derive(Debug, Deserialize, Clone)]
+pub(crate) struct Authorizedotnet {
+    pub api_login_id: String,
+    pub transaction_key: String,
+}
+#[derive(Debug, Deserialize, Clone)]
+pub(crate) struct Bambora {
+    pub passcode: String,
+    pub merchant_id: String,
+}
+#[derive(Debug, Deserialize, Clone)]
+pub(crate) struct Bluesnap {
+    pub username: String,
+    pub password: String,
+}
+#[derive(Debug, Deserialize, Clone)]
+pub(crate) struct Braintree {
+    pub public_key: String,
+    pub merchant_id: String,
+    pub private_key: String,
+}
+#[derive(Debug, Deserialize, Clone)]
+pub(crate) struct Checkout {
+    pub checkout_api_key: String,
+    pub processing_channel_id: String,
+}
+#[derive(Debug, Deserialize, Clone)]
+pub(crate) struct Coinbase {
+    pub api_key: String,
+}
+//TODO:need to check  
+#[derive(Debug, Deserialize, Clone)]
+pub(crate) struct Cybersource {
+    pub key: String,
+    pub merchant_account: String,
+    pub api_secret: String,
+}
+#[derive(Debug, Deserialize, Clone)]
+pub(crate) struct Dlocal {
+    pub x_login: String,
+    pub x_trans_key: String,
+    pub secret: String,
+}
+#[derive(Debug, Deserialize, Clone)]
+pub(crate) struct Fiserv {
+    pub api_key: String,
+    pub merchant_id: String,
+    pub api_secret: String,
+}
+#[derive(Debug, Deserialize, Clone)]
+pub(crate) struct Forte {
+    pub api_key: String,
+}
+#[derive(Debug, Deserialize, Clone)]
+pub(crate) struct Globalpay {
+    pub globalpay_app_id: String,
+    pub globalpay_app_key: String,
+}
+#[derive(Debug, Deserialize, Clone)]
+pub(crate) struct Klarna {
+    pub klarna_api_key: String,
+}
+#[derive(Debug, Deserialize, Clone)]
+pub(crate) struct Mollie {
+    pub api_key: String,
+}
+#[derive(Debug, Deserialize, Clone)]
+pub(crate) struct Multisafepay {
+    pub api_key: String,
+}
+#[derive(Debug, Deserialize, Clone)]
+pub(crate) struct Nexinets {
+    pub api_key: String,
+}
+#[derive(Debug, Deserialize, Clone)]
+pub(crate) struct Nuvei {
+    pub merchant_id: String,
+    pub merchant_site_id: String,
+    pub merchant_secret: String,
+}
+#[derive(Debug, Deserialize, Clone)]
+pub(crate) struct Opennode {
+    pub api_key: String,
+}
+#[derive(Debug, Deserialize, Clone)]
+pub(crate) struct Payeezy {
+    pub api_key: String,
+    pub api_secret: String,
+    pub merchant_token: String,
+}
+#[derive(Debug, Deserialize, Clone)]
+pub(crate) struct Paypal {
+    pub api_key: String,
+    pub api_secret: String,
+}
+#[derive(Debug, Deserialize, Clone)]
+pub(crate) struct Payu {
+    pub api_key: String,
+    pub merchant_pos_id: String,
+}
+#[derive(Debug, Deserialize, Clone)]
+pub(crate) struct Rapyd {
+    pub api_secret: String,
+    pub secret_key: String,
+}
+#[derive(Debug, Deserialize, Clone)]
+pub(crate) struct Shift4 {
+    pub shift4_api_key: String,
+}
+#[derive(Debug, Deserialize, Clone)]
+pub(crate) struct Stripe {
+    pub stripe_api_key: String,
+}
+#[derive(Debug, Deserialize, Clone)]
+pub(crate) struct TrustPay {
+    pub api_key: String,
+    pub project_id: String,
+    pub secret_key: String,
+}
+#[derive(Debug, Deserialize, Clone)]
+pub(crate) struct Worldline {
+    pub api_key: String,
+    pub api_secret: String,
+    pub merchant_account_id: String,
+}
+#[derive(Debug, Deserialize, Clone)]
+pub(crate) struct Worldpay {
+    pub username: String,
+    pub password: String,
 }

--- a/crates/router/tests/connectors/connector_auth.rs
+++ b/crates/router/tests/connectors/connector_auth.rs
@@ -50,7 +50,7 @@ impl ConnectorAuthentication {
 //-------
 impl From<Aci> for ConnectorAuthType {
     fn from(key: Aci) -> Self {
-        Self::Aci {
+        common_enums::AciAuthType {
             api_key: key.api_key,
             entity_id: key.entity_id,
         }
@@ -58,7 +58,7 @@ impl From<Aci> for ConnectorAuthType {
 }
 impl From<Adyen> for ConnectorAuthType {
     fn from(key: Adyen) -> Self {
-        Self::Adyen {
+        common_enums::AdyenAuthType {
             adyen_api_key: key.adyen_api_key,
             adyen_account_id: key.adyen_account_id,
         }
@@ -66,7 +66,7 @@ impl From<Adyen> for ConnectorAuthType {
 }
 impl From<Airwallex> for ConnectorAuthType {
     fn from(key: Airwallex) -> Self {
-        Self::Airwallex {
+        common_enums::AirwallexAuthType {
             app_id: key.app_id,
             key1: key.key1
         }
@@ -74,7 +74,7 @@ impl From<Airwallex> for ConnectorAuthType {
 }
 impl From<Authorizedotnet> for ConnectorAuthType {
     fn from(key: Authorizedotnet) -> Self {
-        Self::Authorizedotnet {
+        common_enums::AuthorizedotnetAuthType {
             api_login_id: key.api_login_id,
             transaction_key: key.transaction_key,
         }
@@ -82,7 +82,7 @@ impl From<Authorizedotnet> for ConnectorAuthType {
 }
 impl From<Bambora> for ConnectorAuthType {
     fn from(key: Bambora) -> Self {
-        Self::Bambora {
+        common_enums::BamboraAuthType {
             passcode: key.passcode,
             merchant_id: key.merchant_id,
         }
@@ -90,7 +90,7 @@ impl From<Bambora> for ConnectorAuthType {
 }
 impl From<Bluesnap> for ConnectorAuthType {
     fn from(key: Bluesnap) -> Self {
-        Self::Bluesnap {
+        common_enums::BluesnapAuthType {
             username: key.username,
             password: key.password,
         }
@@ -98,7 +98,7 @@ impl From<Bluesnap> for ConnectorAuthType {
 }
 impl From<Braintree> for ConnectorAuthType {
     fn from(key: Braintree) -> Self {
-        Self::Braintree {
+        common_enums::BraintreeAuthType {
             public_key: key.public_key,
             merchant_id: key.merchant_id,
             private_key: key.private_key,
@@ -107,7 +107,7 @@ impl From<Braintree> for ConnectorAuthType {
 }
 impl From<Checkout> for ConnectorAuthType {
     fn from(key: Checkout) -> Self {
-        Self::Checkout {
+        common_enums::CheckoutAuthType {
             checkout_api_key: key.checkout_api_key,
             processing_channel_id: key.processing_channel_id,
         }
@@ -115,15 +115,15 @@ impl From<Checkout> for ConnectorAuthType {
 }
 impl From<Coinbase> for ConnectorAuthType {
     fn from(key: Coinbase) -> Self {
-        Self::Coinbase {
+        common_enums::CoinbaseAuthType {
             api_key: key.api_key,
         }
     }
 }
 impl From<Cybersource> for ConnectorAuthType {
     fn from(key: Cybersource) -> Self {
-        Self::Cybersource {
-            key: key.key,
+        common_enums::CybersourceAuthType {
+            api_key: key.api_key,
             merchant_account: key.merchant_account,
             api_secret: key.api_secret,
         }
@@ -132,7 +132,7 @@ impl From<Cybersource> for ConnectorAuthType {
 
 impl From<Dlocal> for ConnectorAuthType {
     fn from(key: Dlocal) -> Self {
-        Self::Dlocal {
+        common_enums::DlocalAuthType {
             x_login: key.x_login,
             x_trans_key: key.x_trans_key,
             secret: key.secret,
@@ -141,7 +141,7 @@ impl From<Dlocal> for ConnectorAuthType {
 }
 impl From<Fiserv> for ConnectorAuthType {
     fn from(key: Fiserv) -> Self {
-        Self::Fiserv {
+        common_enums::FiservAuthType {
             api_key: key.api_key,
             merchant_id: key.merchant_id,
             api_secret: key.api_secret,
@@ -150,14 +150,14 @@ impl From<Fiserv> for ConnectorAuthType {
 }
 impl From<Forte> for ConnectorAuthType {
     fn from(key: Forte) -> Self {
-        Self::Forte {
+        common_enums::ForteAuthType {
             api_key: key.api_key,
         }
     }
 }
 impl From<Globalpay> for ConnectorAuthType {
     fn from(key: Globalpay) -> Self {
-        Self::Globalpay {
+        common_enums::GlobalpayAuthType {
             globalpay_app_id: key.globalpay_app_id,
             globalpay_app_key: key.globalpay_app_key,
         }
@@ -165,35 +165,35 @@ impl From<Globalpay> for ConnectorAuthType {
 }
 impl From<Klarna> for ConnectorAuthType {
     fn from(key: Klarna) -> Self {
-        Self::Klarna {
+        common_enums::KlarnaAuthType {
             klarna_api_key: key.klarna_api_key,
         }
     }
 }
 impl From<Mollie> for ConnectorAuthType {
     fn from(key: Mollie) -> Self {
-        Self::Mollie {
+        common_enums::MollieAuthType {
             api_key: key.api_key,
         }
     }
 }
 impl From<Multisafepay> for ConnectorAuthType {
     fn from(key: Multisafepay) -> Self {
-        Self::Multisafepay {
+        common_enums::MultisafepayAuthType {
             api_key: key.api_key,
         }
     }
 }
 impl From<Nexinets> for ConnectorAuthType {
     fn from(key: Nexinets) -> Self {
-        Self::Nexinets {
+        common_enums::NexinetsAuthType {
             api_key: key.api_key,
         }
     }
 }
 impl From<Nuvei> for ConnectorAuthType {
     fn from(key: Nuvei) -> Self {
-        Self::Nuvei {
+        common_enums::NuveiAuthType {
             merchant_id: key.merchant_id,
             merchant_site_id: key.merchant_site_id,
             merchant_secret: key.merchant_secret,
@@ -202,14 +202,14 @@ impl From<Nuvei> for ConnectorAuthType {
 }
 impl From<Opennode> for ConnectorAuthType {
     fn from(key: Opennode) -> Self {
-        Self::Opennode {
+        common_enums::OpennodeAuthType {
             api_key: key.api_key,
         }
     }
 }
 impl From<Payeezy> for ConnectorAuthType {
     fn from(key: Payeezy) -> Self {
-        Self::Payeezy {
+        common_enums::PayeezyAuthType {
             api_key: key.api_key,
             api_secret: key.api_secret,
             merchant_token: key.merchant_token,
@@ -218,7 +218,7 @@ impl From<Payeezy> for ConnectorAuthType {
 }
 impl From<Paypal> for ConnectorAuthType {
     fn from(key: Paypal) -> Self {
-        Self::Paypal {
+        common_enums::PaypalAuthType {
             api_key: key.api_key,
             api_secret: key.api_secret,
         }
@@ -226,7 +226,7 @@ impl From<Paypal> for ConnectorAuthType {
 }
 impl From<Payu> for ConnectorAuthType {
     fn from(key: Payu) -> Self {
-        Self::Payu {
+        common_enums::PayuAuthType {
             api_key: key.api_key,
             merchant_pos_id: key.merchant_pos_id,
         }
@@ -234,7 +234,7 @@ impl From<Payu> for ConnectorAuthType {
 }
 impl From<Rapyd> for ConnectorAuthType {
     fn from(key: Rapyd) -> Self {
-        Self::Rapyd {
+        common_enums::RapydAuthType {
             api_secret: key.api_secret,
             secret_key: key.secret_key,
         }
@@ -242,21 +242,21 @@ impl From<Rapyd> for ConnectorAuthType {
 }
 impl From<Shift4> for ConnectorAuthType {
     fn from(key: Shift4) -> Self {
-        Self::Shift4 {
+        common_enums::Shift4AuthType {
             shift4_api_key: key.shift4_api_key,
         }
     }
 }
 impl From<Stripe> for ConnectorAuthType {
     fn from(key: Stripe) -> Self {
-        Self::Stripe {
+        common_enums::StripeAuthType {
             stripe_api_key: key.stripe_api_key,
         }
     }
 }
 impl From<TrustPay> for ConnectorAuthType {
     fn from(key: TrustPay) -> Self {
-        Self::TrustPay {
+        common_enums::TrustpayAuthType {
             api_key: key.api_key,
             project_id: key.project_id,
             secret_key: key.secret_key,
@@ -265,7 +265,7 @@ impl From<TrustPay> for ConnectorAuthType {
 }
 impl From<Worldline> for ConnectorAuthType {
     fn from(key: Worldline) -> Self {
-        Self::Worldline {
+        common_enums::WorldlineAuthType {
             api_key: key.api_key,
             api_secret: key.api_secret,
             merchant_account_id: key.merchant_account_id,
@@ -274,7 +274,7 @@ impl From<Worldline> for ConnectorAuthType {
 }
 impl From<Worldpay> for ConnectorAuthType {
     fn from(key: Worldpay) -> Self {
-        Self::Worldpay {
+        common_enums::WorldpayAuthType {
             username: key.username,
             password: key.password,
         }
@@ -329,7 +329,7 @@ pub(crate) struct Coinbase {
 //TODO:need to check  
 #[derive(Debug, Deserialize, Clone)]
 pub(crate) struct Cybersource {
-    pub key: String,
+    pub api_key: String,
     pub merchant_account: String,
     pub api_secret: String,
 }

--- a/crates/router/tests/connectors/cybersource.rs
+++ b/crates/router/tests/connectors/cybersource.rs
@@ -19,8 +19,8 @@ impl utils::Connector for Cybersource {
             get_token: types::api::GetToken::Connector,
         }
     }
-    fn get_auth_token(&self) -> types::ConnectorAuthType {
-        types::ConnectorAuthType::from(
+    fn get_auth_token(&self) -> common_enums::ConnectorAuthType {
+        common_enums::ConnectorAuthType::from(
             connector_auth::ConnectorAuthentication::new()
                 .cybersource
                 .expect("Missing connector authentication configuration"),

--- a/crates/router/tests/connectors/dlocal.rs
+++ b/crates/router/tests/connectors/dlocal.rs
@@ -20,8 +20,8 @@ impl utils::Connector for DlocalTest {
         }
     }
 
-    fn get_auth_token(&self) -> types::ConnectorAuthType {
-        types::ConnectorAuthType::from(
+    fn get_auth_token(&self) -> common_enums::ConnectorAuthType {
+        common_enums::ConnectorAuthType::from(
             connector_auth::ConnectorAuthentication::new()
                 .dlocal
                 .expect("Missing connector authentication configuration"),

--- a/crates/router/tests/connectors/fiserv.rs
+++ b/crates/router/tests/connectors/fiserv.rs
@@ -20,8 +20,8 @@ impl utils::Connector for FiservTest {
         }
     }
 
-    fn get_auth_token(&self) -> types::ConnectorAuthType {
-        types::ConnectorAuthType::from(
+    fn get_auth_token(&self) -> common_enums::ConnectorAuthType {
+        common_enums::ConnectorAuthType::from(
             connector_auth::ConnectorAuthentication::new()
                 .fiserv
                 .expect("Missing connector authentication configuration"),

--- a/crates/router/tests/connectors/forte.rs
+++ b/crates/router/tests/connectors/forte.rs
@@ -19,8 +19,8 @@ impl utils::Connector for ForteTest {
         }
     }
 
-    fn get_auth_token(&self) -> types::ConnectorAuthType {
-        types::ConnectorAuthType::from(
+    fn get_auth_token(&self) -> common_enums::ConnectorAuthType {
+        common_enums::ConnectorAuthType::from(
             connector_auth::ConnectorAuthentication::new()
                 .forte
                 .expect("Missing connector authentication configuration"),

--- a/crates/router/tests/connectors/globalpay.rs
+++ b/crates/router/tests/connectors/globalpay.rs
@@ -19,8 +19,8 @@ impl utils::Connector for Globalpay {
         }
     }
 
-    fn get_auth_token(&self) -> types::ConnectorAuthType {
-        types::ConnectorAuthType::from(
+    fn get_auth_token(&self) -> common_enums::ConnectorAuthType {
+        common_enums::ConnectorAuthType::from(
             connector_auth::ConnectorAuthentication::new()
                 .globalpay
                 .expect("Missing connector authentication configuration"),

--- a/crates/router/tests/connectors/mollie.rs
+++ b/crates/router/tests/connectors/mollie.rs
@@ -18,8 +18,8 @@ impl utils::Connector for MollieTest {
         }
     }
 
-    fn get_auth_token(&self) -> types::ConnectorAuthType {
-        types::ConnectorAuthType::from(
+    fn get_auth_token(&self) -> common_enums::ConnectorAuthType {
+        common_enums::ConnectorAuthType::from(
             connector_auth::ConnectorAuthentication::new()
                 .mollie
                 .expect("Missing connector authentication configuration"),

--- a/crates/router/tests/connectors/multisafepay.rs
+++ b/crates/router/tests/connectors/multisafepay.rs
@@ -19,8 +19,8 @@ impl utils::Connector for MultisafepayTest {
         }
     }
 
-    fn get_auth_token(&self) -> types::ConnectorAuthType {
-        types::ConnectorAuthType::from(
+    fn get_auth_token(&self) -> common_enums::ConnectorAuthType {
+        common_enums::ConnectorAuthType::from(
             connector_auth::ConnectorAuthentication::new()
                 .multisafepay
                 .expect("Missing connector authentication configuration"),

--- a/crates/router/tests/connectors/nexinets.rs
+++ b/crates/router/tests/connectors/nexinets.rs
@@ -19,8 +19,8 @@ impl utils::Connector for NexinetsTest {
         }
     }
 
-    fn get_auth_token(&self) -> types::ConnectorAuthType {
-        types::ConnectorAuthType::from(
+    fn get_auth_token(&self) -> common_enums::ConnectorAuthType {
+        common_enums::ConnectorAuthType::from(
             connector_auth::ConnectorAuthentication::new()
                 .nexinets
                 .expect("Missing connector authentication configuration"),

--- a/crates/router/tests/connectors/nuvei.rs
+++ b/crates/router/tests/connectors/nuvei.rs
@@ -23,8 +23,8 @@ impl utils::Connector for NuveiTest {
         }
     }
 
-    fn get_auth_token(&self) -> types::ConnectorAuthType {
-        types::ConnectorAuthType::from(
+    fn get_auth_token(&self) -> common_enums::ConnectorAuthType {
+        common_enums::ConnectorAuthType::from(
             connector_auth::ConnectorAuthentication::new()
                 .nuvei
                 .expect("Missing connector authentication configuration"),

--- a/crates/router/tests/connectors/opennode.rs
+++ b/crates/router/tests/connectors/opennode.rs
@@ -19,8 +19,8 @@ impl utils::Connector for OpennodeTest {
         }
     }
 
-    fn get_auth_token(&self) -> types::ConnectorAuthType {
-        types::ConnectorAuthType::from(
+    fn get_auth_token(&self) -> common_enums::ConnectorAuthType {
+        common_enums::ConnectorAuthType::from(
             connector_auth::ConnectorAuthentication::new()
                 .opennode
                 .expect("Missing connector authentication configuration"),

--- a/crates/router/tests/connectors/payeezy.rs
+++ b/crates/router/tests/connectors/payeezy.rs
@@ -24,8 +24,8 @@ impl utils::Connector for PayeezyTest {
         }
     }
 
-    fn get_auth_token(&self) -> types::ConnectorAuthType {
-        types::ConnectorAuthType::from(
+    fn get_auth_token(&self) -> common_enums::ConnectorAuthType {
+        common_enums::ConnectorAuthType::from(
             connector_auth::ConnectorAuthentication::new()
                 .payeezy
                 .expect("Missing connector authentication configuration"),

--- a/crates/router/tests/connectors/paypal.rs
+++ b/crates/router/tests/connectors/paypal.rs
@@ -1,5 +1,6 @@
+use common_enums::ConnectorAuthType;
 use masking::Secret;
-use router::types::{self, api, storage::enums, AccessToken, ConnectorAuthType};
+use router::types::{self, api, storage::enums, AccessToken};
 
 use crate::{
     connector_auth,
@@ -19,7 +20,7 @@ impl Connector for PaypalTest {
     }
 
     fn get_auth_token(&self) -> ConnectorAuthType {
-        types::ConnectorAuthType::from(
+        common_enums::ConnectorAuthType::from(
             connector_auth::ConnectorAuthentication::new()
                 .paypal
                 .expect("Missing connector authentication configuration"),
@@ -36,7 +37,7 @@ fn get_access_token() -> Option<AccessToken> {
     let connector = PaypalTest {};
 
     match connector.get_auth_token() {
-        ConnectorAuthType::BodyKey { api_key, key1: _ } => Some(AccessToken {
+        ConnectorAuthType::Paypal { api_key, api_secret: _ } => Some(AccessToken {
             token: api_key,
             expires: 18600,
         }),

--- a/crates/router/tests/connectors/paypal.rs
+++ b/crates/router/tests/connectors/paypal.rs
@@ -37,8 +37,8 @@ fn get_access_token() -> Option<AccessToken> {
     let connector = PaypalTest {};
 
     match connector.get_auth_token() {
-        ConnectorAuthType::Paypal { api_key, api_secret: _ } => Some(AccessToken {
-            token: api_key,
+        ConnectorAuthType::Paypal (_auth) => Some(AccessToken {
+            token: _auth.api_key,
             expires: 18600,
         }),
         _ => None,

--- a/crates/router/tests/connectors/payu.rs
+++ b/crates/router/tests/connectors/payu.rs
@@ -33,9 +33,9 @@ impl Connector for Payu {
 fn get_access_token() -> Option<AccessToken> {
     let connector = Payu {};
     match connector.get_auth_token() {
-        ConnectorAuthType::Payu { api_key, merchant_pos_id } => Some(AccessToken {
-            token: api_key,
-            expires: merchant_pos_id.parse::<i64>().unwrap(),
+        ConnectorAuthType::Payu (_auth) => Some(AccessToken {
+            token: _auth.api_key,
+            expires: _auth.merchant_pos_id.parse::<i64>().unwrap(),
         }),
         _ => None,
     }

--- a/crates/router/tests/connectors/payu.rs
+++ b/crates/router/tests/connectors/payu.rs
@@ -1,4 +1,5 @@
-use router::types::{self, api, storage::enums, AccessToken, ConnectorAuthType};
+use router::types::{self, api, storage::enums, AccessToken};
+use common_enums::ConnectorAuthType;
 
 use crate::{
     connector_auth,
@@ -17,7 +18,7 @@ impl Connector for Payu {
     }
 
     fn get_auth_token(&self) -> ConnectorAuthType {
-        types::ConnectorAuthType::from(
+        common_enums::ConnectorAuthType::from(
             connector_auth::ConnectorAuthentication::new()
                 .payu
                 .expect("Missing connector authentication configuration"),
@@ -32,9 +33,9 @@ impl Connector for Payu {
 fn get_access_token() -> Option<AccessToken> {
     let connector = Payu {};
     match connector.get_auth_token() {
-        ConnectorAuthType::BodyKey { api_key, key1 } => Some(AccessToken {
+        ConnectorAuthType::Payu { api_key, merchant_pos_id } => Some(AccessToken {
             token: api_key,
-            expires: key1.parse::<i64>().unwrap(),
+            expires: merchant_pos_id.parse::<i64>().unwrap(),
         }),
         _ => None,
     }

--- a/crates/router/tests/connectors/rapyd.rs
+++ b/crates/router/tests/connectors/rapyd.rs
@@ -20,8 +20,8 @@ impl utils::Connector for Rapyd {
         }
     }
 
-    fn get_auth_token(&self) -> types::ConnectorAuthType {
-        types::ConnectorAuthType::from(
+    fn get_auth_token(&self) -> common_enums::ConnectorAuthType {
+        common_enums::ConnectorAuthType::from(
             connector_auth::ConnectorAuthentication::new()
                 .rapyd
                 .expect("Missing connector authentication configuration"),

--- a/crates/router/tests/connectors/sample_auth.toml
+++ b/crates/router/tests/connectors/sample_auth.toml
@@ -18,7 +18,7 @@ checkout_api_key = "Bearer MyApiKey"
 processing_channel_id = "MyProcessingChannelId"
 
 [cybersource]
-key = "Bearer MyApiKey"
+api_key = "Bearer MyApiKey"
 merchant_account = "Merchant id"
 api_secret = "Secret key"
 

--- a/crates/router/tests/connectors/sample_auth.toml
+++ b/crates/router/tests/connectors/sample_auth.toml
@@ -3,50 +3,51 @@
 
 [aci]
 api_key = "Bearer MyApiKey"
-key1 = "MyEntityId"
+entity_id = "MyEntityId"
 
 [adyen]
-api_key = "Bearer MyApiKey"
-key1 = "MerchantId"
+adyen_api_key = "Bearer MyApiKey"
+adyen_account_id = "MerchantId"
 
 [authorizedotnet]
-api_key = "MyMerchantName"
-key1 = "MyTransactionKey"
+api_login_id = "MyMerchantName"
+transaction_key = "MyTransactionKey"
 
 [checkout]
-api_key = "Bearer MyApiKey"
-key1 = "MyProcessingChannelId"
+checkout_api_key = "Bearer MyApiKey"
+processing_channel_id = "MyProcessingChannelId"
 
 [cybersource]
-api_key = "Bearer MyApiKey"
-key1 = "Merchant id"
+key = "Bearer MyApiKey"
+merchant_account = "Merchant id"
 api_secret = "Secret key"
 
 [shift4]
-api_key = "Bearer MyApiKey"
+shift4_api_key = "Bearer MyApiKey"
 
 [worldpay]
-api_key = "api_key"
-key1 = "key1"
+username = "api_key"
+password = "key1"
 
 [payu]
-api_key = "Bearer MyApiKey"
-key1 = "MerchantPosId"
+api_secret = "Bearer MyApiKey"
+secret_key = "MerchantPosId"
 
+# TODO: need to check once 
 [globalpay]
 api_key = "Bearer MyApiKey"
 
 [rapyd]
-api_key = "access_key"
-key1 = "secret_key"
+api_secret = "access_key"
+secret_key = "secret_key"
 
 [fiserv]
 api_key = "MyApiKey"
-key1 = "MerchantID"
+merchant_id = "MerchantID"
 api_secret = "MySecretKey"
 
 [worldline]
-key1 = "Merchant Id"
+merchant_account_id = "Merchant Id"
 api_key = "API Key"
 api_secret = "API Secret Key"
 
@@ -54,29 +55,28 @@ api_secret = "API Secret Key"
 api_key = "API Key"
 
 [dlocal]
-key1 = "key1"
-api_key = "api_key"
-api_secret = "secret"
+x_login = "key1"
+x_trans_key = "api_key"
+secret = "secret"
 
 [bambora]
-api_key = "api_key"
-key1= "key1"
+passcode = "api_key"
+merchant_id= "key1"
 
 [nuvei]
-api_key = "api_key"
-key1 = "key1"
-api_secret = "secret"
+merchant_id = "api_key"
+merchant_site_id = "key1"
+merchant_secret = "secret"
 
 [paypal]
 api_key = "api_key"
-key1 = "key1"
+api_secret = "key1"
 
 [mollie]
 api_key = "API Key"
 
 [forte]
 api_key="API Key"
-
 
 [coinbase]
 api_key="API Key"
@@ -90,5 +90,5 @@ key1 = "key1"
 
 [payeezy]
 api_key = "api_key"
-key1 = "key1"
+merchant_token = "key1"
 api_secret = "secret"

--- a/crates/router/tests/connectors/shift4.rs
+++ b/crates/router/tests/connectors/shift4.rs
@@ -19,8 +19,8 @@ impl utils::Connector for Shift4Test {
         }
     }
 
-    fn get_auth_token(&self) -> types::ConnectorAuthType {
-        types::ConnectorAuthType::from(
+    fn get_auth_token(&self) -> common_enums::ConnectorAuthType {
+        common_enums::ConnectorAuthType::from(
             connector_auth::ConnectorAuthentication::new()
                 .shift4
                 .expect("Missing connector authentication configuration"),

--- a/crates/router/tests/connectors/stripe.rs
+++ b/crates/router/tests/connectors/stripe.rs
@@ -18,8 +18,8 @@ impl utils::Connector for Stripe {
         }
     }
 
-    fn get_auth_token(&self) -> types::ConnectorAuthType {
-        types::ConnectorAuthType::from(
+    fn get_auth_token(&self) -> common_enums::ConnectorAuthType {
+        common_enums::ConnectorAuthType::from(
             connector_auth::ConnectorAuthentication::new()
                 .stripe
                 .expect("Missing connector authentication configuration"),

--- a/crates/router/tests/connectors/trustpay.rs
+++ b/crates/router/tests/connectors/trustpay.rs
@@ -19,8 +19,8 @@ impl utils::Connector for TrustpayTest {
         }
     }
 
-    fn get_auth_token(&self) -> types::ConnectorAuthType {
-        types::ConnectorAuthType::from(
+    fn get_auth_token(&self) -> common_enums::ConnectorAuthType {
+        common_enums::ConnectorAuthType::from(
             connector_auth::ConnectorAuthentication::new()
                 .trustpay
                 .expect("Missing connector authentication configuration"),

--- a/crates/router/tests/connectors/utils.rs
+++ b/crates/router/tests/connectors/utils.rs
@@ -14,7 +14,7 @@ use wiremock::{Mock, MockServer};
 
 pub trait Connector {
     fn get_data(&self) -> types::api::ConnectorData;
-    fn get_auth_token(&self) -> types::ConnectorAuthType;
+    fn get_auth_token(&self) -> common_enums::ConnectorAuthType;
     fn get_name(&self) -> String;
     fn get_connector_meta(&self) -> Option<serde_json::Value> {
         None

--- a/crates/router/tests/connectors/worldline.rs
+++ b/crates/router/tests/connectors/worldline.rs
@@ -23,8 +23,8 @@ impl utils::Connector for WorldlineTest {
         }
     }
 
-    fn get_auth_token(&self) -> types::ConnectorAuthType {
-        types::ConnectorAuthType::from(
+    fn get_auth_token(&self) -> common_enums::ConnectorAuthType {
+        common_enums::ConnectorAuthType::from(
             ConnectorAuthentication::new()
                 .worldline
                 .expect("Missing connector authentication configuration"),

--- a/crates/router/tests/connectors/worldpay.rs
+++ b/crates/router/tests/connectors/worldpay.rs
@@ -26,8 +26,8 @@ impl utils::Connector for Worldpay {
         }
     }
 
-    fn get_auth_token(&self) -> types::ConnectorAuthType {
-        types::ConnectorAuthType::from(
+    fn get_auth_token(&self) -> common_enums::ConnectorAuthType {
+        common_enums::ConnectorAuthType::from(
             connector_auth::ConnectorAuthentication::new()
                 .worldpay
                 .expect("Missing connector authentication configuration"),

--- a/crates/router/tests/integration_demo.rs
+++ b/crates/router/tests/integration_demo.rs
@@ -77,7 +77,7 @@ async fn partial_refund() {
             &server,
             &merchant_id,
             "stripe",
-            &authentication.checkout.unwrap().api_key,
+            &authentication.checkout.unwrap().checkout_api_key,
         )
         .await;
 
@@ -143,7 +143,7 @@ async fn exceed_refund() {
             &server,
             &merchant_id,
             "stripe",
-            &authentication.checkout.unwrap().api_key,
+            &authentication.checkout.unwrap().checkout_api_key,
         )
         .await;
 

--- a/crates/storage_models/src/enums.rs
+++ b/crates/storage_models/src/enums.rs
@@ -128,7 +128,6 @@ pub enum ConnectorType {
     PaymentVas,
     /// Accounting, Billing, Invoicing, Tax etc
     FinOperations,
-    /// Inventory, ERP, CRM, KYC etc
     FizOperations,
     /// Payment Networks like Visa, MasterCard etc
     Networks,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates

## Description
In this PR the general ConnectorAuth types `headerkey` `body key` `signatureKey` to connector specific Auth Types
this change will reflect `Payment connector - create` API request body {connector_account_details} - The keys will be different for each connector - you can find old and new keys as  [change](https://github.com/juspay/hyperswitch/pull/867/commits/a2d29e7b6707bfa9fed3b61da19889f67b15cec9#diff-b59a23bf9075ffa14151e4e1830b831e75a1d3e30d086426b2f9e28e6036c25c)
<!-- Describe your changes in detail -->
[sheet](https://docs.google.com/spreadsheets/d/1CM5yLrdZiccruZEEDoYb9BfaI1zozSQBYFlb-ATOMPw/edit#gid=748960791)
<!-- 
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->

## How did you test it?
tested this change manually from postman

<!--
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
