### PR TITLE
fix: Update events table after notifying merchant

### DIFF
--- a/crates/router/src/core/errors.rs
+++ b/crates/router/src/core/errors.rs
@@ -430,6 +430,8 @@ pub enum WebhooksFlowError {
     DisputeCoreFailed,
     #[error("Webhook event creation failed")]
     WebhookEventCreationFailed,
+    #[error("Webhook event updation failed")]
+    WebhookEventUpdationFailed,
     #[error("Unable to fork webhooks flow for outgoing webhooks")]
     ForkFlowFailed,
     #[error("Webhook api call to merchant failed")]

--- a/crates/router/src/db/events.rs
+++ b/crates/router/src/db/events.rs
@@ -13,6 +13,11 @@ pub trait EventInterface {
         &self,
         event: storage::EventNew,
     ) -> CustomResult<storage::Event, errors::StorageError>;
+    async fn update_event(
+        &self,
+        event_id: String,
+        event: storage::EventUpdate,
+    ) -> CustomResult<storage::Event, errors::StorageError>;
 }
 
 #[async_trait::async_trait]
@@ -24,6 +29,17 @@ impl EventInterface for Store {
         let conn = connection::pg_connection_write(self).await?;
         event.insert(&conn).await.map_err(Into::into).into_report()
     }
+    async fn update_event(
+        &self,
+        event_id: String,
+        event: storage::EventUpdate,
+    ) -> CustomResult<storage::Event, errors::StorageError> {
+        let conn = connection::pg_connection_write(self).await?;
+        storage::Event::update(&conn, &event_id, event)
+            .await
+            .map_err(Into::into)
+            .into_report()
+    }
 }
 
 #[async_trait::async_trait]
@@ -33,6 +49,13 @@ impl EventInterface for MockDb {
         _event: storage::EventNew,
     ) -> CustomResult<storage::Event, errors::StorageError> {
         // [#172]: Implement function for `MockDb`
+        Err(errors::StorageError::MockDbError)?
+    }
+    async fn update_event(
+        &self,
+        _event_id: String,
+        _event: storage::EventUpdate,
+    ) -> CustomResult<storage::Event, errors::StorageError> {
         Err(errors::StorageError::MockDbError)?
     }
 }

--- a/crates/router/src/types/storage/events.rs
+++ b/crates/router/src/types/storage/events.rs
@@ -1,1 +1,1 @@
-pub use storage_models::events::{Event, EventNew};
+pub use storage_models::events::{Event, EventNew, EventUpdate};

--- a/crates/storage_models/src/events.rs
+++ b/crates/storage_models/src/events.rs
@@ -19,24 +19,14 @@ pub struct EventNew {
 }
 
 #[derive(Debug)]
-pub struct EventUpdate {
-    pub event_type: Option<storage_enums::EventType>,
-    pub event_class: Option<storage_enums::EventClass>,
-    pub is_webhook_notified: Option<bool>,
-    pub intent_reference_id: Option<String>,
-    pub primary_object_id: Option<String>,
-    pub primary_object_type: Option<storage_enums::EventObjectType>,
+pub enum EventUpdate {
+    UpdateWebhookNotified { is_webhook_notified: Option<bool> },
 }
 
 #[derive(Clone, Debug, Default, AsChangeset, router_derive::DebugAsDisplay)]
 #[diesel(table_name = events)]
 pub struct EventUpdateInternal {
-    pub event_type: Option<storage_enums::EventType>,
-    pub event_class: Option<storage_enums::EventClass>,
     pub is_webhook_notified: Option<bool>,
-    pub intent_reference_id: Option<String>,
-    pub primary_object_id: Option<String>,
-    pub primary_object_type: Option<storage_enums::EventObjectType>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, Identifiable, Queryable)]
@@ -57,13 +47,12 @@ pub struct Event {
 
 impl From<EventUpdate> for EventUpdateInternal {
     fn from(event_update: EventUpdate) -> Self {
-        Self {
-            event_type: event_update.event_type,
-            event_class: event_update.event_class,
-            is_webhook_notified: event_update.is_webhook_notified,
-            intent_reference_id: event_update.intent_reference_id,
-            primary_object_id: event_update.primary_object_id,
-            primary_object_type: event_update.primary_object_type,
+        match event_update {
+            EventUpdate::UpdateWebhookNotified {
+                is_webhook_notified,
+            } => Self {
+                is_webhook_notified,
+            },
         }
     }
 }

--- a/crates/storage_models/src/events.rs
+++ b/crates/storage_models/src/events.rs
@@ -1,5 +1,5 @@
 use common_utils::custom_serde;
-use diesel::{Identifiable, Insertable, Queryable};
+use diesel::{AsChangeset, Identifiable, Insertable, Queryable};
 use serde::{Deserialize, Serialize};
 use time::PrimitiveDateTime;
 
@@ -18,6 +18,27 @@ pub struct EventNew {
     pub primary_object_type: storage_enums::EventObjectType,
 }
 
+#[derive(Debug)]
+pub struct EventUpdate {
+    pub event_type: Option<storage_enums::EventType>,
+    pub event_class: Option<storage_enums::EventClass>,
+    pub is_webhook_notified: Option<bool>,
+    pub intent_reference_id: Option<String>,
+    pub primary_object_id: Option<String>,
+    pub primary_object_type: Option<storage_enums::EventObjectType>,
+}
+
+#[derive(Clone, Debug, Default, AsChangeset, router_derive::DebugAsDisplay)]
+#[diesel(table_name = events)]
+pub struct EventUpdateInternal {
+    pub event_type: Option<storage_enums::EventType>,
+    pub event_class: Option<storage_enums::EventClass>,
+    pub is_webhook_notified: Option<bool>,
+    pub intent_reference_id: Option<String>,
+    pub primary_object_id: Option<String>,
+    pub primary_object_type: Option<storage_enums::EventObjectType>,
+}
+
 #[derive(Clone, Debug, Deserialize, Serialize, Identifiable, Queryable)]
 #[diesel(table_name = events)]
 pub struct Event {
@@ -32,4 +53,17 @@ pub struct Event {
     pub primary_object_type: storage_enums::EventObjectType,
     #[serde(with = "custom_serde::iso8601")]
     pub created_at: PrimitiveDateTime,
+}
+
+impl From<EventUpdate> for EventUpdateInternal {
+    fn from(event_update: EventUpdate) -> Self {
+        Self {
+            event_type: event_update.event_type,
+            event_class: event_update.event_class,
+            is_webhook_notified: event_update.is_webhook_notified,
+            intent_reference_id: event_update.intent_reference_id,
+            primary_object_id: event_update.primary_object_id,
+            primary_object_type: event_update.primary_object_type,
+        }
+    }
 }

--- a/crates/storage_models/src/query/events.rs
+++ b/crates/storage_models/src/query/events.rs
@@ -1,8 +1,10 @@
+use diesel::{associations::HasTable, ExpressionMethods};
 use router_env::{instrument, tracing};
 
 use super::generics;
 use crate::{
-    events::{Event, EventNew},
+    events::{Event, EventNew, EventUpdate, EventUpdateInternal},
+    schema::events::dsl,
     PgPooledConn, StorageResult,
 };
 
@@ -10,5 +12,26 @@ impl EventNew {
     #[instrument(skip(conn))]
     pub async fn insert(self, conn: &PgPooledConn) -> StorageResult<Event> {
         generics::generic_insert(conn, self).await
+    }
+}
+
+impl Event {
+    #[instrument(skip(conn))]
+    pub async fn update(
+        conn: &PgPooledConn,
+        event_id: &str,
+        event: EventUpdate,
+    ) -> StorageResult<Self> {
+        generics::generic_update_with_unique_predicate_get_result::<
+            <Self as HasTable>::Table,
+            _,
+            _,
+            _,
+        >(
+            conn,
+            dsl::event_id.eq(event_id.to_owned()),
+            EventUpdateInternal::from(event),
+        )
+        .await
     }
 }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->
Update the `is_webhook_notified` column in `events` table after an outgoing Webhook notification is successfully triggered.

### Additional Changes

- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!-- 
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
After triggering Webhook notification, db was not getting updated to record that a successful notification has been delivered to the merchant.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Triggered Webhooks and accordingly based on outgoing Webhook notification, observed the changes in `events` table.

![Screenshot 2023-04-13 at 12 24 40 PM](https://user-images.githubusercontent.com/55536657/231680052-6b513ce3-a5ab-4c4f-910e-8a7e9cfa10f8.png)




## Checklist
<!-- Put an `x` in the boxes that apply -->

- [X] I formatted the code `cargo +nightly fmt --all`
- [X] I addressed lints thrown by `cargo clippy`
- [X] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
