### PR TITLE
ci(manual_release): add `multiple_mca` feature in ci

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -11,6 +11,11 @@ on:
         options:
           - Sandbox
           - Production
+      backwards_compatibility:
+        description: "Whether to enable the backwards_compatibility feature"
+        required: true
+        default: true
+        type: boolean
 
 jobs:
   build:
@@ -27,11 +32,16 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_PASSWD }}
 
+      - name: Add backwards_compatibility feature if enabled
+        if: ${{ inputs.backwards_compatibility == true }}
+        run: echo "--features backwards_compatibility" >> EXTRA_FEATURES
+
       - name: Build and push router Docker image
         uses: docker/build-push-action@v4
         with:
           build-args: |
             RUN_ENV=${{ inputs.environment }}
+            EXTRA_FEATURES=EXTRA_FEATURES
             BINARY=router
           context: .
           push: true
@@ -53,7 +63,6 @@ jobs:
         with:
           build-args: |
             RUN_ENV=${{ inputs.environment }}
-            BINARY=scheduler
             SCHEDULER_FLOW=Producer
           context: .
           push: true

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -63,6 +63,7 @@ jobs:
         with:
           build-args: |
             RUN_ENV=${{ inputs.environment }}
+            BINARY=scheduler
             SCHEDULER_FLOW=Producer
           context: .
           push: true

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -11,10 +11,10 @@ on:
         options:
           - Sandbox
           - Production
-      backwards_compatibility:
-        description: "Whether to enable the backwards_compatibility feature"
+      multiple_mca:
+        description: "Whether to enable the multiple_mca feature"
         required: true
-        default: true
+        default: false
         type: boolean
 
 jobs:
@@ -32,9 +32,9 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_PASSWD }}
 
-      - name: Add backwards_compatibility feature if enabled
-        if: ${{ inputs.backwards_compatibility == true }}
-        run: echo "--features backwards_compatibility" >> EXTRA_FEATURES
+      - name: Add multiple_mca feature if enabled
+        if: ${{ inputs.multiple_mca == true }}
+        run: echo "--features multiple_mca" >> EXTRA_FEATURES
 
       - name: Build and push router Docker image
         uses: docker/build-push-action@v4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2784,7 +2784,7 @@ dependencies = [
 [[package]]
 name = "opentelemetry"
 version = "0.18.0"
-source = "git+https://github.com/open-telemetry/opentelemetry-rust/?rev=44b90202fd744598db8b0ace5b8f0bad7ec45658#44b90202fd744598db8b0ace5b8f0bad7ec45658"
+source = "git+https://github.com/open-telemetry/opentelemetry-rust?rev=44b90202fd744598db8b0ace5b8f0bad7ec45658#44b90202fd744598db8b0ace5b8f0bad7ec45658"
 dependencies = [
  "opentelemetry_api",
  "opentelemetry_sdk",
@@ -2793,7 +2793,7 @@ dependencies = [
 [[package]]
 name = "opentelemetry-otlp"
 version = "0.11.0"
-source = "git+https://github.com/open-telemetry/opentelemetry-rust/?rev=44b90202fd744598db8b0ace5b8f0bad7ec45658#44b90202fd744598db8b0ace5b8f0bad7ec45658"
+source = "git+https://github.com/open-telemetry/opentelemetry-rust?rev=44b90202fd744598db8b0ace5b8f0bad7ec45658#44b90202fd744598db8b0ace5b8f0bad7ec45658"
 dependencies = [
  "async-trait",
  "futures",
@@ -2810,7 +2810,7 @@ dependencies = [
 [[package]]
 name = "opentelemetry-proto"
 version = "0.1.0"
-source = "git+https://github.com/open-telemetry/opentelemetry-rust/?rev=44b90202fd744598db8b0ace5b8f0bad7ec45658#44b90202fd744598db8b0ace5b8f0bad7ec45658"
+source = "git+https://github.com/open-telemetry/opentelemetry-rust?rev=44b90202fd744598db8b0ace5b8f0bad7ec45658#44b90202fd744598db8b0ace5b8f0bad7ec45658"
 dependencies = [
  "futures",
  "futures-util",
@@ -2822,7 +2822,7 @@ dependencies = [
 [[package]]
 name = "opentelemetry_api"
 version = "0.18.0"
-source = "git+https://github.com/open-telemetry/opentelemetry-rust/?rev=44b90202fd744598db8b0ace5b8f0bad7ec45658#44b90202fd744598db8b0ace5b8f0bad7ec45658"
+source = "git+https://github.com/open-telemetry/opentelemetry-rust?rev=44b90202fd744598db8b0ace5b8f0bad7ec45658#44b90202fd744598db8b0ace5b8f0bad7ec45658"
 dependencies = [
  "fnv",
  "futures-channel",
@@ -2837,7 +2837,7 @@ dependencies = [
 [[package]]
 name = "opentelemetry_sdk"
 version = "0.18.0"
-source = "git+https://github.com/open-telemetry/opentelemetry-rust/?rev=44b90202fd744598db8b0ace5b8f0bad7ec45658#44b90202fd744598db8b0ace5b8f0bad7ec45658"
+source = "git+https://github.com/open-telemetry/opentelemetry-rust?rev=44b90202fd744598db8b0ace5b8f0bad7ec45658#44b90202fd744598db8b0ace5b8f0bad7ec45658"
 dependencies = [
  "async-trait",
  "crossbeam-channel",

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM rust:slim as builder
 
 ARG RUN_ENV=Sandbox
+ARG EXTRA_FEATURES=""
 
 RUN apt-get update \
     && apt-get install -y libpq-dev libssl-dev pkg-config
@@ -34,7 +35,7 @@ ENV CARGO_REGISTRIES_CRATES_IO_PROTOCOL="sparse"
 COPY . .
 
 # Use bash variable substitution to convert environment name to lowercase
-RUN bash -c 'cargo build --release --features ${RUN_ENV@L} ${EXTRA_FEATURES@L}'
+RUN bash -c 'cargo build --release --features ${RUN_ENV@L} ${EXTRA_FEATURES}'
 
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ ENV CARGO_REGISTRIES_CRATES_IO_PROTOCOL="sparse"
 COPY . .
 
 # Use bash variable substitution to convert environment name to lowercase
-RUN bash -c 'cargo build --release --features ${RUN_ENV@L} ${EXTRA_FEATURES}
+RUN bash -c 'cargo build --release --features ${RUN_ENV@L} ${EXTRA_FEATURES@L}'
 
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ ENV CARGO_REGISTRIES_CRATES_IO_PROTOCOL="sparse"
 COPY . .
 
 # Use bash variable substitution to convert environment name to lowercase
-RUN bash -c 'cargo build --release --features ${RUN_ENV@L}'
+RUN bash -c 'cargo build --release --features ${RUN_ENV@L} ${EXTRA_FEATURES}
 
 
 


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] New feature

## Description
<!-- Describe your changes in detail -->
This will add support for choosing whether the `backwards_compatibility` feature when creating the manual release.


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
To support `backwards_compatibility` feature in CI.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
