### PR TITLE
feat(router): add support for filtering PaymentMethodTypes at a session

### DIFF
--- a/crates/api_models/src/payments.rs
+++ b/crates/api_models/src/payments.rs
@@ -212,6 +212,10 @@ pub struct PaymentsRequest {
     /// Merchant connector details used to make payments.
     pub merchant_connector_details: Option<admin::MerchantConnectorDetailsWrap>,
 
+    /// Allowed Payment Method Types for a given PaymentIntent
+    #[schema(value_type = Option<Vec<PaymentMethodType>>)]
+    pub allowed_payment_method_types: Option<Vec<api_enums::PaymentMethodType>>,
+
     /// Business sub label for the payment
     pub business_sub_label: Option<String>,
 }
@@ -978,6 +982,10 @@ pub struct PaymentsResponse {
 
     /// The business_sub_label for this payment
     pub business_sub_label: Option<String>,
+
+    /// Allowed Payment Method Types for a given PaymentIntent
+    #[schema(value_type = Option<Vec<PaymentMethodType>>)]
+    pub allowed_payment_method_types: Option<Vec<api_enums::PaymentMethodType>>,
 }
 
 #[derive(Clone, Debug, serde::Deserialize, ToSchema)]
@@ -1238,6 +1246,10 @@ pub struct Metadata {
     pub data: pii::SecretSerdeValue,
     /// Payload coming in request as a metadata field
     pub payload: Option<pii::SecretSerdeValue>,
+
+    /// Allowed payment method types for a payment intent
+    #[schema(value_type = Option<Vec<PaymentMethodType>>)]
+    pub allowed_payment_method_types: Option<Vec<api_enums::PaymentMethodType>>,
 }
 
 #[derive(Debug, serde::Deserialize, serde::Serialize, Clone, ToSchema)]

--- a/crates/router/src/core/payments.rs
+++ b/crates/router/src/core/payments.rs
@@ -320,6 +320,7 @@ impl PaymentRedirectFlow for PaymentRedirectCompleteAuthorize {
                 order_details: None,
                 data: masking::Secret::new("{}".into()),
                 payload: Some(req.json_payload.unwrap_or(serde_json::json!({})).into()),
+                allowed_payment_method_types: None,
             }),
             ..Default::default()
         };

--- a/crates/router/src/core/payments/operations/payment_create.rs
+++ b/crates/router/src/core/payments/operations/payment_create.rs
@@ -485,7 +485,13 @@ impl PaymentCreate {
         let metadata = request
             .metadata
             .as_ref()
-            .map(Encode::<api_models::payments::Metadata>::encode_to_value)
+            .map(|metadata| {
+                let transformed_metadata = api_models::payments::Metadata {
+                    allowed_payment_method_types: request.allowed_payment_method_types.clone(),
+                    ..metadata.clone()
+                };
+                Encode::<api_models::payments::Metadata>::encode_to_value(&transformed_metadata)
+            })
             .transpose()
             .change_context(errors::ApiErrorResponse::InternalServerError)
             .attach_printable("Encoding Metadata to value failed")?;

--- a/crates/router/src/core/payments/transformers.rs
+++ b/crates/router/src/core/payments/transformers.rs
@@ -288,6 +288,19 @@ where
                         connector_name,
                     )
                 });
+                let parsed_metadata: Option<api_models::payments::Metadata> = payment_intent
+                    .metadata
+                    .clone()
+                    .map(|metadata_value| {
+                        metadata_value
+                            .parse_value("metadata")
+                            .change_context(errors::ApiErrorResponse::InvalidDataValue {
+                                field_name: "metadata",
+                            })
+                            .attach_printable("unable to parse metadata")
+                    })
+                    .transpose()
+                    .unwrap_or_default();
                 services::ApplicationResponse::Json(
                     response
                         .set_payment_id(Some(payment_attempt.payment_id))
@@ -369,6 +382,10 @@ where
                         .set_business_country(payment_intent.business_country)
                         .set_business_label(payment_intent.business_label)
                         .set_business_sub_label(payment_attempt.business_sub_label)
+                        .set_allowed_payment_method_types(
+                            parsed_metadata
+                                .and_then(|metadata| metadata.allowed_payment_method_types),
+                        )
                         .to_owned(),
                 )
             }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
A new field allowed_payment_method_types is introduced in /payments (POST) for limiting a payment intent to specified payment method types. If passed, it will be stored as metadata in payment_intent table and will be used to filter the PaymentMethodTypes during /payment_methods (GET) call.


### Additional Changes

- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables


## Motivation and Context
This feature enables merchant to filter certain payment methods only for a particular payment intent. This helps in cases where the merchants wants to limit the payment methods shown for payment intents based on the requirements.

Eg: limiting PaymentMethods for a particular period / amount

## How did you test it?
Tested manually.


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
