### PR TITLE
fix(connector-template): Address unused import and mismatched types in connector-template

### DIFF
--- a/connector-template/mod.rs
+++ b/connector-template/mod.rs
@@ -1,7 +1,6 @@
 mod transformers;
 
 use std::fmt::Debug;
-use common_utils::errors::ReportSwitchExt;
 use error_stack::{ResultExt, IntoReport};
 
 use crate::{

--- a/connector-template/transformers.rs
+++ b/connector-template/transformers.rs
@@ -30,7 +30,7 @@ impl TryFrom<&types::PaymentsAuthorizeRouterData> for {{project-name | downcase 
                     expiry_month: req_card.card_exp_month,
                     expiry_year: req_card.card_exp_year,
                     cvc: req_card.card_cvc,
-                    complete: item.request.is_auto_capture(),
+                    complete: item.request.is_auto_capture()?,
                 };
                 Ok(Self {
                     amount: item.request.amount,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->
When `add_connector.sh` is called to generate new connector files `mod.rs` had an unused declaration, removed it. At the time of development, if needed, one can import it directly instead of pre-bloating the stuff.  
`Transformers.rs` straight away failed and threw an error addressing `mismatched types` as it is expecting `bool` while were providing `Result<bool, Error>`.

### Additional Changes

- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!-- 
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->
connector-template/mod.rs
connector-template/transformers.rs

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
With the changes made, unexpected errors and warnings at the time of generation of connector code is avoided and addressed. 

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
