### PR TITLE
fix(connector): [coinbase] update cancel status on user cancelling the payment

### DIFF
--- a/crates/router/src/connector/coinbase/transformers.rs
+++ b/crates/router/src/connector/coinbase/transformers.rs
@@ -80,6 +80,7 @@ impl From<CoinbasePaymentStatus> for enums::AttemptStatus {
             CoinbasePaymentStatus::Expired => Self::Failure,
             CoinbasePaymentStatus::New => Self::AuthenticationPending,
             CoinbasePaymentStatus::Unresolved => Self::Unresolved,
+            CoinbasePaymentStatus::Canceled => Self::Voided,
             _ => Self::Pending,
         }
     }


### PR DESCRIPTION


## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->
The transaction goes to processing state on user manually cancelling the payment, it should in void state in this scenario

### Additional Changes

- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!-- 
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
Update the payment status to `voided` state when customer cancel the payment

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
<img width="1172" alt="Screen Shot 2023-04-19 at 5 52 52 PM" src="https://user-images.githubusercontent.com/20727598/233073666-139cf59c-1615-48a6-8951-d448296777a2.png">


<img width="1725" alt="Screen Shot 2023-04-19 at 5 51 42 PM" src="https://user-images.githubusercontent.com/20727598/233073390-80b50a84-509b-47ff-9b32-736ebcc8c2a5.png">


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [X] I formatted the code `cargo +nightly fmt --all`
- [X] I addressed lints thrown by `cargo clippy`
- [X] I reviewed submitted code