### PR TITLE
feat(pm_list): add support for bank debits

### DIFF
--- a/crates/api_models/src/payment_methods.rs
+++ b/crates/api_models/src/payment_methods.rs
@@ -183,6 +183,11 @@ pub struct CardNetworkTypes {
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, ToSchema, PartialEq, Eq)]
+pub struct BankDebitTypes {
+    pub eligible_connectors: Vec<String>,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, ToSchema, PartialEq, Eq)]
 pub struct ResponsePaymentMethodTypes {
     /// The payment method type enabled
     #[schema(example = "klarna")]
@@ -196,6 +201,8 @@ pub struct ResponsePaymentMethodTypes {
 
     /// The list of banks enabled, if applicable for a payment method type
     pub bank_names: Option<Vec<BankCodeResponse>>,
+
+    pub bank_debits: Option<BankDebitTypes>,
 }
 
 #[derive(Debug, Clone, serde::Deserialize, serde::Serialize, ToSchema)]

--- a/crates/router/src/core/payment_methods/cards.rs
+++ b/crates/router/src/core/payment_methods/cards.rs
@@ -831,7 +831,7 @@ pub async fn list_payment_methods(
             error.to_not_found_response(errors::ApiErrorResponse::MerchantAccountNotFound)
         })?;
 
-    // filter out connectors based on the busness country
+    // filter out connectors based on the business country
     let filtered_mcas = filter_mca_based_on_business_details(all_mcas, payment_intent.as_ref());
 
     logger::debug!(mca_before_filtering=?filtered_mcas);

--- a/crates/router/src/core/payment_methods/cards.rs
+++ b/crates/router/src/core/payment_methods/cards.rs
@@ -831,10 +831,13 @@ pub async fn list_payment_methods(
             error.to_not_found_response(errors::ApiErrorResponse::MerchantAccountNotFound)
         })?;
 
-    logger::debug!(mca_before_filtering=?all_mcas);
+    // filter out connectors based on the busness country
+    let filtered_mcas = filter_mca_based_on_business_details(all_mcas, payment_intent.as_ref());
+
+    logger::debug!(mca_before_filtering=?filtered_mcas);
 
     let mut response: Vec<ResponsePaymentMethodIntermediate> = vec![];
-    for mca in all_mcas {
+    for mca in filtered_mcas {
         let payment_methods = match mca.payment_methods_enabled {
             Some(pm) => pm,
             None => continue,
@@ -867,6 +870,9 @@ pub async fn list_payment_methods(
 
     let mut banks_consolidated_hm: HashMap<api_enums::PaymentMethodType, Vec<String>> =
         HashMap::new();
+
+    let mut bank_debits_consolidated_hm =
+        HashMap::<api_enums::PaymentMethodType, Vec<String>>::new();
 
     for element in response.clone() {
         let payment_method = element.payment_method;
@@ -958,6 +964,17 @@ pub async fn list_payment_methods(
                 banks_consolidated_hm.insert(element.payment_method_type, vec![connector]);
             }
         }
+
+        if element.payment_method == api_enums::PaymentMethod::BankDebit {
+            let connector = element.connector.clone();
+            if let Some(vector_of_connectors) =
+                bank_debits_consolidated_hm.get_mut(&element.payment_method_type)
+            {
+                vector_of_connectors.push(connector);
+            } else {
+                bank_debits_consolidated_hm.insert(element.payment_method_type, vec![connector]);
+            }
+        }
     }
 
     let mut payment_method_responses: Vec<ResponsePaymentMethodsEnabled> = vec![];
@@ -977,6 +994,7 @@ pub async fn list_payment_methods(
                 payment_experience: Some(payment_experience_types),
                 card_networks: None,
                 bank_names: None,
+                bank_debits: None,
             })
         }
 
@@ -1002,6 +1020,7 @@ pub async fn list_payment_methods(
                 card_networks: Some(card_network_types),
                 payment_experience: None,
                 bank_names: None,
+                bank_debits: None,
             })
         }
 
@@ -1011,26 +1030,52 @@ pub async fn list_payment_methods(
         })
     }
 
-    let mut bank_payment_method_types = vec![];
+    let mut bank_redirect_payment_method_types = vec![];
 
     for key in banks_consolidated_hm.iter() {
         let payment_method_type = *key.0;
         let connectors = key.1.clone();
         let bank_names = get_banks(state, payment_method_type, connectors)?;
-        bank_payment_method_types.push({
+        bank_redirect_payment_method_types.push({
             ResponsePaymentMethodTypes {
                 payment_method_type,
                 bank_names: Some(bank_names),
                 payment_experience: None,
                 card_networks: None,
+                bank_debits: None,
             }
         })
     }
 
-    if !bank_payment_method_types.is_empty() {
+    if !bank_redirect_payment_method_types.is_empty() {
         payment_method_responses.push(ResponsePaymentMethodsEnabled {
             payment_method: api_enums::PaymentMethod::BankRedirect,
-            payment_method_types: bank_payment_method_types,
+            payment_method_types: bank_redirect_payment_method_types,
+        });
+    }
+
+    let mut bank_debit_payment_method_types = vec![];
+
+    for key in bank_debits_consolidated_hm.iter() {
+        let payment_method_type = *key.0;
+        let connectors = key.1.clone();
+        bank_debit_payment_method_types.push({
+            ResponsePaymentMethodTypes {
+                payment_method_type,
+                bank_names: None,
+                payment_experience: None,
+                card_networks: None,
+                bank_debits: Some(api_models::payment_methods::BankDebitTypes {
+                    eligible_connectors: connectors,
+                }),
+            }
+        })
+    }
+
+    if !bank_debit_payment_method_types.is_empty() {
+        payment_method_responses.push(ResponsePaymentMethodsEnabled {
+            payment_method: api_enums::PaymentMethod::BankDebit,
+            payment_method_types: bank_debit_payment_method_types,
         });
     }
 
@@ -1135,6 +1180,25 @@ async fn filter_payment_methods(
         }
     }
     Ok(())
+}
+
+fn filter_mca_based_on_business_details(
+    merchant_connector_accounts: Vec<
+        storage_models::merchant_connector_account::MerchantConnectorAccount,
+    >,
+    payment_intent: Option<&storage_models::payment_intent::PaymentIntent>,
+) -> Vec<storage_models::merchant_connector_account::MerchantConnectorAccount> {
+    if let Some(payment_intent) = payment_intent {
+        merchant_connector_accounts
+            .into_iter()
+            .filter(|mca| {
+                mca.business_country == payment_intent.business_country
+                    && mca.business_label == payment_intent.business_label
+            })
+            .collect::<Vec<_>>()
+    } else {
+        merchant_connector_accounts
+    }
 }
 
 fn filter_pm_based_on_config<'a>(


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] New feature

## Description
<!-- Describe your changes in detail -->
This PR adds support for `bank_redirects` in payment methods list. The response will be of the form 
```json
{
  "payment_method": "bank_debit",
  "payment_method_types": [
    {
      "payment_method_type": "sepa",
      "payment_experience": null,
      "card_networks": null,
      "bank_names": null,
      "bank_debits": {
        "eligible_connectors": [
          "stripe",
          "adyen"
        ]
      }
    },
    {
      "payment_method_type": "ach",
      "payment_experience": null,
      "card_networks": null,
      "bank_names": null,
      "bank_debits": {
        "eligible_connectors": [
          "adyen"
        ]
      }
    }
  ]
}
```


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
- Create a payment connector with `sepa` and `ach` enabled.
- Create a payment with confirm set to false
- Call the pm list.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
