### PR TITLE
ci(connector-sanity-tests): run tests on being queued for merge

### DIFF
--- a/.github/workflows/connector-sanity-tests.yml
+++ b/.github/workflows/connector-sanity-tests.yml
@@ -5,10 +5,12 @@ on:
     branches:
       - main
 
-  pull_request:
-
   schedule:
-    - cron: '5 0 * * *'
+    - cron: "5 0 * * *"
+
+  merge_group:
+    types:
+      - checks_requested
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -41,7 +43,7 @@ jobs:
   test_connectors:
     name: Run tests on stable toolchain for connectors
     runs-on: ubuntu-latest
-    
+
     services:
       redis:
         image: redis
@@ -60,7 +62,7 @@ jobs:
           - stripe
           - aci
           - adyen
-          #- authorizedotnet 
+          #- authorizedotnet
           #- checkout
           #- cybersource
           - shift4
@@ -78,7 +80,7 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3.1.0
-      
+
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
         with:


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [x] CI/CD

## Description
<!-- Describe your changes in detail -->
This PR updates the connector sanity tests workflow to be run on being added to merge queue instead of on PRs being opened/updated.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
This would prevent the connector sanity tests from failing on PRs by external contributors because of a missing secret, and hopefully reduce confusion as to why their tests are failing.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
This PR _should_ not have the connector sanity tests among the PR checks.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
