### PR TITLE
fix: remove old data while deserialization error from cache

### DIFF
--- a/crates/router/src/db/cache.rs
+++ b/crates/router/src/db/cache.rs
@@ -34,13 +34,7 @@ where
     };
     match redis_val {
         Err(err) => match err.current_context() {
-            errors::RedisError::NotFound => get_data_set_redis().await,
-            errors::RedisError::JsonDeserializationFailed => {
-                // In case of deserialization failure remove the old data and insert the new data
-                redis
-                    .delete_key(key)
-                    .await
-                    .change_context(errors::StorageError::KVError)?;
+            errors::RedisError::NotFound | errors::RedisError::JsonDeserializationFailed => {
                 get_data_set_redis().await
             }
             _ => Err(err

--- a/crates/router/src/db/cache.rs
+++ b/crates/router/src/db/cache.rs
@@ -24,15 +24,24 @@ where
         .redis_conn()
         .map_err(Into::<errors::StorageError>::into)?;
     let redis_val = redis.get_and_deserialize_key::<T>(key, type_name).await;
+    let get_data_set_redis = || async {
+        let data = fun().await?;
+        redis
+            .serialize_and_set_key(key, &data)
+            .await
+            .change_context(errors::StorageError::KVError)?;
+        Ok::<_, error_stack::Report<errors::StorageError>>(data)
+    };
     match redis_val {
         Err(err) => match err.current_context() {
-            errors::RedisError::NotFound => {
-                let data = fun().await?;
+            errors::RedisError::NotFound => get_data_set_redis().await,
+            errors::RedisError::JsonDeserializationFailed => {
+                // In case of deserialization failure remove the old data and insert the new data
                 redis
-                    .serialize_and_set_key(key, &data)
+                    .delete_key(key)
                     .await
                     .change_context(errors::StorageError::KVError)?;
-                Ok(data)
+                get_data_set_redis().await
             }
             _ => Err(err
                 .change_context(errors::StorageError::KVError)


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->
- [x] Bugfix

## Description
<!-- Describe your changes in detail -->
In case of a contract change the old data in redis would cause deserialization error, So remove the old data from redis and insert the new value.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
This fixes deserialation error on old data in redis.


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Manual

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code