### PR TITLE
fix(refund_sync): add validation for missing `connector_refund_id`

### DIFF
--- a/crates/api_models/src/refunds.rs
+++ b/crates/api_models/src/refunds.rs
@@ -48,6 +48,11 @@ pub struct RefundRequest {
     pub merchant_connector_details: Option<admin::MerchantConnectorDetailsWrap>,
 }
 
+#[derive(Default, Debug, Clone, Deserialize)]
+pub struct RefundsRetrieveBody {
+    pub force_sync: Option<bool>,
+}
+
 #[derive(Default, Debug, ToSchema, Clone, Deserialize)]
 pub struct RefundsRetrieveRequest {
     /// Unique Identifier for the Refund. This is to ensure idempotency for multiple partial refund initiated against the same payment. If the identifiers is not defined by the merchant, this filed shall be auto generated and provide in the API response. It is recommended to generate uuid(v4) as the refund_id.
@@ -57,6 +62,10 @@ pub struct RefundsRetrieveRequest {
         example = "ref_mbabizu24mvu3mela5njyhpit4"
     )]
     pub refund_id: String,
+
+    /// `force_sync` with the connector to get refund details
+    /// (defaults to false)
+    pub force_sync: Option<bool>,
 
     /// Merchant connector details used to make payments.
     pub merchant_connector_details: Option<admin::MerchantConnectorDetailsWrap>,

--- a/crates/router/src/compatibility/stripe/refunds.rs
+++ b/crates/router/src/compatibility/stripe/refunds.rs
@@ -99,6 +99,7 @@ pub async fn refund_retrieve(
 ) -> HttpResponse {
     let refund_request = refund_types::RefundsRetrieveRequest {
         refund_id: path.into_inner(),
+        force_sync: Some(true),
         merchant_connector_details: None,
     };
     wrap::compatibility_api_wrap::<

--- a/crates/router/src/connector/utils.rs
+++ b/crates/router/src/connector/utils.rs
@@ -292,6 +292,7 @@ pub trait RefundsRequestData {
 }
 
 impl RefundsRequestData for types::RefundsData {
+    #[track_caller]
     fn get_connector_refund_id(&self) -> Result<String, Error> {
         self.connector_refund_id
             .clone()
@@ -373,6 +374,7 @@ impl CardData for api::Card {
     }
 }
 
+#[track_caller]
 fn get_card_issuer(card_number: &str) -> Result<CardIssuer, Error> {
     for (k, v) in CARD_REGEX.iter() {
         let regex: Regex = v

--- a/crates/router/src/core/refunds.rs
+++ b/crates/router/src/core/refunds.rs
@@ -318,17 +318,37 @@ pub async fn refund_retrieve_core(
         .await
         .transpose()?;
 
-    response = sync_refund_with_gateway(
-        state,
-        &merchant_account,
-        &payment_attempt,
-        &payment_intent,
-        &refund,
-        creds_identifier,
-    )
-    .await?;
+    response = if should_call_refund(&refund, request.force_sync.unwrap_or(false)) {
+        sync_refund_with_gateway(
+            state,
+            &merchant_account,
+            &payment_attempt,
+            &payment_intent,
+            &refund,
+            creds_identifier,
+        )
+        .await
+    } else {
+        Ok(refund)
+    }?;
 
     Ok(response)
+}
+
+fn should_call_refund(refund: &storage_models::refund::Refund, force_sync: bool) -> bool {
+    // This implies, we cannot perform a refund sync & `the connector_refund_id`
+    // doesn't exist
+    let predicate1 = refund.connector_refund_id.is_some();
+
+    // This allows refund sync at connector level if force_sync is enabled, or
+    // checks if the refund has failed
+    let predicate2 = force_sync
+        || !matches!(
+            refund.refund_status,
+            storage_models::enums::RefundStatus::Failure
+        );
+
+    predicate1 && predicate2
 }
 
 #[instrument(skip_all)]
@@ -755,6 +775,7 @@ pub async fn sync_refund_with_gateway_workflow(
         merchant_account,
         refunds::RefundsRetrieveRequest {
             refund_id: refund_core.refund_internal_reference_id,
+            force_sync: Some(true),
             merchant_connector_details: None,
         },
     )

--- a/crates/router/src/core/webhooks.rs
+++ b/crates/router/src/core/webhooks.rs
@@ -164,6 +164,7 @@ async fn refunds_incoming_webhook_flow<W: api::OutgoingWebhookType>(
             merchant_account.clone(),
             api_models::refunds::RefundsRetrieveRequest {
                 refund_id: refund_id.to_owned(),
+                force_sync: Some(true),
                 merchant_connector_details: None,
             },
         )

--- a/crates/router/src/routes/refunds.rs
+++ b/crates/router/src/routes/refunds.rs
@@ -65,9 +65,11 @@ pub async fn refunds_retrieve(
     state: web::Data<AppState>,
     req: HttpRequest,
     path: web::Path<String>,
+    query_params: web::Query<api_models::refunds::RefundsRetrieveBody>,
 ) -> HttpResponse {
     let refund_request = refunds::RefundsRetrieveRequest {
         refund_id: path.into_inner(),
+        force_sync: query_params.force_sync,
         merchant_connector_details: None,
     };
     let flow = Flow::RefundsRetrieve;


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

This PR performs the following changes:
- Add validation for `connector_refund_id`
- Adds `force_sync` support in `refund_retrieve_core`

<!-- Describe your changes in detail -->


### Additional Changes

- [x] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables


This introduces a optional query parameter for refund sync
`?force_sync={bool}`
<!-- 
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
compiler guided
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
