### PR TITLE
refactor(config): add independent toggles for enabling traces and metrics

### DIFF
--- a/config/config.example.toml
+++ b/config/config.example.toml
@@ -86,7 +86,9 @@ filtering_directive = "WARN,router=INFO,reqwest=INFO"
 
 # Telemetry configuration for metrics and traces
 [log.telemetry]
-enabled = false                                       # boolean [true or false]
+traces_enabled = false                                # boolean [true or false], whether traces are enabled
+metrics_enabled = false                               # boolean [true or false], whether metrics are enabled
+ignore_errors = false                                 # boolean [true or false], whether to ignore errors during traces or metrics pipeline setup
 sampling_rate = 0.1                                   # decimal rate between 0.0 - 1.0
 otel_exporter_otlp_endpoint = "http://localhost:4317" # endpoint to send metrics and traces to, can include port number
 otel_exporter_otlp_timeout = 5000                     # timeout (in milliseconds) for sending metrics and traces

--- a/config/development.toml
+++ b/config/development.toml
@@ -32,8 +32,6 @@ connection_timeout = 10
 [secrets]
 admin_api_key = "test_admin"
 
-[proxy]
-
 [locker]
 host = ""
 mock_locker = true
@@ -149,10 +147,10 @@ stripe = { banks = "abn_amro,asn_bank,bunq,handelsbanken,ing,knab,moneyou,raboba
 adyen = { banks = "abn_amro,asn_bank,bunq,handelsbanken,ing,knab,moneyou,rabobank,regiobank,revolut,sns_bank,triodos_bank,van_lanschot" }
 
 [bank_config.online_banking_czech_republic]
-adyen = { banks = "ceska_sporitelna,komercni_banka,platnosc_online_karta_platnicza"}
+adyen = { banks = "ceska_sporitelna,komercni_banka,platnosc_online_karta_platnicza" }
 
 [bank_config.online_banking_slovakia]
-adyen = { banks = "e_platby_v_u_b,postova_banka,sporo_pay,tatra_pay,viamo,volksbank_gruppe,volkskredit_bank_ag,vr_bank_braunau"}
+adyen = { banks = "e_platby_v_u_b,postova_banka,sporo_pay,tatra_pay,viamo,volksbank_gruppe,volkskredit_bank_ag,vr_bank_braunau" }
 
 [pm_filters.stripe]
 google_pay = { country = "AL,DZ,AS,AO,AG,AR,AU,AT,AZ,BH,BY,BE,BR,BG,CA,CL,CO,HR,CZ,DK,DO,EG,EE,FI,FR,DE,GR,HK,HU,IN,ID,IE,IL,IT,JP,JO,KZ,KE,KW,LV,LB,LT,LU,MY,MX,NL,NZ,NO,OM,PK,PA,PE,PH,PL,PT,QA,RO,RU,SA,SG,SK,ZA,ES,LK,SE,CH,TW,TH,TR,UA,AE,GB,US,UY,VN" }
@@ -196,5 +194,5 @@ bucket_name = ""
 region = ""
 
 [tokenization]
-stripe = { long_lived_token = false, payment_method = "wallet"}
-checkout = { long_lived_token = false, payment_method = "wallet"}
+stripe = { long_lived_token = false, payment_method = "wallet" }
+checkout = { long_lived_token = false, payment_method = "wallet" }

--- a/config/development.toml
+++ b/config/development.toml
@@ -7,7 +7,8 @@ level = "DEBUG"
 log_format = "default"
 
 [log.telemetry]
-enabled = false
+traces_enabled = false
+metrics_enabled = false
 
 # TODO: Update database credentials before running application
 [master_database]

--- a/config/docker_compose.toml
+++ b/config/docker_compose.toml
@@ -34,10 +34,6 @@ port = 5432
 dbname = "hyperswitch_db"
 pool_size = 5
 
-[proxy]
-# http_url = "http proxy URL"
-# https_url = "https proxy URL"
-
 [secrets]
 admin_api_key = "test_admin"
 jwt_secret = "secret"

--- a/config/docker_compose.toml
+++ b/config/docker_compose.toml
@@ -14,9 +14,10 @@ enabled = true  # Whether you want to see log in your terminal.
 level = "DEBUG" # What you see in your terminal.
 
 [log.telemetry]
-traces_enabled = false  # Whether traces are enabled.
-metrics_enabled = false # Whether metrics are enabled.
-ignore_errors = false   # Whether to ignore errors during traces or metrics pipeline setup.
+traces_enabled = false                                      # Whether traces are enabled.
+metrics_enabled = false                                     # Whether metrics are enabled.
+ignore_errors = false                                       # Whether to ignore errors during traces or metrics pipeline setup.
+otel_exporter_otlp_endpoint = "https://otel-collector:4317" # Endpoint to send metrics and traces to.
 
 [master_database]
 username = "db_user"

--- a/config/docker_compose.toml
+++ b/config/docker_compose.toml
@@ -14,7 +14,9 @@ enabled = true  # Whether you want to see log in your terminal.
 level = "DEBUG" # What you see in your terminal.
 
 [log.telemetry]
-enabled = false # Whether tracing/telemetry is enabled.
+traces_enabled = false  # Whether traces are enabled.
+metrics_enabled = false # Whether metrics are enabled.
+ignore_errors = false   # Whether to ignore errors during traces or metrics pipeline setup.
 
 [master_database]
 username = "db_user"

--- a/crates/drainer/src/env.rs
+++ b/crates/drainer/src/env.rs
@@ -6,9 +6,7 @@ pub mod logger {
     pub use router_env::{log, logger::*};
 
     /// Setup logging sub-system
-    pub fn setup(
-        conf: &config::Log,
-    ) -> error_stack::Result<TelemetryGuard, router_env::opentelemetry::metrics::MetricsError> {
-        Ok(router_env::setup(conf, router_env::service_name!(), [])?)
+    pub fn setup(conf: &config::Log) -> TelemetryGuard {
+        router_env::setup(conf, router_env::service_name!(), [])
     }
 }

--- a/crates/drainer/src/errors.rs
+++ b/crates/drainer/src/errors.rs
@@ -9,8 +9,6 @@ pub enum DrainerError {
     RedisError(error_stack::Report<redis::errors::RedisError>),
     #[error("Application configuration error: {0}")]
     ConfigurationError(config::ConfigError),
-    #[error("Metrics initialization error")]
-    MetricsError,
     #[error("Error while configuring signals: {0}")]
     SignalError(String),
     #[error("Unexpected error occurred: {0}")]

--- a/crates/drainer/src/main.rs
+++ b/crates/drainer/src/main.rs
@@ -1,5 +1,4 @@
-use drainer::{errors, errors::DrainerResult, logger::logger, services, settings, start_drainer};
-use error_stack::ResultExt;
+use drainer::{errors::DrainerResult, logger::logger, services, settings, start_drainer};
 
 #[tokio::main]
 async fn main() -> DrainerResult<()> {
@@ -21,7 +20,7 @@ async fn main() -> DrainerResult<()> {
     let shutdown_intervals = conf.drainer.shutdown_interval;
     let loop_interval = conf.drainer.loop_interval;
 
-    let _guard = logger::setup(&conf.log).change_context(errors::DrainerError::MetricsError)?;
+    let _guard = logger::setup(&conf.log);
 
     logger::info!("Drainer started [{:?}] [{:?}]", conf.drainer, conf.log);
 

--- a/crates/router/src/bin/router.rs
+++ b/crates/router/src/bin/router.rs
@@ -34,7 +34,7 @@ async fn main() -> ApplicationResult<()> {
     conf.validate()
         .expect("Failed to validate router configuration");
 
-    let _guard = logger::setup(&conf.log)?;
+    let _guard = logger::setup(&conf.log);
 
     logger::info!("Application started [{:?}] [{:?}]", conf.server, conf.log);
 

--- a/crates/router/src/bin/scheduler.rs
+++ b/crates/router/src/bin/scheduler.rs
@@ -28,8 +28,7 @@ async fn main() -> CustomResult<(), errors::ProcessTrackerError> {
         redis_shutdown_signal_rx,
         tx.clone(),
     ));
-    let _guard =
-        logger::setup(&state.conf.log).map_err(|_| errors::ProcessTrackerError::UnexpectedFlow)?;
+    let _guard = logger::setup(&state.conf.log);
 
     logger::debug!(startup_config=?state.conf);
 

--- a/crates/router/src/env.rs
+++ b/crates/router/src/env.rs
@@ -4,12 +4,8 @@ pub mod logger {
     #[doc(inline)]
     pub use router_env::{log, logger::*};
 
-    // TODO (prom-monitoring): Ideally tracing/opentelemetry structs shouldn't be pushed out.
-    // Return a custom error type instead of `opentelemetry::metrics::MetricsError`.
     /// Setup logging sub-system.
-    pub fn setup(
-        conf: &config::Log,
-    ) -> Result<TelemetryGuard, router_env::opentelemetry::metrics::MetricsError> {
+    pub fn setup(conf: &config::Log) -> TelemetryGuard {
         router_env::setup(conf, router_env::service_name!(), ["actix_server"])
     }
 }

--- a/crates/router_env/src/logger/config.rs
+++ b/crates/router_env/src/logger/config.rs
@@ -87,8 +87,12 @@ pub struct LogConsole {
 #[derive(Debug, Deserialize, Clone, Default)]
 #[serde(default)]
 pub struct LogTelemetry {
-    /// Whether tracing/telemetry is enabled.
-    pub enabled: bool,
+    /// Whether the traces pipeline is enabled.
+    pub traces_enabled: bool,
+    /// Whether the metrics pipeline is enabled.
+    pub metrics_enabled: bool,
+    /// Whether errors in setting up traces or metrics pipelines must be ignored.
+    pub ignore_errors: bool,
     /// Sampling rate for traces
     pub sampling_rate: Option<f64>,
     /// Base endpoint URL to send metrics and traces to. Can optionally include the port number.

--- a/crates/router_env/tests/logger.rs
+++ b/crates/router_env/tests/logger.rs
@@ -12,7 +12,7 @@ fn logger() -> &'static TelemetryGuard {
     INSTANCE.get_or_init(|| {
         let config = env::Config::new().unwrap();
 
-        env::logger::setup(&config.log, env::service_name!(), []).unwrap()
+        env::logger::setup(&config.log, env::service_name!(), [])
     })
 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -118,7 +118,6 @@ services:
       - cargo_build_cache:/cargo_build_cache
     environment:
       - CARGO_TARGET_DIR=/cargo_build_cache
-      - OTEL_EXPORTER_OTLP_ENDPOINT=https://otel-collector:4317
     labels:
       logs: "promtail"
     healthcheck:
@@ -146,7 +145,6 @@ services:
       - p_cargo_build_cache:/cargo_build_cache
     environment:
       - CARGO_TARGET_DIR=/cargo_build_cache
-      - OTEL_EXPORTER_OTLP_ENDPOINT=https://otel-collector:4317
       - SCHEDULER_FLOW=producer
     depends_on:
       hyperswitch-consumer:
@@ -168,7 +166,6 @@ services:
       - c_cargo_build_cache:/cargo_build_cache
     environment:
       - CARGO_TARGET_DIR=/cargo_build_cache
-      - OTEL_EXPORTER_OTLP_ENDPOINT=https://otel-collector:4317
       - SCHEDULER_FLOW=consumer
     depends_on:
       hyperswitch-server:
@@ -288,7 +285,6 @@ services:
       - cargo_build_cache:/cargo_build_cache
     environment:
       - CARGO_TARGET_DIR=/cargo_build_cache
-      - OTEL_EXPORTER_OTLP_ENDPOINT=https://otel-collector:4317
     restart: unless-stopped
     depends_on:
       hyperswitch-server:

--- a/loadtest/config/development.toml
+++ b/loadtest/config/development.toml
@@ -5,7 +5,9 @@ enabled = false
 enabled = false
 
 [log.telemetry]
-enabled = true
+traces_enabled = true
+metrics_enabled = true
+ignore_errors = false
 
 [master_database]
 username = "postgres"

--- a/loadtest/config/development.toml
+++ b/loadtest/config/development.toml
@@ -121,5 +121,5 @@ cards = [
     "trustpay",
     "worldline",
     "worldpay",
-	"zen",
+    "zen",
 ]


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
This PR adds two configuration variables for toggling traces and metrics independently instead of using a single toggle to enable both. In addition, this PR introduces one more configuration variable to ignore errors during traces and metrics setup, if required.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [x] This PR modifies application configuration/environment variables

<!-- 
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->
The `log.telemetry.enabled` configuration variable is no longer being used, the `log.telemetry.traces_enabled` and `log.telemetry.metrics_enabled` configuration variables must be used instead for toggling traces and metrics, respectively. In addition, errors during traces or metrics setup can be ignored using the `log.telemetry.ignore_errors` configuration variable.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
This would allow us to have metrics and traces independently enabled, as required.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Manually.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
