### PR TITLE
refactor(router): add the `connector_label` field to `DuplicateMerchantConnectorAccount` error message

### DIFF
--- a/crates/router/src/compatibility/stripe/errors.rs
+++ b/crates/router/src/compatibility/stripe/errors.rs
@@ -103,8 +103,8 @@ pub enum StripeErrorCode {
     #[error(error_type = StripeErrorType::InvalidRequestError, code = "token_already_used", message = "duplicate merchant account")]
     DuplicateMerchantAccount,
 
-    #[error(error_type = StripeErrorType::InvalidRequestError, code = "token_already_used", message = "duplicate merchant_connector_account")]
-    DuplicateMerchantConnectorAccount,
+    #[error(error_type = StripeErrorType::InvalidRequestError, code = "token_already_used", message = "The merchant connector account with the specified connector_label '{connector_label}' already exists in our records")]
+    DuplicateMerchantConnectorAccount { connector_label: String },
 
     #[error(error_type = StripeErrorType::InvalidRequestError, code = "token_already_used", message = "duplicate payment method")]
     DuplicatePaymentMethod,
@@ -438,8 +438,8 @@ impl From<errors::ApiErrorResponse> for StripeErrorCode {
             }
             errors::ApiErrorResponse::ReturnUrlUnavailable => Self::ReturnUrlUnavailable,
             errors::ApiErrorResponse::DuplicateMerchantAccount => Self::DuplicateMerchantAccount,
-            errors::ApiErrorResponse::DuplicateMerchantConnectorAccount => {
-                Self::DuplicateMerchantConnectorAccount
+            errors::ApiErrorResponse::DuplicateMerchantConnectorAccount { connector_label} => {
+                Self::DuplicateMerchantConnectorAccount { connector_label }
             }
             errors::ApiErrorResponse::DuplicatePaymentMethod => Self::DuplicatePaymentMethod,
             errors::ApiErrorResponse::ClientSecretInvalid => Self::PaymentIntentInvalidParameter {
@@ -521,7 +521,7 @@ impl actix_web::ResponseError for StripeErrorCode {
             | Self::MandateNotFound
             | Self::ApiKeyNotFound
             | Self::DuplicateMerchantAccount
-            | Self::DuplicateMerchantConnectorAccount
+            | Self::DuplicateMerchantConnectorAccount { .. }
             | Self::DuplicatePaymentMethod
             | Self::PaymentFailed
             | Self::VerificationFailed { .. }

--- a/crates/router/src/compatibility/stripe/errors.rs
+++ b/crates/router/src/compatibility/stripe/errors.rs
@@ -438,7 +438,7 @@ impl From<errors::ApiErrorResponse> for StripeErrorCode {
             }
             errors::ApiErrorResponse::ReturnUrlUnavailable => Self::ReturnUrlUnavailable,
             errors::ApiErrorResponse::DuplicateMerchantAccount => Self::DuplicateMerchantAccount,
-            errors::ApiErrorResponse::DuplicateMerchantConnectorAccount { connector_label} => {
+            errors::ApiErrorResponse::DuplicateMerchantConnectorAccount { connector_label } => {
                 Self::DuplicateMerchantConnectorAccount { connector_label }
             }
             errors::ApiErrorResponse::DuplicatePaymentMethod => Self::DuplicatePaymentMethod,

--- a/crates/router/src/core/admin.rs
+++ b/crates/router/src/core/admin.rs
@@ -422,7 +422,11 @@ pub async fn create_payment_connector(
     let mca = store
         .insert_merchant_connector_account(merchant_connector_account)
         .await
-        .to_duplicate_response(errors::ApiErrorResponse::DuplicateMerchantConnectorAccount { connector_label: connector_label.clone() })?;
+        .to_duplicate_response(
+            errors::ApiErrorResponse::DuplicateMerchantConnectorAccount {
+                connector_label: connector_label.clone(),
+            },
+        )?;
 
     let mca_response = ForeignTryFrom::foreign_try_from(mca)?;
 

--- a/crates/router/src/core/admin.rs
+++ b/crates/router/src/core/admin.rs
@@ -422,7 +422,7 @@ pub async fn create_payment_connector(
     let mca = store
         .insert_merchant_connector_account(merchant_connector_account)
         .await
-        .to_duplicate_response(errors::ApiErrorResponse::DuplicateMerchantConnectorAccount)?;
+        .to_duplicate_response(errors::ApiErrorResponse::DuplicateMerchantConnectorAccount { connector_label: connector_label.clone() })?;
 
     let mca_response = ForeignTryFrom::foreign_try_from(mca)?;
 

--- a/crates/router/src/core/errors/api_error_response.rs
+++ b/crates/router/src/core/errors/api_error_response.rs
@@ -118,8 +118,8 @@ pub enum ApiErrorResponse {
     DuplicateMandate,
     #[error(error_type = ErrorType::DuplicateRequest, code = "HE_01", message = "The merchant account with the specified details already exists in our records")]
     DuplicateMerchantAccount,
-    #[error(error_type = ErrorType::DuplicateRequest, code = "HE_01", message = "The merchant connector account with the specified details already exists in our records")]
-    DuplicateMerchantConnectorAccount,
+    #[error(error_type = ErrorType::DuplicateRequest, code = "HE_01", message = "The merchant connector account with the specified connector_label '{connector_label}' already exists in our records")]
+    DuplicateMerchantConnectorAccount { connector_label: String },
     #[error(error_type = ErrorType::DuplicateRequest, code = "HE_01", message = "The payment method with the specified details already exists in our records")]
     DuplicatePaymentMethod,
     #[error(error_type = ErrorType::DuplicateRequest, code = "HE_01", message = "The payment with the specified payment_id '{payment_id}' already exists in our records")]
@@ -270,7 +270,7 @@ impl actix_web::ResponseError for ApiErrorResponse {
             | Self::ApiKeyNotFound
             | Self::DisputeStatusValidationFailed { .. } => StatusCode::BAD_REQUEST, // 400
             Self::DuplicateMerchantAccount
-            | Self::DuplicateMerchantConnectorAccount
+            | Self::DuplicateMerchantConnectorAccount { .. }
             | Self::DuplicatePaymentMethod
             | Self::DuplicateMandate
             | Self::DisputeNotFound { .. }
@@ -409,8 +409,8 @@ impl common_utils::errors::ErrorSwitch<api_models::errors::types::ApiErrorRespon
             Self::DuplicateRefundRequest => AER::BadRequest(ApiError::new("HE", 1, "Duplicate refund request. Refund already attempted with the refund ID", None)),
             Self::DuplicateMandate => AER::BadRequest(ApiError::new("HE", 1, "Duplicate mandate request. Mandate already attempted with the Mandate ID", None)),
             Self::DuplicateMerchantAccount => AER::BadRequest(ApiError::new("HE", 1, "The merchant account with the specified details already exists in our records", None)),
-            Self::DuplicateMerchantConnectorAccount => {
-                AER::BadRequest(ApiError::new("HE", 1, "The merchant connector account with the specified details already exists in our records", None))
+            Self::DuplicateMerchantConnectorAccount { connector_label } => {
+                AER::BadRequest(ApiError::new("HE", 1, format!("The merchant connector account with the specified connector_label '{connector_label}' already exists in our records"), None))
             }
             Self::DuplicatePaymentMethod => AER::BadRequest(ApiError::new("HE", 1, "The payment method with the specified details already exists in our records", None)),
             Self::DuplicatePayment { payment_id } => {


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
This PR adds the connector_label to the message of the DuplicateMerchantConnectorAccount variant in the ApiErrorResponse enum


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!-- 
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
This resolves #899,
The connector_label is created by Hyperswitch internally hence it is necessary to send back the connector_label is the error response so that the user has an idea of what the connector_label is.


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
