### PR TITLE
fix(common_utils): manually implement diesel queryable for email newtype

### DIFF
--- a/crates/common_utils/src/pii.rs
+++ b/crates/common_utils/src/pii.rs
@@ -117,14 +117,7 @@ where
 }
 /// Email address
 #[derive(
-    serde::Serialize,
-    serde::Deserialize,
-    Debug,
-    Clone,
-    PartialEq,
-    Eq,
-    Default,
-    AsExpression,
+    serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Default, AsExpression,
 )]
 #[diesel(sql_type = diesel::sql_types::Text)]
 pub struct Email(Secret<String, EmailStrategy>);

--- a/crates/common_utils/src/pii.rs
+++ b/crates/common_utils/src/pii.rs
@@ -124,11 +124,22 @@ where
     PartialEq,
     Eq,
     Default,
-    Queryable,
     AsExpression,
 )]
 #[diesel(sql_type = diesel::sql_types::Text)]
 pub struct Email(Secret<String, EmailStrategy>);
+
+impl<DB> Queryable<diesel::sql_types::Text, DB> for Email
+where
+    DB: Backend,
+    Self: FromSql<sql_types::Text, DB>,
+{
+    type Row = Self;
+
+    fn build(row: Self::Row) -> deserialize::Result<Self> {
+        Ok(row)
+    }
+}
 
 impl<DB> FromSql<sql_types::Text, DB> for Email
 where


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
This PR does a manual implementation of the `Queryable` trait on the `Email` pii newtype.

### Additional Changes
None
- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!-- 
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
The `Row` associated type needs to be set to `Self` for newtypes to be compatible with our current manner of using them. deriving `Queryable` sets the `Row` associated type to the newtype's inner type.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Manual, compiler-guided

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
