### PR TITLE
fix(connector_customer): create connector_customer on requirement basis

### DIFF
--- a/config/development.toml
+++ b/config/development.toml
@@ -229,7 +229,7 @@ stripe = { long_lived_token = false, payment_method = "wallet", payment_method_t
 checkout = { long_lived_token = false, payment_method = "wallet"}
 
 [connector_customer]
-connector_list = "bluesnap, stripe"
+connector_list = "bluesnap,stripe"
 
 [dummy_connector]
 payment_ttl = 172800

--- a/crates/router/src/core/payments.rs
+++ b/crates/router/src/core/payments.rs
@@ -120,16 +120,9 @@ where
         get_connector_tokenization_action(state, &operation, payment_data, &validate_result)
             .await?;
 
-    let connector_string = connector
-        .as_ref()
-        .and_then(|connector_type| match connector_type {
-            api::ConnectorCallType::Single(connector) => Some(connector.connector_name.to_string()),
-            _ => None,
-        });
-
     let updated_customer = call_create_connector_customer_if_required(
         state,
-        &connector_string,
+        &payment_data.payment_attempt.connector.clone(),
         &customer,
         &merchant_account,
         &mut payment_data,

--- a/crates/router/src/core/payments.rs
+++ b/crates/router/src/core/payments.rs
@@ -640,7 +640,7 @@ where
                 connector_name,
                 api::GetToken::Connector,
             )?;
-            let (is_eligible, _, connector_customer_map) =
+            let (is_eligible, connector_customer_id, connector_customer_map) =
                 customers::should_call_connector_create_customer(state, &connector, customer)?;
 
             if is_eligible {
@@ -661,7 +661,8 @@ where
                 payment_data.connector_customer_id = connector_customer;
                 Ok(customer_update)
             } else {
-                // Customer already created in previous calls, no need to update
+                // Customer already created in previous calls use the same value, no need to update
+                payment_data.connector_customer_id = connector_customer_id;
                 Ok(None)
             }
         }

--- a/crates/router/src/core/payments/customers.rs
+++ b/crates/router/src/core/payments/customers.rs
@@ -15,68 +15,62 @@ use crate::{
 pub async fn create_connector_customer<F: Clone, T: Clone>(
     state: &AppState,
     connector: &api::ConnectorData,
-    customer: &Option<storage::Customer>,
     router_data: &types::RouterData<F, T, types::PaymentsResponseData>,
     customer_request_data: types::ConnectorCustomerData,
+    connector_customer_map: Option<serde_json::Map<String, serde_json::Value>>,
 ) -> RouterResult<(Option<String>, Option<storage::CustomerUpdate>)> {
-    let (is_eligible, connector_customer_id, connector_customer_map) =
-        should_call_connector_create_customer(state, connector, customer)?;
+    let connector_integration: services::BoxedConnectorIntegration<
+        '_,
+        api::CreateConnectorCustomer,
+        types::ConnectorCustomerData,
+        types::PaymentsResponseData,
+    > = connector.connector.get_connector_integration();
 
-    if is_eligible {
-        let connector_integration: services::BoxedConnectorIntegration<
-            '_,
-            api::CreateConnectorCustomer,
-            types::ConnectorCustomerData,
-            types::PaymentsResponseData,
-        > = connector.connector.get_connector_integration();
+    let customer_response_data: Result<types::PaymentsResponseData, types::ErrorResponse> =
+        Err(types::ErrorResponse::default());
 
-        let customer_response_data: Result<types::PaymentsResponseData, types::ErrorResponse> =
-            Err(types::ErrorResponse::default());
+    let customer_router_data = payments::helpers::router_data_type_conversion::<
+        _,
+        api::CreateConnectorCustomer,
+        _,
+        _,
+        _,
+        _,
+    >(
+        router_data.clone(),
+        customer_request_data,
+        customer_response_data,
+    );
 
-        let customer_router_data = payments::helpers::router_data_type_conversion::<
-            _,
-            api::CreateConnectorCustomer,
-            _,
-            _,
-            _,
-            _,
-        >(
-            router_data.clone(),
-            customer_request_data,
-            customer_response_data,
-        );
+    let resp = services::execute_connector_processing_step(
+        state,
+        connector_integration,
+        &customer_router_data,
+        payments::CallConnectorAction::Trigger,
+    )
+    .await
+    .map_err(|error| error.to_payment_failed_response())?;
 
-        let resp = services::execute_connector_processing_step(
-            state,
-            connector_integration,
-            &customer_router_data,
-            payments::CallConnectorAction::Trigger,
-        )
-        .await
-        .map_err(|error| error.to_payment_failed_response())?;
+    let connector_customer_id = match resp.response {
+        Ok(response) => match response {
+            types::PaymentsResponseData::ConnectorCustomerResponse {
+                connector_customer_id,
+            } => Some(connector_customer_id),
+            _ => None,
+        },
+        Err(err) => {
+            logger::debug!(payment_method_tokenization_error=?err);
+            None
+        }
+    };
 
-        let connector_customer_id = match resp.response {
-            Ok(response) => match response {
-                types::PaymentsResponseData::ConnectorCustomerResponse {
-                    connector_customer_id,
-                } => Some(connector_customer_id),
-                _ => None,
-            },
-            Err(err) => {
-                logger::debug!(payment_method_tokenization_error=?err);
-                None
-            }
-        };
-        let update_customer = update_connector_customer_in_customers(
-            connector,
-            connector_customer_map,
-            &connector_customer_id,
-        )
-        .await?;
-        Ok((connector_customer_id, update_customer))
-    } else {
-        Ok((connector_customer_id, None))
-    }
+    let update_customer = update_connector_customer_in_customers(
+        connector,
+        connector_customer_map,
+        &connector_customer_id,
+    )
+    .await?;
+    Ok((connector_customer_id, update_customer))
 }
 
 type CreateCustomerCheck = (
@@ -96,6 +90,7 @@ pub fn should_call_connector_create_customer(
         .connector_customer
         .connector_list
         .contains(&connector.connector_name);
+
     if connector_customer_filter {
         match customer {
             Some(customer) => match &customer.connector_customer {

--- a/crates/router/src/core/payments/flows.rs
+++ b/crates/router/src/core/payments/flows.rs
@@ -74,7 +74,7 @@ pub trait Feature<F, T> {
         &self,
         _state: &AppState,
         _connector: &api::ConnectorData,
-        _customer: &Option<storage::Customer>,
+        _connector_customer_map: Option<serde_json::Map<String, serde_json::Value>>,
     ) -> RouterResult<(Option<String>, Option<storage::CustomerUpdate>)>
     where
         F: Clone,

--- a/crates/router/src/core/payments/flows/authorize_flow.rs
+++ b/crates/router/src/core/payments/flows/authorize_flow.rs
@@ -100,14 +100,14 @@ impl Feature<api::Authorize, types::PaymentsAuthorizeData> for types::PaymentsAu
         &self,
         state: &AppState,
         connector: &api::ConnectorData,
-        customer: &Option<storage::Customer>,
+        connector_customer_map: Option<serde_json::Map<String, serde_json::Value>>,
     ) -> RouterResult<(Option<String>, Option<storage::CustomerUpdate>)> {
         customers::create_connector_customer(
             state,
             connector,
-            customer,
             self,
             types::ConnectorCustomerData::try_from(self.request.to_owned())?,
+            connector_customer_map,
         )
         .await
     }

--- a/crates/router/src/core/payments/flows/verfiy_flow.rs
+++ b/crates/router/src/core/payments/flows/verfiy_flow.rs
@@ -84,14 +84,14 @@ impl Feature<api::Verify, types::VerifyRequestData> for types::VerifyRouterData 
         &self,
         state: &AppState,
         connector: &api::ConnectorData,
-        customer: &Option<storage::Customer>,
+        connector_customer_map: Option<serde_json::Map<String, serde_json::Value>>,
     ) -> RouterResult<(Option<String>, Option<storage::CustomerUpdate>)> {
         customers::create_connector_customer(
             state,
             connector,
-            customer,
             self,
             types::ConnectorCustomerData::try_from(self.request.to_owned())?,
+            connector_customer_map,
         )
         .await
     }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix

## Description
<!-- Describe your changes in detail -->
There was a function called `should_call_connector_create_customer` which was called after constructing the router data. This PR includes the change to move it outside and break if creating the customer is not required.

### Additional Changes

- [x] This PR modifies application configuration/environment variables
Remove the space and change this value to
```toml
[connector_customer]
connector_list = "bluesnap,stripe"
```

<!-- 
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
BUGFIX

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Manual, create a payment and customer is also created. Subsequent calls are not made to create customer again
<img width="1074" alt="Screenshot 2023-05-09 at 8 47 51 PM" src="https://github.com/juspay/hyperswitch/assets/48803246/b12ab3b4-0cd2-49bd-9be3-db8f26f9e587">

Tested redirect payments too as it was failing previously.
![Screenshot 2023-05-09 at 9 22 37 PM](https://github.com/juspay/hyperswitch/assets/48803246/84121f32-f257-42fb-848b-00e42cdc549d)

Redirect success url https://www.google.com/?status=requires_capture&payment_intent_client_secret=pay_Rs7BYdDa0XODut0zQwpx&amount=10000



## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
