### PR TITLE
ci(connector-sanity-tests): fix invalid YAML syntax

### DIFF
--- a/.github/workflows/connector-sanity-tests.yml
+++ b/.github/workflows/connector-sanity-tests.yml
@@ -100,4 +100,4 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --package router --test connectors -- ${{ matrix.connector }}:: --test-threads=1
+          args: --package router --test connectors -- ${{ matrix.connector }}"::" --test-threads=1


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [x] CI/CD

## Description
<!-- Describe your changes in detail -->
This PR fixes invalid YAML syntax in the connector sanity tests workflow file.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
Fixes CI builds not running due to invalid syntax of the workflow file.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
I have the GitHub Actions VS Code extension installed, which previously complained about the invalid syntax when I opened the file. After this change, it no longer complains, so I believe this fixes it.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
