### PR TITLE
feat(error): add feature-gated stacktrace to error received from API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1781,6 +1781,7 @@ checksum = "5f00447f331c7f726db5b8532ebc9163519eed03c6d7c8b73c90b3ff5646ac85"
 dependencies = [
  "anyhow",
  "rustc_version",
+ "serde",
 ]
 
 [[package]]
@@ -2968,7 +2969,7 @@ dependencies = [
 [[package]]
 name = "opentelemetry"
 version = "0.18.0"
-source = "git+https://github.com/open-telemetry/opentelemetry-rust/?rev=44b90202fd744598db8b0ace5b8f0bad7ec45658#44b90202fd744598db8b0ace5b8f0bad7ec45658"
+source = "git+https://github.com/open-telemetry/opentelemetry-rust?rev=44b90202fd744598db8b0ace5b8f0bad7ec45658#44b90202fd744598db8b0ace5b8f0bad7ec45658"
 dependencies = [
  "opentelemetry_api",
  "opentelemetry_sdk",
@@ -2977,7 +2978,7 @@ dependencies = [
 [[package]]
 name = "opentelemetry-otlp"
 version = "0.11.0"
-source = "git+https://github.com/open-telemetry/opentelemetry-rust/?rev=44b90202fd744598db8b0ace5b8f0bad7ec45658#44b90202fd744598db8b0ace5b8f0bad7ec45658"
+source = "git+https://github.com/open-telemetry/opentelemetry-rust?rev=44b90202fd744598db8b0ace5b8f0bad7ec45658#44b90202fd744598db8b0ace5b8f0bad7ec45658"
 dependencies = [
  "async-trait",
  "futures",
@@ -2994,7 +2995,7 @@ dependencies = [
 [[package]]
 name = "opentelemetry-proto"
 version = "0.1.0"
-source = "git+https://github.com/open-telemetry/opentelemetry-rust/?rev=44b90202fd744598db8b0ace5b8f0bad7ec45658#44b90202fd744598db8b0ace5b8f0bad7ec45658"
+source = "git+https://github.com/open-telemetry/opentelemetry-rust?rev=44b90202fd744598db8b0ace5b8f0bad7ec45658#44b90202fd744598db8b0ace5b8f0bad7ec45658"
 dependencies = [
  "futures",
  "futures-util",
@@ -3006,7 +3007,7 @@ dependencies = [
 [[package]]
 name = "opentelemetry_api"
 version = "0.18.0"
-source = "git+https://github.com/open-telemetry/opentelemetry-rust/?rev=44b90202fd744598db8b0ace5b8f0bad7ec45658#44b90202fd744598db8b0ace5b8f0bad7ec45658"
+source = "git+https://github.com/open-telemetry/opentelemetry-rust?rev=44b90202fd744598db8b0ace5b8f0bad7ec45658#44b90202fd744598db8b0ace5b8f0bad7ec45658"
 dependencies = [
  "fnv",
  "futures-channel",
@@ -3021,7 +3022,7 @@ dependencies = [
 [[package]]
 name = "opentelemetry_sdk"
 version = "0.18.0"
-source = "git+https://github.com/open-telemetry/opentelemetry-rust/?rev=44b90202fd744598db8b0ace5b8f0bad7ec45658#44b90202fd744598db8b0ace5b8f0bad7ec45658"
+source = "git+https://github.com/open-telemetry/opentelemetry-rust?rev=44b90202fd744598db8b0ace5b8f0bad7ec45658#44b90202fd744598db8b0ace5b8f0bad7ec45658"
 dependencies = [
  "async-trait",
  "crossbeam-channel",

--- a/crates/api_models/Cargo.toml
+++ b/crates/api_models/Cargo.toml
@@ -12,6 +12,7 @@ errors = [
 ]
 multiple_mca = []
 dummy_connector = []
+detailed_errors = []
 
 [dependencies]
 actix-web = { version = "4.3.1", optional = true }

--- a/crates/router/Cargo.toml
+++ b/crates/router/Cargo.toml
@@ -26,6 +26,7 @@ vergen = ["router_env/vergen"]
 multiple_mca = ["api_models/multiple_mca"]
 dummy_connector = ["api_models/dummy_connector"]
 external_access_dc = ["dummy_connector"]
+detailed_errors = ["api_models/detailed_errors"]
 
 
 [dependencies]
@@ -45,7 +46,7 @@ crc32fast = "1.3.2"
 diesel = { version = "2.0.3", features = ["postgres"] }
 dyn-clone = "1.0.11"
 encoding_rs = "0.8.32"
-error-stack = "0.3.1"
+error-stack = { version = "0.3.1", features = [ "serde" ] }
 frunk = "0.4.1"
 frunk_core = "0.4.1"
 futures = "0.3.28"

--- a/crates/router/Cargo.toml
+++ b/crates/router/Cargo.toml
@@ -26,7 +26,7 @@ vergen = ["router_env/vergen"]
 multiple_mca = ["api_models/multiple_mca"]
 dummy_connector = ["api_models/dummy_connector"]
 external_access_dc = ["dummy_connector"]
-detailed_errors = ["api_models/detailed_errors"]
+detailed_errors = ["api_models/detailed_errors", "error-stack/serde"]
 
 
 [dependencies]
@@ -46,7 +46,7 @@ crc32fast = "1.3.2"
 diesel = { version = "2.0.3", features = ["postgres"] }
 dyn-clone = "1.0.11"
 encoding_rs = "0.8.32"
-error-stack = { version = "0.3.1", features = [ "serde" ] }
+error-stack = "0.3.1"
 frunk = "0.4.1"
 frunk_core = "0.4.1"
 futures = "0.3.28"

--- a/crates/router/src/compatibility/stripe/errors.rs
+++ b/crates/router/src/compatibility/stripe/errors.rs
@@ -609,3 +609,5 @@ impl common_utils::errors::ErrorSwitch<StripeErrorCode> for errors::ApiErrorResp
         self.clone().into()
     }
 }
+
+impl crate::services::EmbedError for error_stack::Report<StripeErrorCode> {}

--- a/crates/router/src/compatibility/wrap.rs
+++ b/crates/router/src/compatibility/wrap.rs
@@ -8,7 +8,7 @@ use serde::Serialize;
 use crate::{
     core::errors::{self, RouterResult},
     routes::app::AppStateInfo,
-    services::{api, authentication as auth, logger},
+    services::{self, api, authentication as auth, logger},
 };
 
 #[instrument(skip(request, payload, state, func, api_authentication))]
@@ -25,6 +25,7 @@ where
     Q: Serialize + std::fmt::Debug + 'a,
     S: TryFrom<Q> + Serialize,
     E: Serialize + error_stack::Context + actix_web::ResponseError + Clone,
+    error_stack::Report<E>: services::EmbedError,
     errors::ApiErrorResponse: ErrorSwitch<E>,
     T: std::fmt::Debug,
     A: AppStateInfo,

--- a/crates/router/src/core/errors.rs
+++ b/crates/router/src/core/errors.rs
@@ -461,3 +461,45 @@ pub enum WebhooksFlowError {
     #[error("Dispute webhook status validation failed")]
     DisputeWebhookValidationFailed,
 }
+
+#[cfg(feature = "detailed_errors")]
+#[derive(serde::Deserialize)]
+pub struct NestedErrorStack<'a> {
+    context: std::borrow::Cow<'a, str>,
+    attachments: Vec<std::borrow::Cow<'a, str>>,
+    sources: Vec<NestedErrorStack<'a>>,
+}
+
+#[cfg(feature = "detailed_errors")]
+#[derive(serde::Serialize, Debug)]
+struct LinearErrorStack<'a> {
+    context: std::borrow::Cow<'a, str>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    attachments: Vec<std::borrow::Cow<'a, str>>,
+}
+
+#[cfg(feature = "detailed_errors")]
+#[derive(serde::Serialize, Debug)]
+pub struct VecLinearErrorStack<'a>(Vec<LinearErrorStack<'a>>);
+
+#[cfg(feature = "detailed_errors")]
+impl<'a> From<Vec<NestedErrorStack<'a>>> for VecLinearErrorStack<'a> {
+    fn from(value: Vec<NestedErrorStack<'a>>) -> Self {
+        let multi_layered_errors: Vec<_> = value
+            .into_iter()
+            .flat_map(|current_error| {
+                [LinearErrorStack {
+                    context: current_error.context,
+                    attachments: current_error.attachments,
+                }]
+                .into_iter()
+                .chain(
+                    Into::<VecLinearErrorStack<'a>>::into(current_error.sources)
+                        .0
+                        .into_iter(),
+                )
+            })
+            .collect();
+        Self(multi_layered_errors)
+    }
+}

--- a/crates/router/src/core/errors/api_error_response.rs
+++ b/crates/router/src/core/errors/api_error_response.rs
@@ -300,6 +300,8 @@ impl actix_web::ResponseError for ApiErrorResponse {
     }
 }
 
+impl crate::services::EmbedError for error_stack::Report<ApiErrorResponse> {}
+
 impl common_utils::errors::ErrorSwitch<api_models::errors::types::ApiErrorResponse>
     for ApiErrorResponse
 {


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
This change provides a feature-gated functionality for exporting the `stacktrace` in the API response, for easier debugging and faster RCAs

### Additional Changes

- [x] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

This change only affects the outbound error response, adding a optional field `stacktrace` which is only provided when the specific feature is enabled.

<!-- 
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?

via. postman

<img width="1205" alt="Screenshot 2023-05-10 at 1 33 25 PM" src="https://github.com/juspay/hyperswitch/assets/51093026/5845829a-8acf-4bec-86b8-c644e8d4952f">

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
