### PR TITLE
fix(Google Pay): allow custom fields in `GpayTokenParameters` for Google Pay via Stripe

### DIFF
--- a/config/development.toml
+++ b/config/development.toml
@@ -229,7 +229,7 @@ stripe = { long_lived_token = false, payment_method = "wallet", payment_method_t
 checkout = { long_lived_token = false, payment_method = "wallet"}
 
 [connector_customer]
-connector_list = "bluesnap, stripe"
+connector_list = "bluesnap,stripe"
 
 [dummy_connector]
 payment_ttl = 172800

--- a/crates/api_models/src/payments.rs
+++ b/crates/api_models/src/payments.rs
@@ -1442,11 +1442,12 @@ pub struct GpayTokenParameters {
     /// The merchant ID registered in the connector associated
     #[serde(skip_serializing_if = "Option::is_none")]
     pub gateway_merchant_id: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[serde(rename = "stripe:version")]
+    #[serde(skip_serializing_if = "Option::is_none", rename = "stripe:version")]
     pub stripe_version: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[serde(rename = "stripe:publishableKey")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        rename = "stripe:publishableKey"
+    )]
     pub stripe_publishable_key: Option<String>,
 }
 

--- a/crates/api_models/src/payments.rs
+++ b/crates/api_models/src/payments.rs
@@ -1440,7 +1440,14 @@ pub struct GpayTokenParameters {
     /// The name of the connector
     pub gateway: String,
     /// The merchant ID registered in the connector associated
-    pub gateway_merchant_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub gateway_merchant_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "stripe:version")]
+    pub stripe_version: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "stripe:publishableKey")]
+    pub stripe_publishable_key: Option<String>,
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, ToSchema)]

--- a/crates/api_models/src/payments.rs
+++ b/crates/api_models/src/payments.rs
@@ -704,7 +704,7 @@ pub enum WalletData {
 }
 
 #[derive(Eq, PartialEq, Clone, Debug, serde::Deserialize, serde::Serialize, ToSchema)]
-#[serde(rename_all(serialize = "camelCase", deserialize = "snake_case"))]
+#[serde(rename_all = "snake_case")]
 pub struct GooglePayWalletData {
     /// The type of payment method
     #[serde(rename = "type")]
@@ -736,7 +736,7 @@ pub struct MbWayRedirection {
 }
 
 #[derive(Eq, PartialEq, Clone, Debug, serde::Deserialize, serde::Serialize, ToSchema)]
-#[serde(rename_all(serialize = "camelCase", deserialize = "snake_case"))]
+#[serde(rename_all = "snake_case")]
 pub struct GooglePayPaymentMethodInfo {
     /// The name of the card network
     pub card_network: String,

--- a/crates/router/src/connector/bluesnap/transformers.rs
+++ b/crates/router/src/connector/bluesnap/transformers.rs
@@ -92,7 +92,9 @@ impl TryFrom<&types::PaymentsAuthorizeRouterData> for BluesnapPaymentsRequest {
                 api_models::payments::WalletData::GooglePay(payment_method_data) => {
                     let gpay_object = Encode::<BluesnapGooglePayObject>::encode_to_string_of_json(
                         &BluesnapGooglePayObject {
-                            payment_method_data: utils::GooglePayWalletData::from(payment_method_data),
+                            payment_method_data: utils::GooglePayWalletData::from(
+                                payment_method_data,
+                            ),
                         },
                     )
                     .change_context(errors::ConnectorError::RequestEncodingFailed)?;

--- a/crates/router/src/connector/bluesnap/transformers.rs
+++ b/crates/router/src/connector/bluesnap/transformers.rs
@@ -55,10 +55,10 @@ pub struct BluesnapWallet {
     encoded_payment_token: String,
 }
 
-#[derive(Debug, Serialize, Eq, PartialEq)]
+#[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct BluesnapGooglePayObject {
-    payment_method_data: api_models::payments::GooglePayWalletData,
+    payment_method_data: utils::GooglePayWalletData,
 }
 
 #[derive(Debug, Serialize, Eq, PartialEq)]
@@ -92,7 +92,7 @@ impl TryFrom<&types::PaymentsAuthorizeRouterData> for BluesnapPaymentsRequest {
                 api_models::payments::WalletData::GooglePay(payment_method_data) => {
                     let gpay_object = Encode::<BluesnapGooglePayObject>::encode_to_string_of_json(
                         &BluesnapGooglePayObject {
-                            payment_method_data,
+                            payment_method_data: utils::GooglePayWalletData::from(payment_method_data),
                         },
                     )
                     .change_context(errors::ConnectorError::RequestEncodingFailed)?;

--- a/crates/router/src/connector/nuvei/transformers.rs
+++ b/crates/router/src/connector/nuvei/transformers.rs
@@ -425,7 +425,7 @@ impl TryFrom<payments::GooglePayWalletData> for NuveiPaymentsRequest {
                         mobile_token: common_utils::ext_traits::Encode::<
                             payments::GooglePayWalletData,
                         >::encode_to_string_of_json(
-                            &gpay_data
+                            &utils::GooglePayWalletData::from(gpay_data)
                         )
                         .change_context(errors::ConnectorError::RequestEncodingFailed)?,
                     }),

--- a/crates/router/src/connector/utils.rs
+++ b/crates/router/src/connector/utils.rs
@@ -319,6 +319,47 @@ impl RefundsRequestData for types::RefundsData {
     }
 }
 
+#[derive(Clone, Debug, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GooglePayWalletData {
+    #[serde(rename = "type")]
+    pub pm_type: String,
+    pub description: String,
+    pub info: GooglePayPaymentMethodInfo,
+    pub tokenization_data: GpayTokenizationData,
+}
+
+#[derive(Clone, Debug, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GooglePayPaymentMethodInfo {
+    pub card_network: String,
+    pub card_details: String,
+}
+
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct GpayTokenizationData {
+    #[serde(rename = "type")]
+    pub token_type: String,
+    pub token: String,
+}
+
+impl From<api_models::payments::GooglePayWalletData> for GooglePayWalletData {
+    fn from(data: api_models::payments::GooglePayWalletData) -> Self {
+        Self {
+            pm_type: data.pm_type,
+            description: data.description,
+            info: GooglePayPaymentMethodInfo {
+                card_network: data.info.card_network,
+                card_details: data.info.card_details,
+            },
+            tokenization_data: GpayTokenizationData{
+                token_type: data.tokenization_data.token_type,
+                token: data.tokenization_data.token,
+            },
+        }
+    }
+}
+
 static CARD_REGEX: Lazy<HashMap<CardIssuer, Result<Regex, regex::Error>>> = Lazy::new(|| {
     let mut map = HashMap::new();
     // Reference: https://gist.github.com/michaelkeevildown/9096cd3aac9029c4e6e05588448a8841

--- a/crates/router/src/connector/utils.rs
+++ b/crates/router/src/connector/utils.rs
@@ -352,7 +352,7 @@ impl From<api_models::payments::GooglePayWalletData> for GooglePayWalletData {
                 card_network: data.info.card_network,
                 card_details: data.info.card_details,
             },
-            tokenization_data: GpayTokenizationData{
+            tokenization_data: GpayTokenizationData {
                 token_type: data.tokenization_data.token_type,
                 token: data.tokenization_data.token,
             },

--- a/crates/router/src/core/payments.rs
+++ b/crates/router/src/core/payments.rs
@@ -120,16 +120,9 @@ where
         get_connector_tokenization_action(state, &operation, payment_data, &validate_result)
             .await?;
 
-    let connector_string = connector
-        .as_ref()
-        .and_then(|connector_type| match connector_type {
-            api::ConnectorCallType::Single(connector) => Some(connector.connector_name.to_string()),
-            _ => None,
-        });
-
     let updated_customer = call_create_connector_customer_if_required(
         state,
-        &connector_string,
+        &payment_data.payment_attempt.connector.clone(),
         &customer,
         &merchant_account,
         &mut payment_data,

--- a/crates/router/src/core/payments.rs
+++ b/crates/router/src/core/payments.rs
@@ -640,7 +640,7 @@ where
                 connector_name,
                 api::GetToken::Connector,
             )?;
-            let (is_eligible, _, connector_customer_map) =
+            let (is_eligible, connector_customer_id, connector_customer_map) =
                 customers::should_call_connector_create_customer(state, &connector, customer)?;
 
             if is_eligible {
@@ -661,7 +661,8 @@ where
                 payment_data.connector_customer_id = connector_customer;
                 Ok(customer_update)
             } else {
-                // Customer already created in previous calls, no need to update
+                // Customer already created in previous calls use the same value, no need to update
+                payment_data.connector_customer_id = connector_customer_id;
                 Ok(None)
             }
         }

--- a/crates/router/src/core/payments/customers.rs
+++ b/crates/router/src/core/payments/customers.rs
@@ -15,68 +15,62 @@ use crate::{
 pub async fn create_connector_customer<F: Clone, T: Clone>(
     state: &AppState,
     connector: &api::ConnectorData,
-    customer: &Option<storage::Customer>,
     router_data: &types::RouterData<F, T, types::PaymentsResponseData>,
     customer_request_data: types::ConnectorCustomerData,
+    connector_customer_map: Option<serde_json::Map<String, serde_json::Value>>,
 ) -> RouterResult<(Option<String>, Option<storage::CustomerUpdate>)> {
-    let (is_eligible, connector_customer_id, connector_customer_map) =
-        should_call_connector_create_customer(state, connector, customer)?;
+    let connector_integration: services::BoxedConnectorIntegration<
+        '_,
+        api::CreateConnectorCustomer,
+        types::ConnectorCustomerData,
+        types::PaymentsResponseData,
+    > = connector.connector.get_connector_integration();
 
-    if is_eligible {
-        let connector_integration: services::BoxedConnectorIntegration<
-            '_,
-            api::CreateConnectorCustomer,
-            types::ConnectorCustomerData,
-            types::PaymentsResponseData,
-        > = connector.connector.get_connector_integration();
+    let customer_response_data: Result<types::PaymentsResponseData, types::ErrorResponse> =
+        Err(types::ErrorResponse::default());
 
-        let customer_response_data: Result<types::PaymentsResponseData, types::ErrorResponse> =
-            Err(types::ErrorResponse::default());
+    let customer_router_data = payments::helpers::router_data_type_conversion::<
+        _,
+        api::CreateConnectorCustomer,
+        _,
+        _,
+        _,
+        _,
+    >(
+        router_data.clone(),
+        customer_request_data,
+        customer_response_data,
+    );
 
-        let customer_router_data = payments::helpers::router_data_type_conversion::<
-            _,
-            api::CreateConnectorCustomer,
-            _,
-            _,
-            _,
-            _,
-        >(
-            router_data.clone(),
-            customer_request_data,
-            customer_response_data,
-        );
+    let resp = services::execute_connector_processing_step(
+        state,
+        connector_integration,
+        &customer_router_data,
+        payments::CallConnectorAction::Trigger,
+    )
+    .await
+    .map_err(|error| error.to_payment_failed_response())?;
 
-        let resp = services::execute_connector_processing_step(
-            state,
-            connector_integration,
-            &customer_router_data,
-            payments::CallConnectorAction::Trigger,
-        )
-        .await
-        .map_err(|error| error.to_payment_failed_response())?;
+    let connector_customer_id = match resp.response {
+        Ok(response) => match response {
+            types::PaymentsResponseData::ConnectorCustomerResponse {
+                connector_customer_id,
+            } => Some(connector_customer_id),
+            _ => None,
+        },
+        Err(err) => {
+            logger::debug!(payment_method_tokenization_error=?err);
+            None
+        }
+    };
 
-        let connector_customer_id = match resp.response {
-            Ok(response) => match response {
-                types::PaymentsResponseData::ConnectorCustomerResponse {
-                    connector_customer_id,
-                } => Some(connector_customer_id),
-                _ => None,
-            },
-            Err(err) => {
-                logger::debug!(payment_method_tokenization_error=?err);
-                None
-            }
-        };
-        let update_customer = update_connector_customer_in_customers(
-            connector,
-            connector_customer_map,
-            &connector_customer_id,
-        )
-        .await?;
-        Ok((connector_customer_id, update_customer))
-    } else {
-        Ok((connector_customer_id, None))
-    }
+    let update_customer = update_connector_customer_in_customers(
+        connector,
+        connector_customer_map,
+        &connector_customer_id,
+    )
+    .await?;
+    Ok((connector_customer_id, update_customer))
 }
 
 type CreateCustomerCheck = (
@@ -96,6 +90,7 @@ pub fn should_call_connector_create_customer(
         .connector_customer
         .connector_list
         .contains(&connector.connector_name);
+
     if connector_customer_filter {
         match customer {
             Some(customer) => match &customer.connector_customer {

--- a/crates/router/src/core/payments/flows.rs
+++ b/crates/router/src/core/payments/flows.rs
@@ -74,7 +74,7 @@ pub trait Feature<F, T> {
         &self,
         _state: &AppState,
         _connector: &api::ConnectorData,
-        _customer: &Option<storage::Customer>,
+        _connector_customer_map: Option<serde_json::Map<String, serde_json::Value>>,
     ) -> RouterResult<(Option<String>, Option<storage::CustomerUpdate>)>
     where
         F: Clone,

--- a/crates/router/src/core/payments/flows/authorize_flow.rs
+++ b/crates/router/src/core/payments/flows/authorize_flow.rs
@@ -100,14 +100,14 @@ impl Feature<api::Authorize, types::PaymentsAuthorizeData> for types::PaymentsAu
         &self,
         state: &AppState,
         connector: &api::ConnectorData,
-        customer: &Option<storage::Customer>,
+        connector_customer_map: Option<serde_json::Map<String, serde_json::Value>>,
     ) -> RouterResult<(Option<String>, Option<storage::CustomerUpdate>)> {
         customers::create_connector_customer(
             state,
             connector,
-            customer,
             self,
             types::ConnectorCustomerData::try_from(self.request.to_owned())?,
+            connector_customer_map,
         )
         .await
     }

--- a/crates/router/src/core/payments/flows/verfiy_flow.rs
+++ b/crates/router/src/core/payments/flows/verfiy_flow.rs
@@ -84,14 +84,14 @@ impl Feature<api::Verify, types::VerifyRequestData> for types::VerifyRouterData 
         &self,
         state: &AppState,
         connector: &api::ConnectorData,
-        customer: &Option<storage::Customer>,
+        connector_customer_map: Option<serde_json::Map<String, serde_json::Value>>,
     ) -> RouterResult<(Option<String>, Option<storage::CustomerUpdate>)> {
         customers::create_connector_customer(
             state,
             connector,
-            customer,
             self,
             types::ConnectorCustomerData::try_from(self.request.to_owned())?,
+            connector_customer_map,
         )
         .await
     }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Stripe requires 
``` 
"gateway": "stripe"
"stripe:version": "2018-10-31"
"stripe:publishableKey": "YOUR_PUBLIC_STRIPE_KEY"
  ```
dashboard started sending these fields from front-end but backend is not handling the same, this PR will fix the issue.
Previously it was only
```
  "gateway": "assist"
  "gatewayMerchantId": "YOUR_GATEWAY_MERCHANT_ID"
```
### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!-- 
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [X] I formatted the code `cargo +nightly fmt --all`
- [X] I addressed lints thrown by `cargo clippy`
- [X] I reviewed submitted code