### PR TITLE
fix(mandate): only trigger mandate procedure on successful connector call

### DIFF
--- a/crates/router/src/core/mandate.rs
+++ b/crates/router/src/core/mandate.rs
@@ -134,82 +134,86 @@ pub async fn mandate_procedure<F, FData>(
 where
     FData: MandateBehaviour,
 {
-    match resp.request.get_mandate_id() {
-        Some(mandate_id) => {
-            let mandate_id = &mandate_id.mandate_id;
-            let mandate = state
-                .store
-                .find_mandate_by_merchant_id_mandate_id(resp.merchant_id.as_ref(), mandate_id)
-                .await
-                .change_context(errors::ApiErrorResponse::MandateNotFound)?;
-            let mandate = match mandate.mandate_type {
-                storage_enums::MandateType::SingleUse => state
+    match resp.response {
+        Err(_) => {}
+        Ok(_) => match resp.request.get_mandate_id() {
+            Some(mandate_id) => {
+                let mandate_id = &mandate_id.mandate_id;
+                let mandate = state
                     .store
-                    .update_mandate_by_merchant_id_mandate_id(
-                        &resp.merchant_id,
-                        mandate_id,
-                        storage::MandateUpdate::StatusUpdate {
-                            mandate_status: storage_enums::MandateStatus::Revoked,
-                        },
-                    )
+                    .find_mandate_by_merchant_id_mandate_id(resp.merchant_id.as_ref(), mandate_id)
                     .await
-                    .change_context(errors::ApiErrorResponse::MandateUpdateFailed),
-                storage_enums::MandateType::MultiUse => state
-                    .store
-                    .update_mandate_by_merchant_id_mandate_id(
-                        &resp.merchant_id,
-                        mandate_id,
-                        storage::MandateUpdate::CaptureAmountUpdate {
-                            amount_captured: Some(
-                                mandate.amount_captured.unwrap_or(0) + resp.request.get_amount(),
-                            ),
-                        },
-                    )
-                    .await
-                    .change_context(errors::ApiErrorResponse::MandateUpdateFailed),
-            }?;
-            metrics::SUBSEQUENT_MANDATE_PAYMENT.add(
-                &metrics::CONTEXT,
-                1,
-                &[metrics::request::add_attributes(
-                    "connector",
-                    mandate.connector,
-                )],
-            );
-            resp.payment_method_id = Some(mandate.payment_method_id);
-        }
-        None => {
-            if resp.request.get_setup_mandate_details().is_some() {
-                resp.payment_method_id = pm_id.clone();
-                let (mandate_reference, network_txn_id) = match resp.response.as_ref().ok() {
-                    Some(types::PaymentsResponseData::TransactionResponse {
-                        mandate_reference,
+                    .change_context(errors::ApiErrorResponse::MandateNotFound)?;
+                router_env::logger::error!(?resp.response);
+                let mandate = match mandate.mandate_type {
+                    storage_enums::MandateType::SingleUse => state
+                        .store
+                        .update_mandate_by_merchant_id_mandate_id(
+                            &resp.merchant_id,
+                            mandate_id,
+                            storage::MandateUpdate::StatusUpdate {
+                                mandate_status: storage_enums::MandateStatus::Revoked,
+                            },
+                        )
+                        .await
+                        .change_context(errors::ApiErrorResponse::MandateUpdateFailed),
+                    storage_enums::MandateType::MultiUse => state
+                        .store
+                        .update_mandate_by_merchant_id_mandate_id(
+                            &resp.merchant_id,
+                            mandate_id,
+                            storage::MandateUpdate::CaptureAmountUpdate {
+                                amount_captured: Some(
+                                    mandate.amount_captured.unwrap_or(0)
+                                        + resp.request.get_amount(),
+                                ),
+                            },
+                        )
+                        .await
+                        .change_context(errors::ApiErrorResponse::MandateUpdateFailed),
+                }?;
+                metrics::SUBSEQUENT_MANDATE_PAYMENT.add(
+                    &metrics::CONTEXT,
+                    1,
+                    &[metrics::request::add_attributes(
+                        "connector",
+                        mandate.connector,
+                    )],
+                );
+                resp.payment_method_id = Some(mandate.payment_method_id);
+            }
+            None => {
+                if resp.request.get_setup_mandate_details().is_some() {
+                    resp.payment_method_id = pm_id.clone();
+                    let (mandate_reference, network_txn_id) = match resp.response.as_ref().ok() {
+                        Some(types::PaymentsResponseData::TransactionResponse {
+                            mandate_reference,
+                            network_txn_id,
+                            ..
+                        }) => (mandate_reference.clone(), network_txn_id.clone()),
+                        _ => (None, None),
+                    };
+
+                    let mandate_ids = mandate_reference
+                        .map(|md| {
+                            Encode::<types::MandateReference>::encode_to_value(&md)
+                                .change_context(errors::ApiErrorResponse::MandateNotFound)
+                                .map(masking::Secret::new)
+                        })
+                        .transpose()?;
+
+                    if let Some(new_mandate_data) = helpers::generate_mandate(
+                        resp.merchant_id.clone(),
+                        resp.connector.clone(),
+                        resp.request.get_setup_mandate_details().map(Clone::clone),
+                        maybe_customer,
+                        pm_id.get_required_value("payment_method_id")?,
+                        mandate_ids,
                         network_txn_id,
-                        ..
-                    }) => (mandate_reference.clone(), network_txn_id.clone()),
-                    _ => (None, None),
-                };
-
-                let mandate_ids = mandate_reference
-                    .map(|md| {
-                        Encode::<types::MandateReference>::encode_to_value(&md)
-                            .change_context(errors::ApiErrorResponse::MandateNotFound)
-                            .map(masking::Secret::new)
-                    })
-                    .transpose()?;
-
-                if let Some(new_mandate_data) = helpers::generate_mandate(
-                    resp.merchant_id.clone(),
-                    resp.connector.clone(),
-                    resp.request.get_setup_mandate_details().map(Clone::clone),
-                    maybe_customer,
-                    pm_id.get_required_value("payment_method_id")?,
-                    mandate_ids,
-                    network_txn_id,
-                ) {
-                    let connector = new_mandate_data.connector.clone();
-                    logger::debug!("{:?}", new_mandate_data);
-                    resp.request
+                    ) {
+                        let connector = new_mandate_data.connector.clone();
+                        logger::debug!("{:?}", new_mandate_data);
+                        resp.request
                         .set_mandate_id(Some(api_models::payments::MandateIds {
                             mandate_id: new_mandate_data.mandate_id.clone(),
                             mandate_reference_id: new_mandate_data
@@ -236,21 +240,23 @@ where
                                     }
                                 )))
                         }));
-                    state
-                        .store
-                        .insert_mandate(new_mandate_data)
-                        .await
-                        .to_duplicate_response(errors::ApiErrorResponse::DuplicateRefundRequest)?;
-                    metrics::MANDATE_COUNT.add(
-                        &metrics::CONTEXT,
-                        1,
-                        &[metrics::request::add_attributes("connector", connector)],
-                    );
-                };
+                        state
+                            .store
+                            .insert_mandate(new_mandate_data)
+                            .await
+                            .to_duplicate_response(
+                                errors::ApiErrorResponse::DuplicateRefundRequest,
+                            )?;
+                        metrics::MANDATE_COUNT.add(
+                            &metrics::CONTEXT,
+                            1,
+                            &[metrics::request::add_attributes("connector", connector)],
+                        );
+                    };
+                }
             }
-        }
+        },
     }
-
     Ok(resp)
 }
 

--- a/crates/router/src/core/mandate.rs
+++ b/crates/router/src/core/mandate.rs
@@ -144,7 +144,6 @@ where
                     .find_mandate_by_merchant_id_mandate_id(resp.merchant_id.as_ref(), mandate_id)
                     .await
                     .change_context(errors::ApiErrorResponse::MandateNotFound)?;
-                router_env::logger::error!(?resp.response);
                 let mandate = match mandate.mandate_type {
                     storage_enums::MandateType::SingleUse => state
                         .store


### PR DESCRIPTION


## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Consider a scenario where, we are creating a mandate, and there was a failure at the connector side, even in that case the mandate is created.
The bug prominently affects single_use mandate. Where, in the recurring payment, if there was a failure on the connector side, the system still marks the mandate as done

<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!-- 
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
Hackathon
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
Postman and Manual
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
