### PR TITLE
fix(google_pay): allow custom fields in `GpayTokenParameters` for google pay via stripe

### DIFF
--- a/crates/api_models/src/payments.rs
+++ b/crates/api_models/src/payments.rs
@@ -1459,11 +1459,12 @@ pub struct GpayTokenParameters {
     /// The merchant ID registered in the connector associated
     #[serde(skip_serializing_if = "Option::is_none")]
     pub gateway_merchant_id: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[serde(rename = "stripe:version")]
+    #[serde(skip_serializing_if = "Option::is_none", rename = "stripe:version")]
     pub stripe_version: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[serde(rename = "stripe:publishableKey")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        rename = "stripe:publishableKey"
+    )]
     pub stripe_publishable_key: Option<String>,
 }
 

--- a/crates/api_models/src/payments.rs
+++ b/crates/api_models/src/payments.rs
@@ -1457,7 +1457,14 @@ pub struct GpayTokenParameters {
     /// The name of the connector
     pub gateway: String,
     /// The merchant ID registered in the connector associated
-    pub gateway_merchant_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub gateway_merchant_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "stripe:version")]
+    pub stripe_version: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "stripe:publishableKey")]
+    pub stripe_publishable_key: Option<String>,
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, ToSchema)]

--- a/crates/api_models/src/payments.rs
+++ b/crates/api_models/src/payments.rs
@@ -717,7 +717,7 @@ pub enum WalletData {
 }
 
 #[derive(Eq, PartialEq, Clone, Debug, serde::Deserialize, serde::Serialize, ToSchema)]
-#[serde(rename_all(serialize = "camelCase", deserialize = "snake_case"))]
+#[serde(rename_all = "snake_case")]
 pub struct GooglePayWalletData {
     /// The type of payment method
     #[serde(rename = "type")]
@@ -749,7 +749,7 @@ pub struct MbWayRedirection {
 }
 
 #[derive(Eq, PartialEq, Clone, Debug, serde::Deserialize, serde::Serialize, ToSchema)]
-#[serde(rename_all(serialize = "camelCase", deserialize = "snake_case"))]
+#[serde(rename_all = "snake_case")]
 pub struct GooglePayPaymentMethodInfo {
     /// The name of the card network
     pub card_network: String,

--- a/crates/router/src/connector/bluesnap/transformers.rs
+++ b/crates/router/src/connector/bluesnap/transformers.rs
@@ -92,7 +92,9 @@ impl TryFrom<&types::PaymentsAuthorizeRouterData> for BluesnapPaymentsRequest {
                 api_models::payments::WalletData::GooglePay(payment_method_data) => {
                     let gpay_object = Encode::<BluesnapGooglePayObject>::encode_to_string_of_json(
                         &BluesnapGooglePayObject {
-                            payment_method_data: utils::GooglePayWalletData::from(payment_method_data),
+                            payment_method_data: utils::GooglePayWalletData::from(
+                                payment_method_data,
+                            ),
                         },
                     )
                     .change_context(errors::ConnectorError::RequestEncodingFailed)?;

--- a/crates/router/src/connector/bluesnap/transformers.rs
+++ b/crates/router/src/connector/bluesnap/transformers.rs
@@ -55,10 +55,10 @@ pub struct BluesnapWallet {
     encoded_payment_token: String,
 }
 
-#[derive(Debug, Serialize, Eq, PartialEq)]
+#[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct BluesnapGooglePayObject {
-    payment_method_data: api_models::payments::GooglePayWalletData,
+    payment_method_data: utils::GooglePayWalletData,
 }
 
 #[derive(Debug, Serialize, Eq, PartialEq)]
@@ -92,7 +92,7 @@ impl TryFrom<&types::PaymentsAuthorizeRouterData> for BluesnapPaymentsRequest {
                 api_models::payments::WalletData::GooglePay(payment_method_data) => {
                     let gpay_object = Encode::<BluesnapGooglePayObject>::encode_to_string_of_json(
                         &BluesnapGooglePayObject {
-                            payment_method_data,
+                            payment_method_data: utils::GooglePayWalletData::from(payment_method_data),
                         },
                     )
                     .change_context(errors::ConnectorError::RequestEncodingFailed)?;

--- a/crates/router/src/connector/nuvei/transformers.rs
+++ b/crates/router/src/connector/nuvei/transformers.rs
@@ -429,7 +429,7 @@ impl TryFrom<payments::GooglePayWalletData> for NuveiPaymentsRequest {
                         mobile_token: common_utils::ext_traits::Encode::<
                             payments::GooglePayWalletData,
                         >::encode_to_string_of_json(
-                            &gpay_data
+                            &utils::GooglePayWalletData::from(gpay_data)
                         )
                         .change_context(errors::ConnectorError::RequestEncodingFailed)?,
                     }),

--- a/crates/router/src/connector/utils.rs
+++ b/crates/router/src/connector/utils.rs
@@ -325,6 +325,47 @@ impl RefundsRequestData for types::RefundsData {
     }
 }
 
+#[derive(Clone, Debug, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GooglePayWalletData {
+    #[serde(rename = "type")]
+    pub pm_type: String,
+    pub description: String,
+    pub info: GooglePayPaymentMethodInfo,
+    pub tokenization_data: GpayTokenizationData,
+}
+
+#[derive(Clone, Debug, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GooglePayPaymentMethodInfo {
+    pub card_network: String,
+    pub card_details: String,
+}
+
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct GpayTokenizationData {
+    #[serde(rename = "type")]
+    pub token_type: String,
+    pub token: String,
+}
+
+impl From<api_models::payments::GooglePayWalletData> for GooglePayWalletData {
+    fn from(data: api_models::payments::GooglePayWalletData) -> Self {
+        Self {
+            pm_type: data.pm_type,
+            description: data.description,
+            info: GooglePayPaymentMethodInfo {
+                card_network: data.info.card_network,
+                card_details: data.info.card_details,
+            },
+            tokenization_data: GpayTokenizationData{
+                token_type: data.tokenization_data.token_type,
+                token: data.tokenization_data.token,
+            },
+        }
+    }
+}
+
 static CARD_REGEX: Lazy<HashMap<CardIssuer, Result<Regex, regex::Error>>> = Lazy::new(|| {
     let mut map = HashMap::new();
     // Reference: https://gist.github.com/michaelkeevildown/9096cd3aac9029c4e6e05588448a8841

--- a/crates/router/src/connector/utils.rs
+++ b/crates/router/src/connector/utils.rs
@@ -358,7 +358,7 @@ impl From<api_models::payments::GooglePayWalletData> for GooglePayWalletData {
                 card_network: data.info.card_network,
                 card_details: data.info.card_details,
             },
-            tokenization_data: GpayTokenizationData{
+            tokenization_data: GpayTokenizationData {
                 token_type: data.tokenization_data.token_type,
                 token: data.tokenization_data.token,
             },


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Stripe requires 
``` 
"gateway": "stripe"
"stripe:version": "2018-10-31"
"stripe:publishableKey": "YOUR_PUBLIC_STRIPE_KEY"
  ```
dashboard started sending these fields from front-end but backend is not handling the same, this PR will fix the issue.
Previously it was only
```
  "gateway": "assist"
  "gatewayMerchantId": "YOUR_GATEWAY_MERCHANT_ID"
```
### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!-- 
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
All connectors requires the googlepay_data in camelcase but we serialize and deserialize it in snake_case, so we initially made serialization in camelcase and deserialization in snake_case previously. Now an issue happened when they stored the gpay token in camelcase in vault and tried retrieving in snake_case, so to avoid this issue we revert back to old mechanism of all snake_case concept. now whatever connector that requires the google token strictly in camelcase we add a custom logic for those to convert them to camelcase. That's why both have same name but are in different crates

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [X] I formatted the code `cargo +nightly fmt --all`
- [X] I addressed lints thrown by `cargo clippy`
- [X] I reviewed submitted code