### PR TITLE
fix(session_token): log error only when it occurs

### DIFF
--- a/crates/common_utils/src/ext_traits.rs
+++ b/crates/common_utils/src/ext_traits.rs
@@ -3,7 +3,6 @@
 //! & inbuilt datatypes.
 //!
 
-use std::fmt::Display;
 
 use error_stack::{IntoReport, ResultExt};
 use masking::{ExposeInterface, Secret, Strategy};
@@ -448,7 +447,7 @@ pub trait ResultExtLog<T> {
 
 impl<T, E> ResultExtLog<T> for Result<T, E>
 where
-    E: Display + std::fmt::Debug,
+    E: std::fmt::Display,
 {
     fn log_err_and_ok(self, key: &str) -> Option<T> {
         self.map_err(|err| {

--- a/crates/common_utils/src/ext_traits.rs
+++ b/crates/common_utils/src/ext_traits.rs
@@ -3,9 +3,12 @@
 //! & inbuilt datatypes.
 //!
 
+use std::fmt::Display;
+
 use error_stack::{IntoReport, ResultExt};
 use masking::{ExposeInterface, Secret, Strategy};
 use quick_xml::de;
+use router_env::logger;
 use serde::{Deserialize, Serialize};
 
 use crate::errors::{self, CustomResult};
@@ -432,5 +435,26 @@ impl XmlExt for &str {
         T: serde::de::DeserializeOwned,
     {
         de::from_str(self)
+    }
+}
+
+/// Extension trait for logging the error of a Result and then discarding the error
+pub trait ResultExtLog<T> {
+    ///
+    /// Log error if it is of `Err` type else return the `Ok` value wrapped in `Some`
+    ///
+    fn log_err_and_ok(self, key: &str) -> Option<T>;
+}
+
+impl<T, E> ResultExtLog<T> for Result<T, E>
+where
+    E: Display + std::fmt::Debug,
+{
+    fn log_err_and_ok(self, key: &str) -> Option<T> {
+        self.map_err(|err| {
+            logger::error!("{} = {}", key, err);
+            err
+        })
+        .ok()
     }
 }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
```
let error = parsed_payment_method_result.as_ref().err();
logger::error!(session_token_parsing_error=?error);
parsed_payment_method_result.ok()
```


This logic logs the error always. Changed it to log error only when error occurs. 

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!-- 
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Compiles. But please verify the logic while review.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
