### PR TITLE
fix: Convert GooglePay Session token amount and ignore 3DS for Bluesnap wallets

### DIFF
--- a/crates/api_models/src/payments.rs
+++ b/crates/api_models/src/payments.rs
@@ -1480,7 +1480,7 @@ pub struct GpayTransactionInfo {
     /// The total price status (ex: 'FINAL')
     pub total_price_status: String,
     /// The total price
-    pub total_price: i64,
+    pub total_price: String,
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, ToSchema)]

--- a/crates/router/src/connector/bluesnap.rs
+++ b/crates/router/src/connector/bluesnap.rs
@@ -10,7 +10,9 @@ use common_utils::{
 use error_stack::{IntoReport, ResultExt};
 use transformers as bluesnap;
 
-use super::utils::{self as connector_utils, RefundsRequestData, RouterData};
+use super::utils::{
+    self as connector_utils, PaymentsAuthorizeRequestData, RefundsRequestData, RouterData,
+};
 use crate::{
     configs::settings,
     consts,
@@ -517,7 +519,7 @@ impl ConnectorIntegration<api::Authorize, types::PaymentsAuthorizeData, types::P
         req: &types::PaymentsAuthorizeRouterData,
         connectors: &settings::Connectors,
     ) -> CustomResult<String, errors::ConnectorError> {
-        match req.is_three_ds() {
+        match req.is_three_ds() && !req.request.is_wallet() {
             true => Ok(format!(
                 "{}{}{}",
                 self.base_url(connectors),
@@ -570,7 +572,7 @@ impl ConnectorIntegration<api::Authorize, types::PaymentsAuthorizeData, types::P
         data: &types::PaymentsAuthorizeRouterData,
         res: Response,
     ) -> CustomResult<types::PaymentsAuthorizeRouterData, errors::ConnectorError> {
-        match (data.is_three_ds(), res.headers) {
+        match (data.is_three_ds() && !data.request.is_wallet(), res.headers) {
             (true, Some(headers)) => {
                 let location = connector_utils::get_http_header("Location", &headers)?;
                 let payment_fields_token = location

--- a/crates/router/src/connector/utils.rs
+++ b/crates/router/src/connector/utils.rs
@@ -170,6 +170,7 @@ pub trait PaymentsAuthorizeRequestData {
     fn is_mandate_payment(&self) -> bool;
     fn get_webhook_url(&self) -> Result<String, Error>;
     fn get_router_return_url(&self) -> Result<String, Error>;
+    fn is_wallet(&self) -> bool;
 }
 
 impl PaymentsAuthorizeRequestData for types::PaymentsAuthorizeData {
@@ -232,6 +233,9 @@ impl PaymentsAuthorizeRequestData for types::PaymentsAuthorizeData {
         self.router_return_url
             .clone()
             .ok_or_else(missing_field_err("webhook_url"))
+    }
+    fn is_wallet(&self) -> bool {
+        matches!(self.payment_method_data, api::PaymentMethodData::Wallet(_))
     }
 }
 

--- a/crates/router/src/core/payments/flows/session_flow.rs
+++ b/crates/router/src/core/payments/flows/session_flow.rs
@@ -251,7 +251,14 @@ fn create_gpay_session_token(
         country_code: session_data.country.unwrap_or_default(),
         currency_code: router_data.request.currency.to_string(),
         total_price_status: "Final".to_string(),
-        total_price: router_data.request.amount,
+        total_price: utils::to_currency_base_unit(
+            router_data.request.amount,
+            router_data.request.currency,
+        )
+        .attach_printable("Cannot convert given amount to base currency denomination".to_string())
+        .change_context(errors::ApiErrorResponse::InvalidDataValue {
+            field_name: "amount",
+        })?,
     };
 
     let response_router_data = types::PaymentsSessionRouterData {


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
- Convert the `request.amount` to base denomination based on the currency in GooglePay Session flow `create_gpay_session_token`
- If `auth_type` is give as `three_ds` wallets payments should go through regardless of it.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!-- 
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
- GooglePay session token was not converting into base denomination and when an amount is passed in cents it processes in higher denomination like dollars.
- Since Bluesnap 3DS flow has a completely different implementation in Authorize flow, Wallets were getting stuck for payments where `auth_type` is `three_ds`

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [X] I formatted the code `cargo +nightly fmt --all`
- [X] I addressed lints thrown by `cargo clippy`
- [X] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
