### PR TITLE
fix(config): add API route `set_config`

### DIFF
--- a/crates/router/src/core/configs.rs
+++ b/crates/router/src/core/configs.rs
@@ -1,9 +1,27 @@
+use error_stack::ResultExt;
+
 use crate::{
     core::errors::{self, utils::StorageErrorExt, RouterResponse},
     db::StorageInterface,
     services::ApplicationResponse,
     types::{api, transformers::ForeignInto},
 };
+
+pub async fn set_config(
+    store: &dyn StorageInterface,
+    config: api::Config,
+) -> RouterResponse<api::Config> {
+    let config = store
+        .insert_config(storage_models::configs::ConfigNew {
+            key: config.key,
+            config: config.value,
+        })
+        .await
+        .change_context(errors::ApiErrorResponse::InternalServerError)
+        .attach_printable("Unknown error, while setting config key")?;
+
+    Ok(ApplicationResponse::Json(config.foreign_into()))
+}
 
 pub async fn read_config(store: &dyn StorageInterface, key: &str) -> RouterResponse<api::Config> {
     let config = store

--- a/crates/router/src/routes/app.rs
+++ b/crates/router/src/routes/app.rs
@@ -389,6 +389,7 @@ impl Configs {
     pub fn server(config: AppState) -> Scope {
         web::scope("/configs")
             .app_data(web::Data::new(config))
+            .service(web::resource("/").route(web::post().to(config_key_create)))
             .service(
                 web::resource("/{key}")
                     .route(web::get().to(config_key_retrieve))

--- a/crates/router/src/routes/configs.rs
+++ b/crates/router/src/routes/configs.rs
@@ -8,6 +8,26 @@ use crate::{
     types::api as api_types,
 };
 
+#[instrument(skip_all, fields(flow = ?Flow::CreateConfigKey))]
+pub async fn config_key_create(
+    state: web::Data<AppState>,
+    req: HttpRequest,
+    json_payload: web::Json<api_types::Config>,
+) -> impl Responder {
+    let flow = Flow::CreateConfigKey;
+    let payload = json_payload.into_inner();
+
+    api::server_wrap(
+        flow,
+        state.get_ref(),
+        &req,
+        payload,
+        |state, _, data| configs::set_config(&*state.store, data),
+        &auth::AdminApiAuth,
+    )
+    .await
+}
+
 #[instrument(skip_all, fields(flow = ?Flow::ConfigKeyFetch))]
 pub async fn config_key_retrieve(
     state: web::Data<AppState>,

--- a/crates/router/src/types/api/configs.rs
+++ b/crates/router/src/types/api/configs.rs
@@ -1,4 +1,4 @@
-#[derive(Clone, serde::Serialize, Debug)]
+#[derive(Clone, serde::Serialize, Debug, serde::Deserialize)]
 pub struct Config {
     pub key: String,
     pub value: String,

--- a/crates/router_env/src/logger/types.rs
+++ b/crates/router_env/src/logger/types.rs
@@ -176,6 +176,8 @@ pub enum Flow {
     RetrieveFile,
     /// Dispute Evidence submission flow
     DisputesEvidenceSubmit,
+    /// Create Config Key flow
+    CreateConfigKey,
 }
 
 ///


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Adding an API route to provide pays to add keys and values in database/cache.
Currently, we only have exposed retrieve_config and read_config as possible paths.

<!-- Describe your changes in detail -->


### Additional Changes

- [x] This PR modifies the API contract
adding `POST /config`
payload: `{ key: String, value: String }`

<!-- 
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
