### PR TITLE
ci(conventional-commit-check): run checks on being added to queue

### DIFF
--- a/.github/workflows/conventional-commit-check.yml
+++ b/.github/workflows/conventional-commit-check.yml
@@ -39,6 +39,7 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2.2.0
         with:
+          key: "pr_title_check"
           cache-on-failure: "true"
 
       - name: Install cocogitto

--- a/.github/workflows/conventional-commit-check.yml
+++ b/.github/workflows/conventional-commit-check.yml
@@ -8,6 +8,10 @@ on:
       - reopened
       - ready_for_review
 
+  merge_group:
+    types:
+      - checks_requested
+
 permissions:
   # Reference: https://github.com/cli/cli/issues/6274
   repository-projects: read
@@ -43,9 +47,18 @@ jobs:
 
       - name: Verify PR title follows conventional commit standards
         id: pr_title_check
+        if: ${{ github.event_name == 'pull_request' }}
         shell: bash
         continue-on-error: true
         run: cog verify "${{ github.event.pull_request.title }}"
+
+      - name: Verify commit message follows conventional commit standards
+        id: commit_message_check
+        if: ${{ github.event_name == 'merge_group' }}
+        shell: bash
+        # Fail on error, we don't have context about PR information to update labels
+        continue-on-error: false
+        run: cog verify "${{ github.event.merge_group.head_commit.message }}"
 
         # GitHub CLI returns a successful error code even if the PR has the label already attached
       - name: Attach 'S-conventions-not-followed' label if PR title check failed

--- a/.github/workflows/conventional-commit-check.yml
+++ b/.github/workflows/conventional-commit-check.yml
@@ -63,7 +63,7 @@ jobs:
 
         # GitHub CLI returns a successful error code even if the PR has the label already attached
       - name: Attach 'S-conventions-not-followed' label if PR title check failed
-        if: ${{ steps.pr_title_check.outcome == 'failure' }}
+        if: ${{ github.event_name == 'pull_request' && steps.pr_title_check.outcome == 'failure' }}
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
@@ -74,7 +74,7 @@ jobs:
 
         # GitHub CLI returns a successful error code even if the PR does not have the label attached
       - name: Remove 'S-conventions-not-followed' label if PR title check succeeded
-        if: ${{ steps.pr_title_check.outcome == 'success' }}
+        if: ${{ github.event_name == 'pull_request' && steps.pr_title_check.outcome == 'success' }}
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/conventional-commit-check.yml
+++ b/.github/workflows/conventional-commit-check.yml
@@ -14,7 +14,7 @@ on:
 
 permissions:
   # Reference: https://github.com/cli/cli/issues/6274
-  repository-projects: read
+  repository-projects: write
   pull-requests: write
 
 env:


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [x] CI/CD

## Description
<!-- Describe your changes in detail -->
This PR fixes a bug with the commit message check workflow not run on being added to the merge queue. In addition, it specifies the cache key for better caching, and updates the permissions for the token to allow write access to project entries.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
Since this is a required check for a PR to be merged to the `main` branch, this is holding off PRs that have been added to the merge queue, from being merged.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
N/A.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
