### PR TITLE
feat(payments): add support for manual retries in payments confirm call

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2970,7 +2970,7 @@ dependencies = [
 [[package]]
 name = "opentelemetry"
 version = "0.18.0"
-source = "git+https://github.com/open-telemetry/opentelemetry-rust?rev=44b90202fd744598db8b0ace5b8f0bad7ec45658#44b90202fd744598db8b0ace5b8f0bad7ec45658"
+source = "git+https://github.com/open-telemetry/opentelemetry-rust/?rev=44b90202fd744598db8b0ace5b8f0bad7ec45658#44b90202fd744598db8b0ace5b8f0bad7ec45658"
 dependencies = [
  "opentelemetry_api",
  "opentelemetry_sdk",
@@ -2979,7 +2979,7 @@ dependencies = [
 [[package]]
 name = "opentelemetry-otlp"
 version = "0.11.0"
-source = "git+https://github.com/open-telemetry/opentelemetry-rust?rev=44b90202fd744598db8b0ace5b8f0bad7ec45658#44b90202fd744598db8b0ace5b8f0bad7ec45658"
+source = "git+https://github.com/open-telemetry/opentelemetry-rust/?rev=44b90202fd744598db8b0ace5b8f0bad7ec45658#44b90202fd744598db8b0ace5b8f0bad7ec45658"
 dependencies = [
  "async-trait",
  "futures",
@@ -2996,7 +2996,7 @@ dependencies = [
 [[package]]
 name = "opentelemetry-proto"
 version = "0.1.0"
-source = "git+https://github.com/open-telemetry/opentelemetry-rust?rev=44b90202fd744598db8b0ace5b8f0bad7ec45658#44b90202fd744598db8b0ace5b8f0bad7ec45658"
+source = "git+https://github.com/open-telemetry/opentelemetry-rust/?rev=44b90202fd744598db8b0ace5b8f0bad7ec45658#44b90202fd744598db8b0ace5b8f0bad7ec45658"
 dependencies = [
  "futures",
  "futures-util",
@@ -3008,7 +3008,7 @@ dependencies = [
 [[package]]
 name = "opentelemetry_api"
 version = "0.18.0"
-source = "git+https://github.com/open-telemetry/opentelemetry-rust?rev=44b90202fd744598db8b0ace5b8f0bad7ec45658#44b90202fd744598db8b0ace5b8f0bad7ec45658"
+source = "git+https://github.com/open-telemetry/opentelemetry-rust/?rev=44b90202fd744598db8b0ace5b8f0bad7ec45658#44b90202fd744598db8b0ace5b8f0bad7ec45658"
 dependencies = [
  "fnv",
  "futures-channel",
@@ -3023,7 +3023,7 @@ dependencies = [
 [[package]]
 name = "opentelemetry_sdk"
 version = "0.18.0"
-source = "git+https://github.com/open-telemetry/opentelemetry-rust?rev=44b90202fd744598db8b0ace5b8f0bad7ec45658#44b90202fd744598db8b0ace5b8f0bad7ec45658"
+source = "git+https://github.com/open-telemetry/opentelemetry-rust/?rev=44b90202fd744598db8b0ace5b8f0bad7ec45658#44b90202fd744598db8b0ace5b8f0bad7ec45658"
 dependencies = [
  "async-trait",
  "crossbeam-channel",

--- a/crates/api_models/src/enums.rs
+++ b/crates/api_models/src/enums.rs
@@ -974,9 +974,3 @@ pub struct UnresolvedResponseReason {
     /// A message to merchant to give hint on next action he/she should do to resolve
     pub message: String,
 }
-
-#[derive(Debug, Eq, PartialEq, Clone)]
-pub enum AttemptType {
-    New,
-    SameOld,
-}

--- a/crates/api_models/src/payments.rs
+++ b/crates/api_models/src/payments.rs
@@ -221,12 +221,8 @@ pub struct PaymentsRequest {
     pub business_sub_label: Option<String>,
 
     /// If enabled payment can be retried from the client side until the payment is successful or payment expires or the attempts(configured by the merchant) for payment are exhausted.
-    #[serde(default = "get_false")]
+    #[serde(default)]
     pub manual_retry: bool,
-}
-
-fn get_false() -> bool {
-    false
 }
 
 #[derive(Default, Debug, serde::Deserialize, serde::Serialize, Clone, Copy, PartialEq, Eq)]

--- a/crates/router/src/core/payments/helpers.rs
+++ b/crates/router/src/core/payments/helpers.rs
@@ -25,6 +25,7 @@ use crate::{
     core::{
         errors::{self, CustomResult, RouterResult, StorageErrorExt},
         payment_methods::{cards, vault},
+        payments,
     },
     db::StorageInterface,
     routes::{metrics, AppState},
@@ -1680,7 +1681,7 @@ pub fn get_attempt_type(
     payment_attempt: &storage::PaymentAttempt,
     request: &api::PaymentsRequest,
     action: &str,
-) -> RouterResult<api_enums::AttemptType> {
+) -> RouterResult<AttemptType> {
     match payment_intent.status {
         enums::IntentStatus::Failed => {
             if request.manual_retry {
@@ -1707,12 +1708,17 @@ pub fn get_attempt_type(
                             .attach_printable("Payment Attempt unexpected state")
                     }
 
+                    storage_enums::AttemptStatus::VoidFailed
+                    | storage_enums::AttemptStatus::RouterDeclined
+                    | storage_enums::AttemptStatus::CaptureFailed =>  Err(report!(errors::ApiErrorResponse::PreconditionFailed {
+                        message:
+                            format!("You cannot {action} this payment because it has status {}, and the previous attempt has the status {}", payment_intent.status, payment_attempt.status)
+                        }
+                    )),
+
                     storage_enums::AttemptStatus::AuthenticationFailed
                     | storage_enums::AttemptStatus::AuthorizationFailed
-                    | storage_enums::AttemptStatus::VoidFailed
-                    | storage_enums::AttemptStatus::RouterDeclined
-                    | storage_enums::AttemptStatus::CaptureFailed
-                    | storage_enums::AttemptStatus::Failure => Ok(api_enums::AttemptType::New),
+                    | storage_enums::AttemptStatus::Failure => Ok(AttemptType::New),
                 }
             } else {
                 Err(report!(errors::ApiErrorResponse::PreconditionFailed {
@@ -1737,6 +1743,147 @@ pub fn get_attempt_type(
         enums::IntentStatus::RequiresCustomerAction
         | enums::IntentStatus::RequiresMerchantAction
         | enums::IntentStatus::RequiresPaymentMethod
-        | enums::IntentStatus::RequiresConfirmation => Ok(api_enums::AttemptType::SameOld),
+        | enums::IntentStatus::RequiresConfirmation => Ok(AttemptType::SameOld),
+    }
+}
+
+#[derive(Debug, Eq, PartialEq, Clone)]
+pub enum AttemptType {
+    New,
+    SameOld,
+}
+
+impl AttemptType {
+    // The function creates a new payment_attempt from the previous payment attempt but doesn't populate fields like payment_method, error_code etc.
+    // Logic to override the fields with data provided in the request should be done after this if required.
+    // In case if fields are not overridden by the request then they contain the same data that was in the previous attempt provided it is populated in this function.
+    #[inline(always)]
+    fn make_new_payment_attempt(
+        payment_method_data: &Option<api_models::payments::PaymentMethodData>,
+        old_payment_attempt: storage::PaymentAttempt,
+    ) -> storage::PaymentAttemptNew {
+        let created_at @ modified_at @ last_synced = Some(common_utils::date_time::now());
+
+        storage::PaymentAttemptNew {
+            payment_id: old_payment_attempt.payment_id,
+            merchant_id: old_payment_attempt.merchant_id,
+            attempt_id: uuid::Uuid::new_v4().simple().to_string(),
+
+            // A new payment attempt is getting created so, used the same function which is used to populate status in PaymentCreate Flow.
+            status: payment_attempt_status_fsm(payment_method_data, Some(true)),
+
+            amount: old_payment_attempt.amount,
+            currency: old_payment_attempt.currency,
+            save_to_locker: old_payment_attempt.save_to_locker,
+
+            connector: None,
+
+            error_message: None,
+            offer_amount: old_payment_attempt.offer_amount,
+            surcharge_amount: old_payment_attempt.surcharge_amount,
+            tax_amount: old_payment_attempt.tax_amount,
+            payment_method_id: None,
+            payment_method: None,
+            capture_method: old_payment_attempt.capture_method,
+            capture_on: old_payment_attempt.capture_on,
+            confirm: old_payment_attempt.confirm,
+            authentication_type: old_payment_attempt.authentication_type,
+            created_at,
+            modified_at,
+            last_synced,
+            cancellation_reason: None,
+            amount_to_capture: old_payment_attempt.amount_to_capture,
+
+            // Once the payment_attempt is authorised then mandate_id is created. If this payment attempt is authorised then mandate_id will be overridden.
+            // Since mandate_id is a contract between merchant and customer to debit customers amount adding it to newly created attempt
+            mandate_id: old_payment_attempt.mandate_id,
+
+            // The payment could be done from a different browser or same browser, it would probably be overridden by request data.
+            browser_info: None,
+
+            error_code: None,
+            payment_token: None,
+            connector_metadata: None,
+            payment_experience: None,
+            payment_method_type: None,
+            payment_method_data: None,
+
+            // In case it is passed in create and not in confirm,
+            business_sub_label: old_payment_attempt.business_sub_label,
+            // If the algorithm is entered in Create call from server side, it needs to be populated here, however it could be overridden from the request.
+            straight_through_algorithm: old_payment_attempt.straight_through_algorithm,
+        }
+    }
+
+    pub async fn modify_payment_intent_and_payment_attempt(
+        &self,
+        request: &api::PaymentsRequest,
+        fetched_payment_intent: storage::PaymentIntent,
+        fetched_payment_attempt: storage::PaymentAttempt,
+        db: &dyn StorageInterface,
+        storage_scheme: storage::enums::MerchantStorageScheme,
+    ) -> RouterResult<(storage::PaymentIntent, storage::PaymentAttempt)> {
+        match self {
+            Self::SameOld => Ok((fetched_payment_intent, fetched_payment_attempt)),
+            Self::New => {
+                let new_payment_attempt = db
+                    .insert_payment_attempt(
+                        Self::make_new_payment_attempt(
+                            &request.payment_method_data,
+                            fetched_payment_attempt,
+                        ),
+                        storage_scheme,
+                    )
+                    .await
+                    .to_duplicate_response(errors::ApiErrorResponse::DuplicatePayment {
+                        payment_id: fetched_payment_intent.payment_id.to_owned(),
+                    })?;
+
+                let updated_payment_intent = db
+                    .update_payment_intent(
+                        fetched_payment_intent,
+                        storage::PaymentIntentUpdate::StatusAndAttemptUpdate {
+                            status: payment_intent_status_fsm(
+                                &request.payment_method_data,
+                                Some(true),
+                            ),
+                            active_attempt_id: new_payment_attempt.attempt_id.to_owned(),
+                        },
+                        storage_scheme,
+                    )
+                    .await
+                    .to_not_found_response(errors::ApiErrorResponse::PaymentNotFound)?;
+
+                Ok((updated_payment_intent, new_payment_attempt))
+            }
+        }
+    }
+
+    pub async fn get_connector_response(
+        &self,
+        payment_attempt: &storage::PaymentAttempt,
+        db: &dyn StorageInterface,
+        storage_scheme: storage::enums::MerchantStorageScheme,
+    ) -> RouterResult<storage::ConnectorResponse> {
+        match self {
+            Self::New => db
+                .insert_connector_response(
+                    payments::PaymentCreate::make_connector_response(payment_attempt),
+                    storage_scheme,
+                )
+                .await
+                .to_duplicate_response(errors::ApiErrorResponse::DuplicatePayment {
+                    payment_id: payment_attempt.payment_id.clone(),
+                }),
+            Self::SameOld => db
+                .find_connector_response_by_payment_id_merchant_id_attempt_id(
+                    &payment_attempt.payment_id,
+                    &payment_attempt.merchant_id,
+                    &payment_attempt.attempt_id,
+                    storage_scheme,
+                )
+                .await
+                .to_not_found_response(errors::ApiErrorResponse::PaymentNotFound),
+        }
     }
 }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Previously,
- In Payments Flows if the payment was failed due to any reason other payment attempts were not allowed.
- If tried to make confirm call we would get error, 'payment already in Failed status'. 
- So the user is forced to create a new payment_intent using Server API key and then use the client secret and publishable key to confirm the payment. 

Issues: 
- The above is inefficient and a bad user experience, the user should be allowed to enter a new payment method and create try the payment again.

About Solution:
- This PR addresses the above issue. 
- We have multiple payment flows, and the flows through which we can do payment authorization is Create, confirm , update and payment complete authorization flow.
- In create flow manual retry won't be happening as new payment is created in this flow
- This PR adds manual retry support in confirm API only. Will raise a separate PR for support in complete_authorization flow , and update flow(or maybe update flow will be removed to have a cleaner API contract and only be used to update non-critical payment data).


Changes made in this PR 
- Added a bool field `manual_retry` in PaymentsRequest and the default value is `false`.
- In manual retry case, a new payment attempt is created, and the payment intent is updated. 
- A new connector_response is created.

Also possible  todo , should there be a max number of manual retries a merchant can do  ?

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!-- 
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
![image](https://github.com/juspay/hyperswitch/assets/68317979/c7bf1487-73fa-4a83-8db4-514e8657c059)
![image](https://github.com/juspay/hyperswitch/assets/68317979/66cbf649-17bb-412c-a973-9cd6f8a14a1e)
![image](https://github.com/juspay/hyperswitch/assets/68317979/fa6b116e-dde8-4bce-8e3b-45d16699f322)
![image](https://github.com/juspay/hyperswitch/assets/68317979/be349daf-8c40-4fec-9d3e-e08297fce3f4)
```
hyperswitch_db=# select * from payment_attempt where payment_id= 'pay_220wdZUOHL8pt7BE8Uwg'
;
-[ RECORD 1 ]--------------+------------------------------------------------------
id                         | 28
payment_id                 | pay_220wdZUOHL8pt7BE8Uwg
merchant_id                | merchant_1683795848
attempt_id                 | ab80aab13abe4b94b7a136776174b054
status                     | failure
amount                     | 6540
currency                   | USD
save_to_locker             | 
connector                  | checkout
error_message              | Full card payments disabled
offer_amount               | 
surcharge_amount           | 
tax_amount                 | 
payment_method_id          | 
payment_method             | card
connector_transaction_id   | 
capture_method             | automatic
capture_on                 | 2022-09-10 10:11:12
confirm                    | t
authentication_type        | no_three_ds
created_at                 | 2023-05-15 14:07:17.288937
modified_at                | 2023-05-15 14:07:18.311236
last_synced                | 2023-05-15 14:07:17.288937
cancellation_reason        | 
amount_to_capture          | 
mandate_id                 | 
browser_info               | 
error_code                 | No error code
payment_token              | token_0XaJob9VtPd6l09fOGb6
connector_metadata         | 
payment_experience         | 
payment_method_type        | credit
payment_method_data        | {"card": {"card_issuer": null, "card_network": null}}
business_sub_label         | 
straight_through_algorithm | {"algorithm": {"data": "checkout", "type": "single"}}
-[ RECORD 2 ]--------------+------------------------------------------------------
id                         | 29
payment_id                 | pay_220wdZUOHL8pt7BE8Uwg
merchant_id                | merchant_1683795848
attempt_id                 | be3c0240ed90464ebe10380f10baa826
status                     | charged
amount                     | 6540
currency                   | USD
save_to_locker             | 
connector                  | stripe
error_message              | 
offer_amount               | 
surcharge_amount           | 
tax_amount                 | 
payment_method_id          | 
payment_method             | card
connector_transaction_id   | pi_3N823oD5R7gDAGff1m65JGBV
capture_method             | automatic
capture_on                 | 2022-09-10 10:11:12
confirm                    | t
authentication_type        | no_three_ds
created_at                 | 2023-05-15 14:07:35.747434
modified_at                | 2023-05-15 14:07:38.238459
last_synced                | 2023-05-15 14:07:35.747434
cancellation_reason        | 
amount_to_capture          | 
mandate_id                 | 
browser_info               | 
error_code                 | 
payment_token              | token_GJuk7ixB33EhnL9u6f08
connector_metadata         | 
payment_experience         | 
payment_method_type        | credit
payment_method_data        | {"card": {"card_issuer": null, "card_network": null}}
business_sub_label         | 
straight_through_algorithm | {"algorithm": {"data": "stripe", "type": "single"}}
```
<img width="989" alt="image" src="https://github.com/juspay/hyperswitch/assets/68317979/302cbdae-15a7-4d1c-a54a-54ae62dd9e6b">

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
