### PR TITLE
revert(connector): fix stripe status to attempt status map

### DIFF
--- a/crates/router/src/connector/stripe/transformers.rs
+++ b/crates/router/src/connector/stripe/transformers.rs
@@ -1213,6 +1213,8 @@ pub enum StripePaymentStatus {
     RequiresConfirmation,
     Canceled,
     RequiresCapture,
+    // This is the case in
+    Pending,
 }
 
 impl From<StripePaymentStatus> for enums::AttemptStatus {
@@ -1222,10 +1224,11 @@ impl From<StripePaymentStatus> for enums::AttemptStatus {
             StripePaymentStatus::Failed => Self::Failure,
             StripePaymentStatus::Processing => Self::Authorizing,
             StripePaymentStatus::RequiresCustomerAction => Self::AuthenticationPending,
-            StripePaymentStatus::RequiresPaymentMethod => Self::Failure,
+            StripePaymentStatus::RequiresPaymentMethod => Self::PaymentMethodAwaited,
             StripePaymentStatus::RequiresConfirmation => Self::ConfirmationAwaited,
             StripePaymentStatus::Canceled => Self::Voided,
             StripePaymentStatus::RequiresCapture => Self::Authorized,
+            StripePaymentStatus::Pending => Self::Pending,
         }
     }
 }


### PR DESCRIPTION
reverts #1132

This status is required in case of `sofort` bank_redirect payment method. Incorrect comments caused this to be removed.

