### PR TITLE
fix(router): outgoing webhook api call

### DIFF
--- a/crates/api_models/src/webhooks.rs
+++ b/crates/api_models/src/webhooks.rs
@@ -91,5 +91,8 @@ pub enum OutgoingWebhookContent {
     DisputeDetails(Box<disputes::DisputeResponse>),
 }
 
-pub trait OutgoingWebhookType: Serialize + From<OutgoingWebhook> + Sync + Send {}
+pub trait OutgoingWebhookType:
+    Serialize + From<OutgoingWebhook> + Sync + Send + std::fmt::Debug
+{
+}
 impl OutgoingWebhookType for OutgoingWebhook {}

--- a/crates/router/src/compatibility/stripe/payment_intents/types.rs
+++ b/crates/router/src/compatibility/stripe/payment_intents/types.rs
@@ -37,7 +37,7 @@ impl From<StripeBillingDetails> for payments::Address {
     }
 }
 
-#[derive(Default, Serialize, PartialEq, Eq, Deserialize, Clone)]
+#[derive(Default, Serialize, PartialEq, Eq, Deserialize, Clone, Debug)]
 pub struct StripeCard {
     pub number: cards::CardNumber,
     pub exp_month: pii::Secret<String>,
@@ -221,7 +221,7 @@ impl TryFrom<StripePaymentIntentRequest> for payments::PaymentsRequest {
     }
 }
 
-#[derive(Clone, Default, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Default, Eq, PartialEq, Serialize, Deserialize, Debug)]
 #[serde(rename_all = "snake_case")]
 pub enum StripePaymentStatus {
     Succeeded,
@@ -288,7 +288,7 @@ pub struct StripeCaptureRequest {
     pub amount_to_capture: Option<i64>,
 }
 
-#[derive(Default, Eq, PartialEq, Serialize)]
+#[derive(Default, Eq, PartialEq, Serialize, Debug)]
 pub struct StripePaymentIntentResponse {
     pub id: Option<String>,
     pub object: &'static str,
@@ -328,7 +328,7 @@ pub struct StripePaymentIntentResponse {
     pub last_payment_error: Option<LastPaymentError>,
 }
 
-#[derive(Default, Eq, PartialEq, Serialize)]
+#[derive(Default, Eq, PartialEq, Serialize, Debug)]
 pub struct LastPaymentError {
     charge: Option<String>,
     code: Option<String>,
@@ -402,7 +402,7 @@ impl From<payments::PaymentsResponse> for StripePaymentIntentResponse {
     }
 }
 
-#[derive(Default, Eq, PartialEq, Serialize)]
+#[derive(Default, Eq, PartialEq, Serialize, Debug)]
 pub struct StripePaymentMethod {
     #[serde(rename = "id")]
     payment_method_id: String,
@@ -414,7 +414,7 @@ pub struct StripePaymentMethod {
     livemode: bool,
 }
 
-#[derive(Default, Eq, PartialEq, Serialize)]
+#[derive(Default, Eq, PartialEq, Serialize, Debug)]
 pub struct Charges {
     object: &'static str,
     data: Vec<String>,
@@ -604,13 +604,13 @@ impl ForeignFrom<Option<Request3DS>> for api_models::enums::AuthenticationType {
     }
 }
 
-#[derive(Default, Eq, PartialEq, Serialize)]
+#[derive(Default, Eq, PartialEq, Serialize, Debug)]
 pub struct RedirectUrl {
     pub return_url: Option<String>,
     pub url: Option<String>,
 }
 
-#[derive(Eq, PartialEq, Serialize)]
+#[derive(Eq, PartialEq, Serialize, Debug)]
 pub struct StripeNextAction {
     #[serde(rename = "type")]
     stype: payments::NextActionType,

--- a/crates/router/src/compatibility/stripe/refunds/types.rs
+++ b/crates/router/src/compatibility/stripe/refunds/types.rs
@@ -20,7 +20,7 @@ pub struct StripeUpdateRefundRequest {
     pub metadata: Option<pii::SecretSerdeValue>,
 }
 
-#[derive(Clone, Serialize, PartialEq, Eq)]
+#[derive(Clone, Serialize, PartialEq, Eq, Debug)]
 pub struct StripeRefundResponse {
     pub id: String,
     pub amount: i64,
@@ -31,7 +31,7 @@ pub struct StripeRefundResponse {
     pub metadata: pii::SecretSerdeValue,
 }
 
-#[derive(Clone, Serialize, Deserialize, Eq, PartialEq)]
+#[derive(Clone, Serialize, Deserialize, Eq, PartialEq, Debug)]
 #[serde(rename_all = "snake_case")]
 pub enum StripeRefundStatus {
     Succeeded,

--- a/crates/router/src/compatibility/stripe/webhooks.rs
+++ b/crates/router/src/compatibility/stripe/webhooks.rs
@@ -8,7 +8,7 @@ use super::{
     payment_intents::types::StripePaymentIntentResponse, refunds::types::StripeRefundResponse,
 };
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug)]
 pub struct StripeOutgoingWebhook {
     id: Option<String>,
     #[serde(rename = "type")]
@@ -18,7 +18,7 @@ pub struct StripeOutgoingWebhook {
 
 impl api::OutgoingWebhookType for StripeOutgoingWebhook {}
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug)]
 #[serde(tag = "type", content = "object", rename_all = "snake_case")]
 pub enum StripeWebhookObject {
     PaymentIntent(StripePaymentIntentResponse),
@@ -26,7 +26,7 @@ pub enum StripeWebhookObject {
     Dispute(StripeDisputeResponse),
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug)]
 pub struct StripeDisputeResponse {
     pub id: String,
     pub amount: String,
@@ -36,7 +36,7 @@ pub struct StripeDisputeResponse {
     pub status: StripeDisputeStatus,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug)]
 #[serde(rename_all = "snake_case")]
 pub enum StripeDisputeStatus {
     WarningNeedsResponse,

--- a/crates/router/src/core/errors.rs
+++ b/crates/router/src/core/errors.rs
@@ -460,6 +460,8 @@ pub enum WebhooksFlowError {
     NotImplemented,
     #[error("Dispute webhook status validation failed")]
     DisputeWebhookValidationFailed,
+    #[error("Outgoing webhook body encoding failed")]
+    OutgoingWebhookEncodingFailed,
 }
 
 #[cfg(feature = "detailed_errors")]

--- a/crates/router/src/core/webhooks.rs
+++ b/crates/router/src/core/webhooks.rs
@@ -12,7 +12,6 @@ use crate::{
         errors::{self, CustomResult, RouterResponse},
         payments, refunds,
     },
-    db::StorageInterface,
     logger,
     routes::AppState,
     services,
@@ -24,7 +23,7 @@ use crate::{
     utils::{generate_id, Encode, OptionExt, ValueExt},
 };
 
-const OUTGOING_WEBHOOK_TIMEOUT_MS: u64 = 5000;
+const OUTGOING_WEBHOOK_TIMEOUT_SECS: u64 = 5;
 
 #[instrument(skip_all)]
 async fn payments_incoming_webhook_flow<W: api::OutgoingWebhookType>(
@@ -403,8 +402,7 @@ async fn create_event_and_trigger_outgoing_webhook<W: api::OutgoingWebhookType>(
 
         arbiter.spawn(async move {
             let result =
-                trigger_webhook_to_merchant::<W>(merchant_account, outgoing_webhook, state.store)
-                    .await;
+                trigger_webhook_to_merchant::<W>(merchant_account, outgoing_webhook, &state).await;
 
             if let Err(e) = result {
                 logger::error!(?e);
@@ -418,7 +416,7 @@ async fn create_event_and_trigger_outgoing_webhook<W: api::OutgoingWebhookType>(
 async fn trigger_webhook_to_merchant<W: api::OutgoingWebhookType>(
     merchant_account: storage::MerchantAccount,
     webhook: api::OutgoingWebhook,
-    db: Box<dyn StorageInterface>,
+    state: &AppState,
 ) -> CustomResult<(), errors::WebhooksFlowError> {
     let webhook_details_json = merchant_account
         .webhook_details
@@ -440,29 +438,38 @@ async fn trigger_webhook_to_merchant<W: api::OutgoingWebhookType>(
 
     let transformed_outgoing_webhook = W::from(webhook);
 
-    let response = reqwest::Client::new()
-        .post(&webhook_url)
-        .header(reqwest::header::CONTENT_TYPE, "application/json")
-        .json(&transformed_outgoing_webhook)
-        .timeout(core::time::Duration::from_millis(
-            OUTGOING_WEBHOOK_TIMEOUT_MS,
-        ))
-        .send()
-        .await;
+    let transformed_outgoing_webhook_string =
+        Encode::<serde_json::Value>::encode_to_string_of_json(&transformed_outgoing_webhook)
+            .change_context(errors::WebhooksFlowError::OutgoingWebhookEncodingFailed)
+            .attach_printable("There was an issue when encoding the outgoing webhook body")?;
+
+    let request = services::RequestBuilder::new()
+        .method(services::Method::Post)
+        .url(&webhook_url)
+        .attach_default_headers()
+        .headers(vec![(
+            reqwest::header::CONTENT_TYPE.to_string(),
+            "application/json".into(),
+        )])
+        .body(Some(transformed_outgoing_webhook_string))
+        .build();
+
+    let response =
+        services::api::send_request(state, request, Some(OUTGOING_WEBHOOK_TIMEOUT_SECS)).await;
 
     match response {
         Err(e) => {
             // [#217]: Schedule webhook for retry.
-            Err(e)
-                .into_report()
-                .change_context(errors::WebhooksFlowError::CallToMerchantFailed)?;
+            Err(e).change_context(errors::WebhooksFlowError::CallToMerchantFailed)?;
         }
         Ok(res) => {
             if res.status().is_success() {
                 let update_event = storage::EventUpdate::UpdateWebhookNotified {
                     is_webhook_notified: Some(true),
                 };
-                db.update_event(outgoing_webhook_event_id, update_event)
+                state
+                    .store
+                    .update_event(outgoing_webhook_event_id, update_event)
                     .await
                     .change_context(errors::WebhooksFlowError::WebhookEventUpdationFailed)?;
             } else {


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
Outgoing webhook api call wasn't using the proxy to call the external endpoint, so was failing on SBX due to outbound proxy whitelisting. Used the generic `send_request` to send outgoing webhook which uses proxy internally.


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!-- 
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
Tested Manually
Outgoing webhook to merchant
<img width="677" alt="image" src="https://github.com/juspay/hyperswitch/assets/56996463/ca2fecbb-67f2-4eae-982c-53933c3e4afe">

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
