### PR TITLE
chore(CODEOWNERS): add hyperswitch-maintainers as default owners for all files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
-* @jarnura @ashokkjag
+* @juspay/hyperswitch-maintainers @jarnura @ashokkjag
 
 docs/ @juspay/hyperswitch-maintainers
 openapi/ @juspay/hyperswitch-maintainers


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [x] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
This PR updates the `CODEOWNERS` file to include the `hyperswitch-maintainers` team as the default owners/reviewers for all files in the repository.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
Previously, any updates to the `Cargo.lock` file would require approvals from @jarnura and @ashokkjag. This change should remove that requirement for simple changes at least.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
N/A

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
