### PR TITLE
ci(conventional-commit-check): fix checks being skipped for PRs

### DIFF
--- a/.github/workflows/conventional-commit-check.yml
+++ b/.github/workflows/conventional-commit-check.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Verify PR title follows conventional commit standards
         id: pr_title_check
-        if: ${{ github.event_name == 'pull_request' }}
+        if: ${{ github.event_name == 'pull_request_target' }}
         shell: bash
         continue-on-error: true
         run: cog verify '${{ github.event.pull_request.title }}'
@@ -76,7 +76,7 @@ jobs:
 
         # GitHub CLI returns a successful error code even if the PR has the label already attached
       - name: Attach 'S-conventions-not-followed' label if PR title check failed
-        if: ${{ github.event_name == 'pull_request' && steps.pr_title_check.outcome == 'failure' }}
+        if: ${{ github.event_name == 'pull_request_target' && steps.pr_title_check.outcome == 'failure' }}
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
@@ -87,7 +87,7 @@ jobs:
 
         # GitHub CLI returns a successful error code even if the PR does not have the label attached
       - name: Remove 'S-conventions-not-followed' label if PR title check succeeded
-        if: ${{ github.event_name == 'pull_request' && steps.pr_title_check.outcome == 'success' }}
+        if: ${{ github.event_name == 'pull_request_target' && steps.pr_title_check.outcome == 'success' }}
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [x] CI/CD

## Description
<!-- Describe your changes in detail -->
This PR fixes the PR title check not being run on PRs due to an incorrect event type check.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
N/A

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
N/A

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
