### PR TITLE
refactor(core): Add 'redirect_response' field to CompleteAuthorizeData

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -876,7 +876,6 @@ version = "0.55.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22d2a2bcc16e5c4d949ffd2b851da852b9bbed4bb364ed4ae371b42137ca06d9"
 dependencies = [
- "aws-smithy-eventstream",
  "aws-smithy-types",
  "bytes",
  "crc32fast",
@@ -3001,7 +3000,7 @@ dependencies = [
 [[package]]
 name = "opentelemetry"
 version = "0.18.0"
-source = "git+https://github.com/open-telemetry/opentelemetry-rust/?rev=44b90202fd744598db8b0ace5b8f0bad7ec45658#44b90202fd744598db8b0ace5b8f0bad7ec45658"
+source = "git+https://github.com/open-telemetry/opentelemetry-rust?rev=44b90202fd744598db8b0ace5b8f0bad7ec45658#44b90202fd744598db8b0ace5b8f0bad7ec45658"
 dependencies = [
  "opentelemetry_api",
  "opentelemetry_sdk",
@@ -3010,7 +3009,7 @@ dependencies = [
 [[package]]
 name = "opentelemetry-otlp"
 version = "0.11.0"
-source = "git+https://github.com/open-telemetry/opentelemetry-rust/?rev=44b90202fd744598db8b0ace5b8f0bad7ec45658#44b90202fd744598db8b0ace5b8f0bad7ec45658"
+source = "git+https://github.com/open-telemetry/opentelemetry-rust?rev=44b90202fd744598db8b0ace5b8f0bad7ec45658#44b90202fd744598db8b0ace5b8f0bad7ec45658"
 dependencies = [
  "async-trait",
  "futures",
@@ -3027,7 +3026,7 @@ dependencies = [
 [[package]]
 name = "opentelemetry-proto"
 version = "0.1.0"
-source = "git+https://github.com/open-telemetry/opentelemetry-rust/?rev=44b90202fd744598db8b0ace5b8f0bad7ec45658#44b90202fd744598db8b0ace5b8f0bad7ec45658"
+source = "git+https://github.com/open-telemetry/opentelemetry-rust?rev=44b90202fd744598db8b0ace5b8f0bad7ec45658#44b90202fd744598db8b0ace5b8f0bad7ec45658"
 dependencies = [
  "futures",
  "futures-util",
@@ -3039,7 +3038,7 @@ dependencies = [
 [[package]]
 name = "opentelemetry_api"
 version = "0.18.0"
-source = "git+https://github.com/open-telemetry/opentelemetry-rust/?rev=44b90202fd744598db8b0ace5b8f0bad7ec45658#44b90202fd744598db8b0ace5b8f0bad7ec45658"
+source = "git+https://github.com/open-telemetry/opentelemetry-rust?rev=44b90202fd744598db8b0ace5b8f0bad7ec45658#44b90202fd744598db8b0ace5b8f0bad7ec45658"
 dependencies = [
  "fnv",
  "futures-channel",
@@ -3054,7 +3053,7 @@ dependencies = [
 [[package]]
 name = "opentelemetry_sdk"
 version = "0.18.0"
-source = "git+https://github.com/open-telemetry/opentelemetry-rust/?rev=44b90202fd744598db8b0ace5b8f0bad7ec45658#44b90202fd744598db8b0ace5b8f0bad7ec45658"
+source = "git+https://github.com/open-telemetry/opentelemetry-rust?rev=44b90202fd744598db8b0ace5b8f0bad7ec45658#44b90202fd744598db8b0ace5b8f0bad7ec45658"
 dependencies = [
  "async-trait",
  "crossbeam-channel",

--- a/crates/api_models/src/payments.rs
+++ b/crates/api_models/src/payments.rs
@@ -1586,9 +1586,9 @@ pub struct Metadata {
 
 #[derive(Default, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize, Clone, ToSchema)]
 pub struct RedirectResponse {
-    pub param: Option<String>,
+    pub param: Option<Secret<String>>,
     #[schema(value_type = Option<Object>)]
-    pub json_payload: Option<serde_json::Value>,
+    pub json_payload: Option<pii::SecretSerdeValue>,
 }
 
 #[derive(Debug, serde::Deserialize, serde::Serialize, Clone, ToSchema)]

--- a/crates/api_models/src/payments.rs
+++ b/crates/api_models/src/payments.rs
@@ -1576,13 +1576,19 @@ pub struct Metadata {
     #[serde(flatten)]
     pub data: pii::SecretSerdeValue,
 
-    /// Payload coming in request as a metadata field
-    #[schema(value_type = Option<Object>)]
-    pub payload: Option<pii::SecretSerdeValue>,
+    /// Redirection response coming in request as metadata field only for redirection scenarios
+    pub redirect_response: Option<RedirectResponse>,
 
     /// Allowed payment method types for a payment intent
     #[schema(value_type = Option<Vec<PaymentMethodType>>)]
     pub allowed_payment_method_types: Option<Vec<api_enums::PaymentMethodType>>,
+}
+
+#[derive(Default, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize, Clone, ToSchema)]
+pub struct RedirectResponse {
+    pub param: Option<String>,
+    #[schema(value_type = Option<Object>)]
+    pub json_payload: Option<serde_json::Value>,
 }
 
 #[derive(Debug, serde::Deserialize, serde::Serialize, Clone, ToSchema)]

--- a/crates/router/src/connector/airwallex/transformers.rs
+++ b/crates/router/src/connector/airwallex/transformers.rs
@@ -166,7 +166,12 @@ impl TryFrom<&types::PaymentsCompleteAuthorizeRouterData> for AirwallexCompleteR
             three_ds: AirwallexThreeDsData {
                 acs_response: item
                     .request
-                    .payload
+                    .redirect_response
+                    .as_ref()
+                    .map(|f| f.payload.to_owned())
+                    .ok_or(errors::ConnectorError::MissingRequiredField {
+                        field_name: "redirect_response.payload",
+                    })?
                     .as_ref()
                     .map(|data| Secret::new(serde_json::Value::to_string(data))),
             },

--- a/crates/router/src/connector/bambora/transformers.rs
+++ b/crates/router/src/connector/bambora/transformers.rs
@@ -80,10 +80,11 @@ impl TryFrom<&types::CompleteAuthorizeData> for BamboraThreedsContinueRequest {
     type Error = error_stack::Report<errors::ConnectorError>;
     fn try_from(value: &types::CompleteAuthorizeData) -> Result<Self, Self::Error> {
         let card_response: CardResponse = value
-            .payload
-            .clone()
+            .redirect_response
+            .as_ref()
+            .and_then(|f| f.payload.to_owned())
             .ok_or(errors::ConnectorError::MissingRequiredField {
-                field_name: "payload",
+                field_name: "redirect_response.payload",
             })?
             .parse_value("CardResponse")
             .change_context(errors::ConnectorError::ParsingFailed)?;

--- a/crates/router/src/connector/bluesnap/transformers.rs
+++ b/crates/router/src/connector/bluesnap/transformers.rs
@@ -339,10 +339,11 @@ impl TryFrom<&types::PaymentsCompleteAuthorizeRouterData> for BluesnapPaymentsRe
     fn try_from(item: &types::PaymentsCompleteAuthorizeRouterData) -> Result<Self, Self::Error> {
         let redirection_response: BluesnapRedirectionResponse = item
             .request
-            .payload
-            .clone()
+            .redirect_response
+            .as_ref()
+            .and_then(|res| res.payload.to_owned())
             .ok_or(errors::ConnectorError::MissingConnectorRedirectionPayload {
-                field_name: "request.payload",
+                field_name: "request.redirect_response.payload",
             })?
             .parse_value("BluesnapRedirectionResponse")
             .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;

--- a/crates/router/src/core/payments.rs
+++ b/crates/router/src/core/payments.rs
@@ -346,7 +346,10 @@ impl PaymentRedirectFlow for PaymentRedirectCompleteAuthorize {
             metadata: Some(Metadata {
                 order_details: None,
                 data: masking::Secret::new("{}".into()),
-                payload: Some(req.json_payload.unwrap_or(serde_json::json!({})).into()),
+                redirect_response: Some(api_models::payments::RedirectResponse {
+                    param: req.param.clone(),
+                    json_payload: Some(req.json_payload.clone().unwrap_or(serde_json::json!({}))),
+                }),
                 allowed_payment_method_types: None,
             }),
             ..Default::default()
@@ -932,6 +935,7 @@ where
     pub pm_token: Option<String>,
     pub connector_customer_id: Option<String>,
     pub ephemeral_key: Option<ephemeral_key::EphemeralKey>,
+    pub redirect_response: Option<api_models::payments::RedirectResponse>,
 }
 
 #[derive(Debug, Default)]

--- a/crates/router/src/core/payments.rs
+++ b/crates/router/src/core/payments.rs
@@ -347,8 +347,8 @@ impl PaymentRedirectFlow for PaymentRedirectCompleteAuthorize {
                 order_details: None,
                 data: masking::Secret::new("{}".into()),
                 redirect_response: Some(api_models::payments::RedirectResponse {
-                    param: req.param.clone(),
-                    json_payload: Some(req.json_payload.clone().unwrap_or(serde_json::json!({}))),
+                    param: req.param.map(Secret::new),
+                    json_payload: Some(req.json_payload.unwrap_or(serde_json::json!({})).into()),
                 }),
                 allowed_payment_method_types: None,
             }),

--- a/crates/router/src/core/payments/operations/payment_cancel.rs
+++ b/crates/router/src/core/payments/operations/payment_cancel.rs
@@ -152,6 +152,7 @@ impl<F: Send + Clone> GetTracker<F, PaymentData<F>, api::PaymentsCancelRequest> 
                 pm_token: None,
                 connector_customer_id: None,
                 ephemeral_key: None,
+                redirect_response: None,
             },
             None,
         ))

--- a/crates/router/src/core/payments/operations/payment_capture.rs
+++ b/crates/router/src/core/payments/operations/payment_capture.rs
@@ -158,6 +158,7 @@ impl<F: Send + Clone> GetTracker<F, payments::PaymentData<F>, api::PaymentsCaptu
                 pm_token: None,
                 connector_customer_id: None,
                 ephemeral_key: None,
+                redirect_response: None,
             },
             None,
         ))

--- a/crates/router/src/core/payments/operations/payment_confirm.rs
+++ b/crates/router/src/core/payments/operations/payment_confirm.rs
@@ -245,6 +245,7 @@ impl<F: Send + Clone> GetTracker<F, PaymentData<F>, api::PaymentsRequest> for Pa
                 pm_token: None,
                 connector_customer_id: None,
                 ephemeral_key: None,
+                redirect_response: None,
             },
             Some(CustomerDetails {
                 customer_id: request.customer_id.clone(),

--- a/crates/router/src/core/payments/operations/payment_create.rs
+++ b/crates/router/src/core/payments/operations/payment_create.rs
@@ -250,6 +250,7 @@ impl<F: Send + Clone> GetTracker<F, PaymentData<F>, api::PaymentsRequest> for Pa
                 pm_token: None,
                 connector_customer_id: None,
                 ephemeral_key,
+                redirect_response: None,
             },
             Some(CustomerDetails {
                 customer_id: request.customer_id.clone(),

--- a/crates/router/src/core/payments/operations/payment_method_validate.rs
+++ b/crates/router/src/core/payments/operations/payment_method_validate.rs
@@ -179,6 +179,7 @@ impl<F: Send + Clone> GetTracker<F, PaymentData<F>, api::VerifyRequest> for Paym
                 pm_token: None,
                 connector_customer_id: None,
                 ephemeral_key: None,
+                redirect_response: None,
             },
             Some(payments::CustomerDetails {
                 customer_id: request.customer_id.clone(),

--- a/crates/router/src/core/payments/operations/payment_session.rs
+++ b/crates/router/src/core/payments/operations/payment_session.rs
@@ -172,6 +172,7 @@ impl<F: Send + Clone> GetTracker<F, PaymentData<F>, api::PaymentsSessionRequest>
                 pm_token: None,
                 connector_customer_id: None,
                 ephemeral_key: None,
+                redirect_response: None,
             },
             Some(customer_details),
         ))

--- a/crates/router/src/core/payments/operations/payment_start.rs
+++ b/crates/router/src/core/payments/operations/payment_start.rs
@@ -143,6 +143,7 @@ impl<F: Send + Clone> GetTracker<F, PaymentData<F>, api::PaymentsStartRequest> f
                 pm_token: None,
                 connector_customer_id: None,
                 ephemeral_key: None,
+                redirect_response: None,
             },
             Some(customer_details),
         ))

--- a/crates/router/src/core/payments/operations/payment_status.rs
+++ b/crates/router/src/core/payments/operations/payment_status.rs
@@ -291,6 +291,7 @@ async fn get_tracker_for_sync<
             pm_token: None,
             connector_customer_id: None,
             ephemeral_key: None,
+            redirect_response: None,
         },
         None,
     ))

--- a/crates/router/src/core/payments/operations/payment_update.rs
+++ b/crates/router/src/core/payments/operations/payment_update.rs
@@ -304,6 +304,7 @@ impl<F: Send + Clone> GetTracker<F, PaymentData<F>, api::PaymentsRequest> for Pa
                 pm_token: None,
                 connector_customer_id: None,
                 ephemeral_key: None,
+                redirect_response: None,
             },
             Some(CustomerDetails {
                 customer_id: request.customer_id.clone(),

--- a/crates/router/src/types.rs
+++ b/crates/router/src/types.rs
@@ -284,10 +284,16 @@ pub struct CompleteAuthorizeData {
     pub mandate_id: Option<api_models::payments::MandateIds>,
     pub off_session: Option<bool>,
     pub setup_mandate_details: Option<payments::MandateData>,
-    pub payload: Option<serde_json::Value>,
+    pub redirect_response: Option<CompleteAuthorizeRedirectResponse>,
     pub browser_info: Option<BrowserInformation>,
     pub connector_transaction_id: Option<String>,
     pub connector_meta: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Clone)]
+pub struct CompleteAuthorizeRedirectResponse {
+    pub params: Option<String>,
+    pub payload: Option<serde_json::Value>,
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/router/src/types.rs
+++ b/crates/router/src/types.rs
@@ -292,8 +292,8 @@ pub struct CompleteAuthorizeData {
 
 #[derive(Debug, Clone)]
 pub struct CompleteAuthorizeRedirectResponse {
-    pub params: Option<String>,
-    pub payload: Option<serde_json::Value>,
+    pub params: Option<Secret<String>>,
+    pub payload: Option<pii::SecretSerdeValue>,
 }
 
 #[derive(Debug, Default, Clone)]


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->

add redirect_response field to CompleteAuthorizeData instead of payload 

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!-- 
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
Previously we were sending only payload in `CompleteAuthorizedData` , for connector `authorizedotnet` query_params are required. In this PR `redirect_response` is added in `CompleteAuthorizedData` which contains both query_params and payload. 

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Bluesnap goes through complete authorize flow for 3ds payment ,which uses payload in redirect response .So ,i have tested this connector in postman. 
<img width="1290" alt="Screenshot 2023-05-21 at 7 44 05 PM" src="https://github.com/juspay/hyperswitch/assets/121822803/839709f0-82f0-45ca-b492-2f9350aa0327">
<img width="1300" alt="Screenshot 2023-05-21 at 7 44 22 PM" src="https://github.com/juspay/hyperswitch/assets/121822803/c98d4498-836b-4b93-88b5-4ccbb93e528e">


## Check

list
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
