### PR TITLE
fix: remove multiple call to locker

### DIFF
--- a/crates/router/src/core/payments/helpers.rs
+++ b/crates/router/src/core/payments/helpers.rs
@@ -782,40 +782,16 @@ pub async fn make_pm_data<'a, F: Clone, R>(
                     }
                 }
 
-                Some(api::PaymentMethodData::Wallet(wallet_data)) => {
+                Some(api::PaymentMethodData::Wallet(_)) => {
                     payment_data.payment_attempt.payment_method =
                         Some(storage_enums::PaymentMethod::Wallet);
-                    // TODO: Remove redundant update from wallets.
-                    match wallet_data {
-                        api_models::payments::WalletData::PaypalRedirect(_) => pm,
-                        _ => {
-                            let updated_pm = api::PaymentMethodData::Wallet(wallet_data);
-                            vault::Vault::store_payment_method_data_in_locker(
-                                state,
-                                Some(hyperswitch_token),
-                                &updated_pm,
-                                payment_data.payment_intent.customer_id.to_owned(),
-                                enums::PaymentMethod::Wallet,
-                            )
-                            .await?;
-                            Some(updated_pm)
-                        }
-                    }
+                    pm
                 }
 
-                Some(api::PaymentMethodData::BankTransfer(bank_transfer)) => {
+                Some(api::PaymentMethodData::BankTransfer(_)) => {
                     payment_data.payment_attempt.payment_method =
                         Some(storage_enums::PaymentMethod::BankTransfer);
-                    let updated_pm = api::PaymentMethodData::BankTransfer(bank_transfer);
-                    vault::Vault::store_payment_method_data_in_locker(
-                        state,
-                        Some(hyperswitch_token),
-                        &updated_pm,
-                        payment_data.payment_intent.customer_id.to_owned(),
-                        enums::PaymentMethod::BankTransfer,
-                    )
-                    .await?;
-                    Some(updated_pm)
+                    pm
                 }
                 Some(_) => Err(errors::ApiErrorResponse::InternalServerError)
                     .into_report()


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix

## Description
<!-- Describe your changes in detail -->
If we have hyperswitch_token as well as pmd, we get pmd against that hyperswitch token from basilisk.
We used to update the pmd again against that token w.r.t wallets and bank transfers, as both the data will be same, we get error.




## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
Remove duplicate storage in locker

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Manual

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
