### PR TITLE
refactor:  make NextAction as enum 

### DIFF
--- a/crates/api_models/src/payments.rs
+++ b/crates/api_models/src/payments.rs
@@ -1067,17 +1067,16 @@ pub enum NextActionType {
     TriggerApi,
     DisplayBankTransferInformation,
 }
+
 #[derive(Clone, Debug, Eq, PartialEq, serde::Serialize, ToSchema)]
-pub struct NextAction {
-    /// Specifying the action type to be performed next
-    #[serde(rename = "type")]
-    pub next_action_type: NextActionType,
-    //TODO: Make an enum having redirect_to_url and bank_transfer_steps_and_charges_details and use here
-    /// Contains the url for redirection flow
-    #[schema(example = "https://router.juspay.io/redirect/fakushdfjlksdfasklhdfj")]
-    pub redirect_to_url: Option<String>,
-    /// Informs the next steps for bank transfer and also contains the charges details (ex: amount received, amount charged etc)
-    pub bank_transfer_steps_and_charges_details: Option<NextStepsRequirements>,
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum NextActionData {
+    RedirectToUrl {
+        redirect_to_url: String,
+    },
+    DisplayBankTransferInformation {
+        bank_transfer_steps_and_charges_details: NextStepsRequirements,
+    },
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -1268,7 +1267,7 @@ pub struct PaymentsResponse {
     pub statement_descriptor_suffix: Option<String>,
 
     /// Additional information required for redirection
-    pub next_action: Option<NextAction>,
+    pub next_action: Option<NextActionData>,
 
     /// If the payment was cancelled the reason provided here
     pub cancellation_reason: Option<String>,

--- a/crates/router/src/compatibility/stripe/payment_intents/types.rs
+++ b/crates/router/src/compatibility/stripe/payment_intents/types.rs
@@ -610,22 +610,34 @@ pub struct RedirectUrl {
     pub url: Option<String>,
 }
 
-#[derive(Eq, PartialEq, Serialize, Debug)]
-pub struct StripeNextAction {
-    #[serde(rename = "type")]
-    stype: payments::NextActionType,
-    redirect_to_url: RedirectUrl,
+#[derive(Eq, PartialEq, serde::Serialize, Debug)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum StripeNextAction {
+    RedirectToUrl {
+        redirect_to_url: RedirectUrl,
+    },
+    DisplayBankTransferInformation {
+        bank_transfer_steps_and_charges_details: payments::NextStepsRequirements,
+    },
 }
 
-fn into_stripe_next_action(
-    next_action: Option<payments::NextAction>,
+pub(crate) fn into_stripe_next_action(
+    next_action: Option<payments::NextActionData>,
     return_url: Option<String>,
 ) -> Option<StripeNextAction> {
-    next_action.map(|n| StripeNextAction {
-        stype: n.next_action_type,
-        redirect_to_url: RedirectUrl {
-            return_url,
-            url: n.redirect_to_url,
+    next_action.map(|next_action_data| match next_action_data {
+        payments::NextActionData::RedirectToUrl { redirect_to_url } => {
+            StripeNextAction::RedirectToUrl {
+                redirect_to_url: RedirectUrl {
+                    return_url,
+                    url: Some(redirect_to_url),
+                },
+            }
+        }
+        payments::NextActionData::DisplayBankTransferInformation {
+            bank_transfer_steps_and_charges_details,
+        } => StripeNextAction::DisplayBankTransferInformation {
+            bank_transfer_steps_and_charges_details,
         },
     })
 }

--- a/crates/router/src/compatibility/stripe/setup_intents/types.rs
+++ b/crates/router/src/compatibility/stripe/setup_intents/types.rs
@@ -284,22 +284,34 @@ pub struct RedirectUrl {
     pub url: Option<String>,
 }
 
-#[derive(Eq, PartialEq, Serialize)]
-pub struct StripeNextAction {
-    #[serde(rename = "type")]
-    stype: payments::NextActionType,
-    redirect_to_url: RedirectUrl,
+#[derive(Eq, PartialEq, serde::Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum StripeNextAction {
+    RedirectToUrl {
+        redirect_to_url: RedirectUrl,
+    },
+    DisplayBankTransferInformation {
+        bank_transfer_steps_and_charges_details: payments::NextStepsRequirements,
+    },
 }
 
 pub(crate) fn into_stripe_next_action(
-    next_action: Option<payments::NextAction>,
+    next_action: Option<payments::NextActionData>,
     return_url: Option<String>,
 ) -> Option<StripeNextAction> {
-    next_action.map(|n| StripeNextAction {
-        stype: n.next_action_type,
-        redirect_to_url: RedirectUrl {
-            return_url,
-            url: n.redirect_to_url,
+    next_action.map(|next_action_data| match next_action_data {
+        payments::NextActionData::RedirectToUrl { redirect_to_url } => {
+            StripeNextAction::RedirectToUrl {
+                redirect_to_url: RedirectUrl {
+                    return_url,
+                    url: Some(redirect_to_url),
+                },
+            }
+        }
+        payments::NextActionData::DisplayBankTransferInformation {
+            bank_transfer_steps_and_charges_details,
+        } => StripeNextAction::DisplayBankTransferInformation {
+            bank_transfer_steps_and_charges_details,
         },
     })
 }

--- a/crates/router/src/connector/stripe/transformers.rs
+++ b/crates/router/src/connector/stripe/transformers.rs
@@ -1603,6 +1603,9 @@ impl<F, T>
         // Or we identify the mandate txns before hand and always call SetupIntent in case of mandate payment call
         let network_txn_id = Option::foreign_from(item.response.latest_attempt);
 
+        let connector_metadata =
+            get_connector_metadata(item.response.next_action.as_ref(), item.response.amount)?;
+
         Ok(Self {
             status: enums::AttemptStatus::from(item.response.status),
             // client_secret: Some(item.response.client_secret.clone().as_str()),
@@ -1613,7 +1616,7 @@ impl<F, T>
                 resource_id: types::ResponseId::ConnectorTransactionId(item.response.id),
                 redirection_data,
                 mandate_reference,
-                connector_metadata: None,
+                connector_metadata,
                 network_txn_id,
             }),
             amount_captured: Some(item.response.amount_received),

--- a/crates/router/src/core/payments.rs
+++ b/crates/router/src/core/payments.rs
@@ -380,7 +380,10 @@ impl PaymentRedirectFlow for PaymentRedirectCompleteAuthorize {
             api_models::enums::IntentStatus::RequiresCustomerAction => {
                 let startpay_url = payments_response
                     .next_action
-                    .and_then(|next_action| next_action.redirect_to_url)
+                    .and_then(|next_action_data| match next_action_data {
+                        api_models::payments::NextActionData::RedirectToUrl { redirect_to_url } => Some(redirect_to_url),
+                        api_models::payments::NextActionData::DisplayBankTransferInformation { .. } => None,
+                    })
                     .ok_or(errors::ApiErrorResponse::InternalServerError)
                     .into_report()
                     .attach_printable(

--- a/crates/router/src/core/payments/transformers.rs
+++ b/crates/router/src/core/payments/transformers.rs
@@ -309,20 +309,19 @@ where
                 if payment_intent.status == enums::IntentStatus::RequiresCustomerAction
                     || bank_transfer_next_steps.is_some()
                 {
-                    let next_action_type = if bank_transfer_next_steps.is_some() {
-                        api::NextActionType::DisplayBankTransferInformation
-                    } else {
-                        api::NextActionType::RedirectToUrl
-                    };
-                    next_action_response = Some(api::NextAction {
-                        next_action_type,
-                        redirect_to_url: Some(helpers::create_startpay_url(
-                            server,
-                            &payment_attempt,
-                            &payment_intent,
-                        )),
-                        bank_transfer_steps_and_charges_details: bank_transfer_next_steps,
-                    });
+                    next_action_response = bank_transfer_next_steps
+                        .map(|bank_transfer| {
+                            api_models::payments::NextActionData::DisplayBankTransferInformation {
+                                bank_transfer_steps_and_charges_details: bank_transfer,
+                            }
+                        })
+                        .or(Some(api_models::payments::NextActionData::RedirectToUrl {
+                            redirect_to_url: helpers::create_startpay_url(
+                                server,
+                                &payment_attempt,
+                                &payment_intent,
+                            ),
+                        }));
                 };
 
                 let mut response: api::PaymentsResponse = Default::default();

--- a/crates/router/src/openapi.rs
+++ b/crates/router/src/openapi.rs
@@ -177,7 +177,7 @@ Never share your secret api keys. Keep them guarded and secure.
         api_models::payments::NextActionType,
         api_models::payments::Metadata,
         api_models::payments::WalletData,
-        api_models::payments::NextAction,
+        api_models::payments::NextActionData,
         api_models::payments::PayLaterData,
         api_models::payments::MandateData,
         api_models::payments::PhoneDetails,

--- a/crates/router/src/types/api/payments.rs
+++ b/crates/router/src/types/api/payments.rs
@@ -1,7 +1,7 @@
 pub use api_models::payments::{
     AcceptanceType, Address, AddressDetails, Amount, AuthenticationForStartResponse, Card,
     CustomerAcceptance, MandateData, MandateTxnType, MandateType, MandateValidationFields,
-    NextAction, NextActionType, OnlineMandate, PayLaterData, PaymentIdType, PaymentListConstraints,
+    NextActionType, OnlineMandate, PayLaterData, PaymentIdType, PaymentListConstraints,
     PaymentListResponse, PaymentMethodData, PaymentMethodDataResponse, PaymentOp,
     PaymentRetrieveBody, PaymentRetrieveBodyWithCredentials, PaymentsCancelRequest,
     PaymentsCaptureRequest, PaymentsRedirectRequest, PaymentsRedirectionResponse, PaymentsRequest,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Refactoring

## Description
<!-- Describe your changes in detail -->
Earlier NextAction was struct and had only redirect_to_url as optional field but after bank transfer, there is next action which is not redirection to url, so NextAction struct is converted to enum with internally tagged with type. Now, this enum can handle both redirection kind of next action as well as just displaying the information kind of next action.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
To support both redirection and information display in next action

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
For redirect to url:
<img width="1097" alt="Screen Shot 2023-05-22 at 5 55 04 PM" src="https://github.com/juspay/hyperswitch/assets/59434228/585d9265-cc43-475b-aeed-39ba6222e4be">

For bank transfer information:
<img width="861" alt="Screen Shot 2023-05-23 at 11 27 38 AM" src="https://github.com/juspay/hyperswitch/assets/59434228/40e031b6-2c6a-49cc-b854-364b5651d13a">


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
