### PR TITLE
feat(core): add signature to outgoing webhooks 

### DIFF
--- a/crates/router/src/core/errors.rs
+++ b/crates/router/src/core/errors.rs
@@ -444,6 +444,8 @@ pub enum WebhooksFlowError {
     WebhookEventCreationFailed,
     #[error("Webhook event updation failed")]
     WebhookEventUpdationFailed,
+    #[error("Outgoing webhook body signing failed")]
+    OutgoingWebhookSigningFailed,
     #[error("Unable to fork webhooks flow for outgoing webhooks")]
     ForkFlowFailed,
     #[error("Webhook api call to merchant failed")]

--- a/crates/router/src/core/webhooks.rs
+++ b/crates/router/src/core/webhooks.rs
@@ -494,7 +494,7 @@ pub async fn create_event_and_trigger_outgoing_webhook<W: api::OutgoingWebhookTy
                 )
             })
             .transpose()
-            .change_context(errors::WebhooksFlowError::MerchantConfigNotFound)
+            .change_context(errors::WebhooksFlowError::OutgoingWebhookSigningFailed)
             .attach_printable("Failed to sign the message")?
             .map(hex::encode);
 

--- a/crates/router/src/core/webhooks.rs
+++ b/crates/router/src/core/webhooks.rs
@@ -553,7 +553,7 @@ pub async fn trigger_webhook_to_merchant<W: api::OutgoingWebhookType>(
     )];
 
     if let Some(signature) = outgoing_webhooks_signature {
-        header.push((headers::X_WEBHOOOK_SIGNATURE.to_string(), signature))
+        header.push((headers::X_WEBHOOK_SIGNATURE.to_string(), signature))
     }
 
     let request = services::RequestBuilder::new()

--- a/crates/router/src/core/webhooks.rs
+++ b/crates/router/src/core/webhooks.rs
@@ -13,7 +13,7 @@ use crate::{
         errors::{self, CustomResult, RouterResponse},
         payments, refunds,
     },
-    logger,
+    headers, logger,
     routes::AppState,
     services,
     types::{
@@ -553,7 +553,7 @@ pub async fn trigger_webhook_to_merchant<W: api::OutgoingWebhookType>(
     )];
 
     if let Some(signature) = outgoing_webhooks_signature {
-        header.push(("x-webhook-signature".to_string(), signature))
+        header.push((headers::X_WEBHOOOK_SIGNATURE.to_string(), signature))
     }
 
     let request = services::RequestBuilder::new()

--- a/crates/router/src/lib.rs
+++ b/crates/router/src/lib.rs
@@ -63,7 +63,7 @@ pub mod headers {
     pub const X_CC_VERSION: &str = "X-CC-Version";
     pub const X_ACCEPT_VERSION: &str = "X-Accept-Version";
     pub const X_DATE: &str = "X-Date";
-    pub const X_WEBHOOOK_SIGNATURE: &str = "X-Webhook-Signature";
+    pub const X_WEBHOOK_SIGNATURE: &str = "X-Webhook-Signature";
 }
 
 pub mod pii {

--- a/crates/router/src/lib.rs
+++ b/crates/router/src/lib.rs
@@ -63,6 +63,7 @@ pub mod headers {
     pub const X_CC_VERSION: &str = "X-CC-Version";
     pub const X_ACCEPT_VERSION: &str = "X-Accept-Version";
     pub const X_DATE: &str = "X-Date";
+    pub const X_WEBHOOOK_SIGNATURE: &str = "X-Webhook-Signature";
 }
 
 pub mod pii {


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->


- [x] New feature


## Description
<!-- Describe your changes in detail -->
Add signature to outgoing webhooks from hyperswitch by hashing it contents, so that the webhook can be verified on the merchants end.

Implementation details: 
-> Key used here is generated from the CSPRNG (generate_cryptographically_secure_random_string())
-> Hashing algorithm used is Sha512
-> The outgoing webhook contents is hashed using this key and the signature is sent in the header

<!-- 
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
I tested this change manually

Out going webhook to merchant
<img width="1385" alt="Screenshot 2023-05-24 at 11 57 38 AM" src="https://github.com/juspay/hyperswitch/assets/83439957/dc1e2244-8ed9-4089-8e9b-2224bcfd5cf7">

signature verification
<img width="860" alt="Screenshot 2023-05-24 at 11 58 32 AM" src="https://github.com/juspay/hyperswitch/assets/83439957/a0858b45-3853-4ed3-8cdd-b09e20f831bd">



## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
