### PR TITLE
feat(kms): reduce redundant kms calls

### DIFF
--- a/crates/router/src/configs.rs
+++ b/crates/router/src/configs.rs
@@ -1,3 +1,5 @@
 mod defaults;
+#[cfg(feature = "kms")]
+pub(super) mod kms;
 pub mod settings;
 mod validations;

--- a/crates/router/src/configs/kms.rs
+++ b/crates/router/src/configs/kms.rs
@@ -19,8 +19,6 @@ impl KmsDecrypt for settings::Jwekey {
 
         // If this pattern required repetition, a macro approach needs to be deviced
         let (
-            locker_key_identifier1,
-            locker_key_identifier2,
             locker_encryption_key1,
             locker_encryption_key2,
             locker_decryption_key1,
@@ -29,8 +27,6 @@ impl KmsDecrypt for settings::Jwekey {
             vault_private_key,
             tunnel_private_key,
         ) = tokio::try_join!(
-            client.decrypt(self.locker_key_identifier1),
-            client.decrypt(self.locker_key_identifier2),
             client.decrypt(self.locker_encryption_key1),
             client.decrypt(self.locker_encryption_key2),
             client.decrypt(self.locker_decryption_key1),
@@ -41,8 +37,8 @@ impl KmsDecrypt for settings::Jwekey {
         )?;
 
         Ok(Self {
-            locker_key_identifier1,
-            locker_key_identifier2,
+            locker_key_identifier1: self.locker_key_identifier1,
+            locker_key_identifier2: self.locker_key_identifier2,
             locker_encryption_key1,
             locker_encryption_key2,
             locker_decryption_key1,

--- a/crates/router/src/configs/kms.rs
+++ b/crates/router/src/configs/kms.rs
@@ -1,0 +1,64 @@
+use common_utils::errors::CustomResult;
+use external_services::kms;
+use masking::ExposeInterface;
+
+use crate::configs::settings;
+
+#[async_trait::async_trait]
+// This trait performs inplace decryption of the structure on which this is implemented
+pub(crate) trait KmsDecrypt {
+    async fn decrypt_inner(self, kms_config: &kms::KmsConfig) -> CustomResult<Self, kms::KmsError>
+    where
+        Self: Sized;
+}
+
+#[async_trait::async_trait]
+impl KmsDecrypt for settings::Jwekey {
+    async fn decrypt_inner(self, kms_config: &kms::KmsConfig) -> CustomResult<Self, kms::KmsError> {
+        let client = kms::get_kms_client(kms_config).await;
+
+        // If this pattern required repetition, a macro approach needs to be deviced
+        let (
+            locker_key_identifier1,
+            locker_key_identifier2,
+            locker_encryption_key1,
+            locker_encryption_key2,
+            locker_decryption_key1,
+            locker_decryption_key2,
+            vault_encryption_key,
+            vault_private_key,
+            tunnel_private_key,
+        ) = tokio::try_join!(
+            client.decrypt(self.locker_key_identifier1),
+            client.decrypt(self.locker_key_identifier2),
+            client.decrypt(self.locker_encryption_key1),
+            client.decrypt(self.locker_encryption_key2),
+            client.decrypt(self.locker_decryption_key1),
+            client.decrypt(self.locker_decryption_key2),
+            client.decrypt(self.vault_encryption_key),
+            client.decrypt(self.vault_private_key),
+            client.decrypt(self.tunnel_private_key),
+        )?;
+
+        Ok(Self {
+            locker_key_identifier1,
+            locker_key_identifier2,
+            locker_encryption_key1,
+            locker_encryption_key2,
+            locker_decryption_key1,
+            locker_decryption_key2,
+            vault_encryption_key,
+            vault_private_key,
+            tunnel_private_key,
+        })
+    }
+}
+
+#[async_trait::async_trait]
+impl KmsDecrypt for settings::ActiveKmsSecrets {
+    async fn decrypt_inner(self, kms_config: &kms::KmsConfig) -> CustomResult<Self, kms::KmsError> {
+        Ok(Self {
+            jwekey: self.jwekey.expose().decrypt_inner(kms_config).await?.into(),
+        })
+    }
+}

--- a/crates/router/src/configs/settings.rs
+++ b/crates/router/src/configs/settings.rs
@@ -39,6 +39,13 @@ pub enum Subcommand {
     GenerateOpenapiSpec,
 }
 
+#[cfg(feature = "kms")]
+/// Store the decrypted kms secret values for active use in the application
+#[derive(Clone)]
+pub struct ActiveKmsSecrets {
+    pub jwekey: masking::Secret<Jwekey>,
+}
+
 #[derive(Debug, Deserialize, Clone, Default)]
 #[serde(default)]
 pub struct Settings {

--- a/crates/router/src/configs/settings.rs
+++ b/crates/router/src/configs/settings.rs
@@ -41,6 +41,9 @@ pub enum Subcommand {
 
 #[cfg(feature = "kms")]
 /// Store the decrypted kms secret values for active use in the application
+/// Currently using `StrongSecret` won't have any effect as this struct have smart pointers to heap
+/// allocations.
+/// note: we can consider adding such behaviour in the future with custom implementation
 #[derive(Clone)]
 pub struct ActiveKmsSecrets {
     pub jwekey: masking::Secret<Jwekey>,

--- a/crates/router/src/core/payment_methods/cards.rs
+++ b/crates/router/src/core/payment_methods/cards.rs
@@ -250,10 +250,10 @@ pub async fn add_card_hs(
     merchant_account: &storage::MerchantAccount,
 ) -> errors::CustomResult<(api::PaymentMethodResponse, bool), errors::VaultError> {
     let locker = &state.conf.locker;
+    #[cfg(not(feature = "kms"))]
     let jwekey = &state.conf.jwekey;
-
     #[cfg(feature = "kms")]
-    let kms_config = &state.conf.kms;
+    let jwekey = &state.kms_secrets;
 
     let db = &*state.store;
     let merchant_id = &merchant_account.merchant_id;
@@ -264,16 +264,9 @@ pub async fn add_card_hs(
         .get_required_value("locker_id")
         .change_context(errors::VaultError::SaveCardFailed)?;
 
-    let request = payment_methods::mk_add_card_request_hs(
-        jwekey,
-        locker,
-        &card,
-        &customer_id,
-        merchant_id,
-        #[cfg(feature = "kms")]
-        kms_config,
-    )
-    .await?;
+    let request =
+        payment_methods::mk_add_card_request_hs(jwekey, locker, &card, &customer_id, merchant_id)
+            .await?;
 
     let stored_card_response = if !locker.mock_locker {
         let response = services::call_connector_api(state, request)
@@ -284,15 +277,10 @@ pub async fn add_card_hs(
             .get_response_inner("JweBody")
             .change_context(errors::VaultError::FetchCardFailed)?;
 
-        let decrypted_payload = payment_methods::get_decrypted_response_payload(
-            jwekey,
-            jwe_body,
-            #[cfg(feature = "kms")]
-            kms_config,
-        )
-        .await
-        .change_context(errors::VaultError::SaveCardFailed)
-        .attach_printable("Error getting decrypted response payload")?;
+        let decrypted_payload = payment_methods::get_decrypted_response_payload(jwekey, jwe_body)
+            .await
+            .change_context(errors::VaultError::SaveCardFailed)
+            .attach_printable("Error getting decrypted response payload")?;
         let stored_card_resp: payment_methods::StoreCardResp = decrypted_payload
             .parse_struct("StoreCardResp")
             .change_context(errors::VaultError::ResponseDeserializationFailed)?;
@@ -394,10 +382,10 @@ pub async fn get_card_from_hs_locker<'a>(
     card_reference: &'a str,
 ) -> errors::CustomResult<payment_methods::Card, errors::VaultError> {
     let locker = &state.conf.locker;
+    #[cfg(not(feature = "kms"))]
     let jwekey = &state.conf.jwekey;
-
     #[cfg(feature = "kms")]
-    let kms_config = &state.conf.kms;
+    let jwekey = &state.kms_secrets;
 
     let request = payment_methods::mk_get_card_request_hs(
         jwekey,
@@ -405,8 +393,6 @@ pub async fn get_card_from_hs_locker<'a>(
         customer_id,
         merchant_id,
         card_reference,
-        #[cfg(feature = "kms")]
-        kms_config,
     )
     .await
     .change_context(errors::VaultError::FetchCardFailed)
@@ -419,15 +405,10 @@ pub async fn get_card_from_hs_locker<'a>(
         let jwe_body: services::JweBody = response
             .get_response_inner("JweBody")
             .change_context(errors::VaultError::FetchCardFailed)?;
-        let decrypted_payload = payment_methods::get_decrypted_response_payload(
-            jwekey,
-            jwe_body,
-            #[cfg(feature = "kms")]
-            kms_config,
-        )
-        .await
-        .change_context(errors::VaultError::FetchCardFailed)
-        .attach_printable("Error getting decrypted response payload for get card")?;
+        let decrypted_payload = payment_methods::get_decrypted_response_payload(jwekey, jwe_body)
+            .await
+            .change_context(errors::VaultError::FetchCardFailed)
+            .attach_printable("Error getting decrypted response payload for get card")?;
         let get_card_resp: payment_methods::RetrieveCardResp = decrypted_payload
             .parse_struct("RetrieveCardResp")
             .change_context(errors::VaultError::FetchCardFailed)?;
@@ -483,10 +464,10 @@ pub async fn delete_card_from_hs_locker<'a>(
     card_reference: &'a str,
 ) -> errors::RouterResult<payment_methods::DeleteCardResp> {
     let locker = &state.conf.locker;
+    #[cfg(not(feature = "kms"))]
     let jwekey = &state.conf.jwekey;
-
     #[cfg(feature = "kms")]
-    let kms_config = &state.conf.kms;
+    let jwekey = &state.kms_secrets;
 
     let request = payment_methods::mk_delete_card_request_hs(
         jwekey,
@@ -494,8 +475,6 @@ pub async fn delete_card_from_hs_locker<'a>(
         customer_id,
         merchant_id,
         card_reference,
-        #[cfg(feature = "kms")]
-        kms_config,
     )
     .await
     .change_context(errors::ApiErrorResponse::InternalServerError)
@@ -507,15 +486,10 @@ pub async fn delete_card_from_hs_locker<'a>(
             .change_context(errors::ApiErrorResponse::InternalServerError)
             .attach_printable("Failed while executing call_connector_api for delete card");
         let jwe_body: services::JweBody = response.get_response_inner("JweBody")?;
-        let decrypted_payload = payment_methods::get_decrypted_response_payload(
-            jwekey,
-            jwe_body,
-            #[cfg(feature = "kms")]
-            kms_config,
-        )
-        .await
-        .change_context(errors::ApiErrorResponse::InternalServerError)
-        .attach_printable("Error getting decrypted response payload for delete card")?;
+        let decrypted_payload = payment_methods::get_decrypted_response_payload(jwekey, jwe_body)
+            .await
+            .change_context(errors::ApiErrorResponse::InternalServerError)
+            .attach_printable("Error getting decrypted response payload for delete card")?;
         let delete_card_resp: payment_methods::DeleteCardResp = decrypted_payload
             .parse_struct("DeleteCardResp")
             .change_context(errors::ApiErrorResponse::InternalServerError)?;

--- a/crates/router/src/core/payment_methods/vault.rs
+++ b/crates/router/src/core/payment_methods/vault.rs
@@ -3,8 +3,6 @@ use common_utils::generate_id_with_default_len;
 use error_stack::report;
 use error_stack::{IntoReport, ResultExt};
 #[cfg(feature = "basilisk")]
-use external_services::kms;
-#[cfg(feature = "basilisk")]
 use josekit::jwe;
 use masking::PeekInterface;
 use router_env::{instrument, tracing};
@@ -470,11 +468,11 @@ pub fn get_key_id(keys: &settings::Jwekey) -> &str {
 
 #[cfg(feature = "basilisk")]
 async fn get_locker_jwe_keys(
-    keys: &settings::Jwekey,
-    kms_config: &kms::KmsConfig,
+    keys: &settings::ActiveKmsSecrets,
 ) -> CustomResult<(String, String), errors::EncryptionError> {
+    let keys = keys.jwekey.peek();
     let key_id = get_key_id(keys);
-    let (encryption_key, decryption_key) = if key_id == keys.locker_key_identifier1 {
+    let (public_key, private_key) = if key_id == keys.locker_key_identifier1 {
         (&keys.locker_encryption_key1, &keys.locker_decryption_key1)
     } else if key_id == keys.locker_key_identifier2 {
         (&keys.locker_encryption_key2, &keys.locker_decryption_key2)
@@ -482,18 +480,7 @@ async fn get_locker_jwe_keys(
         return Err(errors::EncryptionError.into());
     };
 
-    let public_key = kms::get_kms_client(kms_config)
-        .await
-        .decrypt(encryption_key)
-        .await
-        .change_context(errors::EncryptionError)?;
-    let private_key = kms::get_kms_client(kms_config)
-        .await
-        .decrypt(decryption_key)
-        .await
-        .change_context(errors::EncryptionError)?;
-
-    Ok((public_key, private_key))
+    Ok((public_key.to_string(), private_key.to_string()))
 }
 
 #[cfg(feature = "basilisk")]
@@ -515,7 +502,7 @@ pub async fn create_tokenize(
     )
     .change_context(errors::ApiErrorResponse::InternalServerError)?;
 
-    let (public_key, private_key) = get_locker_jwe_keys(&state.conf.jwekey, &state.conf.kms)
+    let (public_key, private_key) = get_locker_jwe_keys(&state.kms_secrets)
         .await
         .change_context(errors::ApiErrorResponse::InternalServerError)
         .attach_printable("Error getting Encryption key")?;
@@ -592,7 +579,7 @@ pub async fn get_tokenized_data(
     let payload = serde_json::to_string(&payload_to_be_encrypted)
         .map_err(|_x| errors::ApiErrorResponse::InternalServerError)?;
 
-    let (public_key, private_key) = get_locker_jwe_keys(&state.conf.jwekey, &state.conf.kms)
+    let (public_key, private_key) = get_locker_jwe_keys(&state.kms_secrets)
         .await
         .change_context(errors::ApiErrorResponse::InternalServerError)
         .attach_printable("Error getting Encryption key")?;
@@ -663,7 +650,7 @@ pub async fn delete_tokenized_data(
     let payload = serde_json::to_string(&payload_to_be_encrypted)
         .map_err(|_x| errors::ApiErrorResponse::InternalServerError)?;
 
-    let (public_key, _private_key) = get_locker_jwe_keys(&state.conf.jwekey, &state.conf.kms)
+    let (public_key, _private_key) = get_locker_jwe_keys(&state.kms_secrets)
         .await
         .change_context(errors::ApiErrorResponse::InternalServerError)
         .attach_printable("Error getting Encryption key")?;

--- a/crates/router/src/core/payments/helpers.rs
+++ b/crates/router/src/core/payments/helpers.rs
@@ -6,8 +6,6 @@ use common_utils::{
 };
 // TODO : Evaluate all the helper functions ()
 use error_stack::{report, IntoReport, ResultExt};
-#[cfg(feature = "kms")]
-use external_services::kms;
 use josekit::jwe;
 use masking::{ExposeOptionInterface, PeekInterface};
 use router_env::{instrument, tracing};
@@ -1607,15 +1605,7 @@ pub async fn get_merchant_connector_account(
                 )?;
 
             #[cfg(feature = "kms")]
-            let kms_config = &state.conf.kms;
-
-            #[cfg(feature = "kms")]
-            let private_key = kms::get_kms_client(kms_config)
-                .await
-                .decrypt(state.conf.jwekey.tunnel_private_key.to_owned())
-                .await
-                .change_context(errors::ApiErrorResponse::InternalServerError)
-                .attach_printable("Error getting tunnel private key")?;
+            let private_key = state.kms_secrets.jwekey.peek().tunnel_private_key.clone();
 
             #[cfg(not(feature = "kms"))]
             let private_key = state.conf.jwekey.tunnel_private_key.to_owned();


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

This PR introduces changes to changes to KMS decryption:
- It decrypts and stores the KMS keys for vault and locker in a `AppState`.
- It performs concurrent decryption while startup for those KMS keys
- It also supports, retry mechanism for decryption for failures

<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!-- 
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context

Improve the performance

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
compiler guided
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
