### PR TITLE
feat(core): add custom headers capability for application response and make `JWTAuth` private

### DIFF
--- a/crates/router/src/compatibility/stripe/errors.rs
+++ b/crates/router/src/compatibility/stripe/errors.rs
@@ -364,6 +364,7 @@ impl From<errors::ApiErrorResponse> for StripeErrorCode {
             errors::ApiErrorResponse::Unauthorized
             | errors::ApiErrorResponse::InvalidJwtToken
             | errors::ApiErrorResponse::GenericUnauthorized { .. }
+            | errors::ApiErrorResponse::AccessForbidden
             | errors::ApiErrorResponse::InvalidEphemeralKey => Self::Unauthorized,
             errors::ApiErrorResponse::InvalidRequestUrl
             | errors::ApiErrorResponse::InvalidHttpMethod

--- a/crates/router/src/compatibility/wrap.rs
+++ b/crates/router/src/compatibility/wrap.rs
@@ -114,12 +114,8 @@ where
         .respond_to(request)
         .map_into_boxed_body(),
         api::ApplicationResponse::ResponseWithCustomHeader(_, _) => {
-            api::log_and_return_error_response(
-                errors::ApiErrorResponse::InvalidRequestData {
-                    message: "Found header response inside a header response".to_string(),
-                }
-                .into(),
-            )
+            logger::error!("Found header response inside a header response");
+            HttpResponse::from_error(errors::ApiErrorResponse::InternalServerError)
         }
     }
 }

--- a/crates/router/src/core/errors/api_error_response.rs
+++ b/crates/router/src/core/errors/api_error_response.rs
@@ -241,7 +241,7 @@ impl actix_web::ResponseError for ApiErrorResponse {
             }
             Self::AccessForbidden => StatusCode::FORBIDDEN, // 403
             Self::InvalidRequestUrl | Self::WebhookResourceNotFound => StatusCode::NOT_FOUND, // 404
-            Self::InvalidHttpMethod => StatusCode::METHOD_NOT_ALLOWED,                        // 405
+            Self::InvalidHttpMethod => StatusCode::METHOD_NOT_ALLOWED, // 405
             Self::MissingRequiredField { .. }
             | Self::MissingRequiredFields { .. }
             | Self::InvalidDataValue { .. }
@@ -250,9 +250,9 @@ impl actix_web::ResponseError for ApiErrorResponse {
             Self::InvalidDataFormat { .. } | Self::InvalidRequestData { .. } => {
                 StatusCode::UNPROCESSABLE_ENTITY
             } // 422
-            Self::RefundAmountExceedsPaymentAmount => StatusCode::BAD_REQUEST,                // 400
-            Self::MaximumRefundCount => StatusCode::BAD_REQUEST,                              // 400
-            Self::PreconditionFailed { .. } => StatusCode::BAD_REQUEST,                       // 400
+            Self::RefundAmountExceedsPaymentAmount => StatusCode::BAD_REQUEST, // 400
+            Self::MaximumRefundCount => StatusCode::BAD_REQUEST, // 400
+            Self::PreconditionFailed { .. } => StatusCode::BAD_REQUEST, // 400
 
             Self::PaymentAuthorizationFailed { .. }
             | Self::PaymentAuthenticationFailed { .. }

--- a/crates/router/src/core/errors/api_error_response.rs
+++ b/crates/router/src/core/errors/api_error_response.rs
@@ -239,9 +239,9 @@ impl actix_web::ResponseError for ApiErrorResponse {
             Self::ExternalConnectorError { status_code, .. } => {
                 StatusCode::from_u16(*status_code).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR)
             }
-            Self::AccessForbidden => StatusCode::FORBIDDEN, // 403
+            Self::AccessForbidden => StatusCode::FORBIDDEN,                                   // 403
             Self::InvalidRequestUrl | Self::WebhookResourceNotFound => StatusCode::NOT_FOUND, // 404
-            Self::InvalidHttpMethod => StatusCode::METHOD_NOT_ALLOWED, // 405
+            Self::InvalidHttpMethod => StatusCode::METHOD_NOT_ALLOWED,                        // 405
             Self::MissingRequiredField { .. }
             | Self::MissingRequiredFields { .. }
             | Self::InvalidDataValue { .. }
@@ -250,9 +250,9 @@ impl actix_web::ResponseError for ApiErrorResponse {
             Self::InvalidDataFormat { .. } | Self::InvalidRequestData { .. } => {
                 StatusCode::UNPROCESSABLE_ENTITY
             } // 422
-            Self::RefundAmountExceedsPaymentAmount => StatusCode::BAD_REQUEST, // 400
-            Self::MaximumRefundCount => StatusCode::BAD_REQUEST, // 400
-            Self::PreconditionFailed { .. } => StatusCode::BAD_REQUEST, // 400
+            Self::RefundAmountExceedsPaymentAmount => StatusCode::BAD_REQUEST,                // 400
+            Self::MaximumRefundCount => StatusCode::BAD_REQUEST,                              // 400
+            Self::PreconditionFailed { .. } => StatusCode::BAD_REQUEST,                       // 400
 
             Self::PaymentAuthorizationFailed { .. }
             | Self::PaymentAuthenticationFailed { .. }
@@ -409,7 +409,7 @@ impl common_utils::errors::ErrorSwitch<api_models::errors::types::ApiErrorRespon
             Self::MissingRequiredFields { field_names } => AER::BadRequest(
                 ApiError::new("IR", 21, "Missing required params".to_string(), Some(Extra {data: Some(serde_json::json!(field_names)), ..Default::default() })),
             ),
-            Self::AccessForbidden => AER::ForbiddenCommonResource(ApiError::new("IR", 22, format!("Access forbidden. Not authorized to access this resource"), None)),
+            Self::AccessForbidden => AER::ForbiddenCommonResource(ApiError::new("IR", 22, "Access forbidden. Not authorized to access this resource", None)),
             Self::ExternalConnectorError {
                 code,
                 message,

--- a/crates/router/src/core/errors/api_error_response.rs
+++ b/crates/router/src/core/errors/api_error_response.rs
@@ -239,9 +239,9 @@ impl actix_web::ResponseError for ApiErrorResponse {
             Self::ExternalConnectorError { status_code, .. } => {
                 StatusCode::from_u16(*status_code).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR)
             }
-            Self::AccessForbidden => StatusCode::FORBIDDEN,                                   // 403
+            Self::AccessForbidden => StatusCode::FORBIDDEN, // 403
             Self::InvalidRequestUrl | Self::WebhookResourceNotFound => StatusCode::NOT_FOUND, // 404
-            Self::InvalidHttpMethod => StatusCode::METHOD_NOT_ALLOWED,                        // 405
+            Self::InvalidHttpMethod => StatusCode::METHOD_NOT_ALLOWED, // 405
             Self::MissingRequiredField { .. }
             | Self::MissingRequiredFields { .. }
             | Self::InvalidDataValue { .. }
@@ -250,9 +250,9 @@ impl actix_web::ResponseError for ApiErrorResponse {
             Self::InvalidDataFormat { .. } | Self::InvalidRequestData { .. } => {
                 StatusCode::UNPROCESSABLE_ENTITY
             } // 422
-            Self::RefundAmountExceedsPaymentAmount => StatusCode::BAD_REQUEST,                // 400
-            Self::MaximumRefundCount => StatusCode::BAD_REQUEST,                              // 400
-            Self::PreconditionFailed { .. } => StatusCode::BAD_REQUEST,                       // 400
+            Self::RefundAmountExceedsPaymentAmount => StatusCode::BAD_REQUEST, // 400
+            Self::MaximumRefundCount => StatusCode::BAD_REQUEST, // 400
+            Self::PreconditionFailed { .. } => StatusCode::BAD_REQUEST, // 400
 
             Self::PaymentAuthorizationFailed { .. }
             | Self::PaymentAuthenticationFailed { .. }

--- a/crates/router/src/routes/metrics/request.rs
+++ b/crates/router/src/routes/metrics/request.rs
@@ -54,8 +54,15 @@ pub fn status_code_metrics(status_code: i64, flow: String, merchant_id: String) 
 pub fn track_response_status_code<Q>(response: &ApplicationResponse<Q>) -> i64 {
     match response {
         ApplicationResponse::ResponseWithCustomHeader(response, _) => {
-            track_response_status_code(response)
+            track_application_response_status_code(response)
         }
+        _ => track_application_response_status_code(response),
+    }
+}
+
+pub fn track_application_response_status_code<Q>(response: &ApplicationResponse<Q>) -> i64 {
+    match response {
+        ApplicationResponse::ResponseWithCustomHeader(_, _) => 500,
         ApplicationResponse::Json(_)
         | ApplicationResponse::StatusOk
         | ApplicationResponse::TextPlain(_)

--- a/crates/router/src/routes/metrics/request.rs
+++ b/crates/router/src/routes/metrics/request.rs
@@ -54,7 +54,7 @@ pub fn status_code_metrics(status_code: i64, flow: String, merchant_id: String) 
 pub fn track_response_status_code<Q>(response: &ApplicationResponse<Q>) -> i64 {
     match response {
         ApplicationResponse::ResponseWithCustomHeader(response, _) => {
-            track_response_status_code(&*response)
+            track_response_status_code(response)
         }
         ApplicationResponse::Json(_)
         | ApplicationResponse::StatusOk

--- a/crates/router/src/services/api.rs
+++ b/crates/router/src/services/api.rs
@@ -602,7 +602,10 @@ where
 
 fn handle_application_response<Q>(
     request: &HttpRequest,
-    wrap_response: Result<ApplicationResponse<Q>, Report<api_models::errors::types::ApiErrorResponse>>,
+    wrap_response: Result<
+        ApplicationResponse<Q>,
+        Report<api_models::errors::types::ApiErrorResponse>,
+    >,
 ) -> HttpResponse
 where
     Q: Serialize + Debug,

--- a/crates/router/src/services/api.rs
+++ b/crates/router/src/services/api.rs
@@ -672,12 +672,10 @@ where
         )
         .respond_to(request)
         .map_into_boxed_body(),
-        ApplicationResponse::ResponseWithCustomHeader(_, _) => log_and_return_error_response(
-            errors::ApiErrorResponse::InvalidRequestData {
-                message: "Found header response inside a header response".to_string(),
-            }
-            .into(),
-        ),
+        ApplicationResponse::ResponseWithCustomHeader(_, _) => {
+            logger::error!("Found header response inside a header response");
+            HttpResponse::from_error(errors::ApiErrorResponse::InternalServerError)
+        }
     }
 }
 

--- a/crates/router/src/services/api.rs
+++ b/crates/router/src/services/api.rs
@@ -459,7 +459,7 @@ async fn handle_response(
 
 #[derive(Debug, Eq, PartialEq)]
 pub enum ApplicationResponse<R> {
-    ResponseWithCustomHeader(Box<ApplicationResponse<R>>, reqwest::header::HeaderMap),
+    ResponseWithCustomHeader(Box<ApplicationResponse<R>>, http::HeaderMap),
     Json(R),
     StatusOk,
     TextPlain(String),
@@ -614,12 +614,9 @@ where
         Ok(ApplicationResponse::ResponseWithCustomHeader(response, headers)) => {
             let mut final_response = handle_application_response::<Q>(request, Ok(*response));
             let inner_headers = final_response.headers_mut();
-            for ele in headers {
-                match ele {
-                    (Some(name), value) => inner_headers.append(name, value),
-                    _ => continue,
-                }
-            }
+            headers
+                .iter()
+                .for_each(|(name, value)| inner_headers.append(name.to_owned(), value.to_owned()));
             final_response
         }
         Ok(ApplicationResponse::Json(response)) => match serde_json::to_string(&response) {

--- a/crates/router/src/services/authentication.rs
+++ b/crates/router/src/services/authentication.rs
@@ -229,7 +229,7 @@ where
 }
 
 #[derive(Debug)]
-pub struct JWTAuth;
+pub(crate) struct JWTAuth;
 
 #[derive(serde::Deserialize)]
 struct JwtAuthPayloadFetchUnit {
@@ -301,19 +301,6 @@ impl ClientSecretFetch for api_models::cards_info::CardsInfoRequest {
     fn get_client_secret(&self) -> Option<&String> {
         self.client_secret.as_ref()
     }
-}
-
-pub fn jwt_auth_or<'a, T, A: AppStateInfo>(
-    default_auth: &'a dyn AuthenticateAndFetch<T, A>,
-    headers: &HeaderMap,
-) -> Box<&'a dyn AuthenticateAndFetch<T, A>>
-where
-    JWTAuth: AuthenticateAndFetch<T, A>,
-{
-    if is_jwt_auth(headers) {
-        return Box::new(&JWTAuth);
-    }
-    Box::new(default_auth)
 }
 
 pub fn get_auth_type_and_flow<A: AppStateInfo + Sync>(


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
- Add custom headers capability to application response. 
- As we are not using `JWTAuth` in other crates., this one is made private.
- `jwt_auth_or` function is removed, which can be replaced by `auth_type`.
- Create a new `ApiErrorResponse` for 403 (`AccessForbidden`).

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!-- 
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
As we can only add headers to `HttpResponse`, which can be only used in `server_wrap`, it's better if we can control it in the inner function itself, which only has access to `ApplicationResponse`. So I have added this new response type.
Closes #1291 

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Postman


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
