### PR TITLE
fix: invalidation of in-memory cache

### DIFF
--- a/crates/router/src/cache.rs
+++ b/crates/router/src/cache.rs
@@ -57,14 +57,10 @@ impl<'a> TryFrom<RedisValue> for CacheKind<'a> {
             message: "Invalid publish key provided in pubsub".into(),
         };
         let kind = kind.as_string().ok_or(validation_err.clone())?;
-        let mut split = kind.split(',');
-        match split.next().ok_or(validation_err.clone())? {
-            ACCOUNTS_CACHE_PREFIX => Ok(Self::Accounts(Cow::Owned(
-                split.next().ok_or(validation_err)?.to_string(),
-            ))),
-            CONFIG_CACHE_PREFIX => Ok(Self::Config(Cow::Owned(
-                split.next().ok_or(validation_err)?.to_string(),
-            ))),
+        let split = kind.split_once(',').ok_or(validation_err.clone())?;
+        match split.0 {
+            ACCOUNTS_CACHE_PREFIX => Ok(Self::Accounts(Cow::Owned(split.1.to_string()))),
+            CONFIG_CACHE_PREFIX => Ok(Self::Config(Cow::Owned(split.1.to_string()))),
             _ => Err(validation_err.into()),
         }
     }

--- a/crates/router/src/db/merchant_account.rs
+++ b/crates/router/src/db/merchant_account.rs
@@ -175,7 +175,13 @@ impl MerchantAccountInterface for Store {
 
         #[cfg(feature = "accounts_cache")]
         {
-            super::cache::publish_and_redact(self, merchant_id, delete_func, None).await
+            super::cache::publish_and_redact(
+                self,
+                cache::CacheKind::Accounts(merchant_id.into()),
+                delete_func,
+                None,
+            )
+            .await
         }
     }
 }

--- a/crates/router/src/db/merchant_account.rs
+++ b/crates/router/src/db/merchant_account.rs
@@ -136,7 +136,12 @@ impl MerchantAccountInterface for Store {
 
         #[cfg(feature = "accounts_cache")]
         {
-            super::cache::redact_cache(self, merchant_id, update_func, None).await
+            super::cache::publish_and_redact(
+                self,
+                cache::CacheKind::Accounts(merchant_id.into()),
+                update_func,
+            )
+            .await
         }
     }
 

--- a/crates/router/src/db/merchant_account.rs
+++ b/crates/router/src/db/merchant_account.rs
@@ -175,7 +175,7 @@ impl MerchantAccountInterface for Store {
 
         #[cfg(feature = "accounts_cache")]
         {
-            super::cache::redact_cache(self, merchant_id, delete_func, None).await
+            super::cache::publish_and_redact(self, merchant_id, delete_func, None).await
         }
     }
 }

--- a/crates/router/src/db/merchant_account.rs
+++ b/crates/router/src/db/merchant_account.rs
@@ -179,7 +179,6 @@ impl MerchantAccountInterface for Store {
                 self,
                 cache::CacheKind::Accounts(merchant_id.into()),
                 delete_func,
-                None,
             )
             .await
         }

--- a/crates/router/src/services.rs
+++ b/crates/router/src/services.rs
@@ -64,12 +64,20 @@ impl PubSubInterface for redis_interface::RedisConnectionPool {
 
     #[inline]
     async fn on_message(&self) -> errors::CustomResult<(), redis_errors::RedisError> {
+        logger::debug!("Started on message");
         let mut rx = self.subscriber.on_message();
         while let Ok(message) = rx.recv().await {
             logger::debug!("Invalidating {message:?}");
-            let key: CacheKind<'_> = RedisValue::new(message.value)
+            let key: CacheKind<'_> = match RedisValue::new(message.value)
                 .try_into()
-                .change_context(redis_errors::RedisError::OnMessageError)?;
+                .change_context(redis_errors::RedisError::OnMessageError)
+            {
+                Ok(value) => value,
+                Err(err) => {
+                    logger::error!(value_conversion_err=?err);
+                    continue;
+                }
+            };
 
             let key = match key {
                 CacheKind::Config(key) => {
@@ -125,7 +133,10 @@ impl Store {
 
         let subscriber_conn = redis_conn.clone();
 
-        redis_conn.subscribe(consts::PUB_SUB_CHANNEL).await.ok();
+        if let Err(e) = redis_conn.subscribe(consts::PUB_SUB_CHANNEL).await {
+            logger::error!(subscribe_err=?e);
+        }
+
         async_spawn!({
             if let Err(e) = subscriber_conn.on_message().await {
                 logger::error!(pubsub_err=?e);

--- a/crates/router/src/services.rs
+++ b/crates/router/src/services.rs
@@ -86,6 +86,8 @@ impl PubSubInterface for redis_interface::RedisConnectionPool {
                 .await
                 .map_err(|err| logger::error!("Error while deleting redis key: {err:?}"))
                 .ok();
+
+            logger::debug!("Done invalidating {key}");
         }
         Ok(())
     }

--- a/crates/router/src/services.rs
+++ b/crates/router/src/services.rs
@@ -66,21 +66,26 @@ impl PubSubInterface for redis_interface::RedisConnectionPool {
     async fn on_message(&self) -> errors::CustomResult<(), redis_errors::RedisError> {
         let mut rx = self.subscriber.on_message();
         while let Ok(message) = rx.recv().await {
+            logger::debug!("Invalidating {message:?}");
             let key: CacheKind<'_> = RedisValue::new(message.value)
                 .try_into()
                 .change_context(redis_errors::RedisError::OnMessageError)?;
-            match key {
+
+            let key = match key {
                 CacheKind::Config(key) => {
-                    self.delete_key(key.as_ref()).await?;
                     CONFIG_CACHE.invalidate(key.as_ref()).await;
-                    logger::debug!("Successfully deleted {key}");
+                    key
                 }
                 CacheKind::Accounts(key) => {
-                    self.delete_key(key.as_ref()).await?;
                     ACCOUNTS_CACHE.invalidate(key.as_ref()).await;
-                    logger::debug!("Successfully deleted {key}");
+                    key
                 }
-            }
+            };
+
+            self.delete_key(key.as_ref())
+                .await
+                .map_err(|err| logger::error!("Error while deleting redis key: {err:?}"))
+                .ok();
         }
         Ok(())
     }

--- a/crates/router/src/services.rs
+++ b/crates/router/src/services.rs
@@ -73,10 +73,12 @@ impl PubSubInterface for redis_interface::RedisConnectionPool {
                 CacheKind::Config(key) => {
                     self.delete_key(key.as_ref()).await?;
                     CONFIG_CACHE.invalidate(key.as_ref()).await;
+                    logger::debug!("Successfully deleted {key}");
                 }
                 CacheKind::Accounts(key) => {
                     self.delete_key(key.as_ref()).await?;
                     ACCOUNTS_CACHE.invalidate(key.as_ref()).await;
+                    logger::debug!("Successfully deleted {key}");
                 }
             }
         }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->
- [x] Bugfix

## Description
<!-- Describe your changes in detail -->
Fix invalidation of in memory cache for accounts cache.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
Fixes accounts cache

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Manual

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code