### PR TITLE
fix: required customer id and email error if not passed in confirm request

### DIFF
--- a/crates/router/src/core/payments/operations/payment_confirm.rs
+++ b/crates/router/src/core/payments/operations/payment_confirm.rs
@@ -207,6 +207,11 @@ impl<F: Send + Clone> GetTracker<F, PaymentData<F>, api::PaymentsRequest> for Pa
             .await
             .transpose()?;
 
+        let customer_id = request
+            .customer_id
+            .to_owned()
+            .or(payment_intent.customer_id.to_owned());
+
         // The operation merges mandate data from both request and payment_attempt
         let setup_mandate = setup_mandate.map(|mandate_data| api_models::payments::MandateData {
             customer_acceptance: mandate_data.customer_acceptance,
@@ -247,7 +252,7 @@ impl<F: Send + Clone> GetTracker<F, PaymentData<F>, api::PaymentsRequest> for Pa
                 ephemeral_key: None,
             },
             Some(CustomerDetails {
-                customer_id: request.customer_id.clone(),
+                customer_id,
                 name: request.name.clone(),
                 email: request.email.clone(),
                 phone: request.phone.clone(),


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix

## Description
<!-- Describe your changes in detail -->

We used to receive a missing required field error if the customer_id or email_id is not given in the confirm request.The reasoning for this is that if the customer_id and email were not sent with the request, we would not be able to confirm.Therefore, this issue was resolved by getting it from the database or, if present, the request.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
Fix missing required field error

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
![Screen Shot 2023-05-25 at 4 44 21 PM](https://github.com/juspay/hyperswitch/assets/59434228/68efb91b-5062-4a2a-8c70-c04475cb29c4)


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
