### PR TITLE
revert(order_details): revert back `order_details` to be an object, and removing `meta_data` from `PaymentIntent`

### DIFF
--- a/crates/api_models/src/payments.rs
+++ b/crates/api_models/src/payments.rs
@@ -1563,14 +1563,12 @@ pub struct OrderDetails {
     /// The quantity of the product to be purchased
     #[schema(example = 1)]
     pub quantity: u16,
-    /// the amount per quantity of product
-    pub amount: i64,
 }
 
 #[derive(Default, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize, Clone, ToSchema)]
 pub struct Metadata {
     /// Information about the product and quantity for specific connectors. (e.g. Klarna)
-    pub order_details: Option<Vec<OrderDetails>>,
+    pub order_details: Option<OrderDetails>,
     /// Any other metadata that is to be provided
     #[schema(value_type = Object, example = r#"{ "city": "NY", "unit": "245" }"#)]
     #[serde(flatten)]

--- a/crates/router/src/connector/adyen/transformers.rs
+++ b/crates/router/src/connector/adyen/transformers.rs
@@ -896,31 +896,18 @@ fn get_address_info(address: Option<&api_models::payments::Address>) -> Option<A
 }
 
 fn get_line_items(item: &types::PaymentsAuthorizeRouterData) -> Vec<LineItem> {
-    let order_details = item.request.order_details.clone();
-    match order_details {
-        Some(od) => od
-            .iter()
-            .map(|data| LineItem {
-                amount_including_tax: Some(item.request.amount),
-                amount_excluding_tax: Some(item.request.amount),
-                description: Some(data.product_name.clone()),
-                id: Some(String::from("Items #1")),
-                tax_amount: None,
-                quantity: Some(data.quantity),
-            })
-            .collect(),
-        None => {
-            let line_item = LineItem {
-                amount_including_tax: Some(item.request.amount),
-                amount_excluding_tax: Some(item.request.amount),
-                description: None,
-                id: Some(String::from("Items #1")),
-                tax_amount: None,
-                quantity: Some(1),
-            };
-            vec![line_item]
-        }
-    }
+    let order_details = item.request.order_details.as_ref();
+    let line_item = LineItem {
+        amount_including_tax: Some(item.request.amount),
+        amount_excluding_tax: Some(item.request.amount),
+        description: order_details.map(|details| details.product_name.clone()),
+        // We support only one product details in payment request as of now, therefore hard coded the id.
+        // If we begin to support multiple product details in future then this logic should be made to create ID dynamically
+        id: Some(String::from("Items #1")),
+        tax_amount: None,
+        quantity: Some(order_details.map_or(1, |details| details.quantity)),
+    };
+    vec![line_item]
 }
 
 fn get_telephone_number(item: &types::PaymentsAuthorizeRouterData) -> Option<Secret<String>> {

--- a/crates/router/src/connector/klarna/transformers.rs
+++ b/crates/router/src/connector/klarna/transformers.rs
@@ -48,15 +48,12 @@ impl TryFrom<&types::PaymentsSessionRouterData> for KlarnaSessionRequest {
                 purchase_currency: request.currency,
                 order_amount: request.amount,
                 locale: "en-US".to_string(),
-                order_lines: order_details
-                    .iter()
-                    .map(|data| OrderLines {
-                        name: data.product_name.clone(),
-                        quantity: data.quantity,
-                        unit_price: data.amount,
-                        total_amount: i64::from(data.quantity) * (data.amount),
-                    })
-                    .collect(),
+                order_lines: vec![OrderLines {
+                    name: order_details.product_name,
+                    quantity: order_details.quantity,
+                    unit_price: request.amount,
+                    total_amount: request.amount,
+                }],
             }),
             None => Err(report!(errors::ConnectorError::MissingRequiredField {
                 field_name: "product_name",
@@ -96,15 +93,12 @@ impl TryFrom<&types::PaymentsAuthorizeRouterData> for KlarnaPaymentsRequest {
                 purchase_country: "US".to_string(),
                 purchase_currency: request.currency,
                 order_amount: request.amount,
-                order_lines: order_details
-                    .iter()
-                    .map(|data| OrderLines {
-                        name: data.product_name.clone(),
-                        quantity: data.quantity,
-                        unit_price: data.amount,
-                        total_amount: i64::from(data.quantity) * (data.amount),
-                    })
-                    .collect(),
+                order_lines: vec![OrderLines {
+                    name: order_details.product_name,
+                    quantity: order_details.quantity,
+                    unit_price: request.amount,
+                    total_amount: request.amount,
+                }],
             }),
             None => Err(report!(errors::ConnectorError::MissingRequiredField {
                 field_name: "product_name"

--- a/crates/router/src/connector/utils.rs
+++ b/crates/router/src/connector/utils.rs
@@ -173,7 +173,7 @@ pub trait PaymentsAuthorizeRequestData {
     fn is_auto_capture(&self) -> Result<bool, Error>;
     fn get_email(&self) -> Result<Email, Error>;
     fn get_browser_info(&self) -> Result<types::BrowserInformation, Error>;
-    fn get_order_details(&self) -> Result<Vec<OrderDetails>, Error>;
+    fn get_order_details(&self) -> Result<OrderDetails, Error>;
     fn get_card(&self) -> Result<api::Card, Error>;
     fn get_return_url(&self) -> Result<String, Error>;
     fn connector_mandate_id(&self) -> Option<String>;
@@ -200,7 +200,7 @@ impl PaymentsAuthorizeRequestData for types::PaymentsAuthorizeData {
             .clone()
             .ok_or_else(missing_field_err("browser_info"))
     }
-    fn get_order_details(&self) -> Result<Vec<OrderDetails>, Error> {
+    fn get_order_details(&self) -> Result<OrderDetails, Error> {
         self.order_details
             .clone()
             .ok_or_else(missing_field_err("order_details"))

--- a/crates/router/src/connector/zen/transformers.rs
+++ b/crates/router/src/connector/zen/transformers.rs
@@ -204,15 +204,12 @@ impl TryFrom<&types::PaymentsAuthorizeRouterData> for ZenPaymentsRequest {
                 ip,
             },
             custom_ipn_url: item.request.get_webhook_url()?,
-            items: order_details
-                .iter()
-                .map(|data| ZenItemObject {
-                    name: data.product_name.clone(),
-                    quantity: data.quantity,
-                    price: data.amount.to_string(),
-                    line_amount_total: order_amount.clone(),
-                })
-                .collect(),
+            items: vec![ZenItemObject {
+                name: order_details.product_name,
+                price: order_amount.clone(),
+                quantity: 1,
+                line_amount_total: order_amount,
+            }],
         })
     }
 }

--- a/crates/router/src/core/payments/helpers.rs
+++ b/crates/router/src/core/payments/helpers.rs
@@ -1433,7 +1433,6 @@ mod tests {
             active_attempt_id: "nopes".to_string(),
             business_country: storage_enums::CountryAlpha2::AG,
             business_label: "no".to_string(),
-            meta_data: None,
         };
         let req_cs = Some("1".to_string());
         let merchant_fulfillment_time = Some(900);
@@ -1473,7 +1472,6 @@ mod tests {
             active_attempt_id: "nopes".to_string(),
             business_country: storage_enums::CountryAlpha2::AG,
             business_label: "no".to_string(),
-            meta_data: None,
         };
         let req_cs = Some("1".to_string());
         let merchant_fulfillment_time = Some(10);
@@ -1513,7 +1511,6 @@ mod tests {
             active_attempt_id: "nopes".to_string(),
             business_country: storage_enums::CountryAlpha2::AG,
             business_label: "no".to_string(),
-            meta_data: None,
         };
         let req_cs = Some("1".to_string());
         let merchant_fulfillment_time = Some(10);

--- a/crates/router/src/core/payments/operations/payment_create.rs
+++ b/crates/router/src/core/payments/operations/payment_create.rs
@@ -3,7 +3,6 @@ use std::marker::PhantomData;
 use async_trait::async_trait;
 use common_utils::ext_traits::{AsyncExt, Encode, ValueExt};
 use error_stack::{self, ResultExt};
-use masking::Secret;
 use router_derive::PaymentOperation;
 use router_env::{instrument, tracing};
 use storage_models::ephemeral_key;
@@ -545,7 +544,6 @@ impl PaymentCreate {
             .transpose()
             .change_context(errors::ApiErrorResponse::InternalServerError)
             .attach_printable("Encoding Metadata to value failed")?;
-        let meta_data = metadata.clone().map(Secret::new);
 
         let (business_country, business_label) = helpers::get_business_details(
             request.business_country,
@@ -575,7 +573,6 @@ impl PaymentCreate {
             business_country,
             business_label,
             active_attempt_id,
-            meta_data,
             ..storage::PaymentIntentNew::default()
         })
     }

--- a/crates/router/src/core/payments/operations/payment_session.rs
+++ b/crates/router/src/core/payments/operations/payment_session.rs
@@ -196,20 +196,16 @@ impl<F: Clone> UpdateTracker<F, PaymentData<F>, api::PaymentsSessionRequest> for
         F: 'b + Send,
     {
         let metadata = payment_data.payment_intent.metadata.clone();
-        let meta_data = payment_data.payment_intent.meta_data.clone();
-        payment_data.payment_intent = match (metadata, meta_data) {
-            (Some(metadata), Some(meta_data)) => db
+        payment_data.payment_intent = match metadata {
+            Some(metadata) => db
                 .update_payment_intent(
                     payment_data.payment_intent,
-                    storage::PaymentIntentUpdate::MetadataUpdate {
-                        metadata,
-                        meta_data,
-                    },
+                    storage::PaymentIntentUpdate::MetadataUpdate { metadata },
                     storage_scheme,
                 )
                 .await
                 .to_not_found_response(errors::ApiErrorResponse::PaymentNotFound)?,
-            _ => payment_data.payment_intent,
+            None => payment_data.payment_intent,
         };
 
         Ok((Box::new(self), payment_data))

--- a/crates/router/src/core/payments/transformers.rs
+++ b/crates/router/src/core/payments/transformers.rs
@@ -570,14 +570,14 @@ impl<F: Clone> TryFrom<PaymentAdditionalData<'_, F>> for types::PaymentsAuthoriz
 
         let parsed_metadata: Option<api_models::payments::Metadata> = payment_data
             .payment_intent
-            .meta_data
+            .metadata
             .map(|metadata_value| {
                 metadata_value
-                    .parse_value("meta_data")
+                    .parse_value("metadata")
                     .change_context(errors::ApiErrorResponse::InvalidDataValue {
-                        field_name: "meta_data",
+                        field_name: "metadata",
                     })
-                    .attach_printable("unable to parse meta_data")
+                    .attach_printable("unable to parse metadata")
             })
             .transpose()
             .unwrap_or_default();
@@ -741,14 +741,14 @@ impl<F: Clone> TryFrom<PaymentAdditionalData<'_, F>> for types::PaymentsSessionD
         let payment_data = additional_data.payment_data;
         let parsed_metadata: Option<api_models::payments::Metadata> = payment_data
             .payment_intent
-            .meta_data
+            .metadata
             .map(|metadata_value| {
                 metadata_value
-                    .parse_value("meta_data")
+                    .parse_value("metadata")
                     .change_context(errors::ApiErrorResponse::InvalidDataValue {
-                        field_name: "meta_data",
+                        field_name: "metadata",
                     })
-                    .attach_printable("unable to parse meta_data")
+                    .attach_printable("unable to parse metadata")
             })
             .transpose()
             .unwrap_or_default();

--- a/crates/router/src/db/payment_intent.rs
+++ b/crates/router/src/db/payment_intent.rs
@@ -95,7 +95,6 @@ mod storage {
                         business_country: new.business_country,
                         business_label: new.business_label.clone(),
                         active_attempt_id: new.active_attempt_id.to_owned(),
-                        meta_data: new.meta_data.clone(),
                     };
 
                     match self
@@ -354,7 +353,6 @@ impl PaymentIntentInterface for MockDb {
             business_country: new.business_country,
             business_label: new.business_label,
             active_attempt_id: new.active_attempt_id.to_owned(),
-            meta_data: new.meta_data,
         };
         payment_intents.push(payment_intent.clone());
         Ok(payment_intent)

--- a/crates/router/src/types.rs
+++ b/crates/router/src/types.rs
@@ -224,7 +224,7 @@ pub struct PaymentsAuthorizeData {
     pub off_session: Option<bool>,
     pub setup_mandate_details: Option<payments::MandateData>,
     pub browser_info: Option<BrowserInformation>,
-    pub order_details: Option<Vec<api_models::payments::OrderDetails>>,
+    pub order_details: Option<api_models::payments::OrderDetails>,
     pub session_token: Option<String>,
     pub enrolled_for_3ds: bool,
     pub related_transaction_id: Option<String>,
@@ -314,7 +314,7 @@ pub struct PaymentsSessionData {
     pub amount: i64,
     pub currency: storage_enums::Currency,
     pub country: Option<api::enums::CountryAlpha2>,
-    pub order_details: Option<Vec<api_models::payments::OrderDetails>>,
+    pub order_details: Option<api_models::payments::OrderDetails>,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/router/tests/connectors/zen.rs
+++ b/crates/router/tests/connectors/zen.rs
@@ -306,11 +306,10 @@ async fn should_fail_payment_for_incorrect_card_number() {
                     card_number: CardNumber::from_str("1234567891011").unwrap(),
                     ..utils::CCardType::default().0
                 }),
-                order_details: Some(vec![OrderDetails {
+                order_details: Some(OrderDetails {
                     product_name: "test".to_string(),
                     quantity: 1,
-                    amount: 1000,
-                }]),
+                }),
                 email: Some(Email::from_str("test@gmail.com").unwrap()),
                 webhook_url: Some("https://1635-116-74-253-164.ngrok-free.app".to_string()),
                 ..utils::PaymentAuthorizeType::default().0
@@ -341,11 +340,10 @@ async fn should_fail_payment_for_incorrect_cvc() {
                     card_cvc: Secret::new("12345".to_string()),
                     ..utils::CCardType::default().0
                 }),
-                order_details: Some(vec![OrderDetails {
+                order_details: Some(OrderDetails {
                     product_name: "test".to_string(),
                     quantity: 1,
-                    amount: 1000,
-                }]),
+                }),
                 email: Some(Email::from_str("test@gmail.com").unwrap()),
                 webhook_url: Some("https://1635-116-74-253-164.ngrok-free.app".to_string()),
                 ..utils::PaymentAuthorizeType::default().0
@@ -376,11 +374,10 @@ async fn should_fail_payment_for_invalid_exp_month() {
                     card_exp_month: Secret::new("20".to_string()),
                     ..utils::CCardType::default().0
                 }),
-                order_details: Some(vec![OrderDetails {
+                order_details: Some(OrderDetails {
                     product_name: "test".to_string(),
                     quantity: 1,
-                    amount: 1000,
-                }]),
+                }),
                 email: Some(Email::from_str("test@gmail.com").unwrap()),
                 webhook_url: Some("https://1635-116-74-253-164.ngrok-free.app".to_string()),
                 ..utils::PaymentAuthorizeType::default().0
@@ -411,11 +408,10 @@ async fn should_fail_payment_for_incorrect_expiry_year() {
                     card_exp_year: Secret::new("2000".to_string()),
                     ..utils::CCardType::default().0
                 }),
-                order_details: Some(vec![OrderDetails {
+                order_details: Some(OrderDetails {
                     product_name: "test".to_string(),
                     quantity: 1,
-                    amount: 1000,
-                }]),
+                }),
                 email: Some(Email::from_str("test@gmail.com").unwrap()),
                 webhook_url: Some("https://1635-116-74-253-164.ngrok-free.app".to_string()),
                 ..utils::PaymentAuthorizeType::default().0

--- a/crates/storage_models/src/payment_intent.rs
+++ b/crates/storage_models/src/payment_intent.rs
@@ -36,7 +36,6 @@ pub struct PaymentIntent {
     pub active_attempt_id: String,
     pub business_country: storage_enums::CountryAlpha2,
     pub business_label: String,
-    pub meta_data: Option<pii::SecretSerdeValue>,
 }
 
 #[derive(
@@ -79,7 +78,6 @@ pub struct PaymentIntentNew {
     pub active_attempt_id: String,
     pub business_country: storage_enums::CountryAlpha2,
     pub business_label: String,
-    pub meta_data: Option<pii::SecretSerdeValue>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -91,7 +89,6 @@ pub enum PaymentIntentUpdate {
     },
     MetadataUpdate {
         metadata: pii::SecretSerdeValue,
-        meta_data: pii::SecretSerdeValue,
     },
     ReturnUrlUpdate {
         return_url: Option<String>,
@@ -149,7 +146,6 @@ pub struct PaymentIntentUpdateInternal {
     pub active_attempt_id: Option<String>,
     pub business_country: Option<storage_enums::CountryAlpha2>,
     pub business_label: Option<String>,
-    pub meta_data: Option<pii::SecretSerdeValue>,
 }
 
 impl PaymentIntentUpdate {
@@ -177,7 +173,6 @@ impl PaymentIntentUpdate {
                 .shipping_address_id
                 .or(source.shipping_address_id),
             modified_at: common_utils::date_time::now(),
-            meta_data: internal_update.meta_data.or(source.meta_data),
             ..source
         }
     }
@@ -212,12 +207,8 @@ impl From<PaymentIntentUpdate> for PaymentIntentUpdateInternal {
                 business_label,
                 ..Default::default()
             },
-            PaymentIntentUpdate::MetadataUpdate {
-                metadata,
-                meta_data,
-            } => Self {
+            PaymentIntentUpdate::MetadataUpdate { metadata } => Self {
                 metadata: Some(metadata),
-                meta_data: Some(meta_data),
                 modified_at: Some(common_utils::date_time::now()),
                 ..Default::default()
             },

--- a/crates/storage_models/src/schema.rs
+++ b/crates/storage_models/src/schema.rs
@@ -356,7 +356,6 @@ diesel::table! {
         active_attempt_id -> Varchar,
         business_country -> CountryAlpha2,
         business_label -> Varchar,
-        meta_data -> Nullable<Jsonb>,
     }
 }
 

--- a/migrations/2023-05-12-103127_payment_intent.sql/down.sql
+++ b/migrations/2023-05-12-103127_payment_intent.sql/down.sql
@@ -1,1 +1,0 @@
-ALTER TABLE payment_intent DROP COLUMN meta_data;

--- a/migrations/2023-05-12-103127_payment_intent.sql/up.sql
+++ b/migrations/2023-05-12-103127_payment_intent.sql/up.sql
@@ -1,7 +1,0 @@
-ALTER TABLE payment_intent ADD COLUMN meta_data jsonb;
-    
-UPDATE payment_intent SET meta_data = metadata;
-
-UPDATE payment_intent SET meta_data = jsonb_set(meta_data, '{order_details}', to_jsonb(ARRAY(select metadata -> 'order_details')), true);
-
-


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Order_details was changed from an object to a vector in payment-create....reverting it back to an object .
removing field meta_data from payment_intent table.

### Additional Changes

- [x] This PR modifies the API contract
- [x] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!-- 
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
This PR reverts #964.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Payment_create request gave error when order_details was an array,success with obejct .

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
