### PR TITLE
fix(router/webhooks): use api error response for returning errors from webhooks core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3058,7 +3058,7 @@ dependencies = [
 [[package]]
 name = "opentelemetry"
 version = "0.18.0"
-source = "git+https://github.com/open-telemetry/opentelemetry-rust/?rev=44b90202fd744598db8b0ace5b8f0bad7ec45658#44b90202fd744598db8b0ace5b8f0bad7ec45658"
+source = "git+https://github.com/open-telemetry/opentelemetry-rust?rev=44b90202fd744598db8b0ace5b8f0bad7ec45658#44b90202fd744598db8b0ace5b8f0bad7ec45658"
 dependencies = [
  "opentelemetry_api",
  "opentelemetry_sdk",
@@ -3067,7 +3067,7 @@ dependencies = [
 [[package]]
 name = "opentelemetry-otlp"
 version = "0.11.0"
-source = "git+https://github.com/open-telemetry/opentelemetry-rust/?rev=44b90202fd744598db8b0ace5b8f0bad7ec45658#44b90202fd744598db8b0ace5b8f0bad7ec45658"
+source = "git+https://github.com/open-telemetry/opentelemetry-rust?rev=44b90202fd744598db8b0ace5b8f0bad7ec45658#44b90202fd744598db8b0ace5b8f0bad7ec45658"
 dependencies = [
  "async-trait",
  "futures",
@@ -3084,7 +3084,7 @@ dependencies = [
 [[package]]
 name = "opentelemetry-proto"
 version = "0.1.0"
-source = "git+https://github.com/open-telemetry/opentelemetry-rust/?rev=44b90202fd744598db8b0ace5b8f0bad7ec45658#44b90202fd744598db8b0ace5b8f0bad7ec45658"
+source = "git+https://github.com/open-telemetry/opentelemetry-rust?rev=44b90202fd744598db8b0ace5b8f0bad7ec45658#44b90202fd744598db8b0ace5b8f0bad7ec45658"
 dependencies = [
  "futures",
  "futures-util",
@@ -3096,7 +3096,7 @@ dependencies = [
 [[package]]
 name = "opentelemetry_api"
 version = "0.18.0"
-source = "git+https://github.com/open-telemetry/opentelemetry-rust/?rev=44b90202fd744598db8b0ace5b8f0bad7ec45658#44b90202fd744598db8b0ace5b8f0bad7ec45658"
+source = "git+https://github.com/open-telemetry/opentelemetry-rust?rev=44b90202fd744598db8b0ace5b8f0bad7ec45658#44b90202fd744598db8b0ace5b8f0bad7ec45658"
 dependencies = [
  "fnv",
  "futures-channel",
@@ -3111,7 +3111,7 @@ dependencies = [
 [[package]]
 name = "opentelemetry_sdk"
 version = "0.18.0"
-source = "git+https://github.com/open-telemetry/opentelemetry-rust/?rev=44b90202fd744598db8b0ace5b8f0bad7ec45658#44b90202fd744598db8b0ace5b8f0bad7ec45658"
+source = "git+https://github.com/open-telemetry/opentelemetry-rust?rev=44b90202fd744598db8b0ace5b8f0bad7ec45658#44b90202fd744598db8b0ace5b8f0bad7ec45658"
 dependencies = [
  "async-trait",
  "crossbeam-channel",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3000,7 +3000,7 @@ dependencies = [
 [[package]]
 name = "opentelemetry"
 version = "0.18.0"
-source = "git+https://github.com/open-telemetry/opentelemetry-rust?rev=44b90202fd744598db8b0ace5b8f0bad7ec45658#44b90202fd744598db8b0ace5b8f0bad7ec45658"
+source = "git+https://github.com/open-telemetry/opentelemetry-rust/?rev=44b90202fd744598db8b0ace5b8f0bad7ec45658#44b90202fd744598db8b0ace5b8f0bad7ec45658"
 dependencies = [
  "opentelemetry_api",
  "opentelemetry_sdk",
@@ -3009,7 +3009,7 @@ dependencies = [
 [[package]]
 name = "opentelemetry-otlp"
 version = "0.11.0"
-source = "git+https://github.com/open-telemetry/opentelemetry-rust?rev=44b90202fd744598db8b0ace5b8f0bad7ec45658#44b90202fd744598db8b0ace5b8f0bad7ec45658"
+source = "git+https://github.com/open-telemetry/opentelemetry-rust/?rev=44b90202fd744598db8b0ace5b8f0bad7ec45658#44b90202fd744598db8b0ace5b8f0bad7ec45658"
 dependencies = [
  "async-trait",
  "futures",
@@ -3026,7 +3026,7 @@ dependencies = [
 [[package]]
 name = "opentelemetry-proto"
 version = "0.1.0"
-source = "git+https://github.com/open-telemetry/opentelemetry-rust?rev=44b90202fd744598db8b0ace5b8f0bad7ec45658#44b90202fd744598db8b0ace5b8f0bad7ec45658"
+source = "git+https://github.com/open-telemetry/opentelemetry-rust/?rev=44b90202fd744598db8b0ace5b8f0bad7ec45658#44b90202fd744598db8b0ace5b8f0bad7ec45658"
 dependencies = [
  "futures",
  "futures-util",
@@ -3038,7 +3038,7 @@ dependencies = [
 [[package]]
 name = "opentelemetry_api"
 version = "0.18.0"
-source = "git+https://github.com/open-telemetry/opentelemetry-rust?rev=44b90202fd744598db8b0ace5b8f0bad7ec45658#44b90202fd744598db8b0ace5b8f0bad7ec45658"
+source = "git+https://github.com/open-telemetry/opentelemetry-rust/?rev=44b90202fd744598db8b0ace5b8f0bad7ec45658#44b90202fd744598db8b0ace5b8f0bad7ec45658"
 dependencies = [
  "fnv",
  "futures-channel",
@@ -3053,7 +3053,7 @@ dependencies = [
 [[package]]
 name = "opentelemetry_sdk"
 version = "0.18.0"
-source = "git+https://github.com/open-telemetry/opentelemetry-rust?rev=44b90202fd744598db8b0ace5b8f0bad7ec45658#44b90202fd744598db8b0ace5b8f0bad7ec45658"
+source = "git+https://github.com/open-telemetry/opentelemetry-rust/?rev=44b90202fd744598db8b0ace5b8f0bad7ec45658#44b90202fd744598db8b0ace5b8f0bad7ec45658"
 dependencies = [
  "async-trait",
  "crossbeam-channel",

--- a/crates/router/src/compatibility/stripe/errors.rs
+++ b/crates/router/src/compatibility/stripe/errors.rs
@@ -199,6 +199,8 @@ pub enum StripeErrorCode {
     FileNotFound,
     #[error(error_type = StripeErrorType::HyperswitchError, code = "", message = "File not available")]
     FileNotAvailable,
+    #[error(error_type = StripeErrorType::HyperswitchError, code = "", message = "There was an issue with processing webhooks")]
+    WebhookProcessingError,
     // [#216]: https://github.com/juspay/hyperswitch/issues/216
     // Implement the remaining stripe error codes
 
@@ -498,6 +500,10 @@ impl From<errors::ApiErrorResponse> for StripeErrorCode {
                 Self::MerchantConnectorAccountDisabled
             }
             errors::ApiErrorResponse::NotSupported { .. } => Self::InternalServerError,
+            errors::ApiErrorResponse::WebhookBadRequest
+            | errors::ApiErrorResponse::WebhookResourceNotFound
+            | errors::ApiErrorResponse::WebhookProcessingFailure
+            | errors::ApiErrorResponse::WebhookAuthenticationFailed => Self::WebhookProcessingError,
         }
     }
 }
@@ -557,7 +563,8 @@ impl actix_web::ResponseError for StripeErrorCode {
             Self::RefundFailed
             | Self::InternalServerError
             | Self::MandateActive
-            | Self::CustomerRedacted => StatusCode::INTERNAL_SERVER_ERROR,
+            | Self::CustomerRedacted
+            | Self::WebhookProcessingError => StatusCode::INTERNAL_SERVER_ERROR,
             Self::ReturnUrlUnavailable => StatusCode::SERVICE_UNAVAILABLE,
             Self::ExternalConnectorError { status_code, .. } => {
                 StatusCode::from_u16(*status_code).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR)

--- a/crates/router/src/connector/checkout/transformers.rs
+++ b/crates/router/src/connector/checkout/transformers.rs
@@ -678,34 +678,59 @@ impl From<CheckoutRedirectResponseStatus> for enums::AttemptStatus {
     }
 }
 
-pub fn is_refund_event(event_code: &CheckoutTransactionType) -> bool {
+pub fn is_refund_event(event_code: &CheckoutWebhookEventType) -> bool {
     matches!(
         event_code,
-        CheckoutTransactionType::PaymentRefunded | CheckoutTransactionType::PaymentRefundDeclined
+        CheckoutWebhookEventType::PaymentRefunded | CheckoutWebhookEventType::PaymentRefundDeclined
     )
 }
 
-pub fn is_chargeback_event(event_code: &CheckoutTransactionType) -> bool {
+pub fn is_chargeback_event(event_code: &CheckoutWebhookEventType) -> bool {
     matches!(
         event_code,
-        CheckoutTransactionType::DisputeReceived
-            | CheckoutTransactionType::DisputeExpired
-            | CheckoutTransactionType::DisputeAccepted
-            | CheckoutTransactionType::DisputeCanceled
-            | CheckoutTransactionType::DisputeEvidenceSubmitted
-            | CheckoutTransactionType::DisputeEvidenceAcknowledgedByScheme
-            | CheckoutTransactionType::DisputeEvidenceRequired
-            | CheckoutTransactionType::DisputeArbitrationLost
-            | CheckoutTransactionType::DisputeArbitrationWon
-            | CheckoutTransactionType::DisputeWon
-            | CheckoutTransactionType::DisputeLost
+        CheckoutWebhookEventType::DisputeReceived
+            | CheckoutWebhookEventType::DisputeExpired
+            | CheckoutWebhookEventType::DisputeAccepted
+            | CheckoutWebhookEventType::DisputeCanceled
+            | CheckoutWebhookEventType::DisputeEvidenceSubmitted
+            | CheckoutWebhookEventType::DisputeEvidenceAcknowledgedByScheme
+            | CheckoutWebhookEventType::DisputeEvidenceRequired
+            | CheckoutWebhookEventType::DisputeArbitrationLost
+            | CheckoutWebhookEventType::DisputeArbitrationWon
+            | CheckoutWebhookEventType::DisputeWon
+            | CheckoutWebhookEventType::DisputeLost
     )
+}
+
+#[derive(Debug, Deserialize, strum::Display, Clone)]
+#[serde(rename_all = "snake_case")]
+pub enum CheckoutWebhookEventType {
+    AuthenticationStarted,
+    AuthenticationApproved,
+    PaymentApproved,
+    PaymentCaptured,
+    PaymentDeclined,
+    PaymentRefunded,
+    PaymentRefundDeclined,
+    DisputeReceived,
+    DisputeExpired,
+    DisputeAccepted,
+    DisputeCanceled,
+    DisputeEvidenceSubmitted,
+    DisputeEvidenceAcknowledgedByScheme,
+    DisputeEvidenceRequired,
+    DisputeArbitrationLost,
+    DisputeArbitrationWon,
+    DisputeWon,
+    DisputeLost,
+    #[serde(other)]
+    Unknown,
 }
 
 #[derive(Debug, Deserialize)]
 pub struct CheckoutWebhookEventTypeBody {
     #[serde(rename = "type")]
-    pub transaction_type: CheckoutTransactionType,
+    pub transaction_type: CheckoutWebhookEventType,
 }
 
 #[derive(Debug, Deserialize)]
@@ -720,7 +745,7 @@ pub struct CheckoutWebhookData {
 #[derive(Debug, Deserialize)]
 pub struct CheckoutWebhookBody {
     #[serde(rename = "type")]
-    pub transaction_type: CheckoutTransactionType,
+    pub transaction_type: CheckoutWebhookEventType,
     pub data: CheckoutWebhookData,
 }
 
@@ -768,29 +793,30 @@ pub enum CheckoutTransactionType {
     DisputeLost,
 }
 
-impl From<CheckoutTransactionType> for api::IncomingWebhookEvent {
-    fn from(transaction_type: CheckoutTransactionType) -> Self {
+impl From<CheckoutWebhookEventType> for api::IncomingWebhookEvent {
+    fn from(transaction_type: CheckoutWebhookEventType) -> Self {
         match transaction_type {
-            CheckoutTransactionType::AuthenticationStarted => Self::EventNotSupported,
-            CheckoutTransactionType::AuthenticationApproved => Self::EventNotSupported,
-            CheckoutTransactionType::PaymentApproved => Self::EventNotSupported,
-            CheckoutTransactionType::PaymentCaptured => Self::PaymentIntentSuccess,
-            CheckoutTransactionType::PaymentDeclined => Self::PaymentIntentFailure,
-            CheckoutTransactionType::PaymentRefunded => Self::RefundSuccess,
-            CheckoutTransactionType::PaymentRefundDeclined => Self::RefundFailure,
-            CheckoutTransactionType::DisputeReceived
-            | CheckoutTransactionType::DisputeEvidenceRequired => Self::DisputeOpened,
-            CheckoutTransactionType::DisputeExpired => Self::DisputeExpired,
-            CheckoutTransactionType::DisputeAccepted => Self::DisputeAccepted,
-            CheckoutTransactionType::DisputeCanceled => Self::DisputeCancelled,
-            CheckoutTransactionType::DisputeEvidenceSubmitted
-            | CheckoutTransactionType::DisputeEvidenceAcknowledgedByScheme => {
+            CheckoutWebhookEventType::AuthenticationStarted => Self::EventNotSupported,
+            CheckoutWebhookEventType::AuthenticationApproved => Self::EventNotSupported,
+            CheckoutWebhookEventType::PaymentApproved => Self::EventNotSupported,
+            CheckoutWebhookEventType::PaymentCaptured => Self::PaymentIntentSuccess,
+            CheckoutWebhookEventType::PaymentDeclined => Self::PaymentIntentFailure,
+            CheckoutWebhookEventType::PaymentRefunded => Self::RefundSuccess,
+            CheckoutWebhookEventType::PaymentRefundDeclined => Self::RefundFailure,
+            CheckoutWebhookEventType::DisputeReceived
+            | CheckoutWebhookEventType::DisputeEvidenceRequired => Self::DisputeOpened,
+            CheckoutWebhookEventType::DisputeExpired => Self::DisputeExpired,
+            CheckoutWebhookEventType::DisputeAccepted => Self::DisputeAccepted,
+            CheckoutWebhookEventType::DisputeCanceled => Self::DisputeCancelled,
+            CheckoutWebhookEventType::DisputeEvidenceSubmitted
+            | CheckoutWebhookEventType::DisputeEvidenceAcknowledgedByScheme => {
                 Self::DisputeChallenged
             }
-            CheckoutTransactionType::DisputeWon
-            | CheckoutTransactionType::DisputeArbitrationWon => Self::DisputeWon,
-            CheckoutTransactionType::DisputeLost
-            | CheckoutTransactionType::DisputeArbitrationLost => Self::DisputeLost,
+            CheckoutWebhookEventType::DisputeWon
+            | CheckoutWebhookEventType::DisputeArbitrationWon => Self::DisputeWon,
+            CheckoutWebhookEventType::DisputeLost
+            | CheckoutWebhookEventType::DisputeArbitrationLost => Self::DisputeLost,
+            CheckoutWebhookEventType::Unknown => Self::EventNotSupported,
         }
     }
 }

--- a/crates/router/src/core/errors/api_error_response.rs
+++ b/crates/router/src/core/errors/api_error_response.rs
@@ -184,6 +184,14 @@ pub enum ApiErrorResponse {
     MissingFilePurpose,
     #[error(error_type = ErrorType::InvalidRequestError, code = "HE_04", message = "File content type not found / valid")]
     MissingFileContentType,
+    #[error(error_type = ErrorType::InvalidRequestError, code = "WE_01", message = "Failed to authenticate the webhook")]
+    WebhookAuthenticationFailed,
+    #[error(error_type = ErrorType::ObjectNotFound, code = "WE_04", message = "Webhook resource not found")]
+    WebhookResourceNotFound,
+    #[error(error_type = ErrorType::InvalidRequestError, code = "WE_02", message = "Bad request received in webhook")]
+    WebhookBadRequest,
+    #[error(error_type = ErrorType::RouterError, code = "WE_03", message = "There was some issue processing the webhook")]
+    WebhookProcessingFailure,
 }
 
 #[derive(Clone)]
@@ -222,12 +230,13 @@ impl actix_web::ResponseError for ApiErrorResponse {
             Self::Unauthorized
             | Self::InvalidEphemeralKey
             | Self::InvalidJwtToken
-            | Self::GenericUnauthorized { .. } => StatusCode::UNAUTHORIZED, // 401
+            | Self::GenericUnauthorized { .. }
+            | Self::WebhookAuthenticationFailed => StatusCode::UNAUTHORIZED, // 401
             Self::ExternalConnectorError { status_code, .. } => {
                 StatusCode::from_u16(*status_code).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR)
             }
-            Self::InvalidRequestUrl => StatusCode::NOT_FOUND, // 404
-            Self::InvalidHttpMethod => StatusCode::METHOD_NOT_ALLOWED, // 405
+            Self::InvalidRequestUrl | Self::WebhookResourceNotFound => StatusCode::NOT_FOUND, // 404
+            Self::InvalidHttpMethod => StatusCode::METHOD_NOT_ALLOWED,                        // 405
             Self::MissingRequiredField { .. }
             | Self::InvalidDataValue { .. }
             | Self::InvalidCardIin
@@ -235,9 +244,9 @@ impl actix_web::ResponseError for ApiErrorResponse {
             Self::InvalidDataFormat { .. } | Self::InvalidRequestData { .. } => {
                 StatusCode::UNPROCESSABLE_ENTITY
             } // 422
-            Self::RefundAmountExceedsPaymentAmount => StatusCode::BAD_REQUEST, // 400
-            Self::MaximumRefundCount => StatusCode::BAD_REQUEST, // 400
-            Self::PreconditionFailed { .. } => StatusCode::BAD_REQUEST, // 400
+            Self::RefundAmountExceedsPaymentAmount => StatusCode::BAD_REQUEST,                // 400
+            Self::MaximumRefundCount => StatusCode::BAD_REQUEST,                              // 400
+            Self::PreconditionFailed { .. } => StatusCode::BAD_REQUEST,                       // 400
 
             Self::PaymentAuthorizationFailed { .. }
             | Self::PaymentAuthenticationFailed { .. }
@@ -250,9 +259,9 @@ impl actix_web::ResponseError for ApiErrorResponse {
             | Self::PaymentUnexpectedState { .. }
             | Self::MandateValidationFailed { .. } => StatusCode::BAD_REQUEST, // 400
 
-            Self::MandateUpdateFailed | Self::InternalServerError => {
-                StatusCode::INTERNAL_SERVER_ERROR
-            } // 500
+            Self::MandateUpdateFailed
+            | Self::InternalServerError
+            | Self::WebhookProcessingFailure => StatusCode::INTERNAL_SERVER_ERROR, // 500
             Self::DuplicateRefundRequest | Self::DuplicatePayment { .. } => StatusCode::BAD_REQUEST, // 400
             Self::RefundNotFound
             | Self::CustomerNotFound
@@ -275,7 +284,8 @@ impl actix_web::ResponseError for ApiErrorResponse {
             | Self::NotSupported { .. }
             | Self::FlowNotSupported { .. }
             | Self::ApiKeyNotFound
-            | Self::DisputeStatusValidationFailed { .. } => StatusCode::BAD_REQUEST, // 400
+            | Self::DisputeStatusValidationFailed { .. }
+            | Self::WebhookBadRequest => StatusCode::BAD_REQUEST, // 400
             Self::DuplicateMerchantAccount
             | Self::DuplicateMerchantConnectorAccount { .. }
             | Self::DuplicatePaymentMethod
@@ -509,6 +519,18 @@ impl common_utils::errors::ErrorSwitch<api_models::errors::types::ApiErrorRespon
             }
             Self::MissingDisputeId => {
                 AER::BadRequest(ApiError::new("HE", 2, "Dispute id not found in the request", None))
+            }
+            Self::WebhookAuthenticationFailed => {
+                AER::Unauthorized(ApiError::new("WE", 1, "Webhook authentication failed", None))
+            }
+            Self::WebhookResourceNotFound => {
+                AER::NotFound(ApiError::new("WE", 4, "Webhook resource was not found", None))
+            }
+            Self::WebhookBadRequest => {
+                AER::BadRequest(ApiError::new("WE", 2, "Bad request body received", None))
+            }
+            Self::WebhookProcessingFailure => {
+                AER::InternalServerError(ApiError::new("WE", 3, "There was an issue processing the webhook", None))
             }
         }
     }

--- a/crates/router/src/core/webhooks.rs
+++ b/crates/router/src/core/webhooks.rs
@@ -502,7 +502,8 @@ pub async fn create_event_and_trigger_outgoing_webhook<W: api::OutgoingWebhookTy
 
         let webhook_signature_payload =
             ext_traits::Encode::<serde_json::Value>::encode_to_string_of_json(&outgoing_webhook)
-                .change_context(errors::WebhooksFlowError::OutgoingWebhookEncodingFailed)?;
+                .change_context(errors::ApiErrorResponse::WebhookProcessingFailure)
+                .attach_printable("failed encoding outgoing webhook payload")?;
 
         let outgoing_webhooks_signature = merchant_account
             .payment_response_hash_key
@@ -515,7 +516,7 @@ pub async fn create_event_and_trigger_outgoing_webhook<W: api::OutgoingWebhookTy
                 )
             })
             .transpose()
-            .change_context(errors::WebhooksFlowError::OutgoingWebhookSigningFailed)
+            .change_context(errors::ApiErrorResponse::WebhookProcessingFailure)
             .attach_printable("Failed to sign the message")?
             .map(hex::encode);
 

--- a/crates/router/src/core/webhooks/utils.rs
+++ b/crates/router/src/core/webhooks/utils.rs
@@ -1,4 +1,7 @@
+use error_stack::ResultExt;
+
 use crate::{
+    core::errors,
     db::{get_and_deserialize_key, StorageInterface},
     types::api,
 };
@@ -42,6 +45,33 @@ pub async fn lookup_webhook_event(
                 })
                 .unwrap_or_else(|_| default_webhook_config())
                 .contains(event)
+        }
+    }
+}
+
+pub trait WebhookApiErrorSwitch<T> {
+    fn switch(self) -> errors::RouterResult<T>;
+}
+
+impl<T> WebhookApiErrorSwitch<T> for errors::CustomResult<T, errors::ConnectorError> {
+    fn switch(self) -> errors::RouterResult<T> {
+        match self {
+            Ok(res) => Ok(res),
+            Err(e) => match e.current_context() {
+                errors::ConnectorError::WebhookSourceVerificationFailed => {
+                    Err(e).change_context(errors::ApiErrorResponse::WebhookAuthenticationFailed)
+                }
+
+                errors::ConnectorError::WebhookSignatureNotFound
+                | errors::ConnectorError::WebhookReferenceIdNotFound
+                | errors::ConnectorError::WebhookEventTypeNotFound
+                | errors::ConnectorError::WebhookResourceObjectNotFound
+                | errors::ConnectorError::WebhookBodyDecodingFailed => {
+                    Err(e).change_context(errors::ApiErrorResponse::WebhookBadRequest)
+                }
+
+                _ => Err(e).change_context(errors::ApiErrorResponse::InternalServerError),
+            },
         }
     }
 }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
This PR modifies the webhooks core flows to use `ApiErrorResponse` to communicate errors for seamless HTTP Status Code Mapping.

Additionally, we define a mapping between the `ConnectorError` and `ApiErrorResponse` to enable a mapping between these errors as well for the webhooks core flow


### Additional Changes
None
- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!-- 
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
The Webhooks core flow used to send 5xx status codes even for errors where 4xx was more appropriate due to error consolidation using `error_stack`, with this PR we remove this consolidation and allow the error propagated to be more specific to the issue.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Successful webhook
<img width="1001" alt="image" src="https://github.com/juspay/hyperswitch/assets/47862918/9601a2e9-6cdb-4e05-9c63-3d0fa10f4f97">

Unsuccessful webhook (Invalid ID -> Payment Not Found -> 404)
<img width="1013" alt="image" src="https://github.com/juspay/hyperswitch/assets/47862918/71615fc2-6b3f-42fb-9ab4-6895768f4143">

Unsuccessful webhook (Invalid body -> 400)
<img width="1013" alt="image" src="https://github.com/juspay/hyperswitch/assets/47862918/d91e7762-5564-49bb-8db5-8d3718689d31">

Unprocessed successful webhook (Unsupported event type -> 200)
<img width="1013" alt="image" src="https://github.com/juspay/hyperswitch/assets/47862918/dfc80841-f8fe-43b7-a041-f3c4a63098de">


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
