### PR TITLE
chore: address Rust 1.70 clippy lints

### DIFF
--- a/crates/masking/tests/basic.rs
+++ b/crates/masking/tests/basic.rs
@@ -41,7 +41,7 @@ fn basic() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     };
 
     // clone
-
+    #[allow(clippy::redundant_clone)] // We are asserting that the cloned value is equal
     let composite2 = composite.clone();
     assert_eq!(composite, composite2);
 
@@ -134,7 +134,7 @@ fn for_string() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     };
 
     // clone
-
+    #[allow(clippy::redundant_clone)] // We are asserting that the cloned value is equal
     let composite2 = composite.clone();
     assert_eq!(composite, composite2);
 

--- a/crates/router/src/connector/nexinets.rs
+++ b/crates/router/src/connector/nexinets.rs
@@ -95,7 +95,7 @@ impl ConnectorCommon for Nexinets {
             .parse_struct("NexinetsErrorResponse")
             .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
 
-        let errors = response.errors.clone();
+        let errors = response.errors;
         let mut message = String::new();
         let mut static_message = String::new();
         for error in errors.iter() {


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
This PR addresses a clippy lint stabilized in Rust 1.70.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
N/A

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
N/A

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
