### PR TITLE
fix: set `locker_id` to a default value in db

### DIFF
--- a/crates/masking/tests/basic.rs
+++ b/crates/masking/tests/basic.rs
@@ -40,11 +40,6 @@ fn basic() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         not_secret,
     };
 
-    // clone
-
-    let composite2 = composite.clone();
-    assert_eq!(composite, composite2);
-
     // format
 
     let got = format!("{composite:?}");
@@ -132,11 +127,6 @@ fn for_string() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         secret_number,
         not_secret,
     };
-
-    // clone
-
-    let composite2 = composite.clone();
-    assert_eq!(composite, composite2);
 
     // format
 

--- a/crates/masking/tests/basic.rs
+++ b/crates/masking/tests/basic.rs
@@ -40,6 +40,11 @@ fn basic() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         not_secret,
     };
 
+    // clone
+
+    let composite2 = composite.clone();
+    assert_eq!(composite, composite2);
+
     // format
 
     let got = format!("{composite:?}");
@@ -127,6 +132,11 @@ fn for_string() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         secret_number,
         not_secret,
     };
+
+    // clone
+
+    let composite2 = composite.clone();
+    assert_eq!(composite, composite2);
 
     // format
 

--- a/migrations/2023-06-02-060404_set-default-locker-id/down.sql
+++ b/migrations/2023-06-02-060404_set-default-locker-id/down.sql
@@ -1,0 +1,2 @@
+-- This file should undo anything in `up.sql`
+ALTER TABLE merchant_account ALTER COLUMN locker_id DROP DEFAULT;

--- a/migrations/2023-06-02-060404_set-default-locker-id/up.sql
+++ b/migrations/2023-06-02-060404_set-default-locker-id/up.sql
@@ -1,0 +1,2 @@
+-- Your SQL goes here
+ALTER TABLE merchant_account ALTER COLUMN locker_id SET DEFAULT 'm0010';


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
This will set a default value for the `locker_id` field in `merchant_account` table.

### Additional Changes

- [ ] This PR modifies the API contract
- [x] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!-- 
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
This is to fix the saved cards not being accessed because of `locker_id` is null


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Postman


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
