### PR TITLE
fix(encryption): do not log encrypted binary data

### DIFF
--- a/crates/common_utils/src/crypto.rs
+++ b/crates/common_utils/src/crypto.rs
@@ -2,6 +2,7 @@
 use std::ops::Deref;
 
 use error_stack::{IntoReport, ResultExt};
+use masking::{ExposeInterface, Secret};
 use md5;
 use ring::{
     aead::{self, BoundKey, OpeningKey, SealingKey, UnboundKey},
@@ -10,7 +11,7 @@ use ring::{
 
 use crate::{
     errors::{self, CustomResult},
-    pii,
+    pii::{self, EncryptionStratergy},
 };
 
 #[derive(Clone, Debug)]
@@ -103,7 +104,7 @@ pub trait DecodeMessage {
     fn decode_message(
         &self,
         _secret: &[u8],
-        _msg: Vec<u8>,
+        _msg: Secret<Vec<u8>, EncryptionStratergy>,
     ) -> CustomResult<Vec<u8>, errors::CryptoError>;
 }
 
@@ -147,9 +148,9 @@ impl DecodeMessage for NoAlgorithm {
     fn decode_message(
         &self,
         _secret: &[u8],
-        msg: Vec<u8>,
+        msg: Secret<Vec<u8>, EncryptionStratergy>,
     ) -> CustomResult<Vec<u8>, errors::CryptoError> {
-        Ok(msg.to_vec())
+        Ok(msg.expose())
     }
 }
 
@@ -242,8 +243,9 @@ impl DecodeMessage for GcmAes256 {
     fn decode_message(
         &self,
         secret: &[u8],
-        msg: Vec<u8>,
+        msg: Secret<Vec<u8>, EncryptionStratergy>,
     ) -> CustomResult<Vec<u8>, errors::CryptoError> {
+        let msg = msg.expose();
         let key = UnboundKey::new(&aead::AES_256_GCM, secret)
             .into_report()
             .change_context(errors::CryptoError::DecodingFailed)?;
@@ -264,7 +266,7 @@ impl DecodeMessage for GcmAes256 {
             .into_report()
             .change_context(errors::CryptoError::DecodingFailed)?;
 
-        Ok(result.into())
+        Ok(result.to_vec())
     }
 }
 
@@ -380,16 +382,16 @@ pub fn generate_cryptographically_secure_random_bytes<const N: usize>() -> [u8; 
 #[derive(Debug, Clone)]
 pub struct Encryptable<T: Clone> {
     inner: T,
-    encrypted: masking::Secret<Vec<u8>, pii::EncryptionStratergy>,
+    encrypted: Secret<Vec<u8>, EncryptionStratergy>,
 }
 
-impl<T: Clone, S: masking::Strategy<T>> Encryptable<masking::Secret<T, S>> {
+impl<T: Clone, S: masking::Strategy<T>> Encryptable<Secret<T, S>> {
     ///
     /// constructor function to be used by the encryptor and decryptor to generate the data type
     ///
     pub fn new(
-        masked_data: masking::Secret<T, S>,
-        encrypted_data: masking::Secret<Vec<u8>, pii::EncryptionStratergy>,
+        masked_data: Secret<T, S>,
+        encrypted_data: Secret<Vec<u8>, EncryptionStratergy>,
     ) -> Self {
         Self {
             inner: masked_data,
@@ -408,13 +410,13 @@ impl<T: Clone> Encryptable<T> {
     ///
     /// Get the inner encrypted data while consuming self
     ///
-    pub fn into_encrypted(self) -> masking::Secret<Vec<u8>, pii::EncryptionStratergy> {
+    pub fn into_encrypted(self) -> Secret<Vec<u8>, EncryptionStratergy> {
         self.encrypted
     }
 }
 
-impl<T: Clone> Deref for Encryptable<masking::Secret<T>> {
-    type Target = masking::Secret<T>;
+impl<T: Clone> Deref for Encryptable<Secret<T>> {
+    type Target = Secret<T>;
     fn deref(&self) -> &Self::Target {
         &self.inner
     }
@@ -442,18 +444,17 @@ where
 }
 
 /// Type alias for `Option<Encryptable<Secret<String>>>`
-pub type OptionalEncryptableSecretString = Option<Encryptable<masking::Secret<String>>>;
+pub type OptionalEncryptableSecretString = Option<Encryptable<Secret<String>>>;
 /// Type alias for `Option<Encryptable<Secret<String>>>` used for `name` field
-pub type OptionalEncryptableName = Option<Encryptable<masking::Secret<String>>>;
+pub type OptionalEncryptableName = Option<Encryptable<Secret<String>>>;
 /// Type alias for `Option<Encryptable<Secret<String>>>` used for `email` field
-pub type OptionalEncryptableEmail =
-    Option<Encryptable<masking::Secret<String, pii::EmailStrategy>>>;
+pub type OptionalEncryptableEmail = Option<Encryptable<Secret<String, pii::EmailStrategy>>>;
 /// Type alias for `Option<Encryptable<Secret<String>>>` used for `phone` field
-pub type OptionalEncryptablePhone = Option<Encryptable<masking::Secret<String>>>;
+pub type OptionalEncryptablePhone = Option<Encryptable<Secret<String>>>;
 /// Type alias for `Option<Encryptable<Secret<serde_json::Value>>>` used for `phone` field
-pub type OptionalEncryptableValue = Option<Encryptable<masking::Secret<serde_json::Value>>>;
+pub type OptionalEncryptableValue = Option<Encryptable<Secret<serde_json::Value>>>;
 /// Type alias for `Option<Secret<serde_json::Value>>` used for `phone` field
-pub type OptionalSecretValue = Option<masking::Secret<serde_json::Value>>;
+pub type OptionalSecretValue = Option<Secret<serde_json::Value>>;
 
 #[cfg(test)]
 mod crypto_tests {
@@ -575,7 +576,7 @@ mod crypto_tests {
 
         assert_eq!(
             algorithm
-                .decode_message(&secret, encoded_message)
+                .decode_message(&secret, encoded_message.into())
                 .expect("Decode Failed"),
             message
         );
@@ -597,12 +598,12 @@ mod crypto_tests {
         };
 
         let decoded = algorithm
-            .decode_message(&right_secret, message.clone())
+            .decode_message(&right_secret, message.clone().into())
             .expect("Decoded message");
 
         assert_eq!(decoded, r#"{"type":"PAYMENT"}"#.as_bytes());
 
-        let err_decoded = algorithm.decode_message(&wrong_secret, message);
+        let err_decoded = algorithm.decode_message(&wrong_secret, message.into());
 
         assert!(err_decoded.is_err());
     }

--- a/crates/common_utils/src/crypto.rs
+++ b/crates/common_utils/src/crypto.rs
@@ -380,14 +380,17 @@ pub fn generate_cryptographically_secure_random_bytes<const N: usize>() -> [u8; 
 #[derive(Debug, Clone)]
 pub struct Encryptable<T: Clone> {
     inner: T,
-    encrypted: Vec<u8>,
+    encrypted: masking::Secret<Vec<u8>, pii::EncryptionStratergy>,
 }
 
 impl<T: Clone, S: masking::Strategy<T>> Encryptable<masking::Secret<T, S>> {
     ///
     /// constructor function to be used by the encryptor and decryptor to generate the data type
     ///
-    pub fn new(masked_data: masking::Secret<T, S>, encrypted_data: Vec<u8>) -> Self {
+    pub fn new(
+        masked_data: masking::Secret<T, S>,
+        encrypted_data: masking::Secret<Vec<u8>, pii::EncryptionStratergy>,
+    ) -> Self {
         Self {
             inner: masked_data,
             encrypted: encrypted_data,
@@ -405,7 +408,7 @@ impl<T: Clone> Encryptable<T> {
     ///
     /// Get the inner encrypted data while consuming self
     ///
-    pub fn into_encrypted(self) -> Vec<u8> {
+    pub fn into_encrypted(self) -> masking::Secret<Vec<u8>, pii::EncryptionStratergy> {
         self.encrypted
     }
 }

--- a/crates/common_utils/src/pii.rs
+++ b/crates/common_utils/src/pii.rs
@@ -60,8 +60,8 @@ impl<T> Strategy<T> for EncryptionStratergy
 where
     T: AsRef<[u8]>,
 {
-    fn fmt(_value: &T, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        fmt.write_str("*** Encrypted ***")
+    fn fmt(value: &T, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(fmt, "*** Encrypted {} of bytes ***", value.as_ref().len())
     }
 }
 

--- a/crates/common_utils/src/pii.rs
+++ b/crates/common_utils/src/pii.rs
@@ -52,6 +52,19 @@ where
 }
 */
 
+/// Strategy for Encryption
+#[derive(Debug)]
+pub struct EncryptionStratergy;
+
+impl<T> Strategy<T> for EncryptionStratergy
+where
+    T: AsRef<[u8]>,
+{
+    fn fmt(_value: &T, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        fmt.write_str("*** Encrypted ***")
+    }
+}
+
 /// Client secret
 #[derive(Debug)]
 pub struct ClientSecret;

--- a/crates/router/src/types/api/webhooks.rs
+++ b/crates/router/src/types/api/webhooks.rs
@@ -60,7 +60,7 @@ pub trait IncomingWebhook: ConnectorCommon + Sync {
             .change_context(errors::ConnectorError::WebhookBodyDecodingFailed)?;
 
         algorithm
-            .decode_message(&secret, message)
+            .decode_message(&secret, message.into())
             .change_context(errors::ConnectorError::WebhookBodyDecodingFailed)
     }
 

--- a/crates/router/src/types/domain/types.rs
+++ b/crates/router/src/types/domain/types.rs
@@ -55,7 +55,7 @@ impl<
         crypt_algo: V,
     ) -> CustomResult<Self, errors::CryptoError> {
         let encrypted = encrypted_data.into_inner();
-        let data = crypt_algo.decode_message(key, encrypted.clone().expose())?;
+        let data = crypt_algo.decode_message(key, encrypted.clone())?;
 
         let value: String = std::str::from_utf8(&data)
             .into_report()
@@ -94,7 +94,7 @@ impl<
         crypt_algo: V,
     ) -> CustomResult<Self, errors::CryptoError> {
         let encrypted = encrypted_data.into_inner();
-        let data = crypt_algo.decode_message(key, encrypted.clone().expose())?;
+        let data = crypt_algo.decode_message(key, encrypted.clone())?;
 
         let value: serde_json::Value = serde_json::from_slice(&data)
             .into_report()
@@ -128,7 +128,7 @@ impl<
         crypt_algo: V,
     ) -> CustomResult<Self, errors::CryptoError> {
         let encrypted = encrypted_data.into_inner();
-        let data = crypt_algo.decode_message(key, encrypted.clone().expose())?;
+        let data = crypt_algo.decode_message(key, encrypted.clone())?;
 
         Ok(Self::new(data.into(), encrypted))
     }

--- a/crates/router/src/types/domain/types.rs
+++ b/crates/router/src/types/domain/types.rs
@@ -45,7 +45,7 @@ impl<
     ) -> CustomResult<Self, errors::CryptoError> {
         let encrypted_data = crypt_algo.encode_message(key, masked_data.peek().as_bytes())?;
 
-        Ok(Self::new(masked_data, encrypted_data))
+        Ok(Self::new(masked_data, encrypted_data.into()))
     }
 
     #[instrument(skip_all)]
@@ -55,7 +55,7 @@ impl<
         crypt_algo: V,
     ) -> CustomResult<Self, errors::CryptoError> {
         let encrypted = encrypted_data.into_inner();
-        let data = crypt_algo.decode_message(key, encrypted.clone())?;
+        let data = crypt_algo.decode_message(key, encrypted.clone().expose())?;
 
         let value: String = std::str::from_utf8(&data)
             .into_report()
@@ -84,7 +84,7 @@ impl<
             .change_context(errors::CryptoError::DecodingFailed)?;
         let encrypted_data = crypt_algo.encode_message(key, &data)?;
 
-        Ok(Self::new(masked_data, encrypted_data))
+        Ok(Self::new(masked_data, encrypted_data.into()))
     }
 
     #[instrument(skip_all)]
@@ -94,7 +94,7 @@ impl<
         crypt_algo: V,
     ) -> CustomResult<Self, errors::CryptoError> {
         let encrypted = encrypted_data.into_inner();
-        let data = crypt_algo.decode_message(key, encrypted.clone())?;
+        let data = crypt_algo.decode_message(key, encrypted.clone().expose())?;
 
         let value: serde_json::Value = serde_json::from_slice(&data)
             .into_report()
@@ -118,7 +118,7 @@ impl<
     ) -> CustomResult<Self, errors::CryptoError> {
         let encrypted_data = crypt_algo.encode_message(key, masked_data.peek())?;
 
-        Ok(Self::new(masked_data, encrypted_data))
+        Ok(Self::new(masked_data, encrypted_data.into()))
     }
 
     #[instrument(skip_all)]
@@ -128,7 +128,7 @@ impl<
         crypt_algo: V,
     ) -> CustomResult<Self, errors::CryptoError> {
         let encrypted = encrypted_data.into_inner();
-        let data = crypt_algo.decode_message(key, encrypted.clone())?;
+        let data = crypt_algo.decode_message(key, encrypted.clone().expose())?;
 
         Ok(Self::new(data.into(), encrypted))
     }

--- a/crates/storage_models/src/encryption.rs
+++ b/crates/storage_models/src/encryption.rs
@@ -1,11 +1,10 @@
+use common_utils::pii::EncryptionStratergy;
 use diesel::{
     backend::Backend,
     deserialize::{self, FromSql, Queryable},
     serialize::ToSql,
     sql_types, AsExpression,
 };
-
-use common_utils::pii::EncryptionStratergy;
 use masking::Secret;
 
 #[derive(Debug, AsExpression, Clone, serde::Serialize, serde::Deserialize)]


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->
- [x] Enhancement

## Description
<!-- Describe your changes in detail -->
Add secret to encrypted fields so it wont be logged. It will be logged as `*** Encrypted ***`.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
Dont log huge encrypted binary data.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
<img width="1728" alt="image" src="https://github.com/juspay/hyperswitch/assets/43412619/6ad76057-16fd-4d98-8f57-3e8a4a38a592">


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code