### PR TITLE
fix(logging): fix traces export through opentelemetry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3057,22 +3057,12 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69d6c3d7288a106c0a363e4b0e8d308058d56902adefb16f4936f417ffef086e"
-dependencies = [
- "opentelemetry_api 0.18.0",
- "opentelemetry_sdk 0.18.0",
-]
-
-[[package]]
-name = "opentelemetry"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f4b8347cc26099d3aeee044065ecc3ae11469796b4d65d065a23a584ed92a6f"
 dependencies = [
- "opentelemetry_api 0.19.0",
- "opentelemetry_sdk 0.19.0",
+ "opentelemetry_api",
+ "opentelemetry_sdk",
 ]
 
 [[package]]
@@ -3085,7 +3075,7 @@ dependencies = [
  "futures",
  "futures-util",
  "http",
- "opentelemetry 0.19.0",
+ "opentelemetry",
  "opentelemetry-proto",
  "prost",
  "thiserror",
@@ -3101,25 +3091,9 @@ checksum = "045f8eea8c0fa19f7d48e7bc3128a39c2e5c533d5c61298c548dfefc1064474c"
 dependencies = [
  "futures",
  "futures-util",
- "opentelemetry 0.19.0",
+ "opentelemetry",
  "prost",
  "tonic",
-]
-
-[[package]]
-name = "opentelemetry_api"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c24f96e21e7acc813c7a8394ee94978929db2bcc46cf6b5014fc612bf7760c22"
-dependencies = [
- "fnv",
- "futures-channel",
- "futures-util",
- "indexmap",
- "js-sys",
- "once_cell",
- "pin-project-lite",
- "thiserror",
 ]
 
 [[package]]
@@ -3140,26 +3114,6 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ca41c4933371b61c2a2f214bf16931499af4ec90543604ec828f7a625c09113"
-dependencies = [
- "async-trait",
- "crossbeam-channel",
- "dashmap",
- "fnv",
- "futures-channel",
- "futures-executor",
- "futures-util",
- "once_cell",
- "opentelemetry_api 0.18.0",
- "percent-encoding",
- "rand 0.8.5",
- "thiserror",
-]
-
-[[package]]
-name = "opentelemetry_sdk"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b3a2a91fdbfdd4d212c0dcc2ab540de2c2bcbbd90be17de7a7daf8822d010c1"
@@ -3172,7 +3126,7 @@ dependencies = [
  "futures-executor",
  "futures-util",
  "once_cell",
- "opentelemetry_api 0.19.0",
+ "opentelemetry_api",
  "percent-encoding",
  "rand 0.8.5",
  "thiserror",
@@ -3883,7 +3837,7 @@ dependencies = [
  "config",
  "gethostname",
  "once_cell",
- "opentelemetry 0.19.0",
+ "opentelemetry",
  "opentelemetry-otlp",
  "rustc-hash",
  "serde",
@@ -3896,7 +3850,7 @@ dependencies = [
  "tracing-actix-web",
  "tracing-appender",
  "tracing-attributes",
- "tracing-opentelemetry 0.19.0",
+ "tracing-opentelemetry",
  "tracing-subscriber",
  "vergen",
 ]
@@ -4866,10 +4820,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce52ffaf2d544e317d3bef63f49a6a22022866505fa4840a4339b1756834a2a9"
 dependencies = [
  "actix-web",
- "opentelemetry 0.18.0",
+ "opentelemetry",
  "pin-project",
  "tracing",
- "tracing-opentelemetry 0.18.0",
+ "tracing-opentelemetry",
  "uuid",
 ]
 
@@ -4928,26 +4882,12 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21ebb87a95ea13271332df069020513ab70bdb5637ca42d6e492dc3bbbad48de"
-dependencies = [
- "once_cell",
- "opentelemetry 0.18.0",
- "tracing",
- "tracing-core",
- "tracing-log",
- "tracing-subscriber",
-]
-
-[[package]]
-name = "tracing-opentelemetry"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00a39dcf9bfc1742fa4d6215253b33a6e474be78275884c216fc2a06267b3600"
 dependencies = [
  "once_cell",
- "opentelemetry 0.19.0",
+ "opentelemetry",
  "tracing",
  "tracing-core",
  "tracing-log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3058,22 +3058,34 @@ dependencies = [
 [[package]]
 name = "opentelemetry"
 version = "0.18.0"
-source = "git+https://github.com/open-telemetry/opentelemetry-rust?rev=44b90202fd744598db8b0ace5b8f0bad7ec45658#44b90202fd744598db8b0ace5b8f0bad7ec45658"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69d6c3d7288a106c0a363e4b0e8d308058d56902adefb16f4936f417ffef086e"
 dependencies = [
- "opentelemetry_api",
- "opentelemetry_sdk",
+ "opentelemetry_api 0.18.0",
+ "opentelemetry_sdk 0.18.0",
+]
+
+[[package]]
+name = "opentelemetry"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f4b8347cc26099d3aeee044065ecc3ae11469796b4d65d065a23a584ed92a6f"
+dependencies = [
+ "opentelemetry_api 0.19.0",
+ "opentelemetry_sdk 0.19.0",
 ]
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.11.0"
-source = "git+https://github.com/open-telemetry/opentelemetry-rust?rev=44b90202fd744598db8b0ace5b8f0bad7ec45658#44b90202fd744598db8b0ace5b8f0bad7ec45658"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8af72d59a4484654ea8eb183fea5ae4eb6a41d7ac3e3bae5f4d2a282a3a7d3ca"
 dependencies = [
  "async-trait",
  "futures",
  "futures-util",
  "http",
- "opentelemetry",
+ "opentelemetry 0.19.0",
  "opentelemetry-proto",
  "prost",
  "thiserror",
@@ -3083,12 +3095,13 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.1.0"
-source = "git+https://github.com/open-telemetry/opentelemetry-rust?rev=44b90202fd744598db8b0ace5b8f0bad7ec45658#44b90202fd744598db8b0ace5b8f0bad7ec45658"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "045f8eea8c0fa19f7d48e7bc3128a39c2e5c533d5c61298c548dfefc1064474c"
 dependencies = [
  "futures",
  "futures-util",
- "opentelemetry",
+ "opentelemetry 0.19.0",
  "prost",
  "tonic",
 ]
@@ -3096,7 +3109,8 @@ dependencies = [
 [[package]]
 name = "opentelemetry_api"
 version = "0.18.0"
-source = "git+https://github.com/open-telemetry/opentelemetry-rust?rev=44b90202fd744598db8b0ace5b8f0bad7ec45658#44b90202fd744598db8b0ace5b8f0bad7ec45658"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c24f96e21e7acc813c7a8394ee94978929db2bcc46cf6b5014fc612bf7760c22"
 dependencies = [
  "fnv",
  "futures-channel",
@@ -3109,9 +3123,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry_api"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed41783a5bf567688eb38372f2b7a8530f5a607a4b49d38dd7573236c23ca7e2"
+dependencies = [
+ "fnv",
+ "futures-channel",
+ "futures-util",
+ "indexmap",
+ "once_cell",
+ "pin-project-lite",
+ "thiserror",
+ "urlencoding",
+]
+
+[[package]]
 name = "opentelemetry_sdk"
 version = "0.18.0"
-source = "git+https://github.com/open-telemetry/opentelemetry-rust?rev=44b90202fd744598db8b0ace5b8f0bad7ec45658#44b90202fd744598db8b0ace5b8f0bad7ec45658"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ca41c4933371b61c2a2f214bf16931499af4ec90543604ec828f7a625c09113"
 dependencies = [
  "async-trait",
  "crossbeam-channel",
@@ -3121,7 +3152,27 @@ dependencies = [
  "futures-executor",
  "futures-util",
  "once_cell",
- "opentelemetry_api",
+ "opentelemetry_api 0.18.0",
+ "percent-encoding",
+ "rand 0.8.5",
+ "thiserror",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b3a2a91fdbfdd4d212c0dcc2ab540de2c2bcbbd90be17de7a7daf8822d010c1"
+dependencies = [
+ "async-trait",
+ "crossbeam-channel",
+ "dashmap",
+ "fnv",
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "once_cell",
+ "opentelemetry_api 0.19.0",
  "percent-encoding",
  "rand 0.8.5",
  "thiserror",
@@ -3832,7 +3883,7 @@ dependencies = [
  "config",
  "gethostname",
  "once_cell",
- "opentelemetry",
+ "opentelemetry 0.19.0",
  "opentelemetry-otlp",
  "rustc-hash",
  "serde",
@@ -3845,7 +3896,7 @@ dependencies = [
  "tracing-actix-web",
  "tracing-appender",
  "tracing-attributes",
- "tracing-opentelemetry",
+ "tracing-opentelemetry 0.19.0",
  "tracing-subscriber",
  "vergen",
 ]
@@ -4815,10 +4866,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce52ffaf2d544e317d3bef63f49a6a22022866505fa4840a4339b1756834a2a9"
 dependencies = [
  "actix-web",
- "opentelemetry",
+ "opentelemetry 0.18.0",
  "pin-project",
  "tracing",
- "tracing-opentelemetry",
+ "tracing-opentelemetry 0.18.0",
  "uuid",
 ]
 
@@ -4882,7 +4933,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21ebb87a95ea13271332df069020513ab70bdb5637ca42d6e492dc3bbbad48de"
 dependencies = [
  "once_cell",
- "opentelemetry",
+ "opentelemetry 0.18.0",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "tracing-opentelemetry"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00a39dcf9bfc1742fa4d6215253b33a6e474be78275884c216fc2a06267b3600"
+dependencies = [
+ "once_cell",
+ "opentelemetry 0.19.0",
  "tracing",
  "tracing-core",
  "tracing-log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,3 @@ members = ["crates/*", "examples/*"]
 strip = true
 lto = true
 codegen-units = 1
-
-[patch.crates-io]
-opentelemetry = { git = "https://github.com/open-telemetry/opentelemetry-rust", rev = "44b90202fd744598db8b0ace5b8f0bad7ec45658" }

--- a/config/docker_compose.toml
+++ b/config/docker_compose.toml
@@ -39,6 +39,7 @@ pool_size = 5
 [secrets]
 admin_api_key = "test_admin"
 jwt_secret = "secret"
+master_enc_key = "73ad7bbbbc640c845a150f67d058b279849370cd2c1f3c67c4dd6c869213e13a"
 
 [locker]
 host = ""

--- a/crates/router_env/Cargo.toml
+++ b/crates/router_env/Cargo.toml
@@ -11,8 +11,8 @@ license = "Apache-2.0"
 config = { version = "0.13.3", features = ["toml"] }
 gethostname = "0.4.2"
 once_cell = "1.17.1"
-opentelemetry = { git = "https://github.com/open-telemetry/opentelemetry-rust/", rev = "44b90202fd744598db8b0ace5b8f0bad7ec45658", features = ["rt-tokio-current-thread", "metrics"] }
-opentelemetry-otlp = { git = "https://github.com/open-telemetry/opentelemetry-rust/", rev = "44b90202fd744598db8b0ace5b8f0bad7ec45658", features = ["metrics"] }
+opentelemetry = { version = "0.19.0", features = ["rt-tokio-current-thread", "metrics"] }
+opentelemetry-otlp = { version = "0.12.0", features = ["metrics"] }
 rustc-hash = "1.1"
 serde = { version = "1.0.160", features = ["derive"] }
 serde_json = "1.0.96"
@@ -24,7 +24,7 @@ tracing = { version = "=0.1.36" }
 tracing-actix-web = { version = "0.7.4", features = ["opentelemetry_0_18"], optional = true }
 tracing-appender = { version = "0.2.2" }
 tracing-attributes = "=0.1.22"
-tracing-opentelemetry = { version = "0.18.0" }
+tracing-opentelemetry = { version = "0.19.0" }
 tracing-subscriber = { version = "0.3.16", default-features = true, features = ["env-filter", "json", "registry"] }
 vergen = { version = "8.1.1", optional = true, features = ["cargo", "git", "git2", "rustc"] }
 

--- a/crates/router_env/Cargo.toml
+++ b/crates/router_env/Cargo.toml
@@ -21,7 +21,7 @@ strum = { version = "0.24.1", features = ["derive"] }
 time = { version = "0.3.20", default-features = false, features = ["formatting"] }
 tokio = { version = "1.27.0" }
 tracing = { version = "=0.1.36" }
-tracing-actix-web = { version = "0.7.4", features = ["opentelemetry_0_18"], optional = true }
+tracing-actix-web = { version = "0.7.4", features = ["opentelemetry_0_19"], optional = true }
 tracing-appender = { version = "0.2.2" }
 tracing-attributes = "=0.1.22"
 tracing-opentelemetry = { version = "0.19.0" }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -84,7 +84,7 @@ services:
       - POSTGRES_DB=hyperswitch_db
 
   migration_runner:
-    image: rust:1.69
+    image: rust:1.70
     command: "bash -c 'cargo install diesel_cli --no-default-features --features \"postgres\" && diesel migration --database-url postgres://db_user:db_pass@pg:5432/hyperswitch_db run'"
     working_dir: /app
     networks:
@@ -93,7 +93,7 @@ services:
       - ./:/app
 
   hyperswitch-server-init:
-    image: rust:1.69
+    image: rust:1.70
     command: cargo build --bin router
     working_dir: /app
     networks:
@@ -104,9 +104,8 @@ services:
       - cargo_build_cache:/cargo_build_cache
     environment:
       - CARGO_TARGET_DIR=/cargo_build_cache
-      - CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
   hyperswitch-server:
-    image: rust:1.69
+    image: rust:1.70
     command: /cargo_build_cache/debug/router -f ./config/docker_compose.toml
     working_dir: /app
     ports:
@@ -133,7 +132,7 @@ services:
         condition: service_completed_successfully
 
   hyperswitch-producer:
-    image: rust:1.69
+    image: rust:1.70
     command: cargo run --bin scheduler -- -f ./config/docker_compose.toml
     working_dir: /app
     networks:
@@ -147,7 +146,6 @@ services:
     environment:
       - CARGO_TARGET_DIR=/cargo_build_cache
       - SCHEDULER_FLOW=producer
-      - CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
     depends_on:
       hyperswitch-consumer:
         condition: service_healthy
@@ -155,7 +153,7 @@ services:
       logs: "promtail"
 
   hyperswitch-consumer:
-    image: rust:1.69
+    image: rust:1.70
     command: cargo run --bin scheduler -- -f ./config/docker_compose.toml
     working_dir: /app
     networks:
@@ -169,7 +167,6 @@ services:
     environment:
       - CARGO_TARGET_DIR=/cargo_build_cache
       - SCHEDULER_FLOW=consumer
-      - CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
     depends_on:
       hyperswitch-server:
         condition: service_started
@@ -273,7 +270,7 @@ services:
       - "4317" # otlp grpc
     restart: unless-stopped
   hyperswitch-drainer:
-    image: rust:1.69
+    image: rust:1.70
     command: cargo run --bin drainer -- -f ./config/docker_compose.toml
     working_dir: /app
     deploy:
@@ -288,7 +285,6 @@ services:
       - cargo_build_cache:/cargo_build_cache
     environment:
       - CARGO_TARGET_DIR=/cargo_build_cache
-      - CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
     restart: unless-stopped
     depends_on:
       hyperswitch-server:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -84,7 +84,7 @@ services:
       - POSTGRES_DB=hyperswitch_db
 
   migration_runner:
-    image: rust:1.65
+    image: rust:1.69
     command: "bash -c 'cargo install diesel_cli --no-default-features --features \"postgres\" && diesel migration --database-url postgres://db_user:db_pass@pg:5432/hyperswitch_db run'"
     working_dir: /app
     networks:
@@ -93,7 +93,7 @@ services:
       - ./:/app
 
   hyperswitch-server-init:
-    image: rust:1.65
+    image: rust:1.69
     command: cargo build --bin router
     working_dir: /app
     networks:
@@ -104,8 +104,9 @@ services:
       - cargo_build_cache:/cargo_build_cache
     environment:
       - CARGO_TARGET_DIR=/cargo_build_cache
+      - CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
   hyperswitch-server:
-    image: rust:1.65
+    image: rust:1.69
     command: /cargo_build_cache/debug/router -f ./config/docker_compose.toml
     working_dir: /app
     ports:
@@ -132,7 +133,7 @@ services:
         condition: service_completed_successfully
 
   hyperswitch-producer:
-    image: rust:1.65
+    image: rust:1.69
     command: cargo run --bin scheduler -- -f ./config/docker_compose.toml
     working_dir: /app
     networks:
@@ -146,6 +147,7 @@ services:
     environment:
       - CARGO_TARGET_DIR=/cargo_build_cache
       - SCHEDULER_FLOW=producer
+      - CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
     depends_on:
       hyperswitch-consumer:
         condition: service_healthy
@@ -153,7 +155,7 @@ services:
       logs: "promtail"
 
   hyperswitch-consumer:
-    image: rust:1.65
+    image: rust:1.69
     command: cargo run --bin scheduler -- -f ./config/docker_compose.toml
     working_dir: /app
     networks:
@@ -167,6 +169,7 @@ services:
     environment:
       - CARGO_TARGET_DIR=/cargo_build_cache
       - SCHEDULER_FLOW=consumer
+      - CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
     depends_on:
       hyperswitch-server:
         condition: service_started
@@ -270,7 +273,7 @@ services:
       - "4317" # otlp grpc
     restart: unless-stopped
   hyperswitch-drainer:
-    image: rust:1.65
+    image: rust:1.69
     command: cargo run --bin drainer -- -f ./config/docker_compose.toml
     working_dir: /app
     deploy:
@@ -285,6 +288,7 @@ services:
       - cargo_build_cache:/cargo_build_cache
     environment:
       - CARGO_TARGET_DIR=/cargo_build_cache
+      - CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
     restart: unless-stopped
     depends_on:
       hyperswitch-server:


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
opentelemetry sdk currently isn't exporting traces to otel collector. This now works after changing to batch exporter which is better for performance reasons. Pipeline is now changed to batch exporter with the timeout of 1 second.


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!-- 
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
Traces are vital to debug failures and to diagnose latency issues. Traces aren't getting exported/reflecting in Grafana/Tempo. This change fixes the issue and traces are available in Grafana.


## How did you test it?
- set `log.telemetry.traces_enabled = true` in `config/docker_compose.toml`
- start docker compose `docker compose -f docker-compose.yml -p hyperswitch-tempo --profile monitoring up`
- after the hyperswitch server is up, hit the endpoints and verify the traces in Grafana/Tempo

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
