### PR TITLE
fix(connector): [Zen] fix additional base url required for Zen apple pay checkout integration

### DIFF
--- a/config/development.toml
+++ b/config/development.toml
@@ -140,9 +140,8 @@ worldline.base_url = "https://eu.sandbox.api-ingenico.com/"
 worldpay.base_url = "https://try.access.worldpay.com/"
 trustpay.base_url = "https://test-tpgw.trustpay.eu/"
 trustpay.base_url_bank_redirects = "https://aapi.trustpay.eu/"
-
-[connectors.zen]
-base_url = "https://api.zen-test.com/"
+zen.base_url = "https://api.zen-test.com/"
+zen.secondary_base_url = "https://secure.zen.com/"
 
 [scheduler]
 stream = "SCHEDULER_STREAM"

--- a/crates/router/src/configs/settings.rs
+++ b/crates/router/src/configs/settings.rs
@@ -421,6 +421,7 @@ pub struct Connectors {
 #[serde(default)]
 pub struct ConnectorParams {
     pub base_url: String,
+    pub secondary_base_url: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Clone, Default)]

--- a/crates/router/src/connector/zen.rs
+++ b/crates/router/src/connector/zen.rs
@@ -175,10 +175,17 @@ impl ConnectorIntegration<api::Authorize, types::PaymentsAuthorizeData, types::P
         let endpoint = match &req.request.payment_method_data {
             api_models::payments::PaymentMethodData::Wallet(
                 api_models::payments::WalletData::ApplePayRedirect(_),
-            ) => "api/checkouts",
-            _ => "v1/transactions",
+            ) => {
+                let base_url = connectors
+                    .zen
+                    .secondary_base_url
+                    .as_ref()
+                    .ok_or(errors::ConnectorError::FailedToObtainIntegrationUrl)?;
+                format!("{base_url}api/checkouts")
+            }
+            _ => format!("{}v1/transactions", self.base_url(connectors)),
         };
-        Ok(format!("{}{}", self.base_url(connectors), endpoint))
+        Ok(endpoint)
     }
 
     fn get_request_body(


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
Zen supports 2 integration and base url for both the integration differs. This change will introduce new filed in connector_params which supports base url for secondary integration.


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [x] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
Zen checkout integration:


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
