### PR TITLE
feat(router): [Bluesnap] add kount frms session_id support for bluesnap connector

### DIFF
--- a/crates/router/src/connector/bluesnap/transformers.rs
+++ b/crates/router/src/connector/bluesnap/transformers.rs
@@ -17,7 +17,7 @@ use crate::{
     utils::{Encode, OptionExt},
 };
 
-#[derive(Debug, Serialize, PartialEq)]
+#[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct BluesnapPaymentsRequest {
     amount: String,
@@ -26,9 +26,16 @@ pub struct BluesnapPaymentsRequest {
     currency: enums::Currency,
     card_transaction_type: BluesnapTxnType,
     three_d_secure: Option<BluesnapThreeDSecureInfo>,
+    transaction_fraud_info: Option<TransactionFraudInfo>,
 }
 
-#[derive(Debug, Serialize, PartialEq)]
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TransactionFraudInfo {
+    fraud_session_id: String,
+}
+
+#[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct BluesnapCreateWalletToken {
     wallet_type: String,
@@ -37,20 +44,20 @@ pub struct BluesnapCreateWalletToken {
     display_name: Option<String>,
 }
 
-#[derive(Debug, Serialize, PartialEq)]
+#[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct BluesnapThreeDSecureInfo {
     three_d_secure_reference_id: String,
 }
 
-#[derive(Debug, Serialize, Eq, PartialEq)]
+#[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub enum PaymentMethodDetails {
     CreditCard(Card),
     Wallet(BluesnapWallet),
 }
 
-#[derive(Default, Debug, Serialize, Eq, PartialEq)]
+#[derive(Default, Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Card {
     card_number: cards::CardNumber,
@@ -59,7 +66,7 @@ pub struct Card {
     security_code: Secret<String>,
 }
 
-#[derive(Debug, Serialize, Eq, PartialEq)]
+#[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct BluesnapWallet {
     wallet_type: BluesnapWalletTypes,
@@ -72,27 +79,27 @@ pub struct BluesnapGooglePayObject {
     payment_method_data: utils::GooglePayWalletData,
 }
 
-#[derive(Debug, Serialize, Eq, PartialEq)]
+#[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct BluesnapApplePayObject {
     token: api_models::payments::ApplePayWalletData,
 }
 
-#[derive(Debug, Serialize, Eq, PartialEq)]
+#[derive(Debug, Serialize)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum BluesnapWalletTypes {
     GooglePay,
     ApplePay,
 }
 
-#[derive(Debug, Serialize, Eq, PartialEq)]
+#[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct EncodedPaymentToken {
     billing_contact: BillingDetails,
     token: ApplepayPaymentData,
 }
 
-#[derive(Debug, Serialize, Eq, PartialEq)]
+#[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct BillingDetails {
     country_code: Option<api_enums::CountryAlpha2>,
@@ -102,7 +109,7 @@ pub struct BillingDetails {
     postal_code: Option<Secret<String>>,
 }
 
-#[derive(Debug, Serialize, Deserialize, Eq, PartialEq, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct ApplepayPaymentData {
     payment_data: ApplePayEncodedPaymentData,
@@ -110,7 +117,7 @@ pub struct ApplepayPaymentData {
     transaction_identifier: String,
 }
 
-#[derive(Debug, Serialize, Deserialize, Eq, PartialEq, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct ApplepayPaymentMethod {
     display_name: String,
@@ -119,7 +126,7 @@ pub struct ApplepayPaymentMethod {
     pm_type: String,
 }
 
-#[derive(Debug, Serialize, Deserialize, Eq, PartialEq, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct ApplePayEncodedPaymentData {
     data: String,
     header: Option<ApplepayHeader>,
@@ -127,7 +134,7 @@ pub struct ApplePayEncodedPaymentData {
     version: String,
 }
 
-#[derive(Debug, Serialize, Deserialize, Eq, PartialEq, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct ApplepayHeader {
     ephemeral_public_key: Secret<String>,
@@ -242,6 +249,9 @@ impl TryFrom<&types::PaymentsAuthorizeRouterData> for BluesnapPaymentsRequest {
             currency: item.request.currency,
             card_transaction_type: auth_mode,
             three_d_secure: None,
+            transaction_fraud_info: Some(TransactionFraudInfo {
+                fraud_session_id: item.payment_id.clone(),
+            }),
         })
     }
 }
@@ -384,29 +394,32 @@ impl TryFrom<&types::PaymentsCompleteAuthorizeRouterData> for BluesnapPaymentsRe
                     })?
                     .three_d_secure_reference_id,
             }),
+            transaction_fraud_info: Some(TransactionFraudInfo {
+                fraud_session_id: item.payment_id.clone(),
+            }),
         })
     }
 }
 
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Debug, Deserialize)]
 pub struct BluesnapRedirectionResponse {
     pub authentication_response: String,
 }
 
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct BluesnapThreeDsResult {
     three_d_secure: Option<BluesnapThreeDsReference>,
     pub status: String,
 }
 
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct BluesnapThreeDsReference {
     three_d_secure_reference_id: String,
 }
 
-#[derive(Debug, Serialize, PartialEq)]
+#[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct BluesnapVoidRequest {
     card_transaction_type: BluesnapTxnType,
@@ -425,7 +438,7 @@ impl TryFrom<&types::PaymentsCancelRouterData> for BluesnapVoidRequest {
     }
 }
 
-#[derive(Debug, Serialize, PartialEq)]
+#[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct BluesnapCaptureRequest {
     card_transaction_type: BluesnapTxnType,
@@ -468,7 +481,7 @@ impl TryFrom<&types::ConnectorAuthType> for BluesnapAuthType {
     }
 }
 
-#[derive(Debug, Serialize, PartialEq)]
+#[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct BluesnapCustomerRequest {
     email: Option<Email>,
@@ -483,7 +496,7 @@ impl TryFrom<&types::ConnectorCustomerRouterData> for BluesnapCustomerRequest {
     }
 }
 
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct BluesnapCustomerResponse {
     vaulted_shopper_id: u64,
@@ -511,7 +524,7 @@ impl<F, T>
 }
 
 // PaymentsResponse
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum BluesnapTxnType {
     AuthOnly,
@@ -521,7 +534,7 @@ pub enum BluesnapTxnType {
     Refund,
 }
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "UPPERCASE")]
 pub enum BluesnapProcessingStatus {
     #[serde(alias = "success")]
@@ -567,7 +580,7 @@ impl From<BluesnapProcessingStatus> for enums::RefundStatus {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct BluesnapPaymentsResponse {
     processing_info: ProcessingInfoResponse,
@@ -575,21 +588,21 @@ pub struct BluesnapPaymentsResponse {
     card_transaction_type: BluesnapTxnType,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct BluesnapWalletTokenResponse {
     wallet_type: String,
     wallet_token: Secret<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Default, Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Refund {
     refund_transaction_id: String,
     amount: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Default, Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ProcessingInfoResponse {
     processing_status: BluesnapProcessingStatus,
@@ -629,7 +642,7 @@ impl<F, T>
     }
 }
 
-#[derive(Default, Debug, Eq, PartialEq, Serialize)]
+#[derive(Default, Debug, Serialize)]
 pub struct BluesnapRefundRequest {
     amount: Option<String>,
     reason: Option<String>,
@@ -689,7 +702,7 @@ impl TryFrom<types::RefundsResponseRouterData<api::Execute, RefundResponse>>
         })
     }
 }
-#[derive(Debug, Clone, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct BluesnapWebhookBody {
     pub auth_key: String,
@@ -712,7 +725,7 @@ pub enum BluesnapWebhookEvents {
     #[serde(other)]
     Unknown,
 }
-#[derive(Default, Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Default, Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct BluesnapWebhookObjectResource {
     pub auth_key: String,
@@ -720,27 +733,27 @@ pub struct BluesnapWebhookObjectResource {
     pub reference_number: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Default, Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ErrorDetails {
     pub code: String,
     pub description: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize, PartialEq)]
+#[derive(Default, Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct BluesnapErrorResponse {
     pub message: Vec<ErrorDetails>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize, PartialEq)]
+#[derive(Default, Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct BluesnapAuthErrorResponse {
     pub error_code: String,
     pub error_description: String,
 }
 
-#[derive(Debug, Clone, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Deserialize)]
 #[serde(untagged)]
 pub enum BluesnapErrors {
     PaymentError(BluesnapErrorResponse),


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
Bluesnap required fraudSessionId to be passed in the payment request for FRMS DDC verification. This can be handled by passing hyper switch payment_id in the blue snap payment request. 


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
Manual Testing in postman
<img width="1260" alt="Screen Shot 2023-06-09 at 5 31 34 PM" src="https://github.com/juspay/hyperswitch/assets/20727986/40afb7ad-9a67-40d8-ae0c-7df3c5854063">



## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
