### PR TITLE
fix(router): [Trustpay] fix email & user-agent information as mandatory fields in trustpay card payment request

### DIFF
--- a/crates/router/src/connector/trustpay/transformers.rs
+++ b/crates/router/src/connector/trustpay/transformers.rs
@@ -9,7 +9,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     connector::utils::{
-        self, AddressDetailsData, CardData, PaymentsAuthorizeRequestData, RouterData,
+        self, AddressDetailsData, BrowserInformationData, CardData, PaymentsAuthorizeRequestData,
+        RouterData,
     },
     consts,
     core::errors,
@@ -221,6 +222,7 @@ fn get_card_request_data(
     return_url: String,
 ) -> Result<TrustpayPaymentsRequest, Error> {
     let email = item.request.get_email()?;
+    let customer_ip_address = browser_info.get_ip_address()?;
     Ok(TrustpayPaymentsRequest::CardsPaymentRequest(Box::new(
         PaymentRequestCards {
             amount,
@@ -236,12 +238,7 @@ fn get_card_request_data(
             billing_street1: params.billing_street1,
             billing_postcode: params.billing_postcode,
             customer_email: email,
-            customer_ip_address: browser_info
-                .ip_address
-                .get_required_value("ip_address")
-                .change_context(errors::ConnectorError::MissingRequiredField {
-                    field_name: "ip_address",
-                })?,
+            customer_ip_address,
             browser_accept_header: browser_info
                 .accept_header
                 .clone()

--- a/crates/router/src/connector/trustpay/transformers.rs
+++ b/crates/router/src/connector/trustpay/transformers.rs
@@ -130,7 +130,7 @@ pub struct PaymentRequestCards {
     #[serde(rename = "billing[postcode]")]
     pub billing_postcode: Secret<String>,
     #[serde(rename = "customer[email]")]
-    pub customer_email: Option<Email>,
+    pub customer_email: Email,
     #[serde(rename = "customer[ipAddress]")]
     pub customer_ip_address: Option<std::net::IpAddr>,
     #[serde(rename = "browser[acceptHeader]")]
@@ -220,6 +220,7 @@ fn get_card_request_data(
     ccard: &api_models::payments::Card,
     return_url: String,
 ) -> Result<TrustpayPaymentsRequest, Error> {
+    let email = item.request.get_email()?;
     Ok(TrustpayPaymentsRequest::CardsPaymentRequest(Box::new(
         PaymentRequestCards {
             amount,
@@ -234,7 +235,7 @@ fn get_card_request_data(
             billing_country: params.billing_country,
             billing_street1: params.billing_street1,
             billing_postcode: params.billing_postcode,
-            customer_email: item.request.email.clone(),
+            customer_email: email,
             customer_ip_address: browser_info.ip_address,
             browser_accept_header: browser_info
                 .accept_header
@@ -349,7 +350,7 @@ impl TryFrom<&types::PaymentsAuthorizeRouterData> for TrustpayPaymentsRequest {
             screen_width: Some(1920),
             time_zone: Some(3600),
             accept_header: Some("*".to_string()),
-            user_agent: Some("none".to_string()),
+            user_agent: Some("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/111.0.0.0 Safari/537.36".to_string()),
             ip_address: None,
         };
         let browser_info = item

--- a/crates/router/src/connector/utils.rs
+++ b/crates/router/src/connector/utils.rs
@@ -262,7 +262,8 @@ pub trait BrowserInformationData {
 
 impl BrowserInformationData for types::BrowserInformation {
     fn get_ip_address(&self) -> Result<std::net::IpAddr, Error> {
-        self.ip_address.ok_or_else(missing_field_err("ip_address"))
+        self.ip_address
+            .ok_or_else(missing_field_err("browser_info.ip_address"))
     }
 }
 


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
Email should be passed as a mandatory field and user-agent should be passed as default value if not passed in TrustPay card payment request 


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
Manual Testing & verified trustpay card payment request
<img width="1262" alt="Screen Shot 2023-06-12 at 5 31 03 PM" src="https://github.com/juspay/hyperswitch/assets/20727986/77ca9b10-acce-4302-ba9e-62c9c137447c">


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
