### PR TITLE
feat(compatibility): add receipt_ipaddress and user_agent in stripe compatibility

### DIFF
--- a/crates/router/src/compatibility/stripe/payment_intents/types.rs
+++ b/crates/router/src/compatibility/stripe/payment_intents/types.rs
@@ -13,7 +13,6 @@ use crate::{
     types::{
         api::{admin, enums as api_enums},
         transformers::{ForeignFrom, ForeignTryFrom},
-        BrowserInformation,
     },
 };
 
@@ -150,6 +149,7 @@ pub struct StripePaymentIntentRequest {
     pub mandate_id: Option<String>,
     pub off_session: Option<bool>,
     pub receipt_ipaddress: Option<String>,
+    pub user_agent: Option<String>,
 }
 
 impl TryFrom<StripePaymentIntentRequest> for payments::PaymentsRequest {
@@ -243,8 +243,9 @@ impl TryFrom<StripePaymentIntentRequest> for payments::PaymentsRequest {
             off_session: item.off_session,
             routing,
             browser_info: Some(
-                serde_json::to_value(BrowserInformation {
+                serde_json::to_value(crate::types::BrowserInformation {
                     ip_address,
+                    user_agent: item.user_agent,
                     ..Default::default()
                 })
                 .into_report()

--- a/crates/router/src/types.rs
+++ b/crates/router/src/types.rs
@@ -442,7 +442,7 @@ pub struct RefundsData {
     pub connector_metadata: Option<serde_json::Value>,
 }
 
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Debug, Default, serde::Serialize, serde::Deserialize)]
 pub struct BrowserInformation {
     pub color_depth: Option<u8>,
     pub java_enabled: Option<bool>,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
add receipt_ipaddress and user_agent in stripe compatibility

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Compiles and mapped correctly

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
