### PR TITLE
refactor(router): send 200 response for 5xx status codes received from connector

### DIFF
--- a/crates/router/src/core/payments/helpers.rs
+++ b/crates/router/src/core/payments/helpers.rs
@@ -2069,6 +2069,7 @@ impl AttemptType {
             straight_through_algorithm: old_payment_attempt.straight_through_algorithm,
             mandate_details: old_payment_attempt.mandate_details,
             preprocessing_step_id: None,
+            error_reason: None,
         }
     }
 

--- a/crates/router/src/core/payments/operations/payment_response.rs
+++ b/crates/router/src/core/payments/operations/payment_response.rs
@@ -64,15 +64,19 @@ impl<F: Clone> PostUpdateTracker<F, PaymentData<F>, types::PaymentsAuthorizeData
         .await?;
 
         router_response.map(|_| ()).or_else(|error_response| {
-            fp_utils::when(!(200..300).contains(&error_response.status_code), || {
-                Err(errors::ApiErrorResponse::ExternalConnectorError {
-                    code: error_response.code,
-                    message: error_response.message,
-                    connector,
-                    status_code: error_response.status_code,
-                    reason: error_response.reason,
-                })
-            })
+            fp_utils::when(
+                !(200..300).contains(&error_response.status_code)
+                    && !(500..=511).contains(&error_response.status_code),
+                || {
+                    Err(errors::ApiErrorResponse::ExternalConnectorError {
+                        code: error_response.code,
+                        message: error_response.message,
+                        connector,
+                        status_code: error_response.status_code,
+                        reason: error_response.reason,
+                    })
+                },
+            )
         })?;
 
         Ok(payment_data)
@@ -295,9 +299,13 @@ async fn payment_response_update_tracker<F: Clone, T>(
         Err(err) => (
             Some(storage::PaymentAttemptUpdate::ErrorUpdate {
                 connector: None,
-                status: storage::enums::AttemptStatus::Failure,
+                status: match err.status_code {
+                    400..=499 => storage::enums::AttemptStatus::Failure,
+                    _ => storage::enums::AttemptStatus::Pending,
+                },
                 error_message: Some(Some(err.message)),
                 error_code: Some(Some(err.code)),
+                error_reason: Some(err.reason),
             }),
             Some(storage::ConnectorResponseUpdate::ErrorUpdate {
                 connector_name: Some(router_data.connector.clone()),
@@ -361,7 +369,8 @@ async fn payment_response_update_tracker<F: Clone, T>(
                     connector_metadata,
                     payment_token: None,
                     error_code: error_status.clone(),
-                    error_message: error_status,
+                    error_message: error_status.clone(),
+                    error_reason: error_status,
                 };
 
                 let connector_response_update = storage::ConnectorResponseUpdate::ResponseUpdate {
@@ -392,7 +401,8 @@ async fn payment_response_update_tracker<F: Clone, T>(
                         connector_transaction_id,
                         payment_method_id: Some(router_data.payment_method_id),
                         error_code: Some(reason.clone().map(|cd| cd.code)),
-                        error_message: Some(reason.map(|cd| cd.message)),
+                        error_message: Some(reason.clone().map(|cd| cd.message)),
+                        error_reason: Some(reason.map(|cd| cd.message)),
                     }),
                     None,
                 )
@@ -436,9 +446,12 @@ async fn payment_response_update_tracker<F: Clone, T>(
             None
         }
     });
-    let payment_intent_update = match router_data.response {
-        Err(_) => storage::PaymentIntentUpdate::PGStatusUpdate {
-            status: enums::IntentStatus::Failed,
+    let payment_intent_update = match &router_data.response {
+        Err(err) => storage::PaymentIntentUpdate::PGStatusUpdate {
+            status: match err.status_code {
+                400..=499 => enums::IntentStatus::Failed,
+                _ => enums::IntentStatus::Processing,
+            },
         },
         Ok(_) => storage::PaymentIntentUpdate::ResponseUpdate {
             status: router_data.status.foreign_into(),

--- a/crates/router/src/core/payments/transformers.rs
+++ b/crates/router/src/core/payments/transformers.rs
@@ -402,7 +402,7 @@ where
                             auth_flow == services::AuthFlow::Merchant,
                         )
                         .set_payment_token(payment_attempt.payment_token)
-                        .set_error_message(payment_attempt.error_message)
+                        .set_error_message(payment_attempt.error_reason)
                         .set_error_code(payment_attempt.error_code)
                         .set_shipping(address.shipping)
                         .set_billing(address.billing)

--- a/crates/router/src/db/payment_attempt.rs
+++ b/crates/router/src/db/payment_attempt.rs
@@ -303,6 +303,7 @@ impl PaymentAttemptInterface for MockDb {
             straight_through_algorithm: payment_attempt.straight_through_algorithm,
             mandate_details: payment_attempt.mandate_details,
             preprocessing_step_id: payment_attempt.preprocessing_step_id,
+            error_reason: payment_attempt.error_reason,
         };
         payment_attempts.push(payment_attempt.clone());
         Ok(payment_attempt)
@@ -440,6 +441,7 @@ mod storage {
                             .clone(),
                         mandate_details: payment_attempt.mandate_details.clone(),
                         preprocessing_step_id: payment_attempt.preprocessing_step_id.clone(),
+                        error_reason: payment_attempt.error_reason.clone(),
                     };
 
                     let field = format!("pa_{}", created_attempt.attempt_id);

--- a/crates/router/src/services/api.rs
+++ b/crates/router/src/services/api.rs
@@ -145,27 +145,27 @@ pub trait ConnectorIntegration<T, Req, Resp>: ConnectorIntegrationAny<T, Req, Re
         Ok(ErrorResponse::get_not_implemented())
     }
 
-    fn get_server_error_response(
+    fn get_5xx_error_response(
         &self,
         res: types::Response,
     ) -> CustomResult<ErrorResponse, errors::ConnectorError> {
-        let error_mssg = match res.status_code {
-            500 => "InternalServerError",
-            501 => "NotImplemented",
-            502 => "BadGateway",
-            503 => "ServiceUnavailable",
-            504 => "GatewayTimeout",
-            505 => "HttpVersionNotSupported",
-            506 => "VariantAlsoNegotiates",
-            507 => "InsufficientStorage",
-            508 => "LoopDetected",
-            510 => "NotExtended",
-            511 => "NetworkAuthenticationRequired",
-            _ => "UnknownError",
+        let error_message = match res.status_code {
+            500 => "internal_server_error",
+            501 => "not_implemented",
+            502 => "bad_gateway",
+            503 => "service_unavailable",
+            504 => "gateway_timeout",
+            505 => "http_version_not_supported",
+            506 => "variant_also_negotiates",
+            507 => "insufficient_storage",
+            508 => "loop_detected",
+            510 => "not_extended",
+            511 => "network_authentication_required",
+            _ => "unknown_error",
         };
         Ok(ErrorResponse {
             code: res.status_code.to_string(),
-            message: error_mssg.to_string(),
+            message: error_message.to_string(),
             reason: String::from_utf8(res.response.to_vec()).ok(),
             status_code: res.status_code,
         })
@@ -306,7 +306,7 @@ where
                                     );
                                     let error = match body.status_code {
                                         500..=511 => {
-                                            connector_integration.get_server_error_response(body)?
+                                            connector_integration.get_5xx_error_response(body)?
                                         }
                                         _ => connector_integration.get_error_response(body)?,
                                     };

--- a/crates/storage_models/src/payment_attempt.rs
+++ b/crates/storage_models/src/payment_attempt.rs
@@ -49,6 +49,7 @@ pub struct PaymentAttempt {
     pub preprocessing_step_id: Option<String>,
     // providing a location to store mandate details intermediately for transaction
     pub mandate_details: Option<storage_enums::MandateDataType>,
+    pub error_reason: Option<String>,
 }
 
 #[derive(
@@ -96,6 +97,7 @@ pub struct PaymentAttemptNew {
     pub straight_through_algorithm: Option<serde_json::Value>,
     pub preprocessing_step_id: Option<String>,
     pub mandate_details: Option<storage_enums::MandateDataType>,
+    pub error_reason: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -150,6 +152,7 @@ pub enum PaymentAttemptUpdate {
         payment_token: Option<String>,
         error_code: Option<Option<String>>,
         error_message: Option<Option<String>>,
+        error_reason: Option<Option<String>>,
     },
     UnresolvedResponseUpdate {
         status: storage_enums::AttemptStatus,
@@ -158,6 +161,7 @@ pub enum PaymentAttemptUpdate {
         payment_method_id: Option<Option<String>>,
         error_code: Option<Option<String>>,
         error_message: Option<Option<String>>,
+        error_reason: Option<Option<String>>,
     },
     StatusUpdate {
         status: storage_enums::AttemptStatus,
@@ -167,6 +171,7 @@ pub enum PaymentAttemptUpdate {
         status: storage_enums::AttemptStatus,
         error_code: Option<Option<String>>,
         error_message: Option<Option<String>>,
+        error_reason: Option<Option<String>>,
     },
     PreprocessingUpdate {
         status: storage_enums::AttemptStatus,
@@ -201,6 +206,7 @@ pub struct PaymentAttemptUpdateInternal {
     business_sub_label: Option<String>,
     straight_through_algorithm: Option<serde_json::Value>,
     preprocessing_step_id: Option<String>,
+    error_reason: Option<Option<String>>,
 }
 
 impl PaymentAttemptUpdate {
@@ -319,6 +325,7 @@ impl From<PaymentAttemptUpdate> for PaymentAttemptUpdateInternal {
                 payment_token,
                 error_code,
                 error_message,
+                error_reason,
             } => Self {
                 status: Some(status),
                 connector,
@@ -331,6 +338,7 @@ impl From<PaymentAttemptUpdate> for PaymentAttemptUpdateInternal {
                 error_code,
                 error_message,
                 payment_token,
+                error_reason,
                 ..Default::default()
             },
             PaymentAttemptUpdate::ErrorUpdate {
@@ -338,12 +346,14 @@ impl From<PaymentAttemptUpdate> for PaymentAttemptUpdateInternal {
                 status,
                 error_code,
                 error_message,
+                error_reason,
             } => Self {
                 connector,
                 status: Some(status),
                 error_message,
                 error_code,
                 modified_at: Some(common_utils::date_time::now()),
+                error_reason,
                 ..Default::default()
             },
             PaymentAttemptUpdate::StatusUpdate { status } => Self {
@@ -367,6 +377,7 @@ impl From<PaymentAttemptUpdate> for PaymentAttemptUpdateInternal {
                 payment_method_id,
                 error_code,
                 error_message,
+                error_reason,
             } => Self {
                 status: Some(status),
                 connector,
@@ -375,6 +386,7 @@ impl From<PaymentAttemptUpdate> for PaymentAttemptUpdateInternal {
                 modified_at: Some(common_utils::date_time::now()),
                 error_code,
                 error_message,
+                error_reason,
                 ..Default::default()
             },
             PaymentAttemptUpdate::PreprocessingUpdate {

--- a/crates/storage_models/src/schema.rs
+++ b/crates/storage_models/src/schema.rs
@@ -429,6 +429,7 @@ diesel::table! {
         straight_through_algorithm -> Nullable<Jsonb>,
         preprocessing_step_id -> Nullable<Varchar>,
         mandate_details -> Nullable<Jsonb>,
+        error_reason -> Nullable<Text>,
     }
 }
 

--- a/migrations/2023-06-14-105035_add_reason_in_payment_attempt/down.sql
+++ b/migrations/2023-06-14-105035_add_reason_in_payment_attempt/down.sql
@@ -1,0 +1,3 @@
+-- This file should undo anything in `up.sql`
+ALTER TABLE payment_attempt
+DROP COLUMN error_reason;

--- a/migrations/2023-06-14-105035_add_reason_in_payment_attempt/up.sql
+++ b/migrations/2023-06-14-105035_add_reason_in_payment_attempt/up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE payment_attempt
+ADD COLUMN error_reason TEXT;


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
Send the 200 response with status as `processing`, populating error_code and error_message when we receive 5xx status codes from connector.


### Additional Changes

- [ ] This PR modifies the API contract
- [x] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
Tested Manually
DB payment_attempt for 5xx code from connector
![image](https://github.com/juspay/hyperswitch/assets/56996463/a3231f83-04ee-4303-bf1c-239d70d3840a)

Payments response for 5xx code from connector
![image](https://github.com/juspay/hyperswitch/assets/56996463/fabebf05-fd28-42b5-a70e-2f086a478bb0)

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
