### PR TITLE
ci(postman-collection-runner): add `workflow_dispatch` trigger and fix failing CI runs

### DIFF
--- a/.github/workflows/postman-collection-runner.yml
+++ b/.github/workflows/postman-collection-runner.yml
@@ -4,6 +4,7 @@ on:
   schedule:
     # Run workflow at 6 AM and 6 PM IST
     - cron: "30 0,12 * * *"
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -33,6 +34,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: api_tests
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
       - name: Run Newman
         run:
           newman run postman/hyperswitch.postman_collection.json --env-var admin_api_key=${{ secrets.INTEG_ADMIN_API_KEY }} --env-var baseUrl=${{ secrets.INTEG_BASE_URL }} --env-var connector_api_key=${{ secrets.STRIPE_API_KEY }}


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [x] CI/CD

## Description
Added github action to trigger the collection manually

