### PR TITLE
refactor(mca): use separate struct for connector metadata

### DIFF
--- a/crates/api_models/src/payments.rs
+++ b/crates/api_models/src/payments.rs
@@ -1762,8 +1762,12 @@ pub struct ApplepaySessionRequest {
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct ConnectorMetadata {
-    pub apple_pay: Option<ApplePayMetadata>,
-    pub google_pay: Option<GpayMetaData>,
+    pub apple_pay: Option<ApplepayConnectorMetadataRequest>,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct ApplepayConnectorMetadataRequest {
+    pub session_token_data: Option<SessionTokenInfo>,
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]

--- a/crates/router/src/core/admin.rs
+++ b/crates/router/src/core/admin.rs
@@ -384,7 +384,7 @@ fn validate_certificate_in_mca_metadata(
     connector_metadata: Secret<serde_json::Value>,
 ) -> RouterResult<()> {
     let parsed_connector_metadata = connector_metadata
-        .parse_value::<api_models::payments::ConnectorMetadata>("ApplepaySessionTokenData")
+        .parse_value::<api_models::payments::ConnectorMetadata>("ConnectorMetadata")
         .change_context(errors::ParsingError::StructParseFailure("Metadata"))
         .change_context(errors::ApiErrorResponse::InvalidDataFormat {
             field_name: "metadata".to_string(),
@@ -393,17 +393,22 @@ fn validate_certificate_in_mca_metadata(
 
     parsed_connector_metadata
         .apple_pay
-        .map(|applepay_metadata| {
-            let api_models::payments::SessionTokenInfo {
-                certificate,
-                certificate_keys,
-                ..
-            } = applepay_metadata.session_token_data;
-            helpers::create_identity_from_certificate_and_key(certificate, certificate_keys)
-                .change_context(errors::ApiErrorResponse::InvalidDataValue {
-                    field_name: "certificate/certificate key",
+        .and_then(|applepay_metadata| {
+            applepay_metadata
+                .session_token_data
+                .map(|session_token_data| {
+                    let api_models::payments::SessionTokenInfo {
+                        certificate,
+                        certificate_keys,
+                        ..
+                    } = session_token_data;
+
+                    helpers::create_identity_from_certificate_and_key(certificate, certificate_keys)
+                        .change_context(errors::ApiErrorResponse::InvalidDataValue {
+                            field_name: "certificate/certificate key",
+                        })
+                        .map(|_identity_result| ())
                 })
-                .map(|_identity_result| ())
         })
         .transpose()?;
 


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix

## Description
<!-- Describe your changes in detail -->
This PR will remove the parsing check for metadata that was added in #1385. 
The reason the parsing check was added ( in addition to certificate validation ), is to ensure that mca cannot be created with malformed data. 

But in https://github.com/juspay/hyperswitch/pull/1390, the connector is expecting the json value to be in specific format. This format is checked only in case the payment is made through that connector and payment method. 

I'm currently removing the type checks ( except for certificate validation ) as its not clear as to where this struct is parsed internally in the connector module to different formats. Ideally the types should be declared in `api_models` and the same type should be used in connector module wherever possible. 

Such type checks can be added later once we consolidate the connector metadata format. 

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
- Create mca with redirect applepay connector metadata - should pass
<img width="473" alt="Screenshot 2023-06-16 at 11 19 43 PM" src="https://github.com/juspay/hyperswitch/assets/48803246/2cb6840f-3d04-48f5-bfa9-3235aae24141">



- Create mca with redirect googlepay connector metadata - should pass
<img width="438" alt="Screenshot 2023-06-16 at 11 20 02 PM" src="https://github.com/juspay/hyperswitch/assets/48803246/d7a8ab63-e783-48e1-b343-3e79c5c1570f">



- Create mca with invalid certificates - should fail
<img width="651" alt="Screenshot 2023-06-16 at 11 20 16 PM" src="https://github.com/juspay/hyperswitch/assets/48803246/eb08c552-6ef7-4da6-b0e5-77a64fe889cb">

- Create mca with valid certificates - should pass
<img width="402" alt="Screenshot 2023-06-16 at 11 21 20 PM" src="https://github.com/juspay/hyperswitch/assets/48803246/57e657ea-774a-4e98-922b-d4a11e4a3ce1">



## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
