### PR TITLE
build(docker): use `debian:bookworm-slim` as base image for builder and runner stages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:slim as builder
+FROM rust:slim-bookworm as builder
 
 ARG EXTRA_FEATURES=""
 
@@ -36,7 +36,7 @@ RUN cargo build --release --features release ${EXTRA_FEATURES}
 
 
 
-FROM debian
+FROM debian:bookworm-slim
 
 # Placing config and binary executable in different directories
 ARG CONFIG_DIR=/local/config


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
This PR updates the `Dockerfile` to use `debian:bookworm-slim` as the base image for both the builder and runner stages.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
This fixes an issue where the application panics because it fails to load the OpenSSL library. Turns out, this is caused by `rust:slim` using Debian bullseye (11) in the builder stage, while `debian` pulled Debian bookworm (12) for the runner stage.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Built and ran Docker images locally.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
