### PR TITLE
chore(migrations): shrink `merchant_id` column of `merchant_key_store` to 64 characters

### DIFF
--- a/crates/storage_models/src/schema.rs
+++ b/crates/storage_models/src/schema.rs
@@ -367,7 +367,7 @@ diesel::table! {
     use crate::enums::diesel_exports::*;
 
     merchant_key_store (merchant_id) {
-        #[max_length = 255]
+        #[max_length = 64]
         merchant_id -> Varchar,
         key -> Bytea,
         created_at -> Timestamp,

--- a/migrations/2023-06-19-071300_merchant_key_store_shrink_merchant_id/down.sql
+++ b/migrations/2023-06-19-071300_merchant_key_store_shrink_merchant_id/down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE merchant_key_store
+ALTER COLUMN merchant_id TYPE VARCHAR(255);

--- a/migrations/2023-06-19-071300_merchant_key_store_shrink_merchant_id/up.sql
+++ b/migrations/2023-06-19-071300_merchant_key_store_shrink_merchant_id/up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE merchant_key_store
+ALTER COLUMN merchant_id TYPE VARCHAR(64);


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
This PR updates the `merchant_id` column of the `merchant_key_store` table to use `VARCHAR(64)` instead of `VARCHAR(255)`, since we're using `VARCHAR(64)` for `merchant_id` everywhere else.

### Additional Changes

- [ ] This PR modifies the API contract
- [x] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->
The migrations are available at [`up.sql`](https://github.com/juspay/hyperswitch/blob/9e62b6ec85dd9583e27f9e817465c94b9ff5e2ad/migrations/2023-06-19-071300_merchant_key_store_shrink_merchant_id/up.sql) and [`down.sql`](https://github.com/juspay/hyperswitch/blob/9e62b6ec85dd9583e27f9e817465c94b9ff5e2ad/migrations/2023-06-19-071300_merchant_key_store_shrink_merchant_id/down.sql).

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
We're using `VARCHAR(64)` for `merchant_id` everywhere else, so the `merchant_key_store` table can also use the same size.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
N/A

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
