### PR TITLE
fix(connector): [Zen] Convert the amount to base denomination in order_details

### DIFF
--- a/crates/router/src/connector/zen/transformers.rs
+++ b/crates/router/src/connector/zen/transformers.rs
@@ -395,15 +395,20 @@ fn get_item_object(
     _amount: String,
 ) -> Result<Vec<ZenItemObject>, error_stack::Report<errors::ConnectorError>> {
     let order_details = item.request.get_order_details()?;
-    Ok(order_details
+
+    order_details
         .iter()
-        .map(|data| ZenItemObject {
-            name: data.product_name.clone(),
-            quantity: data.quantity,
-            price: data.amount.to_string(),
-            line_amount_total: (i64::from(data.quantity) * data.amount).to_string(),
+        .map(|data| {
+            Ok(ZenItemObject {
+                name: data.product_name.clone(),
+                quantity: data.quantity,
+                price: utils::to_currency_base_unit(data.amount, item.request.currency)?,
+                line_amount_total: (f64::from(data.quantity)
+                    * utils::to_currency_base_unit_asf64(data.amount, item.request.currency)?)
+                .to_string(),
+            })
         })
-        .collect())
+        .collect::<Result<_, _>>()
 }
 
 fn get_browser_details(


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Convert the amount to base denomination in order_details

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
The amount and price along with lineItemsTotal should be aligned and should be in base denomination according to the currency

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
<img width="1204" alt="Screenshot 2023-06-19 at 1 42 08 PM" src="https://github.com/juspay/hyperswitch/assets/55536657/b8d59ce5-e730-423f-851b-09b9918a1d2d">



## Checklist
<!-- Put an `x` in the boxes that apply -->

- [X] I formatted the code `cargo +nightly fmt --all`
- [X] I addressed lints thrown by `cargo clippy`
- [X] I reviewed submitted code
- [] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
