### PR TITLE
refactor(core): update trackers for preprocessing steps

### DIFF
--- a/crates/router/src/core/payments.rs
+++ b/crates/router/src/core/payments.rs
@@ -562,7 +562,7 @@ where
     // Update the payment trackers just before calling the connector
     // Since the request is already built in the previous step,
     // there should be no error in request construction from hyperswitch end
-    operation
+    (_, *payment_data) = operation
         .to_update_tracker()?
         .update_trackers(
             &*state.store,
@@ -572,6 +572,10 @@ where
             updated_customer,
         )
         .await?;
+
+    // The status of payment_attempt and intent will be updated in the previous step
+    // This field will be used by the connector
+    router_data.status = payment_data.payment_attempt.status;
 
     let router_data_res = if should_continue_further {
         // Check if the actual flow specific request can be built with available data

--- a/crates/router/src/core/payments.rs
+++ b/crates/router/src/core/payments.rs
@@ -551,26 +551,30 @@ where
         payment_data.sessions_token.push(session_token);
     };
 
+    let connector_request = if should_continue_further {
+        router_data
+            .build_flow_specific_connector_request(state, &connector, call_connector_action.clone())
+            .await?
+    } else {
+        None
+    };
+
+    // Update the payment trackers just before calling the connector
+    // Since the request is already built in the previous step,
+    // there should be no error in request construction from hyperswitch end
+    operation
+        .to_update_tracker()?
+        .update_trackers(
+            &*state.store,
+            payment_data.clone(),
+            customer.clone(),
+            merchant_account.storage_scheme,
+            updated_customer,
+        )
+        .await?;
+
     let router_data_res = if should_continue_further {
         // Check if the actual flow specific request can be built with available data
-        let request = router_data
-            .build_flow_specific_connector_request(state, &connector, call_connector_action.clone())
-            .await?;
-
-        // Update the payment trackers just before calling the connector
-        // Since the request is already built in the previous step,
-        // there should be no error in request construction from hyperswitch end
-        operation
-            .to_update_tracker()?
-            .update_trackers(
-                &*state.store,
-                payment_data.clone(),
-                customer.clone(),
-                merchant_account.storage_scheme,
-                updated_customer,
-            )
-            .await?;
-
         router_data
             .decide_flows(
                 state,
@@ -578,7 +582,7 @@ where
                 customer,
                 call_connector_action,
                 merchant_account,
-                request,
+                connector_request,
             )
             .await
     } else {

--- a/crates/router/src/core/payments.rs
+++ b/crates/router/src/core/payments.rs
@@ -552,6 +552,7 @@ where
     };
 
     let connector_request = if should_continue_further {
+        // Check if the actual flow specific request can be built with available data
         router_data
             .build_flow_specific_connector_request(state, &connector, call_connector_action.clone())
             .await?
@@ -578,7 +579,6 @@ where
     router_data.status = payment_data.payment_attempt.status;
 
     let router_data_res = if should_continue_further {
-        // Check if the actual flow specific request can be built with available data
         router_data
             .decide_flows(
                 state,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Refactoring

## Description
<!-- Describe your changes in detail -->
This PR will move the update trackers outside the conditional block, this is to ensure that even if there is no call to connector, the database is updated ( this was required in pre processing steps ).

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
Persist the data in pre processing steps.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
- Create a payment with missing required field error, ensure that the payment status is not udpated.
- Create applepay trustpay payment, works as expected.
![Screen Shot 2023-06-19 at 11 26 19 PM](https://github.com/juspay/hyperswitch/assets/48803246/2191b7c2-df6f-45b6-85a9-4dd0492314d5)

![Screen Shot 2023-06-19 at 11 26 11 PM](https://github.com/juspay/hyperswitch/assets/48803246/9d2323ce-05d3-46ed-a327-b8368ad9beed)


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
