### PR TITLE
fix(connector): [Trustpay] add reason to all the error responses

### DIFF
--- a/crates/router/src/connector/trustpay.rs
+++ b/crates/router/src/connector/trustpay.rs
@@ -113,7 +113,7 @@ impl ConnectorCommon for Trustpay {
             status_code: res.status_code,
             code: response.status.to_string(),
             message: format!("{:?}", response.errors.first().unwrap_or(&default_error)),
-            reason: None,
+            reason: Some(format!("{:?}", response.errors)),
         })
     }
 }
@@ -242,8 +242,12 @@ impl ConnectorIntegration<api::AccessTokenAuth, types::AccessTokenRequestData, t
         Ok(ErrorResponse {
             status_code: res.status_code,
             code: response.result_info.result_code.to_string(),
-            message: response.result_info.additional_info.unwrap_or_default(),
-            reason: None,
+            message: response
+                .result_info
+                .additional_info
+                .clone()
+                .unwrap_or_default(),
+            reason: response.result_info.additional_info,
         })
     }
 }
@@ -314,8 +318,8 @@ impl ConnectorIntegration<api::PSync, types::PaymentsSyncData, types::PaymentsRe
         Ok(ErrorResponse {
             status_code: res.status_code,
             code: response.status.to_string(),
-            message: response.payment_description,
-            reason: None,
+            message: response.payment_description.clone(),
+            reason: Some(response.payment_description),
         })
     }
 

--- a/crates/router/src/connector/trustpay/transformers.rs
+++ b/crates/router/src/connector/trustpay/transformers.rs
@@ -576,8 +576,10 @@ fn handle_cards_response(
             code: response
                 .payment_status
                 .unwrap_or_else(|| consts::NO_ERROR_CODE.to_string()),
-            message: msg.unwrap_or_else(|| consts::NO_ERROR_MESSAGE.to_string()),
-            reason: None,
+            message: msg
+                .clone()
+                .unwrap_or_else(|| consts::NO_ERROR_MESSAGE.to_string()),
+            reason: msg,
             status_code,
         })
     } else {
@@ -637,8 +639,9 @@ fn handle_bank_redirects_error_response(
         message: response
             .payment_result_info
             .additional_info
+            .clone()
             .unwrap_or_else(|| consts::NO_ERROR_MESSAGE.to_string()),
-        reason: None,
+        reason: response.payment_result_info.additional_info,
         status_code,
     });
     let payment_response_data = types::PaymentsResponseData::TransactionResponse {
@@ -673,8 +676,9 @@ fn handle_bank_redirects_sync_response(
             message: reason_info
                 .reason
                 .reject_reason
+                .clone()
                 .unwrap_or_else(|| consts::NO_ERROR_MESSAGE.to_string()),
-            reason: None,
+            reason: reason_info.reason.reject_reason,
             status_code,
         })
     } else {
@@ -800,8 +804,9 @@ impl<F, T> TryFrom<types::ResponseRouterData<F, TrustpayAuthUpdateResponse, T, t
                         .response
                         .result_info
                         .additional_info
+                        .clone()
                         .unwrap_or_else(|| consts::NO_ERROR_MESSAGE.to_string()),
-                    reason: None,
+                    reason: item.response.result_info.additional_info,
                     status_code: item.http_code,
                 }),
                 ..item.data
@@ -1068,8 +1073,10 @@ fn handle_cards_refund_response(
     let error = if msg.is_some() {
         Some(types::ErrorResponse {
             code: response.payment_status,
-            message: msg.unwrap_or_else(|| consts::NO_ERROR_MESSAGE.to_string()),
-            reason: None,
+            message: msg
+                .clone()
+                .unwrap_or_else(|| consts::NO_ERROR_MESSAGE.to_string()),
+            reason: msg,
             status_code,
         })
     } else {
@@ -1106,7 +1113,7 @@ fn handle_bank_redirects_refund_response(
         Some(types::ErrorResponse {
             code: response.result_info.result_code.to_string(),
             message: msg.unwrap_or(consts::NO_ERROR_MESSAGE).to_owned(),
-            reason: None,
+            reason: msg.map(|message| message.to_string()),
             status_code,
         })
     } else {
@@ -1134,8 +1141,9 @@ fn handle_bank_redirects_refund_sync_response(
             message: reason_info
                 .reason
                 .reject_reason
+                .clone()
                 .unwrap_or_else(|| consts::NO_ERROR_MESSAGE.to_string()),
-            reason: None,
+            reason: reason_info.reason.reject_reason,
             status_code,
         })
     } else {
@@ -1157,8 +1165,9 @@ fn handle_bank_redirects_refund_sync_error_response(
         message: response
             .payment_result_info
             .additional_info
+            .clone()
             .unwrap_or_else(|| consts::NO_ERROR_MESSAGE.to_owned()),
-        reason: None,
+        reason: response.payment_result_info.additional_info,
         status_code,
     });
     //unreachable case as we are sending error as Some()


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
After #1440, we are sending reason as error_message in payments response. Added valid reason for all the error responses. 


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
Tested manually

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
