### PR TITLE
refactor: make bank names optional in payment method data

### DIFF
--- a/crates/api_models/src/payments.rs
+++ b/crates/api_models/src/payments.rs
@@ -621,10 +621,10 @@ impl From<&PaymentMethodData> for AdditionalPaymentData {
             },
             PaymentMethodData::BankRedirect(bank_redirect_data) => match bank_redirect_data {
                 BankRedirectData::Eps { bank_name, .. } => Self::BankRedirect {
-                    bank_name: Some(bank_name.to_owned()),
+                    bank_name: bank_name.to_owned(),
                 },
                 BankRedirectData::Ideal { bank_name, .. } => Self::BankRedirect {
-                    bank_name: Some(bank_name.to_owned()),
+                    bank_name: bank_name.to_owned(),
                 },
                 _ => Self::BankRedirect { bank_name: None },
             },
@@ -670,7 +670,7 @@ pub enum BankRedirectData {
 
         /// The hyperswitch bank code for eps
         #[schema(value_type = BankNames, example = "triodos_bank")]
-        bank_name: api_enums::BankNames,
+        bank_name: Option<api_enums::BankNames>,
     },
     Giropay {
         /// The billing details for bank redirection
@@ -691,7 +691,7 @@ pub enum BankRedirectData {
 
         /// The hyperswitch bank code for ideal
         #[schema(value_type = BankNames, example = "abn_amro")]
-        bank_name: api_enums::BankNames,
+        bank_name: Option<api_enums::BankNames>,
     },
     Interac {
         /// The country for bank payment

--- a/crates/router/src/connector/aci/transformers.rs
+++ b/crates/router/src/connector/aci/transformers.rs
@@ -212,7 +212,8 @@ impl TryFrom<&types::PaymentsAuthorizeRouterData> for AciPaymentsRequest {
                         PaymentDetails::BankRedirect(Box::new(BankRedirectionPMData {
                             payment_brand: PaymentBrand::Ideal,
                             bank_account_country: Some(api_models::enums::CountryAlpha2::NL),
-                            bank_account_bank_name: Some(bank_name.to_string()),
+                            bank_account_bank_name: bank_name
+                                .map(|bank_name| bank_name.to_string()),
                             bank_account_bic: None,
                             bank_account_iban: None,
                             billing_country: None,

--- a/crates/router/src/connector/adyen/transformers.rs
+++ b/crates/router/src/connector/adyen/transformers.rs
@@ -539,7 +539,7 @@ pub struct BankRedirectionPMData {
 pub struct BankRedirectionWithIssuer<'a> {
     #[serde(rename = "type")]
     payment_type: PaymentType,
-    issuer: &'a str,
+    issuer: Option<&'a str>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -1188,7 +1188,10 @@ impl<'a> TryFrom<&api_models::payments::BankRedirectData> for AdyenPaymentMethod
             api_models::payments::BankRedirectData::Eps { bank_name, .. } => Ok(
                 AdyenPaymentMethod::Eps(Box::new(BankRedirectionWithIssuer {
                     payment_type: PaymentType::Eps,
-                    issuer: AdyenTestBankNames::try_from(bank_name)?.0,
+                    issuer: bank_name
+                        .map(|bank_name| AdyenTestBankNames::try_from(&bank_name))
+                        .transpose()?
+                        .map(|adyen_bank_name| adyen_bank_name.0),
                 })),
             ),
             api_models::payments::BankRedirectData::Giropay { .. } => Ok(
@@ -1199,7 +1202,10 @@ impl<'a> TryFrom<&api_models::payments::BankRedirectData> for AdyenPaymentMethod
             api_models::payments::BankRedirectData::Ideal { bank_name, .. } => Ok(
                 AdyenPaymentMethod::Ideal(Box::new(BankRedirectionWithIssuer {
                     payment_type: PaymentType::Ideal,
-                    issuer: AdyenTestBankNames::try_from(bank_name)?.0,
+                    issuer: bank_name
+                        .map(|bank_name| AdyenTestBankNames::try_from(&bank_name))
+                        .transpose()?
+                        .map(|adyen_bank_name| adyen_bank_name.0),
                 })),
             ),
             api_models::payments::BankRedirectData::OnlineBankingCzechRepublic { issuer } => {

--- a/crates/router/src/connector/nexinets/transformers.rs
+++ b/crates/router/src/connector/nexinets/transformers.rs
@@ -103,7 +103,7 @@ pub enum RecurringType {
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct NexinetsBankRedirects {
-    bic: NexinetsBIC,
+    bic: Option<NexinetsBIC>,
 }
 
 #[derive(Debug, Serialize)]
@@ -578,7 +578,9 @@ fn get_payment_details_and_product(
             api_models::payments::BankRedirectData::Ideal { bank_name, .. } => Ok((
                 Some(NexinetsPaymentDetails::BankRedirects(Box::new(
                     NexinetsBankRedirects {
-                        bic: NexinetsBIC::try_from(bank_name)?,
+                        bic: bank_name
+                            .map(|bank_name| NexinetsBIC::try_from(&bank_name))
+                            .transpose()?,
                     },
                 ))),
                 NexinetsProduct::Ideal,

--- a/crates/router/src/connector/nuvei/transformers.rs
+++ b/crates/router/src/connector/nuvei/transformers.rs
@@ -549,7 +549,7 @@ impl<F>
                         email: item.request.get_email()?,
                         country: item.get_billing_country()?,
                     }),
-                    Some(NuveiBIC::try_from(bank_name)?),
+                    bank_name.map(NuveiBIC::try_from).transpose()?,
                 )
             }
             _ => Err(errors::ConnectorError::NotSupported {

--- a/crates/router/src/connector/stripe/transformers.rs
+++ b/crates/router/src/connector/stripe/transformers.rs
@@ -216,15 +216,15 @@ pub struct ChargesResponse {
 pub enum StripeBankName {
     Eps {
         #[serde(rename = "payment_method_data[eps][bank]")]
-        bank_name: StripeBankNames,
+        bank_name: Option<StripeBankNames>,
     },
     Ideal {
         #[serde(rename = "payment_method_data[ideal][bank]")]
-        ideal_bank_name: StripeBankNames,
+        ideal_bank_name: Option<StripeBankNames>,
     },
     Przelewy24 {
         #[serde(rename = "payment_method_data[p24][bank]")]
-        bank_name: StripeBankNames,
+        bank_name: Option<StripeBankNames>,
     },
 }
 
@@ -248,23 +248,25 @@ fn get_bank_name(
             StripePaymentMethodType::Eps,
             api_models::payments::BankRedirectData::Eps { ref bank_name, .. },
         ) => Ok(Some(StripeBankName::Eps {
-            bank_name: StripeBankNames::try_from(bank_name)?,
+            bank_name: bank_name
+                .map(|bank_name| StripeBankNames::try_from(&bank_name))
+                .transpose()?,
         })),
         (
             StripePaymentMethodType::Ideal,
             api_models::payments::BankRedirectData::Ideal { bank_name, .. },
         ) => Ok(Some(StripeBankName::Ideal {
-            ideal_bank_name: StripeBankNames::try_from(bank_name)?,
+            ideal_bank_name: bank_name
+                .map(|bank_name| StripeBankNames::try_from(&bank_name))
+                .transpose()?,
         })),
         (
             StripePaymentMethodType::Przelewy24,
             api_models::payments::BankRedirectData::Przelewy24 { bank_name, .. },
         ) => Ok(Some(StripeBankName::Przelewy24 {
-            bank_name: StripeBankNames::try_from(&bank_name.ok_or(
-                errors::ConnectorError::MissingRequiredField {
-                    field_name: "bank_name",
-                },
-            )?)?,
+            bank_name: bank_name
+                .map(|bank_name| StripeBankNames::try_from(&bank_name))
+                .transpose()?,
         })),
         (
             StripePaymentMethodType::Sofort

--- a/crates/router/src/connector/worldline/transformers.rs
+++ b/crates/router/src/connector/worldline/transformers.rs
@@ -133,7 +133,7 @@ pub struct Giropay {
 #[derive(Debug, Serialize)]
 pub struct Ideal {
     #[serde(rename = "issuerId")]
-    pub issuer_id: WorldlineBic,
+    pub issuer_id: Option<WorldlineBic>,
 }
 
 #[derive(Debug, Serialize)]
@@ -322,7 +322,9 @@ fn make_bank_redirect_request(
         payments::BankRedirectData::Ideal { bank_name, .. } => (
             {
                 PaymentMethodSpecificData::PaymentProduct809SpecificInput(Box::new(Ideal {
-                    issuer_id: WorldlineBic::try_from(bank_name)?,
+                    issuer_id: bank_name
+                        .map(|bank_name| WorldlineBic::try_from(&bank_name))
+                        .transpose()?,
                 }))
             },
             809,

--- a/crates/router/src/core/payments/operations/payment_create.rs
+++ b/crates/router/src/core/payments/operations/payment_create.rs
@@ -464,7 +464,11 @@ impl<F: Send + Clone> ValidateRequest<F, api::PaymentsRequest> for PaymentCreate
                 request.shipping.is_some(),
                 request.billing.is_some(),
                 request.setup_future_usage.is_some(),
-                &request.customer_id,
+                &request
+                    .customer
+                    .clone()
+                    .map(|customer| customer.id)
+                    .or(request.customer_id.clone()),
             )?;
         }
 


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Refactoring

## Description
<!-- Describe your changes in detail -->
This PR will make the bank names as optional in the payment method data. This is required for trustpay as it does not accept any bank names in the payments request. Previously if bank names are not passed, then it would throw 400 bad request with missing required field of bank names, which will no more be the case.


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
Allow for bank redirect payment method to work for trustpay.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
- Create a payment of bank redirect payment with stripe without bank names - should succeed.
```json
{
    "payment_method": "bank_redirect",
    "payment_method_type": "eps",
    "payment_method_data": {
        "bank_redirect": {
            "eps": {
                "billing_details": {

                }
            }
        }
    }
}
```

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
