### PR TITLE
ci(postman-collection-runner): remove duplicate `workflow_dispatch` trigger

### DIFF
--- a/.github/workflows/postman-collection-runner.yml
+++ b/.github/workflows/postman-collection-runner.yml
@@ -2,11 +2,8 @@ name: Postman Collection API test
 
 on:
   workflow_dispatch:
-
   schedule:
-    # Run workflow at 6 AM and 6 PM IST
-    - cron: "30 0,12 * * *"
-  workflow_dispatch:
+    - cron: '30 0,12 * * *' # Run workflow at 6 AM and 6 PM IST
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [x] CI/CD

## Description
<!-- Describe your changes in detail -->
This PR aims at fixing the scheduling of `postman-collection-runner.yml`. The action is expected to run at 6AM and 6PM everyday with an additional option to run whenever needed manually. I believe, at the time of merge changes on the local branch have made a duplicate of `workflow_dispatch` command which is unexpected and have been fixed.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
This PR aims to fix a bug! Killing bugs are a motivation.


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
A tester cannot be tested. However, tried running the action on my private repo through workflow_dispatch, it worked until it failed without any secrets and collections given to it.


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I reviewed submitted code
