### PR TITLE
perf(logging): remove redundant heap allocation present in the logging framework

### DIFF
--- a/crates/router_env/src/logger/formatter.rs
+++ b/crates/router_env/src/logger/formatter.rs
@@ -205,13 +205,14 @@ where
         map_serializer.serialize_entry(VERSION, &self.version)?;
         #[cfg(feature = "vergen")]
         map_serializer.serialize_entry(BUILD, &self.build)?;
-        map_serializer.serialize_entry(LEVEL, &format!("{}", metadata.level()))?;
+        map_serializer.serialize_entry(LEVEL, &format_args!("{}", metadata.level()))?;
         map_serializer.serialize_entry(TARGET, metadata.target())?;
         map_serializer.serialize_entry(SERVICE, &self.service)?;
         map_serializer.serialize_entry(LINE, &metadata.line())?;
         map_serializer.serialize_entry(FILE, &metadata.file())?;
         map_serializer.serialize_entry(FN, name)?;
-        map_serializer.serialize_entry(FULL_NAME, &format!("{}::{}", metadata.target(), name))?;
+        map_serializer
+            .serialize_entry(FULL_NAME, &format_args!("{}::{}", metadata.target(), name))?;
         if let Ok(time) = &time::OffsetDateTime::now_utc().format(&Iso8601::DEFAULT) {
             map_serializer.serialize_entry(TIME, time)?;
         }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [X] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
Updated macro invocation from the format! to format_args! 


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
[1293](https://github.com/juspay/hyperswitch/issues/1293)


## How did you test it?

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [X] I formatted the code `cargo +nightly fmt --all`
- [X] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
