### PR TITLE
feat(connector): [stripe] webhooks for refund

### DIFF
--- a/crates/api_models/src/webhooks.rs
+++ b/crates/api_models/src/webhooks.rs
@@ -41,21 +41,22 @@ pub enum WebhookFlow {
 impl From<IncomingWebhookEvent> for WebhookFlow {
     fn from(evt: IncomingWebhookEvent) -> Self {
         match evt {
-            IncomingWebhookEvent::PaymentIntentFailure => Self::Payment,
-            IncomingWebhookEvent::PaymentIntentSuccess => Self::Payment,
-            IncomingWebhookEvent::PaymentIntentProcessing => Self::Payment,
-            IncomingWebhookEvent::PaymentActionRequired => Self::Payment,
-            IncomingWebhookEvent::PaymentIntentPartiallyFunded => Self::Payment,
+            IncomingWebhookEvent::PaymentIntentFailure
+            | IncomingWebhookEvent::PaymentIntentSuccess
+            | IncomingWebhookEvent::PaymentIntentProcessing
+            | IncomingWebhookEvent::PaymentActionRequired
+            | IncomingWebhookEvent::PaymentIntentPartiallyFunded => Self::Payment,
             IncomingWebhookEvent::EventNotSupported => Self::ReturnResponse,
-            IncomingWebhookEvent::RefundSuccess => Self::Refund,
-            IncomingWebhookEvent::RefundFailure => Self::Refund,
-            IncomingWebhookEvent::DisputeOpened => Self::Dispute,
-            IncomingWebhookEvent::DisputeAccepted => Self::Dispute,
-            IncomingWebhookEvent::DisputeExpired => Self::Dispute,
-            IncomingWebhookEvent::DisputeCancelled => Self::Dispute,
-            IncomingWebhookEvent::DisputeChallenged => Self::Dispute,
-            IncomingWebhookEvent::DisputeWon => Self::Dispute,
-            IncomingWebhookEvent::DisputeLost => Self::Dispute,
+            IncomingWebhookEvent::RefundSuccess | IncomingWebhookEvent::RefundFailure => {
+                Self::Refund
+            }
+            IncomingWebhookEvent::DisputeOpened
+            | IncomingWebhookEvent::DisputeAccepted
+            | IncomingWebhookEvent::DisputeExpired
+            | IncomingWebhookEvent::DisputeCancelled
+            | IncomingWebhookEvent::DisputeChallenged
+            | IncomingWebhookEvent::DisputeWon
+            | IncomingWebhookEvent::DisputeLost => Self::Dispute,
             IncomingWebhookEvent::EndpointVerification => Self::ReturnResponse,
             IncomingWebhookEvent::SourceChargeable
             | IncomingWebhookEvent::SourceTransactionCreated => Self::BankTransfer,

--- a/crates/router/src/connector/stripe.rs
+++ b/crates/router/src/connector/stripe.rs
@@ -1730,6 +1730,13 @@ impl api::IncomingWebhook for Stripe {
                     ),
                 )
             }
+            stripe::WebhookEventObjectType::Refund => {
+                api_models::webhooks::ObjectReferenceId::RefundId(
+                    api_models::webhooks::RefundIdType::ConnectorRefundId(
+                        details.event_data.event_object.id,
+                    ),
+                )
+            }
         })
     }
 
@@ -1739,7 +1746,7 @@ impl api::IncomingWebhook for Stripe {
     ) -> CustomResult<api::IncomingWebhookEvent, errors::ConnectorError> {
         let details: stripe::WebhookEventTypeBody = request
             .body
-            .parse_struct("WebhookEvent")
+            .parse_struct("WebhookEventTypeBody")
             .change_context(errors::ConnectorError::WebhookReferenceIdNotFound)?;
 
         Ok(match details.event_type {
@@ -1759,6 +1766,18 @@ impl api::IncomingWebhook for Stripe {
                     api::IncomingWebhookEvent::EventNotSupported
                 }
             }
+            stripe::WebhookEventType::ChargeRefundUpdated => details
+                .event_data
+                .event_object
+                .status
+                .map(|status| match status {
+                    stripe::WebhookEventStatus::Succeeded => {
+                        api::IncomingWebhookEvent::RefundSuccess
+                    }
+                    stripe::WebhookEventStatus::Failed => api::IncomingWebhookEvent::RefundFailure,
+                    _ => api::IncomingWebhookEvent::EventNotSupported,
+                })
+                .unwrap_or(api::IncomingWebhookEvent::EventNotSupported),
             stripe::WebhookEventType::SourceChargeable => {
                 api::IncomingWebhookEvent::SourceChargeable
             }
@@ -1785,7 +1804,7 @@ impl api::IncomingWebhook for Stripe {
             | stripe::WebhookEventType::ChargeFailed
             | stripe::WebhookEventType::ChargePending
             | stripe::WebhookEventType::ChargeUpdated
-            | stripe::WebhookEventType::ChanrgeRefunded
+            | stripe::WebhookEventType::ChargeRefunded
             | stripe::WebhookEventType::PaymentIntentCanceled
             | stripe::WebhookEventType::PaymentIntentCreated
             | stripe::WebhookEventType::PaymentIntentProcessing

--- a/crates/router/src/connector/stripe/transformers.rs
+++ b/crates/router/src/connector/stripe/transformers.rs
@@ -569,6 +569,7 @@ pub enum StripeBankNames {
     Boz,
 }
 
+// This is used only for Disputes
 impl From<WebhookEventStatus> for api_models::webhooks::IncomingWebhookEvent {
     fn from(value: WebhookEventStatus) -> Self {
         match value {
@@ -588,6 +589,7 @@ impl From<WebhookEventStatus> for api_models::webhooks::IncomingWebhookEvent {
             | WebhookEventStatus::RequiresCapture
             | WebhookEventStatus::Canceled
             | WebhookEventStatus::Chargeable
+            | WebhookEventStatus::Failed
             | WebhookEventStatus::Unknown => Self::EventNotSupported,
         }
     }
@@ -2369,6 +2371,7 @@ pub enum WebhookEventObjectType {
     Dispute,
     Charge,
     Source,
+    Refund,
 }
 
 #[derive(Debug, Deserialize)]
@@ -2397,12 +2400,14 @@ pub enum WebhookEventType {
     ChargePending,
     #[serde(rename = "charge.captured")]
     ChargeCaptured,
+    #[serde(rename = "charge.refund.updated")]
+    ChargeRefundUpdated,
     #[serde(rename = "charge.succeeded")]
     ChargeSucceeded,
     #[serde(rename = "charge.updated")]
     ChargeUpdated,
     #[serde(rename = "charge.refunded")]
-    ChanrgeRefunded,
+    ChargeRefunded,
     #[serde(rename = "payment_intent.canceled")]
     PaymentIntentCanceled,
     #[serde(rename = "payment_intent.created")]
@@ -2442,6 +2447,7 @@ pub enum WebhookEventStatus {
     RequiresCapture,
     Canceled,
     Chargeable,
+    Failed,
     #[serde(other)]
     Unknown,
 }

--- a/crates/router/src/core/webhooks.rs
+++ b/crates/router/src/core/webhooks.rs
@@ -115,29 +115,27 @@ pub async fn refunds_incoming_webhook_flow<W: api::OutgoingWebhookType>(
     let db = &*state.store;
     //find refund by connector refund id
     let refund = match webhook_details.object_reference_id {
-        api_models::webhooks::ObjectReferenceId::RefundId(
-            api_models::webhooks::RefundIdType::ConnectorRefundId(id),
-        ) => db
-            .find_refund_by_merchant_id_connector_refund_id_connector(
-                &merchant_account.merchant_id,
-                &id,
-                connector_name,
-                merchant_account.storage_scheme,
-            )
-            .await
-            .change_context(errors::ApiErrorResponse::WebhookResourceNotFound)
-            .attach_printable_lazy(|| "Failed fetching the refund")?,
-        api_models::webhooks::ObjectReferenceId::RefundId(
-            api_models::webhooks::RefundIdType::RefundId(id),
-        ) => db
-            .find_refund_by_merchant_id_refund_id(
-                &merchant_account.merchant_id,
-                &id,
-                merchant_account.storage_scheme,
-            )
-            .await
-            .change_context(errors::ApiErrorResponse::WebhookResourceNotFound)
-            .attach_printable_lazy(|| "Failed fetching the refund")?,
+        api_models::webhooks::ObjectReferenceId::RefundId(refund_id_type) => match refund_id_type {
+            api_models::webhooks::RefundIdType::RefundId(id) => db
+                .find_refund_by_merchant_id_refund_id(
+                    &merchant_account.merchant_id,
+                    &id,
+                    merchant_account.storage_scheme,
+                )
+                .await
+                .change_context(errors::ApiErrorResponse::WebhookResourceNotFound)
+                .attach_printable_lazy(|| "Failed fetching the refund")?,
+            api_models::webhooks::RefundIdType::ConnectorRefundId(id) => db
+                .find_refund_by_merchant_id_connector_refund_id_connector(
+                    &merchant_account.merchant_id,
+                    &id,
+                    connector_name,
+                    merchant_account.storage_scheme,
+                )
+                .await
+                .change_context(errors::ApiErrorResponse::WebhookResourceNotFound)
+                .attach_printable_lazy(|| "Failed fetching the refund")?,
+        },
         _ => Err(errors::ApiErrorResponse::WebhookProcessingFailure)
             .into_report()
             .attach_printable("received a non-refund id when processing refund webhooks")?,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] New feature

## Description
<!-- Describe your changes in detail -->
Refunds are asynchronous: a refund can appear to succeed and later fail, or can appear as pending at first and later succeed. 
Whenever a refund is made for a payment, it can be in pending or failed or succeeded which is not the final state, stripe send `charge.refund.updated` event type, whenever a refund is updated.This `charge.refund.updated` has refund object type containing `refund_id` which uniquely identifies a refund.Whenever we get this event type, we can update the status in our system and webhooks can be triggered to the merchant.

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
Support for refund webhooks

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Using this test cards
![Screen Shot 2023-06-20 at 8 53 12 PM](https://github.com/juspay/hyperswitch/assets/59434228/2cd7d49a-7b77-4adc-ab04-5aba864301f4)

* Test for succesful refund

![Screen Shot 2023-06-20 at 8 41 53 PM](https://github.com/juspay/hyperswitch/assets/59434228/300a0254-ac58-4e10-9ee3-03d76b24e71c)
<img width="1260" alt="Screen Shot 2023-06-20 at 8 39 20 PM" src="https://github.com/juspay/hyperswitch/assets/59434228/9c7413be-6d77-482a-a306-32f9f90f763f">

*  Test for failed refund

Initially got success for refund

<img width="1264" alt="Screen Shot 2023-06-20 at 8 40 19 PM" src="https://github.com/juspay/hyperswitch/assets/59434228/ea821df5-49dc-40ac-abf6-9624da474bd5">

Webhooks for it :
![Screen Shot 2023-06-20 at 8 40 34 PM](https://github.com/juspay/hyperswitch/assets/59434228/81cdec34-57cf-4590-b1e9-916cf49f6001)

Retrieve :
<img width="1274" alt="Screen Shot 2023-06-20 at 8 40 52 PM" src="https://github.com/juspay/hyperswitch/assets/59434228/b9d1243a-a4a6-458a-aa5d-17f9f0e908dc">



## Checklist


<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
