### PR TITLE
fix: invalidate all cache on invalidate cache route

### DIFF
--- a/crates/router/src/cache.rs
+++ b/crates/router/src/cache.rs
@@ -14,6 +14,9 @@ const CONFIG_CACHE_PREFIX: &str = "config";
 /// Prefix for accounts cache key
 const ACCOUNTS_CACHE_PREFIX: &str = "accounts";
 
+/// Prefix for all kinds of cache key
+const ALL_CACHE_PREFIX: &str = "all_cache_kind";
+
 /// Time to live 30 mins
 const CACHE_TTL: u64 = 30 * 60;
 
@@ -38,6 +41,7 @@ pub trait Cacheable: Any + Send + Sync + DynClone {
 pub enum CacheKind<'a> {
     Config(Cow<'a, str>),
     Accounts(Cow<'a, str>),
+    All(Cow<'a, str>),
 }
 
 impl<'a> From<CacheKind<'a>> for RedisValue {
@@ -45,6 +49,7 @@ impl<'a> From<CacheKind<'a>> for RedisValue {
         let value = match kind {
             CacheKind::Config(s) => format!("{CONFIG_CACHE_PREFIX},{s}"),
             CacheKind::Accounts(s) => format!("{ACCOUNTS_CACHE_PREFIX},{s}"),
+            CacheKind::All(s) => format!("{ALL_CACHE_PREFIX},{s}"),
         };
         Self::from_string(value)
     }
@@ -61,6 +66,7 @@ impl<'a> TryFrom<RedisValue> for CacheKind<'a> {
         match split.0 {
             ACCOUNTS_CACHE_PREFIX => Ok(Self::Accounts(Cow::Owned(split.1.to_string()))),
             CONFIG_CACHE_PREFIX => Ok(Self::Config(Cow::Owned(split.1.to_string()))),
+            ALL_CACHE_PREFIX => Ok(Self::All(Cow::Owned(split.1.to_string()))),
             _ => Err(validation_err.into()),
         }
     }

--- a/crates/router/src/core/cache.rs
+++ b/crates/router/src/core/cache.rs
@@ -16,7 +16,7 @@ pub async fn invalidate(
         .await
         .change_context(errors::ApiErrorResponse::InternalServerError)?;
 
-    // If the message was published to 1 or more than channels
+    // If the message was published to atleast one channel
     // then return status Ok
     if result > 0 {
         Ok(services::api::ApplicationResponse::StatusOk)

--- a/crates/router/src/core/cache.rs
+++ b/crates/router/src/core/cache.rs
@@ -16,6 +16,8 @@ pub async fn invalidate(
         .await
         .change_context(errors::ApiErrorResponse::InternalServerError)?;
 
+    // If the message was published to 1 or more than channels
+    // then return status Ok
     if result > 0 {
         Ok(services::api::ApplicationResponse::StatusOk)
     } else {

--- a/crates/router/src/core/cache.rs
+++ b/crates/router/src/core/cache.rs
@@ -1,10 +1,10 @@
 use common_utils::errors::CustomResult;
-use redis_interface::DelReply;
+use error_stack::{report, ResultExt};
 
 use super::errors;
 use crate::{
-    cache::{ACCOUNTS_CACHE, CONFIG_CACHE},
-    db::StorageInterface,
+    cache::CacheKind,
+    db::{cache::publish_into_redact_channel, StorageInterface},
     services,
 };
 
@@ -12,14 +12,14 @@ pub async fn invalidate(
     store: &dyn StorageInterface,
     key: &str,
 ) -> CustomResult<services::api::ApplicationResponse<serde_json::Value>, errors::ApiErrorResponse> {
-    CONFIG_CACHE.remove(key).await;
-    ACCOUNTS_CACHE.remove(key).await;
+    let result = publish_into_redact_channel(store, CacheKind::All(key.into()))
+        .await
+        .change_context(errors::ApiErrorResponse::InternalServerError)?;
 
-    match store.get_redis_conn().delete_key(key).await {
-        Ok(DelReply::KeyDeleted) => Ok(services::api::ApplicationResponse::StatusOk),
-        Ok(DelReply::KeyNotDeleted) => Err(errors::ApiErrorResponse::InvalidRequestUrl.into()),
-        Err(error) => Err(error
-            .change_context(errors::ApiErrorResponse::InternalServerError)
-            .attach_printable("Failed to invalidate cache")),
+    if result > 0 {
+        Ok(services::api::ApplicationResponse::StatusOk)
+    } else {
+        Err(report!(errors::ApiErrorResponse::InternalServerError)
+            .attach_printable("Failed to invalidate cache"))
     }
 }

--- a/crates/router/src/db/cache.rs
+++ b/crates/router/src/db/cache.rs
@@ -1,7 +1,7 @@
 use common_utils::ext_traits::AsyncExt;
 use error_stack::ResultExt;
 
-use super::Store;
+use super::StorageInterface;
 use crate::{
     cache::{self, Cacheable},
     consts,
@@ -10,7 +10,7 @@ use crate::{
 };
 
 pub async fn get_or_populate_redis<T, F, Fut>(
-    store: &Store,
+    store: &dyn StorageInterface,
     key: &str,
     fun: F,
 ) -> CustomResult<T, errors::StorageError>
@@ -20,9 +20,7 @@ where
     Fut: futures::Future<Output = CustomResult<T, errors::StorageError>> + Send,
 {
     let type_name = std::any::type_name::<T>();
-    let redis = &store
-        .redis_conn()
-        .map_err(Into::<errors::StorageError>::into)?;
+    let redis = &store.get_redis_conn();
     let redis_val = redis.get_and_deserialize_key::<T>(key, type_name).await;
     let get_data_set_redis = || async {
         let data = fun().await?;
@@ -46,7 +44,7 @@ where
 }
 
 pub async fn get_or_populate_in_memory<T, F, Fut>(
-    store: &Store,
+    store: &dyn StorageInterface,
     key: &str,
     fun: F,
     cache: &cache::Cache,
@@ -67,7 +65,7 @@ where
 }
 
 pub async fn redact_cache<T, F, Fut>(
-    store: &Store,
+    store: &dyn StorageInterface,
     key: &str,
     fun: F,
     in_memory: Option<&cache::Cache>,
@@ -79,16 +77,26 @@ where
     let data = fun().await?;
     in_memory.async_map(|cache| cache.invalidate(key)).await;
     store
-        .redis_conn()
-        .map_err(Into::<errors::StorageError>::into)?
+        .get_redis_conn()
         .delete_key(key)
         .await
         .change_context(errors::StorageError::KVError)?;
     Ok(data)
 }
 
+pub async fn publish_into_redact_channel<'a>(
+    store: &dyn StorageInterface,
+    key: cache::CacheKind<'a>,
+) -> CustomResult<usize, errors::StorageError> {
+    store
+        .get_redis_conn()
+        .publish(consts::PUB_SUB_CHANNEL, key)
+        .await
+        .change_context(errors::StorageError::KVError)
+}
+
 pub async fn publish_and_redact<'a, T, F, Fut>(
-    store: &Store,
+    store: &dyn StorageInterface,
     key: cache::CacheKind<'a>,
     fun: F,
 ) -> CustomResult<T, errors::StorageError>
@@ -97,11 +105,6 @@ where
     Fut: futures::Future<Output = CustomResult<T, errors::StorageError>> + Send,
 {
     let data = fun().await?;
-    store
-        .redis_conn()
-        .map_err(Into::<errors::StorageError>::into)?
-        .publish(consts::PUB_SUB_CHANNEL, key)
-        .await
-        .change_context(errors::StorageError::KVError)?;
+    publish_into_redact_channel(store, key).await?;
     Ok(data)
 }

--- a/crates/router/src/services.rs
+++ b/crates/router/src/services.rs
@@ -87,6 +87,11 @@ impl PubSubInterface for redis_interface::RedisConnectionPool {
                     ACCOUNTS_CACHE.invalidate(key.as_ref()).await;
                     key
                 }
+                CacheKind::All(key) => {
+                    CONFIG_CACHE.invalidate(key.as_ref()).await;
+                    ACCOUNTS_CACHE.invalidate(key.as_ref()).await;
+                    key
+                }
             };
 
             self.delete_key(key.as_ref())


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->
- [x] Enhancement

## Description
<!-- Describe your changes in detail -->
Publish the keys to redact cache channel in redis instead of using `.remove` directly. Providing a invalidate key will delete all the kinds of cache associated to that key, which are currently configs and accounts cache. This PR will create a pub-sub message to delete the cache on all pods.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
This will fix the inconsistent in memory cache across multiple pods

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Manual

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code