### PR TITLE
fix(process_tracker): log and ignore the duplicate entry error

### DIFF
--- a/crates/router/src/core/payments.rs
+++ b/crates/router/src/core/payments.rs
@@ -134,7 +134,9 @@ where
             operation
                 .to_domain()?
                 .add_task_to_process_tracker(state, &payment_data.payment_attempt)
-                .await?;
+                .await
+                .map_err(|error| logger::error!(process_tracker_error=?error))
+                .ok();
         }
 
         payment_data = match connector_details {


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix

## Description
<!-- Describe your changes in detail -->
If there is a bad request error during confirm, then the payment status is not changed. This will allow the confirm api to be called again with appropriate data. But when it is confirmed again, we get the process tracker duplicate entry, because a tracker has already been inserted in the previous step.


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
This will allow the payment to be confirmed if there is a bad request error.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
- Confirm a payment to get `MissingRequiredField` Error.
- Confirm the payment again with appropriate data.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
