### PR TITLE
fix(connector): [Braintree] Map `SubmittedForSettlement` status to `Pending` instead of `Charged`

### DIFF
--- a/crates/router/src/connector/braintree/transformers.rs
+++ b/crates/router/src/connector/braintree/transformers.rs
@@ -184,9 +184,7 @@ pub enum BraintreePaymentStatus {
 impl From<BraintreePaymentStatus> for enums::AttemptStatus {
     fn from(item: BraintreePaymentStatus) -> Self {
         match item {
-            BraintreePaymentStatus::Succeeded
-            | BraintreePaymentStatus::SubmittedForSettlement
-            | BraintreePaymentStatus::Settling => Self::Charged,
+            BraintreePaymentStatus::Succeeded | BraintreePaymentStatus::Settling => Self::Charged,
             BraintreePaymentStatus::AuthorizedExpired => Self::AuthorizationFailed,
             BraintreePaymentStatus::Failed
             | BraintreePaymentStatus::GatewayRejected


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix

## Description
<!-- Describe your changes in detail -->
`SubmittedForSettlement` in Braintree is set to `Pending` since it `SubmittedForSettlement` changes is a nightly process and takes time to finish the payment. Docs attached below:
- https://developer.paypal.com/braintree/docs/reference/general/statuses#submitted-for-settlement
- https://developer.paypal.com/braintree/docs/reference/general/testing#settlement-status

Only if the payment is successful (Settled) or failed (Declined), a webhook is sent from Braintree's end.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
This change is required as the connector returns the payment as succeeded instead of Processing / Pending. This does not allow the user to initiate a refund. Trying to do the same results in an error that states that the payment is still processing. Also, if the payment fails i.e., the payment status changes from `SubmittedForSettlement` to `Decline`, the user will still be showed as the payment in succeeded status itself and not as failure.


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Manually


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
