### PR TITLE
fix(connector): [Trustpay] handle errors fields as optional in TrustpayErrorResponse object

### DIFF
--- a/crates/router/src/connector/trustpay.rs
+++ b/crates/router/src/connector/trustpay.rs
@@ -112,8 +112,16 @@ impl ConnectorCommon for Trustpay {
         Ok(ErrorResponse {
             status_code: res.status_code,
             code: response.status.to_string(),
-            message: format!("{:?}", response.errors.first().unwrap_or(&default_error)),
-            reason: Some(format!("{:?}", response.errors)),
+            message: format!(
+                "{:?}",
+                response
+                    .errors
+                    .as_ref()
+                    .unwrap_or(&vec![])
+                    .first()
+                    .unwrap_or(&default_error)
+            ),
+            reason: response.errors.map(|errors| format!("{:?}", errors)),
         })
     }
 }

--- a/crates/router/src/connector/trustpay/transformers.rs
+++ b/crates/router/src/connector/trustpay/transformers.rs
@@ -1290,7 +1290,7 @@ pub struct Errors {
 pub struct TrustpayErrorResponse {
     pub status: i64,
     pub description: Option<String>,
-    pub errors: Vec<Errors>,
+    pub errors: Option<Vec<Errors>>,
 }
 
 #[derive(Deserialize)]


### PR DESCRIPTION
…ayErrorResponse object

## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
TrustpayErrorResponse object has errors as a mandatory field but the connector is returning errors fields as an optional field in error response.
Ref Doc: https://doc.trustpay.eu/aapi#tpgw-s2s-response-failed


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<img width="1295" alt="Screen Shot 2023-06-22 at 6 48 06 PM" src="https://github.com/juspay/hyperswitch/assets/20727986/b1614e8e-c1bf-46e7-88ad-9e883f2baba7">



## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
