### PR TITLE
fix: revert commit a610f23

### DIFF
--- a/crates/router/src/types.rs
+++ b/crates/router/src/types.rs
@@ -825,7 +825,7 @@ impl RequestBody {
         F: FnOnce(T) -> errors::CustomResult<String, errors::ParsingError>,
         T: std::fmt::Debug,
     {
-        router_env::logger::info!(connector_request_body=?body);
+        router_env::logger::info!(connector_request=?body);
         Ok(Self(Secret::new(encoder(body)?)))
     }
     pub fn get_inner_value(request_body: Self) -> Secret<String> {


### PR DESCRIPTION
This reverts commit a610f239377b87ade957c568c74b7fe7e91f88d2.

## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Reverting commit a610f23


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
