### PR TITLE
fix(connector): [TrustPay] change the request encoding

### DIFF
--- a/crates/router/src/connector/trustpay.rs
+++ b/crates/router/src/connector/trustpay.rs
@@ -202,7 +202,7 @@ impl ConnectorIntegration<api::AccessTokenAuth, types::AccessTokenRequestData, t
         let connector_req = trustpay::TrustpayAuthUpdateRequest::try_from(req)?;
         let trustpay_req = types::RequestBody::log_and_get_request_body(
             &connector_req,
-            utils::Encode::<trustpay::TrustpayAuthUpdateRequest>::encode_to_string_of_json,
+            utils::Encode::<trustpay::TrustpayAuthUpdateRequest>::url_encode,
         )
         .change_context(errors::ConnectorError::RequestEncodingFailed)?;
         Ok(Some(trustpay_req))
@@ -513,7 +513,7 @@ impl ConnectorIntegration<api::Authorize, types::PaymentsAuthorizeData, types::P
             }
             _ => types::RequestBody::log_and_get_request_body(
                 &connector_req,
-                utils::Encode::<trustpay::PaymentRequestCards>::encode_to_string_of_json,
+                utils::Encode::<trustpay::PaymentRequestCards>::url_encode,
             )
             .change_context(errors::ConnectorError::RequestEncodingFailed)?,
         };
@@ -617,7 +617,7 @@ impl ConnectorIntegration<api::Execute, types::RefundsData, types::RefundsRespon
             _ =>
                 types::RequestBody::log_and_get_request_body(
                     &connector_req,
-                    utils::Encode::<trustpay::TrustpayRefundRequestCards>::encode_to_string_of_json,
+                    utils::Encode::<trustpay::TrustpayRefundRequestCards>::url_encode,
                 )
                 .change_context(errors::ConnectorError::RequestEncodingFailed)?,
         };


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Change the encoding of the request body from string of json to url_encoded.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
TrustPay requires url_encoded data, in #1467 it got changed to string of json which is fixed in this PR

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [X] I formatted the code `cargo +nightly fmt --all`
- [X] I addressed lints thrown by `cargo clippy`
- [X] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
