### PR TITLE
feat(router): add `connector_transaction_id` in payments response

### DIFF
--- a/crates/api_models/src/payments.rs
+++ b/crates/api_models/src/payments.rs
@@ -1392,6 +1392,10 @@ pub struct PaymentsResponse {
     /// Any user defined fields can be passed here.
     #[schema(value_type = Option<Object>, example = r#"{ "udf1": "some-value", "udf2": "some-value" }"#)]
     pub udf: Option<pii::SecretSerdeValue>,
+
+    /// A unique identifier for a payment provided by the connector
+    #[schema(value_type = Option<String>, example = "993672945374576J")]
+    pub connector_transaction_id: Option<String>,
 }
 
 #[derive(Clone, Debug, serde::Deserialize, ToSchema)]

--- a/crates/router/src/core/payments/transformers.rs
+++ b/crates/router/src/core/payments/transformers.rs
@@ -465,6 +465,7 @@ where
                         )
                         .set_ephemeral_key(ephemeral_key_option.map(ForeignFrom::foreign_from))
                         .set_udf(payment_intent.udf)
+                        .set_connector_transaction_id(payment_attempt.connector_transaction_id)
                         .to_owned(),
                 )
             }
@@ -509,6 +510,7 @@ where
             metadata: payment_intent.metadata,
             order_details: payment_intent.order_details,
             udf: payment_intent.udf,
+            connector_transaction_id: payment_attempt.connector_transaction_id,
             ..Default::default()
         }),
     });


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
add `connector_transaction_id` in payments response

### Additional Changes
- [x] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.
Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->

## Motivation and Context 
Currently, in order to debug/validate the status at the connector, we require the `connector_transaction_id`, which is obtained from the payment_attempt table. However, on production, this process is not feasible. Moreover, for the sake of easier debugging, it would be beneficial to include the connector_transaction_id as part of the payments response

## How did you test it?
Payments response
![image](https://github.com/juspay/hyperswitch/assets/56996463/a94b7de2-fc09-43b6-8288-e32c2e744bc9)

## Checklist
<!-- Put an `x` in the boxes that apply -->
- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
