### PR TITLE
fix(redis) invoke redis_conn() method instead of cloning redis_conn property storage interface

### DIFF
--- a/crates/router/src/core/payment_methods/cards.rs
+++ b/crates/router/src/core/payment_methods/cards.rs
@@ -1614,7 +1614,12 @@ pub async fn list_customer_payment_method(
         };
         customer_pms.push(pma.to_owned());
 
-        let redis_conn = state.store.get_redis_conn();
+        let redis_conn = state
+            .store
+            .get_redis_conn()
+            .change_context(errors::ApiErrorResponse::InternalServerError)
+            .attach_printable("Failed to get redis connection")?;
+
         let key_for_hyperswitch_token = format!(
             "pm_token_{}_{}_hyperswitch",
             parent_payment_method_token, pma.payment_method

--- a/crates/router/src/core/payments.rs
+++ b/crates/router/src/core/payments.rs
@@ -898,7 +898,7 @@ async fn decide_payment_method_tokenize_action(
                 .get_redis_conn()
                 .change_context(errors::ApiErrorResponse::InternalServerError)
                 .attach_printable("Failed to get redis connection")?;
-            
+
             let key = format!(
                 "pm_token_{}_{}_{}",
                 token.to_owned(),

--- a/crates/router/src/core/payments.rs
+++ b/crates/router/src/core/payments.rs
@@ -893,7 +893,12 @@ async fn decide_payment_method_tokenize_action(
             }
         }
         Some(token) => {
-            let redis_conn = state.store.get_redis_conn();
+            let redis_conn = state
+                .store
+                .get_redis_conn()
+                .change_context(errors::ApiErrorResponse::InternalServerError)
+                .attach_printable("Failed to get redis connection")?;
+            
             let key = format!(
                 "pm_token_{}_{}_{}",
                 token.to_owned(),

--- a/crates/router/src/core/payments/helpers.rs
+++ b/crates/router/src/core/payments/helpers.rs
@@ -1173,7 +1173,7 @@ pub async fn make_pm_data<'a, F: Clone, R>(
             .get_redis_conn()
             .change_context(errors::ApiErrorResponse::InternalServerError)
             .attach_printable("Failed to get redis connection")?;
-        
+
         let key = format!(
             "pm_token_{}_{}_hyperswitch",
             token,

--- a/crates/router/src/core/payments/helpers.rs
+++ b/crates/router/src/core/payments/helpers.rs
@@ -1168,7 +1168,12 @@ pub async fn make_pm_data<'a, F: Clone, R>(
     let request = &payment_data.payment_method_data;
     let token = payment_data.token.clone();
     let hyperswitch_token = if let Some(token) = token {
-        let redis_conn = state.store.get_redis_conn();
+        let redis_conn = state
+            .store
+            .get_redis_conn()
+            .change_context(errors::ApiErrorResponse::InternalServerError)
+            .attach_printable("Failed to get redis connection")?;
+        
         let key = format!(
             "pm_token_{}_{}_hyperswitch",
             token,

--- a/crates/router/src/db.rs
+++ b/crates/router/src/db.rs
@@ -163,8 +163,13 @@ where
 }
 
 impl services::RedisConnInterface for MockDb {
-    fn get_redis_conn(&self) -> Arc<redis_interface::RedisConnectionPool> {
-        self.redis.clone()
+    fn get_redis_conn(
+        &self,
+    ) -> Result<
+        Arc<redis_interface::RedisConnectionPool>,
+        error_stack::Report<redis_interface::errors::RedisError>,
+    > {
+        Ok(self.redis.clone())
     }
 }
 

--- a/crates/router/src/routes/dummy_connector/errors.rs
+++ b/crates/router/src/routes/dummy_connector/errors.rs
@@ -29,6 +29,9 @@ pub enum DummyConnectorErrors {
 
     #[error(error_type = ErrorType::InvalidRequestError, code = "DC_06", message = "Payment is not successful")]
     PaymentNotSuccessful,
+
+    #[error(error_type = ErrorType::ServerNotAvailable, code = "DC_07", message = "Error occurred while fetching redis connection")]
+    RedisConnectionError,
 }
 
 impl core::fmt::Display for DummyConnectorErrors {
@@ -68,6 +71,9 @@ impl common_utils::errors::ErrorSwitch<api_models::errors::types::ApiErrorRespon
             }
             Self::PaymentNotSuccessful => {
                 AER::BadRequest(ApiError::new("DC", 6, self.error_message(), None))
+            }
+            Self::RedisConnectionError => {
+                AER::BadRequest(ApiError::new("DC", 7, self.error_message(), None))
             }
         }
     }

--- a/crates/router/src/routes/dummy_connector/utils.rs
+++ b/crates/router/src/routes/dummy_connector/utils.rs
@@ -43,7 +43,11 @@ pub async fn payment(
                         timestamp.to_owned(),
                         types::PaymentMethodType::Card,
                     );
-                    let redis_conn = state.store.get_redis_conn();
+                    let redis_conn = state
+                        .store
+                        .get_redis_conn()
+                        .change_context(errors::DummyConnectorErrors::RedisConnectionError)?;
+
                     store_data_in_redis(
                         redis_conn,
                         payment_id.to_owned(),
@@ -80,7 +84,11 @@ pub async fn payment_data(
     )
     .await;
 
-    let redis_conn = state.store.get_redis_conn();
+    let redis_conn = state
+        .store
+        .get_redis_conn()
+        .change_context(errors::DummyConnectorErrors::RedisConnectionError)?;
+
     let payment_data = redis_conn
         .get_and_deserialize_key::<types::DummyConnectorPaymentData>(
             payment_id.as_str(),
@@ -118,7 +126,11 @@ pub async fn refund_payment(
             field_name: "payment_id",
         })?;
 
-    let redis_conn = state.store.get_redis_conn();
+    let redis_conn = state
+        .store
+        .get_redis_conn()
+        .change_context(errors::DummyConnectorErrors::RedisConnectionError)?;
+
     let mut payment_data = redis_conn
         .get_and_deserialize_key::<types::DummyConnectorPaymentData>(
             payment_id.as_str(),
@@ -179,7 +191,11 @@ pub async fn refund_data(
     )
     .await;
 
-    let redis_conn = state.store.get_redis_conn();
+    let redis_conn = state
+        .store
+        .get_redis_conn()
+        .change_context(errors::DummyConnectorErrors::RedisConnectionError)?;
+
     let refund_data = redis_conn
         .get_and_deserialize_key::<types::DummyConnectorRefundResponse>(
             refund_id.as_str(),

--- a/crates/router/src/services.rs
+++ b/crates/router/src/services.rs
@@ -24,21 +24,21 @@ use crate::{
 
 #[async_trait::async_trait]
 pub trait PubSubInterface {
-    async fn subscribe(&self, channel: &str) -> errors::CustomResult<(), redis_errors::RedisError>;
+    async fn subscribe(&self, channel: &str) -> CustomResult<(), redis_errors::RedisError>;
 
     async fn publish<'a>(
         &self,
         channel: &str,
         key: CacheKind<'a>,
-    ) -> errors::CustomResult<usize, redis_errors::RedisError>;
+    ) -> CustomResult<usize, redis_errors::RedisError>;
 
-    async fn on_message(&self) -> errors::CustomResult<(), redis_errors::RedisError>;
+    async fn on_message(&self) -> CustomResult<(), redis_errors::RedisError>;
 }
 
 #[async_trait::async_trait]
 impl PubSubInterface for redis_interface::RedisConnectionPool {
     #[inline]
-    async fn subscribe(&self, channel: &str) -> errors::CustomResult<(), redis_errors::RedisError> {
+    async fn subscribe(&self, channel: &str) -> CustomResult<(), redis_errors::RedisError> {
         // Spawns a task that will automatically re-subscribe to any channels or channel patterns used by the client.
         self.subscriber.manage_subscriptions();
 
@@ -54,7 +54,7 @@ impl PubSubInterface for redis_interface::RedisConnectionPool {
         &self,
         channel: &str,
         key: CacheKind<'a>,
-    ) -> errors::CustomResult<usize, redis_errors::RedisError> {
+    ) -> CustomResult<usize, redis_errors::RedisError> {
         self.publisher
             .publish(channel, RedisValue::from(key).into_inner())
             .await
@@ -63,7 +63,7 @@ impl PubSubInterface for redis_interface::RedisConnectionPool {
     }
 
     #[inline]
-    async fn on_message(&self) -> errors::CustomResult<(), redis_errors::RedisError> {
+    async fn on_message(&self) -> CustomResult<(), redis_errors::RedisError> {
         logger::debug!("Started on message");
         let mut rx = self.subscriber.on_message();
         while let Ok(message) = rx.recv().await {
@@ -203,7 +203,7 @@ impl Store {
 
     pub fn redis_conn(
         &self,
-    ) -> errors::CustomResult<Arc<redis_interface::RedisConnectionPool>, redis_errors::RedisError>
+    ) -> CustomResult<Arc<redis_interface::RedisConnectionPool>, redis_errors::RedisError>
     {
         if self
             .redis_conn
@@ -221,7 +221,7 @@ impl Store {
         &self,
         redis_entry: storage_models::kv::TypedSql,
         partition_key: crate::utils::storage_partitioning::PartitionKey<'_>,
-    ) -> crate::core::errors::CustomResult<(), crate::core::errors::StorageError>
+    ) -> CustomResult<(), crate::core::errors::StorageError>
     where
         T: crate::utils::storage_partitioning::KvStorePartition,
     {
@@ -263,7 +263,7 @@ async fn get_master_enc_key(
 }
 
 #[inline]
-pub fn generate_aes256_key() -> errors::CustomResult<[u8; 32], common_utils::errors::CryptoError> {
+pub fn generate_aes256_key() -> CustomResult<[u8; 32], common_utils::errors::CryptoError> {
     use ring::rand::SecureRandom;
 
     let rng = ring::rand::SystemRandom::new();

--- a/crates/router/src/services.rs
+++ b/crates/router/src/services.rs
@@ -106,12 +106,22 @@ impl PubSubInterface for redis_interface::RedisConnectionPool {
 }
 
 pub trait RedisConnInterface {
-    fn get_redis_conn(&self) -> Arc<redis_interface::RedisConnectionPool>;
+    fn get_redis_conn(
+        &self,
+    ) -> Result<
+        Arc<redis_interface::RedisConnectionPool>,
+        error_stack::Report<redis_errors::RedisError>,
+    >;
 }
 
 impl RedisConnInterface for Store {
-    fn get_redis_conn(&self) -> Arc<redis_interface::RedisConnectionPool> {
-        self.redis_conn.clone()
+    fn get_redis_conn(
+        &self,
+    ) -> Result<
+        Arc<redis_interface::RedisConnectionPool>,
+        error_stack::Report<redis_errors::RedisError>,
+    > {
+        self.redis_conn()
     }
 }
 

--- a/crates/router/src/services.rs
+++ b/crates/router/src/services.rs
@@ -203,8 +203,7 @@ impl Store {
 
     pub fn redis_conn(
         &self,
-    ) -> CustomResult<Arc<redis_interface::RedisConnectionPool>, redis_errors::RedisError>
-    {
+    ) -> CustomResult<Arc<redis_interface::RedisConnectionPool>, redis_errors::RedisError> {
         if self
             .redis_conn
             .is_redis_available

--- a/crates/router/src/services.rs
+++ b/crates/router/src/services.rs
@@ -5,6 +5,7 @@ pub mod logger;
 
 use std::sync::{atomic, Arc};
 
+use common_utils::errors::CustomResult;
 use error_stack::{IntoReport, ResultExt};
 #[cfg(feature = "kms")]
 use external_services::kms;
@@ -108,19 +109,13 @@ impl PubSubInterface for redis_interface::RedisConnectionPool {
 pub trait RedisConnInterface {
     fn get_redis_conn(
         &self,
-    ) -> Result<
-        Arc<redis_interface::RedisConnectionPool>,
-        error_stack::Report<redis_errors::RedisError>,
-    >;
+    ) -> CustomResult<Arc<redis_interface::RedisConnectionPool>, errors::RedisError>;
 }
 
 impl RedisConnInterface for Store {
     fn get_redis_conn(
         &self,
-    ) -> Result<
-        Arc<redis_interface::RedisConnectionPool>,
-        error_stack::Report<redis_errors::RedisError>,
-    > {
+    ) -> CustomResult<Arc<redis_interface::RedisConnectionPool>, errors::RedisError> {
         self.redis_conn()
     }
 }

--- a/crates/router/tests/cache.rs
+++ b/crates/router/tests/cache.rs
@@ -16,13 +16,11 @@ async fn invalidate_existing_cache_success() {
 
     let cache_key = "cacheKey".to_string();
     let cache_key_value = "val".to_string();
-    let redis_conn = state
+    let _ = state
         .store
         .get_redis_conn()
-        .change_context(errors::ApiErrorResponse::InternalServerError)
-        .attach_printable("Failed to get redis connection")?;
-
-    let _ = redis_conn.set_key(&cache_key.clone(), cache_key_value.clone())
+        .unwrap()
+        .set_key(&cache_key.clone(), cache_key_value.clone())
         .await;
 
     let api_key = ("api-key", "test_admin");

--- a/crates/router/tests/cache.rs
+++ b/crates/router/tests/cache.rs
@@ -16,10 +16,13 @@ async fn invalidate_existing_cache_success() {
 
     let cache_key = "cacheKey".to_string();
     let cache_key_value = "val".to_string();
-    let _ = state
+    let redis_conn = state
         .store
         .get_redis_conn()
-        .set_key(&cache_key.clone(), cache_key_value.clone())
+        .change_context(errors::ApiErrorResponse::InternalServerError)
+        .attach_printable("Failed to get redis connection")?;
+
+    let _ = redis_conn.set_key(&cache_key.clone(), cache_key_value.clone())
         .await;
 
     let api_key = ("api-key", "test_admin");

--- a/crates/router/tests/services.rs
+++ b/crates/router/tests/services.rs
@@ -1,0 +1,40 @@
+use router::{configs::settings::Settings, routes};
+use std::sync::atomic;
+
+mod utils;
+
+#[tokio::test]
+#[should_panic]
+async fn get_redis_conn_failure() {
+    // Arrange
+    utils::setup().await;
+    let (tx, _) = tokio::sync::oneshot::channel();
+    let state = routes::AppState::new(Settings::default(), tx).await;
+
+    state
+        .store
+        .get_redis_conn()
+        .expect("")
+        .is_redis_available
+        .store(false, atomic::Ordering::SeqCst);
+
+    // Act
+    state.store.get_redis_conn().expect("");
+
+    // Assert
+    // based on #[should_panic] attribute
+}
+
+#[tokio::test]
+async fn get_redis_conn_success() {
+    // Arrange
+    utils::setup().await;
+    let (tx, _) = tokio::sync::oneshot::channel();
+    let state = routes::AppState::new(Settings::default(), tx).await;
+
+    // Act
+    let result = state.store.get_redis_conn();
+
+    // Assert
+    assert!(result.is_ok())
+}

--- a/crates/router/tests/services.rs
+++ b/crates/router/tests/services.rs
@@ -1,5 +1,6 @@
-use router::{configs::settings::Settings, routes};
 use std::sync::atomic;
+
+use router::{configs::settings::Settings, routes};
 
 mod utils;
 


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->

## Motivation and Context
[1497](https://github.com/juspay/hyperswitch/issues/1497)


## How did you test it?
unit tests and postman

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [X] I formatted the code `cargo +nightly fmt --all`
- [X] I addressed lints thrown by `cargo clippy`
- [X] I reviewed submitted code
- [X] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
