### PR TITLE
fix: add 3ds card_holder_info and 2 digit expiry year

### DIFF
--- a/crates/router/src/connector/bluesnap/transformers.rs
+++ b/crates/router/src/connector/bluesnap/transformers.rs
@@ -11,7 +11,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     connector::utils::{
-        self, AddressDetailsData, ApplePay, CardData, PaymentsAuthorizeRequestData, RouterData,
+        self, AddressDetailsData, ApplePay, CardData, PaymentsAuthorizeRequestData,
+        PaymentsCompleteAuthorizeRequestData, RouterData,
     },
     consts,
     core::errors,
@@ -169,7 +170,7 @@ impl TryFrom<&types::PaymentsAuthorizeRouterData> for BluesnapPaymentsRequest {
                     expiration_year: ccard.get_expiry_year_4_digit(),
                     security_code: ccard.card_cvc.clone(),
                 }),
-                get_card_holder_info(item)?,
+                get_card_holder_info(item.get_billing_address()?, item.request.get_email()?)?,
             )),
             api::PaymentMethodData::Wallet(wallet_data) => match wallet_data {
                 api_models::payments::WalletData::GooglePay(payment_method_data) => {
@@ -256,7 +257,10 @@ impl TryFrom<&types::PaymentsAuthorizeRouterData> for BluesnapPaymentsRequest {
                                 consts::BASE64_ENGINE.encode(apple_pay_object),
                             ),
                         }),
-                        get_card_holder_info(item)?,
+                        get_card_holder_info(
+                            item.get_billing_address()?,
+                            item.request.get_email()?,
+                        )?,
                     ))
                 }
                 _ => Err(errors::ConnectorError::NotImplemented(
@@ -408,9 +412,9 @@ impl TryFrom<&types::PaymentsCompleteAuthorizeRouterData> for BluesnapPaymentsRe
             item.request.payment_method_data.clone()
         {
             PaymentMethodDetails::CreditCard(Card {
-                card_number: ccard.card_number,
+                card_number: ccard.card_number.clone(),
                 expiration_month: ccard.card_exp_month.clone(),
-                expiration_year: ccard.card_exp_year.clone(),
+                expiration_year: ccard.get_expiry_year_4_digit(),
                 security_code: ccard.card_cvc,
             })
         } else {
@@ -434,7 +438,10 @@ impl TryFrom<&types::PaymentsCompleteAuthorizeRouterData> for BluesnapPaymentsRe
             transaction_fraud_info: Some(TransactionFraudInfo {
                 fraud_session_id: item.payment_id.clone(),
             }),
-            card_holder_info: None,
+            card_holder_info: get_card_holder_info(
+                item.get_billing_address()?,
+                item.request.get_email()?,
+            )?,
         })
     }
 }
@@ -807,12 +814,12 @@ pub enum BluesnapErrors {
 }
 
 fn get_card_holder_info(
-    item: &types::PaymentsAuthorizeRouterData,
+    address: &api::AddressDetails,
+    email: Email,
 ) -> CustomResult<Option<BluesnapCardHolderInfo>, errors::ConnectorError> {
-    let address = item.get_billing_address()?;
     Ok(Some(BluesnapCardHolderInfo {
         first_name: address.get_first_name()?.clone(),
         last_name: address.get_last_name()?.clone(),
-        email: item.request.get_email()?,
+        email,
     }))
 }

--- a/crates/router/src/connector/utils.rs
+++ b/crates/router/src/connector/utils.rs
@@ -328,6 +328,7 @@ impl BrowserInformationData for types::BrowserInformation {
 
 pub trait PaymentsCompleteAuthorizeRequestData {
     fn is_auto_capture(&self) -> Result<bool, Error>;
+    fn get_email(&self) -> Result<Email, Error>;
 }
 
 impl PaymentsCompleteAuthorizeRequestData for types::CompleteAuthorizeData {
@@ -337,6 +338,9 @@ impl PaymentsCompleteAuthorizeRequestData for types::CompleteAuthorizeData {
             Some(storage_models::enums::CaptureMethod::Manual) => Ok(false),
             Some(_) => Err(errors::ConnectorError::CaptureMethodNotSupported.into()),
         }
+    }
+    fn get_email(&self) -> Result<Email, Error> {
+        self.email.clone().ok_or_else(missing_field_err("email"))
     }
 }
 


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->

- Add `card_holder_info` in the Bluesnap Connector Request
- Add Conversion Check for 2-Digit Expiry Year in Card Data

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [X] I formatted the code `cargo +nightly fmt --all`
- [X] I addressed lints thrown by `cargo clippy`
- [X] I reviewed submitted code
- [X] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
