### PR TITLE
chore(connector): [Payme] disable payme connector in code

### DIFF
--- a/crates/api_models/src/enums.rs
+++ b/crates/api_models/src/enums.rs
@@ -627,7 +627,7 @@ pub enum Connector {
     Noon,
     Nuvei,
     // Payeezy, As psync and rsync are not supported by this connector, it is added as template code for future usage
-    Payme,
+    // Payme,
     Paypal,
     Payu,
     Rapyd,
@@ -713,7 +713,7 @@ pub enum RoutableConnectors {
     Nuvei,
     Opennode,
     // Payeezy, As psync and rsync are not supported by this connector, it is added as template code for future usage
-    Payme,
+    // Payme,
     Paypal,
     Payu,
     Rapyd,

--- a/crates/router/src/types/api.rs
+++ b/crates/router/src/types/api.rs
@@ -231,7 +231,7 @@ impl ConnectorData {
                 enums::Connector::Nuvei => Ok(Box::new(&connector::Nuvei)),
                 enums::Connector::Opennode => Ok(Box::new(&connector::Opennode)),
                 // "payeezy" => Ok(Box::new(&connector::Payeezy)), As psync and rsync are not supported by this connector, it is added as template code for future usage
-                enums::Connector::Payme => Ok(Box::new(&connector::Payme)),
+                //enums::Connector::Payme => Ok(Box::new(&connector::Payme)),
                 enums::Connector::Payu => Ok(Box::new(&connector::Payu)),
                 enums::Connector::Rapyd => Ok(Box::new(&connector::Rapyd)),
                 enums::Connector::Shift4 => Ok(Box::new(&connector::Shift4)),

--- a/crates/router/tests/connectors/payme.rs
+++ b/crates/router/tests/connectors/payme.rs
@@ -14,7 +14,7 @@ impl utils::Connector for PaymeTest {
         use router::connector::Payme;
         types::api::ConnectorData {
             connector: Box::new(&Payme),
-            connector_name: types::Connector::Payme,
+            connector_name: types::Connector::DummyConnector1,
             get_token: types::api::GetToken::Connector,
         }
     }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [x] CI/CD

## Description
Disabled payme connector through code


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
To skip sanity tests in the CI pipeline, newly generated connectors should be disabled in code.


## How did you test it?
Test not required


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
