### PR TITLE
fix(locker): remove delete_locker_payment_method_by_lookup_key from payments_operation_core

### DIFF
--- a/crates/router/src/core/payments.rs
+++ b/crates/router/src/core/payments.rs
@@ -28,10 +28,7 @@ use self::{
 use super::errors::StorageErrorExt;
 use crate::{
     configs::settings::PaymentMethodTypeTokenFilter,
-    core::{
-        errors::{self, CustomResult, RouterResponse, RouterResult},
-        payment_methods::vault,
-    },
+    core::errors::{self, CustomResult, RouterResponse, RouterResult},
     db::StorageInterface,
     logger,
     routes::{metrics, AppState},
@@ -198,11 +195,6 @@ where
                 .await?
             }
         };
-
-        if should_delete_pm_from_locker(payment_data.payment_intent.status) {
-            vault::Vault::delete_locker_payment_method_by_lookup_key(state, &payment_data.token)
-                .await
-        }
     } else {
         (_, payment_data) = operation
             .to_update_tracker()?
@@ -1185,13 +1177,6 @@ pub fn should_call_connector<Op: Debug, F: Clone>(
         "PaymentSession" => true,
         _ => false,
     }
-}
-
-pub fn should_delete_pm_from_locker(status: storage_enums::IntentStatus) -> bool {
-    !matches!(
-        status,
-        storage_models::enums::IntentStatus::RequiresCustomerAction
-    )
 }
 
 pub fn is_operation_confirm<Op: Debug>(operation: &Op) -> bool {


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
The function call responsible for deleting card details from payments_operations_core() has been removed in this PR. This modification ensures that the redundant deletion of already deleted card details no longer occurs, preventing the unnecessary error from being triggered.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
Previously, there was a function call within payments_operations_core() that deleted card details stored in the Basilisk Locker V3. However, it was discovered that the process tracker was also attempting to delete the same card details, resulting in an unnecessary error when trying to delete an already deleted card.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Manual, compiler-guided

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
