### PR TITLE
fix(core): db error when doing payments through saved card flow

### DIFF
--- a/crates/router/src/core/payments.rs
+++ b/crates/router/src/core/payments.rs
@@ -200,8 +200,12 @@ where
         };
 
         if should_delete_pm_from_locker(payment_data.payment_intent.status) {
-            vault::Vault::delete_locker_payment_method_by_lookup_key(state, &payment_data.token)
-                .await
+            let _ = vault::Vault::delete_locker_payment_method_by_lookup_key(
+                state,
+                &payment_data.token,
+                &payment_data.payment_attempt.payment_method,
+            )
+            .await;
         }
     } else {
         (_, payment_data) = operation


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix

## Description
<!-- Describe your changes in detail -->
This PR aims to fix the database error when doing payments with payment token i.e., the saved card flow.  

When a payment is done succesfully, we get a `payment_token` which is `K1` i.e., the `hyperswitch_token`. On the other hand, `K2` i.e., `connector_token` is generated form the connector's end.  
Once the customer ID is used to save the payment method, we receive yet another `payment_token` and this `payment_token` is `parent_token` that has both `K1` and `K2`.  
As of now, when a successful payment is done, it is trying to delete `K1` which is intended, however, it is trying to delete the `parent_token` which does not exist in the database. This PR, extracts the `K1` from the `parent_token` and allows the core to delete the token after the payment is successful.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Manually through postman.
![image](https://github.com/juspay/hyperswitch/assets/69745008/ee0d91eb-5a2c-4aac-9e24-eca1ef3100ba)


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
