### PR TITLE
fix(build): add a standalone Redis mode in docker-compose installation

### DIFF
--- a/config/docker_compose.toml
+++ b/config/docker_compose.toml
@@ -57,10 +57,10 @@ vault_encryption_key = ""
 vault_private_key = ""
 
 [redis]
-host = "redis-queue"
+host = "redis-standalone"
 port = 6379
-cluster_enabled = true
-cluster_urls = ["redis-queue:6379"]
+cluster_enabled = false
+cluster_urls = ["redis-cluster:6379"]
 
 [refund]
 max_attempts = 10

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -164,7 +164,7 @@ services:
       start_period: 30s
       timeout: 10s
 
-  redis-queue:
+  redis-cluster:
     image: redis:7
     deploy:
       replicas: ${REDIS_CLUSTER_COUNT:-3}
@@ -179,10 +179,19 @@ services:
       - "6379"
       - "16379"
 
+  redis-standalone:
+    image: redis:7
+    labels:
+      - redis
+    networks:
+      - router_net
+    ports:
+      - "6379"
+
   redis-init:
     image: redis:7
     depends_on:
-      - redis-queue
+      - redis-cluster
     networks:
       - router_net
     command: "bash -c 'export COUNT=${REDIS_CLUSTER_COUNT:-3}
@@ -203,7 +212,7 @@ services:
 
       \ do
 
-      \ NODE=$COMPOSE_PROJECT_NAME-redis-queue-$$c:6379
+      \ NODE=$COMPOSE_PROJECT_NAME-redis-cluster-$$c:6379
 
       \ echo $$NODE
 


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
- Adding a redis-standalone state to docker compose
- turning off the cluster mode by default
- The application will connect to the right instance based on whether cluster mode was enabled/disabled

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

- Currently docker runs on redis cluster mode to better test any cluster specific code written
- However the cluster mode is a bit finicky in terms of cluster losing state & being in an unavailable state

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
- local runs

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
