### PR TITLE
fix: map not found error properly in db_not found

### DIFF
--- a/crates/router/src/core/errors.rs
+++ b/crates/router/src/core/errors.rs
@@ -98,6 +98,7 @@ impl StorageError {
                 err.current_context(),
                 storage_errors::DatabaseError::NotFound
             ),
+            Self::ValueNotFound(_) => true,
             _ => false,
         }
     }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->
- [x] Bugfix

## Description
<!-- Describe your changes in detail -->
Map not found error from StorageError properly in is_db_not_found.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
Throws 404 for properly if record not found in DB.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
On multiple deletion on API key.

<img width="1307" alt="image" src="https://github.com/juspay/hyperswitch/assets/43412619/28f87970-3937-4779-8002-64405b4e1fb2">


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code