### PR TITLE
fix(middleware): inlcude `x-request-id` header in `access-control-expose-headers` header value

### DIFF
--- a/crates/router/src/lib.rs
+++ b/crates/router/src/lib.rs
@@ -222,7 +222,7 @@ pub fn get_application_builder(
             errors::error_handlers::custom_error_handlers,
         ))
         .wrap(middleware::default_response_headers())
-        .wrap(cors::cors())
         .wrap(middleware::RequestId)
+        .wrap(cors::cors())
         .wrap(router_env::tracing_actix_web::TracingLogger::default())
 }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
This PR fixes a bug where `x-request-id` was not being included in the `access-control-expose-headers` header. The solution is to register the request ID middleware before the CORS middleware.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
Bugfix.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Before:

```shell
$ curl -i http://localhost:8080/health
[...]
access-control-expose-headers: via, strict-transport-security
[...]
```

After:
```shell
$ curl -i http://localhost:8080/health
[...]
access-control-expose-headers: x-request-id, via, strict-transport-security
[...]
```

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
