### PR TITLE
chore: address Rust 1.71 clippy lints

### DIFF
--- a/crates/router/src/db/api_keys.rs
+++ b/crates/router/src/db/api_keys.rs
@@ -246,7 +246,7 @@ impl ApiKeyInterface for MockDb {
     ) -> CustomResult<storage::ApiKey, errors::StorageError> {
         let mut locked_api_keys = self.api_keys.lock().await;
         // find a key with the given merchant_id and key_id and update, otherwise return an error
-        let mut key_to_update = locked_api_keys
+        let key_to_update = locked_api_keys
             .iter_mut()
             .find(|k| k.merchant_id == merchant_id && k.key_id == key_id)
             .ok_or(errors::StorageError::MockDbError)?;

--- a/crates/router/src/db/dispute.rs
+++ b/crates/router/src/db/dispute.rs
@@ -300,7 +300,7 @@ impl DisputeInterface for MockDb {
     ) -> CustomResult<storage::Dispute, errors::StorageError> {
         let mut locked_disputes = self.disputes.lock().await;
 
-        let mut dispute_to_update = locked_disputes
+        let dispute_to_update = locked_disputes
             .iter_mut()
             .find(|d| d.dispute_id == this.dispute_id)
             .ok_or(errors::StorageError::MockDbError)?;

--- a/crates/router/src/db/events.rs
+++ b/crates/router/src/db/events.rs
@@ -74,7 +74,7 @@ impl EventInterface for MockDb {
         event: storage::EventUpdate,
     ) -> CustomResult<storage::Event, errors::StorageError> {
         let mut locked_events = self.events.lock().await;
-        let mut event_to_update = locked_events
+        let event_to_update = locked_events
             .iter_mut()
             .find(|e| e.event_id == event_id)
             .ok_or(errors::StorageError::MockDbError)?;

--- a/crates/router/tests/connectors/selenium.rs
+++ b/crates/router/tests/connectors/selenium.rs
@@ -311,7 +311,7 @@ pub trait SeleniumTest {
                     Trigger::SwitchTab(position) => match position {
                         Position::Next => {
                             let windows = driver.windows().await?;
-                            if let Some(window) = windows.iter().rev().next() {
+                            if let Some(window) = windows.iter().next_back() {
                                 driver.switch_to_window(window.to_owned()).await?;
                             }
                         }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
This PR addresses a clippy lint stabilized in Rust 1.71.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
N/A

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
N/A

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
