### PR TITLE
fix(ui-test): Run UI tests only on merge-queue

### DIFF
--- a/.github/workflows/connector-ui-sanity-tests.yml
+++ b/.github/workflows/connector-ui-sanity-tests.yml
@@ -36,6 +36,20 @@ env:
   CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
 
 jobs:
+  ignore_test:
+    name: Ignore UI tests on pull request
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Provide success response always
+        shell: bash
+        run: echo true
+
+
   test_connectors:
     name: Run connector UI tests
     if: github.event_name != 'pull_request'

--- a/.github/workflows/connector-ui-sanity-tests.yml
+++ b/.github/workflows/connector-ui-sanity-tests.yml
@@ -81,27 +81,33 @@ jobs:
           exit 0
 
       - name: Checkout repository
+        if: github.event_name != 'pull_request'
         uses: actions/checkout@v3
 
       - name: Decrypt connector auth file
+        if: github.event_name != 'pull_request'
         env:
           CONNECTOR_AUTH_PASSPHRASE: ${{ secrets.CONNECTOR_AUTH_PASSPHRASE }}
         shell: bash
         run: ./scripts/decrypt_connector_auth.sh
 
       - name: Set connector auth file path in env
+        if: github.event_name != 'pull_request'
         shell: bash
         run: echo "CONNECTOR_AUTH_FILE_PATH=$HOME/target/test/connector_auth.toml" >> $GITHUB_ENV
 
       - name: Set connector tests file path in env
+        if: github.event_name != 'pull_request'
         shell: bash
         run: echo "CONNECTOR_TESTS_FILE_PATH=$HOME/target/test/connector_tests.json" >> $GITHUB_ENV
 
       - name: Set ignore_browser_profile usage in env
+        if: github.event_name != 'pull_request'  
         shell: bash
         run: echo "IGNORE_BROWSER_PROFILE=true" >> $GITHUB_ENV
 
       - name: Install latest compiler
+        if: github.event_name != 'pull_request'  
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
@@ -109,18 +115,21 @@ jobs:
       - uses: Swatinem/rust-cache@v2.4.0
 
       - uses: baptiste0928/cargo-install@v2.1.0
+        if: github.event_name != 'pull_request'  
         with:
           crate: diesel_cli
           features: postgres
           args: "--no-default-features"
 
       - name: Diesel migration run
+        if: github.event_name != 'pull_request'  
         shell: bash
         env:
           DATABASE_URL: postgres://db_user:db_pass@localhost:5432/hyperswitch_db
         run: diesel migration run
 
       - name: Start server and run tests
+        if: github.event_name != 'pull_request'  
         env:
           UI_TESTCASES_PATH: ${{ secrets.UI_TESTCASES_PATH }}
           INPUT: ${{ matrix.connector }}
@@ -128,10 +137,12 @@ jobs:
         run: sh .github/scripts/run_ui_tests.sh
 
       - name: View test results
+        if: github.event_name != 'pull_request'  
         shell: bash
         run: cat tests/test_results.log
 
       - name: Check test results
+        if: github.event_name != 'pull_request'  
         shell: bash
         run: |
           if test "$( grep 'test result: FAILED' -r tests/test_results.log | wc -l )" -gt "0"; then

--- a/.github/workflows/connector-ui-sanity-tests.yml
+++ b/.github/workflows/connector-ui-sanity-tests.yml
@@ -68,11 +68,9 @@ jobs:
       fail-fast: false
       matrix:
         connector:
-          # do not use more than 8 runners, try to group less time taking connectors together
-          - stripe
-          - adyen_uk,shift4,worldline,multisafepay
-          - airwallex,bluesnap,checkout
-          - paypal,mollie,payu,trustpay_3ds
+          # do not use more than 2 runners, try to group less time taking connectors together
+          - stripe,airwallex,bluesnap,checkout,trustpay_3ds,payu
+          - adyen_uk,shift4,worldline,multisafepay,paypal,mollie
 
     steps:
       - name: Ignore Tests incase of pull request

--- a/.github/workflows/connector-ui-sanity-tests.yml
+++ b/.github/workflows/connector-ui-sanity-tests.yml
@@ -2,10 +2,8 @@ name: Connector UI Sanity Tests
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - main
-
+  
+  pull_request:
   merge_group:
     types:
       - checks_requested
@@ -39,7 +37,8 @@ env:
 
 jobs:
   test_connectors:
-    name: Run tests on stable toolchain for connectors
+    name: Run connector UI tests
+    if: ${{ !github.event.issue.pull_request }}
     runs-on: ubuntu-latest
 
     services:

--- a/.github/workflows/connector-ui-sanity-tests.yml
+++ b/.github/workflows/connector-ui-sanity-tests.yml
@@ -36,23 +36,8 @@ env:
   CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
 
 jobs:
-  ignore_test:
-    name: Ignore UI tests on pull request
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-
-      - name: Provide success response always
-        shell: bash
-        run: echo true
-
-
   test_connectors:
     name: Run connector UI tests
-    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
 
     services:
@@ -90,6 +75,13 @@ jobs:
           - paypal,mollie,payu,trustpay_3ds
 
     steps:
+      - name: Ignore Tests incase of pull request
+        if: github.event_name != 'pull_request'
+        shell: bash
+        run: |
+          echo "Skipped tests as the event is pull request" 
+          exit 0
+
       - name: Checkout repository
         uses: actions/checkout@v3
 

--- a/.github/workflows/connector-ui-sanity-tests.yml
+++ b/.github/workflows/connector-ui-sanity-tests.yml
@@ -74,7 +74,7 @@ jobs:
 
     steps:
       - name: Ignore Tests incase of pull request
-        if: github.event_name != 'pull_request'
+        if: github.event_name == 'pull_request'
         shell: bash
         run: |
           echo "Skipped tests as the event is pull request" 

--- a/.github/workflows/connector-ui-sanity-tests.yml
+++ b/.github/workflows/connector-ui-sanity-tests.yml
@@ -38,7 +38,7 @@ env:
 jobs:
   test_connectors:
     name: Run connector UI tests
-    if: ${{ !github.event.issue.pull_request }}
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
 
     services:

--- a/crates/router/tests/connectors/trustpay_3ds_ui.rs
+++ b/crates/router/tests/connectors/trustpay_3ds_ui.rs
@@ -35,6 +35,7 @@ async fn should_make_trustpay_3ds_payment(web_driver: WebDriver) -> Result<(), W
 
 #[test]
 #[serial]
+#[ignore]
 fn should_make_trustpay_3ds_payment_test() {
     tester!(should_make_trustpay_3ds_payment);
 }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [X] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Run UI tests only on merge queue so that breaking-PRs will get kicked on failure

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
To make UI tests mandatory for all PRs 

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
