### PR TITLE
feat(metrics): add pod information in metrics pipeline

### DIFF
--- a/crates/router_env/src/logger/setup.rs
+++ b/crates/router_env/src/logger/setup.rs
@@ -186,6 +186,8 @@ fn setup_metrics_pipeline(config: &config::LogTelemetry) -> Option<BasicControll
         buckets
     };
 
+    let pod_name = std::env::var("POD_NAME").ok();
+
     let metrics_controller_result = opentelemetry_otlp::new_pipeline()
         .metrics(
             simple::histogram(histogram_buckets),
@@ -196,6 +198,10 @@ fn setup_metrics_pipeline(config: &config::LogTelemetry) -> Option<BasicControll
         .with_exporter(get_opentelemetry_exporter(config))
         .with_period(Duration::from_secs(3))
         .with_timeout(Duration::from_secs(10))
+        .with_resource(Resource::new(vec![KeyValue::new(
+            "pod",
+            pod_name.unwrap_or("hyperswitch-server-default".to_string()),
+        )]))
         .build();
 
     if config.ignore_errors {

--- a/crates/router_env/src/logger/setup.rs
+++ b/crates/router_env/src/logger/setup.rs
@@ -186,8 +186,6 @@ fn setup_metrics_pipeline(config: &config::LogTelemetry) -> Option<BasicControll
         buckets
     };
 
-    let pod_name = std::env::var("POD_NAME").ok();
-
     let metrics_controller_result = opentelemetry_otlp::new_pipeline()
         .metrics(
             simple::histogram(histogram_buckets),
@@ -200,7 +198,10 @@ fn setup_metrics_pipeline(config: &config::LogTelemetry) -> Option<BasicControll
         .with_timeout(Duration::from_secs(10))
         .with_resource(Resource::new(vec![KeyValue::new(
             "pod",
-            pod_name.unwrap_or("hyperswitch-server-default".to_string()),
+            std::env::var("POD_NAME").map_or(
+                "hyperswitch-server-default".into(),
+                Into::<opentelemetry::Value>::into,
+            ),
         )]))
         .build();
 


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Adding server information in the metrics pipeline.
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context


Adding information specific to the server in the metrics pipeline to support and mitigate issues against counter reset

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
