### PR TITLE
feat(merchant_account): add `is_recon_enabled` field in merchant_account

### DIFF
--- a/crates/api_models/src/admin.rs
+++ b/crates/api_models/src/admin.rs
@@ -227,6 +227,9 @@ pub struct MerchantAccountResponse {
 
     /// The organization id merchant is associated with
     pub organization_id: Option<String>,
+
+    ///  A boolean value to indicate if the merchant has recon service is enabled or not, by default value is false
+    pub is_recon_enabled: bool,
 }
 
 #[derive(Clone, Debug, Deserialize, ToSchema, Serialize)]

--- a/crates/diesel_models/src/merchant_account.rs
+++ b/crates/diesel_models/src/merchant_account.rs
@@ -36,6 +36,7 @@ pub struct MerchantAccount {
     pub modified_at: time::PrimitiveDateTime,
     pub frm_routing_algorithm: Option<serde_json::Value>,
     pub organization_id: Option<String>,
+    pub is_recon_enabled: bool,
 }
 
 #[derive(Clone, Debug, Insertable, router_derive::DebugAsDisplay)]
@@ -61,6 +62,7 @@ pub struct MerchantAccountNew {
     pub modified_at: time::PrimitiveDateTime,
     pub frm_routing_algorithm: Option<serde_json::Value>,
     pub organization_id: Option<String>,
+    pub is_recon_enabled: bool,
 }
 
 #[derive(Clone, Debug, Default, AsChangeset, router_derive::DebugAsDisplay)]
@@ -85,4 +87,5 @@ pub struct MerchantAccountUpdateInternal {
     pub intent_fulfillment_time: Option<i64>,
     pub frm_routing_algorithm: Option<serde_json::Value>,
     pub organization_id: Option<String>,
+    pub is_recon_enabled: bool,
 }

--- a/crates/diesel_models/src/schema.rs
+++ b/crates/diesel_models/src/schema.rs
@@ -330,6 +330,7 @@ diesel::table! {
         frm_routing_algorithm -> Nullable<Jsonb>,
         #[max_length = 32]
         organization_id -> Nullable<Varchar>,
+        is_recon_enabled -> Bool,
     }
 }
 

--- a/crates/router/src/configs/defaults.rs
+++ b/crates/router/src/configs/defaults.rs
@@ -41,11 +41,15 @@ impl Default for super::settings::Secrets {
             jwt_secret: "secret".into(),
             #[cfg(not(feature = "kms"))]
             admin_api_key: "test_admin".into(),
+            #[cfg(not(feature = "kms"))]
+            recon_admin_api_key: "recon_test_admin".into(),
             master_enc_key: "".into(),
             #[cfg(feature = "kms")]
             kms_encrypted_jwt_secret: "".into(),
             #[cfg(feature = "kms")]
             kms_encrypted_admin_api_key: "".into(),
+            #[cfg(feature = "kms")]
+            kms_encrypted_recon_admin_api_key: "".into(),
         }
     }
 }

--- a/crates/router/src/configs/settings.rs
+++ b/crates/router/src/configs/settings.rs
@@ -317,11 +317,15 @@ pub struct Secrets {
     pub jwt_secret: String,
     #[cfg(not(feature = "kms"))]
     pub admin_api_key: String,
+    #[cfg(not(feature = "kms"))]
+    pub recon_admin_api_key: String,
     pub master_enc_key: String,
     #[cfg(feature = "kms")]
     pub kms_encrypted_jwt_secret: String,
     #[cfg(feature = "kms")]
     pub kms_encrypted_admin_api_key: String,
+    #[cfg(feature = "kms")]
+    pub kms_encrypted_recon_admin_api_key: String,
 }
 
 #[derive(Debug, Deserialize, Clone)]

--- a/crates/router/src/core/admin.rs
+++ b/crates/router/src/core/admin.rs
@@ -173,6 +173,7 @@ pub async fn create_merchant_account(
             intent_fulfillment_time: req.intent_fulfillment_time.map(i64::from),
             id: None,
             organization_id: req.organization_id,
+            is_recon_enabled: false,
         })
     }
     .await

--- a/crates/router/src/types/api/admin.rs
+++ b/crates/router/src/types/api/admin.rs
@@ -35,6 +35,7 @@ impl TryFrom<domain::MerchantAccount> for MerchantAccountResponse {
             frm_routing_algorithm: item.frm_routing_algorithm,
             intent_fulfillment_time: item.intent_fulfillment_time,
             organization_id: item.organization_id,
+            is_recon_enabled: item.is_recon_enabled,
         })
     }
 }

--- a/crates/router/src/types/domain/merchant_account.rs
+++ b/crates/router/src/types/domain/merchant_account.rs
@@ -37,6 +37,7 @@ pub struct MerchantAccount {
     pub modified_at: time::PrimitiveDateTime,
     pub intent_fulfillment_time: Option<i64>,
     pub organization_id: Option<String>,
+    pub is_recon_enabled: bool,
 }
 
 #[allow(clippy::large_enum_variant)]
@@ -62,6 +63,9 @@ pub enum MerchantAccountUpdate {
     },
     StorageSchemeUpdate {
         storage_scheme: enums::MerchantStorageScheme,
+    },
+    ReconUpdate {
+        is_recon_enabled: bool,
     },
 }
 
@@ -110,6 +114,10 @@ impl From<MerchantAccountUpdate> for MerchantAccountUpdateInternal {
                 modified_at: Some(date_time::now()),
                 ..Default::default()
             },
+            MerchantAccountUpdate::ReconUpdate { is_recon_enabled } => Self {
+                is_recon_enabled,
+                ..Default::default()
+            },
         }
     }
 }
@@ -144,6 +152,7 @@ impl super::behaviour::Conversion for MerchantAccount {
             intent_fulfillment_time: self.intent_fulfillment_time,
             frm_routing_algorithm: self.frm_routing_algorithm,
             organization_id: self.organization_id,
+            is_recon_enabled: self.is_recon_enabled,
         })
     }
 
@@ -184,6 +193,7 @@ impl super::behaviour::Conversion for MerchantAccount {
                 modified_at: item.modified_at,
                 intent_fulfillment_time: item.intent_fulfillment_time,
                 organization_id: item.organization_id,
+                is_recon_enabled: item.is_recon_enabled,
             })
         }
         .await
@@ -215,6 +225,7 @@ impl super::behaviour::Conversion for MerchantAccount {
             intent_fulfillment_time: self.intent_fulfillment_time,
             frm_routing_algorithm: self.frm_routing_algorithm,
             organization_id: self.organization_id,
+            is_recon_enabled: self.is_recon_enabled,
         })
     }
 }

--- a/migrations/2023-07-11-140347_add_is_recon_enabled_field_in_merchant_account/down.sql
+++ b/migrations/2023-07-11-140347_add_is_recon_enabled_field_in_merchant_account/down.sql
@@ -1,0 +1,2 @@
+-- This file should undo anything in `up.sql`
+ALTER TABLE merchant_account DROP COLUMN is_recon_enabled;

--- a/migrations/2023-07-11-140347_add_is_recon_enabled_field_in_merchant_account/up.sql
+++ b/migrations/2023-07-11-140347_add_is_recon_enabled_field_in_merchant_account/up.sql
@@ -1,0 +1,2 @@
+-- Your SQL goes here
+ALTER TABLE merchant_account ADD COLUMN "is_recon_enabled" BOOLEAN NOT NULL DEFAULT FALSE;

--- a/openapi/openapi_spec.json
+++ b/openapi/openapi_spec.json
@@ -5007,7 +5007,8 @@
           "merchant_id",
           "enable_payment_response_hash",
           "redirect_to_merchant_with_http_post",
-          "primary_business_details"
+          "primary_business_details",
+          "is_recon_enabled"
         ],
         "properties": {
           "merchant_id": {
@@ -5128,6 +5129,10 @@
             "type": "string",
             "description": "The organization id merchant is associated with",
             "nullable": true
+          },
+          "is_recon_enabled": {
+            "type": "boolean",
+            "description": "A boolean value to indicate if the merchant has recon service is enabled or not, by default value is false"
           }
         }
       },


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
Added is_recon_enabled field in merchant_account table and sending it in retrive merchant_account api

### Additional Changes

- [ ] This PR modifies the API contract
- [x] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
* This field will be used to know weather the merchant has recon service enabled or not


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
* check the merchant retrive api


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
