### PR TITLE
fix(ci): Run UI tests only for 15mins max in case of build failure

### DIFF
--- a/.github/scripts/run_ui_tests.sh
+++ b/.github/scripts/run_ui_tests.sh
@@ -22,6 +22,7 @@ cargo run &
 
 #Wait for the server to start in port 8080
 while netstat -lnt | awk '$4 ~ /:8080$/ {exit 1}'; do 
+    echo $SECONDS
     if [ $SECONDS > 900 ]
     then
         exit 1

--- a/.github/scripts/run_ui_tests.sh
+++ b/.github/scripts/run_ui_tests.sh
@@ -18,6 +18,10 @@ done
 firefox --version
 $GECKOWEBDRIVER/geckodriver > tests/geckodriver.log 2>&1 &
 
+echo $SECONDS
+echo "$SECONDS"
+echo "========"
+
 #start server and run ui tests
 cargo run &
 

--- a/.github/scripts/run_ui_tests.sh
+++ b/.github/scripts/run_ui_tests.sh
@@ -11,7 +11,7 @@ do
     then
         exit 1
     fi
-    COUNT = $((COUNT+1))
+    COUNT=$((COUNT+1))
     sleep 2
     wget $UI_TESTCASES_PATH && mv testcases $HOME/target/test/connector_tests.json
 done
@@ -22,14 +22,14 @@ $GECKOWEBDRIVER/geckodriver > tests/geckodriver.log 2>&1 &
 #start server and run ui tests
 cargo run &
 
-COUNT = 0
+COUNT=0
 #Wait for the server to start in port 8080
 while netstat -lnt | awk '$4 ~ /:8080$/ {exit 1}'; do 
     if [ $COUNT -gt 30 ];
     then
         exit 1
     else 
-        COUNT = $((COUNT+1))
+        COUNT=$((COUNT+1))
         sleep 10
     fi
 done

--- a/.github/scripts/run_ui_tests.sh
+++ b/.github/scripts/run_ui_tests.sh
@@ -3,14 +3,14 @@ sudo apt update
 apt install net-tools
 mkdir tests
 
+COUNTER=0
 #download connector ui tests
 while [ ! -f $HOME/target/test/connector_tests.json ]
 do
-    echo $SECONDS
-    if [ $SECONDS > 20 ]
-    then
+    if [ $COUNTER > 10 ]; then
         exit 1
     fi
+    ((COUNTER+=1))
     sleep 2
     wget $UI_TESTCASES_PATH && mv testcases $HOME/target/test/connector_tests.json
 done
@@ -18,20 +18,16 @@ done
 firefox --version
 $GECKOWEBDRIVER/geckodriver > tests/geckodriver.log 2>&1 &
 
-echo $SECONDS
-echo "$SECONDS"
-echo "========"
-
 #start server and run ui tests
 cargo run &
 
+COUNTER=0
 #Wait for the server to start in port 8080
 while netstat -lnt | awk '$4 ~ /:8080$/ {exit 1}'; do 
-    echo $SECONDS
-    if [ $SECONDS > 900 ]
-    then
+    if [ $COUNTER > 300 ]; then
         exit 1
     else 
+        ((COUNTER+=10))
         sleep 10
     fi
 done

--- a/.github/scripts/run_ui_tests.sh
+++ b/.github/scripts/run_ui_tests.sh
@@ -6,6 +6,7 @@ mkdir tests
 #download connector ui tests
 while [ ! -f $HOME/target/test/connector_tests.json ]
 do
+    echo $SECONDS
     if [ $SECONDS > 20 ]
     then
         exit 1

--- a/.github/scripts/run_ui_tests.sh
+++ b/.github/scripts/run_ui_tests.sh
@@ -1,4 +1,4 @@
-#! /usr/bin/env bash
+#!/bin/bash
 sudo apt update
 apt install net-tools
 mkdir tests

--- a/.github/scripts/run_ui_tests.sh
+++ b/.github/scripts/run_ui_tests.sh
@@ -6,7 +6,7 @@ mkdir tests
 #download connector ui tests
 while [ ! -f $HOME/target/test/connector_tests.json ]
 do
-    if (( SECONDS > 30 ))
+    if (( $SECONDS > 30 ))
     then
         exit 1
     fi
@@ -22,7 +22,7 @@ cargo run &
 
 #Wait for the server to start in port 8080
 while netstat -lnt | awk '$4 ~ /:8080$/ {exit 1}'; do 
-    if (( SECONDS > 300 ))
+    if (( $SECONDS > 300 ))
     then
         exit 1
     else 

--- a/.github/scripts/run_ui_tests.sh
+++ b/.github/scripts/run_ui_tests.sh
@@ -1,17 +1,17 @@
-#!/bin/bash
+#!/bin/sh
 sudo apt update
 apt install net-tools
 mkdir tests
 
-COUNT=0
+COUNT = 0
 #download connector ui tests
 while [ ! -f $HOME/target/test/connector_tests.json ]
 do
-    if (( $COUNT > 10 ))
+    if [ {COUNT} -gt 10 ];
     then
         exit 1
     fi
-    ((COUNT++))
+    COUNT = $((COUNT+1))
     sleep 2
     wget $UI_TESTCASES_PATH && mv testcases $HOME/target/test/connector_tests.json
 done
@@ -22,14 +22,14 @@ $GECKOWEBDRIVER/geckodriver > tests/geckodriver.log 2>&1 &
 #start server and run ui tests
 cargo run &
 
-COUNT=0
+COUNT = 0
 #Wait for the server to start in port 8080
 while netstat -lnt | awk '$4 ~ /:8080$/ {exit 1}'; do 
-    if (( $COUNT > 30 ))
+    if [ {COUNT} -gt 30 ];
     then
         exit 1
     else 
-        ((COUNT++))
+        COUNT = $((COUNT+1))
         sleep 10
     fi
 done

--- a/.github/scripts/run_ui_tests.sh
+++ b/.github/scripts/run_ui_tests.sh
@@ -3,14 +3,13 @@ sudo apt update
 apt install net-tools
 mkdir tests
 
-COUNTER=0
 #download connector ui tests
 while [ ! -f $HOME/target/test/connector_tests.json ]
 do
-    if [ $COUNTER > 10 ]; then
+    if [ $SECONDS > 20 ]
+    then
         exit 1
     fi
-    ((COUNTER+=1))
     sleep 2
     wget $UI_TESTCASES_PATH && mv testcases $HOME/target/test/connector_tests.json
 done
@@ -27,7 +26,7 @@ while netstat -lnt | awk '$4 ~ /:8080$/ {exit 1}'; do
     if [ $COUNTER > 300 ]; then
         exit 1
     else 
-        ((COUNTER+=10))
+        COUNTER=`expr $COUNTER + 10`
         sleep 10
     fi
 done

--- a/.github/scripts/run_ui_tests.sh
+++ b/.github/scripts/run_ui_tests.sh
@@ -25,7 +25,8 @@ cargo run &
 COUNT=0
 #Wait for the server to start in port 8080
 while netstat -lnt | awk '$4 ~ /:8080$/ {exit 1}'; do 
-    if [ $COUNT -gt 30 ];
+    #Wait for 15mins to start otherwise kill the task
+    if [ $COUNT -gt 90 ];
     then
         exit 1
     else 

--- a/.github/scripts/run_ui_tests.sh
+++ b/.github/scripts/run_ui_tests.sh
@@ -3,13 +3,15 @@ sudo apt update
 apt install net-tools
 mkdir tests
 
+COUNT=0
 #download connector ui tests
 while [ ! -f $HOME/target/test/connector_tests.json ]
 do
-    if (( $SECONDS > 30 ))
+    if (( $COUNT > 10 ))
     then
         exit 1
     fi
+    ((COUNT++))
     sleep 2
     wget $UI_TESTCASES_PATH && mv testcases $HOME/target/test/connector_tests.json
 done
@@ -20,12 +22,14 @@ $GECKOWEBDRIVER/geckodriver > tests/geckodriver.log 2>&1 &
 #start server and run ui tests
 cargo run &
 
+COUNT=0
 #Wait for the server to start in port 8080
 while netstat -lnt | awk '$4 ~ /:8080$/ {exit 1}'; do 
-    if (( $SECONDS > 300 ))
+    if (( $COUNT > 30 ))
     then
         exit 1
     else 
+        ((COUNT++))
         sleep 10
     fi
 done

--- a/.github/scripts/run_ui_tests.sh
+++ b/.github/scripts/run_ui_tests.sh
@@ -1,13 +1,13 @@
-#!/bin/sh
+#!/bin/bash
 sudo apt update
 apt install net-tools
 mkdir tests
 
-COUNT = 0
+COUNT=0
 #download connector ui tests
 while [ ! -f $HOME/target/test/connector_tests.json ]
 do
-    if [ {COUNT} -gt 10 ];
+    if [ $COUNT -gt 10 ];
     then
         exit 1
     fi
@@ -25,7 +25,7 @@ cargo run &
 COUNT = 0
 #Wait for the server to start in port 8080
 while netstat -lnt | awk '$4 ~ /:8080$/ {exit 1}'; do 
-    if [ {COUNT} -gt 30 ];
+    if [ $COUNT -gt 30 ];
     then
         exit 1
     else 

--- a/.github/scripts/run_ui_tests.sh
+++ b/.github/scripts/run_ui_tests.sh
@@ -6,7 +6,7 @@ mkdir tests
 #download connector ui tests
 while [ ! -f $HOME/target/test/connector_tests.json ]
 do
-    if [ $SECONDS > 20 ]
+    if (( SECONDS > 30 ))
     then
         exit 1
     fi
@@ -20,13 +20,12 @@ $GECKOWEBDRIVER/geckodriver > tests/geckodriver.log 2>&1 &
 #start server and run ui tests
 cargo run &
 
-COUNTER=0
 #Wait for the server to start in port 8080
 while netstat -lnt | awk '$4 ~ /:8080$/ {exit 1}'; do 
-    if [ $COUNTER > 300 ]; then
+    if (( SECONDS > 300 ))
+    then
         exit 1
     else 
-        COUNTER=`expr $COUNTER + 10`
         sleep 10
     fi
 done

--- a/.github/workflows/connector-ui-sanity-tests.yml
+++ b/.github/workflows/connector-ui-sanity-tests.yml
@@ -133,7 +133,6 @@ jobs:
         env:
           UI_TESTCASES_PATH: ${{ secrets.UI_TESTCASES_PATH }}
           INPUT: ${{ matrix.connector }}
-          COUNT: 0
         shell: bash
         run: sh .github/scripts/run_ui_tests.sh
 

--- a/.github/workflows/connector-ui-sanity-tests.yml
+++ b/.github/workflows/connector-ui-sanity-tests.yml
@@ -133,6 +133,7 @@ jobs:
         env:
           UI_TESTCASES_PATH: ${{ secrets.UI_TESTCASES_PATH }}
           INPUT: ${{ matrix.connector }}
+          COUNT: 0
         shell: bash
         run: sh .github/scripts/run_ui_tests.sh
 


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
UI tests running forever when build is failing, so making it to run maximum 15mins

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
