### PR TITLE
feat(router): add attempt_count field in attempt update record of payment_intent

### DIFF
--- a/crates/diesel_models/src/payment_intent.rs
+++ b/crates/diesel_models/src/payment_intent.rs
@@ -134,8 +134,9 @@ pub enum PaymentIntentUpdate {
         order_details: Option<Vec<pii::SecretSerdeValue>>,
         metadata: Option<pii::SecretSerdeValue>,
     },
-    PaymentAttemptUpdate {
+    PaymentAttemptAndAttemptCountUpdate {
         active_attempt_id: String,
+        attempt_count: i16,
     },
     StatusAndAttemptUpdate {
         status: storage_enums::IntentStatus,
@@ -299,8 +300,12 @@ impl From<PaymentIntentUpdate> for PaymentIntentUpdateInternal {
                 modified_at: Some(common_utils::date_time::now()),
                 ..Default::default()
             },
-            PaymentIntentUpdate::PaymentAttemptUpdate { active_attempt_id } => Self {
+            PaymentIntentUpdate::PaymentAttemptAndAttemptCountUpdate {
+                active_attempt_id,
+                attempt_count,
+            } => Self {
                 active_attempt_id: Some(active_attempt_id),
+                attempt_count: Some(attempt_count),
                 ..Default::default()
             },
             PaymentIntentUpdate::StatusAndAttemptUpdate {


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
While updating the payment_intent's active attempt id in automatic retries we need to update attempt_count too. To support that have added attempt_count field in attempt update record of payment_intent

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
Compiler guided


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
