### PR TITLE
fix(connector): [Authorizedotnet] Convert amount from cents to dollar before sending to connector

### DIFF
--- a/crates/router/src/connector/authorizedotnet/transformers.rs
+++ b/crates/router/src/connector/authorizedotnet/transformers.rs
@@ -7,7 +7,7 @@ use masking::{PeekInterface, Secret, StrongSecret};
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    connector::utils::{CardData, PaymentsSyncRequestData, RefundsRequestData, WalletData},
+    connector::utils::{self, CardData, PaymentsSyncRequestData, RefundsRequestData, WalletData},
     core::errors,
     services,
     types::{self, api, storage::enums},
@@ -174,7 +174,7 @@ fn get_pm_and_subsequent_auth_detail(
 #[serde(rename_all = "camelCase")]
 struct TransactionRequest {
     transaction_type: TransactionType,
-    amount: i64,
+    amount: f64,
     currency_code: String,
     payment: PaymentDetails,
     processing_options: Option<ProcessingOptions>,
@@ -218,7 +218,8 @@ struct AuthorizationIndicator {
 #[serde(rename_all = "camelCase")]
 struct TransactionVoidOrCaptureRequest {
     transaction_type: TransactionType,
-    amount: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    amount: Option<f64>,
     ref_trans_id: String,
 }
 
@@ -276,7 +277,7 @@ impl TryFrom<&types::PaymentsAuthorizeRouterData> for CreateTransactionRequest {
             });
         let transaction_request = TransactionRequest {
             transaction_type: TransactionType::from(item.request.capture_method),
-            amount: item.request.amount,
+            amount: utils::to_currency_base_unit_asf64(item.request.amount, item.request.currency)?,
             payment: payment_details,
             currency_code: item.request.currency.to_string(),
             processing_options,
@@ -299,7 +300,7 @@ impl TryFrom<&types::PaymentsCancelRouterData> for CancelOrCaptureTransactionReq
     type Error = error_stack::Report<errors::ConnectorError>;
     fn try_from(item: &types::PaymentsCancelRouterData) -> Result<Self, Self::Error> {
         let transaction_request = TransactionVoidOrCaptureRequest {
-            amount: item.request.amount,
+            amount: None, //amount is not required for void
             transaction_type: TransactionType::Void,
             ref_trans_id: item.request.connector_transaction_id.to_string(),
         };
@@ -319,7 +320,10 @@ impl TryFrom<&types::PaymentsCaptureRouterData> for CancelOrCaptureTransactionRe
     type Error = error_stack::Report<errors::ConnectorError>;
     fn try_from(item: &types::PaymentsCaptureRouterData) -> Result<Self, Self::Error> {
         let transaction_request = TransactionVoidOrCaptureRequest {
-            amount: Some(item.request.amount_to_capture),
+            amount: Some(utils::to_currency_base_unit_asf64(
+                item.request.amount_to_capture,
+                item.request.currency,
+            )?),
             transaction_type: TransactionType::Capture,
             ref_trans_id: item.request.connector_transaction_id.to_string(),
         };
@@ -449,7 +453,6 @@ pub struct AuthorizedotnetVoidResponse {
 #[serde(rename_all = "camelCase")]
 pub struct VoidResponse {
     response_code: AuthorizedotnetVoidStatus,
-    auth_code: String,
     #[serde(rename = "transId")]
     transaction_id: String,
     network_trans_id: Option<String>,
@@ -622,7 +625,7 @@ impl<F, T>
 #[serde(rename_all = "camelCase")]
 struct RefundTransactionRequest {
     transaction_type: TransactionType,
-    amount: i64,
+    amount: f64,
     currency_code: String,
     payment: PaymentDetails,
     #[serde(rename = "refTransId")]
@@ -660,7 +663,10 @@ impl<F> TryFrom<&types::RefundsRouterData<F>> for CreateRefundRequest {
 
         let transaction_request = RefundTransactionRequest {
             transaction_type: TransactionType::Refund,
-            amount: item.request.refund_amount,
+            amount: utils::to_currency_base_unit_asf64(
+                item.request.refund_amount,
+                item.request.currency,
+            )?,
             payment: payment_details
                 .parse_value("PaymentDetails")
                 .change_context(errors::ConnectorError::MissingRequiredField {


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Authorizedotnet don't take cents as input, we need to parse the incoming amount which is in cents to the dollar value.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
This pr contains : 
1) Authorizedotnet don't take cents as input, we need to parse the incoming amount which is in cents to the dollar value.
2) Field `Authcode` is not required in void response

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
<img width="1042" alt="Screenshot 2023-07-20 at 12 10 40 AM" src="https://github.com/juspay/hyperswitch/assets/121822803/afe37b51-cd13-43a2-af20-1d9900ac84e6">
<img width="1055" alt="Screenshot 2023-07-20 at 11 55 03 AM" src="https://github.com/juspay/hyperswitch/assets/121822803/73ededa9-8e6b-40c5-9ad2-d18204375f5a">


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
