### PR TITLE
refactor(fix): [Mollie] Add support for both HeaderKey and BodyKey AuthType

### DIFF
--- a/crates/router/src/connector/mollie/transformers.rs
+++ b/crates/router/src/connector/mollie/transformers.rs
@@ -253,7 +253,9 @@ impl TryFrom<&types::TokenizationRouterData> for MollieCardTokenRequest {
                         .ok_or(errors::ConnectorError::MissingRequiredField {
                             field_name: "test_mode",
                         })?;
-                let profile_token = auth.key1;
+                let profile_token = auth
+                    .key1
+                    .ok_or(errors::ConnectorError::FailedToObtainAuthType)?;
                 Ok(Self {
                     card_holder,
                     card_number,
@@ -434,19 +436,22 @@ pub struct BankDetails {
 
 pub struct MollieAuthType {
     pub(super) api_key: Secret<String>,
-    pub(super) key1: Secret<String>,
+    pub(super) key1: Option<Secret<String>>,
 }
 
 impl TryFrom<&types::ConnectorAuthType> for MollieAuthType {
     type Error = Error;
     fn try_from(auth_type: &types::ConnectorAuthType) -> Result<Self, Self::Error> {
-        if let types::ConnectorAuthType::BodyKey { api_key, key1 } = auth_type {
-            Ok(Self {
+        match auth_type {
+            types::ConnectorAuthType::HeaderKey { api_key } => Ok(Self {
                 api_key: Secret::new(api_key.to_owned()),
-                key1: Secret::new(key1.to_owned()),
-            })
-        } else {
-            Err(errors::ConnectorError::FailedToObtainAuthType.into())
+                key1: None,
+            }),
+            types::ConnectorAuthType::BodyKey { api_key, key1 } => Ok(Self {
+                api_key: Secret::new(api_key.to_owned()),
+                key1: Some(Secret::new(key1.to_owned())),
+            }),
+            _ => Err(errors::ConnectorError::FailedToObtainAuthType)?,
         }
     }
 }

--- a/crates/router/src/connector/mollie/transformers.rs
+++ b/crates/router/src/connector/mollie/transformers.rs
@@ -254,7 +254,7 @@ impl TryFrom<&types::TokenizationRouterData> for MollieCardTokenRequest {
                             field_name: "test_mode",
                         })?;
                 let profile_token = auth
-                    .key1
+                    .profile_token
                     .ok_or(errors::ConnectorError::FailedToObtainAuthType)?;
                 Ok(Self {
                     card_holder,
@@ -436,7 +436,7 @@ pub struct BankDetails {
 
 pub struct MollieAuthType {
     pub(super) api_key: Secret<String>,
-    pub(super) key1: Option<Secret<String>>,
+    pub(super) profile_token: Option<Secret<String>>,
 }
 
 impl TryFrom<&types::ConnectorAuthType> for MollieAuthType {
@@ -445,11 +445,11 @@ impl TryFrom<&types::ConnectorAuthType> for MollieAuthType {
         match auth_type {
             types::ConnectorAuthType::HeaderKey { api_key } => Ok(Self {
                 api_key: Secret::new(api_key.to_owned()),
-                key1: None,
+                profile_token: None,
             }),
             types::ConnectorAuthType::BodyKey { api_key, key1 } => Ok(Self {
                 api_key: Secret::new(api_key.to_owned()),
-                key1: Some(Secret::new(key1.to_owned())),
+                profile_token: Some(Secret::new(key1.to_owned())),
             }),
             _ => Err(errors::ConnectorError::FailedToObtainAuthType)?,
         }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
This PR will work for these following scenarios:
1. If auth_type is BodyKey , all the Mollie payment methods will work fine.
2. If auth_type is HeaderKey, except "Mollie card 3ds" all other payment methods will work fine.
3. If auth_type is HeaderKey, "Mollie card 3ds" will not work and give an "Internal Server Error."


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
4. `crates/router/src/configs`
5. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
Using Postman.
<img width="1728" alt="Screen Shot 2023-07-20 at 4 14 13 PM" src="https://github.com/juspay/hyperswitch/assets/85639103/158e5dbf-f2f7-4011-af9a-07e63ef832f1">
<img width="1728" alt="Screen Shot 2023-07-20 at 4 15 02 PM" src="https://github.com/juspay/hyperswitch/assets/85639103/41ce9d30-468b-4e39-85d6-5180ffb8885c">


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
