### PR TITLE
fix(connector): [Powertranz] Fix response handling for https status code other than 200

### DIFF
--- a/crates/router/src/connector/powertranz.rs
+++ b/crates/router/src/connector/powertranz.rs
@@ -110,26 +110,13 @@ impl ConnectorCommon for Powertranz {
         &self,
         res: Response,
     ) -> CustomResult<ErrorResponse, errors::ConnectorError> {
-        let response: powertranz::PowertranzErrorResponse = res
-            .response
-            .parse_struct("PowertranzErrorResponse")
-            .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
-        let first_error = response.errors.first();
-        let code = first_error.map(|error| error.code.clone());
-        let message = first_error.map(|error| error.message.clone());
-
+        // For error scenerios connector respond with 200 http status code and error response object in response
+        // For http status code other than 200 they send empty response back
         Ok(ErrorResponse {
             status_code: res.status_code,
-            code: code.unwrap_or_else(|| consts::NO_ERROR_CODE.to_string()),
-            message: message.unwrap_or_else(|| consts::NO_ERROR_MESSAGE.to_string()),
-            reason: Some(
-                response
-                    .errors
-                    .iter()
-                    .map(|error| format!("{} : {}", error.code, error.message))
-                    .collect::<Vec<_>>()
-                    .join(", "),
-            ),
+            code: consts::NO_ERROR_CODE.to_string(),
+            message: consts::NO_ERROR_MESSAGE.to_string(),
+            reason: None,
         })
     }
 }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
Incase of non 200 status code connector is not giving any response body. So the same should be handled in the get_error_response methods


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
To reduce unnecessary 5xx in the system


## How did you test it?
<img width="1307" alt="Screen Shot 2023-07-24 at 3 55 32 PM" src="https://github.com/juspay/hyperswitch/assets/20727986/1ccad87f-4cc0-49f1-b777-e54624ffa5ff">

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
