### PR TITLE
fix(config): detect duplicate config insert and throw appropriate error

### DIFF
--- a/crates/router/src/compatibility/stripe/errors.rs
+++ b/crates/router/src/compatibility/stripe/errors.rs
@@ -79,6 +79,9 @@ pub enum StripeErrorCode {
     #[error(error_type = StripeErrorType::InvalidRequestError, code = "resource_missing", message = "No such config")]
     ConfigNotFound,
 
+    #[error(error_type = StripeErrorType::InvalidRequestError, code = "duplicate_resource", message = "Duplicate config")]
+    DuplicateConfig,
+
     #[error(error_type = StripeErrorType::InvalidRequestError, code = "resource_missing", message = "No such payment")]
     PaymentNotFound,
 
@@ -460,6 +463,7 @@ impl From<errors::ApiErrorResponse> for StripeErrorCode {
             errors::ApiErrorResponse::MandateActive => Self::MandateActive, //not a stripe code
             errors::ApiErrorResponse::CustomerRedacted => Self::CustomerRedacted, //not a stripe code
             errors::ApiErrorResponse::ConfigNotFound => Self::ConfigNotFound, // not a stripe code
+            errors::ApiErrorResponse::DuplicateConfig => Self::DuplicateConfig, // not a stripe code
             errors::ApiErrorResponse::DuplicateRefundRequest => Self::DuplicateRefundRequest,
             errors::ApiErrorResponse::DuplicatePayout { payout_id } => {
                 Self::DuplicatePayout { payout_id }
@@ -575,6 +579,7 @@ impl actix_web::ResponseError for StripeErrorCode {
             | Self::RefundNotFound
             | Self::CustomerNotFound
             | Self::ConfigNotFound
+            | Self::DuplicateConfig
             | Self::ClientSecretNotFound
             | Self::PaymentNotFound
             | Self::PaymentMethodNotFound

--- a/crates/router/src/configs/settings.rs
+++ b/crates/router/src/configs/settings.rs
@@ -640,7 +640,6 @@ impl Settings {
                     .with_list_parse_key("redis.cluster_urls")
                     .with_list_parse_key("connectors.supported.wallets")
                     .with_list_parse_key("connector_request_reference_id_config.merchant_ids_send_payment_id_as_connector_request_id"),
-
             )
             .build()?;
 

--- a/crates/router/src/configs/settings.rs
+++ b/crates/router/src/configs/settings.rs
@@ -640,6 +640,7 @@ impl Settings {
                     .with_list_parse_key("redis.cluster_urls")
                     .with_list_parse_key("connectors.supported.wallets")
                     .with_list_parse_key("connector_request_reference_id_config.merchant_ids_send_payment_id_as_connector_request_id"),
+
             )
             .build()?;
 

--- a/crates/router/src/core/configs.rs
+++ b/crates/router/src/core/configs.rs
@@ -24,7 +24,6 @@ pub async fn set_config(
                 err.change_context(errors::ApiErrorResponse::InternalServerError)
             }
         })
-        // .change_context(errors::ApiErrorResponse::InternalServerError)
         .attach_printable("Unknown error, while setting config key")?;
 
     Ok(ApplicationResponse::Json(config.foreign_into()))

--- a/crates/router/src/core/configs.rs
+++ b/crates/router/src/core/configs.rs
@@ -17,13 +17,7 @@ pub async fn set_config(
             config: config.value,
         })
         .await
-        .map_err(|err| {
-            if err.current_context().is_db_unique_violation() {
-                err.change_context(errors::ApiErrorResponse::DuplicateConfig)
-            } else {
-                err.change_context(errors::ApiErrorResponse::InternalServerError)
-            }
-        })
+        .to_duplicate_response(errors::ApiErrorResponse::DuplicateConfig)
         .attach_printable("Unknown error, while setting config key")?;
 
     Ok(ApplicationResponse::Json(config.foreign_into()))

--- a/crates/router/src/core/errors/api_error_response.rs
+++ b/crates/router/src/core/errors/api_error_response.rs
@@ -137,6 +137,8 @@ pub enum ApiErrorResponse {
     DuplicatePayment { payment_id: String },
     #[error(error_type = ErrorType::DuplicateRequest, code = "HE_01", message = "The payout with the specified payout_id '{payout_id}' already exists in our records")]
     DuplicatePayout { payout_id: String },
+    #[error(error_type = ErrorType::DuplicateRequest, code = "HE_01", message = "The config with the specified key already exists in our records")]
+    DuplicateConfig,
     #[error(error_type = ErrorType::ObjectNotFound, code = "HE_02", message = "Refund does not exist in our records")]
     RefundNotFound,
     #[error(error_type = ErrorType::ObjectNotFound, code = "HE_02", message = "Customer does not exist in our records")]

--- a/crates/router/src/core/errors/transformers.rs
+++ b/crates/router/src/core/errors/transformers.rs
@@ -143,6 +143,9 @@ impl ErrorSwitch<api_models::errors::types::ApiErrorResponse> for ApiErrorRespon
             }
             Self::ConfigNotFound => {
                 AER::NotFound(ApiError::new("HE", 2, "Config key does not exist in our records.", None))
+            },
+            Self::DuplicateConfig => {
+                AER::BadRequest(ApiError::new("HE", 1, "The config with the specified key already exists in our records", None))
             }
             Self::PaymentNotFound => {
                 AER::NotFound(ApiError::new("HE", 2, "Payment does not exist in our records", None))


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Added support for handling duplicate config creation appropriately instead of throwing `InternalServerError`

<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?

- compiler guided testing
- Verified changes with VAS, not bump required

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
