### PR TITLE
refactor(payments): dont update client secret on payment intent status update

### DIFF
--- a/crates/diesel_models/src/payment_intent.rs
+++ b/crates/diesel_models/src/payment_intent.rs
@@ -158,7 +158,6 @@ pub struct PaymentIntentUpdateInternal {
     pub setup_future_usage: Option<storage_enums::FutureUsage>,
     pub off_session: Option<bool>,
     pub metadata: Option<pii::SecretSerdeValue>,
-    pub client_secret: Option<Option<String>>,
     pub billing_address_id: Option<String>,
     pub shipping_address_id: Option<String>,
     pub modified_at: Option<PrimitiveDateTime>,
@@ -188,9 +187,6 @@ impl PaymentIntentUpdate {
                 .or(source.setup_future_usage),
             off_session: internal_update.off_session.or(source.off_session),
             metadata: internal_update.metadata.or(source.metadata),
-            client_secret: internal_update
-                .client_secret
-                .unwrap_or(source.client_secret),
             billing_address_id: internal_update
                 .billing_address_id
                 .or(source.billing_address_id),
@@ -229,7 +225,6 @@ impl From<PaymentIntentUpdate> for PaymentIntentUpdateInternal {
                 status: Some(status),
                 setup_future_usage,
                 customer_id,
-                client_secret: make_client_secret_null_based_on_status(status),
                 shipping_address_id,
                 billing_address_id,
                 modified_at: Some(common_utils::date_time::now()),
@@ -257,7 +252,6 @@ impl From<PaymentIntentUpdate> for PaymentIntentUpdateInternal {
             } => Self {
                 return_url,
                 status,
-                client_secret: status.and_then(make_client_secret_null_based_on_status),
                 customer_id,
                 shipping_address_id,
                 billing_address_id,
@@ -267,7 +261,6 @@ impl From<PaymentIntentUpdate> for PaymentIntentUpdateInternal {
             PaymentIntentUpdate::PGStatusUpdate { status } => Self {
                 status: Some(status),
                 modified_at: Some(common_utils::date_time::now()),
-                client_secret: make_client_secret_null_based_on_status(status),
                 ..Default::default()
             },
             PaymentIntentUpdate::MerchantStatusUpdate {
@@ -276,7 +269,6 @@ impl From<PaymentIntentUpdate> for PaymentIntentUpdateInternal {
                 billing_address_id,
             } => Self {
                 status: Some(status),
-                client_secret: make_client_secret_null_based_on_status(status),
                 shipping_address_id,
                 billing_address_id,
                 modified_at: Some(common_utils::date_time::now()),
@@ -296,7 +288,6 @@ impl From<PaymentIntentUpdate> for PaymentIntentUpdateInternal {
                 amount_captured,
                 // customer_id,
                 return_url,
-                client_secret: make_client_secret_null_based_on_status(status),
                 modified_at: Some(common_utils::date_time::now()),
                 ..Default::default()
             },
@@ -319,21 +310,5 @@ impl From<PaymentIntentUpdate> for PaymentIntentUpdateInternal {
                 ..Default::default()
             },
         }
-    }
-}
-
-fn make_client_secret_null_based_on_status(
-    status: storage_enums::IntentStatus,
-) -> Option<Option<String>> {
-    match status {
-        storage_enums::IntentStatus::Cancelled => Some(None),
-        storage_enums::IntentStatus::Succeeded
-        | storage_enums::IntentStatus::Processing
-        | storage_enums::IntentStatus::RequiresCustomerAction
-        | storage_enums::IntentStatus::RequiresMerchantAction
-        | storage_enums::IntentStatus::RequiresPaymentMethod
-        | storage_enums::IntentStatus::RequiresConfirmation
-        | storage_enums::IntentStatus::RequiresCapture
-        | storage_enums::IntentStatus::Failed => None,
     }
 }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
dont update client secret on payment intent status update

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Tested as hotfix

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
