### PR TITLE
fix(connector): [Klarna] Handle error response with both error_messages and error_message fields

### DIFF
--- a/crates/router/src/connector/klarna.rs
+++ b/crates/router/src/connector/klarna.rs
@@ -8,6 +8,7 @@ use transformers as klarna;
 use crate::{
     configs::settings,
     connector::utils as connector_utils,
+    consts,
     core::errors::{self, CustomResult},
     headers,
     services::{
@@ -49,6 +50,27 @@ impl ConnectorCommon for Klarna {
             headers::AUTHORIZATION.to_string(),
             auth.basic_token.into_masked(),
         )])
+    }
+
+    fn build_error_response(
+        &self,
+        res: types::Response,
+    ) -> CustomResult<types::ErrorResponse, errors::ConnectorError> {
+        let response: klarna::KlarnaErrorResponse = res
+            .response
+            .parse_struct("KlarnaErrorResponse")
+            .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
+        // KlarnaErrorResponse will either have error_messages or error_message field Ref: https://docs.klarna.com/api/errors/
+        let reason = response
+            .error_messages
+            .map(|messages| messages.join(" & "))
+            .or(response.error_message);
+        Ok(types::ErrorResponse {
+            status_code: res.status_code,
+            code: response.error_code,
+            message: consts::NO_ERROR_MESSAGE.to_string(),
+            reason,
+        })
     }
 }
 
@@ -174,16 +196,7 @@ impl
         &self,
         res: types::Response,
     ) -> CustomResult<types::ErrorResponse, errors::ConnectorError> {
-        let response: klarna::KlarnaErrorResponse = res
-            .response
-            .parse_struct("KlarnaErrorResponse")
-            .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
-        Ok(types::ErrorResponse {
-            status_code: res.status_code,
-            code: response.error_code,
-            message: response.error_messages.join(" & "),
-            reason: None,
-        })
+        self.build_error_response(res)
     }
 }
 
@@ -338,16 +351,7 @@ impl
         &self,
         res: types::Response,
     ) -> CustomResult<types::ErrorResponse, errors::ConnectorError> {
-        let response: klarna::KlarnaErrorResponse = res
-            .response
-            .parse_struct("KlarnaErrorResponse")
-            .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
-        Ok(types::ErrorResponse {
-            status_code: res.status_code,
-            code: response.error_code,
-            message: response.error_messages.join(" & "),
-            reason: None,
-        })
+        self.build_error_response(res)
     }
 }
 

--- a/crates/router/src/connector/klarna/transformers.rs
+++ b/crates/router/src/connector/klarna/transformers.rs
@@ -188,5 +188,6 @@ impl From<KlarnaFraudStatus> for enums::AttemptStatus {
 #[derive(Deserialize)]
 pub struct KlarnaErrorResponse {
     pub error_code: String,
-    pub error_messages: Vec<String>,
+    pub error_messages: Option<Vec<String>>,
+    pub error_message: Option<String>,
 }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
Incase of error, connector either return error_messages or error_message. Both should be handled in the error scenario


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
To fix deserialization error in case of error response from connector


## How did you test it?
<img width="1290" alt="Screen Shot 2023-07-26 at 8 13 38 PM" src="https://github.com/juspay/hyperswitch/assets/20727986/efa8a286-7650-426c-93f9-3f891f98a4ed">

<img width="1289" alt="Screen Shot 2023-07-26 at 8 10 47 PM" src="https://github.com/juspay/hyperswitch/assets/20727986/e7f91e31-9bca-4df7-a292-0b62c51ed055">



## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
