### PR TITLE
feat(router): add merchant_id check for manual_retry_allowed flag sent in payments response

### DIFF
--- a/crates/router/src/core/payments.rs
+++ b/crates/router/src/core/payments.rs
@@ -258,6 +258,7 @@ where
         auth_flow,
         &state.conf.server,
         operation,
+        &state.conf.connector_request_reference_id_config,
     )
 }
 

--- a/crates/router/src/core/payments/helpers.rs
+++ b/crates/router/src/core/payments/helpers.rs
@@ -19,7 +19,7 @@ use super::{
     CustomerDetails, PaymentData,
 };
 use crate::{
-    configs::settings::Server,
+    configs::settings::{ConnectorRequestReferenceIdConfig, Server},
     consts,
     core::{
         errors::{self, CustomResult, RouterResult, StorageErrorExt},
@@ -2431,8 +2431,10 @@ impl AttemptType {
 pub fn is_manual_retry_allowed(
     intent_status: &storage_enums::IntentStatus,
     attempt_status: &storage_enums::AttemptStatus,
+    connector_request_reference_id_config: &ConnectorRequestReferenceIdConfig,
+    merchant_id: &str,
 ) -> Option<bool> {
-    match intent_status {
+    let is_payment_status_eligible_for_retry = match intent_status {
         enums::IntentStatus::Failed => match attempt_status {
             enums::AttemptStatus::Started
             | enums::AttemptStatus::AuthenticationPending
@@ -2472,7 +2474,12 @@ pub fn is_manual_retry_allowed(
         | enums::IntentStatus::RequiresMerchantAction
         | enums::IntentStatus::RequiresPaymentMethod
         | enums::IntentStatus::RequiresConfirmation => None,
-    }
+    };
+    let is_merchant_id_enabled_for_retries = !connector_request_reference_id_config
+        .merchant_ids_send_payment_id_as_connector_request_id
+        .contains(merchant_id);
+    is_payment_status_eligible_for_retry
+        .map(|payment_status_check| payment_status_check && is_merchant_id_enabled_for_retries)
 }
 
 #[cfg(test)]

--- a/crates/router/src/core/payments/transformers.rs
+++ b/crates/router/src/core/payments/transformers.rs
@@ -8,7 +8,7 @@ use router_env::{instrument, tracing};
 
 use super::{flows::Feature, PaymentAddress, PaymentData};
 use crate::{
-    configs::settings::Server,
+    configs::settings::{ConnectorRequestReferenceIdConfig, Server},
     connector::{Nexinets, Paypal},
     core::{
         errors::{self, RouterResponse, RouterResult},
@@ -155,6 +155,7 @@ where
         auth_flow: services::AuthFlow,
         server: &Server,
         operation: Op,
+        connector_request_reference_id_config: &ConnectorRequestReferenceIdConfig,
     ) -> RouterResponse<Self>;
 }
 
@@ -170,6 +171,7 @@ where
         auth_flow: services::AuthFlow,
         server: &Server,
         operation: Op,
+        connector_request_reference_id_config: &ConnectorRequestReferenceIdConfig,
     ) -> RouterResponse<Self> {
         payments_to_payments_response(
             req,
@@ -188,6 +190,7 @@ where
             payment_data.ephemeral_key,
             payment_data.sessions_token,
             payment_data.setup_mandate,
+            connector_request_reference_id_config,
         )
     }
 }
@@ -205,6 +208,7 @@ where
         _auth_flow: services::AuthFlow,
         _server: &Server,
         _operation: Op,
+        _connector_request_reference_id_config: &ConnectorRequestReferenceIdConfig,
     ) -> RouterResponse<Self> {
         Ok(services::ApplicationResponse::Json(Self {
             session_token: payment_data.sessions_token,
@@ -231,6 +235,7 @@ where
         _auth_flow: services::AuthFlow,
         _server: &Server,
         _operation: Op,
+        _connector_request_reference_id_config: &ConnectorRequestReferenceIdConfig,
     ) -> RouterResponse<Self> {
         let additional_payment_method_data: Option<api_models::payments::AdditionalPaymentData> =
             data.payment_attempt
@@ -288,6 +293,7 @@ pub fn payments_to_payments_response<R, Op>(
     ephemeral_key_option: Option<ephemeral_key::EphemeralKey>,
     session_tokens: Vec<api::SessionToken>,
     mandate_data: Option<api_models::payments::MandateData>,
+    connector_request_reference_id_config: &ConnectorRequestReferenceIdConfig,
 ) -> RouterResponse<api::PaymentsResponse>
 where
     Op: Debug,
@@ -489,6 +495,8 @@ where
                         .set_manual_retry_allowed(helpers::is_manual_retry_allowed(
                             &payment_intent.status,
                             &payment_attempt.status,
+                            connector_request_reference_id_config,
+                            &merchant_id,
                         ))
                         .set_connector_transaction_id(payment_attempt.connector_transaction_id)
                         .set_feature_metadata(payment_intent.feature_metadata)
@@ -536,6 +544,8 @@ where
             manual_retry_allowed: helpers::is_manual_retry_allowed(
                 &payment_intent.status,
                 &payment_attempt.status,
+                connector_request_reference_id_config,
+                &merchant_id,
             ),
             order_details: payment_intent.order_details,
             connector_transaction_id: payment_attempt.connector_transaction_id,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
currently we are relying only on payment_status to decide if manual_retry_allowed, need to have merchant_id check if a merchant is enabled for retries or not

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
Tested Manually
Merchant is enabled for retries
![image](https://github.com/juspay/hyperswitch/assets/56996463/5e122824-4246-41c2-abab-9b305f9e9536)

Payments response for failed payment
![image](https://github.com/juspay/hyperswitch/assets/56996463/4ccbf8ae-8474-47ee-89c0-1cf17b585e2a)

Merchant is not enabled for retries
![image](https://github.com/juspay/hyperswitch/assets/56996463/05c37895-ce02-4f01-bedf-a3629ffbb4c0)

Payments response for failed payment
![image](https://github.com/juspay/hyperswitch/assets/56996463/b97198d2-bc9c-4646-8e81-23ea35214e8e)

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
