### PR TITLE
fix(connector): [Trustpay] send billing address name as cardholder name

### DIFF
--- a/crates/router/src/connector/trustpay/transformers.rs
+++ b/crates/router/src/connector/trustpay/transformers.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use api_models::payments::BankRedirectData;
 use common_utils::{errors::CustomResult, pii};
 use error_stack::{report, IntoReport, ResultExt};
-use masking::Secret;
+use masking::{PeekInterface, Secret};
 use reqwest::Url;
 use serde::{Deserialize, Serialize};
 
@@ -182,6 +182,7 @@ pub struct TrustpayMandatoryParams {
     pub billing_country: api_models::enums::CountryAlpha2,
     pub billing_street1: Secret<String>,
     pub billing_postcode: Secret<String>,
+    pub billing_first_name: Secret<String>,
 }
 
 impl TryFrom<&BankRedirectData> for TrustpayPaymentMethod {
@@ -210,6 +211,7 @@ fn get_mandatory_fields(
         billing_country: billing_address.get_country()?.to_owned(),
         billing_street1: billing_address.get_line1()?.to_owned(),
         billing_postcode: billing_address.get_zip()?.to_owned(),
+        billing_first_name: billing_address.get_first_name()?.to_owned(),
     })
 }
 
@@ -220,6 +222,7 @@ fn get_card_request_data(
     amount: String,
     ccard: &api_models::payments::Card,
     return_url: String,
+    billing_last_name: Option<Secret<String>>,
 ) -> Result<TrustpayPaymentsRequest, Error> {
     let email = item.request.get_email()?;
     let customer_ip_address = browser_info.get_ip_address()?;
@@ -230,7 +233,12 @@ fn get_card_request_data(
             pan: ccard.card_number.clone(),
             cvv: ccard.card_cvc.clone(),
             expiry_date: ccard.get_card_expiry_month_year_2_digit_with_delimiter("/".to_owned()),
-            cardholder: ccard.card_holder_name.clone(),
+            cardholder: match billing_last_name {
+                Some(last_name) => {
+                    format!("{} {}", params.billing_first_name.peek(), last_name.peek()).into()
+                }
+                None => params.billing_first_name,
+            },
             reference: item.payment_id.clone(),
             redirect_url: return_url,
             billing_city: params.billing_city,
@@ -303,6 +311,11 @@ impl TryFrom<&types::PaymentsAuthorizeRouterData> for TrustpayPaymentsRequest {
             ip_address: browser_info.ip_address,
         };
         let params = get_mandatory_fields(item)?;
+        let billing_last_name = item
+            .get_billing()?
+            .address
+            .as_ref()
+            .map(|address| address.last_name.clone().unwrap_or_default());
         let amount = format!(
             "{:.2}",
             utils::to_currency_base_unit(item.request.amount, item.request.currency)?
@@ -320,6 +333,7 @@ impl TryFrom<&types::PaymentsAuthorizeRouterData> for TrustpayPaymentsRequest {
                 amount,
                 ccard,
                 item.request.get_return_url()?,
+                billing_last_name,
             )?),
             api::PaymentMethodData::BankRedirect(ref bank_redirection_data) => {
                 get_bank_redirection_request_data(item, bank_redirection_data, amount, auth)


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
currently we are getting empty string as cardholder name from sdk
cardholder name is mandatory for trustpay, send billing address name name as cardholder name

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
Tested Manually
Payments Request
![image](https://github.com/juspay/hyperswitch/assets/56996463/d505b88e-e3e5-4fdc-a081-72073046c8d6)

Request sent to connector
![image](https://github.com/juspay/hyperswitch/assets/56996463/3b1c2a71-626b-4716-ac1a-b0a28ad63be4)

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
