### PR TITLE
fix(connector): [Payme] Fix refund request fields

### DIFF
--- a/crates/router/src/connector/payme/transformers.rs
+++ b/crates/router/src/connector/payme/transformers.rs
@@ -128,9 +128,9 @@ impl TryFrom<&types::PaymentsInitRouterData> for GenerateSaleRequest {
             sale_price: item.request.amount,
             transaction_id: item.payment_id.clone(),
             product_name,
-            sale_return_url: "https://google.com/".to_string(),
+            sale_return_url: item.request.get_return_url()?,
             seller_payme_id,
-            sale_callback_url: "https://google.com/".to_string(),
+            sale_callback_url: item.request.get_webhook_url()?,
             sale_payment_method: SalePaymentMethod::try_from(&item.request.payment_method_data)?,
         })
     }

--- a/crates/router/src/connector/payme/transformers.rs
+++ b/crates/router/src/connector/payme/transformers.rs
@@ -128,9 +128,9 @@ impl TryFrom<&types::PaymentsInitRouterData> for GenerateSaleRequest {
             sale_price: item.request.amount,
             transaction_id: item.payment_id.clone(),
             product_name,
-            sale_return_url: item.request.get_return_url()?,
+            sale_return_url: "https://google.com/".to_string(),
             seller_payme_id,
-            sale_callback_url: item.request.get_webhook_url()?,
+            sale_callback_url: "https://google.com/".to_string(),
             sale_payment_method: SalePaymentMethod::try_from(&item.request.payment_method_data)?,
         })
     }
@@ -242,6 +242,7 @@ impl TryFrom<&types::PaymentsAuthorizeRouterData> for PayRequest {
 
 // Auth Struct
 pub struct PaymeAuthType {
+    #[allow(dead_code)]
     pub(super) payme_client_key: Secret<String>,
     pub(super) seller_payme_id: Secret<String>,
 }
@@ -361,7 +362,6 @@ pub struct PaymeRefundRequest {
     sale_refund_amount: i64,
     payme_sale_id: String,
     seller_payme_id: Secret<String>,
-    payme_client_key: Secret<String>,
 }
 
 impl<F> TryFrom<&types::RefundsRouterData<F>> for PaymeRefundRequest {
@@ -371,7 +371,6 @@ impl<F> TryFrom<&types::RefundsRouterData<F>> for PaymeRefundRequest {
         Ok(Self {
             payme_sale_id: item.request.connector_transaction_id.clone(),
             seller_payme_id: auth_type.seller_payme_id,
-            payme_client_key: auth_type.payme_client_key,
             sale_refund_amount: item.request.refund_amount,
         })
     }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
Refund does not require field "payme_client_key" in the request


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
As suggested by payme connector support removed "payme_client_key" field from the refund request


## How did you test it?
Manual Testing 
<img width="1300" alt="Screen Shot 2023-08-01 at 11 51 59 AM" src="https://github.com/juspay/hyperswitch/assets/20727986/cca79b30-806c-4e28-b536-055a4afbde97">

<img width="1289" alt="Screen Shot 2023-08-01 at 11 51 43 AM" src="https://github.com/juspay/hyperswitch/assets/20727986/894734fe-c94f-4cce-98b0-6d775dc16c8a">

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
