### PR TITLE
ci(postman): disable `merge_group` trigger

### DIFF
--- a/.github/workflows/postman-collection-runner.yml
+++ b/.github/workflows/postman-collection-runner.yml
@@ -3,8 +3,8 @@ name: Run postman tests
 on:
   workflow_dispatch:
   pull_request:
-  merge_group:
-    types: [checks_requested]
+  # merge_group:
+  #   types: [checks_requested]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/postman-collection-runner.yml
+++ b/.github/workflows/postman-collection-runner.yml
@@ -2,7 +2,7 @@ name: Run postman tests
 
 on:
   workflow_dispatch:
-  pull_request:
+  # pull_request:
   # merge_group:
   #   types: [checks_requested]
 


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] CI/CD

## Description
<!-- Describe your changes in detail -->
This PR disables postman-collection-runner.yml in merge-queue since it is found to be having issues with running in local host that is affecting other PRs. So, commenting it now.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
I  don't want to hurt other's progress / productivity.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
CI failing in GH Actions

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I reviewed submitted code
