### PR TITLE
fix: request amount fix for trustpay apple pay

### DIFF
--- a/crates/router/src/connector/trustpay/transformers.rs
+++ b/crates/router/src/connector/trustpay/transformers.rs
@@ -849,23 +849,33 @@ impl TryFrom<&types::PaymentsPreProcessingRouterData> for TrustpayCreateIntentRe
             .as_ref()
             .map(|pmt| matches!(pmt, diesel_models::enums::PaymentMethodType::GooglePay));
 
+        let request_amount = item
+            .request
+            .amount
+            .get_required_value("amount")
+            .change_context(errors::ConnectorError::MissingRequiredField {
+                field_name: "amount",
+            })?;
+
+        let currency = item
+            .request
+            .currency
+            .get_required_value("currency")
+            .change_context(errors::ConnectorError::MissingRequiredField {
+                field_name: "currency",
+            })?;
+
+        let amount = format!(
+            "{:.2}",
+            utils::to_currency_base_unit(request_amount, currency)?
+                .parse::<f64>()
+                .into_report()
+                .change_context(errors::ConnectorError::RequestEncodingFailed)?
+        );
+
         Ok(Self {
-            amount: item
-                .request
-                .amount
-                .get_required_value("amount")
-                .change_context(errors::ConnectorError::MissingRequiredField {
-                    field_name: "amount",
-                })?
-                .to_string(),
-            currency: item
-                .request
-                .currency
-                .get_required_value("currency")
-                .change_context(errors::ConnectorError::MissingRequiredField {
-                    field_name: "currency",
-                })?
-                .to_string(),
+            amount,
+            currency: currency.to_string(),
             init_apple_pay: is_apple_pay,
             init_google_pay: is_google_pay,
         })


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix

## Description
<!-- Describe your changes in detail -->
For Trustpay Apple Pay, we were sending amount in cents.This PR fixes amount issue by converting to currency base unit.

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
Fix amount issue

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
<img width="414" alt="Screen Shot 2023-08-01 at 3 54 03 PM" src="https://github.com/juspay/hyperswitch/assets/59434228/9d001825-4731-4f4d-a521-06636dab01c4">


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
