### PR TITLE
fix(ui-tests): Run ui-tests for each PR on approval

### DIFF
--- a/.github/workflows/connector-ui-sanity-tests.yml
+++ b/.github/workflows/connector-ui-sanity-tests.yml
@@ -4,6 +4,8 @@ on:
   workflow_dispatch:
   
   pull_request:
+  pull_request_review:
+    types: [submitted]
   merge_group:
     types:
       - checks_requested
@@ -82,33 +84,33 @@ jobs:
           exit 0
 
       - name: Checkout repository
-        if: github.event_name != 'pull_request'
+        if: github.event_name == 'merge_group' || github.event.review.state == 'approved'
         uses: actions/checkout@v3
 
       - name: Decrypt connector auth file
-        if: github.event_name != 'pull_request'
+        if: github.event_name == 'merge_group' || github.event.review.state == 'approved'
         env:
           CONNECTOR_AUTH_PASSPHRASE: ${{ secrets.CONNECTOR_AUTH_PASSPHRASE }}
         shell: bash
         run: ./scripts/decrypt_connector_auth.sh
 
       - name: Set connector auth file path in env
-        if: github.event_name != 'pull_request'
+        if: github.event_name == 'merge_group' || github.event.review.state == 'approved'
         shell: bash
         run: echo "CONNECTOR_AUTH_FILE_PATH=$HOME/target/test/connector_auth.toml" >> $GITHUB_ENV
 
       - name: Set connector tests file path in env
-        if: github.event_name != 'pull_request'
+        if: github.event_name == 'merge_group' || github.event.review.state == 'approved'
         shell: bash
         run: echo "CONNECTOR_TESTS_FILE_PATH=$HOME/target/test/connector_tests.json" >> $GITHUB_ENV
 
       - name: Set ignore_browser_profile usage in env
-        if: github.event_name != 'pull_request'  
+        if: github.event_name == 'merge_group' || github.event.review.state == 'approved'  
         shell: bash
         run: echo "IGNORE_BROWSER_PROFILE=true" >> $GITHUB_ENV
 
       - name: Install latest compiler
-        if: github.event_name != 'pull_request'  
+        if: github.event_name == 'merge_group' || github.event.review.state == 'approved'  
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
@@ -116,21 +118,21 @@ jobs:
       - uses: Swatinem/rust-cache@v2.4.0
 
       - uses: baptiste0928/cargo-install@v2.1.0
-        if: github.event_name != 'pull_request'  
+        if: github.event_name == 'merge_group' || github.event.review.state == 'approved'  
         with:
           crate: diesel_cli
           features: postgres
           args: "--no-default-features"
 
       - name: Diesel migration run
-        if: github.event_name != 'pull_request'  
+        if: github.event_name == 'merge_group' || github.event.review.state == 'approved'  
         shell: bash
         env:
           DATABASE_URL: postgres://db_user:db_pass@localhost:5432/hyperswitch_db
         run: diesel migration run
 
       - name: Start server and run tests
-        if: github.event_name != 'pull_request'  
+        if: github.event_name == 'merge_group' || github.event.review.state == 'approved'  
         env:
           UI_TESTCASES_PATH: ${{ secrets.UI_TESTCASES_PATH }}
           INPUT: ${{ matrix.connector }}
@@ -138,12 +140,12 @@ jobs:
         run: sh .github/scripts/run_ui_tests.sh
 
       - name: View test results
-        if: github.event_name != 'pull_request'  
+        if: github.event_name == 'merge_group' || github.event.review.state == 'approved'  
         shell: bash
         run: cat tests/test_results.log
 
       - name: Check test results
-        if: github.event_name != 'pull_request'  
+        if: github.event_name == 'merge_group' || github.event.review.state == 'approved'  
         shell: bash
         run: |
           if test "$( grep 'test result: FAILED' -r tests/test_results.log | wc -l )" -gt "0"; then


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Currently the author of a PR is getting to know the failure of UI tests only during the merge queue, this blocks other PRs in the merge queue as PRs will be combined with other PRs before them in the merge queue. To avoid this we will run the ui test whenever someone approves the PR. So on first approval the check will run and the author will get to know the result on first approval.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
