### PR TITLE
fix(webhooks): add outgoing webhook for payment sync

### DIFF
--- a/crates/router/Cargo.toml
+++ b/crates/router/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 license.workspace = true
 
 [features]
-default = ["kv_store", "stripe", "oltp", "olap", "accounts_cache", "dummy_connector", "payouts"]
+default = ["kv_store", "stripe", "oltp", "olap", "accounts_cache", "dummy_connector", "payouts", "db_webhooks"]
 s3 = ["dep:aws-sdk-s3", "dep:aws-config"]
 kms = ["external_services/kms", "dep:aws-config"]
 email = ["external_services/email", "dep:aws-config"]
@@ -27,6 +27,7 @@ dummy_connector = ["api_models/dummy_connector"]
 external_access_dc = ["dummy_connector"]
 detailed_errors = ["api_models/detailed_errors", "error-stack/serde"]
 payouts = []
+db_webhooks = []
 
 
 [dependencies]

--- a/crates/router/src/core/payments.rs
+++ b/crates/router/src/core/payments.rs
@@ -171,11 +171,10 @@ where
                 .await?;
 
                 let operation = Box::new(PaymentResponse);
-                let db = &*state.store;
                 operation
                     .to_post_update_tracker()?
                     .update_tracker(
-                        db,
+                        state,
                         &validate_result.payment_id,
                         payment_data,
                         router_data,

--- a/crates/router/src/core/payments/operations.rs
+++ b/crates/router/src/core/payments/operations.rs
@@ -158,7 +158,7 @@ pub trait UpdateTracker<F, D, Req>: Send {
 pub trait PostUpdateTracker<F, D, R>: Send {
     async fn update_tracker<'b>(
         &'b self,
-        db: &dyn StorageInterface,
+        db: &AppState,
         payment_id: &api::PaymentIdType,
         payment_data: D,
         response: types::RouterData<F, R, PaymentsResponseData>,

--- a/crates/router/src/core/webhooks.rs
+++ b/crates/router/src/core/webhooks.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "db_webhooks")]
+pub mod outgoing;
 pub mod types;
 pub mod utils;
 

--- a/crates/router/src/core/webhooks/outgoing.rs
+++ b/crates/router/src/core/webhooks/outgoing.rs
@@ -1,0 +1,210 @@
+use api_models::webhooks;
+use diesel_models::{dispute, enums, payment_intent::PaymentIntent, refund};
+use error_stack::{IntoReport, ResultExt};
+use futures::TryFutureExt;
+
+use super::create_event_and_trigger_outgoing_webhook;
+use crate::{
+    core::{
+        errors, payments,
+        webhooks::types::{OutgoingWebhookTrigger, OutgoingWebhookType},
+    },
+    routes::AppState,
+    services,
+    types::{
+        api, domain,
+        transformers::{ForeignInto, ForeignTryInto},
+    },
+};
+
+#[async_trait::async_trait]
+impl OutgoingWebhookTrigger for PaymentIntent {
+    async fn construct_outgoing_webhook_content(
+        &self,
+        state: &AppState,
+        merchant_account: domain::MerchantAccount,
+        merchant_key_store: domain::MerchantKeyStore,
+    ) -> errors::CustomResult<webhooks::OutgoingWebhookContent, errors::ApiErrorResponse> {
+        payments::payments_core::<api::PSync, api::PaymentsResponse, _, _, _>(
+            state,
+            merchant_account,
+            merchant_key_store,
+            payments::operations::PaymentStatus,
+            api::PaymentsRetrieveRequest {
+                resource_id: api_models::payments::PaymentIdType::PaymentIntentId(
+                    self.payment_id.clone(),
+                ),
+                merchant_id: Some(self.merchant_id.clone()),
+                force_sync: false,
+                ..Default::default()
+            },
+            services::AuthFlow::Merchant,
+            payments::CallConnectorAction::Avoid,
+        )
+        .await
+        .and_then(|application_response| match application_response {
+            services::ApplicationResponse::Json(payments_response) => Ok(
+                webhooks::OutgoingWebhookContent::PaymentDetails(payments_response),
+            ),
+            // This state isn't possible
+            _ => Err(errors::ApiErrorResponse::GenericNotFoundError {
+                message: "Failed while getting payment response".to_string(),
+            })
+            .into_report(),
+        })
+    }
+
+    async fn trigger_outgoing_webhook<W: OutgoingWebhookType>(
+        &self,
+        state: &AppState,
+    ) -> errors::CustomResult<(), errors::ApiErrorResponse> {
+        let (merchant_account, merchant_key_store) = state
+            .store
+            .get_merchant_key_store_by_merchant_id(
+                &self.merchant_id,
+                &state.store.get_master_key().to_vec().into(),
+            )
+            .and_then(|key_store| async {
+                Ok((
+                    state
+                        .store
+                        .find_merchant_account_by_merchant_id(&self.merchant_id, &key_store)
+                        .await?,
+                    key_store,
+                ))
+            })
+            .await
+            .change_context(errors::ApiErrorResponse::MerchantAccountNotFound)?;
+
+        let webhook_content = self
+            .construct_outgoing_webhook_content(state, merchant_account.clone(), merchant_key_store)
+            .await?;
+
+        create_event_and_trigger_outgoing_webhook::<W>(
+            state.clone(),
+            merchant_account,
+            self.status
+                .foreign_try_into()
+                .into_report()
+                .change_context(errors::ApiErrorResponse::WebhookProcessingFailure)?,
+            enums::EventClass::Payments,
+            None,
+            self.payment_id.clone(),
+            enums::EventObjectType::PaymentDetails,
+            webhook_content,
+        )
+        .await
+    }
+}
+
+#[async_trait::async_trait]
+impl OutgoingWebhookTrigger for refund::Refund {
+    async fn construct_outgoing_webhook_content(
+        &self,
+        _state: &AppState,
+        _merchant_account: domain::MerchantAccount,
+        _merchant_key_store: domain::MerchantKeyStore,
+    ) -> errors::CustomResult<webhooks::OutgoingWebhookContent, errors::ApiErrorResponse> {
+        Ok(webhooks::OutgoingWebhookContent::RefundDetails(
+            self.clone().foreign_into(),
+        ))
+    }
+
+    async fn trigger_outgoing_webhook<W: OutgoingWebhookType>(
+        &self,
+        state: &AppState,
+    ) -> errors::CustomResult<(), errors::ApiErrorResponse> {
+        let (merchant_account, merchant_key_store) = state
+            .store
+            .get_merchant_key_store_by_merchant_id(
+                &self.merchant_id,
+                &state.store.get_master_key().to_vec().into(),
+            )
+            .and_then(|key_store| async {
+                Ok((
+                    state
+                        .store
+                        .find_merchant_account_by_merchant_id(&self.merchant_id, &key_store)
+                        .await?,
+                    key_store,
+                ))
+            })
+            .await
+            .change_context(errors::ApiErrorResponse::MerchantAccountNotFound)?;
+
+        let webhook_content = self
+            .construct_outgoing_webhook_content(state, merchant_account.clone(), merchant_key_store)
+            .await?;
+
+        create_event_and_trigger_outgoing_webhook::<W>(
+            state.clone(),
+            merchant_account,
+            self.refund_status
+                .foreign_try_into()
+                .into_report()
+                .change_context(errors::ApiErrorResponse::WebhookProcessingFailure)?,
+            enums::EventClass::Refunds,
+            None,
+            self.refund_id.clone(),
+            enums::EventObjectType::RefundDetails,
+            webhook_content,
+        )
+        .await
+    }
+}
+
+#[async_trait::async_trait]
+impl OutgoingWebhookTrigger for dispute::Dispute {
+    async fn construct_outgoing_webhook_content(
+        &self,
+        _state: &AppState,
+        _merchant_account: domain::MerchantAccount,
+        _merchant_key_store: domain::MerchantKeyStore,
+    ) -> errors::CustomResult<webhooks::OutgoingWebhookContent, errors::ApiErrorResponse> {
+        Ok(webhooks::OutgoingWebhookContent::DisputeDetails(Box::new(
+            self.clone().foreign_into(),
+        )))
+    }
+
+    async fn trigger_outgoing_webhook<W: OutgoingWebhookType>(
+        &self,
+        state: &AppState,
+    ) -> errors::CustomResult<(), errors::ApiErrorResponse> {
+        let (merchant_account, merchant_key_store) = state
+            .store
+            .get_merchant_key_store_by_merchant_id(
+                &self.merchant_id,
+                &state.store.get_master_key().to_vec().into(),
+            )
+            .and_then(|key_store| async {
+                Ok((
+                    state
+                        .store
+                        .find_merchant_account_by_merchant_id(&self.merchant_id, &key_store)
+                        .await?,
+                    key_store,
+                ))
+            })
+            .await
+            .change_context(errors::ApiErrorResponse::MerchantAccountNotFound)?;
+
+        let webhook_content = self
+            .construct_outgoing_webhook_content(state, merchant_account.clone(), merchant_key_store)
+            .await?;
+
+        create_event_and_trigger_outgoing_webhook::<W>(
+            state.clone(),
+            merchant_account,
+            self.dispute_status
+                .foreign_try_into()
+                .into_report()
+                .change_context(errors::ApiErrorResponse::WebhookProcessingFailure)?,
+            enums::EventClass::Disputes,
+            None,
+            self.dispute_id.clone(),
+            enums::EventObjectType::DisputeDetails,
+            webhook_content,
+        )
+        .await
+    }
+}


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

This adds framework to support outgoing webhooks from database models, and adds a webhook trigger for PSync call

<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
