### PR TITLE
fix(webhooks): do not send duplicate webhooks 

### DIFF
--- a/crates/api_models/src/payments.rs
+++ b/crates/api_models/src/payments.rs
@@ -2415,7 +2415,7 @@ pub struct PaymentsCancelRequest {
     pub merchant_connector_details: Option<admin::MerchantConnectorDetailsWrap>,
 }
 
-#[derive(Default, Debug, serde::Deserialize, serde::Serialize, ToSchema)]
+#[derive(Default, Debug, serde::Deserialize, serde::Serialize, ToSchema, Clone)]
 pub struct PaymentsStartRequest {
     /// Unique identifier for the payment. This ensures idempotency for multiple payments
     /// that have been done by a single merchant. This field is auto generated and is returned in the API response.

--- a/crates/router/src/core/webhooks.rs
+++ b/crates/router/src/core/webhooks.rs
@@ -476,7 +476,7 @@ pub async fn create_event_and_trigger_outgoing_webhook<W: types::OutgoingWebhook
 ) -> CustomResult<(), errors::ApiErrorResponse> {
     let event_id = format!("{primary_object_id}_{}", event_type.to_string());
     let new_event = storage::EventNew {
-        event_id,
+        event_id: event_id.clone(),
         event_type,
         event_class,
         is_webhook_notified: false,
@@ -485,12 +485,22 @@ pub async fn create_event_and_trigger_outgoing_webhook<W: types::OutgoingWebhook
         primary_object_type,
     };
 
-    let event = state
-        .store
-        .insert_event(new_event)
-        .await
-        .change_context(errors::ApiErrorResponse::WebhookProcessingFailure)
-        .attach_printable("event insertion failure")?;
+    let event_insert_result = state.store.insert_event(new_event).await;
+
+    let event = match event_insert_result {
+        Ok(event) => Ok(event),
+        Err(error) => {
+            if error.current_context().is_db_unique_violation() {
+                logger::info!("Merchant already notified about the event {event_id}");
+                return Ok(());
+            } else {
+                logger::error!(event_insertion_failure=?error);
+                Err(error
+                    .change_context(errors::ApiErrorResponse::WebhookProcessingFailure)
+                    .attach_printable("Failed to insert event in events table"))
+            }
+        }
+    }?;
 
     if state.conf.webhooks.outgoing_enabled {
         let arbiter = actix::Arbiter::try_current()

--- a/crates/router/src/core/webhooks.rs
+++ b/crates/router/src/core/webhooks.rs
@@ -474,7 +474,7 @@ pub async fn create_event_and_trigger_outgoing_webhook<W: types::OutgoingWebhook
     primary_object_type: enums::EventObjectType,
     content: api::OutgoingWebhookContent,
 ) -> CustomResult<(), errors::ApiErrorResponse> {
-    let event_id = format!("{primary_object_id}_{}", event_type.to_string());
+    let event_id = format!("{primary_object_id}_{}", event_type);
     let new_event = storage::EventNew {
         event_id: event_id.clone(),
         event_type,

--- a/crates/router/src/core/webhooks.rs
+++ b/crates/router/src/core/webhooks.rs
@@ -474,8 +474,9 @@ pub async fn create_event_and_trigger_outgoing_webhook<W: types::OutgoingWebhook
     primary_object_type: enums::EventObjectType,
     content: api::OutgoingWebhookContent,
 ) -> CustomResult<(), errors::ApiErrorResponse> {
+    let event_id = format!("{primary_object_id}_{}", event_type.to_string());
     let new_event = storage::EventNew {
-        event_id: generate_id(consts::ID_LENGTH, "evt"),
+        event_id,
         event_type,
         event_class,
         is_webhook_notified: false,

--- a/migrations/2023-08-01-165717_make_event_id_unique_for_events_table/down.sql
+++ b/migrations/2023-08-01-165717_make_event_id_unique_for_events_table/down.sql
@@ -1,0 +1,2 @@
+-- This file should undo anything in `up.sql`
+ALTER TABLE events DROP CONSTRAINT event_id_unique;

--- a/migrations/2023-08-01-165717_make_event_id_unique_for_events_table/up.sql
+++ b/migrations/2023-08-01-165717_make_event_id_unique_for_events_table/up.sql
@@ -1,0 +1,3 @@
+-- Your SQL goes here
+ALTER TABLE events
+ADD CONSTRAINT event_id_unique UNIQUE (event_id);


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] New feature

## Description
<!-- Describe your changes in detail -->
Hyperswitch triggers a webhook only when it receives a webhook. We will need to trigger a webhook for payments too, but in that case, if we receive a webhook from upstream, that will also trigger a webhook to the merchant. To avoid this, event id is generated using `primary_resource_id` and `event_type`. This will prevent the same event type webhook being repeated.

### Additional Changes

- [x] This PR modifies the database schema

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->
migrations/2023-08-01-165717_make_event_id_unique_for_events_table/down.sql
migrations/2023-08-01-165717_make_event_id_unique_for_events_table/up.sql

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
- Create a payment and test if webhooks are received in the webhook site.
<img width="1559" alt="Screenshot 2023-08-02 at 7 13 52 PM" src="https://github.com/juspay/hyperswitch/assets/48803246/309978c4-c297-41ca-a1f2-a29ac88d0896">



## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
