### PR TITLE
fix(core): If frm is not called, send None in frm_message instead of initial values in update tracker

### DIFF
--- a/crates/router/src/core/payments/operations/payment_status.rs
+++ b/crates/router/src/core/payments/operations/payment_status.rs
@@ -277,17 +277,25 @@ async fn get_tracker_for_sync<
         .attach_printable_lazy(|| {
             format!("Error while retrieving frm_response, merchant_id: {merchant_id}, payment_id: {payment_id_str}")
         });
-    let frm_message = frm_response
-        .ok()
-        .map(|response| api_models::payments::FrmMessage {
-            frm_name: response.frm_name,
-            frm_transaction_id: response.frm_transaction_id,
-            frm_transaction_type: Some(response.frm_transaction_type.to_string()),
-            frm_status: Some(response.frm_status.to_string()),
-            frm_score: response.frm_score,
-            frm_reason: response.frm_reason,
-            frm_error: response.frm_error,
-        });
+
+    let frm_message = match frm_response.ok() {
+        Some(response) => {
+            if response.frm_status.to_string() == "pending" {
+                None
+            } else {
+                Some(api_models::payments::FrmMessage {
+                    frm_name: response.frm_name,
+                    frm_transaction_id: response.frm_transaction_id,
+                    frm_transaction_type: Some(response.frm_transaction_type.to_string()),
+                    frm_status: Some(response.frm_status.to_string()),
+                    frm_score: response.frm_score,
+                    frm_reason: response.frm_reason,
+                    frm_error: response.frm_error,
+                })
+            }
+        }
+        None => None,
+    };
 
     let contains_encoded_data = connector_response.encoded_data.is_some();
 


### PR DESCRIPTION


## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Currently, even if frm is not called, frm message is populated with the initial status for psync api
fixing this to only send frm_message, when status is not pending 

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [X] I formatted the code `cargo +nightly fmt --all`
- [X] I addressed lints thrown by `cargo clippy`
- [X] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
