### PR TITLE
refactor(authorize_flow): suppress error while saving a card to locker after successful payment

### DIFF
--- a/crates/router/src/core/payments/flows/authorize_flow.rs
+++ b/crates/router/src/core/payments/flows/authorize_flow.rs
@@ -80,7 +80,7 @@ impl Feature<api::Authorize, types::PaymentsAuthorizeData> for types::PaymentsAu
 
             metrics::PAYMENT_COUNT.add(&metrics::CONTEXT, 1, &[]); // Metrics
 
-            let pm_id = tokenization::save_payment_method(
+            let save_payment_result = tokenization::save_payment_method(
                 state,
                 connector,
                 resp.to_owned(),
@@ -88,7 +88,19 @@ impl Feature<api::Authorize, types::PaymentsAuthorizeData> for types::PaymentsAu
                 merchant_account,
                 self.request.payment_method_type,
             )
-            .await?;
+            .await;
+
+            let pm_id = match save_payment_result {
+                Ok(payment_method_id) => Ok(payment_method_id),
+                Err(error) => {
+                    if resp.request.setup_mandate_details.clone().is_some() {
+                        Err(error)
+                    } else {
+                        logger::error!(save_payment_method_error=?error);
+                        Ok(None)
+                    }
+                }
+            }?;
 
             Ok(mandate::mandate_procedure(state, resp, maybe_customer, pm_id).await?)
         } else {


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Currently, when a payment succeeds, we save the card details to the locker. If an error occurs during this process, we return an error response, causing an inconsistency between the payment status and the card-saving status. To ensure a more accurate representation of the transaction, we should modify the response behavior in such cases.

Instead if the payment succeeds and saving card to locker fails we should return 200.

In case of mandates payments adding card to locker is a mandatory so we return error if the save card details to the locker fails. During the non mandate payments with setup_future_usage as on_session, if the  payment has succeeded and if save to card to locker fails we just log the error, as it would be inappropriate to return error for a Succeeded payment. 

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Made save_in_locker to return InternalServerError
<img width="970" alt="image" src="https://github.com/juspay/hyperswitch/assets/83439957/f1503023-c68b-4e06-b101-b7ce0c26aba6">

<img width="1230" alt="image" src="https://github.com/juspay/hyperswitch/assets/83439957/984deeb1-bff1-46d9-9033-06c18d145f77">
<img width="599" alt="image" src="https://github.com/juspay/hyperswitch/assets/83439957/1661ffbb-b70e-4dfb-a829-5d8591619685">
<img width="1515" alt="image" src="https://github.com/juspay/hyperswitch/assets/83439957/4a10adb2-6fbe-4cc0-b3a6-8ac226506d2b">


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
