### PR TITLE
 fix(connector): [Adyen] Response Handling in case of RefusalResponse

### DIFF
--- a/crates/router/src/connector/adyen.rs
+++ b/crates/router/src/connector/adyen.rs
@@ -385,6 +385,17 @@ impl
                             ),
                         }
                     }
+                    adyen::AdyenRedirectRequestTypes::AdyenRefusal(req) => {
+                        adyen::AdyenRedirectRequest {
+                            details: adyen::AdyenRedirectRequestTypes::AdyenRefusal(
+                                adyen::AdyenRefusal {
+                                    payload: req.payload,
+                                    type_of_redirection_result: None,
+                                    result_code: None,
+                                },
+                            ),
+                        }
+                    }
                 };
 
                 let adyen_request = types::RequestBody::log_and_get_request_body(

--- a/crates/router/src/connector/adyen/transformers.rs
+++ b/crates/router/src/connector/adyen/transformers.rs
@@ -226,6 +226,16 @@ pub struct AdyenRedirectRequest {
 pub enum AdyenRedirectRequestTypes {
     AdyenRedirection(AdyenRedirection),
     AdyenThreeDS(AdyenThreeDS),
+    AdyenRefusal(AdyenRefusal),
+}
+
+#[derive(Debug, Clone, Serialize, serde::Deserialize, Eq, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct AdyenRefusal {
+    pub payload: String,
+    #[serde(rename = "type")]
+    pub type_of_redirection_result: Option<String>,
+    pub result_code: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, serde::Deserialize, Eq, PartialEq)]


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
In case of Redirection Response in Adyen, it doesn't contain the `payload` field, resulting in deserialization error


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
