### PR TITLE
revert: ci: use `sccache-action` for caching compilation artifacts

### DIFF
--- a/.github/workflows/CI-pr.yml
+++ b/.github/workflows/CI-pr.yml
@@ -35,9 +35,6 @@ env:
   RUST_BACKTRACE: short
   # Use cargo's sparse index protocol
   CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
-  # Enable and use the sccache action for caching
-  SCCACHE_GHA_ENABLED: "true"
-  RUSTC_WRAPPER: "sccache"
 
 jobs:
   formatting:
@@ -87,7 +84,9 @@ jobs:
         with:
           toolchain: 1.65
 
-      - uses: mozilla-actions/sccache-action@v0.0.3
+      - uses: Swatinem/rust-cache@v2.4.0
+        with:
+          save-if: ${{ github.event_name == 'push' }}
 
       - name: Install cargo-hack
         uses: baptiste0928/cargo-install@v2.1.0
@@ -294,7 +293,9 @@ jobs:
       #   with:
       #     crate: cargo-nextest
 
-      - uses: mozilla-actions/sccache-action@v0.0.3
+      - uses: Swatinem/rust-cache@v2.4.0
+        with:
+          save-if: ${{ github.event_name == 'push' }}
 
       # - name: Setup Embark Studios lint rules
       #   shell: bash

--- a/.github/workflows/CI-push.yml
+++ b/.github/workflows/CI-push.yml
@@ -19,32 +19,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-env:
-  # Disable incremental compilation.
-  #
-  # Incremental compilation is useful as part of an edit-build-test-edit cycle,
-  # as it lets the compiler avoid recompiling code that hasn't changed. However,
-  # on CI, we're not making small edits; we're almost always building the entire
-  # project from scratch. Thus, incremental compilation on CI actually
-  # introduces *additional* overhead to support making future builds
-  # faster...but no future builds will ever occur in any given CI environment.
-  #
-  # See https://matklad.github.io/2021/09/04/fast-rust-builds.html#ci-workflow
-  # for details.
-  CARGO_INCREMENTAL: 0
-  # Allow more retries for network requests in cargo (downloading crates) and
-  # rustup (installing toolchains). This should help to reduce flaky CI failures
-  # from transient network timeouts or other issues.
-  CARGO_NET_RETRY: 10
-  RUSTUP_MAX_RETRIES: 10
-  # Don't emit giant backtraces in the CI logs.
-  RUST_BACKTRACE: short
-  # Use cargo's sparse index protocol
-  CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
-  # Enable and use the sccache action for caching
-  SCCACHE_GHA_ENABLED: "true"
-  RUSTC_WRAPPER: "sccache"
-
 jobs:
   formatting:
     name: Check formatting
@@ -89,7 +63,9 @@ jobs:
         with:
           toolchain: 1.65
 
-      - uses: mozilla-actions/sccache-action@v0.0.3
+      - uses: Swatinem/rust-cache@v2.4.0
+        with:
+          save-if: ${{ github.event_name == 'push' }}
 
       - name: Install cargo-hack
         uses: baptiste0928/cargo-install@v2.0.0
@@ -162,7 +138,9 @@ jobs:
       #   with:
       #     crate: cargo-nextest
 
-      - uses: mozilla-actions/sccache-action@v0.0.3
+      - uses: Swatinem/rust-cache@v2.4.0
+        with:
+          save-if: ${{ github.event_name == 'push' }}
 
       # - name: Setup Embark Studios lint rules
       #   shell: bash

--- a/.github/workflows/connector-sanity-tests.yml
+++ b/.github/workflows/connector-sanity-tests.yml
@@ -38,9 +38,6 @@ env:
   RUST_BACKTRACE: short
   # Use cargo's sparse index protocol
   CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
-  # Enable and use the sccache action for caching
-  SCCACHE_GHA_ENABLED: "true"
-  RUSTC_WRAPPER: "sccache"
 
 jobs:
   test_connectors:
@@ -89,7 +86,7 @@ jobs:
         with:
           toolchain: stable
 
-      - uses: mozilla-actions/sccache-action@v0.0.3
+      - uses: Swatinem/rust-cache@v2.4.0
 
       - name: Decrypt connector auth file
         env:

--- a/.github/workflows/connector-ui-sanity-tests.yml
+++ b/.github/workflows/connector-ui-sanity-tests.yml
@@ -2,9 +2,9 @@ name: Connector UI Sanity Tests
 
 on:
   workflow_dispatch:
-
+  
   pull_request_review:
-    types:
+    types: 
       - submitted
   merge_group:
     types:
@@ -26,7 +26,7 @@ env:
   #
   # See https://matklad.github.io/2021/09/04/fast-rust-builds.html#ci-workflow
   # for details.
-  CARGO_INCREMENTAL: 0
+  CARGO_INCREMENTAL: 1
   # Allow more retries for network requests in cargo (downloading crates) and
   # rustup (installing toolchains). This should help to reduce flaky CI failures
   # from transient network timeouts or other issues.
@@ -36,9 +36,6 @@ env:
   RUST_BACKTRACE: short
   # Use cargo's sparse index protocol
   CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
-  # Enable and use the sccache action for caching
-  SCCACHE_GHA_ENABLED: "true"
-  RUSTC_WRAPPER: "sccache"
 
 jobs:
   test_connectors:
@@ -76,13 +73,14 @@ jobs:
           # do not use more than 2 runners, try to group less time taking connectors together
           - stripe,airwallex,bluesnap,checkout,trustpay_3ds,payu,authorizedotnet,aci,noon
           - adyen_uk,shift4,worldline,multisafepay,paypal,mollie,nexinets
+          
 
     steps:
       - name: Ignore Tests incase of pull request
         if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
         shell: bash
         run: |
-          echo "Skipped tests as the event is pull request"
+          echo "Skipped tests as the event is pull request" 
           exit 0
 
       - name: Checkout repository
@@ -107,34 +105,34 @@ jobs:
         run: echo "CONNECTOR_TESTS_FILE_PATH=$HOME/target/test/connector_tests.json" >> $GITHUB_ENV
 
       - name: Set ignore_browser_profile usage in env
-        if: (github.event_name == 'pull_request_review' && github.event.review.state == 'approved') || (github.event_name == 'workflow_dispatch')
+        if: (github.event_name == 'pull_request_review' && github.event.review.state == 'approved') || (github.event_name == 'workflow_dispatch')  
         shell: bash
         run: echo "IGNORE_BROWSER_PROFILE=true" >> $GITHUB_ENV
 
       - name: Install latest compiler
-        if: (github.event_name == 'pull_request_review' && github.event.review.state == 'approved') || (github.event_name == 'workflow_dispatch')
+        if: (github.event_name == 'pull_request_review' && github.event.review.state == 'approved') || (github.event_name == 'workflow_dispatch')  
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
 
-      - uses: mozilla-actions/sccache-action@v0.0.3
+      - uses: Swatinem/rust-cache@v2.4.0
 
       - uses: baptiste0928/cargo-install@v2.1.0
-        if: (github.event_name == 'pull_request_review' && github.event.review.state == 'approved') || (github.event_name == 'workflow_dispatch')
+        if: (github.event_name == 'pull_request_review' && github.event.review.state == 'approved') || (github.event_name == 'workflow_dispatch')  
         with:
           crate: diesel_cli
           features: postgres
           args: "--no-default-features"
 
       - name: Diesel migration run
-        if: (github.event_name == 'pull_request_review' && github.event.review.state == 'approved') || (github.event_name == 'workflow_dispatch')
+        if: (github.event_name == 'pull_request_review' && github.event.review.state == 'approved') || (github.event_name == 'workflow_dispatch')  
         shell: bash
         env:
           DATABASE_URL: postgres://db_user:db_pass@localhost:5432/hyperswitch_db
         run: diesel migration run
 
       - name: Start server and run tests
-        if: (github.event_name == 'pull_request_review' && github.event.review.state == 'approved') || (github.event_name == 'workflow_dispatch')
+        if: (github.event_name == 'pull_request_review' && github.event.review.state == 'approved') || (github.event_name == 'workflow_dispatch')  
         env:
           UI_TESTCASES_PATH: ${{ secrets.UI_TESTCASES_PATH }}
           INPUT: ${{ matrix.connector }}
@@ -142,12 +140,12 @@ jobs:
         run: sh .github/scripts/run_ui_tests.sh
 
       - name: View test results
-        if: (github.event_name == 'pull_request_review' && github.event.review.state == 'approved') || (github.event_name == 'workflow_dispatch')
+        if: (github.event_name == 'pull_request_review' && github.event.review.state == 'approved') || (github.event_name == 'workflow_dispatch')  
         shell: bash
         run: cat tests/test_results.log
 
       - name: Check test results
-        if: (github.event_name == 'pull_request_review' && github.event.review.state == 'approved') || (github.event_name == 'workflow_dispatch')
+        if: (github.event_name == 'pull_request_review' && github.event.review.state == 'approved') || (github.event_name == 'workflow_dispatch')  
         shell: bash
         run: |
           if test "$( grep 'test result: FAILED' -r tests/test_results.log | wc -l )" -gt "0"; then

--- a/.github/workflows/postman-collection-runner.yml
+++ b/.github/workflows/postman-collection-runner.yml
@@ -16,9 +16,7 @@ env:
   RUSTUP_MAX_RETRIES: 10
   RUST_BACKTRACE: short
   CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
-  CONNECTORS: "aci, adyen_uk, airwallex, authorizedotnet, bambora, bambora_3ds, bluesnap, checkout, globalpay, mollie, nexinets, nmi, shift4, stripe, trustpay, worldline"
-  SCCACHE_GHA_ENABLED: "true"
-  RUSTC_WRAPPER: "sccache"
+  CONNECTORS: aci, adyen_uk, airwallex, authorizedotnet, bambora, bambora_3ds, bluesnap, checkout, globalpay, mollie, nexinets, nmi, shift4, stripe, trustpay, worldline
 
 jobs:
   runner:
@@ -35,7 +33,6 @@ jobs:
           --health-retries 5
         ports:
           - 6379:6379
-
       postgres:
         image: "${{ github.event_name != 'pull_request' && 'postgres:14.5' || '' }}"
         env:
@@ -55,7 +52,7 @@ jobs:
         if: github.event_name == 'pull_request'
         shell: bash
         run: |
-          echo "Skipped tests as the event is pull request"
+          echo "Skipped tests as the event is pull request" 
           exit 0
 
       - name: Repository checkout
@@ -90,8 +87,9 @@ jobs:
         with:
           toolchain: stable
 
-      - uses: mozilla-actions/sccache-action@v0.0.3
+      - name: Build and Cache Rust Dependencies
         if: github.event_name != 'pull_request'
+        uses: Swatinem/rust-cache@v2.4.0
 
       - name: Install Diesel CLI with Postgres Support
         if: github.event_name != 'pull_request'
@@ -114,12 +112,12 @@ jobs:
           cargo run &
           COUNT=0
           # Wait for the server to start in port 8080
-          while netstat -lnt | awk '$4 ~ /:8080$/ {exit 1}'; do
+          while netstat -lnt | awk '$4 ~ /:8080$/ {exit 1}'; do 
               # Wait for 15 mins to start otherwise kill the task
               if [ $COUNT -gt 90 ];
               then
                   exit 1
-              else
+              else 
                   COUNT=$((COUNT+1))
                   sleep 10
               fi

--- a/.github/workflows/validate-openapi-spec.yml
+++ b/.github/workflows/validate-openapi-spec.yml
@@ -11,32 +11,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-env:
-  # Disable incremental compilation.
-  #
-  # Incremental compilation is useful as part of an edit-build-test-edit cycle,
-  # as it lets the compiler avoid recompiling code that hasn't changed. However,
-  # on CI, we're not making small edits; we're almost always building the entire
-  # project from scratch. Thus, incremental compilation on CI actually
-  # introduces *additional* overhead to support making future builds
-  # faster...but no future builds will ever occur in any given CI environment.
-  #
-  # See https://matklad.github.io/2021/09/04/fast-rust-builds.html#ci-workflow
-  # for details.
-  CARGO_INCREMENTAL: 0
-  # Allow more retries for network requests in cargo (downloading crates) and
-  # rustup (installing toolchains). This should help to reduce flaky CI failures
-  # from transient network timeouts or other issues.
-  CARGO_NET_RETRY: 10
-  RUSTUP_MAX_RETRIES: 10
-  # Don't emit giant backtraces in the CI logs.
-  RUST_BACKTRACE: short
-  # Use cargo's sparse index protocol
-  CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
-  # Enable and use the sccache action for caching
-  SCCACHE_GHA_ENABLED: "true"
-  RUSTC_WRAPPER: "sccache"
-
 jobs:
   validate_json:
     name: Validate generated OpenAPI spec file
@@ -60,8 +34,6 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
-
-      - uses: mozilla-actions/sccache-action@v0.0.3
 
       - name: Generate the OpenAPI spec file
         shell: bash


### PR DESCRIPTION
This PR reverts juspay/hyperswitch#1857 since `sccache` is causing some problems. We might reconsider using it again on a later date.