### PR TITLE
ci: skip all-features check in each pull request

### DIFF
--- a/.github/workflows/CI-push.yml
+++ b/.github/workflows/CI-push.yml
@@ -101,12 +101,12 @@ jobs:
         run: sed -i 's/rustflags = \[/rustflags = \[\n    "-Dwarnings",/' .cargo/config.toml
 
       - name: Cargo hack
-        if: ${{ github.event.pull_request.merged }}
+        if: ${{ github.event_name == 'push' }}
         shell: bash
         run: cargo hack check --each-feature --no-dev-deps
       
       - name: Cargo build release
-        if: ${{ !github.event.pull_request.merged }}
+        if: ${{ github.event_name == 'merge_group' }}
         shell: bash
         run: cargo check --features "release"
 
@@ -185,12 +185,12 @@ jobs:
         run: cargo clippy --all-features --all-targets
 
       - name: Cargo hack
-        if: ${{ github.event.pull_request.merged }}
+        if: ${{ github.event_name == 'merge_group' }}
         shell: bash
         run: cargo hack check --each-feature --no-dev-deps
 
       - name: Cargo build release
-        if: ${{ !github.event.pull_request.merged }}
+        if: ${{ github.event_name == 'merge_group' }}
         shell: bash
         run: cargo check --features "release"
 

--- a/.github/workflows/CI-push.yml
+++ b/.github/workflows/CI-push.yml
@@ -101,8 +101,13 @@ jobs:
         run: sed -i 's/rustflags = \[/rustflags = \[\n    "-Dwarnings",/' .cargo/config.toml
 
       - name: Cargo hack
+        if: ${{ github.event.pull_request.merged }}
         shell: bash
         run: cargo hack check --each-feature --no-dev-deps
+      
+      - name: Cargo build release
+        shell: bash
+        run: cargo hack check --features "release" --no-dev-deps
 
   # cargo-deny:
   #   name: Run cargo-deny
@@ -179,8 +184,13 @@ jobs:
         run: cargo clippy --all-features --all-targets
 
       - name: Cargo hack
+        if: ${{ github.event.pull_request.merged }}
         shell: bash
         run: cargo hack check --each-feature --no-dev-deps
+
+      - name: Cargo build release
+        shell: bash
+        run: cargo hack check --features "release" --no-dev-deps
 
   typos:
     name: Spell check

--- a/.github/workflows/CI-push.yml
+++ b/.github/workflows/CI-push.yml
@@ -108,7 +108,7 @@ jobs:
       - name: Cargo build release
         if: ${{ !github.event.pull_request.merged }}
         shell: bash
-        run: cargo check --features "release" --no-dev-deps
+        run: cargo check --features "release"
 
   # cargo-deny:
   #   name: Run cargo-deny
@@ -192,7 +192,7 @@ jobs:
       - name: Cargo build release
         if: ${{ !github.event.pull_request.merged }}
         shell: bash
-        run: cargo check --features "release" --no-dev-deps
+        run: cargo check --features "release"
 
   typos:
     name: Spell check

--- a/.github/workflows/CI-push.yml
+++ b/.github/workflows/CI-push.yml
@@ -108,7 +108,7 @@ jobs:
       - name: Cargo build release
         if: ${{ !github.event.pull_request.merged }}
         shell: bash
-        run: cargo hack check --features "release" --no-dev-deps
+        run: cargo check --features "release" --no-dev-deps
 
   # cargo-deny:
   #   name: Run cargo-deny
@@ -192,7 +192,7 @@ jobs:
       - name: Cargo build release
         if: ${{ !github.event.pull_request.merged }}
         shell: bash
-        run: cargo hack check --features "release" --no-dev-deps
+        run: cargo check --features "release" --no-dev-deps
 
   typos:
     name: Spell check

--- a/.github/workflows/CI-push.yml
+++ b/.github/workflows/CI-push.yml
@@ -185,7 +185,7 @@ jobs:
         run: cargo clippy --all-features --all-targets
 
       - name: Cargo hack
-        if: ${{ github.event_name == 'merge_group' }}
+        if: ${{ github.event_name == 'push' }}
         shell: bash
         run: cargo hack check --each-feature --no-dev-deps
 

--- a/.github/workflows/CI-push.yml
+++ b/.github/workflows/CI-push.yml
@@ -106,6 +106,7 @@ jobs:
         run: cargo hack check --each-feature --no-dev-deps
       
       - name: Cargo build release
+        if: ${{ !github.event.pull_request.merged }}
         shell: bash
         run: cargo hack check --features "release" --no-dev-deps
 
@@ -189,6 +190,7 @@ jobs:
         run: cargo hack check --each-feature --no-dev-deps
 
       - name: Cargo build release
+        if: ${{ !github.event.pull_request.merged }}
         shell: bash
         run: cargo hack check --features "release" --no-dev-deps
 


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [x] CI/CD

## Description
<!-- Describe your changes in detail -->

- Skip doing build for all features in merge queue for msrv and stable tool-chain's.

- In every pull request in merge queue run only release feature.

- In push to main run cargo hack on each-feature.


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

After a pull request, for every commit is pushed the cargo hack is running with each-feature which consumes action's resource.  


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

After this pr gets merge in action for every pr ci-push action logs will hack build logs only for release feature.


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
