### PR TITLE
ci(postman): Fix collection runner failing to run

### DIFF
--- a/.github/workflows/postman-collection-runner.yml
+++ b/.github/workflows/postman-collection-runner.yml
@@ -11,7 +11,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  CONNECTORS: "aci, adyen_uk, airwallex, authorizedotnet, bambora, bambora_3ds, bluesnap, checkout, mollie, nexinets, nmi, shift4, stripe, trustpay, worldline"
   CARGO_INCREMENTAL: 1
   CARGO_NET_RETRY: 10
   RUSTUP_MAX_RETRIES: 10


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [x] CI/CD

## Description
<!-- Describe your changes in detail -->
This PR is a hotfix to address postman-collection-runner failing to run since it found a duplicate variable `CONNECTOR` that I believe got duplicated at the time of resolving conflicts.


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
<img width="1373" alt="image" src="https://github.com/juspay/hyperswitch/assets/69745008/5d1c1a7a-8b74-4b27-8e57-34e9669934f1">

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Now the Runner runs..

<img width="1373" alt="image" src="https://github.com/juspay/hyperswitch/assets/69745008/1ca9641f-4905-4c85-923c-c5f6a62997a0">

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I reviewed submitted code
