### PR TITLE
feat(router): add webhook source verification support for multiple mca of the same connector

### DIFF
--- a/crates/api_models/src/webhooks.rs
+++ b/crates/api_models/src/webhooks.rs
@@ -66,11 +66,13 @@ impl From<IncomingWebhookEvent> for WebhookFlow {
 
 pub type MerchantWebhookConfig = std::collections::HashSet<IncomingWebhookEvent>;
 
+#[derive(Clone)]
 pub enum RefundIdType {
     RefundId(String),
     ConnectorRefundId(String),
 }
 
+#[derive(Clone)]
 pub enum ObjectReferenceId {
     PaymentId(payments::PaymentIdType),
     RefundId(RefundIdType),

--- a/crates/router/src/connector/bluesnap.rs
+++ b/crates/router/src/connector/bluesnap.rs
@@ -983,9 +983,10 @@ impl api::IncomingWebhook for Bluesnap {
         &self,
         db: &dyn StorageInterface,
         request: &api::IncomingWebhookRequestDetails<'_>,
-        merchant_id: &str,
+        merchant_account: &domain::MerchantAccount,
         connector_label: &str,
         key_store: &domain::MerchantKeyStore,
+        object_reference_id: api_models::webhooks::ObjectReferenceId,
     ) -> CustomResult<bool, errors::ConnectorError> {
         let algorithm = self
             .get_webhook_source_verification_algorithm(request)
@@ -997,14 +998,19 @@ impl api::IncomingWebhook for Bluesnap {
         let mut secret = self
             .get_webhook_source_verification_merchant_secret(
                 db,
-                merchant_id,
+                merchant_account,
                 connector_label,
                 key_store,
+                object_reference_id,
             )
             .await
             .change_context(errors::ConnectorError::WebhookSourceVerificationFailed)?;
         let mut message = self
-            .get_webhook_source_verification_message(request, merchant_id, &secret)
+            .get_webhook_source_verification_message(
+                request,
+                &merchant_account.merchant_id,
+                &secret,
+            )
             .change_context(errors::ConnectorError::WebhookSourceVerificationFailed)?;
         message.append(&mut secret);
         algorithm

--- a/crates/router/src/connector/cashtocode.rs
+++ b/crates/router/src/connector/cashtocode.rs
@@ -322,9 +322,10 @@ impl api::IncomingWebhook for Cashtocode {
         &self,
         db: &dyn StorageInterface,
         request: &api::IncomingWebhookRequestDetails<'_>,
-        merchant_id: &str,
+        merchant_account: &domain::MerchantAccount,
         connector_label: &str,
         key_store: &domain::MerchantKeyStore,
+        object_reference_id: api_models::webhooks::ObjectReferenceId,
     ) -> CustomResult<bool, errors::ConnectorError> {
         let signature = self
             .get_webhook_source_verification_signature(request)
@@ -332,9 +333,10 @@ impl api::IncomingWebhook for Cashtocode {
         let secret = self
             .get_webhook_source_verification_merchant_secret(
                 db,
-                merchant_id,
+                merchant_account,
                 connector_label,
                 key_store,
+                object_reference_id,
             )
             .await
             .change_context(errors::ConnectorError::WebhookSourceVerificationFailed)?;

--- a/crates/router/src/connector/rapyd.rs
+++ b/crates/router/src/connector/rapyd.rs
@@ -739,9 +739,10 @@ impl api::IncomingWebhook for Rapyd {
         &self,
         db: &dyn StorageInterface,
         request: &api::IncomingWebhookRequestDetails<'_>,
-        merchant_id: &str,
+        merchant_account: &domain::MerchantAccount,
         connector_label: &str,
         key_store: &domain::MerchantKeyStore,
+        object_reference_id: api_models::webhooks::ObjectReferenceId,
     ) -> CustomResult<bool, errors::ConnectorError> {
         let signature = self
             .get_webhook_source_verification_signature(request)
@@ -749,14 +750,19 @@ impl api::IncomingWebhook for Rapyd {
         let secret = self
             .get_webhook_source_verification_merchant_secret(
                 db,
-                merchant_id,
+                merchant_account,
                 connector_label,
                 key_store,
+                object_reference_id,
             )
             .await
             .change_context(errors::ConnectorError::WebhookSourceVerificationFailed)?;
         let message = self
-            .get_webhook_source_verification_message(request, merchant_id, &secret)
+            .get_webhook_source_verification_message(
+                request,
+                &merchant_account.merchant_id,
+                &secret,
+            )
             .change_context(errors::ConnectorError::WebhookSourceVerificationFailed)?;
 
         let stringify_auth = String::from_utf8(secret.to_vec())

--- a/crates/router/src/connector/zen.rs
+++ b/crates/router/src/connector/zen.rs
@@ -557,9 +557,10 @@ impl api::IncomingWebhook for Zen {
         &self,
         db: &dyn StorageInterface,
         request: &api::IncomingWebhookRequestDetails<'_>,
-        merchant_id: &str,
+        merchant_account: &domain::MerchantAccount,
         connector_label: &str,
         key_store: &domain::MerchantKeyStore,
+        object_reference_id: api_models::webhooks::ObjectReferenceId,
     ) -> CustomResult<bool, errors::ConnectorError> {
         let algorithm = self.get_webhook_source_verification_algorithm(request)?;
 
@@ -567,13 +568,17 @@ impl api::IncomingWebhook for Zen {
         let mut secret = self
             .get_webhook_source_verification_merchant_secret(
                 db,
-                merchant_id,
+                merchant_account,
                 connector_label,
                 key_store,
+                object_reference_id,
             )
             .await?;
-        let mut message =
-            self.get_webhook_source_verification_message(request, merchant_id, &secret)?;
+        let mut message = self.get_webhook_source_verification_message(
+            request,
+            &merchant_account.merchant_id,
+            &secret,
+        )?;
         message.append(&mut secret);
         algorithm
             .verify_signature(&secret, &signature, &message)

--- a/crates/router/src/core/webhooks.rs
+++ b/crates/router/src/core/webhooks.rs
@@ -726,13 +726,19 @@ pub async fn webhooks_core<W: types::OutgoingWebhookType>(
 
     let flow_type: api::WebhookFlow = event_type.to_owned().into();
     if process_webhook_further && !matches!(flow_type, api::WebhookFlow::ReturnResponse) {
+        let object_ref_id = connector
+            .get_webhook_object_reference_id(&request_details)
+            .switch()
+            .attach_printable("Could not find object reference id in incoming webhook body")?;
+
         let source_verified = connector
             .verify_webhook_source(
                 &*state.store,
                 &request_details,
-                &merchant_account.merchant_id,
+                &merchant_account,
                 connector_name,
                 &key_store,
+                object_ref_id.clone(),
             )
             .await
             .switch()
@@ -750,10 +756,6 @@ pub async fn webhooks_core<W: types::OutgoingWebhookType>(
         }
 
         logger::info!(source_verified=?source_verified);
-        let object_ref_id = connector
-            .get_webhook_object_reference_id(&request_details)
-            .switch()
-            .attach_printable("Could not find object reference id in incoming webhook body")?;
 
         let event_object = connector
             .get_webhook_resource_object(&request_details)

--- a/crates/router/src/utils.rs
+++ b/crates/router/src/utils.rs
@@ -5,7 +5,9 @@ pub mod ext_traits;
 #[cfg(feature = "kv_store")]
 pub mod storage_partitioning;
 
+use api_models::{payments, webhooks};
 use base64::Engine;
+use common_utils::errors::CustomResult;
 pub use common_utils::{
     crypto,
     ext_traits::{ByteSliceExt, BytesExt, Encode, StringExt, ValueExt},
@@ -22,8 +24,10 @@ use uuid::Uuid;
 pub use self::ext_traits::{OptionExt, ValidateCall};
 use crate::{
     consts,
-    core::errors::{self, RouterResult},
-    logger, types,
+    core::errors::{self, RouterResult, StorageErrorExt},
+    db::StorageInterface,
+    logger,
+    types::{self, domain, storage},
 };
 
 pub mod error_parser {
@@ -175,4 +179,126 @@ mod tests {
         let qr_image_data_source_url = utils::QrImage::new_from_data("Hyperswitch".to_string());
         assert!(qr_image_data_source_url.is_ok());
     }
+}
+
+pub async fn find_payment_intent_from_payment_id_type(
+    db: &dyn StorageInterface,
+    payment_id_type: payments::PaymentIdType,
+    merchant_account: &domain::MerchantAccount,
+) -> CustomResult<storage::PaymentIntent, errors::ApiErrorResponse> {
+    match payment_id_type {
+        payments::PaymentIdType::PaymentIntentId(payment_id) => db
+            .find_payment_intent_by_payment_id_merchant_id(
+                &payment_id,
+                &merchant_account.merchant_id,
+                merchant_account.storage_scheme,
+            )
+            .await
+            .to_not_found_response(errors::ApiErrorResponse::PaymentNotFound),
+        payments::PaymentIdType::ConnectorTransactionId(connector_transaction_id) => {
+            let attempt = db
+                .find_payment_attempt_by_merchant_id_connector_txn_id(
+                    &merchant_account.merchant_id,
+                    &connector_transaction_id,
+                    merchant_account.storage_scheme,
+                )
+                .await
+                .to_not_found_response(errors::ApiErrorResponse::PaymentNotFound)?;
+            db.find_payment_intent_by_payment_id_merchant_id(
+                &attempt.payment_id,
+                &merchant_account.merchant_id,
+                merchant_account.storage_scheme,
+            )
+            .await
+            .to_not_found_response(errors::ApiErrorResponse::PaymentNotFound)
+        }
+        payments::PaymentIdType::PaymentAttemptId(attempt_id) => {
+            let attempt = db
+                .find_payment_attempt_by_attempt_id_merchant_id(
+                    &attempt_id,
+                    &merchant_account.merchant_id,
+                    merchant_account.storage_scheme,
+                )
+                .await
+                .to_not_found_response(errors::ApiErrorResponse::PaymentNotFound)?;
+            db.find_payment_intent_by_payment_id_merchant_id(
+                &attempt.payment_id,
+                &merchant_account.merchant_id,
+                merchant_account.storage_scheme,
+            )
+            .await
+            .to_not_found_response(errors::ApiErrorResponse::PaymentNotFound)
+        }
+        payments::PaymentIdType::PreprocessingId(_) => {
+            Err(errors::ApiErrorResponse::PaymentNotFound)?
+        }
+    }
+}
+
+pub async fn find_payment_intent_from_refund_id_type(
+    db: &dyn StorageInterface,
+    refund_id_type: webhooks::RefundIdType,
+    merchant_account: &domain::MerchantAccount,
+    connector_name: &str,
+) -> CustomResult<storage::PaymentIntent, errors::ApiErrorResponse> {
+    let refund = match refund_id_type {
+        webhooks::RefundIdType::RefundId(id) => db
+            .find_refund_by_merchant_id_refund_id(
+                &merchant_account.merchant_id,
+                &id,
+                merchant_account.storage_scheme,
+            )
+            .await
+            .to_not_found_response(errors::ApiErrorResponse::RefundNotFound)?,
+        webhooks::RefundIdType::ConnectorRefundId(id) => db
+            .find_refund_by_merchant_id_connector_refund_id_connector(
+                &merchant_account.merchant_id,
+                &id,
+                connector_name,
+                merchant_account.storage_scheme,
+            )
+            .await
+            .to_not_found_response(errors::ApiErrorResponse::RefundNotFound)?,
+    };
+    let attempt = db
+        .find_payment_attempt_by_attempt_id_merchant_id(
+            &refund.attempt_id,
+            &merchant_account.merchant_id,
+            merchant_account.storage_scheme,
+        )
+        .await
+        .to_not_found_response(errors::ApiErrorResponse::PaymentNotFound)?;
+    db.find_payment_intent_by_payment_id_merchant_id(
+        &attempt.payment_id,
+        &merchant_account.merchant_id,
+        merchant_account.storage_scheme,
+    )
+    .await
+    .to_not_found_response(errors::ApiErrorResponse::PaymentNotFound)
+}
+
+pub async fn get_connector_label_using_object_reference_id(
+    db: &dyn StorageInterface,
+    object_reference_id: webhooks::ObjectReferenceId,
+    merchant_account: &domain::MerchantAccount,
+    connector_name: &str,
+) -> CustomResult<String, errors::ApiErrorResponse> {
+    let payment_intent = match object_reference_id {
+        webhooks::ObjectReferenceId::PaymentId(payment_id_type) => {
+            find_payment_intent_from_payment_id_type(db, payment_id_type, merchant_account).await?
+        }
+        webhooks::ObjectReferenceId::RefundId(refund_id_type) => {
+            find_payment_intent_from_refund_id_type(
+                db,
+                refund_id_type,
+                merchant_account,
+                connector_name,
+            )
+            .await?
+        }
+    };
+    Ok(format!(
+        "{connector_name}_{}_{}",
+        payment_intent.business_country, payment_intent.business_label
+    ))
 }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
add webhook source verification support for multiple mca of the same connector


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
Previous hotfix - https://github.com/juspay/hyperswitch/pull/1896


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
