### PR TITLE
chore: remove spaces at beginning of commit messages when generating changelogs

### DIFF
--- a/.github/git-cliff-changelog.toml
+++ b/.github/git-cliff-changelog.toml
@@ -52,6 +52,7 @@ filter_unconventional = false
 split_commits = false
 # regex for preprocessing the commit messages
 commit_preprocessors = [
+    { pattern = "^ +", replace = "" }, # remove spaces at the beginning of the message
     { pattern = " +", replace = " " }, # replace multiple spaces with a single space
     { pattern = "\\(#([0-9]+)\\)", replace = "([#${1}](https://github.com/juspay/hyperswitch/pull/${1}))" }, # replace PR numbers with links
     { pattern = "(\\n?Co-authored-by: .+ <.+@.+>\\n?)+", replace = "" }, # remove co-author information

--- a/.github/git-cliff-release.toml
+++ b/.github/git-cliff-release.toml
@@ -49,6 +49,7 @@ filter_unconventional = false
 split_commits = false
 # regex for preprocessing the commit messages
 commit_preprocessors = [
+    { pattern = "^ +", replace = "" }, # remove spaces at the beginning of the message
     { pattern = " +", replace = " " }, # replace multiple spaces with a single space
     { pattern = "\\(#([0-9]+)\\)", replace = "([#${1}](https://github.com/juspay/hyperswitch/pull/${1}))" }, # replace PR numbers with links
     { pattern = "(\\n?Co-authored-by: .+ <.+@.+>\\n?)+", replace = "" }, # remove co-author information


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
This PR updates the `git-cliff` templates to remove spaces at the beginning of the commit message.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
Because of the leading spaces in some commit messages, the offending commits were not being included in the release notes. This PR fixes that.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Verified that the changelog generated does include the offending commits. One such PR was #1804, which was included in the `v1.15.0` tag. For verifying my fix, I generated the changelog using the command: `git cliff --config .github/git-cliff-changelog.toml v1.14.1..v1.15.0`.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
