### PR TITLE
fix(connector): [STAX] Add currency filter for payments through Stax

### DIFF
--- a/crates/router/src/connector/stax/transformers.rs
+++ b/crates/router/src/connector/stax/transformers.rs
@@ -26,6 +26,13 @@ pub struct StaxPaymentsRequest {
 impl TryFrom<&types::PaymentsAuthorizeRouterData> for StaxPaymentsRequest {
     type Error = error_stack::Report<errors::ConnectorError>;
     fn try_from(item: &types::PaymentsAuthorizeRouterData) -> Result<Self, Self::Error> {
+        if item.request.currency != enums::Currency::USD {
+            Err(errors::ConnectorError::NotSupported {
+                message: item.request.currency.to_string(),
+                connector: "Stax",
+                payment_experience: api::enums::PaymentExperience::RedirectToUrl.to_string(),
+            })?
+        }
         match item.request.payment_method_data.clone() {
             api::PaymentMethodData::Card(_) => {
                 let pre_auth = !item.request.is_auto_capture()?;


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Connector Stax only supports payments through the default currency(USD). Added a filter to throw an error if any currency other than USD is used to process a transaction through Stax.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
Bugfix: Added a filter to throw an error if any currency other than USD is used to process a transaction through Stax.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Testing was carried out using Unit Tests.
<img width="950" alt="Screenshot 2023-08-10 at 4 06 47 PM" src="https://github.com/juspay/hyperswitch/assets/41580413/d9ad4cf0-c557-48dd-9ee2-b9fcc975bc37">


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
