### PR TITLE
fix(connector): [Braintree] add merchant_account_id field in authorize request

### DIFF
--- a/crates/router/src/connector/braintree.rs
+++ b/crates/router/src/connector/braintree.rs
@@ -18,6 +18,7 @@ use crate::{
     types::{
         self,
         api::{self, ConnectorCommon},
+        ErrorResponse,
     },
     utils::{self, BytesExt},
 };
@@ -50,16 +51,40 @@ impl ConnectorCommon for Braintree {
     fn build_error_response(
         &self,
         res: types::Response,
-    ) -> CustomResult<types::ErrorResponse, errors::ConnectorError> {
+    ) -> CustomResult<ErrorResponse, errors::ConnectorError> {
         let response: Result<braintree::ErrorResponse, Report<common_utils::errors::ParsingError>> =
             res.response.parse_struct("Braintree Error Response");
 
         match response {
-            Ok(response_data) => Ok(types::ErrorResponse {
+            Ok(braintree::ErrorResponse::BraintreeApiErrorResponse(response)) => {
+                let error_object = response.api_error_response.errors;
+                let code = if !error_object.errors.is_empty() {
+                    error_object
+                        .errors
+                        .first()
+                        .map_or(consts::NO_ERROR_CODE.to_string(), |error| {
+                            error.code.clone()
+                        })
+                } else if error_object.transaction.is_some() {
+                    let transaction = error_object.transaction;
+                    transaction.map_or(consts::NO_ERROR_CODE.to_string(), |transaction| {
+                        braintree::get_transaction_error(transaction)
+                    })
+                } else {
+                    consts::NO_ERROR_CODE.to_string()
+                };
+                Ok(ErrorResponse {
+                    status_code: res.status_code,
+                    code,
+                    message: consts::NO_ERROR_MESSAGE.to_string(),
+                    reason: Some(response.api_error_response.message),
+                })
+            }
+            Ok(braintree::ErrorResponse::BraintreeErrorResponse(response)) => Ok(ErrorResponse {
                 status_code: res.status_code,
                 code: consts::NO_ERROR_CODE.to_string(),
-                message: response_data.api_error_response.message,
-                reason: None,
+                message: consts::NO_ERROR_MESSAGE.to_string(),
+                reason: Some(response.errors),
             }),
             Err(error_msg) => {
                 logger::error!(deserialization_error =? error_msg);
@@ -160,7 +185,7 @@ impl
     fn get_error_response(
         &self,
         res: types::Response,
-    ) -> CustomResult<types::ErrorResponse, errors::ConnectorError> {
+    ) -> CustomResult<ErrorResponse, errors::ConnectorError> {
         self.build_error_response(res)
     }
 
@@ -301,7 +326,7 @@ impl
     fn get_error_response(
         &self,
         res: types::Response,
-    ) -> CustomResult<types::ErrorResponse, errors::ConnectorError> {
+    ) -> CustomResult<ErrorResponse, errors::ConnectorError> {
         self.build_error_response(res)
     }
 
@@ -429,7 +454,7 @@ impl
     fn get_error_response(
         &self,
         res: types::Response,
-    ) -> CustomResult<types::ErrorResponse, errors::ConnectorError> {
+    ) -> CustomResult<ErrorResponse, errors::ConnectorError> {
         self.build_error_response(res)
     }
 }
@@ -502,7 +527,7 @@ impl
     fn get_error_response(
         &self,
         res: types::Response,
-    ) -> CustomResult<types::ErrorResponse, errors::ConnectorError> {
+    ) -> CustomResult<ErrorResponse, errors::ConnectorError> {
         self.build_error_response(res)
     }
 
@@ -632,7 +657,7 @@ impl services::ConnectorIntegration<api::Execute, types::RefundsData, types::Ref
     fn get_error_response(
         &self,
         _res: types::Response,
-    ) -> CustomResult<types::ErrorResponse, errors::ConnectorError> {
+    ) -> CustomResult<ErrorResponse, errors::ConnectorError> {
         Err(errors::ConnectorError::NotImplemented("braintree".to_string()).into())
     }
 }

--- a/crates/router/src/connector/braintree.rs
+++ b/crates/router/src/connector/braintree.rs
@@ -58,10 +58,10 @@ impl ConnectorCommon for Braintree {
         match response {
             Ok(braintree::ErrorResponse::BraintreeApiErrorResponse(response)) => {
                 let error_object = response.api_error_response.errors;
-                let error = error_object
-                    .errors
-                    .first()
-                    .or(error_object.transaction.as_ref().and_then(|transaction_error| {
+                let error = error_object.errors.first().or(error_object
+                    .transaction
+                    .as_ref()
+                    .and_then(|transaction_error| {
                         transaction_error.errors.first().or(transaction_error
                             .credit_card
                             .as_ref()

--- a/crates/router/src/connector/braintree.rs
+++ b/crates/router/src/connector/braintree.rs
@@ -67,8 +67,13 @@ impl ConnectorCommon for Braintree {
                             .as_ref()
                             .and_then(|credit_card_error| credit_card_error.errors.first()))
                     }));
-                let (code,message) = error.map_or((consts::NO_ERROR_CODE.to_string(),consts::NO_ERROR_MESSAGE.to_string()), |error| {
-                    (error.code.clone() , error.message.clone())});
+                let (code, message) = error.map_or(
+                    (
+                        consts::NO_ERROR_CODE.to_string(),
+                        consts::NO_ERROR_MESSAGE.to_string(),
+                    ),
+                    |error| (error.code.clone(), error.message.clone()),
+                );
                 Ok(ErrorResponse {
                     status_code: res.status_code,
                     code,

--- a/crates/router/src/connector/braintree.rs
+++ b/crates/router/src/connector/braintree.rs
@@ -67,13 +67,12 @@ impl ConnectorCommon for Braintree {
                             .as_ref()
                             .and_then(|credit_card_error| credit_card_error.errors.first()))
                     }));
-                let code = error.map_or(consts::NO_ERROR_CODE.to_string(), |error| {
-                    error.code.clone()
-                });
+                let (code,message) = error.map_or((consts::NO_ERROR_CODE.to_string(),consts::NO_ERROR_MESSAGE.to_string()), |error| {
+                    (error.code.clone() , error.message.clone())});
                 Ok(ErrorResponse {
                     status_code: res.status_code,
                     code,
-                    message: consts::NO_ERROR_MESSAGE.to_string(),
+                    message,
                     reason: Some(response.api_error_response.message),
                 })
             }

--- a/crates/router/src/connector/braintree.rs
+++ b/crates/router/src/connector/braintree.rs
@@ -2,7 +2,7 @@ pub mod transformers;
 
 use std::fmt::Debug;
 
-use error_stack::{IntoReport, ResultExt};
+use error_stack::{IntoReport, Report, ResultExt};
 use masking::PeekInterface;
 
 use self::transformers as braintree;
@@ -10,7 +10,7 @@ use crate::{
     configs::settings,
     consts,
     core::errors::{self, CustomResult},
-    headers,
+    headers, logger,
     services::{
         self,
         request::{self, Mask},
@@ -45,6 +45,27 @@ impl ConnectorCommon for Braintree {
             headers::AUTHORIZATION.to_string(),
             auth.auth_header.into_masked(),
         )])
+    }
+
+    fn build_error_response(
+        &self,
+        res: types::Response,
+    ) -> CustomResult<types::ErrorResponse, errors::ConnectorError> {
+        let response: Result<braintree::ErrorResponse, Report<common_utils::errors::ParsingError>> =
+            res.response.parse_struct("Braintree Error Response");
+
+        match response {
+            Ok(response_data) => Ok(types::ErrorResponse {
+                status_code: res.status_code,
+                code: consts::NO_ERROR_CODE.to_string(),
+                message: response_data.api_error_response.message,
+                reason: None,
+            }),
+            Err(error_msg) => {
+                logger::error!(deserialization_error =? error_msg);
+                utils::handle_json_response_deserialization_failure(res, "braintree".to_owned())
+            }
+        }
     }
 }
 
@@ -140,17 +161,7 @@ impl
         &self,
         res: types::Response,
     ) -> CustomResult<types::ErrorResponse, errors::ConnectorError> {
-        let response: braintree::ErrorResponse = res
-            .response
-            .parse_struct("Error Response")
-            .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
-
-        Ok(types::ErrorResponse {
-            status_code: res.status_code,
-            code: consts::NO_ERROR_CODE.to_string(),
-            message: response.api_error_response.message,
-            reason: None,
-        })
+        self.build_error_response(res)
     }
 
     fn get_request_body(
@@ -291,17 +302,7 @@ impl
         &self,
         res: types::Response,
     ) -> CustomResult<types::ErrorResponse, errors::ConnectorError> {
-        let response: braintree::ErrorResponse = res
-            .response
-            .parse_struct("Braintree Error Response")
-            .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
-
-        Ok(types::ErrorResponse {
-            status_code: res.status_code,
-            code: consts::NO_ERROR_CODE.to_string(),
-            message: response.api_error_response.message,
-            reason: None,
-        })
+        self.build_error_response(res)
     }
 
     fn get_request_body(
@@ -429,16 +430,7 @@ impl
         &self,
         res: types::Response,
     ) -> CustomResult<types::ErrorResponse, errors::ConnectorError> {
-        let response: braintree::ErrorResponse = res
-            .response
-            .parse_struct("Braintree ErrorResponse")
-            .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
-        Ok(types::ErrorResponse {
-            status_code: res.status_code,
-            code: consts::NO_ERROR_CODE.to_string(),
-            message: response.api_error_response.message,
-            reason: None,
-        })
+        self.build_error_response(res)
     }
 }
 
@@ -511,17 +503,7 @@ impl
         &self,
         res: types::Response,
     ) -> CustomResult<types::ErrorResponse, errors::ConnectorError> {
-        let response: braintree::ErrorResponse = res
-            .response
-            .parse_struct("Braintree ErrorResponse")
-            .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
-
-        Ok(types::ErrorResponse {
-            status_code: res.status_code,
-            code: consts::NO_ERROR_CODE.to_string(),
-            message: response.api_error_response.message,
-            reason: None,
-        })
+        self.build_error_response(res)
     }
 
     fn get_request_body(

--- a/crates/router/src/connector/braintree/transformers.rs
+++ b/crates/router/src/connector/braintree/transformers.rs
@@ -18,6 +18,11 @@ pub struct PaymentOptions {
     submit_for_settlement: bool,
 }
 
+#[derive(Debug, Deserialize)]
+pub struct BraintreeMeta {
+    merchant_account_id: Option<Secret<String>>,
+}
+
 #[derive(Debug, Serialize, Eq, PartialEq)]
 pub struct BraintreePaymentsRequest {
     transaction: TransactionBody,
@@ -48,6 +53,7 @@ impl TryFrom<&types::PaymentsSessionRouterData> for BraintreeSessionRequest {
 #[serde(rename_all = "camelCase")]
 pub struct TransactionBody {
     amount: String,
+    merchant_account_id: Option<Secret<String>>,
     device_data: DeviceData,
     options: PaymentOptions,
     #[serde(flatten)]
@@ -91,7 +97,9 @@ impl TryFrom<&types::PaymentsAuthorizeRouterData> for BraintreePaymentsRequest {
             item.request.capture_method,
             Some(enums::CaptureMethod::Automatic) | None
         );
-
+        let metadata: BraintreeMeta =
+            utils::to_connector_meta_from_secret(item.connector_meta_data.clone())?;
+        let merchant_account_id = metadata.merchant_account_id;
         let amount = utils::to_currency_base_unit(item.request.amount, item.request.currency)?;
         let device_data = DeviceData {};
         let options = PaymentOptions {
@@ -125,6 +133,7 @@ impl TryFrom<&types::PaymentsAuthorizeRouterData> for BraintreePaymentsRequest {
         }?;
         let braintree_transaction_body = TransactionBody {
             amount,
+            merchant_account_id,
             device_data,
             options,
             payment_method_data_type,
@@ -281,15 +290,54 @@ pub struct TransactionResponse {
     status: BraintreePaymentStatus,
 }
 
-#[derive(Debug, Default, Deserialize)]
+#[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct ErrorResponse {
+pub struct BraintreeApiErrorResponse {
     pub api_error_response: ApiErrorResponse,
 }
 
-#[derive(Default, Debug, Clone, Deserialize, Eq, PartialEq)]
+#[derive(Debug, Deserialize)]
+pub struct ErrorsObject {
+    pub errors: Vec<ErrorObject>,
+    pub transaction: Option<TransactionError>,
+}
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TransactionError {
+    pub errors: Vec<ErrorObject>,
+    pub credit_card: Option<CreditCardError>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CreditCardError {
+    pub errors: Vec<ErrorObject>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ErrorObject {
+    pub code: String,
+    pub message: String,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BraintreeErrorResponse {
+    pub errors: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[serde(untagged)]
+
+pub enum ErrorResponse {
+    BraintreeApiErrorResponse(Box<BraintreeApiErrorResponse>),
+    BraintreeErrorResponse(Box<BraintreeErrorResponse>),
+}
+
+#[derive(Debug, Deserialize)]
 pub struct ApiErrorResponse {
     pub message: String,
+    pub errors: ErrorsObject,
 }
 
 #[derive(Default, Debug, Clone, Serialize)]
@@ -368,4 +416,31 @@ impl TryFrom<types::RefundsResponseRouterData<api::RSync, RefundResponse>>
             ..item.data
         })
     }
+}
+
+pub fn get_transaction_error(transaction: TransactionError) -> String {
+    if !transaction.errors.is_empty() {
+        transaction
+            .errors
+            .first()
+            .map_or(consts::NO_ERROR_CODE.to_string(), |error| {
+                error.code.clone()
+            })
+    } else if transaction.credit_card.is_some() {
+        let credit_card = transaction.credit_card;
+        credit_card.map_or(consts::NO_ERROR_CODE.to_string(), |credit_card| {
+            get_credit_card_error(credit_card)
+        })
+    } else {
+        consts::NO_ERROR_CODE.to_string()
+    }
+}
+
+pub fn get_credit_card_error(credit_card: CreditCardError) -> String {
+    credit_card
+        .errors
+        .first()
+        .map_or(consts::NO_ERROR_CODE.to_string(), |error| {
+            error.code.clone()
+        })
 }

--- a/crates/router/src/connector/braintree/transformers.rs
+++ b/crates/router/src/connector/braintree/transformers.rs
@@ -417,30 +417,3 @@ impl TryFrom<types::RefundsResponseRouterData<api::RSync, RefundResponse>>
         })
     }
 }
-
-pub fn get_transaction_error(transaction: TransactionError) -> String {
-    if !transaction.errors.is_empty() {
-        transaction
-            .errors
-            .first()
-            .map_or(consts::NO_ERROR_CODE.to_string(), |error| {
-                error.code.clone()
-            })
-    } else if transaction.credit_card.is_some() {
-        let credit_card = transaction.credit_card;
-        credit_card.map_or(consts::NO_ERROR_CODE.to_string(), |credit_card| {
-            get_credit_card_error(credit_card)
-        })
-    } else {
-        consts::NO_ERROR_CODE.to_string()
-    }
-}
-
-pub fn get_credit_card_error(credit_card: CreditCardError) -> String {
-    credit_card
-        .errors
-        .first()
-        .map_or(consts::NO_ERROR_CODE.to_string(), |error| {
-            error.code.clone()
-        })
-}

--- a/crates/router/src/connector/rapyd.rs
+++ b/crates/router/src/connector/rapyd.rs
@@ -3,7 +3,7 @@ use std::fmt::Debug;
 
 use base64::Engine;
 use common_utils::{date_time, ext_traits::StringExt};
-use error_stack::{IntoReport, ResultExt};
+use error_stack::{IntoReport, Report, ResultExt};
 use masking::{ExposeInterface, PeekInterface};
 use rand::distributions::{Alphanumeric, DistString};
 use ring::hmac;
@@ -15,7 +15,7 @@ use crate::{
     consts,
     core::errors::{self, CustomResult},
     db::StorageInterface,
-    headers,
+    headers, logger,
     services::{
         self,
         request::{self, Mask},
@@ -82,16 +82,23 @@ impl ConnectorCommon for Rapyd {
         &self,
         res: types::Response,
     ) -> CustomResult<ErrorResponse, errors::ConnectorError> {
-        let response: rapyd::RapydPaymentsResponse = res
-            .response
-            .parse_struct("Rapyd ErrorResponse")
-            .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
-        Ok(ErrorResponse {
-            status_code: res.status_code,
-            code: response.status.error_code,
-            message: response.status.status.unwrap_or_default(),
-            reason: response.status.message,
-        })
+        let response: Result<
+            rapyd::RapydPaymentsResponse,
+            Report<common_utils::errors::ParsingError>,
+        > = res.response.parse_struct("Rapyd ErrorResponse");
+
+        match response {
+            Ok(response_data) => Ok(ErrorResponse {
+                status_code: res.status_code,
+                code: response_data.status.error_code,
+                message: response_data.status.status.unwrap_or_default(),
+                reason: response_data.status.message,
+            }),
+            Err(error_msg) => {
+                logger::error!(deserialization_error =? error_msg);
+                utils::handle_json_response_deserialization_failure(res, "rapyd".to_owned())
+            }
+        }
     }
 }
 

--- a/crates/router/src/connector/trustpay.rs
+++ b/crates/router/src/connector/trustpay.rs
@@ -4,7 +4,7 @@ use std::fmt::Debug;
 
 use base64::Engine;
 use common_utils::{crypto, errors::ReportSwitchExt, ext_traits::ByteSliceExt};
-use error_stack::{IntoReport, ResultExt};
+use error_stack::{IntoReport, Report, ResultExt};
 use masking::PeekInterface;
 use transformers as trustpay;
 
@@ -19,7 +19,7 @@ use crate::{
         errors::{self, CustomResult},
         payments,
     },
-    headers,
+    headers, logger,
     services::{
         self,
         request::{self, Mask},
@@ -104,34 +104,43 @@ impl ConnectorCommon for Trustpay {
         &self,
         res: Response,
     ) -> CustomResult<ErrorResponse, errors::ConnectorError> {
-        let response: trustpay::TrustpayErrorResponse = res
-            .response
-            .parse_struct("trustpay ErrorResponse")
-            .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
-        let error_list = response.errors.clone().unwrap_or(vec![]);
-        let option_error_code_message = get_error_code_error_message_based_on_priority(
-            self.clone(),
-            error_list.into_iter().map(|errors| errors.into()).collect(),
-        );
-        let reason = response.errors.map(|errors| {
-            errors
-                .iter()
-                .map(|error| error.description.clone())
-                .collect::<Vec<String>>()
-                .join(" & ")
-        });
-        Ok(ErrorResponse {
-            status_code: res.status_code,
-            code: option_error_code_message
-                .clone()
-                .map(|error_code_message| error_code_message.error_code)
-                .unwrap_or(consts::NO_ERROR_CODE.to_string()),
-            // message vary for the same code, so relying on code alone as it is unique
-            message: option_error_code_message
-                .map(|error_code_message| error_code_message.error_code)
-                .unwrap_or(consts::NO_ERROR_MESSAGE.to_string()),
-            reason: reason.or(response.description),
-        })
+        let response: Result<
+            trustpay::TrustpayErrorResponse,
+            Report<common_utils::errors::ParsingError>,
+        > = res.response.parse_struct("trustpay ErrorResponse");
+
+        match response {
+            Ok(response_data) => {
+                let error_list = response_data.errors.clone().unwrap_or(vec![]);
+                let option_error_code_message = get_error_code_error_message_based_on_priority(
+                    self.clone(),
+                    error_list.into_iter().map(|errors| errors.into()).collect(),
+                );
+                let reason = response_data.errors.map(|errors| {
+                    errors
+                        .iter()
+                        .map(|error| error.description.clone())
+                        .collect::<Vec<String>>()
+                        .join(" & ")
+                });
+                Ok(ErrorResponse {
+                    status_code: res.status_code,
+                    code: option_error_code_message
+                        .clone()
+                        .map(|error_code_message| error_code_message.error_code)
+                        .unwrap_or(consts::NO_ERROR_CODE.to_string()),
+                    // message vary for the same code, so relying on code alone as it is unique
+                    message: option_error_code_message
+                        .map(|error_code_message| error_code_message.error_code)
+                        .unwrap_or(consts::NO_ERROR_MESSAGE.to_string()),
+                    reason: reason.or(response_data.description),
+                })
+            }
+            Err(error_msg) => {
+                logger::error!(deserialization_error =? error_msg);
+                utils::handle_json_response_deserialization_failure(res, "trustpay".to_owned())
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
1) added `Merchant Account id` field in authorize request for braintree. 
2) handle error response in case of wrong merchant account id 
3) cherry pick #1892

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
1) added `Merchant Account id` field in authorize request for braintree. 
2) handle error response in case of wrong merchant account id 
3) cherry pick #1892

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
<img width="850" alt="Screenshot 2023-08-10 at 6 35 50 PM" src="https://github.com/juspay/hyperswitch/assets/121822803/d211f6c8-b8a5-432e-a082-08fecf837876">
<img width="514" alt="Screenshot 2023-08-10 at 6 36 08 PM" src="https://github.com/juspay/hyperswitch/assets/121822803/4bc051c1-e046-44aa-88db-f6c86d5833a0">
<img width="1167" alt="Screenshot 2023-08-10 at 6 37 06 PM" src="https://github.com/juspay/hyperswitch/assets/121822803/90d8d2df-722e-4937-9ec2-948c1ac57cf5">


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
