### PR TITLE
fix(connector): [Braintree] add merchant_account_id field in authorize request

### DIFF
--- a/crates/router/src/connector/braintree.rs
+++ b/crates/router/src/connector/braintree.rs
@@ -67,13 +67,17 @@ impl ConnectorCommon for Braintree {
                             .as_ref()
                             .and_then(|credit_card_error| credit_card_error.errors.first()))
                     }));
-                let code = error.map_or(consts::NO_ERROR_CODE.to_string(), |error| {
-                    error.code.clone()
-                });
+                let (code, message) = error.map_or(
+                    (
+                        consts::NO_ERROR_CODE.to_string(),
+                        consts::NO_ERROR_MESSAGE.to_string(),
+                    ),
+                    |error| (error.code.clone(), error.message.clone()),
+                );
                 Ok(ErrorResponse {
                     status_code: res.status_code,
                     code,
-                    message: consts::NO_ERROR_MESSAGE.to_string(),
+                    message,
                     reason: Some(response.api_error_response.message),
                 })
             }

--- a/crates/router/src/connector/braintree.rs
+++ b/crates/router/src/connector/braintree.rs
@@ -18,6 +18,7 @@ use crate::{
     types::{
         self,
         api::{self, ConnectorCommon},
+        ErrorResponse,
     },
     utils::{self, BytesExt},
 };
@@ -50,16 +51,37 @@ impl ConnectorCommon for Braintree {
     fn build_error_response(
         &self,
         res: types::Response,
-    ) -> CustomResult<types::ErrorResponse, errors::ConnectorError> {
+    ) -> CustomResult<ErrorResponse, errors::ConnectorError> {
         let response: Result<braintree::ErrorResponse, Report<common_utils::errors::ParsingError>> =
             res.response.parse_struct("Braintree Error Response");
 
         match response {
-            Ok(response_data) => Ok(types::ErrorResponse {
+            Ok(braintree::ErrorResponse::BraintreeApiErrorResponse(response)) => {
+                let error_object = response.api_error_response.errors;
+                let error = error_object.errors.first().or(error_object
+                    .transaction
+                    .as_ref()
+                    .and_then(|transaction_error| {
+                        transaction_error.errors.first().or(transaction_error
+                            .credit_card
+                            .as_ref()
+                            .and_then(|credit_card_error| credit_card_error.errors.first()))
+                    }));
+                let code = error.map_or(consts::NO_ERROR_CODE.to_string(), |error| {
+                    error.code.clone()
+                });
+                Ok(ErrorResponse {
+                    status_code: res.status_code,
+                    code,
+                    message: consts::NO_ERROR_MESSAGE.to_string(),
+                    reason: Some(response.api_error_response.message),
+                })
+            }
+            Ok(braintree::ErrorResponse::BraintreeErrorResponse(response)) => Ok(ErrorResponse {
                 status_code: res.status_code,
                 code: consts::NO_ERROR_CODE.to_string(),
-                message: response_data.api_error_response.message,
-                reason: None,
+                message: consts::NO_ERROR_MESSAGE.to_string(),
+                reason: Some(response.errors),
             }),
             Err(error_msg) => {
                 logger::error!(deserialization_error =? error_msg);
@@ -160,7 +182,7 @@ impl
     fn get_error_response(
         &self,
         res: types::Response,
-    ) -> CustomResult<types::ErrorResponse, errors::ConnectorError> {
+    ) -> CustomResult<ErrorResponse, errors::ConnectorError> {
         self.build_error_response(res)
     }
 
@@ -301,7 +323,7 @@ impl
     fn get_error_response(
         &self,
         res: types::Response,
-    ) -> CustomResult<types::ErrorResponse, errors::ConnectorError> {
+    ) -> CustomResult<ErrorResponse, errors::ConnectorError> {
         self.build_error_response(res)
     }
 
@@ -429,7 +451,7 @@ impl
     fn get_error_response(
         &self,
         res: types::Response,
-    ) -> CustomResult<types::ErrorResponse, errors::ConnectorError> {
+    ) -> CustomResult<ErrorResponse, errors::ConnectorError> {
         self.build_error_response(res)
     }
 }
@@ -502,7 +524,7 @@ impl
     fn get_error_response(
         &self,
         res: types::Response,
-    ) -> CustomResult<types::ErrorResponse, errors::ConnectorError> {
+    ) -> CustomResult<ErrorResponse, errors::ConnectorError> {
         self.build_error_response(res)
     }
 
@@ -632,7 +654,7 @@ impl services::ConnectorIntegration<api::Execute, types::RefundsData, types::Ref
     fn get_error_response(
         &self,
         _res: types::Response,
-    ) -> CustomResult<types::ErrorResponse, errors::ConnectorError> {
+    ) -> CustomResult<ErrorResponse, errors::ConnectorError> {
         Err(errors::ConnectorError::NotImplemented("braintree".to_string()).into())
     }
 }

--- a/crates/router/src/connector/braintree/transformers.rs
+++ b/crates/router/src/connector/braintree/transformers.rs
@@ -18,6 +18,11 @@ pub struct PaymentOptions {
     submit_for_settlement: bool,
 }
 
+#[derive(Debug, Deserialize)]
+pub struct BraintreeMeta {
+    merchant_account_id: Option<Secret<String>>,
+}
+
 #[derive(Debug, Serialize, Eq, PartialEq)]
 pub struct BraintreePaymentsRequest {
     transaction: TransactionBody,
@@ -48,6 +53,7 @@ impl TryFrom<&types::PaymentsSessionRouterData> for BraintreeSessionRequest {
 #[serde(rename_all = "camelCase")]
 pub struct TransactionBody {
     amount: String,
+    merchant_account_id: Option<Secret<String>>,
     device_data: DeviceData,
     options: PaymentOptions,
     #[serde(flatten)]
@@ -91,7 +97,9 @@ impl TryFrom<&types::PaymentsAuthorizeRouterData> for BraintreePaymentsRequest {
             item.request.capture_method,
             Some(enums::CaptureMethod::Automatic) | None
         );
-
+        let metadata: BraintreeMeta =
+            utils::to_connector_meta_from_secret(item.connector_meta_data.clone())?;
+        let merchant_account_id = metadata.merchant_account_id;
         let amount = utils::to_currency_base_unit(item.request.amount, item.request.currency)?;
         let device_data = DeviceData {};
         let options = PaymentOptions {
@@ -125,6 +133,7 @@ impl TryFrom<&types::PaymentsAuthorizeRouterData> for BraintreePaymentsRequest {
         }?;
         let braintree_transaction_body = TransactionBody {
             amount,
+            merchant_account_id,
             device_data,
             options,
             payment_method_data_type,
@@ -281,15 +290,54 @@ pub struct TransactionResponse {
     status: BraintreePaymentStatus,
 }
 
-#[derive(Debug, Default, Deserialize)]
+#[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct ErrorResponse {
+pub struct BraintreeApiErrorResponse {
     pub api_error_response: ApiErrorResponse,
 }
 
-#[derive(Default, Debug, Clone, Deserialize, Eq, PartialEq)]
+#[derive(Debug, Deserialize)]
+pub struct ErrorsObject {
+    pub errors: Vec<ErrorObject>,
+    pub transaction: Option<TransactionError>,
+}
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TransactionError {
+    pub errors: Vec<ErrorObject>,
+    pub credit_card: Option<CreditCardError>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CreditCardError {
+    pub errors: Vec<ErrorObject>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ErrorObject {
+    pub code: String,
+    pub message: String,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BraintreeErrorResponse {
+    pub errors: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[serde(untagged)]
+
+pub enum ErrorResponse {
+    BraintreeApiErrorResponse(Box<BraintreeApiErrorResponse>),
+    BraintreeErrorResponse(Box<BraintreeErrorResponse>),
+}
+
+#[derive(Debug, Deserialize)]
 pub struct ApiErrorResponse {
     pub message: String,
+    pub errors: ErrorsObject,
 }
 
 #[derive(Default, Debug, Clone, Serialize)]


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
1)added Merchant Account id field in authorize request for braintree.
2)handle error response in case of wrong merchant account id

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
1)added Merchant Account id field in authorize request for braintree.
2)handle error response in case of wrong merchant account id


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
<img width="850" alt="Screenshot 2023-08-10 at 6 35 50 PM" src="https://github.com/juspay/hyperswitch/assets/121822803/e4fec7da-5033-4257-b70b-7d9dad76928a">
<img width="514" alt="Screenshot 2023-08-10 at 6 36 08 PM" src="https://github.com/juspay/hyperswitch/assets/121822803/13c01437-0793-4e15-8719-2f78e78be5bb">

<img width="1197" alt="Screenshot 2023-08-10 at 7 46 02 PM" src="https://github.com/juspay/hyperswitch/assets/121822803/266ff6aa-62e4-4999-8f6b-d6b136faa20e">

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
