### PR TITLE
feat(router): Amend trait to use `ValidationError`

### DIFF
--- a/crates/router/src/utils/ext_traits.rs
+++ b/crates/router/src/utils/ext_traits.rs
@@ -1,4 +1,4 @@
-use common_utils::ext_traits::ValueExt;
+use common_utils::{errors::ValidationError, ext_traits::ValueExt};
 use error_stack::{IntoReport, Report, ResultExt};
 
 use crate::{
@@ -9,7 +9,7 @@ use crate::{
 pub trait OptionExt<T> {
     fn check_value_present(&self, field_name: &'static str) -> RouterResult<()>;
 
-    fn get_required_value(self, field_name: &'static str) -> RouterResult<T>;
+    fn get_required_value(self, field_name: &'static str) -> CustomResult<T, ValidationError>;
 
     fn parse_enum<E>(self, enum_name: &'static str) -> CustomResult<E, errors::ParsingError>
     where
@@ -41,13 +41,13 @@ where
 
     // This will allow the error message that was generated in this function to point to the call site
     #[track_caller]
-    fn get_required_value(self, field_name: &'static str) -> RouterResult<T> {
+    fn get_required_value(self, field_name: &'static str) -> CustomResult<T, ValidationError> {
         match self {
             Some(v) => Ok(v),
-            None => Err(
-                Report::new(ApiErrorResponse::MissingRequiredField { field_name })
-                    .attach_printable(format!("Missing required field {field_name} in {self:?}")),
-            ),
+            None => Err(Report::new(ValidationError::MissingRequiredField {
+                field_name: field_name.to_owned(),
+            })
+            .attach_printable(format!("Missing required field {field_name} in {self:?}"))),
         }
     }
 


### PR DESCRIPTION
Fixes #860

I'd like you to have a look at changes to <ext_traits.rs> so I'd be sure to propagate it along the `mod`s that use it.

PS The code is astonishing structured and maintained! And still I had some hard time due to different `pub` `ValidationError` in different crates.

## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
Follows https://github.com/juspay/hyperswitch/issues/860#issuecomment-1532963311 comment to the issue.


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
#860

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
This PR created as drafted as it's not tested, only compiler errors/warning eliminated *in the relevant module*.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
