### PR TITLE
fix(core): added is_terminated field in fraud_check table to support 3ds flow

### DIFF
--- a/crates/diesel_models/src/fraud_check.rs
+++ b/crates/diesel_models/src/fraud_check.rs
@@ -24,6 +24,7 @@ pub struct FraudCheck {
     pub payment_details: Option<serde_json::Value>,
     pub metadata: Option<serde_json::Value>,
     pub modified_at: PrimitiveDateTime,
+    pub is_terminated: bool,
 }
 
 #[derive(router_derive::Setter, Clone, Debug, Insertable, router_derive::DebugAsDisplay)]
@@ -44,6 +45,7 @@ pub struct FraudCheckNew {
     pub payment_details: Option<serde_json::Value>,
     pub metadata: Option<serde_json::Value>,
     pub modified_at: PrimitiveDateTime,
+    pub is_terminated: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -56,6 +58,7 @@ pub enum FraudCheckUpdate {
         frm_score: Option<i32>,
         metadata: Option<serde_json::Value>,
         modified_at: PrimitiveDateTime,
+        is_terminated: bool,
     },
     ErrorUpdate {
         status: FraudCheckStatus,
@@ -72,6 +75,7 @@ pub struct FraudCheckUpdateInternal {
     frm_score: Option<i32>,
     frm_error: Option<Option<String>>,
     metadata: Option<serde_json::Value>,
+    is_terminated: bool,
 }
 
 impl From<FraudCheckUpdate> for FraudCheckUpdateInternal {
@@ -84,12 +88,14 @@ impl From<FraudCheckUpdate> for FraudCheckUpdateInternal {
                 frm_score,
                 metadata,
                 modified_at: _,
+                is_terminated,
             } => Self {
                 frm_status: Some(frm_status),
                 frm_transaction_id,
                 frm_reason,
                 frm_score,
                 metadata,
+                is_terminated,
                 ..Default::default()
             },
             FraudCheckUpdate::ErrorUpdate {

--- a/crates/diesel_models/src/schema.rs
+++ b/crates/diesel_models/src/schema.rs
@@ -280,6 +280,7 @@ diesel::table! {
         payment_details -> Nullable<Jsonb>,
         metadata -> Nullable<Jsonb>,
         modified_at -> Timestamp,
+        is_terminated -> Bool,
     }
 }
 

--- a/migrations/2023-08-11-130019_add_is_terminated_to_fraud_check/down.sql
+++ b/migrations/2023-08-11-130019_add_is_terminated_to_fraud_check/down.sql
@@ -1,0 +1,1 @@
+alter table fraud_check drop column is_terminated ;

--- a/migrations/2023-08-11-130019_add_is_terminated_to_fraud_check/up.sql
+++ b/migrations/2023-08-11-130019_add_is_terminated_to_fraud_check/up.sql
@@ -1,0 +1,1 @@
+alter table fraud_check add column is_terminated BOOLEAN NOT NULL DEFAULT FALSE;


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Currently, frm module dosent work for 3ds flow.
It is because, payments operation core is called multiple times in the same request, and so is pre and post frm.
This creates duplicate entries, and also creates discrepencies.
To fix this, we are adding a field is_terminated in the fraud check table. This is to indicate that the frm flow has ended, and no furthur frm calls are to be made for the payment(be that 2nd 3ds call, or psync etc)

### Additional Changes

- [ ] This PR modifies the API contract
- [X] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->
- is_terminated is added to table fraud_check.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
- do a 3ds flow, with frm.
- for both pre and post flow, at the end of the flow, the is_terminated field should be set to true in the fraud_check table.
- for pre flow, signifyd should be called twice(once before and once after transaction), not 4 times.
- for post flow, it should be called only hitting the redirection link, and completing the authentication, i.e., only after the transaction is complete,i.e., frm should be called just once, not twice.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [X] I formatted the code `cargo +nightly fmt --all`
- [X] I addressed lints thrown by `cargo clippy`
- [X] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
