### PR TITLE
refactor(connector): remove payment experience from Not Supported Payment Methods error

### DIFF
--- a/crates/router/src/connector/aci/transformers.rs
+++ b/crates/router/src/connector/aci/transformers.rs
@@ -376,7 +376,6 @@ impl TryFrom<&types::PaymentsAuthorizeRouterData> for AciPaymentsRequest {
             | api::PaymentMethodData::Voucher(_) => Err(errors::ConnectorError::NotSupported {
                 message: format!("{:?}", item.payment_method),
                 connector: "Aci",
-                payment_experience: api_models::enums::PaymentExperience::RedirectToUrl.to_string(),
             })?,
         }
     }

--- a/crates/router/src/connector/adyen/transformers.rs
+++ b/crates/router/src/connector/adyen/transformers.rs
@@ -637,7 +637,6 @@ impl TryFrom<&api_enums::BankNames> for OnlineBankingCzechRepublicBanks {
             _ => Err(errors::ConnectorError::NotSupported {
                 message: String::from("BankRedirect"),
                 connector: "Adyen",
-                payment_experience: api_enums::PaymentExperience::RedirectToUrl.to_string(),
             })?,
         }
     }
@@ -718,7 +717,6 @@ impl TryFrom<&api_enums::BankNames> for OnlineBankingPolandBanks {
             _ => Err(errors::ConnectorError::NotSupported {
                 message: String::from("BankRedirect"),
                 connector: "Adyen",
-                payment_experience: api_enums::PaymentExperience::RedirectToUrl.to_string(),
             })?,
         }
     }
@@ -771,7 +769,6 @@ impl TryFrom<&api_enums::BankNames> for OnlineBankingSlovakiaBanks {
             _ => Err(errors::ConnectorError::NotSupported {
                 message: String::from("BankRedirect"),
                 connector: "Adyen",
-                payment_experience: api_enums::PaymentExperience::RedirectToUrl.to_string(),
             })?,
         }
     }
@@ -802,7 +799,6 @@ impl TryFrom<&api_enums::BankNames> for OnlineBankingFpxIssuer {
             _ => Err(errors::ConnectorError::NotSupported {
                 message: String::from("BankRedirect"),
                 connector: "Adyen",
-                payment_experience: api_enums::PaymentExperience::RedirectToUrl.to_string(),
             })?,
         }
     }
@@ -820,7 +816,6 @@ impl TryFrom<&api_enums::BankNames> for OnlineBankingThailandIssuer {
             _ => Err(errors::ConnectorError::NotSupported {
                 message: String::from("BankRedirect"),
                 connector: "Adyen",
-                payment_experience: api_enums::PaymentExperience::RedirectToUrl.to_string(),
             })?,
         }
     }
@@ -855,7 +850,6 @@ impl TryFrom<&api_enums::BankNames> for OpenBankingUKIssuer {
             _ => Err(errors::ConnectorError::NotSupported {
                 message: String::from("BankRedirect"),
                 connector: "Adyen",
-                payment_experience: api_enums::PaymentExperience::RedirectToUrl.to_string(),
             })?,
         }
     }
@@ -1280,7 +1274,6 @@ impl<'a> TryFrom<&api_enums::BankNames> for AdyenTestBankNames<'a> {
             _ => Err(errors::ConnectorError::NotSupported {
                 message: String::from("BankRedirect"),
                 connector: "Adyen",
-                payment_experience: api_enums::PaymentExperience::RedirectToUrl.to_string(),
             })?,
         })
     }
@@ -1350,8 +1343,6 @@ impl<'a> TryFrom<&types::PaymentsAuthorizeRouterData> for AdyenPaymentRequest<'a
                 _ => Err(errors::ConnectorError::NotSupported {
                     message: format!("{:?}", item.request.payment_method_type),
                     connector: "Adyen",
-                    payment_experience: api_models::enums::PaymentExperience::RedirectToUrl
-                        .to_string(),
                 })?,
             },
         }
@@ -2191,8 +2182,6 @@ impl<'a>
                     _ => Err(errors::ConnectorError::NotSupported {
                         message: format!("mandate_{:?}", item.payment_method),
                         connector: "Adyen",
-                        payment_experience: api_models::enums::PaymentExperience::RedirectToUrl
-                            .to_string(),
                     })?,
                 }
             }
@@ -3785,7 +3774,6 @@ impl<F> TryFrom<&types::PayoutsRouterData<F>> for AdyenPayoutCreateRequest {
             PayoutMethodData::Card(_) => Err(errors::ConnectorError::NotSupported {
                 message: "Card payout creation is not supported".to_string(),
                 connector: "Adyen",
-                payment_experience: "".to_string(),
             })?,
             PayoutMethodData::Bank(bd) => {
                 let bank_details = match bd {
@@ -3801,7 +3789,6 @@ impl<F> TryFrom<&types::PayoutsRouterData<F>> for AdyenPayoutCreateRequest {
                     _ => Err(errors::ConnectorError::NotSupported {
                         message: "Bank transfers via ACH or Bacs are not supported".to_string(),
                         connector: "Adyen",
-                        payment_experience: "".to_string(),
                     })?,
                 };
                 let address: &payments::AddressDetails = item.get_billing_address()?;

--- a/crates/router/src/connector/authorizedotnet/transformers.rs
+++ b/crates/router/src/connector/authorizedotnet/transformers.rs
@@ -136,8 +136,6 @@ fn get_pm_and_subsequent_auth_detail(
                 _ => Err(errors::ConnectorError::NotSupported {
                     message: format!("{:?}", item.request.payment_method_data),
                     connector: "AuthorizeDotNet",
-                    payment_experience: api_models::enums::PaymentExperience::RedirectToUrl
-                        .to_string(),
                 })?,
             }
         }
@@ -164,7 +162,6 @@ fn get_pm_and_subsequent_auth_detail(
             _ => Err(errors::ConnectorError::NotSupported {
                 message: format!("{:?}", item.request.payment_method_data),
                 connector: "AuthorizeDotNet",
-                payment_experience: api_models::enums::PaymentExperience::RedirectToUrl.to_string(),
             })?,
         },
     }

--- a/crates/router/src/connector/boku/transformers.rs
+++ b/crates/router/src/connector/boku/transformers.rs
@@ -84,7 +84,6 @@ impl TryFrom<&types::PaymentsAuthorizeRouterData> for BokuPaymentsRequest {
             _ => Err(errors::ConnectorError::NotSupported {
                 message: format!("{:?}", item.request.payment_method_type),
                 connector: "Boku",
-                payment_experience: api_models::enums::PaymentExperience::RedirectToUrl.to_string(),
             })?,
         }
     }

--- a/crates/router/src/connector/cashtocode.rs
+++ b/crates/router/src/connector/cashtocode.rs
@@ -64,7 +64,6 @@ fn get_auth_cashtocode(
             _ => Err(error_stack::report!(errors::ConnectorError::NotSupported {
                 message: reward_type.to_string(),
                 connector: "cashtocode",
-                payment_experience: "Try with a different payment method".to_string(),
             })),
         },
         Err(_) => Err(errors::ConnectorError::FailedToObtainAuthType.into()),

--- a/crates/router/src/connector/dummyconnector.rs
+++ b/crates/router/src/connector/dummyconnector.rs
@@ -161,7 +161,6 @@ impl<const T: u8>
             _ => Err(error_stack::report!(errors::ConnectorError::NotSupported {
                 message: format!("The payment method {} is not supported", req.payment_method),
                 connector: Into::<transformers::DummyConnectors>::into(T).get_dummy_connector_id(),
-                payment_experience: api::enums::PaymentExperience::RedirectToUrl.to_string(),
             })),
         }
     }

--- a/crates/router/src/connector/forte/transformers.rs
+++ b/crates/router/src/connector/forte/transformers.rs
@@ -57,7 +57,6 @@ impl TryFrom<utils::CardIssuer> for ForteCardType {
             _ => Err(errors::ConnectorError::NotSupported {
                 message: issuer.to_string(),
                 connector: "Forte",
-                payment_experience: api::enums::PaymentExperience::RedirectToUrl.to_string(),
             }
             .into()),
         }
@@ -71,7 +70,6 @@ impl TryFrom<&types::PaymentsAuthorizeRouterData> for FortePaymentsRequest {
             Err(errors::ConnectorError::NotSupported {
                 message: item.request.currency.to_string(),
                 connector: "Forte",
-                payment_experience: api::enums::PaymentExperience::RedirectToUrl.to_string(),
             })?
         }
         match item.request.payment_method_data {

--- a/crates/router/src/connector/klarna.rs
+++ b/crates/router/src/connector/klarna.rs
@@ -288,7 +288,6 @@ impl
                 _ => Err(error_stack::report!(errors::ConnectorError::NotSupported {
                     message: payment_method_type.to_string(),
                     connector: "klarna",
-                    payment_experience: payment_experience.to_string()
                 })),
             },
             _ => Err(error_stack::report!(

--- a/crates/router/src/connector/multisafepay/transformers.rs
+++ b/crates/router/src/connector/multisafepay/transformers.rs
@@ -232,7 +232,6 @@ impl TryFrom<utils::CardIssuer> for Gateway {
             _ => Err(errors::ConnectorError::NotSupported {
                 message: issuer.to_string(),
                 connector: "Multisafe pay",
-                payment_experience: api::enums::PaymentExperience::RedirectToUrl.to_string(),
             }
             .into()),
         }

--- a/crates/router/src/connector/nuvei/transformers.rs
+++ b/crates/router/src/connector/nuvei/transformers.rs
@@ -561,7 +561,6 @@ impl<F>
             _ => Err(errors::ConnectorError::NotSupported {
                 message: "Bank Redirect".to_string(),
                 connector: "Nuvei",
-                payment_experience: "Redirection".to_string(),
             })?,
         };
         Ok(Self {

--- a/crates/router/src/connector/payeezy/transformers.rs
+++ b/crates/router/src/connector/payeezy/transformers.rs
@@ -40,7 +40,6 @@ impl TryFrom<utils::CardIssuer> for PayeezyCardType {
             _ => Err(errors::ConnectorError::NotSupported {
                 message: issuer.to_string(),
                 connector: "Payeezy",
-                payment_experience: api::enums::PaymentExperience::RedirectToUrl.to_string(),
             }
             .into()),
         }

--- a/crates/router/src/connector/payme/transformers.rs
+++ b/crates/router/src/connector/payme/transformers.rs
@@ -257,7 +257,6 @@ impl TryFrom<&PaymentMethodData> for SalePaymentMethod {
                     Err(errors::ConnectorError::NotSupported {
                         message: "Wallet".to_string(),
                         connector: "payme",
-                        payment_experience: "Redirection".to_string(),
                     }
                     .into())
                 }

--- a/crates/router/src/connector/stax/transformers.rs
+++ b/crates/router/src/connector/stax/transformers.rs
@@ -30,7 +30,6 @@ impl TryFrom<&types::PaymentsAuthorizeRouterData> for StaxPaymentsRequest {
             Err(errors::ConnectorError::NotSupported {
                 message: item.request.currency.to_string(),
                 connector: "Stax",
-                payment_experience: api::enums::PaymentExperience::RedirectToUrl.to_string(),
             })?
         }
         match item.request.payment_method_data.clone() {

--- a/crates/router/src/connector/stripe/transformers.rs
+++ b/crates/router/src/connector/stripe/transformers.rs
@@ -813,7 +813,6 @@ impl TryFrom<&api_models::enums::BankNames> for StripeBankNames {
             _ => Err(errors::ConnectorError::NotSupported {
                 message: api_enums::PaymentMethod::BankRedirect.to_string(),
                 connector: "Stripe",
-                payment_experience: api_enums::PaymentExperience::RedirectToUrl.to_string(),
             })?,
         })
     }
@@ -939,7 +938,6 @@ fn infer_stripe_pay_later_type(
         Err(errors::ConnectorError::NotSupported {
             message: pm_type.to_string(),
             connector: "stripe",
-            payment_experience: experience.to_string(),
         })
     }
 }
@@ -3219,7 +3217,6 @@ impl
             | api::PaymentMethodData::Voucher(_) => Err(errors::ConnectorError::NotSupported {
                 message: format!("{pm_type:?}"),
                 connector: "Stripe",
-                payment_experience: api_models::enums::PaymentExperience::RedirectToUrl.to_string(),
             })?,
         }
     }

--- a/crates/router/src/connector/wise/transformers.rs
+++ b/crates/router/src/connector/wise/transformers.rs
@@ -347,7 +347,6 @@ fn get_payout_bank_details(
         _ => Err(errors::ConnectorError::NotSupported {
             message: "Card payout creation is not supported".to_string(),
             connector: "Wise",
-            payment_experience: "".to_string(),
         }),
     }
 }
@@ -375,7 +374,6 @@ impl<F> TryFrom<&types::PayoutsRouterData<F>> for WiseRecipientCreateRequest {
             storage_enums::PayoutType::Card => Err(errors::ConnectorError::NotSupported {
                 message: "Card payout creation is not supported".to_string(),
                 connector: "Wise",
-                payment_experience: "".to_string(),
             })?,
             storage_enums::PayoutType::Bank => {
                 let account_holder_name = customer_details
@@ -437,7 +435,6 @@ impl<F> TryFrom<&types::PayoutsRouterData<F>> for WisePayoutQuoteRequest {
             storage_enums::PayoutType::Card => Err(errors::ConnectorError::NotSupported {
                 message: "Card payout fulfillment is not supported".to_string(),
                 connector: "Wise",
-                payment_experience: "".to_string(),
             })?,
         }
     }
@@ -495,7 +492,6 @@ impl<F> TryFrom<&types::PayoutsRouterData<F>> for WisePayoutCreateRequest {
             storage_enums::PayoutType::Card => Err(errors::ConnectorError::NotSupported {
                 message: "Card payout fulfillment is not supported".to_string(),
                 connector: "Wise",
-                payment_experience: "".to_string(),
             })?,
         }
     }
@@ -540,7 +536,6 @@ impl<F> TryFrom<&types::PayoutsRouterData<F>> for WisePayoutFulfillRequest {
             storage_enums::PayoutType::Card => Err(errors::ConnectorError::NotSupported {
                 message: "Card payout fulfillment is not supported".to_string(),
                 connector: "Wise",
-                payment_experience: "".to_string(),
             })?,
         }
     }
@@ -607,7 +602,6 @@ impl TryFrom<PayoutMethodData> for RecipientType {
             _ => Err(errors::ConnectorError::NotSupported {
                 message: "Requested payout_method_type is not supported".to_string(),
                 connector: "Wise",
-                payment_experience: "".to_string(),
             }
             .into()),
         }

--- a/crates/router/src/connector/worldline/transformers.rs
+++ b/crates/router/src/connector/worldline/transformers.rs
@@ -236,7 +236,6 @@ impl TryFrom<utils::CardIssuer> for Gateway {
             _ => Err(errors::ConnectorError::NotSupported {
                 message: issuer.to_string(),
                 connector: "worldline",
-                payment_experience: api_enums::PaymentExperience::RedirectToUrl.to_string(),
             }
             .into()),
         }

--- a/crates/router/src/core/errors.rs
+++ b/crates/router/src/core/errors.rs
@@ -263,7 +263,6 @@ pub enum ConnectorError {
     NotSupported {
         message: String,
         connector: &'static str,
-        payment_experience: String,
     },
     #[error("{flow} flow not supported by {connector} connector")]
     FlowNotSupported { flow: String, connector: String },

--- a/crates/router/src/core/errors/utils.rs
+++ b/crates/router/src/core/errors/utils.rs
@@ -128,8 +128,8 @@ impl<T> ConnectorErrorExt<T> for error_stack::Result<T, errors::ConnectorError> 
                             "payment_method_data, payment_method_type and payment_experience does not match",
                     }
                 },
-                errors::ConnectorError::NotSupported { message, connector, payment_experience } => {
-                    errors::ApiErrorResponse::NotSupported { message: format!("{message} is not supported by {connector} through payment experience {payment_experience}") }
+                errors::ConnectorError::NotSupported { message, connector } => {
+                    errors::ApiErrorResponse::NotSupported { message: format!("{message} is not supported by {connector}") }
                 },
                 errors::ConnectorError::FlowNotSupported{ flow, connector } => {
                     errors::ApiErrorResponse::FlowNotSupported { flow: flow.to_owned(), connector: connector.to_owned() }

--- a/crates/router/tests/connectors/forte.rs
+++ b/crates/router/tests/connectors/forte.rs
@@ -637,7 +637,6 @@ async fn should_throw_not_implemented_for_unsupported_issuer() {
         router::core::errors::ConnectorError::NotSupported {
             message: "Maestro".to_string(),
             connector: "Forte",
-            payment_experience: api::enums::PaymentExperience::RedirectToUrl.to_string(),
         }
     )
 }

--- a/crates/router/tests/connectors/payeezy.rs
+++ b/crates/router/tests/connectors/payeezy.rs
@@ -382,7 +382,6 @@ async fn should_throw_not_implemented_for_unsupported_issuer() {
         errors::ConnectorError::NotSupported {
             message: "card".to_string(),
             connector: "Payeezy",
-            payment_experience: "RedirectToUrl".to_string(),
         }
     )
 }

--- a/crates/router/tests/connectors/worldline.rs
+++ b/crates/router/tests/connectors/worldline.rs
@@ -152,7 +152,6 @@ async fn should_throw_not_implemented_for_unsupported_issuer() {
         errors::ConnectorError::NotSupported {
             message: "Maestro".to_string(),
             connector: "worldline",
-            payment_experience: "RedirectToUrl".to_string(),
         }
     )
 }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
Removed payment_experience from NotSupported error, as it has no significance.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
