### PR TITLE
fix(frm): added fraud_check_last_step field in fraud_check table to support 3DS transaction in frm

### DIFF
--- a/crates/diesel_models/src/enums.rs
+++ b/crates/diesel_models/src/enums.rs
@@ -6,10 +6,10 @@ pub mod diesel_exports {
         DbConnectorType as ConnectorType, DbCountryAlpha2 as CountryAlpha2, DbCurrency as Currency,
         DbDisputeStage as DisputeStage, DbDisputeStatus as DisputeStatus,
         DbEventClass as EventClass, DbEventObjectType as EventObjectType, DbEventType as EventType,
-        DbFraudCheckStatus as FraudCheckStatus, DbFraudCheckType as FraudCheckType,
-        DbFutureUsage as FutureUsage, DbIntentStatus as IntentStatus,
-        DbMandateStatus as MandateStatus, DbMandateType as MandateType,
-        DbMerchantStorageScheme as MerchantStorageScheme,
+        DbFraudCheckLastStep as FraudCheckLastStep, DbFraudCheckStatus as FraudCheckStatus,
+        DbFraudCheckType as FraudCheckType, DbFutureUsage as FutureUsage,
+        DbIntentStatus as IntentStatus, DbMandateStatus as MandateStatus,
+        DbMandateType as MandateType, DbMerchantStorageScheme as MerchantStorageScheme,
         DbPaymentMethodIssuerCode as PaymentMethodIssuerCode, DbPayoutStatus as PayoutStatus,
         DbPayoutType as PayoutType, DbProcessTrackerStatus as ProcessTrackerStatus,
         DbRefundStatus as RefundStatus, DbRefundType as RefundType,
@@ -373,4 +373,27 @@ pub enum FraudCheckStatus {
     Pending,
     Legit,
     TransactionFailure,
+}
+
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Default,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    strum::Display,
+    strum::EnumString,
+    frunk::LabelledGeneric,
+)]
+#[router_derive::diesel_enum(storage_type = "pg_enum")]
+#[strum(serialize_all = "snake_case")]
+pub enum FraudCheckLastStep {
+    #[default]
+    Processing,
+    CheckoutOrSale,
+    TransactionOrRecordRefund,
+    Fullfillment,
 }

--- a/crates/diesel_models/src/enums.rs
+++ b/crates/diesel_models/src/enums.rs
@@ -6,10 +6,10 @@ pub mod diesel_exports {
         DbConnectorType as ConnectorType, DbCountryAlpha2 as CountryAlpha2, DbCurrency as Currency,
         DbDisputeStage as DisputeStage, DbDisputeStatus as DisputeStatus,
         DbEventClass as EventClass, DbEventObjectType as EventObjectType, DbEventType as EventType,
-        DbFraudCheckLastStep as FraudCheckLastStep, DbFraudCheckStatus as FraudCheckStatus,
-        DbFraudCheckType as FraudCheckType, DbFutureUsage as FutureUsage,
-        DbIntentStatus as IntentStatus, DbMandateStatus as MandateStatus,
-        DbMandateType as MandateType, DbMerchantStorageScheme as MerchantStorageScheme,
+        DbFraudCheckStatus as FraudCheckStatus, DbFraudCheckType as FraudCheckType,
+        DbFutureUsage as FutureUsage, DbIntentStatus as IntentStatus,
+        DbMandateStatus as MandateStatus, DbMandateType as MandateType,
+        DbMerchantStorageScheme as MerchantStorageScheme,
         DbPaymentMethodIssuerCode as PaymentMethodIssuerCode, DbPayoutStatus as PayoutStatus,
         DbPayoutType as PayoutType, DbProcessTrackerStatus as ProcessTrackerStatus,
         DbRefundStatus as RefundStatus, DbRefundType as RefundType,
@@ -388,7 +388,7 @@ pub enum FraudCheckStatus {
     strum::EnumString,
     frunk::LabelledGeneric,
 )]
-#[router_derive::diesel_enum(storage_type = "pg_enum")]
+#[router_derive::diesel_enum(storage_type = "text")]
 #[strum(serialize_all = "snake_case")]
 pub enum FraudCheckLastStep {
     #[default]

--- a/crates/diesel_models/src/fraud_check.rs
+++ b/crates/diesel_models/src/fraud_check.rs
@@ -3,7 +3,7 @@ use masking::{Deserialize, Serialize};
 use time::PrimitiveDateTime;
 
 use crate::{
-    enums::{FraudCheckStatus, FraudCheckType},
+    enums::{FraudCheckLastStep, FraudCheckStatus, FraudCheckType},
     schema::fraud_check,
 };
 #[derive(Clone, Debug, Identifiable, Queryable, Serialize, Deserialize)]
@@ -24,6 +24,7 @@ pub struct FraudCheck {
     pub payment_details: Option<serde_json::Value>,
     pub metadata: Option<serde_json::Value>,
     pub modified_at: PrimitiveDateTime,
+    pub last_step: FraudCheckLastStep,
 }
 
 #[derive(router_derive::Setter, Clone, Debug, Insertable, router_derive::DebugAsDisplay)]
@@ -44,6 +45,7 @@ pub struct FraudCheckNew {
     pub payment_details: Option<serde_json::Value>,
     pub metadata: Option<serde_json::Value>,
     pub modified_at: PrimitiveDateTime,
+    pub last_step: FraudCheckLastStep,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -56,6 +58,7 @@ pub enum FraudCheckUpdate {
         frm_score: Option<i32>,
         metadata: Option<serde_json::Value>,
         modified_at: PrimitiveDateTime,
+        last_step: FraudCheckLastStep,
     },
     ErrorUpdate {
         status: FraudCheckStatus,
@@ -72,6 +75,7 @@ pub struct FraudCheckUpdateInternal {
     frm_score: Option<i32>,
     frm_error: Option<Option<String>>,
     metadata: Option<serde_json::Value>,
+    last_step: FraudCheckLastStep,
 }
 
 impl From<FraudCheckUpdate> for FraudCheckUpdateInternal {
@@ -84,12 +88,14 @@ impl From<FraudCheckUpdate> for FraudCheckUpdateInternal {
                 frm_score,
                 metadata,
                 modified_at: _,
+                last_step,
             } => Self {
                 frm_status: Some(frm_status),
                 frm_transaction_id,
                 frm_reason,
                 frm_score,
                 metadata,
+                last_step,
                 ..Default::default()
             },
             FraudCheckUpdate::ErrorUpdate {

--- a/crates/diesel_models/src/query/fraud_check.rs
+++ b/crates/diesel_models/src/query/fraud_check.rs
@@ -54,4 +54,18 @@ impl FraudCheck {
         )
         .await
     }
+
+    pub async fn get_with_payment_id_if_present(
+        conn: &PgPooledConn,
+        payment_id: String,
+        merchant_id: String,
+    ) -> StorageResult<Option<Self>> {
+        generics::generic_find_one_optional::<<Self as HasTable>::Table, _, _>(
+            conn,
+            dsl::payment_id
+                .eq(payment_id)
+                .and(dsl::merchant_id.eq(merchant_id)),
+        )
+        .await
+    }
 }

--- a/crates/diesel_models/src/schema.rs
+++ b/crates/diesel_models/src/schema.rs
@@ -280,6 +280,7 @@ diesel::table! {
         payment_details -> Nullable<Jsonb>,
         metadata -> Nullable<Jsonb>,
         modified_at -> Timestamp,
+        last_step -> FraudCheckLastStep,
     }
 }
 

--- a/crates/diesel_models/src/schema.rs
+++ b/crates/diesel_models/src/schema.rs
@@ -280,7 +280,8 @@ diesel::table! {
         payment_details -> Nullable<Jsonb>,
         metadata -> Nullable<Jsonb>,
         modified_at -> Timestamp,
-        last_step -> FraudCheckLastStep,
+        #[max_length = 64]
+        last_step -> Varchar,
     }
 }
 

--- a/crates/router/src/db/fraud_check.rs
+++ b/crates/router/src/db/fraud_check.rs
@@ -77,7 +77,6 @@ impl FraudCheckInterface for Store {
             .map_err(Into::into)
             .into_report()
     }
-
 }
 
 #[async_trait::async_trait]

--- a/crates/router/src/db/fraud_check.rs
+++ b/crates/router/src/db/fraud_check.rs
@@ -26,6 +26,12 @@ pub trait FraudCheckInterface {
         payment_id: String,
         merchant_id: String,
     ) -> CustomResult<FraudCheck, errors::StorageError>;
+
+    async fn find_fraud_check_by_payment_id_if_present(
+        &self,
+        payment_id: String,
+        merchant_id: String,
+    ) -> CustomResult<Option<FraudCheck>, errors::StorageError>;
 }
 
 #[async_trait::async_trait]
@@ -59,6 +65,19 @@ impl FraudCheckInterface for Store {
             .map_err(Into::into)
             .into_report()
     }
+
+    async fn find_fraud_check_by_payment_id_if_present(
+        &self,
+        payment_id: String,
+        merchant_id: String,
+    ) -> CustomResult<Option<FraudCheck>, errors::StorageError> {
+        let conn = connection::pg_connection_write(self).await?;
+        FraudCheck::get_with_payment_id_if_present(&conn, payment_id, merchant_id)
+            .await
+            .map_err(Into::into)
+            .into_report()
+    }
+
 }
 
 #[async_trait::async_trait]
@@ -81,6 +100,14 @@ impl FraudCheckInterface for MockDb {
         _payment_id: String,
         _merchant_id: String,
     ) -> CustomResult<FraudCheck, errors::StorageError> {
+        Err(errors::StorageError::MockDbError)?
+    }
+
+    async fn find_fraud_check_by_payment_id_if_present(
+        &self,
+        _payment_id: String,
+        _merchant_id: String,
+    ) -> CustomResult<Option<FraudCheck>, errors::StorageError> {
         Err(errors::StorageError::MockDbError)?
     }
 }

--- a/migrations/2023-08-16-103806_add_last_executed_frm_step/down.sql
+++ b/migrations/2023-08-16-103806_add_last_executed_frm_step/down.sql
@@ -1,0 +1,2 @@
+alter table fraud_check drop column last_step;
+DROP TYPE "FraudCheckLastStep";

--- a/migrations/2023-08-16-103806_add_last_executed_frm_step/down.sql
+++ b/migrations/2023-08-16-103806_add_last_executed_frm_step/down.sql
@@ -1,2 +1,1 @@
 alter table fraud_check drop column last_step;
-DROP TYPE "FraudCheckLastStep";

--- a/migrations/2023-08-16-103806_add_last_executed_frm_step/up.sql
+++ b/migrations/2023-08-16-103806_add_last_executed_frm_step/up.sql
@@ -1,8 +1,1 @@
-CREATE TYPE "FraudCheckLastStep" AS ENUM (
-    'processing',
-    'checkout_or_sale',
-    'transaction_or_record_refund',
-    'fullfillment'
-);
-
-alter table fraud_check add column last_step "FraudCheckLastStep" NOT NULL DEFAULT 'processing'::"FraudCheckLastStep";
+alter table fraud_check add column last_step VARCHAR(64) NOT NULL DEFAULT 'processing';

--- a/migrations/2023-08-16-103806_add_last_executed_frm_step/up.sql
+++ b/migrations/2023-08-16-103806_add_last_executed_frm_step/up.sql
@@ -1,0 +1,8 @@
+CREATE TYPE "FraudCheckLastStep" AS ENUM (
+    'processing',
+    'checkout_or_sale',
+    'transaction_or_record_refund',
+    'fullfillment'
+);
+
+alter table fraud_check add column last_step "FraudCheckLastStep" NOT NULL DEFAULT 'processing'::"FraudCheckLastStep";


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Currently, frm module dosent work for 3ds flow.
It is because, payments operation core is called multiple times in the same request, and so is pre and post frm.
This creates duplicate entries, and also creates discrepencies.
To fix this, we are adding a field fraud_check_last_step in the fraud check table. This is to indicate the last step executed in  the frm flow, and we will restrict few actions based on the last_step. 

Eg 1: if the last_step is `processing`, then we can do `checkout` or `sale` nothing else
Eg 2: if the last_step is `checkout_or_sale`, then we can do `transaction` or `refund` or `fullfillment`
Eg 3: if the last_step is `transaction_or_record_refund`, then we can either only do `fullfillment`

### Additional Changes

- [ ] This PR modifies the API contract
- [X] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->
- is_terminated is added to table fraud_check.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
- do a 3ds flow, with frm.
- for both pre and post flow, at the end of the flow, the is_terminated field should be set to true in the fraud_check table.
- for pre flow, signifyd should be called twice(once before and once after transaction), not 4 times.
- for post flow, it should be called only hitting the redirection link, and completing the authentication, i.e., only after the transaction is complete,i.e., frm should be called just once, not twice.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [X] I formatted the code `cargo +nightly fmt --all`
- [X] I addressed lints thrown by `cargo clippy`
- [X] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
