### PR TITLE
fix(test_utils): remove `cmd` alias for `std::process::Command`

### DIFF
--- a/crates/test_utils/src/main.rs
+++ b/crates/test_utils/src/main.rs
@@ -1,6 +1,6 @@
 use std::{
     env,
-    process::{exit, Command as cmd},
+    process::{exit, Command},
 };
 
 use clap::{arg, command, Parser};
@@ -45,7 +45,7 @@ fn main() {
     // been added to the postman collection, those conditions are set to true and collections that have
     // variables set up for certificate, will consider those variables and will fail.
 
-    let mut newman_command = cmd::new("newman");
+    let mut newman_command = Command::new("newman");
     newman_command.args(["run", &collection_path]);
     newman_command.args(["--env-var", &format!("admin_api_key={admin_api_key}")]);
     newman_command.args(["--env-var", &format!("baseUrl={base_url}")]);


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Refactoring

## Description
<!-- Describe your changes in detail -->
Removes `as cmd` and we will be using `Command` going forward. 

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
Remove bad code practice.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
No tests needed.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
