### PR TITLE
ci: use Rust stable from 2 weeks ago

### DIFF
--- a/.github/workflows/CI-pr.yml
+++ b/.github/workflows/CI-pr.yml
@@ -290,7 +290,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: stable
+          toolchain: stable 2 weeks ago
           components: clippy
 
       - name: Install cargo-hack

--- a/.github/workflows/CI-push.yml
+++ b/.github/workflows/CI-push.yml
@@ -131,7 +131,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: stable
+          toolchain: stable 2 weeks ago
           components: clippy
 
       - name: Install cargo-hack

--- a/.github/workflows/connector-sanity-tests.yml
+++ b/.github/workflows/connector-sanity-tests.yml
@@ -84,7 +84,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: stable
+          toolchain: stable 2 weeks ago
 
       - uses: Swatinem/rust-cache@v2.4.0
 

--- a/.github/workflows/conventional-commit-check.yml
+++ b/.github/workflows/conventional-commit-check.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: stable
+          toolchain: stable 2 weeks ago
 
       - uses: baptiste0928/cargo-install@v2.1.0
         with:

--- a/.github/workflows/migration-check.yaml
+++ b/.github/workflows/migration-check.yaml
@@ -45,7 +45,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: stable
+          toolchain: stable 2 weeks ago
 
       - uses: baptiste0928/cargo-install@v2.1.0
         with:

--- a/.github/workflows/postman-collection-runner.yml
+++ b/.github/workflows/postman-collection-runner.yml
@@ -77,7 +77,7 @@ jobs:
         if: ${{ ((github.event_name == 'pull_request') && (github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name)) || (github.event_name == 'merge_group')}}
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: stable
+          toolchain: stable 2 weeks ago
 
       - name: Build and Cache Rust Dependencies
         if: ${{ ((github.event_name == 'pull_request') && (github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name)) || (github.event_name == 'merge_group')}}

--- a/.github/workflows/release-new-version.yml
+++ b/.github/workflows/release-new-version.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: stable
+          toolchain: stable 2 weeks ago
 
       - name: Install cocogitto
         uses: baptiste0928/cargo-install@v2.1.0

--- a/.github/workflows/validate-openapi-spec.yml
+++ b/.github/workflows/validate-openapi-spec.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: stable
+          toolchain: stable 2 weeks ago
 
       - name: Generate the OpenAPI spec file
         shell: bash

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1645,6 +1645,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "data_models"
+version = "0.1.0"
+dependencies = [
+ "api_models",
+ "async-trait",
+ "common_enums",
+ "common_utils",
+ "error-stack",
+ "serde",
+ "serde_json",
+ "strum 0.25.0",
+ "thiserror",
+ "time 0.3.22",
+]
+
+[[package]]
 name = "deadpool"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1824,9 +1840,9 @@ dependencies = [
 
 [[package]]
 name = "dyn-clone"
-version = "1.0.11"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68b0cf012f1230e43cd00ebb729c6bb58707ecfa8ad08b52ef3a4ccd2697fc30"
+checksum = "bbfc4744c1b8f2a09adc0e55242f60b1af195d88596bd8700be74418c056c555"
 
 [[package]]
 name = "either"
@@ -2998,9 +3014,9 @@ dependencies = [
 
 [[package]]
 name = "moka"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "206bf83f415b0579fd885fe0804eb828e727636657dc1bf73d80d2f1218e14a1"
+checksum = "fa6e72583bf6830c956235bff0d5afec8cf2952f579ebad18ae7821a917d950f"
 dependencies = [
  "async-io",
  "async-lock",
@@ -3968,7 +3984,7 @@ dependencies = [
  "clap",
  "common_utils",
  "config",
- "crc32fast",
+ "data_models",
  "derive_deref",
  "diesel",
  "diesel_models",
@@ -3988,7 +4004,6 @@ dependencies = [
  "maud",
  "mimalloc",
  "mime",
- "moka",
  "nanoid",
  "num_cpus",
  "once_cell",
@@ -4588,11 +4603,24 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 name = "storage_impl"
 version = "0.1.0"
 dependencies = [
+ "api_models",
  "async-bb8-diesel",
  "async-trait",
  "bb8",
+ "common_utils",
+ "crc32fast",
+ "data_models",
  "diesel",
+ "diesel_models",
+ "dyn-clone",
+ "error-stack",
+ "futures",
  "masking",
+ "moka",
+ "once_cell",
+ "redis_interface",
+ "router_env",
+ "tokio",
 ]
 
 [[package]]

--- a/openapi/openapi_spec.json
+++ b/openapi/openapi_spec.json
@@ -10163,11 +10163,6 @@
             "format": "int64",
             "description": "The total number of refunds in the list"
           },
-          "total_count": {
-            "type": "integer",
-            "format": "int64",
-            "description": "The total number of refunds in the list"
-          },
           "data": {
             "type": "array",
             "items": {


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
This would provide us sufficient time to address any clippy lints that would be stabilized.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
Using the latest stable Rust toolchain could block PRs whenever new `clippy` lints are introduced. Using the stable toolchain from 2 weeks ago would give us sufficient time to address these lints.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
N/A

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
