### PR TITLE
refactor(postman): remove `routing algorithm` struct from `merchant account create`

### DIFF
--- a/postman/collection-dir/aci/Flow Testcases/QuickStart/Merchant Account - Create/request.json
+++ b/postman/collection-dir/aci/Flow Testcases/QuickStart/Merchant Account - Create/request.json
@@ -75,10 +75,6 @@
         "payment_succeeded_enabled": true,
         "payment_failed_enabled": true
       },
-      "routing_algorithm": {
-        "type": "single",
-        "data": "aci"
-      },
       "sub_merchants_enabled": false,
       "metadata": {
         "city": "NY",

--- a/postman/collection-dir/adyen_uk/Flow Testcases/QuickStart/Merchant Account - Create/request.json
+++ b/postman/collection-dir/adyen_uk/Flow Testcases/QuickStart/Merchant Account - Create/request.json
@@ -75,10 +75,6 @@
         "payment_succeeded_enabled": true,
         "payment_failed_enabled": true
       },
-      "routing_algorithm": {
-        "type": "single",
-        "data": "adyen"
-      },
       "sub_merchants_enabled": false,
       "metadata": {
         "city": "NY",

--- a/postman/collection-dir/airwallex/Flow Testcases/QuickStart/Merchant Account - Create/request.json
+++ b/postman/collection-dir/airwallex/Flow Testcases/QuickStart/Merchant Account - Create/request.json
@@ -75,10 +75,6 @@
         "payment_succeeded_enabled": true,
         "payment_failed_enabled": true
       },
-      "routing_algorithm": {
-        "type": "single",
-        "data": "airwallex"
-      },
       "sub_merchants_enabled": false,
       "metadata": {
         "city": "NY",

--- a/postman/collection-dir/authorizedotnet/Flow Testcases/QuickStart/Merchant Account - Create/request.json
+++ b/postman/collection-dir/authorizedotnet/Flow Testcases/QuickStart/Merchant Account - Create/request.json
@@ -75,10 +75,6 @@
         "payment_succeeded_enabled": true,
         "payment_failed_enabled": true
       },
-      "routing_algorithm": {
-        "type": "single",
-        "data": "authorizedotnet"
-      },
       "sub_merchants_enabled": false,
       "metadata": {
         "city": "NY",

--- a/postman/collection-dir/bambora/Flow Testcases/QuickStart/Merchant Account - Create/request.json
+++ b/postman/collection-dir/bambora/Flow Testcases/QuickStart/Merchant Account - Create/request.json
@@ -75,10 +75,6 @@
         "payment_succeeded_enabled": true,
         "payment_failed_enabled": true
       },
-      "routing_algorithm": {
-        "type": "single",
-        "data": "bambora"
-      },
       "sub_merchants_enabled": false,
       "metadata": {
         "city": "NY",

--- a/postman/collection-dir/bambora_3ds/Flow Testcases/QuickStart/Merchant Account - Create/request.json
+++ b/postman/collection-dir/bambora_3ds/Flow Testcases/QuickStart/Merchant Account - Create/request.json
@@ -75,10 +75,6 @@
         "payment_succeeded_enabled": true,
         "payment_failed_enabled": true
       },
-      "routing_algorithm": {
-        "type": "single",
-        "data": "bambora"
-      },
       "sub_merchants_enabled": false,
       "metadata": {
         "city": "NY",

--- a/postman/collection-dir/bluesnap/Flow Testcases/QuickStart/Merchant Account - Create/request.json
+++ b/postman/collection-dir/bluesnap/Flow Testcases/QuickStart/Merchant Account - Create/request.json
@@ -75,10 +75,6 @@
         "payment_succeeded_enabled": true,
         "payment_failed_enabled": true
       },
-      "routing_algorithm": {
-        "type": "single",
-        "data": "bluesnap"
-      },
       "sub_merchants_enabled": false,
       "metadata": {
         "city": "NY",

--- a/postman/collection-dir/braintree/Flow Testcases/QuickStart/Merchant Account - Create/request.json
+++ b/postman/collection-dir/braintree/Flow Testcases/QuickStart/Merchant Account - Create/request.json
@@ -75,10 +75,6 @@
         "payment_succeeded_enabled": true,
         "payment_failed_enabled": true
       },
-      "routing_algorithm": {
-        "type": "single",
-        "data": "braintree"
-      },
       "sub_merchants_enabled": false,
       "metadata": {
         "city": "NY",

--- a/postman/collection-dir/checkout/Flow Testcases/QuickStart/Merchant Account - Create/request.json
+++ b/postman/collection-dir/checkout/Flow Testcases/QuickStart/Merchant Account - Create/request.json
@@ -75,10 +75,6 @@
         "payment_succeeded_enabled": true,
         "payment_failed_enabled": true
       },
-      "routing_algorithm": {
-        "type": "single",
-        "data": "checkout"
-      },
       "sub_merchants_enabled": false,
       "metadata": {
         "city": "NY",

--- a/postman/collection-dir/forte/Flow Testcases/QuickStart/Merchant Account - Create/request.json
+++ b/postman/collection-dir/forte/Flow Testcases/QuickStart/Merchant Account - Create/request.json
@@ -69,10 +69,6 @@
         "payment_succeeded_enabled": true,
         "payment_failed_enabled": true
       },
-      "routing_algorithm": {
-        "type": "single",
-        "data": "stripe"
-      },
       "primary_business_details": [
         {
           "country": "US",

--- a/postman/collection-dir/globalpay/Flow Testcases/QuickStart/Merchant Account - Create/request.json
+++ b/postman/collection-dir/globalpay/Flow Testcases/QuickStart/Merchant Account - Create/request.json
@@ -75,10 +75,6 @@
         "payment_succeeded_enabled": true,
         "payment_failed_enabled": true
       },
-      "routing_algorithm": {
-        "type": "single",
-        "data": "globalpay"
-      },
       "sub_merchants_enabled": false,
       "metadata": {
         "city": "NY",

--- a/postman/collection-dir/hyperswitch/Hackathon/QuickStart/Merchant Account - Create/request.json
+++ b/postman/collection-dir/hyperswitch/Hackathon/QuickStart/Merchant Account - Create/request.json
@@ -68,11 +68,7 @@
         "payment_created_enabled": true,
         "payment_succeeded_enabled": true,
         "payment_failed_enabled": true
-      },
-      "routing_algorithm": {
-        "type": "single",
-        "data": "stripe"
-      },
+      },   
       "sub_merchants_enabled": false,
       "metadata": {
         "city": "NY",

--- a/postman/collection-dir/hyperswitch/MerchantAccounts/Merchant Account - Create/request.json
+++ b/postman/collection-dir/hyperswitch/MerchantAccounts/Merchant Account - Create/request.json
@@ -69,10 +69,6 @@
         "payment_succeeded_enabled": true,
         "payment_failed_enabled": true
       },
-      "routing_algorithm": {
-        "type": "single",
-        "data": "stripe"
-      },
       "sub_merchants_enabled": false,
       "metadata": {
         "city": "NY",

--- a/postman/collection-dir/hyperswitch/MerchantAccounts/Merchant Account - Update/request.json
+++ b/postman/collection-dir/hyperswitch/MerchantAccounts/Merchant Account - Update/request.json
@@ -69,10 +69,7 @@
         "payment_succeeded_enabled": true,
         "payment_failed_enabled": true
       },
-      "routing_algorithm": {
-        "type": "single",
-        "data": "stripe"
-      },
+      
       "sub_merchants_enabled": false,
       "parent_merchant_id": "xkkdf909012sdjki2dkh5sdf",
       "metadata": {

--- a/postman/collection-dir/hyperswitch/QuickStart/Merchant Account - Create/request.json
+++ b/postman/collection-dir/hyperswitch/QuickStart/Merchant Account - Create/request.json
@@ -69,10 +69,6 @@
         "payment_succeeded_enabled": true,
         "payment_failed_enabled": true
       },
-      "routing_algorithm": {
-        "type": "single",
-        "data": "stripe"
-      },
       "sub_merchants_enabled": false,
       "metadata": {
         "city": "NY",

--- a/postman/collection-dir/mollie/Flow Testcases/QuickStart/Merchant Account - Create/request.json
+++ b/postman/collection-dir/mollie/Flow Testcases/QuickStart/Merchant Account - Create/request.json
@@ -75,10 +75,6 @@
         "payment_succeeded_enabled": true,
         "payment_failed_enabled": true
       },
-      "routing_algorithm": {
-        "type": "single",
-        "data": "mollie"
-      },
       "sub_merchants_enabled": false,
       "metadata": {
         "city": "NY",

--- a/postman/collection-dir/multisafepay/Flow Testcases/QuickStart/Merchant Account - Create/request.json
+++ b/postman/collection-dir/multisafepay/Flow Testcases/QuickStart/Merchant Account - Create/request.json
@@ -75,10 +75,7 @@
         "payment_succeeded_enabled": true,
         "payment_failed_enabled": true
       },
-      "routing_algorithm": {
-        "type": "single",
-        "data": "stripe"
-      },
+      
       "sub_merchants_enabled": false,
       "metadata": {
         "city": "NY",

--- a/postman/collection-dir/nexinets/Flow Testcases/QuickStart/Merchant Account - Create/request.json
+++ b/postman/collection-dir/nexinets/Flow Testcases/QuickStart/Merchant Account - Create/request.json
@@ -75,10 +75,6 @@
         "payment_succeeded_enabled": true,
         "payment_failed_enabled": true
       },
-      "routing_algorithm": {
-        "type": "single",
-        "data": "nexinets"
-      },
       "sub_merchants_enabled": false,
       "metadata": {
         "city": "NY",

--- a/postman/collection-dir/nmi/Flow Testcases/QuickStart/Merchant Account - Create/request.json
+++ b/postman/collection-dir/nmi/Flow Testcases/QuickStart/Merchant Account - Create/request.json
@@ -75,10 +75,6 @@
         "payment_succeeded_enabled": true,
         "payment_failed_enabled": true
       },
-      "routing_algorithm": {
-        "type": "single",
-        "data": "nmi"
-      },
       "sub_merchants_enabled": false,
       "metadata": {
         "city": "NY",

--- a/postman/collection-dir/payme/Flow Testcases/QuickStart/Merchant Account - Create/request.json
+++ b/postman/collection-dir/payme/Flow Testcases/QuickStart/Merchant Account - Create/request.json
@@ -69,10 +69,6 @@
         "payment_succeeded_enabled": true,
         "payment_failed_enabled": true
       },
-      "routing_algorithm": {
-        "type": "single",
-        "data": "payme"
-      },
       "primary_business_details": [
         {
           "country": "US",

--- a/postman/collection-dir/paypal/Flow Testcases/QuickStart/Merchant Account - Create/request.json
+++ b/postman/collection-dir/paypal/Flow Testcases/QuickStart/Merchant Account - Create/request.json
@@ -75,10 +75,6 @@
         "payment_succeeded_enabled": true,
         "payment_failed_enabled": true
       },
-      "routing_algorithm": {
-        "type": "single",
-        "data": "paypal"
-      },
       "sub_merchants_enabled": false,
       "metadata": {
         "city": "NY",

--- a/postman/collection-dir/powertranz/Flow Testcases/QuickStart/Merchant Account - Create/request.json
+++ b/postman/collection-dir/powertranz/Flow Testcases/QuickStart/Merchant Account - Create/request.json
@@ -69,10 +69,6 @@
         "payment_succeeded_enabled": true,
         "payment_failed_enabled": true
       },
-      "routing_algorithm": {
-        "type": "single",
-        "data": "powertranz"
-      },
       "primary_business_details": [
         {
           "country": "US",

--- a/postman/collection-dir/rapyd/Flow Testcases/QuickStart/Merchant Account - Create/request.json
+++ b/postman/collection-dir/rapyd/Flow Testcases/QuickStart/Merchant Account - Create/request.json
@@ -75,10 +75,6 @@
         "payment_succeeded_enabled": true,
         "payment_failed_enabled": true
       },
-      "routing_algorithm": {
-        "type": "single",
-        "data": "rapyd"
-      },
       "sub_merchants_enabled": false,
       "metadata": {
         "city": "NY",

--- a/postman/collection-dir/shift4/Flow Testcases/QuickStart/Merchant Account - Create/request.json
+++ b/postman/collection-dir/shift4/Flow Testcases/QuickStart/Merchant Account - Create/request.json
@@ -75,10 +75,6 @@
         "payment_succeeded_enabled": true,
         "payment_failed_enabled": true
       },
-      "routing_algorithm": {
-        "type": "single",
-        "data": "shift4"
-      },
       "sub_merchants_enabled": false,
       "metadata": {
         "city": "NY",

--- a/postman/collection-dir/stripe/Flow Testcases/QuickStart/Merchant Account - Create/request.json
+++ b/postman/collection-dir/stripe/Flow Testcases/QuickStart/Merchant Account - Create/request.json
@@ -69,10 +69,6 @@
         "payment_succeeded_enabled": true,
         "payment_failed_enabled": true
       },
-      "routing_algorithm": {
-        "type": "single",
-        "data": "stripe"
-      },
       "sub_merchants_enabled": false,
       "metadata": {
         "city": "NY",

--- a/postman/collection-dir/stripe/MerchantAccounts/Merchant Account - Create/request.json
+++ b/postman/collection-dir/stripe/MerchantAccounts/Merchant Account - Create/request.json
@@ -69,10 +69,7 @@
         "payment_succeeded_enabled": true,
         "payment_failed_enabled": true
       },
-      "routing_algorithm": {
-        "type": "single",
-        "data": "stripe"
-      },
+      
       "sub_merchants_enabled": false,
       "metadata": {
         "city": "NY",

--- a/postman/collection-dir/stripe/MerchantAccounts/Merchant Account - Update/request.json
+++ b/postman/collection-dir/stripe/MerchantAccounts/Merchant Account - Update/request.json
@@ -69,10 +69,6 @@
         "payment_succeeded_enabled": true,
         "payment_failed_enabled": true
       },
-      "routing_algorithm": {
-        "type": "single",
-        "data": "stripe"
-      },
       "sub_merchants_enabled": false,
       "parent_merchant_id": "xkkdf909012sdjki2dkh5sdf",
       "metadata": {

--- a/postman/collection-dir/stripe/QuickStart/Merchant Account - Create/request.json
+++ b/postman/collection-dir/stripe/QuickStart/Merchant Account - Create/request.json
@@ -68,11 +68,7 @@
         "payment_created_enabled": true,
         "payment_succeeded_enabled": true,
         "payment_failed_enabled": true
-      },
-      "routing_algorithm": {
-        "type": "single",
-        "data": "stripe"
-      },
+      },   
       "sub_merchants_enabled": false,
       "metadata": {
         "city": "NY",

--- a/postman/collection-dir/trustpay/Flow Testcases/QuickStart/Merchant Account - Create/request.json
+++ b/postman/collection-dir/trustpay/Flow Testcases/QuickStart/Merchant Account - Create/request.json
@@ -75,10 +75,6 @@
         "payment_succeeded_enabled": true,
         "payment_failed_enabled": true
       },
-      "routing_algorithm": {
-        "type": "single",
-        "data": "trustpay"
-      },
       "sub_merchants_enabled": false,
       "metadata": {
         "city": "NY",

--- a/postman/collection-dir/worldline/Flow Testcases/QuickStart/Merchant Account - Create/request.json
+++ b/postman/collection-dir/worldline/Flow Testcases/QuickStart/Merchant Account - Create/request.json
@@ -75,10 +75,6 @@
         "payment_succeeded_enabled": true,
         "payment_failed_enabled": true
       },
-      "routing_algorithm": {
-        "type": "single",
-        "data": "worldline"
-      },
       "sub_merchants_enabled": false,
       "metadata": {
         "city": "NY",

--- a/postman/collection-dir/zen/Flow Testcases/QuickStart/Merchant Account - Create/request.json
+++ b/postman/collection-dir/zen/Flow Testcases/QuickStart/Merchant Account - Create/request.json
@@ -75,10 +75,6 @@
         "payment_succeeded_enabled": true,
         "payment_failed_enabled": true
       },
-      "routing_algorithm": {
-        "type": "single",
-        "data": "zen"
-      },
       "sub_merchants_enabled": false,
       "metadata": {
         "city": "NY",


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
Now the postman collection won't have `routing_algorithm` struct 


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
