### PR TITLE
feat(connector): [Zen] Use `connector_request_reference_id` as Transaction Id to Retrieve Payments

### DIFF
--- a/crates/router/src/connector/zen.rs
+++ b/crates/router/src/connector/zen.rs
@@ -130,12 +130,10 @@ impl ConnectorCommon for Zen {
 impl ConnectorValidation for Zen {
     fn validate_psync_reference_id(
         &self,
-        _payment_method_type: Option<api_models::enums::PaymentMethodType>,
-        _connector_transaction_id: Option<String>,
-        _connector_metadata: Option<common_utils::pii::SecretSerdeValue>,
-    ) -> bool {
-        // since psync can be made with our own reference id, we don't need connector_transaction_id check
-        true
+        _data: &types::PaymentsSyncRouterData,
+    ) -> Result<(), errors::ConnectorError> {
+        // since we can make psync call with our reference_id, having connector_transaction_id is not an mandatory criteria
+        Ok(())
     }
 }
 

--- a/crates/router/src/connector/zen/transformers.rs
+++ b/crates/router/src/connector/zen/transformers.rs
@@ -195,7 +195,7 @@ impl TryFrom<(&types::PaymentsAuthorizeRouterData, &Card)> for ZenPaymentsReques
                 return_verify_url: item.request.router_return_url.clone(),
             }));
         Ok(Self::ApiRequest(Box::new(ApiRequest {
-            merchant_transaction_id: item.attempt_id.clone(),
+            merchant_transaction_id: item.connector_request_reference_id.clone(),
             payment_channel: ZenPaymentChannels::PclCard,
             currency: item.request.currency,
             payment_specific_data,
@@ -258,7 +258,7 @@ impl
             )?,
         };
         Ok(Self::ApiRequest(Box::new(ApiRequest {
-            merchant_transaction_id: item.attempt_id.clone(),
+            merchant_transaction_id: item.connector_request_reference_id.clone(),
             payment_channel,
             currency: item.request.currency,
             payment_specific_data,
@@ -319,7 +319,7 @@ impl
             }
         };
         Ok(Self::ApiRequest(Box::new(ApiRequest {
-            merchant_transaction_id: item.attempt_id.clone(),
+            merchant_transaction_id: item.connector_request_reference_id.clone(),
             payment_channel,
             currency: item.request.currency,
             payment_specific_data,
@@ -476,7 +476,7 @@ impl
             .clone()
             .ok_or(errors::ConnectorError::RequestEncodingFailed)?;
         let mut checkout_request = CheckoutRequest {
-            merchant_transaction_id: item.attempt_id.clone(),
+            merchant_transaction_id: item.connector_request_reference_id.clone(),
             specified_payment_channel,
             currency: item.request.currency,
             custom_ipn_url: item.request.get_webhook_url()?,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
`connector_request_reference_id` is being pass as merchant_transaction_id which will help in payment retrieval in case of connector timeout.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
