### PR TITLE
docs(CONTRIBUTING): fix open a discussion link

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -86,7 +86,7 @@ having problems, you can [open a discussion] asking for help.
 In exchange for receiving help, we ask that you contribute back a documentation
 PR that helps others avoid the problems that you encountered.
 
-[open a discussion]: https://github.com/juspay/hyperswitch/discussions/new
+[open a discussion]: https://github.com/juspay/hyperswitch/discussions/new/choose
 
 ### Submitting a Bug Report
 


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [x] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Fixed the HTTP path for the open a discussion link in the CONTRIBUITING docs.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
First, this is a hands-on for me about how to follow the [CONTRIBUTING.md](https://github.com/juspay/hyperswitch/blob/main/docs/CONTRIBUTING.md) guidelines. 

Second, the [old link](https://github.com/juspay/hyperswitch/discussions/new) showed a pop-up about not recognizing the category.

![image](https://github.com/juspay/hyperswitch/assets/60368383/7e20214b-1148-47a0-8454-71a2129d7899)

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Opening the [new link](https://github.com/juspay/hyperswitch/discussions/new/choose) does not show the pop-up.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
