### PR TITLE
refactor: include binary name in `service` field in log entries

### DIFF
--- a/crates/drainer/src/env.rs
+++ b/crates/drainer/src/env.rs
@@ -4,13 +4,4 @@ pub use router_env::*;
 pub mod logger {
     #[doc(inline)]
     pub use router_env::{log, logger::*};
-
-    /// Setup logging sub-system
-    pub fn setup(conf: &config::Log) -> TelemetryGuard {
-        router_env::setup(
-            conf,
-            router_env::service_name!(),
-            [router_env::service_name!()],
-        )
-    }
 }

--- a/crates/drainer/src/env.rs
+++ b/crates/drainer/src/env.rs
@@ -1,7 +1,0 @@
-#[doc(inline)]
-pub use router_env::*;
-
-pub mod logger {
-    #[doc(inline)]
-    pub use router_env::{log, logger::*};
-}

--- a/crates/drainer/src/lib.rs
+++ b/crates/drainer/src/lib.rs
@@ -1,6 +1,6 @@
 mod connection;
-pub mod env;
 pub mod errors;
+pub mod logger;
 pub(crate) mod metrics;
 pub mod services;
 pub mod settings;
@@ -9,7 +9,6 @@ use std::sync::{atomic, Arc};
 
 use common_utils::signals::get_allowed_signals;
 use diesel_models::kv;
-pub use env as logger;
 use error_stack::{IntoReport, ResultExt};
 use tokio::sync::mpsc;
 

--- a/crates/drainer/src/logger.rs
+++ b/crates/drainer/src/logger.rs
@@ -1,0 +1,2 @@
+#[doc(inline)]
+pub use router_env::*;

--- a/crates/drainer/src/main.rs
+++ b/crates/drainer/src/main.rs
@@ -20,7 +20,11 @@ async fn main() -> DrainerResult<()> {
     let shutdown_intervals = conf.drainer.shutdown_interval;
     let loop_interval = conf.drainer.loop_interval;
 
-    let _guard = logger::setup(&conf.log);
+    let _guard = router_env::setup(
+        &conf.log,
+        router_env::service_name!(),
+        [router_env::service_name!()],
+    );
 
     logger::info!("Drainer started [{:?}] [{:?}]", conf.drainer, conf.log);
 

--- a/crates/router/src/bin/router.rs
+++ b/crates/router/src/bin/router.rs
@@ -34,7 +34,11 @@ async fn main() -> ApplicationResult<()> {
     conf.validate()
         .expect("Failed to validate router configuration");
 
-    let _guard = logger::setup(&conf.log, [router_env::service_name!(), "actix_server"]);
+    let _guard = router_env::setup(
+        &conf.log,
+        router_env::service_name!(),
+        [router_env::service_name!(), "actix_server"],
+    );
 
     logger::info!("Application started [{:?}] [{:?}]", conf.server, conf.log);
 

--- a/crates/router/src/bin/scheduler.rs
+++ b/crates/router/src/bin/scheduler.rs
@@ -1,5 +1,5 @@
 #![recursion_limit = "256"]
-use std::sync::Arc;
+use std::{str::FromStr, sync::Arc};
 
 use error_stack::ResultExt;
 use router::{
@@ -37,11 +37,23 @@ async fn main() -> CustomResult<(), errors::ProcessTrackerError> {
         redis_shutdown_signal_rx,
         tx.clone(),
     ));
-    let _guard = logger::setup(&state.conf.log, [router_env::service_name!()]);
+
+    #[allow(clippy::expect_used)]
+    let scheduler_flow_str =
+        std::env::var(SCHEDULER_FLOW).expect("SCHEDULER_FLOW environment variable not set");
+    #[allow(clippy::expect_used)]
+    let scheduler_flow = scheduler::SchedulerFlow::from_str(&scheduler_flow_str)
+        .expect("Unable to parse SchedulerFlow from environment variable");
+
+    let _guard = router_env::setup(
+        &state.conf.log,
+        &scheduler_flow_str,
+        [router_env::service_name!()],
+    );
 
     logger::debug!(startup_config=?state.conf);
 
-    start_scheduler(&state, (tx, rx)).await?;
+    start_scheduler(&state, scheduler_flow, (tx, rx)).await?;
 
     eprintln!("Scheduler shut down");
     Ok(())
@@ -49,20 +61,14 @@ async fn main() -> CustomResult<(), errors::ProcessTrackerError> {
 
 async fn start_scheduler(
     state: &routes::AppState,
+    scheduler_flow: scheduler::SchedulerFlow,
     channel: (mpsc::Sender<()>, mpsc::Receiver<()>),
 ) -> CustomResult<(), errors::ProcessTrackerError> {
-    use std::str::FromStr;
-
-    #[allow(clippy::expect_used)]
-    let flow = std::env::var(SCHEDULER_FLOW).expect("SCHEDULER_FLOW environment variable not set");
-    #[allow(clippy::expect_used)]
-    let flow = scheduler::SchedulerFlow::from_str(&flow)
-        .expect("Unable to parse SchedulerFlow from environment variable");
-
     let scheduler_settings = state
         .conf
         .scheduler
         .clone()
         .ok_or(errors::ProcessTrackerError::ConfigurationError)?;
-    scheduler::start_process_tracker(state, flow, Arc::new(scheduler_settings), channel).await
+    scheduler::start_process_tracker(state, scheduler_flow, Arc::new(scheduler_settings), channel)
+        .await
 }

--- a/crates/router/src/env.rs
+++ b/crates/router/src/env.rs
@@ -1,14 +1,7 @@
 #[doc(inline)]
 pub use router_env::*;
+
 pub mod logger {
     #[doc(inline)]
     pub use router_env::{log, logger::*};
-
-    /// Setup logging sub-system.
-    pub fn setup(
-        conf: &config::Log,
-        crates_to_filter: impl AsRef<[&'static str]>,
-    ) -> TelemetryGuard {
-        router_env::setup(conf, router_env::service_name!(), crates_to_filter)
-    }
 }

--- a/crates/router/src/env.rs
+++ b/crates/router/src/env.rs
@@ -1,7 +1,2 @@
 #[doc(inline)]
 pub use router_env::*;
-
-pub mod logger {
-    #[doc(inline)]
-    pub use router_env::{log, logger::*};
-}

--- a/crates/router_env/src/env.rs
+++ b/crates/router_env/src/env.rs
@@ -147,13 +147,14 @@ macro_rules! commit {
 //     };
 // }
 
-/// Service name deduced from name of the crate.
+/// Service name deduced from name of the binary.
+/// This macro must be called within binaries only.
 ///
 /// Example: `router`.
 #[macro_export]
 macro_rules! service_name {
     () => {
-        env!("CARGO_CRATE_NAME")
+        env!("CARGO_BIN_NAME")
     };
 }
 

--- a/crates/router_env/src/logger/setup.rs
+++ b/crates/router_env/src/logger/setup.rs
@@ -32,7 +32,7 @@ pub struct TelemetryGuard {
 /// current cargo workspace are automatically considered for verbose logging.
 pub fn setup(
     config: &config::Log,
-    service_name: &'static str,
+    service_name: &str,
     crates_to_filter: impl AsRef<[&'static str]>,
 ) -> TelemetryGuard {
     let mut guards = Vec::new();
@@ -133,7 +133,7 @@ fn get_opentelemetry_exporter(config: &config::LogTelemetry) -> TonicExporterBui
 
 fn setup_tracing_pipeline(
     config: &config::LogTelemetry,
-    service_name: &'static str,
+    service_name: &str,
 ) -> Option<tracing_opentelemetry::OpenTelemetryLayer<tracing_subscriber::Registry, trace::Tracer>>
 {
     global::set_text_map_propagator(TraceContextPropagator::new());
@@ -144,7 +144,7 @@ fn setup_tracing_pipeline(
         ))
         .with_resource(Resource::new(vec![KeyValue::new(
             "service.name",
-            service_name,
+            service_name.to_owned(),
         )]));
     if config.use_xray_generator {
         trace_config = trace_config.with_id_generator(trace::XrayIdGenerator::default());

--- a/crates/router_env/tests/logger.rs
+++ b/crates/router_env/tests/logger.rs
@@ -1,18 +1,19 @@
 #![allow(clippy::unwrap_used)]
 
-use router_env as env;
 mod test_module;
-use env::TelemetryGuard;
-use test_module::some_module::*;
+
+use router_env::TelemetryGuard;
+
+use self::test_module::some_module::*;
 
 fn logger() -> &'static TelemetryGuard {
     use once_cell::sync::OnceCell;
 
     static INSTANCE: OnceCell<TelemetryGuard> = OnceCell::new();
     INSTANCE.get_or_init(|| {
-        let config = env::Config::new().unwrap();
+        let config = router_env::Config::new().unwrap();
 
-        env::logger::setup(&config.log, env::service_name!(), [])
+        router_env::setup(&config.log, "router_env_test", [])
     })
 }
 


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
This PR updates the logging setup code to include the binary name in the `service` field in log entries. For the scheduler specifically, the `service` field would contain the name of the scheduler flow, namely, `consumer` or `producer`, since each of them are independent Docker containers (and thus, independent deployments).

After this change, the `service` field in logs can have one of four values: `router`, `consumer`, `producer` and `drainer`.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
This would allow us to perform better filtering of logs based on service name. 

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

Started all services using Docker Compose (command: `docker compose --profile scheduler --profile monitoring up --detach`) and verified that logs are available when filtering by the `service` field for `router`, `consumer` and `producer`. Attaching screenshots of the same.

1. `router`:

   ![filtering logs by `router` service name](https://github.com/juspay/hyperswitch/assets/22217505/718047b0-ea5b-4a79-8281-24255934f47f)

2. `consumer`:

   ![filtering logs by `consumer` service name](https://github.com/juspay/hyperswitch/assets/22217505/07ca6131-3a0f-40ce-9a9f-033cd377fdea)

3. `producer`:

   ![filtering logs by `producer` service name](https://github.com/juspay/hyperswitch/assets/22217505/e4d56bad-8aeb-44a3-bc4d-6fe397572261)

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
