### PR TITLE
refactor(refunds): add Success enum in should_call_refund check

### DIFF
--- a/crates/router/src/core/refunds.rs
+++ b/crates/router/src/core/refunds.rs
@@ -355,6 +355,7 @@ fn should_call_refund(refund: &diesel_models::refund::Refund, force_sync: bool) 
         || !matches!(
             refund.refund_status,
             diesel_models::enums::RefundStatus::Failure
+                | diesel_models::enums::RefundStatus::Success
         );
 
     predicate1 && predicate2


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Refactoring

## Description
<!-- Describe your changes in detail -->
The connector call was being made even when `RefundStatus` was `Success` and hence the response time was going over 300ms. It will be reduced to expected now.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
This PR closes https://github.com/juspay/hyperswitch/issues.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code