### PR TITLE
refactor(router): new separate routes for applepay merchant verification

### DIFF
--- a/config/development.toml
+++ b/config/development.toml
@@ -44,6 +44,7 @@ recon_admin_api_key = "recon_test_admin"
 merchant_cert_key = "MERCHANT CERTIFICATE KEY"
 merchant_cert = "MERCHANT CERTIFICATE"
 common_merchant_identifier = "COMMON MERCHANT IDENTIFIER"
+applepay_endpoint = "DOMAIN SPECIFIC ENDPOINT"
 
 [locker]
 host = ""

--- a/crates/router/src/configs/settings.rs
+++ b/crates/router/src/configs/settings.rs
@@ -104,6 +104,7 @@ pub struct ApplepayMerchantConfigs {
     pub merchant_cert: String,
     pub merchant_cert_key: String,
     pub common_merchant_identifier: String,
+    pub applepay_endpoint: String,
 }
 
 #[derive(Debug, Deserialize, Clone, Default)]

--- a/crates/router/src/utils/verification.rs
+++ b/crates/router/src/utils/verification.rs
@@ -12,8 +12,6 @@ use crate::{
     services, types, utils,
 };
 
-const APPLEPAY_MERCHANT_VERIFICATION_URL: &str =
-    "https://apple-pay-gateway.apple.com/paymentservices/registerMerchant";
 const APPLEPAY_INTERNAL_MERCHANT_NAME: &str = "Applepay_merchant";
 
 pub async fn verify_merchant_creds_for_applepay(
@@ -31,6 +29,7 @@ pub async fn verify_merchant_creds_for_applepay(
         .common_merchant_identifier;
     let encrypted_cert = &state.conf.applepay_merchant_configs.merchant_cert;
     let encrypted_key = &state.conf.applepay_merchant_configs.merchant_cert_key;
+    let applepay_endpoint = &state.conf.applepay_merchant_configs.applepay_endpoint;
 
     let applepay_internal_merchant_identifier = kms::get_kms_client(kms_config)
         .await
@@ -66,7 +65,7 @@ pub async fn verify_merchant_creds_for_applepay(
 
     let apple_pay_merch_verification_req = services::RequestBuilder::new()
         .method(services::Method::Post)
-        .url(APPLEPAY_MERCHANT_VERIFICATION_URL)
+        .url(applepay_endpoint)
         .attach_default_headers()
         .headers(vec![(
             headers::CONTENT_TYPE.to_string(),


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Previously we had only one route for apple-pay. we were always hitting their prod servers even when we were using our sbx but now while using our sbx we will be hitting their sbx as well

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [x] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
