### PR TITLE
feat(connector): [payme] Add support for dispute webhooks

### DIFF
--- a/crates/router/src/connector/bluesnap/transformers.rs
+++ b/crates/router/src/connector/bluesnap/transformers.rs
@@ -939,7 +939,7 @@ impl From<ErrorDetails> for utils::ErrorCodeAndMessage {
     fn from(error: ErrorDetails) -> Self {
         Self {
             error_code: error.code.to_string(),
-            error_message: error.error_name.unwrap_or(error.code.to_string()),
+            error_message: error.error_name.unwrap_or(error.code),
         }
     }
 }

--- a/crates/router/src/connector/payme.rs
+++ b/crates/router/src/connector/payme.rs
@@ -859,10 +859,10 @@ impl api::IncomingWebhook for Payme {
                 .change_context(errors::ConnectorError::WebhookBodyDecodingFailed)?;
 
         Ok(api::disputes::DisputePayload {
-            amount: webhook_object.price.to_string(), //check
+            amount: webhook_object.price.to_string(),
             currency: webhook_object.currency.to_string(),
             dispute_stage: api_models::enums::DisputeStage::Dispute,
-            connector_dispute_id: webhook_object.payme_sale_id,
+            connector_dispute_id: webhook_object.payme_transaction_id,
             connector_reason: None,
             connector_reason_code: None,
             challenge_required_by: None,

--- a/crates/router/src/connector/payme/transformers.rs
+++ b/crates/router/src/connector/payme/transformers.rs
@@ -556,7 +556,7 @@ impl TryFrom<&types::PaymentsPreProcessingRouterData> for SaleType {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, strum::Display)]
 #[serde(rename_all = "kebab-case")]
 pub enum SaleStatus {
     Initial,
@@ -774,6 +774,8 @@ pub struct WebhookEventDataResource {
     pub payme_transaction_id: String,
     pub status_error_details: Option<String>,
     pub status_error_code: Option<u32>,
+    pub price: i64,
+    pub currency: enums::Currency,
 }
 
 #[derive(Debug, Deserialize)]
@@ -817,9 +819,9 @@ impl From<NotifyType> for api::IncomingWebhookEvent {
             NotifyType::SaleComplete => Self::PaymentIntentSuccess,
             NotifyType::Refund => Self::RefundSuccess,
             NotifyType::SaleFailure => Self::PaymentIntentFailure,
-            NotifyType::SaleAuthorized
-            | NotifyType::SaleChargeback
-            | NotifyType::SaleChargebackRefund => Self::EventNotSupported,
+            NotifyType::SaleChargeback => Self::DisputeOpened,
+            NotifyType::SaleChargebackRefund => Self::DisputeWon,
+            NotifyType::SaleAuthorized => Self::EventNotSupported,
         }
     }
 }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] New feature

## Description
<!-- Describe your changes in detail -->
Add dispute webhook support for payme



<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
Dispute webhooks are now supported in payme 



## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
