### PR TITLE
ci(release-new-version): correct `node_modules` path

### DIFF
--- a/.github/workflows/release-new-version.yml
+++ b/.github/workflows/release-new-version.yml
@@ -66,7 +66,7 @@ jobs:
           npm ci
           POSTMAN_DIR=postman/collection-dir
           POSTMAN_JSON_DIR=postman/collection-json
-          NEWMAN_PATH=$(pwd)/.node_modules/.bin
+          NEWMAN_PATH=$(pwd)/node_modules/.bin
           export PATH=${NEWMAN_PATH}:${PATH}
           # generate postman collections for all postman directories
           for connector_dir in ${POSTMAN_DIR}/*


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [x] CI/CD

## Description
I had used the wrong path to `node_modules` in the previous commit.  Fixing it in this PR.

## Motivation and Context
This is need to update Postman collection files and keep them in sync with the directory representations.

## How did you test it?
This workflow is a release workflow - which cannot be completely replicated.  Ensured that the code to set the PATH is the same as the one used in the PR workflow.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
