### PR TITLE
fix(router): send connection_closed errors as 5xx instead of 2xx

### DIFF
--- a/crates/router/src/consts.rs
+++ b/crates/router/src/consts.rs
@@ -13,9 +13,6 @@ pub(crate) const ALPHABETS: [char; 62] = [
 pub const REQUEST_TIME_OUT: u64 = 30;
 pub const REQUEST_TIMEOUT_ERROR_CODE: &str = "TIMEOUT";
 pub const REQUEST_TIMEOUT_ERROR_MESSAGE: &str = "Connector did not respond in specified time";
-pub const CONNECTION_CLOSED_ERROR_CODE: &str = "CONNECTION_CLOSED";
-pub const CONNECTION_CLOSED_ERROR_MESSAGE: &str =
-    "Connection closed before a message could complete";
 
 ///Payment intent fulfillment default timeout (in seconds)
 pub const DEFAULT_FULFILLMENT_TIME: i64 = 15 * 60;

--- a/crates/router/src/services/api.rs
+++ b/crates/router/src/services/api.rs
@@ -395,18 +395,6 @@ where
                                 router_data.response = Err(error_response);
                                 router_data.connector_http_status_code = Some(504);
                                 Ok(router_data)
-                            } else if error.current_context().is_connection_closed() {
-                                let error_response = ErrorResponse {
-                                    code: consts::CONNECTION_CLOSED_ERROR_CODE.to_string(),
-                                    message: consts::CONNECTION_CLOSED_ERROR_MESSAGE.to_string(),
-                                    reason: Some(
-                                        consts::CONNECTION_CLOSED_ERROR_MESSAGE.to_string(),
-                                    ),
-                                    status_code: 504,
-                                };
-                                router_data.response = Err(error_response);
-                                router_data.connector_http_status_code = Some(504);
-                                Ok(router_data)
                             } else {
                                 Err(error.change_context(
                                     errors::ConnectorError::ProcessingStepFailed(None),


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
send connection_closed errors as 5xx instead of 2xx as connections are not being closed by external entities


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
