### PR TITLE
chore: address Rust 1.72 clippy lints

### DIFF
--- a/crates/router/src/connection.rs
+++ b/crates/router/src/connection.rs
@@ -9,7 +9,7 @@ pub type PgPool = bb8::Pool<async_bb8_diesel::ConnectionManager<PgConnection>>;
 
 pub type PgPooledConn = async_bb8_diesel::Connection<PgConnection>;
 
-///
+/// Creates a Redis connection pool for the specified Redis settings
 /// # Panics
 ///
 /// Panics if failed to create a redis pool

--- a/crates/router/src/utils.rs
+++ b/crates/router/src/utils.rs
@@ -25,7 +25,7 @@ use uuid::Uuid;
 
 pub use self::{
     ext_traits::{OptionExt, ValidateCall},
-    storage::*,
+    storage::PaymentIntent,
 };
 use crate::{
     consts,

--- a/crates/storage_impl/src/connection.rs
+++ b/crates/storage_impl/src/connection.rs
@@ -7,7 +7,7 @@ pub type PgPool = bb8::Pool<async_bb8_diesel::ConnectionManager<PgConnection>>;
 
 pub type PgPooledConn = async_bb8_diesel::Connection<PgConnection>;
 
-///
+/// Creates a Redis connection pool for the specified Redis settings
 /// # Panics
 ///
 /// Panics if failed to create a redis pool

--- a/crates/storage_impl/src/connection.rs
+++ b/crates/storage_impl/src/connection.rs
@@ -7,6 +7,10 @@ pub type PgPool = bb8::Pool<async_bb8_diesel::ConnectionManager<PgConnection>>;
 
 pub type PgPooledConn = async_bb8_diesel::Connection<PgConnection>;
 
+///
+/// # Panics
+///
+/// Panics if failed to create a redis pool
 #[allow(clippy::expect_used)]
 pub async fn redis_connection(
     redis: &redis_interface::RedisSettings,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
This PR addresses a clippy lint stabilized in Rust 1.72.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
