### PR TITLE
fix(router): `validate_psync_reference_id` only if call_connector_action is trigger in psync flow

### DIFF
--- a/crates/router/src/core/payments/flows/psync_flow.rs
+++ b/crates/router/src/core/payments/flows/psync_flow.rs
@@ -116,16 +116,16 @@ impl Feature<api::PSync, types::PaymentsSyncData>
         connector: &api::ConnectorData,
         call_connector_action: payments::CallConnectorAction,
     ) -> RouterResult<(Option<services::Request>, bool)> {
-        if connector
-            .connector
-            .validate_psync_reference_id(self)
-            .is_err()
-        {
-            return Ok((None, false));
-        }
-
         let request = match call_connector_action {
             payments::CallConnectorAction::Trigger => {
+                //validate_psync_reference_id if call_connector_action is trigger
+                if connector
+                    .connector
+                    .validate_psync_reference_id(self)
+                    .is_err()
+                {
+                    return Ok((None, false));
+                }
                 let connector_integration: services::BoxedConnectorIntegration<
                     '_,
                     api::PSync,

--- a/crates/router/src/core/payments/flows/psync_flow.rs
+++ b/crates/router/src/core/payments/flows/psync_flow.rs
@@ -9,7 +9,7 @@ use crate::{
         payments::{self, access_token, helpers, transformers, PaymentData},
     },
     routes::AppState,
-    services,
+    services::{self, logger},
     types::{self, api, domain},
 };
 

--- a/crates/router/src/core/payments/flows/psync_flow.rs
+++ b/crates/router/src/core/payments/flows/psync_flow.rs
@@ -124,6 +124,9 @@ impl Feature<api::PSync, types::PaymentsSyncData>
                     .validate_psync_reference_id(self)
                     .is_err()
                 {
+                    logger::warn!(
+                        "validate_psync_reference_id failed, hence skipping call to connector"
+                    );
                     return Ok((None, false));
                 }
                 let connector_integration: services::BoxedConnectorIntegration<


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
If call_connector_action is anything other than trigger, we need not validate_psync_reference_id. 
`validate_psync_reference_id` only if call_connector_action is trigger in psync flow


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
