### PR TITLE
refactor(connector): [BraintreeGraphQl] Enhance currency Mapping with `ConnectorCurrencyCommon` Trait

### DIFF
--- a/crates/router/src/types/api.rs
+++ b/crates/router/src/types/api.rs
@@ -112,8 +112,11 @@ pub trait ConnectorCurrencyCommon {
         currency: diesel_models::enums::Currency,
     ) -> Result<f64, error_stack::Report<errors::ConnectorError>> {
         let amount = match self.get_currency_unit() {
-            CurrencyUnit::Minor => amount as f64,
             CurrencyUnit::Base => self.to_currency_base_unit_asf64(amount, currency)?,
+            CurrencyUnit::Minor => u32::try_from(amount)
+                .into_report()
+                .change_context(errors::ConnectorError::RequestEncodingFailed)?
+                .into(),
         };
         Ok(amount)
     }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->

Problem : Currently, amount mapping for different connectors are handled by hard coding dollars/cents which has been leading to multiple bugs due to incorrect mapping. Need to handle this better in code by having separate types for dollar vs cents .

Solution : To address this issue and improve code maintainability, this pull request introduces the `ConnectorCurrencyCommon` trait. This trait allows connectors to declare their accepted currency unit as either "Base" or "Minor" using the `get_currency_unit method`.



### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
Implement the `ConnectorCurrencyCommon` trait, where you can declare the accepted currency unit (either Base or Minor) using the `get_currency_unit method`.


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
tested through braintree dashboard .

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
