### PR TITLE
fix: null value in session token in next action  

### DIFF
--- a/crates/router/src/connector/trustpay/transformers.rs
+++ b/crates/router/src/connector/trustpay/transformers.rs
@@ -1073,8 +1073,8 @@ pub fn get_apple_pay_session<F, T>(
             ))),
             connector_response_reference_id: None,
         }),
-        // We don't get status from TrustPay but status should be pending by default for session response
-        status: diesel_models::enums::AttemptStatus::Pending,
+        // We don't get status from TrustPay but status should be AuthenticationPending by default for session response
+        status: diesel_models::enums::AttemptStatus::AuthenticationPending,
         ..item.data
     })
 }
@@ -1120,8 +1120,8 @@ pub fn get_google_pay_session<F, T>(
             ))),
             connector_response_reference_id: None,
         }),
-        // We don't get status from TrustPay but status should be pending by default for session response
-        status: diesel_models::enums::AttemptStatus::Pending,
+        // We don't get status from TrustPay but status should be AuthenticationPending by default for session response
+        status: diesel_models::enums::AttemptStatus::AuthenticationPending,
         ..item.data
     })
 }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix

## Description
<!-- Describe your changes in detail -->
1. Fixed session token having null value in next action for third party sdk response
2. change status from pending to `requires_customer_action` for gpay and apple pay in trustpay


<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
Fix session token in next_action null value to session response 

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Status changed from pending to requires_customer_action
<img width="1246" alt="image" src="https://github.com/juspay/hyperswitch/assets/59434228/fcffe888-1bd3-41f3-9d74-ae2e3a771488">

session_token response in next_action
<img width="1264" alt="image" src="https://github.com/juspay/hyperswitch/assets/59434228/4beee47c-2dfb-4d41-9d4e-b5a44380967c">

Trustpay retrieve call getting processing as expected
<img width="1254" alt="image" src="https://github.com/juspay/hyperswitch/assets/59434228/456a1440-3fb1-4b8a-b4c1-3e4932ca0937">


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
