### PR TITLE
ci: pin `cargo-hack` version to `v0.6.5` for MSRV check

### DIFF
--- a/.github/workflows/CI-pr.yml
+++ b/.github/workflows/CI-pr.yml
@@ -92,6 +92,7 @@ jobs:
         uses: baptiste0928/cargo-install@v2.1.0
         with:
           crate: cargo-hack
+          version: 0.6.5
 
       - name: Deny warnings
         shell: bash

--- a/.github/workflows/CI-push.yml
+++ b/.github/workflows/CI-push.yml
@@ -71,6 +71,7 @@ jobs:
         uses: baptiste0928/cargo-install@v2.0.0
         with:
           crate: cargo-hack
+          version: 0.6.5
 
       - name: Deny warnings
         shell: bash

--- a/.github/workflows/CI-push.yml
+++ b/.github/workflows/CI-push.yml
@@ -68,7 +68,7 @@ jobs:
           save-if: ${{ github.event_name == 'push' }}
 
       - name: Install cargo-hack
-        uses: baptiste0928/cargo-install@v2.0.0
+        uses: baptiste0928/cargo-install@v2.1.0
         with:
           crate: cargo-hack
           version: 0.6.5
@@ -136,12 +136,12 @@ jobs:
           components: clippy
 
       - name: Install cargo-hack
-        uses: baptiste0928/cargo-install@v2.0.0
+        uses: baptiste0928/cargo-install@v2.1.0
         with:
           crate: cargo-hack
 
       # - name: Install cargo-nextest
-      #   uses: baptiste0928/cargo-install@v2.0.0
+      #   uses: baptiste0928/cargo-install@v2.1.0
       #   with:
       #     crate: cargo-nextest
 


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [x] CI/CD

## Description
<!-- Describe your changes in detail -->
This PR pins the version of `cargo-hack` installed during the MSRV check to `v0.6.5`, since `v0.6.6` has an MSRV of Rust 1.66.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
Fixes failing MSRV check due to unsupported Rust version for `cargo-hack v0.6.6`.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
N/A

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
