### PR TITLE
feat(confirm): reduce the database calls to 2 stages in case of non-retry

### DIFF
--- a/crates/router/src/core/payments/helpers.rs
+++ b/crates/router/src/core/payments/helpers.rs
@@ -2772,7 +2772,7 @@ impl AttemptType {
         }
     }
 
-    pub async fn get_connector_response(
+    pub async fn get_or_insert_connector_response(
         &self,
         payment_attempt: &PaymentAttempt,
         db: &dyn StorageInterface,
@@ -2793,6 +2793,30 @@ impl AttemptType {
                     &payment_attempt.payment_id,
                     &payment_attempt.merchant_id,
                     &payment_attempt.attempt_id,
+                    storage_scheme,
+                )
+                .await
+                .to_not_found_response(errors::ApiErrorResponse::PaymentNotFound),
+        }
+    }
+
+    pub async fn get_connector_response(
+        &self,
+        db: &dyn StorageInterface,
+        payment_id: &str,
+        merchant_id: &str,
+        attempt_id: &str,
+        storage_scheme: storage_enums::MerchantStorageScheme,
+    ) -> RouterResult<storage::ConnectorResponse> {
+        match self {
+            Self::New => Err(errors::ApiErrorResponse::InternalServerError)
+                .into_report()
+                .attach_printable("Precondition failed, the attempt type should not be `New`"),
+            Self::SameOld => db
+                .find_connector_response_by_payment_id_merchant_id_attempt_id(
+                    payment_id,
+                    merchant_id,
+                    attempt_id,
                     storage_scheme,
                 )
                 .await

--- a/crates/router/src/core/payments/operations/payment_confirm.rs
+++ b/crates/router/src/core/payments/operations/payment_confirm.rs
@@ -33,7 +33,6 @@ use crate::{
 pub struct PaymentConfirm;
 #[async_trait]
 impl<F: Send + Clone> GetTracker<F, PaymentData<F>, api::PaymentsRequest> for PaymentConfirm {
-    #[instrument(skip_all)]
     async fn get_trackers<'a>(
         &'a self,
         state: &'a AppState,
@@ -130,31 +129,95 @@ impl<F: Send + Clone> GetTracker<F, PaymentData<F>, api::PaymentsRequest> for Pa
             key_store,
         );
 
-        let (mut payment_attempt, shipping_address, billing_address) = futures::try_join!(
-            payment_attempt_fut,
-            shipping_address_fut,
-            billing_address_fut
-        )?;
+        let config_update_fut = request
+            .merchant_connector_details
+            .to_owned()
+            .async_map(|mcd| async {
+                helpers::insert_merchant_connector_creds_to_config(
+                    db,
+                    merchant_account.merchant_id.as_str(),
+                    mcd,
+                )
+                .await
+            })
+            .map(|x| x.transpose());
+
+        let (mut payment_attempt, shipping_address, billing_address, connector_response) =
+            match payment_intent.status {
+                api_models::enums::IntentStatus::RequiresCustomerAction
+                | api_models::enums::IntentStatus::RequiresMerchantAction
+                | api_models::enums::IntentStatus::RequiresPaymentMethod
+                | api_models::enums::IntentStatus::RequiresConfirmation => {
+                    let attempt_type = helpers::AttemptType::SameOld;
+
+                    let connector_response_fut = attempt_type.get_connector_response(
+                        db,
+                        &payment_intent.payment_id,
+                        &payment_intent.merchant_id,
+                        &payment_intent.active_attempt_id,
+                        storage_scheme,
+                    );
+
+                    let (payment_attempt, shipping_address, billing_address, connector_response, _) =
+                        futures::try_join!(
+                            payment_attempt_fut,
+                            shipping_address_fut,
+                            billing_address_fut,
+                            connector_response_fut,
+                            config_update_fut
+                        )?;
+
+                    (
+                        payment_attempt,
+                        shipping_address,
+                        billing_address,
+                        connector_response,
+                    )
+                }
+                _ => {
+                    let (mut payment_attempt, shipping_address, billing_address, _) = futures::try_join!(
+                        payment_attempt_fut,
+                        shipping_address_fut,
+                        billing_address_fut,
+                        config_update_fut
+                    )?;
+
+                    let attempt_type = helpers::get_attempt_type(
+                        &payment_intent,
+                        &payment_attempt,
+                        request,
+                        "confirm",
+                    )?;
+
+                    (payment_intent, payment_attempt) = attempt_type
+                        .modify_payment_intent_and_payment_attempt(
+                            // 3
+                            request,
+                            payment_intent,
+                            payment_attempt,
+                            db,
+                            storage_scheme,
+                        )
+                        .await?;
+
+                    let connector_response = attempt_type
+                        .get_or_insert_connector_response(&payment_attempt, db, storage_scheme)
+                        .await?;
+
+                    (
+                        payment_attempt,
+                        shipping_address,
+                        billing_address,
+                        connector_response,
+                    )
+                }
+            };
 
         payment_intent.order_details = request
             .get_order_details_as_value()
             .change_context(errors::ApiErrorResponse::InternalServerError)
             .attach_printable("Failed to convert order details to value")?
             .or(payment_intent.order_details);
-
-        let attempt_type =
-            helpers::get_attempt_type(&payment_intent, &payment_attempt, request, "confirm")?;
-
-        (payment_intent, payment_attempt) = attempt_type
-            .modify_payment_intent_and_payment_attempt(
-                // 3
-                request,
-                payment_intent,
-                payment_attempt,
-                db,
-                storage_scheme,
-            )
-            .await?;
 
         payment_intent.setup_future_usage = request
             .setup_future_usage
@@ -219,25 +282,6 @@ impl<F: Send + Clone> GetTracker<F, PaymentData<F>, api::PaymentsRequest> for Pa
             .merchant_connector_details
             .as_ref()
             .map(|mcd| mcd.creds_identifier.to_owned());
-
-        let config_update_fut = request
-            .merchant_connector_details
-            .to_owned()
-            .async_map(|mcd| async {
-                helpers::insert_merchant_connector_creds_to_config(
-                    db,
-                    merchant_account.merchant_id.as_str(),
-                    mcd,
-                )
-                .await
-            })
-            .map(|x| x.transpose());
-
-        let connector_response_fut =
-            attempt_type.get_connector_response(&payment_attempt, db, storage_scheme);
-
-        let (connector_response, _) =
-            futures::try_join!(connector_response_fut, config_update_fut)?;
 
         payment_intent.shipping_address_id = shipping_address.clone().map(|i| i.address_id);
         payment_intent.billing_address_id = billing_address.clone().map(|i| i.address_id);


### PR DESCRIPTION

## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

This reduces the database calls done during the confirm call in the `get_tracker` to 2 concurrent stages.

<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
