### PR TITLE
fix(payment_methods): Default card fetch to locker call

### DIFF
--- a/crates/router/src/core/payment_methods/cards.rs
+++ b/crates/router/src/core/payment_methods/cards.rs
@@ -1921,7 +1921,7 @@ async fn get_card_details(
     state: &routes::AppState,
     hyperswitch_token: &str,
 ) -> errors::RouterResult<Option<api::CardDetailFromLocker>> {
-    let mut card_decrypted =
+    let mut _card_decrypted =
         decrypt::<serde_json::Value, masking::WithType>(pm.payment_method_data.clone(), key)
             .await
             .change_context(errors::StorageError::DecryptionError)
@@ -1934,13 +1934,9 @@ async fn get_card_details(
                 PaymentMethodsData::Card(crd) => api::CardDetailFromLocker::from(crd),
             });
 
-    card_decrypted = if let Some(mut crd) = card_decrypted {
-        crd.scheme = pm.scheme.clone();
-        Some(crd)
-    } else {
-        Some(get_lookup_key_from_locker(state, hyperswitch_token, pm).await?)
-    };
-    Ok(card_decrypted)
+    Ok(Some(
+        get_lookup_key_from_locker(state, hyperswitch_token, pm).await?,
+    ))
 }
 
 pub async fn get_lookup_key_from_locker(


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Fixes the bug caused by previous change of fetching card details from pmt. Now defaulting to locker call.


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
curl - `curl --location --request GET 'http://localhost:8080/customers/StripeCustomer3/payment_methods' \
--header 'Accept: application/json' \
--header 'api-key: dev_ddu3uvKpn01bZtGOgju0Ihfg2troEdhWaoC79wt6V1tDQesrIU4j8zn1LDgsXl6P'`

<img width="1173" alt="image" src="https://github.com/juspay/hyperswitch/assets/76486416/70c8cd8f-0224-4cb4-9a77-788a3aa1b73c">



## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
