### PR TITLE
fix: eliminate recursive call while updating config in database

### DIFF
--- a/crates/router/src/db/configs.rs
+++ b/crates/router/src/db/configs.rs
@@ -146,8 +146,7 @@ impl ConfigInterface for MockDb {
         &self,
         key: &str,
         config_update: storage::ConfigUpdate,
-    ) -> CustomResult<storage::Config, errors::StorageError>
-    {
+    ) -> CustomResult<storage::Config, errors::StorageError> {
         self.update_config_by_key(key, config_update).await
     }
 
@@ -211,5 +210,4 @@ impl ConfigInterface for MockDb {
     ) -> CustomResult<storage::Config, errors::StorageError> {
         self.find_config_by_key(key).await
     }
-
 }

--- a/crates/router/src/db/configs.rs
+++ b/crates/router/src/db/configs.rs
@@ -36,6 +36,12 @@ pub trait ConfigInterface {
         config_update: storage::ConfigUpdate,
     ) -> CustomResult<storage::Config, errors::StorageError>;
 
+    async fn update_config_in_database(
+        &self,
+        key: &str,
+        config_update: storage::ConfigUpdate,
+    ) -> CustomResult<storage::Config, errors::StorageError>;
+
     async fn delete_config_by_key(&self, key: &str) -> CustomResult<bool, errors::StorageError>;
 }
 
@@ -49,6 +55,18 @@ impl ConfigInterface for Store {
         config.insert(&conn).await.map_err(Into::into).into_report()
     }
 
+    async fn update_config_in_database(
+        &self,
+        key: &str,
+        config_update: storage::ConfigUpdate,
+    ) -> CustomResult<storage::Config, errors::StorageError> {
+        let conn = connection::pg_connection_write(self).await?;
+        storage::Config::update_by_key(&conn, key, config_update)
+            .await
+            .map_err(Into::into)
+            .into_report()
+    }
+
     //update in DB and remove in redis and cache
     async fn update_config_by_key(
         &self,
@@ -56,7 +74,7 @@ impl ConfigInterface for Store {
         config_update: storage::ConfigUpdate,
     ) -> CustomResult<storage::Config, errors::StorageError> {
         cache::publish_and_redact(self, CacheKind::Config(key.into()), || {
-            self.update_config_by_key(key, config_update)
+            self.update_config_in_database(key, config_update)
         })
         .await
     }
@@ -124,6 +142,15 @@ impl ConfigInterface for MockDb {
         Ok(config_new)
     }
 
+    async fn update_config_in_database(
+        &self,
+        key: &str,
+        config_update: storage::ConfigUpdate,
+    ) -> CustomResult<storage::Config, errors::StorageError>
+    {
+        self.update_config_by_key(key, config_update).await
+    }
+
     async fn update_config_by_key(
         &self,
         key: &str,
@@ -166,18 +193,6 @@ impl ConfigInterface for MockDb {
         result
     }
 
-    async fn find_config_by_key_from_db(
-        &self,
-        key: &str,
-    ) -> CustomResult<storage::Config, errors::StorageError> {
-        let configs = self.configs.lock().await;
-        let config = configs.iter().find(|c| c.key == key).cloned();
-
-        config.ok_or_else(|| {
-            errors::StorageError::ValueNotFound("cannot find config".to_string()).into()
-        })
-    }
-
     async fn find_config_by_key(
         &self,
         key: &str,
@@ -189,4 +204,12 @@ impl ConfigInterface for MockDb {
             errors::StorageError::ValueNotFound("cannot find config".to_string()).into()
         })
     }
+
+    async fn find_config_by_key_from_db(
+        &self,
+        key: &str,
+    ) -> CustomResult<storage::Config, errors::StorageError> {
+        self.find_config_by_key(key).await
+    }
+
 }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
There is a recursive call which is made in update configs function. We need to remove that and change it to a db call in order for update call to properly function.


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
