### PR TITLE
refactor(masking): move masking implementations to masking crate

### DIFF
--- a/crates/masking/src/lib.rs
+++ b/crates/masking/src/lib.rs
@@ -54,3 +54,8 @@ pub mod prelude {
 
 #[cfg(feature = "diesel")]
 mod diesel;
+
+/// This module contains Masking objects and traits
+pub mod maskable;
+
+pub use maskable::*;

--- a/crates/masking/src/lib.rs
+++ b/crates/masking/src/lib.rs
@@ -55,7 +55,6 @@ pub mod prelude {
 #[cfg(feature = "diesel")]
 mod diesel;
 
-/// This module contains Masking objects and traits
 pub mod maskable;
 
 pub use maskable::*;

--- a/crates/masking/src/maskable.rs
+++ b/crates/masking/src/maskable.rs
@@ -1,3 +1,7 @@
+//!
+//! This module contains Masking objects and traits
+//!
+
 use crate::{ExposeInterface, Secret};
 
 ///
@@ -56,15 +60,15 @@ impl<T: Eq + PartialEq + Clone> Maskable<T> {
     }
 }
 
-/// Trait for providing a method to custom types for creating Maskable
+/// Trait for providing a method on custom types for constructing `Maskable`
 
 pub trait Mask {
-    /// A custom type which implements Eq, Clone and PartialEq
+    /// The type returned by the `into_masked()` method. Must implement `PartialEq`, `Eq` and `Clone`
 
     type Output: Eq + Clone + PartialEq;
 
     ///
-    /// Create a new Masked data where data is of type Output
+    /// Construct a `Maskable` instance that wraps `Self::Output` by consuming `self`
     ///
     fn into_masked(self) -> Maskable<Self::Output>;
 }

--- a/crates/masking/src/maskable.rs
+++ b/crates/masking/src/maskable.rs
@@ -1,0 +1,96 @@
+use crate::{ExposeInterface, Secret};
+
+///
+/// An Enum that allows us to optionally mask data, based on which enum variant that data is stored
+/// in.
+///
+#[derive(Clone, Eq, PartialEq)]
+pub enum Maskable<T: Eq + PartialEq + Clone> {
+    /// Variant which masks the data by wrapping in a Secret
+    Masked(Secret<T>),
+    /// Varant which doesn't mask the data
+    Normal(T),
+}
+
+impl<T: std::fmt::Debug + Clone + Eq + PartialEq> std::fmt::Debug for Maskable<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Masked(secret_value) => std::fmt::Debug::fmt(secret_value, f),
+            Self::Normal(value) => std::fmt::Debug::fmt(value, f),
+        }
+    }
+}
+
+impl<T: Eq + PartialEq + Clone + std::hash::Hash> std::hash::Hash for Maskable<T> {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        match self {
+            Self::Masked(value) => crate::PeekInterface::peek(value).hash(state),
+            Self::Normal(value) => value.hash(state),
+        }
+    }
+}
+
+impl<T: Eq + PartialEq + Clone> Maskable<T> {
+    ///
+    /// Get the inner data while consuming self
+    ///
+    pub fn into_inner(self) -> T {
+        match self {
+            Self::Masked(inner_secret) => inner_secret.expose(),
+            Self::Normal(inner) => inner,
+        }
+    }
+
+    ///
+    /// Create a new Masked data
+    ///
+    pub fn new_masked(item: Secret<T>) -> Self {
+        Self::Masked(item)
+    }
+
+    ///
+    /// Create a new non-masked data
+    ///
+    pub fn new_normal(item: T) -> Self {
+        Self::Normal(item)
+    }
+}
+
+/// Trait for providing a method to custom types for creating Maskable
+
+pub trait Mask {
+    /// A custom type which implements Eq, Clone and PartialEq
+
+    type Output: Eq + Clone + PartialEq;
+
+    ///
+    /// Create a new Masked data where data is of type Output
+    ///
+    fn into_masked(self) -> Maskable<Self::Output>;
+}
+
+impl Mask for String {
+    type Output = Self;
+    fn into_masked(self) -> Maskable<Self::Output> {
+        Maskable::new_masked(self.into())
+    }
+}
+
+impl Mask for Secret<String> {
+    type Output = String;
+    fn into_masked(self) -> Maskable<Self::Output> {
+        Maskable::new_masked(self)
+    }
+}
+
+impl<T: Eq + PartialEq + Clone> From<T> for Maskable<T> {
+    fn from(value: T) -> Self {
+        Self::new_normal(value)
+    }
+}
+
+impl From<&str> for Maskable<String> {
+    fn from(value: &str) -> Self {
+        Self::new_normal(value.to_string())
+    }
+}


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Currently `Maskable` enum and `Mask` trait resides in router crate. Since this is related to masking we can move this to `masking` crate

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
