### PR TITLE
ci(postman): Modify server start logic to address timeouts in actions

### DIFF
--- a/.github/workflows/postman-collection-runner.yml
+++ b/.github/workflows/postman-collection-runner.yml
@@ -118,7 +118,7 @@ jobs:
           # Wait for the server to start in port 8080
           COUNT=0
           while ! nc -z localhost 8080; do
-            if [ $COUNT -gt 12 ]; then # Wait for up to 2 minutes (12 * 10 seconds)
+            if [ $COUNT -gt 90 ]; then # Wait for up to 2 minutes (90 * 10 seconds)
               echo "Server did not start within a reasonable time. Exiting."
               kill $SERVER_PID
               exit 1

--- a/.github/workflows/postman-collection-runner.yml
+++ b/.github/workflows/postman-collection-runner.yml
@@ -25,7 +25,7 @@ jobs:
 
     services:
       redis:
-        image: 'redis'
+        image: "redis"
         options: >-
           --health-cmd "redis-cli ping"
           --health-interval 10s
@@ -34,7 +34,7 @@ jobs:
         ports:
           - 6379:6379
       postgres:
-        image: 'postgres:14.5'
+        image: "postgres:14.5"
         env:
           POSTGRES_USER: db_user
           POSTGRES_PASSWORD: db_pass
@@ -97,28 +97,22 @@ jobs:
         env:
           DATABASE_URL: postgres://db_user:db_pass@localhost:5432/hyperswitch_db
         run: diesel migration run
-      
+
       - name: Build project
         if: ${{ ((github.event_name == 'pull_request') && (github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name)) || (github.event_name == 'merge_group')}}
-        run: cargo build
-  
+        run: cargo build --package router --bin router
+
       - name: Setup Local Server
         if: ${{ ((github.event_name == 'pull_request') && (github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name)) || (github.event_name == 'merge_group')}}
         run: |
-          # Check if the build succeeded
-          if [ $? -ne 0 ]; then
-            echo "Cargo build failed. Exiting."
-            exit 1
-          fi
-
           # Start the server in the background
-          cargo run &
+          target/debug/router &
           SERVER_PID=$!
 
           # Wait for the server to start in port 8080
           COUNT=0
           while ! nc -z localhost 8080; do
-            if [ $COUNT -gt 90 ]; then # Wait for up to 2 minutes (90 * 10 seconds)
+            if [ $COUNT -gt 12 ]; then # Wait for up to 2 minutes (12 * 10 seconds)
               echo "Server did not start within a reasonable time. Exiting."
               kill $SERVER_PID
               exit 1
@@ -127,7 +121,6 @@ jobs:
               sleep 10
             fi
           done
-  
 
       - name: Install newman from fork
         run: |
@@ -147,14 +140,14 @@ jobs:
           NEWMAN_PATH=$(pwd)/node_modules/.bin
           export PATH=${NEWMAN_PATH}:${PATH}
           failed_connectors=()
-      
+
           for i in $(echo "$CONNECTORS" | tr "," "\n"); do
             echo $i
             if ! cargo run --bin test_utils -- --connector_name="$i" --base_url="$BASE_URL" --admin_api_key="$ADMIN_API_KEY"; then
               failed_connectors+=("$i")
             fi
           done
-      
+
           if [ ${#failed_connectors[@]} -gt 0 ]; then
             echo -e "${RED}One or more connectors failed to run:${RESET}"
             printf '%s\n' "${failed_connectors[@]}"

--- a/.github/workflows/postman-collection-runner.yml
+++ b/.github/workflows/postman-collection-runner.yml
@@ -13,10 +13,11 @@ concurrency:
 env:
   CARGO_INCREMENTAL: 1
   CARGO_NET_RETRY: 10
-  RUSTUP_MAX_RETRIES: 10
-  RUST_BACKTRACE: short
   CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
   CONNECTORS: stripe
+  RUST_BACKTRACE: short
+  RUSTUP_MAX_RETRIES: 10
+  RUST_MIN_STACK: 8388608
 
 jobs:
   runner:
@@ -98,6 +99,9 @@ jobs:
           DATABASE_URL: postgres://db_user:db_pass@localhost:5432/hyperswitch_db
         run: diesel migration run
 
+      - name: Install newman from fork
+        run: npm ci
+
       - name: Build project
         if: ${{ ((github.event_name == 'pull_request') && (github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name)) || (github.event_name == 'merge_group')}}
         run: cargo build --package router --bin router
@@ -121,10 +125,6 @@ jobs:
               sleep 10
             fi
           done
-
-      - name: Install newman from fork
-        run: |
-          npm ci
 
       - name: Run Tests
         if: ${{ ((github.event_name == 'pull_request') && (github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name)) || (github.event_name == 'merge_group')}}

--- a/.github/workflows/postman-collection-runner.yml
+++ b/.github/workflows/postman-collection-runner.yml
@@ -97,23 +97,37 @@ jobs:
         env:
           DATABASE_URL: postgres://db_user:db_pass@localhost:5432/hyperswitch_db
         run: diesel migration run
-
+      
+      - name: Build project
+        if: ${{ ((github.event_name == 'pull_request') && (github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name)) || (github.event_name == 'merge_group')}}
+        run: cargo build
+  
       - name: Setup Local Server
         if: ${{ ((github.event_name == 'pull_request') && (github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name)) || (github.event_name == 'merge_group')}}
         run: |
+          # Check if the build succeeded
+          if [ $? -ne 0 ]; then
+            echo "Cargo build failed. Exiting."
+            exit 1
+          fi
+
+          # Start the server in the background
           cargo run &
-          COUNT=0
+          SERVER_PID=$!
+
           # Wait for the server to start in port 8080
-          while netstat -lnt | awk '$4 ~ /:8080$/ {exit 1}'; do 
-              # Wait for 15 mins to start otherwise kill the task
-              if [ $COUNT -gt 90 ];
-              then
-                  exit 1
-              else 
-                  COUNT=$((COUNT+1))
-                  sleep 10
-              fi
+          COUNT=0
+          while ! nc -z localhost 8080; do
+            if [ $COUNT -gt 12 ]; then # Wait for up to 2 minutes (12 * 10 seconds)
+              echo "Server did not start within a reasonable time. Exiting."
+              kill $SERVER_PID
+              exit 1
+            else
+              COUNT=$((COUNT+1))
+              sleep 10
+            fi
           done
+  
 
       - name: Install newman from fork
         run: |


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Refactoring
- [x] CI/CD

## Description
<!-- Describe your changes in detail -->
This PR aims at refactoring the server start logic of `postman-runner.yml` file to address timeout issue that killed the server if the server did not start within 15 minutes.
For context: 
<img width="1582" alt="image" src="https://github.com/juspay/hyperswitch/assets/69745008/0953d483-e016-4ccb-b8df-007ca14c2857">

The above failure is because of the timeout that occurred. 


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
With this PR going in, we'll be building first and then starting the server next in the background in 2 different steps. This way, if the build fails, the check should anyway fail. If the server does not start within the next 2 minutes, fail the check again.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Now that it consumes less than 10 minutes to run, we've reduced the time consumption by 7+ minutes. 
<img width="1383" alt="image" src="https://github.com/juspay/hyperswitch/assets/69745008/78d4f5c6-9172-43e4-83dc-5835ee5199c2">

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
