### PR TITLE
fix(core): update amount_capturable in update trackers

### DIFF
--- a/crates/data_models/src/payments/payment_attempt.rs
+++ b/crates/data_models/src/payments/payment_attempt.rs
@@ -216,6 +216,7 @@ pub enum PaymentAttemptUpdate {
         payment_token: Option<String>,
         connector: Option<String>,
         straight_through_algorithm: Option<serde_json::Value>,
+        amount_capturable: Option<i64>,
     },
     AuthenticationTypeUpdate {
         authentication_type: storage_enums::AuthenticationType,
@@ -236,6 +237,7 @@ pub enum PaymentAttemptUpdate {
         straight_through_algorithm: Option<serde_json::Value>,
         error_code: Option<Option<String>>,
         error_message: Option<Option<String>>,
+        amount_capturable: Option<i64>,
     },
     RejectUpdate {
         status: storage_enums::AttemptStatus,

--- a/crates/diesel_models/src/payment_attempt.rs
+++ b/crates/diesel_models/src/payment_attempt.rs
@@ -137,6 +137,7 @@ pub enum PaymentAttemptUpdate {
         payment_token: Option<String>,
         connector: Option<String>,
         straight_through_algorithm: Option<serde_json::Value>,
+        amount_capturable: Option<i64>,
     },
     AuthenticationTypeUpdate {
         authentication_type: storage_enums::AuthenticationType,
@@ -157,6 +158,7 @@ pub enum PaymentAttemptUpdate {
         straight_through_algorithm: Option<serde_json::Value>,
         error_code: Option<Option<String>>,
         error_message: Option<Option<String>>,
+        amount_capturable: Option<i64>,
     },
     VoidUpdate {
         status: storage_enums::AttemptStatus,
@@ -339,6 +341,7 @@ impl From<PaymentAttemptUpdate> for PaymentAttemptUpdateInternal {
                 straight_through_algorithm,
                 error_code,
                 error_message,
+                amount_capturable,
             } => Self {
                 amount: Some(amount),
                 currency: Some(currency),
@@ -356,6 +359,7 @@ impl From<PaymentAttemptUpdate> for PaymentAttemptUpdateInternal {
                 straight_through_algorithm,
                 error_code,
                 error_message,
+                amount_capturable,
                 ..Default::default()
             },
             PaymentAttemptUpdate::VoidUpdate {
@@ -432,10 +436,12 @@ impl From<PaymentAttemptUpdate> for PaymentAttemptUpdateInternal {
                 payment_token,
                 connector,
                 straight_through_algorithm,
+                amount_capturable,
             } => Self {
                 payment_token,
                 connector,
                 straight_through_algorithm,
+                amount_capturable,
                 ..Default::default()
             },
             PaymentAttemptUpdate::UnresolvedResponseUpdate {

--- a/crates/router/src/core/payments/operations/payment_confirm.rs
+++ b/crates/router/src/core/payments/operations/payment_confirm.rs
@@ -513,7 +513,7 @@ impl<F: Clone> UpdateTracker<F, PaymentData<F>, api::PaymentsRequest> for Paymen
             .take();
         let order_details = payment_data.payment_intent.order_details.clone();
         let metadata = payment_data.payment_intent.metadata.clone();
-
+        let authorized_amount = payment_data.payment_attempt.amount;
         let payment_attempt_fut = db
             .update_payment_attempt_with_attempt_id(
                 payment_data.payment_attempt,
@@ -533,6 +533,7 @@ impl<F: Clone> UpdateTracker<F, PaymentData<F>, api::PaymentsRequest> for Paymen
                     straight_through_algorithm,
                     error_code,
                     error_message,
+                    amount_capturable: Some(authorized_amount),
                 },
                 storage_scheme,
             )

--- a/crates/router/src/core/payments/operations/payment_create.rs
+++ b/crates/router/src/core/payments/operations/payment_create.rs
@@ -386,6 +386,7 @@ impl<F: Clone> UpdateTracker<F, PaymentData<F>, api::PaymentsRequest> for Paymen
             .payment_attempt
             .straight_through_algorithm
             .clone();
+        let authorized_amount = payment_data.payment_attempt.amount;
 
         payment_data.payment_attempt = db
             .update_payment_attempt_with_attempt_id(
@@ -394,6 +395,10 @@ impl<F: Clone> UpdateTracker<F, PaymentData<F>, api::PaymentsRequest> for Paymen
                     payment_token,
                     connector,
                     straight_through_algorithm,
+                    amount_capturable: match payment_data.confirm.unwrap_or(true) {
+                        true => Some(authorized_amount),
+                        false => None,
+                    },
                 },
                 storage_scheme,
             )

--- a/crates/storage_impl/src/payments/payment_attempt.rs
+++ b/crates/storage_impl/src/payments/payment_attempt.rs
@@ -1089,10 +1089,12 @@ impl DataModelExt for PaymentAttemptUpdate {
                 payment_token,
                 connector,
                 straight_through_algorithm,
+                amount_capturable,
             } => DieselPaymentAttemptUpdate::UpdateTrackers {
                 payment_token,
                 connector,
                 straight_through_algorithm,
+                amount_capturable,
             },
             Self::AuthenticationTypeUpdate {
                 authentication_type,
@@ -1115,6 +1117,7 @@ impl DataModelExt for PaymentAttemptUpdate {
                 straight_through_algorithm,
                 error_code,
                 error_message,
+                amount_capturable,
             } => DieselPaymentAttemptUpdate::ConfirmUpdate {
                 amount,
                 currency,
@@ -1131,6 +1134,7 @@ impl DataModelExt for PaymentAttemptUpdate {
                 straight_through_algorithm,
                 error_code,
                 error_message,
+                amount_capturable,
             },
             Self::VoidUpdate {
                 status,
@@ -1275,10 +1279,12 @@ impl DataModelExt for PaymentAttemptUpdate {
                 payment_token,
                 connector,
                 straight_through_algorithm,
+                amount_capturable,
             } => Self::UpdateTrackers {
                 payment_token,
                 connector,
                 straight_through_algorithm,
+                amount_capturable,
             },
             DieselPaymentAttemptUpdate::AuthenticationTypeUpdate {
                 authentication_type,
@@ -1301,6 +1307,7 @@ impl DataModelExt for PaymentAttemptUpdate {
                 straight_through_algorithm,
                 error_code,
                 error_message,
+                amount_capturable,
             } => Self::ConfirmUpdate {
                 amount,
                 currency,
@@ -1317,6 +1324,7 @@ impl DataModelExt for PaymentAttemptUpdate {
                 straight_through_algorithm,
                 error_code,
                 error_message,
+                amount_capturable,
             },
             DieselPaymentAttemptUpdate::VoidUpdate {
                 status,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
amount_capturable was not updated in update_trackers() of payment_create and confirm.
This was causing unexpected values in amount_capturable field in response during payment create and confirm call.


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
