### PR TITLE
refactor(connector): [BraintreeGraphQl] Enhance currency Mapping with ConnectorCurrencyCommon Trait 

### DIFF
--- a/connector-template/mod.rs
+++ b/connector-template/mod.rs
@@ -157,7 +157,14 @@ impl
     }
 
     fn get_request_body(&self, req: &types::PaymentsAuthorizeRouterData) -> CustomResult<Option<types::RequestBody>, errors::ConnectorError> {
-        let req_obj = {{project-name | downcase}}::{{project-name | downcase | pascal_case}}PaymentsRequest::try_from(req)?;
+        let connector_router_data =
+            {{project-name | downcase}}::{{project-name | downcase | pascal_case}}RouterData::try_from((
+                &self.get_currency_unit(),
+                req.request.currency,
+                req.request.amount,
+                req,
+            ))?;
+        let req_obj = {{project-name | downcase}}::{{project-name | downcase | pascal_case}}PaymentsRequest::try_from(&connector_router_data)?;
         let {{project-name | downcase}}_req = types::RequestBody::log_and_get_request_body(&req_obj, utils::Encode::<{{project-name | downcase}}::{{project-name | downcase | pascal_case}}PaymentsRequest>::encode_to_string_of_json)
             .change_context(errors::ConnectorError::RequestEncodingFailed)?;
         Ok(Some({{project-name | downcase}}_req))
@@ -368,7 +375,14 @@ impl
     }
 
     fn get_request_body(&self, req: &types::RefundsRouterData<api::Execute>) -> CustomResult<Option<types::RequestBody>, errors::ConnectorError> {
-        let req_obj = {{project-name | downcase}}::{{project-name | downcase | pascal_case}}RefundRequest::try_from(req)?;
+        let connector_router_data =
+            {{project-name | downcase}}::{{project-name | downcase | pascal_case}}RouterData::try_from((
+                &self.get_currency_unit(),
+                req.request.currency,
+                req.request.refund_amount,
+                req,
+            ))?;
+        let req_obj = {{project-name | downcase}}::{{project-name | downcase | pascal_case}}RefundRequest::try_from(&connector_router_data)?;
         let {{project-name | downcase}}_req = types::RequestBody::log_and_get_request_body(&req_obj, utils::Encode::<{{project-name | downcase}}::{{project-name | downcase | pascal_case}}RefundRequest>::encode_to_string_of_json)
             .change_context(errors::ConnectorError::RequestEncodingFailed)?;
         Ok(Some({{project-name | downcase}}_req))

--- a/connector-template/mod.rs
+++ b/connector-template/mod.rs
@@ -72,7 +72,9 @@ impl ConnectorCommon for {{project-name | downcase | pascal_case}} {
 
     fn get_currency_unit(&self) -> api::CurrencyUnit {
         todo!()
-        // Ex: api::CurrencyUnit::Minor
+    //    TODO! Check connector documentation, on which unit they are processing the currency. 
+    //    If the connector accepts amount in lower unit ( i.e cents for USD) then return api::CurrencyUnit::Minor, 
+    //    if connector accepts amount in base unit (i.e dollars for USD) then return api::CurrencyUnit::Base
     }
 
     fn common_get_content_type(&self) -> &'static str {

--- a/connector-template/mod.rs
+++ b/connector-template/mod.rs
@@ -70,6 +70,11 @@ impl ConnectorCommon for {{project-name | downcase | pascal_case}} {
         "{{project-name | downcase}}"
     }
 
+    fn get_currency_unit(&self) -> api::CurrencyUnit {
+        todo!()
+        // Ex: api::CurrencyUnit::Minor
+    }
+
     fn common_get_content_type(&self) -> &'static str {
         "application/json"
     }

--- a/connector-template/transformers.rs
+++ b/connector-template/transformers.rs
@@ -1,10 +1,10 @@
 use serde::{Deserialize, Serialize};
 use masking::Secret;
-use crate::{connector::utils::PaymentsAuthorizeRequestData,core::errors,types::{self,api, storage::enums}};
+use crate::{connector::utils::{PaymentsAuthorizeRequestData},core::errors,types::{self,api, storage::enums}};
 
 //TODO: Fill the struct with respective fields
-pub struct {{project-name | downcase | pascal_case}}RouterData {
-    pub amount: String, // The type of amount that a connector accepts, for example, String, i64, f64, etc.
+pub struct {{project-name | downcase | pascal_case}}RouterData<T> {
+    pub amount: i64, // The type of amount that a connector accepts, for example, String, i64, f64, etc.
     pub router_data: T,
 }
 
@@ -18,14 +18,14 @@ impl<T>
 {
     type Error = error_stack::Report<errors::ConnectorError>;
     fn try_from(
-        (currency_unit, currency, amount, item): (
+        (_currency_unit, _currency, amount, item): (
             &types::api::CurrencyUnit,
             types::storage::enums::Currency,
             i64,
             T,
         ),
     ) -> Result<Self, Self::Error> {
-        let amount = utils::get_amount_as_string(currency_unit, amount, currency)?; // use utils to convert the amount to the type of amount that a connector accepts
+         //Todo :  use utils to convert the amount to the type of amount that a connector accepts
         Ok(Self {
             amount,
             router_data: item,
@@ -61,7 +61,7 @@ impl TryFrom<&{{project-name | downcase | pascal_case}}RouterData<&types::Paymen
                     expiry_month: req_card.card_exp_month,
                     expiry_year: req_card.card_exp_year,
                     cvc: req_card.card_cvc,
-                    complete: item.request.is_auto_capture()?,
+                    complete: item.router_data.request.is_auto_capture()?,
                 };
                 Ok(Self {
                     amount: item.amount.to_owned(),

--- a/crates/router/src/connector/braintree.rs
+++ b/crates/router/src/connector/braintree.rs
@@ -429,10 +429,19 @@ impl ConnectorIntegration<api::Capture, types::PaymentsCaptureData, types::Payme
         req: &types::PaymentsCaptureRouterData,
     ) -> CustomResult<Option<types::RequestBody>, errors::ConnectorError> {
         let connector_api_version = &req.connector_api_version.clone();
+        let conversion_req =
+            braintree_graphql_transformers::BriantreeAmountConversion::try_from((
+                &self.get_currency_unit(),
+                req.request.currency,
+                req.request.amount_to_capture,
+                req,
+            ))?;
         match self.is_braintree_graphql_version(connector_api_version) {
             true => {
                 let connector_request =
-                    braintree_graphql_transformers::BraintreeCaptureRequest::try_from(req)?;
+                    braintree_graphql_transformers::BraintreeCaptureRequest::try_from(
+                        &conversion_req,
+                    )?;
 
                 let braintree_req = types::RequestBody::log_and_get_request_body(
             &connector_request,

--- a/crates/router/src/connector/braintree.rs
+++ b/crates/router/src/connector/braintree.rs
@@ -429,8 +429,8 @@ impl ConnectorIntegration<api::Capture, types::PaymentsCaptureData, types::Payme
         req: &types::PaymentsCaptureRouterData,
     ) -> CustomResult<Option<types::RequestBody>, errors::ConnectorError> {
         let connector_api_version = &req.connector_api_version.clone();
-        let conversion_req =
-            braintree_graphql_transformers::BriantreeAmountConversion::try_from((
+        let connector_router_data =
+            braintree_graphql_transformers::BraintreeRouterData::try_from((
                 &self.get_currency_unit(),
                 req.request.currency,
                 req.request.amount_to_capture,
@@ -440,7 +440,7 @@ impl ConnectorIntegration<api::Capture, types::PaymentsCaptureData, types::Payme
             true => {
                 let connector_request =
                     braintree_graphql_transformers::BraintreeCaptureRequest::try_from(
-                        &conversion_req,
+                        &connector_router_data,
                     )?;
 
                 let braintree_req = types::RequestBody::log_and_get_request_body(
@@ -749,8 +749,8 @@ impl ConnectorIntegration<api::Authorize, types::PaymentsAuthorizeData, types::P
         req: &types::PaymentsAuthorizeRouterData,
     ) -> CustomResult<Option<types::RequestBody>, errors::ConnectorError> {
         let connector_api_version = &req.connector_api_version;
-        let conversion_req =
-            braintree_graphql_transformers::BriantreeAmountConversion::try_from((
+        let connector_router_data =
+            braintree_graphql_transformers::BraintreeRouterData::try_from((
                 &self.get_currency_unit(),
                 req.request.currency,
                 req.request.amount,
@@ -760,7 +760,7 @@ impl ConnectorIntegration<api::Authorize, types::PaymentsAuthorizeData, types::P
             true => {
                 let connector_request =
                     braintree_graphql_transformers::BraintreePaymentsRequest::try_from(
-                        &conversion_req,
+                        &connector_router_data,
                     )?;
                 let braintree_payment_request = types::RequestBody::log_and_get_request_body(
                     &connector_request,
@@ -1048,8 +1048,8 @@ impl ConnectorIntegration<api::Execute, types::RefundsData, types::RefundsRespon
         req: &types::RefundsRouterData<api::Execute>,
     ) -> CustomResult<Option<types::RequestBody>, errors::ConnectorError> {
         let connector_api_version = &req.connector_api_version;
-        let conversion_req =
-            braintree_graphql_transformers::BriantreeAmountConversion::try_from((
+        let connector_router_data =
+            braintree_graphql_transformers::BraintreeRouterData::try_from((
                 &self.get_currency_unit(),
                 req.request.currency,
                 req.request.refund_amount,
@@ -1059,7 +1059,7 @@ impl ConnectorIntegration<api::Execute, types::RefundsData, types::RefundsRespon
             true => {
                 let connector_request =
                     braintree_graphql_transformers::BraintreeRefundRequest::try_from(
-                        conversion_req,
+                        connector_router_data,
                     )?;
                 let braintree_refund_request = types::RequestBody::log_and_get_request_body(
             &connector_request,
@@ -1341,8 +1341,8 @@ impl
         &self,
         req: &types::PaymentsCompleteAuthorizeRouterData,
     ) -> CustomResult<Option<types::RequestBody>, errors::ConnectorError> {
-        let conversion_req =
-            braintree_graphql_transformers::BriantreeAmountConversion::try_from((
+        let connector_router_data =
+            braintree_graphql_transformers::BraintreeRouterData::try_from((
                 &self.get_currency_unit(),
                 req.request.currency,
                 req.request.amount,
@@ -1353,7 +1353,7 @@ impl
             true => {
                 let connector_request =
                     braintree_graphql_transformers::BraintreePaymentsRequest::try_from(
-                        &conversion_req,
+                        &connector_router_data,
                     )?;
                 let braintree_payment_request = types::RequestBody::log_and_get_request_body(
                     &connector_request,

--- a/crates/router/src/connector/braintree.rs
+++ b/crates/router/src/connector/braintree.rs
@@ -74,6 +74,10 @@ impl ConnectorCommon for Braintree {
         "braintree"
     }
 
+    fn get_currency_unit(&self) -> api::CurrencyUnit {
+        api::CurrencyUnit::Base
+    }
+
     fn base_url<'a>(&self, connectors: &'a settings::Connectors) -> &'a str {
         connectors.braintree.base_url.as_ref()
     }
@@ -736,10 +740,19 @@ impl ConnectorIntegration<api::Authorize, types::PaymentsAuthorizeData, types::P
         req: &types::PaymentsAuthorizeRouterData,
     ) -> CustomResult<Option<types::RequestBody>, errors::ConnectorError> {
         let connector_api_version = &req.connector_api_version;
+        let conversion_req =
+            braintree_graphql_transformers::BriantreeAmountConversion::try_from((
+                &self.get_currency_unit(),
+                req.request.currency,
+                req.request.amount,
+                req,
+            ))?;
         match self.is_braintree_graphql_version(connector_api_version) {
             true => {
                 let connector_request =
-                    braintree_graphql_transformers::BraintreePaymentsRequest::try_from(req)?;
+                    braintree_graphql_transformers::BraintreePaymentsRequest::try_from(
+                        &conversion_req,
+                    )?;
                 let braintree_payment_request = types::RequestBody::log_and_get_request_body(
                     &connector_request,
                     utils::Encode::<braintree_graphql_transformers::BraintreePaymentsRequest>::encode_to_string_of_json,
@@ -1026,10 +1039,19 @@ impl ConnectorIntegration<api::Execute, types::RefundsData, types::RefundsRespon
         req: &types::RefundsRouterData<api::Execute>,
     ) -> CustomResult<Option<types::RequestBody>, errors::ConnectorError> {
         let connector_api_version = &req.connector_api_version;
+        let conversion_req =
+            braintree_graphql_transformers::BriantreeAmountConversion::try_from((
+                &self.get_currency_unit(),
+                req.request.currency,
+                req.request.refund_amount,
+                req,
+            ))?;
         match self.is_braintree_graphql_version(connector_api_version) {
             true => {
                 let connector_request =
-                    braintree_graphql_transformers::BraintreeRefundRequest::try_from(req)?;
+                    braintree_graphql_transformers::BraintreeRefundRequest::try_from(
+                        conversion_req,
+                    )?;
                 let braintree_refund_request = types::RequestBody::log_and_get_request_body(
             &connector_request,
             utils::Encode::<braintree_graphql_transformers::BraintreeRefundRequest>::encode_to_string_of_json,
@@ -1310,11 +1332,20 @@ impl
         &self,
         req: &types::PaymentsCompleteAuthorizeRouterData,
     ) -> CustomResult<Option<types::RequestBody>, errors::ConnectorError> {
+        let conversion_req =
+            braintree_graphql_transformers::BriantreeAmountConversion::try_from((
+                &self.get_currency_unit(),
+                req.request.currency,
+                req.request.amount,
+                req,
+            ))?;
         let connector_api_version = &req.connector_api_version;
         match self.is_braintree_graphql_version(connector_api_version) {
             true => {
                 let connector_request =
-                    braintree_graphql_transformers::BraintreePaymentsRequest::try_from(req)?;
+                    braintree_graphql_transformers::BraintreePaymentsRequest::try_from(
+                        &conversion_req,
+                    )?;
                 let braintree_payment_request = types::RequestBody::log_and_get_request_body(
                     &connector_request,
                     utils::Encode::<braintree_graphql_transformers::BraintreePaymentsRequest>::encode_to_string_of_json,

--- a/crates/router/src/connector/braintree/braintree_graphql_transformers.rs
+++ b/crates/router/src/connector/braintree/braintree_graphql_transformers.rs
@@ -969,18 +969,19 @@ pub struct BraintreeCaptureRequest {
     variables: VariableCaptureInput,
 }
 
-impl TryFrom<&types::PaymentsCaptureRouterData> for BraintreeCaptureRequest {
+impl TryFrom<&BriantreeAmountConversion<&types::PaymentsCaptureRouterData>>
+    for BraintreeCaptureRequest
+{
     type Error = error_stack::Report<errors::ConnectorError>;
-    fn try_from(item: &types::PaymentsCaptureRouterData) -> Result<Self, Self::Error> {
+    fn try_from(
+        item: &BriantreeAmountConversion<&types::PaymentsCaptureRouterData>,
+    ) -> Result<Self, Self::Error> {
         let query = CAPTURE_TRANSACTION_MUTATION.to_string();
         let variables = VariableCaptureInput {
             input: CaptureInputData {
-                transaction_id: item.request.connector_transaction_id.clone(),
+                transaction_id: item.req.request.connector_transaction_id.clone(),
                 transaction: CaptureTransactionBody {
-                    amount: utils::to_currency_base_unit(
-                        item.request.amount_to_capture,
-                        item.request.currency,
-                    )?,
+                    amount: item.amount.to_owned(),
                 },
             },
         };

--- a/crates/router/src/connector/utils.rs
+++ b/crates/router/src/connector/utils.rs
@@ -994,6 +994,33 @@ pub fn to_currency_base_unit_from_optional_amount(
     }
 }
 
+pub fn get_amount_as_string(
+    currency_unit: &types::api::CurrencyUnit,
+    amount: i64,
+    currency: diesel_models::enums::Currency,
+) -> Result<String, error_stack::Report<errors::ConnectorError>> {
+    let amount = match currency_unit {
+        types::api::CurrencyUnit::Minor => amount.to_string(),
+        types::api::CurrencyUnit::Base => to_currency_base_unit(amount, currency)?,
+    };
+    Ok(amount)
+}
+
+pub fn get_amount_as_f64(
+    currency_unit: &types::api::CurrencyUnit,
+    amount: i64,
+    currency: diesel_models::enums::Currency,
+) -> Result<f64, error_stack::Report<errors::ConnectorError>> {
+    let amount = match currency_unit {
+        types::api::CurrencyUnit::Base => to_currency_base_unit_asf64(amount, currency)?,
+        types::api::CurrencyUnit::Minor => u32::try_from(amount)
+            .into_report()
+            .change_context(errors::ConnectorError::ParsingFailed)?
+            .into(),
+    };
+    Ok(amount)
+}
+
 pub fn to_currency_base_unit(
     amount: i64,
     currency: diesel_models::enums::Currency,
@@ -1001,7 +1028,7 @@ pub fn to_currency_base_unit(
     currency
         .to_currency_base_unit(amount)
         .into_report()
-        .change_context(errors::ConnectorError::RequestEncodingFailed)
+        .change_context(errors::ConnectorError::ParsingFailed)
 }
 
 pub fn to_currency_lower_unit(
@@ -1050,7 +1077,7 @@ pub fn to_currency_base_unit_asf64(
     currency
         .to_currency_base_unit_asf64(amount)
         .into_report()
-        .change_context(errors::ConnectorError::RequestEncodingFailed)
+        .change_context(errors::ConnectorError::ParsingFailed)
 }
 
 pub fn str_to_f32<S>(value: &str, serializer: S) -> Result<S::Ok, S::Error>

--- a/crates/router/src/types/api.rs
+++ b/crates/router/src/types/api.rs
@@ -47,9 +47,19 @@ pub trait ConnectorTransactionId: ConnectorCommon + Sync {
     }
 }
 
+pub enum CurrencyUnit {
+    Base,
+    Minor,
+}
+
 pub trait ConnectorCommon {
     /// Name of the connector (in lowercase).
     fn id(&self) -> &'static str;
+
+    /// Connector accepted currency unit as either "Base" or "Minor"
+    fn get_currency_unit(&self) -> CurrencyUnit {
+        CurrencyUnit::Minor // Default implementation should be remove once it is implemented in all connectors
+    }
 
     /// HTTP header used for authorization.
     fn get_auth_header(


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Problem : Currently, amount mapping for different connectors are handled by hard coding dollars/cents which has been leading to multiple bugs due to incorrect mapping. Need to handle this better in code by having separate types for dollar vs cents .

Solution : To address this issue and improve code maintainability, this pull request introduces the `get_currecny_unit` from `ConnectorCommon` trait. This function allows connectors to declare their accepted currency unit as either "Base" or "Minor" .

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
Implement the ConnectorCurrencyCommon trait, where you can declare the accepted currency unit (either Base or Minor) using the get_currency_unit method in `ConnectorCommon` trait .

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
tested it locally 

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x]  I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
