### PR TITLE
fix: payment status fix in trustpay for 3ds and wallets

### DIFF
--- a/crates/router/src/connector/trustpay/transformers.rs
+++ b/crates/router/src/connector/trustpay/transformers.rs
@@ -439,7 +439,7 @@ fn get_transaction_status(
     redirect_url: Option<Url>,
 ) -> CustomResult<(enums::AttemptStatus, Option<String>), errors::ConnectorError> {
     // We don't get payment_status only in case, when the user doesn't complete the authentication step.
-    // If we recieve status, then return the proper status based on the connector response
+    // If we receive status, then return the proper status based on the connector response
     if let Some(payment_status) = payment_status {
         let (is_failed, failure_message) = is_payment_failed(&payment_status);
         if is_failed {

--- a/crates/router/src/connector/trustpay/transformers.rs
+++ b/crates/router/src/connector/trustpay/transformers.rs
@@ -430,7 +430,7 @@ fn is_payment_successful(payment_status: &str) -> CustomResult<bool, errors::Con
 fn get_pending_status_based_on_redirect_url(redirect_url: Option<Url>) -> enums::AttemptStatus {
     match redirect_url {
         Some(_url) => enums::AttemptStatus::AuthenticationPending,
-        None => enums::AttemptStatus::Authorizing,
+        None => enums::AttemptStatus::Pending,
     }
 }
 
@@ -444,7 +444,7 @@ fn get_transaction_status(
         let (is_failed, failure_message) = is_payment_failed(&payment_status);
         if is_failed {
             return Ok((
-                enums::AttemptStatus::AuthorizationFailed,
+                enums::AttemptStatus::Failure,
                 Some(failure_message.to_string()),
             ));
         }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix

## Description
<!-- Describe your changes in detail -->
  We don't get payment_status only in case, when the user doesn't complete the authentication step. So, the status should be mapped to Authentication pending
  If we receive status, then return the proper status based on the connector response

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
Payment status fix


<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
