### PR TITLE
refactor(router): changed the storage of applepay_verified_domains from business_profile to merchant_connector_account table

### DIFF
--- a/crates/api_models/src/admin.rs
+++ b/crates/api_models/src/admin.rs
@@ -633,6 +633,8 @@ pub struct MerchantConnectorCreate {
     pub connector_webhook_details: Option<MerchantConnectorWebhookDetails>,
     /// Identifier for the business profile, if not provided default will be chosen from merchant account
     pub profile_id: Option<String>,
+    /// identifier for the verified domains of a particular connector account
+    pub applepay_verified_domains: Option<Vec<String>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
@@ -734,6 +736,8 @@ pub struct MerchantConnectorResponse {
     /// default value from merchant account is taken if not passed
     #[schema(max_length = 64)]
     pub profile_id: Option<String>,
+    /// identifier for the verified domains of a particular connector account
+    pub applepay_verified_domains: Option<Vec<String>>,
 }
 
 /// Create a new Merchant Connector for the merchant account. The connector could be a payment processor / facilitator / acquirer or specialized services like Fraud / Accounting etc."
@@ -803,6 +807,9 @@ pub struct MerchantConnectorUpdate {
         }
     }))]
     pub connector_webhook_details: Option<MerchantConnectorWebhookDetails>,
+
+    /// Verified applepay domains for a particular profile
+    pub applepay_verified_domains: Option<Vec<String>>,
 }
 
 ///Details of FrmConfigs are mentioned here... it should be passed in payment connector create api call, and stored in merchant_connector_table
@@ -1012,8 +1019,6 @@ pub struct BusinessProfileCreate {
     )]
     pub payout_routing_algorithm: Option<serde_json::Value>,
 
-    /// Verified applepay domains for a particular profile
-    pub applepay_verified_domains: Option<Vec<String>>,
 }
 
 #[derive(Clone, Debug, ToSchema, Serialize)]
@@ -1076,8 +1081,6 @@ pub struct BusinessProfileResponse {
     )]
     pub payout_routing_algorithm: Option<serde_json::Value>,
 
-    /// Verified applepay domains for a particular profile
-    pub applepay_verified_domains: Option<Vec<String>>,
 }
 
 #[derive(Clone, Debug, Deserialize, ToSchema)]
@@ -1133,6 +1136,4 @@ pub struct BusinessProfileUpdate {
     )]
     pub payout_routing_algorithm: Option<serde_json::Value>,
 
-    /// Verified applepay domains for a particular profile
-    pub applepay_verified_domains: Option<Vec<String>>,
 }

--- a/crates/api_models/src/verifications.rs
+++ b/crates/api_models/src/verifications.rs
@@ -13,7 +13,7 @@ pub struct ApplepayMerchantVerificationConfigs {
 #[serde(rename_all = "camelCase")]
 pub struct ApplepayMerchantVerificationRequest {
     pub domain_names: Vec<String>,
-    pub business_profile_id: String,
+    pub merchant_connector_account_id: String,
 }
 
 /// Response to be sent for the verify/applepay api

--- a/crates/diesel_models/src/business_profile.rs
+++ b/crates/diesel_models/src/business_profile.rs
@@ -30,8 +30,6 @@ pub struct BusinessProfile {
     pub frm_routing_algorithm: Option<serde_json::Value>,
     pub payout_routing_algorithm: Option<serde_json::Value>,
     pub is_recon_enabled: bool,
-    #[diesel(deserialize_as = super::OptionalDieselArray<String>)]
-    pub applepay_verified_domains: Option<Vec<String>>,
 }
 
 #[derive(Clone, Debug, Insertable, router_derive::DebugAsDisplay)]
@@ -53,8 +51,6 @@ pub struct BusinessProfileNew {
     pub frm_routing_algorithm: Option<serde_json::Value>,
     pub payout_routing_algorithm: Option<serde_json::Value>,
     pub is_recon_enabled: bool,
-    #[diesel(deserialize_as = super::OptionalDieselArray<String>)]
-    pub applepay_verified_domains: Option<Vec<String>>,
 }
 
 #[derive(Clone, Debug, Default, AsChangeset, router_derive::DebugAsDisplay)]
@@ -73,8 +69,6 @@ pub struct BusinessProfileUpdateInternal {
     pub frm_routing_algorithm: Option<serde_json::Value>,
     pub payout_routing_algorithm: Option<serde_json::Value>,
     pub is_recon_enabled: Option<bool>,
-    #[diesel(deserialize_as = super::OptionalDieselArray<String>)]
-    pub applepay_verified_domains: Option<Vec<String>>,
 }
 
 impl From<BusinessProfileNew> for BusinessProfile {
@@ -96,7 +90,6 @@ impl From<BusinessProfileNew> for BusinessProfile {
             frm_routing_algorithm: new.frm_routing_algorithm,
             payout_routing_algorithm: new.payout_routing_algorithm,
             is_recon_enabled: new.is_recon_enabled,
-            applepay_verified_domains: new.applepay_verified_domains,
         }
     }
 }

--- a/crates/diesel_models/src/merchant_connector_account.rs
+++ b/crates/diesel_models/src/merchant_connector_account.rs
@@ -39,6 +39,8 @@ pub struct MerchantConnectorAccount {
     #[diesel(deserialize_as = super::OptionalDieselArray<pii::SecretSerdeValue>)]
     pub frm_config: Option<Vec<Secret<serde_json::Value>>>,
     pub profile_id: Option<String>,
+    #[diesel(deserialize_as = super::OptionalDieselArray<String>)]
+    pub applepay_verified_domains: Option<Vec<String>>,
 }
 
 #[derive(Clone, Debug, Insertable, router_derive::DebugAsDisplay)]
@@ -64,6 +66,8 @@ pub struct MerchantConnectorAccountNew {
     #[diesel(deserialize_as = super::OptionalDieselArray<pii::SecretSerdeValue>)]
     pub frm_config: Option<Vec<Secret<serde_json::Value>>>,
     pub profile_id: Option<String>,
+    #[diesel(deserialize_as = super::OptionalDieselArray<String>)]
+    pub applepay_verified_domains: Option<Vec<String>>,
 }
 
 #[derive(Clone, Debug, AsChangeset, router_derive::DebugAsDisplay)]
@@ -83,6 +87,8 @@ pub struct MerchantConnectorAccountUpdateInternal {
     pub connector_webhook_details: Option<pii::SecretSerdeValue>,
     #[diesel(deserialize_as = super::OptionalDieselArray<pii::SecretSerdeValue>)]
     pub frm_config: Option<Vec<Secret<serde_json::Value>>>,
+    #[diesel(deserialize_as = super::OptionalDieselArray<String>)]
+    pub applepay_verified_domains: Option<Vec<String>>,
 }
 
 impl MerchantConnectorAccountUpdateInternal {

--- a/crates/diesel_models/src/schema.rs
+++ b/crates/diesel_models/src/schema.rs
@@ -78,7 +78,6 @@ diesel::table! {
         frm_routing_algorithm -> Nullable<Jsonb>,
         payout_routing_algorithm -> Nullable<Jsonb>,
         is_recon_enabled -> Bool,
-        applepay_verified_domains -> Nullable<Array<Nullable<Text>>>,
     }
 }
 
@@ -471,6 +470,7 @@ diesel::table! {
         frm_config -> Nullable<Array<Nullable<Jsonb>>>,
         #[max_length = 64]
         profile_id -> Nullable<Varchar>,
+        applepay_verified_domains -> Nullable<Array<Nullable<Text>>>,
     }
 }
 

--- a/crates/router/src/core/admin.rs
+++ b/crates/router/src/core/admin.rs
@@ -676,6 +676,7 @@ pub async fn create_payment_connector(
             None => None,
         },
         profile_id: Some(profile_id.clone()),
+        applepay_verified_domains: req.applepay_verified_domains,
     };
 
     let mca = state
@@ -837,6 +838,7 @@ pub async fn update_payment_connector(
             }
             None => None,
         },
+        applepay_verified_domains: req.applepay_verified_domains,
     };
 
     let updated_mca = db
@@ -1174,7 +1176,6 @@ pub async fn update_business_profile(
         frm_routing_algorithm: request.frm_routing_algorithm,
         payout_routing_algorithm: request.payout_routing_algorithm,
         is_recon_enabled: None,
-        applepay_verified_domains: request.applepay_verified_domains,
     };
 
     let updated_business_profile = db

--- a/crates/router/src/db/merchant_connector_account.rs
+++ b/crates/router/src/db/merchant_connector_account.rs
@@ -649,6 +649,7 @@ impl MerchantConnectorAccountInterface for MockDb {
             modified_at: common_utils::date_time::now(),
             connector_webhook_details: t.connector_webhook_details,
             profile_id: t.profile_id,
+            applepay_verified_domains: t.applepay_verified_domains,
         };
         accounts.push(account.clone());
         account
@@ -843,6 +844,7 @@ mod merchant_connector_account_cache_tests {
             modified_at: date_time::now(),
             connector_webhook_details: None,
             profile_id: Some(profile_id.to_string()),
+            applepay_verified_domains: None,
         };
 
         db.insert_merchant_connector_account(mca.clone(), &merchant_key)

--- a/crates/router/src/routes/app.rs
+++ b/crates/router/src/routes/app.rs
@@ -12,7 +12,7 @@ use super::dummy_connector::*;
 #[cfg(feature = "payouts")]
 use super::payouts::*;
 #[cfg(all(feature = "olap", feature = "kms"))]
-use super::verification::{apple_pay_merchant_registration, retrieve_apple_pay_verified_domains};
+use super::verification::apple_pay_merchant_registration;
 #[cfg(feature = "olap")]
 use super::{admin::*, api_keys::*, disputes::*, files::*};
 use super::{cache::*, health::*};
@@ -588,10 +588,6 @@ impl Verify {
             .service(
                 web::resource("/{merchant_id}/apple_pay")
                     .route(web::post().to(apple_pay_merchant_registration)),
-            )
-            .service(
-                web::resource("/applepay_verified_domains")
-                    .route(web::get().to(retrieve_apple_pay_verified_domains)),
             )
     }
 }

--- a/crates/router/src/routes/verification.rs
+++ b/crates/router/src/routes/verification.rs
@@ -1,5 +1,4 @@
 use actix_web::{web, HttpRequest, Responder};
-#[cfg(all(feature = "olap", feature = "kms"))]
 use api_models::verifications;
 use router_env::{instrument, tracing, Flow};
 
@@ -15,42 +14,20 @@ pub async fn apple_pay_merchant_registration(
     state: web::Data<AppState>,
     req: HttpRequest,
     json_payload: web::Json<verifications::ApplepayMerchantVerificationRequest>,
+    path: web::Path<String>,
 ) -> impl Responder {
     let flow = Flow::Verification;
+    let merchant_id = path.into_inner();
     api::server_wrap(
         flow,
         state.get_ref(),
         &req,
         json_payload,
         |state, _, body| {
-            verification::verify_merchant_creds_for_applepay(state, &req, body, &state.conf.kms)
+            verification::verify_merchant_creds_for_applepay(state, &req, body, &state.conf.kms, merchant_id.clone())
         },
         auth::auth_type(&auth::ApiKeyAuth, &auth::JWTAuth, req.headers()),
     )
     .await
 }
 
-#[instrument(skip_all, fields(flow = ?Flow::Verification))]
-pub async fn retrieve_apple_pay_verified_domains(
-    state: web::Data<AppState>,
-    req: HttpRequest,
-    params: web::Query<verifications::ApplepayGetVerifiedDomainsParam>,
-) -> impl Responder {
-    let flow = Flow::Verification;
-    let business_profile_id = &params.business_profile_id;
-
-    api::server_wrap(
-        flow,
-        state.get_ref(),
-        &req,
-        business_profile_id.clone(),
-        |state, _, _| {
-            verification::get_verified_apple_domains_with_business_profile_id(
-                &*state.store,
-                business_profile_id.clone(),
-            )
-        },
-        auth::auth_type(&auth::ApiKeyAuth, &auth::JWTAuth, req.headers()),
-    )
-    .await
-}

--- a/crates/router/src/types/api/admin.rs
+++ b/crates/router/src/types/api/admin.rs
@@ -70,7 +70,6 @@ impl ForeignTryFrom<storage::business_profile::BusinessProfile> for BusinessProf
             intent_fulfillment_time: item.intent_fulfillment_time,
             frm_routing_algorithm: item.frm_routing_algorithm,
             payout_routing_algorithm: item.payout_routing_algorithm,
-            applepay_verified_domains: item.applepay_verified_domains,
         })
     }
 }
@@ -137,7 +136,6 @@ impl ForeignTryFrom<(domain::MerchantAccount, BusinessProfileCreate)>
                 .payout_routing_algorithm
                 .or(merchant_account.payout_routing_algorithm),
             is_recon_enabled: merchant_account.is_recon_enabled,
-            applepay_verified_domains: request.applepay_verified_domains,
         })
     }
 }

--- a/crates/router/src/types/domain/merchant_connector_account.rs
+++ b/crates/router/src/types/domain/merchant_connector_account.rs
@@ -33,6 +33,7 @@ pub struct MerchantConnectorAccount {
     pub modified_at: time::PrimitiveDateTime,
     pub connector_webhook_details: Option<pii::SecretSerdeValue>,
     pub profile_id: Option<String>,
+    pub applepay_verified_domains: Option<Vec<String>>,
 }
 
 #[derive(Debug)]
@@ -49,6 +50,7 @@ pub enum MerchantConnectorAccountUpdate {
         metadata: Option<pii::SecretSerdeValue>,
         frm_configs: Option<Vec<Secret<serde_json::Value>>>,
         connector_webhook_details: Option<pii::SecretSerdeValue>,
+        applepay_verified_domains: Option<Vec<String>>,
     },
 }
 
@@ -82,6 +84,7 @@ impl behaviour::Conversion for MerchantConnectorAccount {
                 modified_at: self.modified_at,
                 connector_webhook_details: self.connector_webhook_details,
                 profile_id: self.profile_id,
+                applepay_verified_domains: self.applepay_verified_domains,
             },
         )
     }
@@ -119,6 +122,7 @@ impl behaviour::Conversion for MerchantConnectorAccount {
             modified_at: other.modified_at,
             connector_webhook_details: other.connector_webhook_details,
             profile_id: other.profile_id,
+            applepay_verified_domains: other.applepay_verified_domains,
         })
     }
 
@@ -144,6 +148,7 @@ impl behaviour::Conversion for MerchantConnectorAccount {
             modified_at: now,
             connector_webhook_details: self.connector_webhook_details,
             profile_id: self.profile_id,
+            applepay_verified_domains: self.applepay_verified_domains,
         })
     }
 }
@@ -163,6 +168,7 @@ impl From<MerchantConnectorAccountUpdate> for MerchantConnectorAccountUpdateInte
                 metadata,
                 frm_configs,
                 connector_webhook_details,
+                applepay_verified_domains,
             } => Self {
                 merchant_id,
                 connector_type,
@@ -177,6 +183,7 @@ impl From<MerchantConnectorAccountUpdate> for MerchantConnectorAccountUpdateInte
                 frm_config: frm_configs,
                 modified_at: Some(common_utils::date_time::now()),
                 connector_webhook_details,
+                applepay_verified_domains,
             },
         }
     }

--- a/crates/router/src/types/transformers.rs
+++ b/crates/router/src/types/transformers.rs
@@ -667,6 +667,7 @@ impl TryFrom<domain::MerchantConnectorAccount> for api_models::admin::MerchantCo
                 })
                 .transpose()?,
             profile_id: item.profile_id,
+            applepay_verified_domains: item.applepay_verified_domains,
         })
     }
 }

--- a/crates/router/src/utils/verification.rs
+++ b/crates/router/src/utils/verification.rs
@@ -1,48 +1,27 @@
 use actix_web::web;
-#[cfg(all(feature = "olap", feature = "kms"))]
 use api_models::verifications::{self, ApplepayMerchantResponse};
 use common_utils::errors::CustomResult;
-use diesel_models::business_profile;
 use error_stack::{Report, ResultExt};
 #[cfg(feature = "kms")]
 use external_services::kms;
 
 use crate::{
-    core::errors::{self, api_error_response},
-    db::StorageInterface,
+    core::errors::{self, api_error_response, utils::StorageErrorExt},
     headers, logger,
     routes::AppState,
-    services, types, utils,
+    services, types,
+    types::storage,
+    utils,
 };
 
 const APPLEPAY_INTERNAL_MERCHANT_NAME: &str = "Applepay_merchant";
-
-pub async fn get_verified_apple_domains_with_business_profile_id(
-    db: &dyn StorageInterface,
-    profile_id: String,
-) -> CustomResult<
-    services::ApplicationResponse<api_models::verifications::ApplepayVerifiedDomainsResponse>,
-    api_error_response::ApiErrorResponse,
-> {
-    let verified_domains = db
-        .find_business_profile_by_profile_id(&profile_id)
-        .await
-        .change_context(api_error_response::ApiErrorResponse::ResourceIdNotFound)?
-        .applepay_verified_domains
-        .unwrap_or_default();
-    Ok(services::api::ApplicationResponse::Json(
-        api_models::verifications::ApplepayVerifiedDomainsResponse {
-            status_code: 200,
-            verified_domains,
-        },
-    ))
-}
 
 pub async fn verify_merchant_creds_for_applepay(
     state: &AppState,
     _req: &actix_web::HttpRequest,
     body: web::Json<verifications::ApplepayMerchantVerificationRequest>,
     kms_config: &kms::KmsConfig,
+    merchant_id: String,
 ) -> CustomResult<
     services::ApplicationResponse<ApplepayMerchantResponse>,
     api_error_response::ApiErrorResponse,
@@ -110,7 +89,8 @@ pub async fn verify_merchant_creds_for_applepay(
         Ok(_) => {
             check_existence_and_add_domain_to_db(
                 state,
-                body.business_profile_id.clone(),
+                merchant_id,
+                body.merchant_connector_account_id.clone(),
                 body.domain_names.clone(),
             )
             .await
@@ -129,20 +109,33 @@ pub async fn verify_merchant_creds_for_applepay(
         }
     })
 }
-
-// Checks whether or not the domain verified is already present in db if not adds it
 async fn check_existence_and_add_domain_to_db(
     state: &AppState,
-    business_profile_id: String,
+    merchant_id: String,
+    merchant_connector_id: String,
     domain_from_req: Vec<String>,
-) -> CustomResult<business_profile::BusinessProfile, errors::StorageError> {
-    let business_profile = state
+) -> CustomResult<Vec<String>, errors::ApiErrorResponse> {
+    let key_store = state
         .store
-        .find_business_profile_by_profile_id(&business_profile_id)
-        .await?;
-    let business_profile_to_update = business_profile.clone();
-    let mut already_verified_domains = business_profile
+        .get_merchant_key_store_by_merchant_id(
+            &merchant_id,
+            &state.store.get_master_key().to_vec().into(),
+        )
+        .await
+        .to_not_found_response(errors::ApiErrorResponse::InternalServerError)?;
+
+    let merchant_connector_account = state
+        .store
+        .find_by_merchant_connector_account_merchant_id_merchant_connector_id(
+            &merchant_id,
+            &merchant_connector_id,
+            &key_store,
+        )
+        .await.change_context(errors::ApiErrorResponse::InternalServerError)?;
+
+    let mut already_verified_domains = merchant_connector_account
         .applepay_verified_domains
+        .clone()
         .unwrap_or_default();
 
     let mut new_verified_domains: Vec<String> = domain_from_req
@@ -151,30 +144,34 @@ async fn check_existence_and_add_domain_to_db(
         .collect();
 
     already_verified_domains.append(&mut new_verified_domains);
-
-    let update_business_profile = business_profile::BusinessProfileUpdateInternal {
-        applepay_verified_domains: Some(already_verified_domains),
-        profile_name: Some(business_profile.profile_name),
-        modified_at: Some(business_profile.modified_at),
-        return_url: business_profile.return_url,
-        enable_payment_response_hash: Some(business_profile.enable_payment_response_hash),
-        payment_response_hash_key: business_profile.payment_response_hash_key,
-        redirect_to_merchant_with_http_post: Some(
-            business_profile.redirect_to_merchant_with_http_post,
-        ),
-        webhook_details: business_profile.webhook_details,
-        metadata: business_profile.metadata,
-        routing_algorithm: business_profile.routing_algorithm,
-        intent_fulfillment_time: business_profile.intent_fulfillment_time,
-        frm_routing_algorithm: business_profile.frm_routing_algorithm,
-        payout_routing_algorithm: business_profile.payout_routing_algorithm,
-        is_recon_enabled: Some(business_profile.is_recon_enabled),
+    let updated_mca = storage::MerchantConnectorAccountUpdate::Update {
+        merchant_id: None,
+        connector_type: None,
+        connector_name: None,
+        connector_account_details: None,
+        test_mode: None,
+        disabled: None,
+        merchant_connector_id: None,
+        payment_methods_enabled: None,
+        metadata: None,
+        frm_configs: None,
+        connector_webhook_details: None,
+        applepay_verified_domains: Some(already_verified_domains.clone()),
     };
-
     state
         .store
-        .update_business_profile_by_profile_id(business_profile_to_update, update_business_profile)
+        .update_merchant_connector_account(
+            merchant_connector_account,
+            updated_mca.into(),
+            &key_store,
+        )
         .await
+        .change_context(errors::ApiErrorResponse::InternalServerError)
+        .attach_printable_lazy(|| {
+            format!("Failed while updating MerchantConnectorAccount: id: {merchant_connector_id}")
+        })?;
+
+    Ok(already_verified_domains.clone())
 }
 
 fn log_applepay_verification_response_if_error(

--- a/migrations/2023-09-08-112817_applepay_verified_domains_in_business_profile/down.sql
+++ b/migrations/2023-09-08-112817_applepay_verified_domains_in_business_profile/down.sql
@@ -1,2 +1,0 @@
-ALTER TABLE business_profile DROP COLUMN IF EXISTS applepay_verified_domains;
-

--- a/migrations/2023-09-13-075226_applepay_verified_domains_in_mca/down.sql
+++ b/migrations/2023-09-13-075226_applepay_verified_domains_in_mca/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE merchant_connector_account DROP COLUMN IF EXISTS applepay_verified_domains;

--- a/migrations/2023-09-13-075226_applepay_verified_domains_in_mca/up.sql
+++ b/migrations/2023-09-13-075226_applepay_verified_domains_in_mca/up.sql
@@ -1,3 +1,2 @@
-ALTER TABLE business_profile
+ALTER TABLE merchant_connector_account
 ADD COLUMN IF NOT EXISTS applepay_verified_domains text[];
-


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
We are refactoring the previously added applepay_verified_domains from business_profile to mca table and the request body chamges as now we need to pass `merchant_connector_account_id` instead of `business_profile_id`.

Else all stuffs remains same as earlier.

### Additional Changes

- [x] This PR modifies the API contract
- [x] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
