### PR TITLE
refactor(connector): [Stripe] add support for more incoming woocommerce Stripe disputes webhooks

### DIFF
--- a/crates/router/src/connector/stripe.rs
+++ b/crates/router/src/connector/stripe.rs
@@ -1869,11 +1869,14 @@ impl api::IncomingWebhook for Stripe {
             stripe::WebhookEventType::PaymentIntentRequiresAction => {
                 api::IncomingWebhookEvent::PaymentActionRequired
             }
+            stripe::WebhookEventType::ChargeDisputeFundsWithdrawn => {
+                api::IncomingWebhookEvent::DisputeLost
+            }
+            stripe::WebhookEventType::ChargeDisputeFundsReinstated => {
+                api::IncomingWebhookEvent::DisputeWon
+            }
             stripe::WebhookEventType::Unknown
             | stripe::WebhookEventType::ChargeCaptured
-            | stripe::WebhookEventType::ChargeDisputeCaptured
-            | stripe::WebhookEventType::ChargeDisputeFundsReinstated
-            | stripe::WebhookEventType::ChargeDisputeFundsWithdrawn
             | stripe::WebhookEventType::ChargeExpired
             | stripe::WebhookEventType::ChargeFailed
             | stripe::WebhookEventType::ChargePending

--- a/crates/router/src/connector/stripe/transformers.rs
+++ b/crates/router/src/connector/stripe/transformers.rs
@@ -3055,8 +3055,6 @@ pub enum WebhookEventType {
     PaymentIntentFailed,
     #[serde(rename = "payment_intent.succeeded")]
     PaymentIntentSucceed,
-    #[serde(rename = "charge.dispute.captured")]
-    ChargeDisputeCaptured,
     #[serde(rename = "charge.dispute.created")]
     DisputeCreated,
     #[serde(rename = "charge.dispute.closed")]


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
Add support for some more dispute webhooks events for stripe which is : `Charge Dispute Funds Withdrawn`, `Charge Dispute Funds Reinstated`.
I also removed `Charge Dispute Captured` event as latest stripe documentation does not have this event.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
Can not be tested.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
