### PR TITLE
fix: payment status in trustpay 3ds and wallets

### DIFF
--- a/crates/router/src/connector/trustpay/transformers.rs
+++ b/crates/router/src/connector/trustpay/transformers.rs
@@ -1073,8 +1073,8 @@ pub fn get_apple_pay_session<F, T>(
             ))),
             connector_response_reference_id: None,
         }),
-        // We don't get status from TrustPay but status should be pending by default for session response
-        status: diesel_models::enums::AttemptStatus::Pending,
+        // We don't get status from TrustPay but status should be AuthenticationPending by default for session response
+        status: diesel_models::enums::AttemptStatus::AuthenticationPending,
         ..item.data
     })
 }
@@ -1120,8 +1120,8 @@ pub fn get_google_pay_session<F, T>(
             ))),
             connector_response_reference_id: None,
         }),
-        // We don't get status from TrustPay but status should be pending by default for session response
-        status: diesel_models::enums::AttemptStatus::Pending,
+        // We don't get status from TrustPay but status should be AuthenticationPending by default for session response
+        status: diesel_models::enums::AttemptStatus::AuthenticationPending,
         ..item.data
     })
 }

--- a/crates/router/src/connector/trustpay/transformers.rs
+++ b/crates/router/src/connector/trustpay/transformers.rs
@@ -430,29 +430,35 @@ fn is_payment_successful(payment_status: &str) -> CustomResult<bool, errors::Con
 fn get_pending_status_based_on_redirect_url(redirect_url: Option<Url>) -> enums::AttemptStatus {
     match redirect_url {
         Some(_url) => enums::AttemptStatus::AuthenticationPending,
-        None => enums::AttemptStatus::Authorizing,
+        None => enums::AttemptStatus::Pending,
     }
 }
 
 fn get_transaction_status(
-    payment_status: &str,
+    payment_status: Option<String>,
     redirect_url: Option<Url>,
 ) -> CustomResult<(enums::AttemptStatus, Option<String>), errors::ConnectorError> {
-    let (is_failed, failure_message) = is_payment_failed(payment_status);
-    let pending_status = get_pending_status_based_on_redirect_url(redirect_url);
-    if payment_status == "000.200.000" {
-        return Ok((pending_status, None));
+    // We don't get payment_status only in case, when the user doesn't complete the authentication step.
+    // If we receive status, then return the proper status based on the connector response
+    if let Some(payment_status) = payment_status {
+        let (is_failed, failure_message) = is_payment_failed(&payment_status);
+        if is_failed {
+            return Ok((
+                enums::AttemptStatus::Failure,
+                Some(failure_message.to_string()),
+            ));
+        }
+
+        if is_payment_successful(&payment_status)? {
+            return Ok((enums::AttemptStatus::Charged, None));
+        }
+
+        let pending_status = get_pending_status_based_on_redirect_url(redirect_url);
+
+        Ok((pending_status, None))
+    } else {
+        Ok((enums::AttemptStatus::AuthenticationPending, None))
     }
-    if is_failed {
-        return Ok((
-            enums::AttemptStatus::AuthorizationFailed,
-            Some(failure_message.to_string()),
-        ));
-    }
-    if is_payment_successful(payment_status)? {
-        return Ok((enums::AttemptStatus::Charged, None));
-    }
-    Ok((pending_status, None))
 }
 
 #[derive(Debug, Serialize, Deserialize, Eq, PartialEq, Clone)]
@@ -571,15 +577,11 @@ fn handle_cards_response(
     ),
     errors::ConnectorError,
 > {
-    // By default, payment status is pending(000.200.000 status code)
     let (status, msg) = get_transaction_status(
-        response
-            .payment_status
-            .to_owned()
-            .unwrap_or("000.200.000".to_string())
-            .as_str(),
-        response.redirect_url.clone(),
+        response.payment_status.to_owned(),
+        response.redirect_url.to_owned(),
     )?;
+
     let form_fields = response.redirect_params.unwrap_or_default();
     let redirection_data = response
         .redirect_url


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix

## Description
<!-- Describe your changes in detail -->
This PR fixes:
1. Change payment status from pending to requires_customer_action in the confirm call for wallets, as it would invoke sdk.
2. Change the payment status to requires_customer_action from pending when user do not authenticate


<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
3. `crates/router/src/configs`
4. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
Fix the status change



## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
