### PR TITLE
fix: make amount_capturable zero when payment intent status is processing

### DIFF
--- a/crates/router/src/core/payments/operations/payment_response.rs
+++ b/crates/router/src/core/payments/operations/payment_response.rs
@@ -17,7 +17,10 @@ use crate::{
     services::RedirectForm,
     types::{
         self, api,
-        storage::{self, enums, payment_attempt::PaymentAttemptExt},
+        storage::{
+            self, enums,
+            payment_attempt::{AttemptStatusExt, PaymentAttemptExt},
+        },
         transformers::ForeignTryFrom,
         CaptureSyncResponse,
     },
@@ -318,7 +321,11 @@ async fn payment_response_update_tracker<F: Clone, T: types::Capturable>(
                             error_message: Some(Some(err.message)),
                             error_code: Some(Some(err.code)),
                             error_reason: Some(err.reason),
-                            amount_capturable: if status.is_terminal_status() {
+                            amount_capturable: if status.is_terminal_status()
+                                || router_data
+                                    .status
+                                    .maps_to_intent_status(enums::IntentStatus::Processing)
+                            {
                                 Some(0)
                             } else {
                                 None
@@ -430,7 +437,11 @@ async fn payment_response_update_tracker<F: Clone, T: types::Capturable>(
                                 error_message: error_status.clone(),
                                 error_reason: error_status,
                                 connector_response_reference_id,
-                                amount_capturable: if router_data.status.is_terminal_status() {
+                                amount_capturable: if router_data.status.is_terminal_status()
+                                    || router_data
+                                        .status
+                                        .maps_to_intent_status(enums::IntentStatus::Processing)
+                                {
                                     Some(0)
                                 } else {
                                     None

--- a/crates/router/src/types/storage/payment_attempt.rs
+++ b/crates/router/src/types/storage/payment_attempt.rs
@@ -69,6 +69,16 @@ impl PaymentAttemptExt for PaymentAttempt {
     }
 }
 
+pub trait AttemptStatusExt {
+    fn maps_to_intent_status(self, intent_status: enums::IntentStatus) -> bool;
+}
+
+impl AttemptStatusExt for enums::AttemptStatus {
+    fn maps_to_intent_status(self, intent_status: enums::IntentStatus) -> bool {
+        enums::IntentStatus::foreign_from(self) == intent_status
+    }
+}
+
 #[cfg(test)]
 #[cfg(feature = "dummy_connector")]
 mod tests {


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
amount_capturable must be made `0` when payment status goes to `processing`. Because from `processing` status, the payment can go to either `success` or `failure`. Both are terminal status.


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
