### PR TITLE
refactor: add instrument to trackers for payment_confirm

### DIFF
--- a/crates/router/src/core/payments.rs
+++ b/crates/router/src/core/payments.rs
@@ -548,6 +548,7 @@ impl PaymentRedirectFlow for PaymentRedirectSync {
 }
 
 #[allow(clippy::too_many_arguments)]
+#[instrument(skip_all)]
 pub async fn call_connector_service<F, RouterDReq, ApiRequest>(
     state: &AppState,
     merchant_account: &domain::MerchantAccount,
@@ -1038,6 +1039,7 @@ pub fn is_preprocessing_required_for_wallets(connector_name: String) -> bool {
     connector_name == *"trustpay" || connector_name == *"payme"
 }
 
+#[instrument(skip_all)]
 pub async fn construct_profile_id_and_get_mca<'a, F>(
     state: &'a AppState,
     merchant_account: &domain::MerchantAccount,

--- a/crates/router/src/core/payments/helpers.rs
+++ b/crates/router/src/core/payments/helpers.rs
@@ -103,6 +103,7 @@ pub fn filter_mca_based_on_business_profile(
     }
 }
 
+#[instrument(skip_all)]
 pub async fn get_address_for_payment_request(
     db: &dyn StorageInterface,
     req_address: Option<&api::Address>,
@@ -975,6 +976,7 @@ pub fn validate_customer_details_in_request(
 
 /// Get the customer details from customer field if present
 /// or from the individual fields in `PaymentsRequest`
+#[instrument(skip_all)]
 pub fn get_customer_details_from_request(
     request: &api_models::payments::PaymentsRequest,
 ) -> CustomerDetails {
@@ -2086,6 +2088,7 @@ pub(crate) fn validate_payment_status_against_not_allowed_statuses(
     })
 }
 
+#[instrument(skip_all)]
 pub(crate) fn validate_pm_or_token_given(
     payment_method: &Option<api_enums::PaymentMethod>,
     payment_method_data: &Option<api::PaymentMethodData>,
@@ -2364,6 +2367,7 @@ mod tests {
 }
 
 // This function will be removed after moving this functionality to server_wrap and using cache instead of config
+#[instrument(skip_all)]
 pub async fn insert_merchant_connector_creds_to_config(
     db: &dyn StorageInterface,
     merchant_id: &str,
@@ -2551,6 +2555,7 @@ pub fn router_data_type_conversion<F1, F2, Req1, Req2, Res1, Res2>(
     }
 }
 
+#[instrument(skip_all)]
 pub fn get_attempt_type(
     payment_intent: &PaymentIntent,
     payment_attempt: &PaymentAttempt,
@@ -2740,6 +2745,7 @@ impl AttemptType {
         }
     }
 
+    #[instrument(skip_all)]
     pub async fn modify_payment_intent_and_payment_attempt(
         &self,
         request: &api::PaymentsRequest,
@@ -2793,6 +2799,7 @@ impl AttemptType {
         }
     }
 
+    #[instrument(skip_all)]
     pub async fn get_or_insert_connector_response(
         &self,
         payment_attempt: &PaymentAttempt,
@@ -2821,6 +2828,7 @@ impl AttemptType {
         }
     }
 
+    #[instrument(skip_all)]
     pub async fn get_connector_response(
         &self,
         db: &dyn StorageInterface,
@@ -2927,6 +2935,7 @@ mod test {
     }
 }
 
+#[instrument(skip_all)]
 pub async fn get_additional_payment_data(
     pm_data: &api_models::payments::PaymentMethodData,
     db: &dyn StorageInterface,

--- a/crates/router/src/core/payments/helpers.rs
+++ b/crates/router/src/core/payments/helpers.rs
@@ -2440,6 +2440,7 @@ impl MerchantConnectorAccountType {
 
 /// Query for merchant connector account either by business label or profile id
 /// If profile_id is passed use it, or use connector_label to query merchant connector account
+#[instrument(skip_all)]
 pub async fn get_merchant_connector_account(
     state: &AppState,
     merchant_id: &str,

--- a/crates/router/src/core/payments/operations/payment_confirm.rs
+++ b/crates/router/src/core/payments/operations/payment_confirm.rs
@@ -31,6 +31,7 @@ use crate::{
 pub struct PaymentConfirm;
 #[async_trait]
 impl<F: Send + Clone> GetTracker<F, PaymentData<F>, api::PaymentsRequest> for PaymentConfirm {
+    #[instrument(skip_all)]
     async fn get_trackers<'a>(
         &'a self,
         state: &'a AppState,
@@ -429,6 +430,7 @@ impl<F: Clone + Send> Domain<F, api::PaymentsRequest> for PaymentConfirm {
 
 #[async_trait]
 impl<F: Clone> UpdateTracker<F, PaymentData<F>, api::PaymentsRequest> for PaymentConfirm {
+    #[instrument(skip_all)]
     async fn update_trackers<'b>(
         &'b self,
         db: &dyn StorageInterface,

--- a/crates/router/src/core/payments/operations/payment_response.rs
+++ b/crates/router/src/core/payments/operations/payment_response.rs
@@ -4,6 +4,7 @@ use async_trait::async_trait;
 use error_stack::ResultExt;
 use futures::FutureExt;
 use router_derive;
+use router_env::{instrument, tracing};
 
 use super::{Operation, PostUpdateTracker};
 use crate::{
@@ -276,6 +277,7 @@ impl<F: Clone> PostUpdateTracker<F, PaymentData<F>, types::CompleteAuthorizeData
     }
 }
 
+#[instrument(skip_all)]
 async fn payment_response_update_tracker<F: Clone, T: types::Capturable>(
     db: &dyn StorageInterface,
     _payment_id: &api::PaymentIdType,

--- a/crates/router/src/db/address.rs
+++ b/crates/router/src/db/address.rs
@@ -1,6 +1,7 @@
 use common_utils::ext_traits::AsyncExt;
 use diesel_models::address::AddressUpdateInternal;
 use error_stack::{IntoReport, ResultExt};
+use router_env::{instrument, tracing};
 
 use super::{MockDb, Store};
 use crate::{
@@ -69,6 +70,7 @@ impl AddressInterface for Store {
             .await
     }
 
+    #[instrument(skip_all)]
     async fn update_address(
         &self,
         address_id: String,
@@ -89,6 +91,7 @@ impl AddressInterface for Store {
             .await
     }
 
+    #[instrument(skip_all)]
     async fn insert_address(
         &self,
         address: domain::Address,
@@ -172,6 +175,7 @@ impl AddressInterface for MockDb {
         }
     }
 
+    #[instrument(skip_all)]
     async fn update_address(
         &self,
         address_id: String,
@@ -201,6 +205,7 @@ impl AddressInterface for MockDb {
         }
     }
 
+    #[instrument(skip_all)]
     async fn insert_address(
         &self,
         address_new: domain::Address,

--- a/crates/router/src/db/capture.rs
+++ b/crates/router/src/db/capture.rs
@@ -1,3 +1,5 @@
+use router_env::{instrument, tracing};
+
 use super::MockDb;
 use crate::{
     core::errors::{self, CustomResult},
@@ -199,6 +201,7 @@ impl CaptureInterface for MockDb {
         Ok(capture)
     }
 
+    #[instrument(skip_all)]
     async fn update_capture_with_capture_id(
         &self,
         _this: types::Capture,

--- a/crates/router/src/db/cards_info.rs
+++ b/crates/router/src/db/cards_info.rs
@@ -1,4 +1,5 @@
 use error_stack::IntoReport;
+use router_env::{instrument, tracing};
 
 use crate::{
     connection,
@@ -18,6 +19,7 @@ pub trait CardsInfoInterface {
 
 #[async_trait::async_trait]
 impl CardsInfoInterface for Store {
+    #[instrument(skip_all)]
     async fn get_card_info(
         &self,
         card_iin: &str,
@@ -32,6 +34,7 @@ impl CardsInfoInterface for Store {
 
 #[async_trait::async_trait]
 impl CardsInfoInterface for MockDb {
+    #[instrument(skip_all)]
     async fn get_card_info(
         &self,
         card_iin: &str,

--- a/crates/router/src/db/configs.rs
+++ b/crates/router/src/db/configs.rs
@@ -1,5 +1,6 @@
 use diesel_models::configs::ConfigUpdateInternal;
 use error_stack::{IntoReport, ResultExt};
+use router_env::{instrument, tracing};
 use storage_impl::redis::{
     cache::{CacheKind, CONFIG_CACHE},
     kv_store::RedisConnInterface,
@@ -47,6 +48,7 @@ pub trait ConfigInterface {
 
 #[async_trait::async_trait]
 impl ConfigInterface for Store {
+    #[instrument(skip_all)]
     async fn insert_config(
         &self,
         config: storage::ConfigNew,
@@ -123,6 +125,7 @@ impl ConfigInterface for Store {
 
 #[async_trait::async_trait]
 impl ConfigInterface for MockDb {
+    #[instrument(skip_all)]
     async fn insert_config(
         &self,
         config: storage::ConfigNew,

--- a/crates/router/src/db/connector_response.rs
+++ b/crates/router/src/db/connector_response.rs
@@ -1,4 +1,5 @@
 use error_stack::{IntoReport, ResultExt};
+use router_env::{instrument, tracing};
 
 use super::{MockDb, Store};
 use crate::{
@@ -33,6 +34,7 @@ pub trait ConnectorResponseInterface {
 
 #[async_trait::async_trait]
 impl ConnectorResponseInterface for Store {
+    #[instrument(skip_all)]
     async fn insert_connector_response(
         &self,
         connector_response: storage::ConnectorResponseNew,
@@ -46,6 +48,7 @@ impl ConnectorResponseInterface for Store {
             .into_report()
     }
 
+    #[instrument(skip_all)]
     async fn find_connector_response_by_payment_id_merchant_id_attempt_id(
         &self,
         payment_id: &str,
@@ -81,6 +84,7 @@ impl ConnectorResponseInterface for Store {
 
 #[async_trait::async_trait]
 impl ConnectorResponseInterface for MockDb {
+    #[instrument(skip_all)]
     async fn insert_connector_response(
         &self,
         new: storage::ConnectorResponseNew,
@@ -107,6 +111,7 @@ impl ConnectorResponseInterface for MockDb {
         Ok(response)
     }
 
+    #[instrument(skip_all)]
     async fn find_connector_response_by_payment_id_merchant_id_attempt_id(
         &self,
         _payment_id: &str,

--- a/crates/router/src/db/customers.rs
+++ b/crates/router/src/db/customers.rs
@@ -1,6 +1,7 @@
 use common_utils::ext_traits::AsyncExt;
 use error_stack::{IntoReport, ResultExt};
 use masking::PeekInterface;
+use router_env::{instrument, tracing};
 
 use super::{MockDb, Store};
 use crate::{
@@ -95,6 +96,7 @@ impl CustomerInterface for Store {
         })
     }
 
+    #[instrument(skip_all)]
     async fn update_customer_by_customer_id_merchant_id(
         &self,
         customer_id: String,
@@ -207,6 +209,7 @@ impl CustomerInterface for MockDb {
             .transpose()
     }
 
+    #[instrument(skip_all)]
     async fn update_customer_by_customer_id_merchant_id(
         &self,
         _customer_id: String,

--- a/crates/storage_impl/src/payments/payment_attempt.rs
+++ b/crates/storage_impl/src/payments/payment_attempt.rs
@@ -23,6 +23,7 @@ use diesel_models::{
 };
 use error_stack::{IntoReport, ResultExt};
 use redis_interface::HsetnxReply;
+use router_env::{instrument, tracing};
 
 use crate::{
     lookup::ReverseLookupInterface,
@@ -36,6 +37,7 @@ use crate::{
 
 #[async_trait::async_trait]
 impl<T: DatabaseStore> PaymentAttemptInterface for RouterStore<T> {
+    #[instrument(skip_all)]
     async fn insert_payment_attempt(
         &self,
         payment_attempt: PaymentAttemptNew,
@@ -53,6 +55,7 @@ impl<T: DatabaseStore> PaymentAttemptInterface for RouterStore<T> {
             .map(PaymentAttempt::from_storage_model)
     }
 
+    #[instrument(skip_all)]
     async fn update_payment_attempt_with_attempt_id(
         &self,
         this: PaymentAttempt,
@@ -279,6 +282,7 @@ impl<T: DatabaseStore> PaymentAttemptInterface for RouterStore<T> {
 
 #[async_trait::async_trait]
 impl<T: DatabaseStore> PaymentAttemptInterface for KVRouterStore<T> {
+    #[instrument(skip_all)]
     async fn insert_payment_attempt(
         &self,
         payment_attempt: PaymentAttemptNew,
@@ -403,6 +407,7 @@ impl<T: DatabaseStore> PaymentAttemptInterface for KVRouterStore<T> {
         }
     }
 
+    #[instrument(skip_all)]
     async fn update_payment_attempt_with_attempt_id(
         &self,
         this: PaymentAttempt,
@@ -616,6 +621,7 @@ impl<T: DatabaseStore> PaymentAttemptInterface for KVRouterStore<T> {
         }
     }
 
+    #[instrument(skip_all)]
     async fn find_payment_attempt_by_payment_id_merchant_id_attempt_id(
         &self,
         payment_id: &str,

--- a/crates/storage_impl/src/payments/payment_attempt.rs
+++ b/crates/storage_impl/src/payments/payment_attempt.rs
@@ -135,6 +135,7 @@ impl<T: DatabaseStore> PaymentAttemptInterface for RouterStore<T> {
         .map(PaymentAttempt::from_storage_model)
     }
 
+    #[instrument(skip_all)]
     async fn find_payment_attempt_by_payment_id_merchant_id_attempt_id(
         &self,
         payment_id: &str,

--- a/crates/storage_impl/src/payments/payment_intent.rs
+++ b/crates/storage_impl/src/payments/payment_intent.rs
@@ -30,9 +30,9 @@ use diesel_models::{
 };
 use error_stack::{IntoReport, ResultExt};
 use redis_interface::HsetnxReply;
-use router_env::{instrument, tracing};
 #[cfg(feature = "olap")]
 use router_env::logger;
+use router_env::{instrument, tracing};
 
 use crate::{
     redis::kv_store::{PartitionKey, RedisConnInterface},

--- a/crates/storage_impl/src/payments/payment_intent.rs
+++ b/crates/storage_impl/src/payments/payment_intent.rs
@@ -30,6 +30,7 @@ use diesel_models::{
 };
 use error_stack::{IntoReport, ResultExt};
 use redis_interface::HsetnxReply;
+use router_env::{instrument, tracing};
 #[cfg(feature = "olap")]
 use router_env::logger;
 
@@ -125,6 +126,7 @@ impl<T: DatabaseStore> PaymentIntentInterface for KVRouterStore<T> {
         }
     }
 
+    #[instrument(skip_all)]
     async fn update_payment_intent(
         &self,
         this: PaymentIntent,

--- a/crates/storage_impl/src/payments/payment_intent.rs
+++ b/crates/storage_impl/src/payments/payment_intent.rs
@@ -182,6 +182,7 @@ impl<T: DatabaseStore> PaymentIntentInterface for KVRouterStore<T> {
         }
     }
 
+    #[instrument(skip_all)]
     async fn find_payment_intent_by_payment_id_merchant_id(
         &self,
         payment_id: &str,
@@ -325,6 +326,7 @@ impl<T: DatabaseStore> PaymentIntentInterface for crate::RouterStore<T> {
             .map(PaymentIntent::from_storage_model)
     }
 
+    #[instrument(skip_all)]
     async fn find_payment_intent_by_payment_id_merchant_id(
         &self,
         payment_id: &str,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Refactoring

## Description
<!-- Describe your changes in detail -->
This PR adds `#[instrument(skip_all)]` flag to all db functions in trackers for `payment_confirm.rs`.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Compiles

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code