### PR TITLE
ci(postman): Fix Paypal capture assertion failure

### DIFF
--- a/postman/collection-dir/paypal/Flow Testcases/Happy Cases/Scenario2-Create payment with confirm false/Payments - Confirm/event.test.js
+++ b/postman/collection-dir/paypal/Flow Testcases/Happy Cases/Scenario2-Create payment with confirm false/Payments - Confirm/event.test.js
@@ -88,12 +88,12 @@ if (jsonData?.amount) {
   );
 }
 
-// Response body should have value "6540" for "amount_capturable"
+// Response body should have value "0" for "amount_capturable"
 if (jsonData?.amount) {
   pm.test(
     "[post]:://payments/:id/capture - Content check if value for 'amount_capturable' matches 'amount - 0'",
     function () {
-      pm.expect(jsonData.amount_capturable).to.eql(6540);
+      pm.expect(jsonData.amount_capturable).to.eql(0);
     },
   );
 }

--- a/postman/collection-dir/paypal/Flow Testcases/Happy Cases/Scenario2-Create payment with confirm false/Payments - Retrieve/event.test.js
+++ b/postman/collection-dir/paypal/Flow Testcases/Happy Cases/Scenario2-Create payment with confirm false/Payments - Retrieve/event.test.js
@@ -85,12 +85,12 @@ if (jsonData?.amount) {
   );
 }
 
-// Response body should have value "6540" for "amount_capturable"
+// Response body should have value "0" for "amount_capturable"
 if (jsonData?.amount) {
   pm.test(
     "[post]:://payments/:id/capture - Content check if value for 'amount_capturable' matches 'amount - 0'",
     function () {
-      pm.expect(jsonData.amount_capturable).to.eql(6540);
+      pm.expect(jsonData.amount_capturable).to.eql(0);
     },
   );
 }

--- a/postman/collection-dir/paypal/Flow Testcases/Happy Cases/Scenario3-Create payment without PMD/Payments - Confirm/event.test.js
+++ b/postman/collection-dir/paypal/Flow Testcases/Happy Cases/Scenario3-Create payment without PMD/Payments - Confirm/event.test.js
@@ -88,12 +88,12 @@ if (jsonData?.amount) {
   );
 }
 
-// Response body should have value "6540" for "amount_capturable"
+// Response body should have value "0" for "amount_capturable"
 if (jsonData?.amount) {
   pm.test(
     "[post]:://payments/:id/capture - Content check if value for 'amount_capturable' matches 'amount - 0'",
     function () {
-      pm.expect(jsonData.amount_capturable).to.eql(6540);
+      pm.expect(jsonData.amount_capturable).to.eql(0);
     },
   );
 }

--- a/postman/collection-dir/paypal/Flow Testcases/Happy Cases/Scenario3-Create payment without PMD/Payments - Retrieve/event.test.js
+++ b/postman/collection-dir/paypal/Flow Testcases/Happy Cases/Scenario3-Create payment without PMD/Payments - Retrieve/event.test.js
@@ -85,12 +85,12 @@ if (jsonData?.amount) {
   );
 }
 
-// Response body should have value "6540" for "amount_capturable"
+// Response body should have value "0" for "amount_capturable"
 if (jsonData?.amount) {
   pm.test(
     "[post]:://payments/:id/capture - Content check if value for 'amount_capturable' matches 'amount - 0'",
     function () {
-      pm.expect(jsonData.amount_capturable).to.eql(6540);
+      pm.expect(jsonData.amount_capturable).to.eql(0);
     },
   );
 }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [x] CI/CD

## Description
<!-- Describe your changes in detail -->
This PR fixes assertion issue with Paypal. Amount capturable should 0 after it goes to terminal state

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
Fix it

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Ran against integ environment
<img width="510" alt="image" src="https://github.com/juspay/hyperswitch/assets/69745008/ba924f7c-2b70-431f-8299-62952134afba">

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added unit tests for my changes where possible
