### PR TITLE
fix(router): move `get_connector_tokenization_action_when_confirm_true` above `call_create_connector_customer_if_required`

### DIFF
--- a/crates/router/src/core/payments.rs
+++ b/crates/router/src/core/payments.rs
@@ -594,6 +594,15 @@ where
     )
     .await?;
 
+    let (pd, tokenization_action) = get_connector_tokenization_action_when_confirm_true(
+        state,
+        operation,
+        payment_data,
+        validate_result,
+        &merchant_connector_account,
+    )
+    .await?;
+
     let updated_customer = call_create_connector_customer_if_required(
         state,
         customer,
@@ -603,14 +612,6 @@ where
     )
     .await?;
 
-    let (pd, tokenization_action) = get_connector_tokenization_action_when_confirm_true(
-        state,
-        operation,
-        payment_data,
-        validate_result,
-        &merchant_connector_account,
-    )
-    .await?;
     *payment_data = pd;
 
     let mut router_data = payment_data

--- a/crates/router/src/core/payments.rs
+++ b/crates/router/src/core/payments.rs
@@ -603,6 +603,8 @@ where
     )
     .await?;
 
+    *payment_data = pd;
+
     let updated_customer = call_create_connector_customer_if_required(
         state,
         customer,
@@ -611,8 +613,6 @@ where
         payment_data,
     )
     .await?;
-
-    *payment_data = pd;
 
     let mut router_data = payment_data
         .construct_router_data(


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
This pr includes the changes to move the `get_connector_tokenization_action_when_confirm_true` above `call_create_connector_customer_if_required`.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
This is required because when a payment is created with confirm false, a payment token is returned. Then the token is passed in the confirm call in which we fetch the payment_method_data with the help of the passed token.  This fetch operation happens in the `get_connector_tokenization_action_when_confirm_true` as this function was called after the call_create_connector_customer_if_required payment_method_data was not available for call_create_connector_customer_if_required and hence construct router data in call_create_connector_customer_if_required was failing.


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Stripe
<img width="1173" alt="Screenshot 2023-09-15 at 12 59 38 PM" src="https://github.com/juspay/hyperswitch/assets/83439957/51a664d8-ded7-4c99-83ae-5a9e7ebfdb5c">
<img width="1218" alt="Screenshot 2023-09-15 at 1 01 05 PM" src="https://github.com/juspay/hyperswitch/assets/83439957/2947e037-916a-4af5-8526-8b9199539906">
Bluesnap
<img width="1218" alt="Screenshot 2023-09-15 at 1 05 33 PM" src="https://github.com/juspay/hyperswitch/assets/83439957/5ee19e1e-5a16-4c9c-8f89-2e3f9bb25262">
<img width="1219" alt="Screenshot 2023-09-15 at 1 05 22 PM" src="https://github.com/juspay/hyperswitch/assets/83439957/66470bd7-389f-4f4b-acf8-6627f8808286">
Stripe mandates
<img width="1232" alt="Screenshot 2023-09-15 at 3 08 24 PM" src="https://github.com/juspay/hyperswitch/assets/83439957/f0c3059a-ed89-40dc-a3c8-cd107e92cbc1">
<img width="1224" alt="Screenshot 2023-09-15 at 3 08 38 PM" src="https://github.com/juspay/hyperswitch/assets/83439957/9c1d0c70-4212-493e-933a-bdf0cb976164">

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
