### PR TITLE
fix: remove x-request-id from headers before connector calls

### DIFF
--- a/crates/router/src/services/api.rs
+++ b/crates/router/src/services/api.rs
@@ -453,17 +453,7 @@ pub async fn send_request(
         request.certificate_key,
     )?;
 
-    let mut headers_with_request_id = request.headers;
-    headers_with_request_id.insert((
-        crate::headers::X_REQUEST_ID.to_string(),
-        state
-            .api_client
-            .get_request_id()
-            .ok_or(errors::ApiClientError::InternalServerErrorReceived)
-            .into_report()?
-            .into(),
-    ));
-    let headers = headers_with_request_id.construct_header_map()?;
+    let headers = request.headers.construct_header_map()?;
     let metrics_tag = router_env::opentelemetry::KeyValue {
         key: consts::METRICS_HOST_TAG_NAME.into(),
         value: url.host_str().unwrap_or_default().to_string().into(),


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
Removing x-request-id before connector calls


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
