### PR TITLE
refactor(connector): [Payme]Enhance currency Mapping with ConnectorCurrencyCommon Trait 

### DIFF
--- a/crates/router/src/connector/payme.rs
+++ b/crates/router/src/connector/payme.rs
@@ -11,7 +11,7 @@ use transformers as payme;
 
 use crate::{
     configs::settings,
-    connector::utils as connector_utils,
+    connector::{utils as connector_utils, utils::PaymentsPreProcessingData},
     core::{
         errors::{self, CustomResult},
         payments,
@@ -63,6 +63,10 @@ where
 impl ConnectorCommon for Payme {
     fn id(&self) -> &'static str {
         "payme"
+    }
+
+    fn get_currency_unit(&self) -> api::CurrencyUnit {
+        api::CurrencyUnit::Minor
     }
 
     fn common_get_content_type(&self) -> &'static str {
@@ -249,7 +253,11 @@ impl
         &self,
         req: &types::PaymentsPreProcessingRouterData,
     ) -> CustomResult<Option<types::RequestBody>, errors::ConnectorError> {
-        let req_obj = payme::GenerateSaleRequest::try_from(req)?;
+        let amount = req.request.get_amount()?;
+        let currency = req.request.get_currency()?;
+        let connector_router_data =
+            payme::PaymeRouterData::try_from((&self.get_currency_unit(), currency, amount, req))?;
+        let req_obj = payme::GenerateSaleRequest::try_from(&connector_router_data)?;
         let payme_req = types::RequestBody::log_and_get_request_body(
             &req_obj,
             utils::Encode::<payme::GenerateSaleRequest>::encode_to_string_of_json,
@@ -464,7 +472,13 @@ impl ConnectorIntegration<api::Authorize, types::PaymentsAuthorizeData, types::P
         &self,
         req: &types::PaymentsAuthorizeRouterData,
     ) -> CustomResult<Option<types::RequestBody>, errors::ConnectorError> {
-        let req_obj = payme::PaymePaymentRequest::try_from(req)?;
+        let connector_router_data = payme::PaymeRouterData::try_from((
+            &self.get_currency_unit(),
+            req.request.currency,
+            req.request.amount,
+            req,
+        ))?;
+        let req_obj = payme::PaymePaymentRequest::try_from(&connector_router_data)?;
         let payme_req = types::RequestBody::log_and_get_request_body(
             &req_obj,
             utils::Encode::<payme::PayRequest>::encode_to_string_of_json,
@@ -638,7 +652,13 @@ impl ConnectorIntegration<api::Capture, types::PaymentsCaptureData, types::Payme
         &self,
         req: &types::PaymentsCaptureRouterData,
     ) -> CustomResult<Option<types::RequestBody>, errors::ConnectorError> {
-        let req_obj = payme::PaymentCaptureRequest::try_from(req)?;
+        let connector_router_data = payme::PaymeRouterData::try_from((
+            &self.get_currency_unit(),
+            req.request.currency,
+            req.request.amount_to_capture,
+            req,
+        ))?;
+        let req_obj = payme::PaymentCaptureRequest::try_from(&connector_router_data)?;
         let payme_req = types::RequestBody::log_and_get_request_body(
             &req_obj,
             utils::Encode::<payme::PaymentCaptureRequest>::encode_to_string_of_json,
@@ -738,7 +758,13 @@ impl ConnectorIntegration<api::Execute, types::RefundsData, types::RefundsRespon
         &self,
         req: &types::RefundsRouterData<api::Execute>,
     ) -> CustomResult<Option<types::RequestBody>, errors::ConnectorError> {
-        let req_obj = payme::PaymeRefundRequest::try_from(req)?;
+        let connector_router_data = payme::PaymeRouterData::try_from((
+            &self.get_currency_unit(),
+            req.request.currency,
+            req.request.refund_amount,
+            req,
+        ))?;
+        let req_obj = payme::PaymeRefundRequest::try_from(&connector_router_data)?;
         let payme_req = types::RequestBody::log_and_get_request_body(
             &req_obj,
             utils::Encode::<payme::PaymeRefundRequest>::encode_to_string_of_json,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
This pull request introduces the get_currecny_unit from ConnectorCommon trait for `Payme`. This function allows connectors to declare their accepted currency unit as either "Base" or "Minor" .For Payme it accepts currency as Minor.


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
![image (3)](https://github.com/juspay/hyperswitch/assets/121822803/c2db8d50-5d90-42d1-8ead-993d8dcb7f20)



## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
