### PR TITLE
refactor currency conversion for trustpay

### DIFF
--- a/crates/router/src/connector/trustpay.rs
+++ b/crates/router/src/connector/trustpay.rs
@@ -10,7 +10,7 @@ use transformers as trustpay;
 
 use super::utils::{
     collect_and_sort_values_by_removing_signature, get_error_code_error_message_based_on_priority,
-    ConnectorErrorType, ConnectorErrorTypeMapping,
+    ConnectorErrorType, ConnectorErrorTypeMapping, PaymentsPreProcessingData,
 };
 use crate::{
     configs::settings,
@@ -78,6 +78,10 @@ where
 impl ConnectorCommon for Trustpay {
     fn id(&self) -> &'static str {
         "trustpay"
+    }
+
+    fn get_currency_unit(&self) -> api::CurrencyUnit {
+        api::CurrencyUnit::Base
     }
 
     fn common_get_content_type(&self) -> &'static str {
@@ -422,7 +426,16 @@ impl
         &self,
         req: &types::PaymentsPreProcessingRouterData,
     ) -> CustomResult<Option<types::RequestBody>, errors::ConnectorError> {
-        let create_intent_req = trustpay::TrustpayCreateIntentRequest::try_from(req)?;
+        let amount = req.request.get_amount()?;
+        let currency = req.request.get_currency()?;
+        let connector_router_data = trustpay::TrustpayRouterData::try_from((
+            &self.get_currency_unit(),
+            currency,
+            amount,
+            req,
+        ))?;
+        let create_intent_req =
+            trustpay::TrustpayCreateIntentRequest::try_from(&connector_router_data)?;
         let trustpay_req = types::RequestBody::log_and_get_request_body(
             &create_intent_req,
             utils::Encode::<trustpay::TrustpayCreateIntentRequest>::url_encode,
@@ -525,7 +538,13 @@ impl ConnectorIntegration<api::Authorize, types::PaymentsAuthorizeData, types::P
         &self,
         req: &types::PaymentsAuthorizeRouterData,
     ) -> CustomResult<Option<types::RequestBody>, errors::ConnectorError> {
-        let connector_req = trustpay::TrustpayPaymentsRequest::try_from(req)?;
+        let connector_router_data = trustpay::TrustpayRouterData::try_from((
+            &self.get_currency_unit(),
+            req.request.currency,
+            req.request.amount,
+            req,
+        ))?;
+        let connector_req = trustpay::TrustpayPaymentsRequest::try_from(&connector_router_data)?;
         let trustpay_req_string = match req.payment_method {
             diesel_models::enums::PaymentMethod::BankRedirect => {
                 types::RequestBody::log_and_get_request_body(
@@ -629,7 +648,13 @@ impl ConnectorIntegration<api::Execute, types::RefundsData, types::RefundsRespon
         &self,
         req: &types::RefundsRouterData<api::Execute>,
     ) -> CustomResult<Option<types::RequestBody>, errors::ConnectorError> {
-        let connector_req = trustpay::TrustpayRefundRequest::try_from(req)?;
+        let connector_router_data = trustpay::TrustpayRouterData::try_from((
+            &self.get_currency_unit(),
+            req.request.currency,
+            req.request.refund_amount,
+            req,
+        ))?;
+        let connector_req = trustpay::TrustpayRefundRequest::try_from(&connector_router_data)?;
         let trustpay_req_string = match req.payment_method {
             diesel_models::enums::PaymentMethod::BankRedirect => {
                 types::RequestBody::log_and_get_request_body(


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
This pull request introduces the get_currecny_unit from ConnectorCommon trait for `Trustpay`. This function allows connectors to declare their accepted currency unit as either "Base" or "Minor" .For trustpay it accepts currency as Base.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
