### PR TITLE
feat(payment_attempt): add kv for find last successful attempt

### DIFF
--- a/crates/router/src/db/cache.rs
+++ b/crates/router/src/db/cache.rs
@@ -14,7 +14,7 @@ use crate::{
 
 pub async fn get_or_populate_redis<T, F, Fut>(
     store: &dyn StorageInterface,
-    key: &str,
+    key: impl AsRef<str>,
     fun: F,
 ) -> CustomResult<T, errors::StorageError>
 where
@@ -23,6 +23,7 @@ where
     Fut: futures::Future<Output = CustomResult<T, errors::StorageError>> + Send,
 {
     let type_name = std::any::type_name::<T>();
+    let key = key.as_ref();
     let redis = &store
         .get_redis_conn()
         .change_context(errors::StorageError::RedisError(

--- a/crates/router/src/db/reverse_lookup.rs
+++ b/crates/router/src/db/reverse_lookup.rs
@@ -40,7 +40,7 @@ impl ReverseLookupInterface for Store {
                 .map_err(Into::into)
                 .into_report()
         };
-        cache::get_or_populate_redis(self, id, database_call).await
+        cache::get_or_populate_redis(self, format!("reverse_lookup_{id}"), database_call).await
     }
 }
 

--- a/crates/storage_impl/src/lookup.rs
+++ b/crates/storage_impl/src/lookup.rs
@@ -50,7 +50,7 @@ impl<T: DatabaseStore> ReverseLookupInterface for RouterStore<T> {
                     er.change_context(new_err)
                 })
         };
-        get_or_populate_redis(self, id, database_call).await
+        get_or_populate_redis(self, format!("reverse_lookup_{id}"), database_call).await
     }
 }
 

--- a/crates/storage_impl/src/payments/payment_attempt.rs
+++ b/crates/storage_impl/src/payments/payment_attempt.rs
@@ -373,8 +373,8 @@ impl<T: DatabaseStore> PaymentAttemptInterface for KVRouterStore<T> {
                                 "{}_{}",
                                 &created_attempt.merchant_id, &created_attempt.attempt_id,
                             ),
-                            pk_id: key.clone(),
-                            sk_id: field.clone(),
+                            pk_id: key,
+                            sk_id: field,
                             source: "payment_attempt".to_string(),
                         }
                         .insert(&conn)

--- a/crates/storage_impl/src/payments/payment_attempt.rs
+++ b/crates/storage_impl/src/payments/payment_attempt.rs
@@ -26,6 +26,7 @@ use redis_interface::HsetnxReply;
 use router_env::{instrument, tracing};
 
 use crate::{
+    diesel_error_to_data_error,
     lookup::ReverseLookupInterface,
     redis::kv_store::{PartitionKey, RedisConnInterface},
     utils::{
@@ -49,7 +50,7 @@ impl<T: DatabaseStore> PaymentAttemptInterface for RouterStore<T> {
             .insert(&conn)
             .await
             .map_err(|er| {
-                let new_err = crate::diesel_error_to_data_error(er.current_context());
+                let new_err = diesel_error_to_data_error(er.current_context());
                 er.change_context(new_err)
             })
             .map(PaymentAttempt::from_storage_model)
@@ -67,7 +68,7 @@ impl<T: DatabaseStore> PaymentAttemptInterface for RouterStore<T> {
             .update_with_attempt_id(&conn, payment_attempt.to_storage_model())
             .await
             .map_err(|er| {
-                let new_err = crate::diesel_error_to_data_error(er.current_context());
+                let new_err = diesel_error_to_data_error(er.current_context());
                 er.change_context(new_err)
             })
             .map(PaymentAttempt::from_storage_model)
@@ -89,7 +90,7 @@ impl<T: DatabaseStore> PaymentAttemptInterface for RouterStore<T> {
         )
         .await
         .map_err(|er| {
-            let new_err = crate::diesel_error_to_data_error(er.current_context());
+            let new_err = diesel_error_to_data_error(er.current_context());
             er.change_context(new_err)
         })
         .map(PaymentAttempt::from_storage_model)
@@ -109,7 +110,7 @@ impl<T: DatabaseStore> PaymentAttemptInterface for RouterStore<T> {
         )
         .await
         .map_err(|er| {
-            let new_err = crate::diesel_error_to_data_error(er.current_context());
+            let new_err = diesel_error_to_data_error(er.current_context());
             er.change_context(new_err)
         })
         .map(PaymentAttempt::from_storage_model)
@@ -129,7 +130,7 @@ impl<T: DatabaseStore> PaymentAttemptInterface for RouterStore<T> {
         )
         .await
         .map_err(|er| {
-            let new_err = crate::diesel_error_to_data_error(er.current_context());
+            let new_err = diesel_error_to_data_error(er.current_context());
             er.change_context(new_err)
         })
         .map(PaymentAttempt::from_storage_model)
@@ -153,7 +154,7 @@ impl<T: DatabaseStore> PaymentAttemptInterface for RouterStore<T> {
         )
         .await
         .map_err(|er| {
-            let new_err = crate::diesel_error_to_data_error(er.current_context());
+            let new_err = diesel_error_to_data_error(er.current_context());
             er.change_context(new_err)
         })
         .map(PaymentAttempt::from_storage_model)
@@ -174,7 +175,7 @@ impl<T: DatabaseStore> PaymentAttemptInterface for RouterStore<T> {
         DieselPaymentAttempt::get_filters_for_payments(&conn, intents.as_slice(), merchant_id)
             .await
             .map_err(|er| {
-                let new_err = crate::diesel_error_to_data_error(er.current_context());
+                let new_err = diesel_error_to_data_error(er.current_context());
                 er.change_context(new_err)
             })
             .map(
@@ -202,7 +203,7 @@ impl<T: DatabaseStore> PaymentAttemptInterface for RouterStore<T> {
         )
         .await
         .map_err(|er| {
-            let new_err = crate::diesel_error_to_data_error(er.current_context());
+            let new_err = diesel_error_to_data_error(er.current_context());
             er.change_context(new_err)
         })
         .map(PaymentAttempt::from_storage_model)
@@ -218,7 +219,7 @@ impl<T: DatabaseStore> PaymentAttemptInterface for RouterStore<T> {
         DieselPaymentAttempt::find_by_merchant_id_payment_id(&conn, merchant_id, payment_id)
             .await
             .map_err(|er| {
-                let new_err = crate::diesel_error_to_data_error(er.current_context());
+                let new_err = diesel_error_to_data_error(er.current_context());
                 er.change_context(new_err)
             })
             .map(|a| {
@@ -239,7 +240,7 @@ impl<T: DatabaseStore> PaymentAttemptInterface for RouterStore<T> {
         DieselPaymentAttempt::find_by_merchant_id_attempt_id(&conn, merchant_id, attempt_id)
             .await
             .map_err(|er| {
-                let new_err = crate::diesel_error_to_data_error(er.current_context());
+                let new_err = diesel_error_to_data_error(er.current_context());
                 er.change_context(new_err)
             })
             .map(PaymentAttempt::from_storage_model)
@@ -275,7 +276,7 @@ impl<T: DatabaseStore> PaymentAttemptInterface for RouterStore<T> {
         )
         .await
         .map_err(|er| {
-            let new_err = crate::diesel_error_to_data_error(er.current_context());
+            let new_err = diesel_error_to_data_error(er.current_context());
             er.change_context(new_err)
         })
     }
@@ -380,7 +381,7 @@ impl<T: DatabaseStore> PaymentAttemptInterface for KVRouterStore<T> {
                         .insert(&conn)
                         .await
                         .map_err(|er| {
-                            let new_err = crate::diesel_error_to_data_error(er.current_context());
+                            let new_err = diesel_error_to_data_error(er.current_context());
                             er.change_context(new_err)
                         })?;
 
@@ -1491,7 +1492,7 @@ async fn add_connector_txn_id_to_reverse_lookup<T: DatabaseStore>(
     .insert(&conn)
     .await
     .map_err(|err| {
-        let new_err = crate::diesel_error_to_data_error(err.current_context());
+        let new_err = diesel_error_to_data_error(err.current_context());
         err.change_context(new_err)
     })
 }
@@ -1515,7 +1516,7 @@ async fn add_preprocessing_id_to_reverse_lookup<T: DatabaseStore>(
     .insert(&conn)
     .await
     .map_err(|er| {
-        let new_err = crate::diesel_error_to_data_error(er.current_context());
+        let new_err = diesel_error_to_data_error(er.current_context());
         er.change_context(new_err)
     })
 }

--- a/crates/storage_impl/src/redis/cache.rs
+++ b/crates/storage_impl/src/redis/cache.rs
@@ -138,7 +138,7 @@ impl Cache {
 
 pub async fn get_or_populate_redis<T, F, Fut>(
     store: &(dyn RedisConnInterface + Send + Sync),
-    key: &str,
+    key: impl AsRef<str>,
     fun: F,
 ) -> CustomResult<T, StorageError>
 where
@@ -147,6 +147,7 @@ where
     Fut: futures::Future<Output = CustomResult<T, StorageError>> + Send,
 {
     let type_name = std::any::type_name::<T>();
+    let key = key.as_ref();
     let redis = &store
         .get_redis_conn()
         .map_err(|er| {


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->
- [x] Enhancement

## Description
<!-- Describe your changes in detail -->
Add KV for last successful payment attempt


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
Add it in KV for better latency

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
This function is being used in `refunds_create_core`. So refund should succeed.

<img width="1340" alt="Screenshot 2023-09-20 at 3 06 54 PM" src="https://github.com/juspay/hyperswitch/assets/43412619/f5f4e284-51cb-46ec-8eae-bb30ed4fe23d">

<img width="1329" alt="Screenshot 2023-09-20 at 3 07 15 PM" src="https://github.com/juspay/hyperswitch/assets/43412619/0e8cfa7e-9938-422a-a1a2-86336ba46629">

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code