### PR TITLE
fix(connector): [Trustpay] Add missing error code

### DIFF
--- a/crates/router/src/connector/trustpay/transformers.rs
+++ b/crates/router/src/connector/trustpay/transformers.rs
@@ -438,6 +438,7 @@ fn is_payment_failed(payment_status: &str) -> (bool, &'static str) {
         "800.100.202" => (true, "Account Closed"),
         "800.120.100" => (true, "Rejected by throttling"),
         "800.300.401" => (true, "Bin blacklisted"),
+        "800.300.102" => (true, "Country blacklisted"),
         "800.700.100" => (
             true,
             "Transaction for the same session is currently being processed, please try again later",

--- a/crates/router/src/connector/trustpay/transformers.rs
+++ b/crates/router/src/connector/trustpay/transformers.rs
@@ -437,8 +437,8 @@ fn is_payment_failed(payment_status: &str) -> (bool, &'static str) {
         "800.100.190" => (true, "Transaction declined (invalid configuration data)"),
         "800.100.202" => (true, "Account Closed"),
         "800.120.100" => (true, "Rejected by throttling"),
-        "800.300.401" => (true, "Bin blacklisted"),
         "800.300.102" => (true, "Country blacklisted"),
+        "800.300.401" => (true, "Bin blacklisted"),
         "800.700.100" => (
             true,
             "Transaction for the same session is currently being processed, please try again later",


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix

## Description
<!-- Describe your changes in detail -->
`800.300.102` error code was missing due to which payment remained in `processing` status


<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
Add the  missing error code




## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
