### PR TITLE
fix(router): fix attempt status for techincal failures in psync flow

### DIFF
--- a/crates/router/src/core/payments/operations/payment_response.rs
+++ b/crates/router/src/core/payments/operations/payment_response.rs
@@ -12,6 +12,7 @@ use crate::{
         errors::{self, RouterResult, StorageErrorExt},
         mandate,
         payments::{types::MultipleCaptureData, PaymentData},
+        utils as core_utils,
     },
     db::StorageInterface,
     routes::metrics,
@@ -311,10 +312,17 @@ async fn payment_response_update_tracker<F: Clone, T: types::Capturable>(
                     (Some((multiple_capture_data, capture_update_list)), None)
                 }
                 None => {
-                    let status = match err.status_code {
-                        500..=511 => storage::enums::AttemptStatus::Pending,
-                        _ => storage::enums::AttemptStatus::Failure,
-                    };
+                    let flow_name = core_utils::get_flow_name::<F>()?;
+                    let status =
+                        // mark previous attempt status for techincal failures in PSync flow
+                        if flow_name == "PSync" {
+                            payment_data.payment_attempt.status
+                        } else {
+                            match err.status_code {
+                                500..=511 => storage::enums::AttemptStatus::Pending,
+                                _ => storage::enums::AttemptStatus::Failure,
+                            }
+                        };
                     (
                         None,
                         Some(storage::PaymentAttemptUpdate::ErrorUpdate {

--- a/crates/router/src/core/payments/operations/payment_response.rs
+++ b/crates/router/src/core/payments/operations/payment_response.rs
@@ -316,7 +316,10 @@ async fn payment_response_update_tracker<F: Clone, T: types::Capturable>(
                     let status =
                         // mark previous attempt status for technical failures in PSync flow
                         if flow_name == "PSync" {
-                            payment_data.payment_attempt.status
+                            match err.status_code {
+                                200..=299 => storage::enums::AttemptStatus::Failure,
+                                _ => payment_data.payment_attempt.status,
+                            }
                         } else {
                             match err.status_code {
                                 500..=511 => storage::enums::AttemptStatus::Pending,

--- a/crates/router/src/core/payments/operations/payment_response.rs
+++ b/crates/router/src/core/payments/operations/payment_response.rs
@@ -317,6 +317,7 @@ async fn payment_response_update_tracker<F: Clone, T: types::Capturable>(
                         // mark previous attempt status for technical failures in PSync flow
                         if flow_name == "PSync" {
                             match err.status_code {
+                                // marking failure for 2xx because this is genuine payment failure
                                 200..=299 => storage::enums::AttemptStatus::Failure,
                                 _ => payment_data.payment_attempt.status,
                             }

--- a/crates/router/src/core/payments/operations/payment_response.rs
+++ b/crates/router/src/core/payments/operations/payment_response.rs
@@ -314,7 +314,7 @@ async fn payment_response_update_tracker<F: Clone, T: types::Capturable>(
                 None => {
                     let flow_name = core_utils::get_flow_name::<F>()?;
                     let status =
-                        // mark previous attempt status for techincal failures in PSync flow
+                        // mark previous attempt status for technical failures in PSync flow
                         if flow_name == "PSync" {
                             payment_data.payment_attempt.status
                         } else {

--- a/crates/router/src/core/utils.rs
+++ b/crates/router/src/core/utils.rs
@@ -1025,3 +1025,15 @@ pub async fn get_profile_id_from_business_details(
         },
     }
 }
+
+#[inline]
+pub fn get_flow_name<F>() -> RouterResult<String> {
+    Ok(std::any::type_name::<F>()
+        .to_string()
+        .rsplit("::")
+        .next()
+        .ok_or(errors::ApiErrorResponse::InternalServerError)
+        .into_report()
+        .attach_printable("Flow stringify failed")?
+        .to_string())
+}


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
fix attempt status for techincal failures in psync flow
1. In Psync flow for 4xx / 5xx errors mark the previous attempt status instead of marking it as processing / failure


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
1. 4xx in payments confirm flow, payment status would be marked as failure
![image](https://github.com/juspay/hyperswitch/assets/56996463/f1a0ce9b-f958-4dac-b25f-11311d197f89)
![image](https://github.com/juspay/hyperswitch/assets/56996463/b6197b17-6780-4d34-84fa-15147992733b)

2. 4xx in payments retrieve flow with force_sync = true for processing payment, status is unchanged
![image](https://github.com/juspay/hyperswitch/assets/56996463/6b24bc5d-df9c-42b3-ac84-f0492315b53c)
![image](https://github.com/juspay/hyperswitch/assets/56996463/65a10395-278d-4b16-bebc-9ef18e27c606)

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
