### PR TITLE
feat: Add support for save card in complete authorize flow

### DIFF
--- a/crates/router/src/core/mandate.rs
+++ b/crates/router/src/core/mandate.rs
@@ -132,10 +132,13 @@ fn get_insensitive_payment_method_data_if_exists<F, FData>(
 where
     FData: MandateBehaviour,
 {
-    match &router_data.request.get_payment_method_data() {
-        api_models::payments::PaymentMethodData::Card(_) => None,
-        _ => Some(router_data.request.get_payment_method_data()),
-    }
+    router_data
+        .request
+        .get_payment_method_data()
+        .and_then(|pmd| match pmd {
+            payments::PaymentMethodData::Card(_) => None,
+            _ => router_data.request.get_payment_method_data(),
+        })
 }
 
 pub async fn mandate_procedure<F, FData>(
@@ -324,6 +327,6 @@ pub trait MandateBehaviour {
     fn get_setup_future_usage(&self) -> Option<diesel_models::enums::FutureUsage>;
     fn get_mandate_id(&self) -> Option<&api_models::payments::MandateIds>;
     fn set_mandate_id(&mut self, new_mandate_id: Option<api_models::payments::MandateIds>);
-    fn get_payment_method_data(&self) -> api_models::payments::PaymentMethodData;
+    fn get_payment_method_data(&self) -> Option<api_models::payments::PaymentMethodData>;
     fn get_setup_mandate_details(&self) -> Option<&data_models::mandates::MandateData>;
 }

--- a/crates/router/src/core/payments/flows/authorize_flow.rs
+++ b/crates/router/src/core/payments/flows/authorize_flow.rs
@@ -246,8 +246,8 @@ impl mandate::MandateBehaviour for types::PaymentsAuthorizeData {
     fn get_mandate_id(&self) -> Option<&api_models::payments::MandateIds> {
         self.mandate_id.as_ref()
     }
-    fn get_payment_method_data(&self) -> api_models::payments::PaymentMethodData {
-        self.payment_method_data.clone()
+    fn get_payment_method_data(&self) -> Option<api_models::payments::PaymentMethodData> {
+        Some(self.payment_method_data.clone())
     }
     fn get_setup_future_usage(&self) -> Option<diesel_models::enums::FutureUsage> {
         self.setup_future_usage

--- a/crates/router/src/core/payments/flows/verify_flow.rs
+++ b/crates/router/src/core/payments/flows/verify_flow.rs
@@ -228,8 +228,8 @@ impl mandate::MandateBehaviour for types::VerifyRequestData {
         self.mandate_id = new_mandate_id;
     }
 
-    fn get_payment_method_data(&self) -> api_models::payments::PaymentMethodData {
-        self.payment_method_data.clone()
+    fn get_payment_method_data(&self) -> Option<api_models::payments::PaymentMethodData> {
+        Some(self.payment_method_data.clone())
     }
 
     fn get_setup_mandate_details(&self) -> Option<&data_models::mandates::MandateData> {

--- a/crates/router/src/core/payments/helpers.rs
+++ b/crates/router/src/core/payments/helpers.rs
@@ -836,9 +836,9 @@ pub(crate) async fn get_payment_method_create_request(
                 }
             },
             None => Err(report!(errors::ApiErrorResponse::MissingRequiredField {
-                field_name: "payment_method_type"
+                field_name: "payment_method"
             })
-            .attach_printable("PaymentMethodType Required")),
+            .attach_printable("PaymentMethod Required")),
         },
         None => Err(report!(errors::ApiErrorResponse::MissingRequiredField {
             field_name: "payment_method_data"

--- a/crates/router/src/core/payments/tokenization.rs
+++ b/crates/router/src/core/payments/tokenization.rs
@@ -64,7 +64,7 @@ where
             let pm_id = if resp.request.get_setup_future_usage().is_some() {
                 let customer = maybe_customer.to_owned().get_required_value("customer")?;
                 let payment_method_create_request = helpers::get_payment_method_create_request(
-                    Some(&resp.request.get_payment_method_data()),
+                    resp.request.get_payment_method_data().as_ref(),
                     Some(resp.payment_method),
                     payment_method_type,
                     &customer,

--- a/crates/router/src/core/payments/transformers.rs
+++ b/crates/router/src/core/payments/transformers.rs
@@ -62,7 +62,7 @@ where
         .payment_attempt
         .payment_method
         .or(payment_data.payment_attempt.payment_method)
-        .get_required_value("payment_method_type")?;
+        .get_required_value("payment_method")?;
 
     let resource_id = match payment_data
         .payment_attempt
@@ -1275,6 +1275,7 @@ impl<F: Clone> TryFrom<PaymentAdditionalData<'_, F>> for types::CompleteAuthoriz
             connector_transaction_id: payment_data.connector_response.connector_transaction_id,
             redirect_response,
             connector_meta: payment_data.payment_attempt.connector_metadata,
+            payment_method_type: payment_data.payment_attempt.payment_method_type,
         })
     }
 }

--- a/crates/router/src/types.rs
+++ b/crates/router/src/types.rs
@@ -436,6 +436,7 @@ pub struct PaymentsPreProcessingData {
 #[derive(Debug, Clone)]
 pub struct CompleteAuthorizeData {
     pub payment_method_data: Option<payments::PaymentMethodData>,
+    pub payment_method_type: Option<storage_enums::PaymentMethodType>,
     pub amount: i64,
     pub email: Option<Email>,
     pub currency: storage_enums::Currency,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] New feature

## Description
<!-- Describe your changes in detail -->
Add save payment method, in complete authorize flow which was missing.
This fixes the issue with save card for connectors like payme thats uses complete authorize call.

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
Add support for save card flow in complete authorize.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Steps for testing:
1. Make payment using card through Payme with some setup_future_usage
2. After successful payment, check payment_methods for customer, you should see the payment method that was stored.

![image](https://github.com/juspay/hyperswitch/assets/59434228/6739b146-caaf-4b85-a379-e84ba3f2f11a)


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
