### PR TITLE
fix(router): merchant account delete does not delete the merchant_key_store

### DIFF
--- a/crates/diesel_models/src/query/merchant_key_store.rs
+++ b/crates/diesel_models/src/query/merchant_key_store.rs
@@ -27,4 +27,16 @@ impl MerchantKeyStore {
         )
         .await
     }
+
+    #[instrument(skip(conn))]
+    pub async fn delete_by_merchant_id(
+        conn: &PgPooledConn,
+        merchant_id: &str,
+    ) -> StorageResult<bool> {
+        generics::generic_delete::<<Self as HasTable>::Table, _>(
+            conn,
+            dsl::merchant_id.eq(merchant_id.to_owned()),
+        )
+        .await
+    }
 }

--- a/crates/router/src/core/admin.rs
+++ b/crates/router/src/core/admin.rs
@@ -465,18 +465,22 @@ pub async fn merchant_account_delete(
     state: AppState,
     merchant_id: String,
 ) -> RouterResponse<api::MerchantAccountDeleteResponse> {
+    let mut is_deleted = false;
     let db = state.store.as_ref();
     let is_merchant_account_deleted = db
         .delete_merchant_account_by_merchant_id(&merchant_id)
         .await
         .to_not_found_response(errors::ApiErrorResponse::MerchantAccountNotFound)?;
-    let is_merchant_key_store_deleted = db
-        .delete_merchant_key_store_by_merchant_id(&merchant_id)
-        .await
-        .to_not_found_response(errors::ApiErrorResponse::MerchantAccountNotFound)?;
+    if is_merchant_account_deleted {
+        let is_merchant_key_store_deleted = db
+            .delete_merchant_key_store_by_merchant_id(&merchant_id)
+            .await
+            .to_not_found_response(errors::ApiErrorResponse::MerchantAccountNotFound)?;
+        is_deleted = is_merchant_account_deleted && is_merchant_key_store_deleted;
+    }
     let response = api::MerchantAccountDeleteResponse {
         merchant_id,
-        deleted: is_merchant_account_deleted && is_merchant_key_store_deleted,
+        deleted: is_deleted,
     };
     Ok(service_api::ApplicationResponse::Json(response))
 }

--- a/crates/router/src/core/admin.rs
+++ b/crates/router/src/core/admin.rs
@@ -466,17 +466,17 @@ pub async fn merchant_account_delete(
     merchant_id: String,
 ) -> RouterResponse<api::MerchantAccountDeleteResponse> {
     let db = state.store.as_ref();
-    let is_deleted = db
+    let is_merchant_account_deleted = db
         .delete_merchant_account_by_merchant_id(&merchant_id)
         .await
         .to_not_found_response(errors::ApiErrorResponse::MerchantAccountNotFound)?;
-    let _is_deleted = db
+    let is_merchant_key_store_deleted = db
         .delete_merchant_key_store_by_merchant_id(&merchant_id)
         .await
         .to_not_found_response(errors::ApiErrorResponse::MerchantAccountNotFound)?;
     let response = api::MerchantAccountDeleteResponse {
         merchant_id,
-        deleted: is_deleted,
+        deleted: is_merchant_account_deleted && is_merchant_key_store_deleted,
     };
     Ok(service_api::ApplicationResponse::Json(response))
 }

--- a/crates/router/src/core/admin.rs
+++ b/crates/router/src/core/admin.rs
@@ -470,6 +470,10 @@ pub async fn merchant_account_delete(
         .delete_merchant_account_by_merchant_id(&merchant_id)
         .await
         .to_not_found_response(errors::ApiErrorResponse::MerchantAccountNotFound)?;
+    let _is_deleted = db
+        .delete_merchant_key_store_by_merchant_id(&merchant_id)
+        .await
+        .to_not_found_response(errors::ApiErrorResponse::MerchantAccountNotFound)?;
     let response = api::MerchantAccountDeleteResponse {
         merchant_id,
         deleted: is_deleted,

--- a/crates/router/src/db/merchant_key_store.rs
+++ b/crates/router/src/db/merchant_key_store.rs
@@ -1,5 +1,6 @@
 use error_stack::{IntoReport, ResultExt};
 use masking::Secret;
+use storage_impl::redis::cache::CacheKind;
 #[cfg(feature = "accounts_cache")]
 use storage_impl::redis::cache::ACCOUNTS_CACHE;
 
@@ -119,12 +120,10 @@ impl MerchantKeyStoreInterface for Store {
 
         #[cfg(feature = "accounts_cache")]
         {
-            let key_store_cache_key = format!("merchant_key_store_{}", merchant_id);
-            super::cache::get_or_populate_in_memory(
+            super::cache::publish_and_redact(
                 self,
-                &key_store_cache_key,
+                CacheKind::Accounts(merchant_id.into()),
                 delete_func,
-                &ACCOUNTS_CACHE,
             )
             .await
         }

--- a/crates/router/src/db/merchant_key_store.rs
+++ b/crates/router/src/db/merchant_key_store.rs
@@ -1,7 +1,7 @@
 use error_stack::{IntoReport, ResultExt};
 use masking::Secret;
-use storage_impl::redis::cache::CacheKind;
 #[cfg(feature = "accounts_cache")]
+use storage_impl::redis::cache::CacheKind;
 use storage_impl::redis::cache::ACCOUNTS_CACHE;
 
 use crate::{

--- a/crates/router/src/db/merchant_key_store.rs
+++ b/crates/router/src/db/merchant_key_store.rs
@@ -1,8 +1,7 @@
 use error_stack::{IntoReport, ResultExt};
 use masking::Secret;
 #[cfg(feature = "accounts_cache")]
-use storage_impl::redis::cache::CacheKind;
-use storage_impl::redis::cache::ACCOUNTS_CACHE;
+use storage_impl::redis::cache::{CacheKind, ACCOUNTS_CACHE};
 
 use crate::{
     connection,

--- a/crates/router/src/db/merchant_key_store.rs
+++ b/crates/router/src/db/merchant_key_store.rs
@@ -120,9 +120,10 @@ impl MerchantKeyStoreInterface for Store {
 
         #[cfg(feature = "accounts_cache")]
         {
+            let key_store_cache_key = format!("merchant_key_store_{}", merchant_id);
             super::cache::publish_and_redact(
                 self,
-                CacheKind::Accounts(merchant_id.into()),
+                CacheKind::Accounts(key_store_cache_key.into()),
                 delete_func,
             )
             .await


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Closes #2154 by calling `delete_merchant_key_store_by_merchant_id` at `merchant_account_delete`

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
