### PR TITLE
fix: [stripe] Add customer balance in StripePaymentMethodDetailsResponse

### DIFF
--- a/crates/router/src/connector/stripe/transformers.rs
+++ b/crates/router/src/connector/stripe/transformers.rs
@@ -2181,6 +2181,7 @@ pub enum StripePaymentMethodDetailsResponse {
     #[serde(rename = "wechat_pay")]
     Wechatpay,
     Alipay,
+    CustomerBalance,
 }
 
 #[derive(Deserialize)]


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix

## Description
<!-- Describe your changes in detail -->
Bank Transfer Payment sync was failing due to stripe contract changes , stripe now expecting the payment_method_type as customer_balance.So, this PR supports customer_balance in StripePaymentMethodDetailsResponse


<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
Bank Transfer Payment sync was failing due to stripe contract changes, so fixed in this PR

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Steps:
1. Bank transfer payment
2. Retrieve the payment. (Earlier it was failing here because of stripe changes, so now we should get proper response), attaching the screen shot of the tested repsonse
![image](https://github.com/juspay/hyperswitch/assets/59434228/22b441cf-7abc-4dde-bbbc-4d4aa1507c67)


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
