### PR TITLE
feat(core): create surcharge_metadata field in payment attempt

### DIFF
--- a/crates/data_models/src/payments/payment_attempt.rs
+++ b/crates/data_models/src/payments/payment_attempt.rs
@@ -138,6 +138,7 @@ pub struct PaymentAttempt {
     // reference to the payment at connector side
     pub connector_response_reference_id: Option<String>,
     pub amount_capturable: i64,
+    pub surcharge_metadata: Option<serde_json::Value>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -194,6 +195,7 @@ pub struct PaymentAttemptNew {
     pub connector_response_reference_id: Option<String>,
     pub multiple_capture_count: Option<i16>,
     pub amount_capturable: i64,
+    pub surcharge_metadata: Option<serde_json::Value>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -298,5 +300,8 @@ pub enum PaymentAttemptUpdate {
         preprocessing_step_id: Option<String>,
         connector_transaction_id: Option<String>,
         connector_response_reference_id: Option<String>,
+    },
+    SurchargeMetadataUpdate {
+        surcharge_metadata: Option<serde_json::Value>,
     },
 }

--- a/crates/diesel_models/src/payment_attempt.rs
+++ b/crates/diesel_models/src/payment_attempt.rs
@@ -57,6 +57,7 @@ pub struct PaymentAttempt {
     // reference to the payment at connector side
     pub connector_response_reference_id: Option<String>,
     pub amount_capturable: i64,
+    pub surcharge_metadata: Option<serde_json::Value>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Queryable, Serialize, Deserialize)]
@@ -115,6 +116,7 @@ pub struct PaymentAttemptNew {
     pub connector_response_reference_id: Option<String>,
     pub multiple_capture_count: Option<i16>,
     pub amount_capturable: i64,
+    pub surcharge_metadata: Option<serde_json::Value>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -220,6 +222,9 @@ pub enum PaymentAttemptUpdate {
         connector_transaction_id: Option<String>,
         connector_response_reference_id: Option<String>,
     },
+    SurchargeMetadataUpdate {
+        surcharge_metadata: Option<serde_json::Value>,
+    },
 }
 
 #[derive(Clone, Debug, Default, AsChangeset, router_derive::DebugAsDisplay)]
@@ -253,6 +258,7 @@ pub struct PaymentAttemptUpdateInternal {
     connector_response_reference_id: Option<String>,
     multiple_capture_count: Option<i16>,
     amount_capturable: Option<i64>,
+    surcharge_metadata: Option<serde_json::Value>,
 }
 
 impl PaymentAttemptUpdate {
@@ -279,6 +285,7 @@ impl PaymentAttemptUpdate {
             preprocessing_step_id: pa_update
                 .preprocessing_step_id
                 .or(source.preprocessing_step_id),
+            surcharge_metadata: pa_update.surcharge_metadata.or(source.surcharge_metadata),
             ..source
         }
     }
@@ -494,6 +501,10 @@ impl From<PaymentAttemptUpdate> for PaymentAttemptUpdateInternal {
             } => Self {
                 status: Some(status),
                 amount_capturable: Some(amount_capturable),
+                ..Default::default()
+            },
+            PaymentAttemptUpdate::SurchargeMetadataUpdate { surcharge_metadata } => Self {
+                surcharge_metadata,
                 ..Default::default()
             },
         }

--- a/crates/diesel_models/src/schema.rs
+++ b/crates/diesel_models/src/schema.rs
@@ -551,6 +551,7 @@ diesel::table! {
         #[max_length = 128]
         connector_response_reference_id -> Nullable<Varchar>,
         amount_capturable -> Int8,
+        surcharge_metadata -> Nullable<Jsonb>,
     }
 }
 

--- a/crates/router/src/core/payments/helpers.rs
+++ b/crates/router/src/core/payments/helpers.rs
@@ -2731,6 +2731,7 @@ impl AttemptType {
             multiple_capture_count: None,
             connector_response_reference_id: None,
             amount_capturable: old_payment_attempt.amount,
+            surcharge_metadata: old_payment_attempt.surcharge_metadata,
         }
     }
 

--- a/crates/storage_impl/src/mock_db/payment_attempt.rs
+++ b/crates/storage_impl/src/mock_db/payment_attempt.rs
@@ -138,6 +138,7 @@ impl PaymentAttemptInterface for MockDb {
             multiple_capture_count: payment_attempt.multiple_capture_count,
             connector_response_reference_id: None,
             amount_capturable: payment_attempt.amount_capturable,
+            surcharge_metadata: payment_attempt.surcharge_metadata,
         };
         payment_attempts.push(payment_attempt.clone());
         Ok(payment_attempt)

--- a/crates/storage_impl/src/payments/payment_attempt.rs
+++ b/crates/storage_impl/src/payments/payment_attempt.rs
@@ -348,6 +348,7 @@ impl<T: DatabaseStore> PaymentAttemptInterface for KVRouterStore<T> {
                     multiple_capture_count: payment_attempt.multiple_capture_count,
                     connector_response_reference_id: None,
                     amount_capturable: payment_attempt.amount_capturable,
+                    surcharge_metadata: payment_attempt.surcharge_metadata.clone(),
                 };
 
                 let field = format!("pa_{}", created_attempt.attempt_id);
@@ -943,6 +944,7 @@ impl DataModelExt for PaymentAttempt {
             multiple_capture_count: self.multiple_capture_count,
             connector_response_reference_id: self.connector_response_reference_id,
             amount_capturable: self.amount_capturable,
+            surcharge_metadata: self.surcharge_metadata,
         }
     }
 
@@ -991,6 +993,7 @@ impl DataModelExt for PaymentAttempt {
             multiple_capture_count: storage_model.multiple_capture_count,
             connector_response_reference_id: storage_model.connector_response_reference_id,
             amount_capturable: storage_model.amount_capturable,
+            surcharge_metadata: storage_model.surcharge_metadata,
         }
     }
 }
@@ -1039,6 +1042,7 @@ impl DataModelExt for PaymentAttemptNew {
             connector_response_reference_id: self.connector_response_reference_id,
             multiple_capture_count: self.multiple_capture_count,
             amount_capturable: self.amount_capturable,
+            surcharge_metadata: self.surcharge_metadata,
         }
     }
 
@@ -1085,6 +1089,7 @@ impl DataModelExt for PaymentAttemptNew {
             connector_response_reference_id: storage_model.connector_response_reference_id,
             multiple_capture_count: storage_model.multiple_capture_count,
             amount_capturable: storage_model.amount_capturable,
+            surcharge_metadata: storage_model.surcharge_metadata,
         }
     }
 }
@@ -1279,6 +1284,9 @@ impl DataModelExt for PaymentAttemptUpdate {
                 status,
                 amount_capturable,
             },
+            Self::SurchargeMetadataUpdate { surcharge_metadata } => {
+                DieselPaymentAttemptUpdate::SurchargeMetadataUpdate { surcharge_metadata }
+            }
         }
     }
 
@@ -1469,6 +1477,9 @@ impl DataModelExt for PaymentAttemptUpdate {
                 status,
                 amount_capturable,
             },
+            DieselPaymentAttemptUpdate::SurchargeMetadataUpdate { surcharge_metadata } => {
+                Self::SurchargeMetadataUpdate { surcharge_metadata }
+            }
         }
     }
 }

--- a/migrations/2023-09-25-125007_add_surcharge_metadata_payment_attempt/down.sql
+++ b/migrations/2023-09-25-125007_add_surcharge_metadata_payment_attempt/down.sql
@@ -1,0 +1,3 @@
+-- This file should undo anything in `up.sql`
+ALTER TABLE payment_attempt
+DROP COLUMN surcharge_metadata;

--- a/migrations/2023-09-25-125007_add_surcharge_metadata_payment_attempt/up.sql
+++ b/migrations/2023-09-25-125007_add_surcharge_metadata_payment_attempt/up.sql
@@ -1,0 +1,3 @@
+-- Your SQL goes here
+ALTER TABLE payment_attempt
+ADD COLUMN IF NOT EXISTS surcharge_metadata JSONB DEFAULT NULL;


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
`surcharge_metadata` Field will be used to store the surcharges for each payment_method during list payment method call.

During confirm call, this data can be used to arrive at final amount to send to connector.


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
