### PR TITLE
fix(cards): Allow card cvc 000

### DIFF
--- a/crates/cards/src/lib.rs
+++ b/crates/cards/src/lib.rs
@@ -15,7 +15,7 @@ pub struct CardSecurityCode(StrongSecret<u16>);
 impl TryFrom<u16> for CardSecurityCode {
     type Error = error_stack::Report<errors::ValidationError>;
     fn try_from(csc: u16) -> Result<Self, Self::Error> {
-        if (1..=9999).contains(&csc) {
+        if (0..=9999).contains(&csc) {
             Ok(Self(StrongSecret::new(csc)))
         } else {
             Err(report!(errors::ValidationError::InvalidValue {


### PR DESCRIPTION
Allow card cvc 000

## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
Card CVC can be 000
The CVV code on my credit card is 000. : r/mildlyinteresting
Reddit
[https://www.reddit.com › mildlyinteresting › comments](https://www.reddit.com/r/mildlyinteresting/comments/2g1nz2/the_cvv_code_on_my_credit_card_is_000/)
"Invalid Card CVC" (thrown only when cvc is 000)
### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
