### PR TITLE
feat: gracefully shutdown drainer if redis goes down

### DIFF
--- a/crates/drainer/src/lib.rs
+++ b/crates/drainer/src/lib.rs
@@ -10,7 +10,7 @@ use std::sync::{atomic, Arc};
 use common_utils::signals::get_allowed_signals;
 use diesel_models::kv;
 use error_stack::{IntoReport, ResultExt};
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, oneshot};
 
 use crate::{connection::pg_connection, services::Store};
 
@@ -36,9 +36,18 @@ pub async fn start_drainer(
                 "Failed while getting allowed signals".to_string(),
             ))?;
 
+    let (redis_error_tx, redis_error_rx) = oneshot::channel();
     let (tx, mut rx) = mpsc::channel(1);
     let handle = signal.handle();
-    let task_handle = tokio::spawn(common_utils::signals::signal_handler(signal, tx));
+    let task_handle = tokio::spawn(common_utils::signals::signal_handler(signal, tx.clone()));
+
+    let redis_conn_clone = store.redis_conn.clone();
+
+    // Spawn a task to monitor if redis is down or not
+    tokio::spawn(async move { redis_conn_clone.on_error(redis_error_tx).await });
+
+    //Spawns a task to send shutdown signal if redis goes down
+    tokio::spawn(redis_error_receiver(redis_error_rx, tx));
 
     let active_tasks = Arc::new(atomic::AtomicU64::new(0));
     'event: loop {
@@ -88,6 +97,20 @@ pub async fn start_drainer(
         ))?;
 
     Ok(())
+}
+
+pub async fn redis_error_receiver(rx: oneshot::Receiver<()>, shutdown_channel: mpsc::Sender<()>) {
+    match rx.await {
+        Ok(_) => {
+            logger::error!("The redis server failed ");
+            let _ = shutdown_channel.send(()).await.map_err(|err| {
+                logger::error!("Failed to send signal to the shutdown channel {err}")
+            });
+        }
+        Err(err) => {
+            logger::error!("Channel receiver error{err}");
+        }
+    }
 }
 
 async fn drainer_handler(


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->
- [x] Enhancement

## Description
<!-- Describe your changes in detail -->
Gracefully shutdown drainer if redis goes down.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
If redis goes down drainer won't be able to automatically reconnect to redis after it exhausts max reconnection attempts. So gracefully shutdown drainer and let it reconnect while restart

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
<img width="1728" alt="Screenshot 2023-09-29 at 2 01 46 AM" src="https://github.com/juspay/hyperswitch/assets/43412619/7cd49629-0fb4-4b0c-a0b5-8fb718aabcb0">


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code