### PR TITLE
refactor(connector): [Klarna] Expand wildcard match arms

### DIFF
--- a/crates/router/src/connector/klarna.rs
+++ b/crates/router/src/connector/klarna.rs
@@ -288,12 +288,115 @@ impl
                     self.base_url(connectors),
                     token
                 )),
-                _ => Err(error_stack::report!(errors::ConnectorError::NotSupported {
+                (
+                    storage_enums::PaymentExperience::DisplayQrCode
+                    | storage_enums::PaymentExperience::DisplayWaitScreen
+                    | storage_enums::PaymentExperience::InvokePaymentApp
+                    | storage_enums::PaymentExperience::InvokeSdkClient
+                    | storage_enums::PaymentExperience::LinkWallet
+                    | storage_enums::PaymentExperience::OneClick
+                    | storage_enums::PaymentExperience::RedirectToUrl,
+                    api_models::enums::PaymentMethodType::Ach
+                    | api_models::enums::PaymentMethodType::Affirm
+                    | api_models::enums::PaymentMethodType::AfterpayClearpay
+                    | api_models::enums::PaymentMethodType::Alfamart
+                    | api_models::enums::PaymentMethodType::AliPay
+                    | api_models::enums::PaymentMethodType::AliPayHk
+                    | api_models::enums::PaymentMethodType::Alma
+                    | api_models::enums::PaymentMethodType::ApplePay
+                    | api_models::enums::PaymentMethodType::Atome
+                    | api_models::enums::PaymentMethodType::Bacs
+                    | api_models::enums::PaymentMethodType::BancontactCard
+                    | api_models::enums::PaymentMethodType::Becs
+                    | api_models::enums::PaymentMethodType::Benefit
+                    | api_models::enums::PaymentMethodType::Bizum
+                    | api_models::enums::PaymentMethodType::Blik
+                    | api_models::enums::PaymentMethodType::Boleto
+                    | api_models::enums::PaymentMethodType::BcaBankTransfer
+                    | api_models::enums::PaymentMethodType::BniVa
+                    | api_models::enums::PaymentMethodType::BriVa
+                    | api_models::enums::PaymentMethodType::CimbVa
+                    | api_models::enums::PaymentMethodType::ClassicReward
+                    | api_models::enums::PaymentMethodType::Credit
+                    | api_models::enums::PaymentMethodType::CryptoCurrency
+                    | api_models::enums::PaymentMethodType::Cashapp
+                    | api_models::enums::PaymentMethodType::Dana
+                    | api_models::enums::PaymentMethodType::DanamonVa
+                    | api_models::enums::PaymentMethodType::Debit
+                    | api_models::enums::PaymentMethodType::Efecty
+                    | api_models::enums::PaymentMethodType::Eps
+                    | api_models::enums::PaymentMethodType::Evoucher
+                    | api_models::enums::PaymentMethodType::Giropay
+                    | api_models::enums::PaymentMethodType::Givex
+                    | api_models::enums::PaymentMethodType::GooglePay
+                    | api_models::enums::PaymentMethodType::GoPay
+                    | api_models::enums::PaymentMethodType::Gcash
+                    | api_models::enums::PaymentMethodType::Ideal
+                    | api_models::enums::PaymentMethodType::Interac
+                    | api_models::enums::PaymentMethodType::Indomaret
+                    | api_models::enums::PaymentMethodType::Klarna
+                    | api_models::enums::PaymentMethodType::KakaoPay
+                    | api_models::enums::PaymentMethodType::MandiriVa
+                    | api_models::enums::PaymentMethodType::Knet
+                    | api_models::enums::PaymentMethodType::MbWay
+                    | api_models::enums::PaymentMethodType::MobilePay
+                    | api_models::enums::PaymentMethodType::Momo
+                    | api_models::enums::PaymentMethodType::MomoAtm
+                    | api_models::enums::PaymentMethodType::Multibanco
+                    | api_models::enums::PaymentMethodType::OnlineBankingThailand
+                    | api_models::enums::PaymentMethodType::OnlineBankingCzechRepublic
+                    | api_models::enums::PaymentMethodType::OnlineBankingFinland
+                    | api_models::enums::PaymentMethodType::OnlineBankingFpx
+                    | api_models::enums::PaymentMethodType::OnlineBankingPoland
+                    | api_models::enums::PaymentMethodType::OnlineBankingSlovakia
+                    | api_models::enums::PaymentMethodType::Oxxo
+                    | api_models::enums::PaymentMethodType::PagoEfectivo
+                    | api_models::enums::PaymentMethodType::PermataBankTransfer
+                    | api_models::enums::PaymentMethodType::OpenBankingUk
+                    | api_models::enums::PaymentMethodType::PayBright
+                    | api_models::enums::PaymentMethodType::Paypal
+                    | api_models::enums::PaymentMethodType::Pix
+                    | api_models::enums::PaymentMethodType::PaySafeCard
+                    | api_models::enums::PaymentMethodType::Przelewy24
+                    | api_models::enums::PaymentMethodType::Pse
+                    | api_models::enums::PaymentMethodType::RedCompra
+                    | api_models::enums::PaymentMethodType::RedPagos
+                    | api_models::enums::PaymentMethodType::SamsungPay
+                    | api_models::enums::PaymentMethodType::Sepa
+                    | api_models::enums::PaymentMethodType::Sofort
+                    | api_models::enums::PaymentMethodType::Swish
+                    | api_models::enums::PaymentMethodType::TouchNGo
+                    | api_models::enums::PaymentMethodType::Trustly
+                    | api_models::enums::PaymentMethodType::Twint
+                    | api_models::enums::PaymentMethodType::UpiCollect
+                    | api_models::enums::PaymentMethodType::Vipps
+                    | api_models::enums::PaymentMethodType::Walley
+                    | api_models::enums::PaymentMethodType::WeChatPay
+                    | api_models::enums::PaymentMethodType::SevenEleven
+                    | api_models::enums::PaymentMethodType::Lawson
+                    | api_models::enums::PaymentMethodType::MiniStop
+                    | api_models::enums::PaymentMethodType::FamilyMart
+                    | api_models::enums::PaymentMethodType::Seicomart
+                    | api_models::enums::PaymentMethodType::PayEasy,
+                ) => Err(error_stack::report!(errors::ConnectorError::NotSupported {
                     message: payment_method_type.to_string(),
                     connector: "klarna",
                 })),
             },
-            _ => Err(error_stack::report!(
+
+            api_payments::PaymentMethodData::Card(_)
+            | api_payments::PaymentMethodData::CardRedirect(_)
+            | api_payments::PaymentMethodData::Wallet(_)
+            | api_payments::PaymentMethodData::PayLater(_)
+            | api_payments::PaymentMethodData::BankRedirect(_)
+            | api_payments::PaymentMethodData::BankDebit(_)
+            | api_payments::PaymentMethodData::BankTransfer(_)
+            | api_payments::PaymentMethodData::Crypto(_)
+            | api_payments::PaymentMethodData::MandatePayment
+            | api_payments::PaymentMethodData::Reward
+            | api_payments::PaymentMethodData::Upi(_)
+            | api_payments::PaymentMethodData::Voucher(_)
+            | api_payments::PaymentMethodData::GiftCard(_) => Err(error_stack::report!(
                 errors::ConnectorError::MismatchedPaymentData
             )),
         }


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Match arms using the wildcard patten (`_`) can be dangereous when extending enums since developers may miss locations where new variants should be handled. This patch expands all wildcard patterns in the Klarna connector to avoid this problem.

## Motivation and Context

Fixes #2273 

## How did you test it?

`cargo check`, `cargo clippy`, and `cargo test` all pass without errors in modified files.

## Checklist

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
