### PR TITLE
feat(connector): [Payeezy] Use connector_response_reference_id as reference to merchant

### DIFF
--- a/crates/router/src/connector/payeezy/transformers.rs
+++ b/crates/router/src/connector/payeezy/transformers.rs
@@ -67,6 +67,7 @@ pub struct PayeezyPaymentsRequest {
     pub currency_code: String,
     pub credit_card: PayeezyPaymentMethod,
     pub stored_credentials: Option<StoredCredentials>,
+    pub reference: String,
 }
 
 #[derive(Serialize, Debug)]
@@ -118,6 +119,7 @@ fn get_card_specific_payment_data(
         currency_code,
         credit_card,
         stored_credentials,
+        reference: item.connector_request_reference_id.clone(),
     })
 }
 fn get_transaction_type_and_stored_creds(
@@ -252,6 +254,7 @@ pub struct PayeezyPaymentsResponse {
     pub gateway_resp_code: String,
     pub gateway_message: String,
     pub stored_credentials: Option<PaymentsStoredCredentials>,
+    pub reference: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -354,13 +357,17 @@ impl<F, T>
             status,
             response: Ok(types::PaymentsResponseData::TransactionResponse {
                 resource_id: types::ResponseId::ConnectorTransactionId(
-                    item.response.transaction_id,
+                    item.response.transaction_id.clone(),
                 ),
                 redirection_data: None,
                 mandate_reference,
                 connector_metadata: metadata,
                 network_txn_id: None,
-                connector_response_reference_id: None,
+                connector_response_reference_id: Some(
+                    item.response
+                        .reference
+                        .unwrap_or(item.response.transaction_id),
+                ),
             }),
             ..item.data
         })


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Add `connector_response_reference_id` support for Payeezy
- Used `transaction_id` as the reference id, while implementing this!  

Resolves #2343 and resolves #2312.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?

Need help testing!
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->



## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
