### PR TITLE
build(deps): address `undeclared crate or module` errors on Windows for `scheduler` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -474,18 +474,6 @@ dependencies = [
 [[package]]
 name = "async-bb8-diesel"
 version = "0.1.0"
-source = "git+https://github.com/juspay/async-bb8-diesel?rev=9a71d142726dbc33f41c1fd935ddaa79841c7be5#9a71d142726dbc33f41c1fd935ddaa79841c7be5"
-dependencies = [
- "async-trait",
- "bb8",
- "diesel",
- "thiserror",
- "tokio",
-]
-
-[[package]]
-name = "async-bb8-diesel"
-version = "0.1.0"
 source = "git+https://github.com/oxidecomputer/async-bb8-diesel?rev=be3d9bce50051d8c0e0c06078e8066cc27db3001#be3d9bce50051d8c0e0c06078e8066cc27db3001"
 dependencies = [
  "async-trait",
@@ -733,39 +721,6 @@ dependencies = [
  "tokio-stream",
  "tower",
  "tracing",
-]
-
-[[package]]
-name = "aws-sdk-s3"
-version = "0.25.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "392b9811ca489747ac84349790e49deaa1f16631949e7dd4156000251c260eae"
-dependencies = [
- "aws-credential-types",
- "aws-endpoint",
- "aws-http",
- "aws-sig-auth",
- "aws-sigv4",
- "aws-smithy-async",
- "aws-smithy-checksums",
- "aws-smithy-client",
- "aws-smithy-eventstream",
- "aws-smithy-http",
- "aws-smithy-http-tower",
- "aws-smithy-json",
- "aws-smithy-types",
- "aws-smithy-xml",
- "aws-types",
- "bytes",
- "http",
- "http-body",
- "once_cell",
- "percent-encoding",
- "regex",
- "tokio-stream",
- "tower",
- "tracing",
- "url",
 ]
 
 [[package]]
@@ -1853,9 +1808,9 @@ dependencies = [
 name = "diesel_models"
 version = "0.1.0"
 dependencies = [
- "async-bb8-diesel 0.1.0 (git+https://github.com/oxidecomputer/async-bb8-diesel?rev=be3d9bce50051d8c0e0c06078e8066cc27db3001)",
+ "async-bb8-diesel",
  "aws-config",
- "aws-sdk-s3 0.28.0",
+ "aws-sdk-s3",
  "common_enums",
  "common_utils",
  "diesel",
@@ -1940,7 +1895,7 @@ checksum = "0688c2a7f92e427f44895cd63841bff7b29f8d7a1648b9e7e07a4a365b2e1257"
 name = "drainer"
 version = "0.1.0"
 dependencies = [
- "async-bb8-diesel 0.1.0 (git+https://github.com/oxidecomputer/async-bb8-diesel?rev=be3d9bce50051d8c0e0c06078e8066cc27db3001)",
+ "async-bb8-diesel",
  "bb8",
  "clap",
  "common_utils",
@@ -1988,20 +1943,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
 dependencies = [
  "atty",
- "humantime 1.3.0",
- "log",
- "regex",
- "termcolor",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
-dependencies = [
- "humantime 2.1.0",
- "is-terminal",
+ "humantime",
  "log",
  "regex",
  "termcolor",
@@ -2590,12 +2532,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "humantime"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
-
-[[package]]
 name = "hyper"
 version = "0.14.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2778,18 +2714,6 @@ name = "ipnet"
 version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12b6ee2129af8d4fb011108c73d99a1b83a85977f23b82460c0ae2e25bb4b57f"
-
-[[package]]
-name = "is-terminal"
-version = "0.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
-dependencies = [
- "hermit-abi 0.3.1",
- "io-lifetimes",
- "rustix",
- "windows-sys 0.48.0",
-]
 
 [[package]]
 name = "itertools"
@@ -3680,7 +3604,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "926d36b9553851b8b0005f1275891b392ee4d2d833852c417ed025477350fb9d"
 dependencies = [
- "env_logger 0.7.1",
+ "env_logger",
  "log",
 ]
 
@@ -4134,11 +4058,11 @@ dependencies = [
  "actix-rt",
  "actix-web",
  "api_models",
- "async-bb8-diesel 0.1.0 (git+https://github.com/oxidecomputer/async-bb8-diesel?rev=be3d9bce50051d8c0e0c06078e8066cc27db3001)",
+ "async-bb8-diesel",
  "async-trait",
  "awc",
  "aws-config",
- "aws-sdk-s3 0.28.0",
+ "aws-sdk-s3",
  "base64 0.21.2",
  "bb8",
  "blake3",
@@ -4428,36 +4352,19 @@ dependencies = [
 name = "scheduler"
 version = "0.1.0"
 dependencies = [
- "actix-multipart",
- "actix-rt",
- "actix-web",
- "api_models",
- "async-bb8-diesel 0.1.0 (git+https://github.com/juspay/async-bb8-diesel?rev=9a71d142726dbc33f41c1fd935ddaa79841c7be5)",
  "async-trait",
- "aws-config",
- "aws-sdk-s3 0.25.1",
- "cards",
- "clap",
  "common_utils",
- "diesel",
  "diesel_models",
- "dyn-clone",
- "env_logger 0.10.0",
  "error-stack",
  "external_services",
- "frunk",
- "frunk_core",
  "futures",
- "infer 0.13.0",
  "masking",
  "once_cell",
  "rand 0.8.5",
  "redis_interface",
- "router_derive",
  "router_env",
  "serde",
  "serde_json",
- "signal-hook",
  "signal-hook-tokio",
  "storage_impl",
  "strum 0.24.1",
@@ -4824,7 +4731,7 @@ version = "0.1.0"
 dependencies = [
  "actix-web",
  "api_models",
- "async-bb8-diesel 0.1.0 (git+https://github.com/oxidecomputer/async-bb8-diesel?rev=be3d9bce50051d8c0e0c06078e8066cc27db3001)",
+ "async-bb8-diesel",
  "async-trait",
  "bb8",
  "bytes",

--- a/crates/scheduler/Cargo.toml
+++ b/crates/scheduler/Cargo.toml
@@ -9,50 +9,31 @@ olap = []
 kv_store = []
 
 [dependencies]
-async-bb8-diesel = { git = "https://github.com/juspay/async-bb8-diesel", rev = "9a71d142726dbc33f41c1fd935ddaa79841c7be5" }
-clap = { version = "4.2.2", default-features = false, features = ["std", "derive", "help", "usage"] }
-diesel = { version = "2.0.3", features = ["postgres", "serde_json", "time"] }
+# Third party crates
+async-trait = "0.1.68"
 error-stack = "0.3.1"
-frunk = "0.4.1"
-frunk_core = "0.4.1"
 futures = "0.3.28"
-once_cell = "1.17.1"
-serde = "1.0.159"
-serde_json = "1.0.91"
-strum = { version = "0.24.1", features = ["derive"] }
-time = { version = "0.3.20", features = ["serde", "serde-well-known", "std"] }
-env_logger = "0.10.0"
+once_cell = "1.18.0"
 rand = "0.8.5"
-signal-hook = "0.3.15"
-uuid = { version = "1.3.1", features = ["serde", "v4"] }
+serde = "1.0.163"
+serde_json = "1.0.96"
+strum = { version = "0.24.1", features = ["derive"] }
+thiserror = "1.0.40"
+time = { version = "0.3.21", features = ["serde", "serde-well-known", "std"] }
+tokio = { version = "1.28.2", features = ["macros", "rt-multi-thread"] }
+uuid = { version = "1.3.3", features = ["serde", "v4"] }
 
 # First party crates
-api_models = { version = "0.1.0", path = "../api_models", features = ["errors"] }
 common_utils = { version = "0.1.0", path = "../common_utils", features = ["signals", "async_ext"] }
-cards = { version = "0.1.0", path = "../cards" }
+diesel_models = { version = "0.1.0", path = "../diesel_models", features = ["kv_store"] }
 external_services = { version = "0.1.0", path = "../external_services" }
 masking = { version = "0.1.0", path = "../masking" }
 redis_interface = { version = "0.1.0", path = "../redis_interface" }
-router_derive = { version = "0.1.0", path = "../router_derive" }
-storage_impl = { version = "0.1.0", path = "../storage_impl" , default-features = false }
 router_env = { version = "0.1.0", path = "../router_env", features = ["log_extra_implicit_fields", "log_custom_entries_to_extra"] }
-diesel_models = { version = "0.1.0", path = "../diesel_models", features = ["kv_store"] }
-actix-multipart = "0.6.0"
-aws-sdk-s3 = { version = "0.25.0", optional = true }
-aws-config = {version = "0.55.1", optional = true }
-infer = "0.13.0"
+storage_impl = { version = "0.1.0", path = "../storage_impl", default-features = false }
 
 [target.'cfg(not(target_os = "windows"))'.dependencies]
-signal-hook-tokio = { version = "0.3.1", features = ["futures-v0_3"]}
-
-# Third party crates
-actix-rt = "2.8.0"
-actix-web = "4.3.1"
-thiserror = "1.0.39"
-async-trait = "0.1.66"
-dyn-clone = "1.0.11"
-tokio = { version = "1.26.0", features = ["macros", "rt-multi-thread"] }
-
+signal-hook-tokio = { version = "0.3.1", features = ["futures-v0_3"] }
 
 # [[bin]]
 # name = "scheduler"

--- a/crates/scheduler/src/utils.rs
+++ b/crates/scheduler/src/utils.rs
@@ -381,6 +381,6 @@ where
 #[cfg(target_os = "windows")]
 pub(crate) async fn signal_handler(
     _sig: common_utils::signals::DummySignal,
-    _sender: oneshot::Sender<()>,
+    _sender: tokio::sync::mpsc::Sender<()>,
 ) {
 }

--- a/crates/scheduler/src/utils.rs
+++ b/crates/scheduler/src/utils.rs
@@ -377,10 +377,3 @@ where
         Ok(())
     }
 }
-
-#[cfg(target_os = "windows")]
-pub(crate) async fn signal_handler(
-    _sig: common_utils::signals::DummySignal,
-    _sender: tokio::sync::mpsc::Sender<()>,
-) {
-}


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [x] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
This PR addresses `undeclared crate or module` errors arising from the `scheduler` crate on Windows, due to some crates being excluded on Windows. In addition, some of the unused dependencies of the `scheduler` crate have also been removed.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
Fix failing builds on Windows.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
I was able to build the `scheduler` crate successfully, thus confirming that the removed crates were indeed unused. For the Windows-specific changes, I haven't tested it out on a Windows machine, but I believe the codebase should build successfully.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
