### PR TITLE
refactor(connector): [Klarna] Enhance currency Mapping with ConnectorCurrencyCommon Trait

### DIFF
--- a/crates/router/src/connector/klarna.rs
+++ b/crates/router/src/connector/klarna.rs
@@ -32,6 +32,10 @@ impl ConnectorCommon for Klarna {
         "klarna"
     }
 
+    fn get_currency_unit(&self) -> api::CurrencyUnit {
+        api::CurrencyUnit::Minor
+    }
+
     fn common_get_content_type(&self) -> &'static str {
         "application/json"
     }
@@ -406,7 +410,13 @@ impl
         &self,
         req: &types::PaymentsAuthorizeRouterData,
     ) -> CustomResult<Option<types::RequestBody>, errors::ConnectorError> {
-        let connector_req = klarna::KlarnaPaymentsRequest::try_from(req)?;
+        let connector_router_data = klarna::KlarnaRouterData::try_from((
+            &self.get_currency_unit(),
+            req.request.currency,
+            req.request.amount,
+            req,
+        ))?;
+        let connector_req = klarna::KlarnaPaymentsRequest::try_from(&connector_router_data)?;
         let klarna_req = types::RequestBody::log_and_get_request_body(
             &connector_req,
             utils::Encode::<klarna::KlarnaPaymentsRequest>::encode_to_string_of_json,


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

This pull request implements the `get_currency_unit` from the `ConnectorCommon` trait for the Klarna connector. This function allows connectors to declare their accepted currency unit as either `Base` or `Minor`. For Klarna it accepts currency as `Minor` units.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->

Fixes #2230 

## How did you test it?

`cargo check`, `cargo clippy`, and `cargo test` all pass without any new errors.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
