### PR TITLE
feat(connector): [Stax] Use connector_response_reference_id as reference to merchant

### DIFF
--- a/crates/router/src/connector/stax/transformers.rs
+++ b/crates/router/src/connector/stax/transformers.rs
@@ -23,7 +23,7 @@ pub struct StaxPaymentsRequest {
     is_refundable: bool,
     pre_auth: bool,
     meta: StaxPaymentsRequestMetaData,
-    reference: String,
+    idempotency_id: Option<String>,
 }
 
 impl TryFrom<&types::PaymentsAuthorizeRouterData> for StaxPaymentsRequest {
@@ -52,7 +52,7 @@ impl TryFrom<&types::PaymentsAuthorizeRouterData> for StaxPaymentsRequest {
                             Err(errors::ConnectorError::InvalidWalletToken)?
                         }
                     }),
-                    reference: item.connector_request_reference_id.clone(),
+                    idempotency_id: item.connector_request_reference_id.clone(),
                 })
             }
             api::PaymentMethodData::BankDebit(
@@ -71,7 +71,7 @@ impl TryFrom<&types::PaymentsAuthorizeRouterData> for StaxPaymentsRequest {
                             Err(errors::ConnectorError::InvalidWalletToken)?
                         }
                     }),
-                    reference: item.connector_request_reference_id.clone(),
+                    idempotency_id: item.connector_request_reference_id.clone(),
                 })
             }
             api::PaymentMethodData::BankDebit(_)
@@ -285,7 +285,7 @@ pub struct StaxPaymentsResponse {
     child_captures: Vec<StaxChildCapture>,
     #[serde(rename = "type")]
     payment_response_type: StaxPaymentResponseTypes,
-    reference: Option<String>,
+    idempotency_id: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -334,7 +334,7 @@ impl<F, T>
                 network_txn_id: None,
                 connector_response_reference_id: Some(
                     item.response
-                        .reference
+                        .idempotency_id
                         .unwrap_or(item.response.id),
                 ),
             }),

--- a/crates/router/src/connector/stax/transformers.rs
+++ b/crates/router/src/connector/stax/transformers.rs
@@ -52,7 +52,7 @@ impl TryFrom<&types::PaymentsAuthorizeRouterData> for StaxPaymentsRequest {
                             Err(errors::ConnectorError::InvalidWalletToken)?
                         }
                     }),
-                    idempotency_id: item.connector_request_reference_id.clone(),
+                    idempotency_id: Some(item.connector_request_reference_id.clone()),
                 })
             }
             api::PaymentMethodData::BankDebit(
@@ -71,7 +71,7 @@ impl TryFrom<&types::PaymentsAuthorizeRouterData> for StaxPaymentsRequest {
                             Err(errors::ConnectorError::InvalidWalletToken)?
                         }
                     }),
-                    idempotency_id: item.connector_request_reference_id.clone(),
+                    idempotency_id: Some(item.connector_request_reference_id.clone()),
                 })
             }
             api::PaymentMethodData::BankDebit(_)
@@ -333,9 +333,7 @@ impl<F, T>
                 connector_metadata,
                 network_txn_id: None,
                 connector_response_reference_id: Some(
-                    item.response
-                        .idempotency_id
-                        .unwrap_or(item.response.id),
+                    item.response.idempotency_id.unwrap_or(item.response.id),
                 ),
             }),
             ..item.data

--- a/crates/router/src/connector/stax/transformers.rs
+++ b/crates/router/src/connector/stax/transformers.rs
@@ -71,6 +71,7 @@ impl TryFrom<&types::PaymentsAuthorizeRouterData> for StaxPaymentsRequest {
                             Err(errors::ConnectorError::InvalidWalletToken)?
                         }
                     }),
+                    reference: item.connector_request_reference_id.clone(),
                 })
             }
             api::PaymentMethodData::BankDebit(_)
@@ -326,15 +327,15 @@ impl<F, T>
         Ok(Self {
             status,
             response: Ok(types::PaymentsResponseData::TransactionResponse {
-                resource_id: types::ResponseId::ConnectorTransactionId(
-                    item.response.id.clone(),
-                ),
+                resource_id: types::ResponseId::ConnectorTransactionId(item.response.id.clone()),
                 redirection_data: None,
                 mandate_reference: None,
                 connector_metadata,
                 network_txn_id: None,
                 connector_response_reference_id: Some(
-                    item.response.reference.unwrap_or(item.response.id),
+                    item.response
+                        .reference
+                        .unwrap_or(item.response.id),
                 ),
             }),
             ..item.data


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
This pull request fixes #2348 issue in STAX and uses connector_response_reference_id as reference to merchant.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
Fixes https://github.com/juspay/hyperswitch/issues/2348

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
