### PR TITLE
refactor(frm): fetch frm feature toggle from env config instead of DB

### DIFF
--- a/config/config.example.toml
+++ b/config/config.example.toml
@@ -421,3 +421,6 @@ apple_pay_ppc = "APPLE_PAY_PAYMENT_PROCESSING_CERTIFICATE"              #Payment
 apple_pay_ppc_key = "APPLE_PAY_PAYMENT_PROCESSING_CERTIFICATE_KEY"      #Private key generate by Elliptic-curve prime256v1 curve
 apple_pay_merchant_cert = "APPLE_PAY_MERCHNAT_CERTIFICATE"              #Merchant Certificate provided by Apple Pay (https://developer.apple.com/) Certificates, Identifiers & Profiles > Apple Pay Merchant Identity Certificate
 apple_pay_merchant_cert_key = "APPLE_PAY_MERCHNAT_CERTIFICATE_KEY"      #Private key generate by RSA:2048 algorithm
+
+[frm]
+is_frm_enabled = true

--- a/config/development.toml
+++ b/config/development.toml
@@ -436,3 +436,6 @@ apple_pay_merchant_cert_key = "APPLE_PAY_MERCHNAT_CERTIFICATE_KEY"
 [lock_settings]
 redis_lock_expiry_seconds = 180 # 3 * 60 seconds
 delay_between_retries_in_milliseconds = 500
+
+[frm]
+is_frm_enabled = true

--- a/config/docker_compose.toml
+++ b/config/docker_compose.toml
@@ -306,3 +306,6 @@ supported_connectors = "braintree"
 [lock_settings]
 redis_lock_expiry_seconds = 180 # 3 * 60 seconds
 delay_between_retries_in_milliseconds = 500
+
+[frm]
+is_frm_enabled = true

--- a/crates/router/src/configs/settings.rs
+++ b/crates/router/src/configs/settings.rs
@@ -100,6 +100,7 @@ pub struct Settings {
     pub applepay_merchant_configs: ApplepayMerchantConfigs,
     pub lock_settings: LockSettings,
     pub temp_locker_disable_config: TempLockerDisableConfig,
+    pub frm: Frm
 }
 
 #[derive(Debug, Deserialize, Clone, Default)]
@@ -803,4 +804,9 @@ impl<'de> Deserialize<'de> for LockSettings {
             lock_retries: redis_lock_expiry_seconds / delay_between_retries_in_milliseconds,
         })
     }
+}
+
+#[derive(Debug, Deserialize, Clone, Default)]
+pub struct Frm {
+    pub is_frm_enabled: bool
 }

--- a/crates/router/src/configs/settings.rs
+++ b/crates/router/src/configs/settings.rs
@@ -100,7 +100,7 @@ pub struct Settings {
     pub applepay_merchant_configs: ApplepayMerchantConfigs,
     pub lock_settings: LockSettings,
     pub temp_locker_disable_config: TempLockerDisableConfig,
-    pub frm: Frm
+    pub frm: Frm,
 }
 
 #[derive(Debug, Deserialize, Clone, Default)]
@@ -808,5 +808,5 @@ impl<'de> Deserialize<'de> for LockSettings {
 
 #[derive(Debug, Deserialize, Clone, Default)]
 pub struct Frm {
-    pub is_frm_enabled: bool
+    pub is_frm_enabled: bool,
 }

--- a/loadtest/config/development.toml
+++ b/loadtest/config/development.toml
@@ -218,3 +218,6 @@ payout_eligibility = true
 
 [multiple_api_version_supported_connectors]
 supported_connectors = "braintree"
+
+[frm]
+is_frm_enabled = true


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [X] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
In order to reduce DB calls made during the transaction we are moving the frm_feature flag DB call to ENV variable

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
NA

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
1. Connect a signifyd processor and try making a payment, existing FRM flows should work as expected.
2. Run postman collection tests for FRM
<img width="698" alt="Screenshot 2023-10-03 at 5 13 37 PM" src="https://github.com/juspay/hyperswitch/assets/20727598/fc3f4974-c258-4513-b84f-43984cc93bbd">



## Checklist
<!-- Put an `x` in the boxes that apply -->

- [X] I formatted the code `cargo +nightly fmt --all`
- [X] I addressed lints thrown by `cargo clippy`
- [X] I reviewed the submitted code
- [X] I added unit tests for my changes where possible
