### PR TITLE
feat(connector): [Noon] Use connector_response_reference_id as reference

### DIFF
--- a/crates/router/src/connector/noon/transformers.rs
+++ b/crates/router/src/connector/noon/transformers.rs
@@ -648,7 +648,6 @@ pub struct NoonWebhookEvent {
 pub struct NoonWebhookObject {
     pub order_status: NoonPaymentStatus,
     pub order_id: u64,
-    pub reference: Option<String>,
 }
 
 /// This from will ensure that webhook body would be properly parsed into PSync response
@@ -662,7 +661,7 @@ impl From<NoonWebhookObject> for NoonPaymentsResponse {
                     //For successful payments Noon Always populates error_code as 0.
                     error_code: 0,
                     error_message: None,
-                    reference: value.reference,
+                    reference: None,
                 },
                 checkout_data: None,
                 subscription: None,

--- a/crates/router/src/connector/noon/transformers.rs
+++ b/crates/router/src/connector/noon/transformers.rs
@@ -356,6 +356,7 @@ pub struct NoonPaymentsOrderResponse {
     id: u64,
     error_code: u64,
     error_message: Option<String>,
+    reference: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -416,7 +417,7 @@ impl<F, T>
                     mandate_reference,
                     connector_metadata: None,
                     network_txn_id: None,
-                    connector_response_reference_id: None,
+                    connector_response_reference_id: order.reference,
                 }),
             },
             ..item.data
@@ -647,6 +648,7 @@ pub struct NoonWebhookEvent {
 pub struct NoonWebhookObject {
     pub order_status: NoonPaymentStatus,
     pub order_id: u64,
+    pub reference: Option<String>,
 }
 
 /// This from will ensure that webhook body would be properly parsed into PSync response
@@ -660,6 +662,7 @@ impl From<NoonWebhookObject> for NoonPaymentsResponse {
                     //For successful payments Noon Always populates error_code as 0.
                     error_code: 0,
                     error_message: None,
+                    reference: value.reference,
                 },
                 checkout_data: None,
                 subscription: None,

--- a/crates/router/src/connector/noon/transformers.rs
+++ b/crates/router/src/connector/noon/transformers.rs
@@ -413,7 +413,7 @@ impl<F, T>
                 }),
                 _ => {
                     let connector_response_reference_id =
-                        Some(order.reference.unwrap_or(order.id.to_string()));
+                        order.reference.or(Some(order.id.to_string()));
                     Ok(types::PaymentsResponseData::TransactionResponse {
                         resource_id: types::ResponseId::ConnectorTransactionId(
                             order.id.to_string(),

--- a/crates/router/src/connector/noon/transformers.rs
+++ b/crates/router/src/connector/noon/transformers.rs
@@ -411,14 +411,20 @@ impl<F, T>
                     reason: Some(error_message),
                     status_code: item.http_code,
                 }),
-                _ => Ok(types::PaymentsResponseData::TransactionResponse {
-                    resource_id: types::ResponseId::ConnectorTransactionId(order.id.to_string()),
-                    redirection_data,
-                    mandate_reference,
-                    connector_metadata: None,
-                    network_txn_id: None,
-                    connector_response_reference_id: order.reference,
-                }),
+                _ => {
+                    let connector_response_reference_id =
+                        Some(order.reference.unwrap_or(order.id.to_string()));
+                    Ok(types::PaymentsResponseData::TransactionResponse {
+                        resource_id: types::ResponseId::ConnectorTransactionId(
+                            order.id.to_string(),
+                        ),
+                        redirection_data,
+                        mandate_reference,
+                        connector_metadata: None,
+                        network_txn_id: None,
+                        connector_response_reference_id,
+                    })
+                }
             },
             ..item.data
         })


### PR DESCRIPTION


## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
I have added `reference` that's sent to noon payments order to the `TransactionResponse` in `transformer.rs` of noon that's present in the `connector` directory.

https://github.com/juspay/hyperswitch/blob/main/crates/router/src/connector/noon/transformers.rs

## Motivation and Context
Closes  #2339




## Checklist

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [x] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
