### PR TITLE
refactor(webhook): add a function to retrieve payment_id

### DIFF
--- a/crates/api_models/src/webhooks.rs
+++ b/crates/api_models/src/webhooks.rs
@@ -62,9 +62,9 @@ pub enum WebhookResponseTracker {
 impl WebhookResponseTracker {
     pub fn get_payment_id(&self) -> Option<String> {
         match self {
-            Self::Payment { payment_id, .. } => Some(payment_id.to_string()),
-            Self::Refund { payment_id, .. } => Some(payment_id.to_string()),
-            Self::Dispute { payment_id, .. } => Some(payment_id.to_string()),
+            Self::Payment { payment_id, .. }
+            | Self::Refund { payment_id, .. }
+            | Self::Dispute { payment_id, .. } => Some(payment_id.to_string()),
             Self::NoEffect => None,
         }
     }

--- a/crates/api_models/src/webhooks.rs
+++ b/crates/api_models/src/webhooks.rs
@@ -59,6 +59,17 @@ pub enum WebhookResponseTracker {
     NoEffect,
 }
 
+impl WebhookResponseTracker {
+    pub fn get_payment_id(&self) -> Option<String> {
+        match self {
+            WebhookResponseTracker::Payment { payment_id, .. } => Some(payment_id.to_string()),
+            WebhookResponseTracker::Refund { payment_id, .. } => Some(payment_id.to_string()),
+            WebhookResponseTracker::Dispute { payment_id, .. } => Some(payment_id.to_string()),
+            WebhookResponseTracker::NoEffect => None,
+        }
+    }
+}
+
 impl From<IncomingWebhookEvent> for WebhookFlow {
     fn from(evt: IncomingWebhookEvent) -> Self {
         match evt {

--- a/crates/api_models/src/webhooks.rs
+++ b/crates/api_models/src/webhooks.rs
@@ -62,10 +62,10 @@ pub enum WebhookResponseTracker {
 impl WebhookResponseTracker {
     pub fn get_payment_id(&self) -> Option<String> {
         match self {
-            WebhookResponseTracker::Payment { payment_id, .. } => Some(payment_id.to_string()),
-            WebhookResponseTracker::Refund { payment_id, .. } => Some(payment_id.to_string()),
-            WebhookResponseTracker::Dispute { payment_id, .. } => Some(payment_id.to_string()),
-            WebhookResponseTracker::NoEffect => None,
+            Self::Payment { payment_id, .. } => Some(payment_id.to_string()),
+            Self::Refund { payment_id, .. } => Some(payment_id.to_string()),
+            Self::Dispute { payment_id, .. } => Some(payment_id.to_string()),
+            Self::NoEffect => None,
         }
     }
 }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Refactoring

## Description
<!-- Describe your changes in detail -->
This PR will add a function to retrieve the `payment_id` which can be populated in the webhooks response which can be used by other crates.


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
