### PR TITLE
feat(router): add support for payment_type field in payment intent

### DIFF
--- a/crates/api_models/src/payment_methods.rs
+++ b/crates/api_models/src/payment_methods.rs
@@ -519,6 +519,7 @@ pub struct PaymentMethodListResponse {
     #[schema(value_type = Option<String>)]
     pub merchant_name: OptionalEncryptableName,
 
+    #[schema(value_type = Option<PaymentType>)]
     pub payment_type: Option<api_enums::PaymentType>,
 }
 

--- a/crates/api_models/src/payment_methods.rs
+++ b/crates/api_models/src/payment_methods.rs
@@ -518,6 +518,8 @@ pub struct PaymentMethodListResponse {
 
     #[schema(value_type = Option<String>)]
     pub merchant_name: OptionalEncryptableName,
+
+    pub payment_type: Option<api_enums::PaymentType>,
 }
 
 #[derive(Eq, PartialEq, Hash, Debug, serde::Deserialize, ToSchema)]

--- a/crates/api_models/src/payments.rs
+++ b/crates/api_models/src/payments.rs
@@ -300,6 +300,7 @@ pub struct PaymentsRequest {
     pub profile_id: Option<String>,
 
     /// The type of the payment that differentiates between normal and various types of mandate payments
+    #[schema(value_type = Option<PaymentType>)]
     #[serde(default)]
     pub payment_type: api_enums::PaymentType,
 }

--- a/crates/api_models/src/payments.rs
+++ b/crates/api_models/src/payments.rs
@@ -298,6 +298,10 @@ pub struct PaymentsRequest {
     /// The business profile to use for this payment, if not passed the default business profile
     /// associated with the merchant account will be used.
     pub profile_id: Option<String>,
+
+    /// The type of the payment that differentiates between normal and various types of mandate payments
+    #[serde(default)]
+    pub payment_type: api_enums::PaymentType,
 }
 
 #[derive(Default, Debug, Clone, Copy)]

--- a/crates/common_enums/src/enums.rs
+++ b/crates/common_enums/src/enums.rs
@@ -12,7 +12,7 @@ pub mod diesel_exports {
         DbDisputeStage as DisputeStage, DbDisputeStatus as DisputeStatus, DbEventType as EventType,
         DbFutureUsage as FutureUsage, DbIntentStatus as IntentStatus,
         DbMandateStatus as MandateStatus, DbPaymentMethodIssuerCode as PaymentMethodIssuerCode,
-        DbRefundStatus as RefundStatus,
+        DbPaymentType as PaymentType, DbRefundStatus as RefundStatus,
     };
 }
 
@@ -1063,6 +1063,29 @@ pub enum PaymentMethod {
     Upi,
     Voucher,
     GiftCard,
+}
+
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Default,
+    Eq,
+    PartialEq,
+    serde::Deserialize,
+    serde::Serialize,
+    strum::Display,
+    strum::EnumString,
+)]
+#[router_derive::diesel_enum(storage_type = "pg_enum")]
+#[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "snake_case")]
+pub enum PaymentType {
+    #[default]
+    Normal,
+    NewMandate,
+    SetupMandate,
+    RecurringMandate,
 }
 
 #[derive(

--- a/crates/common_enums/src/enums.rs
+++ b/crates/common_enums/src/enums.rs
@@ -1076,6 +1076,7 @@ pub enum PaymentMethod {
     serde::Serialize,
     strum::Display,
     strum::EnumString,
+    ToSchema,
 )]
 #[router_derive::diesel_enum(storage_type = "pg_enum")]
 #[serde(rename_all = "snake_case")]

--- a/crates/data_models/src/payments/payment_intent.rs
+++ b/crates/data_models/src/payments/payment_intent.rs
@@ -105,7 +105,7 @@ pub struct PaymentIntent {
     // Manual review can occur when the transaction is marked as risky by the frm_processor, payment processor or when there is underpayment/over payment incase of crypto payment
     pub merchant_decision: Option<String>,
     pub payment_confirm_source: Option<storage_enums::PaymentSource>,
-    pub payment_type: storage_enums::PaymentType,
+    pub payment_type: Option<storage_enums::PaymentType>,
 }
 
 #[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
@@ -145,7 +145,7 @@ pub struct PaymentIntentNew {
     pub profile_id: Option<String>,
     pub merchant_decision: Option<String>,
     pub payment_confirm_source: Option<storage_enums::PaymentSource>,
-    pub payment_type: storage_enums::PaymentType,
+    pub payment_type: Option<storage_enums::PaymentType>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/data_models/src/payments/payment_intent.rs
+++ b/crates/data_models/src/payments/payment_intent.rs
@@ -105,6 +105,7 @@ pub struct PaymentIntent {
     // Manual review can occur when the transaction is marked as risky by the frm_processor, payment processor or when there is underpayment/over payment incase of crypto payment
     pub merchant_decision: Option<String>,
     pub payment_confirm_source: Option<storage_enums::PaymentSource>,
+    pub payment_type: storage_enums::PaymentType,
 }
 
 #[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
@@ -144,6 +145,7 @@ pub struct PaymentIntentNew {
     pub profile_id: Option<String>,
     pub merchant_decision: Option<String>,
     pub payment_confirm_source: Option<storage_enums::PaymentSource>,
+    pub payment_type: storage_enums::PaymentType,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/diesel_models/src/enums.rs
+++ b/crates/diesel_models/src/enums.rs
@@ -11,7 +11,7 @@ pub mod diesel_exports {
         DbMandateStatus as MandateStatus, DbMandateType as MandateType,
         DbMerchantStorageScheme as MerchantStorageScheme,
         DbPaymentMethodIssuerCode as PaymentMethodIssuerCode, DbPaymentSource as PaymentSource,
-        DbPayoutStatus as PayoutStatus, DbPayoutType as PayoutType,
+        DbPaymentType as PaymentType, DbPayoutStatus as PayoutStatus, DbPayoutType as PayoutType,
         DbProcessTrackerStatus as ProcessTrackerStatus, DbReconStatus as ReconStatus,
         DbRefundStatus as RefundStatus, DbRefundType as RefundType,
     };

--- a/crates/diesel_models/src/payment_intent.rs
+++ b/crates/diesel_models/src/payment_intent.rs
@@ -47,7 +47,7 @@ pub struct PaymentIntent {
     // Manual review can occur when the transaction is marked as risky by the frm_processor, payment processor or when there is underpayment/over payment incase of crypto payment
     pub merchant_decision: Option<String>,
     pub payment_confirm_source: Option<storage_enums::PaymentSource>,
-    pub payment_type: storage_enums::PaymentType,
+    pub payment_type: Option<storage_enums::PaymentType>,
 }
 
 #[derive(
@@ -99,7 +99,7 @@ pub struct PaymentIntentNew {
     pub profile_id: Option<String>,
     pub merchant_decision: Option<String>,
     pub payment_confirm_source: Option<storage_enums::PaymentSource>,
-    pub payment_type: storage_enums::PaymentType,
+    pub payment_type: Option<storage_enums::PaymentType>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/diesel_models/src/payment_intent.rs
+++ b/crates/diesel_models/src/payment_intent.rs
@@ -47,6 +47,7 @@ pub struct PaymentIntent {
     // Manual review can occur when the transaction is marked as risky by the frm_processor, payment processor or when there is underpayment/over payment incase of crypto payment
     pub merchant_decision: Option<String>,
     pub payment_confirm_source: Option<storage_enums::PaymentSource>,
+    pub payment_type: storage_enums::PaymentType,
 }
 
 #[derive(
@@ -98,6 +99,7 @@ pub struct PaymentIntentNew {
     pub profile_id: Option<String>,
     pub merchant_decision: Option<String>,
     pub payment_confirm_source: Option<storage_enums::PaymentSource>,
+    pub payment_type: storage_enums::PaymentType,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/diesel_models/src/schema.rs
+++ b/crates/diesel_models/src/schema.rs
@@ -609,6 +609,7 @@ diesel::table! {
         #[max_length = 64]
         merchant_decision -> Nullable<Varchar>,
         payment_confirm_source -> Nullable<PaymentSource>,
+        payment_type -> PaymentType,
     }
 }
 

--- a/crates/diesel_models/src/schema.rs
+++ b/crates/diesel_models/src/schema.rs
@@ -609,7 +609,7 @@ diesel::table! {
         #[max_length = 64]
         merchant_decision -> Nullable<Varchar>,
         payment_confirm_source -> Nullable<PaymentSource>,
-        payment_type -> PaymentType,
+        payment_type -> Nullable<PaymentType>,
     }
 }
 

--- a/crates/router/src/core/payment_methods/cards.rs
+++ b/crates/router/src/core/payment_methods/cards.rs
@@ -1281,6 +1281,7 @@ pub async fn list_payment_methods(
             redirect_url: merchant_account.return_url,
             merchant_name: merchant_account.merchant_name,
             payment_methods: payment_method_responses,
+            payment_type: payment_intent.as_ref().map(|pi| pi.payment_type),
             mandate_payment: payment_attempt.and_then(|inner| inner.mandate_details).map(
                 |d| match d {
                     data_models::mandates::MandateDataType::SingleUse(i) => {

--- a/crates/router/src/core/payment_methods/cards.rs
+++ b/crates/router/src/core/payment_methods/cards.rs
@@ -1281,7 +1281,7 @@ pub async fn list_payment_methods(
             redirect_url: merchant_account.return_url,
             merchant_name: merchant_account.merchant_name,
             payment_methods: payment_method_responses,
-            payment_type: payment_intent.as_ref().map(|pi| pi.payment_type),
+            payment_type: payment_intent.as_ref().and_then(|pi| pi.payment_type),
             mandate_payment: payment_attempt.and_then(|inner| inner.mandate_details).map(
                 |d| match d {
                     data_models::mandates::MandateDataType::SingleUse(i) => {

--- a/crates/router/src/core/payments/helpers.rs
+++ b/crates/router/src/core/payments/helpers.rs
@@ -2396,7 +2396,7 @@ mod tests {
             profile_id: None,
             merchant_decision: None,
             payment_confirm_source: None,
-            payment_type: api_enums::PaymentType::Normal,
+            payment_type: Some(api_enums::PaymentType::Normal),
         };
         let req_cs = Some("1".to_string());
         let merchant_fulfillment_time = Some(900);
@@ -2444,7 +2444,7 @@ mod tests {
             profile_id: None,
             merchant_decision: None,
             payment_confirm_source: None,
-            payment_type: api_enums::PaymentType::Normal,
+            payment_type: Some(api_enums::PaymentType::Normal),
         };
         let req_cs = Some("1".to_string());
         let merchant_fulfillment_time = Some(10);
@@ -2492,7 +2492,7 @@ mod tests {
             profile_id: None,
             merchant_decision: None,
             payment_confirm_source: None,
-            payment_type: api_enums::PaymentType::Normal,
+            payment_type: Some(api_enums::PaymentType::Normal),
         };
         let req_cs = Some("1".to_string());
         let merchant_fulfillment_time = Some(10);

--- a/crates/router/src/core/payments/helpers.rs
+++ b/crates/router/src/core/payments/helpers.rs
@@ -633,20 +633,22 @@ pub fn validate_card_data(
 }
 
 pub fn infer_payment_type(
-    req: &api::PaymentsRequest,
+    amount: &api::Amount,
     mandate_type: Option<&api::MandateTransactionType>,
 ) -> api_enums::PaymentType {
     match mandate_type {
         Some(api::MandateTransactionType::NewMandateTransaction) => {
-            if let Some(api::Amount::Value(_)) = req.amount {
+            if let api::Amount::Value(_) = amount {
                 api_enums::PaymentType::NewMandate
             } else {
                 api_enums::PaymentType::SetupMandate
             }
         }
+
         Some(api::MandateTransactionType::RecurringMandateTransaction) => {
             api_enums::PaymentType::RecurringMandate
         }
+
         None => api_enums::PaymentType::Normal,
     }
 }

--- a/crates/router/src/core/payments/helpers.rs
+++ b/crates/router/src/core/payments/helpers.rs
@@ -632,6 +632,25 @@ pub fn validate_card_data(
     Ok(())
 }
 
+pub fn infer_payment_type(
+    req: &api::PaymentsRequest,
+    mandate_type: Option<&api::MandateTransactionType>,
+) -> api_enums::PaymentType {
+    match mandate_type {
+        Some(api::MandateTransactionType::NewMandateTransaction) => {
+            if let Some(api::Amount::Value(_)) = req.amount {
+                api_enums::PaymentType::NewMandate
+            } else {
+                api_enums::PaymentType::SetupMandate
+            }
+        }
+        Some(api::MandateTransactionType::RecurringMandateTransaction) => {
+            api_enums::PaymentType::RecurringMandate
+        }
+        None => api_enums::PaymentType::Normal,
+    }
+}
+
 pub fn validate_mandate(
     req: impl Into<api::MandateValidationFields>,
     is_confirm_operation: bool,
@@ -2377,6 +2396,7 @@ mod tests {
             profile_id: None,
             merchant_decision: None,
             payment_confirm_source: None,
+            payment_type: api_enums::PaymentType::Normal,
         };
         let req_cs = Some("1".to_string());
         let merchant_fulfillment_time = Some(900);
@@ -2424,6 +2444,7 @@ mod tests {
             profile_id: None,
             merchant_decision: None,
             payment_confirm_source: None,
+            payment_type: api_enums::PaymentType::Normal,
         };
         let req_cs = Some("1".to_string());
         let merchant_fulfillment_time = Some(10);
@@ -2471,6 +2492,7 @@ mod tests {
             profile_id: None,
             merchant_decision: None,
             payment_confirm_source: None,
+            payment_type: api_enums::PaymentType::Normal,
         };
         let req_cs = Some("1".to_string());
         let merchant_fulfillment_time = Some(10);

--- a/crates/router/src/core/payments/operations/payment_create.rs
+++ b/crates/router/src/core/payments/operations/payment_create.rs
@@ -671,7 +671,7 @@ impl PaymentCreate {
             profile_id: Some(profile_id),
             merchant_decision: None,
             payment_confirm_source: None,
-            payment_type,
+            payment_type: Some(payment_type),
         })
     }
 

--- a/crates/router/src/core/payments/operations/payment_create.rs
+++ b/crates/router/src/core/payments/operations/payment_create.rs
@@ -75,6 +75,8 @@ impl<F: Send + Clone> GetTracker<F, PaymentData<F>, api::PaymentsRequest> for Pa
         core_utils::validate_and_get_business_profile(db, request.profile_id.as_ref(), merchant_id)
             .await?;
 
+        let payment_type = helpers::infer_payment_type(request, mandate_type.as_ref());
+
         let (
             token,
             payment_method,
@@ -156,6 +158,7 @@ impl<F: Send + Clone> GetTracker<F, PaymentData<F>, api::PaymentsRequest> for Pa
                     request,
                     shipping_address.clone().map(|x| x.address_id),
                     billing_address.clone().map(|x| x.address_id),
+                    payment_type,
                     payment_attempt.attempt_id.to_owned(),
                     state,
                 )
@@ -593,6 +596,7 @@ impl PaymentCreate {
         request: &api::PaymentsRequest,
         shipping_address_id: Option<String>,
         billing_address_id: Option<String>,
+        payment_type: enums::PaymentType,
         active_attempt_id: String,
         state: &AppState,
     ) -> RouterResult<storage::PaymentIntentNew> {
@@ -667,6 +671,7 @@ impl PaymentCreate {
             profile_id: Some(profile_id),
             merchant_decision: None,
             payment_confirm_source: None,
+            payment_type,
         })
     }
 

--- a/crates/router/src/core/payments/operations/payment_create.rs
+++ b/crates/router/src/core/payments/operations/payment_create.rs
@@ -75,7 +75,7 @@ impl<F: Send + Clone> GetTracker<F, PaymentData<F>, api::PaymentsRequest> for Pa
         core_utils::validate_and_get_business_profile(db, request.profile_id.as_ref(), merchant_id)
             .await?;
 
-        let payment_type = helpers::infer_payment_type(request, mandate_type.as_ref());
+        let payment_type = helpers::infer_payment_type(&amount, mandate_type.as_ref());
 
         let (
             token,

--- a/crates/router/src/openapi.rs
+++ b/crates/router/src/openapi.rs
@@ -140,6 +140,7 @@ Never share your secret api keys. Keep them guarded and secure.
         api_models::admin::AcceptedCountries,
         api_models::admin::AcceptedCurrencies,
         api_models::enums::RoutingAlgorithm,
+        api_models::enums::PaymentType,
         api_models::enums::PaymentMethod,
         api_models::enums::PaymentMethodType,
         api_models::enums::ConnectorType,

--- a/crates/storage_impl/src/mock_db/payment_intent.rs
+++ b/crates/storage_impl/src/mock_db/payment_intent.rs
@@ -106,6 +106,7 @@ impl PaymentIntentInterface for MockDb {
             profile_id: new.profile_id,
             merchant_decision: new.merchant_decision,
             payment_confirm_source: new.payment_confirm_source,
+            payment_type: new.payment_type,
         };
         payment_intents.push(payment_intent.clone());
         Ok(payment_intent)

--- a/crates/storage_impl/src/payments/payment_intent.rs
+++ b/crates/storage_impl/src/payments/payment_intent.rs
@@ -91,6 +91,7 @@ impl<T: DatabaseStore> PaymentIntentInterface for KVRouterStore<T> {
                     profile_id: new.profile_id.clone(),
                     merchant_decision: new.merchant_decision.clone(),
                     payment_confirm_source: new.payment_confirm_source,
+                    payment_type: new.payment_type,
                 };
 
                 match self
@@ -707,6 +708,7 @@ impl DataModelExt for PaymentIntentNew {
             profile_id: self.profile_id,
             merchant_decision: self.merchant_decision,
             payment_confirm_source: self.payment_confirm_source,
+            payment_type: self.payment_type,
         }
     }
 
@@ -744,6 +746,7 @@ impl DataModelExt for PaymentIntentNew {
             profile_id: storage_model.profile_id,
             merchant_decision: storage_model.merchant_decision,
             payment_confirm_source: storage_model.payment_confirm_source,
+            payment_type: storage_model.payment_type,
         }
     }
 }
@@ -786,6 +789,7 @@ impl DataModelExt for PaymentIntent {
             profile_id: self.profile_id,
             merchant_decision: self.merchant_decision,
             payment_confirm_source: self.payment_confirm_source,
+            payment_type: self.payment_type,
         }
     }
 
@@ -824,6 +828,7 @@ impl DataModelExt for PaymentIntent {
             profile_id: storage_model.profile_id,
             merchant_decision: storage_model.merchant_decision,
             payment_confirm_source: storage_model.payment_confirm_source,
+            payment_type: storage_model.payment_type,
         }
     }
 }

--- a/migrations/2023-10-04-120026_add_payment_type_column_in_payment_intent/down.sql
+++ b/migrations/2023-10-04-120026_add_payment_type_column_in_payment_intent/down.sql
@@ -1,0 +1,6 @@
+-- This file should undo anything in `up.sql`
+
+ALTER TABLE payment_intent
+DROP COLUMN payment_type;
+
+DROP TYPE "PaymentType";

--- a/migrations/2023-10-04-120026_add_payment_type_column_in_payment_intent/up.sql
+++ b/migrations/2023-10-04-120026_add_payment_type_column_in_payment_intent/up.sql
@@ -8,4 +8,4 @@ CREATE TYPE "PaymentType" AS ENUM (
 );
 
 ALTER TABLE payment_intent
-ADD COLUMN payment_type "PaymentType" NOT NULL DEFAULT 'normal';
+ADD COLUMN payment_type "PaymentType";

--- a/migrations/2023-10-04-120026_add_payment_type_column_in_payment_intent/up.sql
+++ b/migrations/2023-10-04-120026_add_payment_type_column_in_payment_intent/up.sql
@@ -1,0 +1,11 @@
+-- Your SQL goes here
+
+CREATE TYPE "PaymentType" AS ENUM (
+    'normal',
+    'new_mandate',
+    'setup_mandate',
+    'recurring_mandate'
+);
+
+ALTER TABLE payment_intent
+ADD COLUMN payment_type "PaymentType" NOT NULL DEFAULT 'normal';

--- a/openapi/openapi_spec.json
+++ b/openapi/openapi_spec.json
@@ -8084,7 +8084,7 @@
           "payment_type": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/api_enums.PaymentType"
+                "$ref": "#/components/schemas/PaymentType"
               }
             ],
             "nullable": true
@@ -8412,8 +8412,7 @@
         "type": "object",
         "required": [
           "amount",
-          "currency",
-          "payment_type"
+          "currency"
         ],
         "properties": {
           "payment_id": {
@@ -8751,7 +8750,12 @@
             "nullable": true
           },
           "payment_type": {
-            "$ref": "#/components/schemas/api_enums.PaymentType"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PaymentType"
+              }
+            ],
+            "nullable": true
           }
         }
       },
@@ -9093,7 +9097,12 @@
             "nullable": true
           },
           "payment_type": {
-            "$ref": "#/components/schemas/api_enums.PaymentType"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PaymentType"
+              }
+            ],
+            "nullable": true
           }
         }
       },

--- a/openapi/openapi_spec.json
+++ b/openapi/openapi_spec.json
@@ -8080,6 +8080,14 @@
           "merchant_name": {
             "type": "string",
             "nullable": true
+          },
+          "payment_type": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/api_enums.PaymentType"
+              }
+            ],
+            "nullable": true
           }
         }
       },
@@ -8395,7 +8403,8 @@
         "type": "object",
         "required": [
           "amount",
-          "currency"
+          "currency",
+          "payment_type"
         ],
         "properties": {
           "payment_id": {
@@ -8731,6 +8740,9 @@
             "type": "string",
             "description": "The business profile to use for this payment, if not passed the default business profile\nassociated with the merchant account will be used.",
             "nullable": true
+          },
+          "payment_type": {
+            "$ref": "#/components/schemas/api_enums.PaymentType"
           }
         }
       },
@@ -9070,6 +9082,9 @@
             "type": "string",
             "description": "The business profile to use for this payment, if not passed the default business profile\nassociated with the merchant account will be used.",
             "nullable": true
+          },
+          "payment_type": {
+            "$ref": "#/components/schemas/api_enums.PaymentType"
           }
         }
       },

--- a/openapi/openapi_spec.json
+++ b/openapi/openapi_spec.json
@@ -8337,6 +8337,15 @@
           }
         }
       },
+      "PaymentType": {
+        "type": "string",
+        "enum": [
+          "normal",
+          "new_mandate",
+          "setup_mandate",
+          "recurring_mandate"
+        ]
+      },
       "PaymentsCancelRequest": {
         "type": "object",
         "required": [


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
This PR adds a new `payment_type` column in the `payment_intent` table, the value of which is inferred during payment creation, and is also included in the response of the list payment methods call.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
The `payment_type` field will be detrimental in deciding the right mandate flow. Certain merchants may want to just set up the mandate without debiting any amount, whereas some merchants may want to debit some amount as part of the setup. This distinction is done based on the `payment_type`.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
