### PR TITLE
perf: include db min_idle connections and idle_connection_timeout

### DIFF
--- a/config/config.example.toml
+++ b/config/config.example.toml
@@ -26,6 +26,8 @@ port = 5432                 # DB Port
 dbname = "hyperswitch_db"   # Name of Database
 pool_size = 5               # Number of connections to keep open
 connection_timeout = 10     # Timeout for database connection in seconds
+idle_timeout = 60           # Timeout for idle database connection in seconds
+min_idle = 5                # Minimum number of idle connections to keep open
 kms_encrypted_password = "" # Base64-encoded (KMS encrypted) ciphertext of the database password. Only applicable when KMS is enabled.
 
 # Replica SQL data store credentials
@@ -37,6 +39,8 @@ port = 5432                 # DB Port
 dbname = "hyperswitch_db"   # Name of Database
 pool_size = 5               # Number of connections to keep open
 connection_timeout = 10     # Timeout for database connection in seconds
+idle_timeout = 60           # Timeout for idle database connection in seconds
+min_idle = 5                # Minimum number of idle connections to keep open
 kms_encrypted_password = "" # Base64-encoded (KMS encrypted) ciphertext of the database password. Only applicable when KMS is enabled.
 
 # Redis credentials

--- a/config/development.toml
+++ b/config/development.toml
@@ -19,6 +19,8 @@ host = "localhost"
 port = 5432
 dbname = "hyperswitch_db"
 pool_size = 5
+idle_timeout = 60           # Timeout for idle database connection in seconds
+min_idle = 5                # Minimum number of idle connections to keep open
 connection_timeout = 10
 
 [replica_database]
@@ -28,6 +30,8 @@ host = "localhost"
 port = 5432
 dbname = "hyperswitch_db"
 pool_size = 5
+idle_timeout = 60           # Timeout for idle database connection in seconds
+min_idle = 5                # Minimum number of idle connections to keep open
 connection_timeout = 10
 
 [secrets]

--- a/config/docker_compose.toml
+++ b/config/docker_compose.toml
@@ -27,6 +27,8 @@ host = "pg"
 port = 5432
 dbname = "hyperswitch_db"
 pool_size = 5
+idle_timeout = 60           # Timeout for idle database connection in seconds
+min_idle = 5                # Minimum number of idle connections to keep open
 
 [replica_database]
 username = "db_user"
@@ -35,6 +37,8 @@ host = "pg"
 port = 5432
 dbname = "hyperswitch_db"
 pool_size = 5
+idle_timeout = 60           # Timeout for idle database connection in seconds
+min_idle = 5                # Minimum number of idle connections to keep open
 
 [secrets]
 admin_api_key = "test_admin"

--- a/crates/drainer/src/connection.rs
+++ b/crates/drainer/src/connection.rs
@@ -39,6 +39,8 @@ pub async fn diesel_make_pg_pool(
     let manager = async_bb8_diesel::ConnectionManager::<PgConnection>::new(database_url);
     let pool = bb8::Pool::builder()
         .max_size(database.pool_size)
+        .min_idle(database.min_idle)
+        .idle_timeout(database.idle_timeout.map(std::time::Duration::from_secs))
         .connection_timeout(std::time::Duration::from_secs(database.connection_timeout));
 
     pool.build(manager)

--- a/crates/drainer/src/settings.rs
+++ b/crates/drainer/src/settings.rs
@@ -42,6 +42,8 @@ pub struct Database {
     pub dbname: String,
     pub pool_size: u32,
     pub connection_timeout: u64,
+    pub min_idle: Option<u32>,
+    pub idle_timeout: Option<u64>,
     #[cfg(feature = "kms")]
     pub kms_encrypted_password: String,
 }
@@ -66,6 +68,8 @@ impl Default for Database {
             port: 5432,
             dbname: String::new(),
             pool_size: 5,
+            min_idle: Some(2),
+            idle_timeout: Some(10),
             connection_timeout: 10,
             #[cfg(feature = "kms")]
             kms_encrypted_password: String::new(),

--- a/crates/router/src/configs/defaults.rs
+++ b/crates/router/src/configs/defaults.rs
@@ -27,6 +27,8 @@ impl Default for super::settings::Database {
             port: 5432,
             dbname: String::new(),
             pool_size: 5,
+            min_idle: Some(2),
+            idle_timeout: Some(10),
             connection_timeout: 10,
             #[cfg(feature = "kms")]
             kms_encrypted_password: String::new(),

--- a/crates/router/src/configs/settings.rs
+++ b/crates/router/src/configs/settings.rs
@@ -413,6 +413,8 @@ pub struct Database {
     pub dbname: String,
     pub pool_size: u32,
     pub connection_timeout: u64,
+    pub min_idle: Option<u32>,
+    pub idle_timeout: Option<u64>,
     #[cfg(feature = "kms")]
     pub kms_encrypted_password: String,
 }

--- a/loadtest/config/development.toml
+++ b/loadtest/config/development.toml
@@ -16,6 +16,8 @@ host = "db"
 port = 5432
 dbname = "loadtest_router"
 pool_size = 20
+min_idle = 5
+idle_timeout = 10
 connection_timeout = 10
 
 [server]


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
Maintain min_idle connection timeout 


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
Always have a db connection, so that application doesn't need to take time to establish connections. 

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
