### PR TITLE
refactor: disable color in reports in json format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4179,6 +4179,7 @@ version = "0.1.0"
 dependencies = [
  "cargo_metadata 0.15.4",
  "config",
+ "error-stack",
  "gethostname",
  "once_cell",
  "opentelemetry",

--- a/crates/router_env/Cargo.toml
+++ b/crates/router_env/Cargo.toml
@@ -10,6 +10,7 @@ license.workspace = true
 [dependencies]
 cargo_metadata = "0.15.4"
 config = { version = "0.13.3", features = ["toml"] }
+error-stack = "0.3.1"
 gethostname = "0.4.3"
 once_cell = "1.18.0"
 opentelemetry = { version = "0.19.0", features = ["rt-tokio-current-thread", "metrics"] }

--- a/crates/router_env/src/logger/setup.rs
+++ b/crates/router_env/src/logger/setup.rs
@@ -101,6 +101,7 @@ pub fn setup(
                 subscriber.with(logging_layer).init();
             }
             config::LogFormat::Json => {
+                error_stack::Report::set_color_mode(error_stack::fmt::ColorMode::None);
                 let logging_layer =
                     FormattingLayer::new(service_name, console_writer).with_filter(console_filter);
                 subscriber.with(logging_layer).init();


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
This PR includes changes for removing the ansi escape characters from logs when the logs format is set to json

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
This will help in making the logs much cleaner as opposed to having ansi escape characters in json format

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Current log - 

![image](https://github.com/juspay/hyperswitch/assets/70657455/e6658b04-23d4-41fd-af15-e8aba7b83c81)

Log due to current PR changes - 

![image](https://github.com/juspay/hyperswitch/assets/70657455/92e49a22-e1c7-449b-9519-286f0b1a2dbb)


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
