### PR TITLE
ci(release-new-version): update schedule to create releases at 8 PM UTC+05:30 every Sunday to Thursday

### DIFF
--- a/.github/workflows/release-new-version.yml
+++ b/.github/workflows/release-new-version.yml
@@ -2,7 +2,7 @@ name: Release a new version
 
 on:
   schedule:
-    - cron: "30 14 * * 1-5" # Run workflow at 8 PM IST every Monday-Friday
+    - cron: "30 14 * * 0-4" # Run workflow at 8 PM IST every Sunday-Thursday
 
   workflow_dispatch:
 


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [x] CI/CD

## Description
<!-- Describe your changes in detail -->
This PR updates the schedule for the release new version workflow to run at 8 PM IST on Sunday to Thursday, instead of Monday to Friday.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
This would allow us to deploy builds in the morning on all weekdays.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
`crontab.guru` for the cron expression.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
