### PR TITLE
feat(connector): [Paypal] use connector request reference id as reference for paypal

### DIFF
--- a/crates/router/src/connector/paypal.rs
+++ b/crates/router/src/connector/paypal.rs
@@ -1060,7 +1060,7 @@ impl api::IncomingWebhook for Paypal {
                         resource
                             .purchase_units
                             .first()
-                            .map(|unit| unit.reference_id.clone())
+                            .map(|unit| unit.invoice_id.clone())
                             .ok_or(errors::ConnectorError::WebhookReferenceIdNotFound)?,
                     ),
                 ))

--- a/crates/router/src/connector/paypal/transformers.rs
+++ b/crates/router/src/connector/paypal/transformers.rs
@@ -72,7 +72,9 @@ pub struct OrderAmount {
 
 #[derive(Default, Debug, Serialize, Eq, PartialEq)]
 pub struct PurchaseUnitRequest {
-    reference_id: String,
+    reference_id: Option<String>, //reference for an item in purchase_units
+    invoice_id: Option<String>, //The API caller-provided external invoice number for this order. Appears in both the payer's transaction history and the emails that the payer receives.
+    custom_id: Option<String>,  //Used to reconcile client transactions with PayPal transactions.
     amount: OrderAmount,
 }
 
@@ -242,10 +244,13 @@ impl TryFrom<&PaypalRouterData<&types::PaymentsAuthorizeRouterData>> for PaypalP
                     currency_code: item.router_data.request.currency,
                     value: item.amount.to_owned(),
                 };
-                let reference_id = item.router_data.attempt_id.clone();
+                let connector_request_reference_id =
+                    item.router_data.connector_request_reference_id.clone();
 
                 let purchase_units = vec![PurchaseUnitRequest {
-                    reference_id,
+                    reference_id: Some(connector_request_reference_id.clone()),
+                    custom_id: Some(connector_request_reference_id.clone()),
+                    invoice_id: Some(connector_request_reference_id),
                     amount,
                 }];
                 let card = item.router_data.request.get_card()?;
@@ -276,9 +281,13 @@ impl TryFrom<&PaypalRouterData<&types::PaymentsAuthorizeRouterData>> for PaypalP
                         currency_code: item.router_data.request.currency,
                         value: item.amount.to_owned(),
                     };
-                    let reference_id = item.router_data.attempt_id.clone();
+
+                    let connector_req_reference_id = item.router_data.attempt_id.clone();
+
                     let purchase_units = vec![PurchaseUnitRequest {
-                        reference_id,
+                        reference_id: Some(connector_req_reference_id.clone()),
+                        custom_id: Some(connector_req_reference_id.clone()),
+                        invoice_id: Some(connector_req_reference_id),
                         amount,
                     }];
                     let payment_source =
@@ -339,9 +348,13 @@ impl TryFrom<&PaypalRouterData<&types::PaymentsAuthorizeRouterData>> for PaypalP
                     currency_code: item.router_data.request.currency,
                     value: item.amount.to_owned(),
                 };
-                let reference_id = item.router_data.attempt_id.clone();
+                let connector_req_reference_id =
+                    item.router_data.connector_request_reference_id.clone();
+
                 let purchase_units = vec![PurchaseUnitRequest {
-                    reference_id,
+                    reference_id: Some(connector_req_reference_id.clone()),
+                    custom_id: Some(connector_req_reference_id.clone()),
+                    invoice_id: Some(connector_req_reference_id),
                     amount,
                 }];
                 let payment_source =
@@ -628,6 +641,7 @@ pub struct PaymentsCollection {
 #[derive(Default, Debug, Clone, Serialize, Deserialize)]
 pub struct PurchaseUnitItem {
     pub reference_id: String,
+    pub invoice_id: String,
     pub payments: PaymentsCollection,
 }
 
@@ -645,11 +659,17 @@ pub struct PaypalLinks {
     rel: String,
 }
 
+#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+pub struct RedirectPurchaseUnitItem {
+    pub invoice_id: String,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PaypalRedirectResponse {
     id: String,
     intent: PaypalPaymentIntent,
     status: PaypalOrderStatus,
+    purchase_units: Vec<RedirectPurchaseUnitItem>,
     links: Vec<PaypalLinks>,
 }
 
@@ -666,6 +686,7 @@ pub struct PaypalPaymentsSyncResponse {
     id: String,
     status: PaypalPaymentStatus,
     amount: OrderAmount,
+    invoice_id: Option<String>,
     supplementary_data: PaypalSupplementaryData,
 }
 
@@ -767,7 +788,7 @@ impl<F, T>
                 mandate_reference: None,
                 connector_metadata: Some(connector_meta),
                 network_txn_id: None,
-                connector_response_reference_id: None,
+                connector_response_reference_id: Some(purchase_units.invoice_id.clone()),
             }),
             ..item.data
         })
@@ -838,6 +859,11 @@ impl<F, T>
             capture_id: None,
             psync_flow: item.response.intent
         });
+        let purchase_units = item
+            .response
+            .purchase_units
+            .first()
+            .ok_or(errors::ConnectorError::MissingConnectorTransactionID)?;
 
         Ok(Self {
             status,
@@ -850,7 +876,7 @@ impl<F, T>
                 mandate_reference: None,
                 connector_metadata: Some(connector_meta),
                 network_txn_id: None,
-                connector_response_reference_id: None,
+                connector_response_reference_id: Some(purchase_units.invoice_id.clone()),
             }),
             ..item.data
         })
@@ -881,7 +907,7 @@ impl<F, T>
                 mandate_reference: None,
                 connector_metadata: None,
                 network_txn_id: None,
-                connector_response_reference_id: None,
+                connector_response_reference_id: item.response.invoice_id.clone(),
             }),
             ..item.data
         })
@@ -933,6 +959,7 @@ pub struct PaypalCaptureResponse {
     id: String,
     status: PaypalPaymentStatus,
     amount: Option<OrderAmount>,
+    invoice_id: Option<String>,
     final_capture: bool,
 }
 
@@ -978,7 +1005,7 @@ impl TryFrom<types::PaymentsCaptureResponseRouterData<PaypalCaptureResponse>>
                     psync_flow: PaypalPaymentIntent::Capture
                 })),
                 network_txn_id: None,
-                connector_response_reference_id: None,
+                connector_response_reference_id: item.response.invoice_id.clone(),
             }),
             amount_captured: Some(amount_captured),
             ..item.data
@@ -993,11 +1020,11 @@ pub enum PaypalCancelStatus {
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
-#[serde(rename_all = "camelCase")]
 pub struct PaypalPaymentsCancelResponse {
     id: String,
     status: PaypalCancelStatus,
     amount: Option<OrderAmount>,
+    invoice_id: Option<String>,
 }
 
 impl<F, T>
@@ -1025,7 +1052,7 @@ impl<F, T>
                 mandate_reference: None,
                 connector_metadata: None,
                 network_txn_id: None,
-                connector_response_reference_id: None,
+                connector_response_reference_id: item.response.invoice_id.clone(),
             }),
             ..item.data
         })
@@ -1208,6 +1235,7 @@ pub struct PaypalSellerPayableBreakdown {
 pub struct PaypalCardWebhooks {
     pub supplementary_data: PaypalSupplementaryData,
     pub amount: OrderAmount,
+    pub invoice_id: Option<String>,
 }
 
 #[derive(Deserialize, Debug, Serialize)]
@@ -1328,6 +1356,7 @@ impl TryFrom<(PaypalCardWebhooks, PaypalWebhookEventType)> for PaypalPaymentsSyn
             status: PaypalPaymentStatus::try_from(webhook_event)?,
             amount: webhook_body.amount,
             supplementary_data: webhook_body.supplementary_data,
+            invoice_id: webhook_body.invoice_id,
         })
     }
 }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
use connector request reference id as reference - invoice id for paypal

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
<img width="687" alt="Screenshot 2023-10-13 at 5 15 29 PM" src="https://github.com/juspay/hyperswitch/assets/70575890/ea382477-fedc-422d-8c1d-a9624253d3e0">
<img width="764" alt="Screenshot 2023-10-13 at 5 15 58 PM" src="https://github.com/juspay/hyperswitch/assets/70575890/8ab8f4ad-4a9e-4a54-a66c-a3ca65b97b1a">

webhooks
<img width="871" alt="Screenshot 2023-10-13 at 5 14 18 PM" src="https://github.com/juspay/hyperswitch/assets/70575890/f5c13998-7ed5-4c57-abd6-88d0b8645f72">


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
