### PR TITLE
refactor(router): throw bad request error on applepay verification failure

### DIFF
--- a/crates/router/src/core/payments/transformers.rs
+++ b/crates/router/src/core/payments/transformers.rs
@@ -449,7 +449,7 @@ where
         headers.extend(
             external_latency
                 .map(|latency| vec![(X_HS_LATENCY.to_string(), latency.to_string())])
-                .unwrap_or(vec![]),
+                .unwrap_or_default(),
         );
     }
     let output = Ok(match payment_request {

--- a/crates/router/src/core/verification.rs
+++ b/crates/router/src/core/verification.rs
@@ -85,7 +85,7 @@ pub async fn verify_merchant_creds_for_applepay(
         response.change_context(api_error_response::ApiErrorResponse::InternalServerError)?;
 
     // Error is already logged
-    Ok(match applepay_response {
+    match applepay_response {
         Ok(_) => {
             utils::check_existence_and_add_domain_to_db(
                 &state,
@@ -95,17 +95,20 @@ pub async fn verify_merchant_creds_for_applepay(
             )
             .await
             .change_context(api_error_response::ApiErrorResponse::InternalServerError)?;
-            services::api::ApplicationResponse::Json(ApplepayMerchantResponse {
-                status_message: "Applepay verification Completed".to_string(),
-            })
+            Ok(services::api::ApplicationResponse::Json(
+                ApplepayMerchantResponse {
+                    status_message: "Applepay verification Completed".to_string(),
+                },
+            ))
         }
         Err(error) => {
             logger::error!(?error);
-            services::api::ApplicationResponse::Json(ApplepayMerchantResponse {
-                status_message: "Applepay verification Failed".to_string(),
-            })
+            Err(api_error_response::ApiErrorResponse::InvalidRequestData {
+                message: "Applepay verification Failed".to_string(),
+            }
+            .into())
         }
-    })
+    }
 }
 
 pub async fn get_verified_apple_domains_with_mid_mca_id(


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Earlier we were throwing 2xx even when applepay verification was failing refactored it to throw 4xx

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
