### PR TITLE
feat(connector): [Bambora] Use connector_response_reference_id as reference to the connector

### DIFF
--- a/crates/router/src/connector/bambora/transformers.rs
+++ b/crates/router/src/connector/bambora/transformers.rs
@@ -214,7 +214,7 @@ impl<F, T>
                     mandate_reference: None,
                     connector_metadata: None,
                     network_txn_id: None,
-                    connector_response_reference_id: None,
+                    connector_response_reference_id: Some(pg_response.order_number.to_string()),
                 }),
                 ..item.data
             }),
@@ -238,7 +238,9 @@ impl<F, T>
                             .change_context(errors::ConnectorError::ResponseHandlingFailed)?,
                         ),
                         network_txn_id: None,
-                        connector_response_reference_id: None,
+                        connector_response_reference_id: Some(
+                            item.data.connector_request_reference_id.to_string(),
+                        ),
                     }),
                     ..item.data
                 })


### PR DESCRIPTION
## Type of Change

- [x] New feature


## Description

The `connector_response_reference_id` parameter has been set for the Bambora Payment Solutions for uniform reference and transaction tracking.


### File Changes

- [x] This PR modifies the Bambora Transformers file.

**Location- router/src/connector/bambora/transformers.rs**

## Motivation and Context

This PR was raised so that it Fixes #2324  !


## How did you test it?

- **I ran the following command, and all the errors were addressed properly, and the build was successful.**

```bash
cargo clippy --all-features
```

![build](https://github.com/juspay/hyperswitch/assets/47860497/74082946-5ce8-4202-87f2-05648e7fd2ff)

- The code changes were formatted with the following command to fix styling issues.

```bash
cargo +nightly fmt
```

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
