### PR TITLE
feat: add surcharge_applicable to payment_intent and remove surcharge_metadata from payment_attempt

### DIFF
--- a/crates/data_models/src/payments.rs
+++ b/crates/data_models/src/payments.rs
@@ -47,5 +47,7 @@ pub struct PaymentIntent {
     // Manual review can occur when the transaction is marked as risky by the frm_processor, payment processor or when there is underpayment/over payment incase of crypto payment
     pub merchant_decision: Option<String>,
     pub payment_confirm_source: Option<storage_enums::PaymentSource>,
+
     pub updated_by: String,
+    pub surcharge_applicable: Option<bool>,
 }

--- a/crates/data_models/src/payments/payment_attempt.rs
+++ b/crates/data_models/src/payments/payment_attempt.rs
@@ -141,7 +141,6 @@ pub struct PaymentAttempt {
     // reference to the payment at connector side
     pub connector_response_reference_id: Option<String>,
     pub amount_capturable: i64,
-    pub surcharge_metadata: Option<serde_json::Value>,
     pub updated_by: String,
 }
 
@@ -201,7 +200,6 @@ pub struct PaymentAttemptNew {
     pub connector_response_reference_id: Option<String>,
     pub multiple_capture_count: Option<i16>,
     pub amount_capturable: i64,
-    pub surcharge_metadata: Option<serde_json::Value>,
     pub updated_by: String,
 }
 
@@ -321,10 +319,6 @@ pub enum PaymentAttemptUpdate {
         preprocessing_step_id: Option<String>,
         connector_transaction_id: Option<String>,
         connector_response_reference_id: Option<String>,
-        updated_by: String,
-    },
-    SurchargeMetadataUpdate {
-        surcharge_metadata: Option<serde_json::Value>,
         updated_by: String,
     },
 }

--- a/crates/data_models/src/payments/payment_intent.rs
+++ b/crates/data_models/src/payments/payment_intent.rs
@@ -104,7 +104,9 @@ pub struct PaymentIntentNew {
     pub merchant_decision: Option<String>,
     pub payment_link_id: Option<String>,
     pub payment_confirm_source: Option<storage_enums::PaymentSource>,
+
     pub updated_by: String,
+    pub surcharge_applicable: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -204,7 +206,9 @@ pub struct PaymentIntentUpdateInternal {
     // Manual review can occur when the transaction is marked as risky by the frm_processor, payment processor or when there is underpayment/over payment incase of crypto payment
     pub merchant_decision: Option<String>,
     pub payment_confirm_source: Option<storage_enums::PaymentSource>,
+
     pub updated_by: String,
+    pub surcharge_applicable: Option<bool>,
 }
 
 impl PaymentIntentUpdate {

--- a/crates/diesel_models/src/payment_attempt.rs
+++ b/crates/diesel_models/src/payment_attempt.rs
@@ -57,7 +57,6 @@ pub struct PaymentAttempt {
     // reference to the payment at connector side
     pub connector_response_reference_id: Option<String>,
     pub amount_capturable: i64,
-    pub surcharge_metadata: Option<serde_json::Value>,
     pub updated_by: String,
 }
 
@@ -117,7 +116,6 @@ pub struct PaymentAttemptNew {
     pub connector_response_reference_id: Option<String>,
     pub multiple_capture_count: Option<i16>,
     pub amount_capturable: i64,
-    pub surcharge_metadata: Option<serde_json::Value>,
     pub updated_by: String,
 }
 
@@ -239,10 +237,6 @@ pub enum PaymentAttemptUpdate {
         connector_response_reference_id: Option<String>,
         updated_by: String,
     },
-    SurchargeMetadataUpdate {
-        surcharge_metadata: Option<serde_json::Value>,
-        updated_by: String,
-    },
 }
 
 #[derive(Clone, Debug, Default, AsChangeset, router_derive::DebugAsDisplay)]
@@ -278,7 +272,6 @@ pub struct PaymentAttemptUpdateInternal {
     surcharge_amount: Option<i64>,
     tax_amount: Option<i64>,
     amount_capturable: Option<i64>,
-    surcharge_metadata: Option<serde_json::Value>,
     updated_by: String,
 }
 
@@ -306,7 +299,6 @@ impl PaymentAttemptUpdate {
             preprocessing_step_id: pa_update
                 .preprocessing_step_id
                 .or(source.preprocessing_step_id),
-            surcharge_metadata: pa_update.surcharge_metadata.or(source.surcharge_metadata),
             updated_by: pa_update.updated_by,
             ..source
         }
@@ -551,14 +543,6 @@ impl From<PaymentAttemptUpdate> for PaymentAttemptUpdateInternal {
             } => Self {
                 status: Some(status),
                 amount_capturable: Some(amount_capturable),
-                updated_by,
-                ..Default::default()
-            },
-            PaymentAttemptUpdate::SurchargeMetadataUpdate {
-                surcharge_metadata,
-                updated_by,
-            } => Self {
-                surcharge_metadata,
                 updated_by,
                 ..Default::default()
             },

--- a/crates/diesel_models/src/payment_intent.rs
+++ b/crates/diesel_models/src/payment_intent.rs
@@ -48,7 +48,9 @@ pub struct PaymentIntent {
     pub merchant_decision: Option<String>,
     pub payment_link_id: Option<String>,
     pub payment_confirm_source: Option<storage_enums::PaymentSource>,
+
     pub updated_by: String,
+    pub surcharge_applicable: Option<bool>,
 }
 
 #[derive(
@@ -101,7 +103,9 @@ pub struct PaymentIntentNew {
     pub merchant_decision: Option<String>,
     pub payment_link_id: Option<String>,
     pub payment_confirm_source: Option<storage_enums::PaymentSource>,
+
     pub updated_by: String,
+    pub surcharge_applicable: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -202,7 +206,9 @@ pub struct PaymentIntentUpdateInternal {
     pub profile_id: Option<String>,
     merchant_decision: Option<String>,
     payment_confirm_source: Option<storage_enums::PaymentSource>,
+
     pub updated_by: String,
+    pub surcharge_applicable: Option<bool>,
 }
 
 impl PaymentIntentUpdate {

--- a/crates/diesel_models/src/schema.rs
+++ b/crates/diesel_models/src/schema.rs
@@ -559,7 +559,6 @@ diesel::table! {
         #[max_length = 128]
         connector_response_reference_id -> Nullable<Varchar>,
         amount_capturable -> Int8,
-        surcharge_metadata -> Nullable<Jsonb>,
         #[max_length = 32]
         updated_by -> Varchar,
     }
@@ -622,6 +621,7 @@ diesel::table! {
         payment_confirm_source -> Nullable<PaymentSource>,
         #[max_length = 32]
         updated_by -> Varchar,
+        surcharge_applicable -> Nullable<Bool>,
     }
 }
 

--- a/crates/router/src/core/payment_methods.rs
+++ b/crates/router/src/core/payment_methods.rs
@@ -11,7 +11,10 @@ use data_models::payments::{payment_attempt::PaymentAttempt, PaymentIntent};
 use diesel_models::enums;
 
 use crate::{
-    core::{errors::RouterResult, payments::helpers},
+    core::{
+        errors::RouterResult,
+        payments::{helpers, PaymentData},
+    },
     routes::AppState,
     types::api::{self, payments},
 };
@@ -26,6 +29,12 @@ pub trait PaymentMethodRetrieve {
         payment_intent: &PaymentIntent,
         payment_attempt: &PaymentAttempt,
     ) -> RouterResult<(Option<payments::PaymentMethodData>, Option<String>)>;
+
+    fn update_payment_data_before_session_connector_call<F: Clone>(
+        _payment_data: &mut PaymentData<F>,
+    ) -> RouterResult<()> {
+        Ok(())
+    }
 }
 
 #[async_trait::async_trait]

--- a/crates/router/src/core/payments/helpers.rs
+++ b/crates/router/src/core/payments/helpers.rs
@@ -2409,6 +2409,7 @@ mod tests {
             profile_id: None,
             merchant_decision: None,
             payment_confirm_source: None,
+            surcharge_applicable: None,
             updated_by: storage_enums::MerchantStorageScheme::PostgresOnly.to_string(),
         };
         let req_cs = Some("1".to_string());
@@ -2458,6 +2459,7 @@ mod tests {
             profile_id: None,
             merchant_decision: None,
             payment_confirm_source: None,
+            surcharge_applicable: None,
             updated_by: storage_enums::MerchantStorageScheme::PostgresOnly.to_string(),
         };
         let req_cs = Some("1".to_string());
@@ -2507,6 +2509,7 @@ mod tests {
             profile_id: None,
             merchant_decision: None,
             payment_confirm_source: None,
+            surcharge_applicable: None,
             updated_by: storage_enums::MerchantStorageScheme::PostgresOnly.to_string(),
         };
         let req_cs = Some("1".to_string());
@@ -2900,7 +2903,6 @@ impl AttemptType {
             multiple_capture_count: None,
             connector_response_reference_id: None,
             amount_capturable: old_payment_attempt.amount,
-            surcharge_metadata: old_payment_attempt.surcharge_metadata,
             updated_by: storage_scheme.to_string(),
         }
     }

--- a/crates/router/src/core/payments/operations/payment_approve.rs
+++ b/crates/router/src/core/payments/operations/payment_approve.rs
@@ -252,6 +252,7 @@ impl<F: Send + Clone, Ctx: PaymentMethodRetrieve>
                 multiple_capture_data: None,
                 redirect_response,
                 surcharge_details: None,
+                session_surcharge_details: None,
                 frm_message: frm_response.ok(),
                 payment_link_data: None,
             },

--- a/crates/router/src/core/payments/operations/payment_cancel.rs
+++ b/crates/router/src/core/payments/operations/payment_cancel.rs
@@ -172,6 +172,7 @@ impl<F: Send + Clone, Ctx: PaymentMethodRetrieve>
                 multiple_capture_data: None,
                 redirect_response: None,
                 surcharge_details: None,
+                session_surcharge_details: None,
                 frm_message: None,
                 payment_link_data: None,
             },

--- a/crates/router/src/core/payments/operations/payment_capture.rs
+++ b/crates/router/src/core/payments/operations/payment_capture.rs
@@ -234,6 +234,7 @@ impl<F: Send + Clone, Ctx: PaymentMethodRetrieve>
                 multiple_capture_data,
                 redirect_response: None,
                 surcharge_details: None,
+                session_surcharge_details: None,
                 frm_message: None,
                 payment_link_data: None,
             },

--- a/crates/router/src/core/payments/operations/payment_complete_authorize.rs
+++ b/crates/router/src/core/payments/operations/payment_complete_authorize.rs
@@ -247,6 +247,7 @@ impl<F: Send + Clone, Ctx: PaymentMethodRetrieve>
                 multiple_capture_data: None,
                 redirect_response,
                 surcharge_details: None,
+                session_surcharge_details: None,
                 frm_message: None,
                 payment_link_data: None,
             },

--- a/crates/router/src/core/payments/operations/payment_confirm.rs
+++ b/crates/router/src/core/payments/operations/payment_confirm.rs
@@ -382,6 +382,7 @@ impl<F: Send + Clone, Ctx: PaymentMethodRetrieve>
                 multiple_capture_data: None,
                 redirect_response: None,
                 surcharge_details,
+                session_surcharge_details: None,
                 frm_message: None,
                 payment_link_data: None,
             },

--- a/crates/router/src/core/payments/operations/payment_create.rs
+++ b/crates/router/src/core/payments/operations/payment_create.rs
@@ -310,6 +310,7 @@ impl<F: Send + Clone, Ctx: PaymentMethodRetrieve>
                 multiple_capture_data: None,
                 redirect_response: None,
                 surcharge_details: None,
+                session_surcharge_details: None,
                 frm_message: None,
                 payment_link_data,
             },
@@ -720,6 +721,7 @@ impl PaymentCreate {
             merchant_decision: None,
             payment_link_id,
             payment_confirm_source: None,
+            surcharge_applicable: None,
             updated_by: merchant_account.storage_scheme.to_string(),
         })
     }

--- a/crates/router/src/core/payments/operations/payment_method_validate.rs
+++ b/crates/router/src/core/payments/operations/payment_method_validate.rs
@@ -198,6 +198,7 @@ impl<F: Send + Clone, Ctx: PaymentMethodRetrieve>
                 multiple_capture_data: None,
                 redirect_response: None,
                 surcharge_details: None,
+                session_surcharge_details: None,
                 frm_message: None,
                 payment_link_data: None,
             },
@@ -401,6 +402,7 @@ impl PaymentMethodValidate {
             profile_id: Default::default(),
             merchant_decision: Default::default(),
             payment_confirm_source: Default::default(),
+            surcharge_applicable: Default::default(),
             payment_link_id: Default::default(),
             updated_by: storage_scheme.to_string(),
         }

--- a/crates/router/src/core/payments/operations/payment_reject.rs
+++ b/crates/router/src/core/payments/operations/payment_reject.rs
@@ -158,6 +158,7 @@ impl<F: Send + Clone, Ctx: PaymentMethodRetrieve>
                 multiple_capture_data: None,
                 redirect_response: None,
                 surcharge_details: None,
+                session_surcharge_details: None,
                 frm_message: frm_response.ok(),
                 payment_link_data: None,
             },

--- a/crates/router/src/core/payments/operations/payment_session.rs
+++ b/crates/router/src/core/payments/operations/payment_session.rs
@@ -200,6 +200,7 @@ impl<F: Send + Clone, Ctx: PaymentMethodRetrieve>
                 multiple_capture_data: None,
                 redirect_response: None,
                 surcharge_details: None,
+                session_surcharge_details: None,
                 frm_message: None,
                 payment_link_data: None,
             },

--- a/crates/router/src/core/payments/operations/payment_start.rs
+++ b/crates/router/src/core/payments/operations/payment_start.rs
@@ -174,6 +174,7 @@ impl<F: Send + Clone, Ctx: PaymentMethodRetrieve>
                 multiple_capture_data: None,
                 redirect_response: None,
                 surcharge_details: None,
+                session_surcharge_details: None,
                 frm_message: None,
                 payment_link_data: None,
             },

--- a/crates/router/src/core/payments/operations/payment_status.rs
+++ b/crates/router/src/core/payments/operations/payment_status.rs
@@ -411,6 +411,7 @@ async fn get_tracker_for_sync<
             redirect_response: None,
             payment_link_data: None,
             surcharge_details: None,
+            session_surcharge_details: None,
             frm_message: frm_response.ok(),
         },
         None,

--- a/crates/router/src/core/payments/operations/payment_update.rs
+++ b/crates/router/src/core/payments/operations/payment_update.rs
@@ -353,6 +353,7 @@ impl<F: Send + Clone, Ctx: PaymentMethodRetrieve>
                 multiple_capture_data: None,
                 redirect_response: None,
                 surcharge_details: None,
+                session_surcharge_details: None,
                 frm_message: None,
                 payment_link_data: None,
             },

--- a/crates/storage_impl/src/mock_db/payment_attempt.rs
+++ b/crates/storage_impl/src/mock_db/payment_attempt.rs
@@ -140,7 +140,6 @@ impl PaymentAttemptInterface for MockDb {
             multiple_capture_count: payment_attempt.multiple_capture_count,
             connector_response_reference_id: None,
             amount_capturable: payment_attempt.amount_capturable,
-            surcharge_metadata: payment_attempt.surcharge_metadata,
             updated_by: storage_scheme.to_string(),
         };
         payment_attempts.push(payment_attempt.clone());

--- a/crates/storage_impl/src/mock_db/payment_intent.rs
+++ b/crates/storage_impl/src/mock_db/payment_intent.rs
@@ -104,6 +104,7 @@ impl PaymentIntentInterface for MockDb {
             payment_link_id: new.payment_link_id,
             payment_confirm_source: new.payment_confirm_source,
             updated_by: storage_scheme.to_string(),
+            surcharge_applicable: new.surcharge_applicable,
         };
         payment_intents.push(payment_intent.clone());
         Ok(payment_intent)

--- a/crates/storage_impl/src/payments/payment_attempt.rs
+++ b/crates/storage_impl/src/payments/payment_attempt.rs
@@ -360,7 +360,7 @@ impl<T: DatabaseStore> PaymentAttemptInterface for KVRouterStore<T> {
                     multiple_capture_count: payment_attempt.multiple_capture_count,
                     connector_response_reference_id: None,
                     amount_capturable: payment_attempt.amount_capturable,
-                    surcharge_metadata: payment_attempt.surcharge_metadata.clone(),
+
                     updated_by: storage_scheme.to_string(),
                 };
 
@@ -956,7 +956,7 @@ impl DataModelExt for PaymentAttempt {
             multiple_capture_count: self.multiple_capture_count,
             connector_response_reference_id: self.connector_response_reference_id,
             amount_capturable: self.amount_capturable,
-            surcharge_metadata: self.surcharge_metadata,
+
             updated_by: self.updated_by,
         }
     }
@@ -1006,7 +1006,7 @@ impl DataModelExt for PaymentAttempt {
             multiple_capture_count: storage_model.multiple_capture_count,
             connector_response_reference_id: storage_model.connector_response_reference_id,
             amount_capturable: storage_model.amount_capturable,
-            surcharge_metadata: storage_model.surcharge_metadata,
+
             updated_by: storage_model.updated_by,
         }
     }
@@ -1056,7 +1056,7 @@ impl DataModelExt for PaymentAttemptNew {
             connector_response_reference_id: self.connector_response_reference_id,
             multiple_capture_count: self.multiple_capture_count,
             amount_capturable: self.amount_capturable,
-            surcharge_metadata: self.surcharge_metadata,
+
             updated_by: self.updated_by,
         }
     }
@@ -1104,7 +1104,7 @@ impl DataModelExt for PaymentAttemptNew {
             connector_response_reference_id: storage_model.connector_response_reference_id,
             multiple_capture_count: storage_model.multiple_capture_count,
             amount_capturable: storage_model.amount_capturable,
-            surcharge_metadata: storage_model.surcharge_metadata,
+
             updated_by: storage_model.updated_by,
         }
     }
@@ -1330,13 +1330,6 @@ impl DataModelExt for PaymentAttemptUpdate {
                 amount_capturable,
                 updated_by,
             },
-            Self::SurchargeMetadataUpdate {
-                surcharge_metadata,
-                updated_by,
-            } => DieselPaymentAttemptUpdate::SurchargeMetadataUpdate {
-                surcharge_metadata,
-                updated_by,
-            },
         }
     }
 
@@ -1555,13 +1548,6 @@ impl DataModelExt for PaymentAttemptUpdate {
             } => Self::AmountToCaptureUpdate {
                 status,
                 amount_capturable,
-                updated_by,
-            },
-            DieselPaymentAttemptUpdate::SurchargeMetadataUpdate {
-                surcharge_metadata,
-                updated_by,
-            } => Self::SurchargeMetadataUpdate {
-                surcharge_metadata,
                 updated_by,
             },
         }

--- a/crates/storage_impl/src/payments/payment_intent.rs
+++ b/crates/storage_impl/src/payments/payment_intent.rs
@@ -94,6 +94,7 @@ impl<T: DatabaseStore> PaymentIntentInterface for KVRouterStore<T> {
                     payment_link_id: new.payment_link_id.clone(),
                     payment_confirm_source: new.payment_confirm_source,
                     updated_by: storage_scheme.to_string(),
+                    surcharge_applicable: new.surcharge_applicable,
                 };
                 let redis_entry = kv::TypedSql {
                     op: kv::DBOperation::Insert {
@@ -743,6 +744,7 @@ impl DataModelExt for PaymentIntentNew {
             payment_link_id: self.payment_link_id,
             payment_confirm_source: self.payment_confirm_source,
             updated_by: self.updated_by,
+            surcharge_applicable: self.surcharge_applicable,
         }
     }
 
@@ -782,6 +784,7 @@ impl DataModelExt for PaymentIntentNew {
             payment_link_id: storage_model.payment_link_id,
             payment_confirm_source: storage_model.payment_confirm_source,
             updated_by: storage_model.updated_by,
+            surcharge_applicable: storage_model.surcharge_applicable,
         }
     }
 }
@@ -826,6 +829,7 @@ impl DataModelExt for PaymentIntent {
             payment_link_id: self.payment_link_id,
             payment_confirm_source: self.payment_confirm_source,
             updated_by: self.updated_by,
+            surcharge_applicable: self.surcharge_applicable,
         }
     }
 
@@ -866,6 +870,7 @@ impl DataModelExt for PaymentIntent {
             payment_link_id: storage_model.payment_link_id,
             payment_confirm_source: storage_model.payment_confirm_source,
             updated_by: storage_model.updated_by,
+            surcharge_applicable: storage_model.surcharge_applicable,
         }
     }
 }

--- a/migrations/2023-10-19-075810_add_surcharge_applicable_payment_intent/down.sql
+++ b/migrations/2023-10-19-075810_add_surcharge_applicable_payment_intent/down.sql
@@ -1,0 +1,5 @@
+ALTER TABLE payment_attempt
+ADD COLUMN IF NOT EXISTS surcharge_metadata JSONB DEFAULT NULL;
+
+ALTER TABLE payment_intent
+DROP COLUMN surcharge_applicable;

--- a/migrations/2023-10-19-075810_add_surcharge_applicable_payment_intent/up.sql
+++ b/migrations/2023-10-19-075810_add_surcharge_applicable_payment_intent/up.sql
@@ -1,0 +1,6 @@
+ALTER TABLE payment_attempt
+DROP COLUMN surcharge_metadata;
+
+
+ALTER TABLE payment_intent
+ADD surcharge_applicable boolean;


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
changes in this PR:
1. Add surcharge_applicable field to payment_intent
2. Remove surcharge_metadata_field from payment_attempt
3. Add session_surcharge_details to PaymentData
4. Introduce `update_payment_data_before_session_connector_call()` into `PaymentMethodRetrieve` trait

### Additional Changes

- [ ] This PR modifies the API contract
- [x] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
5. `crates/router/src/configs`
6. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Manual


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
