### PR TITLE
feat: add support for updating surcharge_applicable field intent

### DIFF
--- a/crates/common_utils/src/errors.rs
+++ b/crates/common_utils/src/errors.rs
@@ -77,11 +77,20 @@ pub enum QrCodeError {
 }
 
 /// Api Models construction error
-#[derive(Debug, Clone, thiserror::Error, PartialEq, Eq)]
-pub enum ApiModelsError {
+#[derive(Debug, Clone, thiserror::Error, PartialEq)]
+pub enum PercentageError {
     /// Percentage Value provided was invalid
     #[error("Invalid Percentage value")]
     InvalidPercentageValue,
+
+    /// Error occured while calculating percentage
+    #[error("Failed apply percentage of {percentage} on {amount}")]
+    UnableToApplyPercentage {
+        /// percentage value
+        percentage: f32,
+        /// amount value
+        amount: i64,
+    },
 }
 
 /// Allows [error_stack::Report] to change between error contexts

--- a/crates/common_utils/src/errors.rs
+++ b/crates/common_utils/src/errors.rs
@@ -83,7 +83,7 @@ pub enum PercentageError {
     #[error("Invalid Percentage value")]
     InvalidPercentageValue,
 
-    /// Error occured while calculating percentage
+    /// Error occurred while calculating percentage
     #[error("Failed apply percentage of {percentage} on {amount}")]
     UnableToApplyPercentage {
         /// percentage value

--- a/crates/common_utils/tests/percentage.rs
+++ b/crates/common_utils/tests/percentage.rs
@@ -1,5 +1,5 @@
 #![allow(clippy::panic_in_result_fn)]
-use common_utils::{errors::ApiModelsError, types::Percentage};
+use common_utils::{errors::PercentageError, types::Percentage};
 const PRECISION_2: u8 = 2;
 const PRECISION_0: u8 = 0;
 
@@ -10,7 +10,7 @@ fn invalid_range_more_than_100() -> Result<(), Box<dyn std::error::Error + Send 
     if let Err(err) = percentage {
         assert_eq!(
             *err.current_context(),
-            ApiModelsError::InvalidPercentageValue
+            PercentageError::InvalidPercentageValue
         )
     }
     Ok(())
@@ -22,7 +22,7 @@ fn invalid_range_less_than_0() -> Result<(), Box<dyn std::error::Error + Send + 
     if let Err(err) = percentage {
         assert_eq!(
             *err.current_context(),
-            ApiModelsError::InvalidPercentageValue
+            PercentageError::InvalidPercentageValue
         )
     }
     Ok(())
@@ -35,7 +35,7 @@ fn invalid_string() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     if let Err(err) = percentage {
         assert_eq!(
             *err.current_context(),
-            ApiModelsError::InvalidPercentageValue
+            PercentageError::InvalidPercentageValue
         )
     }
     Ok(())
@@ -92,7 +92,7 @@ fn invalid_precision() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     if let Err(err) = percentage {
         assert_eq!(
             *err.current_context(),
-            ApiModelsError::InvalidPercentageValue
+            PercentageError::InvalidPercentageValue
         )
     }
     Ok(())

--- a/crates/data_models/src/payments/payment_intent.rs
+++ b/crates/data_models/src/payments/payment_intent.rs
@@ -178,6 +178,10 @@ pub enum PaymentIntentUpdate {
         merchant_decision: Option<String>,
         updated_by: String,
     },
+    SurchargeApplicableUpdate {
+        surcharge_applicable: Option<bool>,
+        updated_by: String,
+    },
 }
 
 #[derive(Clone, Debug, Default)]
@@ -383,6 +387,14 @@ impl From<PaymentIntentUpdate> for PaymentIntentUpdateInternal {
             } => Self {
                 status: Some(status),
                 merchant_decision,
+                updated_by,
+                ..Default::default()
+            },
+            PaymentIntentUpdate::SurchargeApplicableUpdate {
+                surcharge_applicable,
+                updated_by,
+            } => Self {
+                surcharge_applicable,
                 updated_by,
                 ..Default::default()
             },

--- a/crates/data_models/src/payments/payment_intent.rs
+++ b/crates/data_models/src/payments/payment_intent.rs
@@ -179,7 +179,7 @@ pub enum PaymentIntentUpdate {
         updated_by: String,
     },
     SurchargeApplicableUpdate {
-        surcharge_applicable: Option<bool>,
+        surcharge_applicable: bool,
         updated_by: String,
     },
 }
@@ -394,7 +394,7 @@ impl From<PaymentIntentUpdate> for PaymentIntentUpdateInternal {
                 surcharge_applicable,
                 updated_by,
             } => Self {
-                surcharge_applicable,
+                surcharge_applicable: Some(surcharge_applicable),
                 updated_by,
                 ..Default::default()
             },

--- a/crates/diesel_models/src/payment_intent.rs
+++ b/crates/diesel_models/src/payment_intent.rs
@@ -177,6 +177,10 @@ pub enum PaymentIntentUpdate {
         merchant_decision: Option<String>,
         updated_by: String,
     },
+    SurchargeApplicableUpdate {
+        surcharge_applicable: Option<bool>,
+        updated_by: String,
+    },
 }
 
 #[derive(Clone, Debug, Default, AsChangeset, router_derive::DebugAsDisplay)]
@@ -405,6 +409,14 @@ impl From<PaymentIntentUpdate> for PaymentIntentUpdateInternal {
             } => Self {
                 status: Some(status),
                 merchant_decision,
+                updated_by,
+                ..Default::default()
+            },
+            PaymentIntentUpdate::SurchargeApplicableUpdate {
+                surcharge_applicable,
+                updated_by,
+            } => Self {
+                surcharge_applicable,
                 updated_by,
                 ..Default::default()
             },

--- a/crates/storage_impl/src/payments/payment_intent.rs
+++ b/crates/storage_impl/src/payments/payment_intent.rs
@@ -1009,6 +1009,13 @@ impl DataModelExt for PaymentIntentUpdate {
                 merchant_decision,
                 updated_by,
             },
+            Self::SurchargeApplicableUpdate {
+                surcharge_applicable,
+                updated_by,
+            } => DieselPaymentIntentUpdate::SurchargeApplicableUpdate {
+                surcharge_applicable,
+                updated_by,
+            },
         }
     }
 

--- a/crates/storage_impl/src/payments/payment_intent.rs
+++ b/crates/storage_impl/src/payments/payment_intent.rs
@@ -1013,7 +1013,7 @@ impl DataModelExt for PaymentIntentUpdate {
                 surcharge_applicable,
                 updated_by,
             } => DieselPaymentIntentUpdate::SurchargeApplicableUpdate {
-                surcharge_applicable,
+                surcharge_applicable: Some(surcharge_applicable),
                 updated_by,
             },
         }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] New feature

## Description
<!-- Describe your changes in detail -->
-> Enabled updating surcharge_applicable in payment_intent.

-> Implemented apply_and_ceil_result() function in Percentage struct


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
