### PR TITLE
fix(router): disable openapi examples

### DIFF
--- a/crates/router/src/routes/payments.rs
+++ b/crates/router/src/routes/payments.rs
@@ -13,12 +13,12 @@ use crate::{
         payment_methods::{Oss, PaymentMethodRetrieve},
         payments::{self, PaymentRedirectFlow},
     },
-    openapi::examples::{
-        PAYMENTS_CREATE, PAYMENTS_CREATE_MINIMUM_FIELDS, PAYMENTS_CREATE_WITH_ADDRESS,
-        PAYMENTS_CREATE_WITH_CUSTOMER_DATA, PAYMENTS_CREATE_WITH_FORCED_3DS,
-        PAYMENTS_CREATE_WITH_MANUAL_CAPTURE, PAYMENTS_CREATE_WITH_NOON_ORDER_CATETORY,
-        PAYMENTS_CREATE_WITH_ORDER_DETAILS,
-    },
+    // openapi::examples::{
+    //     PAYMENTS_CREATE, PAYMENTS_CREATE_MINIMUM_FIELDS, PAYMENTS_CREATE_WITH_ADDRESS,
+    //     PAYMENTS_CREATE_WITH_CUSTOMER_DATA, PAYMENTS_CREATE_WITH_FORCED_3DS,
+    //     PAYMENTS_CREATE_WITH_MANUAL_CAPTURE, PAYMENTS_CREATE_WITH_NOON_ORDER_CATETORY,
+    //     PAYMENTS_CREATE_WITH_ORDER_DETAILS,
+    // },
     routes::lock_utils,
     services::{api, authentication as auth},
     types::{
@@ -36,48 +36,49 @@ use crate::{
     path = "/payments",
     request_body(
         content = PaymentsCreateRequest,
-        examples(
-            (
-                "Create a payment with minimul fields" = (
-                    value = json!(PAYMENTS_CREATE_MINIMUM_FIELDS)
-                )
-            ),
-            (
-                "Create a manual capture payment" = (
-                    value = json!(PAYMENTS_CREATE_WITH_MANUAL_CAPTURE)
-                )
-            ),
-            (
-                "Create a payment with address" = (
-                    value = json!(PAYMENTS_CREATE_WITH_ADDRESS)
-                )
-            ),
-            (
-                "Create a payment with customer details" = (
-                    value = json!(PAYMENTS_CREATE_WITH_CUSTOMER_DATA)
-                )
-            ),
-            (
-                "Create a 3DS payment" = (
-                    value = json!(PAYMENTS_CREATE_WITH_FORCED_3DS)
-                )
-            ),
-            (
-                "Create a payment" = (
-                    value = json!(PAYMENTS_CREATE)
-                )
-            ),
-            (
-                "Create a payment with order details" = (
-                    value = json!(PAYMENTS_CREATE_WITH_ORDER_DETAILS)
-                )
-            ),
-            (
-                "Create a payment with order category for noon" = (
-                    value = json!(PAYMENTS_CREATE_WITH_NOON_ORDER_CATETORY)
-                )
-            ),
-        )),
+        // examples(
+        //     (
+        //         "Create a payment with minimul fields" = (
+        //             value = json!(PAYMENTS_CREATE_MINIMUM_FIELDS)
+        //         )
+        //     ),
+        //     (
+        //         "Create a manual capture payment" = (
+        //             value = json!(PAYMENTS_CREATE_WITH_MANUAL_CAPTURE)
+        //         )
+        //     ),
+        //     (
+        //         "Create a payment with address" = (
+        //             value = json!(PAYMENTS_CREATE_WITH_ADDRESS)
+        //         )
+        //     ),
+        //     (
+        //         "Create a payment with customer details" = (
+        //             value = json!(PAYMENTS_CREATE_WITH_CUSTOMER_DATA)
+        //         )
+        //     ),
+        //     (
+        //         "Create a 3DS payment" = (
+        //             value = json!(PAYMENTS_CREATE_WITH_FORCED_3DS)
+        //         )
+        //     ),
+        //     (
+        //         "Create a payment" = (
+        //             value = json!(PAYMENTS_CREATE)
+        //         )
+        //     ),
+        //     (
+        //         "Create a payment with order details" = (
+        //             value = json!(PAYMENTS_CREATE_WITH_ORDER_DETAILS)
+        //         )
+        //     ),
+        //     (
+        //         "Create a payment with order category for noon" = (
+        //             value = json!(PAYMENTS_CREATE_WITH_NOON_ORDER_CATETORY)
+        //         )
+        //     ),
+        // )
+    ),
     responses(
         (status = 200, description = "Payment created", body = PaymentsResponse),
         (status = 400, description = "Missing Mandatory fields")

--- a/openapi/openapi_spec.json
+++ b/openapi/openapi_spec.json
@@ -1063,32 +1063,6 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/PaymentsCreateRequest"
-              },
-              "examples": {
-                "Create a 3DS payment": {
-                  "value": "{\n        \"amount\": 6540,\n        \"currency\": \"USD\",\n        \"authentication_type\" : \"three_ds\"\n    }"
-                },
-                "Create a manual capture payment": {
-                  "value": "{\n        \"amount\": 6540,\n        \"currency\": \"USD\",\n        \"capture_method\":\"manual\"\n    }"
-                },
-                "Create a payment": {
-                  "value": "{\n        \"amount\": 6540,\n        \"currency\": \"USD\",\n        \"payment_id\": \"abcdefghijklmnopqrstuvwxyz\",\n        \"customer\": {\n            \"id\":\"cus_abcdefgh\",\n            \"name\":\"John Dough\",\n            \"phone\":\"9999999999\",\n            \"email\":\"john@example.com\"\n        },\n        \"description\": \"Its my first payment request\",\n        \"statement_descriptor_name\": \"joseph\",\n        \"statement_descriptor_suffix\": \"JS\",\n        \"metadata\": {\n            \"udf1\": \"some-value\",\n            \"udf2\": \"some-value\"\n        }\n    }"
-                },
-                "Create a payment with address": {
-                  "value": "{\n        \"amount\": 6540,\n        \"currency\": \"USD\",\n        \"customer\": {\n            \"id\" : \"cus_abcdefgh\"\n        },\n        \"billing\": {\n            \"address\": {\n                \"line1\": \"1467\",\n                \"line2\": \"Harrison Street\",\n                \"line3\": \"Harrison Street\",\n                \"city\": \"San Fransico\",\n                \"state\": \"California\",\n                \"zip\": \"94122\",\n                \"country\": \"US\",\n                \"first_name\": \"joseph\",\n                \"last_name\": \"Doe\"\n            },\n            \"phone\": {\n                \"number\": \"8056594427\",\n                \"country_code\": \"+91\"\n            }\n        }\n    }"
-                },
-                "Create a payment with customer details": {
-                  "value": "{\n        \"amount\": 6540,\n        \"currency\": \"USD\",\n        \"customer\": {\n            \"id\":\"cus_abcdefgh\",\n            \"name\":\"John Dough\",\n            \"phone\":\"9999999999\",\n            \"email\":\"john@example.com\"\n        }\n    }"
-                },
-                "Create a payment with minimul fields": {
-                  "value": "{\n        \"amount\": 6540,\n        \"currency\": \"USD\",\n    }"
-                },
-                "Create a payment with order category for noon": {
-                  "value": "{\n        \"amount\": 6540,\n        \"currency\": \"USD\",\n        \"connector_metadata\": {\n            \"noon\": {\n                \"order_category\":\"shoes\"\n            }\n        }\n    }"
-                },
-                "Create a payment with order details": {
-                  "value": "{\n        \"amount\": 6540,\n        \"currency\": \"USD\",\n        \"order_details\": [\n            {\n                \"product_name\": \"Apple iPhone 15\",\n                \"quantity\": 1,\n                \"amount\" : 6540\n            }\n        ]\n    }"
-                }
               }
             }
           },


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
disable openapi examples to support api reference documentation


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
