### PR TITLE
fix: kms decryption of redis_temp_locker_encryption_key

### DIFF
--- a/crates/external_services/src/kms.rs
+++ b/crates/external_services/src/kms.rs
@@ -120,6 +120,14 @@ pub enum KmsError {
     /// The KMS client has not been initialized.
     #[error("The KMS client has not been initialized")]
     KmsClientNotInitialized,
+
+    /// The KMS client has not been initialized.
+    #[error("Hex decode failed")]
+    HexDecodeFailed,
+
+    /// The KMS client has not been initialized.
+    #[error("Utf8 decode failed")]
+    Utf8DecodeFailed,
 }
 
 impl KmsConfig {
@@ -140,7 +148,7 @@ impl KmsConfig {
 /// A wrapper around a KMS value that can be decrypted.
 #[derive(Clone, Debug, Default, serde::Deserialize, Eq, PartialEq)]
 #[serde(transparent)]
-pub struct KmsValue(Secret<String>);
+pub struct KmsValue(pub Secret<String>);
 
 impl common_utils::ext_traits::ConfigExt for KmsValue {
     fn is_empty_after_trim(&self) -> bool {

--- a/crates/router/src/configs/kms.rs
+++ b/crates/router/src/configs/kms.rs
@@ -1,8 +1,9 @@
-use crate::configs::settings;
 use common_utils::errors::CustomResult;
 use error_stack::{IntoReport, ResultExt};
 use external_services::kms::{decrypt::KmsDecrypt, KmsClient, KmsError, KmsValue};
 use masking::ExposeInterface;
+
+use crate::configs::settings;
 
 #[async_trait::async_trait]
 impl KmsDecrypt for settings::Jwekey {
@@ -45,7 +46,8 @@ impl KmsDecrypt for settings::ActiveKmsSecrets {
             KmsValue(
                 String::from_utf8(self.redis_temp_locker_encryption_key.expose())
                     .into_report()
-                    .change_context(KmsError::Utf8DecodeFailed)?.into()
+                    .change_context(KmsError::Utf8DecodeFailed)?
+                    .into(),
             )
             .decrypt_inner(kms_client)
             .await?,

--- a/crates/router/src/configs/kms.rs
+++ b/crates/router/src/configs/kms.rs
@@ -1,8 +1,8 @@
-use common_utils::errors::CustomResult;
-use external_services::kms::{decrypt::KmsDecrypt, KmsClient, KmsError};
-use masking::ExposeInterface;
-
 use crate::configs::settings;
+use common_utils::errors::CustomResult;
+use error_stack::{IntoReport, ResultExt};
+use external_services::kms::{decrypt::KmsDecrypt, KmsClient, KmsError, KmsValue};
+use masking::ExposeInterface;
 
 #[async_trait::async_trait]
 impl KmsDecrypt for settings::Jwekey {
@@ -41,6 +41,18 @@ impl KmsDecrypt for settings::ActiveKmsSecrets {
         kms_client: &KmsClient,
     ) -> CustomResult<Self::Output, KmsError> {
         self.jwekey = self.jwekey.expose().decrypt_inner(kms_client).await?.into();
+        self.redis_temp_locker_encryption_key = hex::decode(
+            KmsValue(
+                String::from_utf8(self.redis_temp_locker_encryption_key.expose())
+                    .into_report()
+                    .change_context(KmsError::Utf8DecodeFailed)?.into()
+            )
+            .decrypt_inner(kms_client)
+            .await?,
+        )
+        .into_report()
+        .change_context(KmsError::HexDecodeFailed)?
+        .into();
         Ok(self)
     }
 }

--- a/crates/router/src/configs/settings.rs
+++ b/crates/router/src/configs/settings.rs
@@ -52,7 +52,7 @@ pub enum Subcommand {
 #[derive(Clone)]
 pub struct ActiveKmsSecrets {
     pub jwekey: masking::Secret<Jwekey>,
-    pub redis_temp_locker_encryption_key: masking::Secret<String>,
+    pub redis_temp_locker_encryption_key: masking::Secret<Vec<u8>>,
 }
 
 #[derive(Debug, Deserialize, Clone, Default)]

--- a/crates/router/src/core/payment_methods/vault.rs
+++ b/crates/router/src/core/payment_methods/vault.rs
@@ -721,7 +721,6 @@ fn get_redis_temp_locker_encryption_key(state: &routes::AppState) -> RouterResul
         .kms_secrets
         .redis_temp_locker_encryption_key
         .peek()
-        .as_bytes()
         .to_owned();
 
     #[cfg(not(feature = "kms"))]

--- a/crates/router/src/routes/app.rs
+++ b/crates/router/src/routes/app.rs
@@ -132,6 +132,7 @@ impl AppState {
                 .locker
                 .redis_temp_locker_encryption_key
                 .clone()
+                .into_bytes()
                 .into(),
         }
         .decrypt_inner(kms_client)


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Add kms decryption for redis_temp_locker_encryption_key . hex decode after kms decrypt.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Kms changes can be tested on integ.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
