### PR TITLE
fix(refunds): Add `profile_id` in refunds response

### DIFF
--- a/crates/api_models/src/refunds.rs
+++ b/crates/api_models/src/refunds.rs
@@ -124,6 +124,7 @@ pub struct RefundResponse {
     /// The connector used for the refund and the corresponding payment
     #[schema(example = "stripe")]
     pub connector: String,
+    pub profile_id: Option<String>,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize, ToSchema)]

--- a/crates/router/src/core/refunds.rs
+++ b/crates/router/src/core/refunds.rs
@@ -602,6 +602,7 @@ pub async fn validate_and_create_refund(
         .set_description(req.reason.clone())
         .set_attempt_id(payment_attempt.attempt_id.clone())
         .set_refund_reason(req.reason)
+        .set_profile_id(payment_intent.profile_id.clone())
         .to_owned();
 
     refund = db
@@ -704,6 +705,7 @@ impl ForeignFrom<storage::Refund> for api::RefundResponse {
             currency: refund.currency.to_string(),
             reason: refund.refund_reason,
             status: refund.refund_status.foreign_into(),
+            profile_id: refund.profile_id,
             metadata: refund.metadata,
             error_message: refund.refund_error_message,
             error_code: refund.refund_error_code,

--- a/openapi/openapi_spec.json
+++ b/openapi/openapi_spec.json
@@ -10706,6 +10706,10 @@
             "type": "string",
             "description": "The connector used for the refund and the corresponding payment",
             "example": "stripe"
+          },
+          "profile_id": {
+            "type": "string",
+            "nullable": true
           }
         }
       },

--- a/postman/collection-dir/stripe/QuickStart/Refunds - Create/event.test.js
+++ b/postman/collection-dir/stripe/QuickStart/Refunds - Create/event.test.js
@@ -29,12 +29,12 @@ if (jsonData?.refund_id) {
   );
 }
 
-// Response body should have profile_id
-if (jsonData?.profile_id) {
-  pm.test(
-    "[POST]::/payments - Content check if value for 'profile_id' is not 'null'",
-    function () {
-      pm.expect(jsonData.profile_id).is.not.null;
-    },
-  );
-}
+
+// Response body should have "profile_id" and not "null"
+pm.test(
+  "[POST]::/payments - Content check if 'profile_id' exists and is not 'null'",
+  function () {
+    pm.expect(typeof jsonData.profile_id !== "undefined").to.be.true;
+    pm.expect(jsonData.profile_id).is.not.null;
+  },
+);

--- a/postman/collection-dir/stripe/QuickStart/Refunds - Create/event.test.js
+++ b/postman/collection-dir/stripe/QuickStart/Refunds - Create/event.test.js
@@ -28,3 +28,13 @@ if (jsonData?.refund_id) {
     "INFO - Unable to assign variable {{refund_id}}, as jsonData.refund_id is undefined.",
   );
 }
+
+// Response body should have profile_id
+if (jsonData?.profile_id) {
+  pm.test(
+    "[POST]::/payments - Content check if value for 'profile_id' is not 'null'",
+    function () {
+      pm.expect(jsonData.profile_id).is.not.null;
+    },
+  );
+}


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
We're not passing `profile_id` in Refunds response and it is not being populated in the database as well. This PR aims to fix that.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
Fixes a bug.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
- Make a Payment through any connector
- Do a refund
- You should be able to see `profile_id` being populated in response and the same should be updated in `refunds` table in database as well

Did a payment through Stripe connector:
```json
{
    "payment_id": "pay_aw1wK7Rvpb8iwjvgLKlb",
    "merchant_id": "postman_merchant_GHAction_1f531e91-324f-4d43-b18e-c7b981c591be",
    "status": "succeeded",
    "amount": 6540,
    "amount_capturable": 0,
    "amount_received": 6540,
    "connector": "stripe",
    "client_secret": "pay_aw1wK7Rvpb8iwjvgLKlb_secret_kX76Zixn3YVuu7J6c6yp",
    "created": "2023-10-20T10:36:07.609Z",
    "currency": "USD",
    "customer_id": "StripeCustomer",
    "description": "Its my first payment request",
    "refunds": null,
    "disputes": null,
    "mandate_id": null,
    "mandate_data": null,
    "setup_future_usage": null,
    "off_session": null,
    "capture_on": null,
    "capture_method": "automatic",
    "payment_method": "card",
    "payment_method_data": {
        "card": {
            "last4": "4242",
            "card_type": null,
            "card_network": null,
            "card_issuer": null,
            "card_issuing_country": null,
            "card_isin": "424242",
            "card_exp_month": "10",
            "card_exp_year": "25",
            "card_holder_name": "joseph Doe"
        }
    },
    "payment_token": null,
    "shipping": {
        "address": {
            "city": "San Fransico",
            "country": "US",
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "zip": "94122",
            "state": "California",
            "first_name": "joseph",
            "last_name": "Doe"
        },
        "phone": {
            "number": "8056594427",
            "country_code": "+91"
        }
    },
    "billing": {
        "address": {
            "city": "San Fransico",
            "country": "US",
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "zip": "94122",
            "state": "California",
            "first_name": "joseph",
            "last_name": "Doe"
        },
        "phone": {
            "number": "8056594427",
            "country_code": "+91"
        }
    },
    "order_details": null,
    "email": "guest@example.com",
    "name": "John Doe",
    "phone": "999999999",
    "return_url": "https://duck.com/",
    "authentication_type": "no_three_ds",
    "statement_descriptor_name": "joseph",
    "statement_descriptor_suffix": "JS",
    "next_action": null,
    "cancellation_reason": null,
    "error_code": null,
    "error_message": null,
    "payment_experience": null,
    "payment_method_type": "credit",
    "connector_label": null,
    "business_country": null,
    "business_label": "default",
    "business_sub_label": null,
    "allowed_payment_method_types": null,
    "ephemeral_key": {
        "customer_id": "StripeCustomer",
        "created_at": 1697798167,
        "expires": 1697801767,
        "secret": "epk_597e4d8bcda945eea75f1935ba6e09ab"
    },
    "manual_retry_allowed": false,
    "connector_transaction_id": "pi_3O3G3oD5R7gDAGff1xPG6wiF",
    "frm_message": null,
    "metadata": {
        "udf1": "value1",
        "login_date": "2019-09-10T10:11:12Z",
        "new_customer": "true"
    },
    "connector_metadata": null,
    "feature_metadata": null,
    "reference_id": "pi_3O3G3oD5R7gDAGff1xPG6wiF",
    "payment_link": null,
    "profile_id": "pro_AQkMEjCGBzFDlRsoYKO0",
    "surcharge_details": null,
    "attempt_count": 1,
    "merchant_decision": null
}
```
Asked for a refund:
```json
{
    "refund_id": "ref_otZ4qfyweQhQFLNsLjOs",
    "payment_id": "pay_aw1wK7Rvpb8iwjvgLKlb",
    "amount": 600,
    "currency": "USD",
    "reason": "Customer returned product",
    "status": "pending",
    "metadata": {
        "udf1": "value1",
        "new_customer": "true",
        "login_date": "2019-09-10T10:11:12Z"
    },
    "error_message": null,
    "error_code": null,
    "created_at": "2023-10-20T10:36:09.588Z",
    "updated_at": "2023-10-20T10:36:09.588Z",
    "connector": "stripe",
    "profile_id": "pro_AQkMEjCGBzFDlRsoYKO0"
}
```
DB:
<img width="740" alt="image" src="https://github.com/juspay/hyperswitch/assets/69745008/c6e57dda-f978-4071-a959-b59d5c1255ac">

Added to collection:
If it does not exist:
<img width="563" alt="image" src="https://github.com/juspay/hyperswitch/assets/69745008/1e924aeb-99cf-4b3a-a087-d6979ae2bd3e">
If it exist:
<img width="511" alt="image" src="https://github.com/juspay/hyperswitch/assets/69745008/2c17048e-aa4b-455b-97a0-1c0fad4a108d">
<img width="555" alt="image" src="https://github.com/juspay/hyperswitch/assets/69745008/02896bc9-ab30-4a59-abcc-5fef26d24ed8">

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
