### PR TITLE
feat(connector): [coinbase] currency unit conversion

### DIFF
--- a/crates/router/src/connector/coinbase.rs
+++ b/crates/router/src/connector/coinbase.rs
@@ -74,6 +74,10 @@ impl ConnectorCommon for Coinbase {
         "coinbase"
     }
 
+    fn get_currency_unit(&self) -> api::CurrencyUnit {
+        api::CurrencyUnit::Base
+    }
+
     fn common_get_content_type(&self) -> &'static str {
         "application/json"
     }
@@ -184,7 +188,13 @@ impl ConnectorIntegration<api::Authorize, types::PaymentsAuthorizeData, types::P
         &self,
         req: &types::PaymentsAuthorizeRouterData,
     ) -> CustomResult<Option<types::RequestBody>, errors::ConnectorError> {
-        let connector_request = coinbase::CoinbasePaymentsRequest::try_from(req)?;
+        let connector_router_data = coinbase::CoinbaseRouterData::try_from({
+            &self.get_currency_unit(),
+            req.request.currency,
+            req.request.amount,
+            req,
+        })?;
+        let req_obj = coinbase::CoinbasePaymentsRequest::try_from(&connector_router_data)?;
         let coinbase_payment_request = types::RequestBody::log_and_get_request_body(
             &connector_request,
             Encode::<coinbase::CoinbasePaymentsRequest>::encode_to_string_of_json,

--- a/crates/router/src/connector/coinbase/transformers.rs
+++ b/crates/router/src/connector/coinbase/transformers.rs
@@ -10,6 +10,39 @@ use crate::{
     types::{self, api, storage::enums},
 };
 
+#[derive(Debug, Serialize)]
+pub struct CoinbaseRouterdata<T> {
+    amount: i64,
+    router_data: T,
+}
+
+impl<T>
+    TryFrom<(
+        &types::api::CurrencyUnit,
+        types::storage::enums::Currency,
+        i64,
+        T,
+    )> for CoinbaseRouterData<T>
+{
+    type Error = error_stack::Report<errors::ConnectorError>;
+
+    fn try_from(
+        (_currency_unit, _currency, amount, router_data): (
+            &types::api::CurrencyUnit,
+            types::storage::enums::Currency,
+            i64,
+            T,
+        ),
+    ) -> Result<Self, Self::Error>
+    {
+        let amount = utils::get_amount_as_string(currency_unit, amount, currency)?;
+        Ok(Self {
+            amount,
+            router_data: item,
+        })
+    }
+}
+
 #[derive(Debug, Default, Eq, PartialEq, Serialize)]
 pub struct LocalPrice {
     pub amount: String,
@@ -32,9 +65,9 @@ pub struct CoinbasePaymentsRequest {
     pub cancel_url: String,
 }
 
-impl TryFrom<&types::PaymentsAuthorizeRouterData> for CoinbasePaymentsRequest {
+impl TryFrom<CoinbseRouterData<&types::PaymentsAuthorizeRouterData> for CoinbasePaymentsRequest {
     type Error = error_stack::Report<errors::ConnectorError>;
-    fn try_from(item: &types::PaymentsAuthorizeRouterData) -> Result<Self, Self::Error> {
+    fn try_from(item:&CoinbseRouterData<&types::PaymentsAuthorizeRouterData) -> Result<Self, Self::Error> {
         get_crypto_specific_payment_data(item)
     }
 }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
This pull request introduces the get_currecny_unit from ConnectorCommon trait for `CoinBase`. This function allows connectors to declare their accepted currency unit as either "Base" or "Minor" .For coinbase it accepts currency as Base.


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [x] I added unit tests for my changes where possible
- [x] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
