### PR TITLE
[Feature](connector) [Square] Currency unit conversion

### DIFF
--- a/crates/router/src/connector/square.rs
+++ b/crates/router/src/connector/square.rs
@@ -73,6 +73,10 @@ impl ConnectorCommon for Square {
         "square"
     }
 
+    fn get_currency_unit(&self) -> api::CurrencyUnit {
+        api::CurrencyUnit::Base
+    }
+
     fn common_get_content_type(&self) -> &'static str {
         "application/json"
     }
@@ -242,8 +246,13 @@ impl
         &self,
         req: &types::TokenizationRouterData,
     ) -> CustomResult<Option<types::RequestBody>, errors::ConnectorError> {
-        let connector_request = square::SquareTokenRequest::try_from(req)?;
-
+        let connector_router_data = square::SquareRouterData::try_from((
+            &self.get_currency_unit(),
+            req.request.currency,
+            req.request.amount,
+            req,
+        ))?;
+        let connector_request = square::SquareTokenRequest::try_from(&connector_router_data)?;
         let square_req = types::RequestBody::log_and_get_request_body(
             &connector_request,
             utils::Encode::<square::SquareTokenRequest>::encode_to_string_of_json,
@@ -409,14 +418,28 @@ impl ConnectorIntegration<api::Authorize, types::PaymentsAuthorizeData, types::P
         &self,
         req: &types::PaymentsAuthorizeRouterData,
     ) -> CustomResult<Option<types::RequestBody>, errors::ConnectorError> {
-        let req_obj = square::SquarePaymentsRequest::try_from(req)?;
+        let connector_router_data = square::SquareRouterData::try_from((
+            &self.get_currency_unit(),
+            req.request.currency,
+            req.request.amount,
+            req,
+        ))?;
+        let req_obj = square::SquarePaymentsRequest::try_from(&connector_router_data)?;
 
         let square_req = types::RequestBody::log_and_get_request_body(
             &req_obj,
-            utils::Encode::<square::SquarePaymentsRequest>::encode_to_string_of_json,
+            utils::Encode::<square::SquareTokenRequest>::encode_to_string_of_json,
         )
         .change_context(errors::ConnectorError::RequestEncodingFailed)?;
         Ok(Some(square_req))
+        // let req_obj = square::SquarePaymentsRequest::try_from(req)?;
+
+        // let square_req = types::RequestBody::log_and_get_request_body(
+        //     &req_obj,
+        //     utils::Encode::<square::SquarePaymentsRequest>::encode_to_string_of_json,
+        // )
+        // .change_context(errors::ConnectorError::RequestEncodingFailed)?;
+        // Ok(Some(square_req))
     }
 
     fn build_request(
@@ -699,13 +722,27 @@ impl ConnectorIntegration<api::Execute, types::RefundsData, types::RefundsRespon
         &self,
         req: &types::RefundsRouterData<api::Execute>,
     ) -> CustomResult<Option<types::RequestBody>, errors::ConnectorError> {
-        let req_obj = square::SquareRefundRequest::try_from(req)?;
+        let connector_router_data = square::SquareRouterData::try_from((
+            &self.get_currency_unit(),
+            req.request.currency,
+            req.request,
+            req,
+        ))?;
+        let req_obj = square::SquareRefundRequest::try_from(&connector_router_data)?;
+
         let square_req = types::RequestBody::log_and_get_request_body(
             &req_obj,
-            utils::Encode::<square::SquareRefundRequest>::encode_to_string_of_json,
+            utils::Encode::<square::SquareTokenRequest>::encode_to_string_of_json,
         )
         .change_context(errors::ConnectorError::RequestEncodingFailed)?;
         Ok(Some(square_req))
+        // let req_obj = square::SquareRefundRequest::try_from(req)?;
+        // let square_req = types::RequestBody::log_and_get_request_body(
+        //     &req_obj,
+        //     utils::Encode::<square::SquareRefundRequest>::encode_to_string_of_json,
+        // )
+        // .change_context(errors::ConnectorError::RequestEncodingFailed)?;
+        // Ok(Some(square_req))
     }
 
     fn build_request(


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
Made changes to `square.rs` & `square/transformers.rs` similar to the given [PR for reference](https://github.com/juspay/hyperswitch/pull/2196) 

I am running into the following error
```
error[E0277]: the trait bound `SquareTokenRequest: std::convert::From<(&types::RouterData<types::api::payments::PaymentMethodToken, PaymentMethodTokenizationData, PaymentsResponseData>, api_models::payments::BankDebitData)>` is not satisfied
   --> crates/router/src/connector/square/transformers.rs:174:32
    |
174 |                 Self::try_from((item, bank_debit_data))
    |                 -------------- ^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::convert::From<(&types::RouterData<types::api::payments::PaymentMethodToken, PaymentMethodTokenizationData, PaymentsResponseData>, api_models::payments::BankDebitData)>` is not implemented for `SquareTokenRequest`
    |                 |
    |                 required by a bound introduced by this call
    |
    = help: the following other types implement trait `TryFrom<T>`:
              <SquareTokenRequest as TryFrom<&SquareRouterData<&types::RouterData<types::api::payments::PaymentMethodToken, PaymentMethodTokenizationData, PaymentsResponseData>>>>
              <SquareTokenRequest as TryFrom<(&SquareRouterData<&types::RouterData<types::api::payments::PaymentMethodToken, PaymentMethodTokenizationData, PaymentsResponseData>>, api_models::payments::BankDebitData)>>
              <SquareTokenRequest as TryFrom<(&SquareRouterData<&types::RouterData<types::api::payments::PaymentMethodToken, PaymentMethodTokenizationData, PaymentsResponseData>>, api_models::payments::Card)>>
              <SquareTokenRequest as TryFrom<(&SquareRouterData<&types::RouterData<types::api::payments::PaymentMethodToken, PaymentMethodTokenizationData, PaymentsResponseData>>, api_models::payments::PayLaterData)>>
              <SquareTokenRequest as TryFrom<(&SquareRouterData<&types::RouterData<types::api::payments::PaymentMethodToken, PaymentMethodTokenizationData, PaymentsResponseData>>, api_models::payments::WalletData)>>
    = note: required for `(&RouterData<PaymentMethodToken, ..., ...>, ...)` to implement `std::convert::Into<SquareTokenRequest>`
```

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
