### PR TITLE
refactor(connector): [Nexinets] Currency Unit Conversion

### DIFF
--- a/crates/router/src/connector/nexinets.rs
+++ b/crates/router/src/connector/nexinets.rs
@@ -76,6 +76,10 @@ impl ConnectorCommon for Nexinets {
         "nexinets"
     }
 
+    fn get_currency_unit(&self) -> api::CurrencyUnit {
+        api::CurrencyUnit::Minor
+    }
+
     fn common_get_content_type(&self) -> &'static str {
         "application/json"
     }
@@ -200,9 +204,15 @@ impl ConnectorIntegration<api::Authorize, types::PaymentsAuthorizeData, types::P
         &self,
         req: &types::PaymentsAuthorizeRouterData,
     ) -> CustomResult<Option<types::RequestBody>, errors::ConnectorError> {
-        let req_obj = nexinets::NexinetsPaymentsRequest::try_from(req)?;
+        let connector_router_data = nexinets::NexinetsRouterData::try_from((
+            &self.get_currency_unit(),
+            req.request.currency,
+            req.request.amount,
+            req,
+        ))?;
+        let connector_req = nexinets::NexinetsPaymentsRequest::try_from(&connector_router_data)?;
         let nexinets_req = types::RequestBody::log_and_get_request_body(
-            &req_obj,
+            &connector_req,
             utils::Encode::<nexinets::NexinetsPaymentsRequest>::encode_to_string_of_json,
         )
         .change_context(errors::ConnectorError::RequestEncodingFailed)?;


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ x ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
This pull request implements the get_currency_unit from the ConnectorCommon trait for the Nexinets connector. This function allows connectors to declare their accepted currency unit as either Base or Minor. For Nexinets it accepts currency as Minor units.


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. crates/router/src/connector/nexinets.rs
2.crates/router/src/connector/worldline/nexinets.rs

-->


## Motivation and Context
<!--
closes #2233 

-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ x ] I formatted the code `cargo +nightly fmt --all`
- [ x ] I addressed lints thrown by `cargo clippy`
- [ x ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
