### PR TITLE
ci: perform patch bump to get next bump version if auto bump fails

### DIFF
--- a/.github/workflows/release-new-version.yml
+++ b/.github/workflows/release-new-version.yml
@@ -80,14 +80,21 @@ jobs:
         shell: bash
         # Only consider tags on current branch when setting PREVIOUS_TAG
         run: |
-          echo "PREVIOUS_TAG=$(git tag --sort='version:refname' --merged | tail --lines 1)" >> $GITHUB_ENV
-          echo "NEW_TAG=$(cog bump --auto --dry-run)" >> $GITHUB_ENV
+          PREVIOUS_TAG="$(git tag --sort='version:refname' --merged | tail --lines 1)"
+          if [[ "$(cog bump --auto --dry-run)" == *"No conventional commits for your repository that required a bump"* ]]; then
+            NEW_TAG="$(cog bump --patch --dry-run)"
+          else if [[ "${PREVIOUS_TAG}" != "${NEW_TAG}" ]]
+            NEW_TAG="$(cog bump --auto --dry-run)"
+          fi
+          echo "NEW_TAG=${NEW_TAG}" >> $GITHUB_ENV
+          echo "PREVIOUS_TAG=${PREVIOUS_TAG}" >> $GITHUB_ENV
 
       - name: Update changelog and create tag
         shell: bash
         if: ${{ env.NEW_TAG != env.PREVIOUS_TAG }}
+        # Remove prefix 'v' from 'NEW_TAG' as cog bump --version expects only the version number
         run: |
-          cog bump --auto
+          cog bump --version ${NEW_TAG#v}
 
       - name: Push created commit and tag
         shell: bash


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [x] CI/CD

## Description
<!-- Describe your changes in detail -->
Use `cog bump --patch --dry-run` to get next bump version if `cog bump --auto --dry-run` fails. Also remove prefix 'v' from 'NEW_TAG' as cog bump --version expects only the version number to be passed.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
