### PR TITLE
refactor(connector): [Cryptopay] add psync reference id validation for Cryptopay

### DIFF
--- a/crates/router/src/connector/cryptopay.rs
+++ b/crates/router/src/connector/cryptopay.rs
@@ -171,8 +171,6 @@ impl ConnectorCommon for Cryptopay {
     }
 }
 
-impl ConnectorValidation for Cryptopay {}
-
 impl ConnectorIntegration<api::Session, types::PaymentsSessionData, types::PaymentsResponseData>
     for Cryptopay
 {
@@ -276,6 +274,16 @@ impl ConnectorIntegration<api::Authorize, types::PaymentsAuthorizeData, types::P
         res: Response,
     ) -> CustomResult<ErrorResponse, errors::ConnectorError> {
         self.build_error_response(res)
+    }
+}
+
+impl ConnectorValidation for Cryptopay {
+    fn validate_psync_reference_id(
+        &self,
+        _data: &types::PaymentsSyncRouterData,
+    ) -> CustomResult<(), errors::ConnectorError> {
+        // since we can make psync call with our reference_id, having connector_transaction_id is not an mandatory criteria
+        Ok(())
     }
 }
 


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
`connector_request_reference_id` is being pass as reference id which will help in payment retrieval in case of connector timeout. This will not make connector transaction id as mandatory. It will force sync even though connector transaction id is not present.
pr raised against main - https://github.com/juspay/hyperswitch/pull/2668
### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Test cases - make a payment, update connector_transaction_id with NULL and do a force sync.

<img width="737" alt="Screenshot 2023-10-25 at 4 36 12 PM" src="https://github.com/juspay/hyperswitch/assets/70575890/be975bcb-7d66-4bc3-94f1-4364f06d96d6">
<img width="879" alt="Screenshot 2023-10-25 at 4 36 36 PM" src="https://github.com/juspay/hyperswitch/assets/70575890/f845559a-9a39-46c3-a3ee-8266a9abf111">


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
