### PR TITLE
fix(connector): [Paypal]fix paypal error reason mapping when it is empty string.

### DIFF
--- a/crates/router/src/connector/paypal.rs
+++ b/crates/router/src/connector/paypal.rs
@@ -190,10 +190,13 @@ impl ConnectorCommon for Paypal {
                     })
             })
             .transpose()?;
-        let reason = error_reason
-            .unwrap_or(response.message.to_owned())
-            .is_empty()
-            .then_some(response.message.to_owned());
+        let reason = match error_reason {
+            Some(err_reason) => err_reason
+                .is_empty()
+                .then(|| response.message.to_owned())
+                .or(Some(err_reason)),
+            None => Some(response.message.to_owned()),
+        };
 
         Ok(ErrorResponse {
             status_code: res.status_code,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Error reason mapping in paypal fails when `description` for error reason is empty string .Because current implementation uses `then_some` , which returns Some(t) if the bool is [true], or None otherwise. So `error_reason` always set to `None` .This pr fixes this issue and set the error reason to paypal's error message if error reason is empty string.


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Can't test this if paypal sends empty string in 
`PaypalPaymentErrorResponse -> details -> description `then this will be mapped to `PaypalPaymentErrorResponse-> message` . Although it have same test case as this pr https://github.com/juspay/hyperswitch/pull/2611 to test the previous error mapping .
## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
