### PR TITLE
feat(core): [Paypal] Add Preprocessing flow to CompleteAuthorize for Card 3DS Auth Verification

### DIFF
--- a/crates/router/src/connector/paypal/transformers.rs
+++ b/crates/router/src/connector/paypal/transformers.rs
@@ -683,6 +683,72 @@ pub struct PaypalThreeDsResponse {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PaypalPreProcessingResponse {
+    pub payment_source: CardParams,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CardParams {
+    pub card: AuthResult,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AuthResult {
+    pub authentication_result: PaypalThreeDsParams,
+}
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PaypalThreeDsParams {
+    pub liability_shift: LiabiilityShift,
+    pub three_d_secure: ThreeDsCheck,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ThreeDsCheck {
+    pub enrollment_status: EnrollementStatus,
+    pub authentication_status: Option<AuthenticationStatus>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum LiabiilityShift {
+    Possible,
+    No,
+    Unknown,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum EnrollementStatus {
+    #[serde(rename = "Y")]
+    Ready,
+    #[serde(rename = "N")]
+    NotReady,
+    #[serde(rename = "U")]
+    Unavailable,
+    #[serde(rename = "B")]
+    Bypassed,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum AuthenticationStatus {
+    #[serde(rename = "Y")]
+    Success,
+    #[serde(rename = "N")]
+    Failed,
+    #[serde(rename = "R")]
+    Rejected,
+    #[serde(rename = "A")]
+    Attempted,
+    #[serde(rename = "U")]
+    Unable,
+    #[serde(rename = "C")]
+    ChallengeRequired,
+    #[serde(rename = "I")]
+    InfoOnly,
+    #[serde(rename = "D")]
+    Decoupled,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PaypalOrdersResponse {
     id: String,
     intent: PaypalPaymentIntent,

--- a/crates/router/src/core/payments.rs
+++ b/crates/router/src/core/payments.rs
@@ -1081,7 +1081,21 @@ where
                 (router_data, should_continue_payment)
             }
         }
-        _ => (router_data, should_continue_payment),
+        _ => {
+            // 3DS validation for paypal cards after verification (authorize call)
+            if connector.connector_name == router_types::Connector::Paypal
+                && payment_data.payment_attempt.payment_method
+                    == Some(storage_enums::PaymentMethod::Card)
+                && matches!(format!("{operation:?}").as_str(), "CompleteAuthorize")
+            {
+                router_data = router_data.preprocessing_steps(state, connector).await?;
+                let is_error_in_response = router_data.response.is_err();
+                // If is_error_in_response is true, should_continue_payment should be false, we should throw the error
+                (router_data, !is_error_in_response)
+            } else {
+                (router_data, should_continue_payment)
+            }
+        }
     };
 
     Ok(router_data_and_should_continue_payment)

--- a/crates/router/src/core/payments/flows.rs
+++ b/crates/router/src/core/payments/flows.rs
@@ -854,7 +854,6 @@ default_imp_for_pre_processing_steps!(
     connector::Opayo,
     connector::Opennode,
     connector::Payeezy,
-    connector::Paypal,
     connector::Payu,
     connector::Powertranz,
     connector::Prophetpay,

--- a/crates/router/src/core/payments/flows/authorize_flow.rs
+++ b/crates/router/src/core/payments/flows/authorize_flow.rs
@@ -395,6 +395,30 @@ impl TryFrom<types::PaymentsAuthorizeData> for types::PaymentsPreProcessingData 
             complete_authorize_url: data.complete_authorize_url,
             browser_info: data.browser_info,
             surcharge_details: data.surcharge_details,
+            connector_transaction_id: None,
+        })
+    }
+}
+
+impl TryFrom<types::CompleteAuthorizeData> for types::PaymentsPreProcessingData {
+    type Error = error_stack::Report<errors::ApiErrorResponse>;
+
+    fn try_from(data: types::CompleteAuthorizeData) -> Result<Self, Self::Error> {
+        Ok(Self {
+            payment_method_data: data.payment_method_data,
+            amount: Some(data.amount),
+            email: data.email,
+            currency: Some(data.currency),
+            payment_method_type: None,
+            setup_mandate_details: data.setup_mandate_details,
+            capture_method: data.capture_method,
+            order_details: None,
+            router_return_url: None,
+            webhook_url: None,
+            complete_authorize_url: None,
+            browser_info: data.browser_info,
+            surcharge_details: None,
+            connector_transaction_id: data.connector_transaction_id,
         })
     }
 }

--- a/crates/router/src/core/payments/flows/complete_authorize_flow.rs
+++ b/crates/router/src/core/payments/flows/complete_authorize_flow.rs
@@ -6,7 +6,7 @@ use crate::{
         errors::{self, ConnectorErrorExt, RouterResult},
         payments::{self, access_token, helpers, transformers, PaymentData},
     },
-    routes::AppState,
+    routes::{metrics, AppState},
     services,
     types::{self, api, domain},
     utils::OptionExt,
@@ -143,6 +143,76 @@ impl Feature<api::CompleteAuthorize, types::CompleteAuthorizeData>
         };
 
         Ok((request, true))
+    }
+
+    async fn preprocessing_steps<'a>(
+        self,
+        state: &AppState,
+        connector: &api::ConnectorData,
+    ) -> RouterResult<Self> {
+        complete_authorize_preprocessing_steps(state, &self, true, connector).await
+    }
+}
+
+pub async fn complete_authorize_preprocessing_steps<F: Clone>(
+    state: &AppState,
+    router_data: &types::RouterData<F, types::CompleteAuthorizeData, types::PaymentsResponseData>,
+    confirm: bool,
+    connector: &api::ConnectorData,
+) -> RouterResult<types::RouterData<F, types::CompleteAuthorizeData, types::PaymentsResponseData>> {
+    if confirm {
+        let connector_integration: services::BoxedConnectorIntegration<
+            '_,
+            api::PreProcessing,
+            types::PaymentsPreProcessingData,
+            types::PaymentsResponseData,
+        > = connector.connector.get_connector_integration();
+
+        let preprocessing_request_data =
+            types::PaymentsPreProcessingData::try_from(router_data.request.to_owned())?;
+
+        let preprocessing_response_data: Result<types::PaymentsResponseData, types::ErrorResponse> =
+            Err(types::ErrorResponse::default());
+
+        let preprocessing_router_data =
+            payments::helpers::router_data_type_conversion::<_, api::PreProcessing, _, _, _, _>(
+                router_data.clone(),
+                preprocessing_request_data,
+                preprocessing_response_data,
+            );
+
+        let resp = services::execute_connector_processing_step(
+            state,
+            connector_integration,
+            &preprocessing_router_data,
+            payments::CallConnectorAction::Trigger,
+            None,
+        )
+        .await
+        .to_payment_failed_response()?;
+
+        metrics::PREPROCESSING_STEPS_COUNT.add(
+            &metrics::CONTEXT,
+            1,
+            &[
+                metrics::request::add_attributes("connector", connector.connector_name.to_string()),
+                metrics::request::add_attributes(
+                    "payment_method",
+                    router_data.payment_method.to_string(),
+                ),
+            ],
+        );
+
+        let authorize_router_data =
+            payments::helpers::router_data_type_conversion::<_, F, _, _, _, _>(
+                resp.clone(),
+                router_data.request.to_owned(),
+                resp.response,
+            );
+
+        Ok(authorize_router_data)
+    } else {
+        Ok(router_data.clone())
     }
 }
 

--- a/crates/router/src/core/payments/transformers.rs
+++ b/crates/router/src/core/payments/transformers.rs
@@ -1431,6 +1431,7 @@ impl<F: Clone> TryFrom<PaymentAdditionalData<'_, F>> for types::PaymentsPreProce
             complete_authorize_url,
             browser_info,
             surcharge_details: payment_data.surcharge_details,
+            connector_transaction_id: payment_data.connector_response.connector_transaction_id,
         })
     }
 }

--- a/crates/router/src/types.rs
+++ b/crates/router/src/types.rs
@@ -441,6 +441,7 @@ pub struct PaymentsPreProcessingData {
     pub complete_authorize_url: Option<String>,
     pub surcharge_details: Option<api_models::payment_methods::SurchargeDetailsResponse>,
     pub browser_info: Option<BrowserInformation>,
+    pub connector_transaction_id: Option<String>,
 }
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->

- An auth verification call is made to paypal after 3ds challenge to get the status on whether to continue payment. 
- Pre processing flow is being used for the call since we want to send the response in case of failure
- Pre processing is being called from the complete auth flow.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
