### PR TITLE
ci(postman): Fix collection throwing 404

### DIFF
--- a/postman/collection-dir/stripe/MerchantAccounts/.meta.json
+++ b/postman/collection-dir/stripe/MerchantAccounts/.meta.json
@@ -2,6 +2,7 @@
   "childrenOrder": [
     "Merchant Account - Create",
     "Merchant Account - Retrieve",
+    "Merchant Account - List",
     "Merchant Account - Update"
   ]
 }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [x] CI/CD

## Description
<!-- Describe your changes in detail -->
Since `Merchant Account - List` is not in `meta.json`, it had a different behavior of moving to the top and resulting in it throwing 404.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
Fix unintended behavior

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
<img width="511" alt="image" src="https://github.com/juspay/hyperswitch/assets/69745008/0e588c0b-0668-40ad-bd26-21e238e38432">

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added unit tests for my changes where possible
