### PR TITLE
fix(connector): Add attempt_status in field in error_response

### DIFF
--- a/connector-template/mod.rs
+++ b/connector-template/mod.rs
@@ -105,6 +105,7 @@ impl ConnectorCommon for {{project-name | downcase | pascal_case}} {
             code: response.code,
             message: response.message,
             reason: response.reason,
+            attempt_status: None,
         })
     }
 }

--- a/crates/router/src/connector/aci.rs
+++ b/crates/router/src/connector/aci.rs
@@ -78,6 +78,7 @@ impl ConnectorCommon for Aci {
                     .collect::<Vec<String>>()
                     .join("; ")
             }),
+            attempt_status: None,
         })
     }
 }

--- a/crates/router/src/connector/adyen.rs
+++ b/crates/router/src/connector/adyen.rs
@@ -73,6 +73,7 @@ impl ConnectorCommon for Adyen {
             code: response.error_code,
             message: response.message,
             reason: None,
+            attempt_status: None,
         })
     }
 }
@@ -251,6 +252,7 @@ impl
             code: response.error_code,
             message: response.message,
             reason: None,
+            attempt_status: None,
         })
     }
 }
@@ -366,6 +368,7 @@ impl
             code: response.error_code,
             message: response.message,
             reason: None,
+            attempt_status: None,
         })
     }
 }
@@ -533,6 +536,7 @@ impl
             code: response.error_code,
             message: response.message,
             reason: None,
+            attempt_status: None,
         })
     }
 
@@ -699,6 +703,7 @@ impl
             code: response.error_code,
             message: response.message,
             reason: None,
+            attempt_status: None,
         })
     }
 }
@@ -896,6 +901,7 @@ impl
             code: response.error_code,
             message: response.message,
             reason: None,
+            attempt_status: None,
         })
     }
 }
@@ -1399,6 +1405,7 @@ impl services::ConnectorIntegration<api::Execute, types::RefundsData, types::Ref
             code: response.error_code,
             message: response.message,
             reason: None,
+            attempt_status: None,
         })
     }
 }

--- a/crates/router/src/connector/adyen/transformers.rs
+++ b/crates/router/src/connector/adyen/transformers.rs
@@ -2900,6 +2900,7 @@ pub fn get_adyen_response(
                 .unwrap_or_else(|| consts::NO_ERROR_MESSAGE.to_string()),
             reason: response.refusal_reason,
             status_code,
+            attempt_status: None,
         })
     } else {
         None
@@ -2991,6 +2992,7 @@ pub fn get_redirection_response(
                 .unwrap_or_else(|| consts::NO_ERROR_MESSAGE.to_string()),
             reason: None,
             status_code,
+            attempt_status: None,
         })
     } else {
         None
@@ -3052,6 +3054,7 @@ pub fn get_present_to_shopper_response(
                 .unwrap_or_else(|| consts::NO_ERROR_MESSAGE.to_string()),
             reason: None,
             status_code,
+            attempt_status: None,
         })
     } else {
         None
@@ -3101,6 +3104,7 @@ pub fn get_qr_code_response(
                 .unwrap_or_else(|| consts::NO_ERROR_MESSAGE.to_string()),
             reason: None,
             status_code,
+            attempt_status: None,
         })
     } else {
         None
@@ -3138,6 +3142,7 @@ pub fn get_redirection_error_response(
         message: response.refusal_reason.clone(),
         reason: Some(response.refusal_reason),
         status_code,
+        attempt_status: None,
     });
     // We don't get connector transaction id for redirections in Adyen.
     let payments_response_data = types::PaymentsResponseData::TransactionResponse {

--- a/crates/router/src/connector/airwallex.rs
+++ b/crates/router/src/connector/airwallex.rs
@@ -93,6 +93,7 @@ impl ConnectorCommon for Airwallex {
             code: response.code,
             message: response.message,
             reason: response.source,
+            attempt_status: None,
         })
     }
 }

--- a/crates/router/src/connector/authorizedotnet.rs
+++ b/crates/router/src/connector/authorizedotnet.rs
@@ -893,6 +893,7 @@ fn get_error_response(
                     message: error.error_text.to_owned(),
                     reason: Some(error.error_text),
                     status_code,
+                    attempt_status: None,
                 })
             })
             .unwrap_or_else(|| types::ErrorResponse {
@@ -900,6 +901,7 @@ fn get_error_response(
                 message: consts::NO_ERROR_MESSAGE.to_string(),
                 reason: None,
                 status_code,
+                attempt_status: None,
             })),
         Some(authorizedotnet::TransactionResponse::AuthorizedotnetTransactionResponseError(_))
         | None => {
@@ -909,6 +911,7 @@ fn get_error_response(
                 message: message.to_string(),
                 reason: Some(message.to_string()),
                 status_code,
+                attempt_status: None,
             })
         }
     }

--- a/crates/router/src/connector/authorizedotnet/transformers.rs
+++ b/crates/router/src/connector/authorizedotnet/transformers.rs
@@ -573,6 +573,7 @@ impl<F, T>
                         message: error.error_text.clone(),
                         reason: None,
                         status_code: item.http_code,
+                        attempt_status: None,
                     })
                 });
                 let metadata = transaction_response
@@ -647,6 +648,7 @@ impl<F, T>
                         message: error.error_text.clone(),
                         reason: None,
                         status_code: item.http_code,
+                        attempt_status: None,
                     })
                 });
                 let metadata = transaction_response
@@ -789,6 +791,7 @@ impl<F> TryFrom<types::RefundsResponseRouterData<F, AuthorizedotnetRefundRespons
                 message: error.error_text.clone(),
                 reason: None,
                 status_code: item.http_code,
+                attempt_status: None,
             })
         });
 
@@ -1021,6 +1024,7 @@ fn get_err_response(status_code: u16, message: ResponseMessages) -> types::Error
         message: message.message[0].text.clone(),
         reason: None,
         status_code,
+        attempt_status: None,
     }
 }
 

--- a/crates/router/src/connector/bambora.rs
+++ b/crates/router/src/connector/bambora.rs
@@ -95,6 +95,7 @@ impl ConnectorCommon for Bambora {
             code: response.code.to_string(),
             message: response.message,
             reason: Some(serde_json::to_string(&response.details).unwrap_or_default()),
+            attempt_status: None,
         })
     }
 }

--- a/crates/router/src/connector/bankofamerica.rs
+++ b/crates/router/src/connector/bankofamerica.rs
@@ -111,6 +111,7 @@ impl ConnectorCommon for Bankofamerica {
             code: response.code,
             message: response.message,
             reason: response.reason,
+            attempt_status: None,
         })
     }
 }

--- a/crates/router/src/connector/bitpay.rs
+++ b/crates/router/src/connector/bitpay.rs
@@ -120,6 +120,7 @@ impl ConnectorCommon for Bitpay {
                 .unwrap_or_else(|| consts::NO_ERROR_CODE.to_string()),
             message: response.error,
             reason: response.message,
+            attempt_status: None,
         })
     }
 }

--- a/crates/router/src/connector/boku.rs
+++ b/crates/router/src/connector/boku.rs
@@ -130,6 +130,7 @@ impl ConnectorCommon for Boku {
                 code: response.code,
                 message: response.message,
                 reason: response.reason,
+                attempt_status: None,
             }),
             Err(_) => get_xml_deserialized(res),
         }
@@ -651,6 +652,7 @@ fn get_xml_deserialized(res: Response) -> CustomResult<ErrorResponse, errors::Co
                 code: consts::NO_ERROR_CODE.to_string(),
                 message: consts::UNSUPPORTED_ERROR_MESSAGE.to_string(),
                 reason: Some(response_data),
+                attempt_status: None,
             })
         }
     }

--- a/crates/router/src/connector/braintree.rs
+++ b/crates/router/src/connector/braintree.rs
@@ -132,6 +132,7 @@ impl ConnectorCommon for Braintree {
                     code,
                     message,
                     reason: Some(response.api_error_response.message),
+                    attempt_status: None,
                 })
             }
             Ok(braintree::ErrorResponse::BraintreeErrorResponse(response)) => Ok(ErrorResponse {
@@ -139,6 +140,7 @@ impl ConnectorCommon for Braintree {
                 code: consts::NO_ERROR_CODE.to_string(),
                 message: consts::NO_ERROR_MESSAGE.to_string(),
                 reason: Some(response.errors),
+                attempt_status: None,
             }),
             Err(error_msg) => {
                 logger::error!(deserialization_error =? error_msg);

--- a/crates/router/src/connector/braintree/braintree_graphql_transformers.rs
+++ b/crates/router/src/connector/braintree/braintree_graphql_transformers.rs
@@ -316,6 +316,7 @@ fn get_error_response<T>(
         message: error_msg.unwrap_or_else(|| consts::NO_ERROR_MESSAGE.to_string()),
         reason: error_reason,
         status_code: http_code,
+        attempt_status: None,
     })
 }
 

--- a/crates/router/src/connector/cashtocode.rs
+++ b/crates/router/src/connector/cashtocode.rs
@@ -119,6 +119,7 @@ impl ConnectorCommon for Cashtocode {
             code: response.error.to_string(),
             message: response.error_description,
             reason: None,
+            attempt_status: None,
         })
     }
 }

--- a/crates/router/src/connector/cashtocode/transformers.rs
+++ b/crates/router/src/connector/cashtocode/transformers.rs
@@ -217,6 +217,7 @@ impl<F, T>
                     status_code: item.http_code,
                     message: error_data.error_description,
                     reason: None,
+                    attempt_status: None,
                 }),
             ),
             CashtocodePaymentsResponse::CashtoCodeData(response_data) => {

--- a/crates/router/src/connector/checkout.rs
+++ b/crates/router/src/connector/checkout.rs
@@ -131,6 +131,7 @@ impl ConnectorCommon for Checkout {
                 .error_codes
                 .map(|errors| errors.join(" & "))
                 .or(response.error_type),
+            attempt_status: None,
         })
     }
 }

--- a/crates/router/src/connector/checkout/transformers.rs
+++ b/crates/router/src/connector/checkout/transformers.rs
@@ -576,6 +576,7 @@ impl TryFrom<types::PaymentsResponseRouterData<PaymentsResponse>>
                     .clone()
                     .unwrap_or_else(|| consts::NO_ERROR_MESSAGE.to_string()),
                 reason: item.response.response_summary,
+                attempt_status: None,
             })
         } else {
             None
@@ -623,6 +624,7 @@ impl TryFrom<types::PaymentsSyncResponseRouterData<PaymentsResponse>>
                     .clone()
                     .unwrap_or_else(|| consts::NO_ERROR_MESSAGE.to_string()),
                 reason: item.response.response_summary,
+                attempt_status: None,
             })
         } else {
             None

--- a/crates/router/src/connector/coinbase.rs
+++ b/crates/router/src/connector/coinbase.rs
@@ -108,6 +108,7 @@ impl ConnectorCommon for Coinbase {
             code: response.error.error_type,
             message: response.error.message,
             reason: response.error.code,
+            attempt_status: None,
         })
     }
 }

--- a/crates/router/src/connector/cryptopay.rs
+++ b/crates/router/src/connector/cryptopay.rs
@@ -167,6 +167,7 @@ impl ConnectorCommon for Cryptopay {
             code: response.error.code,
             message: response.error.message,
             reason: response.error.reason,
+            attempt_status: None,
         })
     }
 }

--- a/crates/router/src/connector/cybersource.rs
+++ b/crates/router/src/connector/cybersource.rs
@@ -136,6 +136,7 @@ impl ConnectorCommon for Cybersource {
             code,
             message,
             reason: Some(connector_reason),
+            attempt_status: None,
         })
     }
 }

--- a/crates/router/src/connector/cybersource/transformers.rs
+++ b/crates/router/src/connector/cybersource/transformers.rs
@@ -367,6 +367,7 @@ impl<F, T>
                     message: error.message,
                     reason: Some(error.reason),
                     status_code: item.http_code,
+                    attempt_status: None,
                 }),
                 _ => Ok(types::PaymentsResponseData::TransactionResponse {
                     resource_id: types::ResponseId::ConnectorTransactionId(

--- a/crates/router/src/connector/dlocal.rs
+++ b/crates/router/src/connector/dlocal.rs
@@ -135,6 +135,7 @@ impl ConnectorCommon for Dlocal {
             code: response.code.to_string(),
             message: response.message,
             reason: response.param,
+            attempt_status: None,
         })
     }
 }

--- a/crates/router/src/connector/dummyconnector.rs
+++ b/crates/router/src/connector/dummyconnector.rs
@@ -111,6 +111,7 @@ impl<const T: u8> ConnectorCommon for DummyConnector<T> {
             code: response.error.code,
             message: response.error.message,
             reason: response.error.reason,
+            attempt_status: None,
         })
     }
 }

--- a/crates/router/src/connector/fiserv.rs
+++ b/crates/router/src/connector/fiserv.rs
@@ -151,6 +151,7 @@ impl ConnectorCommon for Fiserv {
                         message: first_error.message.to_owned(),
                         reason: first_error.field.to_owned(),
                         status_code: res.status_code,
+                        attempt_status: None,
                     })
             })
             .unwrap_or(types::ErrorResponse {
@@ -158,6 +159,7 @@ impl ConnectorCommon for Fiserv {
                 message: consts::NO_ERROR_MESSAGE.to_string(),
                 reason: None,
                 status_code: res.status_code,
+                attempt_status: None,
             }))
     }
 }

--- a/crates/router/src/connector/forte.rs
+++ b/crates/router/src/connector/forte.rs
@@ -130,6 +130,7 @@ impl ConnectorCommon for Forte {
             code,
             message,
             reason: None,
+            attempt_status: None,
         })
     }
 }

--- a/crates/router/src/connector/globalpay.rs
+++ b/crates/router/src/connector/globalpay.rs
@@ -104,6 +104,7 @@ impl ConnectorCommon for Globalpay {
             code: response.error_code,
             message: response.detailed_error_description,
             reason: None,
+            attempt_status: None,
         })
     }
 }
@@ -313,6 +314,7 @@ impl ConnectorIntegration<api::AccessTokenAuth, types::AccessTokenRequestData, t
             code: response.error_code,
             message: response.detailed_error_description,
             reason: None,
+            attempt_status: None,
         })
     }
 }

--- a/crates/router/src/connector/globepay.rs
+++ b/crates/router/src/connector/globepay.rs
@@ -122,6 +122,7 @@ impl ConnectorCommon for Globepay {
             code: response.return_code.to_string(),
             message: consts::NO_ERROR_MESSAGE.to_string(),
             reason: Some(response.return_msg),
+            attempt_status: None,
         })
     }
 }

--- a/crates/router/src/connector/globepay/transformers.rs
+++ b/crates/router/src/connector/globepay/transformers.rs
@@ -257,6 +257,7 @@ fn get_error_response(
         message: consts::NO_ERROR_MESSAGE.to_string(),
         reason: return_msg,
         status_code,
+        attempt_status: None,
     }
 }
 

--- a/crates/router/src/connector/gocardless.rs
+++ b/crates/router/src/connector/gocardless.rs
@@ -122,6 +122,7 @@ impl ConnectorCommon for Gocardless {
             code: response.error.code.to_string(),
             message: response.error.error_type,
             reason: Some(error_reason.join("; ")),
+            attempt_status: None,
         })
     }
 }

--- a/crates/router/src/connector/helcim.rs
+++ b/crates/router/src/connector/helcim.rs
@@ -137,6 +137,7 @@ impl ConnectorCommon for Helcim {
             code: NO_ERROR_CODE.to_owned(),
             message: error_string.clone(),
             reason: Some(error_string),
+            attempt_status: None,
         })
     }
 }

--- a/crates/router/src/connector/iatapay.rs
+++ b/crates/router/src/connector/iatapay.rs
@@ -124,6 +124,7 @@ impl ConnectorCommon for Iatapay {
             code: response.error,
             message: response.message,
             reason: response.reason,
+            attempt_status: None,
         })
     }
 }
@@ -235,6 +236,7 @@ impl ConnectorIntegration<api::AccessTokenAuth, types::AccessTokenRequestData, t
             code: response.error,
             message: response.path,
             reason: None,
+            attempt_status: None,
         })
     }
 }

--- a/crates/router/src/connector/klarna.rs
+++ b/crates/router/src/connector/klarna.rs
@@ -75,6 +75,7 @@ impl ConnectorCommon for Klarna {
             code: response.error_code,
             message: consts::NO_ERROR_MESSAGE.to_string(),
             reason,
+            attempt_status: None,
         })
     }
 }

--- a/crates/router/src/connector/mollie.rs
+++ b/crates/router/src/connector/mollie.rs
@@ -98,6 +98,7 @@ impl ConnectorCommon for Mollie {
                 .unwrap_or_else(|| consts::NO_ERROR_CODE.to_string()),
             message: response.detail,
             reason: response.field,
+            attempt_status: None,
         })
     }
 }

--- a/crates/router/src/connector/multisafepay.rs
+++ b/crates/router/src/connector/multisafepay.rs
@@ -83,6 +83,7 @@ impl ConnectorCommon for Multisafepay {
             code: response.error_code.to_string(),
             message: response.error_info,
             reason: None,
+            attempt_status: None,
         })
     }
 }

--- a/crates/router/src/connector/multisafepay/transformers.rs
+++ b/crates/router/src/connector/multisafepay/transformers.rs
@@ -702,6 +702,7 @@ impl<F, T>
                     message: error_response.error_info.clone(),
                     reason: Some(error_response.error_info),
                     status_code: item.http_code,
+                    attempt_status: None,
                 }),
                 ..item.data
             }),
@@ -808,6 +809,7 @@ impl TryFrom<types::RefundsResponseRouterData<api::Execute, MultisafepayRefundRe
                     message: error_response.error_info.clone(),
                     reason: Some(error_response.error_info),
                     status_code: item.http_code,
+                    attempt_status: None,
                 }),
                 ..item.data
             }),
@@ -844,6 +846,7 @@ impl TryFrom<types::RefundsResponseRouterData<api::RSync, MultisafepayRefundResp
                     message: error_response.error_info.clone(),
                     reason: Some(error_response.error_info),
                     status_code: item.http_code,
+                    attempt_status: None,
                 }),
                 ..item.data
             }),

--- a/crates/router/src/connector/nexinets.rs
+++ b/crates/router/src/connector/nexinets.rs
@@ -130,6 +130,7 @@ impl ConnectorCommon for Nexinets {
             code: response.code.to_string(),
             message: static_message,
             reason: Some(connector_reason),
+            attempt_status: None,
         })
     }
 }

--- a/crates/router/src/connector/nmi/transformers.rs
+++ b/crates/router/src/connector/nmi/transformers.rs
@@ -440,6 +440,7 @@ impl ForeignFrom<(StandardResponse, u16)> for types::ErrorResponse {
             message: response.responsetext,
             reason: None,
             status_code: http_code,
+            attempt_status: None,
         }
     }
 }

--- a/crates/router/src/connector/noon.rs
+++ b/crates/router/src/connector/noon.rs
@@ -136,6 +136,7 @@ impl ConnectorCommon for Noon {
             code: response.result_code.to_string(),
             message: response.class_description,
             reason: Some(response.message),
+            attempt_status: None,
         })
     }
 }

--- a/crates/router/src/connector/noon/transformers.rs
+++ b/crates/router/src/connector/noon/transformers.rs
@@ -511,6 +511,7 @@ impl<F, T>
                     message: error_message.clone(),
                     reason: Some(error_message),
                     status_code: item.http_code,
+                    attempt_status: None,
                 }),
                 _ => {
                     let connector_response_reference_id =

--- a/crates/router/src/connector/nuvei/transformers.rs
+++ b/crates/router/src/connector/nuvei/transformers.rs
@@ -1579,6 +1579,7 @@ fn get_error_response<T>(
             .unwrap_or_else(|| consts::NO_ERROR_MESSAGE.to_string()),
         reason: None,
         status_code: http_code,
+        attempt_status: None,
     })
 }
 

--- a/crates/router/src/connector/opayo.rs
+++ b/crates/router/src/connector/opayo.rs
@@ -107,6 +107,7 @@ impl ConnectorCommon for Opayo {
             code: response.code,
             message: response.message,
             reason: response.reason,
+            attempt_status: None,
         })
     }
 }

--- a/crates/router/src/connector/opennode.rs
+++ b/crates/router/src/connector/opennode.rs
@@ -110,6 +110,7 @@ impl ConnectorCommon for Opennode {
             code: consts::NO_ERROR_CODE.to_string(),
             message: response.message,
             reason: None,
+            attempt_status: None,
         })
     }
 }

--- a/crates/router/src/connector/payeezy.rs
+++ b/crates/router/src/connector/payeezy.rs
@@ -123,6 +123,7 @@ impl ConnectorCommon for Payeezy {
             code: response.transaction_status,
             message: error_messages.join(", "),
             reason: None,
+            attempt_status: None,
         })
     }
 }

--- a/crates/router/src/connector/payme.rs
+++ b/crates/router/src/connector/payme.rs
@@ -97,6 +97,7 @@ impl ConnectorCommon for Payme {
                 "{}, additional info: {}",
                 response.status_error_details, response.status_additional_info
             )),
+            attempt_status: None,
         })
     }
 }

--- a/crates/router/src/connector/payme/transformers.rs
+++ b/crates/router/src/connector/payme/transformers.rs
@@ -226,6 +226,7 @@ impl From<(&PaymePaySaleResponse, u16)> for types::ErrorResponse {
                 .unwrap_or(consts::NO_ERROR_MESSAGE.to_string()),
             reason: pay_sale_response.status_error_details.to_owned(),
             status_code: http_code,
+            attempt_status: None,
         }
     }
 }
@@ -308,6 +309,7 @@ impl From<(&SaleQuery, u16)> for types::ErrorResponse {
                 .unwrap_or(consts::NO_ERROR_MESSAGE.to_string()),
             reason: sale_query_response.sale_error_text.clone(),
             status_code: http_code,
+            attempt_status: None,
         }
     }
 }

--- a/crates/router/src/connector/paypal.rs
+++ b/crates/router/src/connector/paypal.rs
@@ -91,6 +91,7 @@ impl Paypal {
             code: response.name,
             message: response.message.clone(),
             reason: error_reason.or(Some(response.message)),
+            attempt_status: None,
         })
     }
 }
@@ -203,6 +204,7 @@ impl ConnectorCommon for Paypal {
             code: response.name,
             message: response.message.clone(),
             reason,
+            attempt_status: None,
         })
     }
 }
@@ -340,6 +342,7 @@ impl ConnectorIntegration<api::AccessTokenAuth, types::AccessTokenRequestData, t
             code: response.error,
             message: response.error_description.clone(),
             reason: Some(response.error_description),
+            attempt_status: None,
         })
     }
 }

--- a/crates/router/src/connector/payu.rs
+++ b/crates/router/src/connector/payu.rs
@@ -96,6 +96,7 @@ impl ConnectorCommon for Payu {
             code: response.status.status_code,
             message: response.status.status_desc,
             reason: response.status.code_literal,
+            attempt_status: None,
         })
     }
 }
@@ -304,6 +305,7 @@ impl ConnectorIntegration<api::AccessTokenAuth, types::AccessTokenRequestData, t
             code: response.error,
             message: response.error_description,
             reason: None,
+            attempt_status: None,
         })
     }
 }

--- a/crates/router/src/connector/powertranz.rs
+++ b/crates/router/src/connector/powertranz.rs
@@ -120,6 +120,7 @@ impl ConnectorCommon for Powertranz {
             code: consts::NO_ERROR_CODE.to_string(),
             message: consts::NO_ERROR_MESSAGE.to_string(),
             reason: None,
+            attempt_status: None,
         })
     }
 }

--- a/crates/router/src/connector/powertranz/transformers.rs
+++ b/crates/router/src/connector/powertranz/transformers.rs
@@ -443,6 +443,7 @@ fn build_error_response(
                         .collect::<Vec<_>>()
                         .join(", "),
                 ),
+                attempt_status: None,
             }
         })
     } else if !ISO_SUCCESS_CODES.contains(&item.iso_response_code.as_str()) {
@@ -452,6 +453,7 @@ fn build_error_response(
             code: item.iso_response_code.clone(),
             message: item.response_message.clone(),
             reason: Some(item.response_message.clone()),
+            attempt_status: None,
         })
     } else {
         None

--- a/crates/router/src/connector/prophetpay.rs
+++ b/crates/router/src/connector/prophetpay.rs
@@ -110,6 +110,7 @@ impl ConnectorCommon for Prophetpay {
             code: response.code,
             message: response.message,
             reason: response.reason,
+            attempt_status: None,
         })
     }
 }

--- a/crates/router/src/connector/rapyd.rs
+++ b/crates/router/src/connector/rapyd.rs
@@ -98,6 +98,7 @@ impl ConnectorCommon for Rapyd {
                 code: response_data.status.error_code,
                 message: response_data.status.status.unwrap_or_default(),
                 reason: response_data.status.message,
+                attempt_status: None,
             }),
             Err(error_msg) => {
                 logger::error!(deserialization_error =? error_msg);

--- a/crates/router/src/connector/rapyd/transformers.rs
+++ b/crates/router/src/connector/rapyd/transformers.rs
@@ -457,6 +457,7 @@ impl<F, T>
                             status_code: item.http_code,
                             message: item.response.status.status.unwrap_or_default(),
                             reason: data.failure_message.to_owned(),
+                            attempt_status: None,
                         }),
                     ),
                     _ => {
@@ -497,6 +498,7 @@ impl<F, T>
                     status_code: item.http_code,
                     message: item.response.status.status.unwrap_or_default(),
                     reason: item.response.status.message,
+                    attempt_status: None,
                 }),
             ),
         };

--- a/crates/router/src/connector/shift4.rs
+++ b/crates/router/src/connector/shift4.rs
@@ -99,6 +99,7 @@ impl ConnectorCommon for Shift4 {
                 .unwrap_or_else(|| consts::NO_ERROR_CODE.to_string()),
             message: response.error.message,
             reason: None,
+            attempt_status: None,
         })
     }
 }

--- a/crates/router/src/connector/square.rs
+++ b/crates/router/src/connector/square.rs
@@ -123,6 +123,7 @@ impl ConnectorCommon for Square {
                 .and_then(|error| error.category.clone())
                 .unwrap_or(consts::NO_ERROR_MESSAGE.to_string()),
             reason: Some(reason),
+            attempt_status: None,
         })
     }
 }

--- a/crates/router/src/connector/stax.rs
+++ b/crates/router/src/connector/stax.rs
@@ -109,6 +109,7 @@ impl ConnectorCommon for Stax {
                     .change_context(errors::ConnectorError::ResponseDeserializationFailed)?
                     .to_owned(),
             ),
+            attempt_status: None,
         })
     }
 }

--- a/crates/router/src/connector/stripe.rs
+++ b/crates/router/src/connector/stripe.rs
@@ -225,6 +225,7 @@ impl
                     })
                     .unwrap_or(message)
             }),
+            attempt_status: None,
         })
     }
 }
@@ -351,6 +352,7 @@ impl
                     })
                     .unwrap_or(message)
             }),
+            attempt_status: None,
         })
     }
 }
@@ -473,6 +475,7 @@ impl
                     })
                     .unwrap_or(message)
             }),
+            attempt_status: None,
         })
     }
 }
@@ -603,6 +606,7 @@ impl
                     })
                     .unwrap_or(message)
             }),
+            attempt_status: None,
         })
     }
 }
@@ -743,6 +747,7 @@ impl
                     })
                     .unwrap_or(message)
             }),
+            attempt_status: None,
         })
     }
 }
@@ -897,6 +902,7 @@ impl
                     })
                     .unwrap_or(message)
             }),
+            attempt_status: None,
         })
     }
 }
@@ -1016,6 +1022,7 @@ impl
                     })
                     .unwrap_or(message)
             }),
+            attempt_status: None,
         })
     }
 }
@@ -1170,6 +1177,7 @@ impl
                     })
                     .unwrap_or(message)
             }),
+            attempt_status: None,
         })
     }
 }
@@ -1287,6 +1295,7 @@ impl services::ConnectorIntegration<api::Execute, types::RefundsData, types::Ref
                     })
                     .unwrap_or(message)
             }),
+            attempt_status: None,
         })
     }
 }
@@ -1390,6 +1399,7 @@ impl services::ConnectorIntegration<api::RSync, types::RefundsData, types::Refun
                     })
                     .unwrap_or(message)
             }),
+            attempt_status: None,
         })
     }
 }
@@ -1534,6 +1544,7 @@ impl
                     })
                     .unwrap_or(message)
             }),
+            attempt_status: None,
         })
     }
 }
@@ -1636,6 +1647,7 @@ impl
                     })
                     .unwrap_or(message)
             }),
+            attempt_status: None,
         })
     }
 }
@@ -1761,6 +1773,7 @@ impl
                     })
                     .unwrap_or(message)
             }),
+            attempt_status: None,
         })
     }
 }

--- a/crates/router/src/connector/stripe/transformers.rs
+++ b/crates/router/src/connector/stripe/transformers.rs
@@ -2475,6 +2475,7 @@ impl<F, T>
                         })
                         .or(Some(error.message.clone())),
                     status_code: item.http_code,
+                    attempt_status: None,
                 });
 
         let connector_metadata =

--- a/crates/router/src/connector/trustpay.rs
+++ b/crates/router/src/connector/trustpay.rs
@@ -138,6 +138,7 @@ impl ConnectorCommon for Trustpay {
                         .map(|error_code_message| error_code_message.error_code)
                         .unwrap_or(consts::NO_ERROR_MESSAGE.to_string()),
                     reason: reason.or(response_data.description),
+                    attempt_status: None,
                 })
             }
             Err(error_msg) => {
@@ -293,6 +294,7 @@ impl ConnectorIntegration<api::AccessTokenAuth, types::AccessTokenRequestData, t
             // message vary for the same code, so relying on code alone as it is unique
             message: response.result_info.result_code.to_string(),
             reason: response.result_info.additional_info,
+            attempt_status: None,
         })
     }
 }
@@ -366,6 +368,7 @@ impl ConnectorIntegration<api::PSync, types::PaymentsSyncData, types::PaymentsRe
             // message vary for the same code, so relying on code alone as it is unique
             message: response.status.to_string(),
             reason: Some(response.payment_description),
+            attempt_status: None,
         })
     }
 

--- a/crates/router/src/connector/trustpay/transformers.rs
+++ b/crates/router/src/connector/trustpay/transformers.rs
@@ -715,6 +715,7 @@ fn handle_cards_response(
                 .unwrap_or_else(|| consts::NO_ERROR_MESSAGE.to_string()),
             reason: msg,
             status_code,
+            attempt_status: None,
         })
     } else {
         None
@@ -776,6 +777,7 @@ fn handle_bank_redirects_error_response(
         message: response.payment_result_info.result_code.to_string(),
         reason: response.payment_result_info.additional_info,
         status_code,
+        attempt_status: None,
     });
     let payment_response_data = types::PaymentsResponseData::TransactionResponse {
         resource_id: types::ResponseId::NoResponseId,
@@ -811,6 +813,7 @@ fn handle_bank_redirects_sync_response(
             message: reason_info.reason.code,
             reason: reason_info.reason.reject_reason,
             status_code,
+            attempt_status: None,
         })
     } else {
         None
@@ -937,6 +940,7 @@ impl<F, T> TryFrom<types::ResponseRouterData<F, TrustpayAuthUpdateResponse, T, t
                     message: item.response.result_info.result_code.to_string(),
                     reason: item.response.result_info.additional_info,
                     status_code: item.http_code,
+                    attempt_status: None,
                 }),
                 ..item.data
             }),
@@ -1408,6 +1412,7 @@ fn handle_cards_refund_response(
                 .unwrap_or_else(|| consts::NO_ERROR_MESSAGE.to_string()),
             reason: msg,
             status_code,
+            attempt_status: None,
         })
     } else {
         None
@@ -1446,6 +1451,7 @@ fn handle_bank_redirects_refund_response(
             message: response.result_info.result_code.to_string(),
             reason: msg.map(|message| message.to_string()),
             status_code,
+            attempt_status: None,
         })
     } else {
         None
@@ -1473,6 +1479,7 @@ fn handle_bank_redirects_refund_sync_response(
             message: reason_info.reason.code,
             reason: reason_info.reason.reject_reason,
             status_code,
+            attempt_status: None,
         })
     } else {
         None
@@ -1494,6 +1501,7 @@ fn handle_bank_redirects_refund_sync_error_response(
         message: response.payment_result_info.result_code.to_string(),
         reason: response.payment_result_info.additional_info,
         status_code,
+        attempt_status: None,
     });
     //unreachable case as we are sending error as Some()
     let refund_response_data = types::RefundsResponseData {

--- a/crates/router/src/connector/tsys/transformers.rs
+++ b/crates/router/src/connector/tsys/transformers.rs
@@ -202,6 +202,7 @@ fn get_error_response(
         message: connector_error_response.response_message.clone(),
         reason: Some(connector_error_response.response_message),
         status_code,
+        attempt_status: None,
     }
 }
 

--- a/crates/router/src/connector/volt.rs
+++ b/crates/router/src/connector/volt.rs
@@ -129,6 +129,7 @@ impl ConnectorCommon for Volt {
             code: response.exception.message.to_string(),
             message: response.exception.message.clone(),
             reason: Some(reason),
+            attempt_status: None,
         })
     }
 }

--- a/crates/router/src/connector/wise.rs
+++ b/crates/router/src/connector/wise.rs
@@ -94,6 +94,7 @@ impl ConnectorCommon for Wise {
                         code: e.code.clone(),
                         message: e.message.clone(),
                         reason: None,
+                        attempt_status: None,
                     })
                 } else {
                     Ok(types::ErrorResponse {
@@ -101,6 +102,7 @@ impl ConnectorCommon for Wise {
                         code: default_status,
                         message: response.message.unwrap_or_default(),
                         reason: None,
+                        attempt_status: None,
                     })
                 }
             }
@@ -109,6 +111,7 @@ impl ConnectorCommon for Wise {
                 code: default_status,
                 message: response.message.unwrap_or_default(),
                 reason: None,
+                attempt_status: None,
             }),
         }
     }
@@ -289,6 +292,7 @@ impl services::ConnectorIntegration<api::PoCancel, types::PayoutsData, types::Pa
             code,
             message,
             reason: None,
+            attempt_status: None,
         })
     }
 }

--- a/crates/router/src/connector/worldpay.rs
+++ b/crates/router/src/connector/worldpay.rs
@@ -94,6 +94,7 @@ impl ConnectorCommon for Worldpay {
             code: response.error_name,
             message: response.message,
             reason: response.validation_errors.map(|e| e.to_string()),
+            attempt_status: None,
         })
     }
 }

--- a/crates/router/src/connector/zen.rs
+++ b/crates/router/src/connector/zen.rs
@@ -126,6 +126,7 @@ impl ConnectorCommon for Zen {
                 |error| error.message,
             ),
             reason: None,
+            attempt_status: None,
         })
     }
 }

--- a/crates/router/src/core/payments/access_token.rs
+++ b/crates/router/src/core/payments/access_token.rs
@@ -173,6 +173,7 @@ pub async fn refresh_connector_auth(
                     message: consts::REQUEST_TIMEOUT_ERROR_MESSAGE.to_string(),
                     reason: Some(consts::REQUEST_TIMEOUT_ERROR_MESSAGE.to_string()),
                     status_code: 504,
+                    attempt_status: None,
                 };
 
                 Ok(Err(error_response))

--- a/crates/router/src/services/api.rs
+++ b/crates/router/src/services/api.rs
@@ -10,7 +10,7 @@ use std::{
 };
 
 use actix_web::{body, web, FromRequest, HttpRequest, HttpResponse, Responder, ResponseError};
-use api_models::enums::{AttemptStatus, CaptureMethod};
+use api_models::enums::CaptureMethod;
 pub use client::{proxy_bypass_urls, ApiClient, MockApiClient, ProxyClient};
 pub use common_utils::request::{ContentType, Method, Request, RequestBuilder};
 use common_utils::{
@@ -226,6 +226,7 @@ pub trait ConnectorIntegration<T, Req, Resp>: ConnectorIntegrationAny<T, Req, Re
             message: error_message.to_string(),
             reason: String::from_utf8(res.response.to_vec()).ok(),
             status_code: res.status_code,
+            attempt_status: None,
         })
     }
 
@@ -303,6 +304,7 @@ where
                     message: error_message.unwrap_or(consts::NO_ERROR_MESSAGE.to_string()),
                     status_code: 200, // This status code is ignored in redirection response it will override with 302 status code.
                     reason: None,
+                    attempt_status: None,
                 })
             } else {
                 None
@@ -406,16 +408,9 @@ where
                                         _ => {
                                             let error_res =
                                                 connector_integration.get_error_response(body)?;
-                                            if router_data.connector == "bluesnap"
-                                                && error_res.status_code == 403
-                                                && error_res.reason
-                                                    == Some(format!(
-                                                        "{} in bluesnap dashboard",
-                                                        consts::REQUEST_TIMEOUT_PAYMENT_NOT_FOUND
-                                                    ))
-                                            {
-                                                router_data.status = AttemptStatus::Failure;
-                                            };
+                                            router_data.status = error_res
+                                                .attempt_status
+                                                .map_or(router_data.status, |status| status);
                                             error_res
                                         }
                                     };
@@ -434,6 +429,7 @@ where
                                     message: consts::REQUEST_TIMEOUT_ERROR_MESSAGE.to_string(),
                                     reason: Some(consts::REQUEST_TIMEOUT_ERROR_MESSAGE.to_string()),
                                     status_code: 504,
+                                    attempt_status: None,
                                 };
                                 router_data.response = Err(error_response);
                                 router_data.connector_http_status_code = Some(504);

--- a/crates/router/src/services/api.rs
+++ b/crates/router/src/services/api.rs
@@ -408,9 +408,9 @@ where
                                         _ => {
                                             let error_res =
                                                 connector_integration.get_error_response(body)?;
-                                            router_data.status = error_res
-                                                .attempt_status
-                                                .map_or(router_data.status, |status| status);
+                                            if let Some(status) = error_res.attempt_status {
+                                                router_data.status = status;
+                                            };
                                             error_res
                                         }
                                     };

--- a/crates/router/src/types.rs
+++ b/crates/router/src/types.rs
@@ -923,6 +923,7 @@ pub struct ErrorResponse {
     pub message: String,
     pub reason: Option<String>,
     pub status_code: u16,
+    pub attempt_status: Option<storage_enums::AttemptStatus>,
 }
 
 impl ErrorResponse {
@@ -938,6 +939,7 @@ impl ErrorResponse {
             .error_message(),
             reason: None,
             status_code: http::StatusCode::INTERNAL_SERVER_ERROR.as_u16(),
+            attempt_status: None,
         }
     }
 }
@@ -980,6 +982,7 @@ impl From<errors::ApiErrorResponse> for ErrorResponse {
                 errors::ApiErrorResponse::ExternalConnectorError { status_code, .. } => status_code,
                 _ => 500,
             },
+            attempt_status: None,
         }
     }
 }

--- a/crates/router/src/types/api.rs
+++ b/crates/router/src/types/api.rs
@@ -111,6 +111,7 @@ pub trait ConnectorCommon {
             code: consts::NO_ERROR_CODE.to_string(),
             message: consts::NO_ERROR_MESSAGE.to_string(),
             reason: None,
+            attempt_status: None,
         })
     }
 }

--- a/crates/router/src/utils.rs
+++ b/crates/router/src/utils.rs
@@ -401,6 +401,7 @@ pub fn handle_json_response_deserialization_failure(
                 code: consts::NO_ERROR_CODE.to_string(),
                 message: consts::UNSUPPORTED_ERROR_MESSAGE.to_string(),
                 reason: Some(response_data),
+                attempt_status: None,
             })
         }
     }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Payment attempt status would remain in non terminal state if psync gets 4xx or 5xx .This needs to handled in connector error response .This PR introduces optional field called attempt_status field in ErrorResponse struct by which we can update payment status in case 4xx and 5xx in connector `get_error_response` .

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
Payment attempt status would remain in non terminal state if psync gets 4xx or 5xx .This needs to handled in connector error response .This PR introduces optional field called attempt_status field in ErrorResponse struct by which we can update payment status in case 4xx and 5xx in connector `get_error_response` .

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
tested using postman .
This can't be tested with exact scenario .Although we can duplicate this scenarion with other case 
1) make a failure payment using failed test scenarios
2)update the status in db to pending
3) psync the payment setting force_synce =true

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
