### PR TITLE
ci: use `env` input to fix the command injection vulnerability

### DIFF
--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -41,7 +41,9 @@ jobs:
     steps:
       - name: Store PR title in a file
         shell: bash
-        run: echo '${{ github.event.pull_request.title }}' > pr_title.txt
+        env:
+          TITLE: ${{ github.event.pull_request.title }}
+        run: echo $TITLE > pr_title.txt
 
       - name: Spell check
         uses: crate-ci/typos@master
@@ -66,8 +68,10 @@ jobs:
         id: pr_title_check
         if: ${{ github.event_name == 'pull_request_target' }}
         shell: bash
+        env:
+          TITLE: ${{ github.event.pull_request.title }}
         continue-on-error: true
-        run: cog verify '${{ github.event.pull_request.title }}'
+        run: cog verify "$TITLE"
 
       - name: Verify commit message follows conventional commit standards
         id: commit_message_check


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [x] CI/CD

## Description
<!-- Describe your changes in detail -->
This pr uses env input form GitHub to prevent the command injection vulnerability. 

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
