### PR TITLE
ci(rustman): Fix Rustman custom headers

### DIFF
--- a/crates/test_utils/src/newman_runner.rs
+++ b/crates/test_utils/src/newman_runner.rs
@@ -1,10 +1,4 @@
-use std::{
-    env,
-    fs::OpenOptions,
-    io::{self, Write},
-    path::Path,
-    process::Command,
-};
+use std::{env, io::Write, path::Path, process::Command};
 
 use clap::{arg, command, Parser};
 use masking::PeekInterface;
@@ -52,22 +46,22 @@ fn get_path(name: impl AsRef<str>) -> String {
 
 // This function currently allows you to add only custom headers.
 // In future, as we scale, this can be modified based on the need
-fn insert_content<T, U>(dir: T, content_to_insert: U) -> io::Result<()>
+fn insert_content<T, U>(dir: T, content_to_insert: U) -> std::io::Result<()>
 where
-    T: AsRef<Path> + std::fmt::Debug,
-    U: AsRef<str> + std::fmt::Debug,
+    T: AsRef<Path>,
+    U: AsRef<str>,
 {
     let file_name = "event.prerequest.js";
     let file_path = dir.as_ref().join(file_name);
 
     // Open the file in write mode or create it if it doesn't exist
-    let mut file = OpenOptions::new()
+    let mut file = std::fs::OpenOptions::new()
         .write(true)
         .append(true)
         .create(true)
         .open(file_path)?;
 
-    write!(file, "\n{:#?}", content_to_insert)?;
+    write!(file, "{}", content_to_insert.as_ref())?;
 
     Ok(())
 }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix

## Description
<!-- Describe your changes in detail -->
I previously used debug which messed up the whole thing that forced custom headers to not work. Now that, it should work as expected by not "stringifying" the commands.

Previously, custom headers were in string format since debug was used to display.
Before: `"pm.request.headers.add({{key: \"{key}\", value: \"{value}\"}});"`
After (with this PR): `pm.request.headers.add({{key: "{key}", value: "{value}"}});`


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
Fixes custom headers.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Ran the collection with added custom-headers and verified that to be working.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
