### PR TITLE
feat(core): Add Intent Status ManualReview

### DIFF
--- a/crates/common_enums/src/enums.rs
+++ b/crates/common_enums/src/enums.rs
@@ -57,6 +57,7 @@ pub enum AttemptStatus {
     PaymentMethodAwaited,
     ConfirmationAwaited,
     DeviceDataCollectionPending,
+    PendingReview,
 }
 
 impl AttemptStatus {
@@ -84,7 +85,8 @@ impl AttemptStatus {
             | Self::Pending
             | Self::PaymentMethodAwaited
             | Self::ConfirmationAwaited
-            | Self::DeviceDataCollectionPending => false,
+            | Self::DeviceDataCollectionPending
+            | Self::PendingReview => false,
         }
     }
 }
@@ -861,6 +863,7 @@ pub enum IntentStatus {
     RequiresConfirmation,
     RequiresCapture,
     PartiallyCaptured,
+    ManualReview,
 }
 
 #[derive(

--- a/crates/router/src/compatibility/stripe/payment_intents/types.rs
+++ b/crates/router/src/compatibility/stripe/payment_intents/types.rs
@@ -409,7 +409,8 @@ impl From<api_enums::IntentStatus> for StripePaymentStatus {
             api_enums::IntentStatus::Failed => Self::Canceled,
             api_enums::IntentStatus::Processing => Self::Processing,
             api_enums::IntentStatus::RequiresCustomerAction
-            | api_enums::IntentStatus::RequiresMerchantAction => Self::RequiresAction,
+            | api_enums::IntentStatus::RequiresMerchantAction
+            | api_enums::IntentStatus::ManualReview => Self::RequiresAction,
             api_enums::IntentStatus::RequiresPaymentMethod => Self::RequiresPaymentMethod,
             api_enums::IntentStatus::RequiresConfirmation => Self::RequiresConfirmation,
             api_enums::IntentStatus::RequiresCapture

--- a/crates/router/src/compatibility/stripe/setup_intents/types.rs
+++ b/crates/router/src/compatibility/stripe/setup_intents/types.rs
@@ -318,6 +318,7 @@ impl From<api_enums::IntentStatus> for StripeSetupStatus {
             api_enums::IntentStatus::Processing => Self::Processing,
             api_enums::IntentStatus::RequiresCustomerAction => Self::RequiresAction,
             api_enums::IntentStatus::RequiresMerchantAction => Self::RequiresAction,
+            api_enums::IntentStatus::ManualReview => Self::RequiresAction,
             api_enums::IntentStatus::RequiresPaymentMethod => Self::RequiresPaymentMethod,
             api_enums::IntentStatus::RequiresConfirmation => Self::RequiresConfirmation,
             api_enums::IntentStatus::RequiresCapture

--- a/crates/router/src/core/payments/helpers.rs
+++ b/crates/router/src/core/payments/helpers.rs
@@ -2786,7 +2786,8 @@ pub fn get_attempt_type(
                     | enums::AttemptStatus::Voided
                     | enums::AttemptStatus::AutoRefunded
                     | enums::AttemptStatus::PaymentMethodAwaited
-                    | enums::AttemptStatus::DeviceDataCollectionPending => {
+                    | enums::AttemptStatus::DeviceDataCollectionPending
+                    | enums::AttemptStatus::PendingReview => {
                         metrics::MANUAL_RETRY_VALIDATION_FAILED.add(
                             &metrics::CONTEXT,
                             1,
@@ -2856,7 +2857,8 @@ pub fn get_attempt_type(
         enums::IntentStatus::RequiresCustomerAction
         | enums::IntentStatus::RequiresMerchantAction
         | enums::IntentStatus::RequiresPaymentMethod
-        | enums::IntentStatus::RequiresConfirmation => Ok(AttemptType::SameOld),
+        | enums::IntentStatus::RequiresConfirmation
+        | enums::IntentStatus::ManualReview => Ok(AttemptType::SameOld),
     }
 }
 
@@ -3079,7 +3081,8 @@ pub fn is_manual_retry_allowed(
             | enums::AttemptStatus::Voided
             | enums::AttemptStatus::AutoRefunded
             | enums::AttemptStatus::PaymentMethodAwaited
-            | enums::AttemptStatus::DeviceDataCollectionPending => {
+            | enums::AttemptStatus::DeviceDataCollectionPending
+            | enums::AttemptStatus::PendingReview=> {
                 logger::error!("Payment Attempt should not be in this state because Attempt to Intent status mapping doesn't allow it");
                 None
             }
@@ -3101,7 +3104,8 @@ pub fn is_manual_retry_allowed(
         enums::IntentStatus::RequiresCustomerAction
         | enums::IntentStatus::RequiresMerchantAction
         | enums::IntentStatus::RequiresPaymentMethod
-        | enums::IntentStatus::RequiresConfirmation => None,
+        | enums::IntentStatus::RequiresConfirmation
+        | enums::IntentStatus::ManualReview => None,
     };
     let is_merchant_id_enabled_for_retries = !connector_request_reference_id_config
         .merchant_ids_send_payment_id_as_connector_request_id

--- a/crates/router/src/core/payments/helpers.rs
+++ b/crates/router/src/core/payments/helpers.rs
@@ -3082,7 +3082,7 @@ pub fn is_manual_retry_allowed(
             | enums::AttemptStatus::AutoRefunded
             | enums::AttemptStatus::PaymentMethodAwaited
             | enums::AttemptStatus::DeviceDataCollectionPending
-            | enums::AttemptStatus::PendingReview=> {
+            | enums::AttemptStatus::PendingReview => {
                 logger::error!("Payment Attempt should not be in this state because Attempt to Intent status mapping doesn't allow it");
                 None
             }

--- a/crates/router/src/types/transformers.rs
+++ b/crates/router/src/types/transformers.rs
@@ -83,7 +83,8 @@ impl ForeignFrom<storage_enums::AttemptStatus> for storage_enums::IntentStatus {
             | storage_enums::AttemptStatus::DeviceDataCollectionPending => {
                 Self::RequiresCustomerAction
             }
-            storage_enums::AttemptStatus::Unresolved => Self::RequiresMerchantAction,
+            storage_enums::AttemptStatus::Unresolved
+            | storage_enums::AttemptStatus::PendingReview => Self::RequiresMerchantAction,
 
             storage_enums::AttemptStatus::PartialCharged => Self::PartiallyCaptured,
             storage_enums::AttemptStatus::Started
@@ -135,7 +136,8 @@ impl ForeignTryFrom<storage_enums::AttemptStatus> for storage_enums::CaptureStat
             | storage_enums::AttemptStatus::Unresolved
             | storage_enums::AttemptStatus::PaymentMethodAwaited
             | storage_enums::AttemptStatus::ConfirmationAwaited
-            | storage_enums::AttemptStatus::DeviceDataCollectionPending => {
+            | storage_enums::AttemptStatus::DeviceDataCollectionPending
+            | storage_enums::AttemptStatus::PendingReview => {
                 Err(errors::ApiErrorResponse::PreconditionFailed {
                     message: "AttemptStatus must be one of these for multiple partial captures [Charged, PartialCharged, Pending, CaptureInitiated, Failure, CaptureFailed]".into(),
                 }.into())
@@ -403,7 +405,8 @@ impl ForeignFrom<api_enums::IntentStatus> for Option<storage_enums::EventType> {
                 Some(storage_enums::EventType::PaymentProcessing)
             }
             api_enums::IntentStatus::RequiresMerchantAction
-            | api_enums::IntentStatus::RequiresCustomerAction => {
+            | api_enums::IntentStatus::RequiresCustomerAction
+            | api_enums::IntentStatus::ManualReview => {
                 Some(storage_enums::EventType::ActionRequired)
             }
             api_enums::IntentStatus::Cancelled => Some(storage_enums::EventType::PaymentCancelled),

--- a/migrations/2023-11-09-105714_add_intent_status_manual_review/down.sql
+++ b/migrations/2023-11-09-105714_add_intent_status_manual_review/down.sql
@@ -1,0 +1,2 @@
+-- This file should undo anything in `up.sql`
+Select 1;

--- a/migrations/2023-11-09-105714_add_intent_status_manual_review/up.sql
+++ b/migrations/2023-11-09-105714_add_intent_status_manual_review/up.sql
@@ -1,0 +1,4 @@
+-- Your SQL goes here
+ALTER TYPE "AttemptStatus" ADD VALUE IF NOT EXISTS 'pending_review';
+
+ALTER TYPE "IntentStatus" ADD VALUE IF NOT EXISTS 'manual_review';

--- a/openapi/openapi_spec.json
+++ b/openapi/openapi_spec.json
@@ -2464,7 +2464,8 @@
           "failure",
           "payment_method_awaited",
           "confirmation_awaited",
-          "device_data_collection_pending"
+          "device_data_collection_pending",
+          "pending_review"
         ]
       },
       "AuthenticationType": {
@@ -5750,7 +5751,8 @@
           "requires_payment_method",
           "requires_confirmation",
           "requires_capture",
-          "partially_captured"
+          "partially_captured",
+          "manual_review"
         ]
       },
       "JCSVoucherData": {


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->
New Intent Status `ManualReview` and New Attempt Status `PendingReview` have been introduced
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Intent Status `ManualReview` has been added which was required in the case where the merchant has to manually review a payment which is yet to be captured.
The corresponding Attempt Status called `PendingReview` has been introduced for this case

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
