### PR TITLE
chore: rename the cleanup file and delete the DB without taking snapshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ The fastest and easiest way to try hyperswitch is via our CDK scripts
 
 &emsp;&emsp; <a title="Bootstrap" href="https://console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks/new?stackName=cdk-hs&templateURL=https://hyperswitch-synth.s3.eu-central-1.amazonaws.com/bootstrap-template.yml"> Click here if you have not bootstrapped your region before deploying</a>
 
-&emsp;&emsp; <a href="https://console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks/new?stackName=Hyperswitch&templateURL=https://hyperswitch-synth.s3.eu-central-1.amazonaws.com/deployment.yaml"><img src="./docs/imgs/aws_button.png" height="35"></a>
+&emsp;&emsp; <a href="https://console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks/new?stackName=hyperswitch&templateURL=https://hyperswitch-synth.s3.eu-central-1.amazonaws.com/deployment.yaml"><img src="./docs/imgs/aws_button.png" height="35"></a>
 
 
 2. Sign-in to your AWS console.

--- a/aws/hyperswitch_cleanup.sh
+++ b/aws/hyperswitch_cleanup.sh
@@ -102,19 +102,10 @@ for resource_id in $ALL_DB_RESOURCES; do
                 --filters "Name=db-instance-id,Values=$resource_id" \
                 --query 'DBInstances[*].DBInstanceIdentifier' --output text)
 
-
-            echo -n "Create a snapshot before deleting ( $DB_INSTANCE_ID ) the database (Y/n)? "
-            if yes_or_no; then
-                echo `aws rds delete-db-instance \
-                    --db-instance-identifier $DB_INSTANCE_ID \
-   --region $REGION \
-                    --final-db-snapshot-identifier hyperswitch-db-snapshot-`date +%s``
-            else
                 echo `aws rds delete-db-instance \
          --region $REGION \
                     --db-instance-identifier $DB_INSTANCE_ID \
                     --skip-final-snapshot`
-            fi
         fi
     fi
 done


### PR DESCRIPTION
chore: rename the cleanup file and delete the DB without taking snapshots. Also case change in the name of the stack in README

## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD
- [x] Infra

## Description
Delete the stack without snapshot


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
