### PR TITLE
feat: moved redis key creation to a common module

### DIFF
--- a/crates/common_utils/src/lib.rs
+++ b/crates/common_utils/src/lib.rs
@@ -11,6 +11,7 @@ pub mod events;
 pub mod ext_traits;
 pub mod fp_utils;
 pub mod pii;
+pub mod redis;
 #[allow(missing_docs)] // Todo: add docs
 pub mod request;
 #[cfg(feature = "signals")]
@@ -19,7 +20,6 @@ pub mod signals;
 pub mod static_cache;
 pub mod types;
 pub mod validation;
-
 /// Date-time utilities.
 pub mod date_time {
     use std::{marker::PhantomData, num::NonZeroU8};

--- a/crates/common_utils/src/redis.rs
+++ b/crates/common_utils/src/redis.rs
@@ -1,32 +1,8 @@
 //!
 //! This module defines a Rust enum `RedisKey` that facilitates the creation of Redis keys for various purposes.
-//!
-//! # Example
-//!
-//! ```rust
-//! let access_token_key = RedisKey::AccsesToken {
-//!     merchant_id: "12345",
-//!     connector_name: "example_connector",
-//! };
-//!
-//! // Converting the Redis key to a string
-//! let key_string = access_token_key.to_string();
-//! println!("Redis Key: {}", key_string);
-//! ```
-//!
-//! The `RedisKey` enum has variants representing different types of Redis keys, each with associated data:
-//!
-//! - `AccsesToken`: Represents a key for access tokens with merchant ID and connector name.
-//! - `McdCredsId`: Represents a key for merchant credentials with merchant ID and credentials identifier.
-//! - `ConnectorResponse`: Represents a key for connector responses with merchant ID, payment ID, and attempt ID.
-//! - `PaymentId`: Represents a key for payment with payment ID.
-//! - `MerchantPaymentId`: Represents a key for merchant and payment with merchant ID and payment ID.
-//! - `Whconf`: Represents a key for webhook configurations with merchant ID and connector ID.
-//! - `WhSecVerification`: Represents a key for webhook security verification with connector label and merchant ID.
-//!
 //! The `RedisKey` enum implements the `ToString` trait, allowing conversion to a string representation of the Redis key.
 //!
-//! # Examples
+//! # Example
 //!
 //! ```rust
 //! let payment_key = RedisKey::PaymentId { payment_id: "67890" };
@@ -44,7 +20,7 @@
 /// Create
 pub enum RedisKey<'a> {
     /// for "access_token_{merchant_id}_{connector_name}"
-    AccsesToken {
+    AccessToken {
         merchant_id: &'a str,
         connector_name: &'a str,
     },
@@ -52,12 +28,6 @@ pub enum RedisKey<'a> {
     McdCredsId {
         merchant_id: &'a str,
         creds_identifier: &'a str,
-    },
-    /// for "connector_resp_{merchant_id}_{payment_id}_{attempt_id}"
-    ConnectorResponse {
-        merchant_id: &'a str,
-        payment_id: &'a str,
-        attempt_id: &'a str,
     },
     /// for "pi_{payment_id}"
     PaymentId { payment_id: &'a str },
@@ -67,14 +37,14 @@ pub enum RedisKey<'a> {
         payment_id: &'a str,
     },
     /// for "whconf_{merchant_id}_{connector_id}"
-    Whconf {
+    WhConf {
         merchant_id: &'a str,
         connector_id: &'a str,
     },
-    /// for "whsec_verification_{connector_label}_{merchant_id}"
-    WhSecVerification {
-        connector_label: &'a str,
+    /// for "whconf_disabled_events_{merchant_id}_{connector_id}"
+    WhConfDisabledEvents {
         merchant_id: &'a str,
+        connector_id: &'a str,
     },
 }
 
@@ -82,19 +52,10 @@ pub enum RedisKey<'a> {
 impl ToString for RedisKey<'_> {
     fn to_string(&self) -> String {
         match self {
-            Self::AccsesToken {
+            Self::AccessToken {
                 merchant_id,
                 connector_name,
-            } => {
-                format!("access_token_{merchant_id}_{connector_name}")
-            }
-            Self::ConnectorResponse {
-                merchant_id,
-                payment_id,
-                attempt_id,
-            } => {
-                format!("connector_resp_{merchant_id}_{payment_id}_{attempt_id}")
-            }
+            } => format!("access_token_{merchant_id}_{connector_name}"),
             Self::McdCredsId {
                 merchant_id,
                 creds_identifier,
@@ -110,17 +71,17 @@ impl ToString for RedisKey<'_> {
             } => {
                 format!("mid_{merchant_id}_pid_{payment_id}")
             }
-            Self::Whconf {
+            Self::WhConf {
                 merchant_id,
                 connector_id,
             } => {
                 format!("whconf_{merchant_id}_{connector_id}")
             }
-            Self::WhSecVerification {
-                connector_label,
+            Self::WhConfDisabledEvents {
                 merchant_id,
+                connector_id,
             } => {
-                format!("whsec_verification_{connector_label}_{merchant_id}")
+                format!("whconf_disabled_events_{merchant_id}_{connector_id}")
             }
         }
     }

--- a/crates/common_utils/src/redis.rs
+++ b/crates/common_utils/src/redis.rs
@@ -1,0 +1,127 @@
+//!
+//! This module defines a Rust enum `RedisKey` that facilitates the creation of Redis keys for various purposes.
+//!
+//! # Example
+//!
+//! ```rust
+//! let access_token_key = RedisKey::AccsesToken {
+//!     merchant_id: "12345",
+//!     connector_name: "example_connector",
+//! };
+//!
+//! // Converting the Redis key to a string
+//! let key_string = access_token_key.to_string();
+//! println!("Redis Key: {}", key_string);
+//! ```
+//!
+//! The `RedisKey` enum has variants representing different types of Redis keys, each with associated data:
+//!
+//! - `AccsesToken`: Represents a key for access tokens with merchant ID and connector name.
+//! - `McdCredsId`: Represents a key for merchant credentials with merchant ID and credentials identifier.
+//! - `ConnectorResponse`: Represents a key for connector responses with merchant ID, payment ID, and attempt ID.
+//! - `PaymentId`: Represents a key for payment with payment ID.
+//! - `MerchantPaymentId`: Represents a key for merchant and payment with merchant ID and payment ID.
+//! - `Whconf`: Represents a key for webhook configurations with merchant ID and connector ID.
+//! - `WhSecVerification`: Represents a key for webhook security verification with connector label and merchant ID.
+//!
+//! The `RedisKey` enum implements the `ToString` trait, allowing conversion to a string representation of the Redis key.
+//!
+//! # Examples
+//!
+//! ```rust
+//! let payment_key = RedisKey::PaymentId { payment_id: "67890" };
+//! assert_eq!(payment_key.to_string(), "pi_67890");
+//!
+//! let creds_key = RedisKey::McdCredsId {
+//!     merchant_id: "54321",
+//!     creds_identifier: "cred_123",
+//! };
+//! assert_eq!(creds_key.to_string(), "mcd_54321_cred_123");
+//! ```
+//!
+#[derive(Debug)]
+#[allow(missing_docs)]
+/// Create
+pub enum RedisKey<'a> {
+    /// for "access_token_{merchant_id}_{connector_name}"
+    AccsesToken {
+        merchant_id: &'a str,
+        connector_name: &'a str,
+    },
+    /// for "mcd_{merchant_id}_{creds_identifier}"
+    McdCredsId {
+        merchant_id: &'a str,
+        creds_identifier: &'a str,
+    },
+    /// for "connector_resp_{merchant_id}_{payment_id}_{attempt_id}"
+    ConnectorResponse {
+        merchant_id: &'a str,
+        payment_id: &'a str,
+        attempt_id: &'a str,
+    },
+    /// for "pi_{payment_id}"
+    PaymentId { payment_id: &'a str },
+    /// for "mid_{merchant_id}_pid_{payment_id}"
+    MerchantPaymentId {
+        merchant_id: &'a str,
+        payment_id: &'a str,
+    },
+    /// for "whconf_{merchant_id}_{connector_id}"
+    Whconf {
+        merchant_id: &'a str,
+        connector_id: &'a str,
+    },
+    /// for "whsec_verification_{connector_label}_{merchant_id}"
+    WhSecVerification {
+        connector_label: &'a str,
+        merchant_id: &'a str,
+    },
+}
+
+/// converts the redis key to string
+impl ToString for RedisKey<'_> {
+    fn to_string(&self) -> String {
+        match self {
+            Self::AccsesToken {
+                merchant_id,
+                connector_name,
+            } => {
+                format!("access_token_{merchant_id}_{connector_name}")
+            }
+            Self::ConnectorResponse {
+                merchant_id,
+                payment_id,
+                attempt_id,
+            } => {
+                format!("connector_resp_{merchant_id}_{payment_id}_{attempt_id}")
+            }
+            Self::McdCredsId {
+                merchant_id,
+                creds_identifier,
+            } => {
+                format!("mcd_{merchant_id}_{creds_identifier}")
+            }
+            Self::PaymentId { payment_id } => {
+                format!("pi_{payment_id}")
+            }
+            Self::MerchantPaymentId {
+                merchant_id,
+                payment_id,
+            } => {
+                format!("mid_{merchant_id}_pid_{payment_id}")
+            }
+            Self::Whconf {
+                merchant_id,
+                connector_id,
+            } => {
+                format!("whconf_{merchant_id}_{connector_id}")
+            }
+            Self::WhSecVerification {
+                connector_label,
+                merchant_id,
+            } => {
+                format!("whsec_verification_{connector_label}_{merchant_id}")
+            }
+        }
+    }
+}

--- a/crates/router/src/connector/utils.rs
+++ b/crates/router/src/connector/utils.rs
@@ -1217,11 +1217,6 @@ pub fn collect_and_sort_values_by_removing_signature(
     values
 }
 
-#[inline]
-pub fn get_webhook_merchant_secret_key(connector_label: &str, merchant_id: &str) -> String {
-    format!("whsec_verification_{connector_label}_{merchant_id}")
-}
-
 impl ForeignTryFrom<String> for UsStatesAbbreviation {
     type Error = error_stack::Report<errors::ConnectorError>;
     fn foreign_try_from(value: String) -> Result<Self, Self::Error> {

--- a/crates/router/src/core/webhooks/utils.rs
+++ b/crates/router/src/core/webhooks/utils.rs
@@ -1,6 +1,6 @@
 use std::marker::PhantomData;
 
-use common_utils::{errors::CustomResult, ext_traits::ValueExt};
+use common_utils::{errors::CustomResult, ext_traits::ValueExt, redis::RedisKey};
 use error_stack::ResultExt;
 
 use crate::{
@@ -29,7 +29,11 @@ pub async fn is_webhook_event_disabled(
     merchant_id: &str,
     event: &api::IncomingWebhookEvent,
 ) -> bool {
-    let redis_key = format!("whconf_disabled_events_{merchant_id}_{connector_id}");
+    let redis_key = RedisKey::WhConfDisabledEvents {
+        merchant_id,
+        connector_id,
+    }
+    .to_string();
     let merchant_webhook_disable_config_result: CustomResult<
         api::MerchantWebhookConfig,
         redis_interface::errors::RedisError,

--- a/crates/router/src/db/refund.rs
+++ b/crates/router/src/db/refund.rs
@@ -267,7 +267,7 @@ mod storage {
 
 #[cfg(feature = "kv_store")]
 mod storage {
-    use common_utils::date_time;
+    use common_utils::{date_time, redis::RedisKey};
     use error_stack::{IntoReport, ResultExt};
     use redis_interface::HsetnxReply;
     use storage_impl::redis::kv_store::{kv_wrapper, KvOperation};
@@ -663,7 +663,11 @@ mod storage {
             match storage_scheme {
                 enums::MerchantStorageScheme::PostgresOnly => database_call().await,
                 enums::MerchantStorageScheme::RedisKv => {
-                    let key = format!("mid_{merchant_id}_pid_{payment_id}");
+                    let key = RedisKey::MerchantPaymentId {
+                        merchant_id,
+                        payment_id,
+                    }
+                    .to_string();
                     db_utils::try_redis_get_else_try_database_get(
                         async {
                             kv_wrapper(

--- a/crates/storage_impl/src/payments/payment_attempt.rs
+++ b/crates/storage_impl/src/payments/payment_attempt.rs
@@ -1,5 +1,5 @@
 use api_models::enums::{AuthenticationType, Connector, PaymentMethod, PaymentMethodType};
-use common_utils::errors::CustomResult;
+use common_utils::{errors::CustomResult, redis::RedisKey};
 use data_models::{
     errors,
     mandates::{MandateAmountData, MandateDataType},
@@ -585,7 +585,11 @@ impl<T: DatabaseStore> PaymentAttemptInterface for KVRouterStore<T> {
         match storage_scheme {
             MerchantStorageScheme::PostgresOnly => database_call().await,
             MerchantStorageScheme::RedisKv => {
-                let key = format!("mid_{merchant_id}_pid_{payment_id}");
+                let key = RedisKey::MerchantPaymentId {
+                    merchant_id,
+                    payment_id,
+                }
+                .to_string();
                 let pattern = "pa_*";
 
                 let redis_fut = async {
@@ -680,7 +684,11 @@ impl<T: DatabaseStore> PaymentAttemptInterface for KVRouterStore<T> {
                     .await
             }
             MerchantStorageScheme::RedisKv => {
-                let key = format!("mid_{merchant_id}_pid_{payment_id}");
+                let key = RedisKey::MerchantPaymentId {
+                    merchant_id,
+                    payment_id,
+                }
+                .to_string();
                 let field = format!("pa_{attempt_id}");
                 try_redis_get_else_try_database_get(
                     async {
@@ -816,7 +824,11 @@ impl<T: DatabaseStore> PaymentAttemptInterface for KVRouterStore<T> {
                     .await
             }
             MerchantStorageScheme::RedisKv => {
-                let key = format!("mid_{merchant_id}_pid_{payment_id}");
+                let key = RedisKey::MerchantPaymentId {
+                    merchant_id,
+                    payment_id,
+                }
+                .to_string();
 
                 kv_wrapper(self, KvOperation::<DieselPaymentAttempt>::Scan("pa_*"), key)
                     .await

--- a/crates/storage_impl/src/payments/payment_intent.rs
+++ b/crates/storage_impl/src/payments/payment_intent.rs
@@ -1,6 +1,6 @@
 #[cfg(feature = "olap")]
 use async_bb8_diesel::{AsyncConnection, AsyncRunQueryDsl};
-use common_utils::{date_time, ext_traits::Encode};
+use common_utils::{date_time, ext_traits::Encode, redis::RedisKey};
 #[cfg(feature = "olap")]
 use data_models::payments::payment_intent::PaymentIntentFetchConstraints;
 use data_models::{
@@ -204,7 +204,11 @@ impl<T: DatabaseStore> PaymentIntentInterface for KVRouterStore<T> {
             MerchantStorageScheme::PostgresOnly => database_call().await,
 
             MerchantStorageScheme::RedisKv => {
-                let key = format!("mid_{merchant_id}_pid_{payment_id}");
+                let key = RedisKey::MerchantPaymentId {
+                    merchant_id,
+                    payment_id,
+                }
+                .to_string();
                 let field = format!("pi_{payment_id}");
                 crate::utils::try_redis_get_else_try_database_get(
                     async {

--- a/crates/storage_impl/src/redis/kv_store.rs
+++ b/crates/storage_impl/src/redis/kv_store.rs
@@ -1,6 +1,6 @@
 use std::{fmt::Debug, sync::Arc};
 
-use common_utils::errors::CustomResult;
+use common_utils::{errors::CustomResult, redis::RedisKey};
 use redis_interface::errors::RedisError;
 use router_derive::TryGetEnumVariant;
 use router_env::logger;
@@ -35,7 +35,13 @@ impl<'a> std::fmt::Display for PartitionKey<'a> {
             PartitionKey::MerchantIdPaymentId {
                 merchant_id,
                 payment_id,
-            } => f.write_str(&format!("mid_{merchant_id}_pid_{payment_id}")),
+            } => f.write_str(
+                &RedisKey::MerchantPaymentId {
+                    merchant_id,
+                    payment_id,
+                }
+                .to_string(),
+            ),
             PartitionKey::MerchantIdPaymentIdCombination { combination } => {
                 f.write_str(combination)
             }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
added a file in common_utils called redis . 
This module defines a Rust enum `RedisKey` that facilitates the creation of Redis keys for various purposes.
The `RedisKey` enum implements the `ToString` trait, allowing conversion to a string representation of the Redis key.

for this issue  
[FEATURE] move redis key creation to a common module #917 
### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
