### PR TITLE
refactor(masking): use empty enums as masking:Strategy<T> types

### DIFF
--- a/crates/cards/src/validate.rs
+++ b/crates/cards/src/validate.rs
@@ -72,7 +72,7 @@ impl<'de> Deserialize<'de> for CardNumber {
     }
 }
 
-pub struct CardNumberStrategy;
+pub enum CardNumberStrategy {}
 
 impl<T> Strategy<T> for CardNumberStrategy
 where

--- a/crates/common_utils/src/pii.rs
+++ b/crates/common_utils/src/pii.rs
@@ -27,7 +27,7 @@ pub type SecretSerdeValue = Secret<serde_json::Value>;
 
 /// Strategy for masking a PhoneNumber
 #[derive(Debug)]
-pub struct PhoneNumberStrategy;
+pub enum PhoneNumberStrategy {}
 
 /// Phone Number
 #[derive(Debug, serde::Deserialize, serde::Serialize)]
@@ -144,7 +144,7 @@ where
 
 /// Strategy for Encryption
 #[derive(Debug)]
-pub struct EncryptionStratergy;
+pub enum EncryptionStratergy {}
 
 impl<T> Strategy<T> for EncryptionStratergy
 where
@@ -157,7 +157,7 @@ where
 
 /// Client secret
 #[derive(Debug)]
-pub struct ClientSecret;
+pub enum ClientSecret {}
 
 impl<T> Strategy<T> for ClientSecret
 where
@@ -189,7 +189,7 @@ where
 
 /// Strategy for masking Email
 #[derive(Debug)]
-pub struct EmailStrategy;
+pub enum EmailStrategy {}
 
 impl<T> Strategy<T> for EmailStrategy
 where
@@ -305,7 +305,7 @@ impl FromStr for Email {
 
 /// IP address
 #[derive(Debug)]
-pub struct IpAddress;
+pub enum IpAddress {}
 
 impl<T> Strategy<T> for IpAddress
 where
@@ -332,7 +332,7 @@ where
 /// Strategy for masking UPI VPA's
 
 #[derive(Debug)]
-pub struct UpiVpaMaskingStrategy;
+pub enum UpiVpaMaskingStrategy {}
 
 impl<T> Strategy<T> for UpiVpaMaskingStrategy
 where

--- a/crates/masking/src/secret.rs
+++ b/crates/masking/src/secret.rs
@@ -12,8 +12,8 @@ use crate::{strategy::Strategy, PeekInterface};
 /// To get access to value use method `expose()` of trait [`crate::ExposeInterface`].
 ///
 /// ## Masking
-/// Use the [`crate::strategy::Strategy`] trait to implement a masking strategy on a unit struct
-/// and pass the unit struct as a second generic parameter to [`Secret`] while defining it.
+/// Use the [`crate::strategy::Strategy`] trait to implement a masking strategy on a zero-variant
+/// enum and pass this enum as a second generic parameter to [`Secret`] while defining it.
 /// [`Secret`] will take care of applying the masking strategy on the inner secret when being
 /// displayed.
 ///
@@ -24,7 +24,7 @@ use crate::{strategy::Strategy, PeekInterface};
 /// use masking::Secret;
 /// use std::fmt;
 ///
-/// struct MyStrategy;
+/// enum MyStrategy {}
 ///
 /// impl<T> Strategy<T> for MyStrategy
 /// where

--- a/crates/masking/src/strategy.rs
+++ b/crates/masking/src/strategy.rs
@@ -7,7 +7,7 @@ pub trait Strategy<T> {
 }
 
 /// Debug with type
-pub struct WithType;
+pub enum WithType {}
 
 impl<T> Strategy<T> for WithType {
     fn fmt(_: &T, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -18,7 +18,7 @@ impl<T> Strategy<T> for WithType {
 }
 
 /// Debug without type
-pub struct WithoutType;
+pub enum WithoutType {}
 
 impl<T> Strategy<T> for WithoutType {
     fn fmt(_: &T, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {


### PR DESCRIPTION
as per #1973

## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
Use empty enums as strategy type parameter, instead of unit structs, to prevent instantiation. 


### Additional Changes

no


## Motivation and Context
#1973

## How did you test it?

`cargo clippy --all-features`

Assuming existing tests should catch side effects if any. 

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
