### PR TITLE
feat(connector): [Prophetpay] Save card token for Refund and remove Void flow

### DIFF
--- a/crates/router/src/connector/prophetpay.rs
+++ b/crates/router/src/connector/prophetpay.rs
@@ -124,6 +124,12 @@ impl ConnectorCommon for Prophetpay {
 
 impl ConnectorValidation for Prophetpay {
     //TODO: implement functions when support enabled
+    fn validate_psync_reference_id(
+        &self,
+        _data: &types::PaymentsSyncRouterData,
+    ) -> CustomResult<(), errors::ConnectorError> {
+        Ok(())
+    }
 }
 
 impl ConnectorIntegration<api::Session, types::PaymentsSessionData, types::PaymentsResponseData>
@@ -629,7 +635,7 @@ impl ConnectorIntegration<api::RSync, types::RefundsData, types::RefundsResponse
     ) -> CustomResult<Option<services::Request>, errors::ConnectorError> {
         Ok(Some(
             services::RequestBuilder::new()
-                .method(services::Method::Get)
+                .method(services::Method::Post)
                 .url(&types::RefundSyncType::get_url(self, req, connectors)?)
                 .attach_default_headers()
                 .headers(types::RefundSyncType::get_headers(self, req, connectors)?)

--- a/crates/router/src/connector/prophetpay.rs
+++ b/crates/router/src/connector/prophetpay.rs
@@ -459,51 +459,28 @@ impl ConnectorIntegration<api::Void, types::PaymentsCancelData, types::PaymentsR
 
     fn get_request_body(
         &self,
-        req: &types::PaymentsCancelRouterData,
+        _req: &types::PaymentsCancelRouterData,
         _connectors: &settings::Connectors,
     ) -> CustomResult<Option<types::RequestBody>, errors::ConnectorError> {
-        let req_obj = prophetpay::ProphetpayVoidRequest::try_from(req)?;
-
-        let prophetpay_req = types::RequestBody::log_and_get_request_body(
-            &req_obj,
-            utils::Encode::<prophetpay::ProphetpayTokenRequest>::encode_to_string_of_json,
-        )
-        .change_context(errors::ConnectorError::RequestEncodingFailed)?;
-        Ok(Some(prophetpay_req))
+        Ok(None)
     }
 
     fn build_request(
         &self,
-        req: &types::PaymentsCancelRouterData,
-        connectors: &settings::Connectors,
+        _req: &types::PaymentsCancelRouterData,
+        _connectors: &settings::Connectors,
     ) -> CustomResult<Option<services::Request>, errors::ConnectorError> {
-        Ok(Some(
-            services::RequestBuilder::new()
-                .method(services::Method::Get)
-                .url(&types::PaymentsVoidType::get_url(self, req, connectors)?)
-                .attach_default_headers()
-                .headers(types::PaymentsVoidType::get_headers(self, req, connectors)?)
-                .body(types::PaymentsVoidType::get_request_body(
-                    self, req, connectors,
-                )?)
-                .build(),
-        ))
+        // We are currently not using void for Prophetpay
+        // This is a valid implementation which is kept for future usage
+        Ok(None)
     }
 
     fn handle_response(
         &self,
         data: &types::PaymentsCancelRouterData,
-        res: Response,
+        _res: Response,
     ) -> CustomResult<types::PaymentsCancelRouterData, errors::ConnectorError> {
-        let response: prophetpay::ProphetpayVoidResponse = res
-            .response
-            .parse_struct("prophetpay PaymentsCancelResponse")
-            .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
-        types::RouterData::try_from(types::ResponseRouterData {
-            response,
-            data: data.clone(),
-            http_code: res.status_code,
-        })
+        Ok(data.clone())
     }
 
     fn get_error_response(

--- a/crates/router/src/connector/prophetpay.rs
+++ b/crates/router/src/connector/prophetpay.rs
@@ -324,7 +324,7 @@ impl
     where
         types::PaymentsResponseData: Clone,
     {
-        let response: prophetpay::ProphetpayResponse = res
+        let response: prophetpay::ProphetpayCompleteAuthResponse = res
             .response
             .parse_struct("prophetpay ProphetpayResponse")
             .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
@@ -407,9 +407,9 @@ impl ConnectorIntegration<api::PSync, types::PaymentsSyncData, types::PaymentsRe
         data: &types::PaymentsSyncRouterData,
         res: Response,
     ) -> CustomResult<types::PaymentsSyncRouterData, errors::ConnectorError> {
-        let response: prophetpay::ProphetpayResponse = res
+        let response: prophetpay::ProphetpaySyncResponse = res
             .response
-            .parse_struct("prophetpay ProphetpayResponse")
+            .parse_struct("prophetpay PaymentsSyncResponse")
             .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
         types::RouterData::try_from(types::ResponseRouterData {
             response,
@@ -495,9 +495,9 @@ impl ConnectorIntegration<api::Void, types::PaymentsCancelData, types::PaymentsR
         data: &types::PaymentsCancelRouterData,
         res: Response,
     ) -> CustomResult<types::PaymentsCancelRouterData, errors::ConnectorError> {
-        let response: prophetpay::ProphetpayResponse = res
+        let response: prophetpay::ProphetpayVoidResponse = res
             .response
-            .parse_struct("prophetpay ProphetpayResponse")
+            .parse_struct("prophetpay PaymentsCancelResponse")
             .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
         types::RouterData::try_from(types::ResponseRouterData {
             response,
@@ -668,7 +668,7 @@ impl ConnectorIntegration<api::RSync, types::RefundsData, types::RefundsResponse
         data: &types::RefundSyncRouterData,
         res: Response,
     ) -> CustomResult<types::RefundSyncRouterData, errors::ConnectorError> {
-        let response: prophetpay::ProphetpayRefundResponse = res
+        let response: prophetpay::ProphetpayRefundSyncResponse = res
             .response
             .parse_struct("prophetpay ProphetpayRefundResponse")
             .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;

--- a/crates/router/src/connector/prophetpay/transformers.rs
+++ b/crates/router/src/connector/prophetpay/transformers.rs
@@ -492,6 +492,9 @@ impl<F, T>
     }
 }
 
+// This is Void Implementation for Prophetpay
+// Since Prophetpay does not have capture this have been commented out but kept if it is required for future usage
+/*
 #[derive(Debug, Clone, Deserialize)]
 pub enum ProphetpayVoidStatus {
     Failure,
@@ -577,6 +580,7 @@ impl TryFrom<&types::PaymentsCancelRouterData> for ProphetpayVoidRequest {
         })
     }
 }
+*/
 
 #[derive(Default, Debug, Serialize)]
 #[serde(rename_all = "camelCase")]

--- a/crates/router/src/connector/prophetpay/transformers.rs
+++ b/crates/router/src/connector/prophetpay/transformers.rs
@@ -360,8 +360,6 @@ pub enum ProphetpayPaymentStatus {
     #[serde(rename = "Transaction Approved")]
     Charged,
     Failure,
-    #[serde(rename = "Transaction Voided")]
-    Voided,
     #[serde(rename = "Requires a card on file.")]
     CardTokenNotFound,
     #[serde(rename = "RefInfo and InquiryReference are duplicated")]
@@ -381,25 +379,162 @@ impl From<ProphetpayPaymentStatus> for enums::AttemptStatus {
             | ProphetpayPaymentStatus::DuplicateValue
             | ProphetpayPaymentStatus::MissingProfile
             | ProphetpayPaymentStatus::EmptyRef => Self::Failure,
-            ProphetpayPaymentStatus::Voided => Self::Voided,
         }
     }
 }
 
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct ProphetpayResponse {
+pub struct ProphetpayCompleteAuthResponse {
     pub response_text: ProphetpayPaymentStatus,
     #[serde(rename = "transactionID")]
     pub transaction_id: String,
 }
 
-impl<F, T> TryFrom<types::ResponseRouterData<F, ProphetpayResponse, T, types::PaymentsResponseData>>
+impl<F, T>
+    TryFrom<
+        types::ResponseRouterData<
+            F,
+            ProphetpayCompleteAuthResponse,
+            T,
+            types::PaymentsResponseData,
+        >,
+    > for types::RouterData<F, T, types::PaymentsResponseData>
+{
+    type Error = error_stack::Report<errors::ConnectorError>;
+    fn try_from(
+        item: types::ResponseRouterData<
+            F,
+            ProphetpayCompleteAuthResponse,
+            T,
+            types::PaymentsResponseData,
+        >,
+    ) -> Result<Self, Self::Error> {
+        Ok(Self {
+            status: enums::AttemptStatus::from(item.response.response_text),
+            response: Ok(types::PaymentsResponseData::TransactionResponse {
+                resource_id: types::ResponseId::ConnectorTransactionId(
+                    item.response.transaction_id,
+                ),
+                redirection_data: None,
+                mandate_reference: None,
+                connector_metadata: None,
+                network_txn_id: None,
+                connector_response_reference_id: None,
+            }),
+            ..item.data
+        })
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub enum ProphetpaySyncStatus {
+    Success,
+    #[serde(rename = "Transaction Approved")]
+    Charged,
+    Failure,
+    #[serde(rename = "Transaction Voided")]
+    Voided,
+    #[serde(rename = "Requires a card on file.")]
+    CardTokenNotFound,
+    #[serde(rename = "RefInfo and InquiryReference are duplicated")]
+    DuplicateValue,
+    #[serde(rename = "Profile is missing")]
+    MissingProfile,
+    #[serde(rename = "RefInfo is empty.")]
+    EmptyRef,
+}
+
+impl From<ProphetpaySyncStatus> for enums::AttemptStatus {
+    fn from(item: ProphetpaySyncStatus) -> Self {
+        match item {
+            ProphetpaySyncStatus::Success | ProphetpaySyncStatus::Charged => Self::Charged,
+            ProphetpaySyncStatus::Failure
+            | ProphetpaySyncStatus::CardTokenNotFound
+            | ProphetpaySyncStatus::DuplicateValue
+            | ProphetpaySyncStatus::MissingProfile
+            | ProphetpaySyncStatus::EmptyRef => Self::Failure,
+            ProphetpaySyncStatus::Voided => Self::Voided,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ProphetpaySyncResponse {
+    pub response_text: ProphetpaySyncStatus,
+    #[serde(rename = "transactionID")]
+    pub transaction_id: String,
+}
+
+impl<F, T>
+    TryFrom<types::ResponseRouterData<F, ProphetpaySyncResponse, T, types::PaymentsResponseData>>
     for types::RouterData<F, T, types::PaymentsResponseData>
 {
     type Error = error_stack::Report<errors::ConnectorError>;
     fn try_from(
-        item: types::ResponseRouterData<F, ProphetpayResponse, T, types::PaymentsResponseData>,
+        item: types::ResponseRouterData<F, ProphetpaySyncResponse, T, types::PaymentsResponseData>,
+    ) -> Result<Self, Self::Error> {
+        Ok(Self {
+            status: enums::AttemptStatus::from(item.response.response_text),
+            response: Ok(types::PaymentsResponseData::TransactionResponse {
+                resource_id: types::ResponseId::ConnectorTransactionId(
+                    item.response.transaction_id,
+                ),
+                redirection_data: None,
+                mandate_reference: None,
+                connector_metadata: None,
+                network_txn_id: None,
+                connector_response_reference_id: None,
+            }),
+            ..item.data
+        })
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub enum ProphetpayVoidStatus {
+    Failure,
+    #[serde(rename = "Transaction Voided")]
+    Voided,
+    #[serde(rename = "Requires a card on file.")]
+    CardTokenNotFound,
+    #[serde(rename = "RefInfo and InquiryReference are duplicated")]
+    DuplicateValue,
+    #[serde(rename = "Profile is missing")]
+    MissingProfile,
+    #[serde(rename = "RefInfo is empty.")]
+    EmptyRef,
+}
+
+impl From<ProphetpayVoidStatus> for enums::AttemptStatus {
+    fn from(item: ProphetpayVoidStatus) -> Self {
+        match item {
+            ProphetpayVoidStatus::Failure
+            | ProphetpayVoidStatus::CardTokenNotFound
+            | ProphetpayVoidStatus::DuplicateValue
+            | ProphetpayVoidStatus::MissingProfile
+            | ProphetpayVoidStatus::EmptyRef => Self::Failure,
+            ProphetpayVoidStatus::Voided => Self::Voided,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ProphetpayVoidResponse {
+    pub response_text: ProphetpayVoidStatus,
+    #[serde(rename = "transactionID")]
+    pub transaction_id: String,
+}
+
+impl<F, T>
+    TryFrom<types::ResponseRouterData<F, ProphetpayVoidResponse, T, types::PaymentsResponseData>>
+    for types::RouterData<F, T, types::PaymentsResponseData>
+{
+    type Error = error_stack::Report<errors::ConnectorError>;
+    fn try_from(
+        item: types::ResponseRouterData<F, ProphetpayVoidResponse, T, types::PaymentsResponseData>,
     ) -> Result<Self, Self::Error> {
         Ok(Self {
             status: enums::AttemptStatus::from(item.response.response_text),
@@ -528,6 +663,61 @@ impl TryFrom<types::RefundsResponseRouterData<api::Execute, ProphetpayRefundResp
     }
 }
 
+#[allow(dead_code)]
+#[derive(Debug, Deserialize, Clone)]
+pub enum RefundSyncStatus {
+    Success,
+    Failure,
+    #[serde(rename = "Transaction Voided")]
+    Voided,
+    #[serde(rename = "Requires a card on file.")]
+    CardTokenNotFound,
+    #[serde(rename = "RefInfo and InquiryReference are duplicated")]
+    DuplicateValue,
+    #[serde(rename = "Profile is missing")]
+    MissingProfile,
+    #[serde(rename = "RefInfo is empty.")]
+    EmptyRef,
+}
+
+impl From<RefundSyncStatus> for enums::RefundStatus {
+    fn from(item: RefundSyncStatus) -> Self {
+        match item {
+            RefundSyncStatus::Success
+            // in retrieving refund, if it is successful, it is shown as voided
+            | RefundSyncStatus::Voided => Self::Success,
+            RefundSyncStatus::Failure
+            | RefundSyncStatus::CardTokenNotFound
+            | RefundSyncStatus::DuplicateValue
+            | RefundSyncStatus::MissingProfile
+            | RefundSyncStatus::EmptyRef => Self::Failure,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ProphetpayRefundSyncResponse {
+    pub response_text: RefundSyncStatus,
+}
+
+impl<T> TryFrom<types::RefundsResponseRouterData<T, ProphetpayRefundSyncResponse>>
+    for types::RefundsRouterData<T>
+{
+    type Error = error_stack::Report<errors::ConnectorError>;
+    fn try_from(
+        item: types::RefundsResponseRouterData<T, ProphetpayRefundSyncResponse>,
+    ) -> Result<Self, Self::Error> {
+        Ok(Self {
+            response: Ok(types::RefundsResponseData {
+                // no refund id is generated, rather transaction id is used for referring to status in refund also
+                connector_refund_id: item.data.request.connector_transaction_id.clone(),
+                refund_status: enums::RefundStatus::from(item.response.response_text),
+            }),
+            ..item.data
+        })
+    }
+}
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ProphetpayRefundSyncRequest {


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->

- Card token is being saved in metadata to later use for refund
- Void flow have been removed with prophetpay doesn't have capture
- Refactor of Rsync
- Minor refactor for the comments given in previous PR for prophetpay

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
