### PR TITLE
fix: status goes from pending to partially captured in psync

### DIFF
--- a/crates/data_models/src/payments/payment_attempt.rs
+++ b/crates/data_models/src/payments/payment_attempt.rs
@@ -315,10 +315,13 @@ pub enum PaymentAttemptUpdate {
         error_message: Option<Option<String>>,
         error_reason: Option<Option<String>>,
         amount_capturable: Option<i64>,
+        surcharge_amount: Option<i64>,
+        tax_amount: Option<i64>,
         updated_by: String,
     },
-    MultipleCaptureCountUpdate {
-        multiple_capture_count: i16,
+    CaptureUpdate {
+        amount_to_capture: Option<i64>,
+        multiple_capture_count: Option<i16>,
         updated_by: String,
     },
     AmountToCaptureUpdate {

--- a/crates/diesel_models/src/payment_attempt.rs
+++ b/crates/diesel_models/src/payment_attempt.rs
@@ -232,10 +232,13 @@ pub enum PaymentAttemptUpdate {
         error_message: Option<Option<String>>,
         error_reason: Option<Option<String>>,
         amount_capturable: Option<i64>,
+        surcharge_amount: Option<i64>,
+        tax_amount: Option<i64>,
         updated_by: String,
     },
-    MultipleCaptureCountUpdate {
-        multiple_capture_count: i16,
+    CaptureUpdate {
+        amount_to_capture: Option<i64>,
+        multiple_capture_count: Option<i16>,
         updated_by: String,
     },
     AmountToCaptureUpdate {
@@ -517,6 +520,8 @@ impl From<PaymentAttemptUpdate> for PaymentAttemptUpdateInternal {
                 error_message,
                 error_reason,
                 amount_capturable,
+                surcharge_amount,
+                tax_amount,
                 updated_by,
             } => Self {
                 connector,
@@ -527,6 +532,8 @@ impl From<PaymentAttemptUpdate> for PaymentAttemptUpdateInternal {
                 error_reason,
                 amount_capturable,
                 updated_by,
+                surcharge_amount,
+                tax_amount,
                 ..Default::default()
             },
             PaymentAttemptUpdate::StatusUpdate { status, updated_by } => Self {
@@ -596,12 +603,14 @@ impl From<PaymentAttemptUpdate> for PaymentAttemptUpdateInternal {
                 updated_by,
                 ..Default::default()
             },
-            PaymentAttemptUpdate::MultipleCaptureCountUpdate {
+            PaymentAttemptUpdate::CaptureUpdate {
                 multiple_capture_count,
                 updated_by,
+                amount_to_capture,
             } => Self {
-                multiple_capture_count: Some(multiple_capture_count),
+                multiple_capture_count,
                 updated_by,
+                amount_to_capture,
                 ..Default::default()
             },
             PaymentAttemptUpdate::AmountToCaptureUpdate {

--- a/crates/router/src/connector/utils.rs
+++ b/crates/router/src/connector/utils.rs
@@ -119,7 +119,7 @@ where
                     } else {
                         enums::AttemptStatus::PartialCharged
                     }
-                }else{
+                } else {
                     self.status
                 }
             }

--- a/crates/router/src/connector/utils.rs
+++ b/crates/router/src/connector/utils.rs
@@ -102,6 +102,7 @@ where
     where
         F: Clone,
     {
+        // let is_psync = self.request.is_psync();
         match self.status {
             enums::AttemptStatus::Voided => {
                 if payment_data.payment_intent.amount_captured > Some(0) {

--- a/crates/router/src/connector/utils.rs
+++ b/crates/router/src/connector/utils.rs
@@ -112,7 +112,14 @@ where
                 }
             }
             enums::AttemptStatus::Charged => {
-                let captured_amount = types::Capturable::get_capture_amount(&self.request);
+                let captured_amount = if self.request.is_psync() {
+                    payment_data
+                        .payment_attempt
+                        .amount_to_capture
+                        .or(Some(payment_data.payment_attempt.get_total_amount()))
+                } else {
+                    types::Capturable::get_capture_amount(&self.request)
+                };
                 if Some(payment_data.payment_attempt.get_total_amount()) == captured_amount {
                     enums::AttemptStatus::Charged
                 } else if captured_amount.is_some() {

--- a/crates/router/src/connector/utils.rs
+++ b/crates/router/src/connector/utils.rs
@@ -112,9 +112,9 @@ where
             }
             enums::AttemptStatus::Charged => {
                 let captured_amount = types::Capturable::get_capture_amount(&self.request);
-                if Some(payment_data.payment_attempt.get_total_amount()) = captured_amount {
+                if Some(payment_data.payment_attempt.get_total_amount()) == captured_amount {
                     enums::AttemptStatus::Charged
-                } else if Some(_) = captured_amount {
+                } else if captured_amount.is_some() {
                     enums::AttemptStatus::PartialCharged
                 } else {
                     self.status

--- a/crates/router/src/connector/utils.rs
+++ b/crates/router/src/connector/utils.rs
@@ -102,7 +102,6 @@ where
     where
         F: Clone,
     {
-        // let is_psync = self.request.is_psync();
         match self.status {
             enums::AttemptStatus::Voided => {
                 if payment_data.payment_intent.amount_captured > Some(0) {

--- a/crates/router/src/connector/utils.rs
+++ b/crates/router/src/connector/utils.rs
@@ -112,13 +112,10 @@ where
             }
             enums::AttemptStatus::Charged => {
                 let captured_amount = types::Capturable::get_capture_amount(&self.request);
-                if let Some(captured_amount) = captured_amount {
-                    let amount_capturable = payment_data.payment_attempt.get_total_amount();
-                    if captured_amount == amount_capturable {
-                        enums::AttemptStatus::Charged
-                    } else {
-                        enums::AttemptStatus::PartialCharged
-                    }
+                if Some(payment_data.payment_attempt.get_total_amount()) = captured_amount {
+                    enums::AttemptStatus::Charged
+                } else if Some(_) = captured_amount {
+                    enums::AttemptStatus::PartialCharged
                 } else {
                     self.status
                 }

--- a/crates/router/src/core/payments/helpers.rs
+++ b/crates/router/src/core/payments/helpers.rs
@@ -601,6 +601,28 @@ pub fn validate_request_amount_and_amount_to_capture(
 }
 
 #[instrument(skip_all)]
+pub fn validate_amount_to_capture_in_create_call_request(
+    request: &api_models::payments::PaymentsRequest,
+) -> CustomResult<(), errors::ApiErrorResponse> {
+    if request.capture_method.unwrap_or_default() == api_enums::CaptureMethod::Automatic
+        && request.confirm.unwrap_or(false)
+    {
+        if let Some((amount_to_capture, amount)) = request.amount_to_capture.zip(request.amount) {
+            let amount_int: i64 = amount.into();
+            utils::when(amount_to_capture != amount_int, || {
+                Err(report!(errors::ApiErrorResponse::PreconditionFailed {
+                    message: "amount_to_capture must be equal to amount when confirm = true and capture_method = automatic".into()
+                }))
+            })
+        } else {
+            Ok(())
+        }
+    } else {
+        Ok(())
+    }
+}
+
+#[instrument(skip_all)]
 pub fn validate_card_data(
     payment_method_data: Option<api::PaymentMethodData>,
 ) -> CustomResult<(), errors::ApiErrorResponse> {

--- a/crates/router/src/core/payments/helpers.rs
+++ b/crates/router/src/core/payments/helpers.rs
@@ -600,6 +600,7 @@ pub fn validate_request_amount_and_amount_to_capture(
     }
 }
 
+/// if confirm = true and capture method = automatic, amount_to_capture(if provided) must be equal to amount
 #[instrument(skip_all)]
 pub fn validate_amount_to_capture_in_create_call_request(
     request: &api_models::payments::PaymentsRequest,

--- a/crates/router/src/core/payments/operations/payment_capture.rs
+++ b/crates/router/src/core/payments/operations/payment_capture.rs
@@ -236,20 +236,29 @@ impl<F: Clone, Ctx: PaymentMethodRetrieve>
     where
         F: 'b + Send,
     {
-        payment_data.payment_attempt = match &payment_data.multiple_capture_data {
-            Some(multiple_capture_data) => db
-                .store
+        payment_data.payment_attempt = if payment_data.multiple_capture_data.is_some()
+            || payment_data.payment_attempt.amount_to_capture.is_some()
+        {
+            let multiple_capture_count = payment_data
+                .multiple_capture_data
+                .as_ref()
+                .map(|multiple_capture_data| multiple_capture_data.get_captures_count())
+                .transpose()?;
+            let amount_to_capture = payment_data.payment_attempt.amount_to_capture;
+            db.store
                 .update_payment_attempt_with_attempt_id(
                     payment_data.payment_attempt,
-                    storage::PaymentAttemptUpdate::MultipleCaptureCountUpdate {
-                        multiple_capture_count: multiple_capture_data.get_captures_count()?,
+                    storage::PaymentAttemptUpdate::CaptureUpdate {
+                        amount_to_capture,
+                        multiple_capture_count,
                         updated_by: storage_scheme.to_string(),
                     },
                     storage_scheme,
                 )
                 .await
-                .to_not_found_response(errors::ApiErrorResponse::PaymentNotFound)?,
-            None => payment_data.payment_attempt,
+                .to_not_found_response(errors::ApiErrorResponse::InternalServerError)?
+        } else {
+            payment_data.payment_attempt
         };
         Ok((Box::new(self), payment_data))
     }

--- a/crates/router/src/core/payments/operations/payment_create.rs
+++ b/crates/router/src/core/payments/operations/payment_create.rs
@@ -1,6 +1,6 @@
 use std::marker::PhantomData;
 
-use api_models::{enums::FrmSuggestion, payment_methods};
+use api_models::enums::FrmSuggestion;
 use async_trait::async_trait;
 use common_utils::ext_traits::{AsyncExt, Encode, ValueExt};
 use data_models::{mandates::MandateData, payments::payment_attempt::PaymentAttempt};
@@ -269,15 +269,7 @@ impl<F: Send + Clone, Ctx: PaymentMethodRetrieve>
 
         // populate payment_data.surcharge_details from request
         let surcharge_details = request.surcharge_details.map(|surcharge_details| {
-            payment_methods::SurchargeDetailsResponse {
-                surcharge: payment_methods::Surcharge::Fixed(surcharge_details.surcharge_amount),
-                tax_on_surcharge: None,
-                surcharge_amount: surcharge_details.surcharge_amount,
-                tax_on_surcharge_amount: surcharge_details.tax_amount.unwrap_or(0),
-                final_amount: payment_attempt.amount
-                    + surcharge_details.surcharge_amount
-                    + surcharge_details.tax_amount.unwrap_or(0),
-            }
+            surcharge_details.get_surcharge_details_object(payment_attempt.amount)
         });
 
         Ok((

--- a/crates/router/src/core/payments/operations/payment_create.rs
+++ b/crates/router/src/core/payments/operations/payment_create.rs
@@ -528,6 +528,8 @@ impl<F: Send + Clone, Ctx: PaymentMethodRetrieve> ValidateRequest<F, api::Paymen
             expected_format: "amount_to_capture lesser than amount".to_string(),
         })?;
 
+        helpers::validate_amount_to_capture_in_create_call_request(request)?;
+
         helpers::validate_card_data(request.payment_method_data.clone())?;
 
         helpers::validate_payment_method_fields_present(request)?;

--- a/crates/router/src/core/payments/operations/payment_response.rs
+++ b/crates/router/src/core/payments/operations/payment_response.rs
@@ -363,6 +363,8 @@ async fn payment_response_update_tracker<F: Clone, T: types::Capturable>(
                             } else {
                                 None
                             },
+                            surcharge_amount: router_data.request.get_surcharge_amount(),
+                            tax_amount: router_data.request.get_tax_on_surcharge_amount(),
                             updated_by: storage_scheme.to_string(),
                         }),
                     )

--- a/crates/router/src/core/payments/retry.rs
+++ b/crates/router/src/core/payments/retry.rs
@@ -437,6 +437,8 @@ where
                     status: storage_enums::AttemptStatus::Failure,
                     error_reason: Some(error_response.reason),
                     amount_capturable: Some(0),
+                    surcharge_amount: None,
+                    tax_amount: None,
                     updated_by: storage_scheme.to_string(),
                 },
                 storage_scheme,

--- a/crates/router/src/types.rs
+++ b/crates/router/src/types.rs
@@ -553,6 +553,9 @@ pub trait Capturable {
     fn get_tax_on_surcharge_amount(&self) -> Option<i64> {
         None
     }
+    fn is_psync(&self) -> bool {
+        false
+    }
 }
 
 impl Capturable for PaymentsAuthorizeData {
@@ -591,7 +594,11 @@ impl Capturable for PaymentsCancelData {}
 impl Capturable for PaymentsApproveData {}
 impl Capturable for PaymentsRejectData {}
 impl Capturable for PaymentsSessionData {}
-impl Capturable for PaymentsSyncData {}
+impl Capturable for PaymentsSyncData {
+    fn is_psync(&self) -> bool {
+        true
+    }
+}
 
 pub struct AddAccessTokenResult {
     pub access_token_result: Result<Option<AccessToken>, ErrorResponse>,

--- a/crates/router/src/types.rs
+++ b/crates/router/src/types.rs
@@ -545,7 +545,7 @@ pub struct AccessTokenRequestData {
 
 pub trait Capturable {
     fn get_capture_amount(&self) -> Option<i64> {
-        Some(0)
+        None
     }
     fn get_surcharge_amount(&self) -> Option<i64> {
         None

--- a/crates/router/src/workflows/payment_sync.rs
+++ b/crates/router/src/workflows/payment_sync.rs
@@ -135,6 +135,8 @@ impl ProcessTrackerWorkflow<AppState> for PaymentsSyncWorkflow {
                                 consts::REQUEST_TIMEOUT_ERROR_MESSAGE_FROM_PSYNC.to_string(),
                             )),
                             amount_capturable: Some(0),
+                            surcharge_amount: None,
+                            tax_amount: None,
                             updated_by: merchant_account.storage_scheme.to_string(),
                         };
 

--- a/crates/storage_impl/src/payments/payment_attempt.rs
+++ b/crates/storage_impl/src/payments/payment_attempt.rs
@@ -1306,6 +1306,8 @@ impl DataModelExt for PaymentAttemptUpdate {
                 error_message,
                 error_reason,
                 amount_capturable,
+                tax_amount,
+                surcharge_amount,
                 updated_by,
             } => DieselPaymentAttemptUpdate::ErrorUpdate {
                 connector,
@@ -1314,14 +1316,18 @@ impl DataModelExt for PaymentAttemptUpdate {
                 error_message,
                 error_reason,
                 amount_capturable,
+                surcharge_amount,
+                tax_amount,
                 updated_by,
             },
-            Self::MultipleCaptureCountUpdate {
+            Self::CaptureUpdate {
                 multiple_capture_count,
                 updated_by,
-            } => DieselPaymentAttemptUpdate::MultipleCaptureCountUpdate {
+                amount_to_capture,
+            } => DieselPaymentAttemptUpdate::CaptureUpdate {
                 multiple_capture_count,
                 updated_by,
+                amount_to_capture,
             },
             Self::PreprocessingUpdate {
                 status,
@@ -1555,6 +1561,8 @@ impl DataModelExt for PaymentAttemptUpdate {
                 error_message,
                 error_reason,
                 amount_capturable,
+                surcharge_amount,
+                tax_amount,
                 updated_by,
             } => Self::ErrorUpdate {
                 connector,
@@ -1564,11 +1572,15 @@ impl DataModelExt for PaymentAttemptUpdate {
                 error_reason,
                 amount_capturable,
                 updated_by,
+                surcharge_amount,
+                tax_amount,
             },
-            DieselPaymentAttemptUpdate::MultipleCaptureCountUpdate {
+            DieselPaymentAttemptUpdate::CaptureUpdate {
+                amount_to_capture,
                 multiple_capture_count,
                 updated_by,
-            } => Self::MultipleCaptureCountUpdate {
+            } => Self::CaptureUpdate {
+                amount_to_capture,
                 multiple_capture_count,
                 updated_by,
             },

--- a/postman/collection-dir/stripe/Flow Testcases/Happy Cases/Scenario1-Create payment with confirm true/Payments - Create/request.json
+++ b/postman/collection-dir/stripe/Flow Testcases/Happy Cases/Scenario1-Create payment with confirm true/Payments - Create/request.json
@@ -25,7 +25,7 @@
       "business_label": "default",
       "capture_method": "automatic",
       "capture_on": "2022-09-10T10:11:12Z",
-      "amount_to_capture": 1,
+      "amount_to_capture": 6540,
       "customer_id": "bernard123",
       "email": "guest@example.com",
       "name": "John Doe",

--- a/postman/collection-dir/stripe/Flow Testcases/Happy Cases/Scenario11-Refund recurring payment/Recurring Payments - Create/request.json
+++ b/postman/collection-dir/stripe/Flow Testcases/Happy Cases/Scenario11-Refund recurring payment/Recurring Payments - Create/request.json
@@ -23,7 +23,7 @@
       "confirm": true,
       "capture_method": "automatic",
       "capture_on": "2022-09-10T10:11:12Z",
-      "amount_to_capture": 6540,
+      "amount_to_capture": 6570,
       "customer_id": "StripeCustomer",
       "email": "guest@example.com",
       "name": "John Doe",

--- a/postman/collection-dir/stripe/Flow Testcases/Happy Cases/Scenario27-Create a failure card payment with confirm true/Payments - Create/request.json
+++ b/postman/collection-dir/stripe/Flow Testcases/Happy Cases/Scenario27-Create a failure card payment with confirm true/Payments - Create/request.json
@@ -25,7 +25,7 @@
       "business_label": "default",
       "capture_method": "automatic",
       "capture_on": "2022-09-10T10:11:12Z",
-      "amount_to_capture": 1,
+      "amount_to_capture": 6540,
       "customer_id": "bernard123",
       "email": "guest@example.com",
       "name": "John Doe",

--- a/postman/collection-dir/stripe/Flow Testcases/Happy Cases/Scenario27-Create payment without customer_id and with billing address and shipping address/Payments - Create/request.json
+++ b/postman/collection-dir/stripe/Flow Testcases/Happy Cases/Scenario27-Create payment without customer_id and with billing address and shipping address/Payments - Create/request.json
@@ -25,7 +25,7 @@
       "business_label": "default",
       "capture_method": "automatic",
       "capture_on": "2022-09-10T10:11:12Z",
-      "amount_to_capture": 1,
+      "amount_to_capture": 6540,
       "customer_id": "bernard123",
       "email": "guest@example.com",
       "name": "John Doe",


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix

## Description
<!-- Describe your changes in detail -->
Original PR: https://github.com/juspay/hyperswitch/pull/2802
Hotfix branch PR for this Main branch PR https://github.com/juspay/hyperswitch/pull/2915

Currently, for a connector that returns `processing` status for full manual capture, if Psync is done later, status would always go from `processing` to `partially_captured` instead of `succeeded`.




### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
1. Create a merchant
2. Create a connector that returns `processing` status for single full capture. Then later gives `succeeded` after some time.
3. Create a payment with confirm = true and capture_method = manual.
4. Capture the payment fully. (status should be `processing`)
5. later do force sync. (status should be `succeeded`)


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
