### PR TITLE
fix(connector): [Prophetpay] Use refund_id as reference_id for Refund

### DIFF
--- a/crates/router/src/connector/prophetpay/transformers.rs
+++ b/crates/router/src/connector/prophetpay/transformers.rs
@@ -576,8 +576,8 @@ impl<F> TryFrom<&ProphetpayRouterData<&types::RefundsRouterData<F>>> for Prophet
                 amount: item.amount.to_owned(),
                 card_token: card_token_data.card_token,
                 profile: auth_data.profile_id,
-                ref_info: item.router_data.connector_request_reference_id.to_owned(),
-                inquiry_reference: item.router_data.connector_request_reference_id.clone(),
+                ref_info: item.router_data.request.refund_id.to_owned(),
+                inquiry_reference: item.router_data.request.refund_id.clone(),
                 action_type: ProphetpayActionType::get_action_type(&ProphetpayActionType::Refund),
             })
         } else {
@@ -594,7 +594,7 @@ impl<F> TryFrom<&ProphetpayRouterData<&types::RefundsRouterData<F>>> for Prophet
 pub struct ProphetpayRefundResponse {
     pub success: bool,
     pub response_text: String,
-    pub tran_seq_number: String,
+    pub tran_seq_number: Option<String>,
     pub response_code: String,
 }
 
@@ -609,7 +609,11 @@ impl TryFrom<types::RefundsResponseRouterData<api::Execute, ProphetpayRefundResp
             Ok(Self {
                 response: Ok(types::RefundsResponseData {
                     // no refund id is generated, tranSeqNumber is kept for future usage
-                    connector_refund_id: item.response.tran_seq_number,
+                    connector_refund_id: item.response.tran_seq_number.ok_or(
+                        errors::ConnectorError::MissingRequiredField {
+                            field_name: "tran_seq_number",
+                        },
+                    )?,
                     refund_status: enums::RefundStatus::Success,
                 }),
                 ..item.data

--- a/crates/router/src/connector/prophetpay/transformers.rs
+++ b/crates/router/src/connector/prophetpay/transformers.rs
@@ -8,6 +8,7 @@ use url::Url;
 
 use crate::{
     connector::utils::{self, to_connector_meta},
+    consts as const_val,
     core::errors,
     services,
     types::{self, api, storage::enums},
@@ -432,7 +433,6 @@ pub struct ProphetpaySyncResponse {
     pub response_text: String,
     #[serde(rename = "transactionID")]
     pub transaction_id: String,
-    pub response_code: String,
 }
 
 impl<F, T>
@@ -462,7 +462,7 @@ impl<F, T>
             Ok(Self {
                 status: enums::AttemptStatus::Failure,
                 response: Err(types::ErrorResponse {
-                    code: item.response.response_code,
+                    code: const_val::NO_ERROR_CODE.to_string(),
                     message: item.response.response_text.clone(),
                     reason: Some(item.response.response_text),
                     status_code: item.http_code,
@@ -481,7 +481,6 @@ pub struct ProphetpayVoidResponse {
     pub response_text: String,
     #[serde(rename = "transactionID")]
     pub transaction_id: String,
-    pub response_code: String,
 }
 
 impl<F, T>
@@ -511,7 +510,7 @@ impl<F, T>
             Ok(Self {
                 status: enums::AttemptStatus::VoidFailed,
                 response: Err(types::ErrorResponse {
-                    code: item.response.response_code,
+                    code: const_val::NO_ERROR_CODE.to_string(),
                     message: item.response.response_text.clone(),
                     reason: Some(item.response.response_text),
                     status_code: item.http_code,
@@ -595,7 +594,6 @@ pub struct ProphetpayRefundResponse {
     pub success: bool,
     pub response_text: String,
     pub tran_seq_number: Option<String>,
-    pub response_code: String,
 }
 
 impl TryFrom<types::RefundsResponseRouterData<api::Execute, ProphetpayRefundResponse>>
@@ -622,7 +620,7 @@ impl TryFrom<types::RefundsResponseRouterData<api::Execute, ProphetpayRefundResp
             Ok(Self {
                 status: enums::AttemptStatus::Failure,
                 response: Err(types::ErrorResponse {
-                    code: item.response.response_code,
+                    code: const_val::NO_ERROR_CODE.to_string(),
                     message: item.response.response_text.clone(),
                     reason: Some(item.response.response_text),
                     status_code: item.http_code,
@@ -639,7 +637,6 @@ impl TryFrom<types::RefundsResponseRouterData<api::Execute, ProphetpayRefundResp
 pub struct ProphetpayRefundSyncResponse {
     pub success: bool,
     pub response_text: String,
-    pub response_code: String,
 }
 
 impl<T> TryFrom<types::RefundsResponseRouterData<T, ProphetpayRefundSyncResponse>>
@@ -662,7 +659,7 @@ impl<T> TryFrom<types::RefundsResponseRouterData<T, ProphetpayRefundSyncResponse
             Ok(Self {
                 status: enums::AttemptStatus::Failure,
                 response: Err(types::ErrorResponse {
-                    code: item.response.response_code,
+                    code: const_val::NO_ERROR_CODE.to_string(),
                     message: item.response.response_text.clone(),
                     reason: Some(item.response.response_text),
                     status_code: item.http_code,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Relative PR in main branch [#2966](https://github.com/juspay/hyperswitch/pull/2966)
- Replaced connector_request_reference_id with refund_id for refund.
- Removed response_code since we are not receiving it in case of failure
- Made tranSeqNumber optional


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Should test the refund
<img width="1728" alt="Screenshot 2023-11-23 at 4 16 19 PM" src="https://github.com/juspay/hyperswitch/assets/73734619/e904fff8-04ee-4e43-b398-c2d1c3b39678">

<img width="1728" alt="Screenshot 2023-11-23 at 4 16 25 PM" src="https://github.com/juspay/hyperswitch/assets/73734619/a2cf1607-c034-49ee-b86b-52f719b1ba43">

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
