### PR TITLE
fix(connector): [BANKOFAMERICA] Add status VOIDED in enum Bankofameri…

### DIFF
--- a/crates/router/src/connector/bankofamerica/transformers.rs
+++ b/crates/router/src/connector/bankofamerica/transformers.rs
@@ -851,7 +851,7 @@ impl From<BankofamericaRefundStatus> for enums::RefundStatus {
             BankofamericaRefundStatus::Succeeded | BankofamericaRefundStatus::Transmitted => {
                 Self::Success
             }
-            BankofamericaRefundStatus::Failed => Self::Failure,
+            BankofamericaRefundStatus::Failed | BankofamericaRefundStatus::Voided => Self::Failure,
             BankofamericaRefundStatus::Pending => Self::Pending,
         }
     }
@@ -888,6 +888,7 @@ pub enum BankofamericaRefundStatus {
     Transmitted,
     Failed,
     Pending,
+    Voided,
 }
 
 #[derive(Debug, Deserialize)]


### PR DESCRIPTION
…caRefundStatus

## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Add status VOIDED in enum BankofamericaRefundStatus and map refunds to failed status.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
https://github.com/juspay/hyperswitch-cloud/issues/3352

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

1. To reproduce this issue do a refund on a payment for connector bankofamerica.
2. While the refund is in processing state, go to boa dashboard and void the refund.
3. Do a RSYNC on the refund and the status of refund should go to failed.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
