### PR TITLE
feat(router): add `connector_transaction_id` in error_response from connector flows

### DIFF
--- a/crates/data_models/src/payments/payment_attempt.rs
+++ b/crates/data_models/src/payments/payment_attempt.rs
@@ -326,6 +326,7 @@ pub enum PaymentAttemptUpdate {
         updated_by: String,
         unified_code: Option<Option<String>>,
         unified_message: Option<Option<String>>,
+        connector_transaction_id: Option<String>,
     },
     CaptureUpdate {
         amount_to_capture: Option<i64>,

--- a/crates/diesel_models/src/payment_attempt.rs
+++ b/crates/diesel_models/src/payment_attempt.rs
@@ -243,6 +243,7 @@ pub enum PaymentAttemptUpdate {
         updated_by: String,
         unified_code: Option<Option<String>>,
         unified_message: Option<Option<String>>,
+        connector_transaction_id: Option<String>,
     },
     CaptureUpdate {
         amount_to_capture: Option<i64>,
@@ -543,6 +544,7 @@ impl From<PaymentAttemptUpdate> for PaymentAttemptUpdateInternal {
                 updated_by,
                 unified_code,
                 unified_message,
+                connector_transaction_id,
             } => Self {
                 connector,
                 status: Some(status),
@@ -556,6 +558,7 @@ impl From<PaymentAttemptUpdate> for PaymentAttemptUpdateInternal {
                 tax_amount,
                 unified_code,
                 unified_message,
+                connector_transaction_id,
                 ..Default::default()
             },
             PaymentAttemptUpdate::StatusUpdate { status, updated_by } => Self {

--- a/crates/router/src/connector/aci.rs
+++ b/crates/router/src/connector/aci.rs
@@ -79,6 +79,7 @@ impl ConnectorCommon for Aci {
                     .join("; ")
             }),
             attempt_status: None,
+            connector_transaction_id: None,
         })
     }
 }

--- a/crates/router/src/connector/adyen.rs
+++ b/crates/router/src/connector/adyen.rs
@@ -74,6 +74,7 @@ impl ConnectorCommon for Adyen {
             message: response.message,
             reason: None,
             attempt_status: None,
+            connector_transaction_id: None,
         })
     }
 }
@@ -256,6 +257,7 @@ impl
             message: response.message,
             reason: None,
             attempt_status: None,
+            connector_transaction_id: None,
         })
     }
 }
@@ -375,6 +377,7 @@ impl
             message: response.message,
             reason: None,
             attempt_status: None,
+            connector_transaction_id: None,
         })
     }
 }
@@ -546,6 +549,7 @@ impl
             message: response.message,
             reason: None,
             attempt_status: None,
+            connector_transaction_id: None,
         })
     }
 
@@ -716,6 +720,7 @@ impl
             message: response.message,
             reason: None,
             attempt_status: None,
+            connector_transaction_id: None,
         })
     }
 }
@@ -920,6 +925,7 @@ impl
             message: response.message,
             reason: None,
             attempt_status: None,
+            connector_transaction_id: None,
         })
     }
 }
@@ -1439,6 +1445,7 @@ impl services::ConnectorIntegration<api::Execute, types::RefundsData, types::Ref
             message: response.message,
             reason: None,
             attempt_status: None,
+            connector_transaction_id: None,
         })
     }
 }

--- a/crates/router/src/connector/adyen/transformers.rs
+++ b/crates/router/src/connector/adyen/transformers.rs
@@ -2907,6 +2907,7 @@ pub fn get_adyen_response(
             reason: response.refusal_reason,
             status_code,
             attempt_status: None,
+            connector_transaction_id: None,
         })
     } else {
         None
@@ -2999,6 +3000,7 @@ pub fn get_redirection_response(
             reason: None,
             status_code,
             attempt_status: None,
+            connector_transaction_id: None,
         })
     } else {
         None
@@ -3061,6 +3063,7 @@ pub fn get_present_to_shopper_response(
             reason: None,
             status_code,
             attempt_status: None,
+            connector_transaction_id: None,
         })
     } else {
         None
@@ -3111,6 +3114,7 @@ pub fn get_qr_code_response(
             reason: None,
             status_code,
             attempt_status: None,
+            connector_transaction_id: None,
         })
     } else {
         None
@@ -3149,6 +3153,7 @@ pub fn get_redirection_error_response(
         reason: Some(response.refusal_reason),
         status_code,
         attempt_status: None,
+        connector_transaction_id: None,
     });
     // We don't get connector transaction id for redirections in Adyen.
     let payments_response_data = types::PaymentsResponseData::TransactionResponse {

--- a/crates/router/src/connector/airwallex.rs
+++ b/crates/router/src/connector/airwallex.rs
@@ -94,6 +94,7 @@ impl ConnectorCommon for Airwallex {
             message: response.message,
             reason: response.source,
             attempt_status: None,
+            connector_transaction_id: None,
         })
     }
 }

--- a/crates/router/src/connector/authorizedotnet.rs
+++ b/crates/router/src/connector/authorizedotnet.rs
@@ -911,6 +911,7 @@ fn get_error_response(
                     reason: Some(error.error_text),
                     status_code,
                     attempt_status: None,
+                    connector_transaction_id: None,
                 })
             })
             .unwrap_or_else(|| types::ErrorResponse {
@@ -919,6 +920,7 @@ fn get_error_response(
                 reason: None,
                 status_code,
                 attempt_status: None,
+                connector_transaction_id: None,
             })),
         Some(authorizedotnet::TransactionResponse::AuthorizedotnetTransactionResponseError(_))
         | None => {
@@ -929,6 +931,7 @@ fn get_error_response(
                 reason: Some(message.to_string()),
                 status_code,
                 attempt_status: None,
+                connector_transaction_id: None,
             })
         }
     }

--- a/crates/router/src/connector/authorizedotnet/transformers.rs
+++ b/crates/router/src/connector/authorizedotnet/transformers.rs
@@ -574,6 +574,7 @@ impl<F, T>
                         reason: None,
                         status_code: item.http_code,
                         attempt_status: None,
+                        connector_transaction_id: None,
                     })
                 });
                 let metadata = transaction_response
@@ -649,6 +650,7 @@ impl<F, T>
                         reason: None,
                         status_code: item.http_code,
                         attempt_status: None,
+                        connector_transaction_id: None,
                     })
                 });
                 let metadata = transaction_response
@@ -792,6 +794,7 @@ impl<F> TryFrom<types::RefundsResponseRouterData<F, AuthorizedotnetRefundRespons
                 reason: None,
                 status_code: item.http_code,
                 attempt_status: None,
+                connector_transaction_id: None,
             })
         });
 
@@ -1025,6 +1028,7 @@ fn get_err_response(status_code: u16, message: ResponseMessages) -> types::Error
         reason: None,
         status_code,
         attempt_status: None,
+        connector_transaction_id: None,
     }
 }
 

--- a/crates/router/src/connector/bambora.rs
+++ b/crates/router/src/connector/bambora.rs
@@ -96,6 +96,7 @@ impl ConnectorCommon for Bambora {
             message: response.message,
             reason: Some(serde_json::to_string(&response.details).unwrap_or_default()),
             attempt_status: None,
+            connector_transaction_id: None,
         })
     }
 }

--- a/crates/router/src/connector/bankofamerica.rs
+++ b/crates/router/src/connector/bankofamerica.rs
@@ -233,6 +233,7 @@ impl ConnectorCommon for Bankofamerica {
             message,
             reason: Some(connector_reason),
             attempt_status: None,
+            connector_transaction_id: None,
         })
     }
 }

--- a/crates/router/src/connector/bankofamerica/transformers.rs
+++ b/crates/router/src/connector/bankofamerica/transformers.rs
@@ -540,6 +540,7 @@ impl<F>
                     reason: error_response.error_information.reason,
                     status_code: item.http_code,
                     attempt_status: None,
+                    connector_transaction_id: None,
                 }),
                 ..item.data
             }),
@@ -596,6 +597,7 @@ impl<F>
                     reason: error_response.error_information.reason,
                     status_code: item.http_code,
                     attempt_status: None,
+                    connector_transaction_id: None,
                 }),
                 ..item.data
             }),
@@ -652,6 +654,7 @@ impl<F>
                     reason: error_response.error_information.reason,
                     status_code: item.http_code,
                     attempt_status: None,
+                    connector_transaction_id: None,
                 }),
                 ..item.data
             }),

--- a/crates/router/src/connector/bitpay.rs
+++ b/crates/router/src/connector/bitpay.rs
@@ -121,6 +121,7 @@ impl ConnectorCommon for Bitpay {
             message: response.error,
             reason: response.message,
             attempt_status: None,
+            connector_transaction_id: None,
         })
     }
 }

--- a/crates/router/src/connector/bluesnap.rs
+++ b/crates/router/src/connector/bluesnap.rs
@@ -127,6 +127,7 @@ impl ConnectorCommon for Bluesnap {
                         .unwrap_or(consts::NO_ERROR_MESSAGE.to_string()),
                     reason: Some(reason),
                     attempt_status: None,
+                    connector_transaction_id: None,
                 }
             }
             bluesnap::BluesnapErrors::Auth(error_res) => ErrorResponse {
@@ -135,6 +136,7 @@ impl ConnectorCommon for Bluesnap {
                 message: error_res.error_name.clone().unwrap_or(error_res.error_code),
                 reason: Some(error_res.error_description),
                 attempt_status: None,
+                connector_transaction_id: None,
             },
             bluesnap::BluesnapErrors::General(error_response) => {
                 let (error_res, attempt_status) = if res.status_code == 403
@@ -156,6 +158,7 @@ impl ConnectorCommon for Bluesnap {
                     message: error_response,
                     reason: Some(error_res),
                     attempt_status,
+                    connector_transaction_id: None,
                 }
             }
         };

--- a/crates/router/src/connector/boku.rs
+++ b/crates/router/src/connector/boku.rs
@@ -131,6 +131,7 @@ impl ConnectorCommon for Boku {
                 message: response.message,
                 reason: response.reason,
                 attempt_status: None,
+                connector_transaction_id: None,
             }),
             Err(_) => get_xml_deserialized(res),
         }
@@ -668,6 +669,7 @@ fn get_xml_deserialized(res: Response) -> CustomResult<ErrorResponse, errors::Co
                 message: consts::UNSUPPORTED_ERROR_MESSAGE.to_string(),
                 reason: Some(response_data),
                 attempt_status: None,
+                connector_transaction_id: None,
             })
         }
     }

--- a/crates/router/src/connector/braintree.rs
+++ b/crates/router/src/connector/braintree.rs
@@ -133,6 +133,7 @@ impl ConnectorCommon for Braintree {
                     message,
                     reason: Some(response.api_error_response.message),
                     attempt_status: None,
+                    connector_transaction_id: None,
                 })
             }
             Ok(braintree::ErrorResponse::BraintreeErrorResponse(response)) => Ok(ErrorResponse {
@@ -141,6 +142,7 @@ impl ConnectorCommon for Braintree {
                 message: consts::NO_ERROR_MESSAGE.to_string(),
                 reason: Some(response.errors),
                 attempt_status: None,
+                connector_transaction_id: None,
             }),
             Err(error_msg) => {
                 logger::error!(deserialization_error =? error_msg);

--- a/crates/router/src/connector/braintree/braintree_graphql_transformers.rs
+++ b/crates/router/src/connector/braintree/braintree_graphql_transformers.rs
@@ -317,6 +317,7 @@ fn get_error_response<T>(
         reason: error_reason,
         status_code: http_code,
         attempt_status: None,
+        connector_transaction_id: None,
     })
 }
 

--- a/crates/router/src/connector/cashtocode.rs
+++ b/crates/router/src/connector/cashtocode.rs
@@ -120,6 +120,7 @@ impl ConnectorCommon for Cashtocode {
             message: response.error_description,
             reason: None,
             attempt_status: None,
+            connector_transaction_id: None,
         })
     }
 }

--- a/crates/router/src/connector/cashtocode/transformers.rs
+++ b/crates/router/src/connector/cashtocode/transformers.rs
@@ -218,6 +218,7 @@ impl<F, T>
                     message: error_data.error_description,
                     reason: None,
                     attempt_status: None,
+                    connector_transaction_id: None,
                 }),
             ),
             CashtocodePaymentsResponse::CashtoCodeData(response_data) => {

--- a/crates/router/src/connector/checkout.rs
+++ b/crates/router/src/connector/checkout.rs
@@ -132,6 +132,7 @@ impl ConnectorCommon for Checkout {
                 .map(|errors| errors.join(" & "))
                 .or(response.error_type),
             attempt_status: None,
+            connector_transaction_id: None,
         })
     }
 }

--- a/crates/router/src/connector/checkout/transformers.rs
+++ b/crates/router/src/connector/checkout/transformers.rs
@@ -577,6 +577,7 @@ impl TryFrom<types::PaymentsResponseRouterData<PaymentsResponse>>
                     .unwrap_or_else(|| consts::NO_ERROR_MESSAGE.to_string()),
                 reason: item.response.response_summary,
                 attempt_status: None,
+                connector_transaction_id: None,
             })
         } else {
             None
@@ -625,6 +626,7 @@ impl TryFrom<types::PaymentsSyncResponseRouterData<PaymentsResponse>>
                     .unwrap_or_else(|| consts::NO_ERROR_MESSAGE.to_string()),
                 reason: item.response.response_summary,
                 attempt_status: None,
+                connector_transaction_id: None,
             })
         } else {
             None

--- a/crates/router/src/connector/coinbase.rs
+++ b/crates/router/src/connector/coinbase.rs
@@ -109,6 +109,7 @@ impl ConnectorCommon for Coinbase {
             message: response.error.message,
             reason: response.error.code,
             attempt_status: None,
+            connector_transaction_id: None,
         })
     }
 }

--- a/crates/router/src/connector/cryptopay.rs
+++ b/crates/router/src/connector/cryptopay.rs
@@ -168,6 +168,7 @@ impl ConnectorCommon for Cryptopay {
             message: response.error.message,
             reason: response.error.reason,
             attempt_status: None,
+            connector_transaction_id: None,
         })
     }
 }

--- a/crates/router/src/connector/cybersource.rs
+++ b/crates/router/src/connector/cybersource.rs
@@ -137,6 +137,7 @@ impl ConnectorCommon for Cybersource {
             message,
             reason: Some(connector_reason),
             attempt_status: None,
+            connector_transaction_id: None,
         })
     }
 }

--- a/crates/router/src/connector/cybersource/transformers.rs
+++ b/crates/router/src/connector/cybersource/transformers.rs
@@ -552,6 +552,7 @@ impl<F, T>
                     reason: Some(error.reason),
                     status_code: item.http_code,
                     attempt_status: None,
+                    connector_transaction_id: None,
                 }),
                 _ => Ok(types::PaymentsResponseData::TransactionResponse {
                     resource_id: types::ResponseId::ConnectorTransactionId(

--- a/crates/router/src/connector/dlocal.rs
+++ b/crates/router/src/connector/dlocal.rs
@@ -136,6 +136,7 @@ impl ConnectorCommon for Dlocal {
             message: response.message,
             reason: response.param,
             attempt_status: None,
+            connector_transaction_id: None,
         })
     }
 }

--- a/crates/router/src/connector/dummyconnector.rs
+++ b/crates/router/src/connector/dummyconnector.rs
@@ -112,6 +112,7 @@ impl<const T: u8> ConnectorCommon for DummyConnector<T> {
             message: response.error.message,
             reason: response.error.reason,
             attempt_status: None,
+            connector_transaction_id: None,
         })
     }
 }

--- a/crates/router/src/connector/fiserv.rs
+++ b/crates/router/src/connector/fiserv.rs
@@ -152,6 +152,7 @@ impl ConnectorCommon for Fiserv {
                         reason: first_error.field.to_owned(),
                         status_code: res.status_code,
                         attempt_status: None,
+                        connector_transaction_id: None,
                     })
             })
             .unwrap_or(types::ErrorResponse {
@@ -160,6 +161,7 @@ impl ConnectorCommon for Fiserv {
                 reason: None,
                 status_code: res.status_code,
                 attempt_status: None,
+                connector_transaction_id: None,
             }))
     }
 }

--- a/crates/router/src/connector/forte.rs
+++ b/crates/router/src/connector/forte.rs
@@ -131,6 +131,7 @@ impl ConnectorCommon for Forte {
             message,
             reason: None,
             attempt_status: None,
+            connector_transaction_id: None,
         })
     }
 }

--- a/crates/router/src/connector/globalpay.rs
+++ b/crates/router/src/connector/globalpay.rs
@@ -105,6 +105,7 @@ impl ConnectorCommon for Globalpay {
             message: response.detailed_error_description,
             reason: None,
             attempt_status: None,
+            connector_transaction_id: None,
         })
     }
 }
@@ -319,6 +320,7 @@ impl ConnectorIntegration<api::AccessTokenAuth, types::AccessTokenRequestData, t
             message: response.detailed_error_description,
             reason: None,
             attempt_status: None,
+            connector_transaction_id: None,
         })
     }
 }

--- a/crates/router/src/connector/globepay.rs
+++ b/crates/router/src/connector/globepay.rs
@@ -123,6 +123,7 @@ impl ConnectorCommon for Globepay {
             message: consts::NO_ERROR_MESSAGE.to_string(),
             reason: Some(response.return_msg),
             attempt_status: None,
+            connector_transaction_id: None,
         })
     }
 }

--- a/crates/router/src/connector/globepay/transformers.rs
+++ b/crates/router/src/connector/globepay/transformers.rs
@@ -258,6 +258,7 @@ fn get_error_response(
         reason: return_msg,
         status_code,
         attempt_status: None,
+        connector_transaction_id: None,
     }
 }
 

--- a/crates/router/src/connector/gocardless.rs
+++ b/crates/router/src/connector/gocardless.rs
@@ -123,6 +123,7 @@ impl ConnectorCommon for Gocardless {
             message: response.error.error_type,
             reason: Some(error_reason.join("; ")),
             attempt_status: None,
+            connector_transaction_id: None,
         })
     }
 }

--- a/crates/router/src/connector/helcim.rs
+++ b/crates/router/src/connector/helcim.rs
@@ -138,6 +138,7 @@ impl ConnectorCommon for Helcim {
             message: error_string.clone(),
             reason: Some(error_string),
             attempt_status: None,
+            connector_transaction_id: None,
         })
     }
 }

--- a/crates/router/src/connector/iatapay.rs
+++ b/crates/router/src/connector/iatapay.rs
@@ -125,6 +125,7 @@ impl ConnectorCommon for Iatapay {
             message: response.message,
             reason: response.reason,
             attempt_status: None,
+            connector_transaction_id: None,
         })
     }
 }
@@ -240,6 +241,7 @@ impl ConnectorIntegration<api::AccessTokenAuth, types::AccessTokenRequestData, t
             message: response.path,
             reason: None,
             attempt_status: None,
+            connector_transaction_id: None,
         })
     }
 }

--- a/crates/router/src/connector/klarna.rs
+++ b/crates/router/src/connector/klarna.rs
@@ -76,6 +76,7 @@ impl ConnectorCommon for Klarna {
             message: consts::NO_ERROR_MESSAGE.to_string(),
             reason,
             attempt_status: None,
+            connector_transaction_id: None,
         })
     }
 }

--- a/crates/router/src/connector/mollie.rs
+++ b/crates/router/src/connector/mollie.rs
@@ -99,6 +99,7 @@ impl ConnectorCommon for Mollie {
             message: response.detail,
             reason: response.field,
             attempt_status: None,
+            connector_transaction_id: None,
         })
     }
 }

--- a/crates/router/src/connector/multisafepay.rs
+++ b/crates/router/src/connector/multisafepay.rs
@@ -84,6 +84,7 @@ impl ConnectorCommon for Multisafepay {
             message: response.error_info,
             reason: None,
             attempt_status: None,
+            connector_transaction_id: None,
         })
     }
 }

--- a/crates/router/src/connector/multisafepay/transformers.rs
+++ b/crates/router/src/connector/multisafepay/transformers.rs
@@ -703,6 +703,7 @@ impl<F, T>
                     reason: Some(error_response.error_info),
                     status_code: item.http_code,
                     attempt_status: None,
+                    connector_transaction_id: None,
                 }),
                 ..item.data
             }),
@@ -810,6 +811,7 @@ impl TryFrom<types::RefundsResponseRouterData<api::Execute, MultisafepayRefundRe
                     reason: Some(error_response.error_info),
                     status_code: item.http_code,
                     attempt_status: None,
+                    connector_transaction_id: None,
                 }),
                 ..item.data
             }),
@@ -847,6 +849,7 @@ impl TryFrom<types::RefundsResponseRouterData<api::RSync, MultisafepayRefundResp
                     reason: Some(error_response.error_info),
                     status_code: item.http_code,
                     attempt_status: None,
+                    connector_transaction_id: None,
                 }),
                 ..item.data
             }),

--- a/crates/router/src/connector/nexinets.rs
+++ b/crates/router/src/connector/nexinets.rs
@@ -131,6 +131,7 @@ impl ConnectorCommon for Nexinets {
             message: static_message,
             reason: Some(connector_reason),
             attempt_status: None,
+            connector_transaction_id: None,
         })
     }
 }

--- a/crates/router/src/connector/nmi/transformers.rs
+++ b/crates/router/src/connector/nmi/transformers.rs
@@ -441,6 +441,7 @@ impl ForeignFrom<(StandardResponse, u16)> for types::ErrorResponse {
             reason: None,
             status_code: http_code,
             attempt_status: None,
+            connector_transaction_id: None,
         }
     }
 }

--- a/crates/router/src/connector/noon.rs
+++ b/crates/router/src/connector/noon.rs
@@ -137,6 +137,7 @@ impl ConnectorCommon for Noon {
             message: response.class_description,
             reason: Some(response.message),
             attempt_status: None,
+            connector_transaction_id: None,
         })
     }
 }

--- a/crates/router/src/connector/noon/transformers.rs
+++ b/crates/router/src/connector/noon/transformers.rs
@@ -512,6 +512,7 @@ impl<F, T>
                     reason: Some(error_message),
                     status_code: item.http_code,
                     attempt_status: None,
+                    connector_transaction_id: None,
                 }),
                 _ => {
                     let connector_response_reference_id =

--- a/crates/router/src/connector/nuvei/transformers.rs
+++ b/crates/router/src/connector/nuvei/transformers.rs
@@ -1580,6 +1580,7 @@ fn get_error_response<T>(
         reason: None,
         status_code: http_code,
         attempt_status: None,
+        connector_transaction_id: None,
     })
 }
 

--- a/crates/router/src/connector/opayo.rs
+++ b/crates/router/src/connector/opayo.rs
@@ -108,6 +108,7 @@ impl ConnectorCommon for Opayo {
             message: response.message,
             reason: response.reason,
             attempt_status: None,
+            connector_transaction_id: None,
         })
     }
 }

--- a/crates/router/src/connector/opennode.rs
+++ b/crates/router/src/connector/opennode.rs
@@ -111,6 +111,7 @@ impl ConnectorCommon for Opennode {
             message: response.message,
             reason: None,
             attempt_status: None,
+            connector_transaction_id: None,
         })
     }
 }

--- a/crates/router/src/connector/payeezy.rs
+++ b/crates/router/src/connector/payeezy.rs
@@ -124,6 +124,7 @@ impl ConnectorCommon for Payeezy {
             message: error_messages.join(", "),
             reason: None,
             attempt_status: None,
+            connector_transaction_id: None,
         })
     }
 }

--- a/crates/router/src/connector/payme.rs
+++ b/crates/router/src/connector/payme.rs
@@ -98,6 +98,7 @@ impl ConnectorCommon for Payme {
                 response.status_error_details, response.status_additional_info
             )),
             attempt_status: None,
+            connector_transaction_id: None,
         })
     }
 }

--- a/crates/router/src/connector/payme/transformers.rs
+++ b/crates/router/src/connector/payme/transformers.rs
@@ -227,6 +227,7 @@ impl From<(&PaymePaySaleResponse, u16)> for types::ErrorResponse {
             reason: pay_sale_response.status_error_details.to_owned(),
             status_code: http_code,
             attempt_status: None,
+            connector_transaction_id: None,
         }
     }
 }
@@ -310,6 +311,7 @@ impl From<(&SaleQuery, u16)> for types::ErrorResponse {
             reason: sale_query_response.sale_error_text.clone(),
             status_code: http_code,
             attempt_status: None,
+            connector_transaction_id: None,
         }
     }
 }

--- a/crates/router/src/connector/paypal.rs
+++ b/crates/router/src/connector/paypal.rs
@@ -92,6 +92,7 @@ impl Paypal {
             message: response.message.clone(),
             reason: error_reason.or(Some(response.message)),
             attempt_status: None,
+            connector_transaction_id: None,
         })
     }
 }
@@ -245,6 +246,7 @@ impl ConnectorCommon for Paypal {
             message: response.message.clone(),
             reason,
             attempt_status: None,
+            connector_transaction_id: None,
         })
     }
 }
@@ -380,6 +382,7 @@ impl ConnectorIntegration<api::AccessTokenAuth, types::AccessTokenRequestData, t
             message: response.error_description.clone(),
             reason: Some(response.error_description),
             attempt_status: None,
+            connector_transaction_id: None,
         })
     }
 }

--- a/crates/router/src/connector/payu.rs
+++ b/crates/router/src/connector/payu.rs
@@ -97,6 +97,7 @@ impl ConnectorCommon for Payu {
             message: response.status.status_desc,
             reason: response.status.code_literal,
             attempt_status: None,
+            connector_transaction_id: None,
         })
     }
 }
@@ -309,6 +310,7 @@ impl ConnectorIntegration<api::AccessTokenAuth, types::AccessTokenRequestData, t
             message: response.error_description,
             reason: None,
             attempt_status: None,
+            connector_transaction_id: None,
         })
     }
 }

--- a/crates/router/src/connector/powertranz.rs
+++ b/crates/router/src/connector/powertranz.rs
@@ -121,6 +121,7 @@ impl ConnectorCommon for Powertranz {
             message: consts::NO_ERROR_MESSAGE.to_string(),
             reason: None,
             attempt_status: None,
+            connector_transaction_id: None,
         })
     }
 }

--- a/crates/router/src/connector/powertranz/transformers.rs
+++ b/crates/router/src/connector/powertranz/transformers.rs
@@ -444,6 +444,7 @@ fn build_error_response(
                         .join(", "),
                 ),
                 attempt_status: None,
+                connector_transaction_id: None,
             }
         })
     } else if !ISO_SUCCESS_CODES.contains(&item.iso_response_code.as_str()) {
@@ -454,6 +455,7 @@ fn build_error_response(
             message: item.response_message.clone(),
             reason: Some(item.response_message.clone()),
             attempt_status: None,
+            connector_transaction_id: None,
         })
     } else {
         None

--- a/crates/router/src/connector/prophetpay.rs
+++ b/crates/router/src/connector/prophetpay.rs
@@ -117,6 +117,7 @@ impl ConnectorCommon for Prophetpay {
             message: consts::NO_ERROR_MESSAGE.to_string(),
             reason: Some(response.to_string()),
             attempt_status: None,
+            connector_transaction_id: None,
         })
     }
 }

--- a/crates/router/src/connector/prophetpay/transformers.rs
+++ b/crates/router/src/connector/prophetpay/transformers.rs
@@ -419,6 +419,7 @@ impl<F>
                     reason: Some(item.response.response_text),
                     status_code: item.http_code,
                     attempt_status: None,
+                    connector_transaction_id: None,
                 }),
                 ..item.data
             })
@@ -467,6 +468,7 @@ impl<F, T>
                     reason: Some(item.response.response_text),
                     status_code: item.http_code,
                     attempt_status: None,
+                    connector_transaction_id: None,
                 }),
                 ..item.data
             })
@@ -515,6 +517,7 @@ impl<F, T>
                     reason: Some(item.response.response_text),
                     status_code: item.http_code,
                     attempt_status: None,
+                    connector_transaction_id: None,
                 }),
                 ..item.data
             })
@@ -625,6 +628,7 @@ impl TryFrom<types::RefundsResponseRouterData<api::Execute, ProphetpayRefundResp
                     reason: Some(item.response.response_text),
                     status_code: item.http_code,
                     attempt_status: None,
+                    connector_transaction_id: None,
                 }),
                 ..item.data
             })
@@ -664,6 +668,7 @@ impl<T> TryFrom<types::RefundsResponseRouterData<T, ProphetpayRefundSyncResponse
                     reason: Some(item.response.response_text),
                     status_code: item.http_code,
                     attempt_status: None,
+                    connector_transaction_id: None,
                 }),
                 ..item.data
             })

--- a/crates/router/src/connector/rapyd.rs
+++ b/crates/router/src/connector/rapyd.rs
@@ -99,6 +99,7 @@ impl ConnectorCommon for Rapyd {
                 message: response_data.status.status.unwrap_or_default(),
                 reason: response_data.status.message,
                 attempt_status: None,
+                connector_transaction_id: None,
             }),
             Err(error_msg) => {
                 logger::error!(deserialization_error =? error_msg);

--- a/crates/router/src/connector/rapyd/transformers.rs
+++ b/crates/router/src/connector/rapyd/transformers.rs
@@ -458,6 +458,7 @@ impl<F, T>
                             message: item.response.status.status.unwrap_or_default(),
                             reason: data.failure_message.to_owned(),
                             attempt_status: None,
+                            connector_transaction_id: None,
                         }),
                     ),
                     _ => {
@@ -499,6 +500,7 @@ impl<F, T>
                     message: item.response.status.status.unwrap_or_default(),
                     reason: item.response.status.message,
                     attempt_status: None,
+                    connector_transaction_id: None,
                 }),
             ),
         };

--- a/crates/router/src/connector/shift4.rs
+++ b/crates/router/src/connector/shift4.rs
@@ -100,6 +100,7 @@ impl ConnectorCommon for Shift4 {
             message: response.error.message,
             reason: None,
             attempt_status: None,
+            connector_transaction_id: None,
         })
     }
 }

--- a/crates/router/src/connector/square.rs
+++ b/crates/router/src/connector/square.rs
@@ -124,6 +124,7 @@ impl ConnectorCommon for Square {
                 .unwrap_or(consts::NO_ERROR_MESSAGE.to_string()),
             reason: Some(reason),
             attempt_status: None,
+            connector_transaction_id: None,
         })
     }
 }

--- a/crates/router/src/connector/stax.rs
+++ b/crates/router/src/connector/stax.rs
@@ -110,6 +110,7 @@ impl ConnectorCommon for Stax {
                     .to_owned(),
             ),
             attempt_status: None,
+            connector_transaction_id: None,
         })
     }
 }

--- a/crates/router/src/connector/stripe.rs
+++ b/crates/router/src/connector/stripe.rs
@@ -227,6 +227,7 @@ impl
                     .unwrap_or(message)
             }),
             attempt_status: None,
+            connector_transaction_id: response.error.payment_intent.map(|pi| pi.id),
         })
     }
 }
@@ -357,6 +358,7 @@ impl
                     .unwrap_or(message)
             }),
             attempt_status: None,
+            connector_transaction_id: response.error.payment_intent.map(|pi| pi.id),
         })
     }
 }
@@ -483,6 +485,7 @@ impl
                     .unwrap_or(message)
             }),
             attempt_status: None,
+            connector_transaction_id: response.error.payment_intent.map(|pi| pi.id),
         })
     }
 }
@@ -617,6 +620,7 @@ impl
                     .unwrap_or(message)
             }),
             attempt_status: None,
+            connector_transaction_id: response.error.payment_intent.map(|pi| pi.id),
         })
     }
 }
@@ -760,6 +764,7 @@ impl
                     .unwrap_or(message)
             }),
             attempt_status: None,
+            connector_transaction_id: response.error.payment_intent.map(|pi| pi.id),
         })
     }
 }
@@ -918,6 +923,7 @@ impl
                     .unwrap_or(message)
             }),
             attempt_status: None,
+            connector_transaction_id: response.error.payment_intent.map(|pi| pi.id),
         })
     }
 }
@@ -1041,6 +1047,7 @@ impl
                     .unwrap_or(message)
             }),
             attempt_status: None,
+            connector_transaction_id: response.error.payment_intent.map(|pi| pi.id),
         })
     }
 }
@@ -1197,6 +1204,7 @@ impl
                     .unwrap_or(message)
             }),
             attempt_status: None,
+            connector_transaction_id: response.error.payment_intent.map(|pi| pi.id),
         })
     }
 }
@@ -1318,6 +1326,7 @@ impl services::ConnectorIntegration<api::Execute, types::RefundsData, types::Ref
                     .unwrap_or(message)
             }),
             attempt_status: None,
+            connector_transaction_id: response.error.payment_intent.map(|pi| pi.id),
         })
     }
 }
@@ -1424,6 +1433,7 @@ impl services::ConnectorIntegration<api::RSync, types::RefundsData, types::Refun
                     .unwrap_or(message)
             }),
             attempt_status: None,
+            connector_transaction_id: response.error.payment_intent.map(|pi| pi.id),
         })
     }
 }
@@ -1569,6 +1579,7 @@ impl
                     .unwrap_or(message)
             }),
             attempt_status: None,
+            connector_transaction_id: response.error.payment_intent.map(|pi| pi.id),
         })
     }
 }
@@ -1672,6 +1683,7 @@ impl
                     .unwrap_or(message)
             }),
             attempt_status: None,
+            connector_transaction_id: response.error.payment_intent.map(|pi| pi.id),
         })
     }
 }
@@ -1801,6 +1813,7 @@ impl
                     .unwrap_or(message)
             }),
             attempt_status: None,
+            connector_transaction_id: response.error.payment_intent.map(|pi| pi.id),
         })
     }
 }

--- a/crates/router/src/connector/stripe/transformers.rs
+++ b/crates/router/src/connector/stripe/transformers.rs
@@ -2480,6 +2480,7 @@ impl<F, T>
                         .or(Some(error.message.clone())),
                     status_code: item.http_code,
                     attempt_status: None,
+                    connector_transaction_id: None,
                 });
 
         let connector_metadata =
@@ -2788,6 +2789,12 @@ pub struct ErrorDetails {
     pub message: Option<String>,
     pub param: Option<String>,
     pub decline_code: Option<String>,
+    pub payment_intent: Option<PaymentIntentErrorResponse>,
+}
+
+#[derive(Debug, Default, Eq, PartialEq, Deserialize, Serialize)]
+pub struct PaymentIntentErrorResponse {
+    pub id: String,
 }
 
 #[derive(Debug, Default, Eq, PartialEq, Deserialize, Serialize)]

--- a/crates/router/src/connector/trustpay.rs
+++ b/crates/router/src/connector/trustpay.rs
@@ -139,6 +139,7 @@ impl ConnectorCommon for Trustpay {
                         .unwrap_or(consts::NO_ERROR_MESSAGE.to_string()),
                     reason: reason.or(response_data.description),
                     attempt_status: None,
+                    connector_transaction_id: None,
                 })
             }
             Err(error_msg) => {
@@ -298,6 +299,7 @@ impl ConnectorIntegration<api::AccessTokenAuth, types::AccessTokenRequestData, t
             message: response.result_info.result_code.to_string(),
             reason: response.result_info.additional_info,
             attempt_status: None,
+            connector_transaction_id: None,
         })
     }
 }
@@ -372,6 +374,7 @@ impl ConnectorIntegration<api::PSync, types::PaymentsSyncData, types::PaymentsRe
             message: response.status.to_string(),
             reason: Some(response.payment_description),
             attempt_status: None,
+            connector_transaction_id: None,
         })
     }
 

--- a/crates/router/src/connector/trustpay/transformers.rs
+++ b/crates/router/src/connector/trustpay/transformers.rs
@@ -716,6 +716,7 @@ fn handle_cards_response(
             reason: msg,
             status_code,
             attempt_status: None,
+            connector_transaction_id: None,
         })
     } else {
         None
@@ -778,6 +779,7 @@ fn handle_bank_redirects_error_response(
         reason: response.payment_result_info.additional_info,
         status_code,
         attempt_status: None,
+        connector_transaction_id: None,
     });
     let payment_response_data = types::PaymentsResponseData::TransactionResponse {
         resource_id: types::ResponseId::NoResponseId,
@@ -814,6 +816,7 @@ fn handle_bank_redirects_sync_response(
             reason: reason_info.reason.reject_reason,
             status_code,
             attempt_status: None,
+            connector_transaction_id: None,
         })
     } else {
         None
@@ -941,6 +944,7 @@ impl<F, T> TryFrom<types::ResponseRouterData<F, TrustpayAuthUpdateResponse, T, t
                     reason: item.response.result_info.additional_info,
                     status_code: item.http_code,
                     attempt_status: None,
+                    connector_transaction_id: None,
                 }),
                 ..item.data
             }),
@@ -1413,6 +1417,7 @@ fn handle_cards_refund_response(
             reason: msg,
             status_code,
             attempt_status: None,
+            connector_transaction_id: None,
         })
     } else {
         None
@@ -1452,6 +1457,7 @@ fn handle_bank_redirects_refund_response(
             reason: msg.map(|message| message.to_string()),
             status_code,
             attempt_status: None,
+            connector_transaction_id: None,
         })
     } else {
         None
@@ -1480,6 +1486,7 @@ fn handle_bank_redirects_refund_sync_response(
             reason: reason_info.reason.reject_reason,
             status_code,
             attempt_status: None,
+            connector_transaction_id: None,
         })
     } else {
         None
@@ -1502,6 +1509,7 @@ fn handle_bank_redirects_refund_sync_error_response(
         reason: response.payment_result_info.additional_info,
         status_code,
         attempt_status: None,
+        connector_transaction_id: None,
     });
     //unreachable case as we are sending error as Some()
     let refund_response_data = types::RefundsResponseData {

--- a/crates/router/src/connector/tsys/transformers.rs
+++ b/crates/router/src/connector/tsys/transformers.rs
@@ -203,6 +203,7 @@ fn get_error_response(
         reason: Some(connector_error_response.response_message),
         status_code,
         attempt_status: None,
+        connector_transaction_id: None,
     }
 }
 

--- a/crates/router/src/connector/volt.rs
+++ b/crates/router/src/connector/volt.rs
@@ -130,6 +130,7 @@ impl ConnectorCommon for Volt {
             message: response.exception.message.clone(),
             reason: Some(reason),
             attempt_status: None,
+            connector_transaction_id: None,
         })
     }
 }

--- a/crates/router/src/connector/wise.rs
+++ b/crates/router/src/connector/wise.rs
@@ -95,6 +95,7 @@ impl ConnectorCommon for Wise {
                         message: e.message.clone(),
                         reason: None,
                         attempt_status: None,
+                        connector_transaction_id: None,
                     })
                 } else {
                     Ok(types::ErrorResponse {
@@ -103,6 +104,7 @@ impl ConnectorCommon for Wise {
                         message: response.message.unwrap_or_default(),
                         reason: None,
                         attempt_status: None,
+                        connector_transaction_id: None,
                     })
                 }
             }
@@ -112,6 +114,7 @@ impl ConnectorCommon for Wise {
                 message: response.message.unwrap_or_default(),
                 reason: None,
                 attempt_status: None,
+                connector_transaction_id: None,
             }),
         }
     }
@@ -293,6 +296,7 @@ impl services::ConnectorIntegration<api::PoCancel, types::PayoutsData, types::Pa
             message,
             reason: None,
             attempt_status: None,
+            connector_transaction_id: None,
         })
     }
 }

--- a/crates/router/src/connector/worldpay.rs
+++ b/crates/router/src/connector/worldpay.rs
@@ -95,6 +95,7 @@ impl ConnectorCommon for Worldpay {
             message: response.message,
             reason: response.validation_errors.map(|e| e.to_string()),
             attempt_status: None,
+            connector_transaction_id: None,
         })
     }
 }

--- a/crates/router/src/connector/zen.rs
+++ b/crates/router/src/connector/zen.rs
@@ -127,6 +127,7 @@ impl ConnectorCommon for Zen {
             ),
             reason: None,
             attempt_status: None,
+            connector_transaction_id: None,
         })
     }
 }

--- a/crates/router/src/core/payments/access_token.rs
+++ b/crates/router/src/core/payments/access_token.rs
@@ -174,6 +174,7 @@ pub async fn refresh_connector_auth(
                     reason: Some(consts::REQUEST_TIMEOUT_ERROR_MESSAGE.to_string()),
                     status_code: 504,
                     attempt_status: None,
+                    connector_transaction_id: None,
                 };
 
                 Ok(Err(error_response))

--- a/crates/router/src/core/payments/operations/payment_response.rs
+++ b/crates/router/src/core/payments/operations/payment_response.rs
@@ -377,6 +377,7 @@ async fn payment_response_update_tracker<F: Clone, T: types::Capturable>(
                             updated_by: storage_scheme.to_string(),
                             unified_code: option_gsm.clone().map(|gsm| gsm.unified_code),
                             unified_message: option_gsm.map(|gsm| gsm.unified_message),
+                            connector_transaction_id: err.connector_transaction_id,
                         }),
                     )
                 }

--- a/crates/router/src/core/payments/retry.rs
+++ b/crates/router/src/core/payments/retry.rs
@@ -415,6 +415,7 @@ where
                     updated_by: storage_scheme.to_string(),
                     unified_code: option_gsm.clone().map(|gsm| gsm.unified_code),
                     unified_message: option_gsm.map(|gsm| gsm.unified_message),
+                    connector_transaction_id: error_response.connector_transaction_id.clone(),
                 },
                 storage_scheme,
             )

--- a/crates/router/src/services/api.rs
+++ b/crates/router/src/services/api.rs
@@ -224,6 +224,7 @@ pub trait ConnectorIntegration<T, Req, Resp>: ConnectorIntegrationAny<T, Req, Re
             reason: String::from_utf8(res.response.to_vec()).ok(),
             status_code: res.status_code,
             attempt_status: None,
+            connector_transaction_id: None,
         })
     }
 
@@ -302,6 +303,7 @@ where
                     status_code: 200, // This status code is ignored in redirection response it will override with 302 status code.
                     reason: None,
                     attempt_status: None,
+                    connector_transaction_id: None,
                 })
             } else {
                 None
@@ -427,6 +429,7 @@ where
                                     reason: Some(consts::REQUEST_TIMEOUT_ERROR_MESSAGE.to_string()),
                                     status_code: 504,
                                     attempt_status: None,
+                                    connector_transaction_id: None,
                                 };
                                 router_data.response = Err(error_response);
                                 router_data.connector_http_status_code = Some(504);

--- a/crates/router/src/types.rs
+++ b/crates/router/src/types.rs
@@ -976,6 +976,7 @@ pub struct ErrorResponse {
     pub reason: Option<String>,
     pub status_code: u16,
     pub attempt_status: Option<storage_enums::AttemptStatus>,
+    pub connector_transaction_id: Option<String>,
 }
 
 impl ErrorResponse {
@@ -992,6 +993,7 @@ impl ErrorResponse {
             reason: None,
             status_code: http::StatusCode::INTERNAL_SERVER_ERROR.as_u16(),
             attempt_status: None,
+            connector_transaction_id: None,
         }
     }
 }
@@ -1035,6 +1037,7 @@ impl From<errors::ApiErrorResponse> for ErrorResponse {
                 _ => 500,
             },
             attempt_status: None,
+            connector_transaction_id: None,
         }
     }
 }

--- a/crates/router/src/types/api.rs
+++ b/crates/router/src/types/api.rs
@@ -114,6 +114,7 @@ pub trait ConnectorCommon {
             message: consts::NO_ERROR_MESSAGE.to_string(),
             reason: None,
             attempt_status: None,
+            connector_transaction_id: None,
         })
     }
 }

--- a/crates/router/src/utils.rs
+++ b/crates/router/src/utils.rs
@@ -405,6 +405,7 @@ pub fn handle_json_response_deserialization_failure(
                 message: consts::UNSUPPORTED_ERROR_MESSAGE.to_string(),
                 reason: Some(response_data),
                 attempt_status: None,
+                connector_transaction_id: None,
             })
         }
     }

--- a/crates/router/src/workflows/payment_sync.rs
+++ b/crates/router/src/workflows/payment_sync.rs
@@ -140,6 +140,7 @@ impl ProcessTrackerWorkflow<AppState> for PaymentsSyncWorkflow {
                             updated_by: merchant_account.storage_scheme.to_string(),
                             unified_code: None,
                             unified_message: None,
+                            connector_transaction_id: None,
                         };
 
                     payment_data.payment_attempt = db

--- a/crates/storage_impl/src/payments/payment_attempt.rs
+++ b/crates/storage_impl/src/payments/payment_attempt.rs
@@ -1325,6 +1325,7 @@ impl DataModelExt for PaymentAttemptUpdate {
                 updated_by,
                 unified_code,
                 unified_message,
+                connector_transaction_id,
             } => DieselPaymentAttemptUpdate::ErrorUpdate {
                 connector,
                 status,
@@ -1337,6 +1338,7 @@ impl DataModelExt for PaymentAttemptUpdate {
                 updated_by,
                 unified_code,
                 unified_message,
+                connector_transaction_id,
             },
             Self::CaptureUpdate {
                 multiple_capture_count,
@@ -1588,6 +1590,7 @@ impl DataModelExt for PaymentAttemptUpdate {
                 updated_by,
                 unified_code,
                 unified_message,
+                connector_transaction_id,
             } => Self::ErrorUpdate {
                 connector,
                 status,
@@ -1600,6 +1603,7 @@ impl DataModelExt for PaymentAttemptUpdate {
                 tax_amount,
                 unified_code,
                 unified_message,
+                connector_transaction_id,
             },
             DieselPaymentAttemptUpdate::CaptureUpdate {
                 amount_to_capture,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
add `connector_transaction_id` in error_response from connector flows
have added the `support` for stripe connector


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
**Tested Manually**
Failed card payment with stripe connector (4000000000006975), to see error_code, error_message and connector_transaction_id being non null values in payments response
![image](https://github.com/juspay/hyperswitch/assets/56996463/fe81e3ac-368f-4e02-aace-378f847f9b39)

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
