### PR TITLE
fix(core): Error propagation for not supporting partial refund

### DIFF
--- a/crates/router/src/connector/prophetpay/transformers.rs
+++ b/crates/router/src/connector/prophetpay/transformers.rs
@@ -580,10 +580,7 @@ impl<F> TryFrom<&ProphetpayRouterData<&types::RefundsRouterData<F>>> for Prophet
                 action_type: ProphetpayActionType::get_action_type(&ProphetpayActionType::Refund),
             })
         } else {
-            Err(errors::ConnectorError::NotImplemented(
-                "Partial Refund".to_string(),
-            )
-            .into())
+            Err(errors::ConnectorError::NotImplemented("Partial Refund".to_string()).into())
         }
     }
 }

--- a/crates/router/src/connector/prophetpay/transformers.rs
+++ b/crates/router/src/connector/prophetpay/transformers.rs
@@ -581,7 +581,7 @@ impl<F> TryFrom<&ProphetpayRouterData<&types::RefundsRouterData<F>>> for Prophet
             })
         } else {
             Err(errors::ConnectorError::NotImplemented(
-                "Partial Refund is Not Supported".to_string(),
+                "Partial Refund".to_string(),
             )
             .into())
         }

--- a/crates/router/src/core/errors/utils.rs
+++ b/crates/router/src/core/errors/utils.rs
@@ -1,5 +1,4 @@
 use common_utils::errors::CustomResult;
-
 use crate::{core::errors, logger};
 
 pub trait StorageErrorExt<T, E> {
@@ -137,10 +136,10 @@ pub trait ConnectorErrorExt<T> {
 impl<T> ConnectorErrorExt<T> for error_stack::Result<T, errors::ConnectorError> {
     fn to_refund_failed_response(self) -> error_stack::Result<T, errors::ApiErrorResponse> {
         self.map_err(|err| {
-            let data = match err.current_context() {
+            match err.current_context() {
                 errors::ConnectorError::ProcessingStepFailed(Some(bytes)) => {
                     let response_str = std::str::from_utf8(bytes);
-                    match response_str {
+                    let data = match response_str {
                         Ok(s) => serde_json::from_str(s)
                             .map_err(
                                 |error| logger::error!(%error,"Failed to convert response to JSON"),
@@ -150,11 +149,68 @@ impl<T> ConnectorErrorExt<T> for error_stack::Result<T, errors::ConnectorError> 
                             logger::error!(%error,"Failed to convert response to UTF8 string");
                             None
                         }
-                    }
+                    };
+                    err.change_context(errors::ApiErrorResponse::RefundFailed { data })
                 }
-                _ => None,
-            };
-            err.change_context(errors::ApiErrorResponse::RefundFailed { data })
+                errors::ConnectorError::NotImplemented(reason) => {
+                    errors::ApiErrorResponse::NotImplemented {
+                        message: errors::api_error_response::NotImplementedMessage::Reason(
+                            reason.to_string(),
+                        ),
+                    }.into()
+                }
+                errors::ConnectorError::FailedToObtainIntegrationUrl
+                | errors::ConnectorError::RequestEncodingFailed
+                | errors::ConnectorError::RequestEncodingFailedWithReason(_)
+                | errors::ConnectorError::ParsingFailed
+                | errors::ConnectorError::ResponseDeserializationFailed
+                | errors::ConnectorError::UnexpectedResponseError(_)
+                | errors::ConnectorError::RoutingRulesParsingError
+                | errors::ConnectorError::FailedToObtainPreferredConnector
+                | errors::ConnectorError::ProcessingStepFailed(_)
+                | errors::ConnectorError::InvalidConnectorName
+                | errors::ConnectorError::InvalidWallet
+                | errors::ConnectorError::ResponseHandlingFailed
+                | errors::ConnectorError::MissingRequiredField { .. }
+                | errors::ConnectorError::MissingRequiredFields { .. }
+                | errors::ConnectorError::FailedToObtainAuthType
+                | errors::ConnectorError::FailedToObtainCertificate
+                | errors::ConnectorError::NoConnectorMetaData
+                | errors::ConnectorError::FailedToObtainCertificateKey
+                | errors::ConnectorError::NotSupported { .. }
+                | errors::ConnectorError::FlowNotSupported { .. }
+                | errors::ConnectorError::CaptureMethodNotSupported
+                | errors::ConnectorError::MissingConnectorMandateID
+                | errors::ConnectorError::MissingConnectorTransactionID
+                | errors::ConnectorError::MissingConnectorRefundID
+                | errors::ConnectorError::MissingApplePayTokenData
+                | errors::ConnectorError::WebhooksNotImplemented
+                | errors::ConnectorError::WebhookBodyDecodingFailed
+                | errors::ConnectorError::WebhookSignatureNotFound
+                | errors::ConnectorError::WebhookSourceVerificationFailed
+                | errors::ConnectorError::WebhookVerificationSecretNotFound
+                | errors::ConnectorError::WebhookVerificationSecretInvalid
+                | errors::ConnectorError::WebhookReferenceIdNotFound
+                | errors::ConnectorError::WebhookEventTypeNotFound
+                | errors::ConnectorError::WebhookResourceObjectNotFound
+                | errors::ConnectorError::WebhookResponseEncodingFailed
+                | errors::ConnectorError::InvalidDateFormat
+                | errors::ConnectorError::DateFormattingFailed
+                | errors::ConnectorError::InvalidDataFormat { .. }
+                | errors::ConnectorError::MismatchedPaymentData
+                | errors::ConnectorError::InvalidWalletToken
+                | errors::ConnectorError::MissingConnectorRelatedTransactionID { .. }
+                | errors::ConnectorError::FileValidationFailed { .. }
+                | errors::ConnectorError::MissingConnectorRedirectionPayload { .. }
+                | errors::ConnectorError::FailedAtConnector { .. }
+                | errors::ConnectorError::MissingPaymentMethodType
+                | errors::ConnectorError::InSufficientBalanceInPaymentMethod
+                | errors::ConnectorError::RequestTimeoutReceived
+                | errors::ConnectorError::CurrencyNotSupported { .. }
+                | errors::ConnectorError::InvalidConnectorConfig { .. } => {
+                    err.change_context(errors::ApiErrorResponse::RefundFailed { data: None })
+                }
+            }
         })
     }
 

--- a/crates/router/src/core/errors/utils.rs
+++ b/crates/router/src/core/errors/utils.rs
@@ -1,4 +1,5 @@
 use common_utils::errors::CustomResult;
+
 use crate::{core::errors, logger};
 
 pub trait StorageErrorExt<T, E> {
@@ -135,81 +136,80 @@ pub trait ConnectorErrorExt<T> {
 
 impl<T> ConnectorErrorExt<T> for error_stack::Result<T, errors::ConnectorError> {
     fn to_refund_failed_response(self) -> error_stack::Result<T, errors::ApiErrorResponse> {
-        self.map_err(|err| {
-            match err.current_context() {
-                errors::ConnectorError::ProcessingStepFailed(Some(bytes)) => {
-                    let response_str = std::str::from_utf8(bytes);
-                    let data = match response_str {
-                        Ok(s) => serde_json::from_str(s)
-                            .map_err(
-                                |error| logger::error!(%error,"Failed to convert response to JSON"),
-                            )
-                            .ok(),
-                        Err(error) => {
-                            logger::error!(%error,"Failed to convert response to UTF8 string");
-                            None
-                        }
-                    };
-                    err.change_context(errors::ApiErrorResponse::RefundFailed { data })
+        self.map_err(|err| match err.current_context() {
+            errors::ConnectorError::ProcessingStepFailed(Some(bytes)) => {
+                let response_str = std::str::from_utf8(bytes);
+                let data = match response_str {
+                    Ok(s) => serde_json::from_str(s)
+                        .map_err(
+                            |error| logger::error!(%error,"Failed to convert response to JSON"),
+                        )
+                        .ok(),
+                    Err(error) => {
+                        logger::error!(%error,"Failed to convert response to UTF8 string");
+                        None
+                    }
+                };
+                err.change_context(errors::ApiErrorResponse::RefundFailed { data })
+            }
+            errors::ConnectorError::NotImplemented(reason) => {
+                errors::ApiErrorResponse::NotImplemented {
+                    message: errors::api_error_response::NotImplementedMessage::Reason(
+                        reason.to_string(),
+                    ),
                 }
-                errors::ConnectorError::NotImplemented(reason) => {
-                    errors::ApiErrorResponse::NotImplemented {
-                        message: errors::api_error_response::NotImplementedMessage::Reason(
-                            reason.to_string(),
-                        ),
-                    }.into()
-                }
-                errors::ConnectorError::FailedToObtainIntegrationUrl
-                | errors::ConnectorError::RequestEncodingFailed
-                | errors::ConnectorError::RequestEncodingFailedWithReason(_)
-                | errors::ConnectorError::ParsingFailed
-                | errors::ConnectorError::ResponseDeserializationFailed
-                | errors::ConnectorError::UnexpectedResponseError(_)
-                | errors::ConnectorError::RoutingRulesParsingError
-                | errors::ConnectorError::FailedToObtainPreferredConnector
-                | errors::ConnectorError::ProcessingStepFailed(_)
-                | errors::ConnectorError::InvalidConnectorName
-                | errors::ConnectorError::InvalidWallet
-                | errors::ConnectorError::ResponseHandlingFailed
-                | errors::ConnectorError::MissingRequiredField { .. }
-                | errors::ConnectorError::MissingRequiredFields { .. }
-                | errors::ConnectorError::FailedToObtainAuthType
-                | errors::ConnectorError::FailedToObtainCertificate
-                | errors::ConnectorError::NoConnectorMetaData
-                | errors::ConnectorError::FailedToObtainCertificateKey
-                | errors::ConnectorError::NotSupported { .. }
-                | errors::ConnectorError::FlowNotSupported { .. }
-                | errors::ConnectorError::CaptureMethodNotSupported
-                | errors::ConnectorError::MissingConnectorMandateID
-                | errors::ConnectorError::MissingConnectorTransactionID
-                | errors::ConnectorError::MissingConnectorRefundID
-                | errors::ConnectorError::MissingApplePayTokenData
-                | errors::ConnectorError::WebhooksNotImplemented
-                | errors::ConnectorError::WebhookBodyDecodingFailed
-                | errors::ConnectorError::WebhookSignatureNotFound
-                | errors::ConnectorError::WebhookSourceVerificationFailed
-                | errors::ConnectorError::WebhookVerificationSecretNotFound
-                | errors::ConnectorError::WebhookVerificationSecretInvalid
-                | errors::ConnectorError::WebhookReferenceIdNotFound
-                | errors::ConnectorError::WebhookEventTypeNotFound
-                | errors::ConnectorError::WebhookResourceObjectNotFound
-                | errors::ConnectorError::WebhookResponseEncodingFailed
-                | errors::ConnectorError::InvalidDateFormat
-                | errors::ConnectorError::DateFormattingFailed
-                | errors::ConnectorError::InvalidDataFormat { .. }
-                | errors::ConnectorError::MismatchedPaymentData
-                | errors::ConnectorError::InvalidWalletToken
-                | errors::ConnectorError::MissingConnectorRelatedTransactionID { .. }
-                | errors::ConnectorError::FileValidationFailed { .. }
-                | errors::ConnectorError::MissingConnectorRedirectionPayload { .. }
-                | errors::ConnectorError::FailedAtConnector { .. }
-                | errors::ConnectorError::MissingPaymentMethodType
-                | errors::ConnectorError::InSufficientBalanceInPaymentMethod
-                | errors::ConnectorError::RequestTimeoutReceived
-                | errors::ConnectorError::CurrencyNotSupported { .. }
-                | errors::ConnectorError::InvalidConnectorConfig { .. } => {
-                    err.change_context(errors::ApiErrorResponse::RefundFailed { data: None })
-                }
+                .into()
+            }
+            errors::ConnectorError::FailedToObtainIntegrationUrl
+            | errors::ConnectorError::RequestEncodingFailed
+            | errors::ConnectorError::RequestEncodingFailedWithReason(_)
+            | errors::ConnectorError::ParsingFailed
+            | errors::ConnectorError::ResponseDeserializationFailed
+            | errors::ConnectorError::UnexpectedResponseError(_)
+            | errors::ConnectorError::RoutingRulesParsingError
+            | errors::ConnectorError::FailedToObtainPreferredConnector
+            | errors::ConnectorError::ProcessingStepFailed(_)
+            | errors::ConnectorError::InvalidConnectorName
+            | errors::ConnectorError::InvalidWallet
+            | errors::ConnectorError::ResponseHandlingFailed
+            | errors::ConnectorError::MissingRequiredField { .. }
+            | errors::ConnectorError::MissingRequiredFields { .. }
+            | errors::ConnectorError::FailedToObtainAuthType
+            | errors::ConnectorError::FailedToObtainCertificate
+            | errors::ConnectorError::NoConnectorMetaData
+            | errors::ConnectorError::FailedToObtainCertificateKey
+            | errors::ConnectorError::NotSupported { .. }
+            | errors::ConnectorError::FlowNotSupported { .. }
+            | errors::ConnectorError::CaptureMethodNotSupported
+            | errors::ConnectorError::MissingConnectorMandateID
+            | errors::ConnectorError::MissingConnectorTransactionID
+            | errors::ConnectorError::MissingConnectorRefundID
+            | errors::ConnectorError::MissingApplePayTokenData
+            | errors::ConnectorError::WebhooksNotImplemented
+            | errors::ConnectorError::WebhookBodyDecodingFailed
+            | errors::ConnectorError::WebhookSignatureNotFound
+            | errors::ConnectorError::WebhookSourceVerificationFailed
+            | errors::ConnectorError::WebhookVerificationSecretNotFound
+            | errors::ConnectorError::WebhookVerificationSecretInvalid
+            | errors::ConnectorError::WebhookReferenceIdNotFound
+            | errors::ConnectorError::WebhookEventTypeNotFound
+            | errors::ConnectorError::WebhookResourceObjectNotFound
+            | errors::ConnectorError::WebhookResponseEncodingFailed
+            | errors::ConnectorError::InvalidDateFormat
+            | errors::ConnectorError::DateFormattingFailed
+            | errors::ConnectorError::InvalidDataFormat { .. }
+            | errors::ConnectorError::MismatchedPaymentData
+            | errors::ConnectorError::InvalidWalletToken
+            | errors::ConnectorError::MissingConnectorRelatedTransactionID { .. }
+            | errors::ConnectorError::FileValidationFailed { .. }
+            | errors::ConnectorError::MissingConnectorRedirectionPayload { .. }
+            | errors::ConnectorError::FailedAtConnector { .. }
+            | errors::ConnectorError::MissingPaymentMethodType
+            | errors::ConnectorError::InSufficientBalanceInPaymentMethod
+            | errors::ConnectorError::RequestTimeoutReceived
+            | errors::ConnectorError::CurrencyNotSupported { .. }
+            | errors::ConnectorError::InvalidConnectorConfig { .. } => {
+                err.change_context(errors::ApiErrorResponse::RefundFailed { data: None })
             }
         })
     }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
In case of refund, error was not being propagated specially for "not implemented error"
### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

- Create a payment through Prophetpay
- Create a refund partial to the amount of the payment
- Should throw the given error
<img width="1728" alt="Screenshot 2023-11-24 at 4 34 38 PM" src="https://github.com/juspay/hyperswitch/assets/73734619/00d895c3-3bbc-441a-825d-a8c27f1010ad">


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
