### PR TITLE
fix: add prefix to connector_transaction_id

### DIFF
--- a/crates/storage_impl/src/payments/payment_attempt.rs
+++ b/crates/storage_impl/src/payments/payment_attempt.rs
@@ -553,7 +553,7 @@ impl<T: DatabaseStore> PaymentAttemptInterface for KVRouterStore<T> {
             }
             MerchantStorageScheme::RedisKv => {
                 // We assume that PaymentAttempt <=> PaymentIntent is a one-to-one relation for now
-                let lookup_id = format!("{merchant_id}_{connector_transaction_id}");
+                let lookup_id = format!("conn_trans_{merchant_id}_{connector_transaction_id}");
                 let lookup = self
                     .get_lookup_by_lookup_id(&lookup_id, storage_scheme)
                     .await?;
@@ -774,7 +774,7 @@ impl<T: DatabaseStore> PaymentAttemptInterface for KVRouterStore<T> {
                     .await
             }
             MerchantStorageScheme::RedisKv => {
-                let lookup_id = format!("{merchant_id}_{preprocessing_id}");
+                let lookup_id = format!("preprocessing_{merchant_id}_{preprocessing_id}");
                 let lookup = self
                     .get_lookup_by_lookup_id(&lookup_id, storage_scheme)
                     .await?;
@@ -1679,7 +1679,7 @@ async fn add_connector_txn_id_to_reverse_lookup<T: DatabaseStore>(
 ) -> CustomResult<ReverseLookup, errors::StorageError> {
     let field = format!("pa_{}", updated_attempt_attempt_id);
     let reverse_lookup_new = ReverseLookupNew {
-        lookup_id: format!("{}_{}", merchant_id, connector_transaction_id),
+        lookup_id: format!("conn_trans_{}_{}", merchant_id, connector_transaction_id),
         pk_id: key.to_owned(),
         sk_id: field.clone(),
         source: "payment_attempt".to_string(),
@@ -1701,7 +1701,7 @@ async fn add_preprocessing_id_to_reverse_lookup<T: DatabaseStore>(
 ) -> CustomResult<ReverseLookup, errors::StorageError> {
     let field = format!("pa_{}", updated_attempt_attempt_id);
     let reverse_lookup_new = ReverseLookupNew {
-        lookup_id: format!("{}_{}", merchant_id, preprocessing_id),
+        lookup_id: format!("preprocessing_{}_{}", merchant_id, preprocessing_id),
         pk_id: key.to_owned(),
         sk_id: field.clone(),
         source: "payment_attempt".to_string(),


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->
- [x] Bugfix

## Description
<!-- Describe your changes in detail -->
This adds prefix to `connector_transaction_id` and `preprocessing_id` while inserting to reverse lookup.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
For some connectors like `cashtocode` the `connector_transaction_id` is same as `payment_attempt_id` it causes duplication in reverse lookup. So add a prefix to the `connector_transaction_id` to fix it.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
- Payments with CashtoCode
```
curl --location 'http://localhost:8080/payments' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: dev_RBXd1eGsgx19XwbcRPyr3xxHlnhrIBfPBE9VhsZrbvmQhfVWgNzER0Kp2gl4NhBW' \
--data-raw '{
    "payment_id":"pay_1700832163",
    "amount": 1000,
    "currency": "EUR",
    "confirm": true,
    "customer_id": "e064f3fe-a027-458a-a373-09eb38122b67",
    "capture_method": "manual",
    "capture_on": "2022-09-10T10:11:12Z",
    "amount_to_capture": 1000,
    "email": "guest@example.com",
    "name": "John Doe",
    "phone": "999999999",
    "phone_country_code": "+65",
    "description": "Its my first payment request",
    "authentication_type": "no_three_ds",
    "return_url": "https://google.com",
    "payment_method": "reward",
    "payment_method_type": "classic",
    "payment_method_data": "reward",
    "billing": {
        "address": {
            "city": "北九州市",
            "country": "JP",
            "line1": "福岡県",
            "line2": null,
            "line3": null,
            "zip": "８０００２０１",
            "state": null,
            "first_name": "SHIHO",
            "last_name": "YAMAGUCHI"
        },
        "phone": {
            "number": "8056594427",
            "country_code": "+91"
        }
    },
    "shipping": {
        "address": {
            "city": "北九州市",
            "country": "JP",
            "line1": "福岡県",
            "line2": null,
            "line3": null,
            "zip": "８０００２０１",
            "state": null,
            "first_name": "SHIHO",
            "last_name": "YAMAGUCHI"
        },
        "phone": {
            "number": "8056594427",
            "country_code": "+91"
        }
    },
    "statement_descriptor_name": "joseph",
    "statement_descriptor_suffix": "JS",
    "metadata": {
        "udf1": "value1",
        "new_customer": "true",
        "login_date": "2019-09-10T10:11:12Z"
    }
}'
```
<img width="1310" alt="Screenshot 2023-11-24 at 6 55 23 PM" src="https://github.com/juspay/hyperswitch/assets/43412619/bba685b9-4478-4c6f-804d-f7402857cd96">

- Test webhooks with a connector

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code