### PR TITLE
feat(payment_methods): receive `card_holder_name` in confirm flow when using token for payment

### DIFF
--- a/crates/api_models/src/payments.rs
+++ b/crates/api_models/src/payments.rs
@@ -719,8 +719,10 @@ pub struct Card {
 
 #[derive(Eq, PartialEq, Debug, serde::Deserialize, serde::Serialize, Clone, ToSchema)]
 #[serde(rename_all = "snake_case")]
-pub struct CardTokenData {
-    pub card_holder_name: Option<String>,
+pub struct CardToken {
+    /// The card holder's name
+    #[schema(value_type = String, example = "John Test")]
+    pub card_holder_name: Option<Secret<String>>,
 }
 
 #[derive(Eq, PartialEq, Clone, Debug, serde::Deserialize, serde::Serialize, ToSchema)]
@@ -852,7 +854,7 @@ pub enum PaymentMethodData {
     Upi(UpiData),
     Voucher(VoucherData),
     GiftCard(Box<GiftCardData>),
-    CardTokenData(CardTokenData),
+    CardToken(CardToken),
 }
 
 impl PaymentMethodData {
@@ -881,7 +883,7 @@ impl PaymentMethodData {
             | Self::Upi(_)
             | Self::Voucher(_)
             | Self::GiftCard(_)
-            | Self::CardTokenData(_) => None,
+            | Self::CardToken(_) => None,
         }
     }
 }
@@ -1100,7 +1102,7 @@ pub enum AdditionalPaymentData {
     GiftCard {},
     Voucher {},
     CardRedirect {},
-    CardTokenData {},
+    CardToken {},
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, serde::Deserialize, serde::Serialize, ToSchema)]
@@ -1669,7 +1671,7 @@ pub enum PaymentMethodDataResponse {
     Voucher,
     GiftCard,
     CardRedirect,
-    CardTokenData,
+    CardToken,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize, ToSchema)]
@@ -2465,7 +2467,7 @@ impl From<AdditionalPaymentData> for PaymentMethodDataResponse {
             AdditionalPaymentData::Voucher {} => Self::Voucher,
             AdditionalPaymentData::GiftCard {} => Self::GiftCard,
             AdditionalPaymentData::CardRedirect {} => Self::CardRedirect,
-            AdditionalPaymentData::CardTokenData {} => Self::CardTokenData,
+            AdditionalPaymentData::CardToken {} => Self::CardToken,
         }
     }
 }

--- a/crates/api_models/src/payments.rs
+++ b/crates/api_models/src/payments.rs
@@ -717,6 +717,12 @@ pub struct Card {
     pub nick_name: Option<Secret<String>>,
 }
 
+#[derive(Eq, PartialEq, Debug, serde::Deserialize, serde::Serialize, Clone, ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub struct CardTokenData {
+    pub card_holder_name: Option<String>,
+}
+
 #[derive(Eq, PartialEq, Clone, Debug, serde::Deserialize, serde::Serialize, ToSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum CardRedirectData {
@@ -846,6 +852,7 @@ pub enum PaymentMethodData {
     Upi(UpiData),
     Voucher(VoucherData),
     GiftCard(Box<GiftCardData>),
+    CardTokenData(CardTokenData),
 }
 
 impl PaymentMethodData {
@@ -873,7 +880,8 @@ impl PaymentMethodData {
             | Self::Reward
             | Self::Upi(_)
             | Self::Voucher(_)
-            | Self::GiftCard(_) => None,
+            | Self::GiftCard(_)
+            | Self::CardTokenData(_) => None,
         }
     }
 }
@@ -1092,6 +1100,7 @@ pub enum AdditionalPaymentData {
     GiftCard {},
     Voucher {},
     CardRedirect {},
+    CardTokenData {},
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, serde::Deserialize, serde::Serialize, ToSchema)]
@@ -1660,6 +1669,7 @@ pub enum PaymentMethodDataResponse {
     Voucher,
     GiftCard,
     CardRedirect,
+    CardTokenData,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize, ToSchema)]
@@ -2455,6 +2465,7 @@ impl From<AdditionalPaymentData> for PaymentMethodDataResponse {
             AdditionalPaymentData::Voucher {} => Self::Voucher,
             AdditionalPaymentData::GiftCard {} => Self::GiftCard,
             AdditionalPaymentData::CardRedirect {} => Self::CardRedirect,
+            AdditionalPaymentData::CardTokenData {} => Self::CardTokenData,
         }
     }
 }

--- a/crates/router/src/connector/aci/transformers.rs
+++ b/crates/router/src/connector/aci/transformers.rs
@@ -410,12 +410,10 @@ impl TryFrom<&AciRouterData<&types::PaymentsAuthorizeRouterData>> for AciPayment
             | api::PaymentMethodData::CardRedirect(_)
             | api::PaymentMethodData::Upi(_)
             | api::PaymentMethodData::Voucher(_)
-            | api::PaymentMethodData::CardTokenData(_) => {
-                Err(errors::ConnectorError::NotSupported {
-                    message: format!("{:?}", item.router_data.payment_method),
-                    connector: "Aci",
-                })?
-            }
+            | api::PaymentMethodData::CardToken(_) => Err(errors::ConnectorError::NotSupported {
+                message: format!("{:?}", item.router_data.payment_method),
+                connector: "Aci",
+            })?,
         }
     }
 }

--- a/crates/router/src/connector/aci/transformers.rs
+++ b/crates/router/src/connector/aci/transformers.rs
@@ -409,10 +409,13 @@ impl TryFrom<&AciRouterData<&types::PaymentsAuthorizeRouterData>> for AciPayment
             | api::PaymentMethodData::GiftCard(_)
             | api::PaymentMethodData::CardRedirect(_)
             | api::PaymentMethodData::Upi(_)
-            | api::PaymentMethodData::Voucher(_) => Err(errors::ConnectorError::NotSupported {
-                message: format!("{:?}", item.router_data.payment_method),
-                connector: "Aci",
-            })?,
+            | api::PaymentMethodData::Voucher(_)
+            | api::PaymentMethodData::CardTokenData(_) => {
+                Err(errors::ConnectorError::NotSupported {
+                    message: format!("{:?}", item.router_data.payment_method),
+                    connector: "Aci",
+                })?
+            }
         }
     }
 }

--- a/crates/router/src/connector/adyen/transformers.rs
+++ b/crates/router/src/connector/adyen/transformers.rs
@@ -1380,7 +1380,8 @@ impl<'a> TryFrom<&AdyenRouterData<&types::PaymentsAuthorizeRouterData>>
                 payments::PaymentMethodData::Crypto(_)
                 | payments::PaymentMethodData::MandatePayment
                 | payments::PaymentMethodData::Reward
-                | payments::PaymentMethodData::Upi(_) => {
+                | payments::PaymentMethodData::Upi(_)
+                | payments::PaymentMethodData::CardTokenData(_) => {
                     Err(errors::ConnectorError::NotSupported {
                         message: utils::SELECTED_PAYMENT_METHOD.to_string(),
                         connector: "Adyen",
@@ -2276,7 +2277,8 @@ impl<'a>
                     | payments::PaymentMethodData::Reward
                     | payments::PaymentMethodData::Upi(_)
                     | payments::PaymentMethodData::Voucher(_)
-                    | payments::PaymentMethodData::GiftCard(_) => {
+                    | payments::PaymentMethodData::GiftCard(_)
+                    | api::PaymentMethodData::CardTokenData(_) => {
                         Err(errors::ConnectorError::NotSupported {
                             message: "Network tokenization for payment method".to_string(),
                             connector: "Adyen",

--- a/crates/router/src/connector/adyen/transformers.rs
+++ b/crates/router/src/connector/adyen/transformers.rs
@@ -1381,7 +1381,7 @@ impl<'a> TryFrom<&AdyenRouterData<&types::PaymentsAuthorizeRouterData>>
                 | payments::PaymentMethodData::MandatePayment
                 | payments::PaymentMethodData::Reward
                 | payments::PaymentMethodData::Upi(_)
-                | payments::PaymentMethodData::CardTokenData(_) => {
+                | payments::PaymentMethodData::CardToken(_) => {
                     Err(errors::ConnectorError::NotSupported {
                         message: utils::SELECTED_PAYMENT_METHOD.to_string(),
                         connector: "Adyen",
@@ -2278,7 +2278,7 @@ impl<'a>
                     | payments::PaymentMethodData::Upi(_)
                     | payments::PaymentMethodData::Voucher(_)
                     | payments::PaymentMethodData::GiftCard(_)
-                    | api::PaymentMethodData::CardTokenData(_) => {
+                    | api::PaymentMethodData::CardToken(_) => {
                         Err(errors::ConnectorError::NotSupported {
                             message: "Network tokenization for payment method".to_string(),
                             connector: "Adyen",

--- a/crates/router/src/connector/airwallex/transformers.rs
+++ b/crates/router/src/connector/airwallex/transformers.rs
@@ -196,9 +196,12 @@ impl TryFrom<&AirwallexRouterData<&types::PaymentsAuthorizeRouterData>>
             | api::PaymentMethodData::Reward
             | api::PaymentMethodData::Upi(_)
             | api::PaymentMethodData::Voucher(_)
-            | api::PaymentMethodData::GiftCard(_) => Err(errors::ConnectorError::NotImplemented(
-                utils::get_unimplemented_payment_method_error_message("airwallex"),
-            )),
+            | api::PaymentMethodData::GiftCard(_)
+            | api::PaymentMethodData::CardTokenData(_) => {
+                Err(errors::ConnectorError::NotImplemented(
+                    utils::get_unimplemented_payment_method_error_message("airwallex"),
+                ))
+            }
         }?;
 
         Ok(Self {

--- a/crates/router/src/connector/airwallex/transformers.rs
+++ b/crates/router/src/connector/airwallex/transformers.rs
@@ -197,11 +197,9 @@ impl TryFrom<&AirwallexRouterData<&types::PaymentsAuthorizeRouterData>>
             | api::PaymentMethodData::Upi(_)
             | api::PaymentMethodData::Voucher(_)
             | api::PaymentMethodData::GiftCard(_)
-            | api::PaymentMethodData::CardTokenData(_) => {
-                Err(errors::ConnectorError::NotImplemented(
-                    utils::get_unimplemented_payment_method_error_message("airwallex"),
-                ))
-            }
+            | api::PaymentMethodData::CardToken(_) => Err(errors::ConnectorError::NotImplemented(
+                utils::get_unimplemented_payment_method_error_message("airwallex"),
+            )),
         }?;
 
         Ok(Self {

--- a/crates/router/src/connector/bankofamerica/transformers.rs
+++ b/crates/router/src/connector/bankofamerica/transformers.rs
@@ -411,7 +411,7 @@ impl TryFrom<&BankOfAmericaRouterData<&types::PaymentsAuthorizeRouterData>>
             | payments::PaymentMethodData::Upi(_)
             | payments::PaymentMethodData::Voucher(_)
             | payments::PaymentMethodData::GiftCard(_)
-            | payments::PaymentMethodData::CardTokenData(_) => {
+            | payments::PaymentMethodData::CardToken(_) => {
                 Err(errors::ConnectorError::NotImplemented(
                     utils::get_unimplemented_payment_method_error_message("Bank of America"),
                 )

--- a/crates/router/src/connector/bankofamerica/transformers.rs
+++ b/crates/router/src/connector/bankofamerica/transformers.rs
@@ -410,7 +410,8 @@ impl TryFrom<&BankOfAmericaRouterData<&types::PaymentsAuthorizeRouterData>>
             | payments::PaymentMethodData::Reward
             | payments::PaymentMethodData::Upi(_)
             | payments::PaymentMethodData::Voucher(_)
-            | payments::PaymentMethodData::GiftCard(_) => {
+            | payments::PaymentMethodData::GiftCard(_)
+            | payments::PaymentMethodData::CardTokenData(_) => {
                 Err(errors::ConnectorError::NotImplemented(
                     utils::get_unimplemented_payment_method_error_message("Bank of America"),
                 )

--- a/crates/router/src/connector/bluesnap/transformers.rs
+++ b/crates/router/src/connector/bluesnap/transformers.rs
@@ -221,7 +221,8 @@ impl TryFrom<&BluesnapRouterData<&types::PaymentsAuthorizeRouterData>>
             | payments::PaymentMethodData::Upi(_)
             | payments::PaymentMethodData::CardRedirect(_)
             | payments::PaymentMethodData::Voucher(_)
-            | payments::PaymentMethodData::GiftCard(_) => {
+            | payments::PaymentMethodData::GiftCard(_)
+            | payments::PaymentMethodData::CardTokenData(_) => {
                 Err(errors::ConnectorError::NotImplemented(
                     "Selected payment method via Token flow through bluesnap".to_string(),
                 ))
@@ -388,7 +389,8 @@ impl TryFrom<&BluesnapRouterData<&types::PaymentsAuthorizeRouterData>> for Blues
                 | payments::PaymentMethodData::Upi(_)
                 | payments::PaymentMethodData::CardRedirect(_)
                 | payments::PaymentMethodData::Voucher(_)
-                | payments::PaymentMethodData::GiftCard(_) => {
+                | payments::PaymentMethodData::GiftCard(_)
+                | api::PaymentMethodData::CardTokenData(_) => {
                     Err(errors::ConnectorError::NotImplemented(
                         utils::get_unimplemented_payment_method_error_message("bluesnap"),
                     ))

--- a/crates/router/src/connector/bluesnap/transformers.rs
+++ b/crates/router/src/connector/bluesnap/transformers.rs
@@ -222,7 +222,7 @@ impl TryFrom<&BluesnapRouterData<&types::PaymentsAuthorizeRouterData>>
             | payments::PaymentMethodData::CardRedirect(_)
             | payments::PaymentMethodData::Voucher(_)
             | payments::PaymentMethodData::GiftCard(_)
-            | payments::PaymentMethodData::CardTokenData(_) => {
+            | payments::PaymentMethodData::CardToken(_) => {
                 Err(errors::ConnectorError::NotImplemented(
                     "Selected payment method via Token flow through bluesnap".to_string(),
                 ))
@@ -241,161 +241,160 @@ impl TryFrom<&BluesnapRouterData<&types::PaymentsAuthorizeRouterData>> for Blues
             Some(enums::CaptureMethod::Manual) => BluesnapTxnType::AuthOnly,
             _ => BluesnapTxnType::AuthCapture,
         };
-        let (payment_method, card_holder_info) =
-            match item.router_data.request.payment_method_data.clone() {
-                api::PaymentMethodData::Card(ref ccard) => Ok((
-                    PaymentMethodDetails::CreditCard(Card {
-                        card_number: ccard.card_number.clone(),
-                        expiration_month: ccard.card_exp_month.clone(),
-                        expiration_year: ccard.get_expiry_year_4_digit(),
-                        security_code: ccard.card_cvc.clone(),
-                    }),
-                    get_card_holder_info(
-                        item.router_data.get_billing_address()?,
-                        item.router_data.request.get_email()?,
-                    )?,
-                )),
-                api::PaymentMethodData::Wallet(wallet_data) => match wallet_data {
-                    api_models::payments::WalletData::GooglePay(payment_method_data) => {
-                        let gpay_object =
-                            Encode::<BluesnapGooglePayObject>::encode_to_string_of_json(
-                                &BluesnapGooglePayObject {
-                                    payment_method_data: utils::GooglePayWalletData::from(
-                                        payment_method_data,
-                                    ),
-                                },
-                            )
-                            .change_context(errors::ConnectorError::RequestEncodingFailed)?;
-                        Ok((
-                            PaymentMethodDetails::Wallet(BluesnapWallet {
-                                wallet_type: BluesnapWalletTypes::GooglePay,
-                                encoded_payment_token: Secret::new(
-                                    consts::BASE64_ENGINE.encode(gpay_object),
-                                ),
-                            }),
-                            None,
-                        ))
+        let (payment_method, card_holder_info) = match item
+            .router_data
+            .request
+            .payment_method_data
+            .clone()
+        {
+            api::PaymentMethodData::Card(ref ccard) => Ok((
+                PaymentMethodDetails::CreditCard(Card {
+                    card_number: ccard.card_number.clone(),
+                    expiration_month: ccard.card_exp_month.clone(),
+                    expiration_year: ccard.get_expiry_year_4_digit(),
+                    security_code: ccard.card_cvc.clone(),
+                }),
+                get_card_holder_info(
+                    item.router_data.get_billing_address()?,
+                    item.router_data.request.get_email()?,
+                )?,
+            )),
+            api::PaymentMethodData::Wallet(wallet_data) => match wallet_data {
+                api_models::payments::WalletData::GooglePay(payment_method_data) => {
+                    let gpay_object = Encode::<BluesnapGooglePayObject>::encode_to_string_of_json(
+                        &BluesnapGooglePayObject {
+                            payment_method_data: utils::GooglePayWalletData::from(
+                                payment_method_data,
+                            ),
+                        },
+                    )
+                    .change_context(errors::ConnectorError::RequestEncodingFailed)?;
+                    Ok((
+                        PaymentMethodDetails::Wallet(BluesnapWallet {
+                            wallet_type: BluesnapWalletTypes::GooglePay,
+                            encoded_payment_token: Secret::new(
+                                consts::BASE64_ENGINE.encode(gpay_object),
+                            ),
+                        }),
+                        None,
+                    ))
+                }
+                api_models::payments::WalletData::ApplePay(payment_method_data) => {
+                    let apple_pay_payment_data = payment_method_data
+                        .get_applepay_decoded_payment_data()
+                        .change_context(errors::ConnectorError::RequestEncodingFailed)?;
+                    let apple_pay_payment_data: ApplePayEncodedPaymentData = apple_pay_payment_data
+                        .expose()[..]
+                        .as_bytes()
+                        .parse_struct("ApplePayEncodedPaymentData")
+                        .change_context(errors::ConnectorError::RequestEncodingFailed)?;
+
+                    let billing = item
+                        .router_data
+                        .address
+                        .billing
+                        .to_owned()
+                        .get_required_value("billing")
+                        .change_context(errors::ConnectorError::MissingRequiredField {
+                            field_name: "billing",
+                        })?;
+
+                    let billing_address = billing
+                        .address
+                        .get_required_value("billing_address")
+                        .change_context(errors::ConnectorError::MissingRequiredField {
+                            field_name: "billing",
+                        })?;
+
+                    let mut address = Vec::new();
+                    if let Some(add) = billing_address.line1.to_owned() {
+                        address.push(add)
                     }
-                    api_models::payments::WalletData::ApplePay(payment_method_data) => {
-                        let apple_pay_payment_data = payment_method_data
-                            .get_applepay_decoded_payment_data()
-                            .change_context(errors::ConnectorError::RequestEncodingFailed)?;
-                        let apple_pay_payment_data: ApplePayEncodedPaymentData =
-                            apple_pay_payment_data.expose()[..]
-                                .as_bytes()
-                                .parse_struct("ApplePayEncodedPaymentData")
-                                .change_context(errors::ConnectorError::RequestEncodingFailed)?;
-
-                        let billing = item
-                            .router_data
-                            .address
-                            .billing
-                            .to_owned()
-                            .get_required_value("billing")
-                            .change_context(errors::ConnectorError::MissingRequiredField {
-                                field_name: "billing",
-                            })?;
-
-                        let billing_address = billing
-                            .address
-                            .get_required_value("billing_address")
-                            .change_context(errors::ConnectorError::MissingRequiredField {
-                                field_name: "billing",
-                            })?;
-
-                        let mut address = Vec::new();
-                        if let Some(add) = billing_address.line1.to_owned() {
-                            address.push(add)
-                        }
-                        if let Some(add) = billing_address.line2.to_owned() {
-                            address.push(add)
-                        }
-                        if let Some(add) = billing_address.line3.to_owned() {
-                            address.push(add)
-                        }
-
-                        let apple_pay_object =
-                            Encode::<EncodedPaymentToken>::encode_to_string_of_json(
-                                &EncodedPaymentToken {
-                                    token: ApplepayPaymentData {
-                                        payment_data: apple_pay_payment_data,
-                                        payment_method: payment_method_data
-                                            .payment_method
-                                            .to_owned()
-                                            .into(),
-                                        transaction_identifier: payment_method_data
-                                            .transaction_identifier,
-                                    },
-                                    billing_contact: BillingDetails {
-                                        country_code: billing_address.country,
-                                        address_lines: Some(address),
-                                        family_name: billing_address.last_name.to_owned(),
-                                        given_name: billing_address.first_name.to_owned(),
-                                        postal_code: billing_address.zip,
-                                    },
-                                },
-                            )
-                            .change_context(errors::ConnectorError::RequestEncodingFailed)?;
-
-                        Ok((
-                            PaymentMethodDetails::Wallet(BluesnapWallet {
-                                wallet_type: BluesnapWalletTypes::ApplePay,
-                                encoded_payment_token: Secret::new(
-                                    consts::BASE64_ENGINE.encode(apple_pay_object),
-                                ),
-                            }),
-                            get_card_holder_info(
-                                item.router_data.get_billing_address()?,
-                                item.router_data.request.get_email()?,
-                            )?,
-                        ))
+                    if let Some(add) = billing_address.line2.to_owned() {
+                        address.push(add)
                     }
-                    payments::WalletData::AliPayQr(_)
-                    | payments::WalletData::AliPayRedirect(_)
-                    | payments::WalletData::AliPayHkRedirect(_)
-                    | payments::WalletData::MomoRedirect(_)
-                    | payments::WalletData::KakaoPayRedirect(_)
-                    | payments::WalletData::GoPayRedirect(_)
-                    | payments::WalletData::GcashRedirect(_)
-                    | payments::WalletData::ApplePayRedirect(_)
-                    | payments::WalletData::ApplePayThirdPartySdk(_)
-                    | payments::WalletData::DanaRedirect {}
-                    | payments::WalletData::GooglePayRedirect(_)
-                    | payments::WalletData::GooglePayThirdPartySdk(_)
-                    | payments::WalletData::MbWayRedirect(_)
-                    | payments::WalletData::MobilePayRedirect(_)
-                    | payments::WalletData::PaypalRedirect(_)
-                    | payments::WalletData::PaypalSdk(_)
-                    | payments::WalletData::SamsungPay(_)
-                    | payments::WalletData::TwintRedirect {}
-                    | payments::WalletData::VippsRedirect {}
-                    | payments::WalletData::TouchNGoRedirect(_)
-                    | payments::WalletData::WeChatPayRedirect(_)
-                    | payments::WalletData::CashappQr(_)
-                    | payments::WalletData::SwishQr(_)
-                    | payments::WalletData::WeChatPayQr(_) => {
-                        Err(errors::ConnectorError::NotImplemented(
-                            utils::get_unimplemented_payment_method_error_message("bluesnap"),
-                        ))
+                    if let Some(add) = billing_address.line3.to_owned() {
+                        address.push(add)
                     }
-                },
-                payments::PaymentMethodData::PayLater(_)
-                | payments::PaymentMethodData::BankRedirect(_)
-                | payments::PaymentMethodData::BankDebit(_)
-                | payments::PaymentMethodData::BankTransfer(_)
-                | payments::PaymentMethodData::Crypto(_)
-                | payments::PaymentMethodData::MandatePayment
-                | payments::PaymentMethodData::Reward
-                | payments::PaymentMethodData::Upi(_)
-                | payments::PaymentMethodData::CardRedirect(_)
-                | payments::PaymentMethodData::Voucher(_)
-                | payments::PaymentMethodData::GiftCard(_)
-                | api::PaymentMethodData::CardTokenData(_) => {
+
+                    let apple_pay_object = Encode::<EncodedPaymentToken>::encode_to_string_of_json(
+                        &EncodedPaymentToken {
+                            token: ApplepayPaymentData {
+                                payment_data: apple_pay_payment_data,
+                                payment_method: payment_method_data
+                                    .payment_method
+                                    .to_owned()
+                                    .into(),
+                                transaction_identifier: payment_method_data.transaction_identifier,
+                            },
+                            billing_contact: BillingDetails {
+                                country_code: billing_address.country,
+                                address_lines: Some(address),
+                                family_name: billing_address.last_name.to_owned(),
+                                given_name: billing_address.first_name.to_owned(),
+                                postal_code: billing_address.zip,
+                            },
+                        },
+                    )
+                    .change_context(errors::ConnectorError::RequestEncodingFailed)?;
+
+                    Ok((
+                        PaymentMethodDetails::Wallet(BluesnapWallet {
+                            wallet_type: BluesnapWalletTypes::ApplePay,
+                            encoded_payment_token: Secret::new(
+                                consts::BASE64_ENGINE.encode(apple_pay_object),
+                            ),
+                        }),
+                        get_card_holder_info(
+                            item.router_data.get_billing_address()?,
+                            item.router_data.request.get_email()?,
+                        )?,
+                    ))
+                }
+                payments::WalletData::AliPayQr(_)
+                | payments::WalletData::AliPayRedirect(_)
+                | payments::WalletData::AliPayHkRedirect(_)
+                | payments::WalletData::MomoRedirect(_)
+                | payments::WalletData::KakaoPayRedirect(_)
+                | payments::WalletData::GoPayRedirect(_)
+                | payments::WalletData::GcashRedirect(_)
+                | payments::WalletData::ApplePayRedirect(_)
+                | payments::WalletData::ApplePayThirdPartySdk(_)
+                | payments::WalletData::DanaRedirect {}
+                | payments::WalletData::GooglePayRedirect(_)
+                | payments::WalletData::GooglePayThirdPartySdk(_)
+                | payments::WalletData::MbWayRedirect(_)
+                | payments::WalletData::MobilePayRedirect(_)
+                | payments::WalletData::PaypalRedirect(_)
+                | payments::WalletData::PaypalSdk(_)
+                | payments::WalletData::SamsungPay(_)
+                | payments::WalletData::TwintRedirect {}
+                | payments::WalletData::VippsRedirect {}
+                | payments::WalletData::TouchNGoRedirect(_)
+                | payments::WalletData::WeChatPayRedirect(_)
+                | payments::WalletData::CashappQr(_)
+                | payments::WalletData::SwishQr(_)
+                | payments::WalletData::WeChatPayQr(_) => {
                     Err(errors::ConnectorError::NotImplemented(
                         utils::get_unimplemented_payment_method_error_message("bluesnap"),
                     ))
                 }
-            }?;
+            },
+            payments::PaymentMethodData::PayLater(_)
+            | payments::PaymentMethodData::BankRedirect(_)
+            | payments::PaymentMethodData::BankDebit(_)
+            | payments::PaymentMethodData::BankTransfer(_)
+            | payments::PaymentMethodData::Crypto(_)
+            | payments::PaymentMethodData::MandatePayment
+            | payments::PaymentMethodData::Reward
+            | payments::PaymentMethodData::Upi(_)
+            | payments::PaymentMethodData::CardRedirect(_)
+            | payments::PaymentMethodData::Voucher(_)
+            | payments::PaymentMethodData::GiftCard(_)
+            | api::PaymentMethodData::CardToken(_) => Err(errors::ConnectorError::NotImplemented(
+                utils::get_unimplemented_payment_method_error_message("bluesnap"),
+            )),
+        }?;
         Ok(Self {
             amount: item.amount.to_owned(),
             payment_method,

--- a/crates/router/src/connector/braintree/braintree_graphql_transformers.rs
+++ b/crates/router/src/connector/braintree/braintree_graphql_transformers.rs
@@ -139,7 +139,7 @@ impl TryFrom<&BraintreeRouterData<&types::PaymentsAuthorizeRouterData>>
             | api_models::payments::PaymentMethodData::Upi(_)
             | api_models::payments::PaymentMethodData::Voucher(_)
             | api_models::payments::PaymentMethodData::GiftCard(_)
-            | api_models::payments::PaymentMethodData::CardTokenData(_) => {
+            | api_models::payments::PaymentMethodData::CardToken(_) => {
                 Err(errors::ConnectorError::NotImplemented(
                     utils::get_unimplemented_payment_method_error_message("braintree"),
                 )
@@ -881,12 +881,10 @@ impl TryFrom<&types::TokenizationRouterData> for BraintreeTokenRequest {
             | api_models::payments::PaymentMethodData::Upi(_)
             | api_models::payments::PaymentMethodData::Voucher(_)
             | api_models::payments::PaymentMethodData::GiftCard(_)
-            | api::PaymentMethodData::CardTokenData(_) => {
-                Err(errors::ConnectorError::NotImplemented(
-                    utils::get_unimplemented_payment_method_error_message("braintree"),
-                )
-                .into())
-            }
+            | api::PaymentMethodData::CardToken(_) => Err(errors::ConnectorError::NotImplemented(
+                utils::get_unimplemented_payment_method_error_message("braintree"),
+            )
+            .into()),
         }
     }
 }
@@ -1426,9 +1424,9 @@ fn get_braintree_redirect_form(
             | api_models::payments::PaymentMethodData::Upi(_)
             | api_models::payments::PaymentMethodData::Voucher(_)
             | api_models::payments::PaymentMethodData::GiftCard(_)
-            | api::PaymentMethodData::CardTokenData(_) => Err(
-                errors::ConnectorError::NotImplemented("given payment method".to_owned()),
-            )?,
+            | api::PaymentMethodData::CardToken(_) => Err(errors::ConnectorError::NotImplemented(
+                "given payment method".to_owned(),
+            ))?,
         },
     })
 }

--- a/crates/router/src/connector/braintree/braintree_graphql_transformers.rs
+++ b/crates/router/src/connector/braintree/braintree_graphql_transformers.rs
@@ -138,7 +138,8 @@ impl TryFrom<&BraintreeRouterData<&types::PaymentsAuthorizeRouterData>>
             | api_models::payments::PaymentMethodData::Reward
             | api_models::payments::PaymentMethodData::Upi(_)
             | api_models::payments::PaymentMethodData::Voucher(_)
-            | api_models::payments::PaymentMethodData::GiftCard(_) => {
+            | api_models::payments::PaymentMethodData::GiftCard(_)
+            | api_models::payments::PaymentMethodData::CardTokenData(_) => {
                 Err(errors::ConnectorError::NotImplemented(
                     utils::get_unimplemented_payment_method_error_message("braintree"),
                 )
@@ -879,7 +880,8 @@ impl TryFrom<&types::TokenizationRouterData> for BraintreeTokenRequest {
             | api_models::payments::PaymentMethodData::Reward
             | api_models::payments::PaymentMethodData::Upi(_)
             | api_models::payments::PaymentMethodData::Voucher(_)
-            | api_models::payments::PaymentMethodData::GiftCard(_) => {
+            | api_models::payments::PaymentMethodData::GiftCard(_)
+            | api::PaymentMethodData::CardTokenData(_) => {
                 Err(errors::ConnectorError::NotImplemented(
                     utils::get_unimplemented_payment_method_error_message("braintree"),
                 )
@@ -1423,7 +1425,8 @@ fn get_braintree_redirect_form(
             | api_models::payments::PaymentMethodData::Reward
             | api_models::payments::PaymentMethodData::Upi(_)
             | api_models::payments::PaymentMethodData::Voucher(_)
-            | api_models::payments::PaymentMethodData::GiftCard(_) => Err(
+            | api_models::payments::PaymentMethodData::GiftCard(_)
+            | api::PaymentMethodData::CardTokenData(_) => Err(
                 errors::ConnectorError::NotImplemented("given payment method".to_owned()),
             )?,
         },

--- a/crates/router/src/connector/checkout/transformers.rs
+++ b/crates/router/src/connector/checkout/transformers.rs
@@ -138,7 +138,8 @@ impl TryFrom<&types::TokenizationRouterData> for TokenRequest {
             | api_models::payments::PaymentMethodData::Upi(_)
             | api_models::payments::PaymentMethodData::Voucher(_)
             | api_models::payments::PaymentMethodData::CardRedirect(_)
-            | api_models::payments::PaymentMethodData::GiftCard(_) => {
+            | api_models::payments::PaymentMethodData::GiftCard(_)
+            | api_models::payments::PaymentMethodData::CardTokenData(_) => {
                 Err(errors::ConnectorError::NotImplemented(
                     utils::get_unimplemented_payment_method_error_message("checkout"),
                 )
@@ -375,7 +376,8 @@ impl TryFrom<&CheckoutRouterData<&types::PaymentsAuthorizeRouterData>> for Payme
             | api_models::payments::PaymentMethodData::Upi(_)
             | api_models::payments::PaymentMethodData::Voucher(_)
             | api_models::payments::PaymentMethodData::CardRedirect(_)
-            | api_models::payments::PaymentMethodData::GiftCard(_) => {
+            | api_models::payments::PaymentMethodData::GiftCard(_)
+            | api::PaymentMethodData::CardTokenData(_) => {
                 Err(errors::ConnectorError::NotImplemented(
                     utils::get_unimplemented_payment_method_error_message("checkout"),
                 ))

--- a/crates/router/src/connector/checkout/transformers.rs
+++ b/crates/router/src/connector/checkout/transformers.rs
@@ -139,7 +139,7 @@ impl TryFrom<&types::TokenizationRouterData> for TokenRequest {
             | api_models::payments::PaymentMethodData::Voucher(_)
             | api_models::payments::PaymentMethodData::CardRedirect(_)
             | api_models::payments::PaymentMethodData::GiftCard(_)
-            | api_models::payments::PaymentMethodData::CardTokenData(_) => {
+            | api_models::payments::PaymentMethodData::CardToken(_) => {
                 Err(errors::ConnectorError::NotImplemented(
                     utils::get_unimplemented_payment_method_error_message("checkout"),
                 )
@@ -377,11 +377,9 @@ impl TryFrom<&CheckoutRouterData<&types::PaymentsAuthorizeRouterData>> for Payme
             | api_models::payments::PaymentMethodData::Voucher(_)
             | api_models::payments::PaymentMethodData::CardRedirect(_)
             | api_models::payments::PaymentMethodData::GiftCard(_)
-            | api::PaymentMethodData::CardTokenData(_) => {
-                Err(errors::ConnectorError::NotImplemented(
-                    utils::get_unimplemented_payment_method_error_message("checkout"),
-                ))
-            }
+            | api::PaymentMethodData::CardToken(_) => Err(errors::ConnectorError::NotImplemented(
+                utils::get_unimplemented_payment_method_error_message("checkout"),
+            )),
         }?;
 
         let three_ds = match item.router_data.auth_type {

--- a/crates/router/src/connector/cryptopay/transformers.rs
+++ b/crates/router/src/connector/cryptopay/transformers.rs
@@ -81,7 +81,7 @@ impl TryFrom<&CryptopayRouterData<&types::PaymentsAuthorizeRouterData>>
             | api_models::payments::PaymentMethodData::Upi(_)
             | api_models::payments::PaymentMethodData::Voucher(_)
             | api_models::payments::PaymentMethodData::GiftCard(_)
-            | api_models::payments::PaymentMethodData::CardTokenData(_) => {
+            | api_models::payments::PaymentMethodData::CardToken(_) => {
                 Err(errors::ConnectorError::NotSupported {
                     message: utils::SELECTED_PAYMENT_METHOD.to_string(),
                     connector: "CryptoPay",

--- a/crates/router/src/connector/cryptopay/transformers.rs
+++ b/crates/router/src/connector/cryptopay/transformers.rs
@@ -80,7 +80,8 @@ impl TryFrom<&CryptopayRouterData<&types::PaymentsAuthorizeRouterData>>
             | api_models::payments::PaymentMethodData::Reward {}
             | api_models::payments::PaymentMethodData::Upi(_)
             | api_models::payments::PaymentMethodData::Voucher(_)
-            | api_models::payments::PaymentMethodData::GiftCard(_) => {
+            | api_models::payments::PaymentMethodData::GiftCard(_)
+            | api_models::payments::PaymentMethodData::CardTokenData(_) => {
                 Err(errors::ConnectorError::NotSupported {
                     message: utils::SELECTED_PAYMENT_METHOD.to_string(),
                     connector: "CryptoPay",

--- a/crates/router/src/connector/cybersource/transformers.rs
+++ b/crates/router/src/connector/cybersource/transformers.rs
@@ -367,7 +367,8 @@ impl TryFrom<&CybersourceRouterData<&types::PaymentsAuthorizeRouterData>>
             | payments::PaymentMethodData::Reward
             | payments::PaymentMethodData::Upi(_)
             | payments::PaymentMethodData::Voucher(_)
-            | payments::PaymentMethodData::GiftCard(_) => {
+            | payments::PaymentMethodData::GiftCard(_)
+            | payments::PaymentMethodData::CardTokenData(_) => {
                 Err(errors::ConnectorError::NotImplemented(
                     utils::get_unimplemented_payment_method_error_message("Cybersource"),
                 ))?

--- a/crates/router/src/connector/cybersource/transformers.rs
+++ b/crates/router/src/connector/cybersource/transformers.rs
@@ -368,7 +368,7 @@ impl TryFrom<&CybersourceRouterData<&types::PaymentsAuthorizeRouterData>>
             | payments::PaymentMethodData::Upi(_)
             | payments::PaymentMethodData::Voucher(_)
             | payments::PaymentMethodData::GiftCard(_)
-            | payments::PaymentMethodData::CardTokenData(_) => {
+            | payments::PaymentMethodData::CardToken(_) => {
                 Err(errors::ConnectorError::NotImplemented(
                     utils::get_unimplemented_payment_method_error_message("Cybersource"),
                 ))?

--- a/crates/router/src/connector/dlocal/transformers.rs
+++ b/crates/router/src/connector/dlocal/transformers.rs
@@ -168,9 +168,14 @@ impl TryFrom<&DlocalRouterData<&types::PaymentsAuthorizeRouterData>> for DlocalP
             | api::PaymentMethodData::Reward
             | api::PaymentMethodData::Upi(_)
             | api::PaymentMethodData::Voucher(_)
-            | api::PaymentMethodData::GiftCard(_) => Err(errors::ConnectorError::NotImplemented(
-                crate::connector::utils::get_unimplemented_payment_method_error_message("Dlocal"),
-            ))?,
+            | api::PaymentMethodData::GiftCard(_)
+            | api::PaymentMethodData::CardTokenData(_) => {
+                Err(errors::ConnectorError::NotImplemented(
+                    crate::connector::utils::get_unimplemented_payment_method_error_message(
+                        "Dlocal",
+                    ),
+                ))?
+            }
         }
     }
 }

--- a/crates/router/src/connector/dlocal/transformers.rs
+++ b/crates/router/src/connector/dlocal/transformers.rs
@@ -169,13 +169,9 @@ impl TryFrom<&DlocalRouterData<&types::PaymentsAuthorizeRouterData>> for DlocalP
             | api::PaymentMethodData::Upi(_)
             | api::PaymentMethodData::Voucher(_)
             | api::PaymentMethodData::GiftCard(_)
-            | api::PaymentMethodData::CardTokenData(_) => {
-                Err(errors::ConnectorError::NotImplemented(
-                    crate::connector::utils::get_unimplemented_payment_method_error_message(
-                        "Dlocal",
-                    ),
-                ))?
-            }
+            | api::PaymentMethodData::CardToken(_) => Err(errors::ConnectorError::NotImplemented(
+                crate::connector::utils::get_unimplemented_payment_method_error_message("Dlocal"),
+            ))?,
         }
     }
 }

--- a/crates/router/src/connector/forte/transformers.rs
+++ b/crates/router/src/connector/forte/transformers.rs
@@ -112,7 +112,8 @@ impl TryFrom<&types::PaymentsAuthorizeRouterData> for FortePaymentsRequest {
             | api_models::payments::PaymentMethodData::Reward {}
             | api_models::payments::PaymentMethodData::Upi(_)
             | api_models::payments::PaymentMethodData::Voucher(_)
-            | api_models::payments::PaymentMethodData::GiftCard(_) => {
+            | api_models::payments::PaymentMethodData::GiftCard(_)
+            | api_models::payments::PaymentMethodData::CardTokenData(_) => {
                 Err(errors::ConnectorError::NotSupported {
                     message: utils::SELECTED_PAYMENT_METHOD.to_string(),
                     connector: "Forte",

--- a/crates/router/src/connector/forte/transformers.rs
+++ b/crates/router/src/connector/forte/transformers.rs
@@ -113,7 +113,7 @@ impl TryFrom<&types::PaymentsAuthorizeRouterData> for FortePaymentsRequest {
             | api_models::payments::PaymentMethodData::Upi(_)
             | api_models::payments::PaymentMethodData::Voucher(_)
             | api_models::payments::PaymentMethodData::GiftCard(_)
-            | api_models::payments::PaymentMethodData::CardTokenData(_) => {
+            | api_models::payments::PaymentMethodData::CardToken(_) => {
                 Err(errors::ConnectorError::NotSupported {
                     message: utils::SELECTED_PAYMENT_METHOD.to_string(),
                     connector: "Forte",

--- a/crates/router/src/connector/gocardless/transformers.rs
+++ b/crates/router/src/connector/gocardless/transformers.rs
@@ -108,7 +108,8 @@ impl TryFrom<&types::ConnectorCustomerRouterData> for GocardlessCustomerRequest 
             | api_models::payments::PaymentMethodData::Reward
             | api_models::payments::PaymentMethodData::Upi(_)
             | api_models::payments::PaymentMethodData::Voucher(_)
-            | api_models::payments::PaymentMethodData::GiftCard(_) => {
+            | api_models::payments::PaymentMethodData::GiftCard(_)
+            | api_models::payments::PaymentMethodData::CardTokenData(_) => {
                 Err(errors::ConnectorError::NotImplemented(
                     utils::get_unimplemented_payment_method_error_message("Gocardless"),
                 ))
@@ -297,7 +298,8 @@ impl TryFrom<&types::TokenizationRouterData> for CustomerBankAccount {
             | api_models::payments::PaymentMethodData::Reward
             | api_models::payments::PaymentMethodData::Upi(_)
             | api_models::payments::PaymentMethodData::Voucher(_)
-            | api_models::payments::PaymentMethodData::GiftCard(_) => {
+            | api_models::payments::PaymentMethodData::GiftCard(_)
+            | api::PaymentMethodData::CardTokenData(_) => {
                 Err(errors::ConnectorError::NotImplemented(
                     utils::get_unimplemented_payment_method_error_message("Gocardless"),
                 )
@@ -483,7 +485,8 @@ impl TryFrom<&types::SetupMandateRouterData> for GocardlessMandateRequest {
             | api_models::payments::PaymentMethodData::Reward
             | api_models::payments::PaymentMethodData::Upi(_)
             | api_models::payments::PaymentMethodData::Voucher(_)
-            | api_models::payments::PaymentMethodData::GiftCard(_) => {
+            | api_models::payments::PaymentMethodData::GiftCard(_)
+            | api::PaymentMethodData::CardTokenData(_) => {
                 Err(errors::ConnectorError::NotImplemented(
                     "Setup Mandate flow for selected payment method through Gocardless".to_string(),
                 ))

--- a/crates/router/src/connector/gocardless/transformers.rs
+++ b/crates/router/src/connector/gocardless/transformers.rs
@@ -109,7 +109,7 @@ impl TryFrom<&types::ConnectorCustomerRouterData> for GocardlessCustomerRequest 
             | api_models::payments::PaymentMethodData::Upi(_)
             | api_models::payments::PaymentMethodData::Voucher(_)
             | api_models::payments::PaymentMethodData::GiftCard(_)
-            | api_models::payments::PaymentMethodData::CardTokenData(_) => {
+            | api_models::payments::PaymentMethodData::CardToken(_) => {
                 Err(errors::ConnectorError::NotImplemented(
                     utils::get_unimplemented_payment_method_error_message("Gocardless"),
                 ))
@@ -299,12 +299,10 @@ impl TryFrom<&types::TokenizationRouterData> for CustomerBankAccount {
             | api_models::payments::PaymentMethodData::Upi(_)
             | api_models::payments::PaymentMethodData::Voucher(_)
             | api_models::payments::PaymentMethodData::GiftCard(_)
-            | api::PaymentMethodData::CardTokenData(_) => {
-                Err(errors::ConnectorError::NotImplemented(
-                    utils::get_unimplemented_payment_method_error_message("Gocardless"),
-                )
-                .into())
-            }
+            | api::PaymentMethodData::CardToken(_) => Err(errors::ConnectorError::NotImplemented(
+                utils::get_unimplemented_payment_method_error_message("Gocardless"),
+            )
+            .into()),
         }
     }
 }
@@ -486,11 +484,9 @@ impl TryFrom<&types::SetupMandateRouterData> for GocardlessMandateRequest {
             | api_models::payments::PaymentMethodData::Upi(_)
             | api_models::payments::PaymentMethodData::Voucher(_)
             | api_models::payments::PaymentMethodData::GiftCard(_)
-            | api::PaymentMethodData::CardTokenData(_) => {
-                Err(errors::ConnectorError::NotImplemented(
-                    "Setup Mandate flow for selected payment method through Gocardless".to_string(),
-                ))
-            }
+            | api::PaymentMethodData::CardToken(_) => Err(errors::ConnectorError::NotImplemented(
+                "Setup Mandate flow for selected payment method through Gocardless".to_string(),
+            )),
         }?;
         let payment_method_token = item.get_payment_method_token()?;
         let customer_bank_account = match payment_method_token {

--- a/crates/router/src/connector/helcim/transformers.rs
+++ b/crates/router/src/connector/helcim/transformers.rs
@@ -142,7 +142,7 @@ impl TryFrom<&types::SetupMandateRouterData> for HelcimVerifyRequest {
             | api_models::payments::PaymentMethodData::Upi(_)
             | api_models::payments::PaymentMethodData::Voucher(_)
             | api_models::payments::PaymentMethodData::GiftCard(_)
-            | api_models::payments::PaymentMethodData::CardTokenData(_) => {
+            | api_models::payments::PaymentMethodData::CardToken(_) => {
                 Err(errors::ConnectorError::NotSupported {
                     message: format!("{:?}", item.request.payment_method_data),
                     connector: "Helcim",
@@ -225,12 +225,10 @@ impl TryFrom<&HelcimRouterData<&types::PaymentsAuthorizeRouterData>> for HelcimP
             | api_models::payments::PaymentMethodData::Upi(_)
             | api_models::payments::PaymentMethodData::Voucher(_)
             | api_models::payments::PaymentMethodData::GiftCard(_)
-            | api::PaymentMethodData::CardTokenData(_) => {
-                Err(errors::ConnectorError::NotSupported {
-                    message: format!("{:?}", item.router_data.request.payment_method_data),
-                    connector: "Helcim",
-                })?
-            }
+            | api::PaymentMethodData::CardToken(_) => Err(errors::ConnectorError::NotSupported {
+                message: format!("{:?}", item.router_data.request.payment_method_data),
+                connector: "Helcim",
+            })?,
         }
     }
 }

--- a/crates/router/src/connector/helcim/transformers.rs
+++ b/crates/router/src/connector/helcim/transformers.rs
@@ -141,7 +141,8 @@ impl TryFrom<&types::SetupMandateRouterData> for HelcimVerifyRequest {
             | api_models::payments::PaymentMethodData::Reward
             | api_models::payments::PaymentMethodData::Upi(_)
             | api_models::payments::PaymentMethodData::Voucher(_)
-            | api_models::payments::PaymentMethodData::GiftCard(_) => {
+            | api_models::payments::PaymentMethodData::GiftCard(_)
+            | api_models::payments::PaymentMethodData::CardTokenData(_) => {
                 Err(errors::ConnectorError::NotSupported {
                     message: format!("{:?}", item.request.payment_method_data),
                     connector: "Helcim",
@@ -223,7 +224,8 @@ impl TryFrom<&HelcimRouterData<&types::PaymentsAuthorizeRouterData>> for HelcimP
             | api_models::payments::PaymentMethodData::Reward
             | api_models::payments::PaymentMethodData::Upi(_)
             | api_models::payments::PaymentMethodData::Voucher(_)
-            | api_models::payments::PaymentMethodData::GiftCard(_) => {
+            | api_models::payments::PaymentMethodData::GiftCard(_)
+            | api::PaymentMethodData::CardTokenData(_) => {
                 Err(errors::ConnectorError::NotSupported {
                     message: format!("{:?}", item.router_data.request.payment_method_data),
                     connector: "Helcim",

--- a/crates/router/src/connector/klarna.rs
+++ b/crates/router/src/connector/klarna.rs
@@ -406,7 +406,8 @@ impl
             | api_payments::PaymentMethodData::Reward
             | api_payments::PaymentMethodData::Upi(_)
             | api_payments::PaymentMethodData::Voucher(_)
-            | api_payments::PaymentMethodData::GiftCard(_) => Err(error_stack::report!(
+            | api_payments::PaymentMethodData::GiftCard(_)
+            | api_payments::PaymentMethodData::CardTokenData(_) => Err(error_stack::report!(
                 errors::ConnectorError::MismatchedPaymentData
             )),
         }

--- a/crates/router/src/connector/klarna.rs
+++ b/crates/router/src/connector/klarna.rs
@@ -407,7 +407,7 @@ impl
             | api_payments::PaymentMethodData::Upi(_)
             | api_payments::PaymentMethodData::Voucher(_)
             | api_payments::PaymentMethodData::GiftCard(_)
-            | api_payments::PaymentMethodData::CardTokenData(_) => Err(error_stack::report!(
+            | api_payments::PaymentMethodData::CardToken(_) => Err(error_stack::report!(
                 errors::ConnectorError::MismatchedPaymentData
             )),
         }

--- a/crates/router/src/connector/multisafepay/transformers.rs
+++ b/crates/router/src/connector/multisafepay/transformers.rs
@@ -365,9 +365,12 @@ impl TryFrom<&MultisafepayRouterData<&types::PaymentsAuthorizeRouterData>>
             | api::PaymentMethodData::Reward
             | api::PaymentMethodData::Upi(_)
             | api::PaymentMethodData::Voucher(_)
-            | api::PaymentMethodData::GiftCard(_) => Err(errors::ConnectorError::NotImplemented(
-                utils::get_unimplemented_payment_method_error_message("multisafepay"),
-            ))?,
+            | api::PaymentMethodData::GiftCard(_)
+            | api::PaymentMethodData::CardTokenData(_) => {
+                Err(errors::ConnectorError::NotImplemented(
+                    utils::get_unimplemented_payment_method_error_message("multisafepay"),
+                ))?
+            }
         };
         let description = item.router_data.get_description()?;
         let payment_options = PaymentOptions {
@@ -509,9 +512,12 @@ impl TryFrom<&MultisafepayRouterData<&types::PaymentsAuthorizeRouterData>>
             | api::PaymentMethodData::Reward
             | api::PaymentMethodData::Upi(_)
             | api::PaymentMethodData::Voucher(_)
-            | api::PaymentMethodData::GiftCard(_) => Err(errors::ConnectorError::NotImplemented(
-                utils::get_unimplemented_payment_method_error_message("multisafepay"),
-            ))?,
+            | api::PaymentMethodData::GiftCard(_)
+            | api::PaymentMethodData::CardTokenData(_) => {
+                Err(errors::ConnectorError::NotImplemented(
+                    utils::get_unimplemented_payment_method_error_message("multisafepay"),
+                ))?
+            }
         };
 
         Ok(Self {

--- a/crates/router/src/connector/multisafepay/transformers.rs
+++ b/crates/router/src/connector/multisafepay/transformers.rs
@@ -366,11 +366,9 @@ impl TryFrom<&MultisafepayRouterData<&types::PaymentsAuthorizeRouterData>>
             | api::PaymentMethodData::Upi(_)
             | api::PaymentMethodData::Voucher(_)
             | api::PaymentMethodData::GiftCard(_)
-            | api::PaymentMethodData::CardTokenData(_) => {
-                Err(errors::ConnectorError::NotImplemented(
-                    utils::get_unimplemented_payment_method_error_message("multisafepay"),
-                ))?
-            }
+            | api::PaymentMethodData::CardToken(_) => Err(errors::ConnectorError::NotImplemented(
+                utils::get_unimplemented_payment_method_error_message("multisafepay"),
+            ))?,
         };
         let description = item.router_data.get_description()?;
         let payment_options = PaymentOptions {
@@ -513,11 +511,9 @@ impl TryFrom<&MultisafepayRouterData<&types::PaymentsAuthorizeRouterData>>
             | api::PaymentMethodData::Upi(_)
             | api::PaymentMethodData::Voucher(_)
             | api::PaymentMethodData::GiftCard(_)
-            | api::PaymentMethodData::CardTokenData(_) => {
-                Err(errors::ConnectorError::NotImplemented(
-                    utils::get_unimplemented_payment_method_error_message("multisafepay"),
-                ))?
-            }
+            | api::PaymentMethodData::CardToken(_) => Err(errors::ConnectorError::NotImplemented(
+                utils::get_unimplemented_payment_method_error_message("multisafepay"),
+            ))?,
         };
 
         Ok(Self {

--- a/crates/router/src/connector/nexinets/transformers.rs
+++ b/crates/router/src/connector/nexinets/transformers.rs
@@ -625,7 +625,7 @@ fn get_payment_details_and_product(
         | PaymentMethodData::Upi(_)
         | PaymentMethodData::Voucher(_)
         | PaymentMethodData::GiftCard(_)
-        | PaymentMethodData::CardTokenData(_) => Err(errors::ConnectorError::NotImplemented(
+        | PaymentMethodData::CardToken(_) => Err(errors::ConnectorError::NotImplemented(
             utils::get_unimplemented_payment_method_error_message("nexinets"),
         ))?,
     }

--- a/crates/router/src/connector/nexinets/transformers.rs
+++ b/crates/router/src/connector/nexinets/transformers.rs
@@ -624,7 +624,8 @@ fn get_payment_details_and_product(
         | PaymentMethodData::Reward
         | PaymentMethodData::Upi(_)
         | PaymentMethodData::Voucher(_)
-        | PaymentMethodData::GiftCard(_) => Err(errors::ConnectorError::NotImplemented(
+        | PaymentMethodData::GiftCard(_)
+        | PaymentMethodData::CardTokenData(_) => Err(errors::ConnectorError::NotImplemented(
             utils::get_unimplemented_payment_method_error_message("nexinets"),
         ))?,
     }

--- a/crates/router/src/connector/nmi/transformers.rs
+++ b/crates/router/src/connector/nmi/transformers.rs
@@ -188,11 +188,14 @@ impl TryFrom<&api_models::payments::PaymentMethodData> for PaymentMethod {
             | api::PaymentMethodData::Reward
             | api::PaymentMethodData::Upi(_)
             | api::PaymentMethodData::Voucher(_)
-            | api::PaymentMethodData::GiftCard(_) => Err(errors::ConnectorError::NotSupported {
-                message: utils::SELECTED_PAYMENT_METHOD.to_string(),
-                connector: "nmi",
-            })
-            .into_report(),
+            | api::PaymentMethodData::GiftCard(_)
+            | api::PaymentMethodData::CardTokenData(_) => {
+                Err(errors::ConnectorError::NotSupported {
+                    message: utils::SELECTED_PAYMENT_METHOD.to_string(),
+                    connector: "nmi",
+                })
+                .into_report()
+            }
         }
     }
 }

--- a/crates/router/src/connector/nmi/transformers.rs
+++ b/crates/router/src/connector/nmi/transformers.rs
@@ -189,13 +189,11 @@ impl TryFrom<&api_models::payments::PaymentMethodData> for PaymentMethod {
             | api::PaymentMethodData::Upi(_)
             | api::PaymentMethodData::Voucher(_)
             | api::PaymentMethodData::GiftCard(_)
-            | api::PaymentMethodData::CardTokenData(_) => {
-                Err(errors::ConnectorError::NotSupported {
-                    message: utils::SELECTED_PAYMENT_METHOD.to_string(),
-                    connector: "nmi",
-                })
-                .into_report()
-            }
+            | api::PaymentMethodData::CardToken(_) => Err(errors::ConnectorError::NotSupported {
+                message: utils::SELECTED_PAYMENT_METHOD.to_string(),
+                connector: "nmi",
+            })
+            .into_report(),
         }
     }
 }

--- a/crates/router/src/connector/noon/transformers.rs
+++ b/crates/router/src/connector/noon/transformers.rs
@@ -284,7 +284,8 @@ impl TryFrom<&types::PaymentsAuthorizeRouterData> for NoonPaymentsRequest {
                     | api::PaymentMethodData::Reward {}
                     | api::PaymentMethodData::Upi(_)
                     | api::PaymentMethodData::Voucher(_)
-                    | api::PaymentMethodData::GiftCard(_) => {
+                    | api::PaymentMethodData::GiftCard(_)
+                    | api::PaymentMethodData::CardTokenData(_) => {
                         Err(errors::ConnectorError::NotSupported {
                             message: conn_utils::SELECTED_PAYMENT_METHOD.to_string(),
                             connector: "Noon",

--- a/crates/router/src/connector/noon/transformers.rs
+++ b/crates/router/src/connector/noon/transformers.rs
@@ -285,7 +285,7 @@ impl TryFrom<&types::PaymentsAuthorizeRouterData> for NoonPaymentsRequest {
                     | api::PaymentMethodData::Upi(_)
                     | api::PaymentMethodData::Voucher(_)
                     | api::PaymentMethodData::GiftCard(_)
-                    | api::PaymentMethodData::CardTokenData(_) => {
+                    | api::PaymentMethodData::CardToken(_) => {
                         Err(errors::ConnectorError::NotSupported {
                             message: conn_utils::SELECTED_PAYMENT_METHOD.to_string(),
                             connector: "Noon",

--- a/crates/router/src/connector/nuvei/transformers.rs
+++ b/crates/router/src/connector/nuvei/transformers.rs
@@ -859,8 +859,9 @@ impl<F>
             | payments::PaymentMethodData::Reward
             | payments::PaymentMethodData::Upi(_)
             | payments::PaymentMethodData::Voucher(_)
-            | api_models::payments::PaymentMethodData::CardRedirect(_)
-            | payments::PaymentMethodData::GiftCard(_) => {
+            | payments::PaymentMethodData::CardRedirect(_)
+            | payments::PaymentMethodData::GiftCard(_)
+            | payments::PaymentMethodData::CardTokenData(_) => {
                 Err(errors::ConnectorError::NotImplemented(
                     utils::get_unimplemented_payment_method_error_message("nuvei"),
                 )
@@ -1040,6 +1041,7 @@ impl TryFrom<(&types::PaymentsCompleteAuthorizeRouterData, String)> for NuveiPay
             | Some(api::PaymentMethodData::CardRedirect(..))
             | Some(api::PaymentMethodData::Reward)
             | Some(api::PaymentMethodData::Upi(..))
+            | Some(api::PaymentMethodData::CardTokenData(..))
             | None => Err(errors::ConnectorError::NotImplemented(
                 utils::get_unimplemented_payment_method_error_message("nuvei"),
             )),

--- a/crates/router/src/connector/nuvei/transformers.rs
+++ b/crates/router/src/connector/nuvei/transformers.rs
@@ -858,7 +858,7 @@ impl<F>
             | payments::PaymentMethodData::Voucher(_)
             | payments::PaymentMethodData::CardRedirect(_)
             | payments::PaymentMethodData::GiftCard(_)
-            | payments::PaymentMethodData::CardTokenData(_) => {
+            | payments::PaymentMethodData::CardToken(_) => {
                 Err(errors::ConnectorError::NotImplemented(
                     utils::get_unimplemented_payment_method_error_message("nuvei"),
                 )
@@ -1038,7 +1038,7 @@ impl TryFrom<(&types::PaymentsCompleteAuthorizeRouterData, String)> for NuveiPay
             | Some(api::PaymentMethodData::CardRedirect(..))
             | Some(api::PaymentMethodData::Reward)
             | Some(api::PaymentMethodData::Upi(..))
-            | Some(api::PaymentMethodData::CardTokenData(..))
+            | Some(api::PaymentMethodData::CardToken(..))
             | None => Err(errors::ConnectorError::NotImplemented(
                 utils::get_unimplemented_payment_method_error_message("nuvei"),
             )),

--- a/crates/router/src/connector/opayo/transformers.rs
+++ b/crates/router/src/connector/opayo/transformers.rs
@@ -52,10 +52,13 @@ impl TryFrom<&types::PaymentsAuthorizeRouterData> for OpayoPaymentsRequest {
             | api::PaymentMethodData::Reward
             | api::PaymentMethodData::Upi(_)
             | api::PaymentMethodData::Voucher(_)
-            | api::PaymentMethodData::GiftCard(_) => Err(errors::ConnectorError::NotImplemented(
-                utils::get_unimplemented_payment_method_error_message("Opayo"),
-            )
-            .into()),
+            | api::PaymentMethodData::GiftCard(_)
+            | api::PaymentMethodData::CardTokenData(_) => {
+                Err(errors::ConnectorError::NotImplemented(
+                    utils::get_unimplemented_payment_method_error_message("Opayo"),
+                )
+                .into())
+            }
         }
     }
 }

--- a/crates/router/src/connector/opayo/transformers.rs
+++ b/crates/router/src/connector/opayo/transformers.rs
@@ -53,12 +53,10 @@ impl TryFrom<&types::PaymentsAuthorizeRouterData> for OpayoPaymentsRequest {
             | api::PaymentMethodData::Upi(_)
             | api::PaymentMethodData::Voucher(_)
             | api::PaymentMethodData::GiftCard(_)
-            | api::PaymentMethodData::CardTokenData(_) => {
-                Err(errors::ConnectorError::NotImplemented(
-                    utils::get_unimplemented_payment_method_error_message("Opayo"),
-                )
-                .into())
-            }
+            | api::PaymentMethodData::CardToken(_) => Err(errors::ConnectorError::NotImplemented(
+                utils::get_unimplemented_payment_method_error_message("Opayo"),
+            )
+            .into()),
         }
     }
 }

--- a/crates/router/src/connector/payeezy/transformers.rs
+++ b/crates/router/src/connector/payeezy/transformers.rs
@@ -261,7 +261,7 @@ fn get_payment_method_data(
         | api::PaymentMethodData::Upi(_)
         | api::PaymentMethodData::Voucher(_)
         | api::PaymentMethodData::GiftCard(_)
-        | api::PaymentMethodData::CardTokenData(_) => Err(errors::ConnectorError::NotImplemented(
+        | api::PaymentMethodData::CardToken(_) => Err(errors::ConnectorError::NotImplemented(
             utils::get_unimplemented_payment_method_error_message("Payeezy"),
         ))?,
     }

--- a/crates/router/src/connector/payeezy/transformers.rs
+++ b/crates/router/src/connector/payeezy/transformers.rs
@@ -260,7 +260,8 @@ fn get_payment_method_data(
         | api::PaymentMethodData::Reward
         | api::PaymentMethodData::Upi(_)
         | api::PaymentMethodData::Voucher(_)
-        | api::PaymentMethodData::GiftCard(_) => Err(errors::ConnectorError::NotImplemented(
+        | api::PaymentMethodData::GiftCard(_)
+        | api::PaymentMethodData::CardTokenData(_) => Err(errors::ConnectorError::NotImplemented(
             utils::get_unimplemented_payment_method_error_message("Payeezy"),
         ))?,
     }

--- a/crates/router/src/connector/payme/transformers.rs
+++ b/crates/router/src/connector/payme/transformers.rs
@@ -432,7 +432,7 @@ impl TryFrom<&PaymentMethodData> for SalePaymentMethod {
             | PaymentMethodData::CardRedirect(_)
             | PaymentMethodData::Upi(_)
             | PaymentMethodData::Voucher(_)
-            | PaymentMethodData::CardTokenData(_) => {
+            | PaymentMethodData::CardToken(_) => {
                 Err(errors::ConnectorError::NotImplemented("Payment methods".to_string()).into())
             }
         }
@@ -668,11 +668,9 @@ impl TryFrom<&types::PaymentsAuthorizeRouterData> for PayRequest {
             | api::PaymentMethodData::Upi(_)
             | api::PaymentMethodData::Voucher(_)
             | api::PaymentMethodData::GiftCard(_)
-            | api::PaymentMethodData::CardTokenData(_) => {
-                Err(errors::ConnectorError::NotImplemented(
-                    utils::get_unimplemented_payment_method_error_message("payme"),
-                ))?
-            }
+            | api::PaymentMethodData::CardToken(_) => Err(errors::ConnectorError::NotImplemented(
+                utils::get_unimplemented_payment_method_error_message("payme"),
+            ))?,
         }
     }
 }
@@ -729,7 +727,7 @@ impl TryFrom<&types::PaymentsCompleteAuthorizeRouterData> for Pay3dsRequest {
             | Some(api::PaymentMethodData::Upi(_))
             | Some(api::PaymentMethodData::Voucher(_))
             | Some(api::PaymentMethodData::GiftCard(_))
-            | Some(api::PaymentMethodData::CardTokenData(_))
+            | Some(api::PaymentMethodData::CardToken(_))
             | None => {
                 Err(errors::ConnectorError::NotImplemented("Tokenize Flow".to_string()).into())
             }
@@ -767,7 +765,7 @@ impl TryFrom<&types::TokenizationRouterData> for CaptureBuyerRequest {
             | api::PaymentMethodData::Upi(_)
             | api::PaymentMethodData::Voucher(_)
             | api::PaymentMethodData::GiftCard(_)
-            | api::PaymentMethodData::CardTokenData(_) => {
+            | api::PaymentMethodData::CardToken(_) => {
                 Err(errors::ConnectorError::NotImplemented("Tokenize Flow".to_string()).into())
             }
         }

--- a/crates/router/src/connector/payme/transformers.rs
+++ b/crates/router/src/connector/payme/transformers.rs
@@ -431,7 +431,8 @@ impl TryFrom<&PaymentMethodData> for SalePaymentMethod {
             | PaymentMethodData::GiftCard(_)
             | PaymentMethodData::CardRedirect(_)
             | PaymentMethodData::Upi(_)
-            | api::PaymentMethodData::Voucher(_) => {
+            | PaymentMethodData::Voucher(_)
+            | PaymentMethodData::CardTokenData(_) => {
                 Err(errors::ConnectorError::NotImplemented("Payment methods".to_string()).into())
             }
         }
@@ -666,9 +667,12 @@ impl TryFrom<&types::PaymentsAuthorizeRouterData> for PayRequest {
             | api::PaymentMethodData::Reward
             | api::PaymentMethodData::Upi(_)
             | api::PaymentMethodData::Voucher(_)
-            | api::PaymentMethodData::GiftCard(_) => Err(errors::ConnectorError::NotImplemented(
-                utils::get_unimplemented_payment_method_error_message("payme"),
-            ))?,
+            | api::PaymentMethodData::GiftCard(_)
+            | api::PaymentMethodData::CardTokenData(_) => {
+                Err(errors::ConnectorError::NotImplemented(
+                    utils::get_unimplemented_payment_method_error_message("payme"),
+                ))?
+            }
         }
     }
 }
@@ -725,6 +729,7 @@ impl TryFrom<&types::PaymentsCompleteAuthorizeRouterData> for Pay3dsRequest {
             | Some(api::PaymentMethodData::Upi(_))
             | Some(api::PaymentMethodData::Voucher(_))
             | Some(api::PaymentMethodData::GiftCard(_))
+            | Some(api::PaymentMethodData::CardTokenData(_))
             | None => {
                 Err(errors::ConnectorError::NotImplemented("Tokenize Flow".to_string()).into())
             }
@@ -761,7 +766,8 @@ impl TryFrom<&types::TokenizationRouterData> for CaptureBuyerRequest {
             | api::PaymentMethodData::Reward
             | api::PaymentMethodData::Upi(_)
             | api::PaymentMethodData::Voucher(_)
-            | api::PaymentMethodData::GiftCard(_) => {
+            | api::PaymentMethodData::GiftCard(_)
+            | api::PaymentMethodData::CardTokenData(_) => {
                 Err(errors::ConnectorError::NotImplemented("Tokenize Flow".to_string()).into())
             }
         }

--- a/crates/router/src/connector/paypal/transformers.rs
+++ b/crates/router/src/connector/paypal/transformers.rs
@@ -585,7 +585,7 @@ impl TryFrom<&PaypalRouterData<&types::PaymentsAuthorizeRouterData>> for PaypalP
             api_models::payments::PaymentMethodData::Reward
             | api_models::payments::PaymentMethodData::Crypto(_)
             | api_models::payments::PaymentMethodData::Upi(_)
-            | api_models::payments::PaymentMethodData::CardTokenData(_) => {
+            | api_models::payments::PaymentMethodData::CardToken(_) => {
                 Err(errors::ConnectorError::NotSupported {
                     message: utils::SELECTED_PAYMENT_METHOD.to_string(),
                     connector: "Paypal",

--- a/crates/router/src/connector/paypal/transformers.rs
+++ b/crates/router/src/connector/paypal/transformers.rs
@@ -584,7 +584,8 @@ impl TryFrom<&PaypalRouterData<&types::PaymentsAuthorizeRouterData>> for PaypalP
             }
             api_models::payments::PaymentMethodData::Reward
             | api_models::payments::PaymentMethodData::Crypto(_)
-            | api_models::payments::PaymentMethodData::Upi(_) => {
+            | api_models::payments::PaymentMethodData::Upi(_)
+            | api_models::payments::PaymentMethodData::CardTokenData(_) => {
                 Err(errors::ConnectorError::NotSupported {
                     message: utils::SELECTED_PAYMENT_METHOD.to_string(),
                     connector: "Paypal",

--- a/crates/router/src/connector/powertranz/transformers.rs
+++ b/crates/router/src/connector/powertranz/transformers.rs
@@ -114,13 +114,11 @@ impl TryFrom<&types::PaymentsAuthorizeRouterData> for PowertranzPaymentsRequest 
             | api::PaymentMethodData::Upi(_)
             | api::PaymentMethodData::Voucher(_)
             | api::PaymentMethodData::GiftCard(_)
-            | api::PaymentMethodData::CardTokenData(_) => {
-                Err(errors::ConnectorError::NotSupported {
-                    message: utils::SELECTED_PAYMENT_METHOD.to_string(),
-                    connector: "powertranz",
-                })
-                .into_report()
-            }
+            | api::PaymentMethodData::CardToken(_) => Err(errors::ConnectorError::NotSupported {
+                message: utils::SELECTED_PAYMENT_METHOD.to_string(),
+                connector: "powertranz",
+            })
+            .into_report(),
         }?;
         // let billing_address = get_address_details(&item.address.billing, &item.request.email);
         // let shipping_address = get_address_details(&item.address.shipping, &item.request.email);

--- a/crates/router/src/connector/powertranz/transformers.rs
+++ b/crates/router/src/connector/powertranz/transformers.rs
@@ -113,11 +113,14 @@ impl TryFrom<&types::PaymentsAuthorizeRouterData> for PowertranzPaymentsRequest 
             | api::PaymentMethodData::Reward
             | api::PaymentMethodData::Upi(_)
             | api::PaymentMethodData::Voucher(_)
-            | api::PaymentMethodData::GiftCard(_) => Err(errors::ConnectorError::NotSupported {
-                message: utils::SELECTED_PAYMENT_METHOD.to_string(),
-                connector: "powertranz",
-            })
-            .into_report(),
+            | api::PaymentMethodData::GiftCard(_)
+            | api::PaymentMethodData::CardTokenData(_) => {
+                Err(errors::ConnectorError::NotSupported {
+                    message: utils::SELECTED_PAYMENT_METHOD.to_string(),
+                    connector: "powertranz",
+                })
+                .into_report()
+            }
         }?;
         // let billing_address = get_address_details(&item.address.billing, &item.request.email);
         // let shipping_address = get_address_details(&item.address.shipping, &item.request.email);

--- a/crates/router/src/connector/shift4/transformers.rs
+++ b/crates/router/src/connector/shift4/transformers.rs
@@ -167,7 +167,7 @@ impl<T> TryFrom<&types::RouterData<T, types::PaymentsAuthorizeData, types::Payme
             | payments::PaymentMethodData::MandatePayment
             | payments::PaymentMethodData::Reward
             | payments::PaymentMethodData::Upi(_)
-            | payments::PaymentMethodData::CardTokenData(_) => {
+            | payments::PaymentMethodData::CardToken(_) => {
                 Err(errors::ConnectorError::NotSupported {
                     message: utils::SELECTED_PAYMENT_METHOD.to_string(),
                     connector: "Shift4",
@@ -400,7 +400,7 @@ impl<T> TryFrom<&types::RouterData<T, types::CompleteAuthorizeData, types::Payme
             | Some(payments::PaymentMethodData::Voucher(_))
             | Some(payments::PaymentMethodData::Reward)
             | Some(payments::PaymentMethodData::Upi(_))
-            | Some(api::PaymentMethodData::CardTokenData(_))
+            | Some(api::PaymentMethodData::CardToken(_))
             | None => Err(errors::ConnectorError::NotSupported {
                 message: "Flow".to_string(),
                 connector: "Shift4",

--- a/crates/router/src/connector/shift4/transformers.rs
+++ b/crates/router/src/connector/shift4/transformers.rs
@@ -166,11 +166,14 @@ impl<T> TryFrom<&types::RouterData<T, types::PaymentsAuthorizeData, types::Payme
             | payments::PaymentMethodData::Crypto(_)
             | payments::PaymentMethodData::MandatePayment
             | payments::PaymentMethodData::Reward
-            | payments::PaymentMethodData::Upi(_) => Err(errors::ConnectorError::NotSupported {
-                message: utils::SELECTED_PAYMENT_METHOD.to_string(),
-                connector: "Shift4",
+            | payments::PaymentMethodData::Upi(_)
+            | payments::PaymentMethodData::CardTokenData(_) => {
+                Err(errors::ConnectorError::NotSupported {
+                    message: utils::SELECTED_PAYMENT_METHOD.to_string(),
+                    connector: "Shift4",
+                }
+                .into())
             }
-            .into()),
         }
     }
 }
@@ -397,6 +400,7 @@ impl<T> TryFrom<&types::RouterData<T, types::CompleteAuthorizeData, types::Payme
             | Some(payments::PaymentMethodData::Voucher(_))
             | Some(payments::PaymentMethodData::Reward)
             | Some(payments::PaymentMethodData::Upi(_))
+            | Some(api::PaymentMethodData::CardTokenData(_))
             | None => Err(errors::ConnectorError::NotSupported {
                 message: "Flow".to_string(),
                 connector: "Shift4",

--- a/crates/router/src/connector/square/transformers.rs
+++ b/crates/router/src/connector/square/transformers.rs
@@ -192,12 +192,10 @@ impl TryFrom<&types::TokenizationRouterData> for SquareTokenRequest {
             | api::PaymentMethodData::Reward
             | api::PaymentMethodData::Upi(_)
             | api::PaymentMethodData::Voucher(_)
-            | api::PaymentMethodData::CardTokenData(_) => {
-                Err(errors::ConnectorError::NotSupported {
-                    message: format!("{:?}", item.request.payment_method_data),
-                    connector: "Square",
-                })?
-            }
+            | api::PaymentMethodData::CardToken(_) => Err(errors::ConnectorError::NotSupported {
+                message: format!("{:?}", item.request.payment_method_data),
+                connector: "Square",
+            })?,
         }
     }
 }
@@ -311,12 +309,10 @@ impl TryFrom<&types::PaymentsAuthorizeRouterData> for SquarePaymentsRequest {
             | api::PaymentMethodData::Reward
             | api::PaymentMethodData::Upi(_)
             | api::PaymentMethodData::Voucher(_)
-            | api::PaymentMethodData::CardTokenData(_) => {
-                Err(errors::ConnectorError::NotSupported {
-                    message: format!("{:?}", item.request.payment_method_data),
-                    connector: "Square",
-                })?
-            }
+            | api::PaymentMethodData::CardToken(_) => Err(errors::ConnectorError::NotSupported {
+                message: format!("{:?}", item.request.payment_method_data),
+                connector: "Square",
+            })?,
         }
     }
 }

--- a/crates/router/src/connector/square/transformers.rs
+++ b/crates/router/src/connector/square/transformers.rs
@@ -191,10 +191,13 @@ impl TryFrom<&types::TokenizationRouterData> for SquareTokenRequest {
             | api::PaymentMethodData::MandatePayment
             | api::PaymentMethodData::Reward
             | api::PaymentMethodData::Upi(_)
-            | api::PaymentMethodData::Voucher(_) => Err(errors::ConnectorError::NotSupported {
-                message: format!("{:?}", item.request.payment_method_data),
-                connector: "Square",
-            })?,
+            | api::PaymentMethodData::Voucher(_)
+            | api::PaymentMethodData::CardTokenData(_) => {
+                Err(errors::ConnectorError::NotSupported {
+                    message: format!("{:?}", item.request.payment_method_data),
+                    connector: "Square",
+                })?
+            }
         }
     }
 }
@@ -307,10 +310,13 @@ impl TryFrom<&types::PaymentsAuthorizeRouterData> for SquarePaymentsRequest {
             | api::PaymentMethodData::MandatePayment
             | api::PaymentMethodData::Reward
             | api::PaymentMethodData::Upi(_)
-            | api::PaymentMethodData::Voucher(_) => Err(errors::ConnectorError::NotSupported {
-                message: format!("{:?}", item.request.payment_method_data),
-                connector: "Square",
-            })?,
+            | api::PaymentMethodData::Voucher(_)
+            | api::PaymentMethodData::CardTokenData(_) => {
+                Err(errors::ConnectorError::NotSupported {
+                    message: format!("{:?}", item.request.payment_method_data),
+                    connector: "Square",
+                })?
+            }
         }
     }
 }

--- a/crates/router/src/connector/stax/transformers.rs
+++ b/crates/router/src/connector/stax/transformers.rs
@@ -119,12 +119,10 @@ impl TryFrom<&StaxRouterData<&types::PaymentsAuthorizeRouterData>> for StaxPayme
             | api::PaymentMethodData::GiftCard(_)
             | api::PaymentMethodData::CardRedirect(_)
             | api::PaymentMethodData::Upi(_)
-            | api::PaymentMethodData::CardTokenData(_) => {
-                Err(errors::ConnectorError::NotSupported {
-                    message: "SELECTED_PAYMENT_METHOD".to_string(),
-                    connector: "Stax",
-                })?
-            }
+            | api::PaymentMethodData::CardToken(_) => Err(errors::ConnectorError::NotSupported {
+                message: "SELECTED_PAYMENT_METHOD".to_string(),
+                connector: "Stax",
+            })?,
         }
     }
 }
@@ -272,12 +270,10 @@ impl TryFrom<&types::TokenizationRouterData> for StaxTokenRequest {
             | api::PaymentMethodData::GiftCard(_)
             | api::PaymentMethodData::CardRedirect(_)
             | api::PaymentMethodData::Upi(_)
-            | api::PaymentMethodData::CardTokenData(_) => {
-                Err(errors::ConnectorError::NotSupported {
-                    message: "SELECTED_PAYMENT_METHOD".to_string(),
-                    connector: "Stax",
-                })?
-            }
+            | api::PaymentMethodData::CardToken(_) => Err(errors::ConnectorError::NotSupported {
+                message: "SELECTED_PAYMENT_METHOD".to_string(),
+                connector: "Stax",
+            })?,
         }
     }
 }

--- a/crates/router/src/connector/stax/transformers.rs
+++ b/crates/router/src/connector/stax/transformers.rs
@@ -118,10 +118,13 @@ impl TryFrom<&StaxRouterData<&types::PaymentsAuthorizeRouterData>> for StaxPayme
             | api::PaymentMethodData::Voucher(_)
             | api::PaymentMethodData::GiftCard(_)
             | api::PaymentMethodData::CardRedirect(_)
-            | api::PaymentMethodData::Upi(_) => Err(errors::ConnectorError::NotSupported {
-                message: "SELECTED_PAYMENT_METHOD".to_string(),
-                connector: "Stax",
-            })?,
+            | api::PaymentMethodData::Upi(_)
+            | api::PaymentMethodData::CardTokenData(_) => {
+                Err(errors::ConnectorError::NotSupported {
+                    message: "SELECTED_PAYMENT_METHOD".to_string(),
+                    connector: "Stax",
+                })?
+            }
         }
     }
 }
@@ -268,10 +271,13 @@ impl TryFrom<&types::TokenizationRouterData> for StaxTokenRequest {
             | api::PaymentMethodData::Voucher(_)
             | api::PaymentMethodData::GiftCard(_)
             | api::PaymentMethodData::CardRedirect(_)
-            | api::PaymentMethodData::Upi(_) => Err(errors::ConnectorError::NotSupported {
-                message: "SELECTED_PAYMENT_METHOD".to_string(),
-                connector: "Stax",
-            })?,
+            | api::PaymentMethodData::Upi(_)
+            | api::PaymentMethodData::CardTokenData(_) => {
+                Err(errors::ConnectorError::NotSupported {
+                    message: "SELECTED_PAYMENT_METHOD".to_string(),
+                    connector: "Stax",
+                })?
+            }
         }
     }
 }

--- a/crates/router/src/connector/stripe/transformers.rs
+++ b/crates/router/src/connector/stripe/transformers.rs
@@ -1433,13 +1433,11 @@ fn create_stripe_payment_method(
 
         payments::PaymentMethodData::Upi(_)
         | payments::PaymentMethodData::MandatePayment
-        | payments::PaymentMethodData::CardTokenData(_) => {
-            Err(errors::ConnectorError::NotSupported {
-                message: connector_util::SELECTED_PAYMENT_METHOD.to_string(),
-                connector: "stripe",
-            }
-            .into())
+        | payments::PaymentMethodData::CardToken(_) => Err(errors::ConnectorError::NotSupported {
+            message: connector_util::SELECTED_PAYMENT_METHOD.to_string(),
+            connector: "stripe",
         }
+        .into()),
     }
 }
 
@@ -2997,7 +2995,7 @@ impl TryFrom<&types::PaymentsPreProcessingRouterData> for StripeCreditTransferSo
             | Some(payments::PaymentMethodData::GiftCard(..))
             | Some(payments::PaymentMethodData::CardRedirect(..))
             | Some(payments::PaymentMethodData::Voucher(..))
-            | Some(payments::PaymentMethodData::CardTokenData(..))
+            | Some(payments::PaymentMethodData::CardToken(..))
             | None => Err(errors::ConnectorError::NotImplemented(
                 connector_util::get_unimplemented_payment_method_error_message("stripe"),
             )
@@ -3420,12 +3418,10 @@ impl
             | api::PaymentMethodData::Upi(_)
             | api::PaymentMethodData::CardRedirect(_)
             | api::PaymentMethodData::Voucher(_)
-            | api::PaymentMethodData::CardTokenData(_) => {
-                Err(errors::ConnectorError::NotSupported {
-                    message: format!("{pm_type:?}"),
-                    connector: "Stripe",
-                })?
-            }
+            | api::PaymentMethodData::CardToken(_) => Err(errors::ConnectorError::NotSupported {
+                message: format!("{pm_type:?}"),
+                connector: "Stripe",
+            })?,
         }
     }
 }

--- a/crates/router/src/connector/stripe/transformers.rs
+++ b/crates/router/src/connector/stripe/transformers.rs
@@ -1431,7 +1431,9 @@ fn create_stripe_payment_method(
             .into()),
         },
 
-        payments::PaymentMethodData::Upi(_) | payments::PaymentMethodData::MandatePayment => {
+        payments::PaymentMethodData::Upi(_)
+        | payments::PaymentMethodData::MandatePayment
+        | payments::PaymentMethodData::CardTokenData(_) => {
             Err(errors::ConnectorError::NotSupported {
                 message: connector_util::SELECTED_PAYMENT_METHOD.to_string(),
                 connector: "stripe",
@@ -2995,6 +2997,7 @@ impl TryFrom<&types::PaymentsPreProcessingRouterData> for StripeCreditTransferSo
             | Some(payments::PaymentMethodData::GiftCard(..))
             | Some(payments::PaymentMethodData::CardRedirect(..))
             | Some(payments::PaymentMethodData::Voucher(..))
+            | Some(payments::PaymentMethodData::CardTokenData(..))
             | None => Err(errors::ConnectorError::NotImplemented(
                 connector_util::get_unimplemented_payment_method_error_message("stripe"),
             )
@@ -3416,10 +3419,13 @@ impl
             | api::PaymentMethodData::GiftCard(_)
             | api::PaymentMethodData::Upi(_)
             | api::PaymentMethodData::CardRedirect(_)
-            | api::PaymentMethodData::Voucher(_) => Err(errors::ConnectorError::NotSupported {
-                message: format!("{pm_type:?}"),
-                connector: "Stripe",
-            })?,
+            | api::PaymentMethodData::Voucher(_)
+            | api::PaymentMethodData::CardTokenData(_) => {
+                Err(errors::ConnectorError::NotSupported {
+                    message: format!("{pm_type:?}"),
+                    connector: "Stripe",
+                })?
+            }
         }
     }
 }

--- a/crates/router/src/connector/trustpay/transformers.rs
+++ b/crates/router/src/connector/trustpay/transformers.rs
@@ -445,10 +445,13 @@ impl TryFrom<&TrustpayRouterData<&types::PaymentsAuthorizeRouterData>> for Trust
             | api::PaymentMethodData::Reward
             | api::PaymentMethodData::Upi(_)
             | api::PaymentMethodData::Voucher(_)
-            | api::PaymentMethodData::GiftCard(_) => Err(errors::ConnectorError::NotImplemented(
-                utils::get_unimplemented_payment_method_error_message("trustpay"),
-            )
-            .into()),
+            | api::PaymentMethodData::GiftCard(_)
+            | api::PaymentMethodData::CardTokenData(_) => {
+                Err(errors::ConnectorError::NotImplemented(
+                    utils::get_unimplemented_payment_method_error_message("trustpay"),
+                )
+                .into())
+            }
         }
     }
 }

--- a/crates/router/src/connector/trustpay/transformers.rs
+++ b/crates/router/src/connector/trustpay/transformers.rs
@@ -446,12 +446,10 @@ impl TryFrom<&TrustpayRouterData<&types::PaymentsAuthorizeRouterData>> for Trust
             | api::PaymentMethodData::Upi(_)
             | api::PaymentMethodData::Voucher(_)
             | api::PaymentMethodData::GiftCard(_)
-            | api::PaymentMethodData::CardTokenData(_) => {
-                Err(errors::ConnectorError::NotImplemented(
-                    utils::get_unimplemented_payment_method_error_message("trustpay"),
-                )
-                .into())
-            }
+            | api::PaymentMethodData::CardToken(_) => Err(errors::ConnectorError::NotImplemented(
+                utils::get_unimplemented_payment_method_error_message("trustpay"),
+            )
+            .into()),
         }
     }
 }

--- a/crates/router/src/connector/tsys/transformers.rs
+++ b/crates/router/src/connector/tsys/transformers.rs
@@ -78,7 +78,7 @@ impl TryFrom<&types::PaymentsAuthorizeRouterData> for TsysPaymentsRequest {
             | api::PaymentMethodData::Upi(_)
             | api::PaymentMethodData::Voucher(_)
             | api::PaymentMethodData::GiftCard(_)
-            | api::PaymentMethodData::CardTokenData(_) => {
+            | api::PaymentMethodData::CardToken(_) => {
                 Err(errors::ConnectorError::NotImplemented(
                     utils::get_unimplemented_payment_method_error_message("tsys"),
                 ))?

--- a/crates/router/src/connector/tsys/transformers.rs
+++ b/crates/router/src/connector/tsys/transformers.rs
@@ -78,11 +78,9 @@ impl TryFrom<&types::PaymentsAuthorizeRouterData> for TsysPaymentsRequest {
             | api::PaymentMethodData::Upi(_)
             | api::PaymentMethodData::Voucher(_)
             | api::PaymentMethodData::GiftCard(_)
-            | api::PaymentMethodData::CardToken(_) => {
-                Err(errors::ConnectorError::NotImplemented(
-                    utils::get_unimplemented_payment_method_error_message("tsys"),
-                ))?
-            }
+            | api::PaymentMethodData::CardToken(_) => Err(errors::ConnectorError::NotImplemented(
+                utils::get_unimplemented_payment_method_error_message("tsys"),
+            ))?,
         }
     }
 }

--- a/crates/router/src/connector/tsys/transformers.rs
+++ b/crates/router/src/connector/tsys/transformers.rs
@@ -77,9 +77,12 @@ impl TryFrom<&types::PaymentsAuthorizeRouterData> for TsysPaymentsRequest {
             | api::PaymentMethodData::Reward
             | api::PaymentMethodData::Upi(_)
             | api::PaymentMethodData::Voucher(_)
-            | api::PaymentMethodData::GiftCard(_) => Err(errors::ConnectorError::NotImplemented(
-                utils::get_unimplemented_payment_method_error_message("tsys"),
-            ))?,
+            | api::PaymentMethodData::GiftCard(_)
+            | api::PaymentMethodData::CardTokenData(_) => {
+                Err(errors::ConnectorError::NotImplemented(
+                    utils::get_unimplemented_payment_method_error_message("tsys"),
+                ))?
+            }
         }
     }
 }

--- a/crates/router/src/connector/volt/transformers.rs
+++ b/crates/router/src/connector/volt/transformers.rs
@@ -149,7 +149,7 @@ impl TryFrom<&VoltRouterData<&types::PaymentsAuthorizeRouterData>> for VoltPayme
             | api_models::payments::PaymentMethodData::Upi(_)
             | api_models::payments::PaymentMethodData::Voucher(_)
             | api_models::payments::PaymentMethodData::GiftCard(_)
-            | api_models::payments::PaymentMethodData::CardTokenData(_) => {
+            | api_models::payments::PaymentMethodData::CardToken(_) => {
                 Err(errors::ConnectorError::NotSupported {
                     message: utils::SELECTED_PAYMENT_METHOD.to_string(),
                     connector: "Volt",

--- a/crates/router/src/connector/volt/transformers.rs
+++ b/crates/router/src/connector/volt/transformers.rs
@@ -148,7 +148,8 @@ impl TryFrom<&VoltRouterData<&types::PaymentsAuthorizeRouterData>> for VoltPayme
             | api_models::payments::PaymentMethodData::Reward
             | api_models::payments::PaymentMethodData::Upi(_)
             | api_models::payments::PaymentMethodData::Voucher(_)
-            | api_models::payments::PaymentMethodData::GiftCard(_) => {
+            | api_models::payments::PaymentMethodData::GiftCard(_)
+            | api_models::payments::PaymentMethodData::CardTokenData(_) => {
                 Err(errors::ConnectorError::NotSupported {
                     message: utils::SELECTED_PAYMENT_METHOD.to_string(),
                     connector: "Volt",

--- a/crates/router/src/connector/worldline/transformers.rs
+++ b/crates/router/src/connector/worldline/transformers.rs
@@ -258,11 +258,9 @@ impl
             | api::PaymentMethodData::Upi(_)
             | api::PaymentMethodData::Voucher(_)
             | api::PaymentMethodData::GiftCard(_)
-            | api::PaymentMethodData::CardTokenData(_) => {
-                Err(errors::ConnectorError::NotImplemented(
-                    utils::get_unimplemented_payment_method_error_message("worldline"),
-                ))?
-            }
+            | api::PaymentMethodData::CardToken(_) => Err(errors::ConnectorError::NotImplemented(
+                utils::get_unimplemented_payment_method_error_message("worldline"),
+            ))?,
         };
 
         let customer =

--- a/crates/router/src/connector/worldline/transformers.rs
+++ b/crates/router/src/connector/worldline/transformers.rs
@@ -257,9 +257,12 @@ impl
             | api::PaymentMethodData::Reward
             | api::PaymentMethodData::Upi(_)
             | api::PaymentMethodData::Voucher(_)
-            | api::PaymentMethodData::GiftCard(_) => Err(errors::ConnectorError::NotImplemented(
-                utils::get_unimplemented_payment_method_error_message("worldline"),
-            ))?,
+            | api::PaymentMethodData::GiftCard(_)
+            | api::PaymentMethodData::CardTokenData(_) => {
+                Err(errors::ConnectorError::NotImplemented(
+                    utils::get_unimplemented_payment_method_error_message("worldline"),
+                ))?
+            }
         };
 
         let customer =

--- a/crates/router/src/connector/worldpay/transformers.rs
+++ b/crates/router/src/connector/worldpay/transformers.rs
@@ -120,7 +120,8 @@ fn fetch_payment_instrument(
         | api_models::payments::PaymentMethodData::Upi(_)
         | api_models::payments::PaymentMethodData::Voucher(_)
         | api_models::payments::PaymentMethodData::CardRedirect(_)
-        | api_models::payments::PaymentMethodData::GiftCard(_) => {
+        | api_models::payments::PaymentMethodData::GiftCard(_)
+        | api_models::payments::PaymentMethodData::CardTokenData(_) => {
             Err(errors::ConnectorError::NotImplemented(
                 utils::get_unimplemented_payment_method_error_message("worldpay"),
             )

--- a/crates/router/src/connector/worldpay/transformers.rs
+++ b/crates/router/src/connector/worldpay/transformers.rs
@@ -121,7 +121,7 @@ fn fetch_payment_instrument(
         | api_models::payments::PaymentMethodData::Voucher(_)
         | api_models::payments::PaymentMethodData::CardRedirect(_)
         | api_models::payments::PaymentMethodData::GiftCard(_)
-        | api_models::payments::PaymentMethodData::CardTokenData(_) => {
+        | api_models::payments::PaymentMethodData::CardToken(_) => {
             Err(errors::ConnectorError::NotImplemented(
                 utils::get_unimplemented_payment_method_error_message("worldpay"),
             )

--- a/crates/router/src/connector/zen/transformers.rs
+++ b/crates/router/src/connector/zen/transformers.rs
@@ -708,7 +708,7 @@ impl TryFrom<&ZenRouterData<&types::PaymentsAuthorizeRouterData>> for ZenPayment
             | api_models::payments::PaymentMethodData::MandatePayment
             | api_models::payments::PaymentMethodData::Reward
             | api_models::payments::PaymentMethodData::Upi(_)
-            | api_models::payments::PaymentMethodData::CardTokenData(_) => {
+            | api_models::payments::PaymentMethodData::CardToken(_) => {
                 Err(errors::ConnectorError::NotImplemented(
                     utils::get_unimplemented_payment_method_error_message("Zen"),
                 ))?

--- a/crates/router/src/connector/zen/transformers.rs
+++ b/crates/router/src/connector/zen/transformers.rs
@@ -707,7 +707,8 @@ impl TryFrom<&ZenRouterData<&types::PaymentsAuthorizeRouterData>> for ZenPayment
             api_models::payments::PaymentMethodData::Crypto(_)
             | api_models::payments::PaymentMethodData::MandatePayment
             | api_models::payments::PaymentMethodData::Reward
-            | api_models::payments::PaymentMethodData::Upi(_) => {
+            | api_models::payments::PaymentMethodData::Upi(_)
+            | api_models::payments::PaymentMethodData::CardTokenData(_) => {
                 Err(errors::ConnectorError::NotImplemented(
                     utils::get_unimplemented_payment_method_error_message("Zen"),
                 ))?

--- a/crates/router/src/core/payment_methods.rs
+++ b/crates/router/src/core/payment_methods.rs
@@ -3,6 +3,7 @@ pub mod surcharge_decision_configs;
 pub mod transformers;
 pub mod vault;
 
+use api_models::payments::CardTokenData;
 pub use api_models::{
     enums::{Connector, PayoutConnectors},
     payouts as payout_types,
@@ -42,6 +43,7 @@ pub trait PaymentMethodRetrieve {
         token: &storage::PaymentTokenData,
         payment_intent: &PaymentIntent,
         card_cvc: Option<masking::Secret<String>>,
+        card_token_data: Option<&CardTokenData>,
     ) -> RouterResult<Option<(payments::PaymentMethodData, enums::PaymentMethod)>>;
 }
 
@@ -125,6 +127,7 @@ impl PaymentMethodRetrieve for Oss {
         token_data: &storage::PaymentTokenData,
         payment_intent: &PaymentIntent,
         card_cvc: Option<masking::Secret<String>>,
+        card_token_data: Option<&CardTokenData>,
     ) -> RouterResult<Option<(payments::PaymentMethodData, enums::PaymentMethod)>> {
         match token_data {
             storage::PaymentTokenData::TemporaryGeneric(generic_token) => {
@@ -134,6 +137,7 @@ impl PaymentMethodRetrieve for Oss {
                     payment_intent,
                     card_cvc,
                     merchant_key_store,
+                    card_token_data,
                 )
                 .await
             }
@@ -145,6 +149,7 @@ impl PaymentMethodRetrieve for Oss {
                     payment_intent,
                     card_cvc,
                     merchant_key_store,
+                    card_token_data,
                 )
                 .await
             }
@@ -155,6 +160,7 @@ impl PaymentMethodRetrieve for Oss {
                     &card_token.token,
                     payment_intent,
                     card_cvc,
+                    card_token_data,
                 )
                 .await
                 .map(|card| Some((card, enums::PaymentMethod::Card)))
@@ -166,6 +172,7 @@ impl PaymentMethodRetrieve for Oss {
                     &card_token.token,
                     payment_intent,
                     card_cvc,
+                    card_token_data,
                 )
                 .await
                 .map(|card| Some((card, enums::PaymentMethod::Card)))

--- a/crates/router/src/core/payment_methods.rs
+++ b/crates/router/src/core/payment_methods.rs
@@ -3,7 +3,7 @@ pub mod surcharge_decision_configs;
 pub mod transformers;
 pub mod vault;
 
-use api_models::payments::CardTokenData;
+use api_models::payments::CardToken;
 pub use api_models::{
     enums::{Connector, PayoutConnectors},
     payouts as payout_types,
@@ -43,7 +43,7 @@ pub trait PaymentMethodRetrieve {
         token: &storage::PaymentTokenData,
         payment_intent: &PaymentIntent,
         card_cvc: Option<masking::Secret<String>>,
-        card_token_data: Option<&CardTokenData>,
+        card_token_data: Option<&CardToken>,
     ) -> RouterResult<Option<(payments::PaymentMethodData, enums::PaymentMethod)>>;
 }
 
@@ -127,7 +127,7 @@ impl PaymentMethodRetrieve for Oss {
         token_data: &storage::PaymentTokenData,
         payment_intent: &PaymentIntent,
         card_cvc: Option<masking::Secret<String>>,
-        card_token_data: Option<&CardTokenData>,
+        card_token_data: Option<&CardToken>,
     ) -> RouterResult<Option<(payments::PaymentMethodData, enums::PaymentMethod)>> {
         match token_data {
             storage::PaymentTokenData::TemporaryGeneric(generic_token) => {

--- a/crates/router/src/core/payments/helpers.rs
+++ b/crates/router/src/core/payments/helpers.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 
-use api_models::payments::GetPaymentMethodType;
+use api_models::payments::{CardTokenData, GetPaymentMethodType};
 use base64::Engine;
 use common_utils::{
     ext_traits::{AsyncExt, ByteSliceExt, ValueExt},
@@ -1356,6 +1356,7 @@ pub async fn retrieve_payment_method_with_temporary_token(
     payment_intent: &PaymentIntent,
     card_cvc: Option<masking::Secret<String>>,
     merchant_key_store: &domain::MerchantKeyStore,
+    card_token_data: Option<&CardTokenData>,
 ) -> RouterResult<Option<(api::PaymentMethodData, enums::PaymentMethod)>> {
     let (pm, supplementary_data) =
         vault::Vault::get_payment_method_data_from_locker(state, token, merchant_key_store)
@@ -1375,9 +1376,30 @@ pub async fn retrieve_payment_method_with_temporary_token(
 
     Ok::<_, error_stack::Report<errors::ApiErrorResponse>>(match pm {
         Some(api::PaymentMethodData::Card(card)) => {
+            let mut updated_card = card.clone();
+            let mut is_card_updated = false;
+
+            let name_on_card = if card.card_holder_name.clone().expose().is_empty() {
+                card_token_data
+                    .and_then(|token_data| {
+                        is_card_updated = true;
+                        token_data.card_holder_name.clone()
+                    })
+                    .filter(|name_on_card| !name_on_card.is_empty())
+                    .map(masking::Secret::new)
+                    .ok_or(errors::ApiErrorResponse::MissingRequiredField {
+                        field_name: "card_holder_name",
+                    })?
+            } else {
+                card.card_holder_name.clone()
+            };
+            updated_card.card_holder_name = name_on_card;
+
             if let Some(cvc) = card_cvc {
-                let mut updated_card = card;
+                is_card_updated = true;
                 updated_card.card_cvc = cvc;
+            }
+            if is_card_updated {
                 let updated_pm = api::PaymentMethodData::Card(updated_card);
                 vault::Vault::store_payment_method_data_in_locker(
                     state,
@@ -1423,6 +1445,7 @@ pub async fn retrieve_card_with_permanent_token(
     token: &str,
     payment_intent: &PaymentIntent,
     card_cvc: Option<masking::Secret<String>>,
+    card_token_data: Option<&CardTokenData>,
 ) -> RouterResult<api::PaymentMethodData> {
     let customer_id = payment_intent
         .customer_id
@@ -1437,13 +1460,27 @@ pub async fn retrieve_card_with_permanent_token(
         .change_context(errors::ApiErrorResponse::InternalServerError)
         .attach_printable("failed to fetch card information from the permanent locker")?;
 
+    let name = card
+        .name_on_card
+        .get_required_value("name_on_card")
+        .change_context(errors::ApiErrorResponse::InternalServerError)
+        .attach_printable("card holder name was not saved in permanent locker")?;
+
+    let name_on_card = if name.clone().expose().is_empty() {
+        card_token_data
+            .and_then(|token_data| token_data.card_holder_name.clone())
+            .filter(|name_on_card| !name_on_card.is_empty())
+            .map(masking::Secret::new)
+            .ok_or(errors::ApiErrorResponse::MissingRequiredField {
+                field_name: "card_holder_name",
+            })?
+    } else {
+        name
+    };
+
     let api_card = api::Card {
         card_number: card.card_number,
-        card_holder_name: card
-            .name_on_card
-            .get_required_value("name_on_card")
-            .change_context(errors::ApiErrorResponse::InternalServerError)
-            .attach_printable("card holder name was not saved in permanent locker")?,
+        card_holder_name: name_on_card,
         card_exp_month: card.card_exp_month,
         card_exp_year: card.card_exp_year,
         card_cvc: card_cvc.unwrap_or_default(),
@@ -1529,6 +1566,11 @@ pub async fn make_pm_data<'a, F: Clone, R, Ctx: PaymentMethodRetrieve>(
 
     let card_cvc = payment_data.card_cvc.clone();
 
+    let card_token_data = request.as_ref().and_then(|pmd| match pmd {
+        api_models::payments::PaymentMethodData::CardTokenData(token_data) => Some(token_data),
+        _ => None,
+    });
+
     // TODO: Handle case where payment method and token both are present in request properly.
     let payment_method = match (request, hyperswitch_token) {
         (_, Some(hyperswitch_token)) => {
@@ -1538,6 +1580,7 @@ pub async fn make_pm_data<'a, F: Clone, R, Ctx: PaymentMethodRetrieve>(
                 &hyperswitch_token,
                 &payment_data.payment_intent,
                 card_cvc,
+                card_token_data,
             )
             .await
             .attach_printable("in 'make_pm_data'")?;
@@ -3316,6 +3359,9 @@ pub async fn get_additional_payment_data(
         api_models::payments::PaymentMethodData::GiftCard(_) => {
             api_models::payments::AdditionalPaymentData::GiftCard {}
         }
+        api_models::payments::PaymentMethodData::CardTokenData(_) => {
+            api_models::payments::AdditionalPaymentData::CardTokenData {}
+        }
     }
 }
 
@@ -3615,6 +3661,12 @@ pub fn get_key_params_for_surcharge_details(
             gift_card.get_payment_method_type(),
             None,
         )),
+        api_models::payments::PaymentMethodData::CardTokenData(_) => {
+            Err(errors::ApiErrorResponse::InvalidDataValue {
+                field_name: "payment_method_data",
+            }
+            .into())
+        }
     }
 }
 

--- a/crates/router/src/openapi.rs
+++ b/crates/router/src/openapi.rs
@@ -248,6 +248,7 @@ Never share your secret api keys. Keep them guarded and secure.
         api_models::payments::OnlineMandate,
         api_models::payments::Card,
         api_models::payments::CardRedirectData,
+        api_models::payments::CardTokenData,
         api_models::payments::CustomerAcceptance,
         api_models::payments::PaymentsRequest,
         api_models::payments::PaymentsCreateRequest,

--- a/crates/router/src/openapi.rs
+++ b/crates/router/src/openapi.rs
@@ -248,7 +248,7 @@ Never share your secret api keys. Keep them guarded and secure.
         api_models::payments::OnlineMandate,
         api_models::payments::Card,
         api_models::payments::CardRedirectData,
-        api_models::payments::CardTokenData,
+        api_models::payments::CardToken,
         api_models::payments::CustomerAcceptance,
         api_models::payments::PaymentsRequest,
         api_models::payments::PaymentsCreateRequest,

--- a/crates/router/src/types/transformers.rs
+++ b/crates/router/src/types/transformers.rs
@@ -523,7 +523,7 @@ impl ForeignTryFrom<api_models::payments::PaymentMethodData> for api_enums::Paym
     ) -> Result<Self, Self::Error> {
         match payment_method_data {
             api_models::payments::PaymentMethodData::Card(..)
-            | api_models::payments::PaymentMethodData::CardTokenData(..) => Ok(Self::Card),
+            | api_models::payments::PaymentMethodData::CardToken(..) => Ok(Self::Card),
             api_models::payments::PaymentMethodData::Wallet(..) => Ok(Self::Wallet),
             api_models::payments::PaymentMethodData::PayLater(..) => Ok(Self::PayLater),
             api_models::payments::PaymentMethodData::BankRedirect(..) => Ok(Self::BankRedirect),

--- a/crates/router/src/types/transformers.rs
+++ b/crates/router/src/types/transformers.rs
@@ -522,7 +522,8 @@ impl ForeignTryFrom<api_models::payments::PaymentMethodData> for api_enums::Paym
         payment_method_data: api_models::payments::PaymentMethodData,
     ) -> Result<Self, Self::Error> {
         match payment_method_data {
-            api_models::payments::PaymentMethodData::Card(..) => Ok(Self::Card),
+            api_models::payments::PaymentMethodData::Card(..)
+            | api_models::payments::PaymentMethodData::CardTokenData(..) => Ok(Self::Card),
             api_models::payments::PaymentMethodData::Wallet(..) => Ok(Self::Wallet),
             api_models::payments::PaymentMethodData::PayLater(..) => Ok(Self::PayLater),
             api_models::payments::PaymentMethodData::BankRedirect(..) => Ok(Self::BankRedirect),

--- a/openapi/openapi_spec.json
+++ b/openapi/openapi_spec.json
@@ -4053,6 +4053,15 @@
           }
         ]
       },
+      "CardTokenData": {
+        "type": "object",
+        "properties": {
+          "card_holder_name": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
       "CashappQr": {
         "type": "object"
       },
@@ -8655,6 +8664,17 @@
             "properties": {
               "gift_card": {
                 "$ref": "#/components/schemas/GiftCardData"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "card_token_data"
+            ],
+            "properties": {
+              "card_token_data": {
+                "$ref": "#/components/schemas/CardTokenData"
               }
             }
           }

--- a/openapi/openapi_spec.json
+++ b/openapi/openapi_spec.json
@@ -4053,12 +4053,16 @@
           }
         ]
       },
-      "CardTokenData": {
+      "CardToken": {
         "type": "object",
+        "required": [
+          "card_holder_name"
+        ],
         "properties": {
           "card_holder_name": {
             "type": "string",
-            "nullable": true
+            "description": "The card holder's name",
+            "example": "John Test"
           }
         }
       },
@@ -8670,11 +8674,11 @@
           {
             "type": "object",
             "required": [
-              "card_token_data"
+              "card_token"
             ],
             "properties": {
-              "card_token_data": {
-                "$ref": "#/components/schemas/CardTokenData"
+              "card_token": {
+                "$ref": "#/components/schemas/CardToken"
               }
             }
           }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Currently, even though `card_holder_name` was empty, `/confirm` would occur without any error. But few connectors require `card_holder_name` to be sent. 
This PR includes changes for adding new object `CardToken` in `payment_method_data` object which can be used to send the `card_holder_name` during `/confirm` flow along with the token.
The token will fetch the stored card from locker. If this response has a `card_holder_name`, then it proceeds as usual without any error. Else it will check whether any `CardToken` object inside `payment_method_data` is sent or not. If not then error is thrown, if present then we update the `card` object received from locker to include the `card_holder_name` passed in `CardToken` during `/confirm` flow

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
1. Make a payment with saving the card. pass card_holder_name empty while saving
```
curl --location 'http://localhost:8080/payments' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: dev_u67d5zdpJVfHQ5jRhWXNg5F0Wy8MhzG2STAeHBhIKJowJJxAuVtvwhB2lsL427C8' \
--data-raw '{
    "amount": 6540,
    "currency": "USD",
    "confirm": true,
    "capture_method": "automatic",
    "capture_on": "2022-09-10T10:11:12Z",
    "amount_to_capture": 6540,
    "customer_id": "StripeCustomer",
    "email": "guest@example.com",
    "name": "John Doe",
    "phone": "999999999",
    "phone_country_code": "+1",
    "description": "Its my first payment request",
    "authentication_type": "no_three_ds",
    "setup_future_usage": "on_session",
    "return_url": "https://google.com",
    "payment_method": "card",
    "payment_method_type": "credit",
    "payment_method_data": {
        "card": {
            "card_number": "4242424242424242",
            "card_exp_month": "10",
            "card_exp_year": "25",
            "card_holder_name": "",
            "card_cvc": "123"
        }
    },
    "billing": {
        "address": {
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "city": "San Fransico",
            "state": "California",
            "zip": "94122",
            "country": "US",
            "first_name": "joseph",
            "last_name": "Doe"
        },
        "phone": {
            "number": "8056594427",
            "country_code": "+91"
        }
    },
    "shipping": {
        "address": {
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "city": "San Fransico",
            "state": "California",
            "zip": "94122",
            "country": "US",
            "first_name": "joseph",
            "last_name": "Doe"
        },
        "phone": {
            "number": "8056594427",
            "country_code": "+91"
        }
    },
    "statement_descriptor_name": "joseph",
    "statement_descriptor_suffix": "JS",
    "metadata": {
        "udf1": "value1",
        "new_customer": "true",
        "login_date": "2019-09-10T10:11:12Z"
    },
    "business_label": "default",
    "business_country": "US"
}'
```

2. Do `list_customer_payment_method` to get the `payment_token` 
3.  Now when you use that token to do payment again, you will get below error

![image](https://github.com/juspay/hyperswitch/assets/70657455/e4cfbd6b-a0fd-4e76-89d7-853a39fe1f78)

4. Now pass the `payment_method_data` object passing the `card_holder_name` here along with token in confirm call
```
curl --location 'http://localhost:8080/payments' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: dev_u67d5zdpJVfHQ5jRhWXNg5F0Wy8MhzG2STAeHBhIKJowJJxAuVtvwhB2lsL427C8' \
--data-raw '{
    "amount": 6540,
    "currency": "USD",
    "confirm": true,
    "capture_method": "automatic",
    "capture_on": "2022-09-10T10:11:12Z",
    "amount_to_capture": 6540,
    "customer_id": "StripeCustomer",
    "email": "guest@example.com",
    "name": "John Doe",
    "phone": "999999999",
    "phone_country_code": "+1",
    "description": "Its my first payment request",
    "authentication_type": "no_three_ds",
    "return_url": "https://google.com",
    "payment_method": "card",
    "payment_method_type": "credit",
    "payment_token": "token_PLmf9CALewF4hxRSCkC4",
    "payment_method_data": {
        "card_token": {
            "card_holder_name": "Joseph"
        }
    },
    "billing": {
        "address": {
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "city": "San Fransico",
            "state": "California",
            "zip": "94122",
            "country": "US",
            "first_name": "joseph",
            "last_name": "Doe"
        },
        "phone": {
            "number": "8056594427",
            "country_code": "+91"
        }
    },
    "shipping": {
        "address": {
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "city": "San Fransico",
            "state": "California",
            "zip": "94122",
            "country": "US",
            "first_name": "joseph",
            "last_name": "Doe"
        },
        "phone": {
            "number": "8056594427",
            "country_code": "+91"
        }
    },
    "statement_descriptor_name": "joseph",
    "statement_descriptor_suffix": "JS",
    "metadata": {
        "udf1": "value1",
        "new_customer": "true",
        "login_date": "2019-09-10T10:11:12Z"
    },
    "business_label": "default",
    "business_country": "US"
}'
``` 
If you see the response from confirm call, the `payment_method_data` object will have the `card_holder_name` passed above

![image](https://github.com/juspay/hyperswitch/assets/70657455/fdba9c8b-b1d9-4ee9-ad0f-0f0cdb7bf2ed)


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
