### PR TITLE
feat(core): Add ability to verify connector credentials before integrating the connector

### DIFF
--- a/crates/api_models/src/events.rs
+++ b/crates/api_models/src/events.rs
@@ -7,6 +7,7 @@ pub mod payouts;
 pub mod refund;
 pub mod routing;
 pub mod user;
+pub mod verify_connector;
 
 use common_utils::{
     events::{ApiEventMetric, ApiEventsType},

--- a/crates/api_models/src/events/verify_connector.rs
+++ b/crates/api_models/src/events/verify_connector.rs
@@ -1,0 +1,4 @@
+use crate::verify_connector::VerifyConnectorRequest;
+use common_utils::events::{ApiEventMetric, ApiEventsType};
+
+common_utils::impl_misc_api_event_type!(VerifyConnectorRequest);

--- a/crates/api_models/src/lib.rs
+++ b/crates/api_models/src/lib.rs
@@ -27,3 +27,4 @@ pub mod surcharge_decision_configs;
 pub mod user;
 pub mod verifications;
 pub mod webhooks;
+pub mod verify_connector;

--- a/crates/api_models/src/verify_connector.rs
+++ b/crates/api_models/src/verify_connector.rs
@@ -1,0 +1,9 @@
+use common_utils::pii;
+use serde::{Deserialize, Serialize};
+
+use crate::enums as api_enums;
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct VerifyConnectorRequest {
+    pub connector_name: api_enums::Connector,
+    pub connector_account_details: Option<pii::SecretSerdeValue>,
+}

--- a/crates/router/src/consts.rs
+++ b/crates/router/src/consts.rs
@@ -60,3 +60,8 @@ pub const LOCKER_REDIS_EXPIRY_SECONDS: u32 = 60 * 15; // 15 minutes
 pub const JWT_TOKEN_TIME_IN_SECS: u64 = 60 * 60 * 24 * 2; // 2 days
 
 pub const ROLE_ID_ORGANIZATION_ADMIN: &str = "org_admin";
+
+#[cfg(feature = "olap")]
+pub const VERIFY_CONNECTOR_ID_PREFIX: &str = "conn_verify";
+#[cfg(feature = "olap")]
+pub const VERIFY_CONNECTOR_MERCHANT_ID: &str = "test_merchant";

--- a/crates/router/src/core.rs
+++ b/crates/router/src/core.rs
@@ -26,4 +26,6 @@ pub mod user;
 pub mod utils;
 #[cfg(all(feature = "olap", feature = "kms"))]
 pub mod verification;
+#[cfg(feature = "olap")]
+pub mod verify_connector;
 pub mod webhooks;

--- a/crates/router/src/core/verify_connector.rs
+++ b/crates/router/src/core/verify_connector.rs
@@ -5,10 +5,11 @@ use error_stack::{IntoReport, ResultExt};
 use crate::types::api::verify_connector::{self as types, VerifyConnector};
 use crate::utils::verify_connector as utils;
 use crate::{services, AppState};
+use api_models::verify_connector::VerifyConnectorRequest;
 
 pub async fn verify_connector_credentials(
     state: AppState,
-    req: api::MerchantConnectorCreate,
+    req: VerifyConnectorRequest,
 ) -> errors::RouterResponse<()> {
     let boxed_connector = api::ConnectorData::get_connector_by_name(
         &state.conf.connectors,

--- a/crates/router/src/core/verify_connector.rs
+++ b/crates/router/src/core/verify_connector.rs
@@ -1,0 +1,59 @@
+use crate::{connector, core::errors, types::api, utils::OptionExt};
+use api_models::enums::Connector;
+use error_stack::{IntoReport, ResultExt};
+
+use crate::types::api::verify_connector::{self as types, VerifyConnector};
+use crate::utils::verify_connector as utils;
+use crate::{services, AppState};
+
+pub async fn verify_connector_credentials(
+    state: AppState,
+    req: api::MerchantConnectorCreate,
+) -> errors::RouterResponse<()> {
+    let boxed_connector = api::ConnectorData::get_connector_by_name(
+        &state.conf.connectors,
+        &req.connector_name.to_string(),
+        api::GetToken::Connector,
+        None,
+    )
+    .change_context(errors::ApiErrorResponse::IncorrectConnectorNameGiven)?;
+    let connector_auth = req
+        .connector_account_details
+        .clone()
+        .parse_value("ConnectorAuthType")
+        .change_context(errors::ApiErrorResponse::InvalidDataFormat {
+            field_name: "connector_account_details".to_string(),
+            expected_format: "auth_type and api_key".to_string(),
+        })?;
+
+    match req.connector_name {
+        Connector::Stripe => {
+            connector::Stripe::verify(
+                &state,
+                types::VerifyConnectorData {
+                    connector: *boxed_connector.connector,
+                    connector_auth,
+                    card_details: utils::get_test_card_details(req.connector_name)?,
+                },
+            )
+            .await
+        }
+        Connector::Paypal => connector::Paypal::get_access_token(
+            &state,
+            types::VerifyConnectorData {
+                connector: *boxed_connector.connector,
+                connector_auth,
+                card_details: utils::get_test_card_details(req.connector_name)?,
+            },
+        )
+        .await
+        .map(|_| services::ApplicationResponse::StatusOk),
+        _ => Err(errors::ApiErrorResponse::NotImplemented {
+            message: errors::api_error_response::NotImplementedMessage::Reason(format!(
+                "Verification for {}",
+                req.connector_name
+            )),
+        })
+        .into_report(),
+    }
+}

--- a/crates/router/src/routes.rs
+++ b/crates/router/src/routes.rs
@@ -28,6 +28,8 @@ pub mod user;
 #[cfg(all(feature = "olap", feature = "kms"))]
 pub mod verification;
 pub mod webhooks;
+#[cfg(feature = "olap")]
+pub mod verify_connector;
 
 pub mod locker_migration;
 #[cfg(feature = "dummy_connector")]

--- a/crates/router/src/routes/app.rs
+++ b/crates/router/src/routes/app.rs
@@ -32,7 +32,7 @@ use crate::{
     configs::settings,
     db::{StorageImpl, StorageInterface},
     events::{event_logger::EventLogger, EventHandler},
-    routes::cards_info::card_iin_info,
+    routes::{cards_info::card_iin_info, verify_connector::payment_connector_verify},
     services::get_store,
 };
 
@@ -507,6 +507,10 @@ impl MerchantConnectorAccount {
             use super::admin::*;
 
             route = route
+                .service(
+                    web::resource("/connectors/verify")
+                        .route(web::post().to(payment_connector_verify)),
+                )
                 .service(
                     web::resource("/{merchant_id}/connectors")
                         .route(web::post().to(payment_connector_create))

--- a/crates/router/src/routes/app.rs
+++ b/crates/router/src/routes/app.rs
@@ -28,11 +28,13 @@ use super::{cache::*, health::*};
 use super::{configs::*, customers::*, mandates::*, payments::*, refunds::*};
 #[cfg(feature = "oltp")]
 use super::{ephemeral_key::*, payment_methods::*, webhooks::*};
+#[cfg(feature = "olap")]
+use crate::routes::verify_connector::payment_connector_verify;
 use crate::{
     configs::settings,
     db::{StorageImpl, StorageInterface},
     events::{event_logger::EventLogger, EventHandler},
-    routes::{cards_info::card_iin_info, verify_connector::payment_connector_verify},
+    routes::cards_info::card_iin_info,
     services::get_store,
 };
 

--- a/crates/router/src/routes/lock_utils.rs
+++ b/crates/router/src/routes/lock_utils.rs
@@ -144,7 +144,9 @@ impl From<Flow> for ApiIdentifier {
             | Flow::GsmRuleUpdate
             | Flow::GsmRuleDelete => Self::Gsm,
 
-            Flow::UserConnectAccount | Flow::ChangePassword => Self::User,
+            Flow::UserConnectAccount | Flow::ChangePassword | Flow::VerifyPaymentConnector => {
+                Self::User
+            }
         }
     }
 }

--- a/crates/router/src/routes/verify_connector.rs
+++ b/crates/router/src/routes/verify_connector.rs
@@ -4,14 +4,14 @@ use crate::{
     services::{self, authentication as auth, authorization::permissions::Permission},
 };
 use actix_web::{web, HttpRequest, HttpResponse};
-use api_models::admin::MerchantConnectorCreate;
+use api_models::verify_connector::VerifyConnectorRequest;
 use router_env::{instrument, tracing, Flow};
 
 #[instrument(skip_all, fields(flow = ?Flow::VerifyPaymentConnector))]
 pub async fn payment_connector_verify(
     state: web::Data<AppState>,
     req: HttpRequest,
-    json_payload: web::Json<MerchantConnectorCreate>,
+    json_payload: web::Json<VerifyConnectorRequest>,
 ) -> HttpResponse {
     let flow = Flow::VerifyPaymentConnector;
     Box::pin(services::server_wrap(

--- a/crates/router/src/routes/verify_connector.rs
+++ b/crates/router/src/routes/verify_connector.rs
@@ -1,0 +1,27 @@
+use super::AppState;
+use crate::{
+    core::{api_locking, verify_connector},
+    services::{self, authentication as auth, authorization::permissions::Permission},
+};
+use actix_web::{web, HttpRequest, HttpResponse};
+use api_models::admin::MerchantConnectorCreate;
+use router_env::{instrument, tracing, Flow};
+
+#[instrument(skip_all, fields(flow = ?Flow::VerifyPaymentConnector))]
+pub async fn payment_connector_verify(
+    state: web::Data<AppState>,
+    req: HttpRequest,
+    json_payload: web::Json<MerchantConnectorCreate>,
+) -> HttpResponse {
+    let flow = Flow::VerifyPaymentConnector;
+    Box::pin(services::server_wrap(
+        flow,
+        state,
+        &req,
+        json_payload.into_inner(),
+        |state, _: (), req| verify_connector::verify_connector_credentials(state, req),
+        &auth::JWTAuth(Permission::MerchantConnectorAccountWrite),
+        api_locking::LockAction::NotApplicable,
+    ))
+    .await
+}

--- a/crates/router/src/types/api.rs
+++ b/crates/router/src/types/api.rs
@@ -14,6 +14,7 @@ pub mod payouts;
 pub mod refunds;
 pub mod routing;
 pub mod webhooks;
+pub mod verify_connector;
 
 use std::{fmt::Debug, str::FromStr};
 

--- a/crates/router/src/types/api.rs
+++ b/crates/router/src/types/api.rs
@@ -13,8 +13,9 @@ pub mod payments;
 pub mod payouts;
 pub mod refunds;
 pub mod routing;
-pub mod webhooks;
+#[cfg(feature = "olap")]
 pub mod verify_connector;
+pub mod webhooks;
 
 use std::{fmt::Debug, str::FromStr};
 

--- a/crates/router/src/types/api/verify_connector.rs
+++ b/crates/router/src/types/api/verify_connector.rs
@@ -1,0 +1,248 @@
+use crate::{
+    connector,
+    core::errors,
+    services,
+    types::{self, api, storage::enums as storage_enums},
+};
+use error_stack::{IntoReport, ResultExt};
+use router_env as env;
+
+use crate::{consts, services::ConnectorIntegration, AppState};
+
+#[derive(Clone, Debug)]
+pub struct VerifyConnectorData {
+    pub connector: &'static (dyn types::api::Connector + Sync),
+    pub connector_auth: types::ConnectorAuthType,
+    pub card_details: api::Card,
+}
+
+impl VerifyConnectorData {
+    fn get_payment_authorize_data(&self) -> types::PaymentsAuthorizeData {
+        types::PaymentsAuthorizeData {
+            payment_method_data: api::PaymentMethodData::Card(self.card_details.clone()),
+            email: None,
+            amount: 1000,
+            confirm: true,
+            currency: storage_enums::Currency::USD,
+            mandate_id: None,
+            webhook_url: None,
+            customer_id: None,
+            off_session: None,
+            browser_info: None,
+            session_token: None,
+            order_details: None,
+            order_category: None,
+            capture_method: None,
+            enrolled_for_3ds: false,
+            router_return_url: None,
+            surcharge_details: None,
+            setup_future_usage: None,
+            payment_experience: None,
+            payment_method_type: None,
+            statement_descriptor: None,
+            setup_mandate_details: None,
+            complete_authorize_url: None,
+            related_transaction_id: None,
+            statement_descriptor_suffix: None,
+        }
+    }
+
+    fn get_router_data<F, R1, R2>(
+        &self,
+        request_data: R1,
+        access_token: Option<types::AccessToken>,
+    ) -> types::RouterData<F, R1, R2> {
+        let attempt_id =
+            common_utils::generate_id_with_default_len(consts::VERIFY_CONNECTOR_ID_PREFIX);
+        types::RouterData {
+            flow: std::marker::PhantomData,
+            status: storage_enums::AttemptStatus::Started,
+            request: request_data,
+            response: Err(errors::ApiErrorResponse::InternalServerError.into()),
+            connector: self.connector.id().to_string(),
+            auth_type: storage_enums::AuthenticationType::NoThreeDs,
+            test_mode: Some(!matches!(env::which(), env::Env::Production)),
+            return_url: None,
+            attempt_id: attempt_id.clone(),
+            description: None,
+            customer_id: None,
+            merchant_id: consts::VERIFY_CONNECTOR_MERCHANT_ID.to_string(),
+            reference_id: None,
+            access_token,
+            session_token: None,
+            payment_method: storage_enums::PaymentMethod::Card,
+            amount_captured: None,
+            preprocessing_id: None,
+            payment_method_id: None,
+            connector_customer: None,
+            connector_auth_type: self.connector_auth.clone(),
+            connector_meta_data: None,
+            payment_method_token: None,
+            connector_api_version: None,
+            recurring_mandate_payment_data: None,
+            connector_request_reference_id: attempt_id,
+            address: types::PaymentAddress {
+                shipping: None,
+                billing: None,
+            },
+            payment_id: common_utils::generate_id_with_default_len(
+                consts::VERIFY_CONNECTOR_ID_PREFIX,
+            ),
+            #[cfg(feature = "payouts")]
+            payout_method_data: None,
+            #[cfg(feature = "payouts")]
+            quote_id: None,
+            payment_method_balance: None,
+            connector_http_status_code: None,
+            external_latency: None,
+            apple_pay_flow: None,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+pub trait VerifyConnector {
+    async fn verify(
+        state: &AppState,
+        connector_data: VerifyConnectorData,
+    ) -> errors::RouterResponse<()> {
+        let authorize_data = connector_data.get_payment_authorize_data();
+        let access_token = Self::get_access_token(state, connector_data.clone()).await?;
+        let router_data = connector_data.get_router_data(authorize_data, access_token);
+
+        let request = connector_data
+            .connector
+            .build_request(&router_data, &state.conf.connectors)
+            .change_context(errors::ApiErrorResponse::InvalidRequestData {
+                message: "Payment request cannot be built".to_string(),
+            })?
+            .ok_or(errors::ApiErrorResponse::InternalServerError)?;
+
+        let response = services::call_connector_api(&state.to_owned(), request)
+            .await
+            .change_context(errors::ApiErrorResponse::InternalServerError)?;
+
+        match response {
+            Ok(_) => Ok(services::ApplicationResponse::StatusOk),
+            Err(error_response) => {
+                Self::handle_payment_error_response::<
+                    api::Authorize,
+                    types::PaymentsAuthorizeData,
+                    types::PaymentsResponseData,
+                >(connector_data.connector, error_response)
+                .await
+            }
+        }
+    }
+
+    async fn get_access_token(
+        _state: &AppState,
+        _connector_data: VerifyConnectorData,
+    ) -> errors::CustomResult<Option<types::AccessToken>, errors::ApiErrorResponse> {
+        // AccessToken is None for the connectors without the AccessToken Flow.
+        // If a connector has that, then it should override this implementation.
+        Ok(None)
+    }
+
+    async fn handle_payment_error_response<F, R1, R2>(
+        connector: &(dyn types::api::Connector + Sync),
+        error_response: types::Response,
+    ) -> errors::RouterResponse<()>
+    where
+        dyn types::api::Connector + Sync: ConnectorIntegration<F, R1, R2>,
+    {
+        let error = connector
+            .get_error_response(error_response)
+            .change_context(errors::ApiErrorResponse::InternalServerError)?;
+        Err(errors::ApiErrorResponse::InvalidRequestData {
+            message: error.reason.unwrap_or(error.message),
+        })
+        .into_report()
+    }
+
+    async fn handle_access_token_error_response<F, R1, R2>(
+        connector: &(dyn types::api::Connector + Sync),
+        error_response: types::Response,
+    ) -> errors::RouterResult<Option<types::AccessToken>>
+    where
+        dyn types::api::Connector + Sync: ConnectorIntegration<F, R1, R2>,
+    {
+        let error = connector
+            .get_error_response(error_response)
+            .change_context(errors::ApiErrorResponse::InternalServerError)?;
+        Err(errors::ApiErrorResponse::InvalidRequestData {
+            message: error.reason.unwrap_or(error.message),
+        })
+        .into_report()
+    }
+}
+
+#[async_trait::async_trait]
+impl VerifyConnector for connector::Stripe {
+    async fn handle_payment_error_response<F, R1, R2>(
+        connector: &(dyn types::api::Connector + Sync),
+        error_response: types::Response,
+    ) -> errors::RouterResponse<()>
+    where
+        dyn types::api::Connector + Sync: ConnectorIntegration<F, R1, R2>,
+    {
+        let error = connector
+            .get_error_response(error_response)
+            .change_context(errors::ApiErrorResponse::InternalServerError)?;
+        match (env::which(), error.code.as_str()) {
+            // In situations where an attempt is made to process a payment using a
+            // Stripe production key along with a test card (which verify_connector is using),
+            // Stripe will respond with a "card_declined" error. In production,
+            // when this scenario occurs we will send back an "Ok" response.
+            (env::Env::Production, "card_declined") => Ok(services::ApplicationResponse::StatusOk),
+            _ => Err(errors::ApiErrorResponse::InvalidRequestData {
+                message: error.reason.unwrap_or(error.message),
+            })
+            .into_report(),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl VerifyConnector for connector::Paypal {
+    async fn get_access_token(
+        state: &AppState,
+        connector_data: VerifyConnectorData,
+    ) -> errors::CustomResult<Option<types::AccessToken>, errors::ApiErrorResponse> {
+        let token_data: types::AccessTokenRequestData =
+            connector_data.connector_auth.clone().try_into()?;
+        let router_data = connector_data.get_router_data(token_data, None);
+
+        let request = connector_data
+            .connector
+            .build_request(&router_data, &state.conf.connectors)
+            .change_context(errors::ApiErrorResponse::InvalidRequestData {
+                message: "Payment request cannot be built".to_string(),
+            })?
+            .ok_or(errors::ApiErrorResponse::InternalServerError)?;
+
+        let response = services::call_connector_api(&state.to_owned(), request)
+            .await
+            .change_context(errors::ApiErrorResponse::InternalServerError)?;
+
+        match response {
+            Ok(res) => Some(
+                connector_data
+                    .connector
+                    .handle_response(&router_data, res)
+                    .change_context(errors::ApiErrorResponse::InternalServerError)?
+                    .response
+                    .map_err(|_| errors::ApiErrorResponse::InternalServerError.into()),
+            )
+            .transpose(),
+            Err(response_data) => {
+                Self::handle_access_token_error_response::<
+                    api::AccessTokenAuth,
+                    types::AccessTokenRequestData,
+                    types::AccessToken,
+                >(connector_data.connector, response_data)
+                .await
+            }
+        }
+    }
+}

--- a/crates/router/src/utils.rs
+++ b/crates/router/src/utils.rs
@@ -3,6 +3,8 @@ pub mod db_utils;
 pub mod ext_traits;
 #[cfg(feature = "olap")]
 pub mod user;
+#[cfg(feature = "olap")]
+pub mod verify_connector;
 
 #[cfg(feature = "kv_store")]
 pub mod storage_partitioning;

--- a/crates/router/src/utils/verify_connector.rs
+++ b/crates/router/src/utils/verify_connector.rs
@@ -1,0 +1,45 @@
+use crate::{core::errors, types::api};
+use api_models::enums::Connector;
+
+pub fn generate_card_from_details(
+    card_number: String,
+    card_exp_year: String,
+    card_exp_month: String,
+    card_cvv: String,
+) -> Result<api::Card, errors::ApiErrorResponse> {
+    Ok(api::Card {
+        card_number: card_number
+            .parse()
+            .map_err(|_| errors::ApiErrorResponse::InternalServerError)?,
+        card_issuer: None,
+        card_cvc: masking::Secret::new(card_cvv),
+        card_network: None,
+        card_exp_year: masking::Secret::new(card_exp_year),
+        card_exp_month: masking::Secret::new(card_exp_month),
+        card_holder_name: masking::Secret::new("HyperSwitch".to_string()),
+        nick_name: None,
+        card_type: None,
+        card_issuing_country: None,
+        bank_code: None,
+    })
+}
+
+pub fn get_test_card_details(
+    connector_name: Connector,
+) -> Result<api::Card, errors::ApiErrorResponse> {
+    match connector_name {
+        Connector::Stripe => generate_card_from_details(
+            "4242424242424242".to_string(),
+            "2025".to_string(),
+            "12".to_string(),
+            "100".to_string(),
+        ),
+        Connector::Paypal => generate_card_from_details(
+            "4111111111111111".to_string(),
+            "2025".to_string(),
+            "02".to_string(),
+            "123".to_string(),
+        ),
+        _ => Err(errors::ApiErrorResponse::IncorrectConnectorNameGiven),
+    }
+}

--- a/crates/router_env/src/logger/types.rs
+++ b/crates/router_env/src/logger/types.rs
@@ -257,6 +257,8 @@ pub enum Flow {
     DecisionManagerRetrieveConfig,
     /// Change password flow
     ChangePassword,
+    /// Payment Connector Verify
+    VerifyPaymentConnector,
 }
 
 ///


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
This PR adds a new route `/account/connectors/verify`.

### Additional Changes

- [x] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Postman.
```
curl --location 'http://localhost:8080/account/connectors/verify' \
--header 'Content-Type: application/json' \
--header 'Authorization: Bearer JWT Token' \
--data '{
  "connector_name": "stripe",
  "connector_account_details": {
    "auth_type": "HeaderKey",
    "api_key": "some secret"
  }
}'
```
```
curl --location 'http://localhost:8080/account/connectors/verify' \
--header 'Content-Type: application/json' \
--header 'Authorization: Bearer JWT Token' \
--data '{
  "connector_name": "paypal",
  "connector_account_details": {
    "auth_type": "BodyKey",
    "api_key": "some secret",
    "key1": "some other secret"
  }
}'
```

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
