### PR TITLE
fix: remove `dummy_connector` from `default` features in `common_enums`

### DIFF
--- a/crates/api_models/Cargo.toml
+++ b/crates/api_models/Cargo.toml
@@ -14,7 +14,7 @@ connector_choice_bcompat = []
 errors = ["dep:actix-web", "dep:reqwest"]
 backwards_compatibility = ["connector_choice_bcompat"]
 connector_choice_mca_id = ["euclid/connector_choice_mca_id"]
-dummy_connector = ["euclid/dummy_connector"]
+dummy_connector = ["euclid/dummy_connector", "common_enums/dummy_connector"]
 detailed_errors = []
 payouts = []
 

--- a/crates/common_enums/Cargo.toml
+++ b/crates/common_enums/Cargo.toml
@@ -8,7 +8,6 @@ readme = "README.md"
 license.workspace = true
 
 [features]
-default = ["dummy_connector"]
 dummy_connector = []
 
 [dependencies]


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
dummy connector is enabled by default in common enums . This pr disables the dummy connector in common enums .

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
by running `make hack` and `cargo check --no-default-features ` succesfully .

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
