### PR TITLE
fix: remove error propagation if card name not found in locker in case of temporary token

### DIFF
--- a/crates/router/src/core/payments/helpers.rs
+++ b/crates/router/src/core/payments/helpers.rs
@@ -1382,17 +1382,20 @@ pub async fn retrieve_payment_method_with_temporary_token(
             let name_on_card = if card.card_holder_name.clone().expose().is_empty() {
                 card_token_data
                     .and_then(|token_data| {
-                        is_card_updated = true;
                         token_data.card_holder_name.clone()
                     })
                     .filter(|name_on_card| !name_on_card.clone().expose().is_empty())
-                    .ok_or(errors::ApiErrorResponse::MissingRequiredField {
-                        field_name: "card_holder_name",
-                    })?
+                    .map(|name_on_card| {
+                        is_card_updated = true;
+                        name_on_card
+                    })
             } else {
-                card.card_holder_name.clone()
+                Some(card.card_holder_name.clone())
             };
-            updated_card.card_holder_name = name_on_card;
+
+            if let Some(name_on_card) = name_on_card {
+                updated_card.card_holder_name = name_on_card;
+            }
 
             if let Some(cvc) = card_cvc {
                 is_card_updated = true;

--- a/crates/router/src/core/payments/helpers.rs
+++ b/crates/router/src/core/payments/helpers.rs
@@ -1381,9 +1381,7 @@ pub async fn retrieve_payment_method_with_temporary_token(
 
             let name_on_card = if card.card_holder_name.clone().expose().is_empty() {
                 card_token_data
-                    .and_then(|token_data| {
-                        token_data.card_holder_name.clone()
-                    })
+                    .and_then(|token_data| token_data.card_holder_name.clone())
                     .filter(|name_on_card| !name_on_card.clone().expose().is_empty())
                     .map(|name_on_card| {
                         is_card_updated = true;


### PR DESCRIPTION

## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
This PR removes the error propagation if card name not found in locker in case of temporary token. Instead asks during confirm flow

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
1. Make a payment with saving the card. pass card_holder_name empty while saving
```
curl --location 'http://localhost:8080/payments' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: dev_u67d5zdpJVfHQ5jRhWXNg5F0Wy8MhzG2STAeHBhIKJowJJxAuVtvwhB2lsL427C8' \
--data-raw '{
    "amount": 6540,
    "currency": "USD",
    "confirm": false,
    "capture_method": "automatic",
    "capture_on": "2022-09-10T10:11:12Z",
    "amount_to_capture": 6540,
    "customer_id": "StripeCustomer",
    "email": "guest@example.com",
    "name": "John Doe",
    "phone": "999999999",
    "phone_country_code": "+1",
    "description": "Its my first payment request",
    "authentication_type": "no_three_ds",
    "setup_future_usage": "on_session",
    "return_url": "https://google.com",
    "payment_method": "card",
    "payment_method_type": "credit",
    "payment_method_data": {
        "card": {
            "card_number": "4242424242424242",
            "card_exp_month": "10",
            "card_exp_year": "25",
            "card_holder_name": "",
            "card_cvc": "123"
        }
    },
    "billing": {
        "address": {
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "city": "San Fransico",
            "state": "California",
            "zip": "94122",
            "country": "US",
            "first_name": "joseph",
            "last_name": "Doe"
        },
        "phone": {
            "number": "8056594427",
            "country_code": "+91"
        }
    },
    "shipping": {
        "address": {
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "city": "San Fransico",
            "state": "California",
            "zip": "94122",
            "country": "US",
            "first_name": "joseph",
            "last_name": "Doe"
        },
        "phone": {
            "number": "8056594427",
            "country_code": "+91"
        }
    },
    "statement_descriptor_name": "joseph",
    "statement_descriptor_suffix": "JS",
    "metadata": {
        "udf1": "value1",
        "new_customer": "true",
        "login_date": "2019-09-10T10:11:12Z"
    },
    "business_label": "default",
    "business_country": "US"
}'
```

2. Get the `payment_token`  from the above response
3.  Now when you use that token to do payment again, you will get below error

![image](https://github.com/juspay/hyperswitch/assets/70657455/e4cfbd6b-a0fd-4e76-89d7-853a39fe1f78)

4. Now pass the `payment_method_data` object passing the `card_holder_name` here along with token in confirm call
```
curl --location 'http://localhost:8080/payments' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: dev_u67d5zdpJVfHQ5jRhWXNg5F0Wy8MhzG2STAeHBhIKJowJJxAuVtvwhB2lsL427C8' \
--data-raw '{
    "amount": 6540,
    "currency": "USD",
    "confirm": true,
    "capture_method": "automatic",
    "capture_on": "2022-09-10T10:11:12Z",
    "amount_to_capture": 6540,
    "customer_id": "StripeCustomer",
    "email": "guest@example.com",
    "name": "John Doe",
    "phone": "999999999",
    "phone_country_code": "+1",
    "description": "Its my first payment request",
    "authentication_type": "no_three_ds",
    "return_url": "https://google.com",
    "payment_method": "card",
    "payment_method_type": "credit",
    "payment_token": "token_PLmf9CALewF4hxRSCkC4",
    "payment_method_data": {
        "card_token": {
            "card_holder_name": "Joseph"
        }
    },
    "billing": {
        "address": {
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "city": "San Fransico",
            "state": "California",
            "zip": "94122",
            "country": "US",
            "first_name": "joseph",
            "last_name": "Doe"
        },
        "phone": {
            "number": "8056594427",
            "country_code": "+91"
        }
    },
    "shipping": {
        "address": {
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "city": "San Fransico",
            "state": "California",
            "zip": "94122",
            "country": "US",
            "first_name": "joseph",
            "last_name": "Doe"
        },
        "phone": {
            "number": "8056594427",
            "country_code": "+91"
        }
    },
    "statement_descriptor_name": "joseph",
    "statement_descriptor_suffix": "JS",
    "metadata": {
        "udf1": "value1",
        "new_customer": "true",
        "login_date": "2019-09-10T10:11:12Z"
    },
    "business_label": "default",
    "business_country": "US"
}'
``` 
If you see the response from confirm call, the `payment_method_data` object will have the `card_holder_name` passed above

![image](https://github.com/juspay/hyperswitch/assets/70657455/fdba9c8b-b1d9-4ee9-ad0f-0f0cdb7bf2ed)

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
