### PR TITLE
fix(router): make use of warning to log errors when apple pay metadata parsing fails

### DIFF
--- a/crates/router/src/core/payments.rs
+++ b/crates/router/src/core/payments.rs
@@ -1554,7 +1554,7 @@ fn check_apple_pay_metadata(
                         })
                 })
                 .map_err(
-                    |error| logger::error!(%error, "Failed to Parse Value to ApplepaySessionTokenData"),
+                    |error| logger::warn!(%error, "Failed to Parse Value to ApplepaySessionTokenData"),
                 );
 
             parsed_metadata.ok().map(|metadata| match metadata {


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
For some of the connectors apple pay metadata is not required to process the apple pay payments. For such type of payment it is adding unnecessary error logs as apple pay metadata is being used to decide the apple pay flow (simplified or manual). This pr contains the changes to  make use of warning to log errors when apple pay metadata parsing fails which will avoid unnecessary error logs.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
