### PR TITLE
refactor: create separate struct for surcharge details response

### DIFF
--- a/crates/api_models/src/payments.rs
+++ b/crates/api_models/src/payments.rs
@@ -16,7 +16,6 @@ use crate::{
     admin, disputes,
     enums::{self as api_enums},
     ephemeral_key::EphemeralKeyCreateResponse,
-    payment_methods::{Surcharge, SurchargeDetailsResponse},
     refunds,
 };
 
@@ -338,17 +337,6 @@ pub struct RequestSurchargeDetails {
 impl RequestSurchargeDetails {
     pub fn is_surcharge_zero(&self) -> bool {
         self.surcharge_amount == 0 && self.tax_amount.unwrap_or(0) == 0
-    }
-    pub fn get_surcharge_details_object(&self, original_amount: i64) -> SurchargeDetailsResponse {
-        let surcharge_amount = self.surcharge_amount;
-        let tax_on_surcharge_amount = self.tax_amount.unwrap_or(0);
-        SurchargeDetailsResponse {
-            surcharge: Surcharge::Fixed(self.surcharge_amount),
-            tax_on_surcharge: None,
-            surcharge_amount,
-            tax_on_surcharge_amount,
-            final_amount: original_amount + surcharge_amount + tax_on_surcharge_amount,
-        }
     }
     pub fn get_total_surcharge_amount(&self) -> i64 {
         self.surcharge_amount + self.tax_amount.unwrap_or(0)

--- a/crates/api_models/src/surcharge_decision_configs.rs
+++ b/crates/api_models/src/surcharge_decision_configs.rs
@@ -7,21 +7,21 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
-pub struct SurchargeDetails {
-    pub surcharge: Surcharge,
+pub struct SurchargeDetailsOutput {
+    pub surcharge: SurchargeOutput,
     pub tax_on_surcharge: Option<Percentage<SURCHARGE_PERCENTAGE_PRECISION_LENGTH>>,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case", tag = "type", content = "value")]
-pub enum Surcharge {
-    Fixed(i64),
+pub enum SurchargeOutput {
+    Fixed { amount: i64 },
     Rate(Percentage<SURCHARGE_PERCENTAGE_PRECISION_LENGTH>),
 }
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct SurchargeDecisionConfigs {
-    pub surcharge_details: Option<SurchargeDetails>,
+    pub surcharge_details: Option<SurchargeDetailsOutput>,
 }
 impl EuclidDirFilter for SurchargeDecisionConfigs {
     const ALLOWED: &'static [DirKeyKind] = &[

--- a/crates/common_utils/src/types.rs
+++ b/crates/common_utils/src/types.rs
@@ -2,7 +2,10 @@
 use error_stack::{IntoReport, ResultExt};
 use serde::{de::Visitor, Deserialize, Deserializer};
 
-use crate::errors::{CustomResult, PercentageError};
+use crate::{
+    consts,
+    errors::{CustomResult, PercentageError},
+};
 
 /// Represents Percentage Value between 0 and 100 both inclusive
 #[derive(Clone, Default, Debug, PartialEq, serde::Serialize)]
@@ -135,4 +138,14 @@ impl<'de, const PRECISION: u8> Deserialize<'de> for Percentage<PRECISION> {
     {
         data.deserialize_map(PercentageVisitor::<PRECISION> {})
     }
+}
+
+/// represents surcharge type and value
+#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case", tag = "type", content = "value")]
+pub enum Surcharge {
+    /// Fixed Surcharge value
+    Fixed(i64),
+    /// Surcharge percentage
+    Rate(Percentage<{ consts::SURCHARGE_PERCENTAGE_PRECISION_LENGTH }>),
 }

--- a/crates/diesel_models/src/payment_intent.rs
+++ b/crates/diesel_models/src/payment_intent.rs
@@ -106,7 +106,6 @@ pub struct PaymentIntentNew {
     pub merchant_decision: Option<String>,
     pub payment_link_id: Option<String>,
     pub payment_confirm_source: Option<storage_enums::PaymentSource>,
-
     pub updated_by: String,
     pub surcharge_applicable: Option<bool>,
     pub request_incremental_authorization: RequestIncrementalAuthorization,

--- a/crates/router/src/core/payment_methods/surcharge_decision_configs.rs
+++ b/crates/router/src/core/payment_methods/surcharge_decision_configs.rs
@@ -107,8 +107,10 @@ pub async fn perform_surcharge_decision_management_for_payment_method_list(
                     card_network_type.surcharge_details = surcharge_output
                         .surcharge_details
                         .map(|surcharge_details| {
-                            let surcharge_details =
-                                get_surcharge_details_response(surcharge_details, payment_attempt)?;
+                            let surcharge_details = get_surcharge_details_from_surcharge_output(
+                                surcharge_details,
+                                payment_attempt,
+                            )?;
                             surcharge_metadata.insert_surcharge_details(
                                 &payment_methods_enabled.payment_method,
                                 &payment_method_type_response.payment_method_type,
@@ -117,7 +119,7 @@ pub async fn perform_surcharge_decision_management_for_payment_method_list(
                             );
                             SurchargeDetailsResponse::foreign_try_from((
                                 &surcharge_details,
-                                &payment_attempt,
+                                payment_attempt,
                             ))
                             .into_report()
                             .change_context(ConfigError::DslExecutionError)
@@ -131,8 +133,10 @@ pub async fn perform_surcharge_decision_management_for_payment_method_list(
                 payment_method_type_response.surcharge_details = surcharge_output
                     .surcharge_details
                     .map(|surcharge_details| {
-                        let surcharge_details =
-                            get_surcharge_details_response(surcharge_details, payment_attempt)?;
+                        let surcharge_details = get_surcharge_details_from_surcharge_output(
+                            surcharge_details,
+                            payment_attempt,
+                        )?;
                         surcharge_metadata.insert_surcharge_details(
                             &payment_methods_enabled.payment_method,
                             &payment_method_type_response.payment_method_type,
@@ -141,7 +145,7 @@ pub async fn perform_surcharge_decision_management_for_payment_method_list(
                         );
                         SurchargeDetailsResponse::foreign_try_from((
                             &surcharge_details,
-                            &payment_attempt,
+                            payment_attempt,
                         ))
                         .into_report()
                         .change_context(ConfigError::DslExecutionError)
@@ -197,8 +201,10 @@ where
         let surcharge_output =
             execute_dsl_and_get_conditional_config(backend_input.clone(), interpreter)?;
         if let Some(surcharge_details) = surcharge_output.surcharge_details {
-            let surcharge_details_response =
-                get_surcharge_details_response(surcharge_details, &payment_data.payment_attempt)?;
+            let surcharge_details_response = get_surcharge_details_from_surcharge_output(
+                surcharge_details,
+                &payment_data.payment_attempt,
+            )?;
             surcharge_metadata.insert_surcharge_details(
                 &payment_method_type.to_owned().into(),
                 payment_method_type,
@@ -210,7 +216,7 @@ where
     Ok(surcharge_metadata)
 }
 
-fn get_surcharge_details_response(
+fn get_surcharge_details_from_surcharge_output(
     surcharge_details: surcharge_decision_configs::SurchargeDetailsOutput,
     payment_attempt: &oss_storage::PaymentAttempt,
 ) -> ConditionalConfigResult<types::SurchargeDetails> {

--- a/crates/router/src/core/payment_methods/surcharge_decision_configs.rs
+++ b/crates/router/src/core/payment_methods/surcharge_decision_configs.rs
@@ -1,12 +1,10 @@
 use api_models::{
-    payment_methods::{self, SurchargeDetailsResponse, SurchargeMetadata},
+    payment_methods::SurchargeDetailsResponse,
     payments::Address,
     routing,
-    surcharge_decision_configs::{
-        self, SurchargeDecisionConfigs, SurchargeDecisionManagerRecord, SurchargeDetails,
-    },
+    surcharge_decision_configs::{self, SurchargeDecisionConfigs, SurchargeDecisionManagerRecord},
 };
-use common_utils::{ext_traits::StringExt, static_cache::StaticCache};
+use common_utils::{ext_traits::StringExt, static_cache::StaticCache, types as common_utils_types};
 use error_stack::{self, IntoReport, ResultExt};
 use euclid::{
     backend,
@@ -14,7 +12,11 @@ use euclid::{
 };
 use router_env::{instrument, tracing};
 
-use crate::{core::payments::PaymentData, db::StorageInterface, types::storage as oss_storage};
+use crate::{
+    core::payments::{types, PaymentData},
+    db::StorageInterface,
+    types::{storage as oss_storage, transformers::ForeignTryFrom},
+};
 static CONF_CACHE: StaticCache<VirInterpreterBackendCacheWrapper> = StaticCache::new();
 use crate::{
     core::{
@@ -55,10 +57,10 @@ pub async fn perform_surcharge_decision_management_for_payment_method_list(
     billing_address: Option<Address>,
     response_payment_method_types: &mut [api_models::payment_methods::ResponsePaymentMethodsEnabled],
 ) -> ConditionalConfigResult<(
-    SurchargeMetadata,
+    types::SurchargeMetadata,
     surcharge_decision_configs::MerchantSurchargeConfigs,
 )> {
-    let mut surcharge_metadata = SurchargeMetadata::new(payment_attempt.attempt_id.clone());
+    let mut surcharge_metadata = types::SurchargeMetadata::new(payment_attempt.attempt_id.clone());
     let algorithm_id = if let Some(id) = algorithm_ref.surcharge_config_algo_id {
         id
     } else {
@@ -101,20 +103,25 @@ pub async fn perform_surcharge_decision_management_for_payment_method_list(
                         Some(card_network_type.card_network.clone());
                     let surcharge_output =
                         execute_dsl_and_get_conditional_config(backend_input.clone(), interpreter)?;
+                    // let surcharge_details =
                     card_network_type.surcharge_details = surcharge_output
                         .surcharge_details
                         .map(|surcharge_details| {
-                            get_surcharge_details_response(surcharge_details, payment_attempt).map(
-                                |surcharge_details_response| {
-                                    surcharge_metadata.insert_surcharge_details(
-                                        &payment_methods_enabled.payment_method,
-                                        &payment_method_type_response.payment_method_type,
-                                        Some(&card_network_type.card_network),
-                                        surcharge_details_response.clone(),
-                                    );
-                                    surcharge_details_response
-                                },
-                            )
+                            let surcharge_details =
+                                get_surcharge_details_response(surcharge_details, payment_attempt)?;
+                            surcharge_metadata.insert_surcharge_details(
+                                &payment_methods_enabled.payment_method,
+                                &payment_method_type_response.payment_method_type,
+                                Some(&card_network_type.card_network),
+                                surcharge_details.clone(),
+                            );
+                            SurchargeDetailsResponse::foreign_try_from((
+                                &surcharge_details,
+                                &payment_attempt,
+                            ))
+                            .into_report()
+                            .change_context(ConfigError::DslExecutionError)
+                            .attach_printable("Error while constructing Surcharge response type")
                         })
                         .transpose()?;
                 }
@@ -124,17 +131,21 @@ pub async fn perform_surcharge_decision_management_for_payment_method_list(
                 payment_method_type_response.surcharge_details = surcharge_output
                     .surcharge_details
                     .map(|surcharge_details| {
-                        get_surcharge_details_response(surcharge_details, payment_attempt).map(
-                            |surcharge_details_response| {
-                                surcharge_metadata.insert_surcharge_details(
-                                    &payment_methods_enabled.payment_method,
-                                    &payment_method_type_response.payment_method_type,
-                                    None,
-                                    surcharge_details_response.clone(),
-                                );
-                                surcharge_details_response
-                            },
-                        )
+                        let surcharge_details =
+                            get_surcharge_details_response(surcharge_details, payment_attempt)?;
+                        surcharge_metadata.insert_surcharge_details(
+                            &payment_methods_enabled.payment_method,
+                            &payment_method_type_response.payment_method_type,
+                            None,
+                            surcharge_details.clone(),
+                        );
+                        SurchargeDetailsResponse::foreign_try_from((
+                            &surcharge_details,
+                            &payment_attempt,
+                        ))
+                        .into_report()
+                        .change_context(ConfigError::DslExecutionError)
+                        .attach_printable("Error while constructing Surcharge response type")
                     })
                     .transpose()?;
             }
@@ -148,12 +159,12 @@ pub async fn perform_surcharge_decision_management_for_session_flow<O>(
     algorithm_ref: routing::RoutingAlgorithmRef,
     payment_data: &mut PaymentData<O>,
     payment_method_type_list: &Vec<common_enums::PaymentMethodType>,
-) -> ConditionalConfigResult<SurchargeMetadata>
+) -> ConditionalConfigResult<types::SurchargeMetadata>
 where
     O: Send + Clone,
 {
     let mut surcharge_metadata =
-        SurchargeMetadata::new(payment_data.payment_attempt.attempt_id.clone());
+        types::SurchargeMetadata::new(payment_data.payment_attempt.attempt_id.clone());
     let algorithm_id = if let Some(id) = algorithm_ref.surcharge_config_algo_id {
         id
     } else {
@@ -200,12 +211,12 @@ where
 }
 
 fn get_surcharge_details_response(
-    surcharge_details: SurchargeDetails,
+    surcharge_details: surcharge_decision_configs::SurchargeDetailsOutput,
     payment_attempt: &oss_storage::PaymentAttempt,
-) -> ConditionalConfigResult<SurchargeDetailsResponse> {
+) -> ConditionalConfigResult<types::SurchargeDetails> {
     let surcharge_amount = match surcharge_details.surcharge.clone() {
-        surcharge_decision_configs::Surcharge::Fixed(value) => value,
-        surcharge_decision_configs::Surcharge::Rate(percentage) => percentage
+        surcharge_decision_configs::SurchargeOutput::Fixed { amount } => amount,
+        surcharge_decision_configs::SurchargeOutput::Rate(percentage) => percentage
             .apply_and_ceil_result(payment_attempt.amount)
             .change_context(ConfigError::DslExecutionError)
             .attach_printable("Failed to Calculate surcharge amount by applying percentage")?,
@@ -221,13 +232,13 @@ fn get_surcharge_details_response(
         })
         .transpose()?
         .unwrap_or(0);
-    Ok(SurchargeDetailsResponse {
+    Ok(types::SurchargeDetails {
         surcharge: match surcharge_details.surcharge {
-            surcharge_decision_configs::Surcharge::Fixed(surcharge_amount) => {
-                payment_methods::Surcharge::Fixed(surcharge_amount)
+            surcharge_decision_configs::SurchargeOutput::Fixed { amount } => {
+                common_utils_types::Surcharge::Fixed(amount)
             }
-            surcharge_decision_configs::Surcharge::Rate(percentage) => {
-                payment_methods::Surcharge::Rate(percentage)
+            surcharge_decision_configs::SurchargeOutput::Rate(percentage) => {
+                common_utils_types::Surcharge::Rate(percentage)
             }
         },
         tax_on_surcharge: surcharge_details.tax_on_surcharge,

--- a/crates/router/src/core/payments.rs
+++ b/crates/router/src/core/payments.rs
@@ -15,10 +15,9 @@ use std::{fmt::Debug, marker::PhantomData, ops::Deref, time::Instant, vec::IntoI
 
 use api_models::{
     self, enums,
-    payment_methods::{Surcharge, SurchargeDetailsResponse},
     payments::{self, HeaderPayload},
 };
-use common_utils::{ext_traits::AsyncExt, pii};
+use common_utils::{ext_traits::AsyncExt, pii, types::Surcharge};
 use data_models::mandates::MandateData;
 use diesel_models::{ephemeral_key, fraud_check::FraudCheck};
 use error_stack::{IntoReport, ResultExt};
@@ -42,6 +41,7 @@ use self::{
     helpers::get_key_params_for_surcharge_details,
     operations::{payment_complete_authorize, BoxedOperation, Operation},
     routing::{self as self_routing, SessionFlowRoutingInput},
+    types::SurchargeDetails,
 };
 use super::{
     errors::StorageErrorExt, payment_methods::surcharge_decision_configs, utils as core_utils,
@@ -451,12 +451,6 @@ where
                     .into());
                 }
             }
-            (None, Some(_calculated_surcharge_details)) => {
-                return Err(errors::ApiErrorResponse::MissingRequiredField {
-                    field_name: "surcharge_details",
-                }
-                .into());
-            }
             (Some(request_surcharge_details), None) => {
                 if request_surcharge_details.is_surcharge_zero() {
                     return Ok(());
@@ -467,6 +461,9 @@ where
                     .into());
                 }
             }
+            (None, Some(calculated_surcharge_details)) => {
+                payment_data.surcharge_details = Some(calculated_surcharge_details);
+            }
             (None, None) => return Ok(()),
         };
     } else {
@@ -475,8 +472,7 @@ where
                 .payment_attempt
                 .get_surcharge_details()
                 .map(|surcharge_details| {
-                    surcharge_details
-                        .get_surcharge_details_object(payment_data.payment_attempt.amount)
+                    SurchargeDetails::from((&surcharge_details, &payment_data.payment_attempt))
                 });
         payment_data.surcharge_details = surcharge_details;
     }
@@ -509,7 +505,7 @@ where
         let final_amount =
             payment_data.payment_attempt.amount + surcharge_amount + tax_on_surcharge_amount;
         Ok(Some(api::SessionSurchargeDetails::PreDetermined(
-            SurchargeDetailsResponse {
+            SurchargeDetails {
                 surcharge: Surcharge::Fixed(surcharge_amount),
                 tax_on_surcharge: None,
                 surcharge_amount,
@@ -1882,7 +1878,7 @@ where
     pub recurring_mandate_payment_data: Option<RecurringMandatePaymentData>,
     pub ephemeral_key: Option<ephemeral_key::EphemeralKey>,
     pub redirect_response: Option<api_models::payments::RedirectResponse>,
-    pub surcharge_details: Option<SurchargeDetailsResponse>,
+    pub surcharge_details: Option<SurchargeDetails>,
     pub frm_message: Option<FraudCheck>,
     pub payment_link_data: Option<api_models::payments::PaymentLinkResponse>,
 }

--- a/crates/router/src/core/payments.rs
+++ b/crates/router/src/core/payments.rs
@@ -451,6 +451,12 @@ where
                     .into());
                 }
             }
+            (None, Some(_calculated_surcharge_details)) => {
+                return Err(errors::ApiErrorResponse::MissingRequiredField {
+                    field_name: "surcharge_details",
+                }
+                .into());
+            }
             (Some(request_surcharge_details), None) => {
                 if request_surcharge_details.is_surcharge_zero() {
                     return Ok(());
@@ -460,9 +466,6 @@ where
                     }
                     .into());
                 }
-            }
-            (None, Some(calculated_surcharge_details)) => {
-                payment_data.surcharge_details = Some(calculated_surcharge_details);
             }
             (None, None) => return Ok(()),
         };

--- a/crates/router/src/core/payments/types.rs
+++ b/crates/router/src/core/payments/types.rs
@@ -1,10 +1,16 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, num::TryFromIntError};
 
+use api_models::{payment_methods::SurchargeDetailsResponse, payments::RequestSurchargeDetails};
+use common_utils::{consts, types as common_types};
+use data_models::payments::payment_attempt::PaymentAttempt;
 use error_stack::{IntoReport, ResultExt};
 
 use crate::{
     core::errors::{self, RouterResult},
-    types::storage::{self, enums as storage_enums},
+    types::{
+        storage::{self, enums as storage_enums},
+        transformers::ForeignTryFrom,
+    },
 };
 
 #[derive(Clone, Debug)]
@@ -162,5 +168,153 @@ impl MultipleCaptureData {
             .into_iter()
             .filter(|capture| capture.connector_capture_id.is_none())
             .collect()
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
+pub struct SurchargeDetails {
+    /// surcharge value
+    pub surcharge: common_types::Surcharge,
+    /// tax on surcharge value
+    pub tax_on_surcharge:
+        Option<common_types::Percentage<{ consts::SURCHARGE_PERCENTAGE_PRECISION_LENGTH }>>,
+    /// surcharge amount for this payment
+    pub surcharge_amount: i64,
+    /// tax on surcharge amount for this payment
+    pub tax_on_surcharge_amount: i64,
+    /// sum of original amount,
+    pub final_amount: i64,
+}
+
+impl From<(&RequestSurchargeDetails, &PaymentAttempt)> for SurchargeDetails {
+    fn from(
+        (request_surcharge_details, payment_attempt): (&RequestSurchargeDetails, &PaymentAttempt),
+    ) -> Self {
+        let surcharge_amount = request_surcharge_details.surcharge_amount;
+        let tax_on_surcharge_amount = request_surcharge_details.tax_amount.unwrap_or(0);
+        Self {
+            surcharge: common_types::Surcharge::Fixed(request_surcharge_details.surcharge_amount),
+            tax_on_surcharge: None,
+            surcharge_amount,
+            tax_on_surcharge_amount,
+            final_amount: payment_attempt.amount + surcharge_amount + tax_on_surcharge_amount,
+        }
+    }
+}
+
+impl ForeignTryFrom<(&SurchargeDetails, &PaymentAttempt)> for SurchargeDetailsResponse {
+    type Error = TryFromIntError;
+    fn foreign_try_from(
+        (surcharge_details, payment_attempt): (&SurchargeDetails, &PaymentAttempt),
+    ) -> Result<Self, Self::Error> {
+        let currency = payment_attempt.currency.unwrap_or_default();
+        let display_surcharge_amount =
+            currency.to_currency_base_unit_asf64(surcharge_details.surcharge_amount)?;
+        let display_tax_on_surcharge_amount =
+            currency.to_currency_base_unit_asf64(surcharge_details.tax_on_surcharge_amount)?;
+        let display_final_amount =
+            currency.to_currency_base_unit_asf64(surcharge_details.final_amount)?;
+        Ok(Self {
+            surcharge: surcharge_details.surcharge.clone(),
+            tax_on_surcharge: surcharge_details.tax_on_surcharge.clone(),
+            display_surcharge_amount,
+            display_tax_on_surcharge_amount,
+            display_final_amount,
+        })
+    }
+}
+
+impl SurchargeDetails {
+    pub fn is_request_surcharge_matching(
+        &self,
+        request_surcharge_details: RequestSurchargeDetails,
+    ) -> bool {
+        request_surcharge_details.surcharge_amount == self.surcharge_amount
+            && request_surcharge_details.tax_amount.unwrap_or(0) == self.tax_on_surcharge_amount
+    }
+    pub fn get_total_surcharge_amount(&self) -> i64 {
+        self.surcharge_amount + self.tax_on_surcharge_amount
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct SurchargeMetadata {
+    surcharge_results: HashMap<
+        (
+            common_enums::PaymentMethod,
+            common_enums::PaymentMethodType,
+            Option<common_enums::CardNetwork>,
+        ),
+        SurchargeDetails,
+    >,
+    pub payment_attempt_id: String,
+}
+
+impl SurchargeMetadata {
+    pub fn new(payment_attempt_id: String) -> Self {
+        Self {
+            surcharge_results: HashMap::new(),
+            payment_attempt_id,
+        }
+    }
+    pub fn is_empty_result(&self) -> bool {
+        self.surcharge_results.is_empty()
+    }
+    pub fn get_surcharge_results_size(&self) -> usize {
+        self.surcharge_results.len()
+    }
+    pub fn insert_surcharge_details(
+        &mut self,
+        payment_method: &common_enums::PaymentMethod,
+        payment_method_type: &common_enums::PaymentMethodType,
+        card_network: Option<&common_enums::CardNetwork>,
+        surcharge_details: SurchargeDetails,
+    ) {
+        let key = (
+            payment_method.to_owned(),
+            payment_method_type.to_owned(),
+            card_network.cloned(),
+        );
+        self.surcharge_results.insert(key, surcharge_details);
+    }
+    pub fn get_surcharge_details(
+        &self,
+        payment_method: &common_enums::PaymentMethod,
+        payment_method_type: &common_enums::PaymentMethodType,
+        card_network: Option<&common_enums::CardNetwork>,
+    ) -> Option<&SurchargeDetails> {
+        let key = &(
+            payment_method.to_owned(),
+            payment_method_type.to_owned(),
+            card_network.cloned(),
+        );
+        self.surcharge_results.get(key)
+    }
+    pub fn get_surcharge_metadata_redis_key(payment_attempt_id: &str) -> String {
+        format!("surcharge_metadata_{}", payment_attempt_id)
+    }
+    pub fn get_individual_surcharge_key_value_pairs(&self) -> Vec<(String, SurchargeDetails)> {
+        self.surcharge_results
+            .iter()
+            .map(|((pm, pmt, card_network), surcharge_details)| {
+                let key =
+                    Self::get_surcharge_details_redis_hashset_key(pm, pmt, card_network.as_ref());
+                (key, surcharge_details.to_owned())
+            })
+            .collect()
+    }
+    pub fn get_surcharge_details_redis_hashset_key(
+        payment_method: &common_enums::PaymentMethod,
+        payment_method_type: &common_enums::PaymentMethodType,
+        card_network: Option<&common_enums::CardNetwork>,
+    ) -> String {
+        if let Some(card_network) = card_network {
+            format!(
+                "{}_{}_{}",
+                payment_method, payment_method_type, card_network
+            )
+        } else {
+            format!("{}_{}", payment_method, payment_method_type)
+        }
     }
 }

--- a/crates/router/src/types.rs
+++ b/crates/router/src/types.rs
@@ -30,7 +30,7 @@ use crate::core::utils::IRRELEVANT_CONNECTOR_REQUEST_REFERENCE_ID_IN_DISPUTE_FLO
 use crate::{
     core::{
         errors::{self, RouterResult},
-        payments::{PaymentData, RecurringMandatePaymentData},
+        payments::{types, PaymentData, RecurringMandatePaymentData},
     },
     services,
     types::{storage::payment_attempt::PaymentAttemptExt, transformers::ForeignFrom},
@@ -379,7 +379,7 @@ pub struct PaymentsAuthorizeData {
     pub related_transaction_id: Option<String>,
     pub payment_experience: Option<storage_enums::PaymentExperience>,
     pub payment_method_type: Option<storage_enums::PaymentMethodType>,
-    pub surcharge_details: Option<api_models::payment_methods::SurchargeDetailsResponse>,
+    pub surcharge_details: Option<types::SurchargeDetails>,
     pub customer_id: Option<String>,
     pub request_incremental_authorization: bool,
 }
@@ -441,7 +441,7 @@ pub struct PaymentsPreProcessingData {
     pub router_return_url: Option<String>,
     pub webhook_url: Option<String>,
     pub complete_authorize_url: Option<String>,
-    pub surcharge_details: Option<api_models::payment_methods::SurchargeDetailsResponse>,
+    pub surcharge_details: Option<types::SurchargeDetails>,
     pub browser_info: Option<BrowserInformation>,
     pub connector_transaction_id: Option<String>,
 }
@@ -517,7 +517,7 @@ pub struct PaymentsSessionData {
     pub amount: i64,
     pub currency: storage_enums::Currency,
     pub country: Option<api::enums::CountryAlpha2>,
-    pub surcharge_details: Option<api_models::payment_methods::SurchargeDetailsResponse>,
+    pub surcharge_details: Option<types::SurchargeDetails>,
     pub order_details: Option<Vec<api_models::payments::OrderDetailsWithAmount>>,
 }
 

--- a/crates/router/src/types/api.rs
+++ b/crates/router/src/types/api.rs
@@ -19,7 +19,6 @@ pub mod webhooks;
 
 use std::{fmt::Debug, str::FromStr};
 
-use api_models::payment_methods::{SurchargeDetailsResponse, SurchargeMetadata};
 use error_stack::{report, IntoReport, ResultExt};
 
 pub use self::{
@@ -30,7 +29,10 @@ use super::ErrorResponse;
 use crate::{
     configs::settings::Connectors,
     connector, consts,
-    core::errors::{self, CustomResult},
+    core::{
+        errors::{self, CustomResult},
+        payments::types as payments_types,
+    },
     services::{request, ConnectorIntegration, ConnectorRedirectResponse, ConnectorValidation},
     types::{self, api::enums as api_enums},
 };
@@ -222,9 +224,9 @@ pub struct SessionConnectorData {
 /// Session Surcharge type
 pub enum SessionSurchargeDetails {
     /// Surcharge is calculated by hyperswitch
-    Calculated(SurchargeMetadata),
+    Calculated(payments_types::SurchargeMetadata),
     /// Surcharge is sent by merchant
-    PreDetermined(SurchargeDetailsResponse),
+    PreDetermined(payments_types::SurchargeDetails),
 }
 
 impl SessionSurchargeDetails {
@@ -233,7 +235,7 @@ impl SessionSurchargeDetails {
         payment_method: &enums::PaymentMethod,
         payment_method_type: &enums::PaymentMethodType,
         card_network: Option<&enums::CardNetwork>,
-    ) -> Option<SurchargeDetailsResponse> {
+    ) -> Option<payments_types::SurchargeDetails> {
         match self {
             Self::Calculated(surcharge_metadata) => surcharge_metadata
                 .get_surcharge_details(payment_method, payment_method_type, card_network)


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Changes in this PR:
1. Renamed and restructured a few existing enums and structs
2. Introduced new `SurchargeDetails` struct for use in core and `SurchargeDetailsResponse` struct for api response.
3. Surcharge details validation during payment_confirm shall only be made if surcharge_details is sent during confirm call. Not otherwise.
4. Added amount validation is payment create and payment update flow, to cover surcharge.


### Additional Changes

- [x] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
6. `crates/router/src/configs`
7. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Steps to test:
1. Create a merchant with paypal connector
2. Configure some surcharge rules for the merchant
3. Create a payment
4. Do merchant payment_method list. (should get below body in `surcharge_details` field)
```
"surcharge_details": {
    "surcharge": {
        "type": "fixed",
        "value": 123
    },
    "tax_on_surcharge": {
        "percentage": 5.09
    },
    "display_surcharge_amount": 1.23,
    "display_tax_on_surcharge_amount": 0.07,
    "display_final_amount": 66.7
},
```


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
