### PR TITLE
refactor(user): add account verification check in signin

### DIFF
--- a/crates/router/src/core/errors/user.rs
+++ b/crates/router/src/core/errors/user.rs
@@ -18,6 +18,8 @@ pub enum UserErrors {
     UserExists,
     #[error("LinkInvalid")]
     LinkInvalid,
+    #[error("UnverifiedUser")]
+    UnverifiedUser,
     #[error("InvalidOldPassword")]
     InvalidOldPassword,
     #[error("EmailParsingError")]
@@ -79,6 +81,12 @@ impl common_utils::errors::ErrorSwitch<api_models::errors::types::ApiErrorRespon
             Self::LinkInvalid => {
                 AER::Unauthorized(ApiError::new(sub_code, 4, "Invalid or expired link", None))
             }
+            Self::UnverifiedUser => AER::Unauthorized(ApiError::new(
+                sub_code,
+                5,
+                "Kindly verify your account",
+                None,
+            )),
             Self::InvalidOldPassword => AER::BadRequest(ApiError::new(
                 sub_code,
                 6,

--- a/crates/router/src/core/user.rs
+++ b/crates/router/src/core/user.rs
@@ -91,10 +91,11 @@ pub async fn signup(
             UserStatus::Active,
         )
         .await?;
-    let token = utils::user::generate_jwt_auth_token(state, &user_from_db, &user_role).await?;
+    let token =
+        utils::user::generate_jwt_auth_token(state.clone(), &user_from_db, &user_role).await?;
 
     Ok(ApplicationResponse::Json(
-        utils::user::get_dashboard_entry_response(user_from_db, user_role, token),
+        utils::user::get_dashboard_entry_response(state, user_from_db, user_role, token)?,
     ))
 }
 
@@ -118,10 +119,11 @@ pub async fn signin(
     user_from_db.compare_password(request.password)?;
 
     let user_role = user_from_db.get_role_from_db(state.clone()).await?;
-    let token = utils::user::generate_jwt_auth_token(state, &user_from_db, &user_role).await?;
+    let token =
+        utils::user::generate_jwt_auth_token(state.clone(), &user_from_db, &user_role).await?;
 
     Ok(ApplicationResponse::Json(
-        utils::user::get_dashboard_entry_response(user_from_db, user_role, token),
+        utils::user::get_dashboard_entry_response(state, user_from_db, user_role, token)?,
     ))
 }
 
@@ -655,9 +657,10 @@ pub async fn verify_email(
 
     let user_from_db: domain::UserFromStorage = user.into();
     let user_role = user_from_db.get_role_from_db(state.clone()).await?;
-    let jwt_token = utils::user::generate_jwt_auth_token(state, &user_from_db, &user_role).await?;
+    let token =
+        utils::user::generate_jwt_auth_token(state.clone(), &user_from_db, &user_role).await?;
 
     Ok(ApplicationResponse::Json(
-        utils::user::get_dashboard_entry_response(user_from_db, user_role, jwt_token),
+        utils::user::get_dashboard_entry_response(state, user_from_db, user_role, token)?,
     ))
 }

--- a/crates/router/src/utils/user.rs
+++ b/crates/router/src/utils/user.rs
@@ -104,18 +104,25 @@ pub async fn generate_jwt_auth_token_with_custom_merchant_id(
     Ok(Secret::new(token))
 }
 
+#[allow(unused_variables)]
 pub fn get_dashboard_entry_response(
+    state: AppState,
     user: UserFromStorage,
     user_role: UserRole,
     token: Secret<String>,
-) -> user_api::DashboardEntryResponse {
-    user_api::DashboardEntryResponse {
+) -> UserResult<user_api::DashboardEntryResponse> {
+    #[cfg(feature = "email")]
+    let verification_days_left = user.get_verification_days_left(state)?;
+    #[cfg(not(feature = "email"))]
+    let verification_days_left = None;
+
+    Ok(user_api::DashboardEntryResponse {
         merchant_id: user_role.merchant_id,
         token,
         name: user.get_name(),
         email: user.get_email(),
         user_id: user.get_user_id().to_string(),
-        verification_days_left: None,
+        verification_days_left,
         user_role: user_role.role_id,
-    }
+    })
 }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Add account verification check in signin

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
To restrict unverified users to signin.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Postman.
```
curl --location 'http://localhost:8080/user/signin' \
--header 'Content-Type: application/json' \
--data-raw '{
    "email": "email",
    "password": "password"
}'
```
If the account is unverified, you will get the following response.
```
{
    "error": {
        "type": "invalid_request",
        "message": "Kindly verify your account",
        "code": "UR_05"
    }
}
```

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
