### PR TITLE
fix(router): make `request_incremental_authorization` optional in payment_intent

### DIFF
--- a/crates/data_models/src/payments.rs
+++ b/crates/data_models/src/payments.rs
@@ -50,7 +50,7 @@ pub struct PaymentIntent {
 
     pub updated_by: String,
     pub surcharge_applicable: Option<bool>,
-    pub request_incremental_authorization: storage_enums::RequestIncrementalAuthorization,
+    pub request_incremental_authorization: Option<storage_enums::RequestIncrementalAuthorization>,
     pub incremental_authorization_allowed: Option<bool>,
     pub authorization_count: Option<i32>,
 }

--- a/crates/data_models/src/payments/payment_intent.rs
+++ b/crates/data_models/src/payments/payment_intent.rs
@@ -107,7 +107,7 @@ pub struct PaymentIntentNew {
 
     pub updated_by: String,
     pub surcharge_applicable: Option<bool>,
-    pub request_incremental_authorization: storage_enums::RequestIncrementalAuthorization,
+    pub request_incremental_authorization: Option<storage_enums::RequestIncrementalAuthorization>,
     pub incremental_authorization_allowed: Option<bool>,
     pub authorization_count: Option<i32>,
 }

--- a/crates/diesel_models/src/payment_intent.rs
+++ b/crates/diesel_models/src/payment_intent.rs
@@ -52,7 +52,7 @@ pub struct PaymentIntent {
 
     pub updated_by: String,
     pub surcharge_applicable: Option<bool>,
-    pub request_incremental_authorization: RequestIncrementalAuthorization,
+    pub request_incremental_authorization: Option<RequestIncrementalAuthorization>,
     pub incremental_authorization_allowed: Option<bool>,
     pub authorization_count: Option<i32>,
 }
@@ -109,7 +109,7 @@ pub struct PaymentIntentNew {
     pub payment_confirm_source: Option<storage_enums::PaymentSource>,
     pub updated_by: String,
     pub surcharge_applicable: Option<bool>,
-    pub request_incremental_authorization: RequestIncrementalAuthorization,
+    pub request_incremental_authorization: Option<RequestIncrementalAuthorization>,
     pub incremental_authorization_allowed: Option<bool>,
     pub authorization_count: Option<i32>,
 }

--- a/crates/diesel_models/src/schema.rs
+++ b/crates/diesel_models/src/schema.rs
@@ -703,7 +703,7 @@ diesel::table! {
         #[max_length = 32]
         updated_by -> Varchar,
         surcharge_applicable -> Nullable<Bool>,
-        request_incremental_authorization -> RequestIncrementalAuthorization,
+        request_incremental_authorization -> Nullable<RequestIncrementalAuthorization>,
         incremental_authorization_allowed -> Nullable<Bool>,
         authorization_count -> Nullable<Int4>,
     }

--- a/crates/router/src/core/payments/helpers.rs
+++ b/crates/router/src/core/payments/helpers.rs
@@ -2623,8 +2623,9 @@ mod tests {
             payment_confirm_source: None,
             surcharge_applicable: None,
             updated_by: storage_enums::MerchantStorageScheme::PostgresOnly.to_string(),
-            request_incremental_authorization:
+            request_incremental_authorization: Some(
                 common_enums::RequestIncrementalAuthorization::default(),
+            ),
             incremental_authorization_allowed: None,
             authorization_count: None,
         };
@@ -2677,8 +2678,9 @@ mod tests {
             payment_confirm_source: None,
             surcharge_applicable: None,
             updated_by: storage_enums::MerchantStorageScheme::PostgresOnly.to_string(),
-            request_incremental_authorization:
+            request_incremental_authorization: Some(
                 common_enums::RequestIncrementalAuthorization::default(),
+            ),
             incremental_authorization_allowed: None,
             authorization_count: None,
         };
@@ -2731,8 +2733,9 @@ mod tests {
             payment_confirm_source: None,
             surcharge_applicable: None,
             updated_by: storage_enums::MerchantStorageScheme::PostgresOnly.to_string(),
-            request_incremental_authorization:
+            request_incremental_authorization: Some(
                 common_enums::RequestIncrementalAuthorization::default(),
+            ),
             incremental_authorization_allowed: None,
             authorization_count: None,
         };

--- a/crates/router/src/core/payments/transformers.rs
+++ b/crates/router/src/core/payments/transformers.rs
@@ -1062,7 +1062,8 @@ impl<F: Clone> TryFrom<PaymentAdditionalData<'_, F>> for types::PaymentsAuthoriz
                 payment_data
                     .payment_intent
                     .request_incremental_authorization,
-                RequestIncrementalAuthorization::True | RequestIncrementalAuthorization::Default
+                Some(RequestIncrementalAuthorization::True)
+                    | Some(RequestIncrementalAuthorization::Default)
             ),
         })
     }
@@ -1350,7 +1351,8 @@ impl<F: Clone> TryFrom<PaymentAdditionalData<'_, F>> for types::SetupMandateRequ
                 payment_data
                     .payment_intent
                     .request_incremental_authorization,
-                RequestIncrementalAuthorization::True | RequestIncrementalAuthorization::Default
+                Some(RequestIncrementalAuthorization::True)
+                    | Some(RequestIncrementalAuthorization::Default)
             ),
         })
     }

--- a/crates/router/src/core/utils.rs
+++ b/crates/router/src/core/utils.rs
@@ -1066,8 +1066,8 @@ pub fn get_flow_name<F>() -> RouterResult<String> {
 pub fn get_request_incremental_authorization_value(
     request_incremental_authorization: Option<bool>,
     capture_method: Option<common_enums::CaptureMethod>,
-) -> RouterResult<RequestIncrementalAuthorization> {
-    request_incremental_authorization
+) -> RouterResult<Option<RequestIncrementalAuthorization>> {
+    Some(request_incremental_authorization
         .map(|request_incremental_authorization| {
             if request_incremental_authorization {
                 if capture_method == Some(common_enums::CaptureMethod::Automatic) {
@@ -1078,14 +1078,16 @@ pub fn get_request_incremental_authorization_value(
                 Ok(RequestIncrementalAuthorization::False)
             }
         })
-        .unwrap_or(Ok(RequestIncrementalAuthorization::default()))
+        .unwrap_or(Ok(RequestIncrementalAuthorization::default()))).transpose()
 }
 
 pub fn get_incremental_authorization_allowed_value(
     incremental_authorization_allowed: Option<bool>,
-    request_incremental_authorization: RequestIncrementalAuthorization,
+    request_incremental_authorization: Option<RequestIncrementalAuthorization>,
 ) -> Option<bool> {
-    if request_incremental_authorization == common_enums::RequestIncrementalAuthorization::False {
+    if request_incremental_authorization
+        == Some(common_enums::RequestIncrementalAuthorization::False)
+    {
         Some(false)
     } else {
         incremental_authorization_allowed

--- a/migrations/2023-12-07-075240_make-request-incremental-auth-optional-intent/down.sql
+++ b/migrations/2023-12-07-075240_make-request-incremental-auth-optional-intent/down.sql
@@ -1,0 +1,2 @@
+-- This file should undo anything in `up.sql`
+ALTER TABLE payment_intent ALTER COLUMN request_incremental_authorization SET NOT NULL;

--- a/migrations/2023-12-07-075240_make-request-incremental-auth-optional-intent/up.sql
+++ b/migrations/2023-12-07-075240_make-request-incremental-auth-optional-intent/up.sql
@@ -1,0 +1,2 @@
+-- Your SQL goes here
+ALTER TABLE payment_intent ALTER COLUMN request_incremental_authorization DROP NOT NULL;


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
make `request_incremental_authorization` optional in payment_intent for backward compatibility


### Additional Changes

- [ ] This PR modifies the API contract
- [x] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
Tested Manually
1. make request_incremental_authorization false in payments request, to see incremental_authorization allowed as false in payments response. when incremental authorization is tried for this payment, it fails with not allowed error
2. make request_incremental_authorization true, to see incremental_authorization_allowed in the response. Then try to attempt incremental_authorization api to see successfully calling the connector

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
