### PR TITLE
fix(router): allow zero amount for payment intent in list payment methods

### DIFF
--- a/crates/router/src/core/payment_methods/cards.rs
+++ b/crates/router/src/core/payment_methods/cards.rs
@@ -2296,8 +2296,9 @@ fn filter_payment_amount_based(
     pm: &RequestPaymentMethodTypes,
 ) -> bool {
     let amount = payment_intent.amount;
-    pm.maximum_amount.map_or(true, |amt| amount < amt.into())
-        && pm.minimum_amount.map_or(true, |amt| amount > amt.into())
+    (pm.maximum_amount.map_or(true, |amt| amount < amt.into())
+        && pm.minimum_amount.map_or(true, |amt| amount > amt.into()))
+        || payment_intent.amount == 0
 }
 
 async fn filter_payment_mandate_based(

--- a/crates/router/src/core/payment_methods/cards.rs
+++ b/crates/router/src/core/payment_methods/cards.rs
@@ -2296,8 +2296,8 @@ fn filter_payment_amount_based(
     pm: &RequestPaymentMethodTypes,
 ) -> bool {
     let amount = payment_intent.amount;
-    (pm.maximum_amount.map_or(true, |amt| amount < amt.into())
-        && pm.minimum_amount.map_or(true, |amt| amount > amt.into()))
+    (pm.maximum_amount.map_or(true, |amt| amount <= amt.into())
+        && pm.minimum_amount.map_or(true, |amt| amount >= amt.into()))
         || payment_intent.amount == 0
 }
 

--- a/crates/router/src/core/payment_methods/cards.rs
+++ b/crates/router/src/core/payment_methods/cards.rs
@@ -2237,7 +2237,7 @@ fn filter_amount_based(payment_method: &RequestPaymentMethodTypes, amount: Optio
     //     (Some(amt), Some(max_amt)) => amt <= max_amt,
     //     (_, _) => true,
     // };
-    min_check && max_check
+    (min_check && max_check) || amount == Some(0)
 }
 
 fn filter_pm_based_on_allowed_types(


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
This PR updates the List Payment Method core filters to allow payment intents with zero amount


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
Payment intents with zero amount are created for setting up a mandate with the connector and thus are a valid form of connector call.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
1. Create a Merchant Account, 1 Merchant Connector Account
2. Create a payment with amount = 0, confirm = false & no payment method given
3. Do a list payment methods call. The returned list should include all the eligible payment methods despite the amount being 0.

<img width="551" alt="image" src="https://github.com/juspay/hyperswitch/assets/47862918/577f1be7-e714-4951-97ea-2277ddebce6e">
<img width="551" alt="image" src="https://github.com/juspay/hyperswitch/assets/47862918/bfc67914-ee7c-4fc9-adbb-0e00ab17ff2a">


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
