### PR TITLE
fix(connector): [Checkout] Fix status mapping for checkout

### DIFF
--- a/crates/router/src/connector/checkout/transformers.rs
+++ b/crates/router/src/connector/checkout/transformers.rs
@@ -6,7 +6,9 @@ use time::PrimitiveDateTime;
 use url::Url;
 
 use crate::{
-    connector::utils::{self, PaymentsCaptureRequestData, RouterData, WalletData},
+    connector::utils::{
+        self, to_connector_meta, PaymentsCaptureRequestData, RouterData, WalletData,
+    },
     consts,
     core::errors,
     services,
@@ -238,6 +240,17 @@ pub struct PaymentsRequest {
     pub return_url: ReturnUrl,
     pub capture: bool,
     pub reference: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct CheckoutMeta {
+    pub psync_flow: CheckoutPaymentIntent,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
+pub enum CheckoutPaymentIntent {
+    Capture,
+    Authorize,
 }
 
 #[derive(Debug, Serialize)]
@@ -477,7 +490,7 @@ impl ForeignFrom<(CheckoutPaymentStatus, Option<enums::CaptureMethod>)> for enum
                 if capture_method == Some(enums::CaptureMethod::Automatic)
                     || capture_method.is_none()
                 {
-                    Self::Charged
+                    Self::Pending
                 } else {
                     Self::Authorized
                 }
@@ -490,17 +503,14 @@ impl ForeignFrom<(CheckoutPaymentStatus, Option<enums::CaptureMethod>)> for enum
     }
 }
 
-impl ForeignFrom<(CheckoutPaymentStatus, Option<Balances>)> for enums::AttemptStatus {
-    fn foreign_from(item: (CheckoutPaymentStatus, Option<Balances>)) -> Self {
-        let (status, balances) = item;
+impl ForeignFrom<(CheckoutPaymentStatus, CheckoutPaymentIntent)> for enums::AttemptStatus {
+    fn foreign_from(item: (CheckoutPaymentStatus, CheckoutPaymentIntent)) -> Self {
+        let (status, psync_flow) = item;
 
         match status {
             CheckoutPaymentStatus::Authorized => {
-                if let Some(Balances {
-                    available_to_capture: 0,
-                }) = balances
-                {
-                    Self::Charged
+                if psync_flow == CheckoutPaymentIntent::Capture {
+                    Self::Pending
                 } else {
                     Self::Authorized
                 }
@@ -556,6 +566,16 @@ impl TryFrom<types::PaymentsResponseRouterData<PaymentsResponse>>
     fn try_from(
         item: types::PaymentsResponseRouterData<PaymentsResponse>,
     ) -> Result<Self, Self::Error> {
+        let connector_meta = match item.data.request.capture_method {
+            Some(enums::CaptureMethod::Automatic) => serde_json::json!(CheckoutMeta {
+                psync_flow: CheckoutPaymentIntent::Capture,
+            }),
+            Some(enums::CaptureMethod::Manual) => serde_json::json!(CheckoutMeta {
+                psync_flow: CheckoutPaymentIntent::Authorize,
+            }),
+            _ => serde_json::json!({}),
+        };
+
         let redirection_data = item.response.links.redirect.map(|href| {
             services::RedirectForm::from((href.redirection_url, services::Method::Get))
         });
@@ -585,7 +605,7 @@ impl TryFrom<types::PaymentsResponseRouterData<PaymentsResponse>>
             resource_id: types::ResponseId::ConnectorTransactionId(item.response.id.clone()),
             redirection_data,
             mandate_reference: None,
-            connector_metadata: None,
+            connector_metadata: Some(connector_meta),
             network_txn_id: None,
             connector_response_reference_id: Some(
                 item.response.reference.unwrap_or(item.response.id),
@@ -609,8 +629,10 @@ impl TryFrom<types::PaymentsSyncResponseRouterData<PaymentsResponse>>
         let redirection_data = item.response.links.redirect.map(|href| {
             services::RedirectForm::from((href.redirection_url, services::Method::Get))
         });
+        let checkout_meta: CheckoutMeta =
+            to_connector_meta(item.data.request.connector_meta.clone())?;
         let status =
-            enums::AttemptStatus::foreign_from((item.response.status, item.response.balances));
+            enums::AttemptStatus::foreign_from((item.response.status, checkout_meta.psync_flow));
         let error_response = if status == enums::AttemptStatus::Failure {
             Some(types::ErrorResponse {
                 status_code: item.http_code,
@@ -783,6 +805,9 @@ impl TryFrom<types::PaymentsCaptureResponseRouterData<PaymentCaptureResponse>>
     fn try_from(
         item: types::PaymentsCaptureResponseRouterData<PaymentCaptureResponse>,
     ) -> Result<Self, Self::Error> {
+        let connector_meta = serde_json::json!(CheckoutMeta {
+            psync_flow: CheckoutPaymentIntent::Capture,
+        });
         let (status, amount_captured) = if item.http_code == 202 {
             (
                 enums::AttemptStatus::Charged,
@@ -805,7 +830,7 @@ impl TryFrom<types::PaymentsCaptureResponseRouterData<PaymentCaptureResponse>>
                 resource_id: types::ResponseId::ConnectorTransactionId(resource_id),
                 redirection_data: None,
                 mandate_reference: None,
-                connector_metadata: None,
+                connector_metadata: Some(connector_meta),
                 network_txn_id: None,
                 connector_response_reference_id: item.response.reference,
             }),
@@ -965,7 +990,7 @@ impl utils::MultipleCaptureSyncResponse for Box<PaymentsResponse> {
     }
 
     fn get_capture_attempt_status(&self) -> enums::AttemptStatus {
-        enums::AttemptStatus::foreign_from((self.status.clone(), self.balances.clone()))
+        enums::AttemptStatus::foreign_from((self.status.clone(), None))
     }
 
     fn get_connector_reference_id(&self) -> Option<String> {


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
When there is delay in response, we are getting status "`Authorized`" and payment intent status is being set to "`requires_capture`" for `automatic` capture method. 
Updated the status mapping to "`Pending`" in the above case


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
<img width="971" alt="Screenshot 2023-12-06 at 9 21 27 PM" src="https://github.com/juspay/hyperswitch/assets/70575890/6410f92f-c033-4120-bf19-b1ba0b3679c5">
<img width="763" alt="Screenshot 2023-12-06 at 9 21 37 PM" src="https://github.com/juspay/hyperswitch/assets/70575890/3bc1698c-4f8e-462c-8b31-570c9f1acbb3">
<img width="809" alt="Screenshot 2023-12-06 at 9 22 46 PM" src="https://github.com/juspay/hyperswitch/assets/70575890/38380fe3-bc78-43ff-9372-e895e8393230">
<img width="1039" alt="Screenshot 2023-12-06 at 9 23 03 PM" src="https://github.com/juspay/hyperswitch/assets/70575890/12e37f95-71d8-46bc-a496-252c050ec992">



## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
