### PR TITLE
feat(users): Add resend verification email API

### DIFF
--- a/crates/api_models/src/events/user.rs
+++ b/crates/api_models/src/events/user.rs
@@ -8,8 +8,8 @@ use crate::user::{
     },
     AuthorizeResponse, ChangePasswordRequest, ConnectAccountRequest, CreateInternalUserRequest,
     DashboardEntryResponse, ForgotPasswordRequest, GetUsersResponse, InviteUserRequest,
-    InviteUserResponse, ResetPasswordRequest, SignUpRequest, SignUpWithMerchantIdRequest,
-    SwitchMerchantIdRequest, UserMerchantCreate,
+    InviteUserResponse, ResetPasswordRequest, SendVerifyEmailRequest, SignUpRequest,
+    SignUpWithMerchantIdRequest, SwitchMerchantIdRequest, UserMerchantCreate,
 };
 
 impl ApiEventMetric for DashboardEntryResponse {
@@ -38,7 +38,8 @@ common_utils::impl_misc_api_event_type!(
     ForgotPasswordRequest,
     ResetPasswordRequest,
     InviteUserRequest,
-    InviteUserResponse
+    InviteUserResponse,
+    SendVerifyEmailRequest
 );
 
 #[cfg(feature = "dummy_connector")]

--- a/crates/api_models/src/user.rs
+++ b/crates/api_models/src/user.rs
@@ -121,3 +121,8 @@ pub struct UserDetails {
     #[serde(with = "common_utils::custom_serde::iso8601")]
     pub last_modified_at: time::PrimitiveDateTime,
 }
+
+#[derive(serde::Deserialize, Debug, serde::Serialize)]
+pub struct SendVerifyEmailRequest {
+    pub email: pii::Email,
+}

--- a/crates/router/src/core/errors/user.rs
+++ b/crates/router/src/core/errors/user.rs
@@ -26,6 +26,8 @@ pub enum UserErrors {
     NameParsingError,
     #[error("PasswordParsingError")]
     PasswordParsingError,
+    #[error("UserAlreadyVerified")]
+    UserAlreadyVerified,
     #[error("CompanyNameParsingError")]
     CompanyNameParsingError,
     #[error("MerchantAccountCreationError: {0}")]
@@ -93,6 +95,9 @@ impl common_utils::errors::ErrorSwitch<api_models::errors::types::ApiErrorRespon
             }
             Self::PasswordParsingError => {
                 AER::BadRequest(ApiError::new(sub_code, 9, "Invalid Password", None))
+            }
+            Self::UserAlreadyVerified => {
+                AER::Unauthorized(ApiError::new(sub_code, 11, "User already verified", None))
             }
             Self::CompanyNameParsingError => {
                 AER::BadRequest(ApiError::new(sub_code, 14, "Invalid Company Name", None))

--- a/crates/router/src/core/user.rs
+++ b/crates/router/src/core/user.rs
@@ -14,7 +14,6 @@ use super::errors::{UserErrors, UserResponse};
 use crate::services::email::{types as email_types, types::EmailToken};
 use crate::{
     consts,
-    db::user::UserInterface,
     routes::AppState,
     services::{authentication as auth, ApplicationResponse},
     types::domain,
@@ -226,28 +225,30 @@ pub async fn change_password(
     request: user_api::ChangePasswordRequest,
     user_from_token: auth::UserFromToken,
 ) -> UserResponse<()> {
-    let user: domain::UserFromStorage =
-        UserInterface::find_user_by_id(&*state.store, &user_from_token.user_id)
-            .await
-            .change_context(UserErrors::InternalServerError)?
-            .into();
+    let user: domain::UserFromStorage = state
+        .store
+        .find_user_by_id(&user_from_token.user_id)
+        .await
+        .change_context(UserErrors::InternalServerError)?
+        .into();
 
     user.compare_password(request.old_password)
         .change_context(UserErrors::InvalidOldPassword)?;
 
     let new_password_hash = utils::user::password::generate_password_hash(request.new_password)?;
 
-    let _ = UserInterface::update_user_by_user_id(
-        &*state.store,
-        user.get_user_id(),
-        diesel_models::user::UserUpdate::AccountUpdate {
-            name: None,
-            password: Some(new_password_hash),
-            is_verified: None,
-        },
-    )
-    .await
-    .change_context(UserErrors::InternalServerError)?;
+    let _ = state
+        .store
+        .update_user_by_user_id(
+            user.get_user_id(),
+            diesel_models::user::UserUpdate::AccountUpdate {
+                name: None,
+                password: Some(new_password_hash),
+                is_verified: None,
+            },
+        )
+        .await
+        .change_context(UserErrors::InternalServerError)?;
 
     Ok(ApplicationResponse::StatusOk)
 }
@@ -629,4 +630,43 @@ pub async fn get_users_for_merchant_account(
         .collect();
 
     Ok(ApplicationResponse::Json(user_api::GetUsersResponse(users)))
+}
+
+pub async fn send_verification_mail(
+    state: AppState,
+    req: user_api::SendVerifyEmailRequest,
+) -> UserResponse<()> {
+    let user_email = domain::UserEmail::try_from(req.email)?;
+    let user = state
+        .store
+        .find_user_by_email(user_email.clone().get_secret().expose().as_str())
+        .await
+        .map_err(|e| {
+            if e.current_context().is_db_not_found() {
+                e.change_context(UserErrors::UserNotFound)
+            } else {
+                e.change_context(UserErrors::InternalServerError)
+            }
+        })?;
+
+    if user.is_verified {
+        return Err(UserErrors::UserAlreadyVerified.into());
+    }
+
+    let email_contents = email_types::VerifyEmail {
+        recipient_email: domain::UserEmail::from_pii_email(user.email)?,
+        settings: state.conf.clone(),
+        subject: "Welcome to the Hyperswitch community!",
+    };
+
+    state
+        .email_client
+        .compose_and_send_email(
+            Box::new(email_contents),
+            state.conf.proxy.https_url.as_ref(),
+        )
+        .await
+        .change_context(UserErrors::InternalServerError)?;
+
+    Ok(ApplicationResponse::StatusOk)
 }

--- a/crates/router/src/core/user.rs
+++ b/crates/router/src/core/user.rs
@@ -672,6 +672,7 @@ pub async fn verify_email(
     ))
 }
 
+#[cfg(feature = "email")]
 pub async fn send_verification_mail(
     state: AppState,
     req: user_api::SendVerifyEmailRequest,

--- a/crates/router/src/routes/app.rs
+++ b/crates/router/src/routes/app.rs
@@ -897,6 +897,10 @@ impl User {
                 .service(
                     web::resource("/signup_with_merchant_id")
                         .route(web::post().to(user_signup_with_merchant_id)),
+                )
+                .service(
+                    web::resource("/verify_email_request")
+                        .route(web::post().to(verify_email_request)),
                 );
         }
         #[cfg(not(feature = "email"))]

--- a/crates/router/src/routes/lock_utils.rs
+++ b/crates/router/src/routes/lock_utils.rs
@@ -167,7 +167,8 @@ impl From<Flow> for ApiIdentifier {
             | Flow::ForgotPassword
             | Flow::ResetPassword
             | Flow::InviteUser
-            | Flow::UserSignUpWithMerchantId => Self::User,
+            | Flow::UserSignUpWithMerchantId
+            | Flow::VerifyEmailRequest => Self::User,
 
             Flow::ListRoles | Flow::GetRole | Flow::UpdateUserRole | Flow::GetAuthorizationInfo => {
                 Self::UserRole

--- a/crates/router/src/routes/user.rs
+++ b/crates/router/src/routes/user.rs
@@ -33,7 +33,7 @@ pub async fn user_signup_with_merchant_id(
         &http_req,
         req_payload.clone(),
         |state, _, req_body| user_core::signup_with_merchant_id(state, req_body),
-        &auth::NoAuth,
+        &auth::AdminApiAuth,
         api_locking::LockAction::NotApplicable,
     ))
     .await
@@ -347,6 +347,25 @@ pub async fn invite_user(
         payload.into_inner(),
         |state, user, payload| user_core::invite_user(state, payload, user),
         &auth::JWTAuth(Permission::UsersWrite),
+        api_locking::LockAction::NotApplicable,
+    ))
+    .await
+}
+
+#[cfg(feature = "email")]
+pub async fn verify_email_request(
+    state: web::Data<AppState>,
+    http_req: HttpRequest,
+    json_payload: web::Json<user_api::SendVerifyEmailRequest>,
+) -> HttpResponse {
+    let flow = Flow::VerifyEmailRequest;
+    Box::pin(api::server_wrap(
+        flow,
+        state.clone(),
+        &http_req,
+        json_payload.into_inner(),
+        |state, _, req_body| user_core::send_verification_mail(state, req_body),
+        &auth::NoAuth,
         api_locking::LockAction::NotApplicable,
     ))
     .await

--- a/crates/router_env/src/logger/types.rs
+++ b/crates/router_env/src/logger/types.rs
@@ -307,6 +307,8 @@ pub enum Flow {
     GetActionUrl,
     /// Sync connector onboarding status
     SyncOnboardingStatus,
+    /// Send verify email
+    VerifyEmailRequest,
 }
 
 ///


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
This PR adds a new route `/verify_email_request` which will send verify email to the new user.

### Additional Changes

- [x] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
To support the user verification process.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Postman with SES.
```
curl --location 'http://localhost:8080/user/verify_email_request' \
--header 'Content-Type: application/json' \
--data-raw '{
    "email": "email"
}'
```

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
