### PR TITLE
fix(connector): [trustpay] make paymentId optional field

### DIFF
--- a/crates/router/src/connector/trustpay.rs
+++ b/crates/router/src/connector/trustpay.rs
@@ -955,11 +955,15 @@ impl api::IncomingWebhook for Trustpay {
             .switch()?;
         let payment_info = trustpay_response.payment_information;
         let reason = payment_info.status_reason_information.unwrap_or_default();
+        let connector_dispute_id = payment_info
+            .references
+            .payment_id
+            .ok_or(errors::ConnectorError::WebhookReferenceIdNotFound)?;
         Ok(api::disputes::DisputePayload {
             amount: payment_info.amount.amount.to_string(),
             currency: payment_info.amount.currency,
             dispute_stage: api_models::enums::DisputeStage::Dispute,
-            connector_dispute_id: payment_info.references.payment_id,
+            connector_dispute_id,
             connector_reason: reason.reason.reject_reason,
             connector_reason_code: Some(reason.reason.code),
             challenge_required_by: None,

--- a/crates/router/src/connector/trustpay/transformers.rs
+++ b/crates/router/src/connector/trustpay/transformers.rs
@@ -1700,7 +1700,7 @@ impl TryFrom<WebhookStatus> for diesel_models::enums::RefundStatus {
 #[serde(rename_all = "PascalCase")]
 pub struct WebhookReferences {
     pub merchant_reference: String,
-    pub payment_id: String,
+    pub payment_id: Option<String>,
     pub payment_request_id: Option<String>,
 }
 


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
 make paymentId optional field as it is not always sent by the connector in the request body, so it is causing deserialization errors.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Test Webhooks for Trustpay end to end from receiving to triggering outgoing webhook

![Screenshot 2023-12-11 at 7 18 59 PM](https://github.com/juspay/hyperswitch/assets/55536657/df7bd7a5-4017-4650-b9cb-9e1e927adee0)
<img width="1191" alt="Screenshot 2023-12-11 at 7 18 53 PM" src="https://github.com/juspay/hyperswitch/assets/55536657/4847f604-b5b7-4fa3-a96f-6669876d982a">


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [X] I formatted the code `cargo +nightly fmt --all`
- [X] I addressed lints thrown by `cargo clippy`
- [X] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
