### PR TITLE
feat(configs): add application config for setup mandates support under mandates section

### DIFF
--- a/config/config.example.toml
+++ b/config/config.example.toml
@@ -379,6 +379,9 @@ bank_debit.ach = { connector_list = "gocardless" }  # Mandate supported payment 
 bank_debit.becs = { connector_list = "gocardless" } # Mandate supported payment method type and connector for bank_debit
 bank_debit.sepa = { connector_list = "gocardless" } # Mandate supported payment method type and connector for bank_debit
 
+[mandates.setup_mandate_support]
+bank_debit.ach = { connector_list = "gocardless" } # Setup Mandate supported payment method and connectors for bank debits
+
 # Required fields info used while listing the payment_method_data
 [required_fields.pay_later] # payment_method = "pay_later"
 afterpay_clearpay = { fields = { stripe = [ # payment_method_type = afterpay_clearpay, connector = "stripe"

--- a/config/development.toml
+++ b/config/development.toml
@@ -452,6 +452,9 @@ bank_debit.ach = { connector_list = "gocardless"}
 bank_debit.becs = { connector_list = "gocardless"}
 bank_debit.sepa = { connector_list = "gocardless"}
 
+[mandates.setup_mandate_support]
+bank_debit.ach = { connector_list = "gocardless" }
+
 [connector_request_reference_id_config]
 merchant_ids_send_payment_id_as_connector_request_id = []
 

--- a/crates/api_models/src/payment_methods.rs
+++ b/crates/api_models/src/payment_methods.rs
@@ -411,6 +411,13 @@ impl ResponsePaymentMethodIntermediate {
     }
 }
 
+/// This function is required for cases when we want to have a serde(default) annotation over a
+/// mandatory bool field in a struct but want the default value to be 'true' as opposed to the
+/// Default::default() value of bool which is 'false'
+fn bool_true() -> bool {
+    true
+}
+
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, ToSchema, PartialEq, Eq, Hash)]
 pub struct RequestPaymentMethodTypes {
     #[schema(value_type = PaymentMethodType)]
@@ -453,6 +460,11 @@ pub struct RequestPaymentMethodTypes {
     /// Boolean to enable installment / EMI / BNPL payments. Default is true.
     #[schema(default = true, example = false)]
     pub installment_payment_enabled: bool,
+
+    /// Whether a mandate can be set up using this payment method
+    #[serde(default = "bool_true")]
+    #[schema(default = true, example = false)]
+    pub setup_mandate_enabled: bool,
 }
 
 //List Payment Method

--- a/crates/kgraph_utils/benches/evaluation.rs
+++ b/crates/kgraph_utils/benches/evaluation.rs
@@ -38,6 +38,7 @@ fn build_test_data<'a>(total_enabled: usize, total_pm_types: usize) -> graph::Kn
                 maximum_amount: Some(1000),
                 recurring_enabled: true,
                 installment_payment_enabled: true,
+                setup_mandate_enabled: true,
             });
         }
 

--- a/crates/kgraph_utils/src/mca.rs
+++ b/crates/kgraph_utils/src/mca.rs
@@ -382,6 +382,7 @@ mod tests {
                         maximum_amount: Some(1000),
                         recurring_enabled: true,
                         installment_payment_enabled: true,
+                        setup_mandate_enabled: true,
                     },
                     RequestPaymentMethodTypes {
                         payment_method_type: api_enums::PaymentMethodType::Debit,
@@ -399,6 +400,7 @@ mod tests {
                         maximum_amount: Some(1000),
                         recurring_enabled: true,
                         installment_payment_enabled: true,
+                        setup_mandate_enabled: true,
                     },
                 ]),
             }]),

--- a/crates/router/src/configs/defaults.rs
+++ b/crates/router/src/configs/defaults.rs
@@ -115,7 +115,7 @@ impl Default for super::settings::KvConfig {
 
 use super::settings::{
     Mandates, SupportedConnectorsForMandate, SupportedPaymentMethodTypesForMandate,
-    SupportedPaymentMethodsForMandate,
+    SupportedPaymentMethodsForMandate, SupportedPaymentMethodsForSetupMandate,
 };
 
 impl Default for Mandates {
@@ -194,6 +194,7 @@ impl Default for Mandates {
                     ])),
                 ),
             ])),
+            setup_mandate_support: SupportedPaymentMethodsForSetupMandate(HashMap::default()),
         }
     }
 }

--- a/crates/router/src/configs/settings.rs
+++ b/crates/router/src/configs/settings.rs
@@ -263,6 +263,7 @@ pub struct DummyConnector {
 #[derive(Debug, Deserialize, Clone)]
 pub struct Mandates {
     pub supported_payment_methods: SupportedPaymentMethodsForMandate,
+    pub setup_mandate_support: SupportedPaymentMethodsForSetupMandate,
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -277,6 +278,22 @@ pub struct SupportedPaymentMethodTypesForMandate(
 
 #[derive(Debug, Deserialize, Clone)]
 pub struct SupportedConnectorsForMandate {
+    #[serde(deserialize_with = "connector_deser")]
+    pub connector_list: HashSet<api_models::enums::Connector>,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct SupportedPaymentMethodsForSetupMandate(
+    pub HashMap<enums::PaymentMethod, SupportedPaymentMethodTypesForSetupMandate>,
+);
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct SupportedPaymentMethodTypesForSetupMandate(
+    pub HashMap<enums::PaymentMethodType, SupportedConnectorsForSetupMandate>,
+);
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct SupportedConnectorsForSetupMandate {
     #[serde(deserialize_with = "connector_deser")]
     pub connector_list: HashSet<api_models::enums::Connector>,
 }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [x] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
This PR adds a new config for specifying support for the `setup mandate` flow across payment methods for different connectors. Additionally, a `setup_mandate_enabled` boolean field is added to the merchant connector account API contract for the merchant to be able to specify whether they want the setup mandate flow enabled for a particular payment method.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [x] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
The application config allows us to decide whether the setup mandate flow can be invoked for a particular payment method and connector combination, and the merchant connector account config allows the merchant to control whether it is allowed for a particular payment method in that connector account.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
1. Create a Merchant Account
2. Create a Merchant Connector Account. The response `enabled_payment_methods` field should have a default `setup_mandates_enabled: true` for each payment method type.
<img width="551" alt="image" src="https://github.com/juspay/hyperswitch/assets/47862918/97c843e8-6e0a-4909-94bc-794c1b6e029c">


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
