### PR TITLE
chore(refactor): Pipeline explicit

### DIFF
--- a/crates/redis_interface/src/errors.rs
+++ b/crates/redis_interface/src/errors.rs
@@ -65,5 +65,7 @@ pub enum RedisError {
     #[error("Failed while receiving message from publisher")]
     OnMessageError,
     #[error("Got an unknown result from redis")]
+    PipelineError,
+    #[error("Error executing commands in pipeline")]
     UnknownResult,
 }

--- a/crates/router/src/core/api_locking.rs
+++ b/crates/router/src/core/api_locking.rs
@@ -60,15 +60,16 @@ impl LockAction {
                     .change_context(errors::ApiErrorResponse::InternalServerError)?;
 
                 let redis_locking_key = input.get_redis_locking_key(merchant_id);
-                let delay_between_retries_in_milliseconds = state
-                    .conf()
+                let state_ref = state.conf_as_ref();
+                let delay_between_retries_in_milliseconds = state_ref
                     .lock_settings
-                    .delay_between_retries_in_milliseconds;
+                    .delay_between_retries_in_milliseconds
+                    .to_owned();
                 let redis_lock_expiry_seconds =
-                    state.conf().lock_settings.redis_lock_expiry_seconds;
+                    state_ref.lock_settings.redis_lock_expiry_seconds.to_owned();
                 let lock_retries = input
                     .override_lock_retries
-                    .unwrap_or(state.conf().lock_settings.lock_retries);
+                    .unwrap_or(state_ref.lock_settings.lock_retries.to_owned());
                 for _retry in 0..lock_retries {
                     let redis_lock_result = redis_conn
                         .set_key_if_not_exists_with_expiry(

--- a/crates/router/src/routes/app.rs
+++ b/crates/router/src/routes/app.rs
@@ -71,6 +71,7 @@ impl scheduler::SchedulerAppState for AppState {
 }
 
 pub trait AppStateInfo {
+    fn conf_as_ref(&self) -> &settings::Settings;
     fn conf(&self) -> settings::Settings;
     fn store(&self) -> Box<dyn StorageInterface>;
     fn event_handler(&self) -> EventsHandler;
@@ -83,6 +84,9 @@ pub trait AppStateInfo {
 }
 
 impl AppStateInfo for AppState {
+    fn conf_as_ref(&self) -> &settings::Settings {
+        self.conf.as_ref()
+    }
     fn conf(&self) -> settings::Settings {
         self.conf.as_ref().to_owned()
     }

--- a/crates/storage_impl/src/redis/kv_store.rs
+++ b/crates/storage_impl/src/redis/kv_store.rs
@@ -115,7 +115,7 @@ where
                 let set_hash_fut   = redis_conn.set_hash_fields(key, value, Some(ttl.into()));
                 let drain_push_fut = store.push_to_drainer_stream::<S>(sql, partition_key);
                 
-                futures::try_join!(set_has_fut, drain_push_fut)?;
+                futures::try_join!(set_hash_fut, drain_push_fut)?;
 
                 Ok(KvResult::Hset(()))
             }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
- add explicit redis pipeline for hset and expiry
- avoid unnecessary clones of settings in perform_lock_action
- await hset and drainer stream write together


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
