### PR TITLE
fix(locker): fix double serialization for json request

### DIFF
--- a/crates/router/src/core/payment_methods/transformers.rs
+++ b/crates/router/src/core/payment_methods/transformers.rs
@@ -313,9 +313,6 @@ pub async fn mk_add_locker_request_hs<'a>(
         .change_context(errors::VaultError::RequestEncodingFailed)?;
 
     let jwe_payload = mk_basilisk_req(jwekey, &jws, locker_choice).await?;
-
-    let body = utils::Encode::<encryption::JweBody>::encode_to_value(&jwe_payload)
-        .change_context(errors::VaultError::RequestEncodingFailed)?;
     let mut url = match locker_choice {
         api_enums::LockerChoice::Basilisk => locker.host.to_owned(),
         api_enums::LockerChoice::Tartarus => locker.host_rs.to_owned(),
@@ -323,7 +320,7 @@ pub async fn mk_add_locker_request_hs<'a>(
     url.push_str("/cards/add");
     let mut request = services::Request::new(services::Method::Post, &url);
     request.add_header(headers::CONTENT_TYPE, "application/json".into());
-    request.set_body(RequestContent::Json(Box::new(body)));
+    request.set_body(RequestContent::Json(Box::new(jwe_payload)));
     Ok(request)
 }
 
@@ -459,9 +456,6 @@ pub async fn mk_get_card_request_hs(
     let target_locker = locker_choice.unwrap_or(api_enums::LockerChoice::Basilisk);
 
     let jwe_payload = mk_basilisk_req(jwekey, &jws, target_locker).await?;
-
-    let body = utils::Encode::<encryption::JweBody>::encode_to_value(&jwe_payload)
-        .change_context(errors::VaultError::RequestEncodingFailed)?;
     let mut url = match target_locker {
         api_enums::LockerChoice::Basilisk => locker.host.to_owned(),
         api_enums::LockerChoice::Tartarus => locker.host_rs.to_owned(),
@@ -469,7 +463,7 @@ pub async fn mk_get_card_request_hs(
     url.push_str("/cards/retrieve");
     let mut request = services::Request::new(services::Method::Post, &url);
     request.add_header(headers::CONTENT_TYPE, "application/json".into());
-    request.set_body(RequestContent::Json(Box::new(body)));
+    request.set_body(RequestContent::Json(Box::new(jwe_payload)));
     Ok(request)
 }
 
@@ -537,13 +531,11 @@ pub async fn mk_delete_card_request_hs(
 
     let jwe_payload = mk_basilisk_req(jwekey, &jws, api_enums::LockerChoice::Basilisk).await?;
 
-    let body = utils::Encode::<encryption::JweBody>::encode_to_value(&jwe_payload)
-        .change_context(errors::VaultError::RequestEncodingFailed)?;
     let mut url = locker.host.to_owned();
     url.push_str("/cards/delete");
     let mut request = services::Request::new(services::Method::Post, &url);
     request.add_header(headers::CONTENT_TYPE, "application/json".into());
-    request.set_body(RequestContent::Json(Box::new(body)));
+    request.set_body(RequestContent::Json(Box::new(jwe_payload)));
     Ok(request)
 }
 
@@ -602,14 +594,12 @@ pub fn mk_crud_locker_request(
     path: &str,
     req: api::TokenizePayloadEncrypted,
 ) -> CustomResult<services::Request, errors::VaultError> {
-    let body = utils::Encode::<api::TokenizePayloadEncrypted>::encode_to_value(&req)
-        .change_context(errors::VaultError::RequestEncodingFailed)?;
     let mut url = locker.basilisk_host.to_owned();
     url.push_str(path);
     let mut request = services::Request::new(services::Method::Post, &url);
     request.add_default_headers();
     request.add_header(headers::CONTENT_TYPE, "application/json".into());
-    request.set_body(RequestContent::Json(Box::new(body)));
+    request.set_body(RequestContent::Json(Box::new(req)));
     Ok(request)
 }
 

--- a/crates/router/src/core/payment_methods/transformers.rs
+++ b/crates/router/src/core/payment_methods/transformers.rs
@@ -323,7 +323,7 @@ pub async fn mk_add_locker_request_hs<'a>(
     url.push_str("/cards/add");
     let mut request = services::Request::new(services::Method::Post, &url);
     request.add_header(headers::CONTENT_TYPE, "application/json".into());
-    request.set_body(RequestContent::Json(Box::new(body.to_string())));
+    request.set_body(RequestContent::Json(Box::new(body)));
     Ok(request)
 }
 
@@ -469,7 +469,7 @@ pub async fn mk_get_card_request_hs(
     url.push_str("/cards/retrieve");
     let mut request = services::Request::new(services::Method::Post, &url);
     request.add_header(headers::CONTENT_TYPE, "application/json".into());
-    request.set_body(RequestContent::Json(Box::new(body.to_string())));
+    request.set_body(RequestContent::Json(Box::new(body)));
     Ok(request)
 }
 
@@ -543,7 +543,7 @@ pub async fn mk_delete_card_request_hs(
     url.push_str("/cards/delete");
     let mut request = services::Request::new(services::Method::Post, &url);
     request.add_header(headers::CONTENT_TYPE, "application/json".into());
-    request.set_body(RequestContent::Json(Box::new(body.to_string())));
+    request.set_body(RequestContent::Json(Box::new(body)));
     Ok(request)
 }
 
@@ -609,7 +609,7 @@ pub fn mk_crud_locker_request(
     let mut request = services::Request::new(services::Method::Post, &url);
     request.add_default_headers();
     request.add_header(headers::CONTENT_TYPE, "application/json".into());
-    request.set_body(RequestContent::Json(Box::new(body.to_string())));
+    request.set_body(RequestContent::Json(Box::new(body)));
     Ok(request)
 }
 


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
- remove double serialization for locker requests

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->

- fixes invalid request bodies for locker calls

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
