### PR TITLE
fix: [CYBERSOURCE] Fix Status Mapping

### DIFF
--- a/crates/router/src/connector/cybersource.rs
+++ b/crates/router/src/connector/cybersource.rs
@@ -411,15 +411,11 @@ impl ConnectorIntegration<api::Capture, types::PaymentsCaptureData, types::Payme
             .response
             .parse_struct("Cybersource PaymentResponse")
             .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
-        types::RouterData::try_from((
-            types::ResponseRouterData {
-                response,
-                data: data.clone(),
-                http_code: res.status_code,
-            },
-            true,
-        ))
-        .change_context(errors::ConnectorError::ResponseHandlingFailed)
+        types::RouterData::try_from(types::ResponseRouterData {
+            response,
+            data: data.clone(),
+            http_code: res.status_code,
+        })
     }
     fn get_error_response(
         &self,
@@ -489,17 +485,11 @@ impl ConnectorIntegration<api::PSync, types::PaymentsSyncData, types::PaymentsRe
             .response
             .parse_struct("Cybersource PaymentSyncResponse")
             .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
-        let is_auto_capture =
-            data.request.capture_method == Some(diesel_models::enums::CaptureMethod::Automatic);
-        types::RouterData::try_from((
-            types::ResponseRouterData {
-                response,
-                data: data.clone(),
-                http_code: res.status_code,
-            },
-            is_auto_capture,
-        ))
-        .change_context(errors::ConnectorError::ResponseHandlingFailed)
+        types::RouterData::try_from(types::ResponseRouterData {
+            response,
+            data: data.clone(),
+            http_code: res.status_code,
+        })
     }
     fn get_error_response(
         &self,
@@ -580,17 +570,11 @@ impl ConnectorIntegration<api::Authorize, types::PaymentsAuthorizeData, types::P
             .response
             .parse_struct("Cybersource PaymentResponse")
             .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
-        let is_auto_capture =
-            data.request.capture_method == Some(diesel_models::enums::CaptureMethod::Automatic);
-        types::RouterData::try_from((
-            types::ResponseRouterData {
-                response,
-                data: data.clone(),
-                http_code: res.status_code,
-            },
-            is_auto_capture,
-        ))
-        .change_context(errors::ConnectorError::ResponseHandlingFailed)
+        types::RouterData::try_from(types::ResponseRouterData {
+            response,
+            data: data.clone(),
+            http_code: res.status_code,
+        })
     }
 
     fn get_error_response(
@@ -662,15 +646,11 @@ impl ConnectorIntegration<api::Void, types::PaymentsCancelData, types::PaymentsR
             .response
             .parse_struct("Cybersource PaymentResponse")
             .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
-        types::RouterData::try_from((
-            types::ResponseRouterData {
-                response,
-                data: data.clone(),
-                http_code: res.status_code,
-            },
-            false,
-        ))
-        .change_context(errors::ConnectorError::ResponseHandlingFailed)
+        types::RouterData::try_from(types::ResponseRouterData {
+            response,
+            data: data.clone(),
+            http_code: res.status_code,
+        })
     }
 
     fn get_error_response(
@@ -752,16 +732,15 @@ impl ConnectorIntegration<api::Execute, types::RefundsData, types::RefundsRespon
         data: &types::RefundExecuteRouterData,
         res: types::Response,
     ) -> CustomResult<types::RefundExecuteRouterData, errors::ConnectorError> {
-        let response: cybersource::CybersourcePaymentsResponse = res
+        let response: cybersource::CybersourceRefundResponse = res
             .response
-            .parse_struct("Cybersource PaymentResponse")
+            .parse_struct("Cybersource RefundResponse")
             .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
         types::RouterData::try_from(types::ResponseRouterData {
             response,
             data: data.clone(),
             http_code: res.status_code,
         })
-        .change_context(errors::ConnectorError::ResponseHandlingFailed)
     }
     fn get_error_response(
         &self,
@@ -819,17 +798,15 @@ impl ConnectorIntegration<api::RSync, types::RefundsData, types::RefundsResponse
         data: &types::RefundSyncRouterData,
         res: types::Response,
     ) -> CustomResult<types::RefundSyncRouterData, errors::ConnectorError> {
-        let response: cybersource::CybersourceTransactionResponse = res
+        let response: cybersource::CybersourceRsyncResponse = res
             .response
-            .parse_struct("Cybersource RefundsSyncResponse")
+            .parse_struct("Cybersource RefundSyncResponse")
             .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
-        types::ResponseRouterData {
+        types::RouterData::try_from(types::ResponseRouterData {
             response,
             data: data.clone(),
             http_code: res.status_code,
-        }
-        .try_into()
-        .change_context(errors::ConnectorError::ResponseHandlingFailed)
+        })
     }
     fn get_error_response(
         &self,

--- a/crates/router/src/connector/cybersource/transformers.rs
+++ b/crates/router/src/connector/cybersource/transformers.rs
@@ -935,13 +935,6 @@ impl<F>
         match item.response {
             CybersourcePaymentsResponse::ClientReferenceInformation(info_response) => {
                 let status = enums::AttemptStatus::foreign_from((info_response.status, true));
-                let mandate_reference =
-                    info_response
-                        .token_information
-                        .map(|token_info| types::MandateReference {
-                            connector_mandate_id: Some(token_info.instrument_identifier.id),
-                            payment_method_id: None,
-                        });
                 let connector_response_reference_id = Some(
                     info_response
                         .client_reference_information
@@ -953,7 +946,7 @@ impl<F>
                     response: Ok(types::PaymentsResponseData::TransactionResponse {
                         resource_id: types::ResponseId::ConnectorTransactionId(info_response.id),
                         redirection_data: None,
-                        mandate_reference,
+                        mandate_reference: None,
                         connector_metadata: None,
                         network_txn_id: None,
                         connector_response_reference_id,
@@ -991,13 +984,6 @@ impl<F>
         match item.response {
             CybersourcePaymentsResponse::ClientReferenceInformation(info_response) => {
                 let status = enums::AttemptStatus::foreign_from((info_response.status, false));
-                let mandate_reference =
-                    info_response
-                        .token_information
-                        .map(|token_info| types::MandateReference {
-                            connector_mandate_id: Some(token_info.instrument_identifier.id),
-                            payment_method_id: None,
-                        });
                 let connector_response_reference_id = Some(
                     info_response
                         .client_reference_information
@@ -1009,7 +995,7 @@ impl<F>
                     response: Ok(types::PaymentsResponseData::TransactionResponse {
                         resource_id: types::ResponseId::ConnectorTransactionId(info_response.id),
                         redirection_data: None,
-                        mandate_reference,
+                        mandate_reference: None,
                         connector_metadata: None,
                         network_txn_id: None,
                         connector_response_reference_id,

--- a/crates/router/src/connector/cybersource/transformers.rs
+++ b/crates/router/src/connector/cybersource/transformers.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     connector::utils::{
         self, AddressDetailsData, CardData, PaymentsAuthorizeRequestData,
-        PaymentsSetupMandateRequestData, RouterData,
+        PaymentsSetupMandateRequestData, RouterData, PaymentsSyncRequestData,
     },
     consts,
     core::errors,
@@ -15,6 +15,7 @@ use crate::{
         self,
         api::{self, enums as api_enums},
         storage::enums,
+        transformers::ForeignFrom,
     },
 };
 
@@ -684,7 +685,8 @@ impl TryFrom<&types::ConnectorAuthType> for CybersourceAuthType {
         }
     }
 }
-#[derive(Debug, Default, Clone, Deserialize)]
+
+#[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum CybersourcePaymentStatus {
     Authorized,
@@ -696,8 +698,6 @@ pub enum CybersourcePaymentStatus {
     Declined,
     AuthorizedPendingReview,
     Transmitted,
-    #[default]
-    Processing,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -708,18 +708,30 @@ pub enum CybersourceIncrementalAuthorizationStatus {
     AuthorizedPendingReview,
 }
 
-impl From<CybersourcePaymentStatus> for enums::AttemptStatus {
-    fn from(item: CybersourcePaymentStatus) -> Self {
-        match item {
+impl ForeignFrom<(CybersourcePaymentStatus, bool)> for enums::AttemptStatus {
+    fn foreign_from((status, capture): (CybersourcePaymentStatus, bool)) -> Self {
+        match status {
             CybersourcePaymentStatus::Authorized
-            | CybersourcePaymentStatus::AuthorizedPendingReview => Self::Authorized,
+            | CybersourcePaymentStatus::AuthorizedPendingReview => {
+                if capture {
+                    // Because Cybersource will return Payment Status as Authorized even in AutoCapture Payment
+                    Self::Charged
+                } else {
+                    Self::Authorized
+                }
+            }
+            CybersourcePaymentStatus::Pending => {
+                if capture {
+                    Self::Charged
+                } else {
+                    Self::Pending
+                }
+            }
             CybersourcePaymentStatus::Succeeded | CybersourcePaymentStatus::Transmitted => {
                 Self::Charged
             }
             CybersourcePaymentStatus::Voided | CybersourcePaymentStatus::Reversed => Self::Voided,
             CybersourcePaymentStatus::Failed | CybersourcePaymentStatus::Declined => Self::Failure,
-            CybersourcePaymentStatus::Processing => Self::Authorizing,
-            CybersourcePaymentStatus::Pending => Self::Pending,
         }
     }
 }
@@ -746,14 +758,27 @@ impl From<CybersourcePaymentStatus> for enums::RefundStatus {
     }
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+pub enum CybersourcePaymentsResponse {
+    ClientReferenceInformation(CybersourceClientReferenceResponse),
+    ErrorInformation(CybersourceErrorInformationResponse),
+}
+
+#[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct CybersourcePaymentsResponse {
+pub struct CybersourceClientReferenceResponse {
     id: String,
     status: CybersourcePaymentStatus,
-    error_information: Option<CybersourceErrorInformation>,
-    client_reference_information: Option<ClientReferenceInformation>,
+    client_reference_information: ClientReferenceInformation,
     token_information: Option<CybersourceTokenInformation>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CybersourceErrorInformationResponse {
+    id: String,
+    error_information: CybersourceErrorInformation,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -787,69 +812,223 @@ pub struct CybersourceTokenInformation {
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct CybersourceErrorInformation {
-    reason: String,
-    message: String,
+    reason: Option<String>,
+    message: Option<String>,
 }
 
-impl<F, T>
-    TryFrom<(
-        types::ResponseRouterData<F, CybersourcePaymentsResponse, T, types::PaymentsResponseData>,
-        bool,
-    )> for types::RouterData<F, T, types::PaymentsResponseData>
+impl<F>
+    TryFrom<
+        types::ResponseRouterData<
+            F,
+            CybersourcePaymentsResponse,
+            types::PaymentsAuthorizeData,
+            types::PaymentsResponseData,
+        >,
+    > for types::RouterData<F, types::PaymentsAuthorizeData, types::PaymentsResponseData>
 {
     type Error = error_stack::Report<errors::ConnectorError>;
     fn try_from(
-        data: (
-            types::ResponseRouterData<
-                F,
-                CybersourcePaymentsResponse,
-                T,
-                types::PaymentsResponseData,
-            >,
-            bool,
-        ),
+        item: types::ResponseRouterData<
+            F,
+            CybersourcePaymentsResponse,
+            types::PaymentsAuthorizeData,
+            types::PaymentsResponseData,
+        >,
     ) -> Result<Self, Self::Error> {
-        let item = data.0;
-        let is_capture = data.1;
-        let mandate_reference =
-            item.response
-                .token_information
-                .map(|token_info| types::MandateReference {
-                    connector_mandate_id: Some(token_info.instrument_identifier.id),
-                    payment_method_id: None,
-                });
-        let status = get_payment_status(is_capture, item.response.status.into());
-        Ok(Self {
-            status,
-            response: match item.response.error_information {
-                Some(error) => Err(types::ErrorResponse {
+        match item.response {
+            CybersourcePaymentsResponse::ClientReferenceInformation(info_response) => {
+                let status = enums::AttemptStatus::foreign_from((
+                    info_response.status,
+                    item.data.request.is_auto_capture()?,
+                ));
+                let incremental_authorization_allowed =
+                    Some(status == enums::AttemptStatus::Authorized);
+                let mandate_reference =
+                    info_response
+                        .token_information
+                        .map(|token_info| types::MandateReference {
+                            connector_mandate_id: Some(token_info.instrument_identifier.id),
+                            payment_method_id: None,
+                        });
+                let connector_response_reference_id = Some(
+                    info_response
+                        .client_reference_information
+                        .code
+                        .unwrap_or(info_response.id.clone()),
+                );
+                Ok(Self {
+                    status,
+                    response: Ok(types::PaymentsResponseData::TransactionResponse {
+                        resource_id: types::ResponseId::ConnectorTransactionId(
+                            info_response.id,
+                        ),
+                        redirection_data: None,
+                        mandate_reference,
+                        connector_metadata: None,
+                        network_txn_id: None,
+                        connector_response_reference_id,
+                        incremental_authorization_allowed,
+                    }),
+                    ..item.data
+                })
+            }
+            CybersourcePaymentsResponse::ErrorInformation(error_response) => Ok(Self {
+                response: Err(types::ErrorResponse {
                     code: consts::NO_ERROR_CODE.to_string(),
-                    message: error.message,
-                    reason: Some(error.reason),
+                    message: error_response
+                        .error_information
+                        .message
+                        .unwrap_or(consts::NO_ERROR_MESSAGE.to_string()),
+                    reason: error_response.error_information.reason,
                     status_code: item.http_code,
                     attempt_status: None,
-                    connector_transaction_id: Some(item.response.id),
+                    connector_transaction_id: None,
                 }),
-                _ => Ok(types::PaymentsResponseData::TransactionResponse {
-                    resource_id: types::ResponseId::ConnectorTransactionId(
-                        item.response.id.clone(),
-                    ),
-                    redirection_data: None,
-                    mandate_reference,
-                    connector_metadata: None,
-                    network_txn_id: None,
-                    connector_response_reference_id: item
-                        .response
+                ..item.data
+            }),
+        }
+    }
+}
+
+impl<F>
+    TryFrom<
+        types::ResponseRouterData<
+            F,
+            CybersourcePaymentsResponse,
+            types::PaymentsCaptureData,
+            types::PaymentsResponseData,
+        >,
+    > for types::RouterData<F, types::PaymentsCaptureData, types::PaymentsResponseData>
+{
+    type Error = error_stack::Report<errors::ConnectorError>;
+    fn try_from(
+        item: types::ResponseRouterData<
+            F,
+            CybersourcePaymentsResponse,
+            types::PaymentsCaptureData,
+            types::PaymentsResponseData,
+        >,
+    ) -> Result<Self, Self::Error> {
+        match item.response {
+            CybersourcePaymentsResponse::ClientReferenceInformation(info_response) => {
+                let status = enums::AttemptStatus::foreign_from((info_response.status, true));
+                let incremental_authorization_allowed =
+                    Some(status == enums::AttemptStatus::Authorized);
+                let mandate_reference =
+                    info_response
+                        .token_information
+                        .map(|token_info| types::MandateReference {
+                            connector_mandate_id: Some(token_info.instrument_identifier.id),
+                            payment_method_id: None,
+                        });
+                let connector_response_reference_id = Some(
+                    info_response
                         .client_reference_information
-                        .map(|cref| cref.code)
-                        .unwrap_or(Some(item.response.id)),
-                    incremental_authorization_allowed: Some(
-                        status == enums::AttemptStatus::Authorized,
-                    ),
+                        .code
+                        .unwrap_or(info_response.id.clone()),
+                );
+                Ok(Self {
+                    status,
+                    response: Ok(types::PaymentsResponseData::TransactionResponse {
+                        resource_id: types::ResponseId::ConnectorTransactionId(
+                            info_response.id,
+                        ),
+                        redirection_data: None,
+                        mandate_reference,
+                        connector_metadata: None,
+                        network_txn_id: None,
+                        connector_response_reference_id,
+                        incremental_authorization_allowed,
+                    }),
+                    ..item.data
+                })
+            }
+            CybersourcePaymentsResponse::ErrorInformation(error_response) => Ok(Self {
+                response: Err(types::ErrorResponse {
+                    code: consts::NO_ERROR_CODE.to_string(),
+                    message: error_response
+                        .error_information
+                        .message
+                        .unwrap_or(consts::NO_ERROR_MESSAGE.to_string()),
+                    reason: error_response.error_information.reason,
+                    status_code: item.http_code,
+                    attempt_status: None,
+                    connector_transaction_id: None,
                 }),
-            },
-            ..item.data
-        })
+                ..item.data
+            }),
+        }
+    }
+}
+
+impl<F>
+    TryFrom<
+        types::ResponseRouterData<
+            F,
+            CybersourcePaymentsResponse,
+            types::PaymentsCancelData,
+            types::PaymentsResponseData,
+        >,
+    > for types::RouterData<F, types::PaymentsCancelData, types::PaymentsResponseData>
+{
+    type Error = error_stack::Report<errors::ConnectorError>;
+    fn try_from(
+        item: types::ResponseRouterData<
+            F,
+            CybersourcePaymentsResponse,
+            types::PaymentsCancelData,
+            types::PaymentsResponseData,
+        >,
+    ) -> Result<Self, Self::Error> {
+        match item.response {
+            CybersourcePaymentsResponse::ClientReferenceInformation(info_response) => {
+                let status = enums::AttemptStatus::foreign_from((info_response.status, false));
+                let incremental_authorization_allowed =
+                    Some(status == enums::AttemptStatus::Authorized);
+                let mandate_reference =
+                    info_response
+                        .token_information
+                        .map(|token_info| types::MandateReference {
+                            connector_mandate_id: Some(token_info.instrument_identifier.id),
+                            payment_method_id: None,
+                        });
+                let connector_response_reference_id = Some(
+                    info_response
+                        .client_reference_information
+                        .code
+                        .unwrap_or(info_response.id.clone()),
+                );
+                Ok(Self {
+                    status,
+                    response: Ok(types::PaymentsResponseData::TransactionResponse {
+                        resource_id: types::ResponseId::ConnectorTransactionId(
+                            info_response.id,
+                        ),
+                        redirection_data: None,
+                        mandate_reference,
+                        connector_metadata: None,
+                        network_txn_id: None,
+                        connector_response_reference_id,
+                        incremental_authorization_allowed,
+                    }),
+                    ..item.data
+                })
+            }
+            CybersourcePaymentsResponse::ErrorInformation(error_response) => Ok(Self {
+                response: Err(types::ErrorResponse {
+                    code: consts::NO_ERROR_CODE.to_string(),
+                    message: error_response
+                        .error_information
+                        .message
+                        .unwrap_or(consts::NO_ERROR_MESSAGE.to_string()),
+                    reason: error_response.error_information.reason,
+                    status_code: item.http_code,
+                    attempt_status: None,
+                    connector_transaction_id: None,
+                }),
+                ..item.data
+            }),
+        }
     }
 }
 
@@ -879,7 +1058,10 @@ impl<F, T>
                     connector_mandate_id: Some(token_info.instrument_identifier.id),
                     payment_method_id: None,
                 });
-        let mut mandate_status: enums::AttemptStatus = item.response.status.into();
+        let mut mandate_status = enums::AttemptStatus::foreign_from((
+            item.response.status,
+            false,
+        ));
         if matches!(mandate_status, enums::AttemptStatus::Authorized) {
             //In case of zero auth mandates we want to make the payment reach the terminal status so we are converting the authorized status to charged as well.
             mandate_status = enums::AttemptStatus::Charged
@@ -889,8 +1071,10 @@ impl<F, T>
             response: match item.response.error_information {
                 Some(error) => Err(types::ErrorResponse {
                     code: consts::NO_ERROR_CODE.to_string(),
-                    message: error.message,
-                    reason: Some(error.reason),
+                    message: error
+                        .message
+                        .unwrap_or(consts::NO_ERROR_MESSAGE.to_string()),
+                    reason: error.reason,
                     status_code: item.http_code,
                     attempt_status: None,
                     connector_transaction_id: Some(item.response.id),
@@ -947,8 +1131,8 @@ impl<F, T>
                 Some(error) => Ok(
                     types::PaymentsResponseData::IncrementalAuthorizationResponse {
                         status: common_enums::AuthorizationStatus::Failure,
-                        error_code: Some(error.reason),
-                        error_message: Some(error.message),
+                        error_code: error.reason,
+                        error_message: error.message,
                         connector_authorization_id: None,
                     },
                 ),
@@ -967,8 +1151,15 @@ impl<F, T>
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(untagged)]
+pub enum CybersourceTransactionResponse {
+    ApplicationInformation(CybersourceApplicationInfoResponse),
+    ErrorInformation(CybersourceErrorInformationResponse),
+}
+
+#[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct CybersourceTransactionResponse {
+pub struct CybersourceApplicationInfoResponse {
     id: String,
     application_information: ApplicationInformation,
     client_reference_information: Option<ClientReferenceInformation>,
@@ -980,61 +1171,65 @@ pub struct ApplicationInformation {
     status: CybersourcePaymentStatus,
 }
 
-fn get_payment_status(is_capture: bool, status: enums::AttemptStatus) -> enums::AttemptStatus {
-    let is_authorized = matches!(status, enums::AttemptStatus::Authorized);
-    let is_pending = matches!(status, enums::AttemptStatus::Pending);
-    if is_capture && (is_authorized || is_pending) {
-        return enums::AttemptStatus::Charged;
-    }
-    status
-}
-
-impl<F, T>
-    TryFrom<(
+impl<F>
+    TryFrom<
         types::ResponseRouterData<
             F,
             CybersourceTransactionResponse,
-            T,
+            types::PaymentsSyncData,
             types::PaymentsResponseData,
         >,
-        bool,
-    )> for types::RouterData<F, T, types::PaymentsResponseData>
+    > for types::RouterData<F, types::PaymentsSyncData, types::PaymentsResponseData>
 {
     type Error = error_stack::Report<errors::ConnectorError>;
     fn try_from(
-        data: (
-            types::ResponseRouterData<
-                F,
-                CybersourceTransactionResponse,
-                T,
-                types::PaymentsResponseData,
-            >,
-            bool,
-        ),
+        item: types::ResponseRouterData<
+            F,
+            CybersourceTransactionResponse,
+            types::PaymentsSyncData,
+            types::PaymentsResponseData,
+        >,
     ) -> Result<Self, Self::Error> {
-        let item = data.0;
-        let is_capture = data.1;
-        let status = get_payment_status(
-            is_capture,
-            item.response.application_information.status.into(),
-        );
-        Ok(Self {
-            status,
-            response: Ok(types::PaymentsResponseData::TransactionResponse {
-                resource_id: types::ResponseId::ConnectorTransactionId(item.response.id.clone()),
-                redirection_data: None,
-                mandate_reference: None,
-                connector_metadata: None,
-                network_txn_id: None,
-                connector_response_reference_id: item
-                    .response
-                    .client_reference_information
-                    .map(|cref| cref.code)
-                    .unwrap_or(Some(item.response.id)),
-                incremental_authorization_allowed: Some(status == enums::AttemptStatus::Authorized),
+        match item.response {
+            CybersourceTransactionResponse::ApplicationInformation(app_response) => {
+                let status = enums::AttemptStatus::foreign_from((
+                    app_response.application_information.status,
+                    item.data.request.is_auto_capture()?,
+                ));
+                let incremental_authorization_allowed = Some(status == enums::AttemptStatus::Authorized);
+                Ok(Self {
+                    status,
+                    response: Ok(types::PaymentsResponseData::TransactionResponse {
+                        resource_id: types::ResponseId::ConnectorTransactionId(app_response.id.clone()),
+                        redirection_data: None,
+                        mandate_reference: None,
+                        connector_metadata: None,
+                        network_txn_id: None,
+                        incremental_authorization_allowed,
+                        connector_response_reference_id: app_response
+                            .client_reference_information
+                            .map(|cref| cref.code)
+                            .unwrap_or(Some(app_response.id)),
+                    }),
+                    ..item.data
+                })
+            }
+            CybersourceTransactionResponse::ErrorInformation(error_response) => Ok(Self {
+                status: item.data.status,
+                response: Ok(types::PaymentsResponseData::TransactionResponse {
+                    resource_id: types::ResponseId::ConnectorTransactionId(
+                        error_response.id.clone(),
+                    ),
+                    redirection_data: None,
+                    mandate_reference: None,
+                    connector_metadata: None,
+                    network_txn_id: None,
+                    connector_response_reference_id: Some(error_response.id),
+                    incremental_authorization_allowed: None,
+                }),
+                ..item.data
             }),
-            ..item.data
-        })
+        }
     }
 }
 
@@ -1103,30 +1298,71 @@ impl<F> TryFrom<&CybersourceRouterData<&types::RefundsRouterData<F>>> for Cybers
     }
 }
 
-impl TryFrom<types::RefundsResponseRouterData<api::Execute, CybersourcePaymentsResponse>>
+impl From<CybersourceRefundStatus> for enums::RefundStatus {
+    fn from(item: CybersourceRefundStatus) -> Self {
+        match item {
+            CybersourceRefundStatus::Succeeded | CybersourceRefundStatus::Transmitted => {
+                Self::Success
+            }
+            CybersourceRefundStatus::Failed | CybersourceRefundStatus::Voided => Self::Failure,
+            CybersourceRefundStatus::Pending => Self::Pending,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum CybersourceRefundStatus {
+    Succeeded,
+    Transmitted,
+    Failed,
+    Pending,
+    Voided,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CybersourceRefundResponse {
+    id: String,
+    status: CybersourceRefundStatus,
+}
+
+impl TryFrom<types::RefundsResponseRouterData<api::Execute, CybersourceRefundResponse>>
     for types::RefundsRouterData<api::Execute>
 {
     type Error = error_stack::Report<errors::ConnectorError>;
     fn try_from(
-        item: types::RefundsResponseRouterData<api::Execute, CybersourcePaymentsResponse>,
+        item: types::RefundsResponseRouterData<api::Execute, CybersourceRefundResponse>,
     ) -> Result<Self, Self::Error> {
-        let refund_status = enums::RefundStatus::from(item.response.status);
         Ok(Self {
             response: Ok(types::RefundsResponseData {
                 connector_refund_id: item.response.id,
-                refund_status,
+                refund_status: enums::RefundStatus::from(item.response.status),
             }),
             ..item.data
         })
     }
 }
 
-impl TryFrom<types::RefundsResponseRouterData<api::RSync, CybersourceTransactionResponse>>
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RsyncApplicationInformation {
+    status: CybersourceRefundStatus,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CybersourceRsyncResponse {
+    id: String,
+    application_information: RsyncApplicationInformation,
+}
+
+impl TryFrom<types::RefundsResponseRouterData<api::RSync, CybersourceRsyncResponse>>
     for types::RefundsRouterData<api::RSync>
 {
     type Error = error_stack::Report<errors::ConnectorError>;
     fn try_from(
-        item: types::RefundsResponseRouterData<api::RSync, CybersourceTransactionResponse>,
+        item: types::RefundsResponseRouterData<api::RSync, CybersourceRsyncResponse>,
     ) -> Result<Self, Self::Error> {
         Ok(Self {
             response: Ok(types::RefundsResponseData {

--- a/crates/router/src/connector/cybersource/transformers.rs
+++ b/crates/router/src/connector/cybersource/transformers.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     connector::utils::{
         self, AddressDetailsData, CardData, PaymentsAuthorizeRequestData,
-        PaymentsSetupMandateRequestData, RouterData, PaymentsSyncRequestData,
+        PaymentsSetupMandateRequestData, PaymentsSyncRequestData, RouterData,
     },
     consts,
     core::errors,
@@ -859,9 +859,7 @@ impl<F>
                 Ok(Self {
                     status,
                     response: Ok(types::PaymentsResponseData::TransactionResponse {
-                        resource_id: types::ResponseId::ConnectorTransactionId(
-                            info_response.id,
-                        ),
+                        resource_id: types::ResponseId::ConnectorTransactionId(info_response.id),
                         redirection_data: None,
                         mandate_reference,
                         connector_metadata: None,
@@ -930,9 +928,7 @@ impl<F>
                 Ok(Self {
                     status,
                     response: Ok(types::PaymentsResponseData::TransactionResponse {
-                        resource_id: types::ResponseId::ConnectorTransactionId(
-                            info_response.id,
-                        ),
+                        resource_id: types::ResponseId::ConnectorTransactionId(info_response.id),
                         redirection_data: None,
                         mandate_reference,
                         connector_metadata: None,
@@ -1001,9 +997,7 @@ impl<F>
                 Ok(Self {
                     status,
                     response: Ok(types::PaymentsResponseData::TransactionResponse {
-                        resource_id: types::ResponseId::ConnectorTransactionId(
-                            info_response.id,
-                        ),
+                        resource_id: types::ResponseId::ConnectorTransactionId(info_response.id),
                         redirection_data: None,
                         mandate_reference,
                         connector_metadata: None,
@@ -1058,10 +1052,7 @@ impl<F, T>
                     connector_mandate_id: Some(token_info.instrument_identifier.id),
                     payment_method_id: None,
                 });
-        let mut mandate_status = enums::AttemptStatus::foreign_from((
-            item.response.status,
-            false,
-        ));
+        let mut mandate_status = enums::AttemptStatus::foreign_from((item.response.status, false));
         if matches!(mandate_status, enums::AttemptStatus::Authorized) {
             //In case of zero auth mandates we want to make the payment reach the terminal status so we are converting the authorized status to charged as well.
             mandate_status = enums::AttemptStatus::Charged
@@ -1196,11 +1187,14 @@ impl<F>
                     app_response.application_information.status,
                     item.data.request.is_auto_capture()?,
                 ));
-                let incremental_authorization_allowed = Some(status == enums::AttemptStatus::Authorized);
+                let incremental_authorization_allowed =
+                    Some(status == enums::AttemptStatus::Authorized);
                 Ok(Self {
                     status,
                     response: Ok(types::PaymentsResponseData::TransactionResponse {
-                        resource_id: types::ResponseId::ConnectorTransactionId(app_response.id.clone()),
+                        resource_id: types::ResponseId::ConnectorTransactionId(
+                            app_response.id.clone(),
+                        ),
                         redirection_data: None,
                         mandate_reference: None,
                         connector_metadata: None,

--- a/crates/router/src/connector/cybersource/transformers.rs
+++ b/crates/router/src/connector/cybersource/transformers.rs
@@ -817,13 +817,12 @@ pub struct CybersourceErrorInformation {
 }
 
 impl<F, T>
-    TryFrom<(
+    From<(
         &CybersourceErrorInformationResponse,
         types::ResponseRouterData<F, CybersourcePaymentsResponse, T, types::PaymentsResponseData>,
     )> for types::RouterData<F, T, types::PaymentsResponseData>
 {
-    type Error = error_stack::Report<errors::ConnectorError>;
-    fn try_from(
+    fn from(
         (error_response, item): (
             &CybersourceErrorInformationResponse,
             types::ResponseRouterData<
@@ -833,8 +832,8 @@ impl<F, T>
                 types::PaymentsResponseData,
             >,
         ),
-    ) -> Result<Self, Self::Error> {
-        Ok(Self {
+    ) -> Self {
+        Self {
             response: Err(types::ErrorResponse {
                 code: consts::NO_ERROR_CODE.to_string(),
                 message: error_response
@@ -848,7 +847,7 @@ impl<F, T>
                 connector_transaction_id: None,
             }),
             ..item.data
-        })
+        }
     }
 }
 
@@ -907,7 +906,7 @@ impl<F>
                 })
             }
             CybersourcePaymentsResponse::ErrorInformation(ref error_response) => {
-                Self::try_from((&error_response.clone(), item))
+                Ok(Self::from((&error_response.clone(), item)))
             }
         }
     }
@@ -956,7 +955,7 @@ impl<F>
                 })
             }
             CybersourcePaymentsResponse::ErrorInformation(ref error_response) => {
-                Self::try_from((&error_response.clone(), item))
+                Ok(Self::from((&error_response.clone(), item)))
             }
         }
     }
@@ -1005,7 +1004,7 @@ impl<F>
                 })
             }
             CybersourcePaymentsResponse::ErrorInformation(ref error_response) => {
-                Self::try_from((&error_response.clone(), item))
+                Ok(Self::from((&error_response.clone(), item)))
             }
         }
     }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Cybersource status mapping requires update.
Separate the handle_response try_from's for different flows.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
https://github.com/juspay/hyperswitch-cloud/issues/3226

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Authorize(Manual+Automatic), Capture, PSYNC, Refunds and RSYNC flow needs to be tested for Payment Method Cards for connector Cybersource

1. Authorize: 
`{
  "amount": 100,
  "currency": "USD",
  "confirm": true,
  "capture_method": "automatic",
  "email": "bernard.eugine@juspay.in",
  "name": "John Doe",
  "authentication_type": "no_three_ds",
  "return_url": "https://google.com/",
  "payment_method": "card",
  "payment_method_type": "credit",
  "payment_method_data": {
    "card": {
      "card_number": "4111111111111111",
      "card_exp_month": "12",
      "card_exp_year": "30",
      "card_holder_name": "joseph Doe",
      "card_cvc": "123"
    }
  },
  "billing": {
    "address": {
      "line1": "1467",
      "city": "San Fransico",
      "state": "Dubai",
      "zip": "94122",
      "country": "AE",
      "first_name": "joseph",
      "last_name": "Doe"
    }
  }
}`

2. Authorize(Manual):
`{
  "amount": 100,
  "currency": "USD",
  "confirm": true,
  "capture_method": "manual",
  "email": "bernard.eugine@juspay.in",
  "name": "John Doe",
  "authentication_type": "no_three_ds",
  "return_url": "https://google.com/",
  "payment_method": "card",
  "payment_method_type": "credit",
  "payment_method_data": {
    "card": {
      "card_number": "4111111111111111",
      "card_exp_month": "12",
      "card_exp_year": "30",
      "card_holder_name": "joseph Doe",
      "card_cvc": "123"
    }
  },
  "billing": {
    "address": {
      "line1": "1467",
      "city": "San Fransico",
      "state": "Dubai",
      "zip": "94122",
      "country": "AE",
      "first_name": "joseph",
      "last_name": "Doe"
    }
  }
}`

3. Capture:
`{
  "amount_to_capture": 2111,
  "statement_descriptor_name": "Joseph",
  "statement_descriptor_suffix": "JS"
}`

4. Cancel:
`{
  "cancellation_reason": "requested_by_customer",
   "amount": 2111,
   "currency": "USD"
}`

5. Refund:
`{
  "payment_id": "payment_id",
  "amount": 501,
  "reason": "Customer returned product",
  "refund_type": "instant",
  "metadata": {
    "udf1": "value1",
    "new_customer": "true",
    "login_date": "2019-09-10T10:11:12Z"
  }
}`

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
