### PR TITLE
fix(connector): [BOA/CYBERSOURCE] Update error handling

### DIFF
--- a/crates/router/src/connector/bankofamerica.rs
+++ b/crates/router/src/connector/bankofamerica.rs
@@ -203,37 +203,50 @@ impl ConnectorCommon for Bankofamerica {
         } else {
             consts::NO_ERROR_MESSAGE
         };
+        match response {
+            transformers::BankOfAmericaErrorResponse::StandardError(response) => {
+                let (code, message) = match response.error_information {
+                    Some(ref error_info) => (error_info.reason.clone(), error_info.message.clone()),
+                    None => (
+                        response
+                            .reason
+                            .map_or(consts::NO_ERROR_CODE.to_string(), |reason| {
+                                reason.to_string()
+                            }),
+                        response
+                            .message
+                            .map_or(error_message.to_string(), |message| message),
+                    ),
+                };
+                let connector_reason = match response.details {
+                    Some(details) => details
+                        .iter()
+                        .map(|det| format!("{} : {}", det.field, det.reason))
+                        .collect::<Vec<_>>()
+                        .join(", "),
+                    None => message.clone(),
+                };
 
-        let (code, message) = match response.error_information {
-            Some(ref error_info) => (error_info.reason.clone(), error_info.message.clone()),
-            None => (
-                response
-                    .reason
-                    .map_or(consts::NO_ERROR_CODE.to_string(), |reason| {
-                        reason.to_string()
-                    }),
-                response
-                    .message
-                    .map_or(error_message.to_string(), |message| message),
-            ),
-        };
-        let connector_reason = match response.details {
-            Some(details) => details
-                .iter()
-                .map(|det| format!("{} : {}", det.field, det.reason))
-                .collect::<Vec<_>>()
-                .join(", "),
-            None => message.clone(),
-        };
-
-        Ok(ErrorResponse {
-            status_code: res.status_code,
-            code,
-            message,
-            reason: Some(connector_reason),
-            attempt_status: None,
-            connector_transaction_id: None,
-        })
+                Ok(ErrorResponse {
+                    status_code: res.status_code,
+                    code,
+                    message,
+                    reason: Some(connector_reason),
+                    attempt_status: None,
+                    connector_transaction_id: None,
+                })
+            }
+            transformers::BankOfAmericaErrorResponse::AuthenticationError(response) => {
+                Ok(ErrorResponse {
+                    status_code: res.status_code,
+                    code: consts::NO_ERROR_CODE.to_string(),
+                    message: response.response.rmsg,
+                    reason: None,
+                    attempt_status: None,
+                    connector_transaction_id: None,
+                })
+            }
+        }
     }
 }
 

--- a/crates/router/src/connector/bankofamerica.rs
+++ b/crates/router/src/connector/bankofamerica.rs
@@ -240,8 +240,8 @@ impl ConnectorCommon for Bankofamerica {
                 Ok(ErrorResponse {
                     status_code: res.status_code,
                     code: consts::NO_ERROR_CODE.to_string(),
-                    message: response.response.rmsg,
-                    reason: None,
+                    message: response.response.rmsg.clone(),
+                    reason: Some(response.response.rmsg),
                     attempt_status: None,
                     connector_transaction_id: None,
                 })

--- a/crates/router/src/connector/bankofamerica/transformers.rs
+++ b/crates/router/src/connector/bankofamerica/transformers.rs
@@ -1016,12 +1016,24 @@ impl TryFrom<types::RefundsResponseRouterData<api::RSync, BankOfAmericaRsyncResp
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct BankOfAmericaErrorResponse {
+pub struct BankOfAmericaStandardErrorResponse {
     pub error_information: Option<ErrorInformation>,
     pub status: Option<String>,
     pub message: Option<String>,
     pub reason: Option<String>,
     pub details: Option<Vec<Details>>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct BankOfAmericaAuthenticationErrorResponse {
+    pub response: AuthenticationErrorInformation,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+pub enum BankOfAmericaErrorResponse {
+    StandardError(BankOfAmericaStandardErrorResponse),
+    AuthenticationError(BankOfAmericaAuthenticationErrorResponse),
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -1035,4 +1047,9 @@ pub struct Details {
 pub struct ErrorInformation {
     pub message: String,
     pub reason: String,
+}
+
+#[derive(Debug, Default, Deserialize)]
+pub struct AuthenticationErrorInformation {
+    pub rmsg: String,
 }

--- a/crates/router/src/connector/bankofamerica/transformers.rs
+++ b/crates/router/src/connector/bankofamerica/transformers.rs
@@ -1020,28 +1020,8 @@ pub struct BankOfAmericaErrorResponse {
     pub error_information: Option<ErrorInformation>,
     pub status: Option<String>,
     pub message: Option<String>,
-    pub reason: Option<Reason>,
+    pub reason: Option<String>,
     pub details: Option<Vec<Details>>,
-}
-
-#[derive(Debug, Deserialize, strum::Display)]
-#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
-pub enum Reason {
-    MissingField,
-    InvalidData,
-    DuplicateRequest,
-    InvalidCard,
-    AuthAlreadyReversed,
-    CardTypeNotAccepted,
-    InvalidMerchantConfiguration,
-    ProcessorUnavailable,
-    InvalidAmount,
-    InvalidCardType,
-    InvalidPaymentId,
-    NotSupported,
-    SystemError,
-    ServerTimeout,
-    ServiceTimeout,
 }
 
 #[derive(Debug, Deserialize, Clone)]

--- a/crates/router/src/connector/cybersource.rs
+++ b/crates/router/src/connector/cybersource.rs
@@ -109,44 +109,60 @@ impl ConnectorCommon for Cybersource {
         &self,
         res: types::Response,
     ) -> CustomResult<types::ErrorResponse, errors::ConnectorError> {
-        let response: cybersource::ErrorResponse = res
+        let response: cybersource::CybersourceErrorResponse = res
             .response
             .parse_struct("Cybersource ErrorResponse")
             .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
-        let details = response.details.unwrap_or_default();
-        let connector_reason = details
-            .iter()
-            .map(|det| format!("{} : {}", det.field, det.reason))
-            .collect::<Vec<_>>()
-            .join(", ");
 
         let error_message = if res.status_code == 401 {
             consts::CONNECTOR_UNAUTHORIZED_ERROR
         } else {
             consts::NO_ERROR_MESSAGE
         };
+        match response {
+            transformers::CybersourceErrorResponse::StandardError(response) => {
+                let (code, message) = match response.error_information {
+                    Some(ref error_info) => (error_info.reason.clone(), error_info.message.clone()),
+                    None => (
+                        response
+                            .reason
+                            .map_or(consts::NO_ERROR_CODE.to_string(), |reason| {
+                                reason.to_string()
+                            }),
+                        response
+                            .message
+                            .map_or(error_message.to_string(), |message| message),
+                    ),
+                };
+                let connector_reason = match response.details {
+                    Some(details) => details
+                        .iter()
+                        .map(|det| format!("{} : {}", det.field, det.reason))
+                        .collect::<Vec<_>>()
+                        .join(", "),
+                    None => message.clone(),
+                };
 
-        let (code, message) = match response.error_information {
-            Some(ref error_info) => (error_info.reason.clone(), error_info.message.clone()),
-            None => (
-                response
-                    .reason
-                    .map_or(consts::NO_ERROR_CODE.to_string(), |reason| {
-                        reason.to_string()
-                    }),
-                response
-                    .message
-                    .map_or(error_message.to_string(), |message| message),
-            ),
-        };
-        Ok(types::ErrorResponse {
-            status_code: res.status_code,
-            code,
-            message,
-            reason: Some(connector_reason),
-            attempt_status: None,
-            connector_transaction_id: None,
-        })
+                Ok(types::ErrorResponse {
+                    status_code: res.status_code,
+                    code,
+                    message,
+                    reason: Some(connector_reason),
+                    attempt_status: None,
+                    connector_transaction_id: None,
+                })
+            }
+            transformers::CybersourceErrorResponse::AuthenticationError(response) => {
+                Ok(types::ErrorResponse {
+                    status_code: res.status_code,
+                    code: consts::NO_ERROR_CODE.to_string(),
+                    message: response.response.rmsg,
+                    reason: None,
+                    attempt_status: None,
+                    connector_transaction_id: None,
+                })
+            }
+        }
     }
 }
 

--- a/crates/router/src/connector/cybersource.rs
+++ b/crates/router/src/connector/cybersource.rs
@@ -156,8 +156,8 @@ impl ConnectorCommon for Cybersource {
                 Ok(types::ErrorResponse {
                     status_code: res.status_code,
                     code: consts::NO_ERROR_CODE.to_string(),
-                    message: response.response.rmsg,
-                    reason: None,
+                    message: response.response.rmsg.clone(),
+                    reason: Some(response.response.rmsg),
                     attempt_status: None,
                     connector_transaction_id: None,
                 })

--- a/crates/router/src/connector/cybersource/transformers.rs
+++ b/crates/router/src/connector/cybersource/transformers.rs
@@ -1292,28 +1292,8 @@ pub struct ErrorResponse {
     pub error_information: Option<ErrorInformation>,
     pub status: Option<String>,
     pub message: Option<String>,
-    pub reason: Option<Reason>,
+    pub reason: Option<String>,
     pub details: Option<Vec<Details>>,
-}
-
-#[derive(Debug, Deserialize, strum::Display)]
-#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
-pub enum Reason {
-    MissingField,
-    InvalidData,
-    DuplicateRequest,
-    InvalidCard,
-    AuthAlreadyReversed,
-    CardTypeNotAccepted,
-    InvalidMerchantConfiguration,
-    ProcessorUnavailable,
-    InvalidAmount,
-    InvalidCardType,
-    InvalidPaymentId,
-    NotSupported,
-    SystemError,
-    ServerTimeout,
-    ServiceTimeout,
 }
 
 #[derive(Debug, Deserialize, Clone)]

--- a/crates/router/src/connector/cybersource/transformers.rs
+++ b/crates/router/src/connector/cybersource/transformers.rs
@@ -1286,29 +1286,6 @@ impl<F>
     }
 }
 
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct ErrorResponse {
-    pub error_information: Option<ErrorInformation>,
-    pub status: Option<String>,
-    pub message: Option<String>,
-    pub reason: Option<String>,
-    pub details: Option<Vec<Details>>,
-}
-
-#[derive(Debug, Deserialize, Clone)]
-#[serde(rename_all = "camelCase")]
-pub struct Details {
-    pub field: String,
-    pub reason: String,
-}
-
-#[derive(Debug, Deserialize)]
-pub struct ErrorInformation {
-    pub message: String,
-    pub reason: String,
-}
-
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CybersourceRefundRequest {
@@ -1407,4 +1384,44 @@ impl TryFrom<types::RefundsResponseRouterData<api::RSync, CybersourceRsyncRespon
             ..item.data
         })
     }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CybersourceStandardErrorResponse {
+    pub error_information: Option<ErrorInformation>,
+    pub status: Option<String>,
+    pub message: Option<String>,
+    pub reason: Option<String>,
+    pub details: Option<Vec<Details>>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CybersourceAuthenticationErrorResponse {
+    pub response: AuthenticationErrorInformation,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+pub enum CybersourceErrorResponse {
+    StandardError(CybersourceStandardErrorResponse),
+    AuthenticationError(CybersourceAuthenticationErrorResponse),
+}
+
+#[derive(Debug, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct Details {
+    pub field: String,
+    pub reason: String,
+}
+
+#[derive(Debug, Default, Deserialize)]
+pub struct ErrorInformation {
+    pub message: String,
+    pub reason: String,
+}
+
+#[derive(Debug, Default, Deserialize)]
+pub struct AuthenticationErrorInformation {
+    pub rmsg: String,
 }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->

HOTFIX PR:
The field reason in struct BankOfAmericaErrorResponse/ ErrorResponse(in cybersource) will be handled as a string instead of handling it as an enum. The reason for this is the absence of proper documentation for error reason at the connector's end.

Authentication error will also be handled properly now.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
Original PR: https://github.com/juspay/hyperswitch/pull/3156

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
1. Try to create a payment by passing `billing.last_name` as an empty string. You should be then able to successfully generate an error.
```
curl --location 'http://localhost:8080/payments' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: API_KEY_HERE' \
--data-raw '{
  "amount": 100,
  "currency": "USD",
  "confirm": true,
  "capture_method": "automatic",
  "email": "bernard.eugine@juspay.in",
  "name": "John Doe",
  "authentication_type": "no_three_ds",
  "return_url": "https://google.com",
  "payment_method": "card",
  "payment_method_type": "credit",
  "payment_method_data": {
    "card": {
      "card_number": "4111111111111111",
      "card_exp_month": "12",
      "card_exp_year": "30",
      "card_holder_name": "joseph Doe",
      "card_cvc": "123"
    }
  },
  "billing": {
    "address": {
      "line1": "1467",
      "city": "San Fransico",
      "state": "Dubai",
      "zip": "94122",
      "country": "AE",
      "first_name": "joseph",
      "last_name": ""
    }
  }
}'
```
Response: 

![image](https://github.com/juspay/hyperswitch/assets/41580413/bbb01336-7f86-4cf8-b1d3-ac960cd126e1)

2. To generate an authentication error response just put wrong api keys and try to do a payment. You should get the following error in that case:
![image](https://github.com/juspay/hyperswitch/assets/41580413/11aef022-054a-426d-b113-b56acd07af1d)


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
