### PR TITLE
fix(euclid_wasm): add function to retrieve keys for 3ds and surcharge decision manager

### DIFF
--- a/crates/euclid_wasm/src/lib.rs
+++ b/crates/euclid_wasm/src/lib.rs
@@ -8,6 +8,7 @@ use std::{
 
 use api_models::{
     admin as admin_api, conditional_configs::ConditionalConfigs, routing::ConnectorSelection,
+    surcharge_decision_configs::SurchargeDecisionConfigs,
 };
 use common_enums::RoutableConnectors;
 use currency_conversion::{
@@ -210,6 +211,12 @@ pub fn get_key_type(key: &str) -> Result<String, String> {
 #[wasm_bindgen(js_name = getThreeDsKeys)]
 pub fn get_three_ds_keys() -> JsResult {
     let keys = <ConditionalConfigs as EuclidDirFilter>::ALLOWED;
+    Ok(serde_wasm_bindgen::to_value(keys)?)
+}
+
+#[wasm_bindgen(js_name= getSurchargeKeys)]
+pub fn get_surcharge_keys() -> JsResult {
+    let keys = <SurchargeDecisionConfigs as EuclidDirFilter>::ALLOWED;
     Ok(serde_wasm_bindgen::to_value(keys)?)
 }
 

--- a/crates/euclid_wasm/src/lib.rs
+++ b/crates/euclid_wasm/src/lib.rs
@@ -6,7 +6,9 @@ use std::{
     str::FromStr,
 };
 
-use api_models::{admin as admin_api, routing::ConnectorSelection};
+use api_models::{
+    admin as admin_api, conditional_configs::ConditionalConfigs, routing::ConnectorSelection,
+};
 use common_enums::RoutableConnectors;
 use currency_conversion::{
     conversion::convert as convert_currency, types as currency_conversion_types,
@@ -20,7 +22,7 @@ use euclid::{
     },
     frontend::{
         ast,
-        dir::{self, enums as dir_enums},
+        dir::{self, enums as dir_enums, EuclidDirFilter},
     },
 };
 use once_cell::sync::OnceCell;
@@ -203,6 +205,12 @@ pub fn get_key_type(key: &str) -> Result<String, String> {
     let key = dir::DirKeyKind::from_str(key).map_err(|_| "Invalid key received".to_string())?;
     let key_str = key.get_type().to_string();
     Ok(key_str)
+}
+
+#[wasm_bindgen(js_name = getThreeDsKeys)]
+pub fn get_three_ds_keys() -> JsResult {
+    let keys = <ConditionalConfigs as EuclidDirFilter>::ALLOWED;
+    Ok(serde_wasm_bindgen::to_value(keys)?)
 }
 
 #[wasm_bindgen(js_name=parseToString)]


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Add the wasm function to retrieve keys for the 3DS and surcharge decision manager.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
The 3DS decision manager uses a restricted set of keys that's supported by the Euclid framework, which needs a function in the wasm for usage in the dashboard. This PR adds that function.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Local testing, compiler-guided

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
