### PR TITLE
fix(users): send correct `user_role` values in `switch_merchant` response

### DIFF
--- a/crates/router/src/core/user.rs
+++ b/crates/router/src/core/user.rs
@@ -506,69 +506,72 @@ pub async fn switch_merchant_id(
     request: user_api::SwitchMerchantIdRequest,
     user_from_token: auth::UserFromToken,
 ) -> UserResponse<user_api::SwitchMerchantResponse> {
-    if !utils::user_role::is_internal_role(&user_from_token.role_id) {
-        let merchant_list =
-            utils::user_role::get_merchant_ids_for_user(state.clone(), &user_from_token.user_id)
-                .await?;
-        if !merchant_list.contains(&request.merchant_id) {
-            return Err(UserErrors::InvalidRoleOperation.into())
-                .attach_printable("User doesn't have access to switch");
-        }
-    }
-
     if user_from_token.merchant_id == request.merchant_id {
         return Err(UserErrors::InvalidRoleOperation.into())
             .attach_printable("User switch to same merchant id.");
     }
 
-    let user = state
+    let user_roles = state
         .store
-        .find_user_by_id(&user_from_token.user_id)
+        .list_user_roles_by_user_id(&user_from_token.user_id)
         .await
         .change_context(UserErrors::InternalServerError)?;
 
-    let key_store = state
-        .store
-        .get_merchant_key_store_by_merchant_id(
-            request.merchant_id.as_str(),
-            &state.store.get_master_key().to_vec().into(),
+    let active_user_roles = user_roles
+        .into_iter()
+        .filter(|role| role.status == UserStatus::Active)
+        .collect::<Vec<_>>();
+
+    let user = user_from_token.get_user(state.clone()).await?.into();
+
+    let (token, role_id) = if utils::user_role::is_internal_role(&user_from_token.role_id) {
+        let key_store = state
+            .store
+            .get_merchant_key_store_by_merchant_id(
+                request.merchant_id.as_str(),
+                &state.store.get_master_key().to_vec().into(),
+            )
+            .await
+            .map_err(|e| {
+                if e.current_context().is_db_not_found() {
+                    e.change_context(UserErrors::MerchantIdNotFound)
+                } else {
+                    e.change_context(UserErrors::InternalServerError)
+                }
+            })?;
+
+        let org_id = state
+            .store
+            .find_merchant_account_by_merchant_id(request.merchant_id.as_str(), &key_store)
+            .await
+            .map_err(|e| {
+                if e.current_context().is_db_not_found() {
+                    e.change_context(UserErrors::MerchantIdNotFound)
+                } else {
+                    e.change_context(UserErrors::InternalServerError)
+                }
+            })?
+            .organization_id;
+
+        let token = utils::user::generate_jwt_auth_token_with_custom_role_attributes(
+            state,
+            &user,
+            request.merchant_id.clone(),
+            org_id,
+            user_from_token.role_id.clone(),
         )
-        .await
-        .map_err(|e| {
-            if e.current_context().is_db_not_found() {
-                e.change_context(UserErrors::MerchantIdNotFound)
-            } else {
-                e.change_context(UserErrors::InternalServerError)
-            }
-        })?;
+        .await?;
+        (token, user_from_token.role_id)
+    } else {
+        let user_role = active_user_roles
+            .iter()
+            .find(|role| role.merchant_id == request.merchant_id)
+            .ok_or(UserErrors::InvalidRoleOperation.into())
+            .attach_printable("User doesn't have access to switch")?;
 
-    let _org_id = state
-        .store
-        .find_merchant_account_by_merchant_id(request.merchant_id.as_str(), &key_store)
-        .await
-        .map_err(|e| {
-            if e.current_context().is_db_not_found() {
-                e.change_context(UserErrors::MerchantIdNotFound)
-            } else {
-                e.change_context(UserErrors::InternalServerError)
-            }
-        })?
-        .organization_id;
-
-    let user = domain::UserFromStorage::from(user);
-    let user_role = state
-        .store
-        .find_user_role_by_user_id(user.get_user_id())
-        .await
-        .change_context(UserErrors::InternalServerError)?;
-
-    let token = utils::user::generate_jwt_auth_token_with_custom_merchant_id(
-        state,
-        &user,
-        &user_role,
-        request.merchant_id.clone(),
-    )
-    .await?;
+        let token = utils::user::generate_jwt_auth_token(state, &user, user_role).await?;
+        (token, user_role.role_id.clone())
+    };
 
     Ok(ApplicationResponse::Json(
         user_api::SwitchMerchantResponse {
@@ -577,8 +580,8 @@ pub async fn switch_merchant_id(
             email: user.get_email(),
             user_id: user.get_user_id().to_string(),
             verification_days_left: None,
-            user_role: user_role.role_id,
-            merchant_id: user_role.merchant_id,
+            user_role: role_id,
+            merchant_id: request.merchant_id,
         },
     ))
 }
@@ -620,7 +623,7 @@ pub async fn list_merchant_ids_for_user(
     user: auth::UserFromToken,
 ) -> UserResponse<Vec<String>> {
     Ok(ApplicationResponse::Json(
-        utils::user::get_merchant_ids_for_user(state, &user.user_id).await?,
+        utils::user_role::get_merchant_ids_for_user(state, &user.user_id).await?,
     ))
 }
 

--- a/crates/router/src/utils/user.rs
+++ b/crates/router/src/utils/user.rs
@@ -1,5 +1,5 @@
 use api_models::user as user_api;
-use diesel_models::{enums::UserStatus, user_role::UserRole};
+use diesel_models::user_role::UserRole;
 use error_stack::ResultExt;
 use masking::Secret;
 
@@ -55,22 +55,6 @@ impl UserFromToken {
     }
 }
 
-pub async fn get_merchant_ids_for_user(state: AppState, user_id: &str) -> UserResult<Vec<String>> {
-    Ok(state
-        .store
-        .list_user_roles_by_user_id(user_id)
-        .await
-        .change_context(UserErrors::InternalServerError)?
-        .into_iter()
-        .filter_map(|ele| {
-            if ele.status == UserStatus::Active {
-                return Some(ele.merchant_id);
-            }
-            None
-        })
-        .collect())
-}
-
 pub async fn generate_jwt_auth_token(
     state: AppState,
     user: &UserFromStorage,
@@ -87,18 +71,19 @@ pub async fn generate_jwt_auth_token(
     Ok(Secret::new(token))
 }
 
-pub async fn generate_jwt_auth_token_with_custom_merchant_id(
+pub async fn generate_jwt_auth_token_with_custom_role_attributes(
     state: AppState,
     user: &UserFromStorage,
-    user_role: &UserRole,
     merchant_id: String,
+    org_id: String,
+    role_id: String,
 ) -> UserResult<Secret<String>> {
     let token = AuthToken::new_token(
         user.get_user_id().to_string(),
         merchant_id,
-        user_role.role_id.clone(),
+        role_id,
         &state.conf,
-        user_role.org_id.to_owned(),
+        org_id,
     )
     .await?;
     Ok(Secret::new(token))


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
This PR changes switch merchant api so that it sends correct merchant_id, org_id and role_id in the response.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
curl --location 'http://localhost:8080/user/switch_merchant' \
--header 'Content-Type: application/json' \
--header 'Authorization: Bearer JWT' \
--data '{
    "merchant_id": "merchant_1702984450"
}'

Response should be like this
```
{
    "token": "JWT",
    "merchant_id": "merchant_1702984450",
    "name": "name",
    "email": "email",
    "verification_days_left": null,
    "user_role": "org_admin"
}
```
This token and response should have same values in the attributes.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
