### PR TITLE
fix(events): add logger for incoming webhook payload

### DIFF
--- a/crates/router/src/routes/webhooks.rs
+++ b/crates/router/src/routes/webhooks.rs
@@ -21,17 +21,12 @@ pub async fn receive_incoming_webhook<W: types::OutgoingWebhookType>(
     let flow = Flow::IncomingWebhookReceive;
     let (merchant_id, connector_id_or_name) = path.into_inner();
 
-    let body_vec: Vec<u8> = body.to_vec();
-    let payload: serde_json::Value = serde_json::from_slice(&body_vec)
-        .into_report()
-        .change_context(errors::ApiErrorResponse::WebhookProcessingFailure)?;
-
     Box::pin(api::server_wrap(
         flow.clone(),
         state,
         &req,
-        payload,
-        |state, auth, _| {
+        WebhookBytes(body),
+        |state, auth, payload| {
             webhooks::webhooks_wrapper::<W, Oss>(
                 &flow,
                 state.to_owned(),
@@ -39,11 +34,27 @@ pub async fn receive_incoming_webhook<W: types::OutgoingWebhookType>(
                 auth.merchant_account,
                 auth.key_store,
                 &connector_id_or_name,
-                body.clone(),
+                payload.0,
             )
         },
         &auth::MerchantIdAuth(merchant_id),
         api_locking::LockAction::NotApplicable,
     ))
     .await
+}
+
+#[derive(Debug)]
+struct WebhookBytes(web::Bytes);
+
+impl serde::Serialize for WebhookBytes {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let payload: serde_json::Value = serde_json::from_slice(&self.0).unwrap_or_default();
+        payload.serialize(serializer)
+    }
+}
+
+impl common_utils::events::ApiEventMetric for WebhookBytes {
+    fn get_api_event_type(&self) -> Option<common_utils::events::ApiEventsType> {
+        Some(common_utils::events::ApiEventsType::Miscellaneous)
+    }
 }

--- a/crates/router/src/routes/webhooks.rs
+++ b/crates/router/src/routes/webhooks.rs
@@ -21,11 +21,16 @@ pub async fn receive_incoming_webhook<W: types::OutgoingWebhookType>(
     let flow = Flow::IncomingWebhookReceive;
     let (merchant_id, connector_id_or_name) = path.into_inner();
 
+    let body_vec: Vec<u8> = body.to_vec();
+    let payload: serde_json::Value = serde_json::from_slice(&body_vec)
+        .into_report()
+        .change_context(errors::ApiErrorResponse::WebhookProcessingFailure)?;
+
     Box::pin(api::server_wrap(
         flow.clone(),
         state,
         &req,
-        (),
+        payload,
         |state, auth, _| {
             webhooks::webhooks_wrapper::<W, Oss>(
                 &flow,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
add logger for incoming webhook payload. Now, the Webhook payload will be logged in Loki along with its complete body inserted in the api events table.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
test case - make a test payment, its webhook should be logged in Loki, and in api events table, both complete payload as well as the parsed body should be there.
<img width="1728" alt="Screenshot 2023-12-19 at 9 06 03 PM" src="https://github.com/juspay/hyperswitch/assets/70575890/747bdc37-9571-4eab-89ac-955bc43d82be">
<img width="1728" alt="Screenshot 2023-12-19 at 9 17 58 PM" src="https://github.com/juspay/hyperswitch/assets/70575890/413b21c9-6e52-427c-bac7-023ed993657b">
<img width="1728" alt="Screenshot 2023-12-19 at 9 18 02 PM" src="https://github.com/juspay/hyperswitch/assets/70575890/09ffbea8-43dc-4e80-be67-0b0dd471c709">



## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
