### PR TITLE
refactor(payment_methods): make the card_holder_name as an empty string if not sent

### DIFF
--- a/crates/router/src/connector/aci/transformers.rs
+++ b/crates/router/src/connector/aci/transformers.rs
@@ -256,7 +256,7 @@ impl TryFrom<api_models::payments::Card> for PaymentDetails {
             card_number: card_data.card_number,
             card_holder: card_data
                 .card_holder_name
-                .ok_or_else(utils::missing_field_err("card_holder_name"))?,
+                .unwrap_or(Secret::new("".to_string())),
             card_expiry_month: card_data.card_exp_month,
             card_expiry_year: card_data.card_exp_year,
             card_cvv: card_data.card_cvc,

--- a/crates/router/src/connector/bambora/transformers.rs
+++ b/crates/router/src/connector/bambora/transformers.rs
@@ -5,7 +5,7 @@ use masking::{PeekInterface, Secret};
 use serde::{Deserialize, Deserializer, Serialize};
 
 use crate::{
-    connector::utils::{self, BrowserInformationData, PaymentsAuthorizeRequestData},
+    connector::utils::{BrowserInformationData, PaymentsAuthorizeRequestData},
     consts,
     core::errors,
     services,
@@ -119,7 +119,7 @@ impl TryFrom<&types::PaymentsAuthorizeRouterData> for BamboraPaymentsRequest {
                 let bambora_card = BamboraCard {
                     name: req_card
                         .card_holder_name
-                        .ok_or_else(utils::missing_field_err("card_holder_name"))?,
+                        .unwrap_or(Secret::new("".to_string())),
                     number: req_card.card_number,
                     expiry_month: req_card.card_exp_month,
                     expiry_year: req_card.card_exp_year,

--- a/crates/router/src/connector/braintree/braintree_graphql_transformers.rs
+++ b/crates/router/src/connector/braintree/braintree_graphql_transformers.rs
@@ -869,7 +869,7 @@ impl TryFrom<&types::TokenizationRouterData> for BraintreeTokenRequest {
                         cvv: card_data.card_cvc,
                         cardholder_name: card_data
                             .card_holder_name
-                            .ok_or_else(utils::missing_field_err("card_holder_name"))?,
+                            .unwrap_or(Secret::new("".to_string())),
                     },
                 };
                 Ok(Self {

--- a/crates/router/src/connector/dlocal/transformers.rs
+++ b/crates/router/src/connector/dlocal/transformers.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use url::Url;
 
 use crate::{
-    connector::utils::{self, AddressDetailsData, PaymentsAuthorizeRequestData, RouterData},
+    connector::utils::{AddressDetailsData, PaymentsAuthorizeRequestData, RouterData},
     core::errors,
     services,
     types::{self, api, storage::enums},
@@ -128,7 +128,7 @@ impl TryFrom<&DlocalRouterData<&types::PaymentsAuthorizeRouterData>> for DlocalP
                         holder_name: ccard
                             .card_holder_name
                             .clone()
-                            .ok_or_else(utils::missing_field_err("card_holder_name"))?,
+                            .unwrap_or(Secret::new("".to_string())),
                         number: ccard.card_number.clone(),
                         cvv: ccard.card_cvc.clone(),
                         expiration_month: ccard.card_exp_month.clone(),

--- a/crates/router/src/connector/dummyconnector/transformers.rs
+++ b/crates/router/src/connector/dummyconnector/transformers.rs
@@ -4,7 +4,6 @@ use serde::{Deserialize, Serialize};
 use url::Url;
 
 use crate::{
-    connector::utils,
     core::errors,
     services,
     types::{self, api, storage::enums},
@@ -90,7 +89,7 @@ impl TryFrom<api_models::payments::Card> for DummyConnectorCard {
         Ok(Self {
             name: value
                 .card_holder_name
-                .ok_or_else(utils::missing_field_err("card_holder_name"))?,
+                .unwrap_or(Secret::new("".to_string())),
             number: value.card_number,
             expiry_month: value.card_exp_month,
             expiry_year: value.card_exp_year,

--- a/crates/router/src/connector/forte/transformers.rs
+++ b/crates/router/src/connector/forte/transformers.rs
@@ -83,7 +83,7 @@ impl TryFrom<&types::PaymentsAuthorizeRouterData> for FortePaymentsRequest {
                     name_on_card: ccard
                         .card_holder_name
                         .clone()
-                        .ok_or_else(utils::missing_field_err("card_holder_name"))?,
+                        .unwrap_or(Secret::new("".to_string())),
                     account_number: ccard.card_number.clone(),
                     expire_month: ccard.card_exp_month.clone(),
                     expire_year: ccard.card_exp_year.clone(),

--- a/crates/router/src/connector/mollie/transformers.rs
+++ b/crates/router/src/connector/mollie/transformers.rs
@@ -289,7 +289,7 @@ impl TryFrom<&types::TokenizationRouterData> for MollieCardTokenRequest {
                 let card_holder = ccard
                     .card_holder_name
                     .clone()
-                    .ok_or_else(utils::missing_field_err("card_holder_name"))?;
+                    .unwrap_or(Secret::new("".to_string()));
                 let card_number = ccard.card_number.clone();
                 let card_expiry_date =
                     ccard.get_card_expiry_month_year_2_digit_with_delimiter("/".to_owned());

--- a/crates/router/src/connector/noon/transformers.rs
+++ b/crates/router/src/connector/noon/transformers.rs
@@ -203,7 +203,7 @@ impl TryFrom<&types::PaymentsAuthorizeRouterData> for NoonPaymentsRequest {
                         name_on_card: req_card
                             .card_holder_name
                             .clone()
-                            .ok_or_else(conn_utils::missing_field_err("card_holder_name"))?,
+                            .unwrap_or(Secret::new("".to_string())),
                         number_plain: req_card.card_number.clone(),
                         expiry_month: req_card.card_exp_month.clone(),
                         expiry_year: req_card.get_expiry_year_4_digit(),

--- a/crates/router/src/connector/opayo/transformers.rs
+++ b/crates/router/src/connector/opayo/transformers.rs
@@ -31,7 +31,7 @@ impl TryFrom<&types::PaymentsAuthorizeRouterData> for OpayoPaymentsRequest {
                 let card = OpayoCard {
                     name: req_card
                         .card_holder_name
-                        .ok_or_else(utils::missing_field_err("card_holder_name"))?,
+                        .unwrap_or(Secret::new("".to_string())),
                     number: req_card.card_number,
                     expiry_month: req_card.card_exp_month,
                     expiry_year: req_card.card_exp_year,

--- a/crates/router/src/connector/payeezy/transformers.rs
+++ b/crates/router/src/connector/payeezy/transformers.rs
@@ -244,7 +244,7 @@ fn get_payment_method_data(
                 cardholder_name: card
                     .card_holder_name
                     .clone()
-                    .ok_or_else(utils::missing_field_err("card_holder_name"))?,
+                    .unwrap_or(Secret::new("".to_string())),
                 card_number: card.card_number.clone(),
                 exp_date: card.get_card_expiry_month_year_2_digit_with_delimiter("".to_string()),
                 cvv: card.card_cvc.clone(),

--- a/crates/router/src/connector/paypal/transformers.rs
+++ b/crates/router/src/connector/paypal/transformers.rs
@@ -446,7 +446,7 @@ impl TryFrom<&PaypalRouterData<&types::PaymentsAuthorizeRouterData>> for PaypalP
                     name: ccard
                         .card_holder_name
                         .clone()
-                        .ok_or_else(utils::missing_field_err("card_holder_name"))?,
+                        .unwrap_or(Secret::new("".to_string())),
                     number: Some(ccard.card_number.clone()),
                     security_code: Some(ccard.card_cvc.clone()),
                     attributes,

--- a/crates/router/src/connector/powertranz/transformers.rs
+++ b/crates/router/src/connector/powertranz/transformers.rs
@@ -218,7 +218,7 @@ impl TryFrom<&Card> for Source {
             cardholder_name: card
                 .card_holder_name
                 .clone()
-                .ok_or_else(utils::missing_field_err("card_holder_name"))?,
+                .unwrap_or(Secret::new("".to_string())),
             card_pan: card.card_number.clone(),
             card_expiration: card.get_expiry_date_as_yymm(),
             card_cvv: card.card_cvc.clone(),

--- a/crates/router/src/connector/rapyd/transformers.rs
+++ b/crates/router/src/connector/rapyd/transformers.rs
@@ -4,7 +4,7 @@ use time::PrimitiveDateTime;
 use url::Url;
 
 use crate::{
-    connector::utils::{self, PaymentsAuthorizeRequestData},
+    connector::utils::PaymentsAuthorizeRequestData,
     consts,
     core::errors,
     pii::Secret,
@@ -134,7 +134,7 @@ impl TryFrom<&RapydRouterData<&types::PaymentsAuthorizeRouterData>> for RapydPay
                         name: ccard
                             .card_holder_name
                             .to_owned()
-                            .ok_or_else(utils::missing_field_err("card_holder_name"))?,
+                            .unwrap_or(Secret::new("".to_string())),
                         cvv: ccard.card_cvc.to_owned(),
                     }),
                     address: None,

--- a/crates/router/src/connector/shift4/transformers.rs
+++ b/crates/router/src/connector/shift4/transformers.rs
@@ -299,7 +299,7 @@ impl<T>
             cardholder_name: card
                 .card_holder_name
                 .clone()
-                .ok_or_else(utils::missing_field_err("card_holder_name"))?,
+                .unwrap_or(Secret::new("".to_string())),
         };
         if item.is_three_ds() {
             Ok(Self::Cards3DSRequest(Box::new(Cards3DSRequest {

--- a/crates/router/src/connector/stax/transformers.rs
+++ b/crates/router/src/connector/stax/transformers.rs
@@ -228,7 +228,7 @@ impl TryFrom<&types::TokenizationRouterData> for StaxTokenRequest {
                         .get_card_expiry_month_year_2_digit_with_delimiter("".to_string()),
                     person_name: card_data
                         .card_holder_name
-                        .ok_or_else(missing_field_err("card_holder_name"))?,
+                        .unwrap_or(Secret::new("".to_string())),
                     card_number: card_data.card_number,
                     card_cvv: card_data.card_cvc,
                     customer_id: Secret::new(customer_id),

--- a/crates/router/src/connector/worldline/transformers.rs
+++ b/crates/router/src/connector/worldline/transformers.rs
@@ -354,7 +354,7 @@ fn make_card_request(
         cardholder_name: ccard
             .card_holder_name
             .clone()
-            .ok_or_else(utils::missing_field_err("card_holder_name"))?,
+            .unwrap_or(Secret::new("".to_string())),
         cvv: ccard.card_cvc.clone(),
         expiry_date,
     };


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
This PR includes changes for sending the `card_holder_name` as an empty string if not sent during confirm or not present in locker

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
1. Create a noon merchant connector account
2. Create a payment without `card_holder_name`

```
curl --location 'http://localhost:8080/payments' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: dev_ZBWUNGf7TfqeTnt5VsSYyonTiN3Ohdw4JoEba8frZPmKYaHu9tLLBbMPqmhJcIJl' \
--data-raw '{
    "amount": 6540,
    "currency": "USD",
    "confirm": true,
    "capture_method": "manual",
    "capture_on": "2022-09-10T10:11:12Z",
    "amount_to_capture": 6540,
    "customer_id": "StripeCustomer",
    "business_country": "US",
    "business_label": "default",
    "email": "guest@example.com",
    "name": "John Doe",
    "phone": "999999999",
    "phone_country_code": "+1",
    "description": "Its my first payment request",
    "authentication_type": "no_three_ds",
    "return_url": "https://google.com",
    "setup_future_usage": "on_session",
    "payment_method": "card",
    "payment_method_type": "credit",
    "payment_method_data": {
        "card": {
            "card_number": "4242424242424242",
            "card_exp_month": "10",
            "card_exp_year": "25",
            "card_cvc": "123"
        }
    },
    "shipping": {
        "address": {
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "city": "San Fransico",
            "state": "California",
            "zip": "94122",
            "country": "US",
            "first_name": "joseph",
            "last_name": "Doe"
        },
        "phone": {
            "number": "8056594430",
            "country_code": "+91"
        }
    },
    "billing": {
        "address": {
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "city": "San Fransico",
            "state": "California",
            "zip": "94122",
            "country": "US",
            "first_name": "joseph",
            "last_name": "Doe"
        },
        "phone": {
            "number": "8056594427",
            "country_code": "+91"
        }
    },
    "statement_descriptor_name": "joseph",
    "statement_descriptor_suffix": "JS",
    "metadata": {
        "udf1": "value1",
        "new_customer": "true",
        "login_date": "2019-09-10T10:11:12Z"
    }
}'
```

![image](https://github.com/juspay/hyperswitch/assets/70657455/cd81458d-dcd0-4108-9f15-45670606d24b)

Payment went through even though `card_holder_name` was a required field because we are sending an empty string if not present or sent

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
