### PR TITLE
refactor(core): fix payment status for 4xx

### DIFF
--- a/crates/router/src/core/payments/helpers.rs
+++ b/crates/router/src/core/payments/helpers.rs
@@ -953,7 +953,7 @@ pub fn payment_attempt_status_fsm(
 ) -> storage_enums::AttemptStatus {
     match payment_method_data {
         Some(_) => match confirm {
-            Some(true) => storage_enums::AttemptStatus::Pending,
+            Some(true) => storage_enums::AttemptStatus::PaymentMethodAwaited,
             _ => storage_enums::AttemptStatus::ConfirmationAwaited,
         },
         None => storage_enums::AttemptStatus::PaymentMethodAwaited,
@@ -966,7 +966,7 @@ pub fn payment_intent_status_fsm(
 ) -> storage_enums::IntentStatus {
     match payment_method_data {
         Some(_) => match confirm {
-            Some(true) => storage_enums::IntentStatus::RequiresCustomerAction,
+            Some(true) => storage_enums::IntentStatus::RequiresPaymentMethod,
             _ => storage_enums::IntentStatus::RequiresConfirmation,
         },
         None => storage_enums::IntentStatus::RequiresPaymentMethod,


### PR DESCRIPTION

## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
fix payment status for 4xx

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
Through Postman and checked the Status in DB
1. With confirm call true
<img width="1728" alt="Screenshot 2023-12-20 at 3 09 37 PM" src="https://github.com/juspay/hyperswitch/assets/85639103/126e89f4-141b-4562-b079-5ded66ec1647">
<img width="1504" alt="Screenshot 2023-12-20 at 3 10 40 PM" src="https://github.com/juspay/hyperswitch/assets/85639103/aa5148da-6d05-4f16-ac80-6853d4c9e242">


2. With confirm call False
<img width="1728" alt="Screenshot 2023-12-20 at 3 11 25 PM" src="https://github.com/juspay/hyperswitch/assets/85639103/3ca4acbe-b30a-45ea-b40b-760b201778a3">
<img width="1510" alt="Screenshot 2023-12-20 at 3 12 06 PM" src="https://github.com/juspay/hyperswitch/assets/85639103/3285e026-9e74-4567-b38c-82a8ed21602f">



## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
