### PR TITLE
feat(connector): [BOA] Handle BOA 5XX errors

### DIFF
--- a/crates/router/src/connector/bankofamerica.rs
+++ b/crates/router/src/connector/bankofamerica.rs
@@ -385,6 +385,33 @@ impl ConnectorIntegration<api::Authorize, types::PaymentsAuthorizeData, types::P
     ) -> CustomResult<ErrorResponse, errors::ConnectorError> {
         self.build_error_response(res)
     }
+
+    fn get_5xx_error_response(
+        &self,
+        res: Response,
+    ) -> CustomResult<ErrorResponse, errors::ConnectorError> {
+        let response: bankofamerica::BankOfAmerica5XXErrorResponse = res
+            .response
+            .parse_struct("BankOfAmerica 5XX ErrorResponse")
+            .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
+        let attempt_status = match response.reason {
+            Some(reason) => match reason {
+                transformers::Reason::SystemError => Some(enums::AttemptStatus::Failure),
+                transformers::Reason::ServerTimeout | transformers::Reason::ServiceTimeout => None,
+            },
+            None => None,
+        };
+        Ok(ErrorResponse {
+            status_code: res.status_code,
+            reason: response.status.clone(),
+            code: response.status.unwrap_or(consts::NO_ERROR_CODE.to_string()),
+            message: response
+                .message
+                .unwrap_or(consts::NO_ERROR_MESSAGE.to_string()),
+            attempt_status,
+            connector_transaction_id: None,
+        })
+    }
 }
 
 impl ConnectorIntegration<api::PSync, types::PaymentsSyncData, types::PaymentsResponseData>
@@ -546,6 +573,27 @@ impl ConnectorIntegration<api::Capture, types::PaymentsCaptureData, types::Payme
     ) -> CustomResult<ErrorResponse, errors::ConnectorError> {
         self.build_error_response(res)
     }
+
+    fn get_5xx_error_response(
+        &self,
+        res: Response,
+    ) -> CustomResult<ErrorResponse, errors::ConnectorError> {
+        let response: bankofamerica::BankOfAmerica5XXErrorResponse = res
+            .response
+            .parse_struct("BankOfAmerica 5XX ErrorResponse")
+            .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
+
+        Ok(ErrorResponse {
+            status_code: res.status_code,
+            reason: response.status.clone(),
+            code: response.status.unwrap_or(consts::NO_ERROR_CODE.to_string()),
+            message: response
+                .message
+                .unwrap_or(consts::NO_ERROR_MESSAGE.to_string()),
+            attempt_status: None,
+            connector_transaction_id: None,
+        })
+    }
 }
 
 impl ConnectorIntegration<api::Void, types::PaymentsCancelData, types::PaymentsResponseData>
@@ -640,6 +688,27 @@ impl ConnectorIntegration<api::Void, types::PaymentsCancelData, types::PaymentsR
     ) -> CustomResult<ErrorResponse, errors::ConnectorError> {
         self.build_error_response(res)
     }
+
+    fn get_5xx_error_response(
+        &self,
+        res: Response,
+    ) -> CustomResult<ErrorResponse, errors::ConnectorError> {
+        let response: bankofamerica::BankOfAmerica5XXErrorResponse = res
+            .response
+            .parse_struct("BankOfAmerica 5XX ErrorResponse")
+            .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
+
+        Ok(ErrorResponse {
+            status_code: res.status_code,
+            reason: response.status.clone(),
+            code: response.status.unwrap_or(consts::NO_ERROR_CODE.to_string()),
+            message: response
+                .message
+                .unwrap_or(consts::NO_ERROR_MESSAGE.to_string()),
+            attempt_status: None,
+            connector_transaction_id: None,
+        })
+    }
 }
 
 impl ConnectorIntegration<api::Execute, types::RefundsData, types::RefundsResponseData>
@@ -725,6 +794,33 @@ impl ConnectorIntegration<api::Execute, types::RefundsData, types::RefundsRespon
         res: Response,
     ) -> CustomResult<ErrorResponse, errors::ConnectorError> {
         self.build_error_response(res)
+    }
+
+    fn get_5xx_error_response(
+        &self,
+        res: Response,
+    ) -> CustomResult<ErrorResponse, errors::ConnectorError> {
+        let response: bankofamerica::BankOfAmerica5XXErrorResponse = res
+            .response
+            .parse_struct("BankOfAmerica 5XX ErrorResponse")
+            .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
+        let attempt_status = match response.reason {
+            Some(reason) => match reason {
+                transformers::Reason::SystemError => Some(enums::AttemptStatus::Failure),
+                transformers::Reason::ServerTimeout | transformers::Reason::ServiceTimeout => None,
+            },
+            None => None,
+        };
+        Ok(ErrorResponse {
+            status_code: res.status_code,
+            reason: response.status.clone(),
+            code: response.status.unwrap_or(consts::NO_ERROR_CODE.to_string()),
+            message: response
+                .message
+                .unwrap_or(consts::NO_ERROR_MESSAGE.to_string()),
+            attempt_status,
+            connector_transaction_id: None,
+        })
     }
 }
 

--- a/crates/router/src/connector/bankofamerica.rs
+++ b/crates/router/src/connector/bankofamerica.rs
@@ -390,9 +390,9 @@ impl ConnectorIntegration<api::Authorize, types::PaymentsAuthorizeData, types::P
         &self,
         res: Response,
     ) -> CustomResult<ErrorResponse, errors::ConnectorError> {
-        let response: bankofamerica::BankOfAmerica5XXErrorResponse = res
+        let response: bankofamerica::BankOfAmericaServerErrorResponse = res
             .response
-            .parse_struct("BankOfAmerica 5XX ErrorResponse")
+            .parse_struct("BankOfAmericaServerErrorResponse")
             .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
         let attempt_status = match response.reason {
             Some(reason) => match reason {
@@ -578,9 +578,9 @@ impl ConnectorIntegration<api::Capture, types::PaymentsCaptureData, types::Payme
         &self,
         res: Response,
     ) -> CustomResult<ErrorResponse, errors::ConnectorError> {
-        let response: bankofamerica::BankOfAmerica5XXErrorResponse = res
+        let response: bankofamerica::BankOfAmericaServerErrorResponse = res
             .response
-            .parse_struct("BankOfAmerica 5XX ErrorResponse")
+            .parse_struct("BankOfAmericaServerErrorResponse")
             .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
 
         Ok(ErrorResponse {
@@ -693,9 +693,9 @@ impl ConnectorIntegration<api::Void, types::PaymentsCancelData, types::PaymentsR
         &self,
         res: Response,
     ) -> CustomResult<ErrorResponse, errors::ConnectorError> {
-        let response: bankofamerica::BankOfAmerica5XXErrorResponse = res
+        let response: bankofamerica::BankOfAmericaServerErrorResponse = res
             .response
-            .parse_struct("BankOfAmerica 5XX ErrorResponse")
+            .parse_struct("BankOfAmericaServerErrorResponse")
             .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
 
         Ok(ErrorResponse {
@@ -794,33 +794,6 @@ impl ConnectorIntegration<api::Execute, types::RefundsData, types::RefundsRespon
         res: Response,
     ) -> CustomResult<ErrorResponse, errors::ConnectorError> {
         self.build_error_response(res)
-    }
-
-    fn get_5xx_error_response(
-        &self,
-        res: Response,
-    ) -> CustomResult<ErrorResponse, errors::ConnectorError> {
-        let response: bankofamerica::BankOfAmerica5XXErrorResponse = res
-            .response
-            .parse_struct("BankOfAmerica 5XX ErrorResponse")
-            .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
-        let attempt_status = match response.reason {
-            Some(reason) => match reason {
-                transformers::Reason::SystemError => Some(enums::AttemptStatus::Failure),
-                transformers::Reason::ServerTimeout | transformers::Reason::ServiceTimeout => None,
-            },
-            None => None,
-        };
-        Ok(ErrorResponse {
-            status_code: res.status_code,
-            reason: response.status.clone(),
-            code: response.status.unwrap_or(consts::NO_ERROR_CODE.to_string()),
-            message: response
-                .message
-                .unwrap_or(consts::NO_ERROR_MESSAGE.to_string()),
-            attempt_status,
-            connector_transaction_id: None,
-        })
     }
 }
 

--- a/crates/router/src/connector/bankofamerica/transformers.rs
+++ b/crates/router/src/connector/bankofamerica/transformers.rs
@@ -1027,7 +1027,7 @@ pub struct BankOfAmericaStandardErrorResponse {
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct BankOfAmerica5XXErrorResponse {
+pub struct BankOfAmericaServerErrorResponse {
     pub status: Option<String>,
     pub message: Option<String>,
     pub reason: Option<Reason>,

--- a/crates/router/src/connector/bankofamerica/transformers.rs
+++ b/crates/router/src/connector/bankofamerica/transformers.rs
@@ -626,6 +626,7 @@ impl<F>
                     attempt_status: None,
                     connector_transaction_id: None,
                 }),
+                status: enums::AttemptStatus::Failure,
                 ..item.data
             }),
         }

--- a/crates/router/src/connector/bankofamerica/transformers.rs
+++ b/crates/router/src/connector/bankofamerica/transformers.rs
@@ -1026,6 +1026,22 @@ pub struct BankOfAmericaStandardErrorResponse {
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BankOfAmerica5XXErrorResponse {
+    pub status: Option<String>,
+    pub message: Option<String>,
+    pub reason: Option<Reason>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum Reason {
+    SystemError,
+    ServerTimeout,
+    ServiceTimeout,
+}
+
+#[derive(Debug, Deserialize)]
 pub struct BankOfAmericaAuthenticationErrorResponse {
     pub response: AuthenticationErrorInformation,
 }

--- a/crates/router/src/core/payments/operations/payment_response.rs
+++ b/crates/router/src/core/payments/operations/payment_response.rs
@@ -471,20 +471,26 @@ async fn payment_response_update_tracker<F: Clone, T: types::Capturable>(
                         flow_name.clone(),
                     )
                     .await;
-                    let status =
+                    let status = match err.attempt_status {
+                        // Use the status sent by connector in error_response if it's present
+                        Some(status) => status,
+                        None =>
                         // mark previous attempt status for technical failures in PSync flow
-                        if flow_name == "PSync" {
-                            match err.status_code {
-                                // marking failure for 2xx because this is genuine payment failure
-                                200..=299 => storage::enums::AttemptStatus::Failure,
-                                _ => router_data.status,
+                        {
+                            if flow_name == "PSync" {
+                                match err.status_code {
+                                    // marking failure for 2xx because this is genuine payment failure
+                                    200..=299 => storage::enums::AttemptStatus::Failure,
+                                    _ => router_data.status,
+                                }
+                            } else {
+                                match err.status_code {
+                                    500..=511 => storage::enums::AttemptStatus::Pending,
+                                    _ => storage::enums::AttemptStatus::Failure,
+                                }
                             }
-                        } else {
-                            match err.status_code {
-                                500..=511 => storage::enums::AttemptStatus::Pending,
-                                _ => storage::enums::AttemptStatus::Failure,
-                            }
-                        };
+                        }
+                    };
                     (
                         None,
                         Some(storage::PaymentAttemptUpdate::ErrorUpdate {


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
A 5xx error from connector BOA will lead to payment status failing instantaneously.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
https://github.com/juspay/hyperswitch-cloud/issues/3699

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Generate a 5XX payment using BOA (card no: 3566111111111113) and you should get payment status as failed.
![image](https://github.com/juspay/hyperswitch/assets/41580413/89a38798-00f0-44b8-a564-06e304c0dbf9)


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
