### PR TITLE
refactor(testpayment): allow creating test payments via dummy connector

### DIFF
--- a/crates/api_models/src/events/user.rs
+++ b/crates/api_models/src/events/user.rs
@@ -9,7 +9,8 @@ use crate::user::{
     AuthorizeResponse, ChangePasswordRequest, ConnectAccountRequest, CreateInternalUserRequest,
     DashboardEntryResponse, ForgotPasswordRequest, GetUsersResponse, InviteUserRequest,
     InviteUserResponse, ResetPasswordRequest, SendVerifyEmailRequest, SignUpRequest,
-    SignUpWithMerchantIdRequest, SwitchMerchantIdRequest, UserMerchantCreate, VerifyEmailRequest,
+    SignUpWithMerchantIdRequest, SwitchMerchantIdRequest, TestPaymentRequest, UserMerchantCreate,
+    VerifyEmailRequest,
 };
 
 impl ApiEventMetric for DashboardEntryResponse {
@@ -40,7 +41,8 @@ common_utils::impl_misc_api_event_type!(
     InviteUserRequest,
     InviteUserResponse,
     VerifyEmailRequest,
-    SendVerifyEmailRequest
+    SendVerifyEmailRequest,
+    TestPaymentRequest
 );
 
 #[cfg(feature = "dummy_connector")]

--- a/crates/api_models/src/user.rs
+++ b/crates/api_models/src/user.rs
@@ -1,5 +1,7 @@
+use common_enums::Currency;
 use common_utils::pii;
 use masking::Secret;
+use time::PrimitiveDateTime;
 
 use crate::user_role::UserStatus;
 pub mod dashboard_metadata;
@@ -119,7 +121,7 @@ pub struct UserDetails {
     pub role_name: String,
     pub status: UserStatus,
     #[serde(with = "common_utils::custom_serde::iso8601")]
-    pub last_modified_at: time::PrimitiveDateTime,
+    pub last_modified_at: PrimitiveDateTime,
 }
 
 #[derive(Debug, serde::Deserialize, serde::Serialize)]
@@ -132,4 +134,30 @@ pub type VerifyEmailResponse = DashboardEntryResponse;
 #[derive(serde::Deserialize, Debug, serde::Serialize)]
 pub struct SendVerifyEmailRequest {
     pub email: pii::Email,
+}
+
+#[derive(Debug, serde::Deserialize, serde::Serialize, Clone)]
+pub struct TestPaymentRequest {
+    pub token: String,
+    pub payment_create: Option<TestPaymentCreateRequest>,
+}
+
+#[derive(Debug, serde::Serialize, serde::Deserialize, Clone)]
+pub struct TestCreateApiKeyResponse {
+    pub api_key: String,
+    pub merchant_id: String,
+}
+
+#[derive(Debug, serde::Serialize, serde::Deserialize, Clone)]
+pub struct TestPaymentCreateRequest {
+    pub amount: i64,
+    pub merchant_id: String,
+    pub currency: Currency,
+}
+
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+pub struct TestCreateApiKeyRequest {
+    pub name: String,
+    #[serde(with = "common_utils::custom_serde::iso8601")]
+    pub expiration: PrimitiveDateTime,
 }

--- a/crates/router/src/configs/settings.rs
+++ b/crates/router/src/configs/settings.rs
@@ -121,6 +121,7 @@ pub struct Settings {
     pub events: EventsConfig,
     #[cfg(feature = "olap")]
     pub connector_onboarding: ConnectorOnboarding,
+    pub router_internal_ip: InternalConf,
 }
 
 #[cfg(feature = "frm")]
@@ -919,4 +920,18 @@ pub struct PayPalOnboarding {
     pub client_secret: masking::Secret<String>,
     pub partner_id: masking::Secret<String>,
     pub enabled: bool,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+#[serde(default)]
+pub struct InternalConf {
+    pub base_url: String,
+}
+
+impl Default for InternalConf {
+    fn default() -> Self {
+        Self {
+            base_url: "http://localhost:8080".into(),
+        }
+    }
 }

--- a/crates/router/src/core/errors/user.rs
+++ b/crates/router/src/core/errors/user.rs
@@ -4,6 +4,8 @@ use crate::services::ApplicationResponse;
 
 pub type UserResult<T> = CustomResult<T, UserErrors>;
 pub type UserResponse<T> = CustomResult<ApplicationResponse<T>, UserErrors>;
+pub type TestPaymentApiResponse<T> = TestPaymentResult<ApplicationResponse<T>>;
+pub type TestPaymentResult<T> = CustomResult<T, TestPaymentError>;
 pub mod sample_data;
 
 #[derive(Debug, thiserror::Error)]
@@ -157,6 +159,42 @@ impl common_utils::errors::ErrorSwitch<api_models::errors::types::ApiErrorRespon
                 "Old and new password cannot be same",
                 None,
             )),
+        }
+    }
+}
+
+#[derive(Debug, Clone, serde::Serialize, thiserror::Error)]
+pub enum TestPaymentError {
+    #[error("Error from CreateApiKey Api")]
+    CreateApiKeyFailed,
+    #[error("Error while parsing CreateApiKey response")]
+    CreateApiKeyResponseParseFailed,
+    #[error("Error while parsing PaymentCreate response")]
+    PaymentCreateResponseParseFailed,
+    #[error("Error from PaymentCreate Api")]
+    PaymentCreateFailed,
+}
+impl common_utils::errors::ErrorSwitch<api_models::errors::types::ApiErrorResponse>
+    for TestPaymentError
+{
+    fn switch(&self) -> api_models::errors::types::ApiErrorResponse {
+        use api_models::errors::types::{ApiError, ApiErrorResponse};
+        match self {
+            Self::CreateApiKeyFailed => ApiErrorResponse::InternalServerError(ApiError::new(
+                "HE",
+                0,
+                "Generate Api Key Failure",
+                None,
+            )),
+            Self::CreateApiKeyResponseParseFailed => ApiErrorResponse::InternalServerError(
+                ApiError::new("HE", 1, "CreateApiKeyResponse JSON Parsing Failure", None),
+            ),
+            Self::PaymentCreateResponseParseFailed => ApiErrorResponse::InternalServerError(
+                ApiError::new("HE", 2, "PaymentCreateResponse JSON Parsing Failure", None),
+            ),
+            Self::PaymentCreateFailed => {
+                ApiErrorResponse::BadRequest(ApiError::new("HE", 3, "PaymentCreate Failure", None))
+            }
         }
     }
 }

--- a/crates/router/src/routes/app.rs
+++ b/crates/router/src/routes/app.rs
@@ -882,7 +882,8 @@ impl User {
                 web::resource("/data")
                     .route(web::get().to(get_multiple_dashboard_metadata))
                     .route(web::post().to(set_dashboard_metadata)),
-            );
+            )
+            .service(web::resource("/payments/test").route(web::post().to(test_payment)));
 
         #[cfg(feature = "dummy_connector")]
         {

--- a/crates/router/src/routes/lock_utils.rs
+++ b/crates/router/src/routes/lock_utils.rs
@@ -172,7 +172,8 @@ impl From<Flow> for ApiIdentifier {
             | Flow::InviteUser
             | Flow::UserSignUpWithMerchantId
             | Flow::VerifyEmail
-            | Flow::VerifyEmailRequest => Self::User,
+            | Flow::VerifyEmailRequest
+            | Flow::TestPayment => Self::User,
 
             Flow::ListRoles | Flow::GetRole | Flow::UpdateUserRole | Flow::GetAuthorizationInfo => {
                 Self::UserRole

--- a/crates/router/src/routes/user.rs
+++ b/crates/router/src/routes/user.rs
@@ -389,3 +389,23 @@ pub async fn verify_email_request(
     ))
     .await
 }
+
+pub async fn test_payment(
+    state: web::Data<AppState>,
+    http_req: HttpRequest,
+    payload: web::Json<user_api::TestPaymentRequest>,
+) -> HttpResponse {
+    let flow = Flow::TestPayment;
+    Box::pin(api::server_wrap(
+        flow,
+        state,
+        &http_req,
+        payload.into_inner(),
+        |state, auth: auth::AuthenticationData, test_payment_request| {
+            user_core::test_payment(state, auth.merchant_account, test_payment_request)
+        },
+        &auth::JWTAuth(Permission::PaymentWrite),
+        api_locking::LockAction::NotApplicable,
+    ))
+    .await
+}

--- a/crates/router_env/src/logger/types.rs
+++ b/crates/router_env/src/logger/types.rs
@@ -315,6 +315,8 @@ pub enum Flow {
     VerifyEmail,
     /// Send verify email
     VerifyEmailRequest,
+    /// Test payment
+    TestPayment,
 }
 
 ///


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
Add option to test payments via dummy connector.


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Endpoint path: ```/user/payments/test```
method: ```POST```
expected response should be PaymentCreate response

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
