### PR TITLE
feat(router): make the billing country for apple pay as optional field

### DIFF
--- a/crates/api_models/src/payments.rs
+++ b/crates/api_models/src/payments.rs
@@ -3004,7 +3004,7 @@ pub struct SecretInfoToInitiateSdk {
 pub struct ApplePayPaymentRequest {
     /// The code for country
     #[schema(value_type = CountryAlpha2, example = "US")]
-    pub country_code: api_enums::CountryAlpha2,
+    pub country_code: Option<api_enums::CountryAlpha2>,
     /// The code for currency
     #[schema(value_type = Currency, example = "USD")]
     pub currency_code: api_enums::Currency,

--- a/crates/router/src/connector/bluesnap/transformers.rs
+++ b/crates/router/src/connector/bluesnap/transformers.rs
@@ -529,7 +529,7 @@ impl TryFrom<types::PaymentsSessionResponseRouterData<BluesnapWalletTokenRespons
                                 session_response,
                             ),
                         payment_request_data: Some(api_models::payments::ApplePayPaymentRequest {
-                            country_code: item.data.get_billing_country()?,
+                            country_code: item.data.request.country,
                             currency_code: item.data.request.currency,
                             total: api_models::payments::AmountInfo {
                                 label: payment_request_data.label,

--- a/crates/router/src/connector/payme/transformers.rs
+++ b/crates/router/src/connector/payme/transformers.rs
@@ -545,6 +545,13 @@ impl<F>
             }
             _ => {
                 let currency_code = item.data.request.get_currency()?;
+                let country_code = item
+                    .data
+                    .address
+                    .billing
+                    .as_ref()
+                    .and_then(|billing| billing.address.as_ref())
+                    .and_then(|address| address.country);
                 let amount = item.data.request.get_amount()?;
                 let amount_in_base_unit = utils::to_currency_base_unit(amount, currency_code)?;
                 let pmd = item.data.request.payment_method_data.to_owned();
@@ -559,7 +566,7 @@ impl<F>
                                 api_models::payments::ApplePaySessionResponse::NoSessionResponse,
                             payment_request_data: Some(
                                 api_models::payments::ApplePayPaymentRequest {
-                                    country_code: item.data.get_billing_country()?,
+                                    country_code,
                                     currency_code,
                                     total: api_models::payments::AmountInfo {
                                         label: "Apple Pay".to_string(),

--- a/crates/router/src/connector/trustpay/transformers.rs
+++ b/crates/router/src/connector/trustpay/transformers.rs
@@ -1181,7 +1181,7 @@ pub fn get_apple_pay_session<F, T>(
                             },
                         ),
                     payment_request_data: Some(api_models::payments::ApplePayPaymentRequest {
-                        country_code: apple_pay_init_result.country_code,
+                        country_code: Some(apple_pay_init_result.country_code),
                         currency_code: apple_pay_init_result.currency_code,
                         supported_networks: Some(apple_pay_init_result.supported_networks.clone()),
                         merchant_capabilities: Some(

--- a/crates/router/src/core/payments/flows/session_flow.rs
+++ b/crates/router/src/core/payments/flows/session_flow.rs
@@ -371,13 +371,7 @@ fn get_apple_pay_payment_request(
     merchant_identifier: &str,
 ) -> RouterResult<payment_types::ApplePayPaymentRequest> {
     let applepay_payment_request = payment_types::ApplePayPaymentRequest {
-        country_code: session_data
-            .country
-            .to_owned()
-            .get_required_value("country_code")
-            .change_context(errors::ApiErrorResponse::MissingRequiredField {
-                field_name: "country_code",
-            })?,
+        country_code: session_data.country,
         currency_code: session_data.currency,
         total: amount_info,
         merchant_capabilities: Some(payment_request_data.merchant_capabilities),


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
This pr contains the changes to make the billing country for apple pay as optional field. In this case if a billing country is not passed in the payments create call the session call would still be done and the billing country would be collected form sdk during the payments confirm.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
<img width="1146" alt="image" src="https://github.com/juspay/hyperswitch/assets/83439957/cfb60522-08b9-4f01-8aa2-f2a65121c76e">
<img width="1226" alt="image" src="https://github.com/juspay/hyperswitch/assets/83439957/addf5536-5312-4d96-ad89-954568e97f7c">


Test Case :-
This flow needs to be tested for stripe (Manual and simplified flow), trustpay, bluesanp, payme and any important connectors for which apple pay is implemented.
1) Create a apple pay payment with confirm false without apple the country in billing address
2) Make a Session token call. Expected behaviour is response should contain session token for apple pay with the country_code as null.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
