### PR TITLE
fix(connector): [BOA/Cyb] Truncate state length to <20

### DIFF
--- a/crates/router/src/connector/bankofamerica/transformers.rs
+++ b/crates/router/src/connector/bankofamerica/transformers.rs
@@ -1,7 +1,7 @@
 use api_models::payments;
 use base64::Engine;
 use common_utils::pii;
-use masking::Secret;
+use masking::{Secret, PeekInterface};
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -188,12 +188,14 @@ fn build_bill_to(
         .address
         .as_ref()
         .ok_or_else(utils::missing_field_err("billing.address"))?;
+    let mut state = address.to_state_code()?.peek().clone();
+    state.truncate(20);
     Ok(BillTo {
         first_name: address.get_first_name()?.to_owned(),
         last_name: address.get_last_name()?.to_owned(),
         address1: address.get_line1()?.to_owned(),
         locality: address.get_city()?.to_owned(),
-        administrative_area: address.to_state_code()?,
+        administrative_area: Secret::from(state),
         postal_code: address.get_zip()?.to_owned(),
         country: address.get_country()?.to_owned(),
         email,

--- a/crates/router/src/connector/bankofamerica/transformers.rs
+++ b/crates/router/src/connector/bankofamerica/transformers.rs
@@ -1,7 +1,7 @@
 use api_models::payments;
 use base64::Engine;
 use common_utils::pii;
-use masking::{Secret, PeekInterface};
+use masking::{PeekInterface, Secret};
 use serde::{Deserialize, Serialize};
 
 use crate::{

--- a/crates/router/src/connector/cybersource/transformers.rs
+++ b/crates/router/src/connector/cybersource/transformers.rs
@@ -1,7 +1,7 @@
 use api_models::payments;
 use base64::Engine;
 use common_utils::pii;
-use masking::{Secret, PeekInterface};
+use masking::{PeekInterface, Secret};
 use serde::{Deserialize, Serialize};
 
 use crate::{

--- a/crates/router/src/connector/cybersource/transformers.rs
+++ b/crates/router/src/connector/cybersource/transformers.rs
@@ -1,7 +1,7 @@
 use api_models::payments;
 use base64::Engine;
 use common_utils::pii;
-use masking::Secret;
+use masking::{Secret, PeekInterface};
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -427,12 +427,14 @@ fn build_bill_to(
         .address
         .as_ref()
         .ok_or_else(utils::missing_field_err("billing.address"))?;
+    let mut state = address.to_state_code()?.peek().clone();
+    state.truncate(20);
     Ok(BillTo {
         first_name: address.get_first_name()?.to_owned(),
         last_name: address.get_last_name()?.to_owned(),
         address1: address.get_line1()?.to_owned(),
         locality: address.get_city()?.to_owned(),
-        administrative_area: address.to_state_code()?,
+        administrative_area: Secret::from(state),
         postal_code: address.get_zip()?.to_owned(),
         country: address.get_country()?.to_owned(),
         email,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
BOA and cybersource only accept maximum administrative_area length of 20 which is handled by truncating the input state length.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
https://github.com/juspay/hyperswitch-cloud/issues/3708

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Testing can be done by creating a payment by passing states as 'Andaman and Nicobar Islands'

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
