### PR TITLE
feat(connector): [BOA/CYBERSOURCE] Populate connector_transaction_id

### DIFF
--- a/crates/router/src/connector/bankofamerica/transformers.rs
+++ b/crates/router/src/connector/bankofamerica/transformers.rs
@@ -551,9 +551,16 @@ pub enum BankofamericaPaymentStatus {
     Reversed,
     Pending,
     Declined,
+    Rejected,
+    Challenge,
     AuthorizedPendingReview,
     AuthorizedRiskDeclined,
     Transmitted,
+    InvalidRequest,
+    ServerError,
+    PendingAuthentication,
+    PendingReview,
+    //PartialAuthorized, not being consumed yet.
 }
 
 impl ForeignFrom<(BankofamericaPaymentStatus, bool)> for enums::AttemptStatus {
@@ -583,7 +590,14 @@ impl ForeignFrom<(BankofamericaPaymentStatus, bool)> for enums::AttemptStatus {
             }
             BankofamericaPaymentStatus::Failed
             | BankofamericaPaymentStatus::Declined
-            | BankofamericaPaymentStatus::AuthorizedRiskDeclined => Self::Failure,
+            | BankofamericaPaymentStatus::AuthorizedRiskDeclined
+            | BankofamericaPaymentStatus::InvalidRequest
+            | BankofamericaPaymentStatus::Rejected
+            | BankofamericaPaymentStatus::ServerError => Self::Failure,
+            BankofamericaPaymentStatus::PendingAuthentication => Self::AuthenticationPending,
+            BankofamericaPaymentStatus::PendingReview | BankofamericaPaymentStatus::Challenge => {
+                Self::Pending
+            }
         }
     }
 }

--- a/crates/router/src/connector/bankofamerica/transformers.rs
+++ b/crates/router/src/connector/bankofamerica/transformers.rs
@@ -552,6 +552,7 @@ pub enum BankofamericaPaymentStatus {
     Pending,
     Declined,
     AuthorizedPendingReview,
+    AuthorizedRiskDeclined,
     Transmitted,
 }
 
@@ -580,9 +581,9 @@ impl ForeignFrom<(BankofamericaPaymentStatus, bool)> for enums::AttemptStatus {
             BankofamericaPaymentStatus::Voided | BankofamericaPaymentStatus::Reversed => {
                 Self::Voided
             }
-            BankofamericaPaymentStatus::Failed | BankofamericaPaymentStatus::Declined => {
-                Self::Failure
-            }
+            BankofamericaPaymentStatus::Failed
+            | BankofamericaPaymentStatus::Declined
+            | BankofamericaPaymentStatus::AuthorizedRiskDeclined => Self::Failure,
         }
     }
 }
@@ -747,7 +748,7 @@ impl<F>
                     reason: error_response.error_information.reason,
                     status_code: item.http_code,
                     attempt_status: None,
-                    connector_transaction_id: None,
+                    connector_transaction_id: Some(error_response.id),
                 }),
                 status: enums::AttemptStatus::Failure,
                 ..item.data
@@ -796,7 +797,7 @@ impl<F>
                     reason: error_response.error_information.reason,
                     status_code: item.http_code,
                     attempt_status: None,
-                    connector_transaction_id: None,
+                    connector_transaction_id: Some(error_response.id),
                 }),
                 ..item.data
             }),
@@ -844,7 +845,7 @@ impl<F>
                     reason: error_response.error_information.reason,
                     status_code: item.http_code,
                     attempt_status: None,
-                    connector_transaction_id: None,
+                    connector_transaction_id: Some(error_response.id),
                 }),
                 ..item.data
             }),

--- a/crates/router/src/connector/cybersource/transformers.rs
+++ b/crates/router/src/connector/cybersource/transformers.rs
@@ -773,9 +773,16 @@ pub enum CybersourcePaymentStatus {
     Reversed,
     Pending,
     Declined,
+    Rejected,
+    Challenge,
     AuthorizedPendingReview,
     AuthorizedRiskDeclined,
     Transmitted,
+    InvalidRequest,
+    ServerError,
+    PendingAuthentication,
+    PendingReview,
+    //PartialAuthorized, not being consumed yet.
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -811,7 +818,14 @@ impl ForeignFrom<(CybersourcePaymentStatus, bool)> for enums::AttemptStatus {
             CybersourcePaymentStatus::Voided | CybersourcePaymentStatus::Reversed => Self::Voided,
             CybersourcePaymentStatus::Failed
             | CybersourcePaymentStatus::Declined
-            | CybersourcePaymentStatus::AuthorizedRiskDeclined => Self::Failure,
+            | CybersourcePaymentStatus::AuthorizedRiskDeclined
+            | CybersourcePaymentStatus::Rejected
+            | CybersourcePaymentStatus::InvalidRequest
+            | CybersourcePaymentStatus::ServerError => Self::Failure,
+            CybersourcePaymentStatus::PendingAuthentication => Self::AuthenticationPending,
+            CybersourcePaymentStatus::PendingReview | CybersourcePaymentStatus::Challenge => {
+                Self::Pending
+            }
         }
     }
 }

--- a/crates/router/src/connector/cybersource/transformers.rs
+++ b/crates/router/src/connector/cybersource/transformers.rs
@@ -774,6 +774,7 @@ pub enum CybersourcePaymentStatus {
     Pending,
     Declined,
     AuthorizedPendingReview,
+    AuthorizedRiskDeclined,
     Transmitted,
 }
 
@@ -808,7 +809,9 @@ impl ForeignFrom<(CybersourcePaymentStatus, bool)> for enums::AttemptStatus {
                 Self::Charged
             }
             CybersourcePaymentStatus::Voided | CybersourcePaymentStatus::Reversed => Self::Voided,
-            CybersourcePaymentStatus::Failed | CybersourcePaymentStatus::Declined => Self::Failure,
+            CybersourcePaymentStatus::Failed
+            | CybersourcePaymentStatus::Declined
+            | CybersourcePaymentStatus::AuthorizedRiskDeclined => Self::Failure,
         }
     }
 }
@@ -922,7 +925,7 @@ impl<F, T>
                 reason: error_response.error_information.reason.clone(),
                 status_code: item.http_code,
                 attempt_status: None,
-                connector_transaction_id: None,
+                connector_transaction_id: Some(error_response.id.clone()),
             }),
             ..item.data
         }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
For connectors BOA and Cybersource the connector_transaction_id should be populated for error response payments.
Also new introduced payment status' from https://developer.cybersource.com/content/dam/cybsdeveloper2021/responsecode.json.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
https://github.com/juspay/hyperswitch-cloud/issues/3710

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Testing can be done by creating a failure payment by using card `412345678912345678914` and you should see the `connector_transaction_id` in payments response of the failed payment.

<img width="406" alt="Screenshot 2023-12-23 at 2 37 51 PM" src="https://github.com/juspay/hyperswitch/assets/41580413/eb0fcbec-b96e-479f-9367-5e2bf3795c07">


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
