### PR TITLE
feat(connector): [CYBERSOURCE] Refactor cybersource

### DIFF
--- a/crates/router/src/connector/cybersource.rs
+++ b/crates/router/src/connector/cybersource.rs
@@ -702,8 +702,7 @@ impl ConnectorIntegration<api::Void, types::PaymentsCancelData, types::PaymentsR
                 })?,
             req,
         ))?;
-        let connector_req =
-            cybersource::CybersourceVoidRequest::try_from(&connector_router_data)?;
+        let connector_req = cybersource::CybersourceVoidRequest::try_from(&connector_router_data)?;
 
         Ok(RequestContent::Json(Box::new(connector_req)))
     }

--- a/crates/router/src/connector/cybersource.rs
+++ b/crates/router/src/connector/cybersource.rs
@@ -674,9 +674,8 @@ impl ConnectorIntegration<api::Void, types::PaymentsCancelData, types::PaymentsR
     ) -> CustomResult<String, errors::ConnectorError> {
         let connector_payment_id = req.request.connector_transaction_id.clone();
         Ok(format!(
-            "{}pts/v2/payments/{}/voids",
-            self.base_url(connectors),
-            connector_payment_id
+            "{}pts/v2/payments/{connector_payment_id}/reversals",
+            self.base_url(connectors)
         ))
     }
 
@@ -686,10 +685,27 @@ impl ConnectorIntegration<api::Void, types::PaymentsCancelData, types::PaymentsR
 
     fn get_request_body(
         &self,
-        _req: &types::PaymentsCancelRouterData,
+        req: &types::PaymentsCancelRouterData,
         _connectors: &settings::Connectors,
     ) -> CustomResult<RequestContent, errors::ConnectorError> {
-        Ok(RequestContent::Json(Box::new(serde_json::json!({}))))
+        let connector_router_data = cybersource::CybersourceRouterData::try_from((
+            &self.get_currency_unit(),
+            req.request
+                .currency
+                .ok_or(errors::ConnectorError::MissingRequiredField {
+                    field_name: "Currency",
+                })?,
+            req.request
+                .amount
+                .ok_or(errors::ConnectorError::MissingRequiredField {
+                    field_name: "Amount",
+                })?,
+            req,
+        ))?;
+        let connector_req =
+            cybersource::CybersourceVoidRequest::try_from(&connector_router_data)?;
+
+        Ok(RequestContent::Json(Box::new(connector_req)))
     }
 
     fn build_request(

--- a/crates/router/src/connector/cybersource/transformers.rs
+++ b/crates/router/src/connector/cybersource/transformers.rs
@@ -828,6 +828,53 @@ impl TryFrom<&CybersourceRouterData<&types::PaymentsIncrementalAuthorizationRout
     }
 }
 
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CybersourceVoidRequest {
+    client_reference_information: ClientReferenceInformation,
+    reversal_information: ReversalInformation,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ReversalInformation {
+    amount_details: Amount,
+    reason: String,
+}
+
+impl TryFrom<&CybersourceRouterData<&types::PaymentsCancelRouterData>>
+    for CybersourceVoidRequest
+{
+    type Error = error_stack::Report<errors::ConnectorError>;
+    fn try_from(
+        value: &CybersourceRouterData<&types::PaymentsCancelRouterData>,
+    ) -> Result<Self, Self::Error> {
+        Ok(Self {
+            client_reference_information: ClientReferenceInformation {
+                code: Some(value.router_data.connector_request_reference_id.clone()),
+            },
+            reversal_information: ReversalInformation {
+                amount_details: Amount {
+                    total_amount: value.amount.to_owned(),
+                    currency: value.router_data.request.currency.ok_or(
+                        errors::ConnectorError::MissingRequiredField {
+                            field_name: "Currency",
+                        },
+                    )?,
+                },
+                reason: value
+                    .router_data
+                    .request
+                    .cancellation_reason
+                    .clone()
+                    .ok_or(errors::ConnectorError::MissingRequiredField {
+                        field_name: "Cancellation Reason",
+                    })?,
+            },
+        })
+    }
+}
+
 pub struct CybersourceAuthType {
     pub(super) api_key: Secret<String>,
     pub(super) merchant_account: Secret<String>,

--- a/crates/router/src/connector/cybersource/transformers.rs
+++ b/crates/router/src/connector/cybersource/transformers.rs
@@ -842,9 +842,7 @@ pub struct ReversalInformation {
     reason: String,
 }
 
-impl TryFrom<&CybersourceRouterData<&types::PaymentsCancelRouterData>>
-    for CybersourceVoidRequest
-{
+impl TryFrom<&CybersourceRouterData<&types::PaymentsCancelRouterData>> for CybersourceVoidRequest {
     type Error = error_stack::Report<errors::ConnectorError>;
     fn try_from(
         value: &CybersourceRouterData<&types::PaymentsCancelRouterData>,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
The following features have been implemented for the connector Cybersource:
- Apple Pay - Manual Flow
- Explicit handling of connector 5XX response
- Using Authorization Reversal endpoint to Void a transaction
- Passing payment metadata from merchant to connector using `merchant_defined_information` field

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
https://github.com/juspay/hyperswitch-cloud/issues/3719
https://github.com/juspay/hyperswitch-cloud/issues/3721
https://github.com/juspay/hyperswitch-cloud/issues/3722
https://github.com/juspay/hyperswitch-cloud/issues/3723

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

1. Apple pay testing was carried out using postman
<img width="1296" alt="Screenshot 2023-12-28 at 5 19 45 PM" src="https://github.com/juspay/hyperswitch/assets/41580413/083b2dd3-84c1-40bf-ac9d-5e5ddd0b4cad">


2. Generate a 5XX payment using BOA (card no: 3566111111111113) and you should get payment status as failed.
![291885748-89a38798-00f0-44b8-a564-06e304c0dbf9](https://github.com/juspay/hyperswitch/assets/41580413/d60d396a-abab-473c-96ce-16f861aced58)

3. Check void flow for manual authorized payment for cybersource:
```
curl --location 'http://localhost:8080/payments/pay_7nhJwzw5YFQCwQ8YfkEU/cancel' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: API_KEY_HERE' \
--data '{
  "cancellation_reason": "requested_by_customer",
   "amount": 1404,
   "currency": "USD"
}'
```


4. Testing for metadata can be done by creating a card/gpay/applepay payment and by passing the following metadata in PAYMENTS-CREATE:
"metadata": { "count_tickets": 1, "transaction_number": "5590043" }
You should then be able to see the metadata on BOA dashboard for that payment:
![292885857-2693f174-0552-45a9-af42-6606e874231f](https://github.com/juspay/hyperswitch/assets/41580413/7fee7600-6c7d-4282-ac28-64f55ecb7e57)


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
