### PR TITLE
fix(users): Fix wrong redirection url in magic link

### DIFF
--- a/crates/router/src/services/email/types.rs
+++ b/crates/router/src/services/email/types.rs
@@ -77,7 +77,7 @@ pub fn get_link_with_token(
     token: impl std::fmt::Display,
     action: impl std::fmt::Display,
 ) -> String {
-    format!("{base_url}/user/{action}/?token={token}")
+    format!("{base_url}/user/{action}?token={token}")
 }
 
 pub struct VerifyEmail {
@@ -153,7 +153,7 @@ impl EmailData for MagicLink {
             .await
             .change_context(EmailError::TokenGenerationFailure)?;
 
-        let magic_link_login = get_link_with_token(&self.settings.email.base_url, token, "login");
+        let magic_link_login = get_link_with_token(&self.settings.email.base_url, token, "verify_email");
 
         let body = html::get_html_body(EmailBody::MagicLink {
             link: magic_link_login,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Magic link email has redirection url as `/login`. This PR changes it to `/verify_email`.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
To support control center.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
With local SES.
```
curl --location 'http://localhost:8080/user/connect_account' \
--header 'Content-Type: application/json' \
--data-raw '{
    "email": "already registered email"
}'
```
This will send an email to the user. That email has a button, which redirects user to `{dashboard_url}/user/verify_email`.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
