### PR TITLE
fix(connector): [Zen] fix error response handling when payment is failed

### DIFF
--- a/crates/router/src/connector/zen/transformers.rs
+++ b/crates/router/src/connector/zen/transformers.rs
@@ -11,6 +11,7 @@ use crate::{
     connector::utils::{
         self, BrowserInformationData, CardData, PaymentsAuthorizeRequestData, RouterData,
     },
+    consts,
     core::errors::{self, CustomResult},
     services::{self, Method},
     types::{self, api, storage::enums, transformers::ForeignTryFrom},
@@ -848,12 +849,15 @@ impl ForeignTryFrom<(ZenPaymentStatus, Option<ZenActions>)> for enums::AttemptSt
     }
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ApiResponse {
     status: ZenPaymentStatus,
     id: String,
+    // merchant_transaction_id: Option<String>,
     merchant_action: Option<ZenMerchantAction>,
+    reject_code: Option<String>,
+    reject_reason: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -869,18 +873,18 @@ pub struct CheckoutResponse {
     redirect_url: url::Url,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ZenMerchantAction {
     action: ZenActions,
     data: ZenMerchantActionData,
 }
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "UPPERCASE")]
 pub enum ZenActions {
     Redirect,
 }
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ZenMerchantActionData {
     redirect_url: url::Url,
@@ -913,6 +917,57 @@ impl<F, T>
     }
 }
 
+fn get_zen_response(
+    response: ApiResponse,
+    status_code: u16,
+) -> CustomResult<
+    (
+        enums::AttemptStatus,
+        Option<types::ErrorResponse>,
+        types::PaymentsResponseData,
+    ),
+    errors::ConnectorError,
+> {
+    let redirection_data_action = response.merchant_action.map(|merchant_action| {
+        (
+            services::RedirectForm::from((merchant_action.data.redirect_url, Method::Get)),
+            merchant_action.action,
+        )
+    });
+    let (redirection_data, action) = match redirection_data_action {
+        Some((redirect_form, action)) => (Some(redirect_form), Some(action)),
+        None => (None, None),
+    };
+    let status = enums::AttemptStatus::foreign_try_from((response.status, action))?;
+    let error = if status == enums::AttemptStatus::Failure {
+        Some(types::ErrorResponse {
+            code: response
+                .reject_code
+                .unwrap_or_else(|| consts::NO_ERROR_CODE.to_string()),
+            message: response
+                .reject_reason
+                .clone()
+                .unwrap_or_else(|| consts::NO_ERROR_MESSAGE.to_string()),
+            reason: response.reject_reason,
+            status_code,
+            attempt_status: Some(status),
+            connector_transaction_id: Some(response.id.clone()),
+        })
+    } else {
+        None
+    };
+    let payment_response_data = types::PaymentsResponseData::TransactionResponse {
+        resource_id: types::ResponseId::ConnectorTransactionId(response.id.clone()),
+        redirection_data,
+        mandate_reference: None,
+        connector_metadata: None,
+        network_txn_id: None,
+        connector_response_reference_id: None,
+        incremental_authorization_allowed: None,
+    };
+    Ok((status, error, payment_response_data))
+}
+
 impl<F, T> TryFrom<types::ResponseRouterData<F, ApiResponse, T, types::PaymentsResponseData>>
     for types::RouterData<F, T, types::PaymentsResponseData>
 {
@@ -920,28 +975,12 @@ impl<F, T> TryFrom<types::ResponseRouterData<F, ApiResponse, T, types::PaymentsR
     fn try_from(
         value: types::ResponseRouterData<F, ApiResponse, T, types::PaymentsResponseData>,
     ) -> Result<Self, Self::Error> {
-        let redirection_data_action = value.response.merchant_action.map(|merchant_action| {
-            (
-                services::RedirectForm::from((merchant_action.data.redirect_url, Method::Get)),
-                merchant_action.action,
-            )
-        });
-        let (redirection_data, action) = match redirection_data_action {
-            Some((redirect_form, action)) => (Some(redirect_form), Some(action)),
-            None => (None, None),
-        };
+        let (status, error, payment_response_data) =
+            get_zen_response(value.response.clone(), value.http_code)?;
 
         Ok(Self {
-            status: enums::AttemptStatus::foreign_try_from((value.response.status, action))?,
-            response: Ok(types::PaymentsResponseData::TransactionResponse {
-                resource_id: types::ResponseId::ConnectorTransactionId(value.response.id),
-                redirection_data,
-                mandate_reference: None,
-                connector_metadata: None,
-                network_txn_id: None,
-                connector_response_reference_id: None,
-                incremental_authorization_allowed: None,
-            }),
+            status,
+            response: error.map_or_else(|| Ok(payment_response_data), Err),
             ..value.data
         })
     }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
fix error response handling when payment is failed

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
test cases - 1. make a successful payment
2. make a payment, after redirection, cancel the payment. When Psync for the payment has made, status should be failed, and error reason and code should be populated.


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
