### PR TITLE
fix(middleware): add support for logging request-id sent in request

### DIFF
--- a/crates/router/src/middleware.rs
+++ b/crates/router/src/middleware.rs
@@ -53,12 +53,6 @@ where
             let request_id = request_id.as_hyphenated().to_string();
             if let Some(old_request_id) = old_x_request_id {
                 router_env::logger::info!(?request_id, ?old_request_id);
-
-                // router_env::logger::info!(
-                //     "{:?} {:?}",
-                //     value,
-                //     request_id.as_hyphenated().to_string()
-                // );
             }
             let mut response = response_fut.await?;
             response.headers_mut().append(

--- a/crates/router/src/middleware.rs
+++ b/crates/router/src/middleware.rs
@@ -51,8 +51,8 @@ where
         Box::pin(async move {
             let request_id = request_id_fut.await?;
             let request_id = request_id.as_hyphenated().to_string();
-            if let Some(old_request_id) = old_x_request_id {
-                router_env::logger::info!(?request_id, ?old_request_id);
+            if let Some(upstream_request_id) = old_x_request_id {
+                router_env::logger::info!(?request_id, ?upstream_request_id);
             }
             let mut response = response_fut.await?;
             response.headers_mut().append(


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

This adds a log line in the middleware tracking and logging any received request-id in the process. Allow the logs to be linked when multiple services are composed and request id is sent between them

<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
