### PR TITLE
refactor(api_lock): allow api lock on psync only when force sync is true

### DIFF
--- a/crates/router/src/routes/payments.rs
+++ b/crates/router/src/routes/payments.rs
@@ -1230,7 +1230,7 @@ impl GetLockingInput for payment_types::PaymentsRetrieveRequest {
         lock_utils::ApiIdentifier: From<F>,
     {
         match self.resource_id {
-            payment_types::PaymentIdType::PaymentIntentId(ref id) => {
+            payment_types::PaymentIdType::PaymentIntentId(ref id) if self.force_sync == true => {
                 api_locking::LockAction::Hold {
                     input: api_locking::LockingInput {
                         unique_locking_key: id.to_owned(),

--- a/crates/router/src/routes/payments.rs
+++ b/crates/router/src/routes/payments.rs
@@ -1230,7 +1230,7 @@ impl GetLockingInput for payment_types::PaymentsRetrieveRequest {
         lock_utils::ApiIdentifier: From<F>,
     {
         match self.resource_id {
-            payment_types::PaymentIdType::PaymentIntentId(ref id) if self.force_sync == true => {
+            payment_types::PaymentIdType::PaymentIntentId(ref id) if self.force_sync => {
                 api_locking::LockAction::Hold {
                     input: api_locking::LockingInput {
                         unique_locking_key: id.to_owned(),


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Refactoring

## Description
<!-- Describe your changes in detail -->
This change will make changes to the psync api locking to hold the lock only when force_sync = true. In other cases, no locking is necessary.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
This change is to avoid unnecessary api locks when doing psync with force sync as false. This is only reading the payment and will not change the status, so lock is not needed.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
- Fire 10 concurrent requests to psync, with force_sync as false
- Old application with locking
<img width="987" alt="Screenshot 2024-01-04 at 4 43 54 PM" src="https://github.com/juspay/hyperswitch/assets/48803246/660c577e-c4b1-4131-ab5c-5fcd9d677113">

The timings are cumulative because next request is processed only after previous request is completed, adding to the time.

- New application without locking
<img width="955" alt="Screenshot 2024-01-04 at 4 51 54 PM" src="https://github.com/juspay/hyperswitch/assets/48803246/12715388-b716-4d49-9d51-4d44f09ba20a">

All the requests take the same amount of time, as there is no locking.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
