### PR TITLE
fix(user): add integration_completed enum in metadata type

### DIFF
--- a/crates/router/src/utils/user/dashboard_metadata.rs
+++ b/crates/router/src/utils/user/dashboard_metadata.rs
@@ -91,21 +91,12 @@ pub async fn get_merchant_scoped_metadata_from_db(
     org_id: String,
     metadata_keys: Vec<DBEnum>,
 ) -> UserResult<Vec<DashboardMetadata>> {
-    match state
+    state
         .store
         .find_merchant_scoped_dashboard_metadata(&merchant_id, &org_id, metadata_keys)
         .await
-    {
-        Ok(data) => Ok(data),
-        Err(e) => {
-            if e.current_context().is_db_not_found() {
-                return Ok(Vec::with_capacity(0));
-            }
-            Err(e
-                .change_context(UserErrors::InternalServerError)
-                .attach_printable("DB Error Fetching DashboardMetaData"))
-        }
-    }
+        .change_context(UserErrors::InternalServerError)
+        .attach_printable("DB Error Fetching DashboardMetaData")
 }
 pub async fn get_user_scoped_metadata_from_db(
     state: &AppState,

--- a/migrations/2024-01-04-121733_add_dashboard_metadata_key_integration_completed/down.sql
+++ b/migrations/2024-01-04-121733_add_dashboard_metadata_key_integration_completed/down.sql
@@ -1,0 +1,2 @@
+-- This file should undo anything in `up.sql`
+select 1;

--- a/migrations/2024-01-04-121733_add_dashboard_metadata_key_integration_completed/down.sql
+++ b/migrations/2024-01-04-121733_add_dashboard_metadata_key_integration_completed/down.sql
@@ -1,2 +1,2 @@
 -- This file should undo anything in `up.sql`
-select 1;
+SELECT 1;

--- a/migrations/2024-01-04-121733_add_dashboard_metadata_key_integration_completed/up.sql
+++ b/migrations/2024-01-04-121733_add_dashboard_metadata_key_integration_completed/up.sql
@@ -1,0 +1,2 @@
+-- Your SQL goes here
+ALTER TYPE "DashboardMetadata" ADD VALUE IF NOT EXISTS 'integration_completed';


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
- Bug Fix: Add support for integration_completed enum in DB side
- Throw 500 for the enums which are not present in dashboard metadata key type in db

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
To get integration_completed
```
curl --location --request GET 'http://localhost:8080/user/data?keys=IntegrationCompleted' \
--header 'Authorization: Bearer JWT' \
--data '
'
```
Response:
```
[
    {
        "IntegrationCompleted": false
    }
]
```
To set integration_completed, response will be 200 
```
curl --location 'http://localhost:8080/user/data' \
--header 'Authorization: Bearer JWT' \
--data '
"IntegrationCompleted"
'
```
And if we again call Get, response will be
```
[
    {
        "IntegrationCompleted": true
    }
]
```

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
