### PR TITLE
feat(connector): [BOA] Populate merchant_defined_information with metadata

### DIFF
--- a/crates/router/src/core/payments/transformers.rs
+++ b/crates/router/src/core/payments/transformers.rs
@@ -1076,6 +1076,7 @@ impl<F: Clone> TryFrom<PaymentAdditionalData<'_, F>> for types::PaymentsAuthoriz
                 Some(RequestIncrementalAuthorization::True)
                     | Some(RequestIncrementalAuthorization::Default)
             ),
+            metadata: additional_data.payment_data.payment_intent.metadata,
         })
     }
 }

--- a/crates/router/src/types.rs
+++ b/crates/router/src/types.rs
@@ -407,6 +407,7 @@ pub struct PaymentsAuthorizeData {
     pub surcharge_details: Option<types::SurchargeDetails>,
     pub customer_id: Option<String>,
     pub request_incremental_authorization: bool,
+    pub metadata: Option<pii::SecretSerdeValue>,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -1245,6 +1246,7 @@ impl From<&SetupMandateRouterData> for PaymentsAuthorizeData {
             customer_id: None,
             surcharge_details: None,
             request_incremental_authorization: data.request.request_incremental_authorization,
+            metadata: None,
         }
     }
 }

--- a/crates/router/src/types/api/verify_connector.rs
+++ b/crates/router/src/types/api/verify_connector.rs
@@ -27,6 +27,7 @@ impl VerifyConnectorData {
             amount: 1000,
             confirm: true,
             currency: storage_enums::Currency::USD,
+            metadata: None,
             mandate_id: None,
             webhook_url: None,
             customer_id: None,

--- a/crates/router/tests/connectors/aci.rs
+++ b/crates/router/tests/connectors/aci.rs
@@ -70,6 +70,7 @@ fn construct_payment_router_data() -> types::PaymentsAuthorizeRouterData {
             customer_id: None,
             surcharge_details: None,
             request_incremental_authorization: false,
+            metadata: None,
         },
         response: Err(types::ErrorResponse::default()),
         payment_method_id: None,

--- a/crates/router/tests/connectors/adyen.rs
+++ b/crates/router/tests/connectors/adyen.rs
@@ -158,6 +158,7 @@ impl AdyenTest {
             customer_id: None,
             surcharge_details: None,
             request_incremental_authorization: false,
+            metadata: None,
         })
     }
 }

--- a/crates/router/tests/connectors/bitpay.rs
+++ b/crates/router/tests/connectors/bitpay.rs
@@ -93,6 +93,7 @@ fn payment_method_details() -> Option<types::PaymentsAuthorizeData> {
         customer_id: None,
         surcharge_details: None,
         request_incremental_authorization: false,
+        metadata: None,
     })
 }
 

--- a/crates/router/tests/connectors/cashtocode.rs
+++ b/crates/router/tests/connectors/cashtocode.rs
@@ -68,6 +68,7 @@ impl CashtocodeTest {
             customer_id: Some("John Doe".to_owned()),
             surcharge_details: None,
             request_incremental_authorization: false,
+            metadata: None,
         })
     }
 

--- a/crates/router/tests/connectors/coinbase.rs
+++ b/crates/router/tests/connectors/coinbase.rs
@@ -95,6 +95,7 @@ fn payment_method_details() -> Option<types::PaymentsAuthorizeData> {
         customer_id: None,
         surcharge_details: None,
         request_incremental_authorization: false,
+        metadata: None,
     })
 }
 

--- a/crates/router/tests/connectors/cryptopay.rs
+++ b/crates/router/tests/connectors/cryptopay.rs
@@ -93,6 +93,7 @@ fn payment_method_details() -> Option<types::PaymentsAuthorizeData> {
         customer_id: None,
         surcharge_details: None,
         request_incremental_authorization: false,
+        metadata: None,
     })
 }
 

--- a/crates/router/tests/connectors/opennode.rs
+++ b/crates/router/tests/connectors/opennode.rs
@@ -94,6 +94,7 @@ fn payment_method_details() -> Option<types::PaymentsAuthorizeData> {
         customer_id: None,
         surcharge_details: None,
         request_incremental_authorization: false,
+        metadata: None,
     })
 }
 

--- a/crates/router/tests/connectors/utils.rs
+++ b/crates/router/tests/connectors/utils.rs
@@ -911,6 +911,7 @@ impl Default for PaymentAuthorizeType {
             customer_id: None,
             surcharge_details: None,
             request_incremental_authorization: false,
+            metadata: None,
         };
         Self(data)
     }

--- a/crates/router/tests/connectors/worldline.rs
+++ b/crates/router/tests/connectors/worldline.rs
@@ -103,6 +103,7 @@ impl WorldlineTest {
             customer_id: None,
             surcharge_details: None,
             request_incremental_authorization: false,
+            metadata: None,
         })
     }
 }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
We need to populate the merchant_defined_information for each payment with data coming from merchant in payment requests metadata.


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
Testing can be done by creating a card/gpay/applepay payment and by passing the following metadata in PAYMENTS-CREATE:
"metadata": { "count_tickets": 1, "transaction_number": "5590043" }

You should then be able to see the metadata on BOA dashboard for that payment:
Screenshot 2023-12-26 at 8 34 14 PM


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
