### PR TITLE
fix(refund): add merchant_connector_id in refund

### DIFF
--- a/crates/api_models/src/refunds.rs
+++ b/crates/api_models/src/refunds.rs
@@ -127,7 +127,10 @@ pub struct RefundResponse {
     /// The connector used for the refund and the corresponding payment
     #[schema(example = "stripe")]
     pub connector: String,
+    /// The id of business profile for this refund
     pub profile_id: Option<String>,
+    /// The merchant_connector_id of the processor through which this payment went through
+    pub merchant_connector_id: Option<String>,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize, ToSchema)]

--- a/crates/router/src/core/refunds.rs
+++ b/crates/router/src/core/refunds.rs
@@ -650,6 +650,7 @@ pub async fn validate_and_create_refund(
         .set_attempt_id(payment_attempt.attempt_id.clone())
         .set_refund_reason(req.reason)
         .set_profile_id(payment_intent.profile_id.clone())
+        .set_merchant_connector_id(payment_attempt.merchant_connector_id.clone())
         .to_owned();
 
     let refund = match db

--- a/crates/router/src/core/refunds.rs
+++ b/crates/router/src/core/refunds.rs
@@ -777,6 +777,7 @@ impl ForeignFrom<storage::Refund> for api::RefundResponse {
             created_at: Some(refund.created_at),
             updated_at: Some(refund.updated_at),
             connector: refund.connector,
+            merchant_connector_id: refund.merchant_connector_id,
         }
     }
 }

--- a/openapi/openapi_spec.json
+++ b/openapi/openapi_spec.json
@@ -11674,6 +11674,12 @@
           },
           "profile_id": {
             "type": "string",
+            "description": "The id of business profile for this refund",
+            "nullable": true
+          },
+          "merchant_connector_id": {
+            "type": "string",
+            "description": "The merchant_connector_id of the processor through which this payment went through",
             "nullable": true
           }
         }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix

## Description
<!-- Describe your changes in detail -->
Merchant connector id was not being populated in `refunds`. This PR will fix it.


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
This will fix refunds sync

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
- Create a refund and check whether `merchant_connector_id` is populated in the refund.
<img width="1034" alt="Screenshot 2024-01-10 at 3 12 42 PM" src="https://github.com/juspay/hyperswitch/assets/48803246/e5975c60-992c-420d-9c5d-e06d03d149c0">

<img width="651" alt="Screenshot 2024-01-10 at 3 34 57 PM" src="https://github.com/juspay/hyperswitch/assets/48803246/36a1f714-218a-4790-8040-cea27b3878ee">



## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
