### PR TITLE
ci: use git commands for pushing commits and tags in nightly release workflows

### DIFF
--- a/.github/workflows/release-nightly-version-reusable.yml
+++ b/.github/workflows/release-nightly-version-reusable.yml
@@ -3,11 +3,8 @@ name: Create a nightly tag
 on:
   workflow_call:
     secrets:
-      app_id:
-        description: App ID for the GitHub app
-        required: true
-      app_private_key:
-        description: Private key for the GitHub app
+      token:
+        description: GitHub token for authenticating with GitHub
         required: true
     outputs:
       tag:
@@ -31,23 +28,17 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Generate GitHub app token
-        id: generate_app_token
-        uses: actions/create-github-app-token@v1
-        with:
-          app-id: ${{ secrets.app_id }}
-          private-key: ${{ secrets.app_private_key }}
-
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.token }}
 
       - name: Check if the workflow is run on an allowed branch
         shell: bash
         run: |
-          if [[ "${{github.ref}}" != "refs/heads/${ALLOWED_BRANCH_NAME}" ]]; then
-            echo "::error::This workflow is expected to be run from the '${ALLOWED_BRANCH_NAME}' branch. Current branch: '${{github.ref}}'"
+          if [[ "${{ github.ref }}" != "refs/heads/${ALLOWED_BRANCH_NAME}" ]]; then
+            echo "::error::This workflow is expected to be run from the '${ALLOWED_BRANCH_NAME}' branch. Current branch: '${{ github.ref }}'"
             exit 1
           fi
 
@@ -139,62 +130,22 @@ jobs:
             }' CHANGELOG.md
           rm release-notes.md
 
-        # We make use of GitHub API calls to commit and tag the changelog instead of the simpler
-        # `git commit`, `git tag` and `git push` commands to have signed commits and tags
-      - name: Commit generated changelog and create tag
+      - name: Set git configuration
         shell: bash
-        env:
-          GH_TOKEN: ${{ steps.generate_app_token.outputs.token }}
         run: |
-          HEAD_COMMIT="$(git rev-parse 'HEAD^{commit}')"
+          git config --local user.name 'github-actions'
+          git config --local user.email '41898282+github-actions[bot]@users.noreply.github.com'
 
-          # Create a tree based on the HEAD commit of the current branch and updated changelog file
-          TREE_SHA="$(
-            gh api \
-              --method POST \
-              --header 'Accept: application/vnd.github+json' \
-              --header 'X-GitHub-Api-Version: 2022-11-28' \
-              '/repos/{owner}/{repo}/git/trees' \
-              --raw-field base_tree="${HEAD_COMMIT}" \
-              --raw-field 'tree[][path]=CHANGELOG.md' \
-              --raw-field 'tree[][mode]=100644' \
-              --raw-field 'tree[][type]=blob' \
-              --field 'tree[][content]=@CHANGELOG.md' \
-              --jq '.sha'
-          )"
+      - name: Commit, tag and push generated changelog
+        shell: bash
+        run: |
+          git add CHANGELOG.md
+          git commit --message "chore(version): ${NEXT_TAG}"
 
-          # Create a commit to point to the above created tree
-          NEW_COMMIT_SHA="$(
-            gh api \
-              --method POST \
-              --header 'Accept: application/vnd.github+json' \
-              --header 'X-GitHub-Api-Version: 2022-11-28' \
-              '/repos/{owner}/{repo}/git/commits' \
-              --raw-field "message=chore(version): ${NEXT_TAG}" \
-              --raw-field "parents[]=${HEAD_COMMIT}" \
-              --raw-field "tree=${TREE_SHA}" \
-              --jq '.sha'
-          )"
+          git tag "${NEXT_TAG}" HEAD
 
-          # Update the current branch to point to the above created commit
-          # We disable forced update so that the workflow will fail if the branch has been updated since the workflow started
-          # (for example, new commits were pushed to the branch after the workflow execution started).
-          gh api \
-            --method PATCH \
-            --header 'Accept: application/vnd.github+json' \
-            --header 'X-GitHub-Api-Version: 2022-11-28' \
-            "/repos/{owner}/{repo}/git/refs/heads/${ALLOWED_BRANCH_NAME}" \
-            --raw-field "sha=${NEW_COMMIT_SHA}" \
-            --field 'force=false'
-
-          # Create a lightweight tag to point to the above created commit
-          gh api \
-            --method POST \
-            --header 'Accept: application/vnd.github+json' \
-            --header 'X-GitHub-Api-Version: 2022-11-28' \
-            '/repos/{owner}/{repo}/git/refs' \
-            --raw-field "ref=refs/tags/${NEXT_TAG}" \
-            --raw-field "sha=${NEW_COMMIT_SHA}"
+          git push origin "${ALLOWED_BRANCH_NAME}"
+          git push origin "${NEXT_TAG}"
 
       - name: Set job outputs
         shell: bash

--- a/.github/workflows/release-nightly-version-reusable.yml
+++ b/.github/workflows/release-nightly-version-reusable.yml
@@ -20,7 +20,7 @@ env:
 
   # The branch name that this workflow is allowed to run on.
   # If the workflow is run on any other branch, this workflow will fail.
-  ALLOWED_BRANCH_NAME: main
+  ALLOWED_BRANCH_NAME: ci-use-git-commands-for-push-release-workflows
 
 jobs:
   create-nightly-tag:

--- a/.github/workflows/release-nightly-version-reusable.yml
+++ b/.github/workflows/release-nightly-version-reusable.yml
@@ -20,7 +20,7 @@ env:
 
   # The branch name that this workflow is allowed to run on.
   # If the workflow is run on any other branch, this workflow will fail.
-  ALLOWED_BRANCH_NAME: ci-use-git-commands-for-push-release-workflows
+  ALLOWED_BRANCH_NAME: main
 
 jobs:
   create-nightly-tag:

--- a/.github/workflows/release-nightly-version.yml
+++ b/.github/workflows/release-nightly-version.yml
@@ -6,6 +6,10 @@ on:
 
   workflow_dispatch:
 
+  push:
+    branches:
+      - ci-use-git-commands-for-push-release-workflows
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -19,7 +23,7 @@ env:
 
   # The branch name that this workflow is allowed to run on.
   # If the workflow is run on any other branch, this workflow will fail.
-  ALLOWED_BRANCH_NAME: main
+  ALLOWED_BRANCH_NAME: ci-use-git-commands-for-push-release-workflows
 
 jobs:
   update-postman-collections:

--- a/.github/workflows/release-nightly-version.yml
+++ b/.github/workflows/release-nightly-version.yml
@@ -6,10 +6,6 @@ on:
 
   workflow_dispatch:
 
-  push:
-    branches:
-      - ci-use-git-commands-for-push-release-workflows
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -23,7 +19,7 @@ env:
 
   # The branch name that this workflow is allowed to run on.
   # If the workflow is run on any other branch, this workflow will fail.
-  ALLOWED_BRANCH_NAME: ci-use-git-commands-for-push-release-workflows
+  ALLOWED_BRANCH_NAME: main
 
 jobs:
   update-postman-collections:

--- a/.github/workflows/release-nightly-version.yml
+++ b/.github/workflows/release-nightly-version.yml
@@ -27,23 +27,17 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Generate GitHub app token
-        id: generate_app_token
-        uses: actions/create-github-app-token@v1
-        with:
-          app-id: ${{ secrets.HYPERSWITCH_BOT_APP_ID }}
-          private-key: ${{ secrets.HYPERSWITCH_BOT_APP_PRIVATE_KEY }}
-
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.AUTO_RELEASE_PAT }}
 
       - name: Check if the workflow is run on an allowed branch
         shell: bash
         run: |
-          if [[ "${{github.ref}}" != "refs/heads/${ALLOWED_BRANCH_NAME}" ]]; then
-            echo "::error::This workflow is expected to be run from the '${ALLOWED_BRANCH_NAME}' branch. Current branch: '${{github.ref}}'"
+          if [[ "${{ github.ref }}" != "refs/heads/${ALLOWED_BRANCH_NAME}" ]]; then
+            echo "::error::This workflow is expected to be run from the '${ALLOWED_BRANCH_NAME}' branch. Current branch: '${{ github.ref }}'"
             exit 1
           fi
 
@@ -80,66 +74,20 @@ jobs:
             echo "Postman collection files have no modifications"
           fi
 
-      - name: Commit updated Postman collections if modified
+      - name: Set git configuration
         shell: bash
-        env:
-          GH_TOKEN: ${{ steps.generate_app_token.outputs.token }}
+        run: |
+          git config --local user.name 'github-actions'
+          git config --local user.email '41898282+github-actions[bot]@users.noreply.github.com'
+
+      - name: Commit and push updated Postman collections if modified
+        shell: bash
         if: ${{ env.POSTMAN_COLLECTION_FILES_UPDATED == 'true' }}
         run: |
-          # Obtain current HEAD commit SHA and use that as base tree SHA for creating a new tree
-          HEAD_COMMIT="$(git rev-parse 'HEAD^{commit}')"
-          UPDATED_TREE_SHA="${HEAD_COMMIT}"
+          git add postman
+          git commit --message 'chore(postman): update Postman collection files'
 
-          # Obtain the flags to be passed to the GitHub CLI.
-          # Each line contains the flags to be used corresponding to the file.
-          lines="$(
-            git ls-files \
-              --format '--raw-field tree[][path]=%(path) --raw-field tree[][mode]=%(objectmode) --raw-field tree[][type]=%(objecttype) --field tree[][content]=@%(path)' \
-              postman/collection-json
-          )"
-
-          # Create a tree based on the HEAD commit of the current branch, using the contents of the updated Postman collections directory
-          while IFS= read -r line; do
-            # Split each line by space to obtain the flags passed to the GitHub CLI as an array
-            IFS=' ' read -ra flags <<< "${line}"
-
-            # Create a tree by updating each collection JSON file.
-            # The SHA of the created tree is used as the base tree SHA for updating the next collection file.
-            UPDATED_TREE_SHA="$(
-              gh api \
-                --method POST \
-                --header 'Accept: application/vnd.github+json' \
-                --header 'X-GitHub-Api-Version: 2022-11-28' \
-                '/repos/{owner}/{repo}/git/trees' \
-                --raw-field base_tree="${UPDATED_TREE_SHA}" \
-                "${flags[@]}" \
-                --jq '.sha'
-            )"
-          done <<< "${lines}"
-
-          # Create a commit to point to the tree with all updated collections
-          NEW_COMMIT_SHA="$(
-            gh api \
-              --method POST \
-              --header 'Accept: application/vnd.github+json' \
-              --header 'X-GitHub-Api-Version: 2022-11-28' \
-              '/repos/{owner}/{repo}/git/commits' \
-              --raw-field "message=chore(postman): update Postman collection files" \
-              --raw-field "parents[]=${HEAD_COMMIT}" \
-              --raw-field "tree=${UPDATED_TREE_SHA}" \
-              --jq '.sha'
-          )"
-
-          # Update the current branch to point to the above created commit.
-          # We disable forced update so that the workflow will fail if the branch has been updated since the workflow started
-          # (for example, new commits were pushed to the branch after the workflow execution started).
-          gh api \
-            --method PATCH \
-            --header 'Accept: application/vnd.github+json' \
-            --header 'X-GitHub-Api-Version: 2022-11-28' \
-            "/repos/{owner}/{repo}/git/refs/heads/${ALLOWED_BRANCH_NAME}" \
-            --raw-field "sha=${NEW_COMMIT_SHA}" \
-            --field 'force=false'
+          git push origin "${ALLOWED_BRANCH_NAME}"
 
   create-nightly-tag:
     name: Create a nightly tag
@@ -147,5 +95,4 @@ jobs:
     needs:
       - update-postman-collections
     secrets:
-      app_id: ${{ secrets.HYPERSWITCH_BOT_APP_ID }}
-      app_private_key: ${{ secrets.HYPERSWITCH_BOT_APP_PRIVATE_KEY }}
+      token: ${{ secrets.AUTO_RELEASE_PAT }}

--- a/.github/workflows/release-nightly-version.yml
+++ b/.github/workflows/release-nightly-version.yml
@@ -80,6 +80,7 @@ jobs:
 
       - name: Set git configuration
         shell: bash
+        if: ${{ env.POSTMAN_COLLECTION_FILES_UPDATED == 'true' }}
         run: |
           git config --local user.name 'github-actions'
           git config --local user.email '41898282+github-actions[bot]@users.noreply.github.com'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,28 +4,6 @@ All notable changes to HyperSwitch will be documented here.
 
 - - -
 
-## 2024.01.10.1
-
-### Features
-
-- **payment_link:** Add status page for payment link ([#3213](https://github.com/juspay/hyperswitch/pull/3213)) ([`50e4d79`](https://github.com/juspay/hyperswitch/commit/50e4d797da31b570b5920b33d77c24a21d9871e2))
-
-### Bug Fixes
-
-- **euclid_wasm:** Update braintree config prod ([#3288](https://github.com/juspay/hyperswitch/pull/3288)) ([`8830563`](https://github.com/juspay/hyperswitch/commit/8830563748ed20c40b7a21a66e9ad9fd02ddcf0e))
-
-### Refactors
-
-- Removed basilisk feature ([#3281](https://github.com/juspay/hyperswitch/pull/3281)) ([`612f8d9`](https://github.com/juspay/hyperswitch/commit/612f8d9d5f5bcba78aa64c3128cc72be0f2860ea))
-
-### Miscellaneous Tasks
-
-- Nits and small code improvements found during investigation of PR#3168 ([#3259](https://github.com/juspay/hyperswitch/pull/3259)) ([`fe3cf54`](https://github.com/juspay/hyperswitch/commit/fe3cf54781302c733c1682ded2c1735544407a5f))
-
-**Full Changelog:** [`2024.01.10.0...2024.01.10.1`](https://github.com/juspay/hyperswitch/compare/2024.01.10.0...2024.01.10.1)
-
-- - -
-
 ## 2024.01.10.0
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to HyperSwitch will be documented here.
 
 - - -
 
+## 2024.01.10.1
+
+### Features
+
+- **payment_link:** Add status page for payment link ([#3213](https://github.com/juspay/hyperswitch/pull/3213)) ([`50e4d79`](https://github.com/juspay/hyperswitch/commit/50e4d797da31b570b5920b33d77c24a21d9871e2))
+
+### Bug Fixes
+
+- **euclid_wasm:** Update braintree config prod ([#3288](https://github.com/juspay/hyperswitch/pull/3288)) ([`8830563`](https://github.com/juspay/hyperswitch/commit/8830563748ed20c40b7a21a66e9ad9fd02ddcf0e))
+
+### Refactors
+
+- Removed basilisk feature ([#3281](https://github.com/juspay/hyperswitch/pull/3281)) ([`612f8d9`](https://github.com/juspay/hyperswitch/commit/612f8d9d5f5bcba78aa64c3128cc72be0f2860ea))
+
+### Miscellaneous Tasks
+
+- Nits and small code improvements found during investigation of PR#3168 ([#3259](https://github.com/juspay/hyperswitch/pull/3259)) ([`fe3cf54`](https://github.com/juspay/hyperswitch/commit/fe3cf54781302c733c1682ded2c1735544407a5f))
+
+**Full Changelog:** [`2024.01.10.0...2024.01.10.1`](https://github.com/juspay/hyperswitch/compare/2024.01.10.0...2024.01.10.1)
+
+- - -
+
 ## 2024.01.10.0
 
 ### Features


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [x] CI/CD

## Description
<!-- Describe your changes in detail -->
This PR updates the nightly release workflows to make use of git commands to push commits and tags, since GitHub's branch protection rules prevent a bot from pushing commits when the merge queue has been enabled.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
This PR fixes failures with using a GitHub app to push to a protected branch when the merge queue has also been enabled. One such failure happened this morning: https://github.com/juspay/hyperswitch/actions/runs/7468465920/job/20323959428

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Temporarily enabled the workflow to run on branch pushes:
https://github.com/juspay/hyperswitch/actions/runs/7475549987/job/20343942382

Screenshot of the tag pushed (that I had to then delete):
![Screenshot of tag 2024.01.10.1 pushed](https://github.com/juspay/hyperswitch/assets/22217505/104418fd-ed36-482b-8adc-7e823995b3b1)

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
