### PR TITLE
chore: remove connector auth TOML files from `.gitignore` and `.dockerignore`

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -261,7 +261,3 @@ result*
 
 # node_modules
 node_modules/
-
-**/connector_auth.toml
-**/sample_auth.toml
-**/auth.toml

--- a/.gitignore
+++ b/.gitignore
@@ -261,7 +261,3 @@ result*
 
 # node_modules
 node_modules/
-
-**/connector_auth.toml
-**/sample_auth.toml
-**/auth.toml

--- a/crates/router/tests/connectors/sample_auth.toml
+++ b/crates/router/tests/connectors/sample_auth.toml
@@ -108,7 +108,7 @@ api_key = "API Key"
 [iatapay]
 key1 = "key1"
 api_key = "api_key"
-api_secret = "secrect"
+api_secret = "secret"
 
 [dummyconnector]
 api_key = "API Key"

--- a/crates/test_utils/tests/sample_auth.toml
+++ b/crates/test_utils/tests/sample_auth.toml
@@ -108,7 +108,7 @@ api_key = "API Key"
 [iatapay]
 key1 = "key1"
 api_key = "api_key"
-api_secret = "secrect"
+api_secret = "secret"
 
 [dummyconnector]
 api_key = "API Key"


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
This PR fixes the `-dirty` suffix appearing in the `x-hyperswitch-version` header, only with Docker image builds but not when running locally.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
As of today, on the `2024.01.11.0` Docker image running on our sandbox environment, we see a `-dirty` suffix in the `x-hyperswitch-version` header:

```shell
$ curl --silent --include https://sandbox.hyperswitch.io/health | grep 'x-hyperswitch-version:'
x-hyperswitch-version: 2024.01.11.0-dirty
```

This PR fixes the working directory being dirty in Docker builds, and thus the `-dirty` suffix appearing in the header.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Built a Docker image locally and ran the built image using the following commands: 
```shell
$ docker build --progress=plain --build-arg BINARY=router --tag router:latest .
$ docker run --rm --publish 8080:8080 --volume ./config:/local/config --env ROUTER__MASTER_DATABASE__HOST=host.docker.internal --env ROUTER__REDIS__HOST=host.docker.internal --env RUN_ENV=development --net=host router:latest
```

And then checked the version header within the container using the command:

```shell
curl --silent --include http://localhost:8080/health | grep 'x-hyperswitch-version:'
```

(The `2024.01.10.3` tag was something I created locally, it does not exist on GitHub.)

![Screenshot of Dokcer container run](https://github.com/juspay/hyperswitch/assets/22217505/b9bda626-f27b-4d07-8143-777ca4a02a0f)

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
