### PR TITLE
refactor(core): add locker config to enable or disable locker for the mandates flow

### DIFF
--- a/config/config.example.toml
+++ b/config/config.example.toml
@@ -131,6 +131,7 @@ host_rs = ""                   # Rust Locker host
 mock_locker = true             # Emulate a locker locally using Postgres
 basilisk_host = ""             # Basilisk host
 locker_signing_key_id = "1"    # Key_id to sign basilisk hs locker
+locker_enabled = false         # Boolean to enable or disable saving cards in locker
 
 [delayed_session_response]
 connectors_with_delayed_session_response = "trustpay,payme" # List of connectors which has delayed session response

--- a/config/development.toml
+++ b/config/development.toml
@@ -69,6 +69,8 @@ host = ""
 host_rs = ""
 mock_locker = true
 basilisk_host = ""
+locker_enabled= false
+
 
 [forex_api]
 call_delay = 21600

--- a/config/docker_compose.toml
+++ b/config/docker_compose.toml
@@ -56,6 +56,7 @@ host = ""
 host_rs = ""
 mock_locker = true
 basilisk_host = ""
+locker_enabled = false
 
 [jwekey]
 vault_encryption_key = ""

--- a/crates/api_models/src/payment_methods.rs
+++ b/crates/api_models/src/payment_methods.rs
@@ -164,6 +164,10 @@ pub struct CardDetailsPaymentMethod {
     pub expiry_year: Option<masking::Secret<String>>,
     pub nick_name: Option<masking::Secret<String>>,
     pub card_holder_name: Option<masking::Secret<String>>,
+    pub card_isin: Option<String>,
+    pub card_issuer: Option<String>,
+    pub card_network: Option<api_enums::CardNetwork>,
+    pub card_type: Option<String>,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -214,6 +218,13 @@ pub struct CardDetailFromLocker {
 
     #[schema(value_type=Option<String>)]
     pub nick_name: Option<masking::Secret<String>>,
+
+    pub card_isin: Option<String>,
+
+    pub card_issuer: Option<String>,
+
+    pub card_network: Option<api_enums::CardNetwork>,
+    pub card_type: Option<String>,
 }
 
 impl From<CardDetailsPaymentMethod> for CardDetailFromLocker {
@@ -229,6 +240,10 @@ impl From<CardDetailsPaymentMethod> for CardDetailFromLocker {
             card_holder_name: item.card_holder_name,
             card_fingerprint: None,
             nick_name: item.nick_name,
+            card_isin: item.card_isin,
+            card_issuer: item.card_issuer,
+            card_network: item.card_network,
+            card_type: item.card_type,
         }
     }
 }
@@ -242,6 +257,10 @@ impl From<CardDetailFromLocker> for CardDetailsPaymentMethod {
             expiry_year: item.expiry_year,
             nick_name: item.nick_name,
             card_holder_name: item.card_holder_name,
+            card_isin: item.card_isin,
+            card_issuer: item.card_issuer,
+            card_network: item.card_network,
+            card_type: item.card_type,
         }
     }
 }

--- a/crates/router/src/configs/defaults.rs
+++ b/crates/router/src/configs/defaults.rs
@@ -54,6 +54,8 @@ impl Default for super::settings::Locker {
             mock_locker: true,
             basilisk_host: "localhost".into(),
             locker_signing_key_id: "1".into(),
+            //true or false
+            locker_enabled: true,
         }
     }
 }

--- a/crates/router/src/configs/settings.rs
+++ b/crates/router/src/configs/settings.rs
@@ -481,6 +481,7 @@ pub struct Locker {
     pub mock_locker: bool,
     pub basilisk_host: String,
     pub locker_signing_key_id: String,
+    pub locker_enabled: bool,
 }
 
 #[derive(Debug, Deserialize, Clone)]

--- a/crates/router/src/core/payment_methods/cards.rs
+++ b/crates/router/src/core/payment_methods/cards.rs
@@ -456,12 +456,62 @@ pub async fn add_card_hs(
     let store_card_payload =
         call_to_locker_hs(state, &payload, &customer_id, locker_choice).await?;
 
+    //fetch card_bin from db
+
+    let mut card_number = card.card_number.peek().to_owned();
+    let card_isin = req.card.clone().map(|c| c.card_number.get_card_isin());
+    let card = card.clone();
+    let card_detail = card_isin
+        .clone()
+        .async_and_then(|card_isin| async move {
+            state
+                .store
+                .get_card_info(&card_isin)
+                .await
+                .map_err(|error| services::logger::warn!(card_info_error=?error))
+                .ok()
+        })
+        .await
+        .flatten()
+        .map(|card_info| api::CardDetailFromLocker {
+            scheme: None,
+            last4_digits: Some(card_number.split_off(card_number.len() - 4)),
+            issuer_country: None, // [#256] bin mapping
+            card_number: Some(card.card_number.clone()),
+            expiry_month: Some(card.card_exp_month.clone()),
+            expiry_year: Some(card.card_exp_year.clone()),
+            card_token: None,       // [#256]
+            card_fingerprint: None, // fingerprint not send by basilisk-hs need to have this feature in case we need it in future
+            card_holder_name: card.card_holder_name.clone(),
+            nick_name: card.nick_name.clone(),
+            card_isin: card_isin.clone(),
+            card_issuer: card_info.card_issuer,
+            card_network: card_info.card_network,
+            card_type: card_info.card_type,
+        })
+        .unwrap_or(api::CardDetailFromLocker {
+            scheme: None,
+            issuer_country: None,
+            last4_digits: Some(card_number.split_off(card_number.len() - 4)),
+            card_number: Some(card.card_number),
+            expiry_month: Some(card.card_exp_month.clone()),
+            expiry_year: Some(card.card_exp_year),
+            card_token: None,
+            card_holder_name: card.card_holder_name,
+            card_fingerprint: None,
+            nick_name: card.nick_name,
+            card_isin: card_isin.clone(),
+            card_issuer: None,
+            card_network: None,
+            card_type: None,
+        });
     let payment_method_resp = payment_methods::mk_add_card_response_hs(
-        card.clone(),
+        Some(card_detail),
         store_card_payload.card_reference,
         req,
         &merchant_account.merchant_id,
     );
+
     Ok((
         payment_method_resp,
         store_card_payload.duplicate.unwrap_or(false),
@@ -2594,7 +2644,7 @@ pub async fn list_customer_payment_method(
     Ok(services::ApplicationResponse::Json(response))
 }
 
-async fn get_card_details(
+pub async fn get_card_details(
     pm: &payment_method::PaymentMethod,
     key: &[u8],
     state: &routes::AppState,

--- a/crates/router/src/core/payment_methods/transformers.rs
+++ b/crates/router/src/core/payment_methods/transformers.rs
@@ -325,31 +325,18 @@ pub async fn mk_add_locker_request_hs<'a>(
 }
 
 pub fn mk_add_card_response_hs(
-    card: api::CardDetail,
+    card: Option<api::CardDetailFromLocker>,
     card_reference: String,
     req: api::PaymentMethodCreate,
     merchant_id: &str,
 ) -> api::PaymentMethodResponse {
-    let mut card_number = card.card_number.peek().to_owned();
-    let card = api::CardDetailFromLocker {
-        scheme: None,
-        last4_digits: Some(card_number.split_off(card_number.len() - 4)),
-        issuer_country: None, // [#256] bin mapping
-        card_number: Some(card.card_number),
-        expiry_month: Some(card.card_exp_month),
-        expiry_year: Some(card.card_exp_year),
-        card_token: None,       // [#256]
-        card_fingerprint: None, // fingerprint not send by basilisk-hs need to have this feature in case we need it in future
-        card_holder_name: card.card_holder_name,
-        nick_name: card.nick_name,
-    };
     api::PaymentMethodResponse {
         merchant_id: merchant_id.to_owned(),
         customer_id: req.customer_id,
         payment_method_id: card_reference,
         payment_method: req.payment_method,
         payment_method_type: req.payment_method_type,
-        card: Some(card),
+        card,
         metadata: req.metadata,
         created: Some(common_utils::date_time::now()),
         recurring_enabled: false,           // [#256]
@@ -376,6 +363,10 @@ pub fn mk_add_card_response(
         card_fingerprint: Some(response.card_fingerprint),
         card_holder_name: card.card_holder_name,
         nick_name: card.nick_name,
+        card_isin: None,
+        card_issuer: None,
+        card_network: None,
+        card_type: None,
     };
     api::PaymentMethodResponse {
         merchant_id: merchant_id.to_owned(),
@@ -573,6 +564,7 @@ pub fn get_card_detail(
 ) -> CustomResult<api::CardDetailFromLocker, errors::VaultError> {
     let card_number = response.card_number;
     let mut last4_digits = card_number.peek().to_owned();
+    //fetch form card bin or a seperate flow for manadates retrieve
     let card_detail = api::CardDetailFromLocker {
         scheme: pm.scheme.to_owned(),
         issuer_country: pm.issuer_country.clone(),
@@ -584,6 +576,10 @@ pub fn get_card_detail(
         card_fingerprint: None,
         card_holder_name: response.name_on_card,
         nick_name: response.nick_name.map(masking::Secret::new),
+        card_isin: None,
+        card_issuer: None,
+        card_network: None,
+        card_type: None,
     };
     Ok(card_detail)
 }

--- a/crates/router/src/core/payments/flows/authorize_flow.rs
+++ b/crates/router/src/core/payments/flows/authorize_flow.rs
@@ -91,8 +91,10 @@ impl Feature<api::Authorize, types::PaymentsAuthorizeData> for types::PaymentsAu
             .to_payment_failed_response()?;
 
             metrics::PAYMENT_COUNT.add(&metrics::CONTEXT, 1, &[]); // Metrics
+                                                                   //call 1
+            let is_mandate = resp.request.setup_mandate_details.clone().is_some();
 
-            if resp.request.setup_mandate_details.clone().is_some() {
+            if is_mandate {
                 let payment_method_id = Box::pin(tokenization::save_payment_method(
                     state,
                     connector,
@@ -101,6 +103,7 @@ impl Feature<api::Authorize, types::PaymentsAuthorizeData> for types::PaymentsAu
                     merchant_account,
                     self.request.payment_method_type,
                     key_store,
+                    is_mandate,
                 ))
                 .await?;
                 Ok(mandate::mandate_procedure(
@@ -132,6 +135,7 @@ impl Feature<api::Authorize, types::PaymentsAuthorizeData> for types::PaymentsAu
                         &merchant_account,
                         self.request.payment_method_type,
                         &key_store,
+                        is_mandate,
                     ))
                     .await;
 

--- a/crates/router/src/core/payments/flows/setup_mandate_flow.rs
+++ b/crates/router/src/core/payments/flows/setup_mandate_flow.rs
@@ -74,6 +74,8 @@ impl Feature<api::SetupMandate, types::SetupMandateRequestData> for types::Setup
         )
         .await
         .to_setup_mandate_failed_response()?;
+        //in setup_mandate we call this check when (call 3)
+        let is_mandate = resp.request.setup_mandate_details.clone().is_some();
 
         let pm_id = Box::pin(tokenization::save_payment_method(
             state,
@@ -83,6 +85,7 @@ impl Feature<api::SetupMandate, types::SetupMandateRequestData> for types::Setup
             merchant_account,
             self.request.payment_method_type,
             key_store,
+            is_mandate,
         ))
         .await?;
 
@@ -178,6 +181,7 @@ impl TryFrom<types::SetupMandateRequestData> for types::ConnectorCustomerData {
 }
 
 #[allow(clippy::too_many_arguments)]
+
 impl types::SetupMandateRouterData {
     pub async fn decide_flow<'a, 'b>(
         &'b self,
@@ -206,8 +210,10 @@ impl types::SetupMandateRouterData {
                 )
                 .await
                 .to_setup_mandate_failed_response()?;
+                let is_mandate = resp.request.setup_mandate_details.clone().is_some();
 
                 let payment_method_type = self.request.payment_method_type;
+                //in setup flow no call is being made to this fn
                 let pm_id = Box::pin(tokenization::save_payment_method(
                     state,
                     connector,
@@ -216,6 +222,7 @@ impl types::SetupMandateRouterData {
                     merchant_account,
                     payment_method_type,
                     key_store,
+                    is_mandate,
                 ))
                 .await?;
 

--- a/crates/router/src/core/payouts/helpers.rs
+++ b/crates/router/src/core/payouts/helpers.rs
@@ -1,4 +1,7 @@
-use common_utils::{errors::CustomResult, ext_traits::ValueExt};
+use common_utils::{
+    errors::CustomResult,
+    ext_traits::{AsyncExt, ValueExt},
+};
 use diesel_models::encryption::Encryption;
 use error_stack::{IntoReport, ResultExt};
 use masking::{ExposeInterface, PeekInterface, Secret};
@@ -16,6 +19,7 @@ use crate::{
     },
     db::StorageInterface,
     routes::AppState,
+    services,
     types::{
         api::{self, enums as api_enums},
         domain::{
@@ -220,20 +224,60 @@ pub async fn save_payout_data_to_locker(
     .change_context(errors::ApiErrorResponse::InternalServerError)
     .attach_printable("Error updating payouts in saved payout method")?;
 
-    let pm_data = api::payment_methods::PaymentMethodsData::Card(
-        api::payment_methods::CardDetailsPaymentMethod {
-            last4_digits: card_details
-                .as_ref()
-                .map(|c| c.card_number.clone().get_last4()),
-            issuer_country: None,
-            expiry_month: card_details.as_ref().map(|c| c.card_exp_month.clone()),
-            expiry_year: card_details.as_ref().map(|c| c.card_exp_year.clone()),
-            nick_name: card_details.as_ref().and_then(|c| c.nick_name.clone()),
-            card_holder_name: card_details
-                .as_ref()
-                .and_then(|c| c.card_holder_name.clone()),
-        },
-    );
+    let card_isin = card_details
+        .as_ref()
+        .map(|c| c.card_number.clone().get_card_isin());
+
+    let pm_data = card_isin
+        .clone()
+        .async_and_then(|card_isin| async move {
+            db.get_card_info(&card_isin)
+                .await
+                .map_err(|error| services::logger::warn!(card_info_error=?error))
+                .ok()
+        })
+        .await
+        .flatten()
+        .map(|card_info| {
+            api::payment_methods::PaymentMethodsData::Card(
+                api::payment_methods::CardDetailsPaymentMethod {
+                    last4_digits: card_details
+                        .as_ref()
+                        .map(|c| c.card_number.clone().get_last4()),
+                    issuer_country: card_info.card_issuing_country,
+                    expiry_month: card_details.as_ref().map(|c| c.card_exp_month.clone()),
+                    expiry_year: card_details.as_ref().map(|c| c.card_exp_year.clone()),
+                    nick_name: card_details.as_ref().and_then(|c| c.nick_name.clone()),
+                    card_holder_name: card_details
+                        .as_ref()
+                        .and_then(|c| c.card_holder_name.clone()),
+
+                    card_isin: card_isin.clone(),
+                    card_issuer: card_info.card_issuer,
+                    card_network: card_info.card_network,
+                    card_type: card_info.card_type,
+                },
+            )
+        })
+        .unwrap_or(api::payment_methods::PaymentMethodsData::Card(
+            api::payment_methods::CardDetailsPaymentMethod {
+                last4_digits: card_details
+                    .as_ref()
+                    .map(|c| c.card_number.clone().get_last4()),
+                issuer_country: None,
+                expiry_month: card_details.as_ref().map(|c| c.card_exp_month.clone()),
+                expiry_year: card_details.as_ref().map(|c| c.card_exp_year.clone()),
+                nick_name: card_details.as_ref().and_then(|c| c.nick_name.clone()),
+                card_holder_name: card_details
+                    .as_ref()
+                    .and_then(|c| c.card_holder_name.clone()),
+
+                card_isin: card_isin.clone(),
+                card_issuer: None,
+                card_network: None,
+                card_type: None,
+            },
+        ));
 
     let card_details_encrypted =
         cards::create_encrypted_payment_method_data(key_store, Some(pm_data)).await;

--- a/crates/router/src/types/api/mandates.rs
+++ b/crates/router/src/types/api/mandates.rs
@@ -36,6 +36,7 @@ impl MandateResponseExt for MandateResponse {
             .to_not_found_response(errors::ApiErrorResponse::PaymentMethodNotFound)?;
 
         let card = if payment_method.payment_method == storage_enums::PaymentMethod::Card {
+            //if not from locker then decrypt the pmt data and get it , key in key_store
             let card = payment_methods::cards::get_card_from_locker(
                 state,
                 &payment_method.customer_id,
@@ -43,6 +44,7 @@ impl MandateResponseExt for MandateResponse {
                 &payment_method.payment_method_id,
             )
             .await?;
+
             let card_detail = payment_methods::transformers::get_card_detail(&payment_method, card)
                 .change_context(errors::ApiErrorResponse::InternalServerError)
                 .attach_printable("Failed while getting card details")?;

--- a/loadtest/config/development.toml
+++ b/loadtest/config/development.toml
@@ -33,6 +33,7 @@ host = ""
 host_rs = ""
 mock_locker = true
 basilisk_host = ""
+locker_enabled = false
 
 [forex_api]
 call_delay = 21600


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
add locker config to enable or disable locker , so that if the locker is enabled we can store the card_details in the locker else if the config is disabled we don't 

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?

- Create an MA & MCA

- Disable the `locker_enabled` config

> Create  a Mandate payment , the details will not be stored in Locker and payment will be successful 
> List PaymentMethods for a Customer 
> List the Mandates

- Enable the `locker_enabled` config

> Create  a Mandate payment , the details will be stored in Locker and payment will be successful 
> List PaymentMethods for a Customer 
> List the Mandates

- For the Normal Payments , the card_details will always be stored in the locker


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
