### PR TITLE
chore(kv): add metrics while pushing to stream

### DIFF
--- a/crates/storage_impl/src/lib.rs
+++ b/crates/storage_impl/src/lib.rs
@@ -225,6 +225,11 @@ impl<T: DatabaseStore> KVRouterStore<T> {
                     .change_context(RedisError::JsonSerializationFailed)?,
             )
             .await
+            .map(|_| metrics::KV_PUSHED_TO_DRAINER.add(&metrics::CONTEXT, 1, &[]))
+            .map_err(|err| {
+                metrics::KV_FAILED_TO_PUSH_TO_DRAINER.add(&metrics::CONTEXT, 1, &[]);
+                err
+            })
             .change_context(RedisError::StreamAppendFailed)
     }
 }

--- a/crates/storage_impl/src/metrics.rs
+++ b/crates/storage_impl/src/metrics.rs
@@ -8,3 +8,5 @@ counter_metric!(KV_MISS, GLOBAL_METER); // No. of KV misses
 // Metrics for KV
 counter_metric!(KV_OPERATION_SUCCESSFUL, GLOBAL_METER);
 counter_metric!(KV_OPERATION_FAILED, GLOBAL_METER);
+counter_metric!(KV_PUSHED_TO_DRAINER, GLOBAL_METER);
+counter_metric!(KV_FAILED_TO_PUSH_TO_DRAINER, GLOBAL_METER);


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->
- [x] Enhancement

## Description
<!-- Describe your changes in detail -->
Add a metric to indicate data was pushed to drainer

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
Add a proper metrics to indicate data was pushed/failed while pushing to drainer

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
NA

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code