### PR TITLE
refactor(connector): [Volt] Refactor Payments and Refunds Webhooks

### DIFF
--- a/crates/router/src/connector/volt/transformers.rs
+++ b/crates/router/src/connector/volt/transformers.rs
@@ -46,7 +46,6 @@ pub mod webhook_headers {
     pub const X_VOLT_SIGNED: &str = "X-Volt-Signed";
     pub const X_VOLT_TIMED: &str = "X-Volt-Timed";
     pub const USER_AGENT: &str = "User-Agent";
-    pub const X_VOLT_TYPE: &str = "X-Volt-Type";
 }
 
 #[derive(Debug, Serialize)]
@@ -486,6 +485,14 @@ pub struct VoltPaymentWebhookBodyReference {
 pub struct VoltRefundWebhookBodyReference {
     pub refund: String,
     pub external_reference: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+#[serde(untagged)]
+pub enum WebhookResponse {
+    Refund(VoltRefundWebhookBodyReference),
+    Payment(VoltPaymentWebhookBodyReference),
 }
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/crates/router/src/connector/volt/transformers.rs
+++ b/crates/router/src/connector/volt/transformers.rs
@@ -491,6 +491,7 @@ pub struct VoltRefundWebhookBodyReference {
 #[serde(rename_all = "camelCase")]
 #[serde(untagged)]
 pub enum WebhookResponse {
+    // the enum order shouldn't be changed as this is being used during serialization and deserialization
     Refund(VoltRefundWebhookBodyReference),
     Payment(VoltPaymentWebhookBodyReference),
 }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<img width="1202" alt="Screenshot 2024-01-18 at 2 04 44 AM" src="https://github.com/juspay/hyperswitch/assets/85639103/b778cefc-d9c8-4e8e-850a-46b71c91c96b">

Make a payment and do refund , Check for webhooks in Volt dashboard under transactions.  
Then for Notifications check for all webhooks, In All the 4 notifications `PENDING ` , `COMPLETED`, `RECEIVED` and `REFUND_CONFIRMED ` should have status `Delivered` and http code `200 OK`. 

Paymnet Request Body
`{
    "amount": 1178,
    "currency": "EUR",
    "confirm": true,
      "capture_method": "automatic",
      "capture_on": "2022-09-10T10:11:12Z",
      "amount_to_capture": 1178,
    "customer_id": "StripeCustomer",
    "email": "guest@example.com",
    "name": "John Doe",
    "phone": "999999999",
    "phone_country_code": "+1",
    "description": "Its my first payment request",
      "authentication_type": "no_three_ds",
    "return_url": "https://google.com",
    "payment_method": "bank_redirect",
    "payment_method_type": "open_banking_uk",
    "payment_method_data": {
        "bank_redirect": {
            "open_banking_uk": {
            }
        }
    },
    "billing": {
        "address": {
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "city": "San Fransico",
            "state": "California",
            "zip": "94122",
            "country": "DE",
            "first_name": "joseph",
            "last_name": "Doe"
        },
        "phone": {
            "number": "8056594427",
            "country_code": "+91"
        }
    },
    "shipping": {
        "address": {
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "city": "San Fransico",
            "state": "California",
            "zip": "94122",
            "country": "DE",
            "first_name": "joseph",
            "last_name": "Doe"
        },
        "phone": {
            "number": "8056594427",
            "country_code": "+91"
        }
    },
    "statement_descriptor_name": "joseph",
    "statement_descriptor_suffix": "JS",
    "metadata": {
        "udf1": "value1",
        "new_customer": "true",
        "login_date": "2019-09-10T10:11:12Z"
    },
    "business_label": "food",
    "business_country": "US"
}`

Refund Request Body
`{
  "payment_id": "pay_7yr2vANT2GL9JeBdezUJ",
  "amount": 1178,
  "reason": "Customer returned",
  "refund_type": "instant",
  "metadata": {
    "udf1": "value1",
    "new_customer": "true",
    "login_date": "2019-09-10T10:11:12Z"
  }
}`



## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
