### PR TITLE
refactor(core): send `customer_name`to connectors when creating customer

### DIFF
--- a/crates/router/src/connector/stax/transformers.rs
+++ b/crates/router/src/connector/stax/transformers.rs
@@ -147,7 +147,7 @@ pub struct StaxCustomerRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     email: Option<Email>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    firstname: Option<String>,
+    firstname: Option<Secret<String>>,
 }
 
 impl TryFrom<&types::ConnectorCustomerRouterData> for StaxCustomerRequest {

--- a/crates/router/src/connector/stripe/transformers.rs
+++ b/crates/router/src/connector/stripe/transformers.rs
@@ -2018,7 +2018,7 @@ impl TryFrom<&types::ConnectorCustomerRouterData> for CustomerRequest {
             description: item.request.description.to_owned(),
             email: item.request.email.to_owned(),
             phone: item.request.phone.to_owned(),
-            name: item.request.name.to_owned().map(Secret::new),
+            name: item.request.name.to_owned(),
             source: item.request.preprocessing_id.to_owned(),
         })
     }

--- a/crates/router/src/core/payments/flows/authorize_flow.rs
+++ b/crates/router/src/core/payments/flows/authorize_flow.rs
@@ -374,7 +374,7 @@ impl<F> TryFrom<&types::RouterData<F, types::PaymentsAuthorizeData, types::Payme
             payment_method_data: data.request.payment_method_data.clone(),
             description: None,
             phone: None,
-            name: None,
+            name: data.request.customer_name.clone(),
             preprocessing_id: data.preprocessing_id.clone(),
         })
     }

--- a/crates/router/src/core/payments/transformers.rs
+++ b/crates/router/src/core/payments/transformers.rs
@@ -34,7 +34,7 @@ pub async fn construct_payment_router_data<'a, F, T>(
     connector_id: &str,
     merchant_account: &domain::MerchantAccount,
     _key_store: &domain::MerchantKeyStore,
-    customer: &Option<domain::Customer>,
+    customer: &'a Option<domain::Customer>,
     merchant_connector_account: &helpers::MerchantConnectorAccountType,
 ) -> RouterResult<types::RouterData<F, T, types::PaymentsResponseData>>
 where
@@ -89,6 +89,7 @@ where
         connector_name: connector_id.to_string(),
         payment_data: payment_data.clone(),
         state,
+        customer_data: customer,
     };
 
     let customer_id = customer.to_owned().map(|customer| customer.customer_id);
@@ -968,6 +969,7 @@ where
     connector_name: String,
     payment_data: PaymentData<F>,
     state: &'a AppState,
+    customer_data: &'a Option<domain::Customer>,
 }
 impl<F: Clone> TryFrom<PaymentAdditionalData<'_, F>> for types::PaymentsAuthorizeData {
     type Error = error_stack::Report<errors::ApiErrorResponse>;
@@ -1048,6 +1050,17 @@ impl<F: Clone> TryFrom<PaymentAdditionalData<'_, F>> for types::PaymentsAuthoriz
             .as_ref()
             .map(|surcharge_details| surcharge_details.final_amount)
             .unwrap_or(payment_data.amount.into());
+
+        let customer_name = additional_data
+            .customer_data
+            .as_ref()
+            .and_then(|customer_data| {
+                customer_data
+                    .name
+                    .as_ref()
+                    .map(|customer| customer.clone().into_inner())
+            });
+
         Ok(Self {
             payment_method_data: payment_method_data.get_required_value("payment_method_data")?,
             setup_future_usage: payment_data.payment_intent.setup_future_usage,
@@ -1062,6 +1075,7 @@ impl<F: Clone> TryFrom<PaymentAdditionalData<'_, F>> for types::PaymentsAuthoriz
             currency: payment_data.currency,
             browser_info,
             email: payment_data.email,
+            customer_name,
             payment_experience: payment_data.payment_attempt.payment_experience,
             order_details,
             order_category,
@@ -1354,6 +1368,17 @@ impl<F: Clone> TryFrom<PaymentAdditionalData<'_, F>> for types::SetupMandateRequ
             .change_context(errors::ApiErrorResponse::InvalidDataValue {
                 field_name: "browser_info",
             })?;
+
+        let customer_name = additional_data
+            .customer_data
+            .as_ref()
+            .and_then(|customer_data| {
+                customer_data
+                    .name
+                    .as_ref()
+                    .map(|customer| customer.clone().into_inner())
+            });
+
         Ok(Self {
             currency: payment_data.currency,
             confirm: true,
@@ -1368,6 +1393,7 @@ impl<F: Clone> TryFrom<PaymentAdditionalData<'_, F>> for types::SetupMandateRequ
             setup_mandate_details: payment_data.setup_mandate,
             router_return_url,
             email: payment_data.email,
+            customer_name,
             return_url: payment_data.payment_intent.return_url,
             browser_info,
             payment_method_type: attempt.payment_method_type,

--- a/crates/router/src/types.rs
+++ b/crates/router/src/types.rs
@@ -392,6 +392,7 @@ pub struct PaymentsAuthorizeData {
     /// ```
     pub amount: i64,
     pub email: Option<Email>,
+    pub customer_name: Option<Secret<String>>,
     pub currency: storage_enums::Currency,
     pub confirm: bool,
     pub statement_descriptor_suffix: Option<String>,
@@ -461,7 +462,7 @@ pub struct ConnectorCustomerData {
     pub description: Option<String>,
     pub email: Option<Email>,
     pub phone: Option<Secret<String>>,
-    pub name: Option<String>,
+    pub name: Option<Secret<String>>,
     pub preprocessing_id: Option<String>,
     pub payment_method_data: payments::PaymentMethodData,
 }
@@ -586,6 +587,7 @@ pub struct SetupMandateRequestData {
     pub router_return_url: Option<String>,
     pub browser_info: Option<BrowserInformation>,
     pub email: Option<Email>,
+    pub customer_name: Option<Secret<String>>,
     pub return_url: Option<String>,
     pub payment_method_type: Option<storage_enums::PaymentMethodType>,
     pub request_incremental_authorization: bool,
@@ -1342,19 +1344,6 @@ impl From<&&mut PaymentsAuthorizeRouterData> for AuthorizeSessionTokenData {
     }
 }
 
-impl From<&&mut PaymentsAuthorizeRouterData> for ConnectorCustomerData {
-    fn from(data: &&mut PaymentsAuthorizeRouterData) -> Self {
-        Self {
-            email: data.request.email.to_owned(),
-            preprocessing_id: data.preprocessing_id.to_owned(),
-            payment_method_data: data.request.payment_method_data.to_owned(),
-            description: None,
-            phone: None,
-            name: None,
-        }
-    }
-}
-
 impl<F> From<&RouterData<F, PaymentsAuthorizeData, PaymentsResponseData>>
     for PaymentMethodTokenizationData
 {
@@ -1411,6 +1400,7 @@ impl From<&SetupMandateRouterData> for PaymentsAuthorizeData {
             setup_mandate_details: data.request.setup_mandate_details.clone(),
             router_return_url: data.request.router_return_url.clone(),
             email: data.request.email.clone(),
+            customer_name: data.request.customer_name.clone(),
             amount: 0,
             statement_descriptor: None,
             capture_method: None,

--- a/crates/router/src/types/api/verify_connector.rs
+++ b/crates/router/src/types/api/verify_connector.rs
@@ -24,6 +24,7 @@ impl VerifyConnectorData {
         types::PaymentsAuthorizeData {
             payment_method_data: api::PaymentMethodData::Card(self.card_details.clone()),
             email: None,
+            customer_name: None,
             amount: 1000,
             confirm: true,
             currency: storage_enums::Currency::USD,


### PR DESCRIPTION
…t connector end

## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Refactoring

## Description
<!-- Describe your changes in detail -->
This PR adds the support for sending `customer_name` to the connectors when creating the customer at the connectors end. 

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
Passing customer name to the connector might be required for metadata scanning to evaluate the payment score and risk associated with a payment.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
- Create a payment, with customer id, email and customer name.
- Check the customer name at stripe dashboard.
<img width="507" alt="image" src="https://github.com/juspay/hyperswitch/assets/48803246/9df093e0-a66b-41ce-82c0-1b5567d7b4e2">


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
