### PR TITLE
feat(core): Add outgoing webhook for manual `partial_capture` events

### DIFF
--- a/crates/router/src/utils.rs
+++ b/crates/router/src/utils.rs
@@ -51,7 +51,7 @@ use crate::{
             types::{encrypt_optional, AsyncLift},
         },
         storage,
-        transformers::{ForeignTryFrom, ForeignTryInto},
+        transformers::ForeignFrom,
     },
 };
 
@@ -681,23 +681,6 @@ pub fn add_apple_pay_payment_status_metrics(
     }
 }
 
-impl ForeignTryFrom<enums::IntentStatus> for enums::EventType {
-    type Error = errors::ValidationError;
-
-    fn foreign_try_from(value: enums::IntentStatus) -> Result<Self, Self::Error> {
-        match value {
-            enums::IntentStatus::Succeeded => Ok(Self::PaymentSucceeded),
-            enums::IntentStatus::Failed => Ok(Self::PaymentFailed),
-            enums::IntentStatus::Processing => Ok(Self::PaymentProcessing),
-            enums::IntentStatus::RequiresMerchantAction
-            | enums::IntentStatus::RequiresCustomerAction => Ok(Self::ActionRequired),
-            _ => Err(errors::ValidationError::IncorrectValueProvided {
-                field_name: "intent_status",
-            }),
-        }
-    }
-}
-
 pub async fn trigger_payments_webhook<F, Req, Op>(
     merchant_account: domain::MerchantAccount,
     business_profile: diesel_models::business_profile::BusinessProfile,
@@ -726,7 +709,10 @@ where
 
     if matches!(
         status,
-        enums::IntentStatus::Succeeded | enums::IntentStatus::Failed
+        enums::IntentStatus::Succeeded
+            | enums::IntentStatus::Failed
+            | enums::IntentStatus::PartiallyCaptured
+            | enums::IntentStatus::RequiresCapture
     ) {
         let payments_response = crate::core::payments::transformers::payments_to_payments_response(
             req,
@@ -742,11 +728,7 @@ where
             None,
         )?;
 
-        let event_type: enums::EventType = status
-            .foreign_try_into()
-            .into_report()
-            .change_context(errors::ApiErrorResponse::WebhookProcessingFailure)
-            .attach_printable("payment event type mapping failed")?;
+        let event_type = ForeignFrom::foreign_from(status);
 
         if let services::ApplicationResponse::JsonWithHeaders((payments_response_json, _)) =
             payments_response
@@ -755,27 +737,34 @@ where
             // This spawns this futures in a background thread, the exception inside this future won't affect
             // the current thread and the lifecycle of spawn thread is not handled by runtime.
             // So when server shutdown won't wait for this thread's completion.
-            tokio::spawn(
-                async move {
-                    Box::pin(
-                        webhooks_core::create_event_and_trigger_appropriate_outgoing_webhook(
-                            m_state,
-                            merchant_account,
-                            business_profile,
-                            event_type,
-                            diesel_models::enums::EventClass::Payments,
-                            None,
-                            payment_id,
-                            diesel_models::enums::EventObjectType::PaymentDetails,
-                            webhooks::OutgoingWebhookContent::PaymentDetails(
-                                payments_response_json,
+
+            if let Some(event_type) = event_type {
+                tokio::spawn(
+                    async move {
+                        Box::pin(
+                            webhooks_core::create_event_and_trigger_appropriate_outgoing_webhook(
+                                m_state,
+                                merchant_account,
+                                business_profile,
+                                event_type,
+                                diesel_models::enums::EventClass::Payments,
+                                None,
+                                payment_id,
+                                diesel_models::enums::EventObjectType::PaymentDetails,
+                                webhooks::OutgoingWebhookContent::PaymentDetails(
+                                    payments_response_json,
+                                ),
                             ),
-                        ),
-                    )
-                    .await
-                }
-                .in_current_span(),
-            );
+                        )
+                        .await
+                    }
+                    .in_current_span(),
+                );
+            } else {
+                logger::warn!(
+                    "Outgoing webhook not sent because of missing event type status mapping"
+                );
+            }
         }
     }
 

--- a/crates/router/src/utils.rs
+++ b/crates/router/src/utils.rs
@@ -712,7 +712,6 @@ where
         enums::IntentStatus::Succeeded
             | enums::IntentStatus::Failed
             | enums::IntentStatus::PartiallyCaptured
-            | enums::IntentStatus::RequiresCapture
     ) {
         let payments_response = crate::core::payments::transformers::payments_to_payments_response(
             req,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Outgoing webhooks were not being triggered for Partial Capture status for Payment Sync and Process Tracker.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Tested through postman:
Steps to test:
- Create a merchant account and update the webhook endpoint where you want to send the webhooks with it
```
{
    "merchant_id": "merchant_{{$timestamp}}",
    "locker_id": "m0010",
    "merchant_name": "NewAge Retailer",
    "merchant_details": {
        "primary_contact_person": "John Test",
        "primary_email": "JohnTest@test.com",
        "primary_phone": "sunt laborum",
        "secondary_contact_person": "John Test2",
        "secondary_email": "JohnTest2@test.com",
        "secondary_phone": "cillum do dolor id",
        "website": "www.example.com",
        "about_business": "Online Retail with a wide selection of organic products for North America",
        "address": {
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "city": "San Fransico",
            "state": "California",
            "zip": "94122",
            "country": "US"
        }
    },
    "return_url": "https://google.com/success",
    "webhook_details": {
        "webhook_version": "1.0.1",
        "webhook_username": "ekart_retail",
        "webhook_password": "password_ekart@123",
        "payment_created_enabled": true,
        "payment_succeeded_enabled": true,
        "payment_failed_enabled": true,
        "webhook_url": "{{webhook_url}}"
    },
    "routing_algorithm": {
        "type": "single",
        "data": "nmi"
    },
    "sub_merchants_enabled": false,
    "metadata": {
        "city": "NY",
        "unit": "245"
    },
    "primary_business_details": [
        {
            "country": "US",
            "business": "default"
        }
    ]
}
```

- Create a payment connector(NMI for example):
- Create a payment with capture as manual:
```
{
    "amount": 14019,
    "currency": "USD",
    "confirm": true,
    "amount_to_capture": 14019,
    "capture_method": "manual",
    "capture_on": "2022-09-10T10:11:12Z",
    "customer_id": "StripeCustomer",
    "email": "abcdef123@gmail.com",
    "name": "John Doe",
    "phone": "999999999",
    "phone_country_code": "+65",
    "description": "Its my first payment request",
    "authentication_type": "no_three_ds",
    "return_url": "https://google.com",
    "setup_future_usage": "off_session",
    "billing": {
        "address": {
            "first_name": "Sakil",
            "last_name": "Mostak",
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "city": "San Fransico",
            "state": "California",
            "zip": "94122",
            "country": "US"
        }
    },
    "browser_info": {
        "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Safari/537.36",
        "accept_header": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8",
        "language": "nl-NL",
        "color_depth": 24,
        "screen_height": 723,
        "screen_width": 1536,
        "time_zone": 0,
        "java_enabled": true,
        "java_script_enabled": true,
        "ip_address": "127.0.0.1"
    },
    "shipping": {
        "address": {
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "city": "San Fransico",
            "state": "California",
            "zip": "94122",
            "country": "US",
            "first_name": "John",
            "last_name": "Doe"
        }
    },
    "routing": {
        "type": "single",
        "data": "nmi"
    },
    "statement_descriptor_name": "joseph",
    "statement_descriptor_suffix": "JS",
    "metadata": {
        "udf1": "value1",
        "new_customer": "true",
        "login_date": "2019-09-10T10:11:12Z"
    },
    "payment_method": "card",
    "payment_method_type": "credit",
    "payment_method_data": {
        "card": {
            "card_number": "4000000000002503",
            "card_exp_month": "08",
            "card_exp_year": "25",
            "card_holder_name": "joseph Doe",
            "card_cvc": "999"
        }
    }
}
```

- Do a manual partial capture
```
{
"amount_to_capture": 1407,
  "statement_descriptor_name": "Joseph",
  "statement_descriptor_suffix": "JS"
}
```

- Do a Payment Sync to update the status
- You should receive the webhook at the specified url for the partial captured

<img width="1728" alt="Screenshot 2024-01-18 at 5 21 57 PM" src="https://github.com/juspay/hyperswitch/assets/73734619/efb9dd80-c84c-4ee4-b73e-c98fc31c54e5">

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
