### PR TITLE
refactor(connector): [NMI] Handle `connector_transaction_id` filling for ErrorResponse

### DIFF
--- a/crates/router/src/connector/nmi.rs
+++ b/crates/router/src/connector/nmi.rs
@@ -74,13 +74,21 @@ impl ConnectorCommon for Nmi {
             .response
             .parse_struct("StandardResponse")
             .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
+
+        // if transaction id is zero(default case), dont fill the connector_transaction_id
+        let connector_transaction_id = if response.transactionid.as_str() == "0" {
+            None
+        } else {
+            Some(response.transactionid)
+        };
+
         Ok(ErrorResponse {
             message: response.responsetext.to_owned(),
             status_code: res.status_code,
             reason: Some(response.responsetext),
             code: response.response_code,
             attempt_status: None,
-            connector_transaction_id: Some(response.transactionid),
+            connector_transaction_id,
         })
     }
 }

--- a/crates/router/src/connector/nmi.rs
+++ b/crates/router/src/connector/nmi.rs
@@ -74,21 +74,13 @@ impl ConnectorCommon for Nmi {
             .response
             .parse_struct("StandardResponse")
             .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
-
-        // if transaction id is zero(default case), dont fill the connector_transaction_id
-        let connector_transaction_id = if response.transactionid.as_str() == "0" {
-            None
-        } else {
-            Some(response.transactionid)
-        };
-
         Ok(ErrorResponse {
             message: response.responsetext.to_owned(),
             status_code: res.status_code,
             reason: Some(response.responsetext),
             code: response.response_code,
             attempt_status: None,
-            connector_transaction_id,
+            connector_transaction_id: nmi::get_connector_transaction_id(&response.transactionid),
         })
     }
 }

--- a/crates/router/src/connector/nmi/transformers.rs
+++ b/crates/router/src/connector/nmi/transformers.rs
@@ -211,25 +211,19 @@ impl
                 }),
                 enums::AttemptStatus::AuthenticationPending,
             ),
-            Response::Declined | Response::Error => {
-                // if transaction id is zero(default case), dont fill the connector_transaction_id
-                let connector_transaction_id = if item.response.transactionid.as_str() == "0" {
-                    None
-                } else {
-                    Some(item.response.transactionid)
-                };
-                (
-                    Err(types::ErrorResponse {
-                        code: item.response.response_code,
-                        message: item.response.responsetext.to_owned(),
-                        reason: Some(item.response.responsetext),
-                        status_code: item.http_code,
-                        attempt_status: None,
-                        connector_transaction_id,
-                    }),
-                    enums::AttemptStatus::Failure,
-                )
-            }
+            Response::Declined | Response::Error => (
+                Err(types::ErrorResponse {
+                    code: item.response.response_code,
+                    message: item.response.responsetext.to_owned(),
+                    reason: Some(item.response.responsetext),
+                    status_code: item.http_code,
+                    attempt_status: None,
+                    connector_transaction_id: get_connector_transaction_id(
+                        &item.response.transactionid,
+                    ),
+                }),
+                enums::AttemptStatus::Failure,
+            ),
         };
         Ok(Self {
             status,
@@ -391,19 +385,13 @@ impl
 
 impl ForeignFrom<(NmiCompleteResponse, u16)> for types::ErrorResponse {
     fn foreign_from((response, http_code): (NmiCompleteResponse, u16)) -> Self {
-        // if transaction id is zero(default case), dont fill the connector_transaction_id
-        let connector_transaction_id = if response.transactionid.as_str() == "0" {
-            None
-        } else {
-            Some(response.transactionid)
-        };
         Self {
             code: response.response_code,
             message: response.responsetext.to_owned(),
             reason: Some(response.responsetext),
             status_code: http_code,
             attempt_status: None,
-            connector_transaction_id,
+            connector_transaction_id: get_connector_transaction_id(&response.transactionid),
         }
     }
 }
@@ -772,20 +760,23 @@ impl<T>
 
 impl ForeignFrom<(StandardResponse, u16)> for types::ErrorResponse {
     fn foreign_from((response, http_code): (StandardResponse, u16)) -> Self {
-        // if transaction id is zero(default case), dont fill the connector_transaction_id
-        let connector_transaction_id = if response.transactionid.as_str() == "0" {
-            None
-        } else {
-            Some(response.transactionid)
-        };
         Self {
             code: response.response_code,
             message: response.responsetext.to_owned(),
             reason: Some(response.responsetext),
             status_code: http_code,
             attempt_status: None,
-            connector_transaction_id,
+            connector_transaction_id: get_connector_transaction_id(&response.transactionid),
         }
+    }
+}
+
+pub fn get_connector_transaction_id(transaction_id: &String) -> Option<String> {
+    // if transaction id is zero(default case), dont fill the connector_transaction_id
+    if transaction_id.as_str() == "0" {
+        None
+    } else {
+        Some(transaction_id.to_owned())
     }
 }
 


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
In case of wrong credentials, the error response from NMI contained transaction id but it is provided as "0" (zero), resulting in error for identifying the transaction

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Tested through postman
Steps to test:

- Create a merchant account:
```
{
    "merchant_id": "merchant_{{$timestamp}}",
    "locker_id": "m0010",
    "merchant_name": "NewAge Retailer",
    "merchant_details": {
        "primary_contact_person": "John Test",
        "primary_email": "JohnTest@test.com",
        "primary_phone": "sunt laborum",
        "secondary_contact_person": "John Test2",
        "secondary_email": "JohnTest2@test.com",
        "secondary_phone": "cillum do dolor id",
        "website": "www.example.com",
        "about_business": "Online Retail with a wide selection of organic products for North America",
        "address": {
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "city": "San Fransico",
            "state": "California",
            "zip": "94122",
            "country": "US"
        }
    },
    "return_url": "https://google.com/success",
    "webhook_details": {
        "webhook_version": "1.0.1",
        "webhook_username": "ekart_retail",
        "webhook_password": "password_ekart@123",
        "payment_created_enabled": true,
        "payment_succeeded_enabled": true,
        "payment_failed_enabled": true,
        "webhook_url": "{{webhook_url}}"
    },
    "routing_algorithm": {
        "type": "single",
        "data": "nmi"
    },
    "sub_merchants_enabled": false,
    "metadata": {
        "city": "NY",
        "unit": "245"
    },
    "primary_business_details": [
        {
            "country": "US",
            "business": "default"
        }
    ]
}
```

- Create API Key.

- Create a payment connector(NMI):
```
{
    "connector_type": "fiz_operations",
    "connector_name": "nmi",
    "connector_account_details": {
        "auth_type": "BodyKey",
        "api_key": "{{secret_key}}",
        "key1": "{{public_key}}"
    },
    "test_mode": false,
    "disabled": false,
    "payment_methods_enabled": [
        {
            "payment_method": "card",
            "payment_method_types": [
                {
                    "payment_method_type": "credit",
                    "card_networks": [
                        "Visa",
                        "Mastercard"
                    ],
                    "minimum_amount": 1,
                    "maximum_amount": 68607706,
                    "recurring_enabled": true,
                    "installment_payment_enabled": true
                },
                {
                    "payment_method_type": "debit",
                    "card_networks": [
                        "Visa",
                        "Mastercard"
                    ],
                    "minimum_amount": 1,
                    "maximum_amount": 68607706,
                    "recurring_enabled": true,
                    "installment_payment_enabled": true
                }
            ]
        },
        {
            "payment_method": "pay_later",
            "payment_method_types": [
                {
                    "payment_method_type": "klarna",
                    "payment_experience": "redirect_to_url",
                    "minimum_amount": 1,
                    "maximum_amount": 68607706,
                    "recurring_enabled": true,
                    "installment_payment_enabled": true
                },
                {
                    "payment_method_type": "affirm",
                    "payment_experience": "redirect_to_url",
                    "minimum_amount": 1,
                    "maximum_amount": 68607706,
                    "recurring_enabled": true,
                    "installment_payment_enabled": true
                },
                {
                    "payment_method_type": "afterpay_clearpay",
                    "payment_experience": "redirect_to_url",
                    "minimum_amount": 1,
                    "maximum_amount": 68607706,
                    "recurring_enabled": true,
                    "installment_payment_enabled": true
                }
            ]
        }
    ],
    "metadata": {
        "city": "NY",
        "unit": "245"
    },
    "connector_webhook_details": {
        "merchant_secret": "{{webhook_secret_key}}"
    },
    "business_country": "US",
    "business_label": "default"
}
```

- Create a payment:
```
{
    "amount": 14000,
    "currency": "USD",
    "confirm": true,
    "amount_to_capture": 14000,
    "capture_method": "manual",
    "capture_on": "2022-09-10T10:11:12Z",
    "customer_id": "StripeCustomer",
    "email": "abcdef123@gmail.com",
    "name": "John Doe",
    "phone": "999999999",
    "phone_country_code": "+65",
    "description": "Its my first payment request",
    "authentication_type": "no_three_ds",
    "return_url": "https://google.com",
    "setup_future_usage": "off_session",
    "billing": {
        "address": {
            "first_name": "Sakil",
            "last_name": "Mostak",
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "city": "San Fransico",
            "state": "California",
            "zip": "94122",
            "country": "US"
        }
    },
    "browser_info": {
        "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Safari/537.36",
        "accept_header": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8",
        "language": "nl-NL",
        "color_depth": 24,
        "screen_height": 723,
        "screen_width": 1536,
        "time_zone": 0,
        "java_enabled": true,
        "java_script_enabled": true,
        "ip_address": "127.0.0.1"
    },
    "shipping": {
        "address": {
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "city": "San Fransico",
            "state": "California",
            "zip": "94122",
            "country": "US",
            "first_name": "John",
            "last_name": "Doe"
        }
    },
    "routing": {
        "type": "single",
        "data": "nmi"
    },
    "statement_descriptor_name": "joseph",
    "statement_descriptor_suffix": "JS",
    "metadata": {
        "udf1": "value1",
        "new_customer": "true",
        "login_date": "2019-09-10T10:11:12Z"
    },
    "payment_method": "card",
    "payment_method_type": "credit",
    "payment_method_data": {
        "card": {
            "card_number": "4000000000002503",
            "card_exp_month": "08",
            "card_exp_year": "25",
            "card_holder_name": "Joseph Doe",
            "card_cvc": "999"
        }
    }
}
```

- In the response, "connector_transaction_id" should be `null`

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
