### PR TITLE
docs: add link to api docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,14 @@ The single API to access payment ecosystems across 130+ countries</div>
   <a href="#%EF%B8%8F-quick-start-guide">Quick Start Guide</a> •
   <a href="https://github.com/juspay/hyperswitch/blob/main/docs/try_local_system.md">Local Setup Guide</a> •
   <a href="#-fast-integration-for-stripe-users">Fast Integration for Stripe Users</a> •
+  <a href="https://api-reference.hyperswitch.io/introduction"> API Docs </a> •
   <a href="#-supported-features">Supported Features</a> •
-  <a href="#-FAQs">FAQs</a>
   <br>
   <a href="#whats-included">What's Included</a> •
   <a href="#-join-us-in-building-hyperswitch">Join us in building HyperSwitch</a> •
   <a href="#-community">Community</a> •
   <a href="#-bugs-and-feature-requests">Bugs and feature requests</a> •
+  <a href="#-FAQs">FAQs</a> •
   <a href="#-versioning">Versioning</a> •
   <a href="#%EF%B8%8F-copyright-and-license">Copyright and License</a>
 </p>


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [x] Documentation
- [ ] CI/CD

## Description
Add Api Documentation link to the README.md


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
Making Api docs accessible to the users.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
