### PR TITLE
feat(compatibility): add multiuse mandates support in stripe compatibility

### DIFF
--- a/crates/router/src/compatibility/stripe/payment_intents/types.rs
+++ b/crates/router/src/compatibility/stripe/payment_intents/types.rs
@@ -738,9 +738,25 @@ impl ForeignTryFrom<(Option<MandateData>, Option<String>)> for Option<payments::
                             metadata: None,
                         },
                     )),
-                    StripeMandateType::MultiUse => Some(payments::MandateType::MultiUse(None)),
+                    StripeMandateType::MultiUse => Some(payments::MandateType::MultiUse(Some(
+                        payments::MandateAmountData {
+                            amount: mandate.amount.unwrap_or_default(),
+                            currency,
+                            start_date: mandate.start_date,
+                            end_date: mandate.end_date,
+                            metadata: None,
+                        },
+                    ))),
                 },
-                None => Some(api_models::payments::MandateType::MultiUse(None)),
+                None => Some(api_models::payments::MandateType::MultiUse(Some(
+                    payments::MandateAmountData {
+                        amount: mandate.amount.unwrap_or_default(),
+                        currency,
+                        start_date: mandate.start_date,
+                        end_date: mandate.end_date,
+                        metadata: None,
+                    },
+                ))),
             },
             customer_acceptance: Some(payments::CustomerAcceptance {
                 acceptance_type: payments::AcceptanceType::Online,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Populate Mandate data for multi-use mandates
Resolves [#[3908]](https://github.com/juspay/hyperswitch-cloud/issues/3908)


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
1.Create a mandate payment with noon through stripe compatibility layer
<img width="1334" alt="Screenshot 2024-01-23 at 1 56 50 PM" src="https://github.com/juspay/hyperswitch/assets/131388445/e9cd6c97-f1a7-4f07-b252-5fcef6ed62bf">

2.Do a mandate payment with the same
<img width="1006" alt="Screenshot 2024-01-23 at 1 52 49 PM" src="https://github.com/juspay/hyperswitch/assets/131388445/1267b1c6-7739-49ba-a3a4-aedf9d4cec39">

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
