### PR TITLE
fix(connector): add metadata transformation with `encode_to_value` for `MerchantAccountUpdate` and `merchant_account_update`

### DIFF
--- a/crates/api_models/src/admin.rs
+++ b/crates/api_models/src/admin.rs
@@ -161,7 +161,7 @@ pub struct MerchantAccountUpdate {
 
     /// You can specify up to 50 keys, with key names up to 40 characters long and values up to 500 characters long. Metadata is useful for storing additional, structured information on an object.
     #[schema(value_type = Option<Object>, example = r#"{ "city": "NY", "unit": "245" }"#)]
-    pub metadata: Option<pii::SecretSerdeValue>,
+    pub metadata: Option<MerchantAccountMetadata>,
 
     /// API key that will be used for server side API access
     #[schema(example = "AH3423bkjbkjdsfbkj")]

--- a/crates/router/src/core/admin.rs
+++ b/crates/router/src/core/admin.rs
@@ -533,6 +533,18 @@ pub async fn merchant_account_update(
         None
     };
 
+    let metadata = req
+        .metadata
+        .as_ref()
+        .map(|meta| {
+            utils::Encode::<admin_types::MerchantAccountMetadata>::encode_to_value(meta)
+                .change_context(errors::ApiErrorResponse::InvalidDataValue {
+                    field_name: "metadata",
+                })
+        })
+        .transpose()?
+        .map(Secret::new);
+
     // Update the business profile, This is for backwards compatibility
     update_business_profile_cascade(state.clone(), req.clone(), merchant_id.to_string()).await?;
 
@@ -581,7 +593,7 @@ pub async fn merchant_account_update(
         payment_response_hash_key: req.payment_response_hash_key,
         redirect_to_merchant_with_http_post: req.redirect_to_merchant_with_http_post,
         locker_id: req.locker_id,
-        metadata: req.metadata,
+        metadata,
         publishable_key: None,
         primary_business_details,
         frm_routing_algorithm: req.frm_routing_algorithm,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->

This pull request aligns the validation of metadata for the create and update merchant account functionality. In the struct [`MerchantAccountUpdate`](https://github.com/juspay/hyperswitch/blob/main/crates/api_models/src/admin.rs#L111), the request type now contains `metadata: Option<pii::SecretSerdeValue>`, which has been updated to `metadata: Option<MerchantAccountMetadata>`. As a result, validation and transformation for `metadata` have been added to the `fn merchant_account_update`.


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->

When creating a merchant account using [`fn create_merchant_account`](https://github.com/juspay/hyperswitch/blob/main/crates/router/src/core/admin.rs#L52), the [`MerchantAccountCreate`](https://github.com/juspay/hyperswitch/blob/main/crates/api_models/src/admin.rs#L26) request type contains [`metadata: Option<MerchantAccountMetadata>`](https://github.com/juspay/hyperswitch/blob/main/crates/api_models/src/admin.rs#L80). These `metadata` are then transformed into JSON [here](https://github.com/juspay/hyperswitch/blob/main/crates/router/src/core/admin.rs#L133-L143) and subsequently stored in the database as [JSON](https://github.com/juspay/hyperswitch/blob/main/crates/router/src/types/domain/merchant_account.rs#L36).

Another struct, [`MerchantAccountResponse`](https://github.com/juspay/hyperswitch/blob/main/crates/api_models/src/admin.rs#L188), contains [`metadata: Option<pii::SecretSerdeValue>`](https://github.com/juspay/hyperswitch/blob/main/crates/api_models/src/admin.rs#L248). This `MerchantAccountResponse` is utilized for read operations as a result. So far, so good.

When updating a merchant account with [`fn merchant_account_update`](https://github.com/juspay/hyperswitch/blob/main/crates/router/src/core/admin.rs#L456), there is a [`MerchantAccountUpdate`](https://github.com/juspay/hyperswitch/blob/main/crates/api_models/src/admin.rs#L111) request type that contains [`metadata: Option<pii::SecretSerdeValue>`](https://github.com/juspay/hyperswitch/blob/main/crates/api_models/src/admin.rs#L164C9-L164C48) without any validation/transformation. I think this is a bug. When updating a merchant account using the `fn merchant_account_update`, someone can store whatever JSON in the metadata, and this JSON is not even checked for compatibility with `MerchantAccountMetadata` as is done in the `fn create_merchant_account`.



## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
TODO: not yet, but if this PR/issue is relevant to fix, I can do postman test.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [X] I formatted the code `cargo +nightly fmt --all`
- [X] I addressed lints thrown by `cargo clippy`
- [X] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
