### PR TITLE
Refactor(compatibility): revert add multiuse mandates support in stripe compatibility

### DIFF
--- a/crates/router/src/compatibility/stripe/payment_intents/types.rs
+++ b/crates/router/src/compatibility/stripe/payment_intents/types.rs
@@ -738,25 +738,9 @@ impl ForeignTryFrom<(Option<MandateData>, Option<String>)> for Option<payments::
                             metadata: None,
                         },
                     )),
-                    StripeMandateType::MultiUse => Some(payments::MandateType::MultiUse(Some(
-                        payments::MandateAmountData {
-                            amount: mandate.amount.unwrap_or_default(),
-                            currency,
-                            start_date: mandate.start_date,
-                            end_date: mandate.end_date,
-                            metadata: None,
-                        },
-                    ))),
+                    StripeMandateType::MultiUse => Some(payments::MandateType::MultiUse(None)),
                 },
-                None => Some(api_models::payments::MandateType::MultiUse(Some(
-                    payments::MandateAmountData {
-                        amount: mandate.amount.unwrap_or_default(),
-                        currency,
-                        start_date: mandate.start_date,
-                        end_date: mandate.end_date,
-                        metadata: None,
-                    },
-                ))),
+                None => Some(api_models::payments::MandateType::MultiUse(None)),
             },
             customer_acceptance: Some(payments::CustomerAcceptance {
                 acceptance_type: payments::AcceptanceType::Online,


### PR DESCRIPTION
Reverts juspay/hyperswitch#3425
resolves [#3445](https://github.com/juspay/hyperswitch/issues/3445)
Dependency changes not made