### PR TITLE
chore: add compiler_error when `kms` and `hashicorp-vault` are enable…

### DIFF
--- a/crates/external_services/src/lib.rs
+++ b/crates/external_services/src/lib.rs
@@ -38,3 +38,12 @@ pub mod metrics {
     #[cfg(feature = "kms")]
     histogram_metric!(AWS_KMS_ENCRYPT_TIME, GLOBAL_METER); // Histogram for KMS encryption time (in sec)
 }
+
+// Mutually Exclusive - Feature Flags
+//
+// This are some feature flags that shouldn't be used together
+
+#[cfg(all(feature = "kms", feature = "hashicorp-vault"))]
+compile_error!(
+    "feature \"kms\" and feature \"hashicorp-vault\" cannot be enabled at the same time"
+);

--- a/crates/router/src/connector/bankofamerica/transformers.rs
+++ b/crates/router/src/connector/bankofamerica/transformers.rs
@@ -1446,9 +1446,9 @@ impl<F>
                             resource_id: types::ResponseId::NoResponseId,
                             redirection_data,
                             mandate_reference: None,
-                            connector_metadata: Some(
-                                serde_json::json!({"three_ds_data":three_ds_data}),
-                            ),
+                            connector_metadata: Some(serde_json::json!({
+                                "three_ds_data": three_ds_data
+                            })),
                             network_txn_id: None,
                             connector_response_reference_id,
                             incremental_authorization_allowed: None,

--- a/crates/router/src/connector/cybersource/transformers.rs
+++ b/crates/router/src/connector/cybersource/transformers.rs
@@ -2015,9 +2015,9 @@ impl<F>
                             resource_id: types::ResponseId::NoResponseId,
                             redirection_data,
                             mandate_reference: None,
-                            connector_metadata: Some(
-                                serde_json::json!({"three_ds_data":three_ds_data}),
-                            ),
+                            connector_metadata: Some(serde_json::json!({
+                                "three_ds_data": three_ds_data
+                            })),
                             network_txn_id: None,
                             connector_response_reference_id,
                             incremental_authorization_allowed: None,


### PR DESCRIPTION
…d together

## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Add compiler error when `kms` and `hashicorp-vault` feature flag are enabled together.

<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
