### PR TITLE
fix(connector): [Cashtocode] update amount from i64 to f64 in webhook payload

### DIFF
--- a/crates/router/src/connector/cashtocode/transformers.rs
+++ b/crates/router/src/connector/cashtocode/transformers.rs
@@ -193,7 +193,7 @@ pub struct CashtocodePaymentsResponseData {
 #[serde(rename_all = "camelCase")]
 pub struct CashtocodePaymentsSyncResponse {
     pub transaction_id: String,
-    pub amount: i64,
+    pub amount: f64,
 }
 
 fn get_redirect_form_data(
@@ -314,7 +314,6 @@ impl<F, T>
                 connector_response_reference_id: None,
                 incremental_authorization_allowed: None,
             }),
-            amount_captured: Some(item.response.amount),
             ..item.data
         })
     }
@@ -330,7 +329,7 @@ pub struct CashtocodeErrorResponse {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CashtocodeIncomingWebhook {
-    pub amount: i64,
+    pub amount: f64,
     pub currency: String,
     pub foreign_transaction_id: String,
     #[serde(rename = "type")]


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
fix 4xx webhook issue for cashtocode. change amount type from i64 to f64

pr merged in main - #3382

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
test cases - 
1. make a evoucher payment and test webhooks. 

<img width="1060" alt="Screenshot 2024-01-18 at 2 58 51 PM" src="https://github.com/juspay/hyperswitch/assets/70575890/9a7a637d-8273-42fb-abdb-e4421c6d7ede">

issue in prod reproduced in local - 
<img width="1192" alt="Screenshot 2024-01-18 at 1 41 00 PM" src="https://github.com/juspay/hyperswitch/assets/70575890/09f4b11d-36bd-41af-b1de-b633984e5831">

Processing successful webhook
<img width="978" alt="Screenshot 2024-01-18 at 3 05 27 PM" src="https://github.com/juspay/hyperswitch/assets/70575890/2766467d-584b-4867-88ce-b792326abbac">




## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
