### PR TITLE
feat(users): Add `merchant_id` in `EmailToken` and change user status in reset password

### DIFF
--- a/crates/diesel_models/src/query/user.rs
+++ b/crates/diesel_models/src/query/user.rs
@@ -60,7 +60,27 @@ impl User {
         .first()
         .cloned()
         .ok_or_else(|| {
-            report!(errors::DatabaseError::NotFound).attach_printable("Error while updating user")
+            report!(errors::DatabaseError::NotFound)
+                .attach_printable(format!("Error while updating user by user_id={}", user_id))
+        })
+    }
+
+    pub async fn update_by_user_email(
+        conn: &PgPooledConn,
+        user_email: &str,
+        user: UserUpdate,
+    ) -> StorageResult<Self> {
+        generics::generic_update_with_results::<<Self as HasTable>::Table, _, _, _>(
+            conn,
+            users_dsl::email.eq(user_email.to_owned()),
+            UserUpdateInternal::from(user),
+        )
+        .await?
+        .first()
+        .cloned()
+        .ok_or_else(|| {
+            report!(errors::DatabaseError::NotFound)
+                .attach_printable(format!("Error while updating user by email={}", user_email))
         })
     }
 

--- a/crates/router/src/core/user.rs
+++ b/crates/router/src/core/user.rs
@@ -1,4 +1,6 @@
 use api_models::user::{self as user_api, InviteMultipleUserResponse};
+#[cfg(feature = "email")]
+use diesel_models::user_role::UserRoleUpdate;
 use diesel_models::{enums::UserStatus, user as storage_user, user_role::UserRoleNew};
 #[cfg(feature = "email")]
 use error_stack::IntoReport;
@@ -313,18 +315,10 @@ pub async fn reset_password(
 
     let hash_password = utils::user::password::generate_password_hash(password.get_secret())?;
 
-    //TODO: Create Update by email query
-    let user_id = state
+    let user = state
         .store
-        .find_user_by_email(token.get_email())
-        .await
-        .change_context(UserErrors::InternalServerError)?
-        .user_id;
-
-    state
-        .store
-        .update_user_by_user_id(
-            user_id.as_str(),
+        .update_user_by_email(
+            token.get_email(),
             storage_user::UserUpdate::AccountUpdate {
                 name: None,
                 password: Some(hash_password),
@@ -335,7 +329,20 @@ pub async fn reset_password(
         .await
         .change_context(UserErrors::InternalServerError)?;
 
-    //TODO: Update User role status for invited user
+    if let Some(invited_merchant_id) = token.get_merchant_id() {
+        state
+            .store
+            .update_user_role_by_user_id_merchant_id(
+                user.user_id.clone().as_str(),
+                invited_merchant_id,
+                UserRoleUpdate::UpdateStatus {
+                    status: UserStatus::Active,
+                    modified_by: user.user_id,
+                },
+            )
+            .await
+            .change_context(UserErrors::InternalServerError)?;
+    }
 
     Ok(ApplicationResponse::StatusOk)
 }
@@ -418,7 +425,7 @@ pub async fn invite_user(
             .store
             .insert_user_role(UserRoleNew {
                 user_id: new_user.get_user_id().to_owned(),
-                merchant_id: user_from_token.merchant_id,
+                merchant_id: user_from_token.merchant_id.clone(),
                 role_id: request.role_id,
                 org_id: user_from_token.org_id,
                 status: invitation_status,
@@ -444,6 +451,7 @@ pub async fn invite_user(
                 user_name: domain::UserName::new(new_user.get_name())?,
                 settings: state.conf.clone(),
                 subject: "You have been invited to join Hyperswitch Community!",
+                merchant_id: user_from_token.merchant_id,
             };
             let send_email_result = state
                 .email_client
@@ -620,6 +628,7 @@ async fn handle_new_user_invitation(
             user_name: domain::UserName::new(new_user.get_name())?,
             settings: state.conf.clone(),
             subject: "You have been invited to join Hyperswitch Community!",
+            merchant_id: user_from_token.merchant_id.clone(),
         };
         let send_email_result = state
             .email_client

--- a/crates/router/src/db/kafka_store.rs
+++ b/crates/router/src/db/kafka_store.rs
@@ -1896,6 +1896,16 @@ impl UserInterface for KafkaStore {
             .await
     }
 
+    async fn update_user_by_email(
+        &self,
+        user_email: &str,
+        user: storage::UserUpdate,
+    ) -> CustomResult<storage::User, errors::StorageError> {
+        self.diesel_store
+            .update_user_by_email(user_email, user)
+            .await
+    }
+
     async fn delete_user_by_user_id(
         &self,
         user_id: &str,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
This PR will add an optional `merchant_id` field in `EmailToken` struct. And also changes the status of the user from `invitation_sent` to `active` if the `EmailToken` has `merchant_id`.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
To change the status of the user to active once the user resets the password.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Postman.
1. Invite a user using this curl
	```
	curl --location 'http://localhost:8080/user/user/invite' \
	--header 'Content-Type: application/json' \
	--header 'Authorization: Bearer JWT' \
	--data-raw '{
	    "email": "new email",
	    "name": "user name",
	    "role_id": "merchant_admin"
	}'
	```
	You should get invite email to the email you have provided and this following response from the api.
	```
	{
	    "is_email_sent": true,
	    "password": null
	}
	```

2. Use the link in the email to hit the reset password api from the dashboard or the following curl can be used to hit the api if email token is extracted.
	```
	curl --location 'http://localhost:8080/user/reset_password' \
	--header 'Content-Type: application/json' \
	--data-raw '{
	    "token": "Email Token",
	    "password": "new password"
	}'
	```
	You will get 200 OK and the status of the `user_role` with the corresponding `user_id` and `merchant_id` will be active.
## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
