### PR TITLE
fix(core): fix mandate_details to store some value only if mandate_data struct is present

### DIFF
--- a/crates/router/src/core/payment_methods/cards.rs
+++ b/crates/router/src/core/payment_methods/cards.rs
@@ -1823,7 +1823,6 @@ pub async fn list_payment_methods(
         } else {
             api_surcharge_decision_configs::MerchantSurchargeConfigs::default()
         };
-    print!("PAMT{:?}", payment_attempt);
     Ok(services::ApplicationResponse::Json(
         api::PaymentMethodListResponse {
             redirect_url: merchant_account.return_url,

--- a/crates/router/src/core/payment_methods/cards.rs
+++ b/crates/router/src/core/payment_methods/cards.rs
@@ -2068,9 +2068,9 @@ pub async fn filter_payment_methods(
                             format!("unable to parse connector name {connector:?}")
                         })?;
                     let filter7 = payment_attempt
-                        .and_then(|attempt| {
-                            attempt.mandate_details.as_ref().map(|mandate_details| {
-                                let (mandate_type_present, update_mandate_id_present) =
+                        .and_then(|attempt| attempt.mandate_details.as_ref())
+                        .map(|mandate_details| {
+                            let (mandate_type_present, update_mandate_id_present) =
                                 match mandate_details {
                                     data_models::mandates::MandateTypeDetails::MandateType(_) => {
                                         (true, false)
@@ -2083,20 +2083,16 @@ pub async fn filter_payment_methods(
                                     ),
                                 };
 
-                                if attempt.mandate_details.is_some()
-                                    || mandate_type_present
-                                    || update_mandate_id_present
-                                {
-                                    filter_pm_based_on_supported_payments_for_mandate(
-                                        supported_payment_methods_for_mandate,
-                                        &payment_method,
-                                        &payment_method_object.payment_method_type,
-                                        connector_variant,
-                                    )
-                                } else {
-                                    false
-                                }
-                            })
+                            if mandate_type_present || update_mandate_id_present {
+                                filter_pm_based_on_supported_payments_for_mandate(
+                                    supported_payment_methods_for_mandate,
+                                    &payment_method,
+                                    &payment_method_object.payment_method_type,
+                                    connector_variant,
+                                )
+                            } else {
+                                true
+                            }
                         })
                         .unwrap_or(true);
 

--- a/crates/router/src/core/payments/operations/payment_create.rs
+++ b/crates/router/src/core/payments/operations/payment_create.rs
@@ -712,7 +712,9 @@ impl PaymentCreate {
             Err(errors::ApiErrorResponse::InvalidRequestData {message:"Only one field out of 'mandate_type' and 'update_mandate_id' was expected, found both".to_string()})?
         }
 
-        let mandate_dets = if let Some(update_id) = request
+        let mandate_details = if request.mandate_data.is_none() {
+            None
+        } else if let Some(update_id) = request
             .mandate_data
             .as_ref()
             .and_then(|inner| inner.update_mandate_id.clone())
@@ -723,8 +725,6 @@ impl PaymentCreate {
             };
             Some(MandateTypeDetails::MandateDetails(mandate_data))
         } else {
-            // let mandate_type: data_models::mandates::MandateDataType =
-
             let mandate_data = MandateDetails {
                 update_mandate_id: None,
                 mandate_type: request
@@ -761,7 +761,7 @@ impl PaymentCreate {
                 business_sub_label: request.business_sub_label.clone(),
                 surcharge_amount,
                 tax_amount,
-                mandate_details: mandate_dets,
+                mandate_details,
                 ..storage::PaymentAttemptNew::default()
             },
             additional_pm_data,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

ListPaymentMethodsForMerchant was unable to list the payment methods enabled as it was always taking mandate to have Some value even though its respective fields were None. So added a check that, if there's mandate_data present then only any data should be stored in the database

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
- Create MA and MCA 
- Do a payment with confirm as false and then ListPaymentMethodsForMerchnats
> Earlier
![Screenshot 2024-02-01 at 6 15 04 PM](https://github.com/juspay/hyperswitch/assets/55580080/d0b10a50-5694-49e1-93c4-80511fda964c)


> After fix
![Screenshot 2024-02-01 at 6 25 21 PM](https://github.com/juspay/hyperswitch/assets/55580080/685dec2a-061b-4f6a-af93-ba35b9751f60)


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
