### PR TITLE
fix(logging): add an end log line for `LogSpanInitializer`

### DIFF
--- a/crates/router/src/middleware.rs
+++ b/crates/router/src/middleware.rs
@@ -141,9 +141,14 @@ where
         let response_fut = self.service.call(req);
 
         Box::pin(
-            response_fut.instrument(
+            async move {
+                let response = response_fut.await;
+                logger::info!(golden_log_line = true);
+                response
+            }
+            .instrument(
                 router_env::tracing::info_span!(
-                    "golden_log_line",
+                    "ROOT_SPAN",
                     payment_id = Empty,
                     merchant_id = Empty,
                     connector_name = Empty,

--- a/crates/router/src/routes/customers.rs
+++ b/crates/router/src/routes/customers.rs
@@ -147,7 +147,7 @@ pub async fn get_customer_mandates(
         customer_id: path.into_inner(),
     };
 
-    api::server_wrap(
+    Box::pin(api::server_wrap(
         flow,
         state,
         &req,
@@ -166,6 +166,6 @@ pub async fn get_customer_mandates(
             req.headers(),
         ),
         api_locking::LockAction::NotApplicable,
-    )
+    ))
     .await
 }

--- a/crates/router/src/routes/mandates.rs
+++ b/crates/router/src/routes/mandates.rs
@@ -118,7 +118,7 @@ pub async fn retrieve_mandates_list(
 ) -> HttpResponse {
     let flow = Flow::MandatesList;
     let payload = payload.into_inner();
-    api::server_wrap(
+    Box::pin(api::server_wrap(
         flow,
         state,
         &req,
@@ -132,6 +132,6 @@ pub async fn retrieve_mandates_list(
             req.headers(),
         ),
         api_locking::LockAction::NotApplicable,
-    )
+    ))
     .await
 }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
- Add an end request log line for logging keys

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
- Since we no longer log enter & exit spans we need an explicit log line to mark end of request

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
make a health API call & check for the following log line

```json
{
    "message": "[ROOT_SPAN - EVENT] router::middleware",
    "hostname": "sampraslopes-SERIAL.local",
    "pid": 78236,
    "env": "development",
    "level": "INFO",
    "target": "router::middleware",
    "service": "router",
    "line": 146,
    "file": "crates/router/src/middleware.rs",
    "fn": "ROOT_SPAN",
    "full_name": "router::middleware::ROOT_SPAN",
    "time": "2024-02-01T11:54:29.607859000Z",
    "flow": "UNKNOWN",
    "request_id": "018d6485-3b65-7902-8983-fc57988d7e7a",
    "extra": {
        "golden_log_line": true,
        "otel.kind": "server",
        "http.scheme": "http",
        "trace_id": "00000000000000000000000000000000",
        "http.method": "GET",
        "http.host": "localhost:8080",
        "http.user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:123.0) Gecko/20100101 Firefox/123.0",
        "otel.name": "HTTP GET default",
        "http.flavor": "1.1",
        "http.route": "default",
        "http.target": "/favicon.ico",
        "http.client_ip": "127.0.0.1"
    }
}
```
## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
