### PR TITLE
fix(router): handle empty body parse failures in bad request logger middleware

### DIFF
--- a/crates/router/src/lib.rs
+++ b/crates/router/src/lib.rs
@@ -258,8 +258,8 @@ pub fn get_application_builder(
         .wrap(middleware::default_response_headers())
         .wrap(middleware::RequestId)
         .wrap(cors::cors())
-        .wrap(middleware::LogSpanInitializer)
         // this middleware works only for Http1.1 requests
         .wrap(middleware::Http400RequestDetailsLogger)
+        .wrap(middleware::LogSpanInitializer)
         .wrap(router_env::tracing_actix_web::TracingLogger::default())
 }

--- a/crates/router/src/middleware.rs
+++ b/crates/router/src/middleware.rs
@@ -258,13 +258,24 @@ where
             let response = response_fut.await?;
             // Log the request_details when we receive 400 status from the application
             if response.status() == 400 {
-                let value: serde_json::Value = serde_json::from_slice(&bytes)?;
                 let request_id = request_id_fut.await?.as_hyphenated().to_string();
-                logger::info!(
-                    "request_id: {}, request_details: {}",
-                    request_id,
-                    get_request_details_from_value(&value, "")
-                );
+                if !bytes.is_empty() {
+                    let value_result: Result<serde_json::Value, serde_json::Error> =
+                        serde_json::from_slice(&bytes);
+                    match value_result {
+                        Ok(value) => {
+                            logger::info!(
+                                "request_id: {request_id}, request_details: {}",
+                                get_request_details_from_value(&value, "")
+                            );
+                        }
+                        Err(err) => {
+                            logger::warn!("error while parsing the request in json value: {err}");
+                        }
+                    }
+                } else {
+                    logger::info!("request_id: {request_id}, request_details: Empty Body");
+                }
             }
             Ok(response)
         })


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
handle empty body parse failures in bad request logger middleware


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
Main PR - https://github.com/juspay/hyperswitch/pull/3541


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
