### PR TITLE
fix(connector): [NMI] Handle empty response in psync and error response in complete authorize

### DIFF
--- a/crates/router/src/connector/nmi/transformers.rs
+++ b/crates/router/src/connector/nmi/transformers.rs
@@ -247,17 +247,8 @@ pub struct NmiCompleteRequest {
     cavv: Option<String>,
     xid: Option<String>,
     eci: Option<String>,
-    three_ds_version: Option<ThreeDsVersion>,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-pub enum ThreeDsVersion {
-    #[serde(rename = "2.0.0")]
-    VersionTwo,
-    #[serde(rename = "2.1.0")]
-    VersionTwoPointOne,
-    #[serde(rename = "2.2.0")]
-    VersionTwoPointTwo,
+    three_ds_version: Option<String>,
+    directory_server_id: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -267,8 +258,9 @@ pub struct NmiRedirectResponseData {
     xid: Option<String>,
     eci: Option<String>,
     card_holder_auth: Option<String>,
-    three_ds_version: Option<ThreeDsVersion>,
+    three_ds_version: Option<String>,
     order_id: Option<String>,
+    directory_server_id: Option<String>,
 }
 
 impl TryFrom<&NmiRouterData<&types::PaymentsCompleteAuthorizeRouterData>> for NmiCompleteRequest {
@@ -308,6 +300,7 @@ impl TryFrom<&NmiRouterData<&types::PaymentsCompleteAuthorizeRouterData>> for Nm
             xid: three_ds_data.xid,
             eci: three_ds_data.eci,
             three_ds_version: three_ds_data.three_ds_version,
+            directory_server_id: three_ds_data.directory_server_id,
         })
     }
 }

--- a/crates/router/src/connector/nmi/transformers.rs
+++ b/crates/router/src/connector/nmi/transformers.rs
@@ -2,7 +2,7 @@ use api_models::webhooks;
 use cards::CardNumber;
 use common_utils::{errors::CustomResult, ext_traits::XmlExt};
 use error_stack::{IntoReport, Report, ResultExt};
-use masking::{ExposeInterface, Secret};
+use masking::{ExposeInterface, PeekInterface, Secret};
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -141,7 +141,7 @@ fn get_card_details(
 pub struct NmiVaultResponse {
     pub response: Response,
     pub responsetext: String,
-    pub customer_vault_id: Option<String>,
+    pub customer_vault_id: Option<Secret<String>>,
     pub response_code: String,
     pub transactionid: String,
 }
@@ -191,11 +191,14 @@ impl
                         )?
                         .to_string(),
                         currency: currency_data,
-                        customer_vault_id: item.response.customer_vault_id.ok_or(
-                            errors::ConnectorError::MissingRequiredField {
+                        customer_vault_id: item
+                            .response
+                            .customer_vault_id
+                            .ok_or(errors::ConnectorError::MissingRequiredField {
                                 field_name: "customer_vault_id",
-                            },
-                        )?,
+                            })?
+                            .peek()
+                            .to_string(),
                         public_key: auth_type.public_key.ok_or(
                             errors::ConnectorError::InvalidConnectorConfig {
                                 config: "public_key",
@@ -237,20 +240,14 @@ pub struct NmiCompleteRequest {
     #[serde(rename = "type")]
     transaction_type: TransactionType,
     security_key: Secret<String>,
-    orderid: String,
+    orderid: Option<String>,
     ccnumber: CardNumber,
     ccexp: Secret<String>,
-    cardholder_auth: CardHolderAuthType,
-    cavv: String,
-    xid: String,
+    cardholder_auth: Option<String>,
+    cavv: Option<String>,
+    xid: Option<String>,
+    eci: Option<String>,
     three_ds_version: Option<ThreeDsVersion>,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-#[serde(rename_all = "lowercase")]
-pub enum CardHolderAuthType {
-    Verified,
-    Attempted,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -266,11 +263,12 @@ pub enum ThreeDsVersion {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct NmiRedirectResponseData {
-    cavv: String,
-    xid: String,
-    card_holder_auth: CardHolderAuthType,
+    cavv: Option<String>,
+    xid: Option<String>,
+    eci: Option<String>,
+    card_holder_auth: Option<String>,
     three_ds_version: Option<ThreeDsVersion>,
-    order_id: String,
+    order_id: Option<String>,
 }
 
 impl TryFrom<&NmiRouterData<&types::PaymentsCompleteAuthorizeRouterData>> for NmiCompleteRequest {
@@ -308,6 +306,7 @@ impl TryFrom<&NmiRouterData<&types::PaymentsCompleteAuthorizeRouterData>> for Nm
             cardholder_auth: three_ds_data.card_holder_auth,
             cavv: three_ds_data.cavv,
             xid: three_ds_data.xid,
+            eci: three_ds_data.eci,
             three_ds_version: three_ds_data.three_ds_version,
         })
     }
@@ -881,21 +880,22 @@ impl TryFrom<types::PaymentsSyncResponseRouterData<types::Response>>
         item: types::PaymentsSyncResponseRouterData<types::Response>,
     ) -> Result<Self, Self::Error> {
         let response = SyncResponse::try_from(item.response.response.to_vec())?;
-        Ok(Self {
-            status: enums::AttemptStatus::from(NmiStatus::from(response.transaction.condition)),
-            response: Ok(types::PaymentsResponseData::TransactionResponse {
-                resource_id: types::ResponseId::ConnectorTransactionId(
-                    response.transaction.transaction_id,
-                ),
-                redirection_data: None,
-                mandate_reference: None,
-                connector_metadata: None,
-                network_txn_id: None,
-                connector_response_reference_id: None,
-                incremental_authorization_allowed: None,
+        match response.transaction {
+            Some(trn) => Ok(Self {
+                status: enums::AttemptStatus::from(NmiStatus::from(trn.condition)),
+                response: Ok(types::PaymentsResponseData::TransactionResponse {
+                    resource_id: types::ResponseId::ConnectorTransactionId(trn.transaction_id),
+                    redirection_data: None,
+                    mandate_reference: None,
+                    connector_metadata: None,
+                    network_txn_id: None,
+                    connector_response_reference_id: None,
+                    incremental_authorization_allowed: None,
+                }),
+                ..item.data
             }),
-            ..item.data
-        })
+            None => Ok(Self { ..item.data }), //when there is empty connector response i.e. response we get in psync when payment status is in authentication_pending
+        }
     }
 }
 
@@ -1081,7 +1081,7 @@ pub struct SyncTransactionResponse {
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct SyncResponse {
-    pub transaction: SyncTransactionResponse,
+    pub transaction: Option<SyncTransactionResponse>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -1199,10 +1199,10 @@ pub struct NmiWebhookObject {
 impl TryFrom<&NmiWebhookBody> for SyncResponse {
     type Error = Error;
     fn try_from(item: &NmiWebhookBody) -> Result<Self, Self::Error> {
-        let transaction = SyncTransactionResponse {
+        let transaction = Some(SyncTransactionResponse {
             transaction_id: item.event_body.transaction_id.to_owned(),
             condition: item.event_body.condition.to_owned(),
-        };
+        });
 
         Ok(Self { transaction })
     }

--- a/crates/router/src/services/api.rs
+++ b/crates/router/src/services/api.rs
@@ -1715,6 +1715,12 @@ pub fn build_redirection_form(
                         item2.value=e.xid;
                         responseForm.appendChild(item2);
 
+                        var item6=document.createElement('input');
+                        item6.type='hidden';
+                        item6.name='eci';
+                        item6.value=e.eci;
+                        responseForm.appendChild(item6);
+
                         var item3=document.createElement('input');
                         item3.type='hidden';
                         item3.name='cardHolderAuth';

--- a/crates/router/src/services/api.rs
+++ b/crates/router/src/services/api.rs
@@ -1721,6 +1721,12 @@ pub fn build_redirection_form(
                         item6.value=e.eci;
                         responseForm.appendChild(item6);
 
+                        var item7=document.createElement('input');
+                        item7.type='hidden';
+                        item7.name='directoryServerId';
+                        item7.value=e.directoryServerId;
+                        responseForm.appendChild(item7);
+
                         var item3=document.createElement('input');
                         item3.type='hidden';
                         item3.name='cardHolderAuth';


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Handle empty response in psync and error response in complete authorize 

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
test cases - Make payment, when status is in authentication_pending, make a psync, status should remain same
make a payment, after redirection , status should be succeeded.

successful payment - 
<img width="976" alt="Screenshot 2024-02-05 at 4 38 21 PM" src="https://github.com/juspay/hyperswitch/assets/70575890/91da1fb8-4d1d-46eb-9db7-8d5ad50d5fb7">
<img width="630" alt="Screenshot 2024-02-05 at 4 38 36 PM" src="https://github.com/juspay/hyperswitch/assets/70575890/e205fa9d-fab8-4cb9-9a03-02805dc0701d">
<img width="1016" alt="Screenshot 2024-02-05 at 4 39 01 PM" src="https://github.com/juspay/hyperswitch/assets/70575890/d3e162d9-8f53-4ee2-b645-b23de27f59ad">


payment having error code and message when the fields such as cavv, eci, xid
<img width="631" alt="Screenshot 2024-02-05 at 3 35 43 PM" src="https://github.com/juspay/hyperswitch/assets/70575890/a69510c1-a1ea-4827-8885-c4897a62f072">

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
