### PR TITLE
fix(request): Remove idle_pool_connection_timeout as a config

### DIFF
--- a/config/config.example.toml
+++ b/config/config.example.toml
@@ -16,7 +16,6 @@ request_body_limit = 32_768
 [proxy]
 # http_url = "http proxy url"   # Proxy all HTTP traffic via this proxy
 # https_url = "https proxy url" # Proxy all HTTPS traffic via this proxy
-idle_pool_connection_timeout = 90 # Timeout for idle pool connections (defaults to 90s)
 
 
 # Main SQL data store credentials

--- a/crates/router/src/configs/defaults.rs
+++ b/crates/router/src/configs/defaults.rs
@@ -36,15 +36,14 @@ impl Default for super::settings::Database {
     }
 }
 
-impl Default for super::settings::Proxy {
-    fn default() -> Self {
-        Self {
-            http_url: Default::default(),
-            https_url: Default::default(),
-            idle_pool_connection_timeout: Some(90),
-        }
-    }
-}
+// impl Default for super::settings::Proxy {
+//     fn default() -> Self {
+//         Self {
+//             http_url: Default::default(),
+//             https_url: Default::default(),
+//         }
+//     }
+// }
 
 impl Default for super::settings::Locker {
     fn default() -> Self {

--- a/crates/router/src/configs/defaults.rs
+++ b/crates/router/src/configs/defaults.rs
@@ -36,14 +36,6 @@ impl Default for super::settings::Database {
     }
 }
 
-// impl Default for super::settings::Proxy {
-//     fn default() -> Self {
-//         Self {
-//             http_url: Default::default(),
-//             https_url: Default::default(),
-//         }
-//     }
-// }
 
 impl Default for super::settings::Locker {
     fn default() -> Self {

--- a/crates/router/src/configs/defaults.rs
+++ b/crates/router/src/configs/defaults.rs
@@ -36,7 +36,6 @@ impl Default for super::settings::Database {
     }
 }
 
-
 impl Default for super::settings::Locker {
     fn default() -> Self {
         Self {

--- a/crates/router/src/configs/settings.rs
+++ b/crates/router/src/configs/settings.rs
@@ -407,12 +407,11 @@ pub struct Jwekey {
     pub tunnel_private_key: String,
 }
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Clone, Default)]
 #[serde(default)]
 pub struct Proxy {
     pub http_url: Option<String>,
     pub https_url: Option<String>,
-    pub idle_pool_connection_timeout: Option<u64>,
 }
 
 #[derive(Debug, Deserialize, Clone)]

--- a/crates/router/src/services/api/client.rs
+++ b/crates/router/src/services/api/client.rs
@@ -25,13 +25,7 @@ fn get_client_builder(
     proxy_config: &Proxy,
     should_bypass_proxy: bool,
 ) -> CustomResult<reqwest::ClientBuilder, ApiClientError> {
-    let mut client_builder = reqwest::Client::builder()
-        .redirect(reqwest::redirect::Policy::none())
-        .pool_idle_timeout(std::time::Duration::from_secs(
-            proxy_config
-                .idle_pool_connection_timeout
-                .unwrap_or_default(),
-        ));
+    let mut client_builder = reqwest::Client::builder().redirect(reqwest::redirect::Policy::none());
 
     if should_bypass_proxy {
         return Ok(client_builder);


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

We have been encountering below 5xx in sandbox  
`Failed to send request to connector error sending request for url (https://api-m.sandbox.paypal.com/v1/notifications/verify-webhook-signature): connection error: Connection reset by peer (os error 104)
   ├╴at crates/router/src/services/api.rs:655:14
   ╰╴Unable to send request to connector`. 
This is because timeout for idle pool connections defaults to 90s. This PR removes this config.

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
We have been encountering below 5xx in sandbox  
`Failed to send request to connector error sending request for url (https://api-m.sandbox.paypal.com/v1/notifications/verify-webhook-signature): connection error: Connection reset by peer (os error 104)
   ├╴at crates/router/src/services/api.rs:655:14
   ╰╴Unable to send request to connector`. 
This is because timeout for idle pool connections defaults to 90s. This PR removes this config.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [x] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Tested it by making payment from any connector.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
