### PR TITLE
refactor(users): change list roles api to also send inactive merchants

### DIFF
--- a/crates/router/src/core/user.rs
+++ b/crates/router/src/core/user.rs
@@ -945,10 +945,13 @@ pub async fn create_merchant_account(
 
 pub async fn list_merchant_ids_for_user(
     state: AppState,
-    user: auth::UserFromToken,
+    user_from_token: auth::UserFromToken,
 ) -> UserResponse<Vec<user_api::UserMerchantAccount>> {
-    let user_roles =
-        utils::user_role::get_active_user_roles_for_user(&state, &user.user_id).await?;
+    let user_roles = state
+        .store
+        .list_user_roles_by_user_id(user_from_token.user_id.as_str())
+        .await
+        .change_context(UserErrors::InternalServerError)?;
 
     let merchant_accounts = state
         .store

--- a/crates/router/src/utils/user_role.rs
+++ b/crates/router/src/utils/user_role.rs
@@ -1,11 +1,8 @@
 use api_models::user_role as user_role_api;
-use diesel_models::{enums::UserStatus, user_role::UserRole};
-use error_stack::ResultExt;
 
 use crate::{
     consts,
     core::errors::{UserErrors, UserResult},
-    routes::AppState,
     services::authorization::{
         permissions::Permission,
         predefined_permissions::{self, RoleInfo},

--- a/crates/router/src/utils/user_role.rs
+++ b/crates/router/src/utils/user_role.rs
@@ -17,20 +17,6 @@ pub fn is_internal_role(role_id: &str) -> bool {
         || role_id == consts::user_role::ROLE_ID_INTERNAL_VIEW_ONLY_USER
 }
 
-pub async fn get_active_user_roles_for_user(
-    state: &AppState,
-    user_id: &str,
-) -> UserResult<Vec<UserRole>> {
-    Ok(state
-        .store
-        .list_user_roles_by_user_id(user_id)
-        .await
-        .change_context(UserErrors::InternalServerError)?
-        .into_iter()
-        .filter(|ele| ele.status == UserStatus::Active)
-        .collect())
-}
-
 pub fn validate_role_id(role_id: &str) -> UserResult<()> {
     if predefined_permissions::is_role_invitable(role_id) {
         return Ok(());


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Changed switch list api to also send inactive merchants in the response.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
To use this in this api to get all the merchant details

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
```
curl --location 'http://localhost:8080/user/switch/list' \
--header 'Authorization: Bearer JWT'
```
This api will send merchants with `is_active`: `false` in the response from now on.
```
[
    {
        "merchant_id": "merchant_1",
        "merchant_name": null,
        "is_active": false
    },
    {
        "merchant_id": "merchant_2",
        "merchant_name": null,
        "is_active": true
    }
]
```

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
