### PR TITLE
 refactor: [Noon] add new field max_amount to mandate request 

### DIFF
--- a/crates/router/src/compatibility/stripe/payment_intents/types.rs
+++ b/crates/router/src/compatibility/stripe/payment_intents/types.rs
@@ -738,9 +738,25 @@ impl ForeignTryFrom<(Option<MandateData>, Option<String>)> for Option<payments::
                             metadata: None,
                         },
                     )),
-                    StripeMandateType::MultiUse => Some(payments::MandateType::MultiUse(None)),
+                    StripeMandateType::MultiUse => Some(payments::MandateType::MultiUse(Some(
+                        payments::MandateAmountData {
+                            amount: mandate.amount.unwrap_or_default(),
+                            currency,
+                            start_date: mandate.start_date,
+                            end_date: mandate.end_date,
+                            metadata: None,
+                        },
+                    ))),
                 },
-                None => Some(api_models::payments::MandateType::MultiUse(None)),
+                None => Some(api_models::payments::MandateType::MultiUse(Some(
+                    payments::MandateAmountData {
+                        amount: mandate.amount.unwrap_or_default(),
+                        currency,
+                        start_date: mandate.start_date,
+                        end_date: mandate.end_date,
+                        metadata: None,
+                    },
+                ))),
             },
             customer_acceptance: Some(payments::CustomerAcceptance {
                 acceptance_type: payments::AcceptanceType::Online,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Resolves #3445

_Note
1.While connector create ensure `test_mode` is set to true
2.Ensure the currency passed is `AED` and country is `AE`_

## How did you test it?
1.Create a CIT with noon
 with 
```
  "connector_metadata": {
        "noon": {
            "order_category": "pay"
        }
    }
```
<img width="898" alt="Screenshot 2024-01-12 at 2 16 26 PM" src="https://github.com/juspay/hyperswitch/assets/131388445/4b99d41c-7d91-4e5c-b60c-b1d45b5f2e19">

</n>
without order_category it should throw an error

<img width="637" alt="Screenshot 2024-01-12 at 2 16 44 PM" src="https://github.com/juspay/hyperswitch/assets/131388445/24bffbaf-3699-4173-af78-ef432d82d1fe">

2. Make a MIT

<img width="675" alt="Screenshot 2024-01-12 at 2 02 35 PM" src="https://github.com/juspay/hyperswitch/assets/131388445/8d913c5f-cab0-436b-ad1d-8a0b3625f620">

3.Test through stripe compatibility layer
CIT
<img width="1233" alt="Screenshot 2024-02-06 at 7 11 36 PM" src="https://github.com/juspay/hyperswitch/assets/131388445/5015ae7f-36e4-4c71-8bc4-9674907bd9bc">

MIT 
<img width="746" alt="Screenshot 2024-02-06 at 7 11 30 PM" src="https://github.com/juspay/hyperswitch/assets/131388445/fd77df4f-9515-4979-8b5c-0da66ec3a57f">

MIT with greater amount
<img width="875" alt="Screenshot 2024-02-06 at 7 11 19 PM" src="https://github.com/juspay/hyperswitch/assets/131388445/366291ed-0e86-41c8-a247-6be25b7f2b6f">

4.Test Applepay mandates


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
