### PR TITLE
refactor: [Noon] add new field max_amount to mandate request

### DIFF
--- a/crates/router/src/compatibility/stripe/payment_intents/types.rs
+++ b/crates/router/src/compatibility/stripe/payment_intents/types.rs
@@ -738,9 +738,25 @@ impl ForeignTryFrom<(Option<MandateData>, Option<String>)> for Option<payments::
                             metadata: None,
                         },
                     )),
-                    StripeMandateType::MultiUse => Some(payments::MandateType::MultiUse(None)),
+                    StripeMandateType::MultiUse => Some(payments::MandateType::MultiUse(Some(
+                        payments::MandateAmountData {
+                            amount: mandate.amount.unwrap_or_default(),
+                            currency,
+                            start_date: mandate.start_date,
+                            end_date: mandate.end_date,
+                            metadata: None,
+                        },
+                    ))),
                 },
-                None => Some(api_models::payments::MandateType::MultiUse(None)),
+                None => Some(api_models::payments::MandateType::MultiUse(Some(
+                    payments::MandateAmountData {
+                        amount: mandate.amount.unwrap_or_default(),
+                        currency,
+                        start_date: mandate.start_date,
+                        end_date: mandate.end_date,
+                        metadata: None,
+                    },
+                ))),
             },
             customer_acceptance: Some(payments::CustomerAcceptance {
                 acceptance_type: payments::AcceptanceType::Online,

--- a/crates/router/src/connector/noon/transformers.rs
+++ b/crates/router/src/connector/noon/transformers.rs
@@ -1,13 +1,13 @@
 use common_utils::pii;
-use error_stack::ResultExt;
-use masking::Secret;
+use error_stack::{IntoReport, ResultExt};
+use masking::{PeekInterface, Secret};
 use serde::{Deserialize, Serialize};
 
 use crate::{
     connector::utils::{
         self as conn_utils, CardData, PaymentsAuthorizeRequestData, RouterData, WalletData,
     },
-    core::errors,
+    core::{errors, mandate::MandateBehaviour},
     services,
     types::{self, api, storage::enums, transformers::ForeignFrom, ErrorResponse},
     utils,
@@ -35,6 +35,7 @@ pub struct NoonSubscriptionData {
     subscription_type: NoonSubscriptionType,
     //Short description about the subscription.
     name: String,
+    max_amount: String,
 }
 
 #[derive(Debug, Serialize)]
@@ -91,7 +92,7 @@ pub struct NoonSubscription {
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct NoonCard {
-    name_on_card: Secret<String>,
+    name_on_card: Option<Secret<String>>,
     number_plain: cards::CardNumber,
     expiry_month: Secret<String>,
     expiry_year: Secret<String>,
@@ -158,7 +159,7 @@ pub struct NoonPayPal {
 }
 
 #[derive(Debug, Serialize)]
-#[serde(tag = "type", content = "data")]
+#[serde(tag = "type", content = "data", rename_all = "UPPERCASE")]
 pub enum NoonPaymentData {
     Card(NoonCard),
     Subscription(NoonSubscription),
@@ -200,10 +201,7 @@ impl TryFrom<&types::PaymentsAuthorizeRouterData> for NoonPaymentsRequest {
             _ => (
                 match item.request.payment_method_data.clone() {
                     api::PaymentMethodData::Card(req_card) => Ok(NoonPaymentData::Card(NoonCard {
-                        name_on_card: req_card
-                            .card_holder_name
-                            .clone()
-                            .unwrap_or(Secret::new("".to_string())),
+                        name_on_card: req_card.card_holder_name.clone(),
                         number_plain: req_card.card_number.clone(),
                         expiry_month: req_card.card_exp_month.clone(),
                         expiry_year: req_card.get_expiry_year_4_digit(),
@@ -296,7 +294,11 @@ impl TryFrom<&types::PaymentsAuthorizeRouterData> for NoonPaymentsRequest {
                     }
                 }?,
                 Some(item.request.currency),
-                item.request.order_category.clone(),
+                Some(item.request.order_category.clone().ok_or(
+                    errors::ConnectorError::MissingRequiredField {
+                        field_name: "order_category",
+                    },
+                )?),
             ),
         };
 
@@ -330,17 +332,40 @@ impl TryFrom<&types::PaymentsAuthorizeRouterData> for NoonPaymentsRequest {
                 },
             });
 
-        let (subscription, tokenize_c_c) =
-            match item.request.setup_future_usage.is_some().then_some((
-                NoonSubscriptionData {
-                    subscription_type: NoonSubscriptionType::Unscheduled,
-                    name: name.clone(),
-                },
-                true,
-            )) {
-                Some((a, b)) => (Some(a), Some(b)),
-                None => (None, None),
-            };
+        let subscription: Option<NoonSubscriptionData> = item
+            .request
+            .get_setup_mandate_details()
+            .map(|mandate_data| {
+                let max_amount = match &mandate_data.mandate_type {
+                    Some(data_models::mandates::MandateDataType::SingleUse(mandate))
+                    | Some(data_models::mandates::MandateDataType::MultiUse(Some(mandate))) => {
+                        conn_utils::to_currency_base_unit(mandate.amount, mandate.currency)
+                    }
+                    Some(data_models::mandates::MandateDataType::MultiUse(None)) => {
+                        Err(errors::ConnectorError::MissingRequiredField {
+                            field_name:
+                                "setup_future_usage.mandate_data.mandate_type.multi_use.amount",
+                        })
+                        .into_report()
+                    }
+                    None => Err(errors::ConnectorError::MissingRequiredField {
+                        field_name: "setup_future_usage.mandate_data.mandate_type",
+                    })
+                    .into_report(),
+                }?;
+
+                Ok::<NoonSubscriptionData, error_stack::Report<errors::ConnectorError>>(
+                    NoonSubscriptionData {
+                        subscription_type: NoonSubscriptionType::Unscheduled,
+                        name: name.clone(),
+                        max_amount,
+                    },
+                )
+            })
+            .transpose()?;
+
+        let tokenize_c_c = subscription.is_some().then_some(true);
+
         let order = NoonOrder {
             amount: conn_utils::to_currency_base_unit(item.request.amount, item.request.currency)?,
             currency,

--- a/crates/router/src/connector/noon/transformers.rs
+++ b/crates/router/src/connector/noon/transformers.rs
@@ -1,6 +1,6 @@
 use common_utils::pii;
 use error_stack::{IntoReport, ResultExt};
-use masking::{PeekInterface, Secret};
+use masking::Secret;
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -30,6 +30,7 @@ pub enum NoonSubscriptionType {
 }
 
 #[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct NoonSubscriptionData {
     #[serde(rename = "type")]
     subscription_type: NoonSubscriptionType,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Resolves #3445
Original PR:  #3481

_Note
1.While connector create ensure `test_mode` is set to true
2.Ensure the currency passed is `AED` and country is `AE`_

## How did you test it?
1.Create a CIT with noon
 with 
```
  "connector_metadata": {
        "noon": {
            "order_category": "pay"
        }
    }
```
<img width="898" alt="Screenshot 2024-01-12 at 2 16 26 PM" src="https://github.com/juspay/hyperswitch/assets/131388445/4b99d41c-7d91-4e5c-b60c-b1d45b5f2e19">

</n>
without order_category it should throw an error

<img width="637" alt="Screenshot 2024-01-12 at 2 16 44 PM" src="https://github.com/juspay/hyperswitch/assets/131388445/24bffbaf-3699-4173-af78-ef432d82d1fe">

2. Make a MIT

<img width="675" alt="Screenshot 2024-01-12 at 2 02 35 PM" src="https://github.com/juspay/hyperswitch/assets/131388445/8d913c5f-cab0-436b-ad1d-8a0b3625f620">

3.Test through stripe compatibility layer
CIT
<img width="1233" alt="Screenshot 2024-02-06 at 7 11 36 PM" src="https://github.com/juspay/hyperswitch/assets/131388445/5015ae7f-36e4-4c71-8bc4-9674907bd9bc">

MIT 
<img width="746" alt="Screenshot 2024-02-06 at 7 11 30 PM" src="https://github.com/juspay/hyperswitch/assets/131388445/fd77df4f-9515-4979-8b5c-0da66ec3a57f">

MIT with greater amount
<img width="875" alt="Screenshot 2024-02-06 at 7 11 19 PM" src="https://github.com/juspay/hyperswitch/assets/131388445/366291ed-0e86-41c8-a247-6be25b7f2b6f">

4.Test Applepay mandates


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
