### PR TITLE
refactor(webhooks): remove unnecessary clones and lazy evaluations

### DIFF
--- a/crates/diesel_models/src/events.rs
+++ b/crates/diesel_models/src/events.rs
@@ -5,9 +5,8 @@ use time::PrimitiveDateTime;
 
 use crate::{enums as storage_enums, schema::events};
 
-#[derive(Clone, Debug, Deserialize, Insertable, Serialize, router_derive::DebugAsDisplay)]
+#[derive(Clone, Debug, Insertable, router_derive::DebugAsDisplay)]
 #[diesel(table_name = events)]
-#[serde(deny_unknown_fields)]
 pub struct EventNew {
     pub event_id: String,
     pub event_type: storage_enums::EventType,

--- a/crates/router/src/core/webhooks.rs
+++ b/crates/router/src/core/webhooks.rs
@@ -250,12 +250,7 @@ pub async fn refunds_incoming_webhook_flow<W: types::OutgoingWebhookType>(
         )
         .await
         .to_not_found_response(errors::ApiErrorResponse::WebhookResourceNotFound)
-        .attach_printable_lazy(|| {
-            format!(
-                "Failed while updating refund: refund_id: {}",
-                refund_id.to_owned()
-            )
-        })?
+        .attach_printable_lazy(|| format!("Failed while updating refund: refund_id: {refund_id}"))?
     } else {
         refunds::refund_retrieve_core(
             state.clone(),
@@ -268,12 +263,7 @@ pub async fn refunds_incoming_webhook_flow<W: types::OutgoingWebhookType>(
             },
         )
         .await
-        .attach_printable_lazy(|| {
-            format!(
-                "Failed while updating refund: refund_id: {}",
-                refund_id.to_owned()
-            )
-        })?
+        .attach_printable_lazy(|| format!("Failed while updating refund: refund_id: {refund_id}"))?
     };
     let event_type: Option<enums::EventType> = updated_refund.refund_status.foreign_into();
 
@@ -711,7 +701,7 @@ pub async fn create_event_and_trigger_outgoing_webhook<W: types::OutgoingWebhook
     primary_object_type: enums::EventObjectType,
     content: api::OutgoingWebhookContent,
 ) -> CustomResult<(), errors::ApiErrorResponse> {
-    let event_id = format!("{primary_object_id}_{}", event_type);
+    let event_id = format!("{primary_object_id}_{event_type}");
     let new_event = storage::EventNew {
         event_id: event_id.clone(),
         event_type,

--- a/crates/router/src/core/webhooks.rs
+++ b/crates/router/src/core/webhooks.rs
@@ -1067,7 +1067,7 @@ pub async fn webhooks_core<W: types::OutgoingWebhookType, Ctx: PaymentMethodRetr
 
     logger::info!(process_webhook=?process_webhook_further);
 
-    let flow_type: api::WebhookFlow = event_type.to_owned().into();
+    let flow_type: api::WebhookFlow = event_type.into();
     let mut event_object: Box<dyn masking::ErasedMaskSerialize> = Box::new(serde_json::Value::Null);
     let webhook_effect = if process_webhook_further
         && !matches!(flow_type, api::WebhookFlow::ReturnResponse)

--- a/crates/router/src/core/webhooks.rs
+++ b/crates/router/src/core/webhooks.rs
@@ -808,7 +808,7 @@ pub async fn trigger_webhook_to_merchant<W: types::OutgoingWebhookType>(
 
     let mut header = vec![(
         reqwest::header::CONTENT_TYPE.to_string(),
-        "application/json".into(),
+        mime::APPLICATION_JSON.essence_str().into(),
     )];
 
     if let Some(signature) = outgoing_webhooks_signature {

--- a/crates/router/src/core/webhooks.rs
+++ b/crates/router/src/core/webhooks.rs
@@ -772,7 +772,6 @@ pub async fn create_event_and_trigger_outgoing_webhook<W: types::OutgoingWebhook
                 event.event_id.clone(),
                 event_type,
                 outgoing_webhook_event_type,
-                error.is_some(),
                 error,
             );
             match webhook_event.clone().try_into() {

--- a/crates/router/src/core/webhooks.rs
+++ b/crates/router/src/core/webhooks.rs
@@ -214,7 +214,7 @@ pub async fn refunds_incoming_webhook_flow<W: types::OutgoingWebhookType>(
                 )
                 .await
                 .change_context(errors::ApiErrorResponse::WebhookResourceNotFound)
-                .attach_printable_lazy(|| "Failed fetching the refund")?,
+                .attach_printable("Failed to fetch the refund")?,
             api_models::webhooks::RefundIdType::ConnectorRefundId(id) => db
                 .find_refund_by_merchant_id_connector_refund_id_connector(
                     &merchant_account.merchant_id,
@@ -224,7 +224,7 @@ pub async fn refunds_incoming_webhook_flow<W: types::OutgoingWebhookType>(
                 )
                 .await
                 .change_context(errors::ApiErrorResponse::WebhookResourceNotFound)
-                .attach_printable_lazy(|| "Failed fetching the refund")?,
+                .attach_printable("Failed to fetch the refund")?,
         },
         _ => Err(errors::ApiErrorResponse::WebhookProcessingFailure)
             .into_report()
@@ -1165,9 +1165,7 @@ pub async fn webhooks_core<W: types::OutgoingWebhookType, Ctx: PaymentMethodRetr
             resource_object: serde_json::to_vec(&event_object)
                 .into_report()
                 .change_context(errors::ParsingError::EncodeError("byte-vec"))
-                .attach_printable_lazy(|| {
-                    "Unable to convert webhook paylaod to a value".to_string()
-                })
+                .attach_printable("Unable to convert webhook payload to a value")
                 .change_context(errors::ApiErrorResponse::InternalServerError)
                 .attach_printable(
                     "There was an issue when encoding the incoming webhook body to bytes",

--- a/crates/router/src/core/webhooks.rs
+++ b/crates/router/src/core/webhooks.rs
@@ -11,7 +11,11 @@ use api_models::{
 use common_utils::{errors::ReportSwitchExt, events::ApiEventsType, request::RequestContent};
 use error_stack::{report, IntoReport, ResultExt};
 use masking::ExposeInterface;
-use router_env::{instrument, tracing, tracing_actix_web::RequestId};
+use router_env::{
+    instrument,
+    tracing::{self, Instrument},
+    tracing_actix_web::RequestId,
+};
 
 use super::{errors::StorageErrorExt, metrics};
 #[cfg(feature = "stripe")]
@@ -772,7 +776,7 @@ pub async fn create_event_and_trigger_outgoing_webhook<W: types::OutgoingWebhook
                     logger::error!(error=?err, event=?webhook_event, "Error Logging Outgoing Webhook Event");
                 }
             }
-        });
+        }.in_current_span());
     }
 
     Ok(())

--- a/crates/router/src/events/outgoing_webhook_logs.rs
+++ b/crates/router/src/events/outgoing_webhook_logs.rs
@@ -82,7 +82,6 @@ impl OutgoingWebhookEvent {
         event_id: String,
         event_type: OutgoingWebhookEventType,
         content: Option<OutgoingWebhookEventContent>,
-        is_error: bool,
         error: Option<Value>,
     ) -> Self {
         Self {
@@ -90,7 +89,7 @@ impl OutgoingWebhookEvent {
             event_id,
             event_type,
             content,
-            is_error,
+            is_error: error.is_some(),
             error,
             created_at_timestamp: OffsetDateTime::now_utc().unix_timestamp_nanos() / 1_000_000,
         }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
This PR includes minor refactors and improvements to the webhooks code. The PR can easily be reviewed one commit at a time, to understand the changes involved.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
The webhooks flows contains a few redundant clones, unnecessary lazy evaluation (using `attach_printable_lazy()` instead of `attach_printable()`), spawning of a future on the `tokio` runtime without the current `tracing` span information, etc. This PR addresses those concerns.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Most of the changes are such that the code should work if it compiles.
However, I performed a sanity test of incoming and outgoing webhooks for a successful payment and refund.

- Screenshot of Postman folder run containing payments create and retrieve, followed by refunds create and retrieve API calls:

  <img width="800" alt="Screenshot of Postman folder run" src="https://github.com/juspay/hyperswitch/assets/22217505/dc7b2de2-2772-4a39-b895-565719c80651">

- Screenshot of captured outgoing webhooks for a successful payment and refund, respectively:

  
  <img width="500" alt="Screenshot of captured successful payment outgoing webhook" src="https://github.com/juspay/hyperswitch/assets/22217505/f07a30be-26cb-4187-867f-766e43cf07ba">

  <img width="500" alt="Screenshot of captured successful refund outgoing webhook" src="https://github.com/juspay/hyperswitch/assets/22217505/0bfae552-d65b-44bd-9de6-79dd38b4b54c">


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
