### PR TITLE
chore: address Rust 1.76 clippy lints

### DIFF
--- a/crates/router/src/compatibility/wrap.rs
+++ b/crates/router/src/compatibility/wrap.rs
@@ -42,7 +42,7 @@ where
     let start_instant = Instant::now();
     logger::info!(tag = ?Tag::BeginRequest, payload = ?payload);
 
-    let res = match metrics::request::record_request_time_metric(
+    let server_wrap_util_res = metrics::request::record_request_time_metric(
         api::server_wrap_util(
             &flow,
             state.clone().into(),
@@ -58,7 +58,9 @@ where
     .map(|response| {
         logger::info!(api_response =? response);
         response
-    }) {
+    });
+
+    let res = match server_wrap_util_res {
         Ok(api::ApplicationResponse::Json(response)) => {
             let response = S::try_from(response);
             match response {

--- a/crates/router/src/db/address.rs
+++ b/crates/router/src/db/address.rs
@@ -656,7 +656,7 @@ impl AddressInterface for MockDb {
         address_update: storage_types::AddressUpdate,
         key_store: &domain::MerchantKeyStore,
     ) -> CustomResult<domain::Address, errors::StorageError> {
-        match self
+        let updated_addr = self
             .addresses
             .lock()
             .await
@@ -667,7 +667,8 @@ impl AddressInterface for MockDb {
                     AddressUpdateInternal::from(address_update).create_address(a.clone());
                 *a = address_updated.clone();
                 address_updated
-            }) {
+            });
+        match updated_addr {
             Some(address_updated) => address_updated
                 .convert(key_store.key.get_inner())
                 .await
@@ -687,7 +688,7 @@ impl AddressInterface for MockDb {
         key_store: &domain::MerchantKeyStore,
         _storage_scheme: MerchantStorageScheme,
     ) -> CustomResult<domain::Address, errors::StorageError> {
-        match self
+        let updated_addr = self
             .addresses
             .lock()
             .await
@@ -698,7 +699,8 @@ impl AddressInterface for MockDb {
                     AddressUpdateInternal::from(address_update).create_address(a.clone());
                 *a = address_updated.clone();
                 address_updated
-            }) {
+            });
+        match updated_addr {
             Some(address_updated) => address_updated
                 .convert(key_store.key.get_inner())
                 .await
@@ -757,7 +759,7 @@ impl AddressInterface for MockDb {
         address_update: storage_types::AddressUpdate,
         key_store: &domain::MerchantKeyStore,
     ) -> CustomResult<Vec<domain::Address>, errors::StorageError> {
-        match self
+        let updated_addr = self
             .addresses
             .lock()
             .await
@@ -771,7 +773,8 @@ impl AddressInterface for MockDb {
                     AddressUpdateInternal::from(address_update).create_address(a.clone());
                 *a = address_updated.clone();
                 address_updated
-            }) {
+            });
+        match updated_addr {
             Some(address) => {
                 let address: domain::Address = address
                     .convert(key_store.key.get_inner())

--- a/crates/router/src/db/merchant_connector_account.rs
+++ b/crates/router/src/db/merchant_connector_account.rs
@@ -691,7 +691,7 @@ impl MerchantConnectorAccountInterface for MockDb {
         merchant_connector_account: storage::MerchantConnectorAccountUpdateInternal,
         key_store: &domain::MerchantKeyStore,
     ) -> CustomResult<domain::MerchantConnectorAccount, errors::StorageError> {
-        match self
+        let mca_update_res = self
             .merchant_connector_accounts
             .lock()
             .await
@@ -709,8 +709,9 @@ impl MerchantConnectorAccountInterface for MockDb {
                     .await
                     .change_context(errors::StorageError::DecryptionError)
             })
-            .await
-        {
+            .await;
+
+        match mca_update_res {
             Some(result) => result,
             None => {
                 return Err(errors::StorageError::ValueNotFound(

--- a/crates/router/src/db/payment_method.rs
+++ b/crates/router/src/db/payment_method.rs
@@ -212,7 +212,7 @@ impl PaymentMethodInterface for MockDb {
         payment_method: storage::PaymentMethod,
         payment_method_update: storage::PaymentMethodUpdate,
     ) -> CustomResult<storage::PaymentMethod, errors::StorageError> {
-        match self
+        let pm_update_res = self
             .payment_methods
             .lock()
             .await
@@ -224,7 +224,9 @@ impl PaymentMethodInterface for MockDb {
                         .create_payment_method(pm.clone());
                 *pm = payment_method_updated.clone();
                 payment_method_updated
-            }) {
+            });
+
+        match pm_update_res {
             Some(result) => Ok(result),
             None => Err(errors::StorageError::ValueNotFound(
                 "cannot find payment method to update".to_string(),

--- a/crates/router/src/services/api.rs
+++ b/crates/router/src/services/api.rs
@@ -1083,7 +1083,7 @@ where
     let start_instant = Instant::now();
     logger::info!(tag = ?Tag::BeginRequest, payload = ?payload);
 
-    let res = match metrics::request::record_request_time_metric(
+    let server_wrap_util_res = metrics::request::record_request_time_metric(
         server_wrap_util(
             &flow,
             state.clone(),
@@ -1099,7 +1099,9 @@ where
     .map(|response| {
         logger::info!(api_response =? response);
         response
-    }) {
+    });
+
+    let res = match server_wrap_util_res {
         Ok(ApplicationResponse::Json(response)) => match serde_json::to_string(&response) {
             Ok(res) => http_response_json(res),
             Err(_) => http_response_err(

--- a/crates/scheduler/src/utils.rs
+++ b/crates/scheduler/src/utils.rs
@@ -109,7 +109,7 @@ where
     {
         Ok(x) => Ok(x),
         Err(mut err) => {
-            match state
+            let update_res = state
                 .process_tracker_update_process_status_by_ids(
                     pt_batch.trackers.iter().map(|process| process.id.clone()).collect(),
                     storage::ProcessTrackerUpdate::StatusUpdate {
@@ -123,12 +123,14 @@ where
                 }, |count| {
                     logger::debug!("Updated status of {count} processes");
                     Ok(())
-                }) {
-                    Ok(_) => (),
-                    Err(inner_err) => {
-                        err.extend_one(inner_err);
-                    }
-                };
+                });
+
+            match update_res {
+                Ok(_) => (),
+                Err(inner_err) => {
+                    err.extend_one(inner_err);
+                }
+            };
 
             Err(err)
         }

--- a/crates/test_utils/src/newman_runner.rs
+++ b/crates/test_utils/src/newman_runner.rs
@@ -56,7 +56,6 @@ where
 
     // Open the file in write mode or create it if it doesn't exist
     let mut file = std::fs::OpenOptions::new()
-        .write(true)
         .append(true)
         .create(true)
         .open(file_path)?;


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [x] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
This PR addresses the clippy lints occurring due to new rust version 1.76

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Rust updation clippy lints are addressed here. So basic sanity test should suffice

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
