### PR TITLE
fix(payment_methods): unmask last4 digits of card when listing payment methods for customer

### DIFF
--- a/crates/router/src/core/payment_methods/cards.rs
+++ b/crates/router/src/core/payment_methods/cards.rs
@@ -248,11 +248,7 @@ pub async fn add_payment_method(
                         Ok(pm) => {
                             let updated_card = Some(api::CardDetailFromLocker {
                                 scheme: None,
-                                last4_digits: Some(
-                                    card.card_number
-                                        .to_string()
-                                        .split_off(card.card_number.to_string().len() - 4),
-                                ),
+                                last4_digits: Some(card.card_number.clone().get_last4()),
                                 issuer_country: None,
                                 card_number: Some(card.card_number),
                                 expiry_month: Some(card.card_exp_month),


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
When metadata of a saved card is updated and customer payment methods are listed, the updated card's last 4 digit is getting masked in the response. This PR unmasks it and returns the raw digits.

Bug: `last4_digits` is masked -

![image](https://github.com/juspay/hyperswitch/assets/70657455/6c3b9af6-a584-4c76-9645-aae71e004a4b)

Fix: unmasked - 

![image](https://github.com/juspay/hyperswitch/assets/70657455/bc5712f5-bd7f-463c-abb4-5f78a5505215)


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
1. Save a card in locker
2. Change the metadata of the saved card and try to save it again in locker
3. Now when `list_customer_payment_method` is called, the `last4_digits` field of the updated card has to be unmasked

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
