### PR TITLE
fix(payment_methods): unmask last4 when metadata changed during /payments

### DIFF
--- a/crates/router/src/core/payments/tokenization.rs
+++ b/crates/router/src/core/payments/tokenization.rs
@@ -209,9 +209,7 @@ where
                                         let updated_card = Some(CardDetailFromLocker {
                                             scheme: None,
                                             last4_digits: Some(
-                                                card.card_number.to_string().split_off(
-                                                    card.card_number.to_string().len() - 4,
-                                                ),
+                                                card.card_number.clone().get_last4(),
                                             ),
                                             issuer_country: None,
                                             card_number: Some(card.card_number),


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
When a metadata is changed during /payments and list customer payment method is called, last4 digits is getting masked. This PR unmasks it

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
1. Save a card in locker using /payments
2. Change the metadata of the saved card and try to save it again in locker using /payments
3. Now when list_customer_payment_method is called, the last4_digits field of the updated card has to be unmasked

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
