### PR TITLE
docs(connector): Add wasm docs in connector integration docs 

### DIFF
--- a/add_connector.md
+++ b/add_connector.md
@@ -703,11 +703,11 @@ cargo install wasm-pack
 
    provide the necessary configuration details for the `example_connector`. Don't forget to save the file.
 
-3. Update Paths:
+3. Update paths:
 
    Replace `/absolute/path/to/hyperswitch-control-center` with the absolute path to your Hyperswitch Control Center repository and `/absolute/path/to/hyperswitch` with the absolute path to your Hyperswitch repository.
 
-4. Run `wasm-pack` Build:
+4. Run `wasm-pack` build:
 
    Execute the following command in your terminal:
 

--- a/add_connector.md
+++ b/add_connector.md
@@ -668,6 +668,71 @@ In the `connector/utils.rs` file, you'll discover utility functions that aid in 
   let json_wallet_data: CheckoutGooglePayData =wallet_data.get_wallet_token_as_json()?;
 ```
 
+### **Connector configs for control center**
+
+This section is explicitly for developers who are using the [Hyperswitch Control Center](https://github.com/juspay/hyperswitch-control-center). Below is a more detailed documentation that guides you through updating the connector configuration in the development.toml file in Hyperswitch and running the wasm-pack build command. Please replace placeholders such as /absolute/path/to/ with the actual absolute paths.
+
+1. cargo install wasm-pack
+
+Update Connector Configuration
+
+1. Open `development.toml` file:
+
+   Open the `development.toml` file located at `crates/connector_configs/toml/development.toml` in your Hyperswitch project.
+
+2. Add Connector Configuration:
+
+   Locate the [stripe] section as an example and add the configuration for the `example_connector`. Here's an example:
+
+   ```toml
+   # crates/connector_configs/toml/development.toml
+
+   # Other connector configurations...
+
+   [stripe]
+   [stripe.connector_auth.HeaderKey]
+   api_key="Secret Key"
+
+   # Add any other Stripe-specific configuration here
+
+   [example_connector]
+   # Your specific connector configuration for reference
+   # ...
+
+   ```
+
+   provide the necessary configuration details for the `example_connector`.
+
+3. Save the File:
+
+   Save the changes made to `development.toml`.
+
+Run `wasm-pack` Build Command
+
+Now, update the paths in the `wasm-pack` build command and execute it.
+
+1. Update Paths:
+
+   Replace `/absolute/path/to/hyperswitch-control-center` with the absolute path to your Hyperswitch Control Center repository and `/absolute/path/to/hyperswitch` with the absolute path to your Hyperswitch repository.
+
+2. Run `wasm-pack` Build:
+
+   Execute the following command in your terminal:
+
+   ```bash
+   wasm-pack build --target web --out-dir /absolute/path/to/hyperswitch-control-center/public/hyperswitch/wasm --out-name euclid /absolute/path/to/hyperswitch/crates/euclid_wasm -- --features dummy_connector
+   ```
+
+   This command builds the WebAssembly files for the `dummy_connector` feature and places them in the specified directory.
+
+Notes:
+
+- Ensure that you replace placeholders like `/absolute/path/to/` with the actual absolute paths in your file system.
+- Verify that your connector configurations in `development.toml` are correct and saved before running the `wasm-pack` command.
+- Check for any error messages during the build process and resolve them accordingly.
+
+By following these steps, you should be able to update the connector configuration and build the WebAssembly files successfully.
+
 ### **Test the connector**
 
 The template code script generates a test file for the connector, containing 20 sanity tests. We anticipate that you will implement these tests when adding a new connector.

--- a/add_connector.md
+++ b/add_connector.md
@@ -725,6 +725,130 @@ Notes:
 
 By following these steps, you should be able to update the connector configuration and build the WebAssembly files successfully.
 
+Certainly! Below is a detailed documentation guide on updating the `ConnectorTypes.res` and `ConnectorUtils.res` files in your [Hyperswitch Control Center](https://github.com/juspay/hyperswitch-control-center) project.
+
+Update `ConnectorTypes.res`:
+
+1. Open `ConnectorTypes.res`:
+
+   Open the `ConnectorTypes.res` file located at `src/screens/HyperSwitch/Connectors/ConnectorTypes.res` in your Hyperswitch-Control-Center project.
+
+2. Add Connector enum:
+
+   Add the new connector name enum under the `type connectorName` section. Here's an example:
+
+   ```reason
+   /* src/screens/HyperSwitch/Connectors/ConnectorTypes.res */
+
+   type connectorName =
+     | Stripe
+     | DummyConnector
+     | YourNewConnector
+     /* Add any other connector enums as needed */
+   ```
+
+   Replace `YourNewConnector` with the name of your newly added connector.
+
+3. Save the file:
+
+   Save the changes made to `ConnectorTypes.res`.
+
+Update `ConnectorUtils.res`:
+
+1. Open `ConnectorUtils.res`:
+
+   Open the `ConnectorUtils.res` file located at `src/screens/HyperSwitch/Connectors/ConnectorUtils.res` in your [Hyperswitch Control Center](https://github.com/juspay/hyperswitch-control-center) project.
+
+2. Add Connector Description:
+
+   Update the following functions in `ConnectorUtils.res`:
+
+   ```reason
+   /* src/screens/HyperSwitch/Connectors/ConnectorUtils.res */
+
+
+   let connectorList : array<connectorName> = [Stripe,YourNewConnector]
+
+
+   let getConnectorNameString = (connectorName: connectorName) =>
+     switch connectorName {
+     | Stripe => "Stripe"
+     | DummyConnector => "Dummy Connector"
+     | YourNewConnector => "Your New Connector"
+     /* Add cases for other connectors */
+     };
+
+   let getConnectorNameTypeFromString = (str: string) =>
+     switch str {
+     | "Stripe" => Stripe
+     | "Dummy Connector" => DummyConnector
+     | "Your New Connector" => YourNewConnector
+     /* Add cases for other connectors */
+     };
+
+   let getConnectorInfo = (connectorName: connectorName) =>
+     switch connectorName {
+     | Stripe => "Stripe connector description."
+     | DummyConnector => "Dummy Connector description."
+     | YourNewConnector => "Your New Connector description."
+     /* Add descriptions for other connectors */
+     };
+
+   let getDisplayNameForConnectors = (connectorName: connectorName) =>
+     switch connectorName {
+     | Stripe => "Stripe"
+     | DummyConnector => "Dummy Connector"
+     | YourNewConnector => "Your New Connector"
+     /* Add display names for other connectors */
+     };
+   ```
+
+   Adjust the strings and descriptions according to your actual connector names and descriptions.
+
+
+4. Save the File:
+
+   Save the changes made to `ConnectorUtils.res`.
+
+Notes:
+
+- Ensure that you replace placeholders like `YourNewConnector` with the actual names of your connectors.
+- Verify that your connector enums and descriptions are correctly updated.
+- Save the files after making the changes.
+
+By following these steps, you should be able to update the `ConnectorTypes.res` and `ConnectorUtils.res` files with the new connector enum and its related information.
+
+
+
+Certainly! Below is a detailed documentation guide on how to add a new connector icon under the `public/hyperswitch/Gateway` folder in your Hyperswitch-Control-Center project.
+
+Add Connector icon:
+
+1. Prepare the icon:
+
+   Prepare your connector icon in SVG format. Ensure that the icon is named in uppercase, following the convention. For example, name it `YOURCONNECTOR.SVG`.
+
+2. Open file explorer:
+
+   Open your file explorer and navigate to the `public/hyperswitch/Gateway` folder in your Hyperswitch-Control-Center project.
+
+3. Add Icon file:
+
+   Copy and paste your SVG icon file (e.g., `YOURCONNECTOR.SVG`) into the `Gateway` folder.
+
+4. Verify file structure:
+
+   Ensure that the file structure in the `Gateway` folder follows the uppercase convention. For example:
+
+   ```
+   public
+   └── hyperswitch
+       └── Gateway
+           └── YOURCONNECTOR.SVG
+   ```
+    Save the changes made to the `Gateway` folder.
+
+
 ### **Test the connector**
 
 The template code script generates a test file for the connector, containing 20 sanity tests. We anticipate that you will implement these tests when adding a new connector.

--- a/add_connector.md
+++ b/add_connector.md
@@ -672,15 +672,15 @@ In the `connector/utils.rs` file, you'll discover utility functions that aid in 
 
 This section is explicitly for developers who are using the [Hyperswitch Control Center](https://github.com/juspay/hyperswitch-control-center). Below is a more detailed documentation that guides you through updating the connector configuration in the development.toml file in Hyperswitch and running the wasm-pack build command. Please replace placeholders such as /absolute/path/to/ with the actual absolute paths.
 
-1. cargo install wasm-pack
+1. Install wasm-pack: Run the following command to install wasm-pack:
 
-Update Connector Configuration
+```bash 
+cargo install wasm-pack
+```
 
-1. Open `development.toml` file:
+2. Add connector configuration:
 
    Open the `development.toml` file located at `crates/connector_configs/toml/development.toml` in your Hyperswitch project.
-
-2. Add Connector Configuration:
 
    Locate the [stripe] section as an example and add the configuration for the `example_connector`. Here's an example:
 
@@ -701,21 +701,13 @@ Update Connector Configuration
 
    ```
 
-   provide the necessary configuration details for the `example_connector`.
+   provide the necessary configuration details for the `example_connector`. Don't forget to save the file.
 
-3. Save the File:
-
-   Save the changes made to `development.toml`.
-
-Run `wasm-pack` Build Command
-
-Now, update the paths in the `wasm-pack` build command and execute it.
-
-1. Update Paths:
+3. Update Paths:
 
    Replace `/absolute/path/to/hyperswitch-control-center` with the absolute path to your Hyperswitch Control Center repository and `/absolute/path/to/hyperswitch` with the absolute path to your Hyperswitch repository.
 
-2. Run `wasm-pack` Build:
+4. Run `wasm-pack` Build:
 
    Execute the following command in your terminal:
 

--- a/add_connector.md
+++ b/add_connector.md
@@ -670,7 +670,7 @@ In the `connector/utils.rs` file, you'll discover utility functions that aid in 
 
 ### **Connector configs for control center**
 
-This section is explicitly for developers who are using the [Hyperswitch Control Center](https://github.com/juspay/hyperswitch-control-center). Below is a more detailed documentation that guides you through updating the connector configuration in the development.toml file in Hyperswitch and running the wasm-pack build command. Please replace placeholders such as /absolute/path/to/ with the actual absolute paths.
+This section is explicitly for developers who are using the [Hyperswitch Control Center](https://github.com/juspay/hyperswitch-control-center). Below is a more detailed documentation that guides you through updating the connector configuration in the `development.toml` file in Hyperswitch and running the wasm-pack build command. Please replace placeholders such as `/absolute/path/to/` with the actual absolute paths.
 
 1. Install wasm-pack: Run the following command to install wasm-pack:
 


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [x] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
This PR adds documentation to add_connector.md explaining how to add connectors to the Control Center via Wasm configs.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Testing not required

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
