### PR TITLE
refactor(router): remove fallback feature for `/add` and `/get` for locker

### DIFF
--- a/crates/api_models/src/enums.rs
+++ b/crates/api_models/src/enums.rs
@@ -502,8 +502,7 @@ pub enum RetryAction {
 
 #[derive(Clone, Copy)]
 pub enum LockerChoice {
-    Basilisk,
-    Tartarus,
+    HyperswitchCardVault,
 }
 
 #[derive(

--- a/crates/router/src/core/locker_migration.rs
+++ b/crates/router/src/core/locker_migration.rs
@@ -126,7 +126,7 @@ pub async fn call_to_locker(
                 &card_details,
                 customer_id.to_string(),
                 merchant_account,
-                api_enums::LockerChoice::Tartarus,
+                api_enums::LockerChoice::HyperswitchCardVault,
                 Some(&pm.payment_method_id),
             )
             .await

--- a/crates/router/src/core/payment_methods/cards.rs
+++ b/crates/router/src/core/payment_methods/cards.rs
@@ -225,7 +225,7 @@ pub async fn add_payment_method(
                         &card,
                         customer_id.clone(),
                         merchant_account,
-                        api::enums::LockerChoice::Tartarus,
+                        api::enums::LockerChoice::HyperswitchCardVault,
                         Some(&resp.payment_method_id),
                     )
                     .await;
@@ -454,7 +454,7 @@ pub async fn add_bank_to_locker(
         state,
         &payload,
         customer_id,
-        api_enums::LockerChoice::Basilisk,
+        api_enums::LockerChoice::HyperswitchCardVault,
     )
     .await?;
     let payment_method_resp = payment_methods::mk_add_bank_response_hs(
@@ -489,40 +489,8 @@ pub async fn add_card_to_locker(
                 card,
                 customer_id.to_string(),
                 merchant_account,
-                api_enums::LockerChoice::Basilisk,
+                api_enums::LockerChoice::HyperswitchCardVault,
                 None,
-            )
-            .await
-            .map_err(|error| {
-                metrics::CARD_LOCKER_FAILURES.add(
-                    &metrics::CONTEXT,
-                    1,
-                    &[
-                        router_env::opentelemetry::KeyValue::new("locker", "basilisk"),
-                        router_env::opentelemetry::KeyValue::new("operation", "add"),
-                    ],
-                );
-                error
-            })
-        },
-        &metrics::CARD_ADD_TIME,
-        &[router_env::opentelemetry::KeyValue::new(
-            "locker", "basilisk",
-        )],
-    )
-    .await?;
-    logger::debug!("card added to basilisk locker");
-
-    let add_card_to_rs_resp = request::record_operation_time(
-        async {
-            add_card_hs(
-                state,
-                req,
-                card,
-                customer_id.to_string(),
-                merchant_account,
-                api_enums::LockerChoice::Tartarus,
-                Some(&add_card_to_hs_resp.0.payment_method_id),
             )
             .await
             .map_err(|error| {
@@ -540,34 +508,10 @@ pub async fn add_card_to_locker(
         &metrics::CARD_ADD_TIME,
         &[router_env::opentelemetry::KeyValue::new("locker", "rust")],
     )
-    .await;
+    .await?;
 
-    match add_card_to_rs_resp {
-        value @ Ok(_) => {
-            logger::debug!("card added to rust locker");
-            let _ = &metrics::CARD_LOCKER_SUCCESSFUL_RESPONSE.add(
-                &metrics::CONTEXT,
-                1,
-                &[
-                    router_env::opentelemetry::KeyValue::new("locker", "rust"),
-                    router_env::opentelemetry::KeyValue::new("operation", "add"),
-                ],
-            );
-            value
-        }
-        Err(err) => {
-            logger::debug!(error =? err,"failed to add card to rust locker");
-            let _ = &metrics::CARD_LOCKER_SUCCESSFUL_RESPONSE.add(
-                &metrics::CONTEXT,
-                1,
-                &[
-                    router_env::opentelemetry::KeyValue::new("locker", "basilisk"),
-                    router_env::opentelemetry::KeyValue::new("operation", "add"),
-                ],
-            );
-            Ok(add_card_to_hs_resp)
-        }
-    }
+    logger::debug!("card added to hyperswitch-card-vault");
+    Ok(add_card_to_hs_resp)
 }
 
 pub async fn get_card_from_locker(
@@ -585,11 +529,11 @@ pub async fn get_card_from_locker(
                 customer_id,
                 merchant_id,
                 card_reference,
-                api_enums::LockerChoice::Tartarus,
+                api_enums::LockerChoice::HyperswitchCardVault,
             )
             .await
             .change_context(errors::ApiErrorResponse::InternalServerError)
-            .attach_printable("Failed while getting card from basilisk_hs")
+            .attach_printable("Failed while getting card from hyperswitch card vault")
             .map_err(|error| {
                 metrics::CARD_LOCKER_FAILURES.add(
                     &metrics::CONTEXT,
@@ -605,64 +549,10 @@ pub async fn get_card_from_locker(
         &metrics::CARD_GET_TIME,
         &[router_env::opentelemetry::KeyValue::new("locker", "rust")],
     )
-    .await;
+    .await?;
 
-    match get_card_from_rs_locker_resp {
-        Err(_) => request::record_operation_time(
-            async {
-                get_card_from_hs_locker(
-                    state,
-                    customer_id,
-                    merchant_id,
-                    card_reference,
-                    api_enums::LockerChoice::Basilisk,
-                )
-                .await
-                .change_context(errors::ApiErrorResponse::InternalServerError)
-                .attach_printable("Failed while getting card from basilisk_hs")
-                .map_err(|error| {
-                    metrics::CARD_LOCKER_FAILURES.add(
-                        &metrics::CONTEXT,
-                        1,
-                        &[
-                            router_env::opentelemetry::KeyValue::new("locker", "basilisk"),
-                            router_env::opentelemetry::KeyValue::new("operation", "get"),
-                        ],
-                    );
-                    error
-                })
-            },
-            &metrics::CARD_GET_TIME,
-            &[router_env::opentelemetry::KeyValue::new(
-                "locker", "basilisk",
-            )],
-        )
-        .await
-        .map(|inner_card| {
-            logger::debug!("card retrieved from basilisk locker");
-            let _ = &metrics::CARD_LOCKER_SUCCESSFUL_RESPONSE.add(
-                &metrics::CONTEXT,
-                1,
-                &[
-                    router_env::opentelemetry::KeyValue::new("locker", "basilisk"),
-                    router_env::opentelemetry::KeyValue::new("operation", "get"),
-                ],
-            );
-            inner_card
-        }),
-        Ok(_) => {
-            logger::debug!("card retrieved from rust locker");
-            let _ = &metrics::CARD_LOCKER_SUCCESSFUL_RESPONSE.add(
-                &metrics::CONTEXT,
-                1,
-                &[
-                    router_env::opentelemetry::KeyValue::new("locker", "rust"),
-                    router_env::opentelemetry::KeyValue::new("operation", "get"),
-                ],
-            );
-            get_card_from_rs_locker_resp
-        }
-    }
+    logger::debug!("card retrieved from rust locker");
+    Ok(get_card_from_rs_locker_resp)
 }
 
 pub async fn delete_card_from_locker(
@@ -967,7 +857,7 @@ pub async fn delete_card_from_hs_locker<'a>(
         let decrypted_payload = payment_methods::get_decrypted_response_payload(
             jwekey,
             jwe_body,
-            Some(api_enums::LockerChoice::Basilisk),
+            Some(api_enums::LockerChoice::HyperswitchCardVault),
         )
         .await
         .change_context(errors::ApiErrorResponse::InternalServerError)

--- a/crates/router/src/core/payment_methods/transformers.rs
+++ b/crates/router/src/core/payment_methods/transformers.rs
@@ -198,14 +198,11 @@ pub async fn get_decrypted_response_payload(
     jwe_body: encryption::JweBody,
     locker_choice: Option<api_enums::LockerChoice>,
 ) -> CustomResult<String, errors::VaultError> {
-    let target_locker = locker_choice.unwrap_or(api_enums::LockerChoice::Basilisk);
+    let target_locker = locker_choice.unwrap_or(api_enums::LockerChoice::HyperswitchCardVault);
 
     #[cfg(feature = "aws_kms")]
     let public_key = match target_locker {
-        api_enums::LockerChoice::Basilisk => jwekey.jwekey.peek().vault_encryption_key.as_bytes(),
-        api_enums::LockerChoice::Tartarus => {
-            jwekey.jwekey.peek().rust_locker_encryption_key.as_bytes()
-        }
+        api_enums::LockerChoice::HyperswitchCardVault => jwekey.jwekey.peek().vault_encryption_key.as_bytes(),
     };
 
     #[cfg(feature = "aws_kms")]
@@ -213,8 +210,7 @@ pub async fn get_decrypted_response_payload(
 
     #[cfg(not(feature = "aws_kms"))]
     let public_key = match target_locker {
-        api_enums::LockerChoice::Basilisk => jwekey.vault_encryption_key.as_bytes(),
-        api_enums::LockerChoice::Tartarus => jwekey.rust_locker_encryption_key.as_bytes(),
+        api_enums::LockerChoice::HyperswitchCardVault => jwekey.vault_encryption_key.as_bytes(),
     };
 
     #[cfg(not(feature = "aws_kms"))]
@@ -266,16 +262,12 @@ pub async fn mk_basilisk_req(
 
     #[cfg(feature = "aws_kms")]
     let public_key = match locker_choice {
-        api_enums::LockerChoice::Basilisk => jwekey.jwekey.peek().vault_encryption_key.as_bytes(),
-        api_enums::LockerChoice::Tartarus => {
-            jwekey.jwekey.peek().rust_locker_encryption_key.as_bytes()
-        }
+        api_enums::LockerChoice::HyperswitchCardVault => jwekey.jwekey.peek().vault_encryption_key.as_bytes(),
     };
 
     #[cfg(not(feature = "aws_kms"))]
     let public_key = match locker_choice {
-        api_enums::LockerChoice::Basilisk => jwekey.vault_encryption_key.as_bytes(),
-        api_enums::LockerChoice::Tartarus => jwekey.rust_locker_encryption_key.as_bytes(),
+        api_enums::LockerChoice::HyperswitchCardVault => jwekey.vault_encryption_key.as_bytes(),
     };
 
     let jwe_encrypted = encryption::encrypt_jwe(&payload, public_key)
@@ -321,8 +313,7 @@ pub async fn mk_add_locker_request_hs<'a>(
 
     let jwe_payload = mk_basilisk_req(jwekey, &jws, locker_choice).await?;
     let mut url = match locker_choice {
-        api_enums::LockerChoice::Basilisk => locker.host.to_owned(),
-        api_enums::LockerChoice::Tartarus => locker.host_rs.to_owned(),
+        api_enums::LockerChoice::HyperswitchCardVault => locker.host.to_owned(),
     };
     url.push_str("/cards/add");
     let mut request = services::Request::new(services::Method::Post, &url);
@@ -497,12 +488,11 @@ pub async fn mk_get_card_request_hs(
         .await
         .change_context(errors::VaultError::RequestEncodingFailed)?;
 
-    let target_locker = locker_choice.unwrap_or(api_enums::LockerChoice::Basilisk);
+    let target_locker = locker_choice.unwrap_or(api_enums::LockerChoice::HyperswitchCardVault);
 
     let jwe_payload = mk_basilisk_req(jwekey, &jws, target_locker).await?;
     let mut url = match target_locker {
-        api_enums::LockerChoice::Basilisk => locker.host.to_owned(),
-        api_enums::LockerChoice::Tartarus => locker.host_rs.to_owned(),
+        api_enums::LockerChoice::HyperswitchCardVault => locker.host.to_owned(),
     };
     url.push_str("/cards/retrieve");
     let mut request = services::Request::new(services::Method::Post, &url);
@@ -573,7 +563,7 @@ pub async fn mk_delete_card_request_hs(
         .await
         .change_context(errors::VaultError::RequestEncodingFailed)?;
 
-    let jwe_payload = mk_basilisk_req(jwekey, &jws, api_enums::LockerChoice::Basilisk).await?;
+    let jwe_payload = mk_basilisk_req(jwekey, &jws, api_enums::LockerChoice::HyperswitchCardVault).await?;
 
     let mut url = locker.host.to_owned();
     url.push_str("/cards/delete");

--- a/crates/router/src/core/payment_methods/transformers.rs
+++ b/crates/router/src/core/payment_methods/transformers.rs
@@ -202,7 +202,9 @@ pub async fn get_decrypted_response_payload(
 
     #[cfg(feature = "aws_kms")]
     let public_key = match target_locker {
-        api_enums::LockerChoice::HyperswitchCardVault => jwekey.jwekey.peek().vault_encryption_key.as_bytes(),
+        api_enums::LockerChoice::HyperswitchCardVault => {
+            jwekey.jwekey.peek().vault_encryption_key.as_bytes()
+        }
     };
 
     #[cfg(feature = "aws_kms")]
@@ -262,7 +264,9 @@ pub async fn mk_basilisk_req(
 
     #[cfg(feature = "aws_kms")]
     let public_key = match locker_choice {
-        api_enums::LockerChoice::HyperswitchCardVault => jwekey.jwekey.peek().vault_encryption_key.as_bytes(),
+        api_enums::LockerChoice::HyperswitchCardVault => {
+            jwekey.jwekey.peek().vault_encryption_key.as_bytes()
+        }
     };
 
     #[cfg(not(feature = "aws_kms"))]
@@ -563,7 +567,8 @@ pub async fn mk_delete_card_request_hs(
         .await
         .change_context(errors::VaultError::RequestEncodingFailed)?;
 
-    let jwe_payload = mk_basilisk_req(jwekey, &jws, api_enums::LockerChoice::HyperswitchCardVault).await?;
+    let jwe_payload =
+        mk_basilisk_req(jwekey, &jws, api_enums::LockerChoice::HyperswitchCardVault).await?;
 
     let mut url = locker.host.to_owned();
     url.push_str("/cards/delete");

--- a/crates/router/src/core/payments/tokenization.rs
+++ b/crates/router/src/core/payments/tokenization.rs
@@ -179,7 +179,7 @@ where
                                     &card,
                                     customer.customer_id.clone(),
                                     merchant_account,
-                                    api::enums::LockerChoice::Tartarus,
+                                    api::enums::LockerChoice::HyperswitchCardVault,
                                     Some(&locker_response.0.payment_method_id),
                                 )
                                 .await;

--- a/crates/router/src/core/payouts/helpers.rs
+++ b/crates/router/src/core/payouts/helpers.rs
@@ -267,7 +267,7 @@ pub async fn save_payout_data_to_locker(
         state,
         &locker_req,
         &payout_attempt.customer_id,
-        api_enums::LockerChoice::Basilisk,
+        api_enums::LockerChoice::HyperswitchCardVault,
     )
     .await
     .change_context(errors::ApiErrorResponse::InternalServerError)?;

--- a/crates/router/src/lib.rs
+++ b/crates/router/src/lib.rs
@@ -135,7 +135,6 @@ pub fn mk_app(
             .service(routes::Analytics::server(state.clone()))
             .service(routes::Routing::server(state.clone()))
             .service(routes::Blocklist::server(state.clone()))
-            .service(routes::LockerMigrate::server(state.clone()))
             .service(routes::Gsm::server(state.clone()))
             .service(routes::PaymentLink::server(state.clone()))
             .service(routes::User::server(state.clone()))

--- a/crates/router/src/routes.rs
+++ b/crates/router/src/routes.rs
@@ -61,7 +61,7 @@ pub use self::app::Recon;
 pub use self::app::Verify;
 pub use self::app::{
     ApiKeys, AppState, BusinessProfile, Cache, Cards, Configs, ConnectorOnboarding, Customers,
-    Disputes, EphemeralKey, Files, Gsm, Health, LockerMigrate, Mandates, MerchantAccount,
+    Disputes, EphemeralKey, Files, Gsm, Health, Mandates, MerchantAccount,
     MerchantConnectorAccount, PaymentLink, PaymentMethods, Payments, Refunds, User, Webhooks,
 };
 #[cfg(feature = "stripe")]

--- a/crates/router/src/routes/app.rs
+++ b/crates/router/src/routes/app.rs
@@ -38,7 +38,7 @@ use super::verification::{apple_pay_merchant_registration, retrieve_apple_pay_ve
 #[cfg(feature = "olap")]
 use super::{
     admin::*, api_keys::*, connector_onboarding::*, disputes::*, files::*, gsm::*,
-    locker_migration, payment_link::*, user::*, user_role::*,
+    payment_link::*, user::*, user_role::*,
 };
 use super::{cache::*, health::*};
 #[cfg(any(feature = "olap", feature = "oltp"))]
@@ -1061,19 +1061,6 @@ impl User {
             )
         }
         route
-    }
-}
-
-pub struct LockerMigrate;
-
-#[cfg(feature = "olap")]
-impl LockerMigrate {
-    pub fn server(state: AppState) -> Scope {
-        web::scope("locker_migration/{merchant_id}")
-            .app_data(web::Data::new(state))
-            .service(
-                web::resource("").route(web::post().to(locker_migration::rust_locker_migration)),
-            )
     }
 }
 

--- a/crates/router/src/routes/app.rs
+++ b/crates/router/src/routes/app.rs
@@ -37,8 +37,8 @@ use super::routing as cloud_routing;
 use super::verification::{apple_pay_merchant_registration, retrieve_apple_pay_verified_domains};
 #[cfg(feature = "olap")]
 use super::{
-    admin::*, api_keys::*, connector_onboarding::*, disputes::*, files::*, gsm::*,
-    payment_link::*, user::*, user_role::*,
+    admin::*, api_keys::*, connector_onboarding::*, disputes::*, files::*, gsm::*, payment_link::*,
+    user::*, user_role::*,
 };
 use super::{cache::*, health::*};
 #[cfg(any(feature = "olap", feature = "oltp"))]


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Fallback was added for card and retrieve card from rust locker (`hyperswitch card vault`).  This changes was to add card to both the locker (Basilisk HS and Rust Locker) and during the retrieve call try to fetch card details from the rust locker first, if it fails it tries to fetch it form Basilisk HS. https://github.com/juspay/hyperswitch/pull/2888

Now as we are no more using `Basilisk` this code is being removed.

This PR also removes the locker_migration route since the card migration is completed. However, the code for it remains as we may require the migration API in the future.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Payment create with `"setup_future_usage": "on_session"`
<img width="943" alt="image" src="https://github.com/juspay/hyperswitch/assets/83439957/7ea9a535-9b56-44d5-844d-d67aed17b128">
```
{
    "amount": 6540,
    "currency": "USD",
    "confirm": true,
    "capture_method": "automatic",
    "capture_on": "2022-09-10T10:11:12Z",
    "amount_to_capture": 6540,
    "customer_id": "stripe",
    "email": "guest@example.com",
    "name": "John Doe",
    "phone": "999999999",
    "phone_country_code": "+1",
    "description": "Its my first payment request",
    "authentication_type": "no_three_ds",
    "return_url": "http://127.0.0.1:4040",
    "setup_future_usage": "on_session",
    "payment_method": "card",
    "payment_method_type": "credit",
    "payment_method_data": {
        "card": {
            "card_number": "4111111111111111",
            "card_exp_month": "03",
            "card_exp_year": "2030",
            "card_holder_name": "joseph Doe",
            "card_cvc": "123"
        }
    },
    "billing": {
        "address": {
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "city": "San Fransico",
            "state": "California",
            "zip": "94122",
            "country": "US",
            "first_name": "PiX"
        }
    },
    "shipping": {
        "address": {
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "city": "San Fransico",
            "state": "California",
            "zip": "94122",
            "country": "US",
            "first_name": "PiX"
        }
    },
    "statement_descriptor_name": "joseph",
    "statement_descriptor_suffix": "JS",
    "metadata": {
        "udf1": "value1",
        "new_customer": "true",
        "login_date": "2019-09-10T10:11:12Z"
    }
}
```
List payment methods for customer
<img width="891" alt="image" src="https://github.com/juspay/hyperswitch/assets/83439957/212fe82f-ec58-403f-80a6-00ed5d42be1d">
```
curl --location 'http://localhost:8080/customers/stripe/payment_methods' \
--header 'Accept: application/json' \
--header 'api-key:'
```
Payment methods create
<img width="988" alt="image" src="https://github.com/juspay/hyperswitch/assets/83439957/e43fb2d1-f900-4361-82f9-3960bb9d85ce">
List payment methods for customer
<img width="1041" alt="image" src="https://github.com/juspay/hyperswitch/assets/83439957/53aabdbd-179e-4358-9d1e-ef925741171c">
Saved card payment
<img width="970" alt="image" src="https://github.com/juspay/hyperswitch/assets/83439957/1d54b4b7-31a6-41ce-85e4-5865fb1c7e77">
```
{
    "amount": 6540,
    "currency": "USD",
    "confirm": true,
    "capture_method": "automatic",
    "capture_on": "2022-09-10T10:11:12Z",
    "amount_to_capture": 6540,
    "customer_id": "stripe",
    "email": "guest@example.com",
    "name": "John Doe",
    "phone": "999999999",
    "phone_country_code": "+1",
    "description": "Its my first payment request",
    "authentication_type": "no_three_ds",
    "return_url": "http://127.0.0.1:4040",
    "setup_future_usage": "on_session",
    "payment_method": "card",
    "payment_token": "payment_token",
    "billing": {
        "address": {
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "city": "San Fransico",
            "state": "California",
            "zip": "94122",
            "country": "US",
            "first_name": "PiX"
        }
    },
    "shipping": {
        "address": {
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "city": "San Fransico",
            "state": "California",
            "zip": "94122",
            "country": "US",
            "first_name": "PiX"
        }
    },
    "statement_descriptor_name": "joseph",
    "statement_descriptor_suffix": "JS",
    "metadata": {
        "udf1": "value1",
        "new_customer": "true",
        "login_date": "2019-09-10T10:11:12Z"
    }
}
```


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
