### PR TITLE
fix: allow all headers on cors

### DIFF
--- a/crates/router/src/cors.rs
+++ b/crates/router/src/cors.rs
@@ -7,6 +7,7 @@ pub fn cors(config: settings::CorsSettings) -> actix_cors::Cors {
 
     let mut cors = actix_cors::Cors::default()
         .allowed_methods(allowed_methods)
+        .allow_any_header()
         .max_age(config.max_age);
 
     if config.wildcard_origin {

--- a/crates/router/src/cors.rs
+++ b/crates/router/src/cors.rs
@@ -16,6 +16,8 @@ pub fn cors(config: settings::CorsSettings) -> actix_cors::Cors {
         for origin in &config.origins {
             cors = cors.allowed_origin(origin);
         }
+        // Only allow this in case if it's not wildcard origins. ref: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Credentials
+        cors = cors.supports_credentials();
     }
 
     cors


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->
- [x] Bugfix

## Description
<!-- Describe your changes in detail -->
Allow all headers on CORS

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
This fixes CORS error on headers not being allowed

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
- Do a preflight request to `/user/role`
```bash
curl --location --request OPTIONS 'http://localhost:8080/user/role' \
--header 'authority: sandbox.hyperswitch.io' \
--header 'accept: */*' \
--header 'accept-language: en-GB,en-US;q=0.9,en;q=0.8' \
--header 'access-control-request-headers: api-key,authorization,content-type' \
--header 'access-control-request-method: GET' \
--header 'cache-control: no-cache' \
--header 'origin: https://app.hyperswitch.io' \
--header 'pragma: no-cache' \
--header 'referer: https://app.hyperswitch.io/' \
--header 'sec-fetch-dest: empty' \
--header 'sec-fetch-mode: cors' \
--header 'sec-fetch-site: same-site' \
--header 'user-agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36'
```
Should send a 200 OK response

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code