### PR TITLE
fix(connector): [noon] Fail the payment for specific error_response

### DIFF
--- a/crates/router/src/connector/noon.rs
+++ b/crates/router/src/connector/noon.rs
@@ -141,7 +141,7 @@ impl ConnectorCommon for Noon {
                 };
                 Ok(ErrorResponse {
                     status_code: res.status_code,
-                    code: consts::NO_ERROR_CODE.to_string(),
+                    code: noon_error_response.result_code.to_string(),
                     message: noon_error_response.class_description,
                     reason: Some(noon_error_response.message),
                     attempt_status,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Currently in Psync if 4xx or 5xx comes the payment_status is not changed for all the error_codes, for specific error_codes like order does not exist should be failed immediately.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
#3675 

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

- Create a sync with noon for payment that was not registered with noon, it should fail rather than stuck in pending state.

<img width="1124" alt="Screenshot 2024-02-16 at 2 02 08 PM" src="https://github.com/juspay/hyperswitch/assets/55536657/133a10ae-73bd-4fac-a73e-d00775ecad97">
<img width="1115" alt="Screenshot 2024-02-16 at 2 02 01 PM" src="https://github.com/juspay/hyperswitch/assets/55536657/bb3aff72-759b-43f4-b63c-b5b2bf298203">


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [X] I formatted the code `cargo +nightly fmt --all`
- [X] I addressed lints thrown by `cargo clippy`
- [X] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
