### PR TITLE
refactor(ext_traits): simplify the signatures of some methods in `Encode` extension trait

### DIFF
--- a/add_connector.md
+++ b/add_connector.md
@@ -531,7 +531,7 @@ Within the `ConnectorIntegration` trait, you'll find the following methods imple
       let connector_req = checkout::PaymentsRequest::try_from(&connector_router_data)?;
       let checkout_req = types::RequestBody::log_and_get_request_body(
           &connector_req,
-          utils::Encode::<checkout::PaymentsRequest>::encode_to_string_of_json,
+          utils::Encode::encode_to_string_of_json,
       )
       .change_context(errors::ConnectorError::RequestEncodingFailed)?;
       Ok(Some(checkout_req))

--- a/crates/api_models/src/payments.rs
+++ b/crates/api_models/src/payments.rs
@@ -625,7 +625,7 @@ impl PaymentsRequest {
     > {
         self.feature_metadata
             .as_ref()
-            .map(Encode::<FeatureMetadata>::encode_to_value)
+            .map(Encode::encode_to_value)
             .transpose()
     }
 
@@ -637,7 +637,7 @@ impl PaymentsRequest {
     > {
         self.connector_metadata
             .as_ref()
-            .map(Encode::<ConnectorMetadata>::encode_to_value)
+            .map(Encode::encode_to_value)
             .transpose()
     }
 
@@ -649,7 +649,7 @@ impl PaymentsRequest {
     > {
         self.allowed_payment_method_types
             .as_ref()
-            .map(Encode::<Vec<api_enums::PaymentMethodType>>::encode_to_value)
+            .map(Encode::encode_to_value)
             .transpose()
     }
 
@@ -663,10 +663,7 @@ impl PaymentsRequest {
             .as_ref()
             .map(|od| {
                 od.iter()
-                    .map(|order| {
-                        Encode::<OrderDetailsWithAmount>::encode_to_value(order)
-                            .map(masking::Secret::new)
-                    })
+                    .map(|order| order.encode_to_value().map(masking::Secret::new))
                     .collect::<Result<Vec<_>, _>>()
             })
             .transpose()

--- a/crates/common_utils/src/ext_traits.rs
+++ b/crates/common_utils/src/ext_traits.rs
@@ -18,7 +18,7 @@ use crate::{
 /// Encode interface
 /// An interface for performing type conversions and serialization
 ///
-pub trait Encode<'e, P>
+pub trait Encode<'e>
 where
     Self: 'e + std::fmt::Debug,
 {
@@ -28,7 +28,7 @@ where
     /// and then performing encoding operation using the `Serialize` trait from `serde`
     /// Specifically to convert into json, by using `serde_json`
     ///
-    fn convert_and_encode(&'e self) -> CustomResult<String, errors::ParsingError>
+    fn convert_and_encode<P>(&'e self) -> CustomResult<String, errors::ParsingError>
     where
         P: TryFrom<&'e Self> + Serialize,
         Result<P, <P as TryFrom<&'e Self>>::Error>: ResultExt,
@@ -39,7 +39,7 @@ where
     /// and then performing encoding operation using the `Serialize` trait from `serde`
     /// Specifically, to convert into urlencoded, by using `serde_urlencoded`
     ///
-    fn convert_and_url_encode(&'e self) -> CustomResult<String, errors::ParsingError>
+    fn convert_and_url_encode<P>(&'e self) -> CustomResult<String, errors::ParsingError>
     where
         P: TryFrom<&'e Self> + Serialize,
         Result<P, <P as TryFrom<&'e Self>>::Error>: ResultExt,
@@ -88,11 +88,11 @@ where
         Self: Serialize;
 }
 
-impl<'e, P, A> Encode<'e, P> for A
+impl<'e, A> Encode<'e> for A
 where
     Self: 'e + std::fmt::Debug,
 {
-    fn convert_and_encode(&'e self) -> CustomResult<String, errors::ParsingError>
+    fn convert_and_encode<P>(&'e self) -> CustomResult<String, errors::ParsingError>
     where
         P: TryFrom<&'e Self> + Serialize,
         Result<P, <P as TryFrom<&'e Self>>::Error>: ResultExt,
@@ -106,7 +106,7 @@ where
         .attach_printable_lazy(|| format!("Unable to convert {self:?} to a request"))
     }
 
-    fn convert_and_url_encode(&'e self) -> CustomResult<String, errors::ParsingError>
+    fn convert_and_url_encode<P>(&'e self) -> CustomResult<String, errors::ParsingError>
     where
         P: TryFrom<&'e Self> + Serialize,
         Result<P, <P as TryFrom<&'e Self>>::Error>: ResultExt,

--- a/crates/redis_interface/src/commands.rs
+++ b/crates/redis_interface/src/commands.rs
@@ -75,7 +75,8 @@ impl super::RedisConnectionPool {
     where
         V: serde::Serialize + Debug,
     {
-        let serialized = Encode::<V>::encode_to_vec(&value)
+        let serialized = value
+            .encode_to_vec()
             .change_context(errors::RedisError::JsonSerializationFailed)?;
         self.set_key_if_not_exists_with_expiry(key, serialized.as_slice(), ttl)
             .await
@@ -90,7 +91,8 @@ impl super::RedisConnectionPool {
     where
         V: serde::Serialize + Debug,
     {
-        let serialized = Encode::<V>::encode_to_vec(&value)
+        let serialized = value
+            .encode_to_vec()
             .change_context(errors::RedisError::JsonSerializationFailed)?;
 
         self.set_key(key, serialized.as_slice()).await
@@ -106,7 +108,8 @@ impl super::RedisConnectionPool {
     where
         V: serde::Serialize + Debug,
     {
-        let serialized = Encode::<V>::encode_to_vec(&value)
+        let serialized = value
+            .encode_to_vec()
             .change_context(errors::RedisError::JsonSerializationFailed)?;
 
         self.pool
@@ -307,7 +310,8 @@ impl super::RedisConnectionPool {
     where
         V: serde::Serialize + Debug,
     {
-        let serialized = Encode::<V>::encode_to_vec(&value)
+        let serialized = value
+            .encode_to_vec()
             .change_context(errors::RedisError::JsonSerializationFailed)?;
 
         self.set_hash_field_if_not_exist(key, field, serialized.as_slice(), ttl)

--- a/crates/router/src/compatibility/stripe/webhooks.rs
+++ b/crates/router/src/compatibility/stripe/webhooks.rs
@@ -2,7 +2,7 @@ use api_models::{
     enums::{DisputeStatus, MandateStatus},
     webhooks::{self as api},
 };
-use common_utils::{crypto::SignMessage, date_time, ext_traits};
+use common_utils::{crypto::SignMessage, date_time, ext_traits::Encode};
 use error_stack::{IntoReport, ResultExt};
 use router_env::logger;
 use serde::Serialize;
@@ -39,10 +39,10 @@ impl OutgoingWebhookType for StripeOutgoingWebhook {
             .into_report()
             .attach_printable("For stripe compatibility payment_response_hash_key is mandatory")?;
 
-        let webhook_signature_payload =
-            ext_traits::Encode::<serde_json::Value>::encode_to_string_of_json(self)
-                .change_context(errors::WebhooksFlowError::OutgoingWebhookEncodingFailed)
-                .attach_printable("failed encoding outgoing webhook payload")?;
+        let webhook_signature_payload = self
+            .encode_to_string_of_json()
+            .change_context(errors::WebhooksFlowError::OutgoingWebhookEncodingFailed)
+            .attach_printable("failed encoding outgoing webhook payload")?;
 
         let new_signature_payload = format!("{timestamp}.{webhook_signature_payload}");
         let v1 = hex::encode(

--- a/crates/router/src/connector/adyen/transformers.rs
+++ b/crates/router/src/connector/adyen/transformers.rs
@@ -2,6 +2,7 @@
 use api_models::payouts::PayoutMethodData;
 use api_models::{enums, payments, webhooks};
 use cards::CardNumber;
+use common_utils::ext_traits::Encode;
 use error_stack::ResultExt;
 use masking::PeekInterface;
 use reqwest::Url;
@@ -3331,32 +3332,26 @@ pub fn get_qr_metadata(
             qr_code_url,
             display_to_timestamp,
         };
-        Some(common_utils::ext_traits::Encode::<
-            payments::QrCodeInformation,
-        >::encode_to_value(&qr_code_info))
-        .transpose()
-        .change_context(errors::ConnectorError::ResponseHandlingFailed)
+        Some(qr_code_info.encode_to_value())
+            .transpose()
+            .change_context(errors::ConnectorError::ResponseHandlingFailed)
     } else if let (None, Some(qr_code_url)) = (image_data_url.clone(), qr_code_url.clone()) {
         let qr_code_info = payments::QrCodeInformation::QrCodeImageUrl {
             qr_code_url,
             display_to_timestamp,
         };
-        Some(common_utils::ext_traits::Encode::<
-            payments::QrCodeInformation,
-        >::encode_to_value(&qr_code_info))
-        .transpose()
-        .change_context(errors::ConnectorError::ResponseHandlingFailed)
+        Some(qr_code_info.encode_to_value())
+            .transpose()
+            .change_context(errors::ConnectorError::ResponseHandlingFailed)
     } else if let (Some(image_data_url), None) = (image_data_url, qr_code_url) {
         let qr_code_info = payments::QrCodeInformation::QrDataUrl {
             image_data_url,
             display_to_timestamp,
         };
 
-        Some(common_utils::ext_traits::Encode::<
-            payments::QrCodeInformation,
-        >::encode_to_value(&qr_code_info))
-        .transpose()
-        .change_context(errors::ConnectorError::ResponseHandlingFailed)
+        Some(qr_code_info.encode_to_value())
+            .transpose()
+            .change_context(errors::ConnectorError::ResponseHandlingFailed)
     } else {
         Ok(None)
     }
@@ -3481,11 +3476,9 @@ pub fn get_present_to_shopper_metadata(
                 instructions_url: response.action.instructions_url.clone(),
             };
 
-            Some(common_utils::ext_traits::Encode::<
-                payments::VoucherNextStepData,
-            >::encode_to_value(&voucher_data))
-            .transpose()
-            .change_context(errors::ConnectorError::ResponseHandlingFailed)
+            Some(voucher_data.encode_to_value())
+                .transpose()
+                .change_context(errors::ConnectorError::ResponseHandlingFailed)
         }
         PaymentType::PermataBankTransfer
         | PaymentType::BcaBankTransfer
@@ -3503,11 +3496,9 @@ pub fn get_present_to_shopper_metadata(
                 }),
             );
 
-            Some(common_utils::ext_traits::Encode::<
-                payments::DokuBankTransferInstructions,
-            >::encode_to_value(&voucher_data))
-            .transpose()
-            .change_context(errors::ConnectorError::ResponseHandlingFailed)
+            Some(voucher_data.encode_to_value())
+                .transpose()
+                .change_context(errors::ConnectorError::ResponseHandlingFailed)
         }
         PaymentType::Affirm
         | PaymentType::Afterpaytouch

--- a/crates/router/src/connector/authorizedotnet/transformers.rs
+++ b/crates/router/src/connector/authorizedotnet/transformers.rs
@@ -581,9 +581,7 @@ impl<F, T>
                     .account_number
                     .as_ref()
                     .map(|acc_no| {
-                        Encode::<'_, PaymentDetails>::encode_to_value(
-                            &construct_refund_payment_details(acc_no.clone()),
-                        )
+                        construct_refund_payment_details(acc_no.clone()).encode_to_value()
                     })
                     .transpose()
                     .change_context(errors::ConnectorError::MissingRequiredField {
@@ -658,9 +656,7 @@ impl<F, T>
                     .account_number
                     .as_ref()
                     .map(|acc_no| {
-                        Encode::<'_, PaymentDetails>::encode_to_value(
-                            &construct_refund_payment_details(acc_no.clone()),
-                        )
+                        construct_refund_payment_details(acc_no.clone()).encode_to_value()
                     })
                     .transpose()
                     .change_context(errors::ConnectorError::MissingRequiredField {

--- a/crates/router/src/connector/bluesnap/transformers.rs
+++ b/crates/router/src/connector/bluesnap/transformers.rs
@@ -294,13 +294,10 @@ impl TryFrom<&BluesnapRouterData<&types::PaymentsAuthorizeRouterData>> for Blues
             )),
             api::PaymentMethodData::Wallet(wallet_data) => match wallet_data {
                 api_models::payments::WalletData::GooglePay(payment_method_data) => {
-                    let gpay_object = Encode::<BluesnapGooglePayObject>::encode_to_string_of_json(
-                        &BluesnapGooglePayObject {
-                            payment_method_data: utils::GooglePayWalletData::from(
-                                payment_method_data,
-                            ),
-                        },
-                    )
+                    let gpay_object = BluesnapGooglePayObject {
+                        payment_method_data: utils::GooglePayWalletData::from(payment_method_data),
+                    }
+                    .encode_to_string_of_json()
                     .change_context(errors::ConnectorError::RequestEncodingFailed)?;
                     Ok((
                         PaymentMethodDetails::Wallet(BluesnapWallet {
@@ -350,25 +347,21 @@ impl TryFrom<&BluesnapRouterData<&types::PaymentsAuthorizeRouterData>> for Blues
                         address.push(add)
                     }
 
-                    let apple_pay_object = Encode::<EncodedPaymentToken>::encode_to_string_of_json(
-                        &EncodedPaymentToken {
-                            token: ApplepayPaymentData {
-                                payment_data: apple_pay_payment_data,
-                                payment_method: payment_method_data
-                                    .payment_method
-                                    .to_owned()
-                                    .into(),
-                                transaction_identifier: payment_method_data.transaction_identifier,
-                            },
-                            billing_contact: BillingDetails {
-                                country_code: billing_address.country,
-                                address_lines: Some(address),
-                                family_name: billing_address.last_name.to_owned(),
-                                given_name: billing_address.first_name.to_owned(),
-                                postal_code: billing_address.zip,
-                            },
+                    let apple_pay_object = EncodedPaymentToken {
+                        token: ApplepayPaymentData {
+                            payment_data: apple_pay_payment_data,
+                            payment_method: payment_method_data.payment_method.to_owned().into(),
+                            transaction_identifier: payment_method_data.transaction_identifier,
                         },
-                    )
+                        billing_contact: BillingDetails {
+                            country_code: billing_address.country,
+                            address_lines: Some(address),
+                            family_name: billing_address.last_name.to_owned(),
+                            given_name: billing_address.first_name.to_owned(),
+                            postal_code: billing_address.zip,
+                        },
+                    }
+                    .encode_to_string_of_json()
                     .change_context(errors::ConnectorError::RequestEncodingFailed)?;
 
                     Ok((

--- a/crates/router/src/connector/checkout.rs
+++ b/crates/router/src/connector/checkout.rs
@@ -2,7 +2,11 @@ pub mod transformers;
 
 use std::fmt::Debug;
 
-use common_utils::{crypto, ext_traits::ByteSliceExt, request::RequestContent};
+use common_utils::{
+    crypto,
+    ext_traits::{ByteSliceExt, Encode},
+    request::RequestContent,
+};
 use diesel_models::enums;
 use error_stack::{IntoReport, ResultExt};
 use masking::PeekInterface;
@@ -30,7 +34,6 @@ use crate::{
         self,
         api::{self, ConnectorCommon, ConnectorCommonExt},
     },
-    utils,
     utils::BytesExt,
 };
 
@@ -1297,7 +1300,8 @@ impl api::IncomingWebhook for Checkout {
         } else {
             // if payment_event, construct PaymentResponse and then serialize it to json and return.
             let payment_response = checkout::PaymentsResponse::try_from(request)?;
-            utils::Encode::<checkout::PaymentsResponse>::encode_to_value(&payment_response)
+            payment_response
+                .encode_to_value()
                 .change_context(errors::ConnectorError::WebhookResourceObjectNotFound)?
         };
         // Ideally this should be a strict type that has type information

--- a/crates/router/src/connector/globepay/transformers.rs
+++ b/crates/router/src/connector/globepay/transformers.rs
@@ -1,3 +1,4 @@
+use common_utils::ext_traits::Encode;
 use error_stack::ResultExt;
 use masking::Secret;
 use serde::{Deserialize, Serialize};
@@ -169,11 +170,9 @@ impl<F, T>
                     .qrcode_img
                     .ok_or(errors::ConnectorError::ResponseHandlingFailed)?,
             };
-            let connector_metadata = Some(common_utils::ext_traits::Encode::<
-                GlobepayConnectorMetadata,
-            >::encode_to_value(&globepay_metadata))
-            .transpose()
-            .change_context(errors::ConnectorError::ResponseHandlingFailed)?;
+            let connector_metadata = Some(globepay_metadata.encode_to_value())
+                .transpose()
+                .change_context(errors::ConnectorError::ResponseHandlingFailed)?;
             let globepay_status = item
                 .response
                 .result_code

--- a/crates/router/src/connector/noon/transformers.rs
+++ b/crates/router/src/connector/noon/transformers.rs
@@ -1,4 +1,4 @@
-use common_utils::pii;
+use common_utils::{ext_traits::Encode, pii};
 use error_stack::{IntoReport, ResultExt};
 use masking::{PeekInterface, Secret};
 use serde::{Deserialize, Serialize};
@@ -11,7 +11,6 @@ use crate::{
     core::{errors, mandate::MandateBehaviour},
     services,
     types::{self, api, storage::enums, transformers::ForeignFrom, ErrorResponse},
-    utils,
 };
 
 // These needs to be accepted from SDK, need to be done after 1.0.0 stability as API contract will change
@@ -271,10 +270,8 @@ impl TryFrom<&types::PaymentsAuthorizeRouterData> for NoonPaymentsRequest {
                                     ),
                                 },
                             };
-                            let payment_token =
-                                utils::Encode::<NoonApplePayTokenData>::encode_to_string_of_json(
-                                    &payment_token_data,
-                                )
+                            let payment_token = payment_token_data
+                                .encode_to_string_of_json()
                                 .change_context(errors::ConnectorError::RequestEncodingFailed)?;
 
                             Ok(NoonPaymentData::ApplePay(NoonApplePay {

--- a/crates/router/src/connector/nuvei/transformers.rs
+++ b/crates/router/src/connector/nuvei/transformers.rs
@@ -1,7 +1,9 @@
 use api_models::payments;
 use common_utils::{
     crypto::{self, GenerateDigest},
-    date_time, fp_utils, pii,
+    date_time,
+    ext_traits::Encode,
+    fp_utils, pii,
     pii::Email,
 };
 use data_models::mandates::MandateDataType;
@@ -433,23 +435,14 @@ impl TryFrom<payments::GooglePayWalletData> for NuveiPaymentsRequest {
         Ok(Self {
             payment_option: PaymentOption {
                 card: Some(Card {
-                    external_token:
-                        Some(
-                            ExternalToken {
-                                external_token_provider: ExternalTokenProvider::GooglePay,
-                                mobile_token:
-                                    Secret::new(
-                                        common_utils::ext_traits::Encode::<
-                                            payments::GooglePayWalletData,
-                                        >::encode_to_string_of_json(
-                                            &utils::GooglePayWalletData::from(gpay_data),
-                                        )
-                                        .change_context(
-                                            errors::ConnectorError::RequestEncodingFailed,
-                                        )?,
-                                    ),
-                            },
+                    external_token: Some(ExternalToken {
+                        external_token_provider: ExternalTokenProvider::GooglePay,
+                        mobile_token: Secret::new(
+                            utils::GooglePayWalletData::from(gpay_data)
+                                .encode_to_string_of_json()
+                                .change_context(errors::ConnectorError::RequestEncodingFailed)?,
                         ),
+                    }),
                     ..Default::default()
                 }),
                 ..Default::default()

--- a/crates/router/src/connector/payeezy/transformers.rs
+++ b/crates/router/src/connector/payeezy/transformers.rs
@@ -407,11 +407,7 @@ impl<F, T>
         let metadata = item
             .response
             .transaction_tag
-            .map(|txn_tag| {
-                Encode::<'_, PayeezyPaymentsMetadata>::encode_to_value(
-                    &construct_payeezy_payments_metadata(txn_tag),
-                )
-            })
+            .map(|txn_tag| construct_payeezy_payments_metadata(txn_tag).encode_to_value())
             .transpose()
             .change_context(errors::ConnectorError::ResponseHandlingFailed)?;
 

--- a/crates/router/src/connector/stripe/transformers.rs
+++ b/crates/router/src/connector/stripe/transformers.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, ops::Deref};
 use api_models::{self, enums as api_enums, payments};
 use common_utils::{
     errors::CustomResult,
-    ext_traits::ByteSliceExt,
+    ext_traits::{ByteSliceExt, Encode},
     pii::{self, Email},
     request::RequestContent,
 };
@@ -2437,11 +2437,7 @@ pub fn get_connector_metadata(
                     },
                 };
 
-                Some(common_utils::ext_traits::Encode::<
-                    SepaAndBacsBankTransferInstructions,
-                >::encode_to_value(
-                    &bank_transfer_instructions
-                ))
+                Some(bank_transfer_instructions.encode_to_value())
             }
             StripeNextActionResponse::WechatPayDisplayQrCode(response) => {
                 let wechat_pay_instructions = QrCodeNextInstructions {
@@ -2449,22 +2445,14 @@ pub fn get_connector_metadata(
                     display_to_timestamp: None,
                 };
 
-                Some(
-                    common_utils::ext_traits::Encode::<QrCodeNextInstructions>::encode_to_value(
-                        &wechat_pay_instructions,
-                    ),
-                )
+                Some(wechat_pay_instructions.encode_to_value())
             }
             StripeNextActionResponse::CashappHandleRedirectOrDisplayQrCode(response) => {
                 let cashapp_qr_instructions: QrCodeNextInstructions = QrCodeNextInstructions {
                     image_data_url: response.qr_code.image_url_png.to_owned(),
                     display_to_timestamp: response.qr_code.expires_at.to_owned(),
                 };
-                Some(
-                    common_utils::ext_traits::Encode::<QrCodeNextInstructions>::encode_to_value(
-                        &cashapp_qr_instructions,
-                    ),
-                )
+                Some(cashapp_qr_instructions.encode_to_value())
             }
             _ => None,
         })
@@ -3144,10 +3132,8 @@ impl<F, T>
         item: types::ResponseRouterData<F, StripeSourceResponse, T, types::PaymentsResponseData>,
     ) -> Result<Self, Self::Error> {
         let connector_source_response = item.response.to_owned();
-        let connector_metadata =
-            common_utils::ext_traits::Encode::<StripeSourceResponse>::encode_to_value(
-                &connector_source_response,
-            )
+        let connector_metadata = connector_source_response
+            .encode_to_value()
             .change_context(errors::ConnectorError::ResponseHandlingFailed)?;
         // We get pending as the status from stripe, but hyperswitch should give it as requires_customer_action as
         // customer has to make payment to the virtual account number given in the source response
@@ -3201,10 +3187,9 @@ impl<F, T> TryFrom<types::ResponseRouterData<F, ChargesResponse, T, types::Payme
         item: types::ResponseRouterData<F, ChargesResponse, T, types::PaymentsResponseData>,
     ) -> Result<Self, Self::Error> {
         let connector_source_response = item.response.to_owned();
-        let connector_metadata =
-            common_utils::ext_traits::Encode::<StripeSourceResponse>::encode_to_value(
-                &connector_source_response.source,
-            )
+        let connector_metadata = connector_source_response
+            .source
+            .encode_to_value()
             .change_context(errors::ConnectorError::ResponseHandlingFailed)?;
         let status = enums::AttemptStatus::from(item.response.status);
         let response = if connector_util::is_payment_failure(status) {

--- a/crates/router/src/core/admin.rs
+++ b/crates/router/src/core/admin.rs
@@ -62,36 +62,39 @@ pub async fn create_merchant_account(
 
     let publishable_key = Some(create_merchant_publishable_key());
 
-    let primary_business_details =
-        utils::Encode::<Vec<admin_types::PrimaryBusinessDetails>>::encode_to_value(
-            &req.primary_business_details.clone().unwrap_or_default(),
-        )
+    let primary_business_details = req
+        .primary_business_details
+        .clone()
+        .unwrap_or_default()
+        .encode_to_value()
         .change_context(errors::ApiErrorResponse::InvalidDataValue {
             field_name: "primary_business_details",
         })?;
 
-    let merchant_details: OptionalSecretValue =
-        req.merchant_details
-            .as_ref()
-            .map(|merchant_details| {
-                utils::Encode::<api::MerchantDetails>::encode_to_value(merchant_details)
-                    .change_context(errors::ApiErrorResponse::InvalidDataValue {
-                        field_name: "merchant_details",
-                    })
-            })
-            .transpose()?
-            .map(Into::into);
+    let merchant_details: OptionalSecretValue = req
+        .merchant_details
+        .as_ref()
+        .map(|merchant_details| {
+            merchant_details.encode_to_value().change_context(
+                errors::ApiErrorResponse::InvalidDataValue {
+                    field_name: "merchant_details",
+                },
+            )
+        })
+        .transpose()?
+        .map(Into::into);
 
-    let webhook_details =
-        req.webhook_details
-            .as_ref()
-            .map(|webhook_details| {
-                utils::Encode::<api::WebhookDetails>::encode_to_value(webhook_details)
-                    .change_context(errors::ApiErrorResponse::InvalidDataValue {
-                        field_name: "webhook details",
-                    })
-            })
-            .transpose()?;
+    let webhook_details = req
+        .webhook_details
+        .as_ref()
+        .map(|webhook_details| {
+            webhook_details.encode_to_value().change_context(
+                errors::ApiErrorResponse::InvalidDataValue {
+                    field_name: "webhook details",
+                },
+            )
+        })
+        .transpose()?;
 
     if let Some(ref routing_algorithm) = req.routing_algorithm {
         let _: api_models::routing::RoutingAlgorithm = routing_algorithm
@@ -134,7 +137,7 @@ pub async fn create_merchant_account(
         .metadata
         .as_ref()
         .map(|meta| {
-            utils::Encode::<admin_types::MerchantAccountMetadata>::encode_to_value(meta)
+            meta.encode_to_value()
                 .change_context(errors::ApiErrorResponse::InvalidDataValue {
                     field_name: "metadata",
                 })
@@ -493,12 +496,11 @@ pub async fn merchant_account_update(
         .primary_business_details
         .as_ref()
         .map(|primary_business_details| {
-            utils::Encode::<Vec<admin_types::PrimaryBusinessDetails>>::encode_to_value(
-                primary_business_details,
+            primary_business_details.encode_to_value().change_context(
+                errors::ApiErrorResponse::InvalidDataValue {
+                    field_name: "primary_business_details",
+                },
             )
-            .change_context(errors::ApiErrorResponse::InvalidDataValue {
-                field_name: "primary_business_details",
-            })
         })
         .transpose()?;
 
@@ -548,7 +550,7 @@ pub async fn merchant_account_update(
         merchant_details: req
             .merchant_details
             .as_ref()
-            .map(utils::Encode::<api::MerchantDetails>::encode_to_value)
+            .map(utils::Encode::encode_to_value)
             .transpose()
             .change_context(errors::ApiErrorResponse::InternalServerError)
             .attach_printable("Unable to convert merchant_details to a value")?
@@ -563,7 +565,7 @@ pub async fn merchant_account_update(
         webhook_details: req
             .webhook_details
             .as_ref()
-            .map(utils::Encode::<api::WebhookDetails>::encode_to_value)
+            .map(utils::Encode::encode_to_value)
             .transpose()
             .change_context(errors::ApiErrorResponse::InternalServerError)?,
 
@@ -817,7 +819,8 @@ pub async fn create_payment_connector(
     let payment_methods_enabled = match req.payment_methods_enabled {
         Some(val) => {
             for pm in val.into_iter() {
-                let pm_value = utils::Encode::<api::PaymentMethodsEnabled>::encode_to_value(&pm)
+                let pm_value = pm
+                    .encode_to_value()
                     .change_context(errors::ApiErrorResponse::InternalServerError)
                     .attach_printable(
                         "Failed while encoding to serde_json::Value, PaymentMethod",
@@ -929,8 +932,7 @@ pub async fn create_payment_connector(
         id: None,
         connector_webhook_details: match req.connector_webhook_details {
             Some(connector_webhook_details) => {
-                Encode::<api_models::admin::MerchantConnectorWebhookDetails>::encode_to_value(
-                    &connector_webhook_details,
+                connector_webhook_details.encode_to_value(
                 )
                 .change_context(errors::ApiErrorResponse::InternalServerError)
                 .attach_printable(format!("Failed to serialize api_models::admin::MerchantConnectorWebhookDetails for Merchant: {}", merchant_id))
@@ -1155,9 +1157,7 @@ pub async fn update_payment_connector(
     let payment_methods_enabled = req.payment_methods_enabled.map(|pm_enabled| {
         pm_enabled
             .iter()
-            .flat_map(|payment_method| {
-                utils::Encode::<api::PaymentMethodsEnabled>::encode_to_value(payment_method)
-            })
+            .flat_map(Encode::encode_to_value)
             .collect::<Vec<serde_json::Value>>()
     });
 
@@ -1249,14 +1249,11 @@ pub async fn update_payment_connector(
         metadata: req.metadata,
         frm_configs,
         connector_webhook_details: match &req.connector_webhook_details {
-            Some(connector_webhook_details) => {
-                Encode::<api_models::admin::MerchantConnectorWebhookDetails>::encode_to_value(
-                    connector_webhook_details,
-                )
+            Some(connector_webhook_details) => connector_webhook_details
+                .encode_to_value()
                 .change_context(errors::ApiErrorResponse::InternalServerError)
                 .map(Some)?
-                .map(masking::Secret::new)
-            }
+                .map(masking::Secret::new),
             None => None,
         },
         applepay_verified_domains: None,
@@ -1434,7 +1431,8 @@ pub fn get_frm_config_as_secret(
             let configs_for_frm_value: Vec<Secret<serde_json::Value>> = frm_value
                 .iter()
                 .map(|config| {
-                    utils::Encode::<api_models::admin::FrmConfigs>::encode_to_value(&config)
+                    config
+                        .encode_to_value()
                         .change_context(errors::ApiErrorResponse::ConfigNotFound)
                         .map(masking::Secret::new)
                 })
@@ -1597,7 +1595,7 @@ pub async fn update_business_profile(
         .webhook_details
         .as_ref()
         .map(|webhook_details| {
-            utils::Encode::<api::WebhookDetails>::encode_to_value(webhook_details).change_context(
+            webhook_details.encode_to_value().change_context(
                 errors::ApiErrorResponse::InvalidDataValue {
                     field_name: "webhook details",
                 },
@@ -1619,10 +1617,11 @@ pub async fn update_business_profile(
         .payment_link_config
         .as_ref()
         .map(|pl_metadata| {
-            utils::Encode::<admin_types::BusinessPaymentLinkConfig>::encode_to_value(pl_metadata)
-                .change_context(errors::ApiErrorResponse::InvalidDataValue {
+            pl_metadata.encode_to_value().change_context(
+                errors::ApiErrorResponse::InvalidDataValue {
                     field_name: "payment_link_config",
-                })
+                },
+            )
         })
         .transpose()?;
 

--- a/crates/router/src/core/conditional_config.rs
+++ b/crates/router/src/core/conditional_config.rs
@@ -1,8 +1,8 @@
 use api_models::{
     conditional_configs::{DecisionManager, DecisionManagerRecord, DecisionManagerResponse},
-    routing::{self},
+    routing,
 };
-use common_utils::ext_traits::{StringExt, ValueExt};
+use common_utils::ext_traits::{Encode, StringExt, ValueExt};
 use diesel_models::configs;
 use error_stack::{IntoReport, ResultExt};
 use euclid::frontend::ast;
@@ -15,7 +15,7 @@ use crate::{
     routes::AppState,
     services::api as service_api,
     types::domain,
-    utils::{self, OptionExt},
+    utils::OptionExt,
 };
 
 pub async fn upsert_conditional_config(
@@ -86,10 +86,10 @@ pub async fn upsert_conditional_config(
                 created_at: previous_record.created_at,
             };
 
-            let serialize_updated_str =
-                utils::Encode::<DecisionManagerRecord>::encode_to_string_of_json(&new_algo)
-                    .change_context(errors::ApiErrorResponse::InternalServerError)
-                    .attach_printable("Unable to serialize config to string")?;
+            let serialize_updated_str = new_algo
+                .encode_to_string_of_json()
+                .change_context(errors::ApiErrorResponse::InternalServerError)
+                .attach_printable("Unable to serialize config to string")?;
 
             let updated_config = configs::ConfigUpdate::Update {
                 config: Some(serialize_updated_str),
@@ -121,10 +121,10 @@ pub async fn upsert_conditional_config(
                 created_at: timestamp,
             };
 
-            let serialized_str =
-                utils::Encode::<DecisionManagerRecord>::encode_to_string_of_json(&new_rec)
-                    .change_context(errors::ApiErrorResponse::InternalServerError)
-                    .attach_printable("Error serializing the config")?;
+            let serialized_str = new_rec
+                .encode_to_string_of_json()
+                .change_context(errors::ApiErrorResponse::InternalServerError)
+                .attach_printable("Error serializing the config")?;
             let new_config = configs::ConfigNew {
                 key: key.clone(),
                 config: serialized_str,

--- a/crates/router/src/core/connector_onboarding/paypal.rs
+++ b/crates/router/src/core/connector_onboarding/paypal.rs
@@ -141,10 +141,10 @@ pub async fn update_mca(
     connector_id: String,
     auth_details: oss_types::ConnectorAuthType,
 ) -> RouterResult<oss_api_types::MerchantConnectorResponse> {
-    let connector_auth_json =
-        Encode::<oss_types::ConnectorAuthType>::encode_to_value(&auth_details)
-            .change_context(ApiErrorResponse::InternalServerError)
-            .attach_printable("Error while deserializing connector_account_details")?;
+    let connector_auth_json = auth_details
+        .encode_to_value()
+        .change_context(ApiErrorResponse::InternalServerError)
+        .attach_printable("Error while deserializing connector_account_details")?;
 
     let request = MerchantConnectorUpdate {
         connector_type: common_enums::ConnectorType::PaymentProcessor,

--- a/crates/router/src/core/disputes.rs
+++ b/crates/router/src/core/disputes.rs
@@ -1,5 +1,5 @@
 use api_models::{disputes as dispute_models, files as files_api_models};
-use common_utils::ext_traits::ValueExt;
+use common_utils::ext_traits::{Encode, ValueExt};
 use error_stack::{IntoReport, ResultExt};
 use router_env::{instrument, tracing};
 pub mod transformers;
@@ -20,7 +20,6 @@ use crate::{
         AcceptDisputeRequestData, AcceptDisputeResponse, DefendDisputeRequestData,
         DefendDisputeResponse, SubmitEvidenceRequestData, SubmitEvidenceResponse,
     },
-    utils,
 };
 
 #[instrument(skip(state))]
@@ -384,7 +383,8 @@ pub async fn attach_evidence(
         file_id,
     );
     let update_dispute = diesel_models::dispute::DisputeUpdate::EvidenceUpdate {
-        evidence: utils::Encode::<api::DisputeEvidence>::encode_to_value(&updated_dispute_evidence)
+        evidence: updated_dispute_evidence
+            .encode_to_value()
             .change_context(errors::ApiErrorResponse::InternalServerError)
             .attach_printable("Error while encoding dispute evidence")?
             .into(),
@@ -446,7 +446,8 @@ pub async fn delete_evidence(
     let updated_dispute_evidence =
         transformers::delete_evidence_file(dispute_evidence, delete_evidence_request.evidence_type);
     let update_dispute = diesel_models::dispute::DisputeUpdate::EvidenceUpdate {
-        evidence: utils::Encode::<api::DisputeEvidence>::encode_to_value(&updated_dispute_evidence)
+        evidence: updated_dispute_evidence
+            .encode_to_value()
             .change_context(errors::ApiErrorResponse::InternalServerError)
             .attach_printable("Error while encoding dispute evidence")?
             .into(),

--- a/crates/router/src/core/fraud_check/operation/fraud_check_post.rs
+++ b/crates/router/src/core/fraud_check/operation/fraud_check_post.rs
@@ -77,9 +77,9 @@ impl GetTracker<PaymentToFrmData> for FraudCheckPost {
     ) -> RouterResult<Option<FrmData>> {
         let db = &*state.store;
 
-        let payment_details: Option<serde_json::Value> =
-            Encode::<PaymentDetails>::encode_to_value(&PaymentDetails::from(payment_data.clone()))
-                .ok();
+        let payment_details: Option<serde_json::Value> = PaymentDetails::from(payment_data.clone())
+            .encode_to_value()
+            .ok();
         let existing_fraud_check = db
             .find_fraud_check_by_payment_id_if_present(
                 payment_data.payment_intent.payment_id.clone(),

--- a/crates/router/src/core/fraud_check/operation/fraud_check_pre.rs
+++ b/crates/router/src/core/fraud_check/operation/fraud_check_pre.rs
@@ -72,9 +72,9 @@ impl GetTracker<PaymentToFrmData> for FraudCheckPre {
     ) -> RouterResult<Option<FrmData>> {
         let db = &*state.store;
 
-        let payment_details: Option<serde_json::Value> =
-            Encode::<PaymentDetails>::encode_to_value(&PaymentDetails::from(payment_data.clone()))
-                .ok();
+        let payment_details: Option<serde_json::Value> = PaymentDetails::from(payment_data.clone())
+            .encode_to_value()
+            .ok();
 
         let existing_fraud_check = db
             .find_fraud_check_by_payment_id_if_present(

--- a/crates/router/src/core/mandate.rs
+++ b/crates/router/src/core/mandate.rs
@@ -162,7 +162,7 @@ pub async fn update_connector_mandate_id(
     let connector_mandate_id = mandate_details
         .clone()
         .map(|md| {
-            Encode::<types::MandateReference>::encode_to_value(&md)
+            md.encode_to_value()
                 .change_context(errors::ApiErrorResponse::InternalServerError)
                 .map(masking::Secret::new)
         })
@@ -288,10 +288,10 @@ where
         update_history: Some(update_history),
     };
 
-    let connector_mandate_ids =
-        Encode::<types::MandateReference>::encode_to_value(&updated_mandate_ref)
-            .change_context(errors::ApiErrorResponse::InternalServerError)
-            .map(masking::Secret::new)?;
+    let connector_mandate_ids = updated_mandate_ref
+        .encode_to_value()
+        .change_context(errors::ApiErrorResponse::InternalServerError)
+        .map(masking::Secret::new)?;
 
     let _update_mandate_details = state
         .store
@@ -384,7 +384,7 @@ where
                     let mandate_ids = mandate_reference
                         .as_ref()
                         .map(|md| {
-                            Encode::<types::MandateReference>::encode_to_value(&md)
+                            md.encode_to_value()
                                 .change_context(
                                     errors::ApiErrorResponse::MandateSerializationFailed,
                                 )

--- a/crates/router/src/core/payment_methods/cards.rs
+++ b/crates/router/src/core/payment_methods/cards.rs
@@ -18,7 +18,7 @@ use api_models::{
 };
 use common_utils::{
     consts,
-    ext_traits::{AsyncExt, StringExt, ValueExt},
+    ext_traits::{AsyncExt, Encode, StringExt, ValueExt},
     generate_id,
 };
 use diesel_models::{
@@ -1568,7 +1568,8 @@ pub async fn list_payment_methods(
 
         routing_info.pre_routing_results = Some(pre_routing_results);
 
-        let encoded = utils::Encode::<storage::PaymentRoutingInfo>::encode_to_value(&routing_info)
+        let encoded = routing_info
+            .encode_to_value()
             .change_context(errors::ApiErrorResponse::InternalServerError)
             .attach_printable("Unable to serialize payment routing info to value")?;
 
@@ -3220,11 +3221,13 @@ impl TempLockerCardSupport {
         let value1 = vault::VaultPaymentMethod::Card(value1);
         let value2 = vault::VaultPaymentMethod::Card(value2);
 
-        let value1 = utils::Encode::<vault::VaultPaymentMethod>::encode_to_string_of_json(&value1)
+        let value1 = value1
+            .encode_to_string_of_json()
             .change_context(errors::ApiErrorResponse::InternalServerError)
             .attach_printable("Wrapped value1 construction failed when saving card to locker")?;
 
-        let value2 = utils::Encode::<vault::VaultPaymentMethod>::encode_to_string_of_json(&value2)
+        let value2 = value2
+            .encode_to_string_of_json()
             .change_context(errors::ApiErrorResponse::InternalServerError)
             .attach_printable("Wrapped value2 construction failed when saving card to locker")?;
 
@@ -3359,7 +3362,7 @@ pub async fn create_encrypted_payment_method_data(
 
     let pm_data_encrypted: Option<Encryption> = pm_data
         .as_ref()
-        .map(utils::Encode::<PaymentMethodsData>::encode_to_value)
+        .map(utils::Encode::encode_to_value)
         .transpose()
         .change_context(errors::StorageError::SerializationFailed)
         .attach_printable("Unable to convert payment method data to a value")

--- a/crates/router/src/core/payment_methods/transformers.rs
+++ b/crates/router/src/core/payment_methods/transformers.rs
@@ -1,7 +1,11 @@
 use std::str::FromStr;
 
 use api_models::enums as api_enums;
-use common_utils::{ext_traits::StringExt, pii::Email, request::RequestContent};
+use common_utils::{
+    ext_traits::{Encode, StringExt},
+    pii::Email,
+    request::RequestContent,
+};
 use error_stack::ResultExt;
 use josekit::jwe;
 use serde::{Deserialize, Serialize};
@@ -13,7 +17,7 @@ use crate::{
     pii::{prelude::*, Secret},
     services::{api as services, encryption},
     types::{api, storage},
-    utils::{self, OptionExt},
+    utils::OptionExt,
 };
 
 #[derive(Debug, Serialize)]
@@ -261,7 +265,8 @@ pub async fn mk_basilisk_req(
 
     let jws_body = generate_jws_body(jws_payload).ok_or(errors::VaultError::SaveCardFailed)?;
 
-    let payload = utils::Encode::<encryption::JwsBody>::encode_to_vec(&jws_body)
+    let payload = jws_body
+        .encode_to_vec()
         .change_context(errors::VaultError::SaveCardFailed)?;
 
     #[cfg(feature = "aws_kms")]
@@ -306,7 +311,8 @@ pub async fn mk_add_locker_request_hs<'a>(
     payload: &StoreLockerReq<'a>,
     locker_choice: api_enums::LockerChoice,
 ) -> CustomResult<services::Request, errors::VaultError> {
-    let payload = utils::Encode::<StoreLockerReq<'_>>::encode_to_vec(&payload)
+    let payload = payload
+        .encode_to_vec()
         .change_context(errors::VaultError::RequestEncodingFailed)?;
 
     #[cfg(feature = "aws_kms")]
@@ -484,7 +490,8 @@ pub async fn mk_get_card_request_hs(
         merchant_customer_id,
         card_reference: card_reference.to_owned(),
     };
-    let payload = utils::Encode::<CardReqBody<'_>>::encode_to_vec(&card_req_body)
+    let payload = card_req_body
+        .encode_to_vec()
         .change_context(errors::VaultError::RequestEncodingFailed)?;
 
     #[cfg(feature = "aws_kms")]
@@ -560,7 +567,8 @@ pub async fn mk_delete_card_request_hs(
         merchant_customer_id,
         card_reference: card_reference.to_owned(),
     };
-    let payload = utils::Encode::<CardReqBody<'_>>::encode_to_vec(&card_req_body)
+    let payload = card_req_body
+        .encode_to_vec()
         .change_context(errors::VaultError::RequestEncodingFailed)?;
 
     #[cfg(feature = "aws_kms")]
@@ -672,7 +680,8 @@ pub fn mk_card_value1(
         card_last_four,
         card_token,
     };
-    let value1_req = utils::Encode::<api::TokenizedCardValue1>::encode_to_string_of_json(&value1)
+    let value1_req = value1
+        .encode_to_string_of_json()
         .change_context(errors::VaultError::FetchCardFailed)?;
     Ok(value1_req)
 }
@@ -691,7 +700,8 @@ pub fn mk_card_value2(
         customer_id,
         payment_method_id,
     };
-    let value2_req = utils::Encode::<api::TokenizedCardValue2>::encode_to_string_of_json(&value2)
+    let value2_req = value2
+        .encode_to_string_of_json()
         .change_context(errors::VaultError::FetchCardFailed)?;
     Ok(value2_req)
 }

--- a/crates/router/src/core/payment_methods/vault.rs
+++ b/crates/router/src/core/payment_methods/vault.rs
@@ -1,6 +1,6 @@
 use common_utils::{
     crypto::{DecodeMessage, EncodeMessage, GcmAes256},
-    ext_traits::BytesExt,
+    ext_traits::{BytesExt, Encode},
     generate_id_with_default_len,
 };
 use error_stack::{report, IntoReport, ResultExt};
@@ -19,7 +19,7 @@ use crate::{
         api, domain,
         storage::{self, enums, ProcessTrackerExt},
     },
-    utils::{self, StringExt},
+    utils::StringExt,
 };
 const VAULT_SERVICE_NAME: &str = "CARD";
 
@@ -54,7 +54,8 @@ impl Vaultable for api::Card {
             card_token: None,
         };
 
-        utils::Encode::<api::TokenizedCardValue1>::encode_to_string_of_json(&value1)
+        value1
+            .encode_to_string_of_json()
             .change_context(errors::VaultError::RequestEncodingFailed)
             .attach_printable("Failed to encode card value1")
     }
@@ -68,7 +69,8 @@ impl Vaultable for api::Card {
             payment_method_id: None,
         };
 
-        utils::Encode::<api::TokenizedCardValue2>::encode_to_string_of_json(&value2)
+        value2
+            .encode_to_string_of_json()
             .change_context(errors::VaultError::RequestEncodingFailed)
             .attach_printable("Failed to encode card value2")
     }
@@ -121,7 +123,8 @@ impl Vaultable for api_models::payments::BankTransferData {
             data: self.to_owned(),
         };
 
-        utils::Encode::<api_models::payment_methods::TokenizedBankTransferValue1>::encode_to_string_of_json(&value1)
+        value1
+            .encode_to_string_of_json()
             .change_context(errors::VaultError::RequestEncodingFailed)
             .attach_printable("Failed to encode bank transfer data")
     }
@@ -129,7 +132,8 @@ impl Vaultable for api_models::payments::BankTransferData {
     fn get_value2(&self, customer_id: Option<String>) -> CustomResult<String, errors::VaultError> {
         let value2 = api_models::payment_methods::TokenizedBankTransferValue2 { customer_id };
 
-        utils::Encode::<api_models::payment_methods::TokenizedBankTransferValue2>::encode_to_string_of_json(&value2)
+        value2
+            .encode_to_string_of_json()
             .change_context(errors::VaultError::RequestEncodingFailed)
             .attach_printable("Failed to encode bank transfer supplementary data")
     }
@@ -165,7 +169,8 @@ impl Vaultable for api::WalletData {
             data: self.to_owned(),
         };
 
-        utils::Encode::<api::TokenizedWalletValue1>::encode_to_string_of_json(&value1)
+        value1
+            .encode_to_string_of_json()
             .change_context(errors::VaultError::RequestEncodingFailed)
             .attach_printable("Failed to encode wallet data value1")
     }
@@ -173,7 +178,8 @@ impl Vaultable for api::WalletData {
     fn get_value2(&self, customer_id: Option<String>) -> CustomResult<String, errors::VaultError> {
         let value2 = api::TokenizedWalletValue2 { customer_id };
 
-        utils::Encode::<api::TokenizedWalletValue2>::encode_to_string_of_json(&value2)
+        value2
+            .encode_to_string_of_json()
             .change_context(errors::VaultError::RequestEncodingFailed)
             .attach_printable("Failed to encode wallet data value2")
     }
@@ -209,7 +215,8 @@ impl Vaultable for api_models::payments::BankRedirectData {
             data: self.to_owned(),
         };
 
-        utils::Encode::<api_models::payment_methods::TokenizedBankRedirectValue1>::encode_to_string_of_json(&value1)
+        value1
+            .encode_to_string_of_json()
             .change_context(errors::VaultError::RequestEncodingFailed)
             .attach_printable("Failed to encode bank redirect data")
     }
@@ -217,7 +224,8 @@ impl Vaultable for api_models::payments::BankRedirectData {
     fn get_value2(&self, customer_id: Option<String>) -> CustomResult<String, errors::VaultError> {
         let value2 = api_models::payment_methods::TokenizedBankRedirectValue2 { customer_id };
 
-        utils::Encode::<api_models::payment_methods::TokenizedBankRedirectValue2>::encode_to_string_of_json(&value2)
+        value2
+            .encode_to_string_of_json()
             .change_context(errors::VaultError::RequestEncodingFailed)
             .attach_printable("Failed to encode bank redirect supplementary data")
     }
@@ -272,7 +280,8 @@ impl Vaultable for api::PaymentMethodData {
                 .attach_printable("Payment method not supported")?,
         };
 
-        utils::Encode::<VaultPaymentMethod>::encode_to_string_of_json(&value1)
+        value1
+            .encode_to_string_of_json()
             .change_context(errors::VaultError::RequestEncodingFailed)
             .attach_printable("Failed to encode payment method value1")
     }
@@ -292,7 +301,8 @@ impl Vaultable for api::PaymentMethodData {
                 .attach_printable("Payment method not supported")?,
         };
 
-        utils::Encode::<VaultPaymentMethod>::encode_to_string_of_json(&value2)
+        value2
+            .encode_to_string_of_json()
             .change_context(errors::VaultError::RequestEncodingFailed)
             .attach_printable("Failed to encode payment method value2")
     }
@@ -357,7 +367,8 @@ impl Vaultable for api::CardPayout {
             card_token: None,
         };
 
-        utils::Encode::<api::TokenizedCardValue1>::encode_to_string_of_json(&value1)
+        value1
+            .encode_to_string_of_json()
             .change_context(errors::VaultError::RequestEncodingFailed)
             .attach_printable("Failed to encode card value1")
     }
@@ -371,7 +382,8 @@ impl Vaultable for api::CardPayout {
             payment_method_id: None,
         };
 
-        utils::Encode::<api::TokenizedCardValue2>::encode_to_string_of_json(&value2)
+        value2
+            .encode_to_string_of_json()
             .change_context(errors::VaultError::RequestEncodingFailed)
             .attach_printable("Failed to encode card value2")
     }
@@ -420,7 +432,8 @@ impl Vaultable for api::WalletPayout {
             },
         };
 
-        utils::Encode::<api::TokenizedWalletValue1>::encode_to_string_of_json(&value1)
+        value1
+            .encode_to_string_of_json()
             .change_context(errors::VaultError::RequestEncodingFailed)
             .attach_printable("Failed to encode wallet value1")
     }
@@ -428,7 +441,8 @@ impl Vaultable for api::WalletPayout {
     fn get_value2(&self, customer_id: Option<String>) -> CustomResult<String, errors::VaultError> {
         let value2 = api::TokenizedWalletValue2 { customer_id };
 
-        utils::Encode::<api::TokenizedWalletValue2>::encode_to_string_of_json(&value2)
+        value2
+            .encode_to_string_of_json()
             .change_context(errors::VaultError::RequestEncodingFailed)
             .attach_printable("Failed to encode wallet value2")
     }
@@ -509,11 +523,10 @@ impl Vaultable for api::BankPayout {
             },
         };
 
-        utils::Encode::<TokenizedBankSensitiveValues>::encode_to_string_of_json(
-            &bank_sensitive_data,
-        )
-        .change_context(errors::VaultError::RequestEncodingFailed)
-        .attach_printable("Failed to encode wallet data bank_sensitive_data")
+        bank_sensitive_data
+            .encode_to_string_of_json()
+            .change_context(errors::VaultError::RequestEncodingFailed)
+            .attach_printable("Failed to encode wallet data bank_sensitive_data")
     }
 
     fn get_value2(&self, customer_id: Option<String>) -> CustomResult<String, errors::VaultError> {
@@ -538,11 +551,10 @@ impl Vaultable for api::BankPayout {
             },
         };
 
-        utils::Encode::<TokenizedBankInsensitiveValues>::encode_to_string_of_json(
-            &bank_insensitive_data,
-        )
-        .change_context(errors::VaultError::RequestEncodingFailed)
-        .attach_printable("Failed to encode wallet data bank_insensitive_data")
+        bank_insensitive_data
+            .encode_to_string_of_json()
+            .change_context(errors::VaultError::RequestEncodingFailed)
+            .attach_printable("Failed to encode wallet data bank_insensitive_data")
     }
 
     fn from_values(
@@ -619,7 +631,8 @@ impl Vaultable for api::PayoutMethodData {
             Self::Wallet(wallet) => VaultPayoutMethod::Wallet(wallet.get_value1(customer_id)?),
         };
 
-        utils::Encode::<VaultPaymentMethod>::encode_to_string_of_json(&value1)
+        value1
+            .encode_to_string_of_json()
             .change_context(errors::VaultError::RequestEncodingFailed)
             .attach_printable("Failed to encode payout method value1")
     }
@@ -631,7 +644,8 @@ impl Vaultable for api::PayoutMethodData {
             Self::Wallet(wallet) => VaultPayoutMethod::Wallet(wallet.get_value2(customer_id)?),
         };
 
-        utils::Encode::<VaultPaymentMethod>::encode_to_string_of_json(&value2)
+        value2
+            .encode_to_string_of_json()
             .change_context(errors::VaultError::RequestEncodingFailed)
             .attach_printable("Failed to encode payout method value2")
     }
@@ -822,10 +836,9 @@ pub async fn create_tokenize(
             service_name: VAULT_SERVICE_NAME.to_string(),
         };
 
-        let payload = utils::Encode::<api::TokenizePayloadRequest>::encode_to_string_of_json(
-            &payload_to_be_encrypted,
-        )
-        .change_context(errors::ApiErrorResponse::InternalServerError)?;
+        let payload = payload_to_be_encrypted
+            .encode_to_string_of_json()
+            .change_context(errors::ApiErrorResponse::InternalServerError)?;
 
         let encrypted_payload = GcmAes256
             .encode_message(encryption_key.peek().as_ref(), payload.as_bytes())

--- a/crates/router/src/core/payments.rs
+++ b/crates/router/src/core/payments.rs
@@ -2553,10 +2553,11 @@ where
     )
     .await?;
 
-    let encoded_info =
-        Encode::<storage::PaymentRoutingInfo>::encode_to_value(&routing_data.routing_info)
-            .change_context(errors::ApiErrorResponse::InternalServerError)
-            .attach_printable("error serializing payment routing info to serde value")?;
+    let encoded_info = routing_data
+        .routing_info
+        .encode_to_value()
+        .change_context(errors::ApiErrorResponse::InternalServerError)
+        .attach_printable("error serializing payment routing info to serde value")?;
 
     payment_data.payment_attempt.connector = routing_data.routed_through;
     #[cfg(feature = "connector_choice_mca_id")]

--- a/crates/router/src/core/payments/operations/payment_complete_authorize.rs
+++ b/crates/router/src/core/payments/operations/payment_complete_authorize.rs
@@ -18,7 +18,6 @@ use crate::{
     routes::AppState,
     services,
     types::{
-        self,
         api::{self, PaymentIdTypeExt},
         domain,
         storage::{self, enums as storage_enums},
@@ -91,7 +90,8 @@ impl<F: Send + Clone, Ctx: PaymentMethodRetrieve>
         let browser_info = request
             .browser_info
             .clone()
-            .map(|x| utils::Encode::<types::BrowserInformation>::encode_to_value(&x))
+            .as_ref()
+            .map(utils::Encode::encode_to_value)
             .transpose()
             .change_context(errors::ApiErrorResponse::InvalidDataValue {
                 field_name: "browser_info",

--- a/crates/router/src/core/payments/operations/payment_confirm.rs
+++ b/crates/router/src/core/payments/operations/payment_confirm.rs
@@ -25,7 +25,6 @@ use crate::{
     routes::AppState,
     services,
     types::{
-        self,
         api::{self, PaymentIdTypeExt},
         domain,
         storage::{self, enums as storage_enums},
@@ -354,7 +353,8 @@ impl<F: Send + Clone, Ctx: PaymentMethodRetrieve>
             .browser_info
             .clone()
             .or(payment_attempt.browser_info)
-            .map(|x| utils::Encode::<types::BrowserInformation>::encode_to_value(&x))
+            .as_ref()
+            .map(Encode::encode_to_value)
             .transpose()
             .change_context(errors::ApiErrorResponse::InvalidDataValue {
                 field_name: "browser_info",
@@ -697,7 +697,7 @@ impl<F: Clone, Ctx: PaymentMethodRetrieve>
             })
             .await
             .as_ref()
-            .map(Encode::<api_models::payments::AdditionalPaymentData>::encode_to_value)
+            .map(Encode::encode_to_value)
             .transpose()
             .change_context(errors::ApiErrorResponse::InternalServerError)
             .attach_printable("Failed to encode additional pm data")?;

--- a/crates/router/src/core/payments/operations/payment_create.rs
+++ b/crates/router/src/core/payments/operations/payment_create.rs
@@ -149,9 +149,8 @@ impl<F: Send + Clone, Ctx: PaymentMethodRetrieve>
         let browser_info = request
             .browser_info
             .clone()
-            .map(|x| {
-                common_utils::ext_traits::Encode::<types::BrowserInformation>::encode_to_value(&x)
-            })
+            .as_ref()
+            .map(Encode::encode_to_value)
             .transpose()
             .change_context(errors::ApiErrorResponse::InvalidDataValue {
                 field_name: "browser_info",
@@ -708,7 +707,7 @@ impl PaymentCreate {
             .await;
         let additional_pm_data_value = additional_pm_data
             .as_ref()
-            .map(Encode::<api_models::payments::AdditionalPaymentData>::encode_to_value)
+            .map(Encode::encode_to_value)
             .transpose()
             .change_context(errors::ApiErrorResponse::InternalServerError)
             .attach_printable("Failed to encode additional pm data")?;
@@ -933,12 +932,11 @@ async fn create_payment_link(
         payment_id.clone()
     );
 
-    let payment_link_config_encoded_value = common_utils::ext_traits::Encode::<
-        api_models::admin::PaymentLinkConfig,
-    >::encode_to_value(&payment_link_config)
-    .change_context(errors::ApiErrorResponse::InvalidDataValue {
-        field_name: "payment_link_config",
-    })?;
+    let payment_link_config_encoded_value = payment_link_config.encode_to_value().change_context(
+        errors::ApiErrorResponse::InvalidDataValue {
+            field_name: "payment_link_config",
+        },
+    )?;
 
     let payment_link_req = storage::PaymentLinkNew {
         payment_link_id: payment_link_id.clone(),

--- a/crates/router/src/core/payments/operations/payment_response.rs
+++ b/crates/router/src/core/payments/operations/payment_response.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 
 use async_trait::async_trait;
 use common_enums::AuthorizationStatus;
+use common_utils::ext_traits::Encode;
 use data_models::payments::payment_attempt::PaymentAttempt;
 use error_stack::{report, IntoReport, ResultExt};
 use futures::FutureExt;
@@ -21,7 +22,6 @@ use crate::{
         utils as core_utils,
     },
     routes::{metrics, AppState},
-    services::RedirectForm,
     types::{
         self, api,
         storage::{self, enums},
@@ -590,7 +590,8 @@ async fn payment_response_update_tracker<F: Clone, T: types::Capturable>(
                     let encoded_data = payment_data.payment_attempt.encoded_data.clone();
 
                     let authentication_data = redirection_data
-                        .map(|data| utils::Encode::<RedirectForm>::encode_to_value(&data))
+                        .as_ref()
+                        .map(Encode::encode_to_value)
                         .transpose()
                         .change_context(errors::ApiErrorResponse::InternalServerError)
                         .attach_printable("Could not parse the connector response")?;

--- a/crates/router/src/core/payments/operations/payment_update.rs
+++ b/crates/router/src/core/payments/operations/payment_update.rs
@@ -520,7 +520,7 @@ impl<F: Clone, Ctx: PaymentMethodRetrieve>
             })
             .await
             .as_ref()
-            .map(Encode::<api_models::payments::AdditionalPaymentData>::encode_to_value)
+            .map(Encode::encode_to_value)
             .transpose()
             .change_context(errors::ApiErrorResponse::InternalServerError)
             .attach_printable("Failed to encode additional pm data")?;

--- a/crates/router/src/core/payments/retry.rs
+++ b/crates/router/src/core/payments/retry.rs
@@ -1,5 +1,6 @@
 use std::{str::FromStr, vec::IntoIter};
 
+use common_utils::ext_traits::Encode;
 use diesel_models::enums as storage_enums;
 use error_stack::{IntoReport, ResultExt};
 use router_env::{
@@ -20,8 +21,7 @@ use crate::{
     db::StorageInterface,
     routes,
     routes::{app, metrics},
-    services::{self, RedirectForm},
-    types,
+    services, types,
     types::{api, domain, storage},
     utils,
 };
@@ -352,7 +352,8 @@ where
             let encoded_data = payment_data.payment_attempt.encoded_data.clone();
 
             let authentication_data = redirection_data
-                .map(|data| utils::Encode::<RedirectForm>::encode_to_value(&data))
+                .as_ref()
+                .map(Encode::encode_to_value)
                 .transpose()
                 .change_context(errors::ApiErrorResponse::InternalServerError)
                 .attach_printable("Could not parse the connector response")?;

--- a/crates/router/src/core/payments/types.rs
+++ b/crates/router/src/core/payments/types.rs
@@ -336,7 +336,8 @@ impl SurchargeMetadata {
             for (key, value) in self.get_individual_surcharge_key_value_pairs().into_iter() {
                 value_list.push((
                     key,
-                    Encode::<SurchargeDetails>::encode_to_string_of_json(&value)
+                    value
+                        .encode_to_string_of_json()
                         .change_context(errors::ApiErrorResponse::InternalServerError)
                         .attach_printable("Failed to encode to string of json")?,
                 ));

--- a/crates/router/src/core/routing.rs
+++ b/crates/router/src/core/routing.rs
@@ -162,10 +162,10 @@ pub async fn create_routing_config(
 
     #[cfg(not(feature = "business_profile_routing"))]
     {
-        let algorithm_str =
-            utils::Encode::<routing_types::RoutingAlgorithm>::encode_to_string_of_json(&algorithm)
-                .change_context(errors::ApiErrorResponse::InternalServerError)
-                .attach_printable("Unable to serialize routing algorithm to string")?;
+        let algorithm_str = algorithm
+            .encode_to_string_of_json()
+            .change_context(errors::ApiErrorResponse::InternalServerError)
+            .attach_printable("Unable to serialize routing algorithm to string")?;
 
         let mut algorithm_ref: routing_types::RoutingAlgorithmRef = merchant_account
             .routing_algorithm
@@ -548,10 +548,10 @@ pub async fn unlink_routing_config(
         )
         .await?;
 
-        let ref_value =
-            Encode::<routing_types::RoutingAlgorithmRef>::encode_to_value(&routing_algorithm)
-                .change_context(errors::ApiErrorResponse::InternalServerError)
-                .attach_printable("Failed converting routing algorithm ref to json value")?;
+        let ref_value = routing_algorithm
+            .encode_to_value()
+            .change_context(errors::ApiErrorResponse::InternalServerError)
+            .attach_printable("Failed converting routing algorithm ref to json value")?;
 
         let merchant_account_update = storage::MerchantAccountUpdate::Update {
             merchant_name: None,

--- a/crates/router/src/core/routing/helpers.rs
+++ b/crates/router/src/core/routing/helpers.rs
@@ -15,7 +15,7 @@ use crate::{
     core::errors::{self, RouterResult},
     db::StorageInterface,
     types::{domain, storage},
-    utils::{self, StringExt},
+    utils::StringExt,
 };
 
 /// provides the complete merchant routing dictionary that is basically a list of all the routing
@@ -42,10 +42,8 @@ pub async fn get_merchant_routing_dictionary(
                 records: Vec::new(),
             };
 
-            let serialized =
-                utils::Encode::<routing_types::RoutingDictionary>::encode_to_string_of_json(
-                    &new_dictionary,
-                )
+            let serialized = new_dictionary
+                .encode_to_string_of_json()
                 .change_context(errors::ApiErrorResponse::InternalServerError)
                 .attach_printable("Error serializing newly created merchant dictionary")?;
 
@@ -86,10 +84,8 @@ pub async fn get_merchant_default_config(
 
         Err(e) if e.current_context().is_db_not_found() => {
             let new_config_conns = Vec::<routing_types::RoutableConnectorChoice>::new();
-            let serialized =
-                utils::Encode::<Vec<routing_types::RoutableConnectorChoice>>::encode_to_string_of_json(
-                    &new_config_conns,
-                )
+            let serialized = new_config_conns
+                .encode_to_string_of_json()
                 .change_context(errors::ApiErrorResponse::InternalServerError)
                 .attach_printable(
                     "Error while creating and serializing new merchant default config",
@@ -122,10 +118,8 @@ pub async fn update_merchant_default_config(
     connectors: Vec<routing_types::RoutableConnectorChoice>,
 ) -> RouterResult<()> {
     let key = get_default_config_key(merchant_id);
-    let config_str =
-        Encode::<Vec<routing_types::RoutableConnectorChoice>>::encode_to_string_of_json(
-            &connectors,
-        )
+    let config_str = connectors
+        .encode_to_string_of_json()
         .change_context(errors::ApiErrorResponse::InternalServerError)
         .attach_printable("Unable to serialize merchant default routing config during update")?;
 
@@ -147,10 +141,10 @@ pub async fn update_merchant_routing_dictionary(
     dictionary: routing_types::RoutingDictionary,
 ) -> RouterResult<()> {
     let key = get_routing_dictionary_key(merchant_id);
-    let dictionary_str =
-        Encode::<routing_types::RoutingDictionary>::encode_to_string_of_json(&dictionary)
-            .change_context(errors::ApiErrorResponse::InternalServerError)
-            .attach_printable("Unable to serialize routing dictionary during update")?;
+    let dictionary_str = dictionary
+        .encode_to_string_of_json()
+        .change_context(errors::ApiErrorResponse::InternalServerError)
+        .attach_printable("Unable to serialize routing dictionary during update")?;
 
     let config_update = configs::ConfigUpdate::Update {
         config: Some(dictionary_str),
@@ -169,10 +163,10 @@ pub async fn update_routing_algorithm(
     algorithm_id: String,
     algorithm: routing_types::RoutingAlgorithm,
 ) -> RouterResult<()> {
-    let algorithm_str =
-        Encode::<routing_types::RoutingAlgorithm>::encode_to_string_of_json(&algorithm)
-            .change_context(errors::ApiErrorResponse::InternalServerError)
-            .attach_printable("Unable to serialize routing algorithm to string")?;
+    let algorithm_str = algorithm
+        .encode_to_string_of_json()
+        .change_context(errors::ApiErrorResponse::InternalServerError)
+        .attach_printable("Unable to serialize routing algorithm to string")?;
 
     let config_update = configs::ConfigUpdate::Update {
         config: Some(algorithm_str),
@@ -193,7 +187,8 @@ pub async fn update_merchant_active_algorithm_ref(
     key_store: &domain::MerchantKeyStore,
     algorithm_id: routing_types::RoutingAlgorithmRef,
 ) -> RouterResult<()> {
-    let ref_value = Encode::<routing_types::RoutingAlgorithmRef>::encode_to_value(&algorithm_id)
+    let ref_value = algorithm_id
+        .encode_to_value()
         .change_context(errors::ApiErrorResponse::InternalServerError)
         .attach_printable("Failed converting routing algorithm ref to json value")?;
 
@@ -236,7 +231,8 @@ pub async fn update_business_profile_active_algorithm_ref(
     current_business_profile: BusinessProfile,
     algorithm_id: routing_types::RoutingAlgorithmRef,
 ) -> RouterResult<()> {
-    let ref_val = Encode::<routing_types::RoutingAlgorithmRef>::encode_to_value(&algorithm_id)
+    let ref_val = algorithm_id
+        .encode_to_value()
         .change_context(errors::ApiErrorResponse::InternalServerError)
         .attach_printable("Failed to convert routing ref to value")?;
 
@@ -282,10 +278,8 @@ pub async fn get_merchant_connector_agnostic_mandate_config(
         Err(e) if e.current_context().is_db_not_found() => {
             let new_mandate_config: Vec<routing_types::DetailedConnectorChoice> = Vec::new();
 
-            let serialized =
-                utils::Encode::<Vec<routing_types::DetailedConnectorChoice>>::encode_to_string_of_json(
-                    &new_mandate_config,
-                )
+            let serialized = new_mandate_config
+                .encode_to_string_of_json()
                 .change_context(errors::ApiErrorResponse::InternalServerError)
                 .attach_printable("error serializing newly created pg agnostic mandate config")?;
 
@@ -314,10 +308,8 @@ pub async fn update_merchant_connector_agnostic_mandate_config(
     mandate_config: Vec<routing_types::DetailedConnectorChoice>,
 ) -> RouterResult<Vec<routing_types::DetailedConnectorChoice>> {
     let key = get_pg_agnostic_mandate_config_key(merchant_id);
-    let mandate_config_str =
-        Encode::<Vec<routing_types::DetailedConnectorChoice>>::encode_to_string_of_json(
-            &mandate_config,
-        )
+    let mandate_config_str = mandate_config
+        .encode_to_string_of_json()
         .change_context(errors::ApiErrorResponse::InternalServerError)
         .attach_printable("unable to serialize pg agnostic mandate config during update")?;
 

--- a/crates/router/src/core/surcharge_decision_config.rs
+++ b/crates/router/src/core/surcharge_decision_config.rs
@@ -1,11 +1,11 @@
 use api_models::{
-    routing::{self},
+    routing,
     surcharge_decision_configs::{
         SurchargeDecisionConfigReq, SurchargeDecisionManagerRecord,
         SurchargeDecisionManagerResponse,
     },
 };
-use common_utils::ext_traits::{StringExt, ValueExt};
+use common_utils::ext_traits::{Encode, StringExt, ValueExt};
 use diesel_models::configs;
 use error_stack::{IntoReport, ResultExt};
 use euclid::frontend::ast;
@@ -18,7 +18,7 @@ use crate::{
     routes::AppState,
     services::api as service_api,
     types::domain,
-    utils::{self, OptionExt},
+    utils::OptionExt,
 };
 
 pub async fn upsert_surcharge_decision_config(
@@ -75,10 +75,8 @@ pub async fn upsert_surcharge_decision_config(
                 merchant_surcharge_configs,
             };
 
-            let serialize_updated_str =
-                utils::Encode::<SurchargeDecisionManagerRecord>::encode_to_string_of_json(
-                    &new_algo,
-                )
+            let serialize_updated_str = new_algo
+                .encode_to_string_of_json()
                 .change_context(errors::ApiErrorResponse::InternalServerError)
                 .attach_printable("Unable to serialize config to string")?;
 
@@ -113,10 +111,10 @@ pub async fn upsert_surcharge_decision_config(
                 created_at: timestamp,
             };
 
-            let serialized_str =
-                utils::Encode::<SurchargeDecisionManagerRecord>::encode_to_string_of_json(&new_rec)
-                    .change_context(errors::ApiErrorResponse::InternalServerError)
-                    .attach_printable("Error serializing the config")?;
+            let serialized_str = new_rec
+                .encode_to_string_of_json()
+                .change_context(errors::ApiErrorResponse::InternalServerError)
+                .attach_printable("Error serializing the config")?;
             let new_config = configs::ConfigNew {
                 key: key.clone(),
                 config: serialized_str,

--- a/crates/router/src/core/webhooks/types.rs
+++ b/crates/router/src/core/webhooks/types.rs
@@ -1,5 +1,5 @@
 use api_models::webhooks;
-use common_utils::{crypto::SignMessage, ext_traits};
+use common_utils::{crypto::SignMessage, ext_traits::Encode};
 use error_stack::ResultExt;
 use serde::Serialize;
 
@@ -21,10 +21,10 @@ impl OutgoingWebhookType for webhooks::OutgoingWebhook {
         &self,
         payment_response_hash_key: Option<String>,
     ) -> errors::CustomResult<Option<String>, errors::WebhooksFlowError> {
-        let webhook_signature_payload =
-            ext_traits::Encode::<serde_json::Value>::encode_to_string_of_json(self)
-                .change_context(errors::WebhooksFlowError::OutgoingWebhookEncodingFailed)
-                .attach_printable("failed encoding outgoing webhook payload")?;
+        let webhook_signature_payload = self
+            .encode_to_string_of_json()
+            .change_context(errors::WebhooksFlowError::OutgoingWebhookEncodingFailed)
+            .attach_printable("failed encoding outgoing webhook payload")?;
 
         Ok(payment_response_hash_key
             .map(|key| {

--- a/crates/router/src/db/merchant_connector_account.rs
+++ b/crates/router/src/db/merchant_connector_account.rs
@@ -69,9 +69,9 @@ impl ConnectorAccessToken for Store {
         access_token: types::AccessToken,
     ) -> CustomResult<(), errors::StorageError> {
         let key = format!("access_token_{merchant_id}_{connector_name}");
-        let serialized_access_token =
-            Encode::<types::AccessToken>::encode_to_string_of_json(&access_token)
-                .change_context(errors::StorageError::SerializationFailed)?;
+        let serialized_access_token = access_token
+            .encode_to_string_of_json()
+            .change_context(errors::StorageError::SerializationFailed)?;
         self.get_redis_conn()
             .map_err(Into::<errors::StorageError>::into)?
             .set_key_with_expiry(&key, serialized_access_token, access_token.expires)

--- a/crates/router/src/db/refund.rs
+++ b/crates/router/src/db/refund.rs
@@ -267,7 +267,7 @@ mod storage {
 
 #[cfg(feature = "kv_store")]
 mod storage {
-    use common_utils::{date_time, fallback_reverse_lookup_not_found};
+    use common_utils::{date_time, ext_traits::Encode, fallback_reverse_lookup_not_found};
     use error_stack::{IntoReport, ResultExt};
     use redis_interface::HsetnxReply;
     use storage_impl::redis::kv_store::{kv_wrapper, KvOperation};
@@ -279,7 +279,7 @@ mod storage {
         db::reverse_lookup::ReverseLookupInterface,
         services::Store,
         types::storage::{self as storage_types, enums, kv},
-        utils::{self, db_utils},
+        utils::db_utils,
     };
     #[async_trait::async_trait]
     impl RefundInterface for Store {
@@ -520,10 +520,8 @@ mod storage {
                     let field = format!("pa_{}_ref_{}", &this.attempt_id, &this.refund_id);
                     let updated_refund = refund.clone().apply_changeset(this.clone());
 
-                    let redis_value =
-                        utils::Encode::<storage_types::Refund>::encode_to_string_of_json(
-                            &updated_refund,
-                        )
+                    let redis_value = updated_refund
+                        .encode_to_string_of_json()
                         .change_context(errors::StorageError::SerializationFailed)?;
 
                     let redis_entry = kv::TypedSql {

--- a/crates/router/src/routes/payment_methods.rs
+++ b/crates/router/src/routes/payment_methods.rs
@@ -299,7 +299,8 @@ impl ParentPaymentMethodToken {
         token: PaymentTokenData,
         state: &AppState,
     ) -> CustomResult<(), errors::ApiErrorResponse> {
-        let token_json_str = Encode::<PaymentTokenData>::encode_to_string_of_json(&token)
+        let token_json_str = token
+            .encode_to_string_of_json()
             .change_context(errors::ApiErrorResponse::InternalServerError)
             .attach_printable("failed to serialize hyperswitch token to json")?;
         let redis_conn = state

--- a/crates/router/src/routes/payments/helpers.rs
+++ b/crates/router/src/routes/payments/helpers.rs
@@ -73,7 +73,8 @@ pub fn populate_ip_into_browser_info(
             .or_else(|| ip_address_from_header.map(|ip| masking::Secret::new(ip.to_string())));
     }
 
-    let encoded = Encode::<types::BrowserInformation>::encode_to_value(&browser_info)
+    let encoded = browser_info
+        .encode_to_value()
         .change_context(errors::ApiErrorResponse::InternalServerError)
         .attach_printable(
             "failed to re-encode browser information to json after setting ip address",

--- a/crates/storage_impl/src/payments/payment_intent.rs
+++ b/crates/storage_impl/src/payments/payment_intent.rs
@@ -160,9 +160,9 @@ impl<T: DatabaseStore> PaymentIntentInterface for KVRouterStore<T> {
                     .apply_changeset(origin_diesel_intent.clone());
                 // Check for database presence as well Maybe use a read replica here ?
 
-                let redis_value =
-                    Encode::<DieselPaymentIntent>::encode_to_string_of_json(&diesel_intent)
-                        .change_context(StorageError::SerializationFailed)?;
+                let redis_value = diesel_intent
+                    .encode_to_string_of_json()
+                    .change_context(StorageError::SerializationFailed)?;
 
                 let redis_entry = kv::TypedSql {
                     op: kv::DBOperation::Update {


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
This PR simplifies the definition of the `common_utils::ext_traits::Encode` trait to simplify the invocation of the trait methods.

In addition, this PR addresses a clippy lint introduced in Rust 1.76.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
Closes #3685.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
The changes in this should work fine as long as the code compiles. However, sanity testing can be performed by running Postman collection(s). I have performed sanity testing locally by successfully creating a payment and refund via Postman.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
