### PR TITLE
fix(core): validate capture method before update trackers

### DIFF
--- a/crates/router/src/core/payments/flows/authorize_flow.rs
+++ b/crates/router/src/core/payments/flows/authorize_flow.rs
@@ -72,13 +72,6 @@ impl Feature<api::Authorize, types::PaymentsAuthorizeData> for types::PaymentsAu
             types::PaymentsAuthorizeData,
             types::PaymentsResponseData,
         > = connector.connector.get_connector_integration();
-        connector
-            .connector
-            .validate_capture_method(
-                self.request.capture_method,
-                self.request.payment_method_type,
-            )
-            .to_payment_failed_response()?;
 
         if self.should_proceed_with_authorize() {
             self.decide_authentication_type();
@@ -210,13 +203,19 @@ impl Feature<api::Authorize, types::PaymentsAuthorizeData> for types::PaymentsAu
     ) -> RouterResult<(Option<services::Request>, bool)> {
         match call_connector_action {
             payments::CallConnectorAction::Trigger => {
+                connector
+                    .connector
+                    .validate_capture_method(
+                        self.request.capture_method,
+                        self.request.payment_method_type,
+                    )
+                    .to_payment_failed_response()?;
                 let connector_integration: services::BoxedConnectorIntegration<
                     '_,
                     api::Authorize,
                     types::PaymentsAuthorizeData,
                     types::PaymentsResponseData,
                 > = connector.connector.get_connector_integration();
-
                 connector_integration
                     .execute_pretasks(self, state)
                     .await


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Currently capture method validation is done in `decide_flows`(after update_trackers). Because of this intent status changes to `processing`. 

In this PR, I have validated capture method in `build_flow_specific_connector_request`(before udpate_trackers). Hence intent status will remain same as before.


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Manual
1. Create a merchant with stripe connector
2. Create a payment without payment_method_data and confirm: false and capture_method : manual_multiple.
<img width="1728" alt="Screenshot 2024-02-20 at 1 03 21 PM" src="https://github.com/juspay/hyperswitch/assets/61539176/78b52bb8-42a6-499d-b588-3d7dc9cdde3c">


3. Confirm the payment
<img width="1728" alt="Screenshot 2024-02-20 at 1 03 37 PM" src="https://github.com/juspay/hyperswitch/assets/61539176/c318010e-9245-4adc-9e61-a6fce7c979c3">


4. Do Psyn -> Status remains `requires payment method`
<img width="1728" alt="Screenshot 2024-02-20 at 1 03 48 PM" src="https://github.com/juspay/hyperswitch/assets/61539176/fad5b52e-955a-405c-bc28-685a1ea58686">



## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
