### PR TITLE
fix: remove status_code being printed in EndRequest log

### DIFF
--- a/crates/router/src/services/api.rs
+++ b/crates/router/src/services/api.rs
@@ -1243,7 +1243,6 @@ where
     let request_duration = end_instant.saturating_duration_since(start_instant);
     logger::info!(
         tag = ?Tag::EndRequest,
-        status_code = response_code,
         time_taken_ms = request_duration.as_millis(),
     );
     res


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix

## Description
<!-- Describe your changes in detail -->
This change will remove the explicit status code that is being printed in the `EndRequest` log. This is causing problems in the higher environments due to some infra issue.


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
- Run the application locally and create a merchant account.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
