### PR TITLE
feat: add unique constraint restriction for KV

### DIFF
--- a/crates/redis_interface/src/commands.rs
+++ b/crates/redis_interface/src/commands.rs
@@ -15,11 +15,11 @@ use common_utils::{
 };
 use error_stack::{IntoReport, ResultExt};
 use fred::{
-    interfaces::{HashesInterface, KeysInterface, StreamsInterface},
+    interfaces::{HashesInterface, KeysInterface, SetsInterface, StreamsInterface},
     prelude::RedisErrorKind,
     types::{
         Expiration, FromRedis, MultipleIDs, MultipleKeys, MultipleOrderedPairs, MultipleStrings,
-        RedisKey, RedisMap, RedisValue, Scanner, SetOptions, XCap, XReadResponse,
+        MultipleValues, RedisKey, RedisMap, RedisValue, Scanner, SetOptions, XCap, XReadResponse,
     },
 };
 use futures::StreamExt;
@@ -27,7 +27,7 @@ use router_env::{instrument, logger, tracing};
 
 use crate::{
     errors,
-    types::{DelReply, HsetnxReply, MsetnxReply, RedisEntryId, SetnxReply},
+    types::{DelReply, HsetnxReply, MsetnxReply, RedisEntryId, SaddReply, SetnxReply},
 };
 
 impl super::RedisConnectionPool {
@@ -464,6 +464,23 @@ impl super::RedisConnectionPool {
         value_bytes
             .parse_struct(type_name)
             .change_context(errors::RedisError::JsonDeserializationFailed)
+    }
+
+    #[instrument(level = "DEBUG", skip(self))]
+    pub async fn sadd<V>(
+        &self,
+        key: &str,
+        members: V,
+    ) -> CustomResult<SaddReply, errors::RedisError>
+    where
+        V: TryInto<MultipleValues> + Debug + Send,
+        V::Error: Into<fred::error::RedisError> + Send,
+    {
+        self.pool
+            .sadd(key, members)
+            .await
+            .into_report()
+            .change_context(errors::RedisError::SetAddMembersFailed)
     }
 
     #[instrument(level = "DEBUG", skip(self))]

--- a/crates/redis_interface/src/errors.rs
+++ b/crates/redis_interface/src/errors.rs
@@ -50,6 +50,8 @@ pub enum RedisError {
     SetHashFailed,
     #[error("Failed to set hash field in Redis")]
     SetHashFieldFailed,
+    #[error("Failed to add members to set in Redis")]
+    SetAddMembersFailed,
     #[error("Failed to get hash field in Redis")]
     GetHashFieldFailed,
     #[error("The requested value was not found in Redis")]

--- a/crates/redis_interface/src/types.rs
+++ b/crates/redis_interface/src/types.rs
@@ -255,3 +255,22 @@ impl fred::types::FromRedis for DelReply {
         }
     }
 }
+
+#[derive(Debug)]
+pub enum SaddReply {
+    KeySet,
+    KeyNotSet,
+}
+
+impl fred::types::FromRedis for SaddReply {
+    fn from_value(value: fred::types::RedisValue) -> Result<Self, fred::error::RedisError> {
+        match value {
+            fred::types::RedisValue::Integer(1) => Ok(Self::KeySet),
+            fred::types::RedisValue::Integer(0) => Ok(Self::KeyNotSet),
+            _ => Err(fred::error::RedisError::new(
+                fred::error::RedisErrorKind::Unknown,
+                "Unexpected sadd command reply",
+            )),
+        }
+    }
+}

--- a/crates/storage_impl/src/errors.rs
+++ b/crates/storage_impl/src/errors.rs
@@ -164,10 +164,12 @@ impl RedisErrorExt for error_stack::Report<RedisError> {
             RedisError::NotFound => self.change_context(DataStorageError::ValueNotFound(format!(
                 "Data does not exist for key {key}",
             ))),
-            RedisError::SetNxFailed => self.change_context(DataStorageError::DuplicateValue {
-                entity: "redis",
-                key: Some(key.to_string()),
-            }),
+            RedisError::SetNxFailed | RedisError::SetAddMembersFailed => {
+                self.change_context(DataStorageError::DuplicateValue {
+                    entity: "redis",
+                    key: Some(key.to_string()),
+                })
+            }
             _ => self.change_context(DataStorageError::KVError),
         }
     }

--- a/crates/storage_impl/src/redis/kv_store.rs
+++ b/crates/storage_impl/src/redis/kv_store.rs
@@ -7,7 +7,7 @@ use router_derive::TryGetEnumVariant;
 use router_env::logger;
 use serde::de;
 
-use crate::{metrics, store::kv::TypedSql, KVRouterStore};
+use crate::{metrics, store::kv::TypedSql, KVRouterStore, UniqueConstraints};
 
 pub trait KvStorePartition {
     fn partition_number(key: PartitionKey<'_>, num_partitions: u8) -> u32 {
@@ -95,7 +95,7 @@ pub async fn kv_wrapper<'a, T, D, S>(
 where
     T: de::DeserializeOwned,
     D: crate::database::store::DatabaseStore,
-    S: serde::Serialize + Debug + KvStorePartition,
+    S: serde::Serialize + Debug + KvStorePartition + UniqueConstraints + Sync,
 {
     let redis_conn = store.get_redis_conn()?;
 
@@ -147,6 +147,8 @@ where
             KvOperation::HSetNx(field, value, sql) => {
                 logger::debug!(kv_operation= %operation, value = ?value);
 
+                value.check_for_constraints(&redis_conn).await?;
+
                 let result = redis_conn
                     .serialize_and_set_hash_field_if_not_exist(key, field, value, Some(ttl))
                     .await?;
@@ -167,6 +169,8 @@ where
                 let result = redis_conn
                     .serialize_and_set_key_if_not_exist(key, value, Some(ttl.into()))
                     .await?;
+
+                value.check_for_constraints(&redis_conn).await?;
 
                 if matches!(result, redis_interface::SetnxReply::KeySet) {
                     store


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->
- [x] Enhancement

## Description
<!-- Describe your changes in detail -->
Add constraint per table for KV.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
Currently we are storing the data in redis to give a buffer time for drainer to drain the data in the database. So the problem is after drainer drains the database and the data in redis is already expired, When you insert the data with the same ID as the last it will succeed from application side but fail in drainer, So all constraints will be forgotten.

This PR fixes the above issue by using `Redis Sets` to save the constraint `id's` in place. This will check Sets everytime before inserting the data and throw the Error if the `id` exists.

Limits of Redis Sets:
- Size limit of redis instance.
- 2^64 -1 number of keys, Since Redis uses 64-bit unsigned integer for keys.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
`Unique Constraint with Payments`

- Create a payment. With an `payment_id`. Should Succeed
```bash
{
  "payment_id": "pay_sm3WbVmQxQ09gL1Eo5kx",
  "amount": 6540,
  "currency": "USD",
  "confirm": true,
  "capture_method": "automatic",
  "capture_on": "2022-09-10T10:11:12Z",
  "amount_to_capture": 6540,
  "customer_id": "StripeCustomer",
  "email": "guest@example.com",
  "name": "John Doe",
  "phone": "999999999",
  "connector": ["adyen_test"],
  "phone_country_code": "+1",
  "description": "Its my first payment request",
  "authentication_type": "no_three_ds",
  "return_url": "https://google.com",
  "payment_method": "card",
  "payment_method_type": "credit",
  "payment_method_data": {
    "card": {
      "card_number": "4242424242424242",
      "card_exp_month": "10",
      "card_exp_year": "25",
      "card_holder_name": "joseph Doe",
      "card_cvc": "123"
    }
  },
  "billing": {
    "address": {
      "line1": "1467",
      "line2": "Harrison Street",
      "line3": "Harrison Street",
      "city": "San Fransico",
      "state": "California",
      "zip": "94122",
      "country": "US",
      "first_name": "joseph",
      "last_name": "Doe"
    },
    "phone": {
      "number": "8056594427",
      "country_code": "+91"
    }
  },
  "shipping": {
    "address": {
      "line1": "1467",
      "line2": "Harrison Street",
      "line3": "Harrison Street",
      "city": "San Fransico",
      "state": "California",
      "zip": "94122",
      "country": "US",
      "first_name": "joseph",
      "last_name": "Doe"
    },
    "phone": {
      "number": "8056594427",
      "country_code": "+91"
    }
  },
  "statement_descriptor_name": "joseph",
  "statement_descriptor_suffix": "JS",
  "metadata": {
    "udf1": "value1",
    "new_customer": "true",
    "login_date": "2019-09-10T10:11:12Z"
  }
}
```
- Wait for 15 mins (TTL of KV in Sandbox) and create payment with same id again. It should give Unique constraint error
<img width="1305" alt="Screenshot 2024-02-20 at 4 16 07 PM" src="https://github.com/juspay/hyperswitch/assets/43412619/87e778e1-e5ab-4515-b88d-c2903775a6fc">

- Do the same thing for Refund

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code