### PR TITLE
refactor(connector): [Braintree] Mask PII data

### DIFF
--- a/crates/router/src/connector/braintree/braintree_graphql_transformers.rs
+++ b/crates/router/src/connector/braintree/braintree_graphql_transformers.rs
@@ -54,7 +54,7 @@ impl<T>
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PaymentInput {
-    payment_method_id: String,
+    payment_method_id: Secret<String>,
     transaction: TransactionBody,
 }
 
@@ -899,7 +899,7 @@ impl TryFrom<&types::TokenizationRouterData> for BraintreeTokenRequest {
 
 #[derive(Default, Debug, Clone, Deserialize, Serialize)]
 pub struct TokenizePaymentMethodData {
-    id: String,
+    id: Secret<String>,
 }
 
 #[derive(Default, Debug, Clone, Deserialize, Serialize)]
@@ -969,6 +969,7 @@ impl<F, T>
                             .tokenize_credit_card
                             .payment_method
                             .id
+                            .expose()
                             .clone(),
                     })
                 }
@@ -1277,7 +1278,7 @@ impl<F, T>
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct BraintreeThreeDsResponse {
-    pub nonce: String,
+    pub nonce: Secret<String>,
     pub liability_shifted: bool,
     pub liability_shift_possible: bool,
 }
@@ -1332,7 +1333,7 @@ impl
             variables: VariablePaymentInput {
                 input: PaymentInput {
                     payment_method_id: match item.router_data.get_payment_method_token()? {
-                        types::PaymentMethodToken::Token(token) => token,
+                        types::PaymentMethodToken::Token(token) => token.into(),
                         types::PaymentMethodToken::ApplePayDecrypt(_) => {
                             Err(errors::ConnectorError::InvalidWalletToken)?
                         }

--- a/crates/router/src/connector/braintree/transformers.rs
+++ b/crates/router/src/connector/braintree/transformers.rs
@@ -1,6 +1,6 @@
 use api_models::payments;
 use base64::Engine;
-use masking::{PeekInterface, Secret};
+use masking::{ExposeInterface, PeekInterface, Secret};
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -77,7 +77,7 @@ pub enum PaymentMethodType {
 
 #[derive(Default, Debug, Serialize, Eq, PartialEq)]
 pub struct Nonce {
-    payment_method_nonce: String,
+    payment_method_nonce: Secret<String>,
 }
 
 #[derive(Default, Debug, Serialize, Eq, PartialEq)]
@@ -130,7 +130,8 @@ impl TryFrom<&types::PaymentsAuthorizeRouterData> for BraintreePaymentsRequest {
                             Ok(wallet_data.token.to_owned())
                         }
                         _ => Err(errors::ConnectorError::InvalidWallet),
-                    }?,
+                    }?
+                    .into(),
                 }))
             }
             _ => Err(errors::ConnectorError::NotImplemented(format!(
@@ -263,7 +264,7 @@ impl<F, T>
             response: Ok(types::PaymentsResponseData::SessionResponse {
                 session_token: types::api::SessionToken::Paypal(Box::new(
                     payments::PaypalSessionTokenResponse {
-                        session_token: item.response.client_token.value,
+                        session_token: item.response.client_token.value.expose(),
                     },
                 )),
             }),
@@ -281,7 +282,7 @@ pub struct BraintreePaymentsResponse {
 #[derive(Default, Debug, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ClientToken {
-    pub value: String,
+    pub value: Secret<String>,
 }
 
 #[derive(Default, Debug, Clone, Deserialize, Serialize)]


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Mask pii information passed and received in the connector request and response for Braintree.

## Test Case
Check if sensitive fields within connector request and response is masked in the click house for Braintree
Test for both graphQL and the normal version

Sanity test
1. Payment create - 3ds card
```
curl --location 'http://localhost:8080/payments' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: {{api_key}}' \
--data-raw '{
  "amount": 2000,
  "currency": "GBP",
  "confirm": true,
  "capture_method": "automatic",
  "capture_on": "2022-09-10T10:11:12Z",
  "customer_id": "StripeCustomer",
  "email": "abcdef123@gmail.com",
  "name": "John Doe",
  "phone": "999999999",
  "phone_country_code": "+65",
  "description": "Its my first payment request",
  "authentication_type": "three_ds",
  "return_url": "https://google.com",

  "billing": {
    "address": {
      "line1": "1467",
      "line2": "Harrison Street",
      "line3": "Harrison Street",
      "city": "San Fransico",
      "state": "California",
      "zip": "94122",
      "country": "US",
      "first_name": "John",
      "last_name": "Doe"
    }
  },
  "browser_info": {
    "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Safari/537.36",
    "accept_header": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8",
    "language": "nl-NL",
    "color_depth": 24,
    "screen_height": 723,
    "screen_width": 1536,
    "time_zone": 0,
    "java_enabled": true,
    "java_script_enabled": true,
    "ip_address": "127.0.0.1"
  },
  "shipping": {
    "address": {
      "line1": "1467",
      "line2": "Harrison Street",
      "line3": "Harrison Street",
      "city": "San Fransico",
      "state": "California",
      "zip": "94122",
      "country": "US",
      "first_name": "John",
      "last_name": "Doe"
    }
  },
  "statement_descriptor_name": "joseph",
  "statement_descriptor_suffix": "JS",
  "metadata": {
    "udf1": "value1",
    "new_customer": "true",
    "login_date": "2019-09-10T10:11:12Z"
  },
  "payment_method": "card",
  "payment_method_data": {
    "card": {
      "card_number": "5123456789012346",
      "card_exp_month": "10",
      "card_exp_year": "30",
      "card_holder_name": "Joseph Doe",
      "card_cvc": "123"
    }
  }
}'
```
response

```
ClientTokenResponse(ClientTokenResponse { data: ClientTokenData { create_client_token: ClientToken { client_token: *** alloc::string::String *** } } })
```

```
router::connector::braintree: connector_response: TokenResponse(TokenResponse { data: TokenizeCreditCard { tokenize_credit_card: TokenizeCreditCardData { payment_method: TokenizePaymentMethodData { id: *** alloc::string::String *** } } } })
```

In logs check for
`topic = "hyperswitch-outgoing-connector-events" `


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
