### PR TITLE
fix(api_keys): fix internal server error being thrown when trying to update or delete non-existent API key

### DIFF
--- a/crates/storage_impl/src/errors.rs
+++ b/crates/storage_impl/src/errors.rs
@@ -139,6 +139,7 @@ impl StorageError {
     pub fn is_db_not_found(&self) -> bool {
         match self {
             Self::DatabaseError(err) => matches!(err.current_context(), DatabaseError::NotFound),
+            Self::ValueNotFound(_) => true,
             _ => false,
         }
     }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
This PR fixes a bug with the update API key and delete API key endpoints throwing an internal server error when a non-existent API key was provided.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
Fixes #3761.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

Locally. Trying to either update a non-existent API key returns a 404 status code, with an error message stating that the API key does not exist.

1. Update API key (request body may contain data or could just be an empty object): 

   ```shell
   curl --location 'http://localhost:8080/api_keys/<merchant_id>/invalid-api-key-id' \
     --header 'Content-Type: application/json' \
     --header 'Accept: application/json' \
     --header 'api-key: <ADMIN_API_KEY>' \
     --data '{}' 
   ```

2. Delete API key:

   ```shell
   curl --location --request DELETE 'http://localhost:8080/<merchant_id>/merchant_1708546282/invalid-api-key-id' \
     --header 'Content-Type: application/json' \
     --header 'Accept: application/json' \
     --header 'api-key:<ADMIN_API_KEY>'
   ```

In both cases, the response returned should be the same, with a 404 status code:

```json
{
  "error": {
    "type": "invalid_request",
    "message": "API Key does not exist in our records",
    "code": "HE_02"
  }
}
```

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [X] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
