### PR TITLE
fix(cards): Return a 200 response indicating that a customer is none

### DIFF
--- a/crates/api_models/src/payment_methods.rs
+++ b/crates/api_models/src/payment_methods.rs
@@ -717,6 +717,8 @@ impl serde::Serialize for PaymentMethodList {
 pub struct CustomerPaymentMethodsListResponse {
     /// List of payment methods for customer
     pub customer_payment_methods: Vec<CustomerPaymentMethod>,
+    /// Returns whether a customer id is not tied to a payment intent (only when the request is made against a client secret)
+    pub is_guest_customer: Option<bool>,
 }
 
 #[derive(Debug, serde::Serialize, ToSchema)]

--- a/crates/router/src/core/payment_methods/cards.rs
+++ b/crates/router/src/core/payment_methods/cards.rs
@@ -2569,18 +2569,28 @@ pub async fn do_list_customer_pm_fetch_customer_if_not_passed(
             )
             .await?;
 
-        let customer_id = payment_intent
+        match payment_intent
             .as_ref()
             .and_then(|intent| intent.customer_id.to_owned())
-            .ok_or(errors::ApiErrorResponse::CustomerNotFound)?;
-        Box::pin(list_customer_payment_method(
-            &state,
-            merchant_account,
-            key_store,
-            payment_intent,
-            &customer_id,
-        ))
-        .await
+        {
+            Some(customer_id) => {
+                Box::pin(list_customer_payment_method(
+                    &state,
+                    merchant_account,
+                    key_store,
+                    payment_intent,
+                    &customer_id,
+                ))
+                .await
+            }
+            None => {
+                let response = api::CustomerPaymentMethodsListResponse {
+                    customer_payment_methods: Vec::new(),
+                    is_guest_customer: Some(true),
+                };
+                Ok(services::ApplicationResponse::Json(response))
+            }
+        }
     }
 }
 
@@ -2776,6 +2786,7 @@ pub async fn list_customer_payment_method(
 
     let mut response = api::CustomerPaymentMethodsListResponse {
         customer_payment_methods: customer_pms,
+        is_guest_customer: payment_intent.as_ref().map(|_| false), //to return this key only when the request is tied to a payment intent
     };
     let payment_attempt = payment_intent
         .as_ref()

--- a/openapi/openapi_spec.json
+++ b/openapi/openapi_spec.json
@@ -7506,6 +7506,11 @@
               "$ref": "#/components/schemas/CustomerPaymentMethod"
             },
             "description": "List of payment methods for customer"
+          },
+          "is_guest_customer": {
+            "type": "boolean",
+            "description": "Returns whether a customer id is not tied to a payment intent (only when the request is made against a client secret)",
+            "nullable": true
           }
         }
       },


### PR DESCRIPTION
## Type of Change
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
Bug Description
CustomerPaymentMethodsListResponse returns 404 when there is no customer tied to a payment

Proposed Behavior
Return a 200 response somehow indicating that a customer is not associated with the payment

Current Behavior
A 404 response with "Customer does not exist in our records" is being returned, although the customer_id is null


### Additional Changes

- [x] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable

Fixes https://github.com/juspay/hyperswitch/issues/3767