### PR TITLE
refactor(connector): [NMI] Include customer_vault_id for card 3ds transaction request

### DIFF
--- a/crates/router/src/connector/nmi/transformers.rs
+++ b/crates/router/src/connector/nmi/transformers.rs
@@ -1,7 +1,11 @@
 use api_models::webhooks;
 use cards::CardNumber;
 use common_enums::CountryAlpha2;
-use common_utils::{errors::CustomResult, ext_traits::XmlExt, pii};
+use common_utils::{
+    errors::CustomResult,
+    ext_traits::XmlExt,
+    pii::{self, Email},
+};
 use error_stack::{IntoReport, Report, ResultExt};
 use masking::{ExposeInterface, PeekInterface, Secret};
 use serde::{Deserialize, Serialize};
@@ -254,12 +258,13 @@ pub struct NmiCompleteRequest {
     transaction_type: TransactionType,
     security_key: Secret<String>,
     orderid: Option<String>,
-    ccnumber: CardNumber,
-    ccexp: Secret<String>,
+    customer_vault_id: String,
+    email: Option<Email>,
     cardholder_auth: Option<String>,
     cavv: Option<String>,
     xid: Option<String>,
     eci: Option<String>,
+    cvv: Secret<String>,
     three_ds_version: Option<String>,
     directory_server_id: Option<String>,
 }
@@ -274,6 +279,7 @@ pub struct NmiRedirectResponseData {
     three_ds_version: Option<String>,
     order_id: Option<String>,
     directory_server_id: Option<String>,
+    customer_vault_id: Option<String>,
 }
 
 impl TryFrom<&NmiRouterData<&types::PaymentsCompleteAuthorizeRouterData>> for NmiCompleteRequest {
@@ -298,16 +304,20 @@ impl TryFrom<&NmiRouterData<&types::PaymentsCompleteAuthorizeRouterData>> for Nm
                 field_name: "three_ds_data",
             })?;
 
-        let (ccnumber, ccexp, ..) =
-            get_card_details(item.router_data.request.payment_method_data.clone())?;
+        let (_, _, cvv) = get_card_details(item.router_data.request.payment_method_data.clone())?;
 
         Ok(Self {
             amount: item.amount,
             transaction_type,
             security_key: auth_type.api_key,
             orderid: three_ds_data.order_id,
-            ccnumber,
-            ccexp,
+            customer_vault_id: three_ds_data.customer_vault_id.ok_or(
+                errors::ConnectorError::MissingRequiredField {
+                    field_name: "customer_vault_id",
+                },
+            )?,
+            email: item.router_data.request.email.clone(),
+            cvv,
             cardholder_auth: three_ds_data.card_holder_auth,
             cavv: three_ds_data.cavv,
             xid: three_ds_data.xid,

--- a/crates/router/src/services/api.rs
+++ b/crates/router/src/services/api.rs
@@ -1845,10 +1845,16 @@ pub fn build_redirection_form(
                         responseForm.appendChild(item4);
 
                         var item5=document.createElement('input');
-                        item4.type='hidden';
-                        item4.name='orderId';
-                        item4.value='{order_id}';
+                        item5.type='hidden';
+                        item5.name='orderId';
+                        item5.value='{order_id}';
                         responseForm.appendChild(item5);
+
+                        var item6=document.createElement('input');
+                        item6.type='hidden';
+                        item6.name='customerVaultId';
+                        item6.value='{customer_vault_id}';
+                        responseForm.appendChild(item6);
 
                         document.body.appendChild(responseForm);
                         responseForm.submit();


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
NMI card 3DS was failing in production. This is because `customer_vault_id` was not being provided in the transaction requeset. 

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
Create a 3ds card payment via NMI connector
```
{
    "amount": 250,
    "currency": "USD",
    "confirm": true,
    "amount_to_capture": 250,
    "capture_method": "automatic",
    "capture_on": "2022-09-10T10:11:12Z",
    "customer_id": "StripeCustomer",
    "email": "abcdef123@gmail.com",
    "name": "John Doe",
    "phone": "999999999",
    "phone_country_code": "+65",
    "description": "Its my first payment request",
    "authentication_type": "three_ds",
    "return_url": "https://google.com",
    "setup_future_usage": "on_session",
    "browser_info": {
        "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Safari/537.36",
        "accept_header": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8",
        "language": "nl-NL",
        "color_depth": 24,
        "screen_height": 723,
        "screen_width": 1536,
        "time_zone": 0,
        "java_enabled": true,
        "java_script_enabled": true,
        "ip_address": "127.0.0.1"
    },
    "shipping": {
        "address": {          
            "zip": "94122",
            "country": "US",
            "first_name": "John",
            "last_name": "Doe"
        }
    },
    "routing": {
        "type": "single",
        "data": "nmi"
    },
    "statement_descriptor_name": "joseph",
    "statement_descriptor_suffix": "JS",
    "metadata": {
        "udf1": "value1",
        "new_customer": "true",
        "login_date": "2019-09-10T10:11:12Z"
    },
    "payment_method": "card",
    "payment_method_type": "credit",
   "payment_method_data": {
        "card": {
            "card_number": "4000000000002503",
            "card_exp_month": "08",
            "card_exp_year": "25",
            "card_holder_name": "joseph Doe",
            "card_cvc": "999"
        }
    },
    "billing": {
        "address": {        
            "zip": "560095",
            "country": "IN",
            "first_name": "Sakil",
            "last_name": "Mostak"
        }
    }
}
```

Response 
```
{
    "payment_id": "pay_rWI6bP0Ku5wXWx9An4u6",
    "merchant_id": "merchant_1708511310",
    "status": "requires_customer_action",
    "amount": 250,
    "net_amount": 250,
    "amount_capturable": 250,
    "amount_received": null,
    "connector": "nmi",
    "client_secret": "pay_rWI6bP0Ku5wXWx9An4u6_secret_AAECzeFI3VJIjKP01prW",
    "created": "2024-02-21T13:05:51.462Z",
    "currency": "USD",
    "customer_id": "StripeCustomer",
    "description": "Its my first payment request",
    "refunds": null,
    "disputes": null,
    "mandate_id": null,
    "mandate_data": null,
    "setup_future_usage": "on_session",
    "off_session": null,
    "capture_on": null,
    "capture_method": "automatic",
    "payment_method": "card",
    "payment_method_data": {
        "card": {
            "last4": "2503",
            "card_type": null,
            "card_network": null,
            "card_issuer": null,
            "card_issuing_country": null,
            "card_isin": "400000",
            "card_extended_bin": "40000000",
            "card_exp_month": "08",
            "card_exp_year": "25",
            "card_holder_name": "joseph Doe"
        }
    },
    "payment_token": "token_KU2VgSIuhZHuoIvKj7kO",
    "shipping": {
        "address": {
            "city": null,
            "country": "US",
            "line1": null,
            "line2": null,
            "line3": null,
            "zip": "94122",
            "state": null,
            "first_name": "John",
            "last_name": "Doe"
        },
        "phone": {
            "number": null,
            "country_code": null
        }
    },
    "billing": {
        "address": {
            "city": null,
            "country": "IN",
            "line1": null,
            "line2": null,
            "line3": null,
            "zip": "560095",
            "state": null,
            "first_name": "Sakil",
            "last_name": "Mostak"
        },
        "phone": {
            "number": null,
            "country_code": null
        }
    },
    "order_details": null,
    "email": "abcdef123@gmail.com",
    "name": "John Doe",
    "phone": "999999999",
    "return_url": "https://google.com/",
    "authentication_type": "three_ds",
    "statement_descriptor_name": "joseph",
    "statement_descriptor_suffix": "JS",
    "next_action": {
        "type": "redirect_to_url",
        "redirect_to_url": "http://localhost:8080/payments/redirect/pay_rWI6bP0Ku5wXWx9An4u6/merchant_1708511310/pay_rWI6bP0Ku5wXWx9An4u6_1"
    },
    "cancellation_reason": null,
    "error_code": null,
    "error_message": null,
    "unified_code": null,
    "unified_message": null,
    "payment_experience": null,
    "payment_method_type": "credit",
    "connector_label": null,
    "business_country": null,
    "business_label": "default",
    "business_sub_label": null,
    "allowed_payment_method_types": null,
    "ephemeral_key": {
        "customer_id": "StripeCustomer",
        "created_at": 1708520751,
        "expires": 1708524351,
        "secret": "epk_974b0280533e423c80f0e0fc2c7cbd55"
    },
    "manual_retry_allowed": null,
    "connector_transaction_id": null,
    "frm_message": null,
    "metadata": {
        "udf1": "value1",
        "login_date": "2019-09-10T10:11:12Z",
        "new_customer": "true"
    },
    "connector_metadata": null,
    "feature_metadata": null,
    "reference_id": "",
    "payment_link": null,
    "profile_id": "pro_DCfNvYJmaYR1ec8aIjnk",
    "surcharge_details": null,
    "attempt_count": 1,
    "merchant_decision": null,
    "merchant_connector_id": "mca_ozs2QPSJD9d2pqKUAMrx",
    "incremental_authorization_allowed": null,
    "authorization_count": null,
    "incremental_authorizations": null,
    "expires_on": "2024-02-21T13:20:51.462Z",
    "fingerprint": null
}
```
Payment should go in processing state.

Payment sync should be done to get the status on the payment
## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
