### PR TITLE
chore(tests): add unit tests for backwards compatibility

### DIFF
--- a/crates/diesel_models/src/payment_attempt.rs
+++ b/crates/diesel_models/src/payment_attempt.rs
@@ -776,3 +776,100 @@ impl From<PaymentAttemptUpdate> for PaymentAttemptUpdateInternal {
         }
     }
 }
+
+mod tests {
+
+    #[test]
+    fn test_backwards_compatibility() {
+        let serialized_payment_attempt = r#"{
+    "id": 1,
+    "payment_id": "PMT123456789",
+    "merchant_id": "M123456789",
+    "attempt_id": "ATMPT123456789",
+    "status": "pending",
+    "amount": 10000,
+    "currency": "USD",
+    "save_to_locker": true,
+    "connector": "stripe",
+    "error_message": null,
+    "offer_amount": 9500,
+    "surcharge_amount": 500,
+    "tax_amount": 800,
+    "payment_method_id": "CRD123456789",
+    "payment_method": "card",
+    "connector_transaction_id": "CNTR123456789",
+    "capture_method": "automatic",
+    "capture_on": "2022-09-10T10:11:12Z",
+    "confirm": false,
+    "authentication_type": "no_three_ds",
+    "created_at": "2024-02-26T12:00:00Z",
+    "modified_at": "2024-02-26T12:00:00Z",
+    "last_synced": null,
+    "cancellation_reason": null,
+    "amount_to_capture": 10000,
+    "mandate_id": null,
+    "browser_info": {
+        "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Safari/537.36",
+        "accept_header": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8",
+        "language": "nl-NL",
+        "color_depth": 24,
+        "screen_height": 723,
+        "screen_width": 1536,
+        "time_zone": 0,
+        "java_enabled": true,
+        "java_script_enabled": true,
+        "ip_address": "127.0.0.1"
+    },
+    "error_code": null,
+    "payment_token": "TOKEN123456789",
+    "connector_metadata": null,
+    "payment_experience": "redirect_to_url",
+    "payment_method_type": "credit",
+    "payment_method_data": {
+        "card": {
+            "card_number": "4242424242424242",
+            "card_exp_month": "10",
+            "card_cvc": "123",
+            "card_exp_year": "2024",
+            "card_holder_name": "John Doe"
+        }
+    },
+    "business_sub_label": "Premium",
+    "straight_through_algorithm": null,
+    "preprocessing_step_id": null,
+    "mandate_details": null,
+    "error_reason": null,
+    "multiple_capture_count": 0,
+    "connector_response_reference_id": null,
+    "amount_capturable": 10000,
+    "updated_by": "redis_kv",
+    "merchant_connector_id": "MCN123456789",
+    "authentication_data": null,
+    "encoded_data": null,
+    "unified_code": null,
+    "unified_message": null,
+    "net_amount": 10200,
+    "mandate_data": {
+    "customer_acceptance": {
+        "acceptance_type": "offline",
+        "accepted_at": "1963-05-03T04:07:52.723Z",
+        "online": {
+            "ip_address": "127.0.0.1",
+            "user_agent": "amet irure esse"
+        }
+    },
+    "mandate_type": {
+        "single_use": {
+            "amount": 6540,
+            "currency": "USD"
+        }
+    }
+},
+    "fingerprint_id": null
+}"#;
+        let deserialized =
+            serde_json::from_str::<super::PaymentAttempt>(serialized_payment_attempt);
+
+        assert!(deserialized.is_ok());
+    }
+}

--- a/crates/diesel_models/src/payment_intent.rs
+++ b/crates/diesel_models/src/payment_intent.rs
@@ -485,3 +485,56 @@ impl From<PaymentIntentUpdate> for PaymentIntentUpdateInternal {
         }
     }
 }
+
+mod tests {
+    #[test]
+    fn test_backwards_compatibility() {
+        let serialized_payment_intent = r#"{
+    "id": 123,
+    "payment_id": "payment_12345",
+    "merchant_id": "merchant_67890",
+    "status": "succeeded",
+    "amount": 10000,
+    "currency": "USD",
+    "amount_captured": null,
+    "customer_id": "cust_123456",
+    "description": "Test Payment",
+    "return_url": "https://example.com/return",
+    "metadata": null,
+    "connector_id": "connector_001",
+    "shipping_address_id": null,
+    "billing_address_id": null,
+    "statement_descriptor_name": null,
+    "statement_descriptor_suffix": null,
+    "created_at": "2024-02-01T12:00:00Z",
+    "modified_at": "2024-02-01T12:00:00Z",
+    "last_synced": null,
+    "setup_future_usage": null,
+    "off_session": null,
+    "client_secret": "sec_abcdef1234567890",
+    "active_attempt_id": "attempt_123",
+    "business_country": "US",
+    "business_label": null,
+    "order_details": null,
+    "allowed_payment_method_types": "credit",
+    "connector_metadata": null,
+    "feature_metadata": null,
+    "attempt_count": 1,
+    "profile_id": null,
+    "merchant_decision": null,
+    "payment_link_id": null,
+    "payment_confirm_source": null,
+    "updated_by": "admin",
+    "surcharge_applicable": null,
+    "request_incremental_authorization": null,
+    "incremental_authorization_allowed": null,
+    "authorization_count": null,
+    "session_expiry": null,
+    "fingerprint_id": null
+}"#;
+        let deserialized_payment_intent =
+            serde_json::from_str::<super::PaymentIntent>(serialized_payment_intent);
+
+        assert!(deserialized_payment_intent.is_ok());
+    }
+}

--- a/crates/diesel_models/src/refund.rs
+++ b/crates/diesel_models/src/refund.rs
@@ -244,3 +244,41 @@ impl common_utils::events::ApiEventMetric for Refund {
         })
     }
 }
+
+mod tests {
+    #[test]
+    fn test_backwards_compatibility() {
+        let serialized_refund = r#"{
+    "id": 1,
+    "internal_reference_id": "internal_ref_123",
+    "refund_id": "refund_456",
+    "payment_id": "payment_789",
+    "merchant_id": "merchant_123",
+    "connector_transaction_id": "connector_txn_789",
+    "connector": "stripe",
+    "connector_refund_id": null,
+    "external_reference_id": null,
+    "refund_type": "instant_refund",
+    "total_amount": 10000,
+    "currency": "USD",
+    "refund_amount": 9500,
+    "refund_status": "Success",
+    "sent_to_gateway": true,
+    "refund_error_message": null,
+    "metadata": null,
+    "refund_arn": null,
+    "created_at": "2024-02-26T12:00:00Z",
+    "updated_at": "2024-02-26T12:00:00Z",
+    "description": null,
+    "attempt_id": "attempt_123",
+    "refund_reason": null,
+    "refund_error_code": null,
+    "profile_id": null,
+    "updated_by": "admin",
+    "merchant_connector_id": null
+}"#;
+        let deserialized = serde_json::from_str::<super::Refund>(serialized_refund);
+
+        assert!(deserialized.is_ok());
+    }
+}


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->
- [x] Enhancement

## Description
<!-- Describe your changes in detail -->
Add Unit tests for testing backwards compatibility

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
This tests if the type is backwards compatible or not

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
 ## Local Testing
- Run `cargo tests --all-features -p diesel_models` it should pass all tests

## Sandbox
- Cannot be tested in sandbox

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code