### PR TITLE
fix(core): do not construct request if it is already available

### DIFF
--- a/crates/router/src/services/api.rs
+++ b/crates/router/src/services/api.rs
@@ -363,8 +363,6 @@ where
 
             match connector_request {
                 Some(request) => {
-                    logger::debug!(connector_request=?request);
-
                     let masked_request_body = match &request.body {
                         Some(request) => match request {
                             RequestContent::Json(i)


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix

## Description
<!-- Describe your changes in detail -->
This PR fixes the duplicate request that was being constructed even if the connector_request already exists.


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
The `or()` function does eager evaluation. This means that even if there is Some(val) the part of code in the or part is evaluated. This is causing the request to be constructed twice.

Fixes #3799 

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
- Manual, compiler guided.
- Create a payment and check if `connector_request` is logged only once.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
