### PR TITLE
fix(core): validate amount_to_capture in payment update

### DIFF
--- a/crates/router/src/core/payments/helpers.rs
+++ b/crates/router/src/core/payments/helpers.rs
@@ -677,8 +677,11 @@ pub fn validate_amount_to_capture_and_capture_method(
             .unwrap_or(0);
         let total_capturable_amount =
             original_amount.map(|original_amount| original_amount + surcharge_amount);
+        let amount_to_capture = request
+            .amount_to_capture
+            .or(payment_attempt.and_then(|pa| pa.amount_to_capture));
         if let Some((total_capturable_amount, amount_to_capture)) =
-            total_capturable_amount.zip(request.amount_to_capture)
+            total_capturable_amount.zip(amount_to_capture)
         {
             utils::when(amount_to_capture != total_capturable_amount, || {
                 Err(report!(errors::ApiErrorResponse::PreconditionFailed {

--- a/postman/collection-dir/stripe/Flow Testcases/Happy Cases/Scenario23- Update Amount/Payments - Update/request.json
+++ b/postman/collection-dir/stripe/Flow Testcases/Happy Cases/Scenario23- Update Amount/Payments - Update/request.json
@@ -18,7 +18,8 @@
       }
     },
     "raw_json_formatted": {
-      "amount": 1000
+      "amount": 1000,
+      "amount_to_capture": 1000
     }
   },
   "url": {


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
If capture method is automatic then `amount` must be equal to `amount_to_capture`, if `amount_to_capture` is sent in payment_create request.

This validation works in payments_create call but doesn't work as expected in payments_update call.


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Manual
Payment create with confirm false
<img width="1728" alt="Screenshot 2024-02-26 at 11 27 30 PM" src="https://github.com/juspay/hyperswitch/assets/61539176/e25ac97f-8695-40a7-b831-98b7e6568629">

Update payment amount (fails with validation error)
<img width="1728" alt="Screenshot 2024-02-26 at 11 26 28 PM" src="https://github.com/juspay/hyperswitch/assets/61539176/75d48f45-4164-4563-a5da-b6447614b3ba">

Send correct `amount_to_capture` field and update is successful
<img width="1728" alt="Screenshot 2024-02-26 at 11 27 01 PM" src="https://github.com/juspay/hyperswitch/assets/61539176/a590e46a-1431-4ff3-a939-09f5ac01ece1">



## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
