### PR TITLE
 refactor(connector): [Multisafepay] Mask PII data 

### DIFF
--- a/crates/masking/src/serde.rs
+++ b/crates/masking/src/serde.rs
@@ -27,6 +27,7 @@ pub trait SerializableSecret: Serialize {}
 impl SerializableSecret for Value {}
 impl SerializableSecret for u8 {}
 impl SerializableSecret for u16 {}
+impl SerializableSecret for i32 {}
 
 impl<'de, T, I> Deserialize<'de> for Secret<T, I>
 where

--- a/crates/router/src/connector/multisafepay/transformers.rs
+++ b/crates/router/src/connector/multisafepay/transformers.rs
@@ -130,7 +130,7 @@ pub struct Customer {
     pub forward_ip: Option<Secret<String, IpAddress>>,
     pub first_name: Option<Secret<String>>,
     pub last_name: Option<Secret<String>>,
-    pub gender: Option<String>,
+    pub gender: Option<Secret<String>>,
     pub birthday: Option<Secret<String>>,
     pub address1: Option<Secret<String>>,
     pub address2: Option<Secret<String>>,

--- a/crates/router/src/connector/multisafepay/transformers.rs
+++ b/crates/router/src/connector/multisafepay/transformers.rs
@@ -625,7 +625,7 @@ pub struct MultisafepayPaymentDetails {
     pub account_id: Option<Secret<String>>,
     pub card_expiry_date: Option<Secret<String>>,
     pub external_transaction_id: Option<serde_json::Value>,
-    pub last4: Option<String>,
+    pub last4: Option<Secret<String>>,
     pub recurring_flow: Option<String>,
     pub recurring_id: Option<Secret<String>>,
     pub recurring_model: Option<String>,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Mask pii information passed and received in the connector request and response for Mulisafepay.


## Test Case
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
1. Create a card payment
```
curl --location 'http://localhost:8080/payments' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key:{{api_key}}' \
--data-raw '{
  "amount": 6540,
  "currency": "USD",
  "confirm": true,
  "capture_method": "automatic",
  "capture_on": "2022-09-10T10:11:12Z",
  "customer_id": "StripeCustomer",
  "email": "abcdef123@gmail.com",
  "name": "John Doe",
  "phone": "999999999",
  "phone_country_code": "+65",
  "description": "Its my first payment request",
  "authentication_type": "no_three_ds",
  "return_url": "https://google.com",

  "billing": {
    "address": {
      "line1": "1467",
      "line2": "Harrison Street",
      "line3": "Harrison Street",
      "city": "San Fransico",
      "state": "California",
      "zip": "94122",
      "country": "US",
      "first_name": "John",
      "last_name": "Doe"
    }
  },
  "browser_info": {
    "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Safari/537.36",
    "accept_header": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8",
    "language": "nl-NL",
    "color_depth": 24,
    "screen_height": 723,
    "screen_width": 1536,
    "time_zone": 0,
    "java_enabled": true,
    "java_script_enabled": true,
    "ip_address": "127.0.0.1"
  },
  "shipping": {
    "address": {
      "line1": "1467",
      "line2": "Harrison Street",
      "line3": "Harrison Street",
      "city": "San Fransico",
      "state": "California",
      "zip": "94122",
      "country": "US",
      "first_name": "John",
      "last_name": "Doe"
    }
  },
  "statement_descriptor_name": "joseph",
  "statement_descriptor_suffix": "JS",
  "metadata": {
    "udf1": "value1",
    "new_customer": "true",
    "login_date": "2019-09-10T10:11:12Z"
  },
  "payment_method": "card",
  "payment_method_data": {
    "card": {
      "card_number": "4111111111111111",
      "card_exp_month": "10",
      "card_exp_year": "25",
      "card_holder_name": "Joseph Doe",
      "card_cvc": "123"
    }
  }
}'
```
2. Check if `apple_pay_payment_token`  in the `masked_response` is masked

```
curl --location '{{base_url}}/analytics/v1/connector_event_logs?type=Payment&payment_id={{payment_id}}' \
--header 'sec-ch-ua: "Not A(Brand";v="99", "Google Chrome";v="121", "Chromium";v="121"' \
--header 'sec-ch-ua-mobile: ?0' \
--header 'authorization: Bearer JWT_token' \
--header 'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Safari/537.36' \
--header 'Content-Type: application/json' \
--header 'Referer: https://integ.hyperswitch.io/' \
--header 'api-key: {{api-key}}' \
--header 'sec-ch-ua-platform: "macOS"'
```
Response
```
request  \":\"{\\\"type\\\":\\\"direct\\\",\\\"gateway\\\":\\\"VISA\\\",\\\"order_id\\\":\\\"pay_aqRMznVMpndvmmh3IweN_1\\\",\\\"currency\\\":\\\"USD\\\",\\\"amount\\\":6540,\\\"description\\\":\\\"Its my first payment request\\\",\\\"payment_options\\\":{\\\"redirect_url\\\":\\\"http://localhost:8080/payments/pay_aqRMznVMpndvmmh3IweN/merchant_1709116328/redirect/response/multisafepay\\\",\\\"cancel_url\\\":\\\"http://localhost:8080/payments/pay_aqRMznVMpndvmmh3IweN/merchant_1709116328/redirect/response/multisafepay\\\"},\\\"customer\\\":{\\\"email\\\":\\\"*********@gmail.com\\\",\\\"reference\\\":\\\"pay_aqRMznVMpndvmmh3IweN_1\\\"},\\\"gateway_info\\\":{\\\"card_number\\\":\\\"411111**********\\\",\\\"card_holder_name\\\":null,\\\"card_expiry_date\\\":\\\"*** i32 ***\\\",\\\"card_cvc\\\":\\\"*** alloc::string::String ***\\\",\\\"flexible_3d\\\":null,\\\"moto\\\":null,\\\"term_url\\\":null},\\\"delivery\\\":{\\\"first_name\\\":\\\"*** alloc::string::String ***\\\",\\\"last_name\\\":\\\"*** alloc::string::String ***\\\",\\\"address1\\\":\\\"*** alloc::string::String ***\\\",\\\"house_number\\\":\\\"*** alloc::string::String ***\\\",\\\"zip_code\\\":\\\"*** alloc::string::String ***\\\",\\\"city\\\":\\\"San Fransico\\\",\\\"country\\\":\\\"US\\\"},\\\"days_active\\\":30,\\\"seconds_active\\\":259200}\",

"masked_response\":\"{\\\"success\\\":true,\\\"data\\\":{\\\"type\\\":null,\\\"order_id\\\":\\\"pay_aqRMznVMpndvmmh3IweN_1\\\",\\\"currency\\\":\\\"USD\\\",\\\"amount\\\":6540,\\\"description\\\":\\\"Its my first payment request\\\",\\\"capture\\\":null,\\\"payment_url\\\":\\\"https://testpay.multisafepay.com/customer-verification?sessionid=823HdSBIRUOQocDMYVsEILa3mj9hkmSKeRQ&type=3ds&md=2db93e2cd11234567890%2C0e728044058c4081898bbd2db93e2cd1&lang=en_US\\\",\\\"status\\\":\\\"initialized\\\",\\\"error_code\\\":null,\\\"error_info\\\":null,\\\"payment_details\\\":{\\\"account_holder_name\\\":null,\\\"account_id\\\":null,\\\"card_expiry_date\\\":\\\"*** alloc::string::String ***\\\",\\\"external_transaction_id\\\":null,\\\"last4\\\":\\\"*** alloc::string::String ***\\\",\\\"recurring_flow\\\":null,\\\"recurring_id\\\":null,\\\"recurring_model\\\":null,\\\"type\\\":\\\"VISA\\\"}}}\",\"error\":null,\"url\":\"https://testapi.multisafepay.com/v1/json/orders?api_key=86c095c1595b4b5cdc4462ec9b6c35ec9302a37e\",\"method\":\"POST\",\"payment_id\":\"pay_aqRMznVMpndvmmh3IweN\",\"merchant_id\":\"merchant_1709116328\",\"created_at\":1709118709865,\"request_id\":\"018def69-d6e4-7db8-b4af-f3f9b786fc84\",\"latency\":2345,\"refund_id\":null,\"dispute_id\":null,\"status_code\":200}
```


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
