### PR TITLE
feat(roles): Add groups for `get_from_token` api

### DIFF
--- a/crates/api_models/src/events/user_role.rs
+++ b/crates/api_models/src/events/user_role.rs
@@ -2,8 +2,8 @@ use common_utils::events::{ApiEventMetric, ApiEventsType};
 
 use crate::user_role::{
     role::{
-        CreateRoleRequest, GetRoleRequest, ListRolesResponse, RoleInfoResponse,
-        RoleInfoWithPermissionsResponse, UpdateRoleRequest,
+        CreateRoleRequest, GetRoleFromTokenResponse, GetRoleRequest, ListRolesResponse,
+        RoleInfoResponse, RoleInfoWithPermissionsResponse, UpdateRoleRequest,
     },
     AcceptInvitationRequest, AuthorizationInfoResponse, DeleteUserRoleRequest,
     TransferOrgOwnershipRequest, UpdateUserRoleRequest,
@@ -20,5 +20,6 @@ common_utils::impl_misc_api_event_type!(
     CreateRoleRequest,
     UpdateRoleRequest,
     ListRolesResponse,
-    RoleInfoResponse
+    RoleInfoResponse,
+    GetRoleFromTokenResponse
 );

--- a/crates/api_models/src/user_role/role.rs
+++ b/crates/api_models/src/user_role/role.rs
@@ -24,6 +24,12 @@ pub struct GetGroupsQueryParam {
 }
 
 #[derive(Debug, serde::Serialize)]
+pub enum GetRoleFromTokenResponse {
+    Permissions(Vec<Permission>),
+    Groups(Vec<PermissionGroup>),
+}
+
+#[derive(Debug, serde::Serialize)]
 #[serde(untagged)]
 pub enum RoleInfoResponse {
     Permissions(RoleInfoWithPermissionsResponse),

--- a/crates/api_models/src/user_role/role.rs
+++ b/crates/api_models/src/user_role/role.rs
@@ -24,6 +24,7 @@ pub struct GetGroupsQueryParam {
 }
 
 #[derive(Debug, serde::Serialize)]
+#[serde(untagged)]
 pub enum GetRoleFromTokenResponse {
     Permissions(Vec<Permission>),
     Groups(Vec<PermissionGroup>),


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Get role from token will respond with groups if asked.

### Additional Changes

- [x] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
Closes #3871 

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
The following api will take a query param called `groups` and if it is set to `true` it will respond with array of groups.

This api was already present previously but was responding with permissions. The default behaviour without the `groups` query param is still the same (permissions will be returned). Groups will only be returned when `groups` param is set to true.
```
curl --location 'http://localhost:8080/user/role?groups=true' \
--header 'Authorization: Bearer JWT'
```
```
[
    "users_view"
]
```

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
