### PR TITLE
refactor(connector): [Noon] Mask PII data

### DIFF
--- a/crates/router/src/connector/noon/transformers.rs
+++ b/crates/router/src/connector/noon/transformers.rs
@@ -1,6 +1,6 @@
 use common_utils::{ext_traits::Encode, pii};
 use error_stack::{IntoReport, ResultExt};
-use masking::{PeekInterface, Secret, ExposeInterface};
+use masking::{ExposeInterface, PeekInterface, Secret};
 use serde::{Deserialize, Serialize};
 
 use crate::{

--- a/crates/router/src/connector/noon/transformers.rs
+++ b/crates/router/src/connector/noon/transformers.rs
@@ -1,6 +1,6 @@
 use common_utils::{ext_traits::Encode, pii};
 use error_stack::{IntoReport, ResultExt};
-use masking::{PeekInterface, Secret};
+use masking::{PeekInterface, Secret, ExposeInterface};
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -124,7 +124,7 @@ pub struct NoonConfiguration {
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct NoonSubscription {
-    subscription_identifier: String,
+    subscription_identifier: Secret<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -230,9 +230,9 @@ impl TryFrom<&types::PaymentsAuthorizeRouterData> for NoonPaymentsRequest {
     type Error = error_stack::Report<errors::ConnectorError>;
     fn try_from(item: &types::PaymentsAuthorizeRouterData) -> Result<Self, Self::Error> {
         let (payment_data, currency, category) = match item.request.connector_mandate_id() {
-            Some(subscription_identifier) => (
+            Some(mandate_id) => (
                 NoonPaymentData::Subscription(NoonSubscription {
-                    subscription_identifier,
+                    subscription_identifier: Secret::new(mandate_id),
                 }),
                 None,
                 None,
@@ -512,7 +512,7 @@ impl ForeignFrom<(NoonPaymentStatus, Self)> for enums::AttemptStatus {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct NoonSubscriptionObject {
-    identifier: String,
+    identifier: Secret<String>,
 }
 
 #[derive(Default, Debug, Serialize, Deserialize)]
@@ -566,7 +566,7 @@ impl<F, T>
                 .result
                 .subscription
                 .map(|subscription_data| types::MandateReference {
-                    connector_mandate_id: Some(subscription_data.identifier),
+                    connector_mandate_id: Some(subscription_data.identifier.expose()),
                     payment_method_id: None,
                 });
         Ok(Self {
@@ -678,7 +678,7 @@ impl TryFrom<&types::MandateRevokeRouterData> for NoonRevokeMandateRequest {
         Ok(Self {
             api_operation: NoonApiOperations::CancelSubscription,
             subscription: NoonSubscriptionObject {
-                identifier: item.request.get_connector_mandate_id()?,
+                identifier: Secret::new(item.request.get_connector_mandate_id()?),
             },
         })
     }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Mask pii information passed and received in the connector request and response for Noon.


## Test Case
1. Create a mandate payment with Noon
```
 curl --location 'http://localhost:8080/payments' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: dev_DSA7zgwLkTw5bHT6khsixyQNDlvsM6HDvyhxwMulGlRk8gnjJwejcmvOCniHFWT6' \
--data-raw '{
  "amount": 10000,
  "currency": "AED",
  "confirm": true,
  "capture_method": "automatic",
  "capture_on": "2022-09-10T10:11:12Z",
  "customer_id": "c1",
  "email": "abcdef123@gmail.com",
  "name": "John Doe",
  "phone": "999999999",
  "phone_country_code": "+65",
  "description": "Its my first payment request",
  "authentication_type": "three_ds",
  "return_url": "https://google.com",
  "billing": {
    "address": {
      "line1": "1467",
      "line2": "Harrison Street",
      "line3": "Harrison Street",
      "city": "San Fransico",
      "state": "California",
      "zip": "94122",
      "country": "AE",
        "first_name": "John",
      "last_name": "Doe"
    }
  },
      "shipping": {
        "address": {
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "city": "San Fransico",
            "state": "California",
            "zip": "94122",
            "country": "AE",
            "first_name": "John",
            "last_name": "Doe"
        }
    },
  "browser_info": {
    "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Safari/537.36",
    "accept_header": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8",
    "language": "nl-NL",
    "color_depth": 24,
    "screen_height": 723,
    "screen_width": 1536,
    "time_zone": 0,
    "java_enabled": true,
    "java_script_enabled": true,
    "ip_address": "13.232.74.226"
  },
  "statement_descriptor_name": "joseph",
  "statement_descriptor_suffix": "JS",
  "metadata": {
    "pru": "value1"
    
  },
      "payment_method": "card",
    "payment_method_data": {
        "card": {
            "card_number": "4000000000002503",
            "card_exp_month": "01",
            "card_exp_year": "2026",
            "card_holder_name": "Joseph Doe",
            "card_cvc": "124"
        }
    },
   "setup_future_usage": "off_session",
  "mandate_data": {
    "customer_acceptance": {
      "acceptance_type": "offline",
      "accepted_at": "1963-05-03T04:07:52.723Z",
      "online": {
        "ip_address": "13.232.74.226",
        "user_agent": "amet irure esse"
      }
    }
    ,
    "mandate_type": {
      "multi_use": {
        "amount": 700,
         "currency": "AED"
      }
    }
  },
  "connector_metadata": {
        "noon": {
            "order_category": "pay"
        }
    }
}'
```
2. Create a MIT 
```
curl --location 'http://localhost:8080/payments' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key:{{}}' \
--data '{
  "amount": 700,
  "currency": "AED",
  "off_session": true,
  "confirm": true,
  "capture_method": "automatic",
  "description": "Initiated by merchant",
  "mandate_id": "man_spNAzYmZ2Sq3119WEe4q",
  "customer_id": "c1",
  "billing": {
    "address": {
      "line1": "1467",
      "line2": "Harrison Street",
      "line3": "Harrison Street",
      "city": "San Fransico",
      "state": "California",
      "zip": "94122",
      "country": "US",
      "first_name": "John",
      "last_name": "Doe"
    }
  }
}'
```
3. Check if `subscription_data.identifier`  in the `masked_response` is masked

```
curl --location '{{base_url}}/analytics/v1/connector_event_logs?type=Payment&payment_id={{payment_id}}' \
--header 'sec-ch-ua: "Not A(Brand";v="99", "Google Chrome";v="121", "Chromium";v="121"' \
--header 'sec-ch-ua-mobile: ?0' \
--header 'authorization: Bearer JWT_token' \
--header 'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Safari/537.36' \
--header 'Content-Type: application/json' \
--header 'Referer: https://integ.hyperswitch.io/' \
--header 'api-key: {{api-key}}' \
--header 'sec-ch-ua-platform: "macOS"'
```

Response
```
"masked_response\":\"{\\\"result\\\":{\\\"order\\\":{\\\"status\\\":\\\"CAPTURED\\\",\\\"id\\\":510639573125,\\\"errorCode\\\":0,\\\"errorMessage\\\":null,\\\"reference\\\":\\\"pay_7WNBRRI9bCY29pnKwDn8_1\\\"},\\\"checkoutData\\\":null,\\\"subscription\\\":{\\\"identifier\\\":\\\"*** alloc::string::String ***\\\"}}
```
```
"masked_response\":\"{\\\"result\\\":{\\\"order\\\":{\\\"status\\\":\\\"CAPTURED\\\",\\\"id\\\":291984139449,\\\"errorCode\\\":0,\\\"errorMessage\\\":null,\\\"reference\\\":\\\"pay_LqEgkjiIOHZfT7ax1QHl_1\\\"},\\\"checkoutData\\\":null,\\\"subscription\\\":{\\\"identifier\\\":\\\"*** alloc::string::String ***\\\"}}}
```



## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
