### PR TITLE
refactor(payment_methods): remove `payment_method_id` being used as a fallback for `locker_id`

### DIFF
--- a/crates/router/src/core/payment_methods/transformers.rs
+++ b/crates/router/src/core/payment_methods/transformers.rs
@@ -334,7 +334,6 @@ pub fn mk_add_bank_response_hs(
 
 pub fn mk_add_card_response_hs(
     card: api::CardDetail,
-    card_reference: String,
     req: api::PaymentMethodCreate,
     merchant_id: &str,
 ) -> api::PaymentMethodResponse {
@@ -362,7 +361,7 @@ pub fn mk_add_card_response_hs(
     api::PaymentMethodResponse {
         merchant_id: merchant_id.to_owned(),
         customer_id: req.customer_id,
-        payment_method_id: card_reference,
+        payment_method_id: String::default(),
         payment_method: req.payment_method,
         payment_method_type: req.payment_method_type,
         bank_transfer: None,

--- a/crates/router/src/core/payouts/helpers.rs
+++ b/crates/router/src/core/payouts/helpers.rs
@@ -87,9 +87,8 @@ pub async fn make_payout_method_data<'a>(
             let payment_token = match payment_token_data {
                 storage::PaymentTokenData::PermanentCard(storage::CardTokenData {
                     locker_id,
-                    token,
                     ..
-                }) => locker_id.or(Some(token)),
+                }) => locker_id,
                 storage::PaymentTokenData::TemporaryGeneric(storage::GenericTokenData {
                     token,
                 }) => Some(token),

--- a/crates/router/src/types/storage/payment_method.rs
+++ b/crates/router/src/types/storage/payment_method.rs
@@ -13,9 +13,8 @@ pub enum PaymentTokenKind {
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct CardTokenData {
-    pub payment_method_id: Option<String>,
+    pub payment_method_id: String,
     pub locker_id: Option<String>,
-    pub token: String,
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
@@ -36,15 +35,10 @@ pub enum PaymentTokenData {
 }
 
 impl PaymentTokenData {
-    pub fn permanent_card(
-        payment_method_id: Option<String>,
-        locker_id: Option<String>,
-        token: String,
-    ) -> Self {
+    pub fn permanent_card(payment_method_id: String, locker_id: Option<String>) -> Self {
         Self::PermanentCard(CardTokenData {
             payment_method_id,
             locker_id,
-            token,
         })
     }
 


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Currently, if `locker_id` was not found in the payment_methods entry, we used to assume `payment_method_id` as locker_id. But since all the migrations have been taken care of, it is safe to remove this fallback logic. `locker_id` itself is an optional field in the application. So, if it is not found in case of `card` and `bank_transfer`, we should throw an error.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
