### PR TITLE
fix(connector): [BOA/CYB] Pass ucaf for apple pay mastercard users

### DIFF
--- a/crates/router/src/connector/bankofamerica/transformers.rs
+++ b/crates/router/src/connector/bankofamerica/transformers.rs
@@ -604,7 +604,7 @@ impl
         let processing_information = ProcessingInformation::from((
             item,
             Some(PaymentSolution::ApplePay),
-            Some(apple_pay_wallet_data.payment_method.network),
+            Some(apple_pay_wallet_data.payment_method.network.clone()),
         ));
         let client_reference_information = ClientReferenceInformation::from(item);
         let expiration_month = apple_pay_data.get_expiry_month()?;
@@ -622,14 +622,29 @@ impl
             item.router_data.request.metadata.clone().map(|metadata| {
                 Vec::<MerchantDefinedInformation>::foreign_from(metadata.peek().to_owned())
             });
-
+        let ucaf_collection_indicator = match apple_pay_wallet_data
+            .payment_method
+            .network
+            .to_lowercase()
+            .as_str()
+        {
+            "mastercard" => Some("2".to_string()),
+            _ => None,
+        };
         Ok(Self {
             processing_information,
             payment_information,
             order_information,
             client_reference_information,
             merchant_defined_information,
-            consumer_authentication_information: None,
+            consumer_authentication_information: Some(BankOfAmericaConsumerAuthInformation {
+                ucaf_collection_indicator,
+                cavv: None,
+                ucaf_authentication_data: None,
+                xid: None,
+                directory_server_transaction_id: None,
+                specification_version: None,
+            }),
         })
     }
 }
@@ -703,7 +718,7 @@ impl TryFrom<&BankOfAmericaRouterData<&types::PaymentsAuthorizeRouterData>>
                             let processing_information = ProcessingInformation::from((
                                 item,
                                 Some(PaymentSolution::ApplePay),
-                                Some(apple_pay_data.payment_method.network),
+                                Some(apple_pay_data.payment_method.network.clone()),
                             ));
                             let client_reference_information =
                                 ClientReferenceInformation::from(item);
@@ -723,13 +738,31 @@ impl TryFrom<&BankOfAmericaRouterData<&types::PaymentsAuthorizeRouterData>>
                                         metadata.peek().to_owned(),
                                     )
                                 });
+                            let ucaf_collection_indicator = match apple_pay_data
+                                .payment_method
+                                .network
+                                .to_lowercase()
+                                .as_str()
+                            {
+                                "mastercard" => Some("2".to_string()),
+                                _ => None,
+                            };
                             Ok(Self {
                                 processing_information,
                                 payment_information,
                                 order_information,
                                 merchant_defined_information,
                                 client_reference_information,
-                                consumer_authentication_information: None,
+                                consumer_authentication_information: Some(
+                                    BankOfAmericaConsumerAuthInformation {
+                                        ucaf_collection_indicator,
+                                        cavv: None,
+                                        ucaf_authentication_data: None,
+                                        xid: None,
+                                        directory_server_transaction_id: None,
+                                        specification_version: None,
+                                    },
+                                ),
                             })
                         }
                     }

--- a/crates/router/src/connector/cybersource/transformers.rs
+++ b/crates/router/src/connector/cybersource/transformers.rs
@@ -850,7 +850,7 @@ impl
         let processing_information = ProcessingInformation::try_from((
             item,
             Some(PaymentSolution::ApplePay),
-            Some(apple_pay_wallet_data.payment_method.network),
+            Some(apple_pay_wallet_data.payment_method.network.clone()),
         ))?;
         let client_reference_information = ClientReferenceInformation::from(item);
         let expiration_month = apple_pay_data.get_expiry_month()?;
@@ -868,13 +868,28 @@ impl
             item.router_data.request.metadata.clone().map(|metadata| {
                 Vec::<MerchantDefinedInformation>::foreign_from(metadata.peek().to_owned())
             });
-
+        let ucaf_collection_indicator = match apple_pay_wallet_data
+            .payment_method
+            .network
+            .to_lowercase()
+            .as_str()
+        {
+            "mastercard" => Some("2".to_string()),
+            _ => None,
+        };
         Ok(Self {
             processing_information,
             payment_information,
             order_information,
             client_reference_information,
-            consumer_authentication_information: None,
+            consumer_authentication_information: Some(CybersourceConsumerAuthInformation {
+                ucaf_collection_indicator,
+                cavv: None,
+                ucaf_authentication_data: None,
+                xid: None,
+                directory_server_transaction_id: None,
+                specification_version: None,
+            }),
             merchant_defined_information,
         })
     }
@@ -956,7 +971,7 @@ impl TryFrom<&CybersourceRouterData<&types::PaymentsAuthorizeRouterData>>
                                         ProcessingInformation::try_from((
                                             item,
                                             Some(PaymentSolution::ApplePay),
-                                            Some(apple_pay_data.payment_method.network),
+                                            Some(apple_pay_data.payment_method.network.clone()),
                                         ))?;
                                     let client_reference_information =
                                         ClientReferenceInformation::from(item);
@@ -976,14 +991,31 @@ impl TryFrom<&CybersourceRouterData<&types::PaymentsAuthorizeRouterData>>
                                                 metadata.peek().to_owned(),
                                             )
                                         });
-
+                                    let ucaf_collection_indicator = match apple_pay_data
+                                        .payment_method
+                                        .network
+                                        .to_lowercase()
+                                        .as_str()
+                                    {
+                                        "mastercard" => Some("2".to_string()),
+                                        _ => None,
+                                    };
                                     Ok(Self {
                                         processing_information,
                                         payment_information,
                                         order_information,
                                         client_reference_information,
                                         merchant_defined_information,
-                                        consumer_authentication_information: None,
+                                        consumer_authentication_information: Some(
+                                            CybersourceConsumerAuthInformation {
+                                                ucaf_collection_indicator,
+                                                cavv: None,
+                                                ucaf_authentication_data: None,
+                                                xid: None,
+                                                directory_server_transaction_id: None,
+                                                specification_version: None,
+                                            },
+                                        ),
                                     })
                                 }
                             }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
[HOTFIX PR]
Original PR: https://github.com/juspay/hyperswitch/pull/3899
`ucaf_collection_indicator` is now being passed for apple pay payments via BOA/Cybersource for Mastercard users.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
https://github.com/juspay/hyperswitch/issues/3898

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Apple pay payments need to be tested using simplified and manual flow for connectors BOA and Cybersource using a mastercard network card.
![image](https://github.com/juspay/hyperswitch/assets/41580413/dcd9cb38-bf10-4568-b124-c919b774c02a)
![image](https://github.com/juspay/hyperswitch/assets/41580413/6ab51790-70a1-4dea-88f4-a3c8f646974d)


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
