### PR TITLE
 refactor(connector): [Prophetpay][Rapyd][Shift4][Square] Mask PII data 

### DIFF
--- a/crates/router/src/connector/rapyd/transformers.rs
+++ b/crates/router/src/connector/rapyd/transformers.rs
@@ -418,7 +418,7 @@ impl TryFrom<types::RefundsResponseRouterData<api::RSync, RefundResponse>>
 #[derive(Debug, Serialize, Clone)]
 pub struct CaptureRequest {
     amount: Option<i64>,
-    receipt_email: Option<String>,
+    receipt_email: Option<Secret<String>>,
     statement_descriptor: Option<String>,
 }
 

--- a/crates/router/src/connector/rapyd/transformers.rs
+++ b/crates/router/src/connector/rapyd/transformers.rs
@@ -87,7 +87,7 @@ pub struct Address {
     city: Option<String>,
     state: Option<Secret<String>>,
     country: Option<String>,
-    zip: Option<String>,
+    zip: Option<Secret<String>>,
     phone_number: Option<Secret<String>>,
 }
 
@@ -96,7 +96,7 @@ pub struct RapydWallet {
     #[serde(rename = "type")]
     payment_type: String,
     #[serde(rename = "details")]
-    token: Option<String>,
+    token: Option<Secret<String>>,
 }
 
 impl TryFrom<&RapydRouterData<&types::PaymentsAuthorizeRouterData>> for RapydPaymentsRequest {
@@ -145,11 +145,11 @@ impl TryFrom<&RapydRouterData<&types::PaymentsAuthorizeRouterData>> for RapydPay
                 let digital_wallet = match wallet_data {
                     api_models::payments::WalletData::GooglePay(data) => Some(RapydWallet {
                         payment_type: "google_pay".to_string(),
-                        token: Some(data.tokenization_data.token.to_owned()),
+                        token: Some(Secret::new(data.tokenization_data.token.to_owned())),
                     }),
                     api_models::payments::WalletData::ApplePay(data) => Some(RapydWallet {
                         payment_type: "apple_pay".to_string(),
-                        token: Some(data.payment_data.to_string()),
+                        token: Some(Secret::new(data.payment_data.to_string())),
                     }),
                     _ => None,
                 };

--- a/crates/router/src/connector/shift4/transformers.rs
+++ b/crates/router/src/connector/shift4/transformers.rs
@@ -117,7 +117,7 @@ pub struct Card {
 #[serde(untagged)]
 pub enum CardPayment {
     RawCard(Box<Card>),
-    CardToken(String),
+    CardToken(Secret<String>),
 }
 
 impl<T> TryFrom<&types::RouterData<T, types::PaymentsAuthorizeData, types::PaymentsResponseData>>
@@ -577,12 +577,12 @@ pub struct Shift4ThreeDsResponse {
 
 #[derive(Default, Debug, Deserialize, Serialize)]
 pub struct Token {
-    pub id: String,
+    pub id: Secret<String>,
     pub created: i64,
     #[serde(rename = "objectType")]
     pub object_type: String,
     pub first6: String,
-    pub last4: String,
+    pub last4: Secret<String>,
     pub fingerprint: Secret<String>,
     pub brand: String,
     #[serde(rename = "type")]
@@ -629,7 +629,7 @@ pub enum NextAction {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Shift4CardToken {
-    pub id: String,
+    pub id: Secret<String>,
 }
 
 impl<F>

--- a/crates/router/src/connector/shift4/transformers.rs
+++ b/crates/router/src/connector/shift4/transformers.rs
@@ -582,7 +582,7 @@ pub struct Token {
     #[serde(rename = "objectType")]
     pub object_type: String,
     pub first6: String,
-    pub last4: Secret<String>,
+    pub last4: String,
     pub fingerprint: Secret<String>,
     pub brand: String,
     #[serde(rename = "type")]

--- a/crates/router/src/connector/square/transformers.rs
+++ b/crates/router/src/connector/square/transformers.rs
@@ -181,7 +181,7 @@ impl TryFrom<&types::TokenizationRouterData> for SquareTokenRequest {
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SquareSessionResponse {
-    session_id: String,
+    session_id: Secret<String>,
 }
 
 impl<F, T>
@@ -194,9 +194,9 @@ impl<F, T>
     ) -> Result<Self, Self::Error> {
         Ok(Self {
             status: storage::enums::AttemptStatus::Pending,
-            session_token: Some(item.response.session_id.clone()),
+            session_token: Some(item.response.session_id.clone().expose()),
             response: Ok(types::PaymentsResponseData::SessionTokenResponse {
-                session_token: item.response.session_id,
+                session_token: item.response.session_id.expose(),
             }),
             ..item.data
         })


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Mask pii information passed and received in the connector request and response for Prophetpay, rapyd, shift4 and square.


## Test Case
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
1. Create a card redirect payment with Prophetpay
```
curl --location 'http://localhost:8080/payments' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key:{{api_key}}' \
--data '{
    "amount": 8000,
    "currency": "USD",
    "confirm": true,
    "amount_to_capture": 8000,
    "business_country": "US",
    "customer_id": "custhype1232",
    "return_url": "https://www.google.com",
    "payment_method": "card_redirect",
    "payment_method_type": "card_redirect",
    "payment_method_data": {
        "card_redirect": {
            "card_redirect": {}
        }
    },
    "routing": {
        "type": "single",
        "data": "prophetpay"
    }
}'
```
2.Rapyd Applepay 

3.Create a 3DS payment with Shift4
_Note: Currently there is a known bug in this flow. We get an  `Unable to parse request - unrecognized field: card[number]` error_

4.Square card payment there is a known bug - #3974


5. Check if all the sensitive data in the `masked_response` is masked

```
curl --location '{{base_url}}/analytics/v1/connector_event_logs?type=Payment&payment_id={{payment_id}}' \
--header 'sec-ch-ua: "Not A(Brand";v="99", "Google Chrome";v="121", "Chromium";v="121"' \
--header 'sec-ch-ua-mobile: ?0' \
--header 'authorization: Bearer JWT_token' \
--header 'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Safari/537.36' \
--header 'Content-Type: application/json' \
--header 'Referer: https://integ.hyperswitch.io/' \
--header 'api-key: {{api-key}}' \
--header 'sec-ch-ua-platform: "macOS"'
```

1. Prophetpay Response
```
\"masked_response\":\"{\\\"hostedTokenizeId\\\":\\\"*** alloc::string::String ***\\\"}\
```
```
request\":\"{\\\"amount\\\":80.0,\\\"refInfo\\\":\\\"pay_MBu0Wfts32TfURFTNJJn_1\\\",\\\"inquiryReference\\\":\\\"pay_MBu0Wfts32TfURFTNJJn_1\\\",\\\"profile\\\":\\\"*** alloc::string::String ***\\\",\\\"actionType\\\":1,\\\"cardToken\\\":\\\"*** alloc::string::String ***\\\"}\",\"masked_response\":\"{\\\"success\\\":true,\\\"responseText\\\":\\\"Success\\\",\\\"transactionID\\\":\\\"2237854484\\\",\\\"responseCode\\\":\\\"0\\\"}
```



## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
