### PR TITLE
chore: upgrade msrv to 1.70

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -13,4 +13,4 @@ name = "rust"
 enabled = true
 
 [analyzers.meta]
-msrv = "1.65.0"
+msrv = "1.70.0"

--- a/.github/workflows/CI-pr.yml
+++ b/.github/workflows/CI-pr.yml
@@ -114,7 +114,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.65
+          toolchain: 1.70
 
       - uses: Swatinem/rust-cache@v2.7.0
         with:
@@ -124,7 +124,6 @@ jobs:
         uses: baptiste0928/cargo-install@v2.2.0
         with:
           crate: cargo-hack
-          version: 0.6.5
 
       - name: Deny warnings
         shell: bash

--- a/.github/workflows/CI-pr.yml
+++ b/.github/workflows/CI-pr.yml
@@ -114,7 +114,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.70
+          toolchain: "1.70"
 
       - uses: Swatinem/rust-cache@v2.7.0
         with:

--- a/.github/workflows/CI-push.yml
+++ b/.github/workflows/CI-push.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.70
+          toolchain: "1.70"
 
       - uses: Swatinem/rust-cache@v2.7.0
         with:

--- a/.github/workflows/CI-push.yml
+++ b/.github/workflows/CI-push.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.65
+          toolchain: 1.70
 
       - uses: Swatinem/rust-cache@v2.7.0
         with:
@@ -71,7 +71,6 @@ jobs:
         uses: baptiste0928/cargo-install@v2.2.0
         with:
           crate: cargo-hack
-          version: 0.6.5
 
       - name: Deny warnings
         shell: bash

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 resolver = "2"
 members = ["crates/*"]
 package.edition = "2021"
-package.rust-version = "1.65"
+package.rust-version = "1.70"
 package.license = "Apache-2.0"
 
 [profile.release]

--- a/INSTALL_dependencies.sh
+++ b/INSTALL_dependencies.sh
@@ -9,7 +9,7 @@ if [[ "${TRACE-0}" == "1" ]]; then
     set -o xtrace
 fi
 
-RUST_MSRV=1.65.0
+RUST_MSRV=1.70.0
 _DB_NAME="hyperswitch_db"
 _DB_USER="db_user"
 _DB_PASS="db_password"

--- a/crates/router/src/routes/lock_utils.rs
+++ b/crates/router/src/routes/lock_utils.rs
@@ -176,7 +176,7 @@ impl From<Flow> for ApiIdentifier {
             | Flow::Signout
             | Flow::ChangePassword
             | Flow::SetDashboardMetadata
-            | Flow::GetMutltipleDashboardMetadata
+            | Flow::GetMultipleDashboardMetadata
             | Flow::VerifyPaymentConnector
             | Flow::InternalUserSignup
             | Flow::SwitchMerchant

--- a/crates/router/src/routes/user.rs
+++ b/crates/router/src/routes/user.rs
@@ -179,7 +179,7 @@ pub async fn get_multiple_dashboard_metadata(
     req: HttpRequest,
     query: web::Query<user_api::dashboard_metadata::GetMultipleMetaDataRequest>,
 ) -> HttpResponse {
-    let flow = Flow::GetMutltipleDashboardMetadata;
+    let flow = Flow::GetMultipleDashboardMetadata;
     let payload = match ReportSwitchExt::<_, ApiErrorResponse>::switch(parse_string_to_enums(
         query.into_inner().keys,
     )) {

--- a/crates/router_env/src/logger/types.rs
+++ b/crates/router_env/src/logger/types.rs
@@ -309,7 +309,7 @@ pub enum Flow {
     /// Set Dashboard Metadata flow
     SetDashboardMetadata,
     /// Get Multiple Dashboard Metadata flow
-    GetMutltipleDashboardMetadata,
+    GetMultipleDashboardMetadata,
     /// Payment Connector Verify
     VerifyPaymentConnector,
     /// Internal user signup

--- a/crates/test_utils/tests/connectors/selenium.rs
+++ b/crates/test_utils/tests/connectors/selenium.rs
@@ -9,7 +9,7 @@ use std::{
     collections::{HashMap, HashSet},
     env,
     io::Read,
-    path::MAIN_SEPARATOR,
+    path::{MAIN_SEPARATOR, MAIN_SEPARATOR_STR},
     time::Duration,
 };
 
@@ -862,7 +862,7 @@ fn get_chrome_profile_path() -> Result<String, WebDriverError> {
         .map(|str| {
             let mut fp = str.split(MAIN_SEPARATOR).collect::<Vec<_>>();
             fp.truncate(3);
-            fp.join(&MAIN_SEPARATOR.to_string())
+            fp.join(MAIN_SEPARATOR_STR)
         })
         .unwrap();
     if env::consts::OS == "macos" {
@@ -880,7 +880,7 @@ fn get_firefox_profile_path() -> Result<String, WebDriverError> {
         .map(|str| {
             let mut fp = str.split(MAIN_SEPARATOR).collect::<Vec<_>>();
             fp.truncate(3);
-            fp.join(&MAIN_SEPARATOR.to_string())
+            fp.join(MAIN_SEPARATOR_STR)
         })
         .unwrap();
     if env::consts::OS == "macos" {

--- a/loadtest/Dockerfile
+++ b/loadtest/Dockerfile
@@ -1,10 +1,10 @@
-FROM rust:1.65 AS builder
+FROM rust:latest AS builder
 
 WORKDIR /app
 COPY . .
 RUN cargo install diesel_cli && cargo build --bin router --release
 
-FROM rust:1.65 AS runtime
+FROM rust:latest AS runtime
 WORKDIR /app
 COPY --from=builder /app/migrations migrations
 COPY --from=builder /app/target/release/router router

--- a/monitoring/docker-compose-ckh.yaml
+++ b/monitoring/docker-compose-ckh.yaml
@@ -156,7 +156,7 @@ services:
         hard: 262144
 
   hyperswitch-server:
-    image: rust:1.65
+    image: rust:latest
     command: cargo run -- -f ./config/docker_compose.toml
     working_dir: /app
     ports:


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [x] Dependency updates
- [ ] Documentation
- [x] CI/CD

## Description
upgraded msrv to 1.70


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
opensearch crate depends on aws-smithy-types which requires msrv >= 1.67

upgrading msrv to 1.70

opensearch is used in dashboard global search - https://github.com/juspay/hyperswitch/issues/3866

## How did you test it?
CI checks passed locally

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
