### PR TITLE
fix(user): improve role validation to prevent duplicate groups

### DIFF
--- a/crates/common_enums/src/enums.rs
+++ b/crates/common_enums/src/enums.rs
@@ -2327,6 +2327,7 @@ pub enum RoleScope {
     Debug,
     Eq,
     PartialEq,
+    Hash,
     serde::Serialize,
     serde::Deserialize,
     strum::Display,

--- a/crates/router/src/utils/user_role.rs
+++ b/crates/router/src/utils/user_role.rs
@@ -57,7 +57,7 @@ pub fn validate_role_groups(groups: &[PermissionGroup]) -> UserResult<()> {
 
     if groups.iter().collect::<HashSet<_>>().len() != groups.len() {
         return Err(UserErrors::InvalidRoleOperation.into())
-            .attach_printable("Duplicate role group found");
+            .attach_printable("Duplicate permission group found");
     }
 
     Ok(())

--- a/crates/router/src/utils/user_role.rs
+++ b/crates/router/src/utils/user_role.rs
@@ -50,12 +50,14 @@ pub fn validate_role_groups(groups: &[PermissionGroup]) -> UserResult<()> {
             .attach_printable("Role groups cannot be empty");
     }
 
-    if groups.contains(&PermissionGroup::OrganizationManage) {
+    let unique_groups: HashSet<_> = groups.iter().cloned().collect();
+
+    if unique_groups.contains(&PermissionGroup::OrganizationManage) {
         return Err(UserErrors::InvalidRoleOperation.into())
             .attach_printable("Organization manage group cannot be added to role");
     }
 
-    if groups.iter().collect::<HashSet<_>>().len() != groups.len() {
+    if unique_groups.len() != groups.len() {
         return Err(UserErrors::InvalidRoleOperation.into())
             .attach_printable("Duplicate permission group found");
     }

--- a/crates/router/src/utils/user_role.rs
+++ b/crates/router/src/utils/user_role.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use api_models::user_role as user_role_api;
 use common_enums::PermissionGroup;
 use error_stack::ResultExt;
@@ -51,6 +53,11 @@ pub fn validate_role_groups(groups: &[PermissionGroup]) -> UserResult<()> {
     if groups.contains(&PermissionGroup::OrganizationManage) {
         return Err(UserErrors::InvalidRoleOperation.into())
             .attach_printable("Organization manage group cannot be added to role");
+    }
+
+    if groups.iter().collect::<HashSet<_>>().len() != groups.len() {
+        return Err(UserErrors::InvalidRoleOperation.into())
+            .attach_printable("Duplicate role group found");
     }
 
     Ok(())


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
Enforce uniqueness of groups while role create or update.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
Currently duplicate groups are allowed while role create/update.

## How did you test it?
Try to create/update role with duplicate groups:
Create
```
curl --location 'http://localhost:8080/user/role' \
--header 'Authorization: Bearer JWT' \
--header 'Content-Type: application/json' \
--data '{
  "role_name": "test007",
  "groups": ["operations_view", "operations_manage", "operations_manage"],
  "role_scope": "organization"
}'
```
Response:
```
{
    "error": {
        "type": "invalid_request",
        "message": "User Role Operation Not Supported",
        "code": "UR_23"
    }
}
```
Update
```
curl --location --request PUT 'http://localhost:8080/user/role/role_DGLY2gKDdS48cFoY573Y' \
--header 'Authorization: Bearer JWT' \
--header 'Content-Type: application/json' \
--data '{

  "groups": ["operations_view", "operations_view"]

}'
```
Response:
```
{
    "error": {
        "type": "invalid_request",
        "message": "User Role Operation Not Supported",
        "code": "UR_23"
    }
}
```

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
