### PR TITLE
fix(connector): [Volt] Fix status mapping for Volt

### DIFF
--- a/crates/router/src/connector/volt/transformers.rs
+++ b/crates/router/src/connector/volt/transformers.rs
@@ -240,10 +240,8 @@ impl TryFrom<&types::ConnectorAuthType> for VoltAuthType {
 impl From<VoltPaymentStatus> for enums::AttemptStatus {
     fn from(item: VoltPaymentStatus) -> Self {
         match item {
-            VoltPaymentStatus::Completed
-            | VoltPaymentStatus::Received
-            | VoltPaymentStatus::Settled => Self::Charged,
-            VoltPaymentStatus::DelayedAtBank => Self::Pending,
+            VoltPaymentStatus::Received | VoltPaymentStatus::Settled => Self::Charged,
+            VoltPaymentStatus::Completed | VoltPaymentStatus::DelayedAtBank => Self::Pending,
             VoltPaymentStatus::NewPayment
             | VoltPaymentStatus::BankRedirect
             | VoltPaymentStatus::AwaitingCheckoutAuthorisation => Self::AuthenticationPending,
@@ -421,13 +419,13 @@ impl<F, T>
 impl From<VoltWebhookPaymentStatus> for enums::AttemptStatus {
     fn from(status: VoltWebhookPaymentStatus) -> Self {
         match status {
-            VoltWebhookPaymentStatus::Completed | VoltWebhookPaymentStatus::Received => {
-                Self::Charged
-            }
+            VoltWebhookPaymentStatus::Received => Self::Charged,
             VoltWebhookPaymentStatus::Failed | VoltWebhookPaymentStatus::NotReceived => {
                 Self::Failure
             }
-            VoltWebhookPaymentStatus::Pending => Self::Pending,
+            VoltWebhookPaymentStatus::Completed | VoltWebhookPaymentStatus::Pending => {
+                Self::Pending
+            }
         }
     }
 }
@@ -577,13 +575,13 @@ impl From<VoltWebhookBodyEventType> for api::IncomingWebhookEvent {
     fn from(status: VoltWebhookBodyEventType) -> Self {
         match status {
             VoltWebhookBodyEventType::Payment(payment_data) => match payment_data.status {
-                VoltWebhookPaymentStatus::Completed | VoltWebhookPaymentStatus::Received => {
-                    Self::PaymentIntentSuccess
-                }
+                VoltWebhookPaymentStatus::Received => Self::PaymentIntentSuccess,
                 VoltWebhookPaymentStatus::Failed | VoltWebhookPaymentStatus::NotReceived => {
                     Self::PaymentIntentFailure
                 }
-                VoltWebhookPaymentStatus::Pending => Self::PaymentIntentProcessing,
+                VoltWebhookPaymentStatus::Completed | VoltWebhookPaymentStatus::Pending => {
+                    Self::PaymentIntentProcessing
+                }
             },
             VoltWebhookBodyEventType::Refund(refund_data) => match refund_data.status {
                 VoltWebhookRefundsStatus::RefundConfirmed => Self::RefundSuccess,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
Fixes [4419](https://github.com/juspay/hyperswitch-cloud/issues/4419)
Hotfix for [3915](https://github.com/juspay/hyperswitch/pull/3915)

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
Configure Webhooks before creating a payment.

Create a open_banking_uk payment
Payment create request
`{
    "amount": 8000,
    "currency": "EUR",
    "confirm": true,
      "capture_method": "automatic",
      "capture_on": "2022-09-10T10:11:12Z",
      "amount_to_capture": 8000,
    "customer_id": "StripeCustomer",
    "email": "guest@example.com",
    "name": "John Doe",
    "phone": "999999999",
    "phone_country_code": "+1",
    "description": "Its my first payment request",
      "authentication_type": "no_three_ds",
    "return_url": "https://www.google.com/",
    "payment_method": "bank_redirect",
    "payment_method_type": "open_banking_uk",
    "payment_method_data": {
        "bank_redirect": {
            "open_banking_uk": {
            }
        }
    },
    "billing": {
        "address": {
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "city": "San Fransico",
            "state": "California",
            "zip": "94122",
            "country": "DE",
            "first_name": "joseph",
            "last_name": "Doe"
        },
        "phone": {
            "number": "8056594427",
            "country_code": "+91"
        }
    },
    "shipping": {
        "address": {
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "city": "San Fransico",
            "state": "California",
            "zip": "94122",
            "country": "DE",
            "first_name": "joseph",
            "last_name": "Doe"
        },
        "phone": {
            "number": "8056594427",
            "country_code": "+91"
        }
    },
    "statement_descriptor_name": "joseph",
    "statement_descriptor_suffix": "JS",
    "metadata": {
        "udf1": "value1",
        "new_customer": "true",
        "login_date": "2019-09-10T10:11:12Z"
    },
    "business_label": "food",
    "business_country": "US"
}`


Payment Response
`{
    "payment_id": "pay_DONy0943veIJhCokj2gd",
    "merchant_id": "merchant_1709296013",
    "status": "requires_customer_action",
    "amount": 8000,
    "net_amount": 8000,
    "amount_capturable": 8000,
    "amount_received": null,
    "connector": "volt",
    "client_secret": "pay_DONy0943veIJhCokj2gd_secret_hbXbYN5kfq6pkvS0tR0Y",
    "created": "2024-03-01T12:28:04.151Z",
    "currency": "EUR",
    "customer_id": "StripeCustomer",
    "description": "Its my first payment request",
    "refunds": null,
    "disputes": null,
    "mandate_id": null,
    "mandate_data": null,
    "setup_future_usage": null,
    "off_session": null,
    "capture_on": null,
    "capture_method": "automatic",
    "payment_method": "bank_redirect",
    "payment_method_data": "bank_redirect",
    "payment_token": null,
    "shipping": {
        "address": {
            "city": "San Fransico",
            "country": "DE",
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "zip": "94122",
            "state": "California",
            "first_name": "joseph",
            "last_name": "Doe"
        },
        "phone": {
            "number": "8056594427",
            "country_code": "+91"
        },
        "email": null
    },
    "billing": {
        "address": {
            "city": "San Fransico",
            "country": "DE",
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "zip": "94122",
            "state": "California",
            "first_name": "joseph",
            "last_name": "Doe"
        },
        "phone": {
            "number": "8056594427",
            "country_code": "+91"
        },
        "email": null
    },
    "order_details": null,
    "email": "guest@example.com",
    "name": "John Doe",
    "phone": "999999999",
    "return_url": "https://www.google.com/",
    "authentication_type": "no_three_ds",
    "statement_descriptor_name": "joseph",
    "statement_descriptor_suffix": "JS",
    "next_action": {
        "type": "redirect_to_url",
        "redirect_to_url": "http://localhost:8080/payments/redirect/pay_DONy0943veIJhCokj2gd/merchant_1709296013/pay_DONy0943veIJhCokj2gd_1"
    },
    "cancellation_reason": null,
    "error_code": null,
    "error_message": null,
    "unified_code": null,
    "unified_message": null,
    "payment_experience": null,
    "payment_method_type": "open_banking_uk",
    "connector_label": "volt_US_food",
    "business_country": "US",
    "business_label": "food",
    "business_sub_label": null,
    "allowed_payment_method_types": null,
    "ephemeral_key": {
        "customer_id": "StripeCustomer",
        "created_at": 1709296084,
        "expires": 1709299684,
        "secret": "epk_44bf0942de794c2f9631408566ad4e0d"
    },
    "manual_retry_allowed": null,
    "connector_transaction_id": "c0be2e5f-d6f1-4e2a-ac53-9073cffb522c",
    "frm_message": null,
    "metadata": {
        "udf1": "value1",
        "login_date": "2019-09-10T10:11:12Z",
        "new_customer": "true"
    },
    "connector_metadata": null,
    "feature_metadata": null,
    "reference_id": "c0be2e5f-d6f1-4e2a-ac53-9073cffb522c",
    "payment_link": null,
    "profile_id": "pro_mjzXurWnJR0SvGRYyyC0",
    "surcharge_details": null,
    "attempt_count": 1,
    "merchant_decision": null,
    "merchant_connector_id": "mca_exJTJERQBlq1U003bhV6",
    "incremental_authorization_allowed": null,
    "authorization_count": null,
    "incremental_authorizations": null,
    "expires_on": "2024-03-01T12:43:04.151Z",
    "fingerprint": null
}`


Create a Refund
`{
  "payment_id": "pay_DONy0943veIJhCokj2gd",
  "amount": 8000,
  "reason": "Customer returned product",
  "refund_type": "instant",
  "metadata": {
    "udf1": "value1",
    "new_customer": "true",
    "login_date": "2019-09-10T10:11:12Z"
  }
}`

Refund Response
`{
    "refund_id": "ref_UySypbZ202MVUpSGj3AW",
    "payment_id": "pay_DONy0943veIJhCokj2gd",
    "amount": 8000,
    "currency": "EUR",
    "status": "pending",
    "reason": "Customer returned product",
    "metadata": {
        "udf1": "value1",
        "new_customer": "true",
        "login_date": "2019-09-10T10:11:12Z"
    },
    "error_message": null,
    "error_code": null,
    "created_at": "2024-03-01T12:30:35.688Z",
    "updated_at": "2024-03-01T12:30:35.688Z",
    "connector": "volt",
    "profile_id": "pro_mjzXurWnJR0SvGRYyyC0",
    "merchant_connector_id": "mca_exJTJERQBlq1U003bhV6"
}`

In volt dashboard check for all the notification received 
It should have all these 
<img width="720" alt="Screenshot 2024-03-01 at 6 12 44 PM" src="https://github.com/juspay/hyperswitch/assets/85639103/c5d9ec25-f66d-43ba-8be6-b175ad80b510">


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
