### PR TITLE
feat(connector): [AUTHORIZEDOTNET] Add billing address in payments request

### DIFF
--- a/crates/router/src/connector/authorizedotnet/transformers.rs
+++ b/crates/router/src/connector/authorizedotnet/transformers.rs
@@ -368,8 +368,10 @@ impl TryFrom<&AuthorizedotnetRouterData<&types::PaymentsAuthorizeRouterData>>
             }),
             None => None,
         };
-        let bill_to = match item.router_data.get_billing() {
-            Ok(billing) => billing.address.as_ref().map(|address| BillTo {
+        let bill_to = item
+            .router_data
+            .get_billing_address_details_as_optional()
+            .map(|address| BillTo {
                 first_name: address.first_name.clone(),
                 last_name: address.last_name.clone(),
                 address: address.line1.clone(),
@@ -377,9 +379,7 @@ impl TryFrom<&AuthorizedotnetRouterData<&types::PaymentsAuthorizeRouterData>>
                 state: address.state.clone(),
                 zip: address.zip.clone(),
                 country: address.country,
-            }),
-            Err(_) => None,
-        };
+            });
         let transaction_request = TransactionRequest {
             transaction_type: TransactionType::from(item.router_data.request.capture_method),
             amount: item.amount,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->

- If the billing address is included in the payments request, it will be transmitted to the connector.
- Additionally, the `connector_request_reference_id` is now transmitted within the order description, making it visible in the transaction details on the connector dashboard.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
https://github.com/juspay/hyperswitch/issues/3980

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Test payments (manual and automatic) for authorizedotnet.

1. Automatic: 

- Request: `curl --location 'http://localhost:8080/payments' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: API_KEY_HERE' \
--data '{
    "amount": 1234,
    "currency": "USD",
    "confirm": true,
    "capture_method": "automatic",
    "customer_id": "StripeCustomer",
    "payment_method": "card",
    "payment_method_type": "credit",
    "payment_method_data": {
        "card": {
            "card_number": "5424000000000015",
            "card_exp_month": "02",
            "card_exp_year": "35",
            "card_holder_name": "John Doe",
            "card_cvc": "123"
        }
    },
    "billing": {
        "address": {
            "first_name": "John",
            "last_name": "Doe",
            "line1": "Harrison Street",
            "city": "San Francisco",
            "state": "California",
            "zip": "94016",
            "country": "US"
        }
    },
    "setup_future_usage": "on_session"
}'`

- Response: `{
    "payment_id": "pay_cuLkCdbQQzkHymq2TKDU",
    "merchant_id": "merchant_1709720492",
    "status": "succeeded",
    "amount": 1234,
    "net_amount": 1234,
    "amount_capturable": 0,
    "amount_received": 1234,
    "connector": "authorizedotnet",
    "client_secret": "pay_cuLkCdbQQzkHymq2TKDU_secret_F8avCQMZYy6Ayy6KUeQd",
    "created": "2024-03-06T11:14:34.973Z",
    "currency": "USD",
    "customer_id": "StripeCustomer",
    "description": null,
    "refunds": null,
    "disputes": null,
    "mandate_id": null,
    "mandate_data": null,
    "setup_future_usage": "on_session",
    "off_session": null,
    "capture_on": null,
    "capture_method": "automatic",
    "payment_method": "card",
    "payment_method_data": {
        "card": {
            "last4": "0015",
            "card_type": null,
            "card_network": null,
            "card_issuer": null,
            "card_issuing_country": null,
            "card_isin": "542400",
            "card_extended_bin": "54240000",
            "card_exp_month": "02",
            "card_exp_year": "35",
            "card_holder_name": "John Doe"
        },
        "billing": null
    },
    "payment_token": null,
    "shipping": null,
    "billing": {
        "address": {
            "city": "San Francisco",
            "country": "US",
            "line1": "Harrison Street",
            "line2": null,
            "line3": null,
            "zip": "94016",
            "state": "California",
            "first_name": "John",
            "last_name": "Doe"
        },
        "phone": {
            "number": null,
            "country_code": null
        },
        "email": null
    },
    "order_details": null,
    "email": null,
    "name": null,
    "phone": null,
    "return_url": null,
    "authentication_type": "no_three_ds",
    "statement_descriptor_name": null,
    "statement_descriptor_suffix": null,
    "next_action": null,
    "cancellation_reason": null,
    "error_code": null,
    "error_message": null,
    "unified_code": null,
    "unified_message": null,
    "payment_experience": null,
    "payment_method_type": "credit",
    "connector_label": null,
    "business_country": null,
    "business_label": "default",
    "business_sub_label": null,
    "allowed_payment_method_types": null,
    "ephemeral_key": {
        "customer_id": "StripeCustomer",
        "created_at": 1709723674,
        "expires": 1709727274,
        "secret": "epk_6a7570ed25eb463d91972aa3c5a6cca6"
    },
    "manual_retry_allowed": false,
    "connector_transaction_id": "80015569706",
    "frm_message": null,
    "metadata": null,
    "connector_metadata": null,
    "feature_metadata": null,
    "reference_id": "80015569706",
    "payment_link": null,
    "profile_id": "pro_4aXJeUeyy9BzdhcV9Xue",
    "surcharge_details": null,
    "attempt_count": 1,
    "merchant_decision": null,
    "merchant_connector_id": "mca_3mX9fbzXfxIkG0uwmy2D",
    "incremental_authorization_allowed": null,
    "authorization_count": null,
    "incremental_authorizations": null,
    "external_authentication_details": null,
    "request_external_3ds_authentication": null,
    "expires_on": "2024-03-06T11:29:34.973Z",
    "fingerprint": null
}`

2. Manual:

- Authorize request: `curl --location 'http://localhost:8080/payments' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: API_KEY_HERE' \
--data '{
    "amount": 1234,
    "currency": "USD",
    "confirm": true,
    "capture_method": "manual",
    "customer_id": "StripeCustomer",
    "payment_method": "card",
    "payment_method_type": "credit",
    "payment_method_data": {
        "card": {
            "card_number": "5424000000000015",
            "card_exp_month": "02",
            "card_exp_year": "35",
            "card_holder_name": "John Doe",
            "card_cvc": "123"
        }
    },
    "billing": {
        "address": {
            "first_name": "John",
            "last_name": "Doe",
            "line1": "Harrison Street",
            "city": "San Francisco",
            "state": "California",
            "zip": "94016",
            "country": "US"
        }
    },
    "setup_future_usage": "on_session"
}'`

- Authorize Response: `{
    "payment_id": "pay_GCVt2jy4rwpznGCPVpvs",
    "merchant_id": "merchant_1709720492",
    "status": "requires_capture",
    "amount": 1234,
    "net_amount": 1234,
    "amount_capturable": 1234,
    "amount_received": null,
    "connector": "authorizedotnet",
    "client_secret": "pay_GCVt2jy4rwpznGCPVpvs_secret_go6S99MiGAsLgJYaG7xB",
    "created": "2024-03-06T11:16:02.569Z",
    "currency": "USD",
    "customer_id": "StripeCustomer",
    "description": null,
    "refunds": null,
    "disputes": null,
    "mandate_id": null,
    "mandate_data": null,
    "setup_future_usage": "on_session",
    "off_session": null,
    "capture_on": null,
    "capture_method": "manual",
    "payment_method": "card",
    "payment_method_data": {
        "card": {
            "last4": "0015",
            "card_type": null,
            "card_network": null,
            "card_issuer": null,
            "card_issuing_country": null,
            "card_isin": "542400",
            "card_extended_bin": "54240000",
            "card_exp_month": "02",
            "card_exp_year": "35",
            "card_holder_name": "John Doe"
        },
        "billing": null
    },
    "payment_token": null,
    "shipping": null,
    "billing": {
        "address": {
            "city": "San Francisco",
            "country": "US",
            "line1": "Harrison Street",
            "line2": null,
            "line3": null,
            "zip": "94016",
            "state": "California",
            "first_name": "John",
            "last_name": "Doe"
        },
        "phone": {
            "number": null,
            "country_code": null
        },
        "email": null
    },
    "order_details": null,
    "email": null,
    "name": null,
    "phone": null,
    "return_url": null,
    "authentication_type": "no_three_ds",
    "statement_descriptor_name": null,
    "statement_descriptor_suffix": null,
    "next_action": null,
    "cancellation_reason": null,
    "error_code": null,
    "error_message": null,
    "unified_code": null,
    "unified_message": null,
    "payment_experience": null,
    "payment_method_type": "credit",
    "connector_label": null,
    "business_country": null,
    "business_label": "default",
    "business_sub_label": null,
    "allowed_payment_method_types": null,
    "ephemeral_key": {
        "customer_id": "StripeCustomer",
        "created_at": 1709723762,
        "expires": 1709727362,
        "secret": "epk_cc979868f4114736aa643b628b57c171"
    },
    "manual_retry_allowed": false,
    "connector_transaction_id": "80015569729",
    "frm_message": null,
    "metadata": null,
    "connector_metadata": null,
    "feature_metadata": null,
    "reference_id": "80015569729",
    "payment_link": null,
    "profile_id": "pro_4aXJeUeyy9BzdhcV9Xue",
    "surcharge_details": null,
    "attempt_count": 1,
    "merchant_decision": null,
    "merchant_connector_id": "mca_3mX9fbzXfxIkG0uwmy2D",
    "incremental_authorization_allowed": null,
    "authorization_count": null,
    "incremental_authorizations": null,
    "external_authentication_details": null,
    "request_external_3ds_authentication": null,
    "expires_on": "2024-03-06T11:31:02.569Z",
    "fingerprint": null
}`

- Capture Request: `curl --location 'http://localhost:8080/payments/pay_GCVt2jy4rwpznGCPVpvs/capture' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: API_KEY_HERE' \
--data '{}'`
- Capture Response: `{
    "payment_id": "pay_GCVt2jy4rwpznGCPVpvs",
    "merchant_id": "merchant_1709720492",
    "status": "succeeded",
    "amount": 1234,
    "net_amount": 1234,
    "amount_capturable": 0,
    "amount_received": 1234,
    "connector": "authorizedotnet",
    "client_secret": "pay_GCVt2jy4rwpznGCPVpvs_secret_go6S99MiGAsLgJYaG7xB",
    "created": "2024-03-06T11:16:02.569Z",
    "currency": "USD",
    "customer_id": "StripeCustomer",
    "description": null,
    "refunds": null,
    "disputes": null,
    "mandate_id": null,
    "mandate_data": null,
    "setup_future_usage": "on_session",
    "off_session": null,
    "capture_on": null,
    "capture_method": "manual",
    "payment_method": "card",
    "payment_method_data": {
        "card": {
            "last4": "0015",
            "card_type": null,
            "card_network": null,
            "card_issuer": null,
            "card_issuing_country": null,
            "card_isin": "542400",
            "card_extended_bin": "54240000",
            "card_exp_month": "02",
            "card_exp_year": "35",
            "card_holder_name": "John Doe"
        },
        "billing": null
    },
    "payment_token": null,
    "shipping": null,
    "billing": {
        "address": {
            "city": "San Francisco",
            "country": "US",
            "line1": "Harrison Street",
            "line2": null,
            "line3": null,
            "zip": "94016",
            "state": "California",
            "first_name": "John",
            "last_name": "Doe"
        },
        "phone": {
            "number": null,
            "country_code": null
        },
        "email": null
    },
    "order_details": null,
    "email": null,
    "name": null,
    "phone": null,
    "return_url": null,
    "authentication_type": "no_three_ds",
    "statement_descriptor_name": null,
    "statement_descriptor_suffix": null,
    "next_action": null,
    "cancellation_reason": null,
    "error_code": null,
    "error_message": null,
    "unified_code": null,
    "unified_message": null,
    "payment_experience": null,
    "payment_method_type": "credit",
    "connector_label": null,
    "business_country": null,
    "business_label": "default",
    "business_sub_label": null,
    "allowed_payment_method_types": null,
    "ephemeral_key": null,
    "manual_retry_allowed": false,
    "connector_transaction_id": "80015569729",
    "frm_message": null,
    "metadata": null,
    "connector_metadata": null,
    "feature_metadata": null,
    "reference_id": "80015569729",
    "payment_link": null,
    "profile_id": "pro_4aXJeUeyy9BzdhcV9Xue",
    "surcharge_details": null,
    "attempt_count": 1,
    "merchant_decision": null,
    "merchant_connector_id": "mca_3mX9fbzXfxIkG0uwmy2D",
    "incremental_authorization_allowed": null,
    "authorization_count": null,
    "incremental_authorizations": null,
    "external_authentication_details": null,
    "request_external_3ds_authentication": null,
    "expires_on": "2024-03-06T11:31:02.569Z",
    "fingerprint": null
}`

For all the mentioned scenarios, both the billing address and the connector_request_reference_id should be visible on the Authorized.net dashboard.
<img width="596" alt="Screenshot 2024-03-06 at 4 14 57 PM" src="https://github.com/juspay/hyperswitch/assets/41580413/9a70dbea-98d8-4695-9b28-00c4e20a9c3b">

NOTE: In all the mentioned scenarios, attempt submitting partial billing addresses, and at times, no billing address at all, ensuring that all payment transactions still function correctly.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
