### PR TITLE
fix(core): [REFUNDS] Fix Not Supported Connector Error

### DIFF
--- a/crates/router/src/core/errors/utils.rs
+++ b/crates/router/src/core/errors/utils.rs
@@ -160,6 +160,12 @@ impl<T> ConnectorErrorExt<T> for error_stack::Result<T, errors::ConnectorError> 
                 }
                 .into()
             }
+            errors::ConnectorError::NotSupported { message, connector } => {
+                errors::ApiErrorResponse::NotSupported {
+                    message: format!("{message} is not supported by {connector}"),
+                }
+                .into()
+            }
             errors::ConnectorError::FailedToObtainIntegrationUrl
             | errors::ConnectorError::RequestEncodingFailed
             | errors::ConnectorError::RequestEncodingFailedWithReason(_)
@@ -178,7 +184,6 @@ impl<T> ConnectorErrorExt<T> for error_stack::Result<T, errors::ConnectorError> 
             | errors::ConnectorError::FailedToObtainCertificate
             | errors::ConnectorError::NoConnectorMetaData
             | errors::ConnectorError::FailedToObtainCertificateKey
-            | errors::ConnectorError::NotSupported { .. }
             | errors::ConnectorError::FlowNotSupported { .. }
             | errors::ConnectorError::CaptureMethodNotSupported
             | errors::ConnectorError::MissingConnectorMandateID

--- a/crates/router/src/core/refunds.rs
+++ b/crates/router/src/core/refunds.rs
@@ -219,6 +219,16 @@ pub async fn trigger_refund_to_gateway(
                             updated_by: storage_scheme.to_string(),
                         })
                     }
+                    errors::ConnectorError::NotSupported { message, connector } => {
+                        Some(storage::RefundUpdate::ErrorUpdate {
+                            refund_status: Some(enums::RefundStatus::Failure),
+                            refund_error_message: Some(format!(
+                                "{message} is not supported by {connector}"
+                            )),
+                            refund_error_code: Some("NOT_SUPPORTED".to_string()),
+                            updated_by: storage_scheme.to_string(),
+                        })
+                    }
                     _ => None,
                 });
         // Update the refund status as failure if connector_error is NotImplemented


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->

- The handling of the `ConnectorError` with the type `NotSupported` has been implemented for refunds. In cases where the connector raises a `NotSupported` error, the refund status will now be set to failure.
- Additionally, in this scenario, the error message will be presented as `{message} is not supported by {connector}`.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
https://github.com/juspay/hyperswitch-cloud/issues/4439

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Create a partial refund for connector placetopay which should result in connector throwing `NotSupported` error.
Request:
```
curl --location 'http://localhost:8080/refunds' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: API_KEY_HERE' \
--data '{
  "amount": 100,
  "payment_id": "pay_yv0as66Wx6FRR5okC840",
  "refund_type": "instant"
}'
```

Response:
```
{
    "error": {
        "type": "invalid_request",
        "message": "Payment method type not supported",
        "code": "HE_03",
        "reason": "Partial Refund is not supported by placetopay"
    }
}
```

Also the status of this refund should be `failure` in database.
<img width="1138" alt="Screenshot 2024-03-12 at 6 27 29 PM" src="https://github.com/juspay/hyperswitch/assets/41580413/0615a9bf-bf36-4637-844f-4b65a6b47884">

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
