### PR TITLE
fix: get valid test cards list based on wasm feature config

### DIFF
--- a/crates/cards/src/validate.rs
+++ b/crates/cards/src/validate.rs
@@ -2,7 +2,7 @@ use std::{fmt, ops::Deref, str::FromStr};
 
 use masking::{PeekInterface, Strategy, StrongSecret, WithType};
 #[cfg(not(target_arch = "wasm32"))]
-use router_env::logger;
+use router_env::{logger, which as router_env_which, Env};
 use serde::{Deserialize, Deserializer, Serialize};
 use thiserror::Error;
 
@@ -52,14 +52,16 @@ impl FromStr for CardNumber {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         // Valid test cards for threedsecureio
-        let valid_test_cards = match router_env::which() {
-            router_env::Env::Development | router_env::Env::Sandbox => vec![
-                "4000100511112003",
-                "6000100611111203",
-                "3000100811111072",
-                "9000100111111111",
-            ],
-            router_env::Env::Production => vec![],
+        let valid_test_cards = vec![
+            "4000100511112003",
+            "6000100611111203",
+            "3000100811111072",
+            "9000100111111111",
+        ];
+        #[cfg(not(target_arch = "wasm32"))]
+        let valid_test_cards = match router_env_which() {
+            Env::Development | Env::Sandbox => valid_test_cards,
+            Env::Production => vec![],
         };
         if luhn::valid(s) || valid_test_cards.contains(&s) {
             let cc_no_whitespace: String = s.split_whitespace().collect();


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Fixed `FromStr` implementation on `CardNumber` to work with wasm related feature configs.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Run `make euclid-wasm` to verify if Wasm build was successful.
<img width="1180" alt="Screenshot 2024-03-13 at 3 12 07 PM" src="https://github.com/juspay/hyperswitch/assets/61539176/480b4373-36ba-401a-a18c-849541c524d7">


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
