### PR TITLE
feat(connector): [cybersource] add card holder name in dynamic fields

### DIFF
--- a/crates/router/src/configs/defaults.rs
+++ b/crates/router/src/configs/defaults.rs
@@ -757,7 +757,8 @@ impl Default for super::settings::RequiredFields {
                                 enums::Connector::Cybersource,
                                 RequiredFieldFinal {
                                     mandate: HashMap::new(),
-                                    non_mandate: HashMap::from(
+                                    non_mandate: HashMap::new(),
+                                    common:HashMap::from(
                                         [
                                             (
                                                 "payment_method_data.card.card_number".to_string(),
@@ -792,6 +793,15 @@ impl Default for super::settings::RequiredFields {
                                                     required_field: "payment_method_data.card.card_cvc".to_string(),
                                                     display_name: "card_cvc".to_string(),
                                                     field_type: enums::FieldType::UserCardCvc,
+                                                    value: None,
+                                                }
+                                            ),
+                                            (
+                                                "payment_method_data.card.card_holder_name".to_string(),
+                                                RequiredFieldInfo {
+                                                    required_field: "payment_method_data.card.card_holder_name".to_string(),
+                                                    display_name: "card_holder_name".to_string(),
+                                                    field_type: enums::FieldType::UserFullName,
                                                     value: None,
                                                 }
                                             ),
@@ -873,7 +883,6 @@ impl Default for super::settings::RequiredFields {
                                             )
                                         ]
                                     ),
-                                    common:HashMap::new(),
                                 }
                             ),
                             (
@@ -2854,6 +2863,15 @@ impl Default for super::settings::RequiredFields {
                                                 }
                                             ),
                                             (
+                                                "payment_method_data.card.card_holder_name".to_string(),
+                                                RequiredFieldInfo {
+                                                    required_field: "payment_method_data.card.card_holder_name".to_string(),
+                                                    display_name: "card_holder_name".to_string(),
+                                                    field_type: enums::FieldType::UserFullName,
+                                                    value: None,
+                                                }
+                                            ),
+                                            (
                                                 "email".to_string(),
                                                 RequiredFieldInfo {
                                                     required_field: "email".to_string(),
@@ -4783,7 +4801,8 @@ impl Default for super::settings::RequiredFields {
                                                     field_type: enums::FieldType::UserBank,
                                                     value: None,
                                                 }
-                                            )
+                                            ),
+
                                         ]),
                                     }
                                 ),


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [X] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
add card holder name as a required field in dynamic fields for cyber source

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
#4083


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

- Create a payment for Cybersource with confirm false
```
curl --location 'http://localhost:8080/payments' \
--header 'Accept: application/json' \
--header 'Content-Type: application/json' \
--header 'api-key: dev_NEqxtA08zn0qi3szJqYNmFXpQQt41BfwDpOE1sVucX37yJUN7jpR6QkmrlJCuWf5' \
--data-raw '{
    "amount": 9040,
    "currency": "USD",
    "confirm": false,
    
    
    "capture_method": "automatic",
    
    "customer_id": "shanks5",
    
    "authentication_type": "no_three_ds",
    "return_url": "https://google.com",
    "email": "abc-ext.kylta@flowbird.group",
    "name": "Joseph Doe",
    "phone": "999999999",
    "phone_country_code": "+65",
    "description": "Its my first payment",
    "statement_descriptor_name": "Juspay",
    "statement_descriptor_suffix": "Router",
    "billing": {
        "address": {
            "city": "SanFransico",
            "country": "AE",
            "line1": "1562",
            "line2": "HarrisonStreet",
            "line3": "HarrisonStreet",
            "zip": "94122",
            "state": "California",
            "first_name": "joseph",
            "last_name": "Doe"
        },
        "phone": {
            "number": "8056594427",
            "country_code": "+91"
        }
    },
    
    "setup_future_usage": "off_session",
    "browser_info": {
        "user_agent": "Mozilla\/5.0 (iPhone NT 10.0; Win64; x64) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/70.0.3538.110 Safari\/537.36",
        "accept_header": "text\/html,application\/xhtml+xml,application\/xml;q=0.9,image\/webp,image\/apng,*\/*;q=0.8",
        "language": "nl-NL",
        "color_depth": 24,
        "screen_height": 723,
        "screen_width": 1536,
        "time_zone": 0,
        "java_enabled": true,
        "java_script_enabled": true,
        "ip_address": "128.0.0.1"
    },
    "connector_metadata": {
        "noon": {
            "order_category": "pay"
        }
    },
    "order_details": [
        {
            "product_name": "Apple iphone 15",
            "quantity": 1,
            "amount": 10,
            "account_name": "transaction_processing"
        }
    ]
}'
```
- Retrieve payment method list for the merchant, card holder name should be present as required field
<img width="1129" alt="Screenshot 2024-03-14 at 1 02 47 AM" src="https://github.com/juspay/hyperswitch/assets/55536657/78879e1d-4f5d-4aa4-bb51-13020bee4e6e">


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [X] I formatted the code `cargo +nightly fmt --all`
- [X] I addressed lints thrown by `cargo clippy`
- [X] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
