### PR TITLE
fix(api_response): ghost payment_method_billing being populated in the response

### DIFF
--- a/crates/router/src/core/payments.rs
+++ b/crates/router/src/core/payments.rs
@@ -2123,7 +2123,7 @@ pub mod payment_address {
         shipping: Option<api::Address>,
         billing: Option<api::Address>,
         payment_method_billing: Option<api::Address>,
-        is_payment_method_billing_passed: bool,
+        payment_method_billing_from_request: Option<api::Address>,
     }
 
     impl PaymentAddress {
@@ -2132,7 +2132,7 @@ pub mod payment_address {
             billing: Option<api::Address>,
             payment_method_billing: Option<api::Address>,
         ) -> Self {
-            let is_payment_method_billing_passed = payment_method_billing.is_some();
+            let payment_method_billing_from_request = payment_method_billing.clone();
 
             let payment_method_billing = match (payment_method_billing, billing.clone()) {
                 (Some(payment_method_billing), Some(order_billing)) => Some(api::Address {
@@ -2149,7 +2149,7 @@ pub mod payment_address {
                 shipping,
                 billing,
                 payment_method_billing,
-                is_payment_method_billing_passed,
+                payment_method_billing_from_request,
             }
         }
 
@@ -2162,11 +2162,7 @@ pub mod payment_address {
         }
 
         pub fn get_request_payment_method_billing(&self) -> Option<&api::Address> {
-            if self.is_payment_method_billing_passed {
-                self.payment_method_billing.as_ref()
-            } else {
-                None
-            }
+            self.payment_method_billing_from_request.as_ref()
         }
 
         pub fn get_payment_billing(&self) -> Option<&api::Address> {

--- a/crates/router/src/core/payments.rs
+++ b/crates/router/src/core/payments.rs
@@ -2123,6 +2123,7 @@ pub mod payment_address {
         shipping: Option<api::Address>,
         billing: Option<api::Address>,
         payment_method_billing: Option<api::Address>,
+        is_payment_method_billing_passed: bool,
     }
 
     impl PaymentAddress {
@@ -2131,6 +2132,8 @@ pub mod payment_address {
             billing: Option<api::Address>,
             payment_method_billing: Option<api::Address>,
         ) -> Self {
+            let is_payment_method_billing_passed = payment_method_billing.is_some();
+
             let payment_method_billing = match (payment_method_billing, billing.clone()) {
                 (Some(payment_method_billing), Some(order_billing)) => Some(api::Address {
                     address: payment_method_billing.address.or(order_billing.address),
@@ -2146,6 +2149,7 @@ pub mod payment_address {
                 shipping,
                 billing,
                 payment_method_billing,
+                is_payment_method_billing_passed,
             }
         }
 
@@ -2155,6 +2159,14 @@ pub mod payment_address {
 
         pub fn get_payment_method_billing(&self) -> Option<&api::Address> {
             self.payment_method_billing.as_ref()
+        }
+
+        pub fn get_request_payment_method_billing(&self) -> Option<&api::Address> {
+            if self.is_payment_method_billing_passed {
+                self.payment_method_billing.as_ref()
+            } else {
+                None
+            }
         }
 
         pub fn get_payment_billing(&self) -> Option<&api::Address> {

--- a/crates/router/src/core/payments.rs
+++ b/crates/router/src/core/payments.rs
@@ -2122,7 +2122,7 @@ pub mod payment_address {
     pub struct PaymentAddress {
         shipping: Option<api::Address>,
         billing: Option<api::Address>,
-        merged_payment_method_billing: Option<api::Address>,
+        unified_payment_method_billing: Option<api::Address>,
         payment_method_billing: Option<api::Address>,
     }
 
@@ -2133,10 +2133,10 @@ pub mod payment_address {
             payment_method_billing: Option<api::Address>,
         ) -> Self {
             // Merge the billing details field from both `payment.billing` and `payment.payment_method_data.billing`
-            // The merged payment_method_billing will be used as billing address and passed to the connector module
-            // This merging is required in order to provide backwards compatibility
+            // The unified payment_method_billing will be used as billing address and passed to the connector module
+            // This unification is required in order to provide backwards compatibility
             // so that if `payment.billing` is passed it should be sent to the connector module
-            let merged_payment_method_billing =
+            let unified_payment_method_billing =
                 match (payment_method_billing.clone(), billing.clone()) {
                     (Some(payment_method_billing), Some(order_billing)) => Some(api::Address {
                         address: payment_method_billing.address.or(order_billing.address),
@@ -2151,7 +2151,7 @@ pub mod payment_address {
             Self {
                 shipping,
                 billing,
-                merged_payment_method_billing,
+                unified_payment_method_billing,
                 payment_method_billing,
             }
         }
@@ -2161,7 +2161,7 @@ pub mod payment_address {
         }
 
         pub fn get_payment_method_billing(&self) -> Option<&api::Address> {
-            self.merged_payment_method_billing.as_ref()
+            self.unified_payment_method_billing.as_ref()
         }
 
         pub fn get_request_payment_method_billing(&self) -> Option<&api::Address> {

--- a/crates/router/src/core/payments/transformers.rs
+++ b/crates/router/src/core/payments/transformers.rs
@@ -467,7 +467,10 @@ where
     let payment_method_data_response = payment_method_data.map(|payment_method_data| {
         api_models::payments::PaymentMethodDataResponseWithBilling {
             payment_method_data,
-            billing: payment_data.address.get_payment_method_billing().cloned(),
+            billing: payment_data
+                .address
+                .get_request_payment_method_billing()
+                .cloned(),
         }
     });
 

--- a/crates/router/src/types/transformers.rs
+++ b/crates/router/src/types/transformers.rs
@@ -583,7 +583,7 @@ impl<'a> ForeignFrom<&'a api_types::ConfigUpdate> for storage::ConfigUpdate {
 
 impl<'a> From<&'a domain::Address> for api_types::Address {
     fn from(address: &domain::Address) -> Self {
-        // If all the fields of address are none, then
+        // If all the fields of address are none, then pass the address as None
         let address_details = if address.city.is_none()
             && address.line1.is_none()
             && address.line2.is_none()
@@ -608,12 +608,19 @@ impl<'a> From<&'a domain::Address> for api_types::Address {
             })
         };
 
-        Self {
-            address: address_details,
-            phone: Some(api_types::PhoneDetails {
+        // If all the fields of phone are none, then pass the phone as None
+        let phone_details = if address.phone_number.is_none() && address.country_code.is_none() {
+            None
+        } else {
+            Some(api_types::PhoneDetails {
                 number: address.phone_number.clone().map(Encryptable::into_inner),
                 country_code: address.country_code.clone(),
-            }),
+            })
+        };
+
+        Self {
+            address: address_details,
+            phone: phone_details,
             email: address.email.clone().map(pii::Email::from),
         }
     }

--- a/postman/collection-dir/stripe/Flow Testcases/Happy Cases/Scenario29-Create payment with payment method billing/Payments - Create/event.test.js
+++ b/postman/collection-dir/stripe/Flow Testcases/Happy Cases/Scenario29-Create payment with payment method billing/Payments - Create/event.test.js
@@ -87,3 +87,11 @@ pm.test(
       .true;
   },
 );
+
+// Response body should not have "payment.billing"
+pm.test(
+  "[POST]::/payments - Content check if 'payment.billing' is null",
+  function () {
+    pm.expect(jsonData?.billing).to.be.null
+  },
+);

--- a/postman/collection-dir/stripe/Flow Testcases/Happy Cases/Scenario29-Create payment with payment method billing/Payments - Create/request.json
+++ b/postman/collection-dir/stripe/Flow Testcases/Happy Cases/Scenario29-Create payment with payment method billing/Payments - Create/request.json
@@ -60,19 +60,6 @@
           "email": "example@juspay.in"
         }
       },
-      "billing": {
-        "address": {
-          "line1": "1467",
-          "line2": "Harrison Street",
-          "line3": "Harrison Street",
-          "city": "San Fransico",
-          "state": "California",
-          "zip": "94122",
-          "country": "US",
-          "first_name": "sundari",
-          "last_name": "sundari"
-        }
-      },
       "shipping": {
         "address": {
           "line1": "1467",

--- a/postman/collection-dir/stripe/QuickStart/Payments - Create/event.test.js
+++ b/postman/collection-dir/stripe/QuickStart/Payments - Create/event.test.js
@@ -97,3 +97,11 @@ pm.test(
       .true;
   },
 );
+
+// Response body should not have "payment_method_data.billing"
+pm.test(
+  "[POST]::/payments - Content check if 'payment_method_data.billing' should be null",
+  function () {
+    pm.expect(jsonData?.payment_method_data?.billing).to.be.null;
+  },
+);

--- a/postman/collection-json/stripe.postman_collection.json
+++ b/postman/collection-json/stripe.postman_collection.json
@@ -2451,6 +2451,14 @@
                   "      .true;",
                   "  },",
                   ");",
+                  "",
+                  "// Response body should not have \"payment_method_data.billing\"",
+                  "pm.test(",
+                  "  \"[POST]::/payments - Content check if 'payment_method_data.billing' should be null\",",
+                  "  function () {",
+                  "    pm.expect(jsonData?.payment_method_data?.billing).to.be.null;",
+                  "  },",
+                  ");",
                   ""
                 ],
                 "type": "text/javascript"
@@ -20865,6 +20873,14 @@
                           "      .true;",
                           "  },",
                           ");",
+                          "",
+                          "// Response body should not have \"payment.billing\"",
+                          "pm.test(",
+                          "  \"[POST]::/payments - Content check if 'payment.billing' is null\",",
+                          "  function () {",
+                          "    pm.expect(jsonData?.billing).to.be.null",
+                          "  },",
+                          ");",
                           ""
                         ],
                         "type": "text/javascript"
@@ -20890,7 +20906,7 @@
                           "language": "json"
                         }
                       },
-                      "raw": "{\"amount\":6540,\"currency\":\"USD\",\"confirm\":true,\"business_country\":\"US\",\"business_label\":\"default\",\"capture_method\":\"automatic\",\"capture_on\":\"2022-09-10T10:11:12Z\",\"amount_to_capture\":6540,\"customer_id\":\"bernard123\",\"email\":\"guest@example.com\",\"name\":\"John Doe\",\"phone\":\"999999999\",\"phone_country_code\":\"+65\",\"description\":\"Its my first payment request\",\"authentication_type\":\"no_three_ds\",\"return_url\":\"https://duck.com\",\"setup_future_usage\":\"on_session\",\"payment_method\":\"card\",\"payment_method_type\":\"debit\",\"payment_method_data\":{\"card\":{\"card_number\":\"4242424242424242\",\"card_exp_month\":\"01\",\"card_exp_year\":\"26\",\"card_holder_name\":\"joseph Doe\",\"card_cvc\":\"123\"},\"billing\":{\"address\":{\"line1\":\"1467\",\"line2\":\"Harrison Street\",\"line3\":\"Harrisoff Street\",\"city\":\"San Fransico\",\"state\":\"California\",\"zip\":\"94122\",\"country\":\"US\",\"first_name\":\"Narayan\",\"last_name\":\"Doe\"},\"email\":\"example@juspay.in\"}},\"billing\":{\"address\":{\"line1\":\"1467\",\"line2\":\"Harrison Street\",\"line3\":\"Harrison Street\",\"city\":\"San Fransico\",\"state\":\"California\",\"zip\":\"94122\",\"country\":\"US\",\"first_name\":\"sundari\",\"last_name\":\"sundari\"}},\"shipping\":{\"address\":{\"line1\":\"1467\",\"line2\":\"Harrison Street\",\"line3\":\"Harrison Street\",\"city\":\"San Fransico\",\"state\":\"California\",\"zip\":\"94122\",\"country\":\"US\",\"first_name\":\"sundari\",\"last_name\":\"sundari\"}},\"statement_descriptor_name\":\"joseph\",\"statement_descriptor_suffix\":\"JS\",\"metadata\":{\"udf1\":\"value1\",\"new_customer\":\"true\",\"login_date\":\"2019-09-10T10:11:12Z\"},\"routing\":{\"type\":\"single\",\"data\":\"stripe\"}}"
+                      "raw": "{\"amount\":6540,\"currency\":\"USD\",\"confirm\":true,\"business_country\":\"US\",\"business_label\":\"default\",\"capture_method\":\"automatic\",\"capture_on\":\"2022-09-10T10:11:12Z\",\"amount_to_capture\":6540,\"customer_id\":\"bernard123\",\"email\":\"guest@example.com\",\"name\":\"John Doe\",\"phone\":\"999999999\",\"phone_country_code\":\"+65\",\"description\":\"Its my first payment request\",\"authentication_type\":\"no_three_ds\",\"return_url\":\"https://duck.com\",\"setup_future_usage\":\"on_session\",\"payment_method\":\"card\",\"payment_method_type\":\"debit\",\"payment_method_data\":{\"card\":{\"card_number\":\"4242424242424242\",\"card_exp_month\":\"01\",\"card_exp_year\":\"26\",\"card_holder_name\":\"joseph Doe\",\"card_cvc\":\"123\"},\"billing\":{\"address\":{\"line1\":\"1467\",\"line2\":\"Harrison Street\",\"line3\":\"Harrisoff Street\",\"city\":\"San Fransico\",\"state\":\"California\",\"zip\":\"94122\",\"country\":\"US\",\"first_name\":\"Narayan\",\"last_name\":\"Doe\"},\"email\":\"example@juspay.in\"}},\"shipping\":{\"address\":{\"line1\":\"1467\",\"line2\":\"Harrison Street\",\"line3\":\"Harrison Street\",\"city\":\"San Fransico\",\"state\":\"California\",\"zip\":\"94122\",\"country\":\"US\",\"first_name\":\"sundari\",\"last_name\":\"sundari\"}},\"statement_descriptor_name\":\"joseph\",\"statement_descriptor_suffix\":\"JS\",\"metadata\":{\"udf1\":\"value1\",\"new_customer\":\"true\",\"login_date\":\"2019-09-10T10:11:12Z\"},\"routing\":{\"type\":\"single\",\"data\":\"stripe\"}}"
                     },
                     "url": {
                       "raw": "{{baseUrl}}/payments",


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix

## Description
<!-- Describe your changes in detail -->
This PR fixes the inconsistency in payments response. More details can be found in the linked issue.


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
- Added postman test cases

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code