### PR TITLE
fix(payments): populate merchant connector id and profile id in list

### DIFF
--- a/crates/router/src/core/payments/transformers.rs
+++ b/crates/router/src/core/payments/transformers.rs
@@ -954,7 +954,6 @@ impl ForeignFrom<(storage::PaymentIntent, storage::PaymentAttempt)> for api::Pay
             attempt_count: pi.attempt_count,
             profile_id: pi.profile_id,
             merchant_connector_id: pa.merchant_connector_id,
-
             ..Default::default()
         }
     }

--- a/crates/router/src/core/payments/transformers.rs
+++ b/crates/router/src/core/payments/transformers.rs
@@ -952,6 +952,9 @@ impl ForeignFrom<(storage::PaymentIntent, storage::PaymentAttempt)> for api::Pay
             authentication_type: pa.authentication_type,
             connector_transaction_id: pa.connector_transaction_id,
             attempt_count: pi.attempt_count,
+            profile_id: pi.profile_id,
+            merchant_connector_id: pa.merchant_connector_id,
+
             ..Default::default()
         }
     }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
`Profile_id` and `merchant_connector_id` is to be populated for payments list response.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
closes #4103 

## How did you test it?
Use the curl to get payments list:
```
curl --location 'http://localhost:8080/payments/list' \
--header 'Content-Type: application/json' \
--header 'Cookie: token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoiMWZjNzgyOTUtM2JiMy00OGJjLThlZDgtNzFjMzVjMzMxYWU2IiwibWVyY2hhbnRfaWQiOiJtZXJjaGFudF8xNjk3NzE2ODcwIiwicm9sZV9pZCI6Im1lcmNoYW50X2FkbWluIiwiZXhwIjoxNjk3ODg5NjcxLCJvcmdfaWQiOiJvcmdfejQ5ZExMeTdmbllUODN5TDY3clEifQ.CJzEQ2qbhn-qUiiVBSdvCJiLvWp-5wCF9R54gth6QbQ' \
--header 'Authorization: Bearer JWT' \
--data '{ 
}'
```
In Response fields `profile_id` and `merchant_connector_id` fields properly populated.
```
{
    "count": 5,
    "total_count": 100,
    "data": [
        {
            "payment_id": "test_fhYXl6ExKokyMqAlnDiz",
            "merchant_id": "merchant_1710153863",
            "status": "succeeded",
            "amount": 16700,
            "net_amount": 0,
            "amount_capturable": 16700,
            "amount_received": null,
            "connector": "stripe_test",
            "client_secret": "test_fhYXl6ExKokyMqAlnDiz_secret_0Lfp0rpudua13MFoT8NU",
            "created": "2024-03-14T08:10:15.000Z",
            "currency": "USD",
            "customer_id": "hs-dashboard-user",
            "description": "This is a sample payment",
            "refunds": null,
            "disputes": null,
            "mandate_id": null,
            "mandate_data": null,
            "setup_future_usage": null,
            "off_session": null,
            "capture_on": null,
            "capture_method": null,
            "payment_method": "card",
            "payment_method_data": null,
            "payment_token": null,
            "shipping": null,
            "billing": null,
            "order_details": null,
            "email": null,
            "name": null,
            "phone": null,
            "return_url": null,
            "authentication_type": "three_ds",
            "statement_descriptor_name": null,
            "statement_descriptor_suffix": null,
            "next_action": null,
            "cancellation_reason": null,
            "error_code": null,
            "error_message": null,
            "unified_code": null,
            "unified_message": null,
            "payment_experience": null,
            "payment_method_type": "credit",
            "connector_label": null,
            "business_country": null,
            "business_label": "default",
            "business_sub_label": null,
            "allowed_payment_method_types": null,
            "ephemeral_key": null,
            "manual_retry_allowed": null,
            "connector_transaction_id": "test_fhYXl6ExKokyMqAlnDiz_1",
            "frm_message": null,
            "metadata": null,
            "connector_metadata": null,
            "feature_metadata": null,
            "reference_id": null,
            "payment_link": null,
            "profile_id": "pro_4TBk8LY9HGp5dGXqxFTF",
            "surcharge_details": null,
            "attempt_count": 1,
            "merchant_decision": null,
            "merchant_connector_id": "test",
            "incremental_authorization_allowed": null,
            "authorization_count": null,
            "incremental_authorizations": null,
            "external_authentication_details": null,
            "external_3ds_authentication_attempted": null,
            "expires_on": null,
            "fingerprint": null,
            "payment_method_id": null,
            "payment_method_status": null
        },
        {
            "payment_id": "test_ejaOwTOxyNQu5WrDeZnk",
            "merchant_id": "merchant_1710153863",
            "status": "succeeded",
            "amount": 14600,
            "net_amount": 0,
            "amount_capturable": 14600,
            "amount_received": null,
            "connector": "paypal_test",
            "client_secret": "test_ejaOwTOxyNQu5WrDeZnk_secret_l6jUZkSzjkNpa8xnzwwj",
            "created": "2024-03-14T05:25:35.000Z",
            "currency": "USD",
            "customer_id": "hs-dashboard-user",
            "description": "This is a sample payment",
            "refunds": null,
            "disputes": null,
            "mandate_id": null,
            "mandate_data": null,
            "setup_future_usage": null,
            "off_session": null,
            "capture_on": null,
            "capture_method": null,
            "payment_method": "card",
            "payment_method_data": null,
            "payment_token": null,
            "shipping": null,
            "billing": null,
            "order_details": null,
            "email": null,
            "name": null,
            "phone": null,
            "return_url": null,
            "authentication_type": "no_three_ds",
            "statement_descriptor_name": null,
            "statement_descriptor_suffix": null,
            "next_action": null,
            "cancellation_reason": null,
            "error_code": null,
            "error_message": null,
            "unified_code": null,
            "unified_message": null,
            "payment_experience": null,
            "payment_method_type": "credit",
            "connector_label": null,
            "business_country": null,
            "business_label": "default",
            "business_sub_label": null,
            "allowed_payment_method_types": null,
            "ephemeral_key": null,
            "manual_retry_allowed": null,
            "connector_transaction_id": "test_ejaOwTOxyNQu5WrDeZnk_1",
            "frm_message": null,
            "metadata": null,
            "connector_metadata": null,
            "feature_metadata": null,
            "reference_id": null,
            "payment_link": null,
            "profile_id": "pro_4TBk8LY9HGp5dGXqxFTF",
            "surcharge_details": null,
            "attempt_count": 1,
            "merchant_decision": null,
            "merchant_connector_id": "test",
            "incremental_authorization_allowed": null,
            "authorization_count": null,
            "incremental_authorizations": null,
            "external_authentication_details": null,
            "external_3ds_authentication_attempted": null,
            "expires_on": null,
            "fingerprint": null,
            "payment_method_id": null,
            "payment_method_status": null
        },
        {
            "payment_id": "test_MB9kqEtqMONlQEPHb1dT",
            "merchant_id": "merchant_1710153863",
            "status": "succeeded",
            "amount": 12900,
            "net_amount": 0,
            "amount_capturable": 12900,
            "amount_received": null,
            "connector": "stripe_test",
            "client_secret": "test_MB9kqEtqMONlQEPHb1dT_secret_kSeuhHJkrZcBndgMWRP2",
            "created": "2024-03-14T05:02:09.000Z",
            "currency": "USD",
            "customer_id": "hs-dashboard-user",
            "description": "This is a sample payment",
            "refunds": null,
            "disputes": null,
            "mandate_id": null,
            "mandate_data": null,
            "setup_future_usage": null,
            "off_session": null,
            "capture_on": null,
            "capture_method": null,
            "payment_method": "card",
            "payment_method_data": null,
            "payment_token": null,
            "shipping": null,
            "billing": null,
            "order_details": null,
            "email": null,
            "name": null,
            "phone": null,
            "return_url": null,
            "authentication_type": "three_ds",
            "statement_descriptor_name": null,
            "statement_descriptor_suffix": null,
            "next_action": null,
            "cancellation_reason": null,
            "error_code": null,
            "error_message": null,
            "unified_code": null,
            "unified_message": null,
            "payment_experience": null,
            "payment_method_type": "debit",
            "connector_label": null,
            "business_country": null,
            "business_label": "default",
            "business_sub_label": null,
            "allowed_payment_method_types": null,
            "ephemeral_key": null,
            "manual_retry_allowed": null,
            "connector_transaction_id": "test_MB9kqEtqMONlQEPHb1dT_1",
            "frm_message": null,
            "metadata": null,
            "connector_metadata": null,
            "feature_metadata": null,
            "reference_id": null,
            "payment_link": null,
            "profile_id": "pro_4TBk8LY9HGp5dGXqxFTF",
            "surcharge_details": null,
            "attempt_count": 1,
            "merchant_decision": null,
            "merchant_connector_id": "test",
            "incremental_authorization_allowed": null,
            "authorization_count": null,
            "incremental_authorizations": null,
            "external_authentication_details": null,
            "external_3ds_authentication_attempted": null,
            "expires_on": null,
            "fingerprint": null,
            "payment_method_id": null,
            "payment_method_status": null
        },
        {
            "payment_id": "test_kWl22oD2BdhPq3LM260p",
            "merchant_id": "merchant_1710153863",
            "status": "succeeded",
            "amount": 11100,
            "net_amount": 0,
            "amount_capturable": 11100,
            "amount_received": null,
            "connector": "paypal_test",
            "client_secret": "test_kWl22oD2BdhPq3LM260p_secret_1KRPGPVx25PyjGcowDti",
            "created": "2024-03-14T04:27:59.000Z",
            "currency": "USD",
            "customer_id": "hs-dashboard-user",
            "description": "This is a sample payment",
            "refunds": null,
            "disputes": null,
            "mandate_id": null,
            "mandate_data": null,
            "setup_future_usage": null,
            "off_session": null,
            "capture_on": null,
            "capture_method": null,
            "payment_method": "card",
            "payment_method_data": null,
            "payment_token": null,
            "shipping": null,
            "billing": null,
            "order_details": null,
            "email": null,
            "name": null,
            "phone": null,
            "return_url": null,
            "authentication_type": "no_three_ds",
            "statement_descriptor_name": null,
            "statement_descriptor_suffix": null,
            "next_action": null,
            "cancellation_reason": null,
            "error_code": null,
            "error_message": null,
            "unified_code": null,
            "unified_message": null,
            "payment_experience": null,
            "payment_method_type": "debit",
            "connector_label": null,
            "business_country": null,
            "business_label": "default",
            "business_sub_label": null,
            "allowed_payment_method_types": null,
            "ephemeral_key": null,
            "manual_retry_allowed": null,
            "connector_transaction_id": "test_kWl22oD2BdhPq3LM260p_1",
            "frm_message": null,
            "metadata": null,
            "connector_metadata": null,
            "feature_metadata": null,
            "reference_id": null,
            "payment_link": null,
            "profile_id": "pro_4TBk8LY9HGp5dGXqxFTF",
            "surcharge_details": null,
            "attempt_count": 1,
            "merchant_decision": null,
            "merchant_connector_id": "test",
            "incremental_authorization_allowed": null,
            "authorization_count": null,
            "incremental_authorizations": null,
            "external_authentication_details": null,
            "external_3ds_authentication_attempted": null,
            "expires_on": null,
            "fingerprint": null,
            "payment_method_id": null,
            "payment_method_status": null
        },
        {
            "payment_id": "test_uNRkJ3WbgCmZr7CF58Ev",
            "merchant_id": "merchant_1710153863",
            "status": "succeeded",
            "amount": 12900,
            "net_amount": 0,
            "amount_capturable": 12900,
            "amount_received": null,
            "connector": "stripe_test",
            "client_secret": "test_uNRkJ3WbgCmZr7CF58Ev_secret_yzc8nAG4qTdQVpSjmnwP",
            "created": "2024-03-14T03:43:12.000Z",
            "currency": "USD",
            "customer_id": "hs-dashboard-user",
            "description": "This is a sample payment",
            "refunds": null,
            "disputes": null,
            "mandate_id": null,
            "mandate_data": null,
            "setup_future_usage": null,
            "off_session": null,
            "capture_on": null,
            "capture_method": null,
            "payment_method": "card",
            "payment_method_data": null,
            "payment_token": null,
            "shipping": null,
            "billing": null,
            "order_details": null,
            "email": null,
            "name": null,
            "phone": null,
            "return_url": null,
            "authentication_type": "three_ds",
            "statement_descriptor_name": null,
            "statement_descriptor_suffix": null,
            "next_action": null,
            "cancellation_reason": null,
            "error_code": null,
            "error_message": null,
            "unified_code": null,
            "unified_message": null,
            "payment_experience": null,
            "payment_method_type": "debit",
            "connector_label": null,
            "business_country": null,
            "business_label": "default",
            "business_sub_label": null,
            "allowed_payment_method_types": null,
            "ephemeral_key": null,
            "manual_retry_allowed": null,
            "connector_transaction_id": "test_uNRkJ3WbgCmZr7CF58Ev_1",
            "frm_message": null,
            "metadata": null,
            "connector_metadata": null,
            "feature_metadata": null,
            "reference_id": null,
            "payment_link": null,
            "profile_id": "pro_4TBk8LY9HGp5dGXqxFTF",
            "surcharge_details": null,
            "attempt_count": 1,
            "merchant_decision": null,
            "merchant_connector_id": "test",
            "incremental_authorization_allowed": null,
            "authorization_count": null,
            "incremental_authorizations": null,
            "external_authentication_details": null,
            "external_3ds_authentication_attempted": null,
            "expires_on": null,
            "fingerprint": null,
            "payment_method_id": null,
            "payment_method_status": null
        }
    ]
}
```
## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
