### PR TITLE
fix: make reverse lookup store in redis only

### DIFF
--- a/crates/drainer/src/settings.rs
+++ b/crates/drainer/src/settings.rs
@@ -145,7 +145,7 @@ impl Default for Server {
     fn default() -> Self {
         Self {
             host: "127.0.0.1".to_string(),
-            port: 8080,
+            port: 8000,
             workers: 1,
         }
     }

--- a/crates/router/src/db/reverse_lookup.rs
+++ b/crates/router/src/db/reverse_lookup.rs
@@ -1,10 +1,21 @@
 use super::{MockDb, Store};
 use crate::{
+    connection,
+    core::errors::utils::RedisErrorExt,
     errors::{self, CustomResult},
     types::storage::{
         enums,
         reverse_lookup::{ReverseLookup, ReverseLookupNew},
     },
+    utils::db_utils,
+};
+
+use error_stack::{IntoReport, ResultExt};
+use redis_interface::SetnxReply;
+use router_env::{instrument, tracing};
+use storage_impl::{
+    redis::kv_store::{kv_wrapper, KvOperation, RedisConnInterface},
+    UniqueConstraints,
 };
 
 #[async_trait::async_trait]
@@ -21,150 +32,81 @@ pub trait ReverseLookupInterface {
     ) -> CustomResult<ReverseLookup, errors::StorageError>;
 }
 
-#[cfg(not(feature = "kv_store"))]
-mod storage {
-    use error_stack::IntoReport;
-    use router_env::{instrument, tracing};
+#[async_trait::async_trait]
+impl ReverseLookupInterface for Store {
+    #[instrument(skip_all)]
+    async fn insert_reverse_lookup(
+        &self,
+        new: ReverseLookupNew,
+        storage_scheme: enums::MerchantStorageScheme,
+    ) -> CustomResult<ReverseLookup, errors::StorageError> {
+        let redis_conn = self
+            .get_redis_conn()
+            .map_err(|err| errors::StorageError::RedisError(err))?;
 
-    use super::{ReverseLookupInterface, Store};
-    use crate::{
-        connection,
-        errors::{self, CustomResult},
-        types::storage::{
-            enums,
-            reverse_lookup::{ReverseLookup, ReverseLookupNew},
-        },
-    };
+        let created_rev_lookup = ReverseLookup {
+            lookup_id: new.lookup_id.clone(),
+            sk_id: new.sk_id.clone(),
+            pk_id: new.pk_id.clone(),
+            source: new.source.clone(),
+            updated_by: storage_scheme.to_string(),
+        };
 
-    #[async_trait::async_trait]
-    impl ReverseLookupInterface for Store {
-        #[instrument(skip_all)]
-        async fn insert_reverse_lookup(
-            &self,
-            new: ReverseLookupNew,
-            _storage_scheme: enums::MerchantStorageScheme,
-        ) -> CustomResult<ReverseLookup, errors::StorageError> {
-            let conn = connection::pg_connection_write(self).await?;
-            new.insert(&conn).await.map_err(Into::into).into_report()
+        let ttl = self.ttl_for_kv.saturating_add(120);
+
+        created_rev_lookup
+            .check_for_constraints(&redis_conn)
+            .await
+            .map_err(|err| err.to_redis_failed_response(&created_rev_lookup.lookup_id))?;
+
+        match redis_conn
+            .serialize_and_set_key_if_not_exist(
+                &format!("reverse_lookup_{}", &created_rev_lookup.lookup_id),
+                &created_rev_lookup,
+                Some(ttl.into()),
+            )
+            .await
+            .map_err(|err| err.to_redis_failed_response(&created_rev_lookup.lookup_id))
+        {
+            Ok(SetnxReply::KeySet) => Ok(created_rev_lookup),
+            Ok(SetnxReply::KeyNotSet) => Err(errors::StorageError::DuplicateValue {
+                entity: "reverse_lookup",
+                key: Some(created_rev_lookup.lookup_id.clone()),
+            })
+            .into_report(),
+            Err(er) => Err(er).change_context(errors::StorageError::KVError),
         }
+    }
 
-        #[instrument(skip_all)]
-        async fn get_lookup_by_lookup_id(
-            &self,
-            id: &str,
-            _storage_scheme: enums::MerchantStorageScheme,
-        ) -> CustomResult<ReverseLookup, errors::StorageError> {
+    #[instrument(skip_all)]
+    async fn get_lookup_by_lookup_id(
+        &self,
+        id: &str,
+        _storage_scheme: enums::MerchantStorageScheme,
+    ) -> CustomResult<ReverseLookup, errors::StorageError> {
+        let database_call = || async {
             let conn = connection::pg_connection_read(self).await?;
             ReverseLookup::find_by_lookup_id(id, &conn)
                 .await
                 .map_err(Into::into)
                 .into_report()
-        }
-    }
-}
+        };
 
-#[cfg(feature = "kv_store")]
-mod storage {
-    use error_stack::{IntoReport, ResultExt};
-    use redis_interface::SetnxReply;
-    use router_env::{instrument, tracing};
-    use storage_impl::redis::kv_store::{kv_wrapper, KvOperation};
+        let redis_fut = async {
+            kv_wrapper(
+                self,
+                KvOperation::<ReverseLookup>::Get,
+                format!("reverse_lookup_{id}"),
+            )
+            .await?
+            .try_into_get()
+        };
 
-    use super::{ReverseLookupInterface, Store};
-    use crate::{
-        connection,
-        core::errors::utils::RedisErrorExt,
-        errors::{self, CustomResult},
-        types::storage::{
-            enums, kv,
-            reverse_lookup::{ReverseLookup, ReverseLookupNew},
-        },
-        utils::db_utils,
-    };
-
-    #[async_trait::async_trait]
-    impl ReverseLookupInterface for Store {
-        #[instrument(skip_all)]
-        async fn insert_reverse_lookup(
-            &self,
-            new: ReverseLookupNew,
-            storage_scheme: enums::MerchantStorageScheme,
-        ) -> CustomResult<ReverseLookup, errors::StorageError> {
-            match storage_scheme {
-                enums::MerchantStorageScheme::PostgresOnly => {
-                    let conn = connection::pg_connection_write(self).await?;
-                    new.insert(&conn).await.map_err(Into::into).into_report()
-                }
-                enums::MerchantStorageScheme::RedisKv => {
-                    let created_rev_lookup = ReverseLookup {
-                        lookup_id: new.lookup_id.clone(),
-                        sk_id: new.sk_id.clone(),
-                        pk_id: new.pk_id.clone(),
-                        source: new.source.clone(),
-                        updated_by: storage_scheme.to_string(),
-                    };
-                    let redis_entry = kv::TypedSql {
-                        op: kv::DBOperation::Insert {
-                            insertable: kv::Insertable::ReverseLookUp(new),
-                        },
-                    };
-
-                    match kv_wrapper::<ReverseLookup, _, _>(
-                        self,
-                        KvOperation::SetNx(&created_rev_lookup, redis_entry),
-                        format!("reverse_lookup_{}", &created_rev_lookup.lookup_id),
-                    )
-                    .await
-                    .map_err(|err| err.to_redis_failed_response(&created_rev_lookup.lookup_id))?
-                    .try_into_setnx()
-                    {
-                        Ok(SetnxReply::KeySet) => Ok(created_rev_lookup),
-                        Ok(SetnxReply::KeyNotSet) => Err(errors::StorageError::DuplicateValue {
-                            entity: "reverse_lookup",
-                            key: Some(created_rev_lookup.lookup_id.clone()),
-                        })
-                        .into_report(),
-                        Err(er) => Err(er).change_context(errors::StorageError::KVError),
-                    }
-                }
-            }
-        }
-
-        #[instrument(skip_all)]
-        async fn get_lookup_by_lookup_id(
-            &self,
-            id: &str,
-            storage_scheme: enums::MerchantStorageScheme,
-        ) -> CustomResult<ReverseLookup, errors::StorageError> {
-            let database_call = || async {
-                let conn = connection::pg_connection_read(self).await?;
-                ReverseLookup::find_by_lookup_id(id, &conn)
-                    .await
-                    .map_err(Into::into)
-                    .into_report()
-            };
-
-            match storage_scheme {
-                enums::MerchantStorageScheme::PostgresOnly => database_call().await,
-                enums::MerchantStorageScheme::RedisKv => {
-                    let redis_fut = async {
-                        kv_wrapper(
-                            self,
-                            KvOperation::<ReverseLookup>::Get,
-                            format!("reverse_lookup_{id}"),
-                        )
-                        .await?
-                        .try_into_get()
-                    };
-
-                    Box::pin(db_utils::try_redis_get_else_try_database_get(
-                        redis_fut,
-                        database_call,
-                    ))
-                    .await
-                }
-            }
-        }
+        Box::pin(db_utils::try_redis_get_else_try_database_get(
+            redis_fut,
+            database_call,
+        ))
+        .await
     }
 }
 

--- a/crates/storage_impl/src/lib.rs
+++ b/crates/storage_impl/src/lib.rs
@@ -140,7 +140,7 @@ pub struct KVRouterStore<T: DatabaseStore> {
     router_store: RouterStore<T>,
     drainer_stream_name: String,
     drainer_num_partitions: u8,
-    ttl_for_kv: u32,
+    pub ttl_for_kv: u32,
     pub request_id: Option<String>,
 }
 

--- a/crates/storage_impl/src/redis/kv_store.rs
+++ b/crates/storage_impl/src/redis/kv_store.rs
@@ -166,11 +166,11 @@ where
             KvOperation::SetNx(value, sql) => {
                 logger::debug!(kv_operation= %operation, value = ?value);
 
+                value.check_for_constraints(&redis_conn).await?;
+
                 let result = redis_conn
                     .serialize_and_set_key_if_not_exist(key, value, Some(ttl.into()))
                     .await?;
-
-                value.check_for_constraints(&redis_conn).await?;
 
                 if matches!(result, redis_interface::SetnxReply::KeySet) {
                     store


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->
- [x] Enhancement


## Description
<!-- Describe your changes in detail -->
Move ReverseLookup table to Redis only.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
- Affected Tables:  `ReverseLookup`
- Removed Reverselookup from storing in the DB.
- Kept the drainer and fallback to DB code in place to make it backwards compatible

After the transition is done, we will have two subsequent tasks to remove the redundant code
- [ ]  Remove Drainer code for draining ReverseLookup
- [ ] Remove DB fallback for Reverselookup

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
- Enable KV for a merchant 
```
curl --location 'http://localhost:8080/accounts/merchant_1710746068/kv' \
--header 'Content-Type: application/json' \
--header 'api-key: test_admin' \
--data '{
  "kv_enabled": true
}'
```
### Payments
- Make a payment
```
curl --location 'http://localhost:8080/payments' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: dev_N1nUguE0Mue3z1CrAMAt5ZahpeFGVcwzuiBM9mM6DR9ClR4r5uFrKfI7UcdDnToM' \
--data-raw '{
    "amount": 10000,
    "currency": "USD",
    "confirm": true,
    "capture_method": "automatic",
    "customer_id": "HScustomer1234",
    "email": "p143@example.com",
    "amount_to_capture": 10000,
    "description": "Its my first payment request",
    "capture_on": "2022-09-10T10:11:12Z",
    "return_url": "https://google.com",
    "name": "Preetam",
    "phone": "999999999",
    "setup_future_usage": "off_session",
    "phone_country_code": "+65",
    "authentication_type": "no_three_ds",
    "payment_method": "card",
    "payment_method_type": "debit",
    "payment_method_data": {
        "card": {
            "card_number": "4242424242424242",
            "card_exp_month": "03",
            "card_exp_year": "2030",
            "card_holder_name": "joseph Doe",
            "card_cvc": "737"
        }
    },
    "connector_metadata": {
        "noon": {
            "order_category": "applepay"
        }
    },
    "browser_info": {
        "user_agent": "Mozilla\/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/70.0.3538.110 Safari\/537.36",
        "accept_header": "text\/html,application\/xhtml+xml,application\/xml;q=0.9,image\/webp,image\/apng,*\/*;q=0.8",
        "language": "nl-NL",
        "color_depth": 24,
        "screen_height": 723,
        "screen_width": 1536,
        "time_zone": 0,
        "java_enabled": true,
        "java_script_enabled": true,
        "ip_address": "128.0.0.1"
    },
    "billing": {
        "address": {
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "city": "San Fransico",
            "state": "California",
            "zip": "94122",
            "country": "US",
            "first_name": "preetam",
            "last_name": "revankar"
        },
        "phone": {
            "number": "8056594427",
            "country_code": "+91"
        }
    },
    "shipping": {
        "address": {
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "city": "San Fransico",
            "state": "California",
            "zip": "94122",
            "country": "US",
            "first_name": "joseph",
            "last_name": "Doe"
        },
        "phone": {
            "number": "8056594427",
            "country_code": "+91"
        }
    },
    "order_details": [
        {
            "product_name": "Apple iphone 15",
            "quantity": 1,
            "amount": 6540,
            "account_name": "transaction_processing"
        }
    ],
    "statement_descriptor_name": "joseph",
    "statement_descriptor_suffix": "JS",
    "metadata": {
        "udf1": "value1",
        "new_customer": "true",
        "login_date": "2019-09-10T10:11:12Z"
    }
}'
```
- Retrieve the Payment 
```
curl --location 'http://localhost:8080/payments/pay_yIItoIkIkBahoaa03w6R?expand_attempts=true' \
--header 'Accept: application/json' \
--header 'api-key: dev_N1nUguE0Mue3z1CrAMAt5ZahpeFGVcwzuiBM9mM6DR9ClR4r5uFrKfI7UcdDnToM'
```

### Refunds
- Create a refund
```
curl --location 'http://localhost:8080/refunds' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: dev_N1nUguE0Mue3z1CrAMAt5ZahpeFGVcwzuiBM9mM6DR9ClR4r5uFrKfI7UcdDnToM' \
--data '{
    "payment_id": "pay_yIItoIkIkBahoaa03w6R",
    "amount": 600,
    "reason": "Customer returned product",
    "refund_type": "instant",
    "metadata": {
        "udf1": "value1",
        "new_customer": "true",
        "login_date": "2019-09-10T10:11:12Z"
    }
}'
```
- Retrieve the Refund
```
curl --location 'http://localhost:8080/refunds/ref_1CRSbKgrKWw9B4tKP1Hz' \
--header 'Accept: application/json' \
--header 'api-key: dev_N1nUguE0Mue3z1CrAMAt5ZahpeFGVcwzuiBM9mM6DR9ClR4r5uFrKfI7UcdDnToM'
```

Both of these should return 200

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code