### PR TITLE
fix(payment_methods): make `ApplepayPaymentMethod` in payment_method_data column of `payment_attempt` table as json

### DIFF
--- a/crates/api_models/src/payments.rs
+++ b/crates/api_models/src/payments.rs
@@ -1482,18 +1482,14 @@ pub struct AdditionalCardInfo {
 
 #[derive(Debug, Clone, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(rename_all = "snake_case")]
-pub enum Wallets {
-    ApplePay(ApplepayPaymentMethod),
-}
-
-#[derive(Debug, Clone, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
-#[serde(rename_all = "snake_case")]
 pub enum AdditionalPaymentData {
     Card(Box<AdditionalCardInfo>),
     BankRedirect {
         bank_name: Option<api_enums::BankNames>,
     },
-    Wallet(Option<Wallets>),
+    Wallet {
+        apple_pay: Option<ApplepayPaymentMethod>,
+    },
     PayLater {},
     BankTransfer {},
     Crypto {},
@@ -2084,7 +2080,7 @@ where
             | PaymentMethodDataResponse::PayLater {}
             | PaymentMethodDataResponse::Paypal {}
             | PaymentMethodDataResponse::Upi {}
-            | PaymentMethodDataResponse::Wallet(_)
+            | PaymentMethodDataResponse::Wallet {}
             | PaymentMethodDataResponse::BankTransfer {}
             | PaymentMethodDataResponse::Voucher {} => {
                 payment_method_data_response.serialize(serializer)
@@ -2101,7 +2097,7 @@ pub enum PaymentMethodDataResponse {
     #[serde(rename = "card")]
     Card(Box<CardResponse>),
     BankTransfer {},
-    Wallet(Option<Wallets>),
+    Wallet {},
     PayLater {},
     Paypal {},
     BankRedirect {},
@@ -3040,7 +3036,7 @@ impl From<AdditionalPaymentData> for PaymentMethodDataResponse {
         match payment_method_data {
             AdditionalPaymentData::Card(card) => Self::Card(Box::new(CardResponse::from(*card))),
             AdditionalPaymentData::PayLater {} => Self::PayLater {},
-            AdditionalPaymentData::Wallet(wallet) => Self::Wallet(wallet),
+            AdditionalPaymentData::Wallet { .. } => Self::Wallet {},
             AdditionalPaymentData::BankRedirect { .. } => Self::BankRedirect {},
             AdditionalPaymentData::Crypto {} => Self::Crypto {},
             AdditionalPaymentData::BankDebit {} => Self::BankDebit {},

--- a/crates/router/src/core/payments/helpers.rs
+++ b/crates/router/src/core/payments/helpers.rs
@@ -3527,13 +3527,11 @@ pub async fn get_additional_payment_data(
         }
         api_models::payments::PaymentMethodData::Wallet(wallet) => match wallet {
             api_models::payments::WalletData::ApplePay(apple_pay_wallet_data) => {
-                api_models::payments::AdditionalPaymentData::Wallet(Some(
-                    api_models::payments::Wallets::ApplePay(
-                        apple_pay_wallet_data.payment_method.to_owned(),
-                    ),
-                ))
+                api_models::payments::AdditionalPaymentData::Wallet {
+                    apple_pay: Some(apple_pay_wallet_data.payment_method.to_owned()),
+                }
             }
-            _ => api_models::payments::AdditionalPaymentData::Wallet(None),
+            _ => api_models::payments::AdditionalPaymentData::Wallet { apple_pay: None },
         },
         api_models::payments::PaymentMethodData::PayLater(_) => {
             api_models::payments::AdditionalPaymentData::PayLater {}


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
make ApplepayPaymentMethod in payment_method_data column of payment_attempt table as json because retrieve payment fails for the old payments for which the payment_method_data in the payment_attempt table was stored as {"wallet": {}}

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
Closes #4153.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Checkout to old commit where we were storing the `{"wallet": {}}` for apple pay in the `payment_attempt`  table
<img width="1450" alt="image" src="https://github.com/juspay/hyperswitch/assets/83439957/15cbd523-f2cb-4275-8d61-897ae958d8c5">

Make a payment create call for apple pay
```
{
    "amount": 650,
    "currency": "USD",
    "confirm": false,
    "business_country": "US",
    "business_label": "default",
    "amount_to_capture": 650,
    "customer_id": "custhype1232",
    "capture_method": "automatic",
    "capture_on": "2022-09-10T10:11:12Z",
    "authentication_type": "three_ds",
    "return_url": "https://google.com",
    "email": "something@gmail.com",
    "name": "Joseph Doe",
    "phone": "999999999",
    "phone_country_code": "+65",
    "description": "Its my first payment request",
    "statement_descriptor_name": "Juspay",
    "statement_descriptor_suffix": "Router",
    "payment_method": "wallet",
    "payment_method_type": "apple_pay",
    "billing": {
        "address": {
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "city": "San Fransico",
            "state": "California",
            "zip": "94122",
            "country": "US",
            "first_name": "joseph",
            "last_name": "Doe"
        },
        "phone": {
            "number": "8056594427",
            "country_code": "+91"
        }
    },
    "payment_method_data": {
        "wallet": {
            "apple_pay": {
                "payment_data":"payment_data",
                "payment_method": {
                    "display_name": "Visa 0326",
                    "network": "Mastercard",
                    "type": "debit"
                },
                "transaction_identifier": "55CC32D7BF7890B9064433F15B9F23F849CF84AFD01E4E65DD8ADE306300E9D8"
            }
        }
    }
}
```
Checkout to the latest main and retrieve the payment with the `payment_id`
```
curl --location 'http://localhost:8080/payments/pay_rhuPyFWzD4SM0spkpjXi' \
--header 'Accept: application/json' \
--header 'api-key: dev_jhuZ9QNa1RSObflo1fGgAc7ZsZDGLQ20XKErfgB3uXyfOZEtAWM73JI8QbD2t9j0' \
--data ''
```
<img width="1425" alt="image" src="https://github.com/juspay/hyperswitch/assets/83439957/0d7bfa20-b980-4376-a0f3-10cd8671ba0a">
<img width="1534" alt="image" src="https://github.com/juspay/hyperswitch/assets/83439957/29b13f8d-36f2-454a-af82-51e95bb5492c">


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
