### PR TITLE
fix(router): handle redirection to return_url from nested iframe in separate 3ds flow

### DIFF
--- a/crates/router/src/core/payments.rs
+++ b/crates/router/src/core/payments.rs
@@ -1100,7 +1100,7 @@ impl<Ctx: PaymentMethodRetrieve> PaymentRedirectFlow<Ctx> for PaymentAuthenticat
                             try {{
                                 // if inside iframe, send post message to parent for redirection
                                 if (window.self !== window.parent) {{
-                                    window.parent.postMessage({{openurl: return_url}}, '*')
+                                    window.top.postMessage({{openurl: return_url}}, '*')
                                 // if parent, redirect self to return_url
                                 }} else {{
                                     window.location.href = return_url


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
handle redirection to return_url from nested iframe in separate 3ds flow

Currently, we are opening bank page in nested iframe in SDK. So, the redirection post message should be sent to top level instead of immediate parent. 

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
Tested Manually
1. Sanity Separate 3ds flow testing, redirecting properly to return_url of merchant


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
