### PR TITLE
fix(core): make eci in AuthenticationData optional

### DIFF
--- a/crates/router/src/connector/checkout/transformers.rs
+++ b/crates/router/src/connector/checkout/transformers.rs
@@ -391,7 +391,7 @@ impl TryFrom<&CheckoutRouterData<&types::PaymentsAuthorizeRouterData>> for Payme
             enums::AuthenticationType::ThreeDs => CheckoutThreeDS {
                 enabled: true,
                 force_3ds: true,
-                eci: authentication_data.map(|auth| auth.eci.clone()),
+                eci: authentication_data.and_then(|auth| auth.eci.clone()),
                 cryptogram: authentication_data.map(|auth| auth.cavv.clone()),
                 xid: authentication_data.map(|auth| auth.threeds_server_transaction_id.clone()),
                 version: authentication_data.map(|auth| auth.message_version.clone()),

--- a/crates/router/src/core/payments/types.rs
+++ b/crates/router/src/core/payments/types.rs
@@ -379,7 +379,7 @@ impl SurchargeMetadata {
 
 #[derive(Debug, Clone)]
 pub struct AuthenticationData {
-    pub eci: String,
+    pub eci: Option<String>,
     pub cavv: String,
     pub threeds_server_transaction_id: String,
     pub message_version: String,
@@ -409,14 +409,8 @@ impl ForeignTryFrom<&storage::Authentication> for AuthenticationData {
                 .get_required_value("cavv")
                 .change_context(errors::ApiErrorResponse::InternalServerError)
                 .attach_printable("cavv must not be null when authentication_status is success")?;
-            let eci = authentication
-                .eci
-                .clone()
-                .get_required_value("eci")
-                .change_context(errors::ApiErrorResponse::InternalServerError)
-                .attach_printable("eci must not be null when authentication_status is success")?;
             Ok(Self {
-                eci,
+                eci: authentication.eci.clone(),
                 cavv,
                 threeds_server_transaction_id,
                 message_version: message_version.to_string(),


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
After authentication is successful, authorization call must be made to the payment connector with authentication results to complete the transaction.

`eci`(e commerce indicator) is one of authentication result values. This `eci` is only returned during challenge flow and not in frictionless flow So had to make it an optional field.


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Manual

Tested the external authenticaiton flow.

1. Create a merchant with checkout payment connector and threedsecure.io 3ds connector.
Create merchant
```
curl --location 'http://localhost:8080/accounts' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: test_admin' \
--data-raw '{
    "merchant_id": "postman_merchant_GHAction_4e597812-7532-4497-b9c2-327975aab5fb",
    "locker_id": "m0010",
    "merchant_name": "NewAge Retailer",
    "primary_business_details": [
        {
            "country": "US",
            "business": "default"
        }
    ],
    "merchant_details": {
        "primary_contact_person": "John Test",
        "primary_email": "JohnTest@test.com",
        "primary_phone": "sunt laborum",
        "secondary_contact_person": "John Test2",
        "secondary_email": "JohnTest2@test.com",
        "secondary_phone": "cillum do dolor id",
        "website": "www.example.com",
        "about_business": "Online Retail with a wide selection of organic products for North America",
        "address": {
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "city": "San Fransico",
            "state": "California",
            "zip": "94122",
            "country": "US"
        }
    },
    "return_url": "https://duck.com",
    "webhook_details": {
        "webhook_version": "1.0.1",
        "webhook_username": "ekart_retail",
        "webhook_password": "password_ekart@123",
        "payment_created_enabled": true,
        "payment_succeeded_enabled": true,
        "payment_failed_enabled": true
    },
    "sub_merchants_enabled": false,
    "metadata": {
        "city": "NY",
        "unit": "245"
    }
}'
```

Update BusinessProfile
```
curl --location 'http://localhost:8080/account/postman_merchant_GHAction_c44d9457-6713-44d4-a028-99f33ed58e3d/business_profile/pro_wosSRDWs0Gcm9yA6w0gM' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: test_admin' \
--data '{
    "authentication_connector_details": {
        "authentication_connectors": ["threedsecureio"],
        "three_ds_requestor_url": "https://google.com"
    }
}'
```

Create checkout connector
```
curl --location 'http://localhost:8080/account/postman_merchant_GHAction_c44d9457-6713-44d4-a028-99f33ed58e3d/connectors' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: test_admin' \
--data '{
    "connector_type": "fiz_operations",
    "connector_name": "checkout",
    "connector_account_details": {
        "auth_type": "SignatureKey",
        "api_key" : "{{}}",
        "api_secret" : "{{}}",
        "key1" : "{{}}"
    },
    "test_mode": false,
    "disabled": false,
    "business_country": "US",
    "business_label": "default",
    "payment_methods_enabled": [
        {
            "payment_method": "card",
            "payment_method_types": [
                {
                    "payment_method_type": "credit",
                    "card_networks": [
                        "Visa",
                        "Mastercard"
                    ],
                    "minimum_amount": 1,
                    "maximum_amount": 68607706,
                    "recurring_enabled": true,
                    "installment_payment_enabled": true
                },
                {
                    "payment_method_type": "debit",
                    "card_networks": [
                        "Visa",
                        "Mastercard"
                    ],
                    "minimum_amount": 1,
                    "maximum_amount": 68607706,
                    "recurring_enabled": true,
                    "installment_payment_enabled": true
                }
            ]
        },
        {
            "payment_method": "wallet",
            "payment_method_types": [
                {
                    "payment_method_type": "paypal",
                    "payment_experience": "redirect_to_url",
                    "minimum_amount": 1,
                    "maximum_amount": 68607706,
                    "recurring_enabled": false,
                    "installment_payment_enabled": false
                }
            ]
        }
    ],
    "metadata": {
        "acquirer_bin": "438309",
        "acquirer_merchant_id": "00002000000",
        "city": "NY",
        "unit": "245"
    }
}'
``` 

Create threedsecure.io connector
```
curl --location 'http://localhost:8080/account/postman_merchant_GHAction_c44d9457-6713-44d4-a028-99f33ed58e3d/connectors' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: test_admin' \
--data '{
    "connector_type": "authentication_processor",
    "business_country": "US",
    "business_label": "default",
    "connector_name": "threedsecureio",
    "connector_account_details": {
        "auth_type": "HeaderKey",
        "api_key": "{{api_key}}"
    },
    "test_mode": true,
    "disabled": false,
    "metadata": {
        "mcc": "5411",
        "merchant_country_code": "840",
        "merchant_name": "Dummy Merchant"
    }
}'
```

2. Create Payment with `request_external_three_ds_authentication` set to true.
```
curl --location 'http://localhost:8080/payments' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: {{api-key}}' \
--data-raw '{
    "amount": 6540,
    "currency": "USD",
    "confirm": false,
    "capture_method": "automatic",
    "capture_on": "2022-09-10T10:11:12Z",
    "amount_to_capture": 6540,
    "customer_id": "StripeCustomer",
    "email": "guest@example.com",
    "name": "John Doe",
    "phone": "999999999",
    "phone_country_code": "+65",
    "description": "Its my first payment request",
    "authentication_type": "three_ds",
    "return_url": "https://duck.com",
    "billing": {
        "address": {
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "city": "San Fransico",
            "state": "California",
            "zip": "94122",
            "country": "US",
            "first_name": "PiX"
        }
    },
    "shipping": {
        "address": {
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "city": "San Fransico",
            "state": "California",
            "zip": "94122",
            "country": "US",
            "first_name": "PiX"
        }
    },
    "request_external_three_ds_authentication": true,
    "statement_descriptor_name": "joseph",
    "statement_descriptor_suffix": "JS",
    "metadata": {
        "udf1": "value1",
        "new_customer": "true",
        "login_date": "2019-09-10T10:11:12Z"
    }
}'
```

3. Confirm the payment:
```
curl --location 'http://localhost:8080/payments/pay_eEBCYU9RdKdrJWJPVE2g/confirm' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: {{publishable_key}}' \
--data '{
    "browser_info": {
        "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Safari/537.36",
        "accept_header": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8",
        "language": "nl-NL",
        "color_depth": 24,
        "screen_height": 723,
        "screen_width": 1536,
        "time_zone": 0,
        "java_enabled": true,
        "java_script_enabled": true,
        "ip_address": "115.99.183.2"
    },
    "client_secret": "pay_eEBCYU9RdKdrJWJPVE2g_secret_xoDIcgprj9jyhkDBpyHY",
    "payment_method": "card",
    "payment_method_data": {
        "card": {
            "card_number": "4000100511112003",
            "card_exp_month": "10",
            "card_exp_year": "25",
            "card_holder_name": "joseph Doe",
            "card_cvc": "123"
        }
    }
}'
```

4. Do the 3ds method collection.

5. Do authenticaition .
```
curl --location 'localhost:8080/payments/pay_eEBCYU9RdKdrJWJPVE2g/3ds/authentication' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: {{publishable_key}}' \
--data '{
    "client_secret": "pay_eEBCYU9RdKdrJWJPVE2g_secret_xoDIcgprj9jyhkDBpyHY",
    "device_channel": "BRW",
    "threeds_method_comp_ind": "Y"
}'
```
Should get the below response:
<img width="994" alt="Screenshot 2024-03-25 at 1 43 18 PM" src="https://github.com/juspay/hyperswitch/assets/61539176/4a45f592-06ed-4e39-ae5d-0b530444f930">


7. Do authorization.
```
curl --location 'http://localhost:8080/payments/{{payment_id}}/{{merchant_id}}/authorize/checkout' \
--header 'Content-Type: application/json' \
--data '{
    
}'
```

8. Do PSync. Should get failed status with error message `card_number_invalid`
```
{
    "payment_id": "pay_eEBCYU9RdKdrJWJPVE2g",
    "merchant_id": "postman_merchant_GHAction_c44d9457-6713-44d4-a028-99f33ed58e3d",
    "status": "failed",
    "amount": 6540,
    "net_amount": 6540,
    "amount_capturable": 0,
    "amount_received": null,
    "connector": "checkout",
    "client_secret": "pay_eEBCYU9RdKdrJWJPVE2g_secret_xoDIcgprj9jyhkDBpyHY",
    "created": "2024-03-18T09:39:47.910Z",
    "currency": "USD",
    "customer_id": "StripeCustomer",
    "description": "Its my first payment request",
    "refunds": null,
    "disputes": null,
    "mandate_id": null,
    "mandate_data": null,
    "setup_future_usage": null,
    "off_session": null,
    "capture_on": null,
    "capture_method": "automatic",
    "payment_method": "card",
    "payment_method_data": {
        "card": {
            "last4": "1072",
            "card_type": null,
            "card_network": null,
            "card_issuer": null,
            "card_issuing_country": null,
            "card_isin": "300010",
            "card_extended_bin": "30001008",
            "card_exp_month": "10",
            "card_exp_year": "25",
            "card_holder_name": "joseph Doe"
        },
        "billing": {
            "address": {
                "city": "San Fransico",
                "country": "US",
                "line1": "1467",
                "line2": "Harrison Street",
                "line3": "Harrison Street",
                "zip": "94122",
                "state": "California",
                "first_name": "PiX",
                "last_name": null
            },
            "phone": {
                "number": null,
                "country_code": null
            },
            "email": null
        }
    },
    "payment_token": "token_ZsNzi1orqGgkJb8EgV1s",
    "shipping": {
        "address": {
            "city": "San Fransico",
            "country": "US",
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "zip": "94122",
            "state": "California",
            "first_name": "PiX",
            "last_name": null
        },
        "phone": {
            "number": null,
            "country_code": null
        },
        "email": null
    },
    "billing": {
        "address": {
            "city": "San Fransico",
            "country": "US",
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "zip": "94122",
            "state": "California",
            "first_name": "PiX",
            "last_name": null
        },
        "phone": {
            "number": null,
            "country_code": null
        },
        "email": null
    },
    "order_details": null,
    "email": "guest@example.com",
    "name": "John Doe",
    "phone": "999999999",
    "return_url": "https://duck.com/",
    "authentication_type": "three_ds",
    "statement_descriptor_name": "joseph",
    "statement_descriptor_suffix": "JS",
    "next_action": null,
    "cancellation_reason": null,
    "error_code": "card_number_invalid",
    "error_message": "card_number_invalid",
    "unified_code": null,
    "unified_message": null,
    "payment_experience": null,
    "payment_method_type": null,
    "connector_label": null,
    "business_country": null,
    "business_label": "default",
    "business_sub_label": null,
    "allowed_payment_method_types": null,
    "ephemeral_key": null,
    "manual_retry_allowed": true,
    "connector_transaction_id": "b0cbdb6d-f61e-4739-a847-0f1e288c1e14",
    "frm_message": null,
    "metadata": {
        "udf1": "value1",
        "login_date": "2019-09-10T10:11:12Z",
        "new_customer": "true"
    },
    "connector_metadata": null,
    "feature_metadata": null,
    "reference_id": null,
    "payment_link": null,
    "profile_id": "pro_wosSRDWs0Gcm9yA6w0gM",
    "surcharge_details": null,
    "attempt_count": 1,
    "merchant_decision": null,
    "merchant_connector_id": "mca_0Sa2ZLqjh2QSsIjJWjO3",
    "incremental_authorization_allowed": false,
    "authorization_count": null,
    "incremental_authorizations": null,
    "external_authentication_details": {
        "authentication_flow": "challenge",
        "electronic_commerce_indicator": "05",
        "status": "success",
        "ds_transaction_id": "c1061ffd-a13b-4bed-905a-379a4cbc9229",
        "version": "2.1.0",
        "error_code": null,
        "error_message": null
    },
    "external_3ds_authentication_attempted": true,
    "expires_on": "2024-03-18T09:54:47.910Z",
    "fingerprint": null,
    "payment_method_id": null,
    "payment_method_status": null
}
```



## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
