### PR TITLE
build(docker): add web, control-center in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -122,6 +122,37 @@ services:
     labels:
       logs: "promtail"
 
+  hyperswitch-web:
+    ports:
+      - "9050:9050"
+      - "9060:9060"
+      - "5252:5252"
+    build:
+      context: ./docker
+      dockerfile: web.Dockerfile
+    networks:
+      - router_net
+    environment:
+      - HYPERSWITCH_SERVER_URL=http://localhost:8080
+    depends_on:
+      hyperswitch-server:
+        condition: service_started
+
+  hyperswitch-control-center:
+    image: juspaydotin/hyperswitch-control-center
+    ports:
+      - "9000:9000"
+    networks:
+      - router_net
+    environment:
+      - apiBaseUrl=http://localhost:8080
+      - sdkBaseUrl=http://localhost:9050
+    depends_on:
+      hyperswitch-server:
+        condition: service_started
+      hyperswitch-web:
+        condition: service_started
+
   ### Clustered Redis setup
   redis-cluster:
     image: redis:7

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -132,8 +132,14 @@ services:
       dockerfile: web.Dockerfile
     networks:
       - router_net
+    env_file:
+      - ./.env
     environment:
-      - HYPERSWITCH_SERVER_URL=http://localhost:8080
+      - HYPERSWITCH_PUBLISHABLE_KEY=$HYPERSWITCH_PUBLISHABLE_KEY
+      - HYPERSWITCH_SECRET_KEY=$HYPERSWITCH_SECRET_KEY
+      - HYPERSWITCH_SERVER_URL=${HYPERSWITCH_SERVER_URL:-http://hyperswitch-server:8080}
+      - HYPERSWITCH_CLIENT_URL=${HYPERSWITCH_CLIENT_URL:-http://hyperswitch-web:9050}
+      - SELF_SERVER_URL=${SELF_SERVER_URL:-http://hyperswitch-web:5252}
     depends_on:
       hyperswitch-server:
         condition: service_started
@@ -145,8 +151,8 @@ services:
     networks:
       - router_net
     environment:
-      - apiBaseUrl=http://localhost:8080
-      - sdkBaseUrl=http://localhost:9050
+      - apiBaseUrl=http://hyperswitch-server:8080
+      - sdkBaseUrl=http://hyperswitch-web:9050
     depends_on:
       hyperswitch-server:
         condition: service_started

--- a/docker/web.Dockerfile
+++ b/docker/web.Dockerfile
@@ -1,0 +1,18 @@
+FROM node:latest
+
+RUN npm install concurrently -g
+
+WORKDIR /app
+
+RUN git clone https://github.com/juspay/hyperswitch-web .
+
+RUN sed -i '/hot: true,/a \  host: "0.0.0.0",' webpack.dev.js
+RUN sed -i '/hot: true,/a \  host: "0.0.0.0",' Hyperswitch-React-Demo-App/webpack.dev.js
+
+RUN npm install
+
+EXPOSE 9050
+EXPOSE 5252
+EXPOSE 9060
+
+CMD concurrently "npm run start:dev" "npm run start:playground"


### PR DESCRIPTION
Added hyperswitch-web and hyperswitch-control-center in docker-compose

## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
Two new services were added to start the SDK, demo, and control center automatically within docker-compose.

Solves #4110 

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [x] This PR modifies application configuration/environment variables
