### PR TITLE
 fix(docker): Integrate Hyperswitch Web Client and Control Center into Docker Compose Setup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,7 +51,7 @@ services:
     ports:
       - "8080:8080"
     networks:
-      - router_net
+      - hyperswitch_net
     volumes:
       - ./config:/local/config
       - ./files:/local/bin/files
@@ -63,6 +63,21 @@ services:
       retries: 3
       start_period: 5s
       timeout: 10s
+
+  hyperswitch-web:
+    ports:
+      - "9050:9050"
+      - "9060:9060"
+      - "5252:5252"
+    build:
+      context: ./docker
+      dockerfile: web.Dockerfile
+    networks:
+      - hyperswitch_net
+    environment:
+      - HYPERSWITCH_SERVER_URL=http://hyperswitch-server:8080
+    depends_on:
+      - hyperswitch-server
 
   hyperswitch-producer:
     image: juspaydotin/hyperswitch-producer:standalone
@@ -80,6 +95,23 @@ services:
         condition: service_healthy
     labels:
       logs: "promtail"
+
+  hyperswitch-control-center:
+    image: juspaydotin/hyperswitch-control-center
+    ports:
+      - "9000:9000"
+    networks:
+      - hyperswitch_net
+    environment:
+      - apiBaseUrl=http://hyperswitch-server:8080
+      - sdkBaseUrl=http://hyperswitch-web:9050
+    depends_on:
+      - hyperswitch-server
+      - hyperswitch-web
+
+  networks:
+    hyperswitch_net:
+    #network configurations here if required
 
   hyperswitch-consumer:
     image: juspaydotin/hyperswitch-consumer:standalone


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
This docker-compose.yml file now includes code for setting up the hyperswitch-web and hyperswitch-control-center services along with the existing hyperswitch-server service. These services are configured to communicate with each other within the hyperswitch_net network, ensuring better isolation and reliability.

### Additional Changes

- [x] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [x] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
