### PR TITLE
build(router_env): obtain workspace member package names from cargo_metadata more deterministically

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1457,9 +1457,9 @@ dependencies = [
 
 [[package]]
 name = "cargo_metadata"
-version = "0.15.4"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eee4243f1f26fc7a42710e7439c149e2b10b05472f88090acce52632f231a73a"
+checksum = "2d886547e41f740c616ae73108f6eb70afe6d940c7bc697cb30f13daec073037"
 dependencies = [
  "camino",
  "cargo-platform",
@@ -5276,7 +5276,7 @@ dependencies = [
 name = "router_env"
 version = "0.1.0"
 dependencies = [
- "cargo_metadata 0.15.4",
+ "cargo_metadata 0.18.1",
  "config",
  "error-stack",
  "gethostname",

--- a/crates/router_env/Cargo.toml
+++ b/crates/router_env/Cargo.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 license.workspace = true
 
 [dependencies]
-cargo_metadata = "0.15.4"
+cargo_metadata = "0.18.1"
 config = { version = "0.13.3", features = ["toml"] }
 error-stack = "0.3.1"
 gethostname = "0.4.3"
@@ -34,7 +34,7 @@ vergen = { version = "8.2.1", optional = true, features = ["cargo", "git", "git2
 tokio = { version = "1.36.0", features = ["macros", "rt-multi-thread"] }
 
 [build-dependencies]
-cargo_metadata = "0.15.4"
+cargo_metadata = "0.18.1"
 vergen = { version = "8.2.1", features = ["cargo", "git", "git2", "rustc"], optional = true }
 
 [features]


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [x] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
ORIGINAL PR: https://github.com/juspay/hyperswitch/pull/4139
This PR updates the build script code to obtain cargo workspace member package names to use a better and more deterministic way to do so. 

Previously, we used to perform string manipulation on the package ID format (obtained from the `workspace_members` field in `cargo metadata --format-version=1`), and the package ID format was not stabilized (until recently). The package ID format has been [stabilized](https://github.com/rust-lang/cargo/pull/12914) in Rust 1.77, and the stabilized format breaks our existing build scripts. This PR updates the build script code to instead obtain the workspace member package names using the [`Metadata::workspace_packages()`](https://docs.rs/cargo_metadata/0.18.1/cargo_metadata/struct.Metadata.html#method.workspace_packages) method that the `cargo_metadata` crate provides.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
This would fix builds from breaking once Rust 1.77 is released as the stable version on March 21st, 2024.

Fixes #4137.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
`cargo run` was successful with both Rust 1.76 and 1.77 (although with warnings).

I installed the Rust 1.77 toolchain by following the instructions from the [Rust 1.77.0 pre-release testing](https://blog.rust-lang.org/inside-rust/2024/03/17/1.77.0-prerelease.html) blog post.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
