### PR TITLE
fix(connector): [Trustpay] fix deserialization error for incoming webhook response for trustpay and add error code mapping '800.100.203'

### DIFF
--- a/crates/router/src/connector/trustpay.rs
+++ b/crates/router/src/connector/trustpay.rs
@@ -983,7 +983,7 @@ impl api::IncomingWebhook for Trustpay {
             dispute_stage: api_models::enums::DisputeStage::Dispute,
             connector_dispute_id,
             connector_reason: reason.reason.reject_reason,
-            connector_reason_code: Some(reason.reason.code),
+            connector_reason_code: reason.reason.code,
             challenge_required_by: None,
             connector_status: payment_info.status.to_string(),
             created_at: None,

--- a/crates/router/src/connector/trustpay/transformers.rs
+++ b/crates/router/src/connector/trustpay/transformers.rs
@@ -112,7 +112,7 @@ pub struct Amount {
 #[derive(Default, Debug, Serialize, Deserialize, Eq, PartialEq, Clone)]
 #[serde(rename_all = "PascalCase")]
 pub struct Reason {
-    pub code: String,
+    pub code: Option<String>,
     pub reject_reason: Option<String>,
 }
 
@@ -510,6 +510,7 @@ fn is_payment_failed(payment_status: &str) -> (bool, &'static str) {
         "800.100.172" => (true, "Transaction declined (account blocked)"),
         "800.100.190" => (true, "Transaction declined (invalid configuration data)"),
         "800.100.202" => (true, "Account Closed"),
+        "800.100.203" => (true, "Insufficient Funds"),
         "800.120.100" => (true, "Rejected by throttling"),
         "800.300.102" => (true, "Country blacklisted"),
         "800.300.401" => (true, "Bin blacklisted"),
@@ -823,9 +824,16 @@ fn handle_bank_redirects_sync_response(
             .status_reason_information
             .unwrap_or_default();
         Some(types::ErrorResponse {
-            code: reason_info.reason.code.clone(),
+            code: reason_info
+                .reason
+                .code
+                .clone()
+                .unwrap_or(consts::NO_ERROR_CODE.to_string()),
             // message vary for the same code, so relying on code alone as it is unique
-            message: reason_info.reason.code,
+            message: reason_info
+                .reason
+                .code
+                .unwrap_or(consts::NO_ERROR_MESSAGE.to_string()),
             reason: reason_info.reason.reject_reason,
             status_code,
             attempt_status: None,
@@ -875,9 +883,16 @@ pub fn handle_webhook_response(
             .status_reason_information
             .unwrap_or_default();
         Some(types::ErrorResponse {
-            code: reason_info.reason.code.clone(),
+            code: reason_info
+                .reason
+                .code
+                .clone()
+                .unwrap_or(consts::NO_ERROR_CODE.to_string()),
             // message vary for the same code, so relying on code alone as it is unique
-            message: reason_info.reason.code,
+            message: reason_info
+                .reason
+                .code
+                .unwrap_or(consts::NO_ERROR_MESSAGE.to_string()),
             reason: reason_info.reason.reject_reason,
             status_code,
             attempt_status: None,
@@ -1483,9 +1498,16 @@ fn handle_webhooks_refund_response(
     let error = if utils::is_refund_failure(refund_status) {
         let reason_info = response.status_reason_information.unwrap_or_default();
         Some(types::ErrorResponse {
-            code: reason_info.reason.code.clone(),
+            code: reason_info
+                .reason
+                .code
+                .clone()
+                .unwrap_or(consts::NO_ERROR_CODE.to_string()),
             // message vary for the same code, so relying on code alone as it is unique
-            message: reason_info.reason.code,
+            message: reason_info
+                .reason
+                .code
+                .unwrap_or(consts::NO_ERROR_MESSAGE.to_string()),
             reason: reason_info.reason.reject_reason,
             status_code,
             attempt_status: None,
@@ -1540,9 +1562,16 @@ fn handle_bank_redirects_refund_sync_response(
             .status_reason_information
             .unwrap_or_default();
         Some(types::ErrorResponse {
-            code: reason_info.reason.code.clone(),
+            code: reason_info
+                .reason
+                .code
+                .clone()
+                .unwrap_or(consts::NO_ERROR_CODE.to_string()),
             // message vary for the same code, so relying on code alone as it is unique
-            message: reason_info.reason.code,
+            message: reason_info
+                .reason
+                .code
+                .unwrap_or(consts::NO_ERROR_MESSAGE.to_string()),
             reason: reason_info.reason.reject_reason,
             status_code,
             attempt_status: None,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
- fix deserialization error for incoming webhook response for trustpay 
   made `Code` as optional field
- add error code mapping '800.100.203'

PR raised against main - #4199

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
No testing can be done since it matches error code in production which cant be replicated


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
