### PR TITLE
refactor: add updated field to paymentResponse

### DIFF
--- a/crates/api_models/src/payments.rs
+++ b/crates/api_models/src/payments.rs
@@ -3198,8 +3198,9 @@ pub struct PaymentsResponse {
     pub payment_method_status: Option<common_enums::PaymentMethodStatus>,
 
     /// Date time at which payment was updated
-    #[serde(with = "common_utils::custom_serde::iso8601")]
-    pub updated: PrimitiveDateTime,
+    #[schema(example = "2022-09-10T10:11:12Z")]
+    #[serde(default, with = "common_utils::custom_serde::iso8601::option")]
+    pub updated: Option<PrimitiveDateTime>,
 }
 
 #[derive(Setter, Clone, Default, Debug, PartialEq, serde::Serialize, ToSchema)]

--- a/crates/api_models/src/payments.rs
+++ b/crates/api_models/src/payments.rs
@@ -3196,6 +3196,10 @@ pub struct PaymentsResponse {
     /// Payment Method Status
     #[schema(value_type = Option<PaymentMethodStatus>)]
     pub payment_method_status: Option<common_enums::PaymentMethodStatus>,
+
+    /// Date time at which payment was updated
+    #[serde(with = "common_utils::custom_serde::iso8601")]
+    pub updated: PrimitiveDateTime,
 }
 
 #[derive(Setter, Clone, Default, Debug, PartialEq, serde::Serialize, ToSchema)]

--- a/crates/router/src/core/payments/transformers.rs
+++ b/crates/router/src/core/payments/transformers.rs
@@ -773,7 +773,7 @@ where
                 .set_payment_method_status(payment_data.payment_method_info.map(|info| info.status))
                 .set_customer(customer_details_response.clone())
                 .set_browser_info(payment_attempt.browser_info)
-                .set_updated(payment_intent.modified_at)
+                .set_updated(Some(payment_intent.modified_at))
                 .to_owned(),
             headers,
         ))

--- a/crates/router/src/core/payments/transformers.rs
+++ b/crates/router/src/core/payments/transformers.rs
@@ -773,6 +773,7 @@ where
                 .set_payment_method_status(payment_data.payment_method_info.map(|info| info.status))
                 .set_customer(customer_details_response.clone())
                 .set_browser_info(payment_attempt.browser_info)
+                .set_updated(payment_intent.modified_at)
                 .to_owned(),
             headers,
         ))


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [X] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!--  -->
This change adds the `updated` field to the PaymentResponse.
It takes the value from the `payment_intent.modified_at` field.

### Additional Changes

- [X] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. 
-->
https://github.com/juspay/hyperswitch/blob/97fbc899c12a0c66ac89a7feaa6d45d39239a746/crates/router/src/core/payments/transformers.rs#L792
https://github.com/juspay/hyperswitch/blob/97fbc899c12a0c66ac89a7feaa6d45d39239a746/crates/api_models/src/payments.rs#L3195


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ X] I formatted the code `cargo +nightly fmt --all`
- [X ] I addressed lints thrown by `cargo clippy`
- [ X] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
