### PR TITLE
feat(users): Implemented cookie parsing for auth

### DIFF
--- a/crates/router/src/compatibility/stripe/errors.rs
+++ b/crates/router/src/compatibility/stripe/errors.rs
@@ -427,6 +427,7 @@ impl From<errors::ApiErrorResponse> for StripeErrorCode {
             | errors::ApiErrorResponse::InvalidJwtToken
             | errors::ApiErrorResponse::GenericUnauthorized { .. }
             | errors::ApiErrorResponse::AccessForbidden { .. }
+            | errors::ApiErrorResponse::InvalidCookie
             | errors::ApiErrorResponse::InvalidEphemeralKey => Self::Unauthorized,
             errors::ApiErrorResponse::InvalidRequestUrl
             | errors::ApiErrorResponse::InvalidHttpMethod

--- a/crates/router/src/core/errors/api_error_response.rs
+++ b/crates/router/src/core/errors/api_error_response.rs
@@ -262,7 +262,7 @@ pub enum ApiErrorResponse {
     PaymentMethodDeleteFailed,
     #[error(
         error_type = ErrorType::InvalidRequestError, code = "IR_26",
-        message = "Cookie "
+        message = "Invalid Cookie"
     )]
     InvalidCookie,
 }

--- a/crates/router/src/core/errors/api_error_response.rs
+++ b/crates/router/src/core/errors/api_error_response.rs
@@ -260,6 +260,11 @@ pub enum ApiErrorResponse {
     CurrencyConversionFailed,
     #[error(error_type = ErrorType::InvalidRequestError, code = "IR_25", message = "Cannot delete the default payment method")]
     PaymentMethodDeleteFailed,
+    #[error(
+        error_type = ErrorType::InvalidRequestError, code = "IR_26",
+        message = "Cookie "
+    )]
+    InvalidCookie,
 }
 
 impl PTError for ApiErrorResponse {

--- a/crates/router/src/core/errors/transformers.rs
+++ b/crates/router/src/core/errors/transformers.rs
@@ -292,6 +292,9 @@ impl ErrorSwitch<api_models::errors::types::ApiErrorResponse> for ApiErrorRespon
             Self::PaymentMethodDeleteFailed => {
                 AER::BadRequest(ApiError::new("IR", 25, "Cannot delete the default payment method", None))
             }
+            Self::InvalidCookie => {
+                AER::BadRequest(ApiError::new("IR", 26, "Invalid Cookie", None))
+            }
         }
     }
 }

--- a/crates/router/src/services/authentication.rs
+++ b/crates/router/src/services/authentication.rs
@@ -600,8 +600,7 @@ where
     let token = get_jwt_from_authorization_header(headers)?;
     if let Some(token_from_cookies) = get_cookie_from_header(headers)
         .ok()
-        .map(|cookies| cookies::parse_cookie(cookies).ok())
-        .flatten()
+        .and_then(|cookies| cookies::parse_cookie(cookies).ok())
     {
         logger::info!(
             "Cookie header and authorization header JWT comparison result: {}",
@@ -972,8 +971,7 @@ pub fn get_jwt_from_authorization_header(headers: &HeaderMap) -> RouterResult<&s
 pub fn get_cookie_from_header(headers: &HeaderMap) -> RouterResult<&str> {
     headers
         .get(cookies::get_cookie_header())
-        .map(|header_value| header_value.to_str().ok())
-        .flatten()
+        .and_then(|header_value| header_value.to_str().ok())
         .ok_or(errors::ApiErrorResponse::InvalidCookie.into())
 }
 

--- a/crates/router/src/services/authentication.rs
+++ b/crates/router/src/services/authentication.rs
@@ -34,7 +34,6 @@ use crate::{
     utils::OptionExt,
 };
 pub mod blacklist;
-#[cfg(feature = "olap")]
 pub mod cookies;
 
 #[derive(Clone, Debug)]

--- a/crates/router/src/services/authentication.rs
+++ b/crates/router/src/services/authentication.rs
@@ -5,6 +5,7 @@ use common_utils::date_time;
 use error_stack::{report, ResultExt};
 use jsonwebtoken::{decode, Algorithm, DecodingKey, Validation};
 use masking::PeekInterface;
+use router_env::logger;
 use serde::Serialize;
 
 use self::blacklist::BlackList;
@@ -32,7 +33,6 @@ use crate::{
     types::domain,
     utils::OptionExt,
 };
-use router_env::logger;
 pub mod blacklist;
 #[cfg(feature = "olap")]
 pub mod cookies;

--- a/crates/router/src/services/authentication/cookies.rs
+++ b/crates/router/src/services/authentication/cookies.rs
@@ -1,16 +1,27 @@
+use cookie::Cookie;
+#[cfg(feature = "olap")]
 use cookie::{
     time::{Duration, OffsetDateTime},
-    Cookie, SameSite,
+    SameSite,
 };
 use error_stack::{report, ResultExt};
-use masking::{ExposeInterface, Mask, Secret};
+#[cfg(feature = "olap")]
+use masking::Mask;
+#[cfg(feature = "olap")]
+use masking::{ExposeInterface, Secret};
 
 use crate::{
-    consts::{JWT_TOKEN_COOKIE_NAME, JWT_TOKEN_TIME_IN_SECS},
-    core::errors::{ApiErrorResponse, RouterResult, UserErrors, UserResponse},
+    consts::JWT_TOKEN_COOKIE_NAME,
+    core::errors::{ApiErrorResponse, RouterResult},
+};
+#[cfg(feature = "olap")]
+use crate::{
+    consts::JWT_TOKEN_TIME_IN_SECS,
+    core::errors::{UserErrors, UserResponse},
     services::ApplicationResponse,
 };
 
+#[cfg(feature = "olap")]
 pub fn set_cookie_response<R>(response: R, token: Secret<String>) -> UserResponse<R> {
     let jwt_expiry_in_seconds = JWT_TOKEN_TIME_IN_SECS
         .try_into()
@@ -26,6 +37,7 @@ pub fn set_cookie_response<R>(response: R, token: Secret<String>) -> UserRespons
     Ok(ApplicationResponse::JsonWithHeaders((response, header)))
 }
 
+#[cfg(feature = "olap")]
 pub fn remove_cookie_response() -> UserResponse<()> {
     let (expiry, max_age) = get_expiry_and_max_age_from_seconds(0);
 
@@ -49,6 +61,7 @@ pub fn parse_cookie(cookies: &str) -> RouterResult<String> {
         .attach_printable("Cookie Parsing Failed")
 }
 
+#[cfg(feature = "olap")]
 fn create_cookie<'c>(
     token: Secret<String>,
     expires: OffsetDateTime,
@@ -64,12 +77,14 @@ fn create_cookie<'c>(
         .build()
 }
 
+#[cfg(feature = "olap")]
 fn get_expiry_and_max_age_from_seconds(seconds: i64) -> (OffsetDateTime, Duration) {
     let max_age = Duration::seconds(seconds);
     let expiry = OffsetDateTime::now_utc().saturating_add(max_age);
     (expiry, max_age)
 }
 
+#[cfg(feature = "olap")]
 fn get_set_cookie_header() -> String {
     actix_http::header::SET_COOKIE.to_string()
 }

--- a/crates/router/src/services/authentication/cookies.rs
+++ b/crates/router/src/services/authentication/cookies.rs
@@ -2,11 +2,12 @@ use cookie::{
     time::{Duration, OffsetDateTime},
     Cookie, SameSite,
 };
+use error_stack::ResultExt;
 use masking::{ExposeInterface, Mask, Secret};
 
 use crate::{
     consts::{JWT_TOKEN_COOKIE_NAME, JWT_TOKEN_TIME_IN_SECS},
-    core::errors::{UserErrors, UserResponse},
+    core::errors::{ApiErrorResponse, RouterResult, UserErrors, UserResponse},
     services::ApplicationResponse,
 };
 
@@ -19,7 +20,7 @@ pub fn set_cookie_response<R>(response: R, token: Secret<String>) -> UserRespons
     let header_value = create_cookie(token, expiry, max_age)
         .to_string()
         .into_masked();
-    let header_key = get_cookie_header();
+    let header_key = get_set_cookie_header();
     let header = vec![(header_key, header_value)];
 
     Ok(ApplicationResponse::JsonWithHeaders((response, header)))
@@ -28,12 +29,24 @@ pub fn set_cookie_response<R>(response: R, token: Secret<String>) -> UserRespons
 pub fn remove_cookie_response() -> UserResponse<()> {
     let (expiry, max_age) = get_expiry_and_max_age_from_seconds(0);
 
-    let header_key = get_cookie_header();
+    let header_key = get_set_cookie_header();
     let header_value = create_cookie("".to_string().into(), expiry, max_age)
         .to_string()
         .into_masked();
     let header = vec![(header_key, header_value)];
     Ok(ApplicationResponse::JsonWithHeaders(((), header)))
+}
+
+pub fn parse_cookie(cookies: &str) -> RouterResult<String> {
+    Cookie::split_parse(cookies)
+        .find_map(|cookie| {
+            cookie
+                .ok()
+                .filter(|parsed_cookie| parsed_cookie.name() == JWT_TOKEN_COOKIE_NAME)
+                .map(|parsed_cookie| parsed_cookie.value().to_owned())
+        })
+        .ok_or(ApiErrorResponse::InvalidCookie.into())
+        .attach_printable("Cookie Parsing Failed")
 }
 
 fn create_cookie<'c>(
@@ -57,6 +70,10 @@ fn get_expiry_and_max_age_from_seconds(seconds: i64) -> (OffsetDateTime, Duratio
     (expiry, max_age)
 }
 
-fn get_cookie_header() -> String {
+fn get_set_cookie_header() -> String {
     actix_http::header::SET_COOKIE.to_string()
+}
+
+pub fn get_cookie_header() -> String {
+    actix_http::header::COOKIE.to_string()
 }

--- a/crates/router/src/services/authentication/cookies.rs
+++ b/crates/router/src/services/authentication/cookies.rs
@@ -2,7 +2,7 @@ use cookie::{
     time::{Duration, OffsetDateTime},
     Cookie, SameSite,
 };
-use error_stack::ResultExt;
+use error_stack::{ResultExt,report};
 use masking::{ExposeInterface, Mask, Secret};
 
 use crate::{
@@ -45,7 +45,7 @@ pub fn parse_cookie(cookies: &str) -> RouterResult<String> {
                 .filter(|parsed_cookie| parsed_cookie.name() == JWT_TOKEN_COOKIE_NAME)
                 .map(|parsed_cookie| parsed_cookie.value().to_owned())
         })
-        .ok_or(ApiErrorResponse::InvalidCookie.into())
+        .ok_or(report!(ApiErrorResponse::InvalidCookie))
         .attach_printable("Cookie Parsing Failed")
 }
 

--- a/crates/router/src/services/authentication/cookies.rs
+++ b/crates/router/src/services/authentication/cookies.rs
@@ -2,7 +2,7 @@ use cookie::{
     time::{Duration, OffsetDateTime},
     Cookie, SameSite,
 };
-use error_stack::{ResultExt,report};
+use error_stack::{report, ResultExt};
 use masking::{ExposeInterface, Mask, Secret};
 
 use crate::{


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [X] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
This is the second PR for cookie implementation.
In this PR, cookie header is parsed to retrieve JWT that was set during dashboard entry.
This PR does not remove old auth flow where `Authorization` header was used to retrieve JWT from request. Instead, it compares  the JWT retrieved from `Authorization` header and `Cookie` header and logs the result. 
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
Storing JWT in cookies instead of local storage.
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
No testing required, feature is not complete and hence is not enabled.
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [X] I formatted the code `cargo +nightly fmt --all`
- [X] I addressed lints thrown by `cargo clippy`
- [X] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
