### PR TITLE
fix(redis_interface): remove mget function from redis interface

### DIFF
--- a/crates/redis_interface/src/commands.rs
+++ b/crates/redis_interface/src/commands.rs
@@ -305,7 +305,7 @@ impl super::RedisConnectionPool {
         self.set_hash_field_if_not_exist(key, field, serialized.as_slice(), ttl)
             .await
     }
-    
+
     #[instrument(level = "DEBUG", skip(self))]
     pub async fn serialize_and_set_multiple_hash_field_if_not_exist<V>(
         &self,

--- a/crates/redis_interface/src/commands.rs
+++ b/crates/redis_interface/src/commands.rs
@@ -305,46 +305,7 @@ impl super::RedisConnectionPool {
         self.set_hash_field_if_not_exist(key, field, serialized.as_slice(), ttl)
             .await
     }
-
-    #[instrument(level = "DEBUG", skip(self))]
-    pub async fn get_multiple_keys<K, V>(
-        &self,
-        keys: K,
-    ) -> CustomResult<Vec<Option<V>>, errors::RedisError>
-    where
-        V: FromRedis + Unpin + Send + 'static,
-        K: Into<MultipleKeys> + Send + Debug,
-    {
-        self.pool
-            .mget(keys)
-            .await
-            .change_context(errors::RedisError::GetFailed)
-    }
-
-    #[instrument(level = "DEBUG", skip(self))]
-    pub async fn get_and_deserialize_multiple_keys<K, V>(
-        &self,
-        keys: K,
-        type_name: &'static str,
-    ) -> CustomResult<Vec<Option<V>>, errors::RedisError>
-    where
-        K: Into<MultipleKeys> + Send + Debug,
-        V: serde::de::DeserializeOwned,
-    {
-        let data = self.get_multiple_keys::<K, Vec<u8>>(keys).await?;
-        data.into_iter()
-            .map(|value_bytes| {
-                value_bytes
-                    .map(|bytes| {
-                        bytes
-                            .parse_struct(type_name)
-                            .change_context(errors::RedisError::JsonSerializationFailed)
-                    })
-                    .transpose()
-            })
-            .collect()
-    }
-
+    
     #[instrument(level = "DEBUG", skip(self))]
     pub async fn serialize_and_set_multiple_hash_field_if_not_exist<V>(
         &self,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
Getting multiple values from Redis at one time was working fine in local environment but was failing when deployed because  of mutiple clusters at infra level.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
closes #4302


## How did you test it?
#3945 when deployed, caused sandbox to fail.


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
