### PR TITLE
airwallex eps and sofort implementation

### DIFF
--- a/crates/router/src/connector/airwallex/transformers.rs
+++ b/crates/router/src/connector/airwallex/transformers.rs
@@ -1,8 +1,9 @@
+use std::collections::HashSet;
+
 use api_models::payments::{BankRedirectBilling, BankRedirectData};
 use error_stack::{IntoReport, ResultExt};
 use masking::{ExposeInterface, PeekInterface, Secret};
 use serde::{Deserialize, Serialize};
-use std::collections::HashSet;
 use time::PrimitiveDateTime;
 use url::Url;
 use uuid::Uuid;
@@ -161,7 +162,6 @@ pub struct AirwallexCardPaymentOptions {
     auto_capture: bool,
 }
 
-
 // airwallex bank redirect request input data models
 // since the input json consists of multiple nested objects, a combination of enums and
 // structs is required to properly transform the hyperswitch input data
@@ -171,16 +171,16 @@ pub struct BankRedirectPaymentMethod {
     type_field: AirwallexPaymentType,
     #[serde(flatten)]
     // flattening here since here a variant of this enum can be stored
-    data_field: AirwallexBankRedirectType
+    data_field: AirwallexBankRedirectType,
 }
 
 // using untagged enums here so that only the actual values are serialized
 #[derive(Debug, Serialize)]
-pub enum AirwallexBankRedirectType{
+pub enum AirwallexBankRedirectType {
     #[serde(untagged)]
     Eps(EpsDetails),
     #[serde(untagged)]
-    Sofort(SofortDetails)
+    Sofort(SofortDetails),
 }
 
 // need to have multiple objects here since rust does not support nested enums.
@@ -193,7 +193,6 @@ pub struct SofortDetails {
 pub struct EpsDetails {
     eps: EpsData,
 }
-
 
 // here shopper_name is a Secret<String> as data is recd. in the same format in input
 #[derive(Debug, Serialize)]
@@ -271,7 +270,7 @@ impl TryFrom<&AirwallexRouterData<&types::PaymentsAuthorizeRouterData>>
                                     .get_billing_name()
                                     .unwrap(),
                             },
-                        })
+                        }),
                     },
                 )),
                 // sofort transform


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
This PR implements [the linked issue](https://github.com/juspay/hyperswitch/issues/4309), which is created based on [this hiring challenge discussion](https://github.com/juspay/hyperswitch/discussions/4144)

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables


Following files were changed:
`crates/router/src/connector/airwallex/transformers.rs`

No config change was done.



## Motivation and Context

Implementing EPS and SOFORT bank redirect payment methods for the Airwallex payment processor which is supported by airwallex but unimplemented on hyperswitch.
[Linked issue](https://github.com/juspay/hyperswitch/issues/4309)



## How did you test it?

I tested this manually as I am new to rust and due to some time constraints. Will add proper unit tests further maybe.  

For testing, I created a merchant account, api key, payment connector supporting bank redirect and finally a payment using the postman collection provied in the discussion doc. Attaching screenshots below.

Currently the implementation fails as the demo Airwallex account mentioned in the discussions page does not seem to support EPS and Sofort.   
The following log supports my claim:  
```
  2024-04-04T15:23:20.200229Z DEBUG diesel_models::query::generics: query: UPDATE "payment_attempt" SET "net_amount" = $1, "status" = $2, "error_message" = $3, "modified_at" = $4, "error_code" = $5, "error_reason" = $6, "amount_capturable" = $7, "updated_by" = $8 WHERE (("payment_attempt"."attempt_id" = $9) AND ("payment_attempt"."merchant_id" = $10)) -- binds: [100, Failure, Some("The payment method is not enabled. Please contact your account manager."), 2024-04-04 15:23:20.197973, Some("payment_method_not_allowed"), None, 100, "postgres_only", "pay_EbGirVJG8pSBAl3EfuG9_1", "merchant_1712118047"]
```


But the trasformer works fine and converts the input data into proper airwallex input JSON as below:

The following 2 lines were generated by the statement `println!("{:#?}",serde_json::to_string(&payment_method));` for debugging purposes.

Transformed and serialized EPS payment_method data:
```
"{\"type\":\"eps\",\"eps\":{\"shopper_name\":\"John Doe\"}}"
```

Transformed and serialized Sofort payment_method data:
```
"{\"type\":\"sofort\",\"sofort\":{\"shopper_name\":\"John Doe\",\"country_code\":\"US\"}}"
```

Payment creation returned 200. Couldn't test further as demo account does not support it yet.

<img width="1018" alt="image" src="https://github.com/juspay/hyperswitch/assets/110537573/9357ce16-8f83-4d0e-9a9f-bb40c33c7d5f">





## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
