### PR TITLE
fix(psync): log the error if payment method retrieve fails in the `psync flow`

### DIFF
--- a/crates/router/src/core/payments/operations/payment_status.rs
+++ b/crates/router/src/core/payments/operations/payment_status.rs
@@ -409,7 +409,9 @@ async fn get_tracker_for_sync<
                         logger::info!("Payment Method not found in db {:?}", error);
                         None
                     } else {
-                        Err(error).change_context(errors::ApiErrorResponse::InternalServerError)?
+                        Err(error)
+                            .change_context(errors::ApiErrorResponse::InternalServerError)
+                            .attach_printable("Error retrieving payment method from db")?
                     }
                 }
             }

--- a/crates/router/src/core/payments/operations/payment_status.rs
+++ b/crates/router/src/core/payments/operations/payment_status.rs
@@ -406,7 +406,7 @@ async fn get_tracker_for_sync<
                 Ok(payment_method) => Some(payment_method),
                 Err(error) => {
                     if error.current_context().is_db_not_found() {
-                        logger::info!("Error retrieving payment method from DB {:?}", error);
+                        logger::info!("Payment Method not found in db {:?}", error);
                         None
                     } else {
                         Err(error).change_context(errors::ApiErrorResponse::InternalServerError)?


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
-> When a payment is created with save card we store the card in the locker and also a payment method entry is created in the payment method table. And the corresponding payment_method_id will be stored in the payment_attempt table.
-> And later when that payment method is deleted, psycn is failing as we are trying to fetch the payment method data from the payment_method table in the psync flow.
-> The error occurred because of the recent change that was trying to fetch the payment method in the psync flow using the payment_method_id in the payment attempt.

This is fixed by adding a validation for the error that occurs during fetching the payment method data from the db. If it is not found in db error then just log the error (do not propagate it), any other error needs to be returned as it is.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Create a payment with save card
<img width="1101" alt="image" src="https://github.com/juspay/hyperswitch/assets/83439957/08e7e91f-c395-49f3-811c-f78fa79e4c92">
```
{
    "amount": 100,
    "amount_to_capture": 100,
    "currency": "USD",
    "confirm": true,
    "capture_method": "automatic",
    "capture_on": "2022-09-10T10:11:12Z",
    "customer_id": "aaa",
    "email": "guest@example.com",
    "name": "John Doe",
    "phone": "999999999",
    "phone_country_code": "+1",
    "description": "Its my first payment request",
    "authentication_type": "no_three_ds",
    "setup_future_usage": "on_session",
    "return_url": "http://127.0.0.1:4040",
    "customer_acceptance": {
        "acceptance_type": "offline",
        "accepted_at": "1963-05-03T04:07:52.723Z",
        "online": {
            "ip_address": "in sit",
            "user_agent": "amet irure esse"
        }
    },
    "payment_method": "card",
    "payment_method_data": {
        "card": {
            "card_number": "4242424242424242",
            "card_exp_month": "03",
            "card_exp_year": "2030",
            "card_holder_name": "joseph Doe",
            "card_cvc": "838"
        }
    },
    "billing": {
        "address": {
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "city": "San Fransico",
            "state": "California",
            "zip": "94122",
            "country": "US",
            "first_name": "PiX",
            "last_name": "ss"
        }
    },
    "shipping": {
        "address": {
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "city": "San Fransico",
            "state": "California",
            "zip": "94122",
            "country": "US",
            "first_name": "PiX"
        }
    },
    "browser_info": {
        "user_agent": "Mozilla\/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/70.0.3538.110 Safari\/537.36",
        "accept_header": "text\/html,application\/xhtml+xml,application\/xml;q=0.9,image\/webp,image\/apng,*\/*;q=0.8",
        "language": "nl-NL",
        "color_depth": 24,
        "screen_height": 723,
        "screen_width": 1536,
        "time_zone": 0,
        "java_enabled": true,
        "java_script_enabled": true,
        "ip_address": "125.0.0.1"
    },
    "statement_descriptor_name": "joseph",
    "statement_descriptor_suffix": "JS",
    "metadata": {
        "udf1": "value1",
        "new_customer": "true",
        "login_date": "2019-09-10T10:11:12Z"
    }
}
```
Delete the saved payment mehtod
```
curl --location --request DELETE 'http://localhost:8080/payment_methods/{{pm_id}}' \
--header 'Accept: application/json' \
--header 'api-key: abc'
```
payment method entry being deleted from db
<img width="1124" alt="image" src="https://github.com/juspay/hyperswitch/assets/83439957/7251dffc-e358-4b3d-86e3-f2209c83964d">
Retrieve the above payment
```
curl --location 'http://localhost:8080/payments/pay_7VFY24kczcTpt0xQfU8M?force_sync=true' \
--header 'Accept: application/json' \
--header 'api-key: dev_uU4PZwC903VYtQnTBvTxgU0QFDmah0mcPN5qehIq7tS0oapEfBBVp96oaIHyjDdM'
```
<img width="1035" alt="image" src="https://github.com/juspay/hyperswitch/assets/83439957/b518693a-7544-4342-9da6-51057ca06384">

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
