### PR TITLE
refactor(configs): Config default write defer

### DIFF
--- a/crates/diesel_models/src/configs.rs
+++ b/crates/diesel_models/src/configs.rs
@@ -47,3 +47,9 @@ impl From<ConfigUpdate> for ConfigUpdateInternal {
         }
     }
 }
+
+impl From<ConfigNew> for Config{
+    fn from(config_new: ConfigNew) -> Self{
+        Self { id: 0i32, key: config_new.key , config: config_new.config }
+    }
+}

--- a/crates/router/src/db/configs.rs
+++ b/crates/router/src/db/configs.rs
@@ -65,10 +65,19 @@ impl ConfigInterface for Store {
         config: storage::ConfigNew,
     ) -> CustomResult<storage::Config, errors::StorageError> {
         let conn = connection::pg_connection_write(self).await?;
-        config
+        let inserted = config
             .insert(&conn)
             .await
-            .map_err(|error| report!(errors::StorageError::from(error)))
+            .map_err(|error| report!(errors::StorageError::from(error)))?;
+
+        self.get_redis_conn()
+            .map_err(Into::<errors::StorageError>::into)?
+            .publish(consts::PUB_SUB_CHANNEL, CacheKind::Config((&inserted.key).into()))
+            .await
+            .map_err(Into::<errors::StorageError>::into)?;
+
+        Ok(inserted)
+
     }
 
     #[instrument(skip_all)]
@@ -138,18 +147,13 @@ impl ConfigInterface for Store {
                 Ok(a) => Ok(a),
                 Err(err) => {
                     if err.current_context().is_db_not_found() {
-                        default_config
-                            .ok_or(err)
-                            .async_and_then(|c| async {
-                                storage::ConfigNew {
-                                    key: key.to_string(),
-                                    config: c,
-                                }
-                                .insert(&conn)
-                                .await
-                                .map_err(|error| report!(errors::StorageError::from(error)))
-                            })
-                            .await
+                        default_config.map(|c| {
+                            storage::ConfigNew{
+                                key : key.to_string(),
+                                config: c
+                            }.into()
+                        })
+                        .ok_or(err)
                     } else {
                         Err(err)
                     }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Existing behavior is to insert configs in db with default if not found, this introduces interaction with master db which can be avoided.
This pr  has changes that avoids the db insert in case of configs entry not found in inmem, cache or db, the default will be cached in in mem and redis to avoid freq reads to db (as previously) and a redis publish to channel is done for inserts now


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
Existing behavior is to insert configs in db with default if not found, this introduces interaction with master db which can be avoided.
This pr  has changes that avoids the db insert in case of configs entry not found in inmem, cache or db, the default will be cached in in mem and redis to avoid freq reads to db (as previously) and a redis publish to channel is done for inserts now

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

test /payments/:id/confirm and check if insert is going to db for configs table 

`curl --location 'http://localhost:8080/payments/pay_g07QuGKSJwZi3pXC1Rdk/confirm' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key:***' \
--data '{"payment_method": "card",
        "payment_method_type": "debit",
        "payment_method_data": {
            "card": {
                "card_number": "4242424242424242",
                "card_exp_month": "10",
                "card_exp_year": "25",
                "card_holder_name": "joseph Doe",
                "card_cvc": "123"
            }
        },
        "browser_info": {
            "user_agent": "***",
            "accept_header": "**",
            "language": "nl-NL",
            "color_depth": 24,
            "screen_height": 723,
            "screen_width": 1536,
            "time_zone": 0,
            "java_enabled": true,
            "java_script_enabled": true,
            "ip_address": "125.0.0.1"
        }
    }'`
NOTE: this behavior is only observed when configs entry doesnt exist in db

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
