### PR TITLE
fix(payouts): update payout's state in app after DB operations

### DIFF
--- a/crates/router/src/core/payouts/helpers.rs
+++ b/crates/router/src/core/payouts/helpers.rs
@@ -50,7 +50,7 @@ pub async fn make_payout_method_data<'a>(
     merchant_id: &str,
     payout_type: Option<&api_enums::PayoutType>,
     merchant_key_store: &domain::MerchantKeyStore,
-    payout_data: Option<&PayoutData>,
+    payout_data: Option<&mut PayoutData>,
     storage_scheme: storage::enums::MerchantStorageScheme,
 ) -> RouterResult<Option<api::PayoutMethodData>> {
     let db = &*state.store;
@@ -168,15 +168,16 @@ pub async fn make_payout_method_data<'a>(
                 let updated_payout_attempt = storage::PayoutAttemptUpdate::PayoutTokenUpdate {
                     payout_token: lookup_key,
                 };
-                db.update_payout_attempt(
-                    &payout_data.payout_attempt,
-                    updated_payout_attempt,
-                    &payout_data.payouts,
-                    storage_scheme,
-                )
-                .await
-                .change_context(errors::ApiErrorResponse::InternalServerError)
-                .attach_printable("Error updating token in payout attempt")?;
+                payout_data.payout_attempt = db
+                    .update_payout_attempt(
+                        &payout_data.payout_attempt,
+                        updated_payout_attempt,
+                        &payout_data.payouts,
+                        storage_scheme,
+                    )
+                    .await
+                    .change_context(errors::ApiErrorResponse::InternalServerError)
+                    .attach_printable("Error updating token in payout attempt")?;
             }
             Ok(Some(payout_method.clone()))
         }
@@ -188,7 +189,7 @@ pub async fn make_payout_method_data<'a>(
 
 pub async fn save_payout_data_to_locker(
     state: &AppState,
-    payout_data: &PayoutData,
+    payout_data: &mut PayoutData,
     payout_method_data: &api::PayoutMethodData,
     merchant_account: &domain::MerchantAccount,
     key_store: &domain::MerchantKeyStore,
@@ -547,15 +548,16 @@ pub async fn save_payout_data_to_locker(
     let updated_payout = storage::PayoutsUpdate::PayoutMethodIdUpdate {
         payout_method_id: stored_resp.card_reference.to_owned(),
     };
-    db.update_payout(
-        &payout_data.payouts,
-        updated_payout,
-        payout_attempt,
-        merchant_account.storage_scheme,
-    )
-    .await
-    .change_context(errors::ApiErrorResponse::InternalServerError)
-    .attach_printable("Error updating payouts in saved payout method")?;
+    payout_data.payouts = db
+        .update_payout(
+            &payout_data.payouts,
+            updated_payout,
+            payout_attempt,
+            merchant_account.storage_scheme,
+        )
+        .await
+        .change_context(errors::ApiErrorResponse::InternalServerError)
+        .attach_printable("Error updating payouts in saved payout method")?;
 
     Ok(())
 }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
This PR ensures PayoutData's state is being updated after DB operations. It is important for the app's state to be updated as these objects are later used when updating entries in Redis KV.




### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
Any asynchronous payout operation is likely to fail as KV will not be updated with latest data. This PR ensures the fix for the same!


## How did you test it?
- Enable KV for a merchant
- Perform payout txns in stages (Create + Confirm + Fulfill)
- Postman collection - https://galactic-capsule-229427.postman.co/workspace/My-Workspace~2b563e0d-bad3-420f-8c0b-0fd5b278a4fe/collection/9906252-8f51a4d2-86d6-4f72-8198-3fff5a4e71af?action=share&creator=9906252

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
