### PR TITLE
fix(router): capture billing country in payments request

### DIFF
--- a/crates/router/src/connector/zsl/transformers.rs
+++ b/crates/router/src/connector/zsl/transformers.rs
@@ -221,11 +221,7 @@ impl TryFrom<&ZslRouterData<&types::PaymentsAuthorizeRouterData>> for ZslPayment
         let family_name = item.router_data.get_optional_billing_last_name();
         let router_url = item.router_data.request.get_router_return_url()?;
         let webhook_url = item.router_data.request.get_webhook_url()?;
-        let billing_country = item.router_data.get_optional_billing_country().ok_or(
-            errors::ConnectorError::MissingRequiredField {
-                field_name: "billing.address.country",
-            },
-        )?;
+        let billing_country = item.router_data.get_billing_country()?;
 
         let lang = item
             .router_data

--- a/crates/router/src/types/transformers.rs
+++ b/crates/router/src/types/transformers.rs
@@ -588,6 +588,7 @@ impl<'a> From<&'a domain::Address> for api_types::Address {
             && address.line2.is_none()
             && address.line3.is_none()
             && address.state.is_none()
+            && address.country.is_none()
             && address.zip.is_none()
             && address.first_name.is_none()
             && address.last_name.is_none()


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
This PR address the issue where billing.address is None despite billing.address.country being passed in the /payments call. 



## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
1. Make a zsl local bank transfer payment as follows 
```
curl --location 'http://localhost:8080/payments' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: "" ' \
--data-raw '{
    "amount": 120,
    "currency": "CNY",
    "confirm": true,
    "capture_method": "automatic",
    "capture_on": "2022-09-10T10:11:12Z",
    "customer_id": "111111234567890",
    "email": "abcdef123@gmail.com",
    "name": "John Doe",
    "phone": "999999999",
    "phone_country_code": "+65",
    "description": "Its my first payment request",
    "authentication_type": "three_ds",
    "return_url": "https://google.com",
    "billing": {
        "address": {
            "country": "CN"
        }
    },
    "browser_info": {
        "language": "en"
    },
    "statement_descriptor_name": "joseph",
    "statement_descriptor_suffix": "JS",
    "payment_method": "bank_transfer",
    "payment_method_type": "local_bank_transfer",
    "payment_method_data": {
        "bank_transfer": {
            "local_bank_transfer": {}
        }
    }
    
}'
``` 
Response must be a 2xx
```
{
    "payment_id": "pay_LVCCAnhFSMY7Szf6MQJ6",
    "merchant_id": "merchant_1712909588",
    "status": "requires_customer_action",
    "amount": 120,
    "net_amount": 120,
    "amount_capturable": 120,
    "amount_received": null,
    "connector": "zsl",
    "client_secret": "pay_LVCCAnhFSMY7Szf6MQJ6_secret_RfCDrBYxaUGBl488r6wT",
    "created": "2024-04-12T10:00:28.020Z",
    "currency": "CNY",
    "customer_id": "111111234567890",
    "customer": {
        "id": "111111234567890",
        "name": "John Doe",
        "email": "abcdef123@gmail.com",
        "phone": "999999999",
        "phone_country_code": "+65"
    },
    "description": "Its my first payment request",
    "refunds": null,
    "disputes": null,
    "mandate_id": null,
    "mandate_data": null,
    "setup_future_usage": null,
    "off_session": null,
    "capture_on": null,
    "capture_method": "automatic",
    "payment_method": "bank_transfer",
    "payment_method_data": {
        "bank_transfer": {},
        "billing": null
    },
    "payment_token": null,
    "shipping": null,
    "billing": {
        "address": {
            "city": null,
            "country": "CN",
            "line1": null,
            "line2": null,
            "line3": null,
            "zip": null,
            "state": null,
            "first_name": null,
            "last_name": null
        },
        "phone": null,
        "email": null
    },
    "order_details": null,
    "email": "abcdef123@gmail.com",
    "name": "John Doe",
    "phone": "999999999",
    "return_url": "https://google.com/",
    "authentication_type": "three_ds",
    "statement_descriptor_name": "joseph",
    "statement_descriptor_suffix": "JS",
    "next_action": {
        "type": "redirect_to_url",
        "redirect_to_url": ""
    },
    "cancellation_reason": null,
    "error_code": null,
    "error_message": null,
    "unified_code": null,
    "unified_message": null,
    "payment_experience": null,
    "payment_method_type": "local_bank_transfer",
    "connector_label": null,
    "business_country": null,
    "business_label": "default",
    "business_sub_label": null,
    "allowed_payment_method_types": null,
    "ephemeral_key": {
        "customer_id": "111111234567890",
        "created_at": 1712916027,
        "expires": 1712919627,
        "secret": "epk_1b6e8f3c7a31487d82480de36b1405f0"
    },
    "manual_retry_allowed": null,
    "connector_transaction_id": "pay_LVCCAnhFSMY7Szf6MQJ6_1",
    "frm_message": null,
    "metadata": null,
    "connector_metadata": null,
    "feature_metadata": null,
    "reference_id": "pay_LVCCAnhFSMY7Szf6MQJ6_1",
    "payment_link": null,
    "profile_id": "pro_dbZdFcC1OTv8wPEJm1Gk",
    "surcharge_details": null,
    "attempt_count": 1,
    "merchant_decision": null,
    "merchant_connector_id": "mca_AHh1EmNCxHmUSiCFsBQk",
    "incremental_authorization_allowed": null,
    "authorization_count": null,
    "incremental_authorizations": null,
    "external_authentication_details": null,
    "external_3ds_authentication_attempted": false,
    "expires_on": "2024-04-12T10:15:28.020Z",
    "fingerprint": null,
    "browser_info": {
        "language": "en"
    },
    "payment_method_id": null,
    "payment_method_status": null,
    "updated": "2024-04-12T10:00:29.336Z"
}
```


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
