### PR TITLE
fix(user): add onboarding_survey enum in dashboard metadata type

### DIFF
--- a/crates/api_models/src/user/dashboard_metadata.rs
+++ b/crates/api_models/src/user/dashboard_metadata.rs
@@ -49,16 +49,16 @@ pub struct ProcessorConnected {
 
 #[derive(Debug, serde::Deserialize, serde::Serialize)]
 pub struct OnboardingSurvey {
-    pub designation: String,
-    pub about_business: String,
-    pub business_website: String,
-    pub hyperswitch_req: String,
-    pub major_markets: Vec<String>,
-    pub business_size: String,
-    pub required_features: Vec<String>,
-    pub required_processors: Vec<String>,
-    pub planned_live_date: String,
-    pub miscellaneous: String,
+    pub designation: Option<String>,
+    pub about_business: Option<String>,
+    pub business_website: Option<String>,
+    pub hyperswitch_req: Option<String>,
+    pub major_markets: Option<Vec<String>>,
+    pub business_size: Option<String>,
+    pub required_features: Option<Vec<String>>,
+    pub required_processors: Option<Vec<String>>,
+    pub planned_live_date: Option<String>,
+    pub miscellaneous: Option<String>,
 }
 
 #[derive(Debug, serde::Deserialize, serde::Serialize)]

--- a/crates/api_models/src/user/dashboard_metadata.rs
+++ b/crates/api_models/src/user/dashboard_metadata.rs
@@ -26,6 +26,7 @@ pub enum SetMetaDataRequest {
     IsMultipleConfiguration,
     #[serde(skip)]
     IsChangePasswordRequired,
+    OnboardingSurvey(OnboardingSurvey),
 }
 
 #[derive(Debug, serde::Deserialize, serde::Serialize)]
@@ -44,6 +45,20 @@ pub struct SetupProcessor {
 pub struct ProcessorConnected {
     pub processor_id: String,
     pub processor_name: String,
+}
+
+#[derive(Debug, serde::Deserialize, serde::Serialize)]
+pub struct OnboardingSurvey {
+    pub designation: String,
+    pub about_business: String,
+    pub business_website: String,
+    pub hyperswitch_req: String,
+    pub major_markets: Vec<String>,
+    pub business_size: String,
+    pub required_features: Vec<String>,
+    pub required_processors: Vec<String>,
+    pub planned_live_date: String,
+    pub miscellaneous: String,
 }
 
 #[derive(Debug, serde::Deserialize, serde::Serialize)]
@@ -113,6 +128,7 @@ pub enum GetMetaDataRequest {
     SetupWoocomWebhook,
     IsMultipleConfiguration,
     IsChangePasswordRequired,
+    OnboardingSurvey,
 }
 
 #[derive(Debug, serde::Deserialize, serde::Serialize)]
@@ -150,4 +166,5 @@ pub enum GetMetaDataResponse {
     SetupWoocomWebhook(bool),
     IsMultipleConfiguration(bool),
     IsChangePasswordRequired(bool),
+    OnboardingSurvey(Option<OnboardingSurvey>),
 }

--- a/crates/diesel_models/src/enums.rs
+++ b/crates/diesel_models/src/enums.rs
@@ -348,4 +348,5 @@ pub enum DashboardMetadata {
     SetupWoocomWebhook,
     IsMultipleConfiguration,
     IsChangePasswordRequired,
+    OnboardingSurvey,
 }

--- a/crates/diesel_models/src/schema.rs
+++ b/crates/diesel_models/src/schema.rs
@@ -6,7 +6,9 @@ diesel::table! {
 
     address (address_id) {
         id -> Nullable<Int4>,
+        #[max_length = 64]
         address_id -> Varchar,
+        #[max_length = 128]
         city -> Nullable<Varchar>,
         country -> Nullable<CountryAlpha2>,
         line1 -> Nullable<Bytea>,
@@ -17,12 +19,17 @@ diesel::table! {
         first_name -> Nullable<Bytea>,
         last_name -> Nullable<Bytea>,
         phone_number -> Nullable<Bytea>,
+        #[max_length = 8]
         country_code -> Nullable<Varchar>,
         created_at -> Timestamp,
         modified_at -> Timestamp,
+        #[max_length = 64]
         customer_id -> Nullable<Varchar>,
+        #[max_length = 64]
         merchant_id -> Varchar,
+        #[max_length = 64]
         payment_id -> Nullable<Varchar>,
+        #[max_length = 32]
         updated_by -> Varchar,
         email -> Nullable<Bytea>,
     }
@@ -33,11 +40,17 @@ diesel::table! {
     use crate::enums::diesel_exports::*;
 
     api_keys (key_id) {
+        #[max_length = 64]
         key_id -> Varchar,
+        #[max_length = 64]
         merchant_id -> Varchar,
+        #[max_length = 64]
         name -> Varchar,
+        #[max_length = 256]
         description -> Nullable<Varchar>,
+        #[max_length = 128]
         hashed_api_key -> Varchar,
+        #[max_length = 16]
         prefix -> Varchar,
         created_at -> Timestamp,
         expires_at -> Nullable<Timestamp>,
@@ -50,28 +63,45 @@ diesel::table! {
     use crate::enums::diesel_exports::*;
 
     authentication (authentication_id) {
+        #[max_length = 64]
         authentication_id -> Varchar,
+        #[max_length = 64]
         merchant_id -> Varchar,
+        #[max_length = 64]
         authentication_connector -> Varchar,
+        #[max_length = 64]
         connector_authentication_id -> Nullable<Varchar>,
         authentication_data -> Nullable<Jsonb>,
+        #[max_length = 64]
         payment_method_id -> Varchar,
+        #[max_length = 64]
         authentication_type -> Nullable<Varchar>,
+        #[max_length = 64]
         authentication_status -> Varchar,
+        #[max_length = 64]
         authentication_lifecycle_status -> Varchar,
         created_at -> Timestamp,
         modified_at -> Timestamp,
+        #[max_length = 64]
         error_message -> Nullable<Varchar>,
+        #[max_length = 64]
         error_code -> Nullable<Varchar>,
         connector_metadata -> Nullable<Jsonb>,
         maximum_supported_version -> Nullable<Jsonb>,
+        #[max_length = 64]
         threeds_server_transaction_id -> Nullable<Varchar>,
+        #[max_length = 64]
         cavv -> Nullable<Varchar>,
+        #[max_length = 64]
         authentication_flow_type -> Nullable<Varchar>,
         message_version -> Nullable<Jsonb>,
+        #[max_length = 64]
         eci -> Nullable<Varchar>,
+        #[max_length = 64]
         trans_status -> Nullable<Varchar>,
+        #[max_length = 64]
         acquirer_bin -> Nullable<Varchar>,
+        #[max_length = 64]
         acquirer_merchant_id -> Nullable<Varchar>,
         three_ds_method_data -> Nullable<Varchar>,
         three_ds_method_url -> Nullable<Varchar>,
@@ -90,7 +120,9 @@ diesel::table! {
 
     blocklist (id) {
         id -> Int4,
+        #[max_length = 64]
         merchant_id -> Varchar,
+        #[max_length = 64]
         fingerprint_id -> Varchar,
         data_kind -> BlocklistDataKind,
         metadata -> Nullable<Jsonb>,
@@ -104,7 +136,9 @@ diesel::table! {
 
     blocklist_fingerprint (id) {
         id -> Int4,
+        #[max_length = 64]
         merchant_id -> Varchar,
+        #[max_length = 64]
         fingerprint_id -> Varchar,
         data_kind -> BlocklistDataKind,
         encrypted_fingerprint -> Text,
@@ -118,6 +152,7 @@ diesel::table! {
 
     blocklist_lookup (id) {
         id -> Int4,
+        #[max_length = 64]
         merchant_id -> Varchar,
         fingerprint -> Text,
     }
@@ -128,13 +163,17 @@ diesel::table! {
     use crate::enums::diesel_exports::*;
 
     business_profile (profile_id) {
+        #[max_length = 64]
         profile_id -> Varchar,
+        #[max_length = 64]
         merchant_id -> Varchar,
+        #[max_length = 64]
         profile_name -> Varchar,
         created_at -> Timestamp,
         modified_at -> Timestamp,
         return_url -> Nullable<Text>,
         enable_payment_response_hash -> Bool,
+        #[max_length = 255]
         payment_response_hash_key -> Nullable<Varchar>,
         redirect_to_merchant_with_http_post -> Bool,
         webhook_details -> Nullable<Json>,
@@ -156,22 +195,32 @@ diesel::table! {
     use crate::enums::diesel_exports::*;
 
     captures (capture_id) {
+        #[max_length = 64]
         capture_id -> Varchar,
+        #[max_length = 64]
         payment_id -> Varchar,
+        #[max_length = 64]
         merchant_id -> Varchar,
         status -> CaptureStatus,
         amount -> Int8,
         currency -> Nullable<Currency>,
+        #[max_length = 255]
         connector -> Varchar,
+        #[max_length = 255]
         error_message -> Nullable<Varchar>,
+        #[max_length = 255]
         error_code -> Nullable<Varchar>,
+        #[max_length = 255]
         error_reason -> Nullable<Varchar>,
         tax_amount -> Nullable<Int8>,
         created_at -> Timestamp,
         modified_at -> Timestamp,
+        #[max_length = 64]
         authorized_attempt_id -> Varchar,
+        #[max_length = 128]
         connector_capture_id -> Nullable<Varchar>,
         capture_sequence -> Int2,
+        #[max_length = 128]
         connector_response_reference_id -> Nullable<Varchar>,
     }
 }
@@ -181,14 +230,18 @@ diesel::table! {
     use crate::enums::diesel_exports::*;
 
     cards_info (card_iin) {
+        #[max_length = 16]
         card_iin -> Varchar,
         card_issuer -> Nullable<Text>,
         card_network -> Nullable<Text>,
         card_type -> Nullable<Text>,
         card_subtype -> Nullable<Text>,
         card_issuing_country -> Nullable<Text>,
+        #[max_length = 32]
         bank_code_id -> Nullable<Varchar>,
+        #[max_length = 32]
         bank_code -> Nullable<Varchar>,
+        #[max_length = 32]
         country_code -> Nullable<Varchar>,
         date_created -> Timestamp,
         last_updated -> Nullable<Timestamp>,
@@ -202,6 +255,7 @@ diesel::table! {
 
     configs (key) {
         id -> Int4,
+        #[max_length = 255]
         key -> Varchar,
         config -> Text,
     }
@@ -213,18 +267,24 @@ diesel::table! {
 
     customers (customer_id, merchant_id) {
         id -> Int4,
+        #[max_length = 64]
         customer_id -> Varchar,
+        #[max_length = 64]
         merchant_id -> Varchar,
         name -> Nullable<Bytea>,
         email -> Nullable<Bytea>,
         phone -> Nullable<Bytea>,
+        #[max_length = 8]
         phone_country_code -> Nullable<Varchar>,
+        #[max_length = 255]
         description -> Nullable<Varchar>,
         created_at -> Timestamp,
         metadata -> Nullable<Json>,
         connector_customer -> Nullable<Jsonb>,
         modified_at -> Timestamp,
+        #[max_length = 64]
         address_id -> Nullable<Varchar>,
+        #[max_length = 64]
         default_payment_method_id -> Nullable<Varchar>,
     }
 }
@@ -235,13 +295,18 @@ diesel::table! {
 
     dashboard_metadata (id) {
         id -> Int4,
+        #[max_length = 64]
         user_id -> Nullable<Varchar>,
+        #[max_length = 64]
         merchant_id -> Varchar,
+        #[max_length = 64]
         org_id -> Varchar,
         data_key -> DashboardMetadata,
         data_value -> Json,
+        #[max_length = 64]
         created_by -> Varchar,
         created_at -> Timestamp,
+        #[max_length = 64]
         last_modified_by -> Varchar,
         last_modified_at -> Timestamp,
     }
@@ -253,26 +318,39 @@ diesel::table! {
 
     dispute (id) {
         id -> Int4,
+        #[max_length = 64]
         dispute_id -> Varchar,
+        #[max_length = 255]
         amount -> Varchar,
+        #[max_length = 255]
         currency -> Varchar,
         dispute_stage -> DisputeStage,
         dispute_status -> DisputeStatus,
+        #[max_length = 64]
         payment_id -> Varchar,
+        #[max_length = 64]
         attempt_id -> Varchar,
+        #[max_length = 255]
         merchant_id -> Varchar,
+        #[max_length = 255]
         connector_status -> Varchar,
+        #[max_length = 255]
         connector_dispute_id -> Varchar,
+        #[max_length = 255]
         connector_reason -> Nullable<Varchar>,
+        #[max_length = 255]
         connector_reason_code -> Nullable<Varchar>,
         challenge_required_by -> Nullable<Timestamp>,
         connector_created_at -> Nullable<Timestamp>,
         connector_updated_at -> Nullable<Timestamp>,
         created_at -> Timestamp,
         modified_at -> Timestamp,
+        #[max_length = 255]
         connector -> Varchar,
         evidence -> Jsonb,
+        #[max_length = 64]
         profile_id -> Nullable<Varchar>,
+        #[max_length = 32]
         merchant_connector_id -> Nullable<Varchar>,
         dispute_amount -> Int8,
     }
@@ -283,17 +361,23 @@ diesel::table! {
     use crate::enums::diesel_exports::*;
 
     events (event_id) {
+        #[max_length = 64]
         event_id -> Varchar,
         event_type -> EventType,
         event_class -> EventClass,
         is_webhook_notified -> Bool,
+        #[max_length = 64]
         primary_object_id -> Varchar,
         primary_object_type -> EventObjectType,
         created_at -> Timestamp,
+        #[max_length = 64]
         merchant_id -> Nullable<Varchar>,
+        #[max_length = 64]
         business_profile_id -> Nullable<Varchar>,
         primary_object_created_at -> Nullable<Timestamp>,
+        #[max_length = 64]
         idempotent_event_id -> Nullable<Varchar>,
+        #[max_length = 64]
         initial_attempt_id -> Nullable<Varchar>,
         request -> Nullable<Bytea>,
         response -> Nullable<Bytea>,
@@ -306,17 +390,26 @@ diesel::table! {
     use crate::enums::diesel_exports::*;
 
     file_metadata (file_id, merchant_id) {
+        #[max_length = 64]
         file_id -> Varchar,
+        #[max_length = 255]
         merchant_id -> Varchar,
+        #[max_length = 255]
         file_name -> Nullable<Varchar>,
         file_size -> Int4,
+        #[max_length = 255]
         file_type -> Varchar,
+        #[max_length = 255]
         provider_file_id -> Nullable<Varchar>,
+        #[max_length = 255]
         file_upload_provider -> Nullable<Varchar>,
         available -> Bool,
         created_at -> Timestamp,
+        #[max_length = 255]
         connector_label -> Nullable<Varchar>,
+        #[max_length = 64]
         profile_id -> Nullable<Varchar>,
+        #[max_length = 32]
         merchant_connector_id -> Nullable<Varchar>,
     }
 }
@@ -326,21 +419,29 @@ diesel::table! {
     use crate::enums::diesel_exports::*;
 
     fraud_check (frm_id, attempt_id, payment_id, merchant_id) {
+        #[max_length = 64]
         frm_id -> Varchar,
+        #[max_length = 64]
         payment_id -> Varchar,
+        #[max_length = 64]
         merchant_id -> Varchar,
+        #[max_length = 64]
         attempt_id -> Varchar,
         created_at -> Timestamp,
+        #[max_length = 255]
         frm_name -> Varchar,
+        #[max_length = 255]
         frm_transaction_id -> Nullable<Varchar>,
         frm_transaction_type -> FraudCheckType,
         frm_status -> FraudCheckStatus,
         frm_score -> Nullable<Int4>,
         frm_reason -> Nullable<Jsonb>,
+        #[max_length = 255]
         frm_error -> Nullable<Varchar>,
         payment_details -> Nullable<Jsonb>,
         metadata -> Nullable<Jsonb>,
         modified_at -> Timestamp,
+        #[max_length = 64]
         last_step -> Varchar,
     }
 }
@@ -350,18 +451,28 @@ diesel::table! {
     use crate::enums::diesel_exports::*;
 
     gateway_status_map (connector, flow, sub_flow, code, message) {
+        #[max_length = 64]
         connector -> Varchar,
+        #[max_length = 64]
         flow -> Varchar,
+        #[max_length = 64]
         sub_flow -> Varchar,
+        #[max_length = 255]
         code -> Varchar,
+        #[max_length = 1024]
         message -> Varchar,
+        #[max_length = 64]
         status -> Varchar,
+        #[max_length = 64]
         router_error -> Nullable<Varchar>,
+        #[max_length = 64]
         decision -> Varchar,
         created_at -> Timestamp,
         last_modified -> Timestamp,
         step_up_possible -> Bool,
+        #[max_length = 255]
         unified_code -> Nullable<Varchar>,
+        #[max_length = 1024]
         unified_message -> Nullable<Varchar>,
     }
 }
@@ -371,15 +482,21 @@ diesel::table! {
     use crate::enums::diesel_exports::*;
 
     incremental_authorization (authorization_id, merchant_id) {
+        #[max_length = 64]
         authorization_id -> Varchar,
+        #[max_length = 64]
         merchant_id -> Varchar,
+        #[max_length = 64]
         payment_id -> Varchar,
         amount -> Int8,
         created_at -> Timestamp,
         modified_at -> Timestamp,
+        #[max_length = 64]
         status -> Varchar,
+        #[max_length = 255]
         error_code -> Nullable<Varchar>,
         error_message -> Nullable<Text>,
+        #[max_length = 64]
         connector_authorization_id -> Nullable<Varchar>,
         previously_authorized_amount -> Int8,
     }
@@ -391,19 +508,32 @@ diesel::table! {
 
     locker_mock_up (id) {
         id -> Int4,
+        #[max_length = 255]
         card_id -> Varchar,
+        #[max_length = 255]
         external_id -> Varchar,
+        #[max_length = 255]
         card_fingerprint -> Varchar,
+        #[max_length = 255]
         card_global_fingerprint -> Varchar,
+        #[max_length = 255]
         merchant_id -> Varchar,
+        #[max_length = 255]
         card_number -> Varchar,
+        #[max_length = 255]
         card_exp_year -> Varchar,
+        #[max_length = 255]
         card_exp_month -> Varchar,
+        #[max_length = 255]
         name_on_card -> Nullable<Varchar>,
+        #[max_length = 255]
         nickname -> Nullable<Varchar>,
+        #[max_length = 255]
         customer_id -> Nullable<Varchar>,
         duplicate -> Nullable<Bool>,
+        #[max_length = 8]
         card_cvc -> Nullable<Varchar>,
+        #[max_length = 64]
         payment_method_id -> Nullable<Varchar>,
         enc_card_data -> Nullable<Text>,
     }
@@ -415,28 +545,40 @@ diesel::table! {
 
     mandate (id) {
         id -> Int4,
+        #[max_length = 64]
         mandate_id -> Varchar,
+        #[max_length = 64]
         customer_id -> Varchar,
+        #[max_length = 64]
         merchant_id -> Varchar,
+        #[max_length = 64]
         payment_method_id -> Varchar,
         mandate_status -> MandateStatus,
         mandate_type -> MandateType,
         customer_accepted_at -> Nullable<Timestamp>,
+        #[max_length = 64]
         customer_ip_address -> Nullable<Varchar>,
+        #[max_length = 255]
         customer_user_agent -> Nullable<Varchar>,
+        #[max_length = 128]
         network_transaction_id -> Nullable<Varchar>,
+        #[max_length = 64]
         previous_attempt_id -> Nullable<Varchar>,
         created_at -> Timestamp,
         mandate_amount -> Nullable<Int8>,
         mandate_currency -> Nullable<Currency>,
         amount_captured -> Nullable<Int8>,
+        #[max_length = 64]
         connector -> Varchar,
+        #[max_length = 128]
         connector_mandate_id -> Nullable<Varchar>,
         start_date -> Nullable<Timestamp>,
         end_date -> Nullable<Timestamp>,
         metadata -> Nullable<Jsonb>,
         connector_mandate_ids -> Nullable<Jsonb>,
+        #[max_length = 64]
         original_payment_id -> Nullable<Varchar>,
+        #[max_length = 32]
         merchant_connector_id -> Nullable<Varchar>,
     }
 }
@@ -447,18 +589,24 @@ diesel::table! {
 
     merchant_account (id) {
         id -> Int4,
+        #[max_length = 64]
         merchant_id -> Varchar,
+        #[max_length = 255]
         return_url -> Nullable<Varchar>,
         enable_payment_response_hash -> Bool,
+        #[max_length = 255]
         payment_response_hash_key -> Nullable<Varchar>,
         redirect_to_merchant_with_http_post -> Bool,
         merchant_name -> Nullable<Bytea>,
         merchant_details -> Nullable<Bytea>,
         webhook_details -> Nullable<Json>,
         sub_merchants_enabled -> Nullable<Bool>,
+        #[max_length = 64]
         parent_merchant_id -> Nullable<Varchar>,
+        #[max_length = 128]
         publishable_key -> Nullable<Varchar>,
         storage_scheme -> MerchantStorageScheme,
+        #[max_length = 64]
         locker_id -> Nullable<Varchar>,
         metadata -> Nullable<Jsonb>,
         routing_algorithm -> Nullable<Json>,
@@ -468,8 +616,10 @@ diesel::table! {
         modified_at -> Timestamp,
         frm_routing_algorithm -> Nullable<Jsonb>,
         payout_routing_algorithm -> Nullable<Jsonb>,
+        #[max_length = 32]
         organization_id -> Varchar,
         is_recon_enabled -> Bool,
+        #[max_length = 64]
         default_profile -> Nullable<Varchar>,
         recon_status -> ReconStatus,
         payment_link_config -> Nullable<Jsonb>,
@@ -482,24 +632,31 @@ diesel::table! {
 
     merchant_connector_account (id) {
         id -> Int4,
+        #[max_length = 64]
         merchant_id -> Varchar,
+        #[max_length = 64]
         connector_name -> Varchar,
         connector_account_details -> Bytea,
         test_mode -> Nullable<Bool>,
         disabled -> Nullable<Bool>,
+        #[max_length = 128]
         merchant_connector_id -> Varchar,
         payment_methods_enabled -> Nullable<Array<Nullable<Json>>>,
         connector_type -> ConnectorType,
         metadata -> Nullable<Jsonb>,
+        #[max_length = 255]
         connector_label -> Nullable<Varchar>,
         business_country -> Nullable<CountryAlpha2>,
+        #[max_length = 255]
         business_label -> Nullable<Varchar>,
+        #[max_length = 64]
         business_sub_label -> Nullable<Varchar>,
         frm_configs -> Nullable<Jsonb>,
         created_at -> Timestamp,
         modified_at -> Timestamp,
         connector_webhook_details -> Nullable<Jsonb>,
         frm_config -> Nullable<Array<Nullable<Jsonb>>>,
+        #[max_length = 64]
         profile_id -> Nullable<Varchar>,
         applepay_verified_domains -> Nullable<Array<Nullable<Text>>>,
         pm_auth_config -> Nullable<Jsonb>,
@@ -512,6 +669,7 @@ diesel::table! {
     use crate::enums::diesel_exports::*;
 
     merchant_key_store (merchant_id) {
+        #[max_length = 64]
         merchant_id -> Varchar,
         key -> Bytea,
         created_at -> Timestamp,
@@ -523,6 +681,7 @@ diesel::table! {
     use crate::enums::diesel_exports::*;
 
     organization (org_id) {
+        #[max_length = 32]
         org_id -> Varchar,
         org_name -> Nullable<Text>,
     }
@@ -534,20 +693,26 @@ diesel::table! {
 
     payment_attempt (id) {
         id -> Int4,
+        #[max_length = 64]
         payment_id -> Varchar,
+        #[max_length = 64]
         merchant_id -> Varchar,
+        #[max_length = 64]
         attempt_id -> Varchar,
         status -> AttemptStatus,
         amount -> Int8,
         currency -> Nullable<Currency>,
         save_to_locker -> Nullable<Bool>,
+        #[max_length = 64]
         connector -> Nullable<Varchar>,
         error_message -> Nullable<Text>,
         offer_amount -> Nullable<Int8>,
         surcharge_amount -> Nullable<Int8>,
         tax_amount -> Nullable<Int8>,
+        #[max_length = 64]
         payment_method_id -> Nullable<Varchar>,
         payment_method -> Nullable<Varchar>,
+        #[max_length = 128]
         connector_transaction_id -> Nullable<Varchar>,
         capture_method -> Nullable<CaptureMethod>,
         capture_on -> Nullable<Timestamp>,
@@ -556,36 +721,52 @@ diesel::table! {
         created_at -> Timestamp,
         modified_at -> Timestamp,
         last_synced -> Nullable<Timestamp>,
+        #[max_length = 255]
         cancellation_reason -> Nullable<Varchar>,
         amount_to_capture -> Nullable<Int8>,
+        #[max_length = 64]
         mandate_id -> Nullable<Varchar>,
         browser_info -> Nullable<Jsonb>,
+        #[max_length = 255]
         error_code -> Nullable<Varchar>,
+        #[max_length = 128]
         payment_token -> Nullable<Varchar>,
         connector_metadata -> Nullable<Jsonb>,
+        #[max_length = 50]
         payment_experience -> Nullable<Varchar>,
+        #[max_length = 64]
         payment_method_type -> Nullable<Varchar>,
         payment_method_data -> Nullable<Jsonb>,
+        #[max_length = 64]
         business_sub_label -> Nullable<Varchar>,
         straight_through_algorithm -> Nullable<Jsonb>,
         preprocessing_step_id -> Nullable<Varchar>,
         mandate_details -> Nullable<Jsonb>,
         error_reason -> Nullable<Text>,
         multiple_capture_count -> Nullable<Int2>,
+        #[max_length = 128]
         connector_response_reference_id -> Nullable<Varchar>,
         amount_capturable -> Int8,
+        #[max_length = 32]
         updated_by -> Varchar,
+        #[max_length = 32]
         merchant_connector_id -> Nullable<Varchar>,
         authentication_data -> Nullable<Json>,
         encoded_data -> Nullable<Text>,
+        #[max_length = 255]
         unified_code -> Nullable<Varchar>,
+        #[max_length = 1024]
         unified_message -> Nullable<Varchar>,
         net_amount -> Nullable<Int8>,
         external_three_ds_authentication_attempted -> Nullable<Bool>,
+        #[max_length = 64]
         authentication_connector -> Nullable<Varchar>,
+        #[max_length = 64]
         authentication_id -> Nullable<Varchar>,
         mandate_data -> Nullable<Jsonb>,
+        #[max_length = 64]
         fingerprint_id -> Nullable<Varchar>,
+        #[max_length = 64]
         payment_method_billing_address_id -> Nullable<Varchar>,
     }
 }
@@ -596,45 +777,63 @@ diesel::table! {
 
     payment_intent (id) {
         id -> Int4,
+        #[max_length = 64]
         payment_id -> Varchar,
+        #[max_length = 64]
         merchant_id -> Varchar,
         status -> IntentStatus,
         amount -> Int8,
         currency -> Nullable<Currency>,
         amount_captured -> Nullable<Int8>,
+        #[max_length = 64]
         customer_id -> Nullable<Varchar>,
+        #[max_length = 255]
         description -> Nullable<Varchar>,
+        #[max_length = 255]
         return_url -> Nullable<Varchar>,
         metadata -> Nullable<Jsonb>,
+        #[max_length = 64]
         connector_id -> Nullable<Varchar>,
+        #[max_length = 64]
         shipping_address_id -> Nullable<Varchar>,
+        #[max_length = 64]
         billing_address_id -> Nullable<Varchar>,
+        #[max_length = 255]
         statement_descriptor_name -> Nullable<Varchar>,
+        #[max_length = 255]
         statement_descriptor_suffix -> Nullable<Varchar>,
         created_at -> Timestamp,
         modified_at -> Timestamp,
         last_synced -> Nullable<Timestamp>,
         setup_future_usage -> Nullable<FutureUsage>,
         off_session -> Nullable<Bool>,
+        #[max_length = 128]
         client_secret -> Nullable<Varchar>,
+        #[max_length = 64]
         active_attempt_id -> Varchar,
         business_country -> Nullable<CountryAlpha2>,
+        #[max_length = 64]
         business_label -> Nullable<Varchar>,
         order_details -> Nullable<Array<Nullable<Jsonb>>>,
         allowed_payment_method_types -> Nullable<Json>,
         connector_metadata -> Nullable<Json>,
         feature_metadata -> Nullable<Json>,
         attempt_count -> Int2,
+        #[max_length = 64]
         profile_id -> Nullable<Varchar>,
+        #[max_length = 64]
         merchant_decision -> Nullable<Varchar>,
+        #[max_length = 255]
         payment_link_id -> Nullable<Varchar>,
         payment_confirm_source -> Nullable<PaymentSource>,
+        #[max_length = 32]
         updated_by -> Varchar,
         surcharge_applicable -> Nullable<Bool>,
         request_incremental_authorization -> Nullable<RequestIncrementalAuthorization>,
         incremental_authorization_allowed -> Nullable<Bool>,
         authorization_count -> Nullable<Int4>,
         session_expiry -> Nullable<Timestamp>,
+        #[max_length = 64]
         fingerprint_id -> Nullable<Varchar>,
         request_external_three_ds_authentication -> Nullable<Bool>,
     }
@@ -645,18 +844,25 @@ diesel::table! {
     use crate::enums::diesel_exports::*;
 
     payment_link (payment_link_id) {
+        #[max_length = 255]
         payment_link_id -> Varchar,
+        #[max_length = 64]
         payment_id -> Varchar,
+        #[max_length = 255]
         link_to_pay -> Varchar,
+        #[max_length = 64]
         merchant_id -> Varchar,
         amount -> Int8,
         currency -> Nullable<Currency>,
         created_at -> Timestamp,
         last_modified_at -> Timestamp,
         fulfilment_time -> Nullable<Timestamp>,
+        #[max_length = 64]
         custom_merchant_name -> Nullable<Varchar>,
         payment_link_config -> Nullable<Jsonb>,
+        #[max_length = 255]
         description -> Nullable<Varchar>,
+        #[max_length = 64]
         profile_id -> Nullable<Varchar>,
     }
 }
@@ -667,32 +873,47 @@ diesel::table! {
 
     payment_methods (id) {
         id -> Int4,
+        #[max_length = 64]
         customer_id -> Varchar,
+        #[max_length = 64]
         merchant_id -> Varchar,
+        #[max_length = 64]
         payment_method_id -> Varchar,
         accepted_currency -> Nullable<Array<Nullable<Currency>>>,
+        #[max_length = 32]
         scheme -> Nullable<Varchar>,
+        #[max_length = 128]
         token -> Nullable<Varchar>,
+        #[max_length = 255]
         cardholder_name -> Nullable<Varchar>,
+        #[max_length = 64]
         issuer_name -> Nullable<Varchar>,
+        #[max_length = 64]
         issuer_country -> Nullable<Varchar>,
         payer_country -> Nullable<Array<Nullable<Text>>>,
         is_stored -> Nullable<Bool>,
+        #[max_length = 32]
         swift_code -> Nullable<Varchar>,
+        #[max_length = 128]
         direct_debit_token -> Nullable<Varchar>,
         created_at -> Timestamp,
         last_modified -> Timestamp,
         payment_method -> Varchar,
+        #[max_length = 64]
         payment_method_type -> Nullable<Varchar>,
+        #[max_length = 128]
         payment_method_issuer -> Nullable<Varchar>,
         payment_method_issuer_code -> Nullable<PaymentMethodIssuerCode>,
         metadata -> Nullable<Json>,
         payment_method_data -> Nullable<Bytea>,
+        #[max_length = 64]
         locker_id -> Nullable<Varchar>,
         last_used_at -> Timestamp,
         connector_mandate_details -> Nullable<Jsonb>,
         customer_acceptance -> Nullable<Jsonb>,
+        #[max_length = 64]
         status -> Varchar,
+        #[max_length = 255]
         network_transaction_id -> Nullable<Varchar>,
     }
 }
@@ -702,23 +923,35 @@ diesel::table! {
     use crate::enums::diesel_exports::*;
 
     payout_attempt (payout_attempt_id) {
+        #[max_length = 64]
         payout_attempt_id -> Varchar,
+        #[max_length = 64]
         payout_id -> Varchar,
+        #[max_length = 64]
         customer_id -> Varchar,
+        #[max_length = 64]
         merchant_id -> Varchar,
+        #[max_length = 64]
         address_id -> Varchar,
+        #[max_length = 64]
         connector -> Nullable<Varchar>,
+        #[max_length = 128]
         connector_payout_id -> Varchar,
+        #[max_length = 64]
         payout_token -> Nullable<Varchar>,
         status -> PayoutStatus,
         is_eligible -> Nullable<Bool>,
         error_message -> Nullable<Text>,
+        #[max_length = 64]
         error_code -> Nullable<Varchar>,
         business_country -> Nullable<CountryAlpha2>,
+        #[max_length = 64]
         business_label -> Nullable<Varchar>,
         created_at -> Timestamp,
         last_modified_at -> Timestamp,
+        #[max_length = 64]
         profile_id -> Varchar,
+        #[max_length = 32]
         merchant_connector_id -> Nullable<Varchar>,
         routing_info -> Nullable<Jsonb>,
     }
@@ -729,24 +962,33 @@ diesel::table! {
     use crate::enums::diesel_exports::*;
 
     payouts (payout_id) {
+        #[max_length = 64]
         payout_id -> Varchar,
+        #[max_length = 64]
         merchant_id -> Varchar,
+        #[max_length = 64]
         customer_id -> Varchar,
+        #[max_length = 64]
         address_id -> Varchar,
         payout_type -> PayoutType,
+        #[max_length = 64]
         payout_method_id -> Nullable<Varchar>,
         amount -> Int8,
         destination_currency -> Currency,
         source_currency -> Currency,
+        #[max_length = 255]
         description -> Nullable<Varchar>,
         recurring -> Bool,
         auto_fulfill -> Bool,
+        #[max_length = 255]
         return_url -> Nullable<Varchar>,
+        #[max_length = 64]
         entity_type -> Varchar,
         metadata -> Nullable<Jsonb>,
         created_at -> Timestamp,
         last_modified_at -> Timestamp,
         attempt_count -> Int2,
+        #[max_length = 64]
         profile_id -> Varchar,
         status -> PayoutStatus,
     }
@@ -757,14 +999,19 @@ diesel::table! {
     use crate::enums::diesel_exports::*;
 
     process_tracker (id) {
+        #[max_length = 127]
         id -> Varchar,
+        #[max_length = 64]
         name -> Nullable<Varchar>,
         tag -> Array<Nullable<Text>>,
+        #[max_length = 64]
         runner -> Nullable<Varchar>,
         retry_count -> Int4,
         schedule_time -> Nullable<Timestamp>,
+        #[max_length = 255]
         rule -> Varchar,
         tracking_data -> Json,
+        #[max_length = 255]
         business_status -> Varchar,
         status -> ProcessTrackerStatus,
         event -> Array<Nullable<Text>>,
@@ -779,13 +1026,21 @@ diesel::table! {
 
     refund (id) {
         id -> Int4,
+        #[max_length = 64]
         internal_reference_id -> Varchar,
+        #[max_length = 64]
         refund_id -> Varchar,
+        #[max_length = 64]
         payment_id -> Varchar,
+        #[max_length = 64]
         merchant_id -> Varchar,
+        #[max_length = 128]
         connector_transaction_id -> Varchar,
+        #[max_length = 64]
         connector -> Varchar,
+        #[max_length = 128]
         connector_refund_id -> Nullable<Varchar>,
+        #[max_length = 64]
         external_reference_id -> Nullable<Varchar>,
         refund_type -> RefundType,
         total_amount -> Int8,
@@ -795,15 +1050,22 @@ diesel::table! {
         sent_to_gateway -> Bool,
         refund_error_message -> Nullable<Text>,
         metadata -> Nullable<Json>,
+        #[max_length = 128]
         refund_arn -> Nullable<Varchar>,
         created_at -> Timestamp,
         modified_at -> Timestamp,
+        #[max_length = 255]
         description -> Nullable<Varchar>,
+        #[max_length = 64]
         attempt_id -> Varchar,
+        #[max_length = 255]
         refund_reason -> Nullable<Varchar>,
         refund_error_code -> Nullable<Text>,
+        #[max_length = 64]
         profile_id -> Nullable<Varchar>,
+        #[max_length = 32]
         updated_by -> Varchar,
+        #[max_length = 32]
         merchant_connector_id -> Nullable<Varchar>,
     }
 }
@@ -813,10 +1075,15 @@ diesel::table! {
     use crate::enums::diesel_exports::*;
 
     reverse_lookup (lookup_id) {
+        #[max_length = 128]
         lookup_id -> Varchar,
+        #[max_length = 128]
         sk_id -> Varchar,
+        #[max_length = 128]
         pk_id -> Varchar,
+        #[max_length = 128]
         source -> Varchar,
+        #[max_length = 32]
         updated_by -> Varchar,
     }
 }
@@ -827,15 +1094,21 @@ diesel::table! {
 
     roles (id) {
         id -> Int4,
+        #[max_length = 64]
         role_name -> Varchar,
+        #[max_length = 64]
         role_id -> Varchar,
+        #[max_length = 64]
         merchant_id -> Varchar,
+        #[max_length = 64]
         org_id -> Varchar,
         groups -> Array<Nullable<Text>>,
         scope -> RoleScope,
         created_at -> Timestamp,
+        #[max_length = 64]
         created_by -> Varchar,
         last_modified_at -> Timestamp,
+        #[max_length = 64]
         last_modified_by -> Varchar,
     }
 }
@@ -845,10 +1118,15 @@ diesel::table! {
     use crate::enums::diesel_exports::*;
 
     routing_algorithm (algorithm_id) {
+        #[max_length = 64]
         algorithm_id -> Varchar,
+        #[max_length = 64]
         profile_id -> Varchar,
+        #[max_length = 64]
         merchant_id -> Varchar,
+        #[max_length = 64]
         name -> Varchar,
+        #[max_length = 256]
         description -> Nullable<Varchar>,
         kind -> RoutingAlgorithmKind,
         algorithm_data -> Jsonb,
@@ -864,12 +1142,18 @@ diesel::table! {
 
     user_roles (id) {
         id -> Int4,
+        #[max_length = 64]
         user_id -> Varchar,
+        #[max_length = 64]
         merchant_id -> Varchar,
+        #[max_length = 64]
         role_id -> Varchar,
+        #[max_length = 64]
         org_id -> Varchar,
         status -> UserStatus,
+        #[max_length = 64]
         created_by -> Varchar,
+        #[max_length = 64]
         last_modified_by -> Varchar,
         created_at -> Timestamp,
         last_modified -> Timestamp,
@@ -882,13 +1166,18 @@ diesel::table! {
 
     users (id) {
         id -> Int4,
+        #[max_length = 64]
         user_id -> Varchar,
+        #[max_length = 255]
         email -> Varchar,
+        #[max_length = 255]
         name -> Varchar,
+        #[max_length = 255]
         password -> Varchar,
         is_verified -> Bool,
         created_at -> Timestamp,
         last_modified_at -> Timestamp,
+        #[max_length = 64]
         preferred_merchant_id -> Nullable<Varchar>,
     }
 }

--- a/crates/diesel_models/src/schema.rs
+++ b/crates/diesel_models/src/schema.rs
@@ -6,9 +6,7 @@ diesel::table! {
 
     address (address_id) {
         id -> Nullable<Int4>,
-        #[max_length = 64]
         address_id -> Varchar,
-        #[max_length = 128]
         city -> Nullable<Varchar>,
         country -> Nullable<CountryAlpha2>,
         line1 -> Nullable<Bytea>,
@@ -19,17 +17,12 @@ diesel::table! {
         first_name -> Nullable<Bytea>,
         last_name -> Nullable<Bytea>,
         phone_number -> Nullable<Bytea>,
-        #[max_length = 8]
         country_code -> Nullable<Varchar>,
         created_at -> Timestamp,
         modified_at -> Timestamp,
-        #[max_length = 64]
         customer_id -> Nullable<Varchar>,
-        #[max_length = 64]
         merchant_id -> Varchar,
-        #[max_length = 64]
         payment_id -> Nullable<Varchar>,
-        #[max_length = 32]
         updated_by -> Varchar,
         email -> Nullable<Bytea>,
     }
@@ -40,17 +33,11 @@ diesel::table! {
     use crate::enums::diesel_exports::*;
 
     api_keys (key_id) {
-        #[max_length = 64]
         key_id -> Varchar,
-        #[max_length = 64]
         merchant_id -> Varchar,
-        #[max_length = 64]
         name -> Varchar,
-        #[max_length = 256]
         description -> Nullable<Varchar>,
-        #[max_length = 128]
         hashed_api_key -> Varchar,
-        #[max_length = 16]
         prefix -> Varchar,
         created_at -> Timestamp,
         expires_at -> Nullable<Timestamp>,
@@ -63,45 +50,28 @@ diesel::table! {
     use crate::enums::diesel_exports::*;
 
     authentication (authentication_id) {
-        #[max_length = 64]
         authentication_id -> Varchar,
-        #[max_length = 64]
         merchant_id -> Varchar,
-        #[max_length = 64]
         authentication_connector -> Varchar,
-        #[max_length = 64]
         connector_authentication_id -> Nullable<Varchar>,
         authentication_data -> Nullable<Jsonb>,
-        #[max_length = 64]
         payment_method_id -> Varchar,
-        #[max_length = 64]
         authentication_type -> Nullable<Varchar>,
-        #[max_length = 64]
         authentication_status -> Varchar,
-        #[max_length = 64]
         authentication_lifecycle_status -> Varchar,
         created_at -> Timestamp,
         modified_at -> Timestamp,
-        #[max_length = 64]
         error_message -> Nullable<Varchar>,
-        #[max_length = 64]
         error_code -> Nullable<Varchar>,
         connector_metadata -> Nullable<Jsonb>,
         maximum_supported_version -> Nullable<Jsonb>,
-        #[max_length = 64]
         threeds_server_transaction_id -> Nullable<Varchar>,
-        #[max_length = 64]
         cavv -> Nullable<Varchar>,
-        #[max_length = 64]
         authentication_flow_type -> Nullable<Varchar>,
         message_version -> Nullable<Jsonb>,
-        #[max_length = 64]
         eci -> Nullable<Varchar>,
-        #[max_length = 64]
         trans_status -> Nullable<Varchar>,
-        #[max_length = 64]
         acquirer_bin -> Nullable<Varchar>,
-        #[max_length = 64]
         acquirer_merchant_id -> Nullable<Varchar>,
         three_ds_method_data -> Nullable<Varchar>,
         three_ds_method_url -> Nullable<Varchar>,
@@ -120,9 +90,7 @@ diesel::table! {
 
     blocklist (id) {
         id -> Int4,
-        #[max_length = 64]
         merchant_id -> Varchar,
-        #[max_length = 64]
         fingerprint_id -> Varchar,
         data_kind -> BlocklistDataKind,
         metadata -> Nullable<Jsonb>,
@@ -136,9 +104,7 @@ diesel::table! {
 
     blocklist_fingerprint (id) {
         id -> Int4,
-        #[max_length = 64]
         merchant_id -> Varchar,
-        #[max_length = 64]
         fingerprint_id -> Varchar,
         data_kind -> BlocklistDataKind,
         encrypted_fingerprint -> Text,
@@ -152,7 +118,6 @@ diesel::table! {
 
     blocklist_lookup (id) {
         id -> Int4,
-        #[max_length = 64]
         merchant_id -> Varchar,
         fingerprint -> Text,
     }
@@ -163,17 +128,13 @@ diesel::table! {
     use crate::enums::diesel_exports::*;
 
     business_profile (profile_id) {
-        #[max_length = 64]
         profile_id -> Varchar,
-        #[max_length = 64]
         merchant_id -> Varchar,
-        #[max_length = 64]
         profile_name -> Varchar,
         created_at -> Timestamp,
         modified_at -> Timestamp,
         return_url -> Nullable<Text>,
         enable_payment_response_hash -> Bool,
-        #[max_length = 255]
         payment_response_hash_key -> Nullable<Varchar>,
         redirect_to_merchant_with_http_post -> Bool,
         webhook_details -> Nullable<Json>,
@@ -195,32 +156,22 @@ diesel::table! {
     use crate::enums::diesel_exports::*;
 
     captures (capture_id) {
-        #[max_length = 64]
         capture_id -> Varchar,
-        #[max_length = 64]
         payment_id -> Varchar,
-        #[max_length = 64]
         merchant_id -> Varchar,
         status -> CaptureStatus,
         amount -> Int8,
         currency -> Nullable<Currency>,
-        #[max_length = 255]
         connector -> Varchar,
-        #[max_length = 255]
         error_message -> Nullable<Varchar>,
-        #[max_length = 255]
         error_code -> Nullable<Varchar>,
-        #[max_length = 255]
         error_reason -> Nullable<Varchar>,
         tax_amount -> Nullable<Int8>,
         created_at -> Timestamp,
         modified_at -> Timestamp,
-        #[max_length = 64]
         authorized_attempt_id -> Varchar,
-        #[max_length = 128]
         connector_capture_id -> Nullable<Varchar>,
         capture_sequence -> Int2,
-        #[max_length = 128]
         connector_response_reference_id -> Nullable<Varchar>,
     }
 }
@@ -230,18 +181,14 @@ diesel::table! {
     use crate::enums::diesel_exports::*;
 
     cards_info (card_iin) {
-        #[max_length = 16]
         card_iin -> Varchar,
         card_issuer -> Nullable<Text>,
         card_network -> Nullable<Text>,
         card_type -> Nullable<Text>,
         card_subtype -> Nullable<Text>,
         card_issuing_country -> Nullable<Text>,
-        #[max_length = 32]
         bank_code_id -> Nullable<Varchar>,
-        #[max_length = 32]
         bank_code -> Nullable<Varchar>,
-        #[max_length = 32]
         country_code -> Nullable<Varchar>,
         date_created -> Timestamp,
         last_updated -> Nullable<Timestamp>,
@@ -255,7 +202,6 @@ diesel::table! {
 
     configs (key) {
         id -> Int4,
-        #[max_length = 255]
         key -> Varchar,
         config -> Text,
     }
@@ -267,24 +213,18 @@ diesel::table! {
 
     customers (customer_id, merchant_id) {
         id -> Int4,
-        #[max_length = 64]
         customer_id -> Varchar,
-        #[max_length = 64]
         merchant_id -> Varchar,
         name -> Nullable<Bytea>,
         email -> Nullable<Bytea>,
         phone -> Nullable<Bytea>,
-        #[max_length = 8]
         phone_country_code -> Nullable<Varchar>,
-        #[max_length = 255]
         description -> Nullable<Varchar>,
         created_at -> Timestamp,
         metadata -> Nullable<Json>,
         connector_customer -> Nullable<Jsonb>,
         modified_at -> Timestamp,
-        #[max_length = 64]
         address_id -> Nullable<Varchar>,
-        #[max_length = 64]
         default_payment_method_id -> Nullable<Varchar>,
     }
 }
@@ -295,18 +235,13 @@ diesel::table! {
 
     dashboard_metadata (id) {
         id -> Int4,
-        #[max_length = 64]
         user_id -> Nullable<Varchar>,
-        #[max_length = 64]
         merchant_id -> Varchar,
-        #[max_length = 64]
         org_id -> Varchar,
         data_key -> DashboardMetadata,
         data_value -> Json,
-        #[max_length = 64]
         created_by -> Varchar,
         created_at -> Timestamp,
-        #[max_length = 64]
         last_modified_by -> Varchar,
         last_modified_at -> Timestamp,
     }
@@ -318,39 +253,26 @@ diesel::table! {
 
     dispute (id) {
         id -> Int4,
-        #[max_length = 64]
         dispute_id -> Varchar,
-        #[max_length = 255]
         amount -> Varchar,
-        #[max_length = 255]
         currency -> Varchar,
         dispute_stage -> DisputeStage,
         dispute_status -> DisputeStatus,
-        #[max_length = 64]
         payment_id -> Varchar,
-        #[max_length = 64]
         attempt_id -> Varchar,
-        #[max_length = 255]
         merchant_id -> Varchar,
-        #[max_length = 255]
         connector_status -> Varchar,
-        #[max_length = 255]
         connector_dispute_id -> Varchar,
-        #[max_length = 255]
         connector_reason -> Nullable<Varchar>,
-        #[max_length = 255]
         connector_reason_code -> Nullable<Varchar>,
         challenge_required_by -> Nullable<Timestamp>,
         connector_created_at -> Nullable<Timestamp>,
         connector_updated_at -> Nullable<Timestamp>,
         created_at -> Timestamp,
         modified_at -> Timestamp,
-        #[max_length = 255]
         connector -> Varchar,
         evidence -> Jsonb,
-        #[max_length = 64]
         profile_id -> Nullable<Varchar>,
-        #[max_length = 32]
         merchant_connector_id -> Nullable<Varchar>,
         dispute_amount -> Int8,
     }
@@ -361,23 +283,17 @@ diesel::table! {
     use crate::enums::diesel_exports::*;
 
     events (event_id) {
-        #[max_length = 64]
         event_id -> Varchar,
         event_type -> EventType,
         event_class -> EventClass,
         is_webhook_notified -> Bool,
-        #[max_length = 64]
         primary_object_id -> Varchar,
         primary_object_type -> EventObjectType,
         created_at -> Timestamp,
-        #[max_length = 64]
         merchant_id -> Nullable<Varchar>,
-        #[max_length = 64]
         business_profile_id -> Nullable<Varchar>,
         primary_object_created_at -> Nullable<Timestamp>,
-        #[max_length = 64]
         idempotent_event_id -> Nullable<Varchar>,
-        #[max_length = 64]
         initial_attempt_id -> Nullable<Varchar>,
         request -> Nullable<Bytea>,
         response -> Nullable<Bytea>,
@@ -390,26 +306,17 @@ diesel::table! {
     use crate::enums::diesel_exports::*;
 
     file_metadata (file_id, merchant_id) {
-        #[max_length = 64]
         file_id -> Varchar,
-        #[max_length = 255]
         merchant_id -> Varchar,
-        #[max_length = 255]
         file_name -> Nullable<Varchar>,
         file_size -> Int4,
-        #[max_length = 255]
         file_type -> Varchar,
-        #[max_length = 255]
         provider_file_id -> Nullable<Varchar>,
-        #[max_length = 255]
         file_upload_provider -> Nullable<Varchar>,
         available -> Bool,
         created_at -> Timestamp,
-        #[max_length = 255]
         connector_label -> Nullable<Varchar>,
-        #[max_length = 64]
         profile_id -> Nullable<Varchar>,
-        #[max_length = 32]
         merchant_connector_id -> Nullable<Varchar>,
     }
 }
@@ -419,29 +326,21 @@ diesel::table! {
     use crate::enums::diesel_exports::*;
 
     fraud_check (frm_id, attempt_id, payment_id, merchant_id) {
-        #[max_length = 64]
         frm_id -> Varchar,
-        #[max_length = 64]
         payment_id -> Varchar,
-        #[max_length = 64]
         merchant_id -> Varchar,
-        #[max_length = 64]
         attempt_id -> Varchar,
         created_at -> Timestamp,
-        #[max_length = 255]
         frm_name -> Varchar,
-        #[max_length = 255]
         frm_transaction_id -> Nullable<Varchar>,
         frm_transaction_type -> FraudCheckType,
         frm_status -> FraudCheckStatus,
         frm_score -> Nullable<Int4>,
         frm_reason -> Nullable<Jsonb>,
-        #[max_length = 255]
         frm_error -> Nullable<Varchar>,
         payment_details -> Nullable<Jsonb>,
         metadata -> Nullable<Jsonb>,
         modified_at -> Timestamp,
-        #[max_length = 64]
         last_step -> Varchar,
     }
 }
@@ -451,28 +350,18 @@ diesel::table! {
     use crate::enums::diesel_exports::*;
 
     gateway_status_map (connector, flow, sub_flow, code, message) {
-        #[max_length = 64]
         connector -> Varchar,
-        #[max_length = 64]
         flow -> Varchar,
-        #[max_length = 64]
         sub_flow -> Varchar,
-        #[max_length = 255]
         code -> Varchar,
-        #[max_length = 1024]
         message -> Varchar,
-        #[max_length = 64]
         status -> Varchar,
-        #[max_length = 64]
         router_error -> Nullable<Varchar>,
-        #[max_length = 64]
         decision -> Varchar,
         created_at -> Timestamp,
         last_modified -> Timestamp,
         step_up_possible -> Bool,
-        #[max_length = 255]
         unified_code -> Nullable<Varchar>,
-        #[max_length = 1024]
         unified_message -> Nullable<Varchar>,
     }
 }
@@ -482,21 +371,15 @@ diesel::table! {
     use crate::enums::diesel_exports::*;
 
     incremental_authorization (authorization_id, merchant_id) {
-        #[max_length = 64]
         authorization_id -> Varchar,
-        #[max_length = 64]
         merchant_id -> Varchar,
-        #[max_length = 64]
         payment_id -> Varchar,
         amount -> Int8,
         created_at -> Timestamp,
         modified_at -> Timestamp,
-        #[max_length = 64]
         status -> Varchar,
-        #[max_length = 255]
         error_code -> Nullable<Varchar>,
         error_message -> Nullable<Text>,
-        #[max_length = 64]
         connector_authorization_id -> Nullable<Varchar>,
         previously_authorized_amount -> Int8,
     }
@@ -508,32 +391,19 @@ diesel::table! {
 
     locker_mock_up (id) {
         id -> Int4,
-        #[max_length = 255]
         card_id -> Varchar,
-        #[max_length = 255]
         external_id -> Varchar,
-        #[max_length = 255]
         card_fingerprint -> Varchar,
-        #[max_length = 255]
         card_global_fingerprint -> Varchar,
-        #[max_length = 255]
         merchant_id -> Varchar,
-        #[max_length = 255]
         card_number -> Varchar,
-        #[max_length = 255]
         card_exp_year -> Varchar,
-        #[max_length = 255]
         card_exp_month -> Varchar,
-        #[max_length = 255]
         name_on_card -> Nullable<Varchar>,
-        #[max_length = 255]
         nickname -> Nullable<Varchar>,
-        #[max_length = 255]
         customer_id -> Nullable<Varchar>,
         duplicate -> Nullable<Bool>,
-        #[max_length = 8]
         card_cvc -> Nullable<Varchar>,
-        #[max_length = 64]
         payment_method_id -> Nullable<Varchar>,
         enc_card_data -> Nullable<Text>,
     }
@@ -545,40 +415,28 @@ diesel::table! {
 
     mandate (id) {
         id -> Int4,
-        #[max_length = 64]
         mandate_id -> Varchar,
-        #[max_length = 64]
         customer_id -> Varchar,
-        #[max_length = 64]
         merchant_id -> Varchar,
-        #[max_length = 64]
         payment_method_id -> Varchar,
         mandate_status -> MandateStatus,
         mandate_type -> MandateType,
         customer_accepted_at -> Nullable<Timestamp>,
-        #[max_length = 64]
         customer_ip_address -> Nullable<Varchar>,
-        #[max_length = 255]
         customer_user_agent -> Nullable<Varchar>,
-        #[max_length = 128]
         network_transaction_id -> Nullable<Varchar>,
-        #[max_length = 64]
         previous_attempt_id -> Nullable<Varchar>,
         created_at -> Timestamp,
         mandate_amount -> Nullable<Int8>,
         mandate_currency -> Nullable<Currency>,
         amount_captured -> Nullable<Int8>,
-        #[max_length = 64]
         connector -> Varchar,
-        #[max_length = 128]
         connector_mandate_id -> Nullable<Varchar>,
         start_date -> Nullable<Timestamp>,
         end_date -> Nullable<Timestamp>,
         metadata -> Nullable<Jsonb>,
         connector_mandate_ids -> Nullable<Jsonb>,
-        #[max_length = 64]
         original_payment_id -> Nullable<Varchar>,
-        #[max_length = 32]
         merchant_connector_id -> Nullable<Varchar>,
     }
 }
@@ -589,24 +447,18 @@ diesel::table! {
 
     merchant_account (id) {
         id -> Int4,
-        #[max_length = 64]
         merchant_id -> Varchar,
-        #[max_length = 255]
         return_url -> Nullable<Varchar>,
         enable_payment_response_hash -> Bool,
-        #[max_length = 255]
         payment_response_hash_key -> Nullable<Varchar>,
         redirect_to_merchant_with_http_post -> Bool,
         merchant_name -> Nullable<Bytea>,
         merchant_details -> Nullable<Bytea>,
         webhook_details -> Nullable<Json>,
         sub_merchants_enabled -> Nullable<Bool>,
-        #[max_length = 64]
         parent_merchant_id -> Nullable<Varchar>,
-        #[max_length = 128]
         publishable_key -> Nullable<Varchar>,
         storage_scheme -> MerchantStorageScheme,
-        #[max_length = 64]
         locker_id -> Nullable<Varchar>,
         metadata -> Nullable<Jsonb>,
         routing_algorithm -> Nullable<Json>,
@@ -616,10 +468,8 @@ diesel::table! {
         modified_at -> Timestamp,
         frm_routing_algorithm -> Nullable<Jsonb>,
         payout_routing_algorithm -> Nullable<Jsonb>,
-        #[max_length = 32]
         organization_id -> Varchar,
         is_recon_enabled -> Bool,
-        #[max_length = 64]
         default_profile -> Nullable<Varchar>,
         recon_status -> ReconStatus,
         payment_link_config -> Nullable<Jsonb>,
@@ -632,31 +482,24 @@ diesel::table! {
 
     merchant_connector_account (id) {
         id -> Int4,
-        #[max_length = 64]
         merchant_id -> Varchar,
-        #[max_length = 64]
         connector_name -> Varchar,
         connector_account_details -> Bytea,
         test_mode -> Nullable<Bool>,
         disabled -> Nullable<Bool>,
-        #[max_length = 128]
         merchant_connector_id -> Varchar,
         payment_methods_enabled -> Nullable<Array<Nullable<Json>>>,
         connector_type -> ConnectorType,
         metadata -> Nullable<Jsonb>,
-        #[max_length = 255]
         connector_label -> Nullable<Varchar>,
         business_country -> Nullable<CountryAlpha2>,
-        #[max_length = 255]
         business_label -> Nullable<Varchar>,
-        #[max_length = 64]
         business_sub_label -> Nullable<Varchar>,
         frm_configs -> Nullable<Jsonb>,
         created_at -> Timestamp,
         modified_at -> Timestamp,
         connector_webhook_details -> Nullable<Jsonb>,
         frm_config -> Nullable<Array<Nullable<Jsonb>>>,
-        #[max_length = 64]
         profile_id -> Nullable<Varchar>,
         applepay_verified_domains -> Nullable<Array<Nullable<Text>>>,
         pm_auth_config -> Nullable<Jsonb>,
@@ -669,7 +512,6 @@ diesel::table! {
     use crate::enums::diesel_exports::*;
 
     merchant_key_store (merchant_id) {
-        #[max_length = 64]
         merchant_id -> Varchar,
         key -> Bytea,
         created_at -> Timestamp,
@@ -681,7 +523,6 @@ diesel::table! {
     use crate::enums::diesel_exports::*;
 
     organization (org_id) {
-        #[max_length = 32]
         org_id -> Varchar,
         org_name -> Nullable<Text>,
     }
@@ -693,26 +534,20 @@ diesel::table! {
 
     payment_attempt (id) {
         id -> Int4,
-        #[max_length = 64]
         payment_id -> Varchar,
-        #[max_length = 64]
         merchant_id -> Varchar,
-        #[max_length = 64]
         attempt_id -> Varchar,
         status -> AttemptStatus,
         amount -> Int8,
         currency -> Nullable<Currency>,
         save_to_locker -> Nullable<Bool>,
-        #[max_length = 64]
         connector -> Nullable<Varchar>,
         error_message -> Nullable<Text>,
         offer_amount -> Nullable<Int8>,
         surcharge_amount -> Nullable<Int8>,
         tax_amount -> Nullable<Int8>,
-        #[max_length = 64]
         payment_method_id -> Nullable<Varchar>,
         payment_method -> Nullable<Varchar>,
-        #[max_length = 128]
         connector_transaction_id -> Nullable<Varchar>,
         capture_method -> Nullable<CaptureMethod>,
         capture_on -> Nullable<Timestamp>,
@@ -721,52 +556,36 @@ diesel::table! {
         created_at -> Timestamp,
         modified_at -> Timestamp,
         last_synced -> Nullable<Timestamp>,
-        #[max_length = 255]
         cancellation_reason -> Nullable<Varchar>,
         amount_to_capture -> Nullable<Int8>,
-        #[max_length = 64]
         mandate_id -> Nullable<Varchar>,
         browser_info -> Nullable<Jsonb>,
-        #[max_length = 255]
         error_code -> Nullable<Varchar>,
-        #[max_length = 128]
         payment_token -> Nullable<Varchar>,
         connector_metadata -> Nullable<Jsonb>,
-        #[max_length = 50]
         payment_experience -> Nullable<Varchar>,
-        #[max_length = 64]
         payment_method_type -> Nullable<Varchar>,
         payment_method_data -> Nullable<Jsonb>,
-        #[max_length = 64]
         business_sub_label -> Nullable<Varchar>,
         straight_through_algorithm -> Nullable<Jsonb>,
         preprocessing_step_id -> Nullable<Varchar>,
         mandate_details -> Nullable<Jsonb>,
         error_reason -> Nullable<Text>,
         multiple_capture_count -> Nullable<Int2>,
-        #[max_length = 128]
         connector_response_reference_id -> Nullable<Varchar>,
         amount_capturable -> Int8,
-        #[max_length = 32]
         updated_by -> Varchar,
-        #[max_length = 32]
         merchant_connector_id -> Nullable<Varchar>,
         authentication_data -> Nullable<Json>,
         encoded_data -> Nullable<Text>,
-        #[max_length = 255]
         unified_code -> Nullable<Varchar>,
-        #[max_length = 1024]
         unified_message -> Nullable<Varchar>,
         net_amount -> Nullable<Int8>,
         external_three_ds_authentication_attempted -> Nullable<Bool>,
-        #[max_length = 64]
         authentication_connector -> Nullable<Varchar>,
-        #[max_length = 64]
         authentication_id -> Nullable<Varchar>,
         mandate_data -> Nullable<Jsonb>,
-        #[max_length = 64]
         fingerprint_id -> Nullable<Varchar>,
-        #[max_length = 64]
         payment_method_billing_address_id -> Nullable<Varchar>,
     }
 }
@@ -777,63 +596,45 @@ diesel::table! {
 
     payment_intent (id) {
         id -> Int4,
-        #[max_length = 64]
         payment_id -> Varchar,
-        #[max_length = 64]
         merchant_id -> Varchar,
         status -> IntentStatus,
         amount -> Int8,
         currency -> Nullable<Currency>,
         amount_captured -> Nullable<Int8>,
-        #[max_length = 64]
         customer_id -> Nullable<Varchar>,
-        #[max_length = 255]
         description -> Nullable<Varchar>,
-        #[max_length = 255]
         return_url -> Nullable<Varchar>,
         metadata -> Nullable<Jsonb>,
-        #[max_length = 64]
         connector_id -> Nullable<Varchar>,
-        #[max_length = 64]
         shipping_address_id -> Nullable<Varchar>,
-        #[max_length = 64]
         billing_address_id -> Nullable<Varchar>,
-        #[max_length = 255]
         statement_descriptor_name -> Nullable<Varchar>,
-        #[max_length = 255]
         statement_descriptor_suffix -> Nullable<Varchar>,
         created_at -> Timestamp,
         modified_at -> Timestamp,
         last_synced -> Nullable<Timestamp>,
         setup_future_usage -> Nullable<FutureUsage>,
         off_session -> Nullable<Bool>,
-        #[max_length = 128]
         client_secret -> Nullable<Varchar>,
-        #[max_length = 64]
         active_attempt_id -> Varchar,
         business_country -> Nullable<CountryAlpha2>,
-        #[max_length = 64]
         business_label -> Nullable<Varchar>,
         order_details -> Nullable<Array<Nullable<Jsonb>>>,
         allowed_payment_method_types -> Nullable<Json>,
         connector_metadata -> Nullable<Json>,
         feature_metadata -> Nullable<Json>,
         attempt_count -> Int2,
-        #[max_length = 64]
         profile_id -> Nullable<Varchar>,
-        #[max_length = 64]
         merchant_decision -> Nullable<Varchar>,
-        #[max_length = 255]
         payment_link_id -> Nullable<Varchar>,
         payment_confirm_source -> Nullable<PaymentSource>,
-        #[max_length = 32]
         updated_by -> Varchar,
         surcharge_applicable -> Nullable<Bool>,
         request_incremental_authorization -> Nullable<RequestIncrementalAuthorization>,
         incremental_authorization_allowed -> Nullable<Bool>,
         authorization_count -> Nullable<Int4>,
         session_expiry -> Nullable<Timestamp>,
-        #[max_length = 64]
         fingerprint_id -> Nullable<Varchar>,
         request_external_three_ds_authentication -> Nullable<Bool>,
     }
@@ -844,25 +645,18 @@ diesel::table! {
     use crate::enums::diesel_exports::*;
 
     payment_link (payment_link_id) {
-        #[max_length = 255]
         payment_link_id -> Varchar,
-        #[max_length = 64]
         payment_id -> Varchar,
-        #[max_length = 255]
         link_to_pay -> Varchar,
-        #[max_length = 64]
         merchant_id -> Varchar,
         amount -> Int8,
         currency -> Nullable<Currency>,
         created_at -> Timestamp,
         last_modified_at -> Timestamp,
         fulfilment_time -> Nullable<Timestamp>,
-        #[max_length = 64]
         custom_merchant_name -> Nullable<Varchar>,
         payment_link_config -> Nullable<Jsonb>,
-        #[max_length = 255]
         description -> Nullable<Varchar>,
-        #[max_length = 64]
         profile_id -> Nullable<Varchar>,
     }
 }
@@ -873,47 +667,32 @@ diesel::table! {
 
     payment_methods (id) {
         id -> Int4,
-        #[max_length = 64]
         customer_id -> Varchar,
-        #[max_length = 64]
         merchant_id -> Varchar,
-        #[max_length = 64]
         payment_method_id -> Varchar,
         accepted_currency -> Nullable<Array<Nullable<Currency>>>,
-        #[max_length = 32]
         scheme -> Nullable<Varchar>,
-        #[max_length = 128]
         token -> Nullable<Varchar>,
-        #[max_length = 255]
         cardholder_name -> Nullable<Varchar>,
-        #[max_length = 64]
         issuer_name -> Nullable<Varchar>,
-        #[max_length = 64]
         issuer_country -> Nullable<Varchar>,
         payer_country -> Nullable<Array<Nullable<Text>>>,
         is_stored -> Nullable<Bool>,
-        #[max_length = 32]
         swift_code -> Nullable<Varchar>,
-        #[max_length = 128]
         direct_debit_token -> Nullable<Varchar>,
         created_at -> Timestamp,
         last_modified -> Timestamp,
         payment_method -> Varchar,
-        #[max_length = 64]
         payment_method_type -> Nullable<Varchar>,
-        #[max_length = 128]
         payment_method_issuer -> Nullable<Varchar>,
         payment_method_issuer_code -> Nullable<PaymentMethodIssuerCode>,
         metadata -> Nullable<Json>,
         payment_method_data -> Nullable<Bytea>,
-        #[max_length = 64]
         locker_id -> Nullable<Varchar>,
         last_used_at -> Timestamp,
         connector_mandate_details -> Nullable<Jsonb>,
         customer_acceptance -> Nullable<Jsonb>,
-        #[max_length = 64]
         status -> Varchar,
-        #[max_length = 255]
         network_transaction_id -> Nullable<Varchar>,
     }
 }
@@ -923,35 +702,23 @@ diesel::table! {
     use crate::enums::diesel_exports::*;
 
     payout_attempt (payout_attempt_id) {
-        #[max_length = 64]
         payout_attempt_id -> Varchar,
-        #[max_length = 64]
         payout_id -> Varchar,
-        #[max_length = 64]
         customer_id -> Varchar,
-        #[max_length = 64]
         merchant_id -> Varchar,
-        #[max_length = 64]
         address_id -> Varchar,
-        #[max_length = 64]
         connector -> Nullable<Varchar>,
-        #[max_length = 128]
         connector_payout_id -> Varchar,
-        #[max_length = 64]
         payout_token -> Nullable<Varchar>,
         status -> PayoutStatus,
         is_eligible -> Nullable<Bool>,
         error_message -> Nullable<Text>,
-        #[max_length = 64]
         error_code -> Nullable<Varchar>,
         business_country -> Nullable<CountryAlpha2>,
-        #[max_length = 64]
         business_label -> Nullable<Varchar>,
         created_at -> Timestamp,
         last_modified_at -> Timestamp,
-        #[max_length = 64]
         profile_id -> Varchar,
-        #[max_length = 32]
         merchant_connector_id -> Nullable<Varchar>,
         routing_info -> Nullable<Jsonb>,
     }
@@ -962,33 +729,24 @@ diesel::table! {
     use crate::enums::diesel_exports::*;
 
     payouts (payout_id) {
-        #[max_length = 64]
         payout_id -> Varchar,
-        #[max_length = 64]
         merchant_id -> Varchar,
-        #[max_length = 64]
         customer_id -> Varchar,
-        #[max_length = 64]
         address_id -> Varchar,
         payout_type -> PayoutType,
-        #[max_length = 64]
         payout_method_id -> Nullable<Varchar>,
         amount -> Int8,
         destination_currency -> Currency,
         source_currency -> Currency,
-        #[max_length = 255]
         description -> Nullable<Varchar>,
         recurring -> Bool,
         auto_fulfill -> Bool,
-        #[max_length = 255]
         return_url -> Nullable<Varchar>,
-        #[max_length = 64]
         entity_type -> Varchar,
         metadata -> Nullable<Jsonb>,
         created_at -> Timestamp,
         last_modified_at -> Timestamp,
         attempt_count -> Int2,
-        #[max_length = 64]
         profile_id -> Varchar,
         status -> PayoutStatus,
     }
@@ -999,19 +757,14 @@ diesel::table! {
     use crate::enums::diesel_exports::*;
 
     process_tracker (id) {
-        #[max_length = 127]
         id -> Varchar,
-        #[max_length = 64]
         name -> Nullable<Varchar>,
         tag -> Array<Nullable<Text>>,
-        #[max_length = 64]
         runner -> Nullable<Varchar>,
         retry_count -> Int4,
         schedule_time -> Nullable<Timestamp>,
-        #[max_length = 255]
         rule -> Varchar,
         tracking_data -> Json,
-        #[max_length = 255]
         business_status -> Varchar,
         status -> ProcessTrackerStatus,
         event -> Array<Nullable<Text>>,
@@ -1026,21 +779,13 @@ diesel::table! {
 
     refund (id) {
         id -> Int4,
-        #[max_length = 64]
         internal_reference_id -> Varchar,
-        #[max_length = 64]
         refund_id -> Varchar,
-        #[max_length = 64]
         payment_id -> Varchar,
-        #[max_length = 64]
         merchant_id -> Varchar,
-        #[max_length = 128]
         connector_transaction_id -> Varchar,
-        #[max_length = 64]
         connector -> Varchar,
-        #[max_length = 128]
         connector_refund_id -> Nullable<Varchar>,
-        #[max_length = 64]
         external_reference_id -> Nullable<Varchar>,
         refund_type -> RefundType,
         total_amount -> Int8,
@@ -1050,22 +795,15 @@ diesel::table! {
         sent_to_gateway -> Bool,
         refund_error_message -> Nullable<Text>,
         metadata -> Nullable<Json>,
-        #[max_length = 128]
         refund_arn -> Nullable<Varchar>,
         created_at -> Timestamp,
         modified_at -> Timestamp,
-        #[max_length = 255]
         description -> Nullable<Varchar>,
-        #[max_length = 64]
         attempt_id -> Varchar,
-        #[max_length = 255]
         refund_reason -> Nullable<Varchar>,
         refund_error_code -> Nullable<Text>,
-        #[max_length = 64]
         profile_id -> Nullable<Varchar>,
-        #[max_length = 32]
         updated_by -> Varchar,
-        #[max_length = 32]
         merchant_connector_id -> Nullable<Varchar>,
     }
 }
@@ -1075,15 +813,10 @@ diesel::table! {
     use crate::enums::diesel_exports::*;
 
     reverse_lookup (lookup_id) {
-        #[max_length = 128]
         lookup_id -> Varchar,
-        #[max_length = 128]
         sk_id -> Varchar,
-        #[max_length = 128]
         pk_id -> Varchar,
-        #[max_length = 128]
         source -> Varchar,
-        #[max_length = 32]
         updated_by -> Varchar,
     }
 }
@@ -1094,21 +827,15 @@ diesel::table! {
 
     roles (id) {
         id -> Int4,
-        #[max_length = 64]
         role_name -> Varchar,
-        #[max_length = 64]
         role_id -> Varchar,
-        #[max_length = 64]
         merchant_id -> Varchar,
-        #[max_length = 64]
         org_id -> Varchar,
         groups -> Array<Nullable<Text>>,
         scope -> RoleScope,
         created_at -> Timestamp,
-        #[max_length = 64]
         created_by -> Varchar,
         last_modified_at -> Timestamp,
-        #[max_length = 64]
         last_modified_by -> Varchar,
     }
 }
@@ -1118,15 +845,10 @@ diesel::table! {
     use crate::enums::diesel_exports::*;
 
     routing_algorithm (algorithm_id) {
-        #[max_length = 64]
         algorithm_id -> Varchar,
-        #[max_length = 64]
         profile_id -> Varchar,
-        #[max_length = 64]
         merchant_id -> Varchar,
-        #[max_length = 64]
         name -> Varchar,
-        #[max_length = 256]
         description -> Nullable<Varchar>,
         kind -> RoutingAlgorithmKind,
         algorithm_data -> Jsonb,
@@ -1142,18 +864,12 @@ diesel::table! {
 
     user_roles (id) {
         id -> Int4,
-        #[max_length = 64]
         user_id -> Varchar,
-        #[max_length = 64]
         merchant_id -> Varchar,
-        #[max_length = 64]
         role_id -> Varchar,
-        #[max_length = 64]
         org_id -> Varchar,
         status -> UserStatus,
-        #[max_length = 64]
         created_by -> Varchar,
-        #[max_length = 64]
         last_modified_by -> Varchar,
         created_at -> Timestamp,
         last_modified -> Timestamp,
@@ -1166,18 +882,13 @@ diesel::table! {
 
     users (id) {
         id -> Int4,
-        #[max_length = 64]
         user_id -> Varchar,
-        #[max_length = 255]
         email -> Varchar,
-        #[max_length = 255]
         name -> Varchar,
-        #[max_length = 255]
         password -> Varchar,
         is_verified -> Bool,
         created_at -> Timestamp,
         last_modified_at -> Timestamp,
-        #[max_length = 64]
         preferred_merchant_id -> Nullable<Varchar>,
     }
 }

--- a/crates/router/src/types/domain/user/dashboard_metadata.rs
+++ b/crates/router/src/types/domain/user/dashboard_metadata.rs
@@ -26,6 +26,7 @@ pub enum MetaData {
     SetupWoocomWebhook(bool),
     IsMultipleConfiguration(bool),
     IsChangePasswordRequired(bool),
+    OnboardingSurvey(api::OnboardingSurvey),
 }
 
 impl From<&MetaData> for DBEnum {
@@ -53,6 +54,7 @@ impl From<&MetaData> for DBEnum {
             MetaData::SetupWoocomWebhook(_) => Self::SetupWoocomWebhook,
             MetaData::IsMultipleConfiguration(_) => Self::IsMultipleConfiguration,
             MetaData::IsChangePasswordRequired(_) => Self::IsChangePasswordRequired,
+            MetaData::OnboardingSurvey(_) => Self::OnboardingSurvey,
         }
     }
 }

--- a/crates/router/src/utils/user/dashboard_metadata.rs
+++ b/crates/router/src/utils/user/dashboard_metadata.rs
@@ -214,6 +214,7 @@ pub fn separate_metadata_type_based_on_scope(
             | DBEnum::DownloadWoocom
             | DBEnum::ConfigureWoocom
             | DBEnum::SetupWoocomWebhook
+            | DBEnum::OnboardingSurvey
             | DBEnum::IsMultipleConfiguration => merchant_scoped.push(key),
             DBEnum::Feedback | DBEnum::ProdIntent | DBEnum::IsChangePasswordRequired => {
                 user_scoped.push(key)

--- a/migrations/2024-04-12-100908_add_dashboard_metadata_key_onboarding_survey/down.sql
+++ b/migrations/2024-04-12-100908_add_dashboard_metadata_key_onboarding_survey/down.sql
@@ -1,0 +1,2 @@
+-- This file should undo anything in `up.sql`
+SELECT 1;

--- a/migrations/2024-04-12-100908_add_dashboard_metadata_key_onboarding_survey/up.sql
+++ b/migrations/2024-04-12-100908_add_dashboard_metadata_key_onboarding_survey/up.sql
@@ -1,0 +1,3 @@
+-- Your SQL goes here
+ALTER TYPE "DashboardMetadata"
+ADD VALUE IF NOT EXISTS 'onboarding_survey';


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
Bug Fix: Add support for onboarding_survey enum 


### Additional Changes

- [ ] This PR modifies the API contract
- [X] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
Until now, we've been utilising Calendly to gather comprehensive information regarding both merchants and users. 
After this PR we will capture all the data from the dashboard and store it in dashboard_metadata for better insights.


## How did you test it?
1. Post OnboardingSurvey enum details  
Request 
``` 
curl --location 'http://localhost:8080/user/data?keys=OnboardingSurvey' \
--header 'Authorization: JWT token' \
--header 'Content-Type: application/json' \
--data '{
    "OnboardingSurvey": {
        "designation": "some designation",
        "business_website": "some business website",
        "about_business": "about business ",
        "major_markets": [
            "Europe"
        ],
        "business_size": "business size",
        "hyperswitch_req": "hyperswitch requirement",
        "required_features": [
            "FRM",
            "Recon"
        ],
        "required_processors": [
            "Stripe"
        ],
        "planned_live_date": "planned live date",
        "miscellaneous": "some comment"
    }
}'
```

2. Get OnboardingSurvey enum details request 
```
curl --location 'http://localhost:8080/user/data?keys=OnboardingSurvey' \
--header 'Authorization: JWT token'
```
Response  
a. If data not present for the user 
`[{"OnboardingSurvey":null}]`
b. If data already present for the user 
```
[
    {
        "OnboardingSurvey": {
            "designation": "some designation",
            "about_business": "about business ",
            "business_website": "some business website",
            "hyperswitch_req": "hyperswitch requirement",
            "major_markets": [
                "Europe"
            ],
            "business_size": "business size",
            "required_features": [
                "FRM",
                "Recon"
            ],
            "required_processors": [
                "Stripe"
            ],
            "planned_live_date": "planned live date",
            "miscellaneous": "some comment"
        }
    }
]
```
## Checklist
<!-- Put an `x` in the boxes that apply -->

- [X] I formatted the code `cargo +nightly fmt --all`
- [X] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
