### PR TITLE
feat(payments): add amount and connector id filter in list

### DIFF
--- a/crates/api_models/src/payments.rs
+++ b/crates/api_models/src/payments.rs
@@ -3325,6 +3325,8 @@ pub struct PaymentListFilterConstraints {
     pub limit: u32,
     /// The starting point within a list of objects
     pub offset: Option<u32>,
+    /// The amount to filter payments list
+    pub amount: Option<AmountFilter>,
     /// The time range for which objects are needed. TimeRange has two fields start_time and end_time from which objects can be filtered as per required scenarios (created_at, time less than, greater than etc).
     #[serde(flatten)]
     pub time_range: Option<TimeRange>,
@@ -3340,6 +3342,8 @@ pub struct PaymentListFilterConstraints {
     pub payment_method_type: Option<Vec<enums::PaymentMethodType>>,
     /// The list of authentication types to filter payments list
     pub authentication_type: Option<Vec<enums::AuthenticationType>>,
+    /// The list of merchant connector ids to filter payments list for selected label
+    pub merchant_connector_id: Option<Vec<String>>,
 }
 #[derive(Clone, Debug, serde::Serialize)]
 pub struct PaymentListFilters {
@@ -3355,6 +3359,20 @@ pub struct PaymentListFilters {
     pub payment_method_type: Vec<enums::PaymentMethodType>,
     /// The list of available authentication types
     pub authentication_type: Vec<enums::AuthenticationType>,
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
+pub struct AmountFilter {
+    pub amount: i64,
+    pub filter_option: AmountFilterOption,
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
+pub enum AmountFilterOption {
+    Range { end: i64 },
+    LessThan,
+    EqualTo,
+    GreaterThan,
 }
 
 #[derive(

--- a/crates/data_models/src/payments/payment_attempt.rs
+++ b/crates/data_models/src/payments/payment_attempt.rs
@@ -99,6 +99,7 @@ pub trait PaymentAttemptInterface {
         payment_method: Option<Vec<storage_enums::PaymentMethod>>,
         payment_method_type: Option<Vec<storage_enums::PaymentMethodType>>,
         authentication_type: Option<Vec<storage_enums::AuthenticationType>>,
+        merchant_connector_id: Option<Vec<String>>,
         storage_scheme: storage_enums::MerchantStorageScheme,
     ) -> error_stack::Result<i64, errors::StorageError>;
 }

--- a/crates/diesel_models/src/query/payment_attempt.rs
+++ b/crates/diesel_models/src/query/payment_attempt.rs
@@ -309,6 +309,8 @@ impl PaymentAttempt {
             filter_authentication_type,
         ))
     }
+
+    #[allow(clippy::too_many_arguments)]
     pub async fn get_total_count_of_attempts(
         conn: &PgPooledConn,
         merchant_id: &str,
@@ -317,6 +319,7 @@ impl PaymentAttempt {
         payment_method: Option<Vec<enums::PaymentMethod>>,
         payment_method_type: Option<Vec<enums::PaymentMethodType>>,
         authentication_type: Option<Vec<enums::AuthenticationType>>,
+        merchant_connector_id: Option<Vec<String>>,
     ) -> StorageResult<i64> {
         let mut filter = <Self as HasTable>::table()
             .count()
@@ -336,6 +339,9 @@ impl PaymentAttempt {
         }
         if let Some(authentication_type) = authentication_type.clone() {
             filter = filter.filter(dsl::authentication_type.eq_any(authentication_type));
+        }
+        if let Some(merchant_connector_id) = merchant_connector_id.clone() {
+            filter = filter.filter(dsl::merchant_connector_id.eq_any(merchant_connector_id))
         }
         router_env::logger::debug!(query = %debug_query::<Pg, _>(&filter).to_string());
 

--- a/crates/router/src/core/payments.rs
+++ b/crates/router/src/core/payments.rs
@@ -2518,6 +2518,7 @@ pub async fn apply_filters_on_payments(
             constraints.payment_method,
             constraints.payment_method_type,
             constraints.authentication_type,
+            constraints.merchant_connector_id,
             merchant.storage_scheme,
         )
         .await

--- a/crates/router/src/db/kafka_store.rs
+++ b/crates/router/src/db/kafka_store.rs
@@ -1222,6 +1222,7 @@ impl PaymentAttemptInterface for KafkaStore {
         payment_method: Option<Vec<common_enums::PaymentMethod>>,
         payment_method_type: Option<Vec<common_enums::PaymentMethodType>>,
         authentication_type: Option<Vec<common_enums::AuthenticationType>>,
+        merchant_connector_id: Option<Vec<String>>,
         storage_scheme: MerchantStorageScheme,
     ) -> CustomResult<i64, errors::DataStorageError> {
         self.diesel_store
@@ -1232,6 +1233,7 @@ impl PaymentAttemptInterface for KafkaStore {
                 payment_method,
                 payment_method_type,
                 authentication_type,
+                merchant_connector_id,
                 storage_scheme,
             )
             .await

--- a/crates/storage_impl/src/mock_db/payment_attempt.rs
+++ b/crates/storage_impl/src/mock_db/payment_attempt.rs
@@ -42,6 +42,7 @@ impl PaymentAttemptInterface for MockDb {
         _payment_method: Option<Vec<PaymentMethod>>,
         _payment_method_type: Option<Vec<PaymentMethodType>>,
         _authentication_type: Option<Vec<AuthenticationType>>,
+        _merchanat_connector_id: Option<Vec<String>>,
         _storage_scheme: storage_enums::MerchantStorageScheme,
     ) -> CustomResult<i64, StorageError> {
         Err(StorageError::MockDbError)?

--- a/crates/storage_impl/src/payments/payment_attempt.rs
+++ b/crates/storage_impl/src/payments/payment_attempt.rs
@@ -292,6 +292,7 @@ impl<T: DatabaseStore> PaymentAttemptInterface for RouterStore<T> {
         payment_method: Option<Vec<PaymentMethod>>,
         payment_method_type: Option<Vec<PaymentMethodType>>,
         authentication_type: Option<Vec<AuthenticationType>>,
+        merchant_connector_id: Option<Vec<String>>,
         _storage_scheme: MerchantStorageScheme,
     ) -> CustomResult<i64, errors::StorageError> {
         let conn = self
@@ -314,6 +315,7 @@ impl<T: DatabaseStore> PaymentAttemptInterface for RouterStore<T> {
             payment_method,
             payment_method_type,
             authentication_type,
+            merchant_connector_id,
         )
         .await
         .map_err(|er| {
@@ -995,6 +997,7 @@ impl<T: DatabaseStore> PaymentAttemptInterface for KVRouterStore<T> {
         payment_method: Option<Vec<PaymentMethod>>,
         payment_method_type: Option<Vec<PaymentMethodType>>,
         authentication_type: Option<Vec<AuthenticationType>>,
+        merchant_connector_id: Option<Vec<String>>,
         storage_scheme: MerchantStorageScheme,
     ) -> CustomResult<i64, errors::StorageError> {
         self.router_store
@@ -1005,6 +1008,7 @@ impl<T: DatabaseStore> PaymentAttemptInterface for KVRouterStore<T> {
                 payment_method,
                 payment_method_type,
                 authentication_type,
+                merchant_connector_id,
                 storage_scheme,
             )
             .await


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
This PR add support to filter payments list by amount and merchant connector id.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
closes #4352 


## How did you test it?
curl to test amount filter
```
curl --location 'http://localhost:8080/payments/list' \
--header 'Content-Type: application/json' \
--header 'Cookie: token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoiMWZjNzgyOTUtM2JiMy00OGJjLThlZDgtNzFjMzVjMzMxYWU2IiwibWVyY2hhbnRfaWQiOiJtZXJjaGFudF8xNjk3NzE2ODcwIiwicm9sZV9pZCI6Im1lcmNoYW50X2FkbWluIiwiZXhwIjoxNjk3ODg5NjcxLCJvcmdfaWQiOiJvcmdfejQ5ZExMeTdmbllUODN5TDY3clEifQ.CJzEQ2qbhn-qUiiVBSdvCJiLvWp-5wCF9R54gth6QbQ' \
--header 'Authorization: Bearer JWT' \
--data '{
    "amount": {
        "amount": 16934,
        "filter_option": {
            "Range": {
                "end": 17000
            }
        }
    }
    
}'
```
This will filter payments which are between `amount` and `end`;
Similarly for equal to, less than, greater than following enum can be used: `EqualTo`, `LessThan`, `GreaterThan`. And the curl for that
```
curl --location 'http://localhost:8080/payments/list' \
--header 'Content-Type: application/json' \
--header 'Cookie: token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoiMWZjNzgyOTUtM2JiMy00OGJjLThlZDgtNzFjMzVjMzMxYWU2IiwibWVyY2hhbnRfaWQiOiJtZXJjaGFudF8xNjk3NzE2ODcwIiwicm9sZV9pZCI6Im1lcmNoYW50X2FkbWluIiwiZXhwIjoxNjk3ODg5NjcxLCJvcmdfaWQiOiJvcmdfejQ5ZExMeTdmbllUODN5TDY3clEifQ.CJzEQ2qbhn-qUiiVBSdvCJiLvWp-5wCF9R54gth6QbQ' \
--header 'Authorization: Bearer JWT' \
--data '{
    "amount": {
        "amount": 16934,
        "filter_option":"LessThan"
    }
    
}'
```
To apply merchant_connector_id filter:
```
curl --location 'http://localhost:8080/payments/list' \
--header 'Content-Type: application/json' \
--header 'Cookie: token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoiMWZjNzgyOTUtM2JiMy00OGJjLThlZDgtNzFjMzVjMzMxYWU2IiwibWVyY2hhbnRfaWQiOiJtZXJjaGFudF8xNjk3NzE2ODcwIiwicm9sZV9pZCI6Im1lcmNoYW50X2FkbWluIiwiZXhwIjoxNjk3ODg5NjcxLCJvcmdfaWQiOiJvcmdfejQ5ZExMeTdmbllUODN5TDY3clEifQ.CJzEQ2qbhn-qUiiVBSdvCJiLvWp-5wCF9R54gth6QbQ' \
--header 'Authorization: Bearer JWT' \
--data '{
    "merchant_connector_id": ["mca_test1","mac_test"] 
}'
```

Both filters can also be simultaneously by passing them in json body. And the response after applying above filters will be filters payment list response, something like:
```
{
    "count": 1,
    "total_count": 1,
    "data": [
        {
            "payment_id": "test_9jWD1XIJKZuonpCk4Cdn",
            "merchant_id": "merchant_1712924675",
            "status": "failed",
            "amount": 17000,
            "net_amount": 0,
            "amount_capturable": 17000,
            "amount_received": null,
            "connector": "stripe_test",
            "client_secret": "test_9jWD1XIJKZuonpCk4Cdn_secret_l4KaD6efemXZ9oDLGIVI",
            "created": "2024-04-10T02:25:35.000Z",
            "currency": "USD",
            "customer_id": "hs-dashboard-user",
            "customer": null,
            "description": "This is a sample payment",
            "refunds": null,
            "disputes": null,
            "mandate_id": null,
            "mandate_data": null,
            "setup_future_usage": null,
            "off_session": null,
            "capture_on": null,
            "capture_method": null,
            "payment_method": "card",
            "payment_method_data": null,
            "payment_token": null,
            "shipping": null,
            "billing": null,
            "order_details": null,
            "email": null,
            "name": null,
            "phone": null,
            "return_url": null,
            "authentication_type": "three_ds",
            "statement_descriptor_name": null,
            "statement_descriptor_suffix": null,
            "next_action": null,
            "cancellation_reason": null,
            "error_code": null,
            "error_message": null,
            "unified_code": null,
            "unified_message": null,
            "payment_experience": null,
            "payment_method_type": "debit",
            "connector_label": null,
            "business_country": null,
            "business_label": "default",
            "business_sub_label": null,
            "allowed_payment_method_types": null,
            "ephemeral_key": null,
            "manual_retry_allowed": null,
            "connector_transaction_id": "test_9jWD1XIJKZuonpCk4Cdn_1",
            "frm_message": null,
            "metadata": null,
            "connector_metadata": null,
            "feature_metadata": null,
            "reference_id": null,
            "payment_link": null,
            "profile_id": "pro_0xtUwT8bnGnMR2hYjEJB",
            "surcharge_details": null,
            "attempt_count": 1,
            "merchant_decision": null,
            "merchant_connector_id": null,
            "incremental_authorization_allowed": null,
            "authorization_count": null,
            "incremental_authorizations": null,
            "external_authentication_details": null,
            "external_3ds_authentication_attempted": null,
            "expires_on": null,
            "fingerprint": null,
            "browser_info": null,
            "payment_method_id": null,
            "payment_method_status": null
        }
    ]
}
```
## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
