### PR TITLE
fix: added find all support for pm kv

### DIFF
--- a/crates/router/src/core/payment_methods/cards.rs
+++ b/crates/router/src/core/payment_methods/cards.rs
@@ -2832,6 +2832,7 @@ pub async fn list_customer_payment_method(
             &merchant_account.merchant_id,
             common_enums::PaymentMethodStatus::Active,
             limit,
+            merchant_account.storage_scheme,
         )
         .await
         .to_not_found_response(errors::ApiErrorResponse::PaymentMethodNotFound)?;

--- a/crates/router/src/db/kafka_store.rs
+++ b/crates/router/src/db/kafka_store.rs
@@ -1423,6 +1423,7 @@ impl PaymentMethodInterface for KafkaStore {
         merchant_id: &str,
         status: common_enums::PaymentMethodStatus,
         limit: Option<i64>,
+        storage_scheme: MerchantStorageScheme,
     ) -> CustomResult<Vec<storage::PaymentMethod>, errors::StorageError> {
         self.diesel_store
             .find_payment_method_by_customer_id_merchant_id_status(
@@ -1430,6 +1431,7 @@ impl PaymentMethodInterface for KafkaStore {
                 merchant_id,
                 status,
                 limit,
+                storage_scheme,
             )
             .await
     }

--- a/crates/router/src/db/payment_method.rs
+++ b/crates/router/src/db/payment_method.rs
@@ -395,7 +395,7 @@ mod storage {
                                 .into_iter()
                                 .filter(|pm| pm.status == status)
                                 .collect()
-                            })
+                        })
                     };
 
                     Box::pin(db_utils::find_all_redis_database(
@@ -404,10 +404,8 @@ mod storage {
                         limit,
                     ))
                     .await
-
+                }
             }
-
-        }
         }
 
         async fn delete_payment_method_by_merchant_id_payment_method_id(
@@ -427,7 +425,7 @@ mod storage {
     }
 }
 
-#[cfg(not(feature="kv_store"))]
+#[cfg(not(feature = "kv_store"))]
 mod storage {
     use error_stack::report;
     use router_env::{instrument, tracing};

--- a/crates/router/src/db/payment_method.rs
+++ b/crates/router/src/db/payment_method.rs
@@ -34,6 +34,7 @@ pub trait PaymentMethodInterface {
         merchant_id: &str,
         status: common_enums::PaymentMethodStatus,
         limit: Option<i64>,
+        storage_scheme: MerchantStorageScheme,
     ) -> CustomResult<Vec<storage_types::PaymentMethod>, errors::StorageError>;
 
     async fn get_payment_method_count_by_customer_id_merchant_id_status(
@@ -63,329 +64,370 @@ pub trait PaymentMethodInterface {
     ) -> CustomResult<storage_types::PaymentMethod, errors::StorageError>;
 }
 
-// #[cfg(feature = "kv_store")]
-// mod storage {
-//     use common_utils::fallback_reverse_lookup_not_found;
-//     use diesel_models::{kv, PaymentMethodUpdateInternal};
-//     use error_stack::{report, ResultExt};
-//     use redis_interface::HsetnxReply;
-//     use router_env::{instrument, tracing};
-//     use storage_impl::redis::kv_store::{kv_wrapper, KvOperation, PartitionKey};
+#[cfg(feature = "kv_store")]
+mod storage {
+    use common_utils::fallback_reverse_lookup_not_found;
+    use diesel_models::{kv, PaymentMethodUpdateInternal};
+    use error_stack::{report, ResultExt};
+    use redis_interface::HsetnxReply;
+    use router_env::{instrument, tracing};
+    use storage_impl::redis::kv_store::{kv_wrapper, KvOperation, PartitionKey};
 
-//     use super::PaymentMethodInterface;
-//     use crate::{
-//         connection,
-//         core::errors::{self, utils::RedisErrorExt, CustomResult},
-//         db::reverse_lookup::ReverseLookupInterface,
-//         services::Store,
-//         types::storage::{self as storage_types, enums::MerchantStorageScheme},
-//         utils::db_utils,
-//     };
+    use super::PaymentMethodInterface;
+    use crate::{
+        connection,
+        core::errors::{self, utils::RedisErrorExt, CustomResult},
+        db::reverse_lookup::ReverseLookupInterface,
+        services::Store,
+        types::storage::{self as storage_types, enums::MerchantStorageScheme},
+        utils::db_utils,
+    };
 
-//     #[async_trait::async_trait]
-//     impl PaymentMethodInterface for Store {
-//         #[instrument(skip_all)]
-//         async fn find_payment_method(
-//             &self,
-//             payment_method_id: &str,
-//             storage_scheme: MerchantStorageScheme,
-//         ) -> CustomResult<storage_types::PaymentMethod, errors::StorageError> {
-//             let conn = connection::pg_connection_read(self).await?;
-//             let database_call = || async {
-//                 storage_types::PaymentMethod::find_by_payment_method_id(&conn, payment_method_id)
-//                     .await
-//                     .map_err(|error| report!(errors::StorageError::from(error)))
-//             };
+    #[async_trait::async_trait]
+    impl PaymentMethodInterface for Store {
+        #[instrument(skip_all)]
+        async fn find_payment_method(
+            &self,
+            payment_method_id: &str,
+            storage_scheme: MerchantStorageScheme,
+        ) -> CustomResult<storage_types::PaymentMethod, errors::StorageError> {
+            let conn = connection::pg_connection_read(self).await?;
+            let database_call = || async {
+                storage_types::PaymentMethod::find_by_payment_method_id(&conn, payment_method_id)
+                    .await
+                    .map_err(|error| report!(errors::StorageError::from(error)))
+            };
 
-//             match storage_scheme {
-//                 MerchantStorageScheme::PostgresOnly => database_call().await,
-//                 MerchantStorageScheme::RedisKv => {
-//                     let lookup_id = format!("payment_method_{}", payment_method_id);
-//                     let lookup = fallback_reverse_lookup_not_found!(
-//                         self.get_lookup_by_lookup_id(&lookup_id, storage_scheme)
-//                             .await,
-//                         database_call().await
-//                     );
+            match storage_scheme {
+                MerchantStorageScheme::PostgresOnly => database_call().await,
+                MerchantStorageScheme::RedisKv => {
+                    let lookup_id = format!("payment_method_{}", payment_method_id);
+                    let lookup = fallback_reverse_lookup_not_found!(
+                        self.get_lookup_by_lookup_id(&lookup_id, storage_scheme)
+                            .await,
+                        database_call().await
+                    );
 
-//                     let key = PartitionKey::CombinationKey {
-//                         combination: &lookup.pk_id,
-//                     };
+                    let key = PartitionKey::CombinationKey {
+                        combination: &lookup.pk_id,
+                    };
 
-//                     Box::pin(db_utils::try_redis_get_else_try_database_get(
-//                         async {
-//                             kv_wrapper(
-//                                 self,
-//                                 KvOperation::<storage_types::PaymentMethod>::HGet(&lookup.sk_id),
-//                                 key,
-//                             )
-//                             .await?
-//                             .try_into_hget()
-//                         },
-//                         database_call,
-//                     ))
-//                     .await
-//                 }
-//             }
-//         }
+                    Box::pin(db_utils::try_redis_get_else_try_database_get(
+                        async {
+                            kv_wrapper(
+                                self,
+                                KvOperation::<storage_types::PaymentMethod>::HGet(&lookup.sk_id),
+                                key,
+                            )
+                            .await?
+                            .try_into_hget()
+                        },
+                        database_call,
+                    ))
+                    .await
+                }
+            }
+        }
 
-//         #[instrument(skip_all)]
-//         async fn find_payment_method_by_locker_id(
-//             &self,
-//             locker_id: &str,
-//             storage_scheme: MerchantStorageScheme,
-//         ) -> CustomResult<storage_types::PaymentMethod, errors::StorageError> {
-//             let conn = connection::pg_connection_read(self).await?;
-//             let database_call = || async {
-//                 storage_types::PaymentMethod::find_by_locker_id(&conn, locker_id)
-//                     .await
-//                     .map_err(|error| report!(errors::StorageError::from(error)))
-//             };
+        #[instrument(skip_all)]
+        async fn find_payment_method_by_locker_id(
+            &self,
+            locker_id: &str,
+            storage_scheme: MerchantStorageScheme,
+        ) -> CustomResult<storage_types::PaymentMethod, errors::StorageError> {
+            let conn = connection::pg_connection_read(self).await?;
+            let database_call = || async {
+                storage_types::PaymentMethod::find_by_locker_id(&conn, locker_id)
+                    .await
+                    .map_err(|error| report!(errors::StorageError::from(error)))
+            };
 
-//             match storage_scheme {
-//                 MerchantStorageScheme::PostgresOnly => database_call().await,
-//                 MerchantStorageScheme::RedisKv => {
-//                     let lookup_id = format!("payment_method_locker_{}", locker_id);
-//                     let lookup = fallback_reverse_lookup_not_found!(
-//                         self.get_lookup_by_lookup_id(&lookup_id, storage_scheme)
-//                             .await,
-//                         database_call().await
-//                     );
+            match storage_scheme {
+                MerchantStorageScheme::PostgresOnly => database_call().await,
+                MerchantStorageScheme::RedisKv => {
+                    let lookup_id = format!("payment_method_locker_{}", locker_id);
+                    let lookup = fallback_reverse_lookup_not_found!(
+                        self.get_lookup_by_lookup_id(&lookup_id, storage_scheme)
+                            .await,
+                        database_call().await
+                    );
 
-//                     let key = PartitionKey::CombinationKey {
-//                         combination: &lookup.pk_id,
-//                     };
+                    let key = PartitionKey::CombinationKey {
+                        combination: &lookup.pk_id,
+                    };
 
-//                     Box::pin(db_utils::try_redis_get_else_try_database_get(
-//                         async {
-//                             kv_wrapper(
-//                                 self,
-//                                 KvOperation::<storage_types::PaymentMethod>::HGet(&lookup.sk_id),
-//                                 key,
-//                             )
-//                             .await?
-//                             .try_into_hget()
-//                         },
-//                         database_call,
-//                     ))
-//                     .await
-//                 }
-//             }
-//         }
-//         // not supported in kv
-//         #[instrument(skip_all)]
-//         async fn get_payment_method_count_by_customer_id_merchant_id_status(
-//             &self,
-//             customer_id: &str,
-//             merchant_id: &str,
-//             status: common_enums::PaymentMethodStatus,
-//         ) -> CustomResult<i64, errors::StorageError> {
-//             let conn = connection::pg_connection_read(self).await?;
-//             storage_types::PaymentMethod::get_count_by_customer_id_merchant_id_status(
-//                 &conn,
-//                 customer_id,
-//                 merchant_id,
-//                 status,
-//             )
-//             .await
-//             .map_err(|error| report!(errors::StorageError::from(error)))
-//         }
+                    Box::pin(db_utils::try_redis_get_else_try_database_get(
+                        async {
+                            kv_wrapper(
+                                self,
+                                KvOperation::<storage_types::PaymentMethod>::HGet(&lookup.sk_id),
+                                key,
+                            )
+                            .await?
+                            .try_into_hget()
+                        },
+                        database_call,
+                    ))
+                    .await
+                }
+            }
+        }
+        // not supported in kv
+        #[instrument(skip_all)]
+        async fn get_payment_method_count_by_customer_id_merchant_id_status(
+            &self,
+            customer_id: &str,
+            merchant_id: &str,
+            status: common_enums::PaymentMethodStatus,
+        ) -> CustomResult<i64, errors::StorageError> {
+            let conn = connection::pg_connection_read(self).await?;
+            storage_types::PaymentMethod::get_count_by_customer_id_merchant_id_status(
+                &conn,
+                customer_id,
+                merchant_id,
+                status,
+            )
+            .await
+            .map_err(|error| report!(errors::StorageError::from(error)))
+        }
 
-//         #[instrument(skip_all)]
-//         async fn insert_payment_method(
-//             &self,
-//             payment_method_new: storage_types::PaymentMethodNew,
-//             storage_scheme: MerchantStorageScheme,
-//         ) -> CustomResult<storage_types::PaymentMethod, errors::StorageError> {
-//             match storage_scheme {
-//                 MerchantStorageScheme::PostgresOnly => {
-//                     let conn = connection::pg_connection_write(self).await?;
-//                     payment_method_new
-//                         .insert(&conn)
-//                         .await
-//                         .map_err(|error| report!(errors::StorageError::from(error)))
-//                 }
-//                 MerchantStorageScheme::RedisKv => {
-//                     let merchant_id = payment_method_new.merchant_id.clone();
-//                     let customer_id = payment_method_new.customer_id.clone();
+        #[instrument(skip_all)]
+        async fn insert_payment_method(
+            &self,
+            payment_method_new: storage_types::PaymentMethodNew,
+            storage_scheme: MerchantStorageScheme,
+        ) -> CustomResult<storage_types::PaymentMethod, errors::StorageError> {
+            match storage_scheme {
+                MerchantStorageScheme::PostgresOnly => {
+                    let conn = connection::pg_connection_write(self).await?;
+                    payment_method_new
+                        .insert(&conn)
+                        .await
+                        .map_err(|error| report!(errors::StorageError::from(error)))
+                }
+                MerchantStorageScheme::RedisKv => {
+                    let merchant_id = payment_method_new.merchant_id.clone();
+                    let customer_id = payment_method_new.customer_id.clone();
 
-//                     let key = PartitionKey::MerchantIdCustomerId {
-//                         merchant_id: &merchant_id,
-//                         customer_id: &customer_id,
-//                     };
-//                     let key_str = key.to_string();
-//                     let field =
-//                         format!("payment_method_id_{}", payment_method_new.payment_method_id);
+                    let key = PartitionKey::MerchantIdCustomerId {
+                        merchant_id: &merchant_id,
+                        customer_id: &customer_id,
+                    };
+                    let key_str = key.to_string();
+                    let field =
+                        format!("payment_method_id_{}", payment_method_new.payment_method_id);
 
-//                     let reverse_lookup_entry = |v: String| diesel_models::ReverseLookupNew {
-//                         sk_id: field.clone(),
-//                         pk_id: key_str.clone(),
-//                         lookup_id: v,
-//                         source: "payment_method".to_string(),
-//                         updated_by: storage_scheme.to_string(),
-//                     };
+                    let reverse_lookup_entry = |v: String| diesel_models::ReverseLookupNew {
+                        sk_id: field.clone(),
+                        pk_id: key_str.clone(),
+                        lookup_id: v,
+                        source: "payment_method".to_string(),
+                        updated_by: storage_scheme.to_string(),
+                    };
 
-//                     let lookup_id1 =
-//                         format!("payment_method_{}", &payment_method_new.payment_method_id);
-//                     let mut reverse_lookups = vec![lookup_id1];
-//                     if let Some(locker_id) = &payment_method_new.locker_id {
-//                         reverse_lookups.push(format!("payment_method_locker_{}", locker_id))
-//                     }
+                    let lookup_id1 =
+                        format!("payment_method_{}", &payment_method_new.payment_method_id);
+                    let mut reverse_lookups = vec![lookup_id1];
+                    if let Some(locker_id) = &payment_method_new.locker_id {
+                        reverse_lookups.push(format!("payment_method_locker_{}", locker_id))
+                    }
 
-//                     let results = reverse_lookups.into_iter().map(|v| {
-//                         self.insert_reverse_lookup(reverse_lookup_entry(v), storage_scheme)
-//                     });
+                    let results = reverse_lookups.into_iter().map(|v| {
+                        self.insert_reverse_lookup(reverse_lookup_entry(v), storage_scheme)
+                    });
 
-//                     futures::future::try_join_all(results).await?;
+                    futures::future::try_join_all(results).await?;
 
-//                     let storage_payment_method = (&payment_method_new).into();
+                    let storage_payment_method = (&payment_method_new).into();
 
-//                     let redis_entry = kv::TypedSql {
-//                         op: kv::DBOperation::Insert {
-//                             insertable: kv::Insertable::PaymentMethod(payment_method_new),
-//                         },
-//                     };
+                    let redis_entry = kv::TypedSql {
+                        op: kv::DBOperation::Insert {
+                            insertable: kv::Insertable::PaymentMethod(payment_method_new),
+                        },
+                    };
 
-//                     match kv_wrapper::<diesel_models::PaymentMethod, _, _>(
-//                         self,
-//                         KvOperation::<diesel_models::PaymentMethod>::HSetNx(
-//                             &field,
-//                             &storage_payment_method,
-//                             redis_entry,
-//                         ),
-//                         key,
-//                     )
-//                     .await
-//                     .map_err(|err| err.to_redis_failed_response(&key_str))?
-//                     .try_into_hsetnx()
-//                     {
-//                         Ok(HsetnxReply::KeyNotSet) => Err(errors::StorageError::DuplicateValue {
-//                             entity: "payment_method",
-//                             key: Some(storage_payment_method.payment_method_id),
-//                         }
-//                         .into()),
-//                         Ok(HsetnxReply::KeySet) => Ok(storage_payment_method),
-//                         Err(er) => Err(er).change_context(errors::StorageError::KVError),
-//                     }
-//                 }
-//             }
-//         }
+                    match kv_wrapper::<diesel_models::PaymentMethod, _, _>(
+                        self,
+                        KvOperation::<diesel_models::PaymentMethod>::HSetNx(
+                            &field,
+                            &storage_payment_method,
+                            redis_entry,
+                        ),
+                        key,
+                    )
+                    .await
+                    .map_err(|err| err.to_redis_failed_response(&key_str))?
+                    .try_into_hsetnx()
+                    {
+                        Ok(HsetnxReply::KeyNotSet) => Err(errors::StorageError::DuplicateValue {
+                            entity: "payment_method",
+                            key: Some(storage_payment_method.payment_method_id),
+                        }
+                        .into()),
+                        Ok(HsetnxReply::KeySet) => Ok(storage_payment_method),
+                        Err(er) => Err(er).change_context(errors::StorageError::KVError),
+                    }
+                }
+            }
+        }
 
-//         #[instrument(skip_all)]
-//         async fn update_payment_method(
-//             &self,
-//             payment_method: storage_types::PaymentMethod,
-//             payment_method_update: storage_types::PaymentMethodUpdate,
-//             storage_scheme: MerchantStorageScheme,
-//         ) -> CustomResult<storage_types::PaymentMethod, errors::StorageError> {
-//             match storage_scheme {
-//                 MerchantStorageScheme::PostgresOnly => {
-//                     let conn = connection::pg_connection_write(self).await?;
-//                     payment_method
-//                         .update_with_payment_method_id(&conn, payment_method_update.into())
-//                         .await
-//                         .map_err(|error| report!(errors::StorageError::from(error)))
-//                 }
-//                 MerchantStorageScheme::RedisKv => {
-//                     let merchant_id = payment_method.merchant_id.clone();
-//                     let customer_id = payment_method.customer_id.clone();
-//                     let key = PartitionKey::MerchantIdCustomerId {
-//                         merchant_id: &merchant_id,
-//                         customer_id: &customer_id,
-//                     };
-//                     let key_str = key.to_string();
-//                     let field = format!("payment_method_id_{}", payment_method.payment_method_id);
+        #[instrument(skip_all)]
+        async fn update_payment_method(
+            &self,
+            payment_method: storage_types::PaymentMethod,
+            payment_method_update: storage_types::PaymentMethodUpdate,
+            storage_scheme: MerchantStorageScheme,
+        ) -> CustomResult<storage_types::PaymentMethod, errors::StorageError> {
+            match storage_scheme {
+                MerchantStorageScheme::PostgresOnly => {
+                    let conn = connection::pg_connection_write(self).await?;
+                    payment_method
+                        .update_with_payment_method_id(&conn, payment_method_update.into())
+                        .await
+                        .map_err(|error| report!(errors::StorageError::from(error)))
+                }
+                MerchantStorageScheme::RedisKv => {
+                    let merchant_id = payment_method.merchant_id.clone();
+                    let customer_id = payment_method.customer_id.clone();
+                    let key = PartitionKey::MerchantIdCustomerId {
+                        merchant_id: &merchant_id,
+                        customer_id: &customer_id,
+                    };
+                    let key_str = key.to_string();
+                    let field = format!("payment_method_id_{}", payment_method.payment_method_id);
 
-//                     let p_update: PaymentMethodUpdateInternal = payment_method_update.into();
-//                     let updated_payment_method =
-//                         p_update.clone().apply_changeset(payment_method.clone());
+                    let p_update: PaymentMethodUpdateInternal = payment_method_update.into();
+                    let updated_payment_method =
+                        p_update.clone().apply_changeset(payment_method.clone());
 
-//                     let redis_value = serde_json::to_string(&updated_payment_method)
-//                         .change_context(errors::StorageError::SerializationFailed)?;
+                    let redis_value = serde_json::to_string(&updated_payment_method)
+                        .change_context(errors::StorageError::SerializationFailed)?;
 
-//                     let redis_entry = kv::TypedSql {
-//                         op: kv::DBOperation::Update {
-//                             updatable: kv::Updateable::PaymentMethodUpdate(
-//                                 kv::PaymentMethodUpdateMems {
-//                                     orig: payment_method,
-//                                     update_data: p_update,
-//                                 },
-//                             ),
-//                         },
-//                     };
+                    let redis_entry = kv::TypedSql {
+                        op: kv::DBOperation::Update {
+                            updatable: kv::Updateable::PaymentMethodUpdate(
+                                kv::PaymentMethodUpdateMems {
+                                    orig: payment_method,
+                                    update_data: p_update,
+                                },
+                            ),
+                        },
+                    };
 
-//                     kv_wrapper::<(), _, _>(
-//                         self,
-//                         KvOperation::<diesel_models::PaymentMethod>::Hset(
-//                             (&field, redis_value),
-//                             redis_entry,
-//                         ),
-//                         key,
-//                     )
-//                     .await
-//                     .map_err(|err| err.to_redis_failed_response(&key_str))?
-//                     .try_into_hset()
-//                     .change_context(errors::StorageError::KVError)?;
+                    kv_wrapper::<(), _, _>(
+                        self,
+                        KvOperation::<diesel_models::PaymentMethod>::Hset(
+                            (&field, redis_value),
+                            redis_entry,
+                        ),
+                        key,
+                    )
+                    .await
+                    .map_err(|err| err.to_redis_failed_response(&key_str))?
+                    .try_into_hset()
+                    .change_context(errors::StorageError::KVError)?;
 
-//                     Ok(updated_payment_method)
-//                 }
-//             }
-//         }
+                    Ok(updated_payment_method)
+                }
+            }
+        }
 
-//         #[instrument(skip_all)]
-//         async fn find_payment_method_by_customer_id_merchant_id_list(
-//             &self,
-//             customer_id: &str,
-//             merchant_id: &str,
-//             limit: Option<i64>,
-//         ) -> CustomResult<Vec<storage_types::PaymentMethod>, errors::StorageError> {
-//             let conn = connection::pg_connection_read(self).await?;
-//             storage_types::PaymentMethod::find_by_customer_id_merchant_id(
-//                 &conn,
-//                 customer_id,
-//                 merchant_id,
-//                 limit,
-//             )
-//             .await
-//             .map_err(|error| report!(errors::StorageError::from(error)))
-//         }
+        #[instrument(skip_all)]
+        async fn find_payment_method_by_customer_id_merchant_id_list(
+            &self,
+            customer_id: &str,
+            merchant_id: &str,
+            limit: Option<i64>,
+        ) -> CustomResult<Vec<storage_types::PaymentMethod>, errors::StorageError> {
+            let conn = connection::pg_connection_read(self).await?;
+            storage_types::PaymentMethod::find_by_customer_id_merchant_id(
+                &conn,
+                customer_id,
+                merchant_id,
+                limit,
+            )
+            .await
+            .map_err(|error| report!(errors::StorageError::from(error)))
+        }
 
-//         #[instrument(skip_all)]
-//         async fn find_payment_method_by_customer_id_merchant_id_status(
-//             &self,
-//             customer_id: &str,
-//             merchant_id: &str,
-//             status: common_enums::PaymentMethodStatus,
-//             limit: Option<i64>,
-//         ) -> CustomResult<Vec<storage_types::PaymentMethod>, errors::StorageError> {
-//             let conn = connection::pg_connection_read(self).await?;
-//             storage_types::PaymentMethod::find_by_customer_id_merchant_id_status(
-//                 &conn,
-//                 customer_id,
-//                 merchant_id,
-//                 status,
-//                 limit,
-//             )
-//             .await
-//             .map_err(|error| report!(errors::StorageError::from(error)))
-//         }
+        #[instrument(skip_all)]
+        async fn find_payment_method_by_customer_id_merchant_id_status(
+            &self,
+            customer_id: &str,
+            merchant_id: &str,
+            status: common_enums::PaymentMethodStatus,
+            limit: Option<i64>,
+            storage_scheme: MerchantStorageScheme,
+        ) -> CustomResult<Vec<storage_types::PaymentMethod>, errors::StorageError> {
+            let conn = connection::pg_connection_read(self).await?;
+            let database_call = || async {
+                storage_types::PaymentMethod::find_by_customer_id_merchant_id_status(
+                    &conn,
+                    customer_id,
+                    merchant_id,
+                    status,
+                    limit,
+                )
+                .await
+                .map_err(|error| report!(errors::StorageError::from(error)))
+            };
 
-//         async fn delete_payment_method_by_merchant_id_payment_method_id(
-//             &self,
-//             merchant_id: &str,
-//             payment_method_id: &str,
-//         ) -> CustomResult<storage_types::PaymentMethod, errors::StorageError> {
-//             let conn = connection::pg_connection_write(self).await?;
-//             storage_types::PaymentMethod::delete_by_merchant_id_payment_method_id(
-//                 &conn,
-//                 merchant_id,
-//                 payment_method_id,
-//             )
-//             .await
-//             .map_err(|error| report!(errors::StorageError::from(error)))
-//         }
-//     }
-// }
+            match storage_scheme {
+                MerchantStorageScheme::PostgresOnly => database_call().await,
+                MerchantStorageScheme::RedisKv => {
+                    let key = PartitionKey::MerchantIdCustomerId {
+                        merchant_id,
+                        customer_id,
+                    };
 
+                    let pattern = "payment_method_id_*";
+
+                    let redis_fut = async {
+                        let kv_result = kv_wrapper::<storage_types::PaymentMethod, _, _>(
+                            self,
+                            KvOperation::<storage_types::PaymentMethod>::Scan(pattern),
+                            key,
+                        )
+                        .await?
+                        .try_into_scan();
+                        kv_result.map(|payment_methods| {
+                            payment_methods
+                                .into_iter()
+                                .filter(|pm| pm.status == status)
+                                .collect()
+                            })
+                    };
+
+                    Box::pin(db_utils::find_all_redis_database(
+                        redis_fut,
+                        database_call,
+                        limit,
+                    ))
+                    .await
+
+            }
+
+        }
+        }
+
+        async fn delete_payment_method_by_merchant_id_payment_method_id(
+            &self,
+            merchant_id: &str,
+            payment_method_id: &str,
+        ) -> CustomResult<storage_types::PaymentMethod, errors::StorageError> {
+            let conn = connection::pg_connection_write(self).await?;
+            storage_types::PaymentMethod::delete_by_merchant_id_payment_method_id(
+                &conn,
+                merchant_id,
+                payment_method_id,
+            )
+            .await
+            .map_err(|error| report!(errors::StorageError::from(error)))
+        }
+    }
+}
+
+#[cfg(not(feature="kv_store"))]
 mod storage {
     use error_stack::report;
     use router_env::{instrument, tracing};
@@ -493,6 +535,7 @@ mod storage {
             merchant_id: &str,
             status: common_enums::PaymentMethodStatus,
             limit: Option<i64>,
+            _storage_scheme: MerchantStorageScheme,
         ) -> CustomResult<Vec<storage_types::PaymentMethod>, errors::StorageError> {
             let conn = connection::pg_connection_read(self).await?;
             storage_types::PaymentMethod::find_by_customer_id_merchant_id_status(
@@ -654,6 +697,7 @@ impl PaymentMethodInterface for MockDb {
         merchant_id: &str,
         status: common_enums::PaymentMethodStatus,
         _limit: Option<i64>,
+        _storage_scheme: MerchantStorageScheme,
     ) -> CustomResult<Vec<storage_types::PaymentMethod>, errors::StorageError> {
         let payment_methods = self.payment_methods.lock().await;
         let payment_methods_found: Vec<storage_types::PaymentMethod> = payment_methods

--- a/crates/router/src/db/payment_method.rs
+++ b/crates/router/src/db/payment_method.rs
@@ -398,7 +398,7 @@ mod storage {
                         })
                     };
 
-                    Box::pin(db_utils::find_all_redis_database(
+                    Box::pin(db_utils::find_all_combined_kv_database(
                         redis_fut,
                         database_call,
                         limit,

--- a/crates/router/src/utils/db_utils.rs
+++ b/crates/router/src/utils/db_utils.rs
@@ -37,7 +37,7 @@ where
     }
 }
 
-pub async fn find_all_redis_database<F, RFut, DFut, T>(
+pub async fn find_all_combined_kv_database<F, RFut, DFut, T>(
     redis_fut: RFut,
     database_call: F,
     limit: Option<i64>,

--- a/crates/router/src/utils/db_utils.rs
+++ b/crates/router/src/utils/db_utils.rs
@@ -49,12 +49,18 @@ where
         futures::Future<Output = error_stack::Result<Vec<T>, redis_interface::errors::RedisError>>,
     DFut: futures::Future<Output = error_stack::Result<Vec<T>, errors::StorageError>>,
 {
-    let trunc = |v: &mut Vec<_>| if let Some(l)
-        = limit.and_then(|v| TryInto::try_into(v).ok())
-    { v.truncate(l); };
+    let trunc = |v: &mut Vec<_>| {
+        if let Some(l) = limit.and_then(|v| TryInto::try_into(v).ok()) {
+            v.truncate(l);
+        }
+    };
 
-    let limit_satisfies = |len : usize, limit : i64| TryInto::try_into(limit).ok().map_or(true,  |val : usize| len >= val);
-    
+    let limit_satisfies = |len: usize, limit: i64| {
+        TryInto::try_into(limit)
+            .ok()
+            .map_or(true, |val: usize| len >= val)
+    };
+
     let redis_output = redis_fut.await;
     match (redis_output, limit) {
         (Ok(mut kv_rows), Some(lim)) if limit_satisfies(kv_rows.len(), lim) => {

--- a/crates/router/src/utils/db_utils.rs
+++ b/crates/router/src/utils/db_utils.rs
@@ -82,27 +82,23 @@ where
 use std::collections::HashSet;
 use storage_impl::UniqueConstraints;
 
-fn union_vec<T>(kv_rows: Vec<T>, sql_rows : Vec<T>) -> Vec<T>
+fn union_vec<T>(mut kv_rows: Vec<T>, sql_rows : Vec<T>) -> Vec<T>
 where
     T : UniqueConstraints,
 {
     let mut kv_unique_keys = HashSet::new();
-    let mut kv_iter = kv_rows.iter();
-    while let Some(v) = kv_iter.next(){
-        let unique_key = v.unique_constraints().concat();
-        kv_unique_keys.insert(unique_key);
-    };
 
-    let mut res = kv_rows;
+    kv_rows.iter().for_each(|v| {
+        kv_unique_keys.insert(v.unique_constraints().concat());
+    });
 
-    let mut sql_iter = sql_rows.into_iter();
-    while let Some(v) = sql_iter.next(){
+
+    sql_rows.into_iter().for_each(|v| {
         let unique_key = v.unique_constraints().concat();
         if !kv_unique_keys.contains(&unique_key){
-            res.push(v);
+            kv_rows.push(v);
         }
-    };
+    });
 
-    return res
-    
+    return kv_rows
 }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->

Issue scenario faced:
1. create payment method (in /payments)
2. list payment method by customer (find all query that always went to db)
 above api returns empty list
 
 to handle cases where payment method entry present in kv but not drained to db yet, we have added a lookup in kv as well and combining data for findall from both kv and db

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
list payment method by customer and merchant was eventually consistent when payment method followed kv path,
change here is to combine values from db and redis

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

1. create payment method and drain data to db (can skip this step if payment method entries are already present in db but not kv for the customer <> merchant)
2. create another payment method through kv
3. list payment methods should reflect pm created through kv as well
`curl --location 'http://localhost:8080/customers/<cust_id>/payment_methods' \
--header 'Accept: application/json' \
--header 'api-key:***'`


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
