### PR TITLE
fix(address): use first_name if last_name is not passed

### DIFF
--- a/crates/api_models/src/payments.rs
+++ b/crates/api_models/src/payments.rs
@@ -2709,8 +2709,8 @@ impl AddressDetails {
             };
 
             Self {
-                first_name: first_name.clone(),
-                last_name: last_name.or(first_name),
+                first_name,
+                last_name,
                 city: self.city.or(other.city.clone()),
                 country: self.country.or(other.country),
                 line1: self.line1.or(other.line1.clone()),

--- a/crates/api_models/src/payments.rs
+++ b/crates/api_models/src/payments.rs
@@ -2709,8 +2709,8 @@ impl AddressDetails {
             };
 
             Self {
-                first_name,
-                last_name,
+                first_name: first_name.clone(),
+                last_name: last_name.or(first_name),
                 city: self.city.or(other.city.clone()),
                 country: self.country.or(other.country),
                 line1: self.line1.or(other.line1.clone()),

--- a/crates/router/src/connector/bankofamerica/transformers.rs
+++ b/crates/router/src/connector/bankofamerica/transformers.rs
@@ -424,10 +424,10 @@ fn build_bill_to(
         .ok_or_else(utils::missing_field_err("billing.address"))?;
     let mut state = address.to_state_code()?.peek().clone();
     state.truncate(20);
-    let first_name = address.get_first_name()?.to_owned();
+    let first_name = address.get_first_name()?;
     Ok(BillTo {
         first_name: first_name.clone(),
-        last_name: address.get_last_name().ok().unwrap_or(&first_name).clone(),
+        last_name: address.get_last_name().unwrap_or(first_name).clone(),
         address1: address.get_line1()?.to_owned(),
         locality: Secret::new(address.get_city()?.to_owned()),
         administrative_area: Secret::from(state),

--- a/crates/router/src/connector/bankofamerica/transformers.rs
+++ b/crates/router/src/connector/bankofamerica/transformers.rs
@@ -424,9 +424,10 @@ fn build_bill_to(
         .ok_or_else(utils::missing_field_err("billing.address"))?;
     let mut state = address.to_state_code()?.peek().clone();
     state.truncate(20);
+    let first_name = address.get_first_name()?.to_owned();
     Ok(BillTo {
-        first_name: address.get_first_name()?.to_owned(),
-        last_name: address.get_last_name()?.to_owned(),
+        first_name: first_name.clone(),
+        last_name: address.get_last_name().ok().unwrap_or(&first_name).clone(),
         address1: address.get_line1()?.to_owned(),
         locality: Secret::new(address.get_city()?.to_owned()),
         administrative_area: Secret::from(state),

--- a/crates/router/src/connector/bluesnap/transformers.rs
+++ b/crates/router/src/connector/bluesnap/transformers.rs
@@ -1133,9 +1133,10 @@ fn get_card_holder_info(
     address: &api::AddressDetails,
     email: Email,
 ) -> CustomResult<Option<BluesnapCardHolderInfo>, errors::ConnectorError> {
+    let first_name = address.get_first_name()?.clone();
     Ok(Some(BluesnapCardHolderInfo {
-        first_name: address.get_first_name()?.clone(),
-        last_name: address.get_last_name()?.clone(),
+        first_name: first_name.clone(),
+        last_name: address.get_last_name().ok().unwrap_or(&first_name).clone(),
         email,
     }))
 }

--- a/crates/router/src/connector/bluesnap/transformers.rs
+++ b/crates/router/src/connector/bluesnap/transformers.rs
@@ -1133,10 +1133,10 @@ fn get_card_holder_info(
     address: &api::AddressDetails,
     email: Email,
 ) -> CustomResult<Option<BluesnapCardHolderInfo>, errors::ConnectorError> {
-    let first_name = address.get_first_name()?.clone();
+    let first_name = address.get_first_name()?;
     Ok(Some(BluesnapCardHolderInfo {
         first_name: first_name.clone(),
-        last_name: address.get_last_name().ok().unwrap_or(&first_name).clone(),
+        last_name: address.get_last_name().unwrap_or(first_name).clone(),
         email,
     }))
 }

--- a/crates/router/src/connector/cybersource/transformers.rs
+++ b/crates/router/src/connector/cybersource/transformers.rs
@@ -784,9 +784,10 @@ fn build_bill_to(
         .ok_or_else(utils::missing_field_err("billing.address"))?;
     let mut state = address.to_state_code()?.peek().clone();
     state.truncate(20);
+    let first_name = address.get_first_name()?.to_owned();
     Ok(BillTo {
-        first_name: address.get_first_name()?.to_owned(),
-        last_name: address.get_last_name()?.to_owned(),
+        first_name: first_name.clone(),
+        last_name: address.get_last_name().ok().unwrap_or(&first_name).clone(),
         address1: address.get_line1()?.to_owned(),
         locality: address.get_city()?.to_owned(),
         administrative_area: Secret::from(state),

--- a/crates/router/src/connector/cybersource/transformers.rs
+++ b/crates/router/src/connector/cybersource/transformers.rs
@@ -784,10 +784,10 @@ fn build_bill_to(
         .ok_or_else(utils::missing_field_err("billing.address"))?;
     let mut state = address.to_state_code()?.peek().clone();
     state.truncate(20);
-    let first_name = address.get_first_name()?.to_owned();
+    let first_name = address.get_first_name()?;
     Ok(BillTo {
         first_name: first_name.clone(),
-        last_name: address.get_last_name().ok().unwrap_or(&first_name).clone(),
+        last_name: address.get_last_name().unwrap_or(first_name).clone(),
         address1: address.get_line1()?.to_owned(),
         locality: address.get_city()?.to_owned(),
         administrative_area: Secret::from(state),

--- a/crates/router/src/connector/forte/transformers.rs
+++ b/crates/router/src/connector/forte/transformers.rs
@@ -88,9 +88,10 @@ impl TryFrom<&types::PaymentsAuthorizeRouterData> for FortePaymentsRequest {
                     expire_year: ccard.card_exp_year.clone(),
                     card_verification_value: ccard.card_cvc.clone(),
                 };
+                let first_name = address.get_first_name()?.to_owned();
                 let billing_address = BillingAddress {
-                    first_name: address.get_first_name()?.to_owned(),
-                    last_name: address.get_last_name()?.to_owned(),
+                    first_name: first_name.clone(),
+                    last_name: address.get_last_name().ok().unwrap_or(&first_name).clone(),
                 };
                 let authorization_amount =
                     utils::to_currency_base_unit_asf64(item.request.amount, item.request.currency)?;

--- a/crates/router/src/connector/forte/transformers.rs
+++ b/crates/router/src/connector/forte/transformers.rs
@@ -88,10 +88,10 @@ impl TryFrom<&types::PaymentsAuthorizeRouterData> for FortePaymentsRequest {
                     expire_year: ccard.card_exp_year.clone(),
                     card_verification_value: ccard.card_cvc.clone(),
                 };
-                let first_name = address.get_first_name()?.to_owned();
+                let first_name = address.get_first_name()?;
                 let billing_address = BillingAddress {
                     first_name: first_name.clone(),
-                    last_name: address.get_last_name().ok().unwrap_or(&first_name).clone(),
+                    last_name: address.get_last_name().unwrap_or(first_name).clone(),
                 };
                 let authorization_amount =
                     utils::to_currency_base_unit_asf64(item.request.amount, item.request.currency)?;

--- a/crates/router/src/connector/multisafepay/transformers.rs
+++ b/crates/router/src/connector/multisafepay/transformers.rs
@@ -411,13 +411,12 @@ impl TryFrom<&MultisafepayRouterData<&types::PaymentsAuthorizeRouterData>>
             .address
             .as_ref()
             .ok_or_else(utils::missing_field_err("billing.address"))?;
-        let first_name = billing_address.get_first_name()?.to_owned();
+        let first_name = billing_address.get_first_name()?;
         let delivery = DeliveryObject {
             first_name: first_name.clone(),
             last_name: billing_address
                 .get_last_name()
-                .ok()
-                .unwrap_or(&first_name)
+                .unwrap_or(first_name)
                 .clone(),
             address1: billing_address.get_line1()?.to_owned(),
             house_number: billing_address.get_line2()?.to_owned(),

--- a/crates/router/src/connector/multisafepay/transformers.rs
+++ b/crates/router/src/connector/multisafepay/transformers.rs
@@ -411,9 +411,14 @@ impl TryFrom<&MultisafepayRouterData<&types::PaymentsAuthorizeRouterData>>
             .address
             .as_ref()
             .ok_or_else(utils::missing_field_err("billing.address"))?;
+        let first_name = billing_address.get_first_name()?.to_owned();
         let delivery = DeliveryObject {
-            first_name: billing_address.get_first_name()?.to_owned(),
-            last_name: billing_address.get_last_name()?.to_owned(),
+            first_name: first_name.clone(),
+            last_name: billing_address
+                .get_last_name()
+                .ok()
+                .unwrap_or(&first_name)
+                .clone(),
             address1: billing_address.get_line1()?.to_owned(),
             house_number: billing_address.get_line2()?.to_owned(),
             zip_code: billing_address.get_zip()?.to_owned(),
@@ -917,7 +922,7 @@ impl From<MultisafepayErrorResponse> for Option<AttemptStatus> {
             | 1031 // IncorrectItemPrice
             | 1035 // InvalidSignatureRefund
             | 1036 // InvalidIdealIssuerID
-            | 5001 // CartDataNotValidated 
+            | 5001 // CartDataNotValidated
             | 1032 // InvalidAPIKey
             => {
                 Some(AttemptStatus::AuthenticationFailed)
@@ -925,7 +930,7 @@ impl From<MultisafepayErrorResponse> for Option<AttemptStatus> {
 
             1034 // CannotRefundTransaction
             | 1022 // CannotInitiateTransaction
-            | 1024 //TransactionDeclined 
+            | 1024 //TransactionDeclined
             => Some(AttemptStatus::Failure),
             1017 // InsufficientFunds
             => Some(AttemptStatus::AuthorizationFailed),

--- a/crates/router/src/connector/nmi/transformers.rs
+++ b/crates/router/src/connector/nmi/transformers.rs
@@ -116,7 +116,7 @@ impl TryFrom<&types::PaymentsPreProcessingRouterData> for NmiVaultRequest {
         let auth_type: NmiAuthType = (&item.connector_auth_type).try_into()?;
         let (ccnumber, ccexp, cvv) = get_card_details(item.request.payment_method_data.clone())?;
         let billing_details = item.get_billing_address()?;
-        let first_name = billing_details.get_first_name()?.to_owned();
+        let first_name = billing_details.get_first_name()?;
 
         Ok(Self {
             security_key: auth_type.api_key,
@@ -126,8 +126,7 @@ impl TryFrom<&types::PaymentsPreProcessingRouterData> for NmiVaultRequest {
             first_name: first_name.clone(),
             last_name: billing_details
                 .get_last_name()
-                .ok()
-                .unwrap_or(&first_name)
+                .unwrap_or(first_name)
                 .clone(),
             address1: billing_details.line1.clone(),
             address2: billing_details.line2.clone(),

--- a/crates/router/src/connector/nmi/transformers.rs
+++ b/crates/router/src/connector/nmi/transformers.rs
@@ -116,14 +116,19 @@ impl TryFrom<&types::PaymentsPreProcessingRouterData> for NmiVaultRequest {
         let auth_type: NmiAuthType = (&item.connector_auth_type).try_into()?;
         let (ccnumber, ccexp, cvv) = get_card_details(item.request.payment_method_data.clone())?;
         let billing_details = item.get_billing_address()?;
+        let first_name = billing_details.get_first_name()?.to_owned();
 
         Ok(Self {
             security_key: auth_type.api_key,
             ccnumber,
             ccexp,
             cvv,
-            first_name: billing_details.get_first_name()?.to_owned(),
-            last_name: billing_details.get_last_name()?.to_owned(),
+            first_name: first_name.clone(),
+            last_name: billing_details
+                .get_last_name()
+                .ok()
+                .unwrap_or(&first_name)
+                .clone(),
             address1: billing_details.line1.clone(),
             address2: billing_details.line2.clone(),
             city: billing_details.city.clone(),

--- a/crates/router/src/connector/nuvei/transformers.rs
+++ b/crates/router/src/connector/nuvei/transformers.rs
@@ -667,7 +667,7 @@ impl<F>
                 (
                     Some(BillingAddress {
                         first_name: Some(first_name.clone()),
-                        last_name: Some(address.get_last_name().ok().unwrap_or(first_name).clone()),
+                        last_name: Some(address.get_last_name().unwrap_or(first_name).clone()),
                         email: item.request.get_email()?,
                         country: item.get_billing_country()?,
                     }),
@@ -719,7 +719,7 @@ fn get_pay_later_info<F>(
         .address
         .as_ref()
         .ok_or_else(utils::missing_field_err("billing.address"))?;
-    let first_name = address.get_first_name()?.to_owned();
+    let first_name = address.get_first_name()?;
     let payment_method = payment_method_type;
     Ok(NuveiPaymentsRequest {
         payment_option: PaymentOption {
@@ -730,7 +730,7 @@ fn get_pay_later_info<F>(
             billing_address: Some(BillingAddress {
                 email: item.request.get_email()?,
                 first_name: Some(first_name.clone()),
-                last_name: Some(address.get_last_name().ok().unwrap_or(&first_name).clone()),
+                last_name: Some(address.get_last_name().unwrap_or(first_name).clone()),
                 country: address.get_country()?.to_owned(),
             }),
             ..Default::default()

--- a/crates/router/src/connector/nuvei/transformers.rs
+++ b/crates/router/src/connector/nuvei/transformers.rs
@@ -667,9 +667,7 @@ impl<F>
                 (
                     Some(BillingAddress {
                         first_name: Some(first_name.clone()),
-                        last_name: Some(
-                            address.get_last_name().ok().unwrap_or(&first_name).clone(),
-                        ),
+                        last_name: Some(address.get_last_name().ok().unwrap_or(first_name).clone()),
                         email: item.request.get_email()?,
                         country: item.get_billing_country()?,
                     }),

--- a/crates/router/src/connector/utils.rs
+++ b/crates/router/src/connector/utils.rs
@@ -1194,7 +1194,12 @@ impl AddressDetailsData for api::AddressDetails {
 
     fn get_full_name(&self) -> Result<Secret<String>, Error> {
         let first_name = self.get_first_name()?.peek().to_owned();
-        let last_name = self.get_last_name()?.peek().to_owned();
+        let last_name = self
+            .get_last_name()
+            .ok()
+            .cloned()
+            .unwrap_or(Secret::new("".to_string()));
+        let last_name = last_name.peek();
         let full_name = format!("{} {}", first_name, last_name).trim().to_string();
         Ok(Secret::new(full_name))
     }

--- a/crates/router/src/connector/volt/transformers.rs
+++ b/crates/router/src/connector/volt/transformers.rs
@@ -98,10 +98,11 @@ impl TryFrom<&VoltRouterData<&types::PaymentsAuthorizeRouterData>> for VoltPayme
                     let payment_pending_url = item.router_data.request.router_return_url.clone();
                     let payment_cancel_url = item.router_data.request.router_return_url.clone();
                     let address = item.router_data.get_billing_address()?;
+                    let first_name = address.get_first_name()?;
                     let shopper = ShopperDetails {
                         email: item.router_data.request.email.clone(),
-                        first_name: address.get_first_name()?.to_owned(),
-                        last_name: address.get_last_name()?.to_owned(),
+                        first_name: first_name.to_owned(),
+                        last_name: address.get_last_name().unwrap_or(first_name).to_owned(),
                         reference: item.router_data.get_customer_id()?.to_owned(),
                     };
                     let transaction_type = TransactionType::Services; //transaction_type is a form of enum, it is pre defined and value for this can not be taken from user so we are keeping it as Services as this transaction is type of service.


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix

## Description
<!-- Describe your changes in detail -->
This PR fixes the issue which arises when creating a payement with cybersource and bank of america connectors where billing first name and last name are mandatory.


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
- Create a payment by passing billing address in payment create request, with confirm set to false.
```bash
curl --location 'http://localhost:8080/payments' \
--header 'Content-Type: application/json' \
--header 'api-key: dev_uHrHd27n2djqmWLoWqhpHPf1NmU2dsIbEguhDIB9ji7bQmzf9rLqw9TqrsRybqwm' \
--data-raw '{
    "amount": 6540,
    "currency": "USD",
    "confirm": false,
    "customer": {
        "id": "cus_abc",
        "email": "example@juspay.in"
    },
    "billing": {
        "address": {
            "line1": "1467",
            "line2": "Harrison Street",
            "city": "San Fransico",
            "state": "California",
            "zip": "94122",
            "country": "US",
            "first_name": "Narayan",
            "last_name": "Bhat"
        }
    }
}'
```

- Confirm the payment with `card_holder_name`, by not passing last name
```bash
curl --location 'http://localhost:8080/payments/pay_QHybdDJQVMZVgS4BX4IQ/confirm' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: dev_uHrHd27n2djqmWLoWqhpHPf1NmU2dsIbEguhDIB9ji7bQmzf9rLqw9TqrsRybqwm' \
--data '{
    "payment_method_data": {
        "card": {
            "card_number": "4242424242424242",
            "card_exp_month": "10",
            "card_exp_year": "25",
            "card_holder_name": "Narayan",
            "card_cvc": "123"
        }
    },
    "payment_method": "card"
}'
```

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
