### PR TITLE
refactor(connector): pass optional browser_info to stripe for increased trust

### DIFF
--- a/crates/router/src/connector/stripe/transformers.rs
+++ b/crates/router/src/connector/stripe/transformers.rs
@@ -1996,14 +1996,15 @@ impl TryFrom<&types::PaymentsAuthorizeRouterData> for PaymentIntentRequest {
 
         // We pass browser_info only when payment_data exists.
         // Hence, we're pass Null during recurring payments as payment_method_data[type] is not passed
-        let mut browser_info = None;
-        if payment_data.is_some() {
-            browser_info = item
-                .request
-                .browser_info
-                .clone()
-                .map(StripeBrowserInformation::from);
-        }
+        let browser_info = payment_data.as_ref().map_or_else(
+            || None,
+            |_| {
+                item.request
+                    .browser_info
+                    .clone()
+                    .map(StripeBrowserInformation::from)
+            },
+        );
 
         Ok(Self {
             amount: item.request.amount, //hopefully we don't loose some cents here

--- a/crates/router/src/connector/stripe/transformers.rs
+++ b/crates/router/src/connector/stripe/transformers.rs
@@ -2000,7 +2000,7 @@ impl TryFrom<&types::PaymentsAuthorizeRouterData> for PaymentIntentRequest {
             item.request
                 .browser_info
                 .clone()
-                .map(StripeBrowserInformation)
+                .map(StripeBrowserInformation::from)
         } else {
             None
         };

--- a/crates/router/src/connector/stripe/transformers.rs
+++ b/crates/router/src/connector/stripe/transformers.rs
@@ -1996,15 +1996,11 @@ impl TryFrom<&types::PaymentsAuthorizeRouterData> for PaymentIntentRequest {
 
         // We pass browser_info only when payment_data exists.
         // Hence, we're pass Null during recurring payments as payment_method_data[type] is not passed
-        let browser_info = payment_data.as_ref().map_or_else(
-            || None,
-            |_| {
-                item.request
-                    .browser_info
-                    .clone()
-                    .map(StripeBrowserInformation::from)
-            },
-        );
+        let browser_info = if payment_data.is_some() {
+            item.request.browser_info.clone().map(StripeBrowserInformation)
+        } else {
+            None
+        }
 
         Ok(Self {
             amount: item.request.amount, //hopefully we don't loose some cents here

--- a/crates/router/src/connector/stripe/transformers.rs
+++ b/crates/router/src/connector/stripe/transformers.rs
@@ -1997,10 +1997,13 @@ impl TryFrom<&types::PaymentsAuthorizeRouterData> for PaymentIntentRequest {
         // We pass browser_info only when payment_data exists.
         // Hence, we're pass Null during recurring payments as payment_method_data[type] is not passed
         let browser_info = if payment_data.is_some() {
-            item.request.browser_info.clone().map(StripeBrowserInformation)
+            item.request
+                .browser_info
+                .clone()
+                .map(StripeBrowserInformation)
         } else {
             None
-        }
+        };
 
         Ok(Self {
             amount: item.request.amount, //hopefully we don't loose some cents here

--- a/crates/router/src/connector/stripe/transformers.rs
+++ b/crates/router/src/connector/stripe/transformers.rs
@@ -1991,9 +1991,11 @@ impl TryFrom<&types::PaymentsAuthorizeRouterData> for PaymentIntentRequest {
             });
 
         let meta_data = get_transaction_metadata(item.request.metadata.clone(), order_id);
-        let browser_info =
-            <Option<types::BrowserInformation> as Clone>::clone(&item.request.browser_info)
-                .map(StripeBrowserInformation::from);
+        let browser_info = item
+            .request
+            .browser_info
+            .clone()
+            .map(StripeBrowserInformation::from);
 
         Ok(Self {
             amount: item.request.amount, //hopefully we don't loose some cents here
@@ -2061,10 +2063,7 @@ fn get_payment_method_type_for_saved_payment_method_payment(
 impl From<types::BrowserInformation> for StripeBrowserInformation {
     fn from(item: types::BrowserInformation) -> Self {
         Self {
-            ip_address: item
-                .ip_address
-                .as_ref()
-                .map(|ip| Secret::new(ip.to_string())),
+            ip_address: item.ip_address.map(|ip| Secret::new(ip.to_string())),
             user_agent: item.user_agent,
         }
     }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->

This PR adds optional `browser_info` where we pass the `user_agent` and `ip_address` in the name of added security for increasing trust as recommended [here](https://docs.stripe.com/radar/integration) in their docs.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->

This changes helps increase trust in the transactions done and reduce fraudulent transactions.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

Tested locally.

For a Payment made that has `browser_info` passed, we're passing `ip_address` and `user_agent` info to the connector

Normal Payments

```curl
curl --location 'http://Localhost:8080/payments' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: dev_Ccavmev3Psp3EH7rvFLf0qrgsHbXwEFQKtBFq7Fbx9u2gOtbUXuLdVfhKiQ5Arls' \
--data-raw '{
	"amount": 4545,
	"currency": "USD",
	"confirm": true,
	"capture_method": "automatic",
	"capture_on": "2024-09-10T10:11:12Z",
	"customer_id": "StripeCustomer",
	"email": "guest@example.com",
	"name": "Lapak Landu",
	"phone": "4444999966",
	"phone_country_code": "+1",
	"description": "Its my last payment request",
	"authentication_type": "no_three_ds",
	"return_url": "https://duck.com",
	"browser_info": {
		"ip_address": "62.132.141.1",
		"user_agent": "Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0)"
	},
	"payment_method": "card",
	"payment_method_data": {
		"card": {
			"card_number": "4242424242424242",
			"card_exp_month": "10",
			"card_exp_year": "25",
			"card_holder_name": "Lapak Landu Doe",
			"card_cvc": "123"
		}
	},
	"billing": {
		"address": {
			"line1": "1467",
			"line2": "Harrison Street",
			"line3": "Harrison Street",
			"city": "San Fransico",
			"state": "California",
			"zip": "560001",
			"country": "US",
			"first_name": "PiX"
		}
	},
	"statement_descriptor_name": "PiX",
	"statement_descriptor_suffix": "JS",
	"metadata": {
		"udf1": "value1",
		"new_customer": "true",
		"login_date": "2019-09-10T10:11:12Z"
	}
}'
```
```json
{
	"payment_id": "pay_C8c3HZPT8gI7XsTFqT7D",
	"merchant_id": "postman_merchant_GHAction_523bcf6e-5b18-4f35-9b59-e2edf85b8fc4",
	"status": "succeeded",
	"amount": 4545,
	"net_amount": 4545,
	"amount_capturable": 0,
	"amount_received": 4545,
	"connector": "stripe",
	"client_secret": "pay_C8c3HZPT8gI7XsTFqT7D_secret_lU1l8eCIRDwFpqN74ZjV",
	"created": "2024-04-16T11:55:40.769Z",
	"currency": "USD",
	"customer_id": "StripeCustomer",
	"customer": {
		"id": "StripeCustomer",
		"name": "Lapak Landu",
		"email": "guest@example.com",
		"phone": "4444999966",
		"phone_country_code": "+1"
	},
	"description": "Its my last payment request",
	"refunds": null,
	"disputes": null,
	"mandate_id": null,
	"mandate_data": null,
	"setup_future_usage": null,
	"off_session": null,
	"capture_on": null,
	"capture_method": "automatic",
	"payment_method": "card",
	"payment_method_data": {
		"card": {
			"last4": "4242",
			"card_type": null,
			"card_network": null,
			"card_issuer": null,
			"card_issuing_country": null,
			"card_isin": "424242",
			"card_extended_bin": "42424242",
			"card_exp_month": "10",
			"card_exp_year": "25",
			"card_holder_name": "Lapak Landu Doe",
			"payment_checks": {
				"address_line1_check": "pass",
				"address_postal_code_check": "pass",
				"cvc_check": "pass"
			},
			"authentication_data": null
		},
		"billing": null
	},
	"payment_token": null,
	"shipping": null,
	"billing": {
		"address": {
			"city": "San Fransico",
			"country": "US",
			"line1": "1467",
			"line2": "Harrison Street",
			"line3": "Harrison Street",
			"zip": "560001",
			"state": "California",
			"first_name": "PiX",
			"last_name": null
		},
		"phone": null,
		"email": null
	},
	"order_details": null,
	"email": "guest@example.com",
	"name": "Lapak Landu",
	"phone": "4444999966",
	"return_url": "https://duck.com/",
	"authentication_type": "no_three_ds",
	"statement_descriptor_name": "PiX",
	"statement_descriptor_suffix": "JS",
	"next_action": null,
	"cancellation_reason": null,
	"error_code": null,
	"error_message": null,
	"unified_code": null,
	"unified_message": null,
	"payment_experience": null,
	"payment_method_type": null,
	"connector_label": null,
	"business_country": null,
	"business_label": "default",
	"business_sub_label": null,
	"allowed_payment_method_types": null,
	"ephemeral_key": {
		"customer_id": "StripeCustomer",
		"created_at": 1713268540,
		"expires": 1713272140,
		"secret": "epk_f46f28dd49344d598914ea6c20c66fee"
	},
	"manual_retry_allowed": false,
	"connector_transaction_id": "pi_3P6AbxD5R7gDAGff0vnaupsb",
	"frm_message": null,
	"metadata": {
		"udf1": "value1",
		"login_date": "2019-09-10T10:11:12Z",
		"new_customer": "true"
	},
	"connector_metadata": null,
	"feature_metadata": null,
	"reference_id": "pi_3P6AbxD5R7gDAGff0vnaupsb",
	"payment_link": null,
	"profile_id": "pro_3ywCNBHIQH1mKTMvRQdq",
	"surcharge_details": null,
	"attempt_count": 1,
	"merchant_decision": null,
	"merchant_connector_id": "mca_tZB5c7C6gJ60euyAq6Zy",
	"incremental_authorization_allowed": null,
	"authorization_count": null,
	"incremental_authorizations": null,
	"external_authentication_details": null,
	"external_3ds_authentication_attempted": false,
	"expires_on": "2024-04-16T12:10:40.769Z",
	"fingerprint": null,
	"browser_info": {
		"ip_address": "62.132.141.1",
		"user_agent": "Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0)"
	},
	"payment_method_id": null,
	"payment_method_status": null,
	"updated": "2024-04-16T11:55:42.575Z"
}
```

Logs:
![image](https://github.com/juspay/hyperswitch/assets/69745008/0c5c68d8-dfc8-4d5c-8ef1-879fae8cc5bf)

![image](https://github.com/juspay/hyperswitch/assets/69745008/a4f65571-f668-4535-8101-96d2447138df)

Sent info can also be verified in the Stripe dashboard under `request_parameters`:

![image](https://github.com/juspay/hyperswitch/assets/69745008/2b84a5ee-7d11-4971-9313-8f8cc3f35f0b)


Mandate Payments

Setup Mandate

```curl
curl --location 'http://Localhost:8080/payments' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: dev_1WgNFlrn2dGabBfz7NTVPzC1W8071dZpa5buokChLlUGUvp0ZUM0AyYDNtCCzJ59' \
--data-raw '{
	"amount": 0,
	"currency": "USD",
	"confirm": true,
	"capture_method": "automatic",
	"capture_on": "2022-09-10T10:11:12Z",
	"customer_id": "StripeCustomer",
	"email": "guest@example.com",
	"name": "John Doe",
	"phone": "999999999",
	"phone_country_code": "+65",
	"description": "Its my first payment request",
	"authentication_type": "no_three_ds",
	"return_url": "https://duck.com",
	"payment_method": "card",
	"payment_method_data": {
		"card": {
			"card_number": "4242424242424242",
			"card_exp_month": "10",
			"card_exp_year": "25",
			"card_holder_name": "joseph Doe",
			"card_cvc": "123"
		}
	},
	"browser_info": {
		"ip_address": "192.168.0.1",
		"user_agent": "Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0)"
	},
	"payment_type":"setup_mandate",
	"setup_future_usage": "off_session",
	"mandate_data": {
		"customer_acceptance": {
			"acceptance_type": "offline",
			"accepted_at": "1963-05-03T04:07:52.723Z",
			"online": {
				"ip_address": "127.0.0.1",
				"user_agent": "amet irure esse"
			}
		},
		"mandate_type": {
			"single_use": {
				"amount": 7000,
				"currency": "USD"
			}
		}
	},
	"customer_acceptance": {
		"acceptance_type": "online",
		"accepted_at": "2022-09-10T10:11:12Z",
		"online": {
			"ip_address": "123.32.25.123",
			"user_agent": "Mozilla/5.0 (Linux; Android 12; SM-S906N Build/QP1A.190711.020; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/80.0.3987.119 Mobile Safari/537.36"
		}
	},
	"shipping": {
		"address": {
			"line1": "1467",
			"line2": "Harrison Street",
			"line3": "Harrison Street",
			"city": "San Fransico",
			"state": "California",
			"zip": "94122",
			"country": "US",
			"first_name": "sundari"
		}
	},
	"statement_descriptor_name": "joseph",
	"statement_descriptor_suffix": "JS",
	"metadata": {
		"udf1": "value1",
		"new_customer": "true",
		"login_date": "2019-09-10T10:11:12Z"
	},
	"routing": {
		"type": "single",
		"data": "stripe"
	}
}'
```
```json
{
	"payment_id": "pay_y2sN9MmJcD5EQW4hOEAD",
	"merchant_id": "postman_merchant_GHAction_1ae79909-5aa3-47ec-b90b-254f423247aa",
	"status": "succeeded",
	"amount": 0,
	"net_amount": 0,
	"amount_capturable": 0,
	"amount_received": null,
	"connector": "stripe",
	"client_secret": "pay_y2sN9MmJcD5EQW4hOEAD_secret_yD5rGoVcTH58lNekPDL7",
	"created": "2024-04-18T07:15:45.604Z",
	"currency": "USD",
	"customer_id": "StripeCustomer",
	"customer": {
		"id": "StripeCustomer",
		"name": "John Doe",
		"email": "guest@example.com",
		"phone": "999999999",
		"phone_country_code": "+65"
	},
	"description": "Its my first payment request",
	"refunds": null,
	"disputes": null,
	"mandate_id": "man_QuAFrbLieIFMeZg0i2ym",
	"mandate_data": {
		"update_mandate_id": null,
		"customer_acceptance": {
			"acceptance_type": "offline",
			"accepted_at": "1963-05-03T04:07:52.723Z",
			"online": {
				"ip_address": "127.0.0.1",
				"user_agent": "amet irure esse"
			}
		},
		"mandate_type": {
			"single_use": {
				"amount": 7000,
				"currency": "USD",
				"start_date": null,
				"end_date": null,
				"metadata": null
			}
		}
	},
	"setup_future_usage": "off_session",
	"off_session": null,
	"capture_on": null,
	"capture_method": "automatic",
	"payment_method": "card",
	"payment_method_data": {
		"card": {
			"last4": "4242",
			"card_type": null,
			"card_network": null,
			"card_issuer": null,
			"card_issuing_country": null,
			"card_isin": "424242",
			"card_extended_bin": "42424242",
			"card_exp_month": "10",
			"card_exp_year": "25",
			"card_holder_name": "joseph Doe",
			"payment_checks": {
				"address_line1_check": null,
				"address_postal_code_check": null,
				"cvc_check": "pass"
			},
			"authentication_data": null
		},
		"billing": null
	},
	"payment_token": null,
	"shipping": {
		"address": {
			"city": "San Fransico",
			"country": "US",
			"line1": "1467",
			"line2": "Harrison Street",
			"line3": "Harrison Street",
			"zip": "94122",
			"state": "California",
			"first_name": "sundari",
			"last_name": null
		},
		"phone": null,
		"email": null
	},
	"billing": null,
	"order_details": null,
	"email": "guest@example.com",
	"name": "John Doe",
	"phone": "999999999",
	"return_url": "https://duck.com/",
	"authentication_type": "no_three_ds",
	"statement_descriptor_name": "joseph",
	"statement_descriptor_suffix": "JS",
	"next_action": null,
	"cancellation_reason": null,
	"error_code": null,
	"error_message": null,
	"unified_code": null,
	"unified_message": null,
	"payment_experience": null,
	"payment_method_type": null,
	"connector_label": null,
	"business_country": null,
	"business_label": "default",
	"business_sub_label": null,
	"allowed_payment_method_types": null,
	"ephemeral_key": {
		"customer_id": "StripeCustomer",
		"created_at": 1713424545,
		"expires": 1713428145,
		"secret": "epk_7b1a12da04f6456dae7fa9f2eb43e6f9"
	},
	"manual_retry_allowed": false,
	"connector_transaction_id": "seti_1P6pCBD5R7gDAGffyXxXitZc",
	"frm_message": null,
	"metadata": {
		"udf1": "value1",
		"login_date": "2019-09-10T10:11:12Z",
		"new_customer": "true"
	},
	"connector_metadata": null,
	"feature_metadata": null,
	"reference_id": "seti_1P6pCBD5R7gDAGffyXxXitZc",
	"payment_link": null,
	"profile_id": "pro_7U7w3bCXXYoJdwRW6IXu",
	"surcharge_details": null,
	"attempt_count": 1,
	"merchant_decision": null,
	"merchant_connector_id": "mca_76OuI3JqbGJTnxYz07Dq",
	"incremental_authorization_allowed": null,
	"authorization_count": null,
	"incremental_authorizations": null,
	"external_authentication_details": null,
	"external_3ds_authentication_attempted": false,
	"expires_on": "2024-04-18T07:30:45.604Z",
	"fingerprint": null,
	"browser_info": {
		"ip_address": "192.168.0.1",
		"user_agent": "Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0)"
	},
	"payment_method_id": "pm_g5bq9Pcnivwq3wJJtdec",
	"payment_method_status": null,
	"updated": "2024-04-18T07:15:48.132Z"
}
```

Logs:

<img width="1355" alt="image" src="https://github.com/juspay/hyperswitch/assets/69745008/c0c8434f-ceb4-4d01-8c63-8b97f242b105">

<img width="1357" alt="image" src="https://github.com/juspay/hyperswitch/assets/69745008/7087d0ea-2526-48f7-8dce-6b76813e38df">

In recurring payments, you're cannot pass `browser_information`, hence we pass `null`

```curl
curl --location 'http://Localhost:8080/payments' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: dev_o4U48k4jMj8HIE0NjvXf8j9j2Wz1oRYiKCZvQjIXpvnRXvYoCX7aWJehEys8JcHB' \
--data-raw '{
	"amount": 6570,
	"currency": "USD",
	"confirm": true,
	"capture_method": "automatic",
	"capture_on": "2022-09-10T10:11:12Z",
	"amount_to_capture": 6570,
	"customer_id": "StripeCustomer",
	"email": "guest@example.com",
	"name": "John Doe",
	"phone": "999999999",
	"phone_country_code": "+65",
	"description": "Its my first payment request",
	"authentication_type": "no_three_ds",
	"return_url": "https://duck.com",
	"mandate_id": "man_TySHZjkoArkztQXZGnAt",
	"browser_info": {
		"ip_address": "192.168.0.1",
		"user_agent": "Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0)"
	},
	"off_session": true,
	"shipping": {
		"address": {
			"line1": "1467",
			"line2": "Harrison Street",
			"line3": "Harrison Street",
			"city": "San Fransico",
			"state": "California",
			"zip": "94122",
			"country": "US",
			"first_name": "sundari"
		}
	},
	"statement_descriptor_name": "joseph",
	"statement_descriptor_suffix": "JS",
	"metadata": {
		"udf1": "value1",
		"new_customer": "true",
		"login_date": "2019-09-10T10:11:12Z"
	},
	"routing": {
		"type": "single",
		"data": "stripe"
	}
}'
```
```json
{
	"payment_id": "pay_HkPJoJftfFkgZ8fxQqAa",
	"merchant_id": "postman_merchant_GHAction_26cb565f-989d-4842-9204-433b34cb4137",
	"status": "succeeded",
	"amount": 6570,
	"net_amount": 6570,
	"amount_capturable": 0,
	"amount_received": 6570,
	"connector": "stripe",
	"client_secret": "pay_HkPJoJftfFkgZ8fxQqAa_secret_SU3Xfm6Abq2BMKNs1let",
	"created": "2024-04-18T08:28:10.043Z",
	"currency": "USD",
	"customer_id": "StripeCustomer",
	"customer": {
		"id": "StripeCustomer",
		"name": "John Doe",
		"email": "guest@example.com",
		"phone": "999999999",
		"phone_country_code": "+65"
	},
	"description": "Its my first payment request",
	"refunds": null,
	"disputes": null,
	"mandate_id": "man_TySHZjkoArkztQXZGnAt",
	"mandate_data": null,
	"setup_future_usage": null,
	"off_session": null,
	"capture_on": null,
	"capture_method": "automatic",
	"payment_method": "card",
	"payment_method_data": null,
	"payment_token": "be7040da-0ddb-46e5-889a-f18b03bf89d1",
	"shipping": {
		"address": {
			"city": "San Fransico",
			"country": "US",
			"line1": "1467",
			"line2": "Harrison Street",
			"line3": "Harrison Street",
			"zip": "94122",
			"state": "California",
			"first_name": "sundari",
			"last_name": null
		},
		"phone": null,
		"email": null
	},
	"billing": null,
	"order_details": null,
	"email": "guest@example.com",
	"name": "John Doe",
	"phone": "999999999",
	"return_url": "https://duck.com/",
	"authentication_type": "no_three_ds",
	"statement_descriptor_name": "joseph",
	"statement_descriptor_suffix": "JS",
	"next_action": null,
	"cancellation_reason": null,
	"error_code": null,
	"error_message": null,
	"unified_code": null,
	"unified_message": null,
	"payment_experience": null,
	"payment_method_type": null,
	"connector_label": null,
	"business_country": null,
	"business_label": "default",
	"business_sub_label": null,
	"allowed_payment_method_types": null,
	"ephemeral_key": {
		"customer_id": "StripeCustomer",
		"created_at": 1713428889,
		"expires": 1713432489,
		"secret": "epk_d8bcb9d19df0497b90ef477eef8aaf29"
	},
	"manual_retry_allowed": false,
	"connector_transaction_id": "pi_3P6qKED5R7gDAGff10wwV37R",
	"frm_message": null,
	"metadata": {
		"udf1": "value1",
		"login_date": "2019-09-10T10:11:12Z",
		"new_customer": "true"
	},
	"connector_metadata": null,
	"feature_metadata": null,
	"reference_id": "pi_3P6qKED5R7gDAGff10wwV37R",
	"payment_link": null,
	"profile_id": "pro_MSBOS0KaCvwB2BWENrTg",
	"surcharge_details": null,
	"attempt_count": 1,
	"merchant_decision": null,
	"merchant_connector_id": "mca_Lc3wxpuLCVY5AdYBDiwp",
	"incremental_authorization_allowed": null,
	"authorization_count": null,
	"incremental_authorizations": null,
	"external_authentication_details": null,
	"external_3ds_authentication_attempted": false,
	"expires_on": "2024-04-18T08:43:10.043Z",
	"fingerprint": null,
	"browser_info": {
		"ip_address": "192.168.0.1",
		"user_agent": "Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0)"
	},
	"payment_method_id": null,
	"payment_method_status": null,
	"updated": "2024-04-18T08:28:11.600Z"
}
```
Logs:

<img width="1348" alt="image" src="https://github.com/juspay/hyperswitch/assets/69745008/8ad8027b-f7a2-4d62-b6d0-08f182ab427a">

Ran postman tests for regressions

<img width="1081" alt="image" src="https://github.com/juspay/hyperswitch/assets/69745008/1e8ca133-fb21-4619-8175-7b32c30d46ac">

![image](https://github.com/juspay/hyperswitch/assets/69745008/c79b2486-de94-49c9-903d-4dd80e1415aa)
<img width="362" alt="image" src="https://github.com/juspay/hyperswitch/assets/69745008/653a0aba-e255-4d88-b69b-c47266b9dd14">

Even if you pass entire supported `browser_info`, only `ip_address` and `user_agent` is sent to Stripe

![image](https://github.com/juspay/hyperswitch/assets/69745008/51bf3295-7702-4855-b954-0d30540e87d8)
<img width="389" alt="image" src="https://github.com/juspay/hyperswitch/assets/69745008/72c83bd4-3775-4e09-a818-120e26768685">

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
