### PR TITLE
fix: change time precision to 6

### DIFF
--- a/crates/common_utils/src/custom_serde.rs
+++ b/crates/common_utils/src/custom_serde.rs
@@ -19,7 +19,7 @@ pub mod iso8601 {
 
     const FORMAT_CONFIG: EncodedConfig = Config::DEFAULT
         .set_time_precision(TimePrecision::Second {
-            decimal_digits: NonZeroU8::new(3),
+            decimal_digits: NonZeroU8::new(6),
         })
         .encode();
 


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->
- [x] Bugfix


## Description
<!-- Describe your changes in detail -->
Changed timeprecision from 3 to 6

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
This fixes the bug in time crate where the seconds get rounded off to 60. More on this issue [here](https://github.com/time-rs/time/issues/678)

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Cannot be tested on sandbox. 

You can clone this [repo](https://github.com/dracarys18/reproduce_time_bug) and do,
```bash
cargo r | tee test.txt
cat test.txt | rg ':60.'
```

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code