### PR TITLE
perf: avoid bytes cloning while generating digest and use faster_hex for encoding/decoding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1944,8 +1944,8 @@ dependencies = [
  "diesel",
  "error-stack",
  "fake",
+ "faster-hex",
  "futures 0.3.30",
- "hex",
  "http 0.2.12",
  "masking",
  "md5",
@@ -2870,6 +2870,15 @@ dependencies = [
  "tokio 1.37.0",
  "url",
  "webdriver",
+]
+
+[[package]]
+name = "faster-hex"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2a2b11eda1d40935b26cf18f6833c526845ae8c41e58d09af6adeb6f0269183"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/crates/common_utils/Cargo.toml
+++ b/crates/common_utils/Cargo.toml
@@ -18,8 +18,8 @@ bytes = "1.6.0"
 diesel = "2.1.5"
 error-stack = "0.4.1"
 futures = { version = "0.3.30", optional = true }
-hex = "0.4.3"
 http = "0.2.12"
+faster-hex= { version = "0.9.0",features = ["alloc"] }
 md5 = "0.7.0"
 nanoid = "0.4.0"
 once_cell = "1.19.0"

--- a/crates/common_utils/src/crypto.rs
+++ b/crates/common_utils/src/crypto.rs
@@ -3,8 +3,7 @@ use std::ops::Deref;
 
 use error_stack::ResultExt;
 use masking::{ExposeInterface, Secret};
-use md5;
-use md5::Digest;
+use md5::{self, Digest};
 use ring::{
     aead::{self, BoundKey, OpeningKey, SealingKey, UnboundKey},
     hmac,
@@ -281,7 +280,7 @@ impl DecodeMessage for GcmAes256 {
                     .ok_or(errors::CryptoError::DecodingFailed)
                     .attach_printable("Failed to read the nonce form the encrypted ciphertext")?,
             )
-                .change_context(errors::CryptoError::DecodingFailed)?,
+            .change_context(errors::CryptoError::DecodingFailed)?,
         );
 
         let mut key = OpeningKey::new(key, nonce_sequence);
@@ -312,8 +311,8 @@ pub enum GenerateDigestOutput {
 impl AsRef<[u8]> for GenerateDigestOutput {
     fn as_ref(&self) -> &[u8] {
         match self {
-            GenerateDigestOutput::RingDigest(digest) => { digest.as_ref() }
-            GenerateDigestOutput::Md5Digest(digest) => { digest.as_ref() }
+            GenerateDigestOutput::RingDigest(digest) => digest.as_ref(),
+            GenerateDigestOutput::Md5Digest(digest) => digest.as_ref(),
         }
     }
 }
@@ -321,11 +320,17 @@ impl AsRef<[u8]> for GenerateDigestOutput {
 /// Trait for generating a digest for SHA
 pub trait GenerateDigest {
     /// takes a message and creates a digest for it
-    fn generate_digest(&self, message: &[u8]) -> CustomResult<GenerateDigestOutput, errors::CryptoError>;
+    fn generate_digest(
+        &self,
+        message: &[u8],
+    ) -> CustomResult<GenerateDigestOutput, errors::CryptoError>;
 }
 
 impl GenerateDigest for Sha512 {
-    fn generate_digest(&self, message: &[u8]) -> CustomResult<GenerateDigestOutput, errors::CryptoError> {
+    fn generate_digest(
+        &self,
+        message: &[u8],
+    ) -> CustomResult<GenerateDigestOutput, errors::CryptoError> {
         let digest = ring::digest::digest(&ring::digest::SHA512, message);
         Ok(GenerateDigestOutput::RingDigest(digest))
     }
@@ -341,7 +346,7 @@ impl VerifySignature for Sha512 {
         let hashed_digest = faster_hex::hex_string(
             Self.generate_digest(msg)
                 .change_context(errors::CryptoError::SignatureVerificationFailed)?
-                .as_ref()
+                .as_ref(),
         );
         let hashed_digest_into_bytes = hashed_digest.into_bytes();
         Ok(hashed_digest_into_bytes == signature)
@@ -353,7 +358,10 @@ impl VerifySignature for Sha512 {
 pub struct Md5;
 
 impl GenerateDigest for Md5 {
-    fn generate_digest(&self, message: &[u8]) -> CustomResult<GenerateDigestOutput, errors::CryptoError> {
+    fn generate_digest(
+        &self,
+        message: &[u8],
+    ) -> CustomResult<GenerateDigestOutput, errors::CryptoError> {
         let digest = md5::compute(message);
         Ok(GenerateDigestOutput::Md5Digest(digest))
     }
@@ -374,7 +382,10 @@ impl VerifySignature for Md5 {
 }
 
 impl GenerateDigest for Sha256 {
-    fn generate_digest(&self, message: &[u8]) -> CustomResult<GenerateDigestOutput, errors::CryptoError> {
+    fn generate_digest(
+        &self,
+        message: &[u8],
+    ) -> CustomResult<GenerateDigestOutput, errors::CryptoError> {
         let digest = ring::digest::digest(&ring::digest::SHA256, message);
         Ok(GenerateDigestOutput::RingDigest(digest))
     }
@@ -472,20 +483,20 @@ impl<T: Clone> Deref for Encryptable<Secret<T>> {
 }
 
 impl<T: Clone> masking::Serialize for Encryptable<T>
-    where
-        T: masking::Serialize,
+where
+    T: masking::Serialize,
 {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-        where
-            S: serde::Serializer,
+    where
+        S: serde::Serializer,
     {
         self.inner.serialize(serializer)
     }
 }
 
 impl<T: Clone> PartialEq for Encryptable<T>
-    where
-        T: PartialEq,
+where
+    T: PartialEq,
 {
     fn eq(&self, other: &Self) -> bool {
         self.inner.eq(&other.inner)
@@ -517,8 +528,11 @@ mod crypto_tests {
         let message = r#"{"type":"payment_intent"}"#.as_bytes();
         let secret = "hmac_secret_1234".as_bytes();
         let mut right_signature = vec![0; 32];
-        faster_hex::hex_decode(b"d5550730377011948f12cc28889bee590d2a5434d6f54b87562f2dbc2657823e", &mut right_signature)
-            .expect("Right signature decoding");
+        faster_hex::hex_decode(
+            b"d5550730377011948f12cc28889bee590d2a5434d6f54b87562f2dbc2657823e",
+            &mut right_signature,
+        )
+        .expect("Right signature decoding");
 
         let signature = super::HmacSha256
             .sign_message(secret, message)
@@ -530,12 +544,18 @@ mod crypto_tests {
     #[test]
     fn test_hmac_sha256_verify_signature() {
         let mut right_signature = vec![0; 32];
-        faster_hex::hex_decode(b"d5550730377011948f12cc28889bee590d2a5434d6f54b87562f2dbc2657823e", &mut right_signature)
-            .expect("Wrong signature decoding");
+        faster_hex::hex_decode(
+            b"d5550730377011948f12cc28889bee590d2a5434d6f54b87562f2dbc2657823e",
+            &mut right_signature,
+        )
+        .expect("Wrong signature decoding");
         let mut wrong_signature = vec![0; 32];
 
-        faster_hex::hex_decode(b"d5550730377011948f12cc28889bee590d2a5434d6f54b87562f2dbc2657823f", &mut wrong_signature)
-            .expect("Wrong signature decoding");
+        faster_hex::hex_decode(
+            b"d5550730377011948f12cc28889bee590d2a5434d6f54b87562f2dbc2657823f",
+            &mut wrong_signature,
+        )
+        .expect("Wrong signature decoding");
         let secret = "hmac_secret_1234".as_bytes();
         let data = r#"{"type":"payment_intent"}"#.as_bytes();
 
@@ -555,11 +575,17 @@ mod crypto_tests {
     #[test]
     fn test_sha256_verify_signature() {
         let mut right_signature = vec![0; 32];
-        faster_hex::hex_decode(b"123250a72f4e961f31661dbcee0fec0f4714715dc5ae1b573f908a0a5381ddba", &mut right_signature)
-            .expect("Right signature decoding");
+        faster_hex::hex_decode(
+            b"123250a72f4e961f31661dbcee0fec0f4714715dc5ae1b573f908a0a5381ddba",
+            &mut right_signature,
+        )
+        .expect("Right signature decoding");
         let mut wrong_signature = vec![0; 32];
-        faster_hex::hex_decode(b"123250a72f4e961f31661dbcee0fec0f4714715dc5ae1b573f908a0a5381ddbb", &mut wrong_signature)
-            .expect("Wrong signature decoding");
+        faster_hex::hex_decode(
+            b"123250a72f4e961f31661dbcee0fec0f4714715dc5ae1b573f908a0a5381ddbb",
+            &mut wrong_signature,
+        )
+        .expect("Wrong signature decoding");
         let secret = "".as_bytes();
         let data = r#"AJHFH9349JASFJHADJ9834115USD2020-11-13.13:22:34711000000021406655APPROVED12345product_id"#.as_bytes();
 
@@ -599,8 +625,11 @@ mod crypto_tests {
         faster_hex::hex_decode(b"38b0bc1ea66b14793e39cd58e93d37b799a507442d0dd8d37443fa95dec58e57da6db4742636fea31201c48e57a66e73a308a2e5a5c6bb831e4e39fe2227c00f", &mut right_signature)
             .expect("signature decoding");
         let mut wrong_signature = vec![0; 32];
-        faster_hex::hex_decode(b"d5550730377011948f12cc28889bee590d2a5434d6f54b87562f2dbc2657823f", &mut wrong_signature)
-            .expect("Wrong signature decoding");
+        faster_hex::hex_decode(
+            b"d5550730377011948f12cc28889bee590d2a5434d6f54b87562f2dbc2657823f",
+            &mut wrong_signature,
+        )
+        .expect("Wrong signature decoding");
         let secret = "hmac_secret_1234".as_bytes();
         let data = r#"{"type":"payment_intent"}"#.as_bytes();
 
@@ -621,8 +650,11 @@ mod crypto_tests {
     fn test_gcm_aes_256_encode_message() {
         let message = r#"{"type":"PAYMENT"}"#.as_bytes();
         let mut secret = vec![0; 32];
-        faster_hex::hex_decode(b"000102030405060708090a0b0c0d0e0f000102030405060708090a0b0c0d0e0f", &mut secret)
-            .expect("Secret decoding");
+        faster_hex::hex_decode(
+            b"000102030405060708090a0b0c0d0e0f000102030405060708090a0b0c0d0e0f",
+            &mut secret,
+        )
+        .expect("Secret decoding");
         let algorithm = super::GcmAes256;
 
         let encoded_message = algorithm
@@ -643,11 +675,17 @@ mod crypto_tests {
         // https://github.com/briansmith/ring/blob/95948b3977013aed16db92ae32e6b8384496a740/tests/aead_aes_256_gcm_tests.txt#L447-L452
 
         let mut right_secret = vec![0; 32];
-        faster_hex::hex_decode(b"feffe9928665731c6d6a8f9467308308feffe9928665731c6d6a8f9467308308", &mut right_secret)
-            .expect("Secret decoding");
+        faster_hex::hex_decode(
+            b"feffe9928665731c6d6a8f9467308308feffe9928665731c6d6a8f9467308308",
+            &mut right_secret,
+        )
+        .expect("Secret decoding");
         let mut wrong_secret = vec![0; 32];
-        faster_hex::hex_decode(b"feffe9928665731c6d6a8f9467308308feffe9928665731c6d6a8f9467308309", &mut wrong_secret)
-            .expect("Secret decoding");
+        faster_hex::hex_decode(
+            b"feffe9928665731c6d6a8f9467308308feffe9928665731c6d6a8f9467308309",
+            &mut wrong_secret,
+        )
+        .expect("Secret decoding");
         let mut message = vec![0; 92];
         // The three parts of the message are the nonce, ciphertext and tag from the test vector
         faster_hex::hex_decode(
@@ -664,10 +702,7 @@ mod crypto_tests {
         let mut buf = vec![0; 64];
         faster_hex::hex_decode(b"d9313225f88406e5a55909c5aff5269a86a7a9531534f7da2e4c303d8a318a721c3c0c95956809532fcf0e2449a6b525b16aedf5aa0de657ba637b391aafd255", &mut buf)
             .expect("Decoded plaintext message");
-        assert_eq!(
-            decoded,
-            buf
-        );
+        assert_eq!(decoded, buf);
 
         let err_decoded = algorithm.decode_message(&wrong_secret, message.into());
 
@@ -680,7 +715,12 @@ mod crypto_tests {
         assert_eq!(
             format!(
                 "{}",
-                faster_hex::hex_string(super::Md5.generate_digest(message).expect("Digest").as_ref())
+                faster_hex::hex_string(
+                    super::Md5
+                        .generate_digest(message)
+                        .expect("Digest")
+                        .as_ref()
+                )
             ),
             "c3fcd3d76192e4007dfb496cca67e13b"
         );
@@ -689,10 +729,14 @@ mod crypto_tests {
     #[test]
     fn test_md5_verify_signature() {
         let mut right_signature = vec![0; 16];
-        faster_hex::hex_decode(b"c3fcd3d76192e4007dfb496cca67e13b", &mut right_signature).expect("signature decoding");
+        faster_hex::hex_decode(b"c3fcd3d76192e4007dfb496cca67e13b", &mut right_signature)
+            .expect("signature decoding");
         let mut wrong_signature = vec![0; 32];
-        faster_hex::hex_decode(b"d5550730377011948f12cc28889bee590d2a5434d6f54b87562f2dbc2657823f", &mut wrong_signature)
-            .expect("Wrong signature decoding");
+        faster_hex::hex_decode(
+            b"d5550730377011948f12cc28889bee590d2a5434d6f54b87562f2dbc2657823f",
+            &mut wrong_signature,
+        )
+        .expect("Wrong signature decoding");
         let secret = "".as_bytes();
         let data = "abcdefghijklmnopqrstuvwxyz".as_bytes();
 

--- a/crates/common_utils/src/lib.rs
+++ b/crates/common_utils/src/lib.rs
@@ -2,6 +2,8 @@
 #![warn(missing_docs, missing_debug_implementations)]
 #![doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR" ), "/", "README.md"))]
 
+extern crate core;
+
 pub mod consts;
 pub mod crypto;
 pub mod custom_serde;


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [x] Dependency updates
- [ ] Documentation
- [ ] CI/CD
- [x] Performance

## Description
<!-- Describe your changes in detail -->

see linked issue: #4403 

### Additional Changes

- [x] This PR modifies the API contract
- [x] This PR modifies the database schema
- [x] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
