### PR TITLE
fix(user): blacklist token after delete user role

### DIFF
--- a/crates/diesel_models/src/query/user_role.rs
+++ b/crates/diesel_models/src/query/user_role.rs
@@ -70,8 +70,8 @@ impl UserRole {
         conn: &PgPooledConn,
         user_id: String,
         merchant_id: String,
-    ) -> StorageResult<bool> {
-        generics::generic_delete::<<Self as HasTable>::Table, _>(
+    ) -> StorageResult<Self> {
+        generics::generic_delete_one_with_result::<<Self as HasTable>::Table, _, _>(
             conn,
             dsl::user_id
                 .eq(user_id)

--- a/crates/router/src/core/user_role.rs
+++ b/crates/router/src/core/user_role.rs
@@ -283,7 +283,7 @@ pub async fn delete_user_role(
     };
 
     if user_roles.len() > 1 {
-        state
+        let deleted_user_role = state
             .store
             .delete_user_role_by_user_id_merchant_id(
                 user_from_db.get_user_id(),
@@ -292,6 +292,8 @@ pub async fn delete_user_role(
             .await
             .change_context(UserErrors::InternalServerError)
             .attach_printable("Error while deleting user role")?;
+
+        auth::blacklist::insert_user_in_blacklist(&state, &deleted_user_role.user_id).await?;
 
         Ok(ApplicationResponse::StatusOk)
     } else {
@@ -302,7 +304,7 @@ pub async fn delete_user_role(
             .change_context(UserErrors::InternalServerError)
             .attach_printable("Error while deleting user entry")?;
 
-        state
+        let deleted_user_role = state
             .store
             .delete_user_role_by_user_id_merchant_id(
                 user_from_db.get_user_id(),
@@ -312,6 +314,7 @@ pub async fn delete_user_role(
             .change_context(UserErrors::InternalServerError)
             .attach_printable("Error while deleting user role")?;
 
+        auth::blacklist::insert_user_in_blacklist(&state, &deleted_user_role.user_id).await?;
         Ok(ApplicationResponse::StatusOk)
     }
 }

--- a/crates/router/src/core/user_role.rs
+++ b/crates/router/src/core/user_role.rs
@@ -282,8 +282,9 @@ pub async fn delete_user_role(
         }
     };
 
+    let deleted_user_role;
     if user_roles.len() > 1 {
-        let deleted_user_role = state
+        deleted_user_role = state
             .store
             .delete_user_role_by_user_id_merchant_id(
                 user_from_db.get_user_id(),
@@ -292,10 +293,6 @@ pub async fn delete_user_role(
             .await
             .change_context(UserErrors::InternalServerError)
             .attach_printable("Error while deleting user role")?;
-
-        auth::blacklist::insert_user_in_blacklist(&state, &deleted_user_role.user_id).await?;
-
-        Ok(ApplicationResponse::StatusOk)
     } else {
         state
             .store
@@ -304,7 +301,7 @@ pub async fn delete_user_role(
             .change_context(UserErrors::InternalServerError)
             .attach_printable("Error while deleting user entry")?;
 
-        let deleted_user_role = state
+        deleted_user_role = state
             .store
             .delete_user_role_by_user_id_merchant_id(
                 user_from_db.get_user_id(),
@@ -313,8 +310,8 @@ pub async fn delete_user_role(
             .await
             .change_context(UserErrors::InternalServerError)
             .attach_printable("Error while deleting user role")?;
-
-        auth::blacklist::insert_user_in_blacklist(&state, &deleted_user_role.user_id).await?;
-        Ok(ApplicationResponse::StatusOk)
     }
+
+    auth::blacklist::insert_user_in_blacklist(&state, &deleted_user_role.user_id).await?;
+    Ok(ApplicationResponse::StatusOk)
 }

--- a/crates/router/src/core/user_role.rs
+++ b/crates/router/src/core/user_role.rs
@@ -282,9 +282,8 @@ pub async fn delete_user_role(
         }
     };
 
-    let deleted_user_role;
-    if user_roles.len() > 1 {
-        deleted_user_role = state
+    let deleted_user_role = if user_roles.len() > 1 {
+        state
             .store
             .delete_user_role_by_user_id_merchant_id(
                 user_from_db.get_user_id(),
@@ -292,7 +291,7 @@ pub async fn delete_user_role(
             )
             .await
             .change_context(UserErrors::InternalServerError)
-            .attach_printable("Error while deleting user role")?;
+            .attach_printable("Error while deleting user role")?
     } else {
         state
             .store
@@ -301,7 +300,7 @@ pub async fn delete_user_role(
             .change_context(UserErrors::InternalServerError)
             .attach_printable("Error while deleting user entry")?;
 
-        deleted_user_role = state
+        state
             .store
             .delete_user_role_by_user_id_merchant_id(
                 user_from_db.get_user_id(),
@@ -309,8 +308,8 @@ pub async fn delete_user_role(
             )
             .await
             .change_context(UserErrors::InternalServerError)
-            .attach_printable("Error while deleting user role")?;
-    }
+            .attach_printable("Error while deleting user role")?
+    };
 
     auth::blacklist::insert_user_in_blacklist(&state, &deleted_user_role.user_id).await?;
     Ok(ApplicationResponse::StatusOk)

--- a/crates/router/src/db/kafka_store.rs
+++ b/crates/router/src/db/kafka_store.rs
@@ -2376,7 +2376,7 @@ impl UserRoleInterface for KafkaStore {
         &self,
         user_id: &str,
         merchant_id: &str,
-    ) -> CustomResult<bool, errors::StorageError> {
+    ) -> CustomResult<user_storage::UserRole, errors::StorageError> {
         self.diesel_store
             .delete_user_role_by_user_id_merchant_id(user_id, merchant_id)
             .await

--- a/crates/router/src/db/user_role.rs
+++ b/crates/router/src/db/user_role.rs
@@ -147,15 +147,14 @@ impl UserRoleInterface for Store {
         merchant_id: &str,
     ) -> CustomResult<storage::UserRole, errors::StorageError> {
         let conn = connection::pg_connection_write(self).await?;
-        let deleted_user_role = storage::UserRole::delete_by_user_id_merchant_id(
+
+        storage::UserRole::delete_by_user_id_merchant_id(
             &conn,
             user_id.to_owned(),
             merchant_id.to_owned(),
         )
         .await
-        .map_err(|error| report!(errors::StorageError::from(error)))?;
-
-        Ok(deleted_user_role)
+        .map_err(|error| report!(errors::StorageError::from(error)))
     }
 
     #[instrument(skip_all)]

--- a/crates/router/src/db/user_role.rs
+++ b/crates/router/src/db/user_role.rs
@@ -467,10 +467,7 @@ impl UserRoleInterface for MockDb {
             .iter()
             .position(|role| role.user_id == user_id && role.merchant_id == merchant_id)
         {
-            Some(index) => {
-                let deleted_user_role = user_roles.remove(index);
-                Ok(deleted_user_role)
-            }
+            Some(index) => Ok(user_roles.remove(index)),
             None => Err(errors::StorageError::ValueNotFound(
                 "Cannot find user role to delete".to_string(),
             )


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
The PR add support to blocklist JWT token of the deleted user/user role. After delete signined user won't be able to perform any operation as token is blocklisted.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
closes #4427 


## How did you test it?
SignIn/Signup
```
curl --location 'http://localhost:8080/user/signup' \
--header 'Content-Type: application/json' \
--header 'api-key: test_admin' \
--data-raw '{
    "email": "test1@gmail.com",
    "password": "t"
}'
```

Invite another user
```
curl --location 'http://localhost:8080/user/user/invite' \
--header 'Content-Type: application/json' \
--header 'Authorization: Bearer JWT' \
--data-raw '{
    "email": "test3@gmail.com",
    "name": "test3",
    "role_id": "merchant_view_only"
}'
```

Sign in to this new user account and perform some operations JWT based, like listing payments etc.

Sing in  again into account from which this user was invited.

Delete this new user
```
curl --location --request DELETE 'http://localhost:8080/user/user/delete' \
--header 'Content-Type: application/json' \
--header 'Authorization: Bearer JWT' \
--data-raw '{
  "email": "test3@gmail.com"
}'
```
Response 200 Ok

Try performing same operations for the newly invited user now, it should give response:
```
{
    "error": {
        "type": "invalid_request",
        "message": "Access forbidden, invalid JWT token was used",
        "code": "IR_17"
    }
}
```
This means the previous token is blacklisted sucessfully.
## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
