### PR TITLE
docs: update try_local_system.md to address a memory issue in WSL environments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ All notable changes to HyperSwitch will be documented here.
 
 - **wallet:** Use `billing.phone` instead of `telephone_number` ([#4329](https://github.com/juspay/hyperswitch/pull/4329)) ([`3e6bc19`](https://github.com/juspay/hyperswitch/commit/3e6bc191fd5804feface9ee1a0cb7ddbbe025569))
 
+### Documentation Changes
+
+- **try_local_system:** Add a note about increasing WSL's allowed memory to resolve a SIGKILL error when running `cargo build`
+
 ### Miscellaneous Tasks
 
 - Add wasm toml configs for netcetera authnetication connector ([#4426](https://github.com/juspay/hyperswitch/pull/4426)) ([`4851da1`](https://github.com/juspay/hyperswitch/commit/4851da1595074dbb2760e76f83403e8ac9f7895f))

--- a/docs/try_local_system.md
+++ b/docs/try_local_system.md
@@ -222,6 +222,7 @@ Once you're done with setting up the dependencies, proceed with
 
 [postgresql-install]: https://www.postgresql.org/download/
 [redis-install]: https://redis.io/docs/getting-started/installation/
+[wsl-config]: https://learn.microsoft.com/en-us/windows/wsl/wsl-config/
 
 ### Set up dependencies on Windows (Ubuntu on WSL2)
 
@@ -240,6 +241,8 @@ packages for your distribution and follow along.
    Launch the WSL instance and set up your username and password.
    The following steps assume that you are running the commands within the WSL
    shell environment.
+
+   > Note that a `SIGKILL` error may occur when compiling certain crates if WSL is unable to use sufficient memory. It may be necessary to allow up to 24GB of memory, but your mileage may vary. You may increase the amount of memory WSL can use via a `.wslconfig` file in your Windows user folder, or by creating a swap file in WSL itself. Refer to the [WSL configuration documentation][wsl-config] for more information.
 
 2. Install the stable Rust toolchain using `rustup`:
 


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [x] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
This pull request adds a brief note to `docs/try_local_system.md`, under the section titled "Set up dependencies on Windows (Ubuntu on WSL2)," addressing an error that may occur when running `cargo build` from a WSL environment, and providing resources to help the user prevent the issue from occurring.

Additionally, I added a note about this change to `CHANGELOG.md`.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
I am part of a student team hoping to contribute to hyperswitch over the next several months. After following the instructions in `docs/try_local_system.md` for setting up a development environment using WSL, all members of my team encountered the same issue: upon running `cargo build`, the `router` crate failed to build, producing an error ending in `signal: 9, SIGKILL: kill`.

After some research, we came across [this discussion post](https://github.com/juspay/hyperswitch/discussions/758), where the author encountered a similar issue. After trying the suggested solution of configuring WSL to allow an additional 2GB of memory, the issue persisted, however we were able to resolve it by increasing the amount to 24GB.

Some of our machines do not have 24GB of memory, so we ended up editing `.wslconfig` to include 8GB of memory, and then adding an additional 16GB via a swap file created from within the WSL terminal.

Because the same issue occurred for all of us in the exact same way, across different machines, we feel that `docs/try_local_system.md` should mention the issue, along with instructions on how to configure WSL to prevent the issue from occurring.


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [x] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
