### PR TITLE
feat(users): use cookie for auth

### DIFF
--- a/crates/router/src/services/authentication.rs
+++ b/crates/router/src/services/authentication.rs
@@ -611,9 +611,7 @@ where
     T: serde::de::DeserializeOwned,
     A: AppStateInfo + Sync,
 {
-    let token = match get_cookie_from_header(headers)
-        .and_then(cookies::parse_cookie)
-    {
+    let token = match get_cookie_from_header(headers).and_then(cookies::parse_cookie) {
         Ok(cookies) => cookies,
         Err(e) => {
             let token = get_jwt_from_authorization_header(headers);


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [X] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
Use cookie if present otherwise use `authorization` header for authentication.
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
Use of cookie for authentication for better security.
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
Use any JWT auth API with cookies.
If cookie is present with `login_token` then app will use it for auth otherwise it will fallback to use `Authorization` header.
Example curl,

```curl
curl --location '<URL>/user/permission_info?groups=true' \
--header 'Cookie: login_token=<JWT>'
```
Above should give `200` when valid JWT is used.

```curl
curl --location 'localhost:8080/user/permission_info?groups=true' \
--header 'Authorization: Bearer <JWT>' \
```
Above should also give `200` when valid JWT is used.
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [X] I formatted the code `cargo +nightly fmt --all`
- [X] I addressed lints thrown by `cargo clippy`
- [X] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
