### PR TITLE
feature: add profiles to in mem

### DIFF
--- a/crates/router/src/db/business_profile.rs
+++ b/crates/router/src/db/business_profile.rs
@@ -8,6 +8,8 @@ use crate::{
     db::MockDb,
     types::storage::{self, business_profile},
 };
+#[cfg(feature = "accounts_cache")]
+use storage_impl::redis::cache::{CacheKind, ACCOUNTS_CACHE};
 
 #[async_trait::async_trait]
 pub trait BusinessProfileInterface {
@@ -64,10 +66,20 @@ impl BusinessProfileInterface for Store {
         &self,
         profile_id: &str,
     ) -> CustomResult<business_profile::BusinessProfile, errors::StorageError> {
-        let conn = connection::pg_connection_read(self).await?;
-        storage::business_profile::BusinessProfile::find_by_profile_id(&conn, profile_id)
-            .await
-            .map_err(|error| report!(errors::StorageError::from(error)))
+        let db_func = || async { let conn = connection::pg_connection_read(self).await?;
+                storage::business_profile::BusinessProfile::find_by_profile_id(&conn, profile_id)
+                .await
+                .map_err(|error| report!(errors::StorageError::from(error)))
+        };
+        #[cfg(not(feature = "accounts_cache"))]
+        {
+            db_func().await
+        }
+        #[cfg(feature = "accounts_cache")]
+        {
+            super::cache::get_or_populate_in_memory(self, profile_id, db_func, &ACCOUNTS_CACHE)
+                .await
+        }
     }
 
     #[instrument(skip_all)]
@@ -76,14 +88,28 @@ impl BusinessProfileInterface for Store {
         profile_name: &str,
         merchant_id: &str,
     ) -> CustomResult<business_profile::BusinessProfile, errors::StorageError> {
-        let conn = connection::pg_connection_read(self).await?;
-        storage::business_profile::BusinessProfile::find_by_profile_name_merchant_id(
-            &conn,
-            profile_name,
-            merchant_id,
-        )
-        .await
-        .map_err(|error| report!(errors::StorageError::from(error)))
+        let db_func = || async {
+                let conn = connection::pg_connection_read(self).await?;
+                storage::business_profile::BusinessProfile::find_by_profile_name_merchant_id(
+                    &conn,
+                    profile_name,
+                    merchant_id,
+                )
+                .await
+                .map_err(|error| report!(errors::StorageError::from(error)))
+        };
+
+        #[cfg(feature= "accounts_cache")]
+        {   
+            let key = format!("{}_{}", profile_name ,merchant_id);
+            super::cache::get_or_populate_in_memory(self, &key, db_func, &ACCOUNTS_CACHE)
+                .await
+        }
+
+        #[cfg(not(feature = "accounts_cache"))]
+        {
+            db_func().await
+        }
     }
 
     #[instrument(skip_all)]
@@ -93,13 +119,19 @@ impl BusinessProfileInterface for Store {
         business_profile_update: business_profile::BusinessProfileUpdateInternal,
     ) -> CustomResult<business_profile::BusinessProfile, errors::StorageError> {
         let conn = connection::pg_connection_write(self).await?;
-        storage::business_profile::BusinessProfile::update_by_profile_id(
+        let updated_profile = storage::business_profile::BusinessProfile::update_by_profile_id(
             current_state,
             &conn,
             business_profile_update,
         )
         .await
-        .map_err(|error| report!(errors::StorageError::from(error)))
+        .map_err(|error| report!(errors::StorageError::from(error)))?;
+        
+        #[cfg(feature = "accounts_cache")]
+        {
+            publish_and_redact_business_profile_cache(self, &updated_profile).await?;
+        }
+        Ok(updated_profile)
     }
 
     #[instrument(skip_all)]
@@ -109,13 +141,28 @@ impl BusinessProfileInterface for Store {
         merchant_id: &str,
     ) -> CustomResult<bool, errors::StorageError> {
         let conn = connection::pg_connection_write(self).await?;
-        storage::business_profile::BusinessProfile::delete_by_profile_id_merchant_id(
-            &conn,
-            profile_id,
-            merchant_id,
-        )
-        .await
-        .map_err(|error| report!(errors::StorageError::from(error)))
+        let db_func = || async { storage::business_profile::BusinessProfile::delete_by_profile_id_merchant_id(
+                    &conn,
+                    profile_id,
+                    merchant_id,
+                )
+                .await
+                .map_err(|error| report!(errors::StorageError::from(error)))
+        };
+
+        #[cfg(not(feature = "accounts_cache"))]
+        {
+            db_func().await
+        }
+
+        #[cfg(feature = "accounts_cache")]
+        {
+            let business_profile = self.find_business_profile_by_profile_id(profile_id)
+                .await?;
+            let result: bool = db_func().await?;
+            publish_and_redact_business_profile_cache(self, &business_profile).await?;
+            Ok(result)
+        }
     }
 
     #[instrument(skip_all)]
@@ -131,6 +178,19 @@ impl BusinessProfileInterface for Store {
         .await
         .map_err(|error| report!(errors::StorageError::from(error)))
     }
+}
+
+#[cfg(feature = "accounts_cache")]
+async fn publish_and_redact_business_profile_cache(
+    store: &dyn super::StorageInterface,
+    business_profile : &business_profile::BusinessProfile,
+) -> CustomResult<(), errors::StorageError> {
+    let key1 = CacheKind::Accounts(business_profile.profile_id.as_str().into());
+    let str_key = format!("{}_{}", business_profile.profile_name.as_str(), business_profile.merchant_id.as_str());
+    let key2 = CacheKind::Accounts(str_key.as_str().into());
+    let keys = vec![key1, key2];
+    super::cache::publish_into_redact_channel(store, keys).await?;
+    Ok(())
 }
 
 #[async_trait::async_trait]


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
add business profile to in mem cache

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
add business profile to in mem cache, so that repeated reads from application doesnt go to db

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

try /payments create and check server logs for select query for business_profile
`
DEBUG diesel_models::query::generics: query: SELECT "business_profile"."profile_id", "business_profile"."merchant_id", "business_profile"."profile_name", "business_profile"."created_at", "business_profile"."modified_at", "business_profile"."return_url", "business_profile"."enable_payment_response_hash", "business_profile"."payment_response_hash_key", "business_profile"."redirect_to_merchant_with_http_post", "business_profile"."webhook_details", "business_profile"."metadata", "business_profile"."routing_algorithm", "business_profile"."intent_fulfillment_time", "business_profile"."frm_routing_algorithm", "business_profile"."payout_routing_algorithm", "business_profile"."is_recon_enabled", "business_profile"."applepay_verified_domains", "business_profile"."payment_link_config", "business_profile"."session_expiry", "business_profile"."authentication_connector_details" FROM "business_profile" WHERE ("business_profile"."profile_id" = $1) -- binds: ["***"]
`

hit payments create again, logs shouldnt be showing select query for business profile

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
