### PR TITLE
fix(connector): [CYBERSOURCE] Handle HTML Error Response and add Descriptor field in ApplePay payments request

### DIFF
--- a/crates/router/src/connector/cybersource.rs
+++ b/crates/router/src/connector/cybersource.rs
@@ -5,7 +5,7 @@ use std::fmt::Debug;
 use base64::Engine;
 use common_utils::request::RequestContent;
 use diesel_models::enums;
-use error_stack::{report, ResultExt};
+use error_stack::{report, Report, ResultExt};
 use masking::{ExposeInterface, PeekInterface};
 use ring::{digest, hmac};
 use time::OffsetDateTime;
@@ -116,13 +116,10 @@ impl ConnectorCommon for Cybersource {
         res: types::Response,
         event_builder: Option<&mut ConnectorEvent>,
     ) -> CustomResult<types::ErrorResponse, errors::ConnectorError> {
-        let response: cybersource::CybersourceErrorResponse = res
-            .response
-            .parse_struct("Cybersource ErrorResponse")
-            .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
-
-        event_builder.map(|i| i.set_error_response_body(&response));
-        router_env::logger::info!(connector_response=?response);
+        let response: Result<
+            cybersource::CybersourceErrorResponse,
+            Report<common_utils::errors::ParsingError>,
+        > = res.response.parse_struct("Cybersource ErrorResponse");
 
         let error_message = if res.status_code == 401 {
             consts::CONNECTOR_UNAUTHORIZED_ERROR
@@ -130,7 +127,9 @@ impl ConnectorCommon for Cybersource {
             consts::NO_ERROR_MESSAGE
         };
         match response {
-            transformers::CybersourceErrorResponse::StandardError(response) => {
+            Ok(transformers::CybersourceErrorResponse::StandardError(response)) => {
+                event_builder.map(|i| i.set_error_response_body(&response));
+                router_env::logger::info!(connector_response=?response);
                 let (code, connector_reason) = match response.error_information {
                     Some(ref error_info) => (error_info.reason.clone(), error_info.message.clone()),
                     None => (
@@ -162,7 +161,9 @@ impl ConnectorCommon for Cybersource {
                     connector_transaction_id: None,
                 })
             }
-            transformers::CybersourceErrorResponse::AuthenticationError(response) => {
+            Ok(transformers::CybersourceErrorResponse::AuthenticationError(response)) => {
+                event_builder.map(|i| i.set_error_response_body(&response));
+                router_env::logger::info!(connector_response=?response);
                 Ok(types::ErrorResponse {
                     status_code: res.status_code,
                     code: consts::NO_ERROR_CODE.to_string(),
@@ -172,7 +173,9 @@ impl ConnectorCommon for Cybersource {
                     connector_transaction_id: None,
                 })
             }
-            transformers::CybersourceErrorResponse::NotAvailableError(response) => {
+            Ok(transformers::CybersourceErrorResponse::NotAvailableError(response)) => {
+                event_builder.map(|i| i.set_error_response_body(&response));
+                router_env::logger::info!(connector_response=?response);
                 let error_response = response
                     .errors
                     .iter()
@@ -193,6 +196,14 @@ impl ConnectorCommon for Cybersource {
                     attempt_status: None,
                     connector_transaction_id: None,
                 })
+            }
+            Err(error_msg) => {
+                event_builder.map(|event| event.set_error(serde_json::json!({"error": res.response.escape_ascii().to_string(), "status_code": res.status_code})));
+                router_env::logger::error!(deserialization_error =? error_msg);
+                crate::utils::handle_json_response_deserialization_failure(
+                    res,
+                    "cybersource".to_owned(),
+                )
             }
         }
     }

--- a/crates/router/src/connector/cybersource/transformers.rs
+++ b/crates/router/src/connector/cybersource/transformers.rs
@@ -149,6 +149,7 @@ impl TryFrom<&types::SetupMandateRouterData> for CybersourceZeroMandateRequest {
                             PaymentInformation::ApplePayToken(ApplePayTokenPaymentInformation {
                                 fluid_data: FluidData {
                                     value: Secret::from(apple_pay_data.payment_data),
+                                    descriptor: Some(FLUID_DATA_DESCRIPTOR.to_string()),
                                 },
                                 tokenized_card: ApplePayTokenizedCard {
                                     transaction_type: TransactionType::ApplePay,
@@ -165,6 +166,7 @@ impl TryFrom<&types::SetupMandateRouterData> for CybersourceZeroMandateRequest {
                                 consts::BASE64_ENGINE
                                     .encode(google_pay_data.tokenization_data.token),
                             ),
+                            descriptor: None,
                         },
                     }),
                     Some(PaymentSolution::GooglePay),
@@ -370,7 +372,11 @@ pub struct MandatePaymentInformation {
 #[serde(rename_all = "camelCase")]
 pub struct FluidData {
     value: Secret<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    descriptor: Option<String>,
 }
+
+pub const FLUID_DATA_DESCRIPTOR: &str = "RklEPUNPTU1PTi5BUFBMRS5JTkFQUC5QQVlNRU5U";
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -1031,6 +1037,7 @@ impl
                 value: Secret::from(
                     consts::BASE64_ENGINE.encode(google_pay_data.tokenization_data.token),
                 ),
+                descriptor: None,
             },
         });
         let processing_information =
@@ -1097,6 +1104,7 @@ impl TryFrom<&CybersourceRouterData<&types::PaymentsAuthorizeRouterData>>
                                         ApplePayTokenPaymentInformation {
                                             fluid_data: FluidData {
                                                 value: Secret::from(apple_pay_data.payment_data),
+                                                descriptor: Some(FLUID_DATA_DESCRIPTOR.to_string()),
                                             },
                                             tokenized_card: ApplePayTokenizedCard {
                                                 transaction_type: TransactionType::ApplePay,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Following connector audit changes are done for wallets for connector Cybersource: 

- `paymentInformation.fluidData.descriptor` is passed in apple pay payments request
- HTML Error Response from connector is handled

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
https://github.com/juspay/hyperswitch/issues/4450

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Manual flow apple payments need to be tested via cybersource.
Request:
```
curl --location 'http://localhost:8080/payments' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: API_KEY_HERE' \
--data-raw '{
    "amount": 1900,
    "currency": "USD",
    "confirm": true,
    "business_country": "US",
    "business_label": "food",
    
    "customer_id": "custhype1232",
    "capture_method": "automatic",
    "capture_on": "2022-09-10T10:11:12Z",
    "authentication_type": "three_ds",
    "return_url": "https://google.com",
    "email": "something@gmail.com",
    "name": "Joseph Doe",
    "phone": "999999999",
    "phone_country_code": "+65",
    "description": "Its my first payment request",
    "statement_descriptor_name": "Juspay",
    "statement_descriptor_suffix": "Router",
    "payment_method": "wallet",
    "payment_method_type": "apple_pay",
    "billing": {
        "address": {
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "city": "San Fransico",
            "state": "California",
            "zip": "94122",
            "country": "US",
            "first_name": "joseph",
            "last_name": "Doe"
        },
        "phone": {
            "number": "8056594427",
            "country_code": "+91"
        }
    },
    "payment_method_data": {
      "wallet": {
         "apple_pay": {
            "payment_data": "APPLE_PAY_TOKEN_HERE",
            "payment_method": {
               "display_name": "MasterCard 0839",
               "network": "MasterCard",
               "type": "credit"
            },
            "transaction_identifier": "47417dd24e81e22af0521800f4be217ee1d2424b513d39c10d3351dc849363a5"
         }
      }
   }
}
'
```

Response: 
```
{
    "payment_id": "pay_blKSyuvXMdhAE8Sd2Kz3",
    "merchant_id": "merchant_1709635075",
    "status": "succeeded",
    "amount": 1900,
    "net_amount": 1900,
    "amount_capturable": 0,
    "amount_received": 1900,
    "connector": "cybersource",
    "client_secret": "pay_blKSyuvXMdhAE8Sd2Kz3_secret_VZtPAKUjXzo5wrZqGKuR",
    "created": "2024-04-24T10:57:50.791Z",
    "currency": "USD",
    "customer_id": "custhype1232",
    "customer": {
        "id": "custhype1232",
        "name": "Joseph Doe",
        "email": "something@gmail.com",
        "phone": "999999999",
        "phone_country_code": "+65"
    },
    "description": "Its my first payment request",
    "refunds": null,
    "disputes": null,
    "mandate_id": null,
    "mandate_data": null,
    "setup_future_usage": null,
    "off_session": null,
    "capture_on": null,
    "capture_method": "automatic",
    "payment_method": "wallet",
    "payment_method_data": {
        "wallet": {},
        "billing": null
    },
    "payment_token": null,
    "shipping": null,
    "billing": {
        "address": {
            "city": "San Fransico",
            "country": "US",
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "zip": "94122",
            "state": "California",
            "first_name": "joseph",
            "last_name": "Doe"
        },
        "phone": {
            "number": "8056594427",
            "country_code": "+91"
        },
        "email": null
    },
    "order_details": null,
    "email": "something@gmail.com",
    "name": "Joseph Doe",
    "phone": "999999999",
    "return_url": "https://google.com/",
    "authentication_type": "three_ds",
    "statement_descriptor_name": "Juspay",
    "statement_descriptor_suffix": "Router",
    "next_action": null,
    "cancellation_reason": null,
    "error_code": null,
    "error_message": null,
    "unified_code": null,
    "unified_message": null,
    "payment_experience": null,
    "payment_method_type": "apple_pay",
    "connector_label": "cybersource_US_food_default",
    "business_country": "US",
    "business_label": "food",
    "business_sub_label": null,
    "allowed_payment_method_types": null,
    "ephemeral_key": {
        "customer_id": "custhype1232",
        "created_at": 1713956270,
        "expires": 1713959870,
        "secret": "epk_8a87d76cbb3c4958950df7a299f11102"
    },
    "manual_retry_allowed": false,
    "connector_transaction_id": "7139562721516032004951",
    "frm_message": null,
    "metadata": null,
    "connector_metadata": null,
    "feature_metadata": null,
    "reference_id": "pay_blKSyuvXMdhAE8Sd2Kz3_1",
    "payment_link": null,
    "profile_id": "pro_dMJfhV51DYUbzCBKrQDw",
    "surcharge_details": null,
    "attempt_count": 1,
    "merchant_decision": null,
    "merchant_connector_id": "mca_IPBbnit5cjRQ3IpvfJ6o",
    "incremental_authorization_allowed": false,
    "authorization_count": null,
    "incremental_authorizations": null,
    "external_authentication_details": null,
    "external_3ds_authentication_attempted": false,
    "expires_on": "2024-04-24T11:12:50.790Z",
    "fingerprint": null,
    "browser_info": null,
    "payment_method_id": null,
    "payment_method_status": null,
    "updated": "2024-04-24T10:57:54.088Z"
}
```

<img width="1496" alt="Screenshot 2024-04-24 at 4 34 45 PM" src="https://github.com/juspay/hyperswitch/assets/41580413/a007c4e0-62b7-4d3b-ade6-c79272f69e54">

Bad Request Error(this cannot be tested on sbx):
<img width="1219" alt="Screenshot 2024-04-24 at 5 01 41 PM" src="https://github.com/juspay/hyperswitch/assets/41580413/3848cc20-3598-4df5-8416-5b4b72f212d9">
![image](https://github.com/juspay/hyperswitch/assets/41580413/477094d9-b805-4b0d-8570-5db5898b7e94)



## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
