### PR TITLE
feat(router): handle authorize redirection after webhook processing for external 3ds flow

### DIFF
--- a/crates/router/src/core/authentication.rs
+++ b/crates/router/src/core/authentication.rs
@@ -11,7 +11,6 @@ use masking::{ExposeInterface, PeekInterface};
 
 use super::errors;
 use crate::{
-    consts::POLL_ID_TTL,
     core::{errors::ApiErrorResponse, payments as payments_core},
     routes::AppState,
     types::{self as core_types, api, authentication::AuthenticationResponseData, storage},
@@ -156,31 +155,6 @@ pub async fn perform_post_authentication<F: Clone + Send>(
             //If authentication is not successful, skip the payment connector flows and mark the payment as failure
             if !(authentication_status == api_models::enums::AuthenticationStatus::Success) {
                 *should_continue_confirm_transaction = false;
-            }
-            // When authentication status is non-terminal, Set poll_id in redis to allow the fetch status of poll through retrieve_poll_status api from client
-            if !authentication_status.is_terminal_status() {
-                let req_poll_id = super::utils::get_external_authentication_request_poll_id(
-                    &payment_data.payment_intent.payment_id,
-                );
-                let poll_id = super::utils::get_poll_id(
-                    business_profile.merchant_id.clone(),
-                    req_poll_id.clone(),
-                );
-                let redis_conn = state
-                    .store
-                    .get_redis_conn()
-                    .change_context(errors::ApiErrorResponse::InternalServerError)
-                    .attach_printable("Failed to get redis connection")?;
-                redis_conn
-                    .set_key_with_expiry(
-                        &poll_id,
-                        api_models::poll::PollStatus::Pending.to_string(),
-                        POLL_ID_TTL,
-                    )
-                    .await
-                    .change_context(errors::StorageError::KVError)
-                    .change_context(errors::ApiErrorResponse::InternalServerError)
-                    .attach_printable("Failed to add poll_id in redis")?;
             }
         }
         types::PostAuthenthenticationFlowInput::PaymentMethodAuthNFlow { other_fields: _ } => {


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
handle authorize redirection after webhook processing for external 3ds flow

In authorize flow, check if pull mechanism is enabled. Based on that call either payments confirm / payments sync. Check if, it's in requires_customer_action then set the poll_id in redis for client polling

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Tested Manually
Sanity of external 3ds payments

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
