### PR TITLE
change in time precision

### DIFF
--- a/crates/common_utils/src/custom_serde.rs
+++ b/crates/common_utils/src/custom_serde.rs
@@ -17,11 +17,10 @@ pub mod iso8601 {
         PrimitiveDateTime, UtcOffset,
     };
 
-    const FORMAT_CONFIG: EncodedConfig = Config::DEFAULT
-        .set_time_precision(TimePrecision::Second {
-            decimal_digits: NonZeroU8::new(3),
-        })
-        .encode();
+    const FORMAT_CONFIG: EncodedConfig =
+        Config::DEFAULT.set_time_precision(TimePrecision::Second {
+            decimal_digits: NonZeroU8::new(6),
+        }).encode();
 
     /// Serialize a [`PrimitiveDateTime`] using the well-known ISO 8601 format.
     pub fn serialize<S>(date_time: &PrimitiveDateTime, serializer: S) -> Result<S::Ok, S::Error>


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
round off for ms when precision set to 3 is generating faulty seconds value of 60, having a larger precision so that rounding off doesnt happen (permanent fix is to update time crate once issue is resolved)

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
round off for ms when precision set to 3 is generating faulty seconds value of 60, having a larger precision so that rounding off doesnt happen (permanent fix is to update time crate once issue is resolved)

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

run unit tests by generating timestamps, no specific integration tests


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
