### PR TITLE
fix(masking): mask email while logging SQL query

### DIFF
--- a/crates/common_utils/src/custom_serde.rs
+++ b/crates/common_utils/src/custom_serde.rs
@@ -17,11 +17,10 @@ pub mod iso8601 {
         PrimitiveDateTime, UtcOffset,
     };
 
-    const FORMAT_CONFIG: EncodedConfig = Config::DEFAULT
-        .set_time_precision(TimePrecision::Second {
-            decimal_digits: NonZeroU8::new(3),
-        })
-        .encode();
+    const FORMAT_CONFIG: EncodedConfig =
+        Config::DEFAULT.set_time_precision(TimePrecision::Second {
+            decimal_digits: NonZeroU8::new(6),
+        }).encode();
 
     /// Serialize a [`PrimitiveDateTime`] using the well-known ISO 8601 format.
     pub fn serialize<S>(date_time: &PrimitiveDateTime, serializer: S) -> Result<S::Ok, S::Error>

--- a/crates/common_utils/src/custom_serde.rs
+++ b/crates/common_utils/src/custom_serde.rs
@@ -17,10 +17,11 @@ pub mod iso8601 {
         PrimitiveDateTime, UtcOffset,
     };
 
-    const FORMAT_CONFIG: EncodedConfig =
-        Config::DEFAULT.set_time_precision(TimePrecision::Second {
+    const FORMAT_CONFIG: EncodedConfig = Config::DEFAULT
+        .set_time_precision(TimePrecision::Second {
             decimal_digits: NonZeroU8::new(6),
-        }).encode();
+        })
+        .encode();
 
     /// Serialize a [`PrimitiveDateTime`] using the well-known ISO 8601 format.
     pub fn serialize<S>(date_time: &PrimitiveDateTime, serializer: S) -> Result<S::Ok, S::Error>

--- a/crates/diesel_models/src/query/user.rs
+++ b/crates/diesel_models/src/query/user.rs
@@ -1,4 +1,5 @@
 use async_bb8_diesel::AsyncRunQueryDsl;
+use common_utils::pii;
 use diesel::{
     associations::HasTable, debug_query, result::Error as DieselError, ExpressionMethods,
     JoinOnDsl, QueryDsl,
@@ -26,7 +27,10 @@ impl UserNew {
 }
 
 impl User {
-    pub async fn find_by_user_email(conn: &PgPooledConn, user_email: &str) -> StorageResult<Self> {
+    pub async fn find_by_user_email(
+        conn: &PgPooledConn,
+        user_email: &pii::Email,
+    ) -> StorageResult<Self> {
         generics::generic_find_one::<<Self as HasTable>::Table, _, _>(
             conn,
             users_dsl::email.eq(user_email.to_owned()),
@@ -62,7 +66,7 @@ impl User {
 
     pub async fn update_by_user_email(
         conn: &PgPooledConn,
-        user_email: &str,
+        user_email: &pii::Email,
         user_update: UserUpdate,
     ) -> StorageResult<Self> {
         generics::generic_update_with_unique_predicate_get_result::<

--- a/crates/router/src/core/user_role.rs
+++ b/crates/router/src/core/user_role.rs
@@ -1,7 +1,6 @@
 use api_models::{user as user_api, user_role as user_role_api};
 use diesel_models::{enums::UserStatus, user_role::UserRoleUpdate};
 use error_stack::{report, ResultExt};
-use masking::ExposeInterface;
 use router_env::logger;
 
 use crate::{
@@ -230,12 +229,7 @@ pub async fn delete_user_role(
 ) -> UserResponse<()> {
     let user_from_db: domain::UserFromStorage = state
         .store
-        .find_user_by_email(
-            domain::UserEmail::from_pii_email(request.email)?
-                .get_secret()
-                .expose()
-                .as_str(),
-        )
+        .find_user_by_email(&domain::UserEmail::from_pii_email(request.email)?.into_inner())
         .await
         .map_err(|e| {
             if e.current_context().is_db_not_found() {

--- a/crates/router/src/db/kafka_store.rs
+++ b/crates/router/src/db/kafka_store.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use common_enums::enums::MerchantStorageScheme;
-use common_utils::errors::CustomResult;
+use common_utils::{errors::CustomResult, pii};
 use data_models::payments::{
     payment_attempt::PaymentAttemptInterface, payment_intent::PaymentIntentInterface,
 };
@@ -2267,7 +2267,7 @@ impl UserInterface for KafkaStore {
 
     async fn find_user_by_email(
         &self,
-        user_email: &str,
+        user_email: &pii::Email,
     ) -> CustomResult<storage::User, errors::StorageError> {
         self.diesel_store.find_user_by_email(user_email).await
     }
@@ -2291,7 +2291,7 @@ impl UserInterface for KafkaStore {
 
     async fn update_user_by_email(
         &self,
-        user_email: &str,
+        user_email: &pii::Email,
         user: storage::UserUpdate,
     ) -> CustomResult<storage::User, errors::StorageError> {
         self.diesel_store

--- a/crates/router/src/services/email/types.rs
+++ b/crates/router/src/services/email/types.rs
@@ -1,5 +1,8 @@
 use api_models::user::dashboard_metadata::ProdIntent;
-use common_utils::errors::CustomResult;
+use common_utils::{
+    errors::{self, CustomResult},
+    pii,
+};
 use error_stack::ResultExt;
 use external_services::email::{EmailContents, EmailData, EmailError};
 use masking::{ExposeInterface, PeekInterface, Secret};
@@ -167,8 +170,8 @@ impl EmailToken {
         jwt::generate_jwt(&token_payload, settings).await
     }
 
-    pub fn get_email(&self) -> &str {
-        self.email.as_str()
+    pub fn get_email(&self) -> CustomResult<pii::Email, errors::ParsingError> {
+        pii::Email::try_from(self.email.clone())
     }
 
     pub fn get_merchant_id(&self) -> Option<&str> {

--- a/crates/router/src/types/domain/user.rs
+++ b/crates/router/src/types/domain/user.rs
@@ -515,7 +515,7 @@ impl NewUser {
     pub async fn check_if_already_exists_in_db(&self, state: AppState) -> UserResult<()> {
         if state
             .store
-            .find_user_by_email(self.get_email().into_inner().expose().expose().as_str())
+            .find_user_by_email(&self.get_email().into_inner())
             .await
             .is_ok()
         {

--- a/crates/router/src/utils/user.rs
+++ b/crates/router/src/utils/user.rs
@@ -4,7 +4,7 @@ use api_models::user as user_api;
 use common_utils::errors::CustomResult;
 use diesel_models::{enums::UserStatus, user_role::UserRole};
 use error_stack::ResultExt;
-use masking::{ExposeInterface, Secret};
+use masking::Secret;
 
 use crate::{
     core::errors::{StorageError, UserErrors, UserResult},
@@ -180,7 +180,7 @@ pub async fn get_user_from_db_by_email(
 ) -> CustomResult<UserFromStorage, StorageError> {
     state
         .store
-        .find_user_by_email(email.get_secret().expose().as_str())
+        .find_user_by_email(&email.into_inner())
         .await
         .map(UserFromStorage::from)
 }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
round off for ms when precision set to 3 is generating faulty seconds value of 60, having a larger precision so that rounding off doesnt happen (permanent fix is to update time crate once issue is resolved)

hotfix pr:  https://github.com/juspay/hyperswitch/pull/4436
### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
round off for ms when precision set to 3 is generating faulty seconds value of 60, having a larger precision so that rounding off doesnt happen (permanent fix is to update time crate once issue is resolved)

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

run unit tests by generating timestamps, no specific integration tests


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
