### PR TITLE
ci(postman): Fix Adyen postman collection

### DIFF
--- a/postman/collection-dir/adyen_uk/Flow Testcases/Happy Cases/Scenario14-Refund recurring payment/Payments - Create/request.json
+++ b/postman/collection-dir/adyen_uk/Flow Testcases/Happy Cases/Scenario14-Refund recurring payment/Payments - Create/request.json
@@ -77,8 +77,8 @@
           "state": "California",
           "zip": "94122",
           "country": "US",
-          "first_name": "PiX",
-          "last_name":"Narayana"
+          "first_name": "Joseph",
+          "last_name":"Doe"
         }
       },
       "billing": {
@@ -90,8 +90,8 @@
           "state": "California",
           "zip": "94122",
           "country": "US",
-          "first_name": "PiX",
-          "last_name":"Narayana"
+          "first_name": "Joseph",
+          "last_name":"Doe"
         }
       },
       "statement_descriptor_name": "joseph",

--- a/postman/collection-dir/adyen_uk/Flow Testcases/Happy Cases/Scenario14-Refund recurring payment/Payments - Create/request.json
+++ b/postman/collection-dir/adyen_uk/Flow Testcases/Happy Cases/Scenario14-Refund recurring payment/Payments - Create/request.json
@@ -77,7 +77,21 @@
           "state": "California",
           "zip": "94122",
           "country": "US",
-          "first_name": "PiX"
+          "first_name": "PiX",
+          "last_name":"Narayana"
+        }
+      },
+      "billing": {
+        "address": {
+          "line1": "1467",
+          "line2": "Harrison Street",
+          "line3": "Harrison Street",
+          "city": "San Fransico",
+          "state": "California",
+          "zip": "94122",
+          "country": "US",
+          "first_name": "PiX",
+          "last_name":"Narayana"
         }
       },
       "statement_descriptor_name": "joseph",


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [x] CI/CD

## Description
Added billing address in the request for one of the scenarios which was failing in the automation setup


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
Adyen collection was failing 


## How did you test it?
Postman
<img width="518" alt="image" src="https://github.com/juspay/hyperswitch/assets/131246334/e01d3f58-dc1c-4f7d-8d2c-1b68b71cff6d">

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
