### PR TITLE
refactor(access_token): use `merchant_connector_id` for storing access token

### DIFF
--- a/crates/common_utils/src/access_token.rs
+++ b/crates/common_utils/src/access_token.rs
@@ -1,0 +1,11 @@
+//! Commonly used utilities for access token
+
+use std::fmt::Display;
+
+/// Create a key for fetching the access token from redis
+pub fn create_access_token_key(
+    merchant_id: impl Display,
+    merchant_connector_id: impl Display,
+) -> String {
+    format!("access_token_{merchant_id}_{merchant_connector_id}")
+}

--- a/crates/common_utils/src/lib.rs
+++ b/crates/common_utils/src/lib.rs
@@ -2,6 +2,7 @@
 #![warn(missing_docs, missing_debug_implementations)]
 #![doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR" ), "/", "README.md"))]
 
+pub mod access_token;
 pub mod consts;
 pub mod crypto;
 pub mod custom_serde;

--- a/crates/router/src/core/payments/access_token.rs
+++ b/crates/router/src/core/payments/access_token.rs
@@ -10,7 +10,7 @@ use crate::{
         payments,
     },
     routes::{metrics, AppState},
-    services,
+    services::{self, logger},
     types::{self, api as api_types, domain},
 };
 
@@ -64,8 +64,14 @@ pub async fn add_access_token<
     {
         let merchant_id = &merchant_account.merchant_id;
         let store = &*state.store;
+        let merchant_connector_id = connector
+            .merchant_connector_id
+            .as_ref()
+            .ok_or(errors::ApiErrorResponse::InternalServerError)
+            .attach_printable("Missing merchant_connector_id in ConnectorData")?;
+
         let old_access_token = store
-            .get_access_token(merchant_id, connector.connector.id())
+            .get_access_token(merchant_id, merchant_connector_id)
             .await
             .change_context(errors::ApiErrorResponse::InternalServerError)
             .attach_printable("DB error when accessing the access token")?;
@@ -103,19 +109,24 @@ pub async fn add_access_token<
                 )
                 .await?
                 .async_map(|access_token| async {
-                    //Store the access token in db
+                    // Store the access token in redis with expiry
+                    // The expiry should be adjusted for network delays from the connector
                     let store = &*state.store;
-                    // This error should not be propagated, we don't want payments to fail once we have
-                    // the access token, the next request will create new access token
-                    let _ = store
+                    if let Err(access_token_set_error) = store
                         .set_access_token(
                             merchant_id,
-                            connector.connector.id(),
+                            merchant_connector_id.as_str(),
                             access_token.clone(),
                         )
                         .await
                         .change_context(errors::ApiErrorResponse::InternalServerError)
-                        .attach_printable("DB error when setting the access token");
+                        .attach_printable("DB error when setting the access token")
+                    {
+                        // If we are not able to set the access token in redis, the error should just be logged and proceed with the payment
+                        // Payments should not fail, once the access token is successfully created
+                        // The next request will create new access token, if required
+                        logger::error!(access_token_set_error=?access_token_set_error);
+                    }
                     Some(access_token)
                 })
                 .await

--- a/crates/router/src/db/kafka_store.rs
+++ b/crates/router/src/db/kafka_store.rs
@@ -859,21 +859,21 @@ impl ConnectorAccessToken for KafkaStore {
     async fn get_access_token(
         &self,
         merchant_id: &str,
-        connector_name: &str,
+        merchant_connector_id: &str,
     ) -> CustomResult<Option<AccessToken>, errors::StorageError> {
         self.diesel_store
-            .get_access_token(merchant_id, connector_name)
+            .get_access_token(merchant_id, merchant_connector_id)
             .await
     }
 
     async fn set_access_token(
         &self,
         merchant_id: &str,
-        connector_name: &str,
+        merchant_connector_id: &str,
         access_token: AccessToken,
     ) -> CustomResult<(), errors::StorageError> {
         self.diesel_store
-            .set_access_token(merchant_id, connector_name, access_token)
+            .set_access_token(merchant_id, merchant_connector_id, access_token)
             .await
     }
 }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Refactoring

## Description
<!-- Describe your changes in detail -->
This PR modifies the way in which access tokens are stored in the redis. The key format is changed to 
`access_token_{merchant_id}_{merchant_connector_id}` More information can be found in the linked issue.

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
In order to support multiple connector accounts

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
- Run the Trustpay postman collection locally and check whether the access token is stored in redis
<img width="2056" alt="Screenshot 2024-04-25 at 1 56 18 PM" src="https://github.com/juspay/hyperswitch/assets/48803246/f527d6d4-4af9-49cf-8a3f-bf2fa6952d2c">

## Impact
- All connectors using access token auth.
- Trustpay BankRedirect, Volt and Iatapay

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
