### PR TITLE
feat(user): add single purpose token and auth

### DIFF
--- a/crates/router/src/consts.rs
+++ b/crates/router/src/consts.rs
@@ -68,6 +68,8 @@ pub const LOCKER_REDIS_EXPIRY_SECONDS: u32 = 60 * 15; // 15 minutes
 
 pub const JWT_TOKEN_TIME_IN_SECS: u64 = 60 * 60 * 24 * 2; // 2 days
 
+pub const SINGLE_PURPOSE_TOKEN_TIME_IN_SECS: u64 = 60 * 60 * 24; // 1 day
+
 pub const JWT_TOKEN_COOKIE_NAME: &str = "login_token";
 
 pub const USER_BLACKLIST_PREFIX: &str = "BU_";

--- a/crates/router/src/services/authentication.rs
+++ b/crates/router/src/services/authentication.rs
@@ -149,6 +149,7 @@ impl SinglePurposeToken {
     }
 }
 
+// TODO: This has to be removed once SinglePuposeToken is used as a intermediate token
 #[derive(Clone, Debug)]
 pub struct UserWithoutMerchantFromToken {
     pub user_id: String,

--- a/crates/router/src/services/authentication.rs
+++ b/crates/router/src/services/authentication.rs
@@ -64,6 +64,10 @@ pub enum AuthenticationType {
     UserJwt {
         user_id: String,
     },
+    SinglePurposeJWT {
+        user_id: String,
+        purpose: SinglePurpose,
+    },
     MerchantId {
         merchant_id: String,
     },
@@ -101,8 +105,47 @@ impl AuthenticationType {
                 user_id: _,
             }
             | Self::WebhookAuth { merchant_id } => Some(merchant_id.as_ref()),
-            Self::AdminApiKey | Self::UserJwt { .. } | Self::NoAuth => None,
+            Self::AdminApiKey
+            | Self::UserJwt { .. }
+            | Self::SinglePurposeJWT { .. }
+            | Self::NoAuth => None,
         }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct UserFromSinglePurposesToken {
+    pub user_id: String,
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+pub struct SinglePurposeToken {
+    pub user_id: String,
+    pub purpose: SinglePurpose,
+    pub exp: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, strum::Display, serde::Deserialize, serde::Serialize)]
+pub enum SinglePurpose {
+    AcceptInvite,
+    ForceSetPassword,
+}
+
+#[cfg(feature = "olap")]
+impl SinglePurposeToken {
+    pub async fn new_token(
+        user_id: String,
+        purpose: SinglePurpose,
+        settings: &Settings,
+    ) -> UserResult<String> {
+        let exp_duration = std::time::Duration::from_secs(consts::JWT_TOKEN_TIME_IN_SECS);
+        let exp = jwt::generate_exp(exp_duration)?.as_secs();
+        let token_payload = Self {
+            user_id,
+            purpose,
+            exp,
+        };
+        jwt::generate_jwt(&token_payload, settings).await
     }
 }
 
@@ -311,6 +354,44 @@ where
             },
             AuthenticationType::UserJwt {
                 user_id: payload.user_id,
+            },
+        ))
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct SinglePurposeJWTAuth(pub SinglePurpose);
+
+#[cfg(feature = "olap")]
+#[async_trait]
+impl<A> AuthenticateAndFetch<UserFromSinglePurposesToken, A> for SinglePurposeJWTAuth
+where
+    A: AppStateInfo + Sync,
+{
+    async fn authenticate_and_fetch(
+        &self,
+        request_headers: &HeaderMap,
+        state: &A,
+    ) -> RouterResult<(UserFromSinglePurposesToken, AuthenticationType)> {
+        let payload = parse_jwt_payload::<A, SinglePurposeToken>(request_headers, state).await?;
+        if payload.check_in_blacklist(state).await? {
+            return Err(errors::ApiErrorResponse::InvalidJwtToken.into());
+        }
+
+        if self.0 != payload.purpose {
+            return Err(errors::ApiErrorResponse::AccessForbidden {
+                resource: self.0.to_string(),
+            }
+            .into());
+        }
+
+        Ok((
+            UserFromSinglePurposesToken {
+                user_id: payload.user_id.clone(),
+            },
+            AuthenticationType::SinglePurposeJWT {
+                user_id: payload.user_id,
+                purpose: payload.purpose,
             },
         ))
     }

--- a/crates/router/src/services/authentication.rs
+++ b/crates/router/src/services/authentication.rs
@@ -137,7 +137,8 @@ impl SinglePurposeToken {
         purpose: Purpose,
         settings: &Settings,
     ) -> UserResult<String> {
-        let exp_duration = std::time::Duration::from_secs(consts::JWT_TOKEN_TIME_IN_SECS);
+        let exp_duration =
+            std::time::Duration::from_secs(consts::SINGLE_PURPOSE_TOKEN_TIME_IN_SECS);
         let exp = jwt::generate_exp(exp_duration)?.as_secs();
         let token_payload = Self {
             user_id,
@@ -380,10 +381,7 @@ where
         }
 
         if self.0 != payload.purpose {
-            return Err(errors::ApiErrorResponse::AccessForbidden {
-                resource: self.0.to_string(),
-            }
-            .into());
+            return Err(errors::ApiErrorResponse::InvalidJwtToken.into());
         }
 
         Ok((

--- a/crates/router/src/services/authentication.rs
+++ b/crates/router/src/services/authentication.rs
@@ -128,7 +128,6 @@ pub struct SinglePurposeToken {
 #[derive(Debug, Clone, PartialEq, Eq, strum::Display, serde::Deserialize, serde::Serialize)]
 pub enum SinglePurpose {
     AcceptInvite,
-    ForceSetPassword,
 }
 
 #[cfg(feature = "olap")]
@@ -360,6 +359,7 @@ where
     }
 }
 
+#[allow(dead_code)]
 #[derive(Debug)]
 pub(crate) struct SinglePurposeJWTAuth(pub SinglePurpose);
 

--- a/crates/router/src/services/authentication.rs
+++ b/crates/router/src/services/authentication.rs
@@ -149,7 +149,7 @@ impl SinglePurposeToken {
     }
 }
 
-// TODO: This has to be removed once SinglePuposeToken is used as a intermediate token
+// TODO: This has to be removed once single purpose token is used as a intermediate token
 #[derive(Clone, Debug)]
 pub struct UserWithoutMerchantFromToken {
     pub user_id: String,

--- a/crates/router/src/services/authentication/blacklist.rs
+++ b/crates/router/src/services/authentication/blacklist.rs
@@ -5,7 +5,7 @@ use common_utils::date_time;
 use error_stack::ResultExt;
 use redis_interface::RedisConnectionPool;
 
-use super::{AuthToken, UserAuthToken};
+use super::{AuthToken, SinglePurposeToken, UserAuthToken};
 #[cfg(feature = "email")]
 use crate::consts::{EMAIL_TOKEN_BLACKLIST_PREFIX, EMAIL_TOKEN_TIME_IN_SECS};
 use crate::{
@@ -156,6 +156,16 @@ impl BlackList for AuthToken {
 
 #[async_trait::async_trait]
 impl BlackList for UserAuthToken {
+    async fn check_in_blacklist<A>(&self, state: &A) -> RouterResult<bool>
+    where
+        A: AppStateInfo + Sync,
+    {
+        check_user_in_blacklist(state, &self.user_id, self.exp).await
+    }
+}
+
+#[async_trait::async_trait]
+impl BlackList for SinglePurposeToken {
     async fn check_in_blacklist<A>(&self, state: &A) -> RouterResult<bool>
     where
         A: AppStateInfo + Sync,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
Add single purpose token and authentication for single purpose token. This token will serves as a intermediate token and used to perform a certain action only.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
Closes #4478 


## How did you test it?
This can be tested with upcoming PRs for reset password, TOTP, accept invite etc. Single purpose token and auth will be used for that. 
I also tested this locally, by changing auth type of  change passwor and it was working as expected.


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
