### PR TITLE
fix(connector): send valid sdk information in authentication flow netcetera

### DIFF
--- a/crates/diesel_models/src/schema.rs
+++ b/crates/diesel_models/src/schema.rs
@@ -82,8 +82,7 @@ diesel::table! {
         authentication_lifecycle_status -> Varchar,
         created_at -> Timestamp,
         modified_at -> Timestamp,
-        #[max_length = 64]
-        error_message -> Nullable<Varchar>,
+        error_message -> Nullable<Text>,
         #[max_length = 64]
         error_code -> Nullable<Varchar>,
         connector_metadata -> Nullable<Jsonb>,

--- a/crates/router/src/connector/netcetera/netcetera_types.rs
+++ b/crates/router/src/connector/netcetera/netcetera_types.rs
@@ -1615,7 +1615,7 @@ pub enum ThreeDSReqAuthMethod {
 pub struct DeviceRenderingOptionsSupported {
     pub sdk_interface: SdkInterface,
     /// For Native UI SDK Interface accepted values are 01-04 and for HTML UI accepted values are 01-05.
-    pub sdk_ui_type: SdkUiType,
+    pub sdk_ui_type: Vec<SdkUiType>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/crates/router/src/connector/netcetera/netcetera_types.rs
+++ b/crates/router/src/connector/netcetera/netcetera_types.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use common_utils::pii::Email;
 use serde::{Deserialize, Serialize};
 
-use crate::types::api::MessageCategory;
+use crate::{connector::utils::AddressDetailsData, errors, types::api::MessageCategory};
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
 #[serde(untagged)]
@@ -679,18 +679,19 @@ pub struct Cardholder {
 }
 
 impl
-    From<(
+    TryFrom<(
         api_models::payments::Address,
         Option<api_models::payments::Address>,
     )> for Cardholder
 {
-    fn from(
+    type Error = error_stack::Report<errors::ConnectorError>;
+    fn try_from(
         (billing_address, shipping_address): (
             api_models::payments::Address,
             Option<api_models::payments::Address>,
         ),
-    ) -> Self {
-        Self {
+    ) -> Result<Self, Self::Error> {
+        Ok(Self {
             addr_match: None,
             bill_addr_city: billing_address
                 .address
@@ -716,7 +717,8 @@ impl
             bill_addr_state: billing_address
                 .address
                 .as_ref()
-                .and_then(|add| add.state.clone()),
+                .and_then(|add| add.to_state_code_option().transpose())
+                .transpose()?,
             email: billing_address.email,
             home_phone: billing_address.phone.clone().map(Into::into),
             mobile_phone: billing_address.phone.clone().map(Into::into),
@@ -749,9 +751,10 @@ impl
             ship_addr_state: shipping_address
                 .as_ref()
                 .and_then(|shipping_add| shipping_add.address.as_ref())
-                .and_then(|add| add.state.clone()),
+                .and_then(|add| add.to_state_code_option().transpose())
+                .transpose()?,
             tax_id: None,
-        }
+        })
     }
 }
 
@@ -1377,6 +1380,7 @@ pub struct Sdk {
     ///
     /// Starting from EMV 3DS 2.3.1:
     /// In case of Browser-SDK, the SDK App ID value is not reliable, and may change for each transaction.
+    #[serde(rename = "sdkAppID")]
     sdk_app_id: Option<String>,
 
     /// JWE Object as defined Section 6.2.2.1 containing data encrypted by the SDK for the DS to decrypt. This element is
@@ -1404,6 +1408,7 @@ pub struct Sdk {
     /// Universally unique transaction identifier assigned by the 3DS SDK to identify a single transaction. The field is
     /// limited to 36 characters and it shall be in a canonical format as defined in IETF RFC 4122. This may utilize any of
     /// the specified versions as long as the output meets specific requirements.
+    #[serde(rename = "sdkTransID")]
     sdk_trans_id: Option<String>,
 
     /// Contains the JWS object(represented as a string) created by the Split-SDK Server for the AReq message. A
@@ -1586,4 +1591,36 @@ pub enum ThreeDSReqAuthMethod {
     /// Additionally, 80-99 can be used for PS-specific values, regardless of protocol version.
     #[serde(untagged)]
     PsSpecificValue(String),
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct DeviceRenderingOptionsSupported {
+    pub sdk_interface: SdkInterface,
+    /// For Native UI SDK Interface accepted values are 01-04 and for HTML UI accepted values are 01-05.
+    pub sdk_ui_type: SdkUiType,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub enum SdkInterface {
+    #[serde(rename = "01")]
+    Native,
+    #[serde(rename = "02")]
+    Html,
+    #[serde(rename = "03")]
+    Both,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub enum SdkUiType {
+    #[serde(rename = "01")]
+    Text,
+    #[serde(rename = "02")]
+    SingleSelect,
+    #[serde(rename = "03")]
+    MultiSelect,
+    #[serde(rename = "04")]
+    Oob,
+    #[serde(rename = "05")]
+    HtmlOther,
 }

--- a/crates/router/src/connector/netcetera/netcetera_types.rs
+++ b/crates/router/src/connector/netcetera/netcetera_types.rs
@@ -721,23 +721,23 @@ impl
             bill_addr_state: billing_address
                 .address
                 .as_ref()
-                .and_then(|add| add.to_state_code_option().transpose())
+                .and_then(|add| add.to_state_code_as_optional().transpose())
                 .transpose()?,
             email: billing_address.email,
             home_phone: billing_address
                 .phone
                 .clone()
-                .map(TryInto::try_into)
+                .map(PhoneNumber::try_from)
                 .transpose()?,
             mobile_phone: billing_address
                 .phone
                 .clone()
-                .map(TryInto::try_into)
+                .map(PhoneNumber::try_from)
                 .transpose()?,
             work_phone: billing_address
                 .phone
                 .clone()
-                .map(TryInto::try_into)
+                .map(PhoneNumber::try_from)
                 .transpose()?,
             cardholder_name: billing_address
                 .address
@@ -767,7 +767,7 @@ impl
             ship_addr_state: shipping_address
                 .as_ref()
                 .and_then(|shipping_add| shipping_add.address.as_ref())
-                .and_then(|add| add.to_state_code_option().transpose())
+                .and_then(|add| add.to_state_code_as_optional().transpose())
                 .transpose()?,
             tax_id: None,
         })
@@ -787,7 +787,7 @@ impl TryFrom<api_models::payments::PhoneDetails> for PhoneNumber {
     type Error = error_stack::Report<errors::ConnectorError>;
     fn try_from(value: api_models::payments::PhoneDetails) -> Result<Self, Self::Error> {
         Ok(Self {
-            country_code: Some(value.get_country_code_without_plus()?),
+            country_code: Some(value.extract_country_code()?),
             subscriber: value.number,
         })
     }

--- a/crates/router/src/connector/netcetera/transformers.rs
+++ b/crates/router/src/connector/netcetera/transformers.rs
@@ -154,7 +154,9 @@ impl
                                     .acs_reference_number,
                                 acs_trans_id: response.authentication_response.acs_trans_id,
                                 three_dsserver_trans_id: Some(response.three_ds_server_trans_id),
-                                acs_signed_content: None,
+                                acs_signed_content: response
+                                    .authentication_response
+                                    .acs_signed_content,
                             },
                         ))
                     }
@@ -556,8 +558,14 @@ impl TryFrom<&NetceteraRouterData<&types::authentication::ConnectorAuthenticatio
             api_models::payments::DeviceChannel::App => {
                 Some(netcetera_types::DeviceRenderingOptionsSupported {
                     // hard-coded until core provides these values.
-                    sdk_interface: netcetera_types::SdkInterface::Native,
-                    sdk_ui_type: netcetera_types::SdkUiType::Text,
+                    sdk_interface: netcetera_types::SdkInterface::Both,
+                    sdk_ui_type: vec![
+                        netcetera_types::SdkUiType::Text,
+                        netcetera_types::SdkUiType::SingleSelect,
+                        netcetera_types::SdkUiType::MultiSelect,
+                        netcetera_types::SdkUiType::Oob,
+                        netcetera_types::SdkUiType::HtmlOther,
+                    ],
                 })
             }
             api_models::payments::DeviceChannel::Browser => None,
@@ -635,6 +643,7 @@ pub struct AuthenticationResponse {
     pub acs_reference_number: Option<String>,
     #[serde(rename = "acsTransID")]
     pub acs_trans_id: Option<String>,
+    pub acs_signed_content: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]

--- a/crates/router/src/connector/utils.rs
+++ b/crates/router/src/connector/utils.rs
@@ -1228,6 +1228,7 @@ pub trait AddressDetailsData {
     fn get_country(&self) -> Result<&api_models::enums::CountryAlpha2, Error>;
     fn get_combined_address_line(&self) -> Result<Secret<String>, Error>;
     fn to_state_code(&self) -> Result<Secret<String>, Error>;
+    fn to_state_code_option(&self) -> Result<Option<Secret<String>>, Error>;
 }
 
 impl AddressDetailsData for api::AddressDetails {
@@ -1310,6 +1311,12 @@ impl AddressDetailsData for api::AddressDetails {
             )),
             _ => Ok(state.clone()),
         }
+    }
+    fn to_state_code_option(&self) -> Result<Option<Secret<String>>, Error> {
+        self.state
+            .as_ref()
+            .map(|_| self.to_state_code())
+            .transpose()
     }
 }
 

--- a/crates/router/src/connector/utils.rs
+++ b/crates/router/src/connector/utils.rs
@@ -1186,7 +1186,7 @@ pub trait PhoneDetailsData {
     fn get_country_code(&self) -> Result<String, Error>;
     fn get_number_with_country_code(&self) -> Result<Secret<String>, Error>;
     fn get_number_with_hash_country_code(&self) -> Result<Secret<String>, Error>;
-    fn get_country_code_without_plus(&self) -> Result<String, Error>;
+    fn extract_country_code(&self) -> Result<String, Error>;
 }
 
 impl PhoneDetailsData for api::PhoneDetails {
@@ -1195,7 +1195,7 @@ impl PhoneDetailsData for api::PhoneDetails {
             .clone()
             .ok_or_else(missing_field_err("billing.phone.country_code"))
     }
-    fn get_country_code_without_plus(&self) -> Result<String, Error> {
+    fn extract_country_code(&self) -> Result<String, Error> {
         self.get_country_code()
             .map(|cc| cc.trim_start_matches('+').to_string())
     }
@@ -1233,7 +1233,7 @@ pub trait AddressDetailsData {
     fn get_country(&self) -> Result<&api_models::enums::CountryAlpha2, Error>;
     fn get_combined_address_line(&self) -> Result<Secret<String>, Error>;
     fn to_state_code(&self) -> Result<Secret<String>, Error>;
-    fn to_state_code_option(&self) -> Result<Option<Secret<String>>, Error>;
+    fn to_state_code_as_optional(&self) -> Result<Option<Secret<String>>, Error>;
 }
 
 impl AddressDetailsData for api::AddressDetails {
@@ -1317,7 +1317,7 @@ impl AddressDetailsData for api::AddressDetails {
             _ => Ok(state.clone()),
         }
     }
-    fn to_state_code_option(&self) -> Result<Option<Secret<String>>, Error> {
+    fn to_state_code_as_optional(&self) -> Result<Option<Secret<String>>, Error> {
         self.state
             .as_ref()
             .map(|_| self.to_state_code())

--- a/crates/router/src/connector/utils.rs
+++ b/crates/router/src/connector/utils.rs
@@ -1186,6 +1186,7 @@ pub trait PhoneDetailsData {
     fn get_country_code(&self) -> Result<String, Error>;
     fn get_number_with_country_code(&self) -> Result<Secret<String>, Error>;
     fn get_number_with_hash_country_code(&self) -> Result<Secret<String>, Error>;
+    fn get_country_code_without_plus(&self) -> Result<String, Error>;
 }
 
 impl PhoneDetailsData for api::PhoneDetails {
@@ -1193,6 +1194,10 @@ impl PhoneDetailsData for api::PhoneDetails {
         self.country_code
             .clone()
             .ok_or_else(missing_field_err("billing.phone.country_code"))
+    }
+    fn get_country_code_without_plus(&self) -> Result<String, Error> {
+        self.get_country_code()
+            .map(|cc| cc.trim_start_matches('+').to_string())
     }
     fn get_number(&self) -> Result<Secret<String>, Error> {
         self.number

--- a/crates/router/src/connector/utils.rs
+++ b/crates/router/src/connector/utils.rs
@@ -1320,7 +1320,13 @@ impl AddressDetailsData for api::AddressDetails {
     fn to_state_code_as_optional(&self) -> Result<Option<Secret<String>>, Error> {
         self.state
             .as_ref()
-            .map(|_| self.to_state_code())
+            .map(|state| {
+                if state.peek().len() == 2 {
+                    Ok(state.to_owned())
+                } else {
+                    self.to_state_code()
+                }
+            })
             .transpose()
     }
 }

--- a/migrations/2024-04-28-095920_make_error_message_field_text/down.sql
+++ b/migrations/2024-04-28-095920_make_error_message_field_text/down.sql
@@ -1,2 +1,2 @@
 -- This file should undo anything in `up.sql`
-ALTER TABLE authentication ALTER COLUMN error_message VARCHAR(64);
+ALTER TABLE authentication ALTER COLUMN error_message TYPE VARCHAR(64);

--- a/migrations/2024-04-28-095920_make_error_message_field_text/down.sql
+++ b/migrations/2024-04-28-095920_make_error_message_field_text/down.sql
@@ -1,0 +1,2 @@
+-- This file should undo anything in `up.sql`
+ALTER TABLE authentication ALTER COLUMN error_message VARCHAR(64);

--- a/migrations/2024-04-28-095920_make_error_message_field_text/up.sql
+++ b/migrations/2024-04-28-095920_make_error_message_field_text/up.sql
@@ -1,0 +1,2 @@
+-- Your SQL goes here
+ALTER TABLE authentication ALTER COLUMN error_message TYPE TEXT;


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Two required params in SDK information were not serde renamed properly. This was causing SDK based authentication call to fail. Fixed it.



Other changes:
* Changed the type of `error_message` column in `authentication` table to `TEXT` from `VARCHAR(64)`. Because when length of error_message was greater than 64 chars, update operation was failing.
* Pass Device render options in authentication request because it is also required for SDK based authentication.
* Pass address-state as two character state code.
* pass country code in phone number after trimming `+` prefix


### Additional Changes

- [ ] This PR modifies the API contract
- [x] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Manual


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
