### PR TITLE
chore: make client certificate and private key secret across codebase

### DIFF
--- a/crates/api_models/src/payments.rs
+++ b/crates/api_models/src/payments.rs
@@ -3894,7 +3894,9 @@ pub struct PaymentRequestMetadata {
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, ToSchema)]
 pub struct SessionTokenInfo {
+    #[schema(value_type = String)]
     pub certificate: Secret<String>,
+    #[schema(value_type = String)]
     pub certificate_keys: Secret<String>,
     pub merchant_identifier: String,
     pub display_name: String,

--- a/crates/api_models/src/payments.rs
+++ b/crates/api_models/src/payments.rs
@@ -3894,8 +3894,8 @@ pub struct PaymentRequestMetadata {
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, ToSchema)]
 pub struct SessionTokenInfo {
-    pub certificate: String,
-    pub certificate_keys: String,
+    pub certificate: Secret<String>,
+    pub certificate_keys: Secret<String>,
     pub merchant_identifier: String,
     pub display_name: String,
     pub initiative: String,

--- a/crates/common_utils/src/request.rs
+++ b/crates/common_utils/src/request.rs
@@ -35,8 +35,8 @@ pub struct Request {
     pub url: String,
     pub headers: Headers,
     pub method: Method,
-    pub certificate: Option<String>,
-    pub certificate_key: Option<String>,
+    pub certificate: Option<Secret<String>>,
+    pub certificate_key: Option<Secret<String>>,
     pub body: Option<RequestContent>,
 }
 
@@ -96,11 +96,11 @@ impl Request {
         self.headers.insert((String::from(header), value));
     }
 
-    pub fn add_certificate(&mut self, certificate: Option<String>) {
+    pub fn add_certificate(&mut self, certificate: Option<Secret<String>>) {
         self.certificate = certificate;
     }
 
-    pub fn add_certificate_key(&mut self, certificate_key: Option<String>) {
+    pub fn add_certificate_key(&mut self, certificate_key: Option<Secret<String>>) {
         self.certificate = certificate_key;
     }
 }
@@ -110,8 +110,8 @@ pub struct RequestBuilder {
     pub url: String,
     pub headers: Headers,
     pub method: Method,
-    pub certificate: Option<String>,
-    pub certificate_key: Option<String>,
+    pub certificate: Option<Secret<String>>,
+    pub certificate_key: Option<Secret<String>>,
     pub body: Option<RequestContent>,
 }
 
@@ -157,12 +157,12 @@ impl RequestBuilder {
         self
     }
 
-    pub fn add_certificate(mut self, certificate: Option<String>) -> Self {
+    pub fn add_certificate(mut self, certificate: Option<Secret<String>>) -> Self {
         self.certificate = certificate;
         self
     }
 
-    pub fn add_certificate_key(mut self, certificate_key: Option<String>) -> Self {
+    pub fn add_certificate_key(mut self, certificate_key: Option<Secret<String>>) -> Self {
         self.certificate_key = certificate_key;
         self
     }

--- a/crates/masking/src/secret.rs
+++ b/crates/masking/src/secret.rs
@@ -160,6 +160,6 @@ where
     T: ?Sized,
 {
     fn as_ref(&self) -> &T {
-        self.inner_secret.as_ref()
+        self.peek().as_ref()
     }
 }

--- a/crates/masking/src/secret.rs
+++ b/crates/masking/src/secret.rs
@@ -152,3 +152,14 @@ where
         SecretValue::default().into()
     }
 }
+
+impl<SecretValue, MaskingStrategy, T> AsRef<T> for Secret<SecretValue, MaskingStrategy>
+where
+    SecretValue: AsRef<T>,
+    MaskingStrategy: Strategy<SecretValue>,
+    T: ?Sized,
+{
+    fn as_ref(&self) -> &T {
+        self.inner_secret.as_ref()
+    }
+}

--- a/crates/masking/src/secret.rs
+++ b/crates/masking/src/secret.rs
@@ -152,14 +152,3 @@ where
         SecretValue::default().into()
     }
 }
-
-impl<SecretValue, MaskingStrategy, T> AsRef<T> for Secret<SecretValue, MaskingStrategy>
-where
-    SecretValue: AsRef<T>,
-    MaskingStrategy: Strategy<SecretValue>,
-    T: ?Sized,
-{
-    fn as_ref(&self) -> &T {
-        self.peek().as_ref()
-    }
-}

--- a/crates/router/src/connector/netcetera.rs
+++ b/crates/router/src/connector/netcetera.rs
@@ -5,7 +5,6 @@ use std::fmt::Debug;
 
 use common_utils::{ext_traits::ByteSliceExt, request::RequestContent};
 use error_stack::ResultExt;
-use masking::ExposeInterface;
 use transformers as netcetera;
 
 use crate::{
@@ -297,8 +296,8 @@ impl
                         self, req, connectors,
                     )?,
                 )
-                .add_certificate(Some(netcetera_auth_type.certificate.expose()))
-                .add_certificate_key(Some(netcetera_auth_type.private_key.expose()))
+                .add_certificate(Some(netcetera_auth_type.certificate))
+                .add_certificate_key(Some(netcetera_auth_type.private_key))
                 .build(),
         ))
     }
@@ -407,8 +406,8 @@ impl
                         self, req, connectors,
                     )?,
                 )
-                .add_certificate(Some(netcetera_auth_type.certificate.expose()))
-                .add_certificate_key(Some(netcetera_auth_type.private_key.expose()))
+                .add_certificate(Some(netcetera_auth_type.certificate))
+                .add_certificate_key(Some(netcetera_auth_type.private_key))
                 .build(),
         ))
     }

--- a/crates/router/src/core/payments/flows/session_flow.rs
+++ b/crates/router/src/core/payments/flows/session_flow.rs
@@ -111,8 +111,8 @@ fn get_applepay_metadata(
 fn build_apple_pay_session_request(
     state: &routes::AppState,
     request: payment_types::ApplepaySessionRequest,
-    apple_pay_merchant_cert: String,
-    apple_pay_merchant_cert_key: String,
+    apple_pay_merchant_cert: masking::Secret<String>,
+    apple_pay_merchant_cert_key: masking::Secret<String>,
 ) -> RouterResult<services::Request> {
     let mut url = state.conf.connectors.applepay.base_url.to_owned();
     url.push_str("paymentservices/paymentSession");
@@ -188,16 +188,14 @@ async fn create_applepay_session_token(
                         .applepay_decrypt_keys
                         .get_inner()
                         .apple_pay_merchant_cert
-                        .clone()
-                        .expose();
+                        .clone();
 
                     let apple_pay_merchant_cert_key = state
                         .conf
                         .applepay_decrypt_keys
                         .get_inner()
                         .apple_pay_merchant_cert_key
-                        .clone()
-                        .expose();
+                        .clone();
 
                     (
                         payment_request_data,

--- a/crates/router/src/core/payments/helpers.rs
+++ b/crates/router/src/core/payments/helpers.rs
@@ -70,11 +70,11 @@ pub fn create_identity_from_certificate_and_key(
     encoded_certificate_key: masking::Secret<String>,
 ) -> Result<reqwest::Identity, error_stack::Report<errors::ApiClientError>> {
     let decoded_certificate = BASE64_ENGINE
-        .decode(encoded_certificate)
+        .decode(encoded_certificate.expose())
         .change_context(errors::ApiClientError::CertificateDecodeFailed)?;
 
     let decoded_certificate_key = BASE64_ENGINE
-        .decode(encoded_certificate_key)
+        .decode(encoded_certificate_key.expose())
         .change_context(errors::ApiClientError::CertificateDecodeFailed)?;
 
     let certificate = String::from_utf8(decoded_certificate)

--- a/crates/router/src/core/payments/helpers.rs
+++ b/crates/router/src/core/payments/helpers.rs
@@ -66,8 +66,8 @@ use crate::{
 };
 
 pub fn create_identity_from_certificate_and_key(
-    encoded_certificate: String,
-    encoded_certificate_key: String,
+    encoded_certificate: masking::Secret<String>,
+    encoded_certificate_key: masking::Secret<String>,
 ) -> Result<reqwest::Identity, error_stack::Report<errors::ApiClientError>> {
     let decoded_certificate = BASE64_ENGINE
         .decode(encoded_certificate)

--- a/crates/router/src/core/verification.rs
+++ b/crates/router/src/core/verification.rs
@@ -2,7 +2,7 @@ pub mod utils;
 use api_models::verifications::{self, ApplepayMerchantResponse};
 use common_utils::{errors::CustomResult, request::RequestContent};
 use error_stack::ResultExt;
-use masking::ExposeInterface;
+use masking::{ExposeInterface, Secret};
 
 use crate::{core::errors::api_error_response, headers, logger, pii, routes::AppState, services};
 
@@ -22,8 +22,8 @@ pub async fn verify_merchant_creds_for_applepay(
         .common_merchant_identifier
         .clone()
         .expose();
-    let cert_data = applepay_merchant_configs.merchant_cert.clone().expose();
-    let key_data = applepay_merchant_configs.merchant_cert_key.clone().expose();
+    let cert_data = applepay_merchant_configs.merchant_cert.clone();
+    let key_data = applepay_merchant_configs.merchant_cert_key.clone();
     let applepay_endpoint = &applepay_merchant_configs.applepay_endpoint;
 
     let request_body = verifications::ApplepayMerchantVerificationConfigs {
@@ -42,8 +42,8 @@ pub async fn verify_merchant_creds_for_applepay(
             "application/json".to_string().into(),
         )])
         .set_body(RequestContent::Json(Box::new(request_body)))
-        .add_certificate(Some(pii::Secret::new(cert_data)))
-        .add_certificate_key(Some(pii::Secret::new(key_data)))
+        .add_certificate(Some(cert_data))
+        .add_certificate_key(Some(key_data))
         .build();
 
     let response = services::call_connector_api(

--- a/crates/router/src/core/verification.rs
+++ b/crates/router/src/core/verification.rs
@@ -4,7 +4,7 @@ use common_utils::{errors::CustomResult, request::RequestContent};
 use error_stack::ResultExt;
 use masking::ExposeInterface;
 
-use crate::{core::errors::api_error_response, headers, logger, routes::AppState, services};
+use crate::{core::errors::api_error_response, headers, logger, pii, routes::AppState, services};
 
 const APPLEPAY_INTERNAL_MERCHANT_NAME: &str = "Applepay_merchant";
 
@@ -42,8 +42,8 @@ pub async fn verify_merchant_creds_for_applepay(
             "application/json".to_string().into(),
         )])
         .set_body(RequestContent::Json(Box::new(request_body)))
-        .add_certificate(Some(cert_data))
-        .add_certificate_key(Some(key_data))
+        .add_certificate(Some(pii::Secret::new(cert_data)))
+        .add_certificate_key(Some(pii::Secret::new(key_data)))
         .build();
 
     let response = services::call_connector_api(

--- a/crates/router/src/core/verification.rs
+++ b/crates/router/src/core/verification.rs
@@ -2,9 +2,9 @@ pub mod utils;
 use api_models::verifications::{self, ApplepayMerchantResponse};
 use common_utils::{errors::CustomResult, request::RequestContent};
 use error_stack::ResultExt;
-use masking::{ExposeInterface, Secret};
+use masking::ExposeInterface;
 
-use crate::{core::errors::api_error_response, headers, logger, pii, routes::AppState, services};
+use crate::{core::errors::api_error_response, headers, logger, routes::AppState, services};
 
 const APPLEPAY_INTERNAL_MERCHANT_NAME: &str = "Applepay_merchant";
 

--- a/crates/router/src/services/api/client.rs
+++ b/crates/router/src/services/api/client.rs
@@ -83,8 +83,8 @@ fn get_base_client(
 pub(super) fn create_client(
     proxy_config: &Proxy,
     should_bypass_proxy: bool,
-    client_certificate: Option<String>,
-    client_certificate_key: Option<String>,
+    client_certificate: Option<masking::Secret<String>>,
+    client_certificate_key: Option<masking::Secret<String>>,
 ) -> CustomResult<reqwest::Client, ApiClientError> {
     match (client_certificate, client_certificate_key) {
         (Some(encoded_certificate), Some(encoded_certificate_key)) => {
@@ -154,8 +154,8 @@ where
         &self,
         method: Method,
         url: String,
-        certificate: Option<String>,
-        certificate_key: Option<String>,
+        certificate: Option<masking::Secret<String>>,
+        certificate_key: Option<masking::Secret<String>>,
     ) -> CustomResult<Box<dyn RequestBuilder>, ApiClientError>;
 
     async fn send_request(
@@ -223,8 +223,8 @@ impl ProxyClient {
     pub fn get_reqwest_client(
         &self,
         base_url: String,
-        client_certificate: Option<String>,
-        client_certificate_key: Option<String>,
+        client_certificate: Option<masking::Secret<String>>,
+        client_certificate_key: Option<masking::Secret<String>>,
     ) -> CustomResult<reqwest::Client, ApiClientError> {
         match (client_certificate, client_certificate_key) {
             (Some(certificate), Some(certificate_key)) => {
@@ -323,8 +323,8 @@ impl ApiClient for ProxyClient {
         &self,
         method: Method,
         url: String,
-        certificate: Option<String>,
-        certificate_key: Option<String>,
+        certificate: Option<masking::Secret<String>>,
+        certificate_key: Option<masking::Secret<String>>,
     ) -> CustomResult<Box<dyn RequestBuilder>, ApiClientError> {
         let client_builder = self
             .get_reqwest_client(url.clone(), certificate, certificate_key)
@@ -378,8 +378,8 @@ impl ApiClient for MockApiClient {
         &self,
         _method: Method,
         _url: String,
-        _certificate: Option<String>,
-        _certificate_key: Option<String>,
+        _certificate: Option<masking::Secret<String>>,
+        _certificate_key: Option<masking::Secret<String>>,
     ) -> CustomResult<Box<dyn RequestBuilder>, ApiClientError> {
         // [#2066]: Add Mock implementation for ApiClient
         Err(ApiClientError::UnexpectedState.into())


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Made client Certificates and private keys secret across codebase. Because They are merchant secrets and should not be logged.


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
Certificate and private key was getting logged every time a request is made. This would leak the certificate and private key.


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Manual
1. Integrate a connector that uses Client certificate and private key for api authentication and checked the logs. 
Netcetera can be used.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
