### PR TITLE
refactor(user): use single purpose token and auth to accept invite

### DIFF
--- a/crates/router/src/core/user_role.rs
+++ b/crates/router/src/core/user_role.rs
@@ -170,7 +170,7 @@ pub async fn transfer_org_ownership(
 
 pub async fn accept_invitation(
     state: AppState,
-    user_token: auth::UserWithoutMerchantFromToken,
+    user_token: auth::UserFromSinglePurposeToken,
     req: user_role_api::AcceptInvitationRequest,
     _req_state: ReqState,
 ) -> UserResponse<user_api::DashboardEntryResponse> {

--- a/crates/router/src/routes/user_role.rs
+++ b/crates/router/src/routes/user_role.rs
@@ -214,7 +214,7 @@ pub async fn accept_invitation(
         &req,
         payload,
         user_role_core::accept_invitation,
-        &auth::UserWithoutMerchantJWTAuth,
+        &auth::SinglePurposeJWTAuth(auth::Purpose::AcceptInvite),
         api_locking::LockAction::NotApplicable,
     ))
     .await

--- a/crates/router/src/services/authentication/blacklist.rs
+++ b/crates/router/src/services/authentication/blacklist.rs
@@ -5,7 +5,7 @@ use common_utils::date_time;
 use error_stack::ResultExt;
 use redis_interface::RedisConnectionPool;
 
-use super::{AuthToken, SinglePurposeToken, UserAuthToken};
+use super::{AuthToken, SinglePurposeToken};
 #[cfg(feature = "email")]
 use crate::consts::{EMAIL_TOKEN_BLACKLIST_PREFIX, EMAIL_TOKEN_TIME_IN_SECS};
 use crate::{
@@ -151,16 +151,6 @@ impl BlackList for AuthToken {
             check_user_in_blacklist(state, &self.user_id, self.exp).await?
                 || check_role_in_blacklist(state, &self.role_id, self.exp).await?,
         )
-    }
-}
-
-#[async_trait::async_trait]
-impl BlackList for UserAuthToken {
-    async fn check_in_blacklist<A>(&self, state: &A) -> RouterResult<bool>
-    where
-        A: AppStateInfo + Sync,
-    {
-        check_user_in_blacklist(state, &self.user_id, self.exp).await
     }
 }
 

--- a/crates/router/src/types/domain/user.rs
+++ b/crates/router/src/types/domain/user.rs
@@ -910,8 +910,9 @@ impl SignInWithMultipleRolesStrategy {
             user_api::MerchantSelectResponse {
                 name: self.user.get_name(),
                 email: self.user.get_email(),
-                token: auth::UserAuthToken::new_token(
+                token: auth::SinglePurposeToken::new_token(
                     self.user.get_user_id().to_string(),
+                    auth::Purpose::AcceptInvite,
                     &state.conf,
                 )
                 .await?


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
- Use single purpose JWT auth and single purpose token for accept invite
- Remove user without merchant JWT auth and user auth token

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
closes [#4497](https://github.com/juspay/hyperswitch/issues/4497)


## How did you test it?
- Enable email feature flag
- Signup/ singin 
- Invite a new user from multiple accounts
- Sign in to newly created user
- The response should be merchant select, then do accept invite, it will give dashboard entry response.


<img width="1267" alt="Screenshot 2024-04-29 at 9 23 52 PM" src="https://github.com/juspay/hyperswitch/assets/64925866/190180a5-732c-484b-8ab0-420e96060c9d">

Current and expected behaviour of accept invite should remain same!
```curl
curl --location 'http://localhost:8080/user/user/invite/accept' \
--header 'Content-Type: application/json' \
--header 'Authorization: Bearer JWT' \
--data '{
    "merchant_ids": [
         "merchant_id1",
         "merchant_id2",
         "merchant_id3"
    ],
    "need_dashboard_entry_response": true
}'
```
If any of the `merchant_id` status is `active`, then you will be getting the following response.
```
{
    "token": "JWT with merchant_id, user_id, user_role",
    "merchant_id": "merchant_id",
    "name": "user name",
    "email": "user email",
    "verification_days_left": null,
    "user_role": "user role"
}
```
If `need_dashboard_entry_response` is `false` or not sent, then the response will be 200 OK.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
