### PR TITLE
fix(access_token): use fallback to `connector_name` if `merchant_connector_id` is not present

### DIFF
--- a/crates/common_utils/src/access_token.rs
+++ b/crates/common_utils/src/access_token.rs
@@ -5,7 +5,7 @@ use std::fmt::Display;
 /// Create a key for fetching the access token from redis
 pub fn create_access_token_key(
     merchant_id: impl Display,
-    merchant_connector_id: impl Display,
+    merchant_connector_id_or_connector_name: impl Display,
 ) -> String {
-    format!("access_token_{merchant_id}_{merchant_connector_id}")
+    format!("access_token_{merchant_id}_{merchant_connector_id_or_connector_name}")
 }

--- a/crates/router/src/db/merchant_connector_account.rs
+++ b/crates/router/src/db/merchant_connector_account.rs
@@ -24,13 +24,13 @@ pub trait ConnectorAccessToken {
     async fn get_access_token(
         &self,
         merchant_id: &str,
-        merchant_connector_id: &str,
+        merchant_connector_id_or_connector_name: &str,
     ) -> CustomResult<Option<types::AccessToken>, errors::StorageError>;
 
     async fn set_access_token(
         &self,
         merchant_id: &str,
-        merchant_connector_id: &str,
+        merchant_connector_id_or_connector_name: &str,
         access_token: types::AccessToken,
     ) -> CustomResult<(), errors::StorageError>;
 }
@@ -41,13 +41,15 @@ impl ConnectorAccessToken for Store {
     async fn get_access_token(
         &self,
         merchant_id: &str,
-        merchant_connector_id: &str,
+        merchant_connector_id_or_connector_name: &str,
     ) -> CustomResult<Option<types::AccessToken>, errors::StorageError> {
         //TODO: Handle race condition
         // This function should acquire a global lock on some resource, if access token is already
         // being refreshed by other request then wait till it finishes and use the same access token
-        let key =
-            common_utils::access_token::create_access_token_key(merchant_id, merchant_connector_id);
+        let key = common_utils::access_token::create_access_token_key(
+            merchant_id,
+            merchant_connector_id_or_connector_name,
+        );
 
         let maybe_token = self
             .get_redis_conn()
@@ -69,11 +71,13 @@ impl ConnectorAccessToken for Store {
     async fn set_access_token(
         &self,
         merchant_id: &str,
-        merchant_connector_id: &str,
+        merchant_connector_id_or_connector_name: &str,
         access_token: types::AccessToken,
     ) -> CustomResult<(), errors::StorageError> {
-        let key =
-            common_utils::access_token::create_access_token_key(merchant_id, merchant_connector_id);
+        let key = common_utils::access_token::create_access_token_key(
+            merchant_id,
+            merchant_connector_id_or_connector_name,
+        );
         let serialized_access_token = access_token
             .encode_to_string_of_json()
             .change_context(errors::StorageError::SerializationFailed)?;
@@ -90,7 +94,7 @@ impl ConnectorAccessToken for MockDb {
     async fn get_access_token(
         &self,
         _merchant_id: &str,
-        _merchant_connector_id: &str,
+        _merchant_connector_id_or_connector_name: &str,
     ) -> CustomResult<Option<types::AccessToken>, errors::StorageError> {
         Ok(None)
     }
@@ -98,7 +102,7 @@ impl ConnectorAccessToken for MockDb {
     async fn set_access_token(
         &self,
         _merchant_id: &str,
-        _merchant_connector_id: &str,
+        _merchant_connector_id_or_connector_name: &str,
         _access_token: types::AccessToken,
     ) -> CustomResult<(), errors::StorageError> {
         Ok(())


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix

## Description
<!-- Describe your changes in detail -->
This PR adds a fallback to use `connector_name` in cases where `merhant_connector_id` is not available.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
- Run the postman tests for paypal and trustpay connectors

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
