### PR TITLE
fix(api_request): make `payment_method_data` as optional

### DIFF
--- a/crates/router/src/compatibility/stripe/payment_intents/types.rs
+++ b/crates/router/src/compatibility/stripe/payment_intents/types.rs
@@ -335,7 +335,9 @@ impl TryFrom<StripePaymentIntentRequest> for payments::PaymentsRequest {
                 pmd.payment_method_details
                     .as_ref()
                     .map(|spmd| payments::PaymentMethodDataRequest {
-                        payment_method_data: payments::PaymentMethodData::from(spmd.to_owned()),
+                        payment_method_data: Some(payments::PaymentMethodData::from(
+                            spmd.to_owned(),
+                        )),
                         billing: pmd.billing_details.clone().map(payments::Address::from),
                     })
             }),

--- a/crates/router/src/compatibility/stripe/setup_intents/types.rs
+++ b/crates/router/src/compatibility/stripe/setup_intents/types.rs
@@ -246,7 +246,9 @@ impl TryFrom<StripeSetupIntentRequest> for payments::PaymentsRequest {
                 pmd.payment_method_details
                     .as_ref()
                     .map(|spmd| payments::PaymentMethodDataRequest {
-                        payment_method_data: payments::PaymentMethodData::from(spmd.to_owned()),
+                        payment_method_data: Some(payments::PaymentMethodData::from(
+                            spmd.to_owned(),
+                        )),
                         billing: pmd.billing_details.clone().map(payments::Address::from),
                     })
             }),

--- a/crates/router/src/core/payments/operations/payment_complete_authorize.rs
+++ b/crates/router/src/core/payments/operations/payment_complete_authorize.rs
@@ -138,7 +138,7 @@ impl<F: Send + Clone, Ctx: PaymentMethodRetrieve>
                     &request
                         .payment_method_data
                         .as_ref()
-                        .map(|pmd| pmd.payment_method_data.clone()),
+                        .and_then(|pmd| pmd.payment_method_data.clone()),
                     &request.payment_method_type,
                     &mandate_type,
                     &token,
@@ -284,7 +284,7 @@ impl<F: Send + Clone, Ctx: PaymentMethodRetrieve>
             payment_method_data: request
                 .payment_method_data
                 .as_ref()
-                .map(|pmd| pmd.payment_method_data.clone()),
+                .and_then(|pmd| pmd.payment_method_data.clone()),
             payment_method_info,
             force_sync: None,
             refunds: vec![],

--- a/crates/router/src/core/payments/operations/payment_confirm.rs
+++ b/crates/router/src/core/payments/operations/payment_confirm.rs
@@ -341,7 +341,7 @@ impl<F: Send + Clone, Ctx: PaymentMethodRetrieve>
             request
                 .payment_method_data
                 .as_ref()
-                .map(|pmd| pmd.payment_method_data.clone()),
+                .and_then(|pmd| pmd.payment_method_data.clone()),
         )?;
 
         payment_attempt.browser_info = browser_info;
@@ -412,7 +412,7 @@ impl<F: Send + Clone, Ctx: PaymentMethodRetrieve>
         let n_request_payment_method_data = request
             .payment_method_data
             .as_ref()
-            .map(|pmd| pmd.payment_method_data.clone());
+            .and_then(|pmd| pmd.payment_method_data.clone());
 
         let store = state.clone().store;
 
@@ -524,7 +524,7 @@ impl<F: Send + Clone, Ctx: PaymentMethodRetrieve>
             &request
                 .payment_method_data
                 .as_ref()
-                .map(|pmd| pmd.payment_method_data.clone()),
+                .and_then(|pmd| pmd.payment_method_data.clone()),
             &request.payment_method_type,
             &mandate_type,
             &token,
@@ -570,11 +570,12 @@ impl<F: Send + Clone, Ctx: PaymentMethodRetrieve>
         let payment_method_data_after_card_bin_call = request
             .payment_method_data
             .as_ref()
+            .and_then(|request_payment_method_data| {
+                request_payment_method_data.payment_method_data.as_ref()
+            })
             .zip(additional_pm_data)
             .map(|(payment_method_data, additional_payment_data)| {
-                payment_method_data
-                    .payment_method_data
-                    .apply_additional_payment_data(additional_payment_data)
+                payment_method_data.apply_additional_payment_data(additional_payment_data)
             });
         let authentication = payment_attempt.authentication_id.as_ref().async_map(|authentication_id| async move {
             state

--- a/crates/router/src/core/payments/operations/payment_create.rs
+++ b/crates/router/src/core/payments/operations/payment_create.rs
@@ -396,11 +396,14 @@ impl<F: Send + Clone, Ctx: PaymentMethodRetrieve>
         let payment_method_data_after_card_bin_call = request
             .payment_method_data
             .as_ref()
+            .and_then(|payment_method_data_from_request| {
+                payment_method_data_from_request
+                    .payment_method_data
+                    .as_ref()
+            })
             .zip(additional_payment_data)
             .map(|(payment_method_data, additional_payment_data)| {
-                payment_method_data
-                    .payment_method_data
-                    .apply_additional_payment_data(additional_payment_data)
+                payment_method_data.apply_additional_payment_data(additional_payment_data)
             });
 
         let amount = payment_attempt.get_total_amount().into();
@@ -702,7 +705,7 @@ impl<F: Send + Clone, Ctx: PaymentMethodRetrieve> ValidateRequest<F, api::Paymen
             request
                 .payment_method_data
                 .as_ref()
-                .map(|pmd| pmd.payment_method_data.clone()),
+                .and_then(|pmd| pmd.payment_method_data.clone()),
         )?;
 
         helpers::validate_payment_method_fields_present(request)?;
@@ -722,7 +725,7 @@ impl<F: Send + Clone, Ctx: PaymentMethodRetrieve> ValidateRequest<F, api::Paymen
                 &request
                     .payment_method_data
                     .as_ref()
-                    .map(|pmd| pmd.payment_method_data.clone()),
+                    .and_then(|pmd| pmd.payment_method_data.clone()),
                 &request.payment_method_type,
                 &mandate_type,
                 &request.payment_token,
@@ -772,20 +775,26 @@ impl PaymentCreate {
         storage::PaymentAttemptNew,
         Option<api_models::payments::AdditionalPaymentData>,
     )> {
+        let payment_method_data =
+            request
+                .payment_method_data
+                .as_ref()
+                .and_then(|payment_method_data_request| {
+                    payment_method_data_request.payment_method_data.as_ref()
+                });
+
         let created_at @ modified_at @ last_synced = Some(common_utils::date_time::now());
-        let status =
-            helpers::payment_attempt_status_fsm(&request.payment_method_data, request.confirm);
+        let status = helpers::payment_attempt_status_fsm(payment_method_data, request.confirm);
         let (amount, currency) = (money.0, Some(money.1));
 
         let mut additional_pm_data = request
             .payment_method_data
             .as_ref()
+            .and_then(|payment_method_data_request| {
+                payment_method_data_request.payment_method_data.as_ref()
+            })
             .async_map(|payment_method_data| async {
-                helpers::get_additional_payment_data(
-                    &payment_method_data.payment_method_data,
-                    &*state.store,
-                )
-                .await
+                helpers::get_additional_payment_data(payment_method_data, &*state.store).await
             })
             .await;
 
@@ -944,8 +953,16 @@ impl PaymentCreate {
         session_expiry: PrimitiveDateTime,
     ) -> RouterResult<storage::PaymentIntentNew> {
         let created_at @ modified_at @ last_synced = Some(common_utils::date_time::now());
-        let status =
-            helpers::payment_intent_status_fsm(&request.payment_method_data, request.confirm);
+
+        let status = helpers::payment_intent_status_fsm(
+            request
+                .payment_method_data
+                .as_ref()
+                .and_then(|request_payment_method_data| {
+                    request_payment_method_data.payment_method_data.as_ref()
+                }),
+            request.confirm,
+        );
         let client_secret =
             crate::utils::generate_id(consts::ID_LENGTH, format!("{payment_id}_secret").as_str());
         let (amount, currency) = (money.0, Some(money.1));

--- a/crates/router/src/core/payments/operations/payment_update.rs
+++ b/crates/router/src/core/payments/operations/payment_update.rs
@@ -81,7 +81,7 @@ impl<F: Send + Clone, Ctx: PaymentMethodRetrieve>
             request
                 .payment_method_data
                 .as_ref()
-                .map(|pmd| pmd.payment_method_data.clone()),
+                .and_then(|pmd| pmd.payment_method_data.clone()),
         )?;
 
         helpers::validate_payment_status_against_not_allowed_statuses(
@@ -265,7 +265,7 @@ impl<F: Send + Clone, Ctx: PaymentMethodRetrieve>
                 &request
                     .payment_method_data
                     .as_ref()
-                    .map(|pmd| pmd.payment_method_data.clone()),
+                    .and_then(|pmd| pmd.payment_method_data.clone()),
                 &request.payment_method_type,
                 &mandate_type,
                 &token,
@@ -430,7 +430,7 @@ impl<F: Send + Clone, Ctx: PaymentMethodRetrieve>
             payment_method_data: request
                 .payment_method_data
                 .as_ref()
-                .map(|pmd| pmd.payment_method_data.clone()),
+                .and_then(|pmd| pmd.payment_method_data.clone()),
             payment_method_info,
             force_sync: None,
             refunds: vec![],

--- a/crates/router/src/types/api/payments.rs
+++ b/crates/router/src/types/api/payments.rs
@@ -261,7 +261,7 @@ mod payments_test {
         PaymentsRequest {
             amount: Some(Amount::from(200)),
             payment_method_data: Some(PaymentMethodDataRequest {
-                payment_method_data: PaymentMethodData::Card(card()),
+                payment_method_data: Some(PaymentMethodData::Card(card())),
                 billing: None,
             }),
             ..PaymentsRequest::default()

--- a/crates/router/tests/payments.rs
+++ b/crates/router/tests/payments.rs
@@ -317,7 +317,7 @@ async fn payments_create_core() {
         setup_future_usage: Some(api_enums::FutureUsage::OnSession),
         authentication_type: Some(api_enums::AuthenticationType::NoThreeDs),
         payment_method_data: Some(api::PaymentMethodDataRequest {
-            payment_method_data: api::PaymentMethodData::Card(api::Card {
+            payment_method_data: Some(api::PaymentMethodData::Card(api::Card {
                 card_number: "4242424242424242".to_string().try_into().unwrap(),
                 card_exp_month: "10".to_string().into(),
                 card_exp_year: "35".to_string().into(),
@@ -329,7 +329,7 @@ async fn payments_create_core() {
                 card_issuing_country: None,
                 bank_code: None,
                 nick_name: Some(masking::Secret::new("nick_name".into())),
-            }),
+            })),
             billing: None,
         }),
         payment_method: Some(api_enums::PaymentMethod::Card),
@@ -499,7 +499,7 @@ async fn payments_create_core_adyen_no_redirect() {
         setup_future_usage: Some(api_enums::FutureUsage::OnSession),
         authentication_type: Some(api_enums::AuthenticationType::NoThreeDs),
         payment_method_data: Some(api::PaymentMethodDataRequest {
-            payment_method_data: api::PaymentMethodData::Card(api::Card {
+            payment_method_data: Some(api::PaymentMethodData::Card(api::Card {
                 card_number: "5555 3412 4444 1115".to_string().try_into().unwrap(),
                 card_exp_month: "03".to_string().into(),
                 card_exp_year: "2030".to_string().into(),
@@ -511,7 +511,7 @@ async fn payments_create_core_adyen_no_redirect() {
                 card_issuing_country: None,
                 bank_code: None,
                 nick_name: Some(masking::Secret::new("nick_name".into())),
-            }),
+            })),
             billing: None,
         }),
         payment_method: Some(api_enums::PaymentMethod::Card),

--- a/crates/router/tests/payments2.rs
+++ b/crates/router/tests/payments2.rs
@@ -77,7 +77,7 @@ async fn payments_create_core() {
         setup_future_usage: None,
         authentication_type: Some(api_enums::AuthenticationType::NoThreeDs),
         payment_method_data: Some(api::PaymentMethodDataRequest {
-            payment_method_data: api::PaymentMethodData::Card(api::Card {
+            payment_method_data: Some(api::PaymentMethodData::Card(api::Card {
                 card_number: "4242424242424242".to_string().try_into().unwrap(),
                 card_exp_month: "10".to_string().into(),
                 card_exp_year: "35".to_string().into(),
@@ -89,7 +89,7 @@ async fn payments_create_core() {
                 card_issuing_country: None,
                 bank_code: None,
                 nick_name: Some(masking::Secret::new("nick_name".into())),
-            }),
+            })),
             billing: None,
         }),
         payment_method: Some(api_enums::PaymentMethod::Card),
@@ -266,7 +266,7 @@ async fn payments_create_core_adyen_no_redirect() {
         setup_future_usage: Some(api_enums::FutureUsage::OffSession),
         authentication_type: Some(api_enums::AuthenticationType::NoThreeDs),
         payment_method_data: Some(api::PaymentMethodDataRequest {
-            payment_method_data: api::PaymentMethodData::Card(api::Card {
+            payment_method_data: Some(api::PaymentMethodData::Card(api::Card {
                 card_number: "5555 3412 4444 1115".to_string().try_into().unwrap(),
                 card_exp_month: "03".to_string().into(),
                 card_exp_year: "2030".to_string().into(),
@@ -278,7 +278,7 @@ async fn payments_create_core_adyen_no_redirect() {
                 card_type: None,
                 card_issuing_country: None,
                 nick_name: Some(masking::Secret::new("nick_name".into())),
-            }),
+            })),
             billing: None,
         }),
 

--- a/openapi/openapi_spec.json
+++ b/openapi/openapi_spec.json
@@ -12787,7 +12787,12 @@
       "PaymentMethodDataRequest": {
         "allOf": [
           {
-            "$ref": "#/components/schemas/PaymentMethodData"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PaymentMethodData"
+              }
+            ],
+            "nullable": true
           },
           {
             "type": "object",


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Refactoring

## Description
<!-- Describe your changes in detail -->
Currently payment_method_data.billing cannot be passed without passing the payment method details. This causes problem for saved card payments which require `payment_method_data.billing`

### Additional Changes

- [x] This PR modifies the API contract
`PaymentMethodData` is made optional. This means that the below data in `PaymentsRequest` does not throw any deserialization error.

```json
{
"payment_method_data": {
        "billing": {
            "address": {
                "line1": "1467",
                "line2": "Harrison Street",
                "city": "San Fransico",
                "state": "California",
                "zip": "94122",
                "country": "US",
                "first_name": "Narayan",
                "last_name": "Bhat"
            }
        }
    }
}
```


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
To be able to pass only `payment_method_data.billing`.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
- Create a payment and save the card.
```bash
curl --location 'http://localhost:8080/payments' \
--header 'Content-Type: application/json' \
--header 'api-key: dev_oN54ym4AmrV4om0Cs5Roq2JShISv69npT9BgwdsYABeTkhCmI77V5Gdpeqy7hwWE' \
--data-raw '{
    "amount": 6540,
    "currency": "USD",
    "confirm": true,
    "customer": {
        "id": "cus_abc",
        "email": "example@juspay.in"
    },
    "setup_future_usage":"on_session",
    "customer_acceptance": {
        "acceptance_type": "offline",
        "accepted_at": "1963-05-03T04:07:52.723Z",
        "online": {
            "ip_address": "127.0.0.1",
            "user_agent": "amet irure esse"
        }
    },
    "payment_method": "card",
    "payment_method_type": "debit",
    "payment_method_data": {
        "card": {
            "card_number": "4000000000001091",
            "card_exp_month": "12",
            "card_exp_year": "26",
            "card_holder_name": "joseph Doe",
            "card_cvc": "123"
        },
        "billing": {
            "address": {
                "line1": "1467",
                "line2": "Harrison Street",
                "city": "San Fransico",
                "state": "California",
                "zip": "94122",
                "country": "US",
                "first_name": "Narayan",
                "last_name": "Bhat"
            }
        }
    }
}'
```

- Create a saved card payment by providing the token and `payment_method_data.billing`.
```bash
curl --location 'http://localhost:8080/payments' \
--header 'Content-Type: application/json' \
--header 'api-key: dev_oN54ym4AmrV4om0Cs5Roq2JShISv69npT9BgwdsYABeTkhCmI77V5Gdpeqy7hwWE' \
--data-raw '{
    "amount": 6540,
    "currency": "USD",
    "confirm": false,
    "customer": {
        "id": "cus_abc",
        "email": "example@juspay.in"
    },
    "setup_future_usage":"on_session",
    "customer_acceptance": {
        "acceptance_type": "offline",
        "accepted_at": "1963-05-03T04:07:52.723Z",
        "online": {
            "ip_address": "127.0.0.1",
            "user_agent": "amet irure esse"
        }
    }
}'
```
- List the saved cards for a customer
```bash
curl --location 'http://localhost:8080/customers/payment_methods?client_secret=pay_6a86KmhZmc6KyfNr95GW_secret_VK08mxGjyGXCO1OXW0Oz' \
--header 'Accept: application/json' \
--header 'api-key: pk_dev_96a6042cbe8041ee8d24839d1a3d363c'
```

- Confirm the payment with token and `payment_method_data.billing`
```bash
curl --location 'http://localhost:8080/payments/pay_6a86KmhZmc6KyfNr95GW/confirm' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: dev_oN54ym4AmrV4om0Cs5Roq2JShISv69npT9BgwdsYABeTkhCmI77V5Gdpeqy7hwWE' \
--data '{
    "payment_method": "card",
    "payment_token": "token_vgOyS1EG0gAyehTuwkjQ",
    "payment_method_data": {
        "billing": {
            "address": {
                "line1": "1467",
                "line2": "Harrison Street",
                "city": "San Fransico",
                "state": "California",
                "zip": "94122",
                "country": "US",
                "first_name": "Narayan",
                "last_name": "Bhat"
            }
        }
    }
}'
```



## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
