### PR TITLE
ci(release-stable-version): use `cocogitto` to obtain previous and next tags

### DIFF
--- a/.github/workflows/release-stable-version.yml
+++ b/.github/workflows/release-stable-version.yml
@@ -103,17 +103,17 @@ jobs:
           crate: git-cliff
           version: 1.4.0
 
-      - name: Install convco
+      - name: Install cocogitto
         uses: baptiste0928/cargo-install@v2.2.0
         with:
-          crate: convco
-          version: 0.5.0
+          crate: cocogitto
+          version: 6.1.0
 
       - name: Obtain previous and next tag information
         shell: bash
         run: |
-          PREVIOUS_TAG="v$(convco version --prefix 'v')"
-          NEXT_TAG="v$(convco version --prefix 'v' "--${{ inputs.bump_type }}")"
+          PREVIOUS_TAG="v$(cog --verbose get-version)"
+          NEXT_TAG="$(cog --verbose bump --dry-run "--${{ inputs.bump_type }}")"
 
           echo "PREVIOUS_TAG=${PREVIOUS_TAG}" >> $GITHUB_ENV
           echo "NEXT_TAG=${NEXT_TAG}" >> $GITHUB_ENV


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [x] CI/CD

## Description
<!-- Describe your changes in detail -->
This PR fixes a bug in the release stable version workflow where SemVer tags in the entire repository are not considered when obtaining previous and next tags. The bug is addressed by using `cocogitto` to obtain the previous and next tags, which considers all SemVer tags.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
Fixes a bug in the release stable version workflow.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Locally, by ensuring the commands added here return the expected outputs.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [X] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
