### PR TITLE
refactor(customers): redact default payment method field in customers table for the customer id that is deleted

### DIFF
--- a/crates/diesel_models/src/customers.rs
+++ b/crates/diesel_models/src/customers.rs
@@ -81,7 +81,7 @@ pub struct CustomerUpdateInternal {
     pub phone_country_code: Option<String>,
     pub metadata: Option<pii::SecretSerdeValue>,
     pub modified_at: Option<PrimitiveDateTime>,
-    pub connector_customer: Option<serde_json::Value>,
+    pub connector_customer: Option<Option<serde_json::Value>>,
     pub address_id: Option<String>,
     pub default_payment_method_id: Option<Option<String>>,
 }
@@ -109,7 +109,9 @@ impl CustomerUpdateInternal {
             phone_country_code: phone_country_code.map_or(source.phone_country_code, Some),
             metadata: metadata.map_or(source.metadata, Some),
             modified_at: common_utils::date_time::now(),
-            connector_customer: connector_customer.map_or(source.connector_customer, Some),
+            connector_customer: connector_customer
+                .flatten()
+                .map_or(source.connector_customer, Some),
             address_id: address_id.map_or(source.address_id, Some),
             default_payment_method_id: default_payment_method_id
                 .flatten()

--- a/crates/router/src/core/customers.rs
+++ b/crates/router/src/core/customers.rs
@@ -316,8 +316,9 @@ pub async fn delete_customer(
         description: Some(REDACTED.to_string()),
         phone_country_code: Some(REDACTED.to_string()),
         metadata: None,
-        connector_customer: None,
+        connector_customer: Some(None),
         address_id: None,
+        default_payment_method_id: Some(None),
     };
     db.update_customer_by_customer_id_merchant_id(
         req.customer_id.clone(),
@@ -441,6 +442,7 @@ pub async fn update_customer(
                     description: update_customer.description,
                     connector_customer: None,
                     address_id: address.clone().map(|addr| addr.address_id),
+                    default_payment_method_id: None,
                 })
             }
             .await

--- a/crates/router/src/core/payments/helpers.rs
+++ b/crates/router/src/core/payments/helpers.rs
@@ -1533,6 +1533,7 @@ pub async fn create_customer_if_not_exist<'a, F: Clone, R, Ctx>(
                                     connector_customer: None,
                                     metadata: None,
                                     address_id: None,
+                                    default_payment_method_id: None,
                                 },
                             )
                         }

--- a/crates/router/src/types/domain/customer.rs
+++ b/crates/router/src/types/domain/customer.rs
@@ -111,8 +111,9 @@ pub enum CustomerUpdate {
         description: Option<String>,
         phone_country_code: Option<String>,
         metadata: Option<pii::SecretSerdeValue>,
-        connector_customer: Option<serde_json::Value>,
+        connector_customer: Option<Option<serde_json::Value>>,
         address_id: Option<String>,
+        default_payment_method_id: Option<Option<String>>,
     },
     ConnectorCustomer {
         connector_customer: Option<serde_json::Value>,
@@ -134,6 +135,7 @@ impl From<CustomerUpdate> for CustomerUpdateInternal {
                 metadata,
                 connector_customer,
                 address_id,
+                default_payment_method_id,
             } => Self {
                 name: name.map(Encryption::from),
                 email: email.map(Encryption::from),
@@ -144,10 +146,11 @@ impl From<CustomerUpdate> for CustomerUpdateInternal {
                 connector_customer,
                 modified_at: Some(date_time::now()),
                 address_id,
+                default_payment_method_id,
                 ..Default::default()
             },
             CustomerUpdate::ConnectorCustomer { connector_customer } => Self {
-                connector_customer,
+                connector_customer: Some(connector_customer),
                 modified_at: Some(common_utils::date_time::now()),
                 ..Default::default()
             },


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
redact default payment method field in customers table for the customer id that is deleted make it None


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
- Create a MA and an MCA
- Create a customer
- Make a payment for that customer
- Delete the customer. The default_payment_methods would be redacted 
 <img width="1021" alt="Screenshot 2024-05-06 at 3 40 13 PM" > src="https://github.com/juspay/hyperswitch/assets/55580080/2a293604-3690-494c-a6ce-b6192fbcb8a5">



## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
