### PR TITLE
refactor: store card_cvc in extended_card_info and extend max ttl

### DIFF
--- a/crates/api_models/src/admin.rs
+++ b/crates/api_models/src/admin.rs
@@ -1113,7 +1113,7 @@ pub struct ExtendedCardInfoConfig {
     #[schema(value_type = String)]
     pub public_key: Secret<String>,
     /// TTL for extended card info
-    #[schema(default = 900, maximum = 3600, value_type = u16)]
+    #[schema(default = 900, maximum = 7200, value_type = u16)]
     #[serde(default)]
     pub ttl_in_secs: TtlForExtendedCardInfo,
 }
@@ -1137,7 +1137,7 @@ impl<'de> Deserialize<'de> for TtlForExtendedCardInfo {
         // Check if value exceeds the maximum allowed
         if value > consts::MAX_TTL_FOR_EXTENDED_CARD_INFO {
             Err(serde::de::Error::custom(
-                "ttl_in_secs must be less than or equal to 3600 (1hr)",
+                "ttl_in_secs must be less than or equal to 7200 (2hrs)",
             ))
         } else {
             Ok(Self(value))

--- a/crates/api_models/src/payments.rs
+++ b/crates/api_models/src/payments.rs
@@ -934,6 +934,10 @@ pub struct ExtendedCardInfo {
     #[schema(value_type = String, example = "John Test")]
     pub card_holder_name: Option<Secret<String>>,
 
+    /// The CVC number for the card
+    #[schema(value_type = String, example = "242")]
+    pub card_cvc: Secret<String>,
+
     /// The name of the issuer of card
     #[schema(example = "chase")]
     pub card_issuer: Option<String>,
@@ -959,6 +963,7 @@ impl From<Card> for ExtendedCardInfo {
             card_exp_month: value.card_exp_month,
             card_exp_year: value.card_exp_year,
             card_holder_name: value.card_holder_name,
+            card_cvc: value.card_cvc,
             card_issuer: value.card_issuer,
             card_network: value.card_network,
             card_type: value.card_type,

--- a/crates/common_utils/src/consts.rs
+++ b/crates/common_utils/src/consts.rs
@@ -82,4 +82,4 @@ pub const DEFAULT_ENABLE_SAVED_PAYMENT_METHOD: bool = false;
 pub const DEFAULT_TTL_FOR_EXTENDED_CARD_INFO: u16 = 15 * 60;
 
 /// Max ttl for Extended card info in redis (in seconds)
-pub const MAX_TTL_FOR_EXTENDED_CARD_INFO: u16 = 60 * 60;
+pub const MAX_TTL_FOR_EXTENDED_CARD_INFO: u16 = 60 * 60 * 2;


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
This PR includes `card_cvc` field too to be sent to merchant as part of extended card info. Also extends the maximum ttl for the feature from 1hr to 2hr.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
