### PR TITLE
refactor: remove `Ctx` generic from payments core

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -36,6 +36,7 @@ ws = "ws" # Web socket
 ws2ipdef = "ws2ipdef" # WinSock Extension
 ws2tcpip = "ws2tcpip" # WinSock Extension
 ZAR = "ZAR"  # South African Rand currency code
+JOD = "JOD" # Jordan currency code
 
 
 [default.extend-words]

--- a/crates/router/src/compatibility/stripe/payment_intents.rs
+++ b/crates/router/src/compatibility/stripe/payment_intents.rs
@@ -6,7 +6,7 @@ use router_env::{instrument, tracing, Flow, Tag};
 
 use crate::{
     compatibility::{stripe::errors, wrap},
-    core::{api_locking::GetLockingInput, payment_methods::Oss, payments},
+    core::{api_locking::GetLockingInput, payments},
     logger,
     routes::{self, payments::get_or_generate_payment_id},
     services::{api, authentication as auth},
@@ -58,7 +58,7 @@ pub async fn payment_intents_create(
         create_payment_req,
         |state, auth, req, req_state| {
             let eligible_connectors = req.connector.clone();
-            payments::payments_core::<api_types::Authorize, api_types::PaymentsResponse, _, _, _,Oss>(
+            payments::payments_core::<api_types::Authorize, api_types::PaymentsResponse, _, _, _>(
                 state,
                 req_state,
                 auth.merchant_account,
@@ -118,7 +118,7 @@ pub async fn payment_intents_retrieve(
         &req,
         payload,
         |state, auth, payload, req_state| {
-            payments::payments_core::<api_types::PSync, api_types::PaymentsResponse, _, _, _, Oss>(
+            payments::payments_core::<api_types::PSync, api_types::PaymentsResponse, _, _, _>(
                 state,
                 req_state,
                 auth.merchant_account,
@@ -188,7 +188,7 @@ pub async fn payment_intents_retrieve_with_gateway_creds(
         &req,
         payload,
         |state, auth, req, req_state| {
-            payments::payments_core::<api_types::PSync, payment_types::PaymentsResponse, _, _, _,Oss>(
+            payments::payments_core::<api_types::PSync, payment_types::PaymentsResponse, _, _, _>(
                 state,
                 req_state,
                 auth.merchant_account,
@@ -197,7 +197,7 @@ pub async fn payment_intents_retrieve_with_gateway_creds(
                 req,
                 api::AuthFlow::Merchant,
                 payments::CallConnectorAction::Trigger,
-                    None,
+                None,
                 api_types::HeaderPayload::default(),
             )
         },
@@ -254,7 +254,7 @@ pub async fn payment_intents_update(
         payload,
         |state, auth, req, req_state| {
             let eligible_connectors = req.connector.clone();
-            payments::payments_core::<api_types::Authorize, api_types::PaymentsResponse, _, _, _,Oss>(
+            payments::payments_core::<api_types::Authorize, api_types::PaymentsResponse, _, _, _>(
                 state,
                 req_state,
                 auth.merchant_account,
@@ -326,7 +326,7 @@ pub async fn payment_intents_confirm(
         payload,
         |state, auth, req, req_state| {
             let eligible_connectors = req.connector.clone();
-            payments::payments_core::<api_types::Authorize, api_types::PaymentsResponse, _, _, _,Oss>(
+            payments::payments_core::<api_types::Authorize, api_types::PaymentsResponse, _, _, _>(
                 state,
                 req_state,
                 auth.merchant_account,
@@ -387,7 +387,7 @@ pub async fn payment_intents_capture(
         &req,
         payload,
         |state, auth, payload, req_state| {
-            payments::payments_core::<api_types::Capture, api_types::PaymentsResponse, _, _, _,Oss>(
+            payments::payments_core::<api_types::Capture, api_types::PaymentsResponse, _, _, _>(
                 state,
                 req_state,
                 auth.merchant_account,
@@ -396,7 +396,7 @@ pub async fn payment_intents_capture(
                 payload,
                 api::AuthFlow::Merchant,
                 payments::CallConnectorAction::Trigger,
-                    None,
+                None,
                 api_types::HeaderPayload::default(),
             )
         },
@@ -452,7 +452,7 @@ pub async fn payment_intents_cancel(
         &req,
         payload,
         |state, auth, req, req_state| {
-            payments::payments_core::<api_types::Void, api_types::PaymentsResponse, _, _, _, Oss>(
+            payments::payments_core::<api_types::Void, api_types::PaymentsResponse, _, _, _>(
                 state,
                 req_state,
                 auth.merchant_account,

--- a/crates/router/src/compatibility/stripe/setup_intents.rs
+++ b/crates/router/src/compatibility/stripe/setup_intents.rs
@@ -9,7 +9,7 @@ use crate::{
         stripe::{errors, payment_intents::types as stripe_payment_types},
         wrap,
     },
-    core::{api_locking, payment_methods::Oss, payments},
+    core::{api_locking, payments},
     routes,
     services::{api, authentication as auth},
     types::api as api_types,
@@ -58,8 +58,7 @@ pub async fn setup_intents_create(
                 api_types::PaymentsResponse,
                 _,
                 _,
-                _,
-                Oss,
+                _
             >(
                 state,
                 req_state,
@@ -120,7 +119,7 @@ pub async fn setup_intents_retrieve(
         &req,
         payload,
         |state, auth, payload, req_state| {
-            payments::payments_core::<api_types::PSync, api_types::PaymentsResponse, _, _, _, Oss>(
+            payments::payments_core::<api_types::PSync, api_types::PaymentsResponse, _, _, _>(
                 state,
                 req_state,
                 auth.merchant_account,
@@ -191,8 +190,7 @@ pub async fn setup_intents_update(
                 api_types::PaymentsResponse,
                 _,
                 _,
-                _,
-                Oss,
+                _
             >(
                 state,
                 req_state,
@@ -265,8 +263,7 @@ pub async fn setup_intents_confirm(
                 api_types::PaymentsResponse,
                 _,
                 _,
-                _,
-                Oss,
+                _
             >(
                 state,
                 req_state,

--- a/crates/router/src/connector/rapyd/transformers.rs
+++ b/crates/router/src/connector/rapyd/transformers.rs
@@ -454,7 +454,7 @@ impl<F, T>
                         }),
                     ),
                     _ => {
-                        let redirction_url = data
+                        let redirection_url = data
                             .redirect_url
                             .as_ref()
                             .filter(|redirect_str| !redirect_str.is_empty())
@@ -465,7 +465,7 @@ impl<F, T>
                             })
                             .transpose()?;
 
-                        let redirection_data = redirction_url
+                        let redirection_data = redirection_url
                             .map(|url| services::RedirectForm::from((url, services::Method::Get)));
 
                         (

--- a/crates/router/src/core/fraud_check.rs
+++ b/crates/router/src/core/fraud_check.rs
@@ -437,7 +437,7 @@ where
 }
 
 #[allow(clippy::too_many_arguments)]
-pub async fn pre_payment_frm_core<'a, F, Req, Ctx>(
+pub async fn pre_payment_frm_core<'a, F, Req>(
     state: &AppState,
     merchant_account: &domain::MerchantAccount,
     payment_data: &mut payments::PaymentData<F>,
@@ -447,7 +447,7 @@ pub async fn pre_payment_frm_core<'a, F, Req, Ctx>(
     should_continue_transaction: &mut bool,
     should_continue_capture: &mut bool,
     key_store: domain::MerchantKeyStore,
-    operation: &BoxedOperation<'_, F, Req, Ctx>,
+    operation: &BoxedOperation<'_, F, Req>,
 ) -> RouterResult<Option<FrmData>>
 where
     F: Send + Clone,
@@ -616,9 +616,9 @@ where
 }
 
 #[allow(clippy::too_many_arguments)]
-pub async fn call_frm_before_connector_call<'a, F, Req, Ctx>(
+pub async fn call_frm_before_connector_call<'a, F, Req>(
     db: &dyn StorageInterface,
-    operation: &BoxedOperation<'_, F, Req, Ctx>,
+    operation: &BoxedOperation<'_, F, Req>,
     merchant_account: &domain::MerchantAccount,
     payment_data: &mut payments::PaymentData<F>,
     state: &AppState,

--- a/crates/router/src/core/fraud_check/operation/fraud_check_post.rs
+++ b/crates/router/src/core/fraud_check/operation/fraud_check_post.rs
@@ -17,7 +17,6 @@ use crate::{
             types::{FrmData, PaymentDetails, PaymentToFrmData, CANCEL_INITIATED},
             ConnectorDetailsCore, FrmConfigsObject,
         },
-        payment_methods::Oss,
         payments,
     },
     db::StorageInterface,
@@ -214,7 +213,6 @@ impl<F: Send + Clone> Domain<F> for FraudCheckPost {
                 _,
                 _,
                 _,
-                Oss,
             >(
                 state.clone(),
                 req_state.clone(),
@@ -269,7 +267,6 @@ impl<F: Send + Clone> Domain<F> for FraudCheckPost {
                 _,
                 _,
                 _,
-                Oss,
             >(
                 state.clone(),
                 req_state.clone(),

--- a/crates/router/src/core/payment_methods.rs
+++ b/crates/router/src/core/payment_methods.rs
@@ -9,6 +9,7 @@ use api_models::payments::CardToken;
 pub use api_models::{enums::PayoutConnectors, payouts as payout_types};
 use diesel_models::enums;
 use hyperswitch_domain_models::payments::{payment_attempt::PaymentAttempt, PaymentIntent};
+use router_env::{instrument, tracing};
 
 use crate::{
     core::{errors::RouterResult, payments::helpers, pm_auth as core_pm_auth},
@@ -19,238 +20,214 @@ use crate::{
     },
 };
 
-pub struct Oss;
+#[instrument(skip_all)]
+pub async fn retrieve_payment_method(
+    pm_data: &Option<payments::PaymentMethodData>,
+    state: &AppState,
+    payment_intent: &PaymentIntent,
+    payment_attempt: &PaymentAttempt,
+    merchant_key_store: &domain::MerchantKeyStore,
+) -> RouterResult<(Option<payments::PaymentMethodData>, Option<String>)> {
+    match pm_data {
+        pm_opt @ Some(pm @ api::PaymentMethodData::Card(_)) => {
+            let payment_token = helpers::store_payment_method_data_in_vault(
+                state,
+                payment_attempt,
+                payment_intent,
+                enums::PaymentMethod::Card,
+                pm,
+                merchant_key_store,
+            )
+            .await?;
 
-#[async_trait::async_trait]
-pub trait PaymentMethodRetrieve {
-    async fn retrieve_payment_method(
-        pm_data: &Option<payments::PaymentMethodData>,
-        state: &AppState,
-        payment_intent: &PaymentIntent,
-        payment_attempt: &PaymentAttempt,
-        merchant_key_store: &domain::MerchantKeyStore,
-    ) -> RouterResult<(Option<payments::PaymentMethodData>, Option<String>)>;
+            Ok((pm_opt.to_owned(), payment_token))
+        }
+        pm @ Some(api::PaymentMethodData::PayLater(_)) => Ok((pm.to_owned(), None)),
+        pm @ Some(api::PaymentMethodData::Crypto(_)) => Ok((pm.to_owned(), None)),
+        pm @ Some(api::PaymentMethodData::BankDebit(_)) => Ok((pm.to_owned(), None)),
+        pm @ Some(api::PaymentMethodData::Upi(_)) => Ok((pm.to_owned(), None)),
+        pm @ Some(api::PaymentMethodData::Voucher(_)) => Ok((pm.to_owned(), None)),
+        pm @ Some(api::PaymentMethodData::Reward) => Ok((pm.to_owned(), None)),
+        pm @ Some(api::PaymentMethodData::CardRedirect(_)) => Ok((pm.to_owned(), None)),
+        pm @ Some(api::PaymentMethodData::GiftCard(_)) => Ok((pm.to_owned(), None)),
+        pm_opt @ Some(pm @ api::PaymentMethodData::BankTransfer(_)) => {
+            let payment_token = helpers::store_payment_method_data_in_vault(
+                state,
+                payment_attempt,
+                payment_intent,
+                enums::PaymentMethod::BankTransfer,
+                pm,
+                merchant_key_store,
+            )
+            .await?;
 
-    async fn retrieve_payment_method_with_token(
-        state: &AppState,
-        key_store: &domain::MerchantKeyStore,
-        token: &storage::PaymentTokenData,
-        payment_intent: &PaymentIntent,
-        card_token_data: Option<&CardToken>,
-        customer: &Option<domain::Customer>,
-        storage_scheme: common_enums::enums::MerchantStorageScheme,
-    ) -> RouterResult<storage::PaymentMethodDataWithId>;
+            Ok((pm_opt.to_owned(), payment_token))
+        }
+        pm_opt @ Some(pm @ api::PaymentMethodData::Wallet(_)) => {
+            let payment_token = helpers::store_payment_method_data_in_vault(
+                state,
+                payment_attempt,
+                payment_intent,
+                enums::PaymentMethod::Wallet,
+                pm,
+                merchant_key_store,
+            )
+            .await?;
+
+            Ok((pm_opt.to_owned(), payment_token))
+        }
+        pm_opt @ Some(pm @ api::PaymentMethodData::BankRedirect(_)) => {
+            let payment_token = helpers::store_payment_method_data_in_vault(
+                state,
+                payment_attempt,
+                payment_intent,
+                enums::PaymentMethod::BankRedirect,
+                pm,
+                merchant_key_store,
+            )
+            .await?;
+
+            Ok((pm_opt.to_owned(), payment_token))
+        }
+        _ => Ok((None, None)),
+    }
 }
 
-#[async_trait::async_trait]
-impl PaymentMethodRetrieve for Oss {
-    async fn retrieve_payment_method(
-        pm_data: &Option<payments::PaymentMethodData>,
-        state: &AppState,
-        payment_intent: &PaymentIntent,
-        payment_attempt: &PaymentAttempt,
-        merchant_key_store: &domain::MerchantKeyStore,
-    ) -> RouterResult<(Option<payments::PaymentMethodData>, Option<String>)> {
-        match pm_data {
-            pm_opt @ Some(pm @ api::PaymentMethodData::Card(_)) => {
-                let payment_token = helpers::store_payment_method_data_in_vault(
-                    state,
-                    payment_attempt,
-                    payment_intent,
-                    enums::PaymentMethod::Card,
-                    pm,
-                    merchant_key_store,
-                )
-                .await?;
-
-                Ok((pm_opt.to_owned(), payment_token))
-            }
-            pm @ Some(api::PaymentMethodData::PayLater(_)) => Ok((pm.to_owned(), None)),
-            pm @ Some(api::PaymentMethodData::Crypto(_)) => Ok((pm.to_owned(), None)),
-            pm @ Some(api::PaymentMethodData::BankDebit(_)) => Ok((pm.to_owned(), None)),
-            pm @ Some(api::PaymentMethodData::Upi(_)) => Ok((pm.to_owned(), None)),
-            pm @ Some(api::PaymentMethodData::Voucher(_)) => Ok((pm.to_owned(), None)),
-            pm @ Some(api::PaymentMethodData::Reward) => Ok((pm.to_owned(), None)),
-            pm @ Some(api::PaymentMethodData::CardRedirect(_)) => Ok((pm.to_owned(), None)),
-            pm @ Some(api::PaymentMethodData::GiftCard(_)) => Ok((pm.to_owned(), None)),
-            pm_opt @ Some(pm @ api::PaymentMethodData::BankTransfer(_)) => {
-                let payment_token = helpers::store_payment_method_data_in_vault(
-                    state,
-                    payment_attempt,
-                    payment_intent,
-                    enums::PaymentMethod::BankTransfer,
-                    pm,
-                    merchant_key_store,
-                )
-                .await?;
-
-                Ok((pm_opt.to_owned(), payment_token))
-            }
-            pm_opt @ Some(pm @ api::PaymentMethodData::Wallet(_)) => {
-                let payment_token = helpers::store_payment_method_data_in_vault(
-                    state,
-                    payment_attempt,
-                    payment_intent,
-                    enums::PaymentMethod::Wallet,
-                    pm,
-                    merchant_key_store,
-                )
-                .await?;
-
-                Ok((pm_opt.to_owned(), payment_token))
-            }
-            pm_opt @ Some(pm @ api::PaymentMethodData::BankRedirect(_)) => {
-                let payment_token = helpers::store_payment_method_data_in_vault(
-                    state,
-                    payment_attempt,
-                    payment_intent,
-                    enums::PaymentMethod::BankRedirect,
-                    pm,
-                    merchant_key_store,
-                )
-                .await?;
-
-                Ok((pm_opt.to_owned(), payment_token))
-            }
-            _ => Ok((None, None)),
+#[instrument(skip_all)]
+pub async fn retrieve_payment_method_with_token(
+    state: &AppState,
+    merchant_key_store: &domain::MerchantKeyStore,
+    token_data: &storage::PaymentTokenData,
+    payment_intent: &PaymentIntent,
+    card_token_data: Option<&CardToken>,
+    customer: &Option<domain::Customer>,
+    storage_scheme: common_enums::enums::MerchantStorageScheme,
+) -> RouterResult<storage::PaymentMethodDataWithId> {
+    let token = match token_data {
+        storage::PaymentTokenData::TemporaryGeneric(generic_token) => {
+            helpers::retrieve_payment_method_with_temporary_token(
+                state,
+                &generic_token.token,
+                payment_intent,
+                merchant_key_store,
+                card_token_data,
+            )
+            .await?
+            .map(
+                |(payment_method_data, payment_method)| storage::PaymentMethodDataWithId {
+                    payment_method_data: Some(payment_method_data),
+                    payment_method: Some(payment_method),
+                    payment_method_id: None,
+                },
+            )
+            .unwrap_or_default()
         }
-    }
 
-    async fn retrieve_payment_method_with_token(
-        state: &AppState,
-        merchant_key_store: &domain::MerchantKeyStore,
-        token_data: &storage::PaymentTokenData,
-        payment_intent: &PaymentIntent,
-        card_token_data: Option<&CardToken>,
-        customer: &Option<domain::Customer>,
-        storage_scheme: common_enums::enums::MerchantStorageScheme,
-    ) -> RouterResult<storage::PaymentMethodDataWithId> {
-        let token = match token_data {
-            storage::PaymentTokenData::TemporaryGeneric(generic_token) => {
-                helpers::retrieve_payment_method_with_temporary_token(
-                    state,
-                    &generic_token.token,
-                    payment_intent,
-                    merchant_key_store,
-                    card_token_data,
-                )
-                .await?
-                .map(
-                    |(payment_method_data, payment_method)| storage::PaymentMethodDataWithId {
-                        payment_method_data: Some(payment_method_data),
-                        payment_method: Some(payment_method),
-                        payment_method_id: None,
-                    },
-                )
-                .unwrap_or_default()
-            }
+        storage::PaymentTokenData::Temporary(generic_token) => {
+            helpers::retrieve_payment_method_with_temporary_token(
+                state,
+                &generic_token.token,
+                payment_intent,
+                merchant_key_store,
+                card_token_data,
+            )
+            .await?
+            .map(
+                |(payment_method_data, payment_method)| storage::PaymentMethodDataWithId {
+                    payment_method_data: Some(payment_method_data),
+                    payment_method: Some(payment_method),
+                    payment_method_id: None,
+                },
+            )
+            .unwrap_or_default()
+        }
 
-            storage::PaymentTokenData::Temporary(generic_token) => {
-                helpers::retrieve_payment_method_with_temporary_token(
-                    state,
-                    &generic_token.token,
-                    payment_intent,
-                    merchant_key_store,
-                    card_token_data,
-                )
-                .await?
-                .map(
-                    |(payment_method_data, payment_method)| storage::PaymentMethodDataWithId {
-                        payment_method_data: Some(payment_method_data),
-                        payment_method: Some(payment_method),
-                        payment_method_id: None,
-                    },
-                )
-                .unwrap_or_default()
-            }
+        storage::PaymentTokenData::Permanent(card_token) => {
+            helpers::retrieve_card_with_permanent_token(
+                state,
+                card_token.locker_id.as_ref().unwrap_or(&card_token.token),
+                card_token
+                    .payment_method_id
+                    .as_ref()
+                    .unwrap_or(&card_token.token),
+                payment_intent,
+                card_token_data,
+                merchant_key_store,
+                storage_scheme,
+            )
+            .await
+            .map(|card| Some((card, enums::PaymentMethod::Card)))?
+            .map(
+                |(payment_method_data, payment_method)| storage::PaymentMethodDataWithId {
+                    payment_method_data: Some(payment_method_data),
+                    payment_method: Some(payment_method),
+                    payment_method_id: Some(
+                        card_token
+                            .payment_method_id
+                            .as_ref()
+                            .unwrap_or(&card_token.token)
+                            .to_string(),
+                    ),
+                },
+            )
+            .unwrap_or_default()
+        }
 
-            storage::PaymentTokenData::Permanent(card_token) => {
-                helpers::retrieve_card_with_permanent_token(
-                    state,
-                    card_token.locker_id.as_ref().unwrap_or(&card_token.token),
-                    card_token
-                        .payment_method_id
-                        .as_ref()
-                        .unwrap_or(&card_token.token),
-                    payment_intent,
-                    card_token_data,
-                    merchant_key_store,
-                    storage_scheme,
-                )
-                .await
-                .map(|card| Some((card, enums::PaymentMethod::Card)))?
-                .map(
-                    |(payment_method_data, payment_method)| storage::PaymentMethodDataWithId {
-                        payment_method_data: Some(payment_method_data),
-                        payment_method: Some(payment_method),
-                        payment_method_id: Some(
-                            card_token
-                                .payment_method_id
-                                .as_ref()
-                                .unwrap_or(&card_token.token)
-                                .to_string(),
-                        ),
-                    },
-                )
-                .unwrap_or_default()
-            }
+        storage::PaymentTokenData::PermanentCard(card_token) => {
+            helpers::retrieve_card_with_permanent_token(
+                state,
+                card_token.locker_id.as_ref().unwrap_or(&card_token.token),
+                card_token
+                    .payment_method_id
+                    .as_ref()
+                    .unwrap_or(&card_token.token),
+                payment_intent,
+                card_token_data,
+                merchant_key_store,
+                storage_scheme,
+            )
+            .await
+            .map(|card| Some((card, enums::PaymentMethod::Card)))?
+            .map(
+                |(payment_method_data, payment_method)| storage::PaymentMethodDataWithId {
+                    payment_method_data: Some(payment_method_data),
+                    payment_method: Some(payment_method),
+                    payment_method_id: Some(
+                        card_token
+                            .payment_method_id
+                            .as_ref()
+                            .unwrap_or(&card_token.token)
+                            .to_string(),
+                    ),
+                },
+            )
+            .unwrap_or_default()
+        }
 
-            storage::PaymentTokenData::PermanentCard(card_token) => {
-                helpers::retrieve_card_with_permanent_token(
-                    state,
-                    card_token.locker_id.as_ref().unwrap_or(&card_token.token),
-                    card_token
-                        .payment_method_id
-                        .as_ref()
-                        .unwrap_or(&card_token.token),
-                    payment_intent,
-                    card_token_data,
-                    merchant_key_store,
-                    storage_scheme,
-                )
-                .await
-                .map(|card| Some((card, enums::PaymentMethod::Card)))?
-                .map(
-                    |(payment_method_data, payment_method)| storage::PaymentMethodDataWithId {
-                        payment_method_data: Some(payment_method_data),
-                        payment_method: Some(payment_method),
-                        payment_method_id: Some(
-                            card_token
-                                .payment_method_id
-                                .as_ref()
-                                .unwrap_or(&card_token.token)
-                                .to_string(),
-                        ),
-                    },
-                )
-                .unwrap_or_default()
-            }
+        storage::PaymentTokenData::AuthBankDebit(auth_token) => {
+            core_pm_auth::retrieve_payment_method_from_auth_service(
+                state,
+                merchant_key_store,
+                auth_token,
+                payment_intent,
+                customer,
+            )
+            .await?
+            .map(
+                |(payment_method_data, payment_method)| storage::PaymentMethodDataWithId {
+                    payment_method_data: Some(payment_method_data),
+                    payment_method: Some(payment_method),
+                    payment_method_id: None,
+                },
+            )
+            .unwrap_or_default()
+        }
 
-            storage::PaymentTokenData::AuthBankDebit(auth_token) => {
-                core_pm_auth::retrieve_payment_method_from_auth_service(
-                    state,
-                    merchant_key_store,
-                    auth_token,
-                    payment_intent,
-                    customer,
-                )
-                .await?
-                .map(
-                    |(payment_method_data, payment_method)| storage::PaymentMethodDataWithId {
-                        payment_method_data: Some(payment_method_data),
-                        payment_method: Some(payment_method),
-                        payment_method_id: None,
-                    },
-                )
-                .unwrap_or_default()
-            }
-
-            storage::PaymentTokenData::WalletToken(_) => storage::PaymentMethodDataWithId {
-                payment_method: None,
-                payment_method_data: None,
-                payment_method_id: None,
-            },
-        };
-        Ok(token)
-    }
+        storage::PaymentTokenData::WalletToken(_) => storage::PaymentMethodDataWithId {
+            payment_method: None,
+            payment_method_data: None,
+            payment_method_id: None,
+        },
+    };
+    Ok(token)
 }

--- a/crates/router/src/core/payments.rs
+++ b/crates/router/src/core/payments.rs
@@ -69,7 +69,6 @@ use crate::{
     core::{
         authentication as authentication_core,
         errors::{self, CustomResult, RouterResponse, RouterResult},
-        payment_methods::PaymentMethodRetrieve,
         utils,
     },
     db::StorageInterface,
@@ -93,7 +92,7 @@ use crate::{
 
 #[allow(clippy::too_many_arguments, clippy::type_complexity)]
 #[instrument(skip_all, fields(payment_id, merchant_id))]
-pub async fn payments_operation_core<F, Req, Op, FData, Ctx>(
+pub async fn payments_operation_core<F, Req, Op, FData>(
     state: &AppState,
     req_state: ReqState,
     merchant_account: domain::MerchantAccount,
@@ -114,7 +113,7 @@ pub async fn payments_operation_core<F, Req, Op, FData, Ctx>(
 where
     F: Send + Clone + Sync,
     Req: Authenticate + Clone,
-    Op: Operation<F, Req, Ctx> + Send + Sync,
+    Op: Operation<F, Req> + Send + Sync,
 
     // To create connector flow specific interface data
     PaymentData<F>: ConstructFlowSpecificData<F, FData, router_types::PaymentsResponseData>,
@@ -125,11 +124,10 @@ where
         services::api::ConnectorIntegration<F, FData, router_types::PaymentsResponseData>,
 
     // To perform router related operation for PaymentResponse
-    PaymentResponse: Operation<F, FData, Ctx>,
+    PaymentResponse: Operation<F, FData>,
     FData: Send + Sync + Clone,
-    Ctx: PaymentMethodRetrieve,
 {
-    let operation: BoxedOperation<'_, F, Req, Ctx> = Box::new(operation);
+    let operation: BoxedOperation<'_, F, Req> = Box::new(operation);
 
     tracing::Span::current().record("merchant_id", merchant_account.merchant_id.as_str());
     let (operation, validate_result) = operation
@@ -734,7 +732,7 @@ where
     }
 }
 #[allow(clippy::too_many_arguments)]
-pub async fn payments_core<F, Res, Req, Op, FData, Ctx>(
+pub async fn payments_core<F, Res, Req, Op, FData>(
     state: AppState,
     req_state: ReqState,
     merchant_account: domain::MerchantAccount,
@@ -749,20 +747,19 @@ pub async fn payments_core<F, Res, Req, Op, FData, Ctx>(
 where
     F: Send + Clone + Sync,
     FData: Send + Sync + Clone,
-    Op: Operation<F, Req, Ctx> + Send + Sync + Clone,
+    Op: Operation<F, Req> + Send + Sync + Clone,
     Req: Debug + Authenticate + Clone,
     Res: transformers::ToResponse<PaymentData<F>, Op>,
     // To create connector flow specific interface data
     PaymentData<F>: ConstructFlowSpecificData<F, FData, router_types::PaymentsResponseData>,
     router_types::RouterData<F, FData, router_types::PaymentsResponseData>: Feature<F, FData>,
-    Ctx: PaymentMethodRetrieve,
 
     // To construct connector flow specific api
     dyn api::Connector:
         services::api::ConnectorIntegration<F, FData, router_types::PaymentsResponseData>,
 
     // To perform router related operation for PaymentResponse
-    PaymentResponse: Operation<F, FData, Ctx>,
+    PaymentResponse: Operation<F, FData>,
 {
     let eligible_routable_connectors = eligible_connectors.map(|connectors| {
         connectors
@@ -771,7 +768,7 @@ where
             .collect()
     });
     let (payment_data, _req, customer, connector_http_status_code, external_latency) =
-        payments_operation_core::<_, _, _, _, Ctx>(
+        payments_operation_core::<_, _, _, _>(
             &state,
             req_state,
             merchant_account,
@@ -814,7 +811,7 @@ pub struct PaymentsRedirectResponseData {
 }
 
 #[async_trait::async_trait]
-pub trait PaymentRedirectFlow<Ctx: PaymentMethodRetrieve>: Sync {
+pub trait PaymentRedirectFlow: Sync {
     // Associated type for call_payment_flow response
     type PaymentFlowResponse;
 
@@ -912,7 +909,7 @@ pub trait PaymentRedirectFlow<Ctx: PaymentMethodRetrieve>: Sync {
 pub struct PaymentRedirectCompleteAuthorize;
 
 #[async_trait::async_trait]
-impl<Ctx: PaymentMethodRetrieve> PaymentRedirectFlow<Ctx> for PaymentRedirectCompleteAuthorize {
+impl PaymentRedirectFlow for PaymentRedirectCompleteAuthorize {
     type PaymentFlowResponse = router_types::RedirectPaymentFlowResponse;
 
     #[allow(clippy::too_many_arguments)]
@@ -944,7 +941,6 @@ impl<Ctx: PaymentMethodRetrieve> PaymentRedirectFlow<Ctx> for PaymentRedirectCom
             _,
             _,
             _,
-            Ctx,
         >(
             state.clone(),
             req_state,
@@ -1043,7 +1039,7 @@ impl<Ctx: PaymentMethodRetrieve> PaymentRedirectFlow<Ctx> for PaymentRedirectCom
 pub struct PaymentRedirectSync;
 
 #[async_trait::async_trait]
-impl<Ctx: PaymentMethodRetrieve> PaymentRedirectFlow<Ctx> for PaymentRedirectSync {
+impl PaymentRedirectFlow for PaymentRedirectSync {
     type PaymentFlowResponse = router_types::RedirectPaymentFlowResponse;
 
     #[allow(clippy::too_many_arguments)]
@@ -1074,14 +1070,7 @@ impl<Ctx: PaymentMethodRetrieve> PaymentRedirectFlow<Ctx> for PaymentRedirectSyn
             expand_attempts: None,
             expand_captures: None,
         };
-        let response = Box::pin(payments_core::<
-            api::PSync,
-            api::PaymentsResponse,
-            _,
-            _,
-            _,
-            Ctx,
-        >(
+        let response = Box::pin(payments_core::<api::PSync, api::PaymentsResponse, _, _, _>(
             state.clone(),
             req_state,
             merchant_account,
@@ -1141,7 +1130,7 @@ impl<Ctx: PaymentMethodRetrieve> PaymentRedirectFlow<Ctx> for PaymentRedirectSyn
 pub struct PaymentAuthenticateCompleteAuthorize;
 
 #[async_trait::async_trait]
-impl<Ctx: PaymentMethodRetrieve> PaymentRedirectFlow<Ctx> for PaymentAuthenticateCompleteAuthorize {
+impl PaymentRedirectFlow for PaymentAuthenticateCompleteAuthorize {
     type PaymentFlowResponse = router_types::AuthenticatePaymentFlowResponse;
 
     #[allow(clippy::too_many_arguments)]
@@ -1235,7 +1224,6 @@ impl<Ctx: PaymentMethodRetrieve> PaymentRedirectFlow<Ctx> for PaymentAuthenticat
                 _,
                 _,
                 _,
-                Ctx,
             >(
                 state.clone(),
                 req_state,
@@ -1266,14 +1254,7 @@ impl<Ctx: PaymentMethodRetrieve> PaymentRedirectFlow<Ctx> for PaymentAuthenticat
                 expand_attempts: None,
                 expand_captures: None,
             };
-            Box::pin(payments_core::<
-                api::PSync,
-                api::PaymentsResponse,
-                _,
-                _,
-                _,
-                Ctx,
-            >(
+            Box::pin(payments_core::<api::PSync, api::PaymentsResponse, _, _, _>(
                 state.clone(),
                 req_state,
                 merchant_account.clone(),
@@ -1386,13 +1367,13 @@ impl<Ctx: PaymentMethodRetrieve> PaymentRedirectFlow<Ctx> for PaymentAuthenticat
 
 #[allow(clippy::too_many_arguments)]
 #[instrument(skip_all)]
-pub async fn call_connector_service<F, RouterDReq, ApiRequest, Ctx>(
+pub async fn call_connector_service<F, RouterDReq, ApiRequest>(
     state: &AppState,
     req_state: ReqState,
     merchant_account: &domain::MerchantAccount,
     key_store: &domain::MerchantKeyStore,
     connector: api::ConnectorData,
-    operation: &BoxedOperation<'_, F, ApiRequest, Ctx>,
+    operation: &BoxedOperation<'_, F, ApiRequest>,
     payment_data: &mut PaymentData<F>,
     customer: &Option<domain::Customer>,
     call_connector_action: CallConnectorAction,
@@ -1409,8 +1390,6 @@ where
     PaymentData<F>: ConstructFlowSpecificData<F, RouterDReq, router_types::PaymentsResponseData>,
     router_types::RouterData<F, RouterDReq, router_types::PaymentsResponseData>:
         Feature<F, RouterDReq> + Send,
-    Ctx: PaymentMethodRetrieve,
-
     // To construct connector flow specific api
     dyn api::Connector:
         services::api::ConnectorIntegration<F, RouterDReq, router_types::PaymentsResponseData>,
@@ -1611,15 +1590,14 @@ where
     router_data_res
 }
 
-async fn blocklist_guard<F, ApiRequest, Ctx>(
+async fn blocklist_guard<F, ApiRequest>(
     state: &AppState,
     merchant_account: &domain::MerchantAccount,
-    operation: &BoxedOperation<'_, F, ApiRequest, Ctx>,
+    operation: &BoxedOperation<'_, F, ApiRequest>,
     payment_data: &mut PaymentData<F>,
 ) -> CustomResult<bool, errors::ApiErrorResponse>
 where
     F: Send + Clone + Sync,
-    Ctx: PaymentMethodRetrieve,
 {
     let merchant_id = &payment_data.payment_attempt.merchant_id;
     let blocklist_enabled_key = format!("guard_blocklist_for_{merchant_id}");
@@ -1651,7 +1629,7 @@ where
 }
 
 #[allow(clippy::too_many_arguments)]
-pub async fn call_multiple_connectors_service<F, Op, Req, Ctx>(
+pub async fn call_multiple_connectors_service<F, Op, Req>(
     state: &AppState,
     merchant_account: &domain::MerchantAccount,
     key_store: &domain::MerchantKeyStore,
@@ -1672,10 +1650,9 @@ where
     // To construct connector flow specific api
     dyn api::Connector:
         services::api::ConnectorIntegration<F, Req, router_types::PaymentsResponseData>,
-    Ctx: PaymentMethodRetrieve,
 
     // To perform router related operation for PaymentResponse
-    PaymentResponse: Operation<F, Req, Ctx>,
+    PaymentResponse: Operation<F, Req>,
 {
     let call_connectors_start_time = Instant::now();
     let mut join_handlers = Vec::with_capacity(connectors.len());
@@ -1869,12 +1846,12 @@ where
     }
 }
 
-async fn complete_preprocessing_steps_if_required<F, Req, Q, Ctx>(
+async fn complete_preprocessing_steps_if_required<F, Req, Q>(
     state: &AppState,
     connector: &api::ConnectorData,
     payment_data: &PaymentData<F>,
     mut router_data: router_types::RouterData<F, Req, router_types::PaymentsResponseData>,
-    operation: &BoxedOperation<'_, F, Q, Ctx>,
+    operation: &BoxedOperation<'_, F, Q>,
     should_continue_payment: bool,
 ) -> RouterResult<(
     router_types::RouterData<F, Req, router_types::PaymentsResponseData>,
@@ -2234,9 +2211,9 @@ pub enum TokenizationAction {
 }
 
 #[allow(clippy::too_many_arguments)]
-pub async fn get_connector_tokenization_action_when_confirm_true<F, Req, Ctx>(
+pub async fn get_connector_tokenization_action_when_confirm_true<F, Req>(
     state: &AppState,
-    operation: &BoxedOperation<'_, F, Req, Ctx>,
+    operation: &BoxedOperation<'_, F, Req>,
     payment_data: &mut PaymentData<F>,
     validate_result: &operations::ValidateResult<'_>,
     merchant_connector_account: &helpers::MerchantConnectorAccountType,
@@ -2245,7 +2222,6 @@ pub async fn get_connector_tokenization_action_when_confirm_true<F, Req, Ctx>(
 ) -> RouterResult<(PaymentData<F>, TokenizationAction)>
 where
     F: Send + Clone,
-    Ctx: PaymentMethodRetrieve,
 {
     let connector = payment_data.payment_attempt.connector.to_owned();
 
@@ -2359,9 +2335,9 @@ where
     Ok(payment_data_and_tokenization_action)
 }
 
-pub async fn tokenize_in_router_when_confirm_false_or_external_authentication<F, Req, Ctx>(
+pub async fn tokenize_in_router_when_confirm_false_or_external_authentication<F, Req>(
     state: &AppState,
-    operation: &BoxedOperation<'_, F, Req, Ctx>,
+    operation: &BoxedOperation<'_, F, Req>,
     payment_data: &mut PaymentData<F>,
     validate_result: &operations::ValidateResult<'_>,
     merchant_key_store: &domain::MerchantKeyStore,
@@ -2369,7 +2345,6 @@ pub async fn tokenize_in_router_when_confirm_false_or_external_authentication<F,
 ) -> RouterResult<PaymentData<F>>
 where
     F: Send + Clone,
-    Ctx: PaymentMethodRetrieve,
 {
     // On confirm is false and only router related
     let is_external_authentication_requested = payment_data
@@ -2607,16 +2582,15 @@ impl CustomerDetailsExt for CustomerDetails {
     }
 }
 
-pub fn if_not_create_change_operation<'a, Op, F, Ctx>(
+pub fn if_not_create_change_operation<'a, Op, F>(
     status: storage_enums::IntentStatus,
     confirm: Option<bool>,
     current: &'a Op,
-) -> BoxedOperation<'_, F, api::PaymentsRequest, Ctx>
+) -> BoxedOperation<'_, F, api::PaymentsRequest>
 where
     F: Send + Clone,
-    Op: Operation<F, api::PaymentsRequest, Ctx> + Send + Sync,
-    &'a Op: Operation<F, api::PaymentsRequest, Ctx>,
-    Ctx: PaymentMethodRetrieve,
+    Op: Operation<F, api::PaymentsRequest> + Send + Sync,
+    &'a Op: Operation<F, api::PaymentsRequest>,
 {
     if confirm.unwrap_or(false) {
         Box::new(PaymentConfirm)
@@ -2630,16 +2604,15 @@ where
     }
 }
 
-pub fn is_confirm<'a, F: Clone + Send, R, Op, Ctx>(
+pub fn is_confirm<'a, F: Clone + Send, R, Op>(
     operation: &'a Op,
     confirm: Option<bool>,
-) -> BoxedOperation<'_, F, R, Ctx>
+) -> BoxedOperation<'_, F, R>
 where
-    PaymentConfirm: Operation<F, R, Ctx>,
-    &'a PaymentConfirm: Operation<F, R, Ctx>,
-    Op: Operation<F, R, Ctx> + Send + Sync,
-    &'a Op: Operation<F, R, Ctx>,
-    Ctx: PaymentMethodRetrieve,
+    PaymentConfirm: Operation<F, R>,
+    &'a PaymentConfirm: Operation<F, R>,
+    Op: Operation<F, R> + Send + Sync,
+    &'a Op: Operation<F, R>,
 {
     if confirm.unwrap_or(false) {
         Box::new(&PaymentConfirm)
@@ -3023,8 +2996,8 @@ where
 }
 
 #[allow(clippy::too_many_arguments)]
-pub async fn get_connector_choice<F, Req, Ctx>(
-    operation: &BoxedOperation<'_, F, Req, Ctx>,
+pub async fn get_connector_choice<F, Req>(
+    operation: &BoxedOperation<'_, F, Req>,
     state: &AppState,
     req: &Req,
     merchant_account: &domain::MerchantAccount,
@@ -3036,7 +3009,6 @@ pub async fn get_connector_choice<F, Req, Ctx>(
 ) -> RouterResult<Option<ConnectorCallType>>
 where
     F: Send + Clone,
-    Ctx: PaymentMethodRetrieve,
 {
     let connector_choice = operation
         .to_domain()?

--- a/crates/router/src/core/payments/helpers.rs
+++ b/crates/router/src/core/payments/helpers.rs
@@ -39,12 +39,12 @@ use crate::{
         authentication,
         errors::{self, CustomResult, RouterResult, StorageErrorExt},
         mandate::helpers::MandateGenericData,
-        payment_methods::{cards, vault, PaymentMethodRetrieve},
+        payment_methods::{self, cards, vault},
         payments,
         pm_auth::retrieve_payment_method_from_auth_service,
     },
     db::StorageInterface,
-    routes::{metrics, payment_methods, AppState},
+    routes::{metrics, payment_methods as payment_methods_handler, AppState},
     services,
     types::{
         self as core_types,
@@ -1234,11 +1234,10 @@ where
     }
 }
 
-pub fn response_operation<'a, F, R, Ctx>() -> BoxedOperation<'a, F, R, Ctx>
+pub fn response_operation<'a, F, R>() -> BoxedOperation<'a, F, R>
 where
     F: Send + Clone,
-    Ctx: PaymentMethodRetrieve,
-    PaymentResponse: Operation<F, R, Ctx>,
+    PaymentResponse: Operation<F, R>,
 {
     Box::new(PaymentResponse)
 }
@@ -1468,15 +1467,15 @@ pub async fn get_connector_default(
 
 #[instrument(skip_all)]
 #[allow(clippy::type_complexity)]
-pub async fn create_customer_if_not_exist<'a, F: Clone, R, Ctx>(
-    operation: BoxedOperation<'a, F, R, Ctx>,
+pub async fn create_customer_if_not_exist<'a, F: Clone, R>(
+    operation: BoxedOperation<'a, F, R>,
     db: &dyn StorageInterface,
     payment_data: &mut PaymentData<F>,
     req: Option<CustomerDetails>,
     merchant_id: &str,
     key_store: &domain::MerchantKeyStore,
     storage_scheme: common_enums::enums::MerchantStorageScheme,
-) -> CustomResult<(BoxedOperation<'a, F, R, Ctx>, Option<domain::Customer>), errors::StorageError> {
+) -> CustomResult<(BoxedOperation<'a, F, R>, Option<domain::Customer>), errors::StorageError> {
     let request_customer_details = req
         .get_required_value("customer")
         .change_context(errors::StorageError::ValueNotFound("customer".to_owned()))?;
@@ -1884,15 +1883,15 @@ pub async fn retrieve_payment_token_data(
     Ok(token_data)
 }
 
-pub async fn make_pm_data<'a, F: Clone, R, Ctx: PaymentMethodRetrieve>(
-    operation: BoxedOperation<'a, F, R, Ctx>,
+pub async fn make_pm_data<'a, F: Clone, R>(
+    operation: BoxedOperation<'a, F, R>,
     state: &'a AppState,
     payment_data: &mut PaymentData<F>,
     merchant_key_store: &domain::MerchantKeyStore,
     customer: &Option<domain::Customer>,
     storage_scheme: common_enums::enums::MerchantStorageScheme,
 ) -> RouterResult<(
-    BoxedOperation<'a, F, R, Ctx>,
+    BoxedOperation<'a, F, R>,
     Option<api::PaymentMethodData>,
     Option<String>,
 )> {
@@ -1935,7 +1934,7 @@ pub async fn make_pm_data<'a, F: Clone, R, Ctx: PaymentMethodRetrieve>(
     // TODO: Handle case where payment method and token both are present in request properly.
     let (payment_method, pm_id) = match (request, payment_data.token_data.as_ref()) {
         (_, Some(hyperswitch_token)) => {
-            let pm_data = Ctx::retrieve_payment_method_with_token(
+            let pm_data = payment_methods::retrieve_payment_method_with_token(
                 state,
                 merchant_key_store,
                 hyperswitch_token,
@@ -1963,7 +1962,7 @@ pub async fn make_pm_data<'a, F: Clone, R, Ctx: PaymentMethodRetrieve>(
         }
 
         (Some(_), _) => {
-            let (payment_method_data, payment_token) = Ctx::retrieve_payment_method(
+            let (payment_method_data, payment_token) = payment_methods::retrieve_payment_method(
                 request,
                 state,
                 &payment_data.payment_intent,
@@ -2001,7 +2000,7 @@ pub async fn store_in_vault_and_generate_ppmt(
     .await?;
     let parent_payment_method_token = generate_id(consts::ID_LENGTH, "token");
     let key_for_hyperswitch_token = payment_attempt.payment_method.map(|payment_method| {
-        payment_methods::ParentPaymentMethodToken::create_key_for_token((
+        payment_methods_handler::ParentPaymentMethodToken::create_key_for_token((
             &parent_payment_method_token,
             payment_method,
         ))

--- a/crates/router/src/core/payments/operations/payment_approve.rs
+++ b/crates/router/src/core/payments/operations/payment_approve.rs
@@ -10,7 +10,6 @@ use super::{BoxedOperation, Domain, GetTracker, Operation, UpdateTracker, Valida
 use crate::{
     core::{
         errors::{self, RouterResult, StorageErrorExt},
-        payment_methods::PaymentMethodRetrieve,
         payments::{helpers, operations, PaymentData},
     },
     routes::{app::ReqState, AppState},
@@ -29,8 +28,8 @@ use crate::{
 pub struct PaymentApprove;
 
 #[async_trait]
-impl<F: Send + Clone, Ctx: PaymentMethodRetrieve>
-    GetTracker<F, PaymentData<F>, api::PaymentsCaptureRequest, Ctx> for PaymentApprove
+impl<F: Send + Clone> GetTracker<F, PaymentData<F>, api::PaymentsCaptureRequest>
+    for PaymentApprove
 {
     #[instrument(skip_all)]
     async fn get_trackers<'a>(
@@ -42,7 +41,7 @@ impl<F: Send + Clone, Ctx: PaymentMethodRetrieve>
         key_store: &domain::MerchantKeyStore,
         _auth_flow: services::AuthFlow,
         _payment_confirm_source: Option<common_enums::PaymentSource>,
-    ) -> RouterResult<operations::GetTrackerResponse<'a, F, api::PaymentsCaptureRequest, Ctx>> {
+    ) -> RouterResult<operations::GetTrackerResponse<'a, F, api::PaymentsCaptureRequest>> {
         let db = &*state.store;
         let merchant_id = &merchant_account.merchant_id;
         let storage_scheme = merchant_account.storage_scheme;
@@ -191,9 +190,7 @@ impl<F: Send + Clone, Ctx: PaymentMethodRetrieve>
 }
 
 #[async_trait]
-impl<F: Clone, Ctx: PaymentMethodRetrieve>
-    UpdateTracker<F, PaymentData<F>, api::PaymentsCaptureRequest, Ctx> for PaymentApprove
-{
+impl<F: Clone> UpdateTracker<F, PaymentData<F>, api::PaymentsCaptureRequest> for PaymentApprove {
     #[instrument(skip_all)]
     async fn update_trackers<'b>(
         &'b self,
@@ -207,7 +204,7 @@ impl<F: Clone, Ctx: PaymentMethodRetrieve>
         frm_suggestion: Option<FrmSuggestion>,
         _header_payload: api::HeaderPayload,
     ) -> RouterResult<(
-        BoxedOperation<'b, F, api::PaymentsCaptureRequest, Ctx>,
+        BoxedOperation<'b, F, api::PaymentsCaptureRequest>,
         PaymentData<F>,
     )>
     where
@@ -247,16 +244,14 @@ impl<F: Clone, Ctx: PaymentMethodRetrieve>
     }
 }
 
-impl<F: Send + Clone, Ctx: PaymentMethodRetrieve>
-    ValidateRequest<F, api::PaymentsCaptureRequest, Ctx> for PaymentApprove
-{
+impl<F: Send + Clone> ValidateRequest<F, api::PaymentsCaptureRequest> for PaymentApprove {
     #[instrument(skip_all)]
     fn validate_request<'a, 'b>(
         &'b self,
         request: &api::PaymentsCaptureRequest,
         merchant_account: &'a domain::MerchantAccount,
     ) -> RouterResult<(
-        BoxedOperation<'b, F, api::PaymentsCaptureRequest, Ctx>,
+        BoxedOperation<'b, F, api::PaymentsCaptureRequest>,
         operations::ValidateResult<'a>,
     )> {
         let request_merchant_id = request.merchant_id.as_deref();

--- a/crates/router/src/core/payments/operations/payment_cancel.rs
+++ b/crates/router/src/core/payments/operations/payment_cancel.rs
@@ -11,7 +11,6 @@ use super::{BoxedOperation, Domain, GetTracker, Operation, UpdateTracker, Valida
 use crate::{
     core::{
         errors::{self, RouterResult, StorageErrorExt},
-        payment_methods::PaymentMethodRetrieve,
         payments::{helpers, operations, PaymentData},
     },
     events::audit_events::{AuditEvent, AuditEventType},
@@ -31,9 +30,7 @@ use crate::{
 pub struct PaymentCancel;
 
 #[async_trait]
-impl<F: Send + Clone, Ctx: PaymentMethodRetrieve>
-    GetTracker<F, PaymentData<F>, api::PaymentsCancelRequest, Ctx> for PaymentCancel
-{
+impl<F: Send + Clone> GetTracker<F, PaymentData<F>, api::PaymentsCancelRequest> for PaymentCancel {
     #[instrument(skip_all)]
     async fn get_trackers<'a>(
         &'a self,
@@ -44,7 +41,7 @@ impl<F: Send + Clone, Ctx: PaymentMethodRetrieve>
         key_store: &domain::MerchantKeyStore,
         _auth_flow: services::AuthFlow,
         _payment_confirm_source: Option<common_enums::PaymentSource>,
-    ) -> RouterResult<operations::GetTrackerResponse<'a, F, api::PaymentsCancelRequest, Ctx>> {
+    ) -> RouterResult<operations::GetTrackerResponse<'a, F, api::PaymentsCancelRequest>> {
         let db = &*state.store;
         let merchant_id = &merchant_account.merchant_id;
         let storage_scheme = merchant_account.storage_scheme;
@@ -206,9 +203,7 @@ impl<F: Send + Clone, Ctx: PaymentMethodRetrieve>
 }
 
 #[async_trait]
-impl<F: Clone, Ctx: PaymentMethodRetrieve>
-    UpdateTracker<F, PaymentData<F>, api::PaymentsCancelRequest, Ctx> for PaymentCancel
-{
+impl<F: Clone> UpdateTracker<F, PaymentData<F>, api::PaymentsCancelRequest> for PaymentCancel {
     #[instrument(skip_all)]
     async fn update_trackers<'b>(
         &'b self,
@@ -222,7 +217,7 @@ impl<F: Clone, Ctx: PaymentMethodRetrieve>
         _frm_suggestion: Option<FrmSuggestion>,
         _header_payload: api::HeaderPayload,
     ) -> RouterResult<(
-        BoxedOperation<'b, F, api::PaymentsCancelRequest, Ctx>,
+        BoxedOperation<'b, F, api::PaymentsCancelRequest>,
         PaymentData<F>,
     )>
     where
@@ -276,16 +271,14 @@ impl<F: Clone, Ctx: PaymentMethodRetrieve>
     }
 }
 
-impl<F: Send + Clone, Ctx: PaymentMethodRetrieve>
-    ValidateRequest<F, api::PaymentsCancelRequest, Ctx> for PaymentCancel
-{
+impl<F: Send + Clone> ValidateRequest<F, api::PaymentsCancelRequest> for PaymentCancel {
     #[instrument(skip_all)]
     fn validate_request<'a, 'b>(
         &'b self,
         request: &api::PaymentsCancelRequest,
         merchant_account: &'a domain::MerchantAccount,
     ) -> RouterResult<(
-        BoxedOperation<'b, F, api::PaymentsCancelRequest, Ctx>,
+        BoxedOperation<'b, F, api::PaymentsCancelRequest>,
         operations::ValidateResult<'a>,
     )> {
         Ok((

--- a/crates/router/src/core/payments/operations/payment_capture.rs
+++ b/crates/router/src/core/payments/operations/payment_capture.rs
@@ -10,7 +10,6 @@ use super::{BoxedOperation, Domain, GetTracker, Operation, UpdateTracker, Valida
 use crate::{
     core::{
         errors::{self, RouterResult, StorageErrorExt},
-        payment_methods::PaymentMethodRetrieve,
         payments::{self, helpers, operations, types::MultipleCaptureData},
     },
     routes::{app::ReqState, AppState},
@@ -29,8 +28,8 @@ use crate::{
 pub struct PaymentCapture;
 
 #[async_trait]
-impl<F: Send + Clone, Ctx: PaymentMethodRetrieve>
-    GetTracker<F, payments::PaymentData<F>, api::PaymentsCaptureRequest, Ctx> for PaymentCapture
+impl<F: Send + Clone> GetTracker<F, payments::PaymentData<F>, api::PaymentsCaptureRequest>
+    for PaymentCapture
 {
     #[instrument(skip_all)]
     async fn get_trackers<'a>(
@@ -42,7 +41,7 @@ impl<F: Send + Clone, Ctx: PaymentMethodRetrieve>
         key_store: &domain::MerchantKeyStore,
         _auth_flow: services::AuthFlow,
         _payment_confirm_source: Option<common_enums::PaymentSource>,
-    ) -> RouterResult<operations::GetTrackerResponse<'a, F, api::PaymentsCaptureRequest, Ctx>> {
+    ) -> RouterResult<operations::GetTrackerResponse<'a, F, api::PaymentsCaptureRequest>> {
         let db = &*state.store;
         let merchant_id = &merchant_account.merchant_id;
         let storage_scheme = merchant_account.storage_scheme;
@@ -247,8 +246,7 @@ impl<F: Send + Clone, Ctx: PaymentMethodRetrieve>
 }
 
 #[async_trait]
-impl<F: Clone, Ctx: PaymentMethodRetrieve>
-    UpdateTracker<F, payments::PaymentData<F>, api::PaymentsCaptureRequest, Ctx>
+impl<F: Clone> UpdateTracker<F, payments::PaymentData<F>, api::PaymentsCaptureRequest>
     for PaymentCapture
 {
     #[instrument(skip_all)]
@@ -264,7 +262,7 @@ impl<F: Clone, Ctx: PaymentMethodRetrieve>
         _frm_suggestion: Option<FrmSuggestion>,
         _header_payload: api::HeaderPayload,
     ) -> RouterResult<(
-        BoxedOperation<'b, F, api::PaymentsCaptureRequest, Ctx>,
+        BoxedOperation<'b, F, api::PaymentsCaptureRequest>,
         payments::PaymentData<F>,
     )>
     where
@@ -298,16 +296,14 @@ impl<F: Clone, Ctx: PaymentMethodRetrieve>
     }
 }
 
-impl<F: Send + Clone, Ctx: PaymentMethodRetrieve>
-    ValidateRequest<F, api::PaymentsCaptureRequest, Ctx> for PaymentCapture
-{
+impl<F: Send + Clone> ValidateRequest<F, api::PaymentsCaptureRequest> for PaymentCapture {
     #[instrument(skip_all)]
     fn validate_request<'a, 'b>(
         &'b self,
         request: &api::PaymentsCaptureRequest,
         merchant_account: &'a domain::MerchantAccount,
     ) -> RouterResult<(
-        BoxedOperation<'b, F, api::PaymentsCaptureRequest, Ctx>,
+        BoxedOperation<'b, F, api::PaymentsCaptureRequest>,
         operations::ValidateResult<'a>,
     )> {
         Ok((

--- a/crates/router/src/core/payments/operations/payment_complete_authorize.rs
+++ b/crates/router/src/core/payments/operations/payment_complete_authorize.rs
@@ -11,7 +11,6 @@ use crate::{
     core::{
         errors::{self, CustomResult, RouterResult, StorageErrorExt},
         mandate::helpers as m_helpers,
-        payment_methods::PaymentMethodRetrieve,
         payments::{self, helpers, operations, CustomerDetails, PaymentAddress, PaymentData},
         utils as core_utils,
     },
@@ -31,9 +30,7 @@ use crate::{
 pub struct CompleteAuthorize;
 
 #[async_trait]
-impl<F: Send + Clone, Ctx: PaymentMethodRetrieve>
-    GetTracker<F, PaymentData<F>, api::PaymentsRequest, Ctx> for CompleteAuthorize
-{
+impl<F: Send + Clone> GetTracker<F, PaymentData<F>, api::PaymentsRequest> for CompleteAuthorize {
     #[instrument(skip_all)]
     async fn get_trackers<'a>(
         &'a self,
@@ -44,7 +41,7 @@ impl<F: Send + Clone, Ctx: PaymentMethodRetrieve>
         key_store: &domain::MerchantKeyStore,
         _auth_flow: services::AuthFlow,
         _payment_confirm_source: Option<common_enums::PaymentSource>,
-    ) -> RouterResult<operations::GetTrackerResponse<'a, F, api::PaymentsRequest, Ctx>> {
+    ) -> RouterResult<operations::GetTrackerResponse<'a, F, api::PaymentsRequest>> {
         let db = &*state.store;
         let merchant_id = &merchant_account.merchant_id;
         let storage_scheme = merchant_account.storage_scheme;
@@ -331,9 +328,7 @@ impl<F: Send + Clone, Ctx: PaymentMethodRetrieve>
 }
 
 #[async_trait]
-impl<F: Clone + Send, Ctx: PaymentMethodRetrieve> Domain<F, api::PaymentsRequest, Ctx>
-    for CompleteAuthorize
-{
+impl<F: Clone + Send> Domain<F, api::PaymentsRequest> for CompleteAuthorize {
     #[instrument(skip_all)]
     async fn get_or_create_customer_details<'a>(
         &'a self,
@@ -344,7 +339,7 @@ impl<F: Clone + Send, Ctx: PaymentMethodRetrieve> Domain<F, api::PaymentsRequest
         storage_scheme: common_enums::enums::MerchantStorageScheme,
     ) -> CustomResult<
         (
-            BoxedOperation<'a, F, api::PaymentsRequest, Ctx>,
+            BoxedOperation<'a, F, api::PaymentsRequest>,
             Option<domain::Customer>,
         ),
         errors::StorageError,
@@ -370,7 +365,7 @@ impl<F: Clone + Send, Ctx: PaymentMethodRetrieve> Domain<F, api::PaymentsRequest
         merchant_key_store: &domain::MerchantKeyStore,
         customer: &Option<domain::Customer>,
     ) -> RouterResult<(
-        BoxedOperation<'a, F, api::PaymentsRequest, Ctx>,
+        BoxedOperation<'a, F, api::PaymentsRequest>,
         Option<api::PaymentMethodData>,
         Option<String>,
     )> {
@@ -422,9 +417,7 @@ impl<F: Clone + Send, Ctx: PaymentMethodRetrieve> Domain<F, api::PaymentsRequest
 }
 
 #[async_trait]
-impl<F: Clone, Ctx: PaymentMethodRetrieve>
-    UpdateTracker<F, PaymentData<F>, api::PaymentsRequest, Ctx> for CompleteAuthorize
-{
+impl<F: Clone> UpdateTracker<F, PaymentData<F>, api::PaymentsRequest> for CompleteAuthorize {
     #[instrument(skip_all)]
     async fn update_trackers<'b>(
         &'b self,
@@ -437,10 +430,7 @@ impl<F: Clone, Ctx: PaymentMethodRetrieve>
         _merchant_key_store: &domain::MerchantKeyStore,
         _frm_suggestion: Option<FrmSuggestion>,
         _header_payload: api::HeaderPayload,
-    ) -> RouterResult<(
-        BoxedOperation<'b, F, api::PaymentsRequest, Ctx>,
-        PaymentData<F>,
-    )>
+    ) -> RouterResult<(BoxedOperation<'b, F, api::PaymentsRequest>, PaymentData<F>)>
     where
         F: 'b + Send,
     {
@@ -448,16 +438,14 @@ impl<F: Clone, Ctx: PaymentMethodRetrieve>
     }
 }
 
-impl<F: Send + Clone, Ctx: PaymentMethodRetrieve> ValidateRequest<F, api::PaymentsRequest, Ctx>
-    for CompleteAuthorize
-{
+impl<F: Send + Clone> ValidateRequest<F, api::PaymentsRequest> for CompleteAuthorize {
     #[instrument(skip_all)]
     fn validate_request<'a, 'b>(
         &'b self,
         request: &api::PaymentsRequest,
         merchant_account: &'a domain::MerchantAccount,
     ) -> RouterResult<(
-        BoxedOperation<'b, F, api::PaymentsRequest, Ctx>,
+        BoxedOperation<'b, F, api::PaymentsRequest>,
         operations::ValidateResult<'a>,
     )> {
         let payment_id = request

--- a/crates/router/src/core/payments/operations/payment_confirm.rs
+++ b/crates/router/src/core/payments/operations/payment_confirm.rs
@@ -17,7 +17,6 @@ use crate::{
         blocklist::utils as blocklist_utils,
         errors::{self, CustomResult, RouterResult, StorageErrorExt},
         mandate::helpers as m_helpers,
-        payment_methods::PaymentMethodRetrieve,
         payments::{
             self, helpers, operations, populate_surcharge_details, CustomerDetails, PaymentAddress,
             PaymentData,
@@ -40,9 +39,7 @@ use crate::{
 #[operation(operations = "all", flow = "authorize")]
 pub struct PaymentConfirm;
 #[async_trait]
-impl<F: Send + Clone, Ctx: PaymentMethodRetrieve>
-    GetTracker<F, PaymentData<F>, api::PaymentsRequest, Ctx> for PaymentConfirm
-{
+impl<F: Send + Clone> GetTracker<F, PaymentData<F>, api::PaymentsRequest> for PaymentConfirm {
     #[instrument(skip_all)]
     async fn get_trackers<'a>(
         &'a self,
@@ -53,7 +50,7 @@ impl<F: Send + Clone, Ctx: PaymentMethodRetrieve>
         key_store: &domain::MerchantKeyStore,
         auth_flow: services::AuthFlow,
         payment_confirm_source: Option<common_enums::PaymentSource>,
-    ) -> RouterResult<operations::GetTrackerResponse<'a, F, api::PaymentsRequest, Ctx>> {
+    ) -> RouterResult<operations::GetTrackerResponse<'a, F, api::PaymentsRequest>> {
         let merchant_id = &merchant_account.merchant_id;
         let storage_scheme = merchant_account.storage_scheme;
         let (currency, amount);
@@ -651,9 +648,7 @@ impl<F: Send + Clone, Ctx: PaymentMethodRetrieve>
 }
 
 #[async_trait]
-impl<F: Clone + Send, Ctx: PaymentMethodRetrieve> Domain<F, api::PaymentsRequest, Ctx>
-    for PaymentConfirm
-{
+impl<F: Clone + Send> Domain<F, api::PaymentsRequest> for PaymentConfirm {
     #[instrument(skip_all)]
     async fn get_or_create_customer_details<'a>(
         &'a self,
@@ -664,7 +659,7 @@ impl<F: Clone + Send, Ctx: PaymentMethodRetrieve> Domain<F, api::PaymentsRequest
         storage_scheme: common_enums::enums::MerchantStorageScheme,
     ) -> CustomResult<
         (
-            BoxedOperation<'a, F, api::PaymentsRequest, Ctx>,
+            BoxedOperation<'a, F, api::PaymentsRequest>,
             Option<domain::Customer>,
         ),
         errors::StorageError,
@@ -690,7 +685,7 @@ impl<F: Clone + Send, Ctx: PaymentMethodRetrieve> Domain<F, api::PaymentsRequest
         key_store: &domain::MerchantKeyStore,
         customer: &Option<domain::Customer>,
     ) -> RouterResult<(
-        BoxedOperation<'a, F, api::PaymentsRequest, Ctx>,
+        BoxedOperation<'a, F, api::PaymentsRequest>,
         Option<api::PaymentMethodData>,
         Option<String>,
     )> {
@@ -927,9 +922,7 @@ impl<F: Clone + Send, Ctx: PaymentMethodRetrieve> Domain<F, api::PaymentsRequest
 }
 
 #[async_trait]
-impl<F: Clone, Ctx: PaymentMethodRetrieve>
-    UpdateTracker<F, PaymentData<F>, api::PaymentsRequest, Ctx> for PaymentConfirm
-{
+impl<F: Clone> UpdateTracker<F, PaymentData<F>, api::PaymentsRequest> for PaymentConfirm {
     #[instrument(skip_all)]
     async fn update_trackers<'b>(
         &'b self,
@@ -942,10 +935,7 @@ impl<F: Clone, Ctx: PaymentMethodRetrieve>
         key_store: &domain::MerchantKeyStore,
         frm_suggestion: Option<FrmSuggestion>,
         header_payload: api::HeaderPayload,
-    ) -> RouterResult<(
-        BoxedOperation<'b, F, api::PaymentsRequest, Ctx>,
-        PaymentData<F>,
-    )>
+    ) -> RouterResult<(BoxedOperation<'b, F, api::PaymentsRequest>, PaymentData<F>)>
     where
         F: 'b + Send,
     {
@@ -1245,16 +1235,14 @@ impl<F: Clone, Ctx: PaymentMethodRetrieve>
     }
 }
 
-impl<F: Send + Clone, Ctx: PaymentMethodRetrieve> ValidateRequest<F, api::PaymentsRequest, Ctx>
-    for PaymentConfirm
-{
+impl<F: Send + Clone> ValidateRequest<F, api::PaymentsRequest> for PaymentConfirm {
     #[instrument(skip_all)]
     fn validate_request<'a, 'b>(
         &'b self,
         request: &api::PaymentsRequest,
         merchant_account: &'a domain::MerchantAccount,
     ) -> RouterResult<(
-        BoxedOperation<'b, F, api::PaymentsRequest, Ctx>,
+        BoxedOperation<'b, F, api::PaymentsRequest>,
         operations::ValidateResult<'a>,
     )> {
         helpers::validate_customer_details_in_request(request)?;

--- a/crates/router/src/core/payments/operations/payment_create.rs
+++ b/crates/router/src/core/payments/operations/payment_create.rs
@@ -23,7 +23,6 @@ use crate::{
         errors::{self, CustomResult, RouterResult, StorageErrorExt},
         mandate::helpers as m_helpers,
         payment_link,
-        payment_methods::PaymentMethodRetrieve,
         payments::{self, helpers, operations, CustomerDetails, PaymentAddress, PaymentData},
         utils as core_utils,
     },
@@ -48,9 +47,7 @@ pub struct PaymentCreate;
 /// The `get_trackers` function for `PaymentsCreate` is an entrypoint for new payments
 /// This will create all the entities required for a new payment from the request
 #[async_trait]
-impl<F: Send + Clone, Ctx: PaymentMethodRetrieve>
-    GetTracker<F, PaymentData<F>, api::PaymentsRequest, Ctx> for PaymentCreate
-{
+impl<F: Send + Clone> GetTracker<F, PaymentData<F>, api::PaymentsRequest> for PaymentCreate {
     #[instrument(skip_all)]
     async fn get_trackers<'a>(
         &'a self,
@@ -61,7 +58,7 @@ impl<F: Send + Clone, Ctx: PaymentMethodRetrieve>
         merchant_key_store: &domain::MerchantKeyStore,
         _auth_flow: services::AuthFlow,
         _payment_confirm_source: Option<common_enums::PaymentSource>,
-    ) -> RouterResult<operations::GetTrackerResponse<'a, F, api::PaymentsRequest, Ctx>> {
+    ) -> RouterResult<operations::GetTrackerResponse<'a, F, api::PaymentsRequest>> {
         let db = &*state.store;
         let ephemeral_key = Self::get_ephemeral_key(request, state, merchant_account).await;
         let merchant_id = &merchant_account.merchant_id;
@@ -362,7 +359,7 @@ impl<F: Send + Clone, Ctx: PaymentMethodRetrieve>
             .await
             .transpose()?;
 
-        let operation = payments::if_not_create_change_operation::<_, F, Ctx>(
+        let operation = payments::if_not_create_change_operation::<_, F>(
             payment_intent.status,
             request.confirm,
             self,
@@ -466,9 +463,7 @@ impl<F: Send + Clone, Ctx: PaymentMethodRetrieve>
 }
 
 #[async_trait]
-impl<F: Clone + Send, Ctx: PaymentMethodRetrieve> Domain<F, api::PaymentsRequest, Ctx>
-    for PaymentCreate
-{
+impl<F: Clone + Send> Domain<F, api::PaymentsRequest> for PaymentCreate {
     #[instrument(skip_all)]
     async fn get_or_create_customer_details<'a>(
         &'a self,
@@ -479,7 +474,7 @@ impl<F: Clone + Send, Ctx: PaymentMethodRetrieve> Domain<F, api::PaymentsRequest
         storage_scheme: enums::MerchantStorageScheme,
     ) -> CustomResult<
         (
-            BoxedOperation<'a, F, api::PaymentsRequest, Ctx>,
+            BoxedOperation<'a, F, api::PaymentsRequest>,
             Option<domain::Customer>,
         ),
         errors::StorageError,
@@ -505,7 +500,7 @@ impl<F: Clone + Send, Ctx: PaymentMethodRetrieve> Domain<F, api::PaymentsRequest
         merchant_key_store: &domain::MerchantKeyStore,
         customer: &Option<domain::Customer>,
     ) -> RouterResult<(
-        BoxedOperation<'a, F, api::PaymentsRequest, Ctx>,
+        BoxedOperation<'a, F, api::PaymentsRequest>,
         Option<api::PaymentMethodData>,
         Option<String>,
     )> {
@@ -554,9 +549,7 @@ impl<F: Clone + Send, Ctx: PaymentMethodRetrieve> Domain<F, api::PaymentsRequest
 }
 
 #[async_trait]
-impl<F: Clone, Ctx: PaymentMethodRetrieve>
-    UpdateTracker<F, PaymentData<F>, api::PaymentsRequest, Ctx> for PaymentCreate
-{
+impl<F: Clone> UpdateTracker<F, PaymentData<F>, api::PaymentsRequest> for PaymentCreate {
     #[instrument(skip_all)]
     async fn update_trackers<'b>(
         &'b self,
@@ -569,10 +562,7 @@ impl<F: Clone, Ctx: PaymentMethodRetrieve>
         _merchant_key_store: &domain::MerchantKeyStore,
         _frm_suggestion: Option<FrmSuggestion>,
         _header_payload: api::HeaderPayload,
-    ) -> RouterResult<(
-        BoxedOperation<'b, F, api::PaymentsRequest, Ctx>,
-        PaymentData<F>,
-    )>
+    ) -> RouterResult<(BoxedOperation<'b, F, api::PaymentsRequest>, PaymentData<F>)>
     where
         F: 'b + Send,
     {
@@ -659,16 +649,14 @@ impl<F: Clone, Ctx: PaymentMethodRetrieve>
     }
 }
 
-impl<F: Send + Clone, Ctx: PaymentMethodRetrieve> ValidateRequest<F, api::PaymentsRequest, Ctx>
-    for PaymentCreate
-{
+impl<F: Send + Clone> ValidateRequest<F, api::PaymentsRequest> for PaymentCreate {
     #[instrument(skip_all)]
     fn validate_request<'a, 'b>(
         &'b self,
         request: &api::PaymentsRequest,
         merchant_account: &'a domain::MerchantAccount,
     ) -> RouterResult<(
-        BoxedOperation<'b, F, api::PaymentsRequest, Ctx>,
+        BoxedOperation<'b, F, api::PaymentsRequest>,
         operations::ValidateResult<'a>,
     )> {
         helpers::validate_customer_details_in_request(request)?;

--- a/crates/router/src/core/payments/operations/payment_reject.rs
+++ b/crates/router/src/core/payments/operations/payment_reject.rs
@@ -10,7 +10,6 @@ use super::{BoxedOperation, Domain, GetTracker, Operation, UpdateTracker, Valida
 use crate::{
     core::{
         errors::{self, RouterResult, StorageErrorExt},
-        payment_methods::PaymentMethodRetrieve,
         payments::{helpers, operations, PaymentAddress, PaymentData},
     },
     routes::{app::ReqState, AppState},
@@ -28,9 +27,7 @@ use crate::{
 pub struct PaymentReject;
 
 #[async_trait]
-impl<F: Send + Clone, Ctx: PaymentMethodRetrieve>
-    GetTracker<F, PaymentData<F>, PaymentsCancelRequest, Ctx> for PaymentReject
-{
+impl<F: Send + Clone> GetTracker<F, PaymentData<F>, PaymentsCancelRequest> for PaymentReject {
     #[instrument(skip_all)]
     async fn get_trackers<'a>(
         &'a self,
@@ -41,7 +38,7 @@ impl<F: Send + Clone, Ctx: PaymentMethodRetrieve>
         key_store: &domain::MerchantKeyStore,
         _auth_flow: services::AuthFlow,
         _payment_confirm_source: Option<common_enums::PaymentSource>,
-    ) -> RouterResult<operations::GetTrackerResponse<'a, F, PaymentsCancelRequest, Ctx>> {
+    ) -> RouterResult<operations::GetTrackerResponse<'a, F, PaymentsCancelRequest>> {
         let db = &*state.store;
         let merchant_id = &merchant_account.merchant_id;
         let storage_scheme = merchant_account.storage_scheme;
@@ -190,9 +187,7 @@ impl<F: Send + Clone, Ctx: PaymentMethodRetrieve>
 }
 
 #[async_trait]
-impl<F: Clone, Ctx: PaymentMethodRetrieve>
-    UpdateTracker<F, PaymentData<F>, PaymentsCancelRequest, Ctx> for PaymentReject
-{
+impl<F: Clone> UpdateTracker<F, PaymentData<F>, PaymentsCancelRequest> for PaymentReject {
     #[instrument(skip_all)]
     async fn update_trackers<'b>(
         &'b self,
@@ -205,10 +200,7 @@ impl<F: Clone, Ctx: PaymentMethodRetrieve>
         _mechant_key_store: &domain::MerchantKeyStore,
         _should_decline_transaction: Option<FrmSuggestion>,
         _header_payload: api::HeaderPayload,
-    ) -> RouterResult<(
-        BoxedOperation<'b, F, PaymentsCancelRequest, Ctx>,
-        PaymentData<F>,
-    )>
+    ) -> RouterResult<(BoxedOperation<'b, F, PaymentsCancelRequest>, PaymentData<F>)>
     where
         F: 'b + Send,
     {
@@ -258,16 +250,14 @@ impl<F: Clone, Ctx: PaymentMethodRetrieve>
     }
 }
 
-impl<F: Send + Clone, Ctx: PaymentMethodRetrieve> ValidateRequest<F, PaymentsCancelRequest, Ctx>
-    for PaymentReject
-{
+impl<F: Send + Clone> ValidateRequest<F, PaymentsCancelRequest> for PaymentReject {
     #[instrument(skip_all)]
     fn validate_request<'a, 'b>(
         &'b self,
         request: &PaymentsCancelRequest,
         merchant_account: &'a domain::MerchantAccount,
     ) -> RouterResult<(
-        BoxedOperation<'b, F, PaymentsCancelRequest, Ctx>,
+        BoxedOperation<'b, F, PaymentsCancelRequest>,
         operations::ValidateResult<'a>,
     )> {
         Ok((

--- a/crates/router/src/core/payments/operations/payment_response.rs
+++ b/crates/router/src/core/payments/operations/payment_response.rs
@@ -16,8 +16,7 @@ use crate::{
     connector::utils::PaymentResponseRouterData,
     core::{
         errors::{self, CustomResult, RouterResult, StorageErrorExt},
-        mandate,
-        payment_methods::{self, PaymentMethodRetrieve},
+        mandate, payment_methods,
         payments::{
             helpers::{
                 self as payments_helpers,

--- a/crates/router/src/core/payments/operations/payment_session.rs
+++ b/crates/router/src/core/payments/operations/payment_session.rs
@@ -11,7 +11,6 @@ use super::{BoxedOperation, Domain, GetTracker, Operation, UpdateTracker, Valida
 use crate::{
     core::{
         errors::{self, RouterResult, StorageErrorExt},
-        payment_methods::PaymentMethodRetrieve,
         payments::{self, helpers, operations, PaymentData},
     },
     db::StorageInterface,
@@ -30,8 +29,8 @@ use crate::{
 pub struct PaymentSession;
 
 #[async_trait]
-impl<F: Send + Clone, Ctx: PaymentMethodRetrieve>
-    GetTracker<F, PaymentData<F>, api::PaymentsSessionRequest, Ctx> for PaymentSession
+impl<F: Send + Clone> GetTracker<F, PaymentData<F>, api::PaymentsSessionRequest>
+    for PaymentSession
 {
     #[instrument(skip_all)]
     async fn get_trackers<'a>(
@@ -43,7 +42,7 @@ impl<F: Send + Clone, Ctx: PaymentMethodRetrieve>
         key_store: &domain::MerchantKeyStore,
         _auth_flow: services::AuthFlow,
         _payment_confirm_source: Option<common_enums::PaymentSource>,
-    ) -> RouterResult<operations::GetTrackerResponse<'a, F, api::PaymentsSessionRequest, Ctx>> {
+    ) -> RouterResult<operations::GetTrackerResponse<'a, F, api::PaymentsSessionRequest>> {
         let payment_id = payment_id
             .get_payment_intent_id()
             .change_context(errors::ApiErrorResponse::PaymentNotFound)?;
@@ -215,9 +214,7 @@ impl<F: Send + Clone, Ctx: PaymentMethodRetrieve>
 }
 
 #[async_trait]
-impl<F: Clone, Ctx: PaymentMethodRetrieve>
-    UpdateTracker<F, PaymentData<F>, api::PaymentsSessionRequest, Ctx> for PaymentSession
-{
+impl<F: Clone> UpdateTracker<F, PaymentData<F>, api::PaymentsSessionRequest> for PaymentSession {
     #[instrument(skip_all)]
     async fn update_trackers<'b>(
         &'b self,
@@ -231,7 +228,7 @@ impl<F: Clone, Ctx: PaymentMethodRetrieve>
         _frm_suggestion: Option<FrmSuggestion>,
         _header_payload: api::HeaderPayload,
     ) -> RouterResult<(
-        BoxedOperation<'b, F, api::PaymentsSessionRequest, Ctx>,
+        BoxedOperation<'b, F, api::PaymentsSessionRequest>,
         PaymentData<F>,
     )>
     where
@@ -258,16 +255,14 @@ impl<F: Clone, Ctx: PaymentMethodRetrieve>
     }
 }
 
-impl<F: Send + Clone, Ctx: PaymentMethodRetrieve>
-    ValidateRequest<F, api::PaymentsSessionRequest, Ctx> for PaymentSession
-{
+impl<F: Send + Clone> ValidateRequest<F, api::PaymentsSessionRequest> for PaymentSession {
     #[instrument(skip_all)]
     fn validate_request<'a, 'b>(
         &'b self,
         request: &api::PaymentsSessionRequest,
         merchant_account: &'a domain::MerchantAccount,
     ) -> RouterResult<(
-        BoxedOperation<'b, F, api::PaymentsSessionRequest, Ctx>,
+        BoxedOperation<'b, F, api::PaymentsSessionRequest>,
         operations::ValidateResult<'a>,
     )> {
         //paymentid is already generated and should be sent in the request
@@ -286,13 +281,10 @@ impl<F: Send + Clone, Ctx: PaymentMethodRetrieve>
 }
 
 #[async_trait]
-impl<
-        F: Clone + Send,
-        Ctx: PaymentMethodRetrieve,
-        Op: Send + Sync + Operation<F, api::PaymentsSessionRequest, Ctx>,
-    > Domain<F, api::PaymentsSessionRequest, Ctx> for Op
+impl<F: Clone + Send, Op: Send + Sync + Operation<F, api::PaymentsSessionRequest>>
+    Domain<F, api::PaymentsSessionRequest> for Op
 where
-    for<'a> &'a Op: Operation<F, api::PaymentsSessionRequest, Ctx>,
+    for<'a> &'a Op: Operation<F, api::PaymentsSessionRequest>,
 {
     #[instrument(skip_all)]
     async fn get_or_create_customer_details<'a>(
@@ -304,7 +296,7 @@ where
         storage_scheme: common_enums::enums::MerchantStorageScheme,
     ) -> errors::CustomResult<
         (
-            BoxedOperation<'a, F, api::PaymentsSessionRequest, Ctx>,
+            BoxedOperation<'a, F, api::PaymentsSessionRequest>,
             Option<domain::Customer>,
         ),
         errors::StorageError,
@@ -330,7 +322,7 @@ where
         _merchant_key_store: &domain::MerchantKeyStore,
         _customer: &Option<domain::Customer>,
     ) -> RouterResult<(
-        BoxedOperation<'b, F, api::PaymentsSessionRequest, Ctx>,
+        BoxedOperation<'b, F, api::PaymentsSessionRequest>,
         Option<api::PaymentMethodData>,
         Option<String>,
     )> {

--- a/crates/router/src/core/payments/operations/payment_start.rs
+++ b/crates/router/src/core/payments/operations/payment_start.rs
@@ -10,7 +10,6 @@ use super::{BoxedOperation, Domain, GetTracker, Operation, UpdateTracker, Valida
 use crate::{
     core::{
         errors::{self, CustomResult, RouterResult, StorageErrorExt},
-        payment_methods::PaymentMethodRetrieve,
         payments::{helpers, operations, CustomerDetails, PaymentAddress, PaymentData},
     },
     db::StorageInterface,
@@ -29,9 +28,7 @@ use crate::{
 pub struct PaymentStart;
 
 #[async_trait]
-impl<F: Send + Clone, Ctx: PaymentMethodRetrieve>
-    GetTracker<F, PaymentData<F>, api::PaymentsStartRequest, Ctx> for PaymentStart
-{
+impl<F: Send + Clone> GetTracker<F, PaymentData<F>, api::PaymentsStartRequest> for PaymentStart {
     #[instrument(skip_all)]
     async fn get_trackers<'a>(
         &'a self,
@@ -42,7 +39,7 @@ impl<F: Send + Clone, Ctx: PaymentMethodRetrieve>
         key_store: &domain::MerchantKeyStore,
         _auth_flow: services::AuthFlow,
         _payment_confirm_source: Option<common_enums::PaymentSource>,
-    ) -> RouterResult<operations::GetTrackerResponse<'a, F, api::PaymentsStartRequest, Ctx>> {
+    ) -> RouterResult<operations::GetTrackerResponse<'a, F, api::PaymentsStartRequest>> {
         let (mut payment_intent, payment_attempt, currency, amount);
         let db = &*state.store;
 
@@ -202,9 +199,7 @@ impl<F: Send + Clone, Ctx: PaymentMethodRetrieve>
 }
 
 #[async_trait]
-impl<F: Clone, Ctx: PaymentMethodRetrieve>
-    UpdateTracker<F, PaymentData<F>, api::PaymentsStartRequest, Ctx> for PaymentStart
-{
+impl<F: Clone> UpdateTracker<F, PaymentData<F>, api::PaymentsStartRequest> for PaymentStart {
     #[instrument(skip_all)]
     async fn update_trackers<'b>(
         &'b self,
@@ -218,7 +213,7 @@ impl<F: Clone, Ctx: PaymentMethodRetrieve>
         _frm_suggestion: Option<FrmSuggestion>,
         _header_payload: api::HeaderPayload,
     ) -> RouterResult<(
-        BoxedOperation<'b, F, api::PaymentsStartRequest, Ctx>,
+        BoxedOperation<'b, F, api::PaymentsStartRequest>,
         PaymentData<F>,
     )>
     where
@@ -228,16 +223,14 @@ impl<F: Clone, Ctx: PaymentMethodRetrieve>
     }
 }
 
-impl<F: Send + Clone, Ctx: PaymentMethodRetrieve> ValidateRequest<F, api::PaymentsStartRequest, Ctx>
-    for PaymentStart
-{
+impl<F: Send + Clone> ValidateRequest<F, api::PaymentsStartRequest> for PaymentStart {
     #[instrument(skip_all)]
     fn validate_request<'a, 'b>(
         &'b self,
         request: &api::PaymentsStartRequest,
         merchant_account: &'a domain::MerchantAccount,
     ) -> RouterResult<(
-        BoxedOperation<'b, F, api::PaymentsStartRequest, Ctx>,
+        BoxedOperation<'b, F, api::PaymentsStartRequest>,
         operations::ValidateResult<'a>,
     )> {
         let request_merchant_id = Some(&request.merchant_id[..]);
@@ -262,13 +255,10 @@ impl<F: Send + Clone, Ctx: PaymentMethodRetrieve> ValidateRequest<F, api::Paymen
 }
 
 #[async_trait]
-impl<
-        F: Clone + Send,
-        Ctx: PaymentMethodRetrieve,
-        Op: Send + Sync + Operation<F, api::PaymentsStartRequest, Ctx>,
-    > Domain<F, api::PaymentsStartRequest, Ctx> for Op
+impl<F: Clone + Send, Op: Send + Sync + Operation<F, api::PaymentsStartRequest>>
+    Domain<F, api::PaymentsStartRequest> for Op
 where
-    for<'a> &'a Op: Operation<F, api::PaymentsStartRequest, Ctx>,
+    for<'a> &'a Op: Operation<F, api::PaymentsStartRequest>,
 {
     #[instrument(skip_all)]
     async fn get_or_create_customer_details<'a>(
@@ -280,7 +270,7 @@ where
         storage_scheme: common_enums::enums::MerchantStorageScheme,
     ) -> CustomResult<
         (
-            BoxedOperation<'a, F, api::PaymentsStartRequest, Ctx>,
+            BoxedOperation<'a, F, api::PaymentsStartRequest>,
             Option<domain::Customer>,
         ),
         errors::StorageError,
@@ -306,7 +296,7 @@ where
         merchant_key_store: &domain::MerchantKeyStore,
         customer: &Option<domain::Customer>,
     ) -> RouterResult<(
-        BoxedOperation<'a, F, api::PaymentsStartRequest, Ctx>,
+        BoxedOperation<'a, F, api::PaymentsStartRequest>,
         Option<api::PaymentMethodData>,
         Option<String>,
     )> {

--- a/crates/router/src/core/payments/operations/payment_status.rs
+++ b/crates/router/src/core/payments/operations/payment_status.rs
@@ -11,7 +11,6 @@ use super::{BoxedOperation, Domain, GetTracker, Operation, UpdateTracker, Valida
 use crate::{
     core::{
         errors::{self, CustomResult, RouterResult, StorageErrorExt},
-        payment_methods::PaymentMethodRetrieve,
         payments::{
             helpers, operations, types as payment_types, CustomerDetails, PaymentAddress,
             PaymentData,
@@ -31,39 +30,31 @@ use crate::{
 #[operation(operations = "all", flow = "sync")]
 pub struct PaymentStatus;
 
-impl<F: Send + Clone, Ctx: PaymentMethodRetrieve> Operation<F, api::PaymentsRequest, Ctx>
-    for PaymentStatus
-{
-    fn to_domain(&self) -> RouterResult<&dyn Domain<F, api::PaymentsRequest, Ctx>> {
+impl<F: Send + Clone> Operation<F, api::PaymentsRequest> for PaymentStatus {
+    fn to_domain(&self) -> RouterResult<&dyn Domain<F, api::PaymentsRequest>> {
         Ok(self)
     }
     fn to_update_tracker(
         &self,
-    ) -> RouterResult<
-        &(dyn UpdateTracker<F, PaymentData<F>, api::PaymentsRequest, Ctx> + Send + Sync),
-    > {
+    ) -> RouterResult<&(dyn UpdateTracker<F, PaymentData<F>, api::PaymentsRequest> + Send + Sync)>
+    {
         Ok(self)
     }
 }
-impl<F: Send + Clone, Ctx: PaymentMethodRetrieve> Operation<F, api::PaymentsRequest, Ctx>
-    for &PaymentStatus
-{
-    fn to_domain(&self) -> RouterResult<&dyn Domain<F, api::PaymentsRequest, Ctx>> {
+impl<F: Send + Clone> Operation<F, api::PaymentsRequest> for &PaymentStatus {
+    fn to_domain(&self) -> RouterResult<&dyn Domain<F, api::PaymentsRequest>> {
         Ok(*self)
     }
     fn to_update_tracker(
         &self,
-    ) -> RouterResult<
-        &(dyn UpdateTracker<F, PaymentData<F>, api::PaymentsRequest, Ctx> + Send + Sync),
-    > {
+    ) -> RouterResult<&(dyn UpdateTracker<F, PaymentData<F>, api::PaymentsRequest> + Send + Sync)>
+    {
         Ok(*self)
     }
 }
 
 #[async_trait]
-impl<F: Clone + Send, Ctx: PaymentMethodRetrieve> Domain<F, api::PaymentsRequest, Ctx>
-    for PaymentStatus
-{
+impl<F: Clone + Send> Domain<F, api::PaymentsRequest> for PaymentStatus {
     #[instrument(skip_all)]
     async fn get_or_create_customer_details<'a>(
         &'a self,
@@ -74,7 +65,7 @@ impl<F: Clone + Send, Ctx: PaymentMethodRetrieve> Domain<F, api::PaymentsRequest
         storage_scheme: enums::MerchantStorageScheme,
     ) -> CustomResult<
         (
-            BoxedOperation<'a, F, api::PaymentsRequest, Ctx>,
+            BoxedOperation<'a, F, api::PaymentsRequest>,
             Option<domain::Customer>,
         ),
         errors::StorageError,
@@ -100,7 +91,7 @@ impl<F: Clone + Send, Ctx: PaymentMethodRetrieve> Domain<F, api::PaymentsRequest
         merchant_key_store: &domain::MerchantKeyStore,
         customer: &Option<domain::Customer>,
     ) -> RouterResult<(
-        BoxedOperation<'a, F, api::PaymentsRequest, Ctx>,
+        BoxedOperation<'a, F, api::PaymentsRequest>,
         Option<api::PaymentMethodData>,
         Option<String>,
     )> {
@@ -149,9 +140,28 @@ impl<F: Clone + Send, Ctx: PaymentMethodRetrieve> Domain<F, api::PaymentsRequest
 }
 
 #[async_trait]
-impl<F: Clone, Ctx: PaymentMethodRetrieve>
-    UpdateTracker<F, PaymentData<F>, api::PaymentsRequest, Ctx> for PaymentStatus
-{
+impl<F: Clone> UpdateTracker<F, PaymentData<F>, api::PaymentsRequest> for PaymentStatus {
+    async fn update_trackers<'b>(
+        &'b self,
+        _state: &'b AppState,
+        _req_state: ReqState,
+        payment_data: PaymentData<F>,
+        _customer: Option<domain::Customer>,
+        _storage_scheme: enums::MerchantStorageScheme,
+        _updated_customer: Option<storage::CustomerUpdate>,
+        _key_store: &domain::MerchantKeyStore,
+        _frm_suggestion: Option<FrmSuggestion>,
+        _header_payload: api::HeaderPayload,
+    ) -> RouterResult<(BoxedOperation<'b, F, api::PaymentsRequest>, PaymentData<F>)>
+    where
+        F: 'b + Send,
+    {
+        Ok((Box::new(self), payment_data))
+    }
+}
+
+#[async_trait]
+impl<F: Clone> UpdateTracker<F, PaymentData<F>, api::PaymentsRetrieveRequest> for PaymentStatus {
     async fn update_trackers<'b>(
         &'b self,
         _state: &'b AppState,
@@ -164,7 +174,7 @@ impl<F: Clone, Ctx: PaymentMethodRetrieve>
         _frm_suggestion: Option<FrmSuggestion>,
         _header_payload: api::HeaderPayload,
     ) -> RouterResult<(
-        BoxedOperation<'b, F, api::PaymentsRequest, Ctx>,
+        BoxedOperation<'b, F, api::PaymentsRetrieveRequest>,
         PaymentData<F>,
     )>
     where
@@ -175,34 +185,8 @@ impl<F: Clone, Ctx: PaymentMethodRetrieve>
 }
 
 #[async_trait]
-impl<F: Clone, Ctx: PaymentMethodRetrieve>
-    UpdateTracker<F, PaymentData<F>, api::PaymentsRetrieveRequest, Ctx> for PaymentStatus
-{
-    async fn update_trackers<'b>(
-        &'b self,
-        _state: &'b AppState,
-        _req_state: ReqState,
-        payment_data: PaymentData<F>,
-        _customer: Option<domain::Customer>,
-        _storage_scheme: enums::MerchantStorageScheme,
-        _updated_customer: Option<storage::CustomerUpdate>,
-        _key_store: &domain::MerchantKeyStore,
-        _frm_suggestion: Option<FrmSuggestion>,
-        _header_payload: api::HeaderPayload,
-    ) -> RouterResult<(
-        BoxedOperation<'b, F, api::PaymentsRetrieveRequest, Ctx>,
-        PaymentData<F>,
-    )>
-    where
-        F: 'b + Send,
-    {
-        Ok((Box::new(self), payment_data))
-    }
-}
-
-#[async_trait]
-impl<F: Send + Clone, Ctx: PaymentMethodRetrieve>
-    GetTracker<F, PaymentData<F>, api::PaymentsRetrieveRequest, Ctx> for PaymentStatus
+impl<F: Send + Clone> GetTracker<F, PaymentData<F>, api::PaymentsRetrieveRequest>
+    for PaymentStatus
 {
     #[instrument(skip_all)]
     async fn get_trackers<'a>(
@@ -214,8 +198,7 @@ impl<F: Send + Clone, Ctx: PaymentMethodRetrieve>
         key_store: &domain::MerchantKeyStore,
         _auth_flow: services::AuthFlow,
         _payment_confirm_source: Option<common_enums::PaymentSource>,
-    ) -> RouterResult<operations::GetTrackerResponse<'a, F, api::PaymentsRetrieveRequest, Ctx>>
-    {
+    ) -> RouterResult<operations::GetTrackerResponse<'a, F, api::PaymentsRetrieveRequest>> {
         get_tracker_for_sync(
             payment_id,
             merchant_account,
@@ -232,8 +215,7 @@ impl<F: Send + Clone, Ctx: PaymentMethodRetrieve>
 async fn get_tracker_for_sync<
     'a,
     F: Send + Clone,
-    Ctx: PaymentMethodRetrieve,
-    Op: Operation<F, api::PaymentsRetrieveRequest, Ctx> + 'a + Send + Sync,
+    Op: Operation<F, api::PaymentsRetrieveRequest> + 'a + Send + Sync,
 >(
     payment_id: &api::PaymentIdType,
     merchant_account: &domain::MerchantAccount,
@@ -242,7 +224,7 @@ async fn get_tracker_for_sync<
     request: &api::PaymentsRetrieveRequest,
     operation: Op,
     storage_scheme: enums::MerchantStorageScheme,
-) -> RouterResult<operations::GetTrackerResponse<'a, F, api::PaymentsRetrieveRequest, Ctx>> {
+) -> RouterResult<operations::GetTrackerResponse<'a, F, api::PaymentsRetrieveRequest>> {
     let (payment_intent, mut payment_attempt, currency, amount);
 
     (payment_intent, payment_attempt) = get_payment_intent_payment_attempt(
@@ -504,15 +486,13 @@ async fn get_tracker_for_sync<
     Ok(get_trackers_response)
 }
 
-impl<F: Send + Clone, Ctx: PaymentMethodRetrieve>
-    ValidateRequest<F, api::PaymentsRetrieveRequest, Ctx> for PaymentStatus
-{
+impl<F: Send + Clone> ValidateRequest<F, api::PaymentsRetrieveRequest> for PaymentStatus {
     fn validate_request<'a, 'b>(
         &'b self,
         request: &api::PaymentsRetrieveRequest,
         merchant_account: &'a domain::MerchantAccount,
     ) -> RouterResult<(
-        BoxedOperation<'b, F, api::PaymentsRetrieveRequest, Ctx>,
+        BoxedOperation<'b, F, api::PaymentsRetrieveRequest>,
         operations::ValidateResult<'a>,
     )> {
         let request_merchant_id = request.merchant_id.as_deref();

--- a/crates/router/src/core/payments/operations/payment_update.rs
+++ b/crates/router/src/core/payments/operations/payment_update.rs
@@ -14,7 +14,6 @@ use crate::{
     core::{
         errors::{self, CustomResult, RouterResult, StorageErrorExt},
         mandate::helpers as m_helpers,
-        payment_methods::PaymentMethodRetrieve,
         payments::{self, helpers, operations, CustomerDetails, PaymentAddress, PaymentData},
         utils as core_utils,
     },
@@ -34,9 +33,7 @@ use crate::{
 pub struct PaymentUpdate;
 
 #[async_trait]
-impl<F: Send + Clone, Ctx: PaymentMethodRetrieve>
-    GetTracker<F, PaymentData<F>, api::PaymentsRequest, Ctx> for PaymentUpdate
-{
+impl<F: Send + Clone> GetTracker<F, PaymentData<F>, api::PaymentsRequest> for PaymentUpdate {
     #[instrument(skip_all)]
     async fn get_trackers<'a>(
         &'a self,
@@ -47,7 +44,7 @@ impl<F: Send + Clone, Ctx: PaymentMethodRetrieve>
         key_store: &domain::MerchantKeyStore,
         auth_flow: services::AuthFlow,
         _payment_confirm_source: Option<common_enums::PaymentSource>,
-    ) -> RouterResult<operations::GetTrackerResponse<'a, F, api::PaymentsRequest, Ctx>> {
+    ) -> RouterResult<operations::GetTrackerResponse<'a, F, api::PaymentsRequest>> {
         let (mut payment_intent, mut payment_attempt, currency): (_, _, storage_enums::Currency);
 
         let payment_id = payment_id
@@ -327,7 +324,7 @@ impl<F: Send + Clone, Ctx: PaymentMethodRetrieve>
             })
             .await
             .transpose()?;
-        let (next_operation, amount): (BoxedOperation<'a, F, api::PaymentsRequest, Ctx>, _) =
+        let (next_operation, amount): (BoxedOperation<'a, F, api::PaymentsRequest>, _) =
             if request.confirm.unwrap_or(false) {
                 let amount = {
                     let amount = request
@@ -469,9 +466,7 @@ impl<F: Send + Clone, Ctx: PaymentMethodRetrieve>
 }
 
 #[async_trait]
-impl<F: Clone + Send, Ctx: PaymentMethodRetrieve> Domain<F, api::PaymentsRequest, Ctx>
-    for PaymentUpdate
-{
+impl<F: Clone + Send> Domain<F, api::PaymentsRequest> for PaymentUpdate {
     #[instrument(skip_all)]
     async fn get_or_create_customer_details<'a>(
         &'a self,
@@ -482,7 +477,7 @@ impl<F: Clone + Send, Ctx: PaymentMethodRetrieve> Domain<F, api::PaymentsRequest
         storage_scheme: common_enums::enums::MerchantStorageScheme,
     ) -> CustomResult<
         (
-            BoxedOperation<'a, F, api::PaymentsRequest, Ctx>,
+            BoxedOperation<'a, F, api::PaymentsRequest>,
             Option<domain::Customer>,
         ),
         errors::StorageError,
@@ -508,7 +503,7 @@ impl<F: Clone + Send, Ctx: PaymentMethodRetrieve> Domain<F, api::PaymentsRequest
         merchant_key_store: &domain::MerchantKeyStore,
         customer: &Option<domain::Customer>,
     ) -> RouterResult<(
-        BoxedOperation<'a, F, api::PaymentsRequest, Ctx>,
+        BoxedOperation<'a, F, api::PaymentsRequest>,
         Option<api::PaymentMethodData>,
         Option<String>,
     )> {
@@ -557,9 +552,7 @@ impl<F: Clone + Send, Ctx: PaymentMethodRetrieve> Domain<F, api::PaymentsRequest
 }
 
 #[async_trait]
-impl<F: Clone, Ctx: PaymentMethodRetrieve>
-    UpdateTracker<F, PaymentData<F>, api::PaymentsRequest, Ctx> for PaymentUpdate
-{
+impl<F: Clone> UpdateTracker<F, PaymentData<F>, api::PaymentsRequest> for PaymentUpdate {
     #[instrument(skip_all)]
     async fn update_trackers<'b>(
         &'b self,
@@ -572,10 +565,7 @@ impl<F: Clone, Ctx: PaymentMethodRetrieve>
         _key_store: &domain::MerchantKeyStore,
         _frm_suggestion: Option<FrmSuggestion>,
         _header_payload: api::HeaderPayload,
-    ) -> RouterResult<(
-        BoxedOperation<'b, F, api::PaymentsRequest, Ctx>,
-        PaymentData<F>,
-    )>
+    ) -> RouterResult<(BoxedOperation<'b, F, api::PaymentsRequest>, PaymentData<F>)>
     where
         F: 'b + Send,
     {
@@ -734,16 +724,14 @@ impl<F: Clone, Ctx: PaymentMethodRetrieve>
     }
 }
 
-impl<F: Send + Clone, Ctx: PaymentMethodRetrieve> ValidateRequest<F, api::PaymentsRequest, Ctx>
-    for PaymentUpdate
-{
+impl<F: Send + Clone> ValidateRequest<F, api::PaymentsRequest> for PaymentUpdate {
     #[instrument(skip_all)]
     fn validate_request<'a, 'b>(
         &'b self,
         request: &api::PaymentsRequest,
         merchant_account: &'a domain::MerchantAccount,
     ) -> RouterResult<(
-        BoxedOperation<'b, F, api::PaymentsRequest, Ctx>,
+        BoxedOperation<'b, F, api::PaymentsRequest>,
         operations::ValidateResult<'a>,
     )> {
         helpers::validate_customer_details_in_request(request)?;

--- a/crates/router/src/core/payments/operations/payments_incremental_authorization.rs
+++ b/crates/router/src/core/payments/operations/payments_incremental_authorization.rs
@@ -11,7 +11,6 @@ use super::{BoxedOperation, Domain, GetTracker, Operation, UpdateTracker, Valida
 use crate::{
     core::{
         errors::{self, RouterResult, StorageErrorExt},
-        payment_methods::PaymentMethodRetrieve,
         payments::{
             self, helpers, operations, CustomerDetails, IncrementalAuthorizationDetails,
             PaymentAddress,
@@ -35,8 +34,8 @@ use crate::{
 pub struct PaymentIncrementalAuthorization;
 
 #[async_trait]
-impl<F: Send + Clone, Ctx: PaymentMethodRetrieve>
-    GetTracker<F, payments::PaymentData<F>, PaymentsIncrementalAuthorizationRequest, Ctx>
+impl<F: Send + Clone>
+    GetTracker<F, payments::PaymentData<F>, PaymentsIncrementalAuthorizationRequest>
     for PaymentIncrementalAuthorization
 {
     #[instrument(skip_all)]
@@ -49,9 +48,8 @@ impl<F: Send + Clone, Ctx: PaymentMethodRetrieve>
         _key_store: &domain::MerchantKeyStore,
         _auth_flow: services::AuthFlow,
         _payment_confirm_source: Option<common_enums::PaymentSource>,
-    ) -> RouterResult<
-        operations::GetTrackerResponse<'a, F, PaymentsIncrementalAuthorizationRequest, Ctx>,
-    > {
+    ) -> RouterResult<operations::GetTrackerResponse<'a, F, PaymentsIncrementalAuthorizationRequest>>
+    {
         let db = &*state.store;
         let merchant_id = &merchant_account.merchant_id;
         let storage_scheme = merchant_account.storage_scheme;
@@ -171,8 +169,7 @@ impl<F: Send + Clone, Ctx: PaymentMethodRetrieve>
 }
 
 #[async_trait]
-impl<F: Clone, Ctx: PaymentMethodRetrieve>
-    UpdateTracker<F, payments::PaymentData<F>, PaymentsIncrementalAuthorizationRequest, Ctx>
+impl<F: Clone> UpdateTracker<F, payments::PaymentData<F>, PaymentsIncrementalAuthorizationRequest>
     for PaymentIncrementalAuthorization
 {
     #[instrument(skip_all)]
@@ -188,7 +185,7 @@ impl<F: Clone, Ctx: PaymentMethodRetrieve>
         _frm_suggestion: Option<FrmSuggestion>,
         _header_payload: api::HeaderPayload,
     ) -> RouterResult<(
-        BoxedOperation<'b, F, PaymentsIncrementalAuthorizationRequest, Ctx>,
+        BoxedOperation<'b, F, PaymentsIncrementalAuthorizationRequest>,
         payments::PaymentData<F>,
     )>
     where
@@ -262,8 +259,7 @@ impl<F: Clone, Ctx: PaymentMethodRetrieve>
     }
 }
 
-impl<F: Send + Clone, Ctx: PaymentMethodRetrieve>
-    ValidateRequest<F, PaymentsIncrementalAuthorizationRequest, Ctx>
+impl<F: Send + Clone> ValidateRequest<F, PaymentsIncrementalAuthorizationRequest>
     for PaymentIncrementalAuthorization
 {
     #[instrument(skip_all)]
@@ -272,7 +268,7 @@ impl<F: Send + Clone, Ctx: PaymentMethodRetrieve>
         request: &PaymentsIncrementalAuthorizationRequest,
         merchant_account: &'a domain::MerchantAccount,
     ) -> RouterResult<(
-        BoxedOperation<'b, F, PaymentsIncrementalAuthorizationRequest, Ctx>,
+        BoxedOperation<'b, F, PaymentsIncrementalAuthorizationRequest>,
         operations::ValidateResult<'a>,
     )> {
         Ok((
@@ -288,8 +284,8 @@ impl<F: Send + Clone, Ctx: PaymentMethodRetrieve>
 }
 
 #[async_trait]
-impl<F: Clone + Send, Ctx: PaymentMethodRetrieve>
-    Domain<F, PaymentsIncrementalAuthorizationRequest, Ctx> for PaymentIncrementalAuthorization
+impl<F: Clone + Send> Domain<F, PaymentsIncrementalAuthorizationRequest>
+    for PaymentIncrementalAuthorization
 {
     #[instrument(skip_all)]
     async fn get_or_create_customer_details<'a>(
@@ -301,7 +297,7 @@ impl<F: Clone + Send, Ctx: PaymentMethodRetrieve>
         _storage_scheme: enums::MerchantStorageScheme,
     ) -> CustomResult<
         (
-            BoxedOperation<'a, F, PaymentsIncrementalAuthorizationRequest, Ctx>,
+            BoxedOperation<'a, F, PaymentsIncrementalAuthorizationRequest>,
             Option<domain::Customer>,
         ),
         errors::StorageError,
@@ -318,7 +314,7 @@ impl<F: Clone + Send, Ctx: PaymentMethodRetrieve>
         _merchant_key_store: &domain::MerchantKeyStore,
         _customer: &Option<domain::Customer>,
     ) -> RouterResult<(
-        BoxedOperation<'a, F, PaymentsIncrementalAuthorizationRequest, Ctx>,
+        BoxedOperation<'a, F, PaymentsIncrementalAuthorizationRequest>,
         Option<api::PaymentMethodData>,
         Option<String>,
     )> {

--- a/crates/router/src/core/payments/retry.rs
+++ b/crates/router/src/core/payments/retry.rs
@@ -11,7 +11,6 @@ use router_env::{
 use crate::{
     core::{
         errors::{self, RouterResult, StorageErrorExt},
-        payment_methods::PaymentMethodRetrieve,
         payments::{
             self,
             flows::{ConstructFlowSpecificData, Feature},
@@ -31,7 +30,7 @@ use crate::{
 
 #[instrument(skip_all)]
 #[allow(clippy::too_many_arguments)]
-pub async fn do_gsm_actions<F, ApiRequest, FData, Ctx>(
+pub async fn do_gsm_actions<F, ApiRequest, FData>(
     state: &app::AppState,
     req_state: ReqState,
     payment_data: &mut payments::PaymentData<F>,
@@ -40,7 +39,7 @@ pub async fn do_gsm_actions<F, ApiRequest, FData, Ctx>(
     mut router_data: types::RouterData<F, FData, types::PaymentsResponseData>,
     merchant_account: &domain::MerchantAccount,
     key_store: &domain::MerchantKeyStore,
-    operation: &operations::BoxedOperation<'_, F, ApiRequest, Ctx>,
+    operation: &operations::BoxedOperation<'_, F, ApiRequest>,
     customer: &Option<domain::Customer>,
     validate_result: &operations::ValidateResult<'_>,
     schedule_time: Option<time::PrimitiveDateTime>,
@@ -49,12 +48,11 @@ pub async fn do_gsm_actions<F, ApiRequest, FData, Ctx>(
 where
     F: Clone + Send + Sync,
     FData: Send + Sync,
-    payments::PaymentResponse: operations::Operation<F, FData, Ctx>,
+    payments::PaymentResponse: operations::Operation<F, FData>,
 
     payments::PaymentData<F>: ConstructFlowSpecificData<F, FData, types::PaymentsResponseData>,
     types::RouterData<F, FData, types::PaymentsResponseData>: Feature<F, FData>,
     dyn api::Connector: services::api::ConnectorIntegration<F, FData, types::PaymentsResponseData>,
-    Ctx: PaymentMethodRetrieve,
 {
     let mut retries = None;
 
@@ -267,11 +265,11 @@ fn get_flow_name<F>() -> RouterResult<String> {
 
 #[allow(clippy::too_many_arguments)]
 #[instrument(skip_all)]
-pub async fn do_retry<F, ApiRequest, FData, Ctx>(
+pub async fn do_retry<F, ApiRequest, FData>(
     state: &routes::AppState,
     req_state: ReqState,
     connector: api::ConnectorData,
-    operation: &operations::BoxedOperation<'_, F, ApiRequest, Ctx>,
+    operation: &operations::BoxedOperation<'_, F, ApiRequest>,
     customer: &Option<domain::Customer>,
     merchant_account: &domain::MerchantAccount,
     key_store: &domain::MerchantKeyStore,
@@ -285,12 +283,11 @@ pub async fn do_retry<F, ApiRequest, FData, Ctx>(
 where
     F: Clone + Send + Sync,
     FData: Send + Sync,
-    payments::PaymentResponse: operations::Operation<F, FData, Ctx>,
+    payments::PaymentResponse: operations::Operation<F, FData>,
 
     payments::PaymentData<F>: ConstructFlowSpecificData<F, FData, types::PaymentsResponseData>,
     types::RouterData<F, FData, types::PaymentsResponseData>: Feature<F, FData>,
     dyn api::Connector: services::api::ConnectorIntegration<F, FData, types::PaymentsResponseData>,
-    Ctx: PaymentMethodRetrieve,
 {
     metrics::AUTO_RETRY_PAYMENT_COUNT.add(&metrics::CONTEXT, 1, &[]);
 

--- a/crates/router/src/core/webhooks.rs
+++ b/crates/router/src/core/webhooks.rs
@@ -30,7 +30,6 @@ use crate::{
     core::{
         api_locking,
         errors::{self, ConnectorErrorExt, CustomResult, RouterResponse},
-        payment_methods::PaymentMethodRetrieve,
         payments, refunds,
     },
     db::StorageInterface,
@@ -59,7 +58,7 @@ use crate::{
 const OUTGOING_WEBHOOK_TIMEOUT_SECS: u64 = 5;
 const MERCHANT_ID: &str = "merchant_id";
 
-pub async fn payments_incoming_webhook_flow<Ctx: PaymentMethodRetrieve>(
+pub async fn payments_incoming_webhook_flow(
     state: AppState,
     req_state: ReqState,
     merchant_account: domain::MerchantAccount,
@@ -102,7 +101,6 @@ pub async fn payments_incoming_webhook_flow<Ctx: PaymentMethodRetrieve>(
                 _,
                 _,
                 _,
-                Ctx,
             >(
                 state.clone(),
                 req_state,
@@ -419,7 +417,7 @@ pub async fn get_or_update_dispute_object(
 }
 
 #[allow(clippy::too_many_arguments)]
-pub async fn external_authentication_incoming_webhook_flow<Ctx: PaymentMethodRetrieve>(
+pub async fn external_authentication_incoming_webhook_flow(
     state: AppState,
     req_state: ReqState,
     merchant_account: domain::MerchantAccount,
@@ -511,7 +509,6 @@ pub async fn external_authentication_incoming_webhook_flow<Ctx: PaymentMethodRet
                     _,
                     _,
                     _,
-                    Ctx,
                 >(
                     state.clone(),
                     req_state,
@@ -752,7 +749,7 @@ pub async fn disputes_incoming_webhook_flow(
     }
 }
 
-async fn bank_transfer_webhook_flow<Ctx: PaymentMethodRetrieve>(
+async fn bank_transfer_webhook_flow(
     state: AppState,
     req_state: ReqState,
     merchant_account: domain::MerchantAccount,
@@ -782,7 +779,6 @@ async fn bank_transfer_webhook_flow<Ctx: PaymentMethodRetrieve>(
             _,
             _,
             _,
-            Ctx,
         >(
             state.clone(),
             req_state,
@@ -1448,7 +1444,7 @@ fn raise_webhooks_analytics_event(
 }
 
 #[allow(clippy::too_many_arguments)]
-pub async fn webhooks_wrapper<W: types::OutgoingWebhookType, Ctx: PaymentMethodRetrieve>(
+pub async fn webhooks_wrapper<W: types::OutgoingWebhookType>(
     flow: &impl router_env::types::FlowMetric,
     state: AppState,
     req_state: ReqState,
@@ -1460,7 +1456,7 @@ pub async fn webhooks_wrapper<W: types::OutgoingWebhookType, Ctx: PaymentMethodR
 ) -> RouterResponse<serde_json::Value> {
     let start_instant = Instant::now();
     let (application_response, webhooks_response_tracker, serialized_req) =
-        Box::pin(webhooks_core::<W, Ctx>(
+        Box::pin(webhooks_core::<W>(
             state.clone(),
             req_state,
             req,
@@ -1513,7 +1509,7 @@ pub async fn webhooks_wrapper<W: types::OutgoingWebhookType, Ctx: PaymentMethodR
 }
 
 #[instrument(skip_all)]
-pub async fn webhooks_core<W: types::OutgoingWebhookType, Ctx: PaymentMethodRetrieve>(
+pub async fn webhooks_core<W: types::OutgoingWebhookType>(
     state: AppState,
     req_state: ReqState,
     req: &actix_web::HttpRequest,
@@ -1750,7 +1746,7 @@ pub async fn webhooks_core<W: types::OutgoingWebhookType, Ctx: PaymentMethodRetr
             })?;
 
         match flow_type {
-            api::WebhookFlow::Payment => Box::pin(payments_incoming_webhook_flow::<Ctx>(
+            api::WebhookFlow::Payment => Box::pin(payments_incoming_webhook_flow(
                 state.clone(),
                 req_state,
                 merchant_account,
@@ -1789,7 +1785,7 @@ pub async fn webhooks_core<W: types::OutgoingWebhookType, Ctx: PaymentMethodRetr
             .await
             .attach_printable("Incoming webhook flow for disputes failed")?,
 
-            api::WebhookFlow::BankTransfer => Box::pin(bank_transfer_webhook_flow::<Ctx>(
+            api::WebhookFlow::BankTransfer => Box::pin(bank_transfer_webhook_flow(
                 state.clone(),
                 req_state,
                 merchant_account,
@@ -1816,7 +1812,7 @@ pub async fn webhooks_core<W: types::OutgoingWebhookType, Ctx: PaymentMethodRetr
             .attach_printable("Incoming webhook flow for mandates failed")?,
 
             api::WebhookFlow::ExternalAuthentication => {
-                Box::pin(external_authentication_incoming_webhook_flow::<Ctx>(
+                Box::pin(external_authentication_incoming_webhook_flow(
                     state.clone(),
                     req_state,
                     merchant_account,

--- a/crates/router/src/routes/webhooks.rs
+++ b/crates/router/src/routes/webhooks.rs
@@ -5,7 +5,6 @@ use super::app::AppState;
 use crate::{
     core::{
         api_locking,
-        payment_methods::Oss,
         webhooks::{self, types},
     },
     services::{api, authentication as auth},
@@ -27,7 +26,7 @@ pub async fn receive_incoming_webhook<W: types::OutgoingWebhookType>(
         &req,
         (),
         |state, auth, _, req_state| {
-            webhooks::webhooks_wrapper::<W, Oss>(
+            webhooks::webhooks_wrapper::<W>(
                 &flow,
                 state.to_owned(),
                 req_state,

--- a/crates/router/src/workflows/outgoing_webhook_retry.rs
+++ b/crates/router/src/workflows/outgoing_webhook_retry.rs
@@ -329,7 +329,6 @@ async fn get_outgoing_webhook_content_and_event_type(
         core::{
             disputes::retrieve_dispute,
             mandate::get_mandate,
-            payment_methods::Oss,
             payments::{payments_core, CallConnectorAction, PaymentStatus},
             refunds::refund_retrieve_core,
         },
@@ -351,7 +350,7 @@ async fn get_outgoing_webhook_content_and_event_type(
             };
 
             let payments_response =
-                match Box::pin(payments_core::<PSync, PaymentsResponse, _, _, _, Oss>(
+                match Box::pin(payments_core::<PSync, PaymentsResponse, _, _, _>(
                     state,
                     req_state,
                     merchant_account,

--- a/crates/router/src/workflows/payment_sync.rs
+++ b/crates/router/src/workflows/payment_sync.rs
@@ -10,7 +10,6 @@ use crate::{
     consts,
     core::{
         errors::StorageErrorExt,
-        payment_methods::Oss,
         payments::{self as payment_flows, operations},
     },
     db::StorageInterface,
@@ -60,14 +59,8 @@ impl ProcessTrackerWorkflow<AppState> for PaymentsSyncWorkflow {
             .await?;
 
         // TODO: Add support for ReqState in PT flows
-        let (mut payment_data, _, customer, _, _) =
-            Box::pin(payment_flows::payments_operation_core::<
-                api::PSync,
-                _,
-                _,
-                _,
-                Oss,
-            >(
+        let (mut payment_data, _, customer, _, _) = Box::pin(
+            payment_flows::payments_operation_core::<api::PSync, _, _, _>(
                 state,
                 state.get_req_state(),
                 merchant_account.clone(),
@@ -78,8 +71,9 @@ impl ProcessTrackerWorkflow<AppState> for PaymentsSyncWorkflow {
                 services::AuthFlow::Client,
                 None,
                 api::HeaderPayload::default(),
-            ))
-            .await?;
+            ),
+        )
+        .await?;
 
         let terminal_status = [
             enums::AttemptStatus::RouterDeclined,

--- a/crates/router/tests/payments.rs
+++ b/crates/router/tests/payments.rs
@@ -4,7 +4,7 @@ mod utils;
 
 use router::{
     configs,
-    core::{payment_methods::Oss, payments},
+    core::payments,
     db::StorageImpl,
     routes, services,
     types::{
@@ -371,7 +371,6 @@ async fn payments_create_core() {
         _,
         _,
         _,
-        Oss,
     >(
         state.clone(),
         state.get_req_state(),
@@ -554,7 +553,6 @@ async fn payments_create_core_adyen_no_redirect() {
         _,
         _,
         _,
-        Oss,
     >(
         state.clone(),
         state.get_req_state(),

--- a/crates/router/tests/payments2.rs
+++ b/crates/router/tests/payments2.rs
@@ -3,7 +3,7 @@
 mod utils;
 
 use router::{
-    core::{payment_methods::Oss, payments},
+    core::payments,
     db::StorageImpl,
     types::api::{self, enums as api_enums},
     *,
@@ -131,7 +131,6 @@ async fn payments_create_core() {
         _,
         _,
         _,
-        Oss,
     >(
         state.clone(),
         state.get_req_state(),
@@ -322,7 +321,6 @@ async fn payments_create_core_adyen_no_redirect() {
         _,
         _,
         _,
-        Oss,
     >(
         state.clone(),
         state.get_req_state(),

--- a/crates/router_derive/src/macros/operation.rs
+++ b/crates/router_derive/src/macros/operation.rs
@@ -40,7 +40,7 @@ impl Derives {
         let req_type = Conversion::get_req_type(self);
         quote! {
             #[automatically_derived]
-            impl<F:Send+Clone,Ctx: PaymentMethodRetrieve,> Operation<F,#req_type,Ctx> for #struct_name {
+            impl<F:Send+Clone> Operation<F,#req_type> for #struct_name {
                 #(#fns)*
             }
         }
@@ -54,7 +54,7 @@ impl Derives {
         let req_type = Conversion::get_req_type(self);
         quote! {
             #[automatically_derived]
-            impl<F:Send+Clone,Ctx: PaymentMethodRetrieve,> Operation<F,#req_type,Ctx> for &#struct_name {
+            impl<F:Send+Clone> Operation<F,#req_type> for &#struct_name {
                 #(#ref_fns)*
             }
         }
@@ -110,22 +110,22 @@ impl Conversion {
         let req_type = Self::get_req_type(ident);
         match self {
             Self::ValidateRequest => quote! {
-                fn to_validate_request(&self) -> RouterResult<&(dyn ValidateRequest<F,#req_type,Ctx> + Send + Sync)> {
+                fn to_validate_request(&self) -> RouterResult<&(dyn ValidateRequest<F,#req_type> + Send + Sync)> {
                     Ok(self)
                 }
             },
             Self::GetTracker => quote! {
-                fn to_get_tracker(&self) -> RouterResult<&(dyn GetTracker<F,PaymentData<F>,#req_type,Ctx> + Send + Sync)> {
+                fn to_get_tracker(&self) -> RouterResult<&(dyn GetTracker<F,PaymentData<F>,#req_type> + Send + Sync)> {
                     Ok(self)
                 }
             },
             Self::Domain => quote! {
-                fn to_domain(&self) -> RouterResult<&dyn Domain<F,#req_type,Ctx>> {
+                fn to_domain(&self) -> RouterResult<&dyn Domain<F,#req_type>> {
                     Ok(self)
                 }
             },
             Self::UpdateTracker => quote! {
-                fn to_update_tracker(&self) -> RouterResult<&(dyn UpdateTracker<F,PaymentData<F>,#req_type,Ctx> + Send + Sync)> {
+                fn to_update_tracker(&self) -> RouterResult<&(dyn UpdateTracker<F,PaymentData<F>,#req_type> + Send + Sync)> {
                     Ok(self)
                 }
             },
@@ -158,22 +158,22 @@ impl Conversion {
         let req_type = Self::get_req_type(ident);
         match self {
             Self::ValidateRequest => quote! {
-                fn to_validate_request(&self) -> RouterResult<&(dyn ValidateRequest<F,#req_type,Ctx> + Send + Sync)> {
+                fn to_validate_request(&self) -> RouterResult<&(dyn ValidateRequest<F,#req_type> + Send + Sync)> {
                     Ok(*self)
                 }
             },
             Self::GetTracker => quote! {
-                fn to_get_tracker(&self) -> RouterResult<&(dyn GetTracker<F,PaymentData<F>,#req_type,Ctx> + Send + Sync)> {
+                fn to_get_tracker(&self) -> RouterResult<&(dyn GetTracker<F,PaymentData<F>,#req_type> + Send + Sync)> {
                     Ok(*self)
                 }
             },
             Self::Domain => quote! {
-                fn to_domain(&self) -> RouterResult<&(dyn Domain<F,#req_type,Ctx>)> {
+                fn to_domain(&self) -> RouterResult<&(dyn Domain<F,#req_type>)> {
                     Ok(*self)
                 }
             },
             Self::UpdateTracker => quote! {
-                fn to_update_tracker(&self) -> RouterResult<&(dyn UpdateTracker<F,PaymentData<F>,#req_type,Ctx> + Send + Sync)> {
+                fn to_update_tracker(&self) -> RouterResult<&(dyn UpdateTracker<F,PaymentData<F>,#req_type> + Send + Sync)> {
                     Ok(*self)
                 }
             },


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
This PR removes the `Ctx` generic being used in payments core as this is not required anymore.
This PR also fixes the failing typos CI check

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
As this PR just removes the `Ctx` generic, basic sanity testing should suffice

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
