### PR TITLE
ci(cypress): Fix card expiry for savecard flows

### DIFF
--- a/cypress-tests/cypress/e2e/ConnectorTest/00003-NoThreeDSAutoCapture.cy.js
+++ b/cypress-tests/cypress/e2e/ConnectorTest/00003-NoThreeDSAutoCapture.cy.js
@@ -24,7 +24,7 @@ describe("Card - NoThreeDS payment flow test", () => {
   context("Card-NoThreeDS payment flow test Create and confirm", () => {
 
     it("create-payment-call-test", () => {
-      let det = getConnectorDetails(globalState.get("connectorId"))["No3DS"];
+      let det = getConnectorDetails(globalState.get("connectorId"))["card_pm"]["No3DS"];
       cy.createPaymentIntentTest(createPaymentBody, det, "no_three_ds", "automatic", globalState);
     });
 
@@ -33,7 +33,7 @@ describe("Card - NoThreeDS payment flow test", () => {
     });
 
     it("Confirm No 3DS", () => {
-      let det = getConnectorDetails(globalState.get("connectorId"))["No3DS"];
+      let det = getConnectorDetails(globalState.get("connectorId"))["card_pm"]["No3DS"];
       cy.confirmCallTest(confirmBody, det, true, globalState);
     });
 
@@ -47,7 +47,7 @@ describe("Card - NoThreeDS payment flow test", () => {
 
     it("create+confirm-payment-call-test", () => {
       console.log("confirm -> " + globalState.get("connectorId"));
-      let det = getConnectorDetails(globalState.get("connectorId"))["No3DS"];
+      let det = getConnectorDetails(globalState.get("connectorId"))["card_pm"]["No3DS"];
       cy.createConfirmPaymentTest(createConfirmPaymentBody, det, "no_three_ds", "automatic", globalState);
     });
 

--- a/cypress-tests/cypress/e2e/ConnectorTest/00004-ThreeDSAutoCapture.cy.js
+++ b/cypress-tests/cypress/e2e/ConnectorTest/00004-ThreeDSAutoCapture.cy.js
@@ -25,7 +25,7 @@ describe("Card - ThreeDS payment flow test", () => {
 
 
   it("create-payment-call-test", () => {
-    let det = getConnectorDetails(globalState.get("connectorId"))["No3DS"];
+    let det = getConnectorDetails(globalState.get("connectorId"))["card_pm"]["No3DS"];
     cy.createPaymentIntentTest(createPaymentBody, det, "three_ds", "automatic", globalState);
   });
 
@@ -35,7 +35,7 @@ describe("Card - ThreeDS payment flow test", () => {
   });
 
   it("Confirm 3DS", () => {
-    let det = getConnectorDetails(globalState.get("connectorId"))["3DS"];
+    let det = getConnectorDetails(globalState.get("connectorId"))["card_pm"]["3DS"];
     cy.task('cli_log', "GLOBAL STATE -> " + JSON.stringify(globalState.data));
     cy.confirmCallTest(confirmBody, det, true, globalState);
   });

--- a/cypress-tests/cypress/e2e/ConnectorTest/00005-NoThreeDSManualCapture.cy.js
+++ b/cypress-tests/cypress/e2e/ConnectorTest/00005-NoThreeDSManualCapture.cy.js
@@ -27,7 +27,7 @@ describe("Card - NoThreeDS Manual payment flow test", () => {
         context("payment Create and Confirm", () => {
 
             it("create-payment-call-test", () => {
-                let det = getConnectorDetails(globalState.get("connectorId"))["No3DS"];
+                let det = getConnectorDetails(globalState.get("connectorId"))["card_pm"]["No3DS"];
                 cy.createPaymentIntentTest(createPaymentBody, det, "no_three_ds", "manual", globalState);
             });
 
@@ -37,7 +37,7 @@ describe("Card - NoThreeDS Manual payment flow test", () => {
 
             it("confirm-call-test", () => {
                 console.log("confirm -> " + globalState.get("connectorId"));
-                let det = getConnectorDetails(globalState.get("connectorId"))["No3DS"];
+                let det = getConnectorDetails(globalState.get("connectorId"))["card_pm"]["No3DS"];
                 console.log("det -> " + det.card);
                 cy.confirmCallTest(confirmBody, det, true, globalState);
             });
@@ -47,7 +47,7 @@ describe("Card - NoThreeDS Manual payment flow test", () => {
             });
 
             it("capture-call-test", () => {
-                let det = getConnectorDetails(globalState.get("connectorId"))["No3DS"];
+                let det = getConnectorDetails(globalState.get("connectorId"))["card_pm"]["No3DS"];
                 console.log("det -> " + det.card);
                 cy.captureCallTest(captureBody, 6500, det.paymentSuccessfulStatus, globalState);
             });
@@ -61,7 +61,7 @@ describe("Card - NoThreeDS Manual payment flow test", () => {
         context("Payment Create+Confirm", () => {
             it("create+confirm-payment-call-test", () => {
                 console.log("confirm -> " + globalState.get("connectorId"));
-                let det = getConnectorDetails(globalState.get("connectorId"))["No3DS"];
+                let det = getConnectorDetails(globalState.get("connectorId"))["card_pm"]["No3DS"];
                 console.log("det -> " + det.card);
                 cy.createConfirmPaymentTest(createConfirmPaymentBody, det, "no_three_ds", "manual", globalState);
             });
@@ -71,7 +71,7 @@ describe("Card - NoThreeDS Manual payment flow test", () => {
             });
 
             it("capture-call-test", () => {
-                let det = getConnectorDetails(globalState.get("connectorId"))["No3DS"];
+                let det = getConnectorDetails(globalState.get("connectorId"))["card_pm"]["No3DS"];
                 console.log("det -> " + det.card);
                 cy.captureCallTest(captureBody, 6540, det.paymentSuccessfulStatus, globalState);
             });
@@ -89,7 +89,7 @@ describe("Card - NoThreeDS Manual payment flow test", () => {
         context("payment Create and Payment Confirm", () => {
 
             it("create-payment-call-test", () => {
-                let det = getConnectorDetails(globalState.get("connectorId"))["No3DS"];
+                let det = getConnectorDetails(globalState.get("connectorId"))["card_pm"]["No3DS"];
                 cy.createPaymentIntentTest(createPaymentBody, det, "no_three_ds", "manual", globalState);
             });
 
@@ -99,7 +99,7 @@ describe("Card - NoThreeDS Manual payment flow test", () => {
 
             it("confirm-call-test", () => {
                 console.log("confirm -> " + globalState.get("connectorId"));
-                let det = getConnectorDetails(globalState.get("connectorId"))["No3DS"];
+                let det = getConnectorDetails(globalState.get("connectorId"))["card_pm"]["No3DS"];
                 console.log("det -> " + det.card);
                 cy.confirmCallTest(confirmBody, det, true, globalState);
             });
@@ -109,7 +109,7 @@ describe("Card - NoThreeDS Manual payment flow test", () => {
             });
 
             it("capture-call-test", () => {
-                let det = getConnectorDetails(globalState.get("connectorId"))["No3DS"];
+                let det = getConnectorDetails(globalState.get("connectorId"))["card_pm"]["No3DS"];
                 cy.captureCallTest(captureBody, 100, det.paymentSuccessfulStatus, globalState);
             });
 
@@ -121,7 +121,7 @@ describe("Card - NoThreeDS Manual payment flow test", () => {
         context("payment + Confirm", () => {
             it("create+confirm-payment-call-test", () => {
                 console.log("confirm -> " + globalState.get("connectorId"));
-                let det = getConnectorDetails(globalState.get("connectorId"))["No3DS"];
+                let det = getConnectorDetails(globalState.get("connectorId"))["card_pm"]["No3DS"];
                 console.log("det -> " + det.card);
                 cy.createConfirmPaymentTest(createConfirmPaymentBody, det, "no_three_ds", "manual", globalState);
             });
@@ -131,7 +131,7 @@ describe("Card - NoThreeDS Manual payment flow test", () => {
             });
 
             it("capture-call-test", () => {
-                let det = getConnectorDetails(globalState.get("connectorId"))["No3DS"];
+                let det = getConnectorDetails(globalState.get("connectorId"))["card_pm"]["No3DS"];
                 console.log("det -> " + det.card);
                 cy.captureCallTest(captureBody, 5000, det.paymentSuccessfulStatus, globalState);
             });

--- a/cypress-tests/cypress/e2e/ConnectorTest/00006-VoidPayment.cy.js
+++ b/cypress-tests/cypress/e2e/ConnectorTest/00006-VoidPayment.cy.js
@@ -23,7 +23,7 @@ describe("Card - NoThreeDS Manual payment flow test", () => {
 
     context("Card - void payment in Requires_capture state flow test", () => {
         it("create-payment-call-test", () => {
-            let det = getConnectorDetails(globalState.get("connectorId"))["No3DS"];
+            let det = getConnectorDetails(globalState.get("connectorId"))["card_pm"]["No3DS"];
             cy.createPaymentIntentTest(createPaymentBody, det, "no_three_ds", "manual", globalState);
         });
 
@@ -33,7 +33,7 @@ describe("Card - NoThreeDS Manual payment flow test", () => {
 
         it("confirm-call-test", () => {
             console.log("confirm -> " + globalState.get("connectorId"));
-            let det = getConnectorDetails(globalState.get("connectorId"))["No3DS"];
+            let det = getConnectorDetails(globalState.get("connectorId"))["card_pm"]["No3DS"];
             console.log("det -> " + det.card);
             cy.confirmCallTest(confirmBody, det, true, globalState);
         });
@@ -45,7 +45,7 @@ describe("Card - NoThreeDS Manual payment flow test", () => {
 
     context("Card - void payment in Requires_payment_method state flow test", () => {
         it("create-payment-call-test", () => {
-            let det = getConnectorDetails(globalState.get("connectorId"))["No3DS"];
+            let det = getConnectorDetails(globalState.get("connectorId"))["card_pm"]["No3DS"];
             cy.createPaymentIntentTest(createPaymentBody, det, "no_three_ds", "manual", globalState);
         });
 
@@ -60,7 +60,7 @@ describe("Card - NoThreeDS Manual payment flow test", () => {
 
     context("Card - void payment in Requires_payment_method state flow test", () => {
         it("create-payment-call-test", () => {
-            let det = getConnectorDetails(globalState.get("connectorId"))["No3DS"];
+            let det = getConnectorDetails(globalState.get("connectorId"))["card_pm"]["No3DS"];
             cy.createPaymentIntentTest(createPaymentBody, det, "no_three_ds", "manual", globalState);
         });
 
@@ -70,7 +70,7 @@ describe("Card - NoThreeDS Manual payment flow test", () => {
 
         it("confirm-call-test", () => {
             console.log("confirm -> " + globalState.get("connectorId"));
-            let det = getConnectorDetails(globalState.get("connectorId"))["No3DS"];
+            let det = getConnectorDetails(globalState.get("connectorId"))["card_pm"]["No3DS"];
             console.log("det -> " + det.card);
             cy.confirmCallTest(confirmBody, det, false, globalState);
         });

--- a/cypress-tests/cypress/e2e/ConnectorTest/00007-SyncPayment.cy.js
+++ b/cypress-tests/cypress/e2e/ConnectorTest/00007-SyncPayment.cy.js
@@ -20,7 +20,7 @@ describe("Card - Sync payment flow test", () => {
     cy.task('setGlobalState', globalState.data);
   })
   it("create-payment-call-test", () => {
-    let det = getConnectorDetails(globalState.get("connectorId"))["No3DS"];
+    let det = getConnectorDetails(globalState.get("connectorId"))["card_pm"]["No3DS"];
     cy.createPaymentIntentTest(createPaymentBody, det, "no_three_ds", "automatic", globalState);
   });
 
@@ -30,7 +30,7 @@ describe("Card - Sync payment flow test", () => {
 
   it("confirm-call-test", () => {
     console.log("confirm -> " + globalState.get("connectorId"));
-    let det = getConnectorDetails(globalState.get("connectorId"))["No3DS"];
+    let det = getConnectorDetails(globalState.get("connectorId"))["card_pm"]["No3DS"];
     console.log("det -> " + det.card);
     cy.confirmCallTest(confirmBody, det, true, globalState);
   });

--- a/cypress-tests/cypress/e2e/ConnectorTest/00008-RefundPayment.cy.js
+++ b/cypress-tests/cypress/e2e/ConnectorTest/00008-RefundPayment.cy.js
@@ -29,7 +29,7 @@ describe("Card - Refund flow test", () => {
     context("Card - Full Refund flow test for No-3DS", () => {
 
         it("create-payment-call-test", () => {
-            let det = getConnectorDetails(globalState.get("connectorId"))["No3DS"];
+            let det = getConnectorDetails(globalState.get("connectorId"))["card_pm"]["No3DS"];
             cy.createPaymentIntentTest(createPaymentBody, det, "no_three_ds", "automatic", globalState);
         });
 
@@ -39,7 +39,7 @@ describe("Card - Refund flow test", () => {
 
         it("confirm-call-test", () => {
             console.log("confirm -> " + globalState.get("connectorId"));
-            let det = getConnectorDetails(globalState.get("connectorId"))["No3DS"];
+            let det = getConnectorDetails(globalState.get("connectorId"))["card_pm"]["No3DS"];
             console.log("det -> " + det.card);
             cy.confirmCallTest(confirmBody, det, true, globalState);
         });
@@ -49,7 +49,7 @@ describe("Card - Refund flow test", () => {
         });
 
         it("refund-call-test", () => {
-            let det = getConnectorDetails(globalState.get("connectorId"))["No3DS"];
+            let det = getConnectorDetails(globalState.get("connectorId"))["card_pm"]["No3DS"];
             cy.refundCallTest(refundBody, 6500, det, globalState);
         });
     });
@@ -57,7 +57,7 @@ describe("Card - Refund flow test", () => {
     context("Card - Partial Refund flow test for No-3DS", () => {
 
         it("create-payment-call-test", () => {
-            let det = getConnectorDetails(globalState.get("connectorId"))["No3DS"];
+            let det = getConnectorDetails(globalState.get("connectorId"))["card_pm"]["No3DS"];
             cy.createPaymentIntentTest(createPaymentBody, det, "no_three_ds", "automatic", globalState);
         });
 
@@ -67,7 +67,7 @@ describe("Card - Refund flow test", () => {
 
         it("confirm-call-test", () => {
             console.log("confirm -> " + globalState.get("connectorId"));
-            let det = getConnectorDetails(globalState.get("connectorId"))["No3DS"];
+            let det = getConnectorDetails(globalState.get("connectorId"))["card_pm"]["No3DS"];
             console.log("det -> " + det.card);
             cy.confirmCallTest(confirmBody, det, true, globalState);
         });
@@ -77,12 +77,12 @@ describe("Card - Refund flow test", () => {
         });
 
         it("refund-call-test", () => {
-            let det = getConnectorDetails(globalState.get("connectorId"))["No3DS"];
+            let det = getConnectorDetails(globalState.get("connectorId"))["card_pm"]["No3DS"];
             cy.refundCallTest(refundBody, 1200, det, globalState);
         });
 
         it("refund-call-test", () => {
-            let det = getConnectorDetails(globalState.get("connectorId"))["No3DS"];
+            let det = getConnectorDetails(globalState.get("connectorId"))["card_pm"]["No3DS"];
             cy.refundCallTest(refundBody, 1200, det, globalState);
         });
     });
@@ -90,9 +90,9 @@ describe("Card - Refund flow test", () => {
     context("Fully Refund Card-NoThreeDS payment flow test Create+Confirm", () => {
 
         it("create+confirm-payment-call-test", () => {
-            console.log("confirm -> " + globalState.get("connectorId"));
-            let det = getConnectorDetails(globalState.get("connectorId"))["No3DS"];
-            cy.createConfirmPaymentTest(createConfirmPaymentBody, det, "no_three_ds", "automatic", globalState);
+          console.log("confirm -> " + globalState.get("connectorId"));
+          let det = getConnectorDetails(globalState.get("connectorId"))["card_pm"]["No3DS"];
+          cy.createConfirmPaymentTest( createConfirmPaymentBody, det,"no_three_ds", "automatic", globalState);
         });
 
         it("retrieve-payment-call-test", () => {
@@ -100,7 +100,7 @@ describe("Card - Refund flow test", () => {
         });
 
         it("refund-call-test", () => {
-            let det = getConnectorDetails(globalState.get("connectorId"))["No3DS"];
+            let det = getConnectorDetails(globalState.get("connectorId"))["card_pm"]["No3DS"];
             cy.refundCallTest(refundBody, 6540, det, globalState);
         });
 
@@ -109,9 +109,9 @@ describe("Card - Refund flow test", () => {
     context("Partially Refund Card-NoThreeDS payment flow test Create+Confirm", () => {
 
         it("create+confirm-payment-call-test", () => {
-            console.log("confirm -> " + globalState.get("connectorId"));
-            let det = getConnectorDetails(globalState.get("connectorId"))["No3DS"];
-            cy.createConfirmPaymentTest(createConfirmPaymentBody, det, "no_three_ds", "automatic", globalState);
+          console.log("confirm -> " + globalState.get("connectorId"));
+          let det = getConnectorDetails(globalState.get("connectorId"))["card_pm"]["No3DS"];
+          cy.createConfirmPaymentTest( createConfirmPaymentBody, det,"no_three_ds", "automatic", globalState);
         });
 
         it("retrieve-payment-call-test", () => {
@@ -119,17 +119,17 @@ describe("Card - Refund flow test", () => {
         });
 
         it("refund-call-test", () => {
-            let det = getConnectorDetails(globalState.get("connectorId"))["No3DS"];
+            let det = getConnectorDetails(globalState.get("connectorId"))["card_pm"]["No3DS"];
             cy.refundCallTest(refundBody, 3000, det, globalState);
         });
 
         it("refund-call-test", () => {
-            let det = getConnectorDetails(globalState.get("connectorId"))["No3DS"];
+            let det = getConnectorDetails(globalState.get("connectorId"))["card_pm"]["No3DS"];
             cy.refundCallTest(refundBody, 3000, det, globalState);
         });
 
         it("sync-refund-call-test", () => {
-            let det = getConnectorDetails(globalState.get("connectorId"))["No3DS"];
+            let det = getConnectorDetails(globalState.get("connectorId"))["card_pm"]["No3DS"];
             cy.syncRefundCallTest(det, globalState);
         });
 
@@ -138,7 +138,7 @@ describe("Card - Refund flow test", () => {
     context("Card - Full Refund for fully captured No-3DS payment", () => {
 
         it("create-payment-call-test", () => {
-            let det = getConnectorDetails(globalState.get("connectorId"))["No3DS"];
+            let det = getConnectorDetails(globalState.get("connectorId"))["card_pm"]["No3DS"];
             cy.createPaymentIntentTest(createPaymentBody, det, "no_three_ds", "manual", globalState);
         });
 
@@ -148,7 +148,7 @@ describe("Card - Refund flow test", () => {
 
         it("confirm-call-test", () => {
             console.log("confirm -> " + globalState.get("connectorId"));
-            let det = getConnectorDetails(globalState.get("connectorId"))["No3DS"];
+            let det = getConnectorDetails(globalState.get("connectorId"))["card_pm"]["No3DS"];
             console.log("det -> " + det.card);
             cy.confirmCallTest(confirmBody, det, true, globalState);
         });
@@ -158,7 +158,7 @@ describe("Card - Refund flow test", () => {
         });
 
         it("capture-call-test", () => {
-            let det = getConnectorDetails(globalState.get("connectorId"))["No3DS"];
+            let det = getConnectorDetails(globalState.get("connectorId"))["card_pm"]["No3DS"];
             console.log("det -> " + det.card);
             cy.captureCallTest(captureBody, 6500, det.paymentSuccessfulStatus, globalState);
         });
@@ -168,12 +168,12 @@ describe("Card - Refund flow test", () => {
         });
 
         it("refund-call-test", () => {
-            let det = getConnectorDetails(globalState.get("connectorId"))["No3DS"];
+            let det = getConnectorDetails(globalState.get("connectorId"))["card_pm"]["No3DS"];
             cy.refundCallTest(refundBody, 6500, det, globalState);
         });
 
         it("sync-refund-call-test", () => {
-            let det = getConnectorDetails(globalState.get("connectorId"))["No3DS"];
+            let det = getConnectorDetails(globalState.get("connectorId"))["card_pm"]["No3DS"];
             cy.syncRefundCallTest(det, globalState);
         });
     });
@@ -181,7 +181,7 @@ describe("Card - Refund flow test", () => {
     context("Card - Partial Refund for fully captured No-3DS payment", () => {
 
         it("create-payment-call-test", () => {
-            let det = getConnectorDetails(globalState.get("connectorId"))["No3DS"];
+            let det = getConnectorDetails(globalState.get("connectorId"))["card_pm"]["No3DS"];
             cy.createPaymentIntentTest(createPaymentBody, det, "no_three_ds", "manual", globalState);
         });
 
@@ -191,7 +191,7 @@ describe("Card - Refund flow test", () => {
 
         it("confirm-call-test", () => {
             console.log("confirm -> " + globalState.get("connectorId"));
-            let det = getConnectorDetails(globalState.get("connectorId"))["No3DS"];
+            let det = getConnectorDetails(globalState.get("connectorId"))["card_pm"]["No3DS"];
             console.log("det -> " + det.card);
             cy.confirmCallTest(confirmBody, det, true, globalState);
         });
@@ -201,7 +201,7 @@ describe("Card - Refund flow test", () => {
         });
 
         it("capture-call-test", () => {
-            let det = getConnectorDetails(globalState.get("connectorId"))["No3DS"];
+            let det = getConnectorDetails(globalState.get("connectorId"))["card_pm"]["No3DS"];
             console.log("det -> " + det.card);
             cy.captureCallTest(captureBody, 6500, det.paymentSuccessfulStatus, globalState);
         });
@@ -211,16 +211,16 @@ describe("Card - Refund flow test", () => {
         });
 
         it("refund-call-test", () => {
-            let det = getConnectorDetails(globalState.get("connectorId"))["No3DS"];
+            let det = getConnectorDetails(globalState.get("connectorId"))["card_pm"]["No3DS"];
             cy.refundCallTest(refundBody, 5000, det, globalState);
         });
         it("refund-call-test", () => {
-            let det = getConnectorDetails(globalState.get("connectorId"))["No3DS"];
+            let det = getConnectorDetails(globalState.get("connectorId"))["card_pm"]["No3DS"];
             cy.refundCallTest(refundBody, 500, det, globalState);
         });
 
         it("sync-refund-call-test", () => {
-            let det = getConnectorDetails(globalState.get("connectorId"))["No3DS"];
+            let det = getConnectorDetails(globalState.get("connectorId"))["card_pm"]["No3DS"];
             cy.syncRefundCallTest(det, globalState);
         });
         it("list-refund-call-test", () => {
@@ -231,7 +231,7 @@ describe("Card - Refund flow test", () => {
     context("Card - Full Refund for partially captured No-3DS payment", () => {
 
         it("create-payment-call-test", () => {
-            let det = getConnectorDetails(globalState.get("connectorId"))["No3DS"];
+            let det = getConnectorDetails(globalState.get("connectorId"))["card_pm"]["No3DS"];
             cy.createPaymentIntentTest(createPaymentBody, det, "no_three_ds", "manual", globalState);
         });
 
@@ -241,7 +241,7 @@ describe("Card - Refund flow test", () => {
 
         it("confirm-call-test", () => {
             console.log("confirm -> " + globalState.get("connectorId"));
-            let det = getConnectorDetails(globalState.get("connectorId"))["No3DS"];
+            let det = getConnectorDetails(globalState.get("connectorId"))["card_pm"]["No3DS"];
             console.log("det -> " + det.card);
             cy.confirmCallTest(confirmBody, det, true, globalState);
         });
@@ -251,7 +251,7 @@ describe("Card - Refund flow test", () => {
         });
 
         it("capture-call-test", () => {
-            let det = getConnectorDetails(globalState.get("connectorId"))["No3DS"];
+            let det = getConnectorDetails(globalState.get("connectorId"))["card_pm"]["No3DS"];
             console.log("det -> " + det.card);
             cy.captureCallTest(captureBody, 4000, det.paymentSuccessfulStatus, globalState);
         });
@@ -261,12 +261,12 @@ describe("Card - Refund flow test", () => {
         });
 
         it("refund-call-test", () => {
-            let det = getConnectorDetails(globalState.get("connectorId"))["No3DS"];
+            let det = getConnectorDetails(globalState.get("connectorId"))["card_pm"]["No3DS"];
             cy.refundCallTest(refundBody, 4000, det, globalState);
         });
 
         it("sync-refund-call-test", () => {
-            let det = getConnectorDetails(globalState.get("connectorId"))["No3DS"];
+            let det = getConnectorDetails(globalState.get("connectorId"))["card_pm"]["No3DS"];
             cy.syncRefundCallTest(det, globalState);
         });
     });
@@ -274,7 +274,7 @@ describe("Card - Refund flow test", () => {
     context("Card - partial Refund for partially captured No-3DS payment", () => {
 
         it("create-payment-call-test", () => {
-            let det = getConnectorDetails(globalState.get("connectorId"))["No3DS"];
+            let det = getConnectorDetails(globalState.get("connectorId"))["card_pm"]["No3DS"];
             cy.createPaymentIntentTest(createPaymentBody, det, "no_three_ds", "manual", globalState);
         });
 
@@ -284,7 +284,7 @@ describe("Card - Refund flow test", () => {
 
         it("confirm-call-test", () => {
             console.log("confirm -> " + globalState.get("connectorId"));
-            let det = getConnectorDetails(globalState.get("connectorId"))["No3DS"];
+            let det = getConnectorDetails(globalState.get("connectorId"))["card_pm"]["No3DS"];
             console.log("det -> " + det.card);
             cy.confirmCallTest(confirmBody, det, true, globalState);
         });
@@ -294,7 +294,7 @@ describe("Card - Refund flow test", () => {
         });
 
         it("capture-call-test", () => {
-            let det = getConnectorDetails(globalState.get("connectorId"))["No3DS"];
+            let det = getConnectorDetails(globalState.get("connectorId"))["card_pm"]["No3DS"];
             console.log("det -> " + det.card);
             cy.captureCallTest(captureBody, 4000, det.paymentSuccessfulStatus, globalState);
         });
@@ -304,12 +304,12 @@ describe("Card - Refund flow test", () => {
         });
 
         it("refund-call-test", () => {
-            let det = getConnectorDetails(globalState.get("connectorId"))["No3DS"];
+            let det = getConnectorDetails(globalState.get("connectorId"))["card_pm"]["No3DS"];
             cy.refundCallTest(refundBody, 3000, det, globalState);
         });
 
         it("sync-refund-call-test", () => {
-            let det = getConnectorDetails(globalState.get("connectorId"))["No3DS"];
+            let det = getConnectorDetails(globalState.get("connectorId"))["card_pm"]["No3DS"];
             cy.syncRefundCallTest(det, globalState);
         });
     });
@@ -317,7 +317,7 @@ describe("Card - Refund flow test", () => {
     context("Card - Full Refund for Create + Confirm Automatic CIT and MIT payment flow test", () => {
 
         it("Confirm No 3DS CIT", () => {
-            let det = getConnectorDetails(globalState.get("connectorId"))["MandateMultiUseNo3DS"];
+            let det = getConnectorDetails(globalState.get("connectorId"))["card_pm"]["MandateMultiUseNo3DS"];
             console.log("det -> " + det.card);
             cy.citForMandatesCallTest(citConfirmBody, 7000, det, true, "automatic", "new_mandate", globalState);
         });
@@ -331,13 +331,13 @@ describe("Card - Refund flow test", () => {
         });
 
         it("refund-call-test", () => {
-            let det = getConnectorDetails(globalState.get("connectorId"))["No3DS"];
+            let det = getConnectorDetails(globalState.get("connectorId"))["card_pm"]["MandateMultiUseNo3DS"];
             cy.refundCallTest(refundBody, 7000, det, globalState);
         });
 
         it("sync-refund-call-test", () => {
-            let det = getConnectorDetails(globalState.get("connectorId"))["No3DS"];
-            cy.syncRefundCallTest(det, globalState);
+        let det = getConnectorDetails(globalState.get("connectorId"))["card_pm"]["MandateMultiUseNo3DS"];
+        cy.syncRefundCallTest(det, globalState);
         });
     });
 

--- a/cypress-tests/cypress/e2e/ConnectorTest/00009-SyncRefund.cy.js
+++ b/cypress-tests/cypress/e2e/ConnectorTest/00009-SyncRefund.cy.js
@@ -22,7 +22,7 @@ describe("Card - Sync Refund flow test", () => {
     })
 
     it("create-payment-call-test", () => {
-        let det = getConnectorDetails(globalState.get("connectorId"))["No3DS"];
+        let det = getConnectorDetails(globalState.get("connectorId"))["card_pm"]["No3DS"];
         cy.createPaymentIntentTest(createPaymentBody, det, "no_three_ds", "automatic", globalState);
     });
 
@@ -32,7 +32,7 @@ describe("Card - Sync Refund flow test", () => {
 
     it("confirm-call-test", () => {
         console.log("confirm -> " + globalState.get("connectorId"));
-        let det = getConnectorDetails(globalState.get("connectorId"))["No3DS"];
+        let det = getConnectorDetails(globalState.get("connectorId"))["card_pm"]["No3DS"];
         console.log("det -> " + det.card);
         cy.confirmCallTest(confirmBody, det, true, globalState);
     });
@@ -42,12 +42,12 @@ describe("Card - Sync Refund flow test", () => {
     });
 
     it("refund-call-test", () => {
-        let det = getConnectorDetails(globalState.get("connectorId"))["No3DS"];
+        let det = getConnectorDetails(globalState.get("connectorId"))["card_pm"]["No3DS"];
         cy.refundCallTest(refundBody, 6500, det, globalState);
     });
 
     it("sync-refund-call-test", () => {
-        let det = getConnectorDetails(globalState.get("connectorId"))["No3DS"];
+        let det = getConnectorDetails(globalState.get("connectorId"))["card_pm"]["No3DS"];
         cy.syncRefundCallTest(det, globalState);
     });
 

--- a/cypress-tests/cypress/e2e/ConnectorTest/00010-CreateSingleuseMandate.cy.js
+++ b/cypress-tests/cypress/e2e/ConnectorTest/00010-CreateSingleuseMandate.cy.js
@@ -25,7 +25,7 @@ describe("Card - SingleUse Mandates flow test", () => {
 
         it("Confirm No 3DS CIT", () => {
             console.log("confirm -> " + globalState.get("connectorId"));
-            let det = getConnectorDetails(globalState.get("connectorId"))["MandateSingleUseNo3DS"];
+            let det = getConnectorDetails(globalState.get("connectorId"))["card_pm"]["MandateSingleUseNo3DS"];
             console.log("det -> " + det.card);
             cy.citForMandatesCallTest(citConfirmBody, 7000, det, true, "automatic", "new_mandate", globalState);
         });
@@ -39,13 +39,13 @@ describe("Card - SingleUse Mandates flow test", () => {
 
         it("Confirm No 3DS CIT", () => {
             console.log("confirm -> " + globalState.get("connectorId"));
-            let det = getConnectorDetails(globalState.get("connectorId"))["MandateSingleUseNo3DS"];
+            let det = getConnectorDetails(globalState.get("connectorId"))["card_pm"]["MandateSingleUseNo3DS"];
             console.log("det -> " + det.card);
             cy.citForMandatesCallTest(citConfirmBody, 7000, det, true, "manual", "new_mandate", globalState);
         });
 
         it("cit-capture-call-test", () => {
-            let det = getConnectorDetails(globalState.get("connectorId"))["MandateSingleUseNo3DS"];
+            let det = getConnectorDetails(globalState.get("connectorId"))["card_pm"]["MandateSingleUseNo3DS"];
             console.log("det -> " + det.card);
             cy.captureCallTest(captureBody, 7000, det.paymentSuccessfulStatus, globalState);
         });
@@ -55,7 +55,7 @@ describe("Card - SingleUse Mandates flow test", () => {
         });
 
         it("mit-capture-call-test", () => {
-            let det = getConnectorDetails(globalState.get("connectorId"))["MandateSingleUseNo3DS"];
+            let det = getConnectorDetails(globalState.get("connectorId"))["card_pm"]["MandateSingleUseNo3DS"];
             console.log("det -> " + det.card);
             cy.captureCallTest(captureBody, 7000, det.paymentSuccessfulStatus, globalState);
         });
@@ -69,13 +69,13 @@ describe("Card - SingleUse Mandates flow test", () => {
 
         it("Confirm No 3DS CIT", () => {
             console.log("confirm -> " + globalState.get("connectorId"));
-            let det = getConnectorDetails(globalState.get("connectorId"))["MandateSingleUse3DS"];
+            let det = getConnectorDetails(globalState.get("connectorId"))["card_pm"]["MandateSingleUse3DS"];
             console.log("det -> " + det.card);
             cy.citForMandatesCallTest(citConfirmBody, 6500, det, true, "automatic", "new_mandate", globalState);
         });
 
         it("cit-capture-call-test", () => {
-            let det = getConnectorDetails(globalState.get("connectorId"))["MandateSingleUse3DS"];
+            let det = getConnectorDetails(globalState.get("connectorId"))["card_pm"]["MandateSingleUse3DS"];
             console.log("det -> " + det.card);
             cy.captureCallTest(captureBody, 6500, det.paymentSuccessfulStatus, globalState);
         });

--- a/cypress-tests/cypress/e2e/ConnectorTest/00011-CreateMultiuseMandate.cy.js
+++ b/cypress-tests/cypress/e2e/ConnectorTest/00011-CreateMultiuseMandate.cy.js
@@ -26,7 +26,7 @@ describe("Card - MultiUse Mandates flow test", () => {
 
         it("Confirm No 3DS CIT", () => {
             console.log("confirm -> " + globalState.get("connectorId"));
-            let det = getConnectorDetails(globalState.get("connectorId"))["MandateMultiUseNo3DS"];
+            let det = getConnectorDetails(globalState.get("connectorId"))["card_pm"]["MandateMultiUseNo3DS"];
             console.log("det -> " + det.card);
             cy.citForMandatesCallTest(citConfirmBody, 7000, det, true, "automatic", "new_mandate", globalState);
         });
@@ -43,13 +43,13 @@ describe("Card - MultiUse Mandates flow test", () => {
 
         it("Confirm No 3DS CIT", () => {
             console.log("confirm -> " + globalState.get("connectorId"));
-            let det = getConnectorDetails(globalState.get("connectorId"))["MandateMultiUseNo3DS"];
+            let det = getConnectorDetails(globalState.get("connectorId"))["card_pm"]["MandateMultiUseNo3DS"];
             console.log("det -> " + det.card);
             cy.citForMandatesCallTest(citConfirmBody, 7000, det, true, "manual", "new_mandate", globalState);
         });
 
         it("cit-capture-call-test", () => {
-            let det = getConnectorDetails(globalState.get("connectorId"))["MandateMultiUseNo3DS"];
+            let det = getConnectorDetails(globalState.get("connectorId"))["card_pm"]["MandateMultiUseNo3DS"];
             console.log("det -> " + det.card);
             cy.captureCallTest(captureBody, 7000, det.paymentSuccessfulStatus, globalState);
         });
@@ -59,7 +59,7 @@ describe("Card - MultiUse Mandates flow test", () => {
         });
 
         it("mit-capture-call-test", () => {
-            let det = getConnectorDetails(globalState.get("connectorId"))["MandateMultiUseNo3DS"];
+            let det = getConnectorDetails(globalState.get("connectorId"))["card_pm"]["MandateMultiUseNo3DS"];
             console.log("det -> " + det.card);
             cy.captureCallTest(captureBody, 7000, det.paymentSuccessfulStatus, globalState);
         });
@@ -69,7 +69,7 @@ describe("Card - MultiUse Mandates flow test", () => {
         });
 
         it("mit-capture-call-test", () => {
-            let det = getConnectorDetails(globalState.get("connectorId"))["MandateMultiUseNo3DS"];
+            let det = getConnectorDetails(globalState.get("connectorId"))["card_pm"]["MandateMultiUseNo3DS"];
             console.log("det -> " + det.card);
             cy.captureCallTest(captureBody, 7000, det.paymentSuccessfulStatus, globalState);
         });
@@ -79,13 +79,13 @@ describe("Card - MultiUse Mandates flow test", () => {
 
         it("Confirm No 3DS CIT", () => {
             console.log("confirm -> " + globalState.get("connectorId"));
-            let det = getConnectorDetails(globalState.get("connectorId"))["MandateMultiUse3DS"];
+            let det = getConnectorDetails(globalState.get("connectorId"))["card_pm"]["MandateMultiUse3DS"];
             console.log("det -> " + det.card);
             cy.citForMandatesCallTest(citConfirmBody, 6500, det, true, "automatic", "new_mandate", globalState);
         });
 
         it("cit-capture-call-test", () => {
-            let det = getConnectorDetails(globalState.get("connectorId"))["MandateMultiUse3DS"];
+            let det = getConnectorDetails(globalState.get("connectorId"))["card_pm"]["MandateMultiUse3DS"];
             console.log("det -> " + det.card);
             cy.captureCallTest(captureBody, 6500, det.paymentSuccessfulStatus, globalState);
         });

--- a/cypress-tests/cypress/e2e/ConnectorTest/00012-ListAndRevokeMandate.cy.js
+++ b/cypress-tests/cypress/e2e/ConnectorTest/00012-ListAndRevokeMandate.cy.js
@@ -25,7 +25,7 @@ describe("Card - SingleUse Mandates flow test", () => {
 
         it("Confirm No 3DS CIT", () => {
             console.log("confirm -> " + globalState.get("connectorId"));
-            let det = getConnectorDetails(globalState.get("connectorId"))["MandateSingleUseNo3DS"];
+            let det = getConnectorDetails(globalState.get("connectorId"))["card_pm"]["MandateSingleUseNo3DS"];
             console.log("det -> " + det.card);
             cy.citForMandatesCallTest(citConfirmBody, 7000, det, true, "automatic", "new_mandate", globalState);
         });

--- a/cypress-tests/cypress/e2e/ConnectorTest/00013-SaveCardFlow.cy.js
+++ b/cypress-tests/cypress/e2e/ConnectorTest/00013-SaveCardFlow.cy.js
@@ -1,10 +1,11 @@
 import captureBody from "../../fixtures/capture-flow-body.json";
 import confirmBody from "../../fixtures/confirm-body.json";
+import createPaymentBody from "../../fixtures/create-payment-body.json";
 import createConfirmPaymentBody from "../../fixtures/create-confirm-body.json";
 import customerCreateBody from "../../fixtures/create-customer-body.json";
-import createPaymentBody from "../../fixtures/create-payment-body.json";
-import State from "../../utils/State";
+import SaveCardConfirmBody from "../../fixtures/save-card-confirm-body.json";
 import getConnectorDetails from "../ConnectorUtils/utils";
+import State from "../../utils/State";
 let globalState;
 
 describe("Card - SaveCard payment flow test", () => {
@@ -17,110 +18,106 @@ describe("Card - SaveCard payment flow test", () => {
     })
   })
 
-  after("flush global state", () => {
-    console.log("flushing globalState -> " + JSON.stringify(globalState));
-    cy.task('setGlobalState', globalState.data);
-  })
+  
+    context("Save card for NoThreeDS automatic capture payment- Create+Confirm", () => {
+      it("customer-create-call-test", () => {
+            cy.createCustomerCallTest(customerCreateBody, globalState); 
+      });
+  
+      it("create+confirm-payment-call-test", () => {
+        let det = getConnectorDetails(globalState.get("connectorId"))["card_pm"]["SaveCardUseNo3DS"];
+        cy.createConfirmPaymentTest( createConfirmPaymentBody, det,"no_three_ds", "automatic", globalState);
+      });
+  
+      it("retrieve-payment-call-test", () => {  
+        cy.retrievePaymentCallTest(globalState);
+      });
+       
+      it("retrieve-customerPM-call-test", () => {
+        cy.listCustomerPMCallTest(globalState);
+      });
 
+      it("create-payment-call-test", () => {
+        let det = getConnectorDetails(globalState.get("connectorId"))["card_pm"]["SaveCardUseNo3DS"];
+        cy.createPaymentIntentTest( createPaymentBody, det, "no_three_ds", "automatic", globalState);
+      });
 
-  context("Save card for NoThreeDS automatic capture payment- Create+Confirm", () => {
-    it("customer-create-call-test", () => {
-      cy.createCustomerCallTest(customerCreateBody, globalState);
+      it ("confirm-save-card-payment-call-test", () => {
+        let det = getConnectorDetails(globalState.get("connectorId"))["card_pm"]["SaveCardUseNo3DS"];
+        cy.saveCardConfirmCallTest(SaveCardConfirmBody,det,globalState);
+      });
+      
     });
 
-    it("create+confirm-payment-call-test", () => {
-      let det = getConnectorDetails(globalState.get("connectorId"))["SaveCardUseNo3DS"];
-      cy.createConfirmPaymentTest(createConfirmPaymentBody, det, "no_three_ds", "automatic", globalState);
+    context("Save card for NoThreeDS manual full capture payment- Create+Confirm", () => {
+        it("customer-create-call-test", () => {
+              cy.createCustomerCallTest(customerCreateBody, globalState); 
+        });
+    
+        it("create+confirm-payment-call-test", () => {
+          let det = getConnectorDetails(globalState.get("connectorId"))["card_pm"]["SaveCardUseNo3DS"];
+          cy.createConfirmPaymentTest( createConfirmPaymentBody, det,"no_three_ds", "automatic", globalState);
+        });
+    
+        it("retrieve-payment-call-test", () => {  
+          cy.retrievePaymentCallTest(globalState);
+        });
+         
+        it("retrieve-customerPM-call-test", () => {
+          cy.listCustomerPMCallTest(globalState);
+        });
+  
+        it("create-payment-call-test", () => {
+          let det = getConnectorDetails(globalState.get("connectorId"))["card_pm"]["SaveCardUseNo3DS"];
+          cy.createPaymentIntentTest( createPaymentBody, det, "no_three_ds", "manual", globalState);
+        });
+
+  
+        it ("confirm-save-card-payment-call-test", () => {
+          let det = getConnectorDetails(globalState.get("connectorId"))["card_pm"]["SaveCardUseNo3DS"];
+          cy.saveCardConfirmCallTest(SaveCardConfirmBody,det,globalState);
+        });
+        
+        it("capture-call-test", () => {
+            let det = getConnectorDetails(globalState.get("connectorId"))["card_pm"]["SaveCardUseNo3DS"];
+            cy.captureCallTest(captureBody, 6500, det.paymentSuccessfulStatus, globalState);
+        });       
+
+
+    context("Save card for NoThreeDS manual partial capture payment- Create + Confirm", () => {
+        it("customer-create-call-test", () => {
+              cy.createCustomerCallTest(customerCreateBody, globalState); 
+        });
+    
+        it("create+confirm-payment-call-test", () => {
+          let det = getConnectorDetails(globalState.get("connectorId"))["card_pm"]["SaveCardUseNo3DS"];
+          cy.createConfirmPaymentTest( createConfirmPaymentBody, det,"no_three_ds", "automatic", globalState);
+        });
+    
+        it("retrieve-payment-call-test", () => {  
+          cy.retrievePaymentCallTest(globalState);
+        });
+         
+        it("retrieve-customerPM-call-test", () => {
+          cy.listCustomerPMCallTest(globalState);
+        });
+  
+        it("create-payment-call-test", () => {
+          let det = getConnectorDetails(globalState.get("connectorId"))["card_pm"]["SaveCardUseNo3DS"];
+          cy.createPaymentIntentTest( createPaymentBody, det, "no_three_ds", "manual", globalState);
+        });
+
+  
+        it ("confirm-save-card-payment-call-test", () => {
+          let det = getConnectorDetails(globalState.get("connectorId"))["card_pm"]["SaveCardUseNo3DS"];
+          cy.saveCardConfirmCallTest(SaveCardConfirmBody,det,globalState);
+        });
+        
+        it("capture-call-test", () => {
+            let det = getConnectorDetails(globalState.get("connectorId"))["card_pm"]["SaveCardUseNo3DS"];
+            cy.captureCallTest(captureBody, 5500, det.paymentSuccessfulStatus, globalState);
+        });            
+      });
     });
-
-    it("retrieve-payment-call-test", () => {
-      cy.retrievePaymentCallTest(globalState);
-    });
-
-    it("retrieve-customerPM-call-test", () => {
-      cy.listCustomerPMCallTest(globalState);
-    });
-
-    it("create-payment-call-test", () => {
-      let det = getConnectorDetails(globalState.get("connectorId"))["No3DS"];
-      cy.createPaymentIntentTest(createPaymentBody, det, "no_three_ds", "automatic", globalState);
-    });
-
-    it("confirm-save-card-payment-call-test", () => {
-      let det = getConnectorDetails(globalState.get("connectorId"))["SaveCardUseNo3DS"];
-      cy.saveCardConfirmCallTest(confirmBody, det, globalState);
-    });
-
-  });
-
-  context("Save card for NoThreeDS manual full capture payment- Create+Confirm", () => {
-    it("customer-create-call-test", () => {
-      cy.createCustomerCallTest(customerCreateBody, globalState);
-    });
-
-    it("create+confirm-payment-call-test", () => {
-      let det = getConnectorDetails(globalState.get("connectorId"))["SaveCardUseNo3DS"];
-      cy.createConfirmPaymentTest(createConfirmPaymentBody, det, "no_three_ds", "automatic", globalState);
-    });
-
-    it("retrieve-payment-call-test", () => {
-      cy.retrievePaymentCallTest(globalState);
-    });
-
-    it("retrieve-customerPM-call-test", () => {
-      cy.listCustomerPMCallTest(globalState);
-    });
-
-    it("create-payment-call-test", () => {
-      let det = getConnectorDetails(globalState.get("connectorId"))["No3DS"];
-      cy.createPaymentIntentTest(createPaymentBody, det, "no_three_ds", "manual", globalState);
-    });
-
-
-    it("confirm-save-card-payment-call-test", () => {
-      let det = getConnectorDetails(globalState.get("connectorId"))["SaveCardUseNo3DS"];
-      cy.saveCardConfirmCallTest(confirmBody, det, globalState);
-    });
-
-    it("capture-call-test", () => {
-      let det = getConnectorDetails(globalState.get("connectorId"))["No3DS"];
-      cy.captureCallTest(captureBody, 6500, det.paymentSuccessfulStatus, globalState);
-    });
-  });
-
-  context("Save card for NoThreeDS manual partial capture payment- Create + Confirm", () => {
-    it("customer-create-call-test", () => {
-      cy.createCustomerCallTest(customerCreateBody, globalState);
-    });
-
-    it("create+confirm-payment-call-test", () => {
-      let det = getConnectorDetails(globalState.get("connectorId"))["SaveCardUseNo3DS"];
-      cy.createConfirmPaymentTest(createConfirmPaymentBody, det, "no_three_ds", "automatic", globalState);
-    });
-
-    it("retrieve-payment-call-test", () => {
-      cy.retrievePaymentCallTest(globalState);
-    });
-
-    it("retrieve-customerPM-call-test", () => {
-      cy.listCustomerPMCallTest(globalState);
-    });
-
-    it("create-payment-call-test", () => {
-      let det = getConnectorDetails(globalState.get("connectorId"))["No3DS"];
-      cy.createPaymentIntentTest(createPaymentBody, det, "no_three_ds", "manual", globalState);
-    });
-
-
-    it("confirm-save-card-payment-call-test", () => {
-      let det = getConnectorDetails(globalState.get("connectorId"))["SaveCardUseNo3DS"];
-      cy.saveCardConfirmCallTest(confirmBody, det, globalState);
-    });
-
-    it("capture-call-test", () => {
-      let det = getConnectorDetails(globalState.get("connectorId"))["No3DS"];
-      cy.captureCallTest(captureBody, 5500, det.paymentSuccessfulStatus, globalState);
-    });
-  });
-
-});
+    
+})

--- a/cypress-tests/cypress/e2e/ConnectorTest/00014-ZeroAuthMandate.cy.js
+++ b/cypress-tests/cypress/e2e/ConnectorTest/00014-ZeroAuthMandate.cy.js
@@ -23,7 +23,7 @@ describe("Card - SingleUse Mandates flow test", () => {
     context("Card - NoThreeDS Create + Confirm Automatic CIT and Single use MIT payment flow test", () => {
 
         it("Confirm No 3DS CIT", () => {
-            let det = getConnectorDetails(globalState.get("connectorId"))["MandateSingleUseNo3DS"];
+            let det = getConnectorDetails(globalState.get("connectorId"))["card_pm"]["MandateSingleUseNo3DS"];
             cy.citForMandatesCallTest(citConfirmBody, 0, det, true, "automatic", "setup_mandate", globalState);
         });
 
@@ -34,7 +34,7 @@ describe("Card - SingleUse Mandates flow test", () => {
     context("Card - NoThreeDS Create + Confirm Automatic CIT and Multi use MIT payment flow test", () => {
 
         it("Confirm No 3DS CIT", () => {
-            let det = getConnectorDetails(globalState.get("connectorId"))["MandateSingleUseNo3DS"];
+            let det = getConnectorDetails(globalState.get("connectorId"))["card_pm"]["MandateSingleUseNo3DS"];
             cy.citForMandatesCallTest(citConfirmBody, 0, det, true, "automatic", "setup_mandate", globalState);
         });
 

--- a/cypress-tests/cypress/e2e/ConnectorTest/00015-ThreeDSManualCapture.cy.js
+++ b/cypress-tests/cypress/e2e/ConnectorTest/00015-ThreeDSManualCapture.cy.js
@@ -24,7 +24,7 @@ describe("Card - ThreeDS Manual payment flow test", () => {
     context("Card - ThreeDS Manual Full Capture payment flow test", () => {
         context("payment Create and Confirm", () => {
             it("create-payment-call-test", () => {
-                let det = getConnectorDetails(globalState.get("connectorId"))["3DS"];
+                let det = getConnectorDetails(globalState.get("connectorId"))["card_pm"]["3DS"];
                 cy.createPaymentIntentTest(createPaymentBody, det, "three_ds", "manual", globalState);
             });
 
@@ -33,7 +33,7 @@ describe("Card - ThreeDS Manual payment flow test", () => {
             });
 
             it("confirm-call-test", () => {
-                let det = getConnectorDetails(globalState.get("connectorId"))["3DS"];
+                let det = getConnectorDetails(globalState.get("connectorId"))["card_pm"]["3DS"];
                 cy.confirmCallTest(confirmBody, det, true, globalState);
             });
 
@@ -47,7 +47,7 @@ describe("Card - ThreeDS Manual payment flow test", () => {
             });
 
             it("capture-call-test", () => {
-                let det = getConnectorDetails(globalState.get("connectorId"))["3DS"];
+                let det = getConnectorDetails(globalState.get("connectorId"))["card_pm"]["3DS"];
                 cy.captureCallTest(captureBody, 6500, det.paymentSuccessfulStatus, globalState);
             });
 
@@ -59,7 +59,7 @@ describe("Card - ThreeDS Manual payment flow test", () => {
 
         context("Payment Create+Confirm", () => {
             it("create+confirm-payment-call-test", () => {
-                let det = getConnectorDetails(globalState.get("connectorId"))["3DS"];
+                let det = getConnectorDetails(globalState.get("connectorId"))["card_pm"]["3DS"];
                 cy.createConfirmPaymentTest(createConfirmPaymentBody, det, "three_ds", "manual", globalState);
             });
 
@@ -74,7 +74,7 @@ describe("Card - ThreeDS Manual payment flow test", () => {
             });
 
             it("capture-call-test", () => {
-                let det = getConnectorDetails(globalState.get("connectorId"))["3DS"];
+                let det = getConnectorDetails(globalState.get("connectorId"))["card_pm"]["3DS"];
                 cy.captureCallTest(captureBody, 6540, det.paymentSuccessfulStatus, globalState);
             });
 
@@ -89,7 +89,7 @@ describe("Card - ThreeDS Manual payment flow test", () => {
     context("Card - ThreeDS Manual Partial Capture payment flow test - Create and Confirm", () => {
         context("payment Create and Payment Confirm", () => {
             it("create-payment-call-test", () => {
-                let det = getConnectorDetails(globalState.get("connectorId"))["3DS"];
+                let det = getConnectorDetails(globalState.get("connectorId"))["card_pm"]["3DS"];
                 cy.createPaymentIntentTest(createPaymentBody, det, "three_ds", "manual", globalState);
             });
 
@@ -98,7 +98,7 @@ describe("Card - ThreeDS Manual payment flow test", () => {
             });
 
             it("confirm-call-test", () => {
-                let det = getConnectorDetails(globalState.get("connectorId"))["3DS"];
+                let det = getConnectorDetails(globalState.get("connectorId"))["card_pm"]["3DS"];
                 cy.confirmCallTest(confirmBody, det, true, globalState);
             });
 
@@ -112,7 +112,7 @@ describe("Card - ThreeDS Manual payment flow test", () => {
             });
 
             it("capture-call-test", () => {
-                let det = getConnectorDetails(globalState.get("connectorId"))["3DS"];
+                let det = getConnectorDetails(globalState.get("connectorId"))["card_pm"]["3DS"];
                 cy.captureCallTest(captureBody, 100, det.paymentSuccessfulStatus, globalState);
             });
 
@@ -123,7 +123,7 @@ describe("Card - ThreeDS Manual payment flow test", () => {
 
         context("payment + Confirm", () => {
             it("create+confirm-payment-call-test", () => {
-                let det = getConnectorDetails(globalState.get("connectorId"))["3DS"];
+                let det = getConnectorDetails(globalState.get("connectorId"))["card_pm"]["3DS"];
                 cy.createConfirmPaymentTest(createConfirmPaymentBody, det, "three_ds", "manual", globalState);
             });
 
@@ -137,7 +137,7 @@ describe("Card - ThreeDS Manual payment flow test", () => {
             });
 
             it("capture-call-test", () => {
-                let det = getConnectorDetails(globalState.get("connectorId"))["3DS"];
+                let det = getConnectorDetails(globalState.get("connectorId"))["card_pm"]["3DS"];
                 cy.captureCallTest(captureBody, 5000, det.paymentSuccessfulStatus, globalState);
             });
 

--- a/cypress-tests/cypress/e2e/ConnectorUtils/Adyen.js
+++ b/cypress-tests/cypress/e2e/ConnectorUtils/Adyen.js
@@ -16,6 +16,7 @@ const successfulThreeDSTestCardDetails = {
 };
 
 export const connectorDetails = {
+card_pm:{
     "3DS": {
         "card": successfulThreeDSTestCardDetails,
         "currency": "USD",
@@ -109,4 +110,5 @@ export const connectorDetails = {
             }
         },
     },
+}
 }; 

--- a/cypress-tests/cypress/e2e/ConnectorUtils/BankOfAmerica.js
+++ b/cypress-tests/cypress/e2e/ConnectorUtils/BankOfAmerica.js
@@ -16,6 +16,7 @@ const successfulThreeDSTestCardDetails = {
 };
 
 export const connectorDetails = {
+card_pm:{
     "3DS": {
         "card": successfulThreeDSTestCardDetails,
         "currency": "USD",
@@ -109,5 +110,5 @@ export const connectorDetails = {
             }
         },
     },
-
+}  
 }; 

--- a/cypress-tests/cypress/e2e/ConnectorUtils/Bluesnap.js
+++ b/cypress-tests/cypress/e2e/ConnectorUtils/Bluesnap.js
@@ -15,6 +15,7 @@ const successfulThreeDSTestCardDetails = {
 };
 
 export const connectorDetails = {
+card_pm:{
     "3DS": {
         "card": successfulThreeDSTestCardDetails,
         "currency": "USD",
@@ -108,4 +109,5 @@ export const connectorDetails = {
             }
         },
     },
+ }
 };

--- a/cypress-tests/cypress/e2e/ConnectorUtils/Cybersource.js
+++ b/cypress-tests/cypress/e2e/ConnectorUtils/Cybersource.js
@@ -15,6 +15,7 @@ const successfulThreeDSTestCardDetails = {
 };
 
 export const connectorDetails = {
+card_pm:{
     "3DS": {
         "card": successfulThreeDSTestCardDetails,
         "currency": "USD",
@@ -108,4 +109,5 @@ export const connectorDetails = {
             }
         },
     },
+  }
 };

--- a/cypress-tests/cypress/e2e/ConnectorUtils/Nmi.js
+++ b/cypress-tests/cypress/e2e/ConnectorUtils/Nmi.js
@@ -15,6 +15,7 @@ const successfulThreeDSTestCardDetails = {
 };
 
 export const connectorDetails = {
+card_pm:{
     "3DS": {
         "card": successfulThreeDSTestCardDetails,
         "currency": "USD",
@@ -109,4 +110,5 @@ export const connectorDetails = {
             }
         },
     },
+ }
 };

--- a/cypress-tests/cypress/e2e/ConnectorUtils/Paypal.js
+++ b/cypress-tests/cypress/e2e/ConnectorUtils/Paypal.js
@@ -15,13 +15,6 @@ const successfulThreeDSTestCardDetails = {
     "card_cvc": "123"
 };
 
-const paypalDetails ={
-
-        "wallet": {
-            "paypal_redirect": {}
-        }
-}
-
 export const connectorDetails = {
     card_pm:{
         "3DS": {

--- a/cypress-tests/cypress/e2e/ConnectorUtils/Paypal.js
+++ b/cypress-tests/cypress/e2e/ConnectorUtils/Paypal.js
@@ -15,88 +15,99 @@ const successfulThreeDSTestCardDetails = {
     "card_cvc": "123"
 };
 
+const paypalDetails ={
+
+        "wallet": {
+            "paypal_redirect": {}
+        }
+}
+
 export const connectorDetails = {
-    "3DS": {
-        "card": successfulThreeDSTestCardDetails,
-        "currency": "USD",
-        "paymentSuccessfulStatus": "processing",
-        "paymentSyncStatus": "processing",
-        "customer_acceptance": null,
-        "setup_future_usage": "on_session",
-
-    },
-    "No3DS": {
-        "card": successfulNo3DSCardDetails,
-        "currency": "USD",
-        "paymentSuccessfulStatus": "processing",
-        "paymentSyncStatus": "processing",
-        "customer_acceptance": null,
-        "setup_future_usage": "on_session",
-
-    },
-    "MandateSingleUse3DS": {
-        "card": successfulThreeDSTestCardDetails,
-        "currency": "USD",
-        "paymentSuccessfulStatus": "requires_customer_action",
-        "paymentSyncStatus": "processing",
-        "mandate_type": {
-            "single_use": {
-                "amount": 8000,
-                "currency": "USD"
+    card_pm:{
+        "3DS": {
+            "card": successfulThreeDSTestCardDetails,
+            "currency": "USD",
+            "paymentSuccessfulStatus": "requires_customer_action",
+            "paymentSyncStatus": "processing",
+            "customer_acceptance":null,
+            "setup_future_usage": "on_session",
+    
+        },
+        "No3DS": {
+            "card": successfulNo3DSCardDetails,
+            "currency": "USD",
+            "paymentSuccessfulStatus": "processing",
+            "paymentSyncStatus": "processing",
+            "customer_acceptance":null,
+            "setup_future_usage": "on_session",
+    
+        },
+        "MandateSingleUse3DS": {
+            "card": successfulThreeDSTestCardDetails,
+            "currency": "USD",
+            "paymentSuccessfulStatus": "requires_customer_action",
+            "paymentSyncStatus": "processing",
+            "mandate_type": {
+                "single_use": {
+                    "amount": 8000,
+                    "currency": "USD"
+                }
             }
-        }
-    },
-    "MandateSingleUseNo3DS": {
-        "card": successfulNo3DSCardDetails,
-        "currency": "USD",
-        "paymentSuccessfulStatus": "succeeded",
-        "paymentSyncStatus": "succeeded",
-        "mandate_type": {
-            "single_use": {
-                "amount": 8000,
-                "currency": "USD"
+        },
+        "MandateSingleUseNo3DS": {
+            "card": successfulNo3DSCardDetails,
+            "currency": "USD",
+            "paymentSuccessfulStatus": "succeeded",
+            "paymentSyncStatus": "succeeded",
+            "mandate_type": {
+                "single_use": {
+                    "amount": 8000,
+                    "currency": "USD"
+                }
             }
-        }
-    },
-    "MandateMultiUseNo3DS": {
-        "card": successfulNo3DSCardDetails,
-        "currency": "USD",
-        "paymentSuccessfulStatus": "succeeded",
-        "paymentSyncStatus": "succeeded",
-        "mandate_type": {
-            "multi_use": {
-                "amount": 8000,
-                "currency": "USD"
+        },
+        "MandateMultiUseNo3DS": {
+            "card": successfulNo3DSCardDetails,
+            "currency": "USD",
+            "paymentSuccessfulStatus": "succeeded",
+            "paymentSyncStatus": "succeeded",
+            "mandate_type": {
+                "multi_use": {
+                    "amount": 8000,
+                    "currency": "USD"
+                }
             }
-        }
-    },
-    "MandateMultiUse3DS": {
-        "card": successfulThreeDSTestCardDetails,
-        "currency": "USD",
-        "paymentSuccessfulStatus": "requires_customer_action",
-        "paymentSyncStatus": "processing",
-        "mandate_type": {
-            "multi_use": {
-                "amount": 8000,
-                "currency": "USD"
+        },
+        "MandateMultiUse3DS": {
+            "card": successfulThreeDSTestCardDetails,
+            "currency": "USD",
+            "paymentSuccessfulStatus": "requires_customer_action",
+            "paymentSyncStatus": "processing",
+            "mandate_type": {
+                "multi_use": {
+                    "amount": 8000,
+                    "currency": "USD"
+                }
             }
-        }
-    },
-    "SaveCardUseNo3DS": {
-        "card": successfulNo3DSCardDetails,
-        "currency": "USD",
-        "paymentSuccessfulStatus": "processing",
-        "paymentSyncStatus": "succeeded",
-        "refundStatus": "succeeded",
-        "refundSyncStatus": "succeeded",
-        "setup_future_usage": "on_session",
-        "customer_acceptance": {
-            "acceptance_type": "offline",
-            "accepted_at": "1963-05-03T04:07:52.723Z",
-            "online": {
-                "ip_address": "127.0.0.1",
-                "user_agent": "amet irure esse"
-            }
+        },
+        "SaveCardUseNo3DS": {
+            "card": successfulNo3DSCardDetails,
+            "currency":"USD",
+            "paymentSuccessfulStatus": "processing",
+            "paymentSyncStatus": "succeeded",
+            "refundStatus": "succeeded",
+            "refundSyncStatus": "succeeded",
+            "setup_future_usage": "on_session",
+            "customer_acceptance": {
+                "acceptance_type": "offline",
+                "accepted_at": "1963-05-03T04:07:52.723Z",
+                "online": {
+                    "ip_address": "127.0.0.1",
+                    "user_agent": "amet irure esse"
+                }
+            },
         },
     },
 };
+
+

--- a/cypress-tests/cypress/e2e/ConnectorUtils/Stripe.js
+++ b/cypress-tests/cypress/e2e/ConnectorUtils/Stripe.js
@@ -18,6 +18,7 @@ const successfulThreeDSTestCardDetails = {
 };
 
 export const connectorDetails = {
+card_pm:{
     "3DS": {
         "card": successfulThreeDSTestCardDetails,
         "currency": "USD",
@@ -111,4 +112,5 @@ export const connectorDetails = {
             }
         },
     },
+}
 };

--- a/cypress-tests/cypress/e2e/ConnectorUtils/Trustpay.js
+++ b/cypress-tests/cypress/e2e/ConnectorUtils/Trustpay.js
@@ -15,6 +15,7 @@ const successfulThreeDSTestCardDetails = {
 };
 
 export const connectorDetails = {
+card_pm:{
     "3DS": {
         "card": successfulThreeDSTestCardDetails,
         "currency": "USD",
@@ -108,4 +109,5 @@ export const connectorDetails = {
             }
         },
     },
-};
+}
+}

--- a/cypress-tests/cypress/support/commands.js
+++ b/cypress-tests/cypress/support/commands.js
@@ -295,12 +295,12 @@ Cypress.Commands.add("createConfirmPaymentTest", (createConfirmPaymentBody, deta
 });
 
 // This is consequent saved card payment confirm call test(Using payment token)
-Cypress.Commands.add("saveCardConfirmCallTest", (confirmBody, det, globalState) => {
+Cypress.Commands.add("saveCardConfirmCallTest", (SaveCardConfirmBody,det,globalState) => {
   const paymentIntentID = globalState.get("paymentID");
-  confirmBody.card_cvc = det.card.card_cvc;
-  confirmBody.payment_token = globalState.get("paymentToken");
-  confirmBody.client_secret = globalState.get("clientSecret");
-  console.log("configured connector ->" + globalState.get("connectorId"));
+  SaveCardConfirmBody.card_cvc = det.card_cvc;
+  SaveCardConfirmBody.payment_token = globalState.get("paymentToken");
+  SaveCardConfirmBody.client_secret = globalState.get("clientSecret");
+  console.log("conf conn ->" + globalState.get("connectorId"));
   cy.request({
     method: "POST",
     url: `${globalState.get("baseUrl")}/payments/${paymentIntentID}/confirm`,
@@ -308,7 +308,7 @@ Cypress.Commands.add("saveCardConfirmCallTest", (confirmBody, det, globalState) 
       "Content-Type": "application/json",
       "api-key": globalState.get("publishableKey"),
     },
-    body: confirmBody,
+    body: SaveCardConfirmBody,
   })
     .then((response) => {
       logRequestId(response.headers['x-request-id']);
@@ -731,5 +731,8 @@ Cypress.Commands.add("listRefundCallTest", (requestBody, globalState) => {
 
     expect(response.headers["content-type"]).to.include("application/json");
     expect(response.body.data).to.be.an('array').and.not.empty;
+  
+    });
   });
-});
+
+  


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [x] CI/CD

## Description

-Resolved an issue in the savecard flow where card expiry was incorrectly sourced from the confirmBody.json, resulting in failures. Now, only the payment_token is utilized, ensuring successful payment transactions.
-This pull request includes refactoring of the card_pm details to accommodate the addition of banks and wallet flows.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context

To enhance test coverage for wallet and bank redirect flows.

## How did you test it?

Ran the test manually
<img width="762" alt="Screenshot 2024-05-08 at 3 56 21 PM" src="https://github.com/juspay/hyperswitch/assets/118818938/3981f38d-0276-41c2-9b06-5d5db02f1dc5">


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
