### PR TITLE
fix(core): drop three_dsserver_trans_id from authentication table

### DIFF
--- a/crates/diesel_models/src/authentication.rs
+++ b/crates/diesel_models/src/authentication.rs
@@ -38,7 +38,6 @@ pub struct Authentication {
     pub challenge_request: Option<String>,
     pub acs_reference_number: Option<String>,
     pub acs_trans_id: Option<String>,
-    pub three_ds_server_trans_id: Option<String>,
     pub acs_signed_content: Option<String>,
     pub profile_id: String,
     pub payment_id: Option<String>,
@@ -83,7 +82,6 @@ pub struct AuthenticationNew {
     pub challenge_request: Option<String>,
     pub acs_reference_number: Option<String>,
     pub acs_trans_id: Option<String>,
-    pub three_dsserver_trans_id: Option<String>,
     pub acs_signed_content: Option<String>,
     pub profile_id: String,
     pub payment_id: Option<String>,
@@ -160,7 +158,6 @@ pub struct AuthenticationUpdateInternal {
     pub challenge_request: Option<String>,
     pub acs_reference_number: Option<String>,
     pub acs_trans_id: Option<String>,
-    pub three_dsserver_trans_id: Option<String>,
     pub acs_signed_content: Option<String>,
 }
 
@@ -191,7 +188,6 @@ impl Default for AuthenticationUpdateInternal {
             challenge_request: Default::default(),
             acs_reference_number: Default::default(),
             acs_trans_id: Default::default(),
-            three_dsserver_trans_id: Default::default(),
             acs_signed_content: Default::default(),
         }
     }
@@ -224,7 +220,6 @@ impl AuthenticationUpdateInternal {
             challenge_request,
             acs_reference_number,
             acs_trans_id,
-            three_dsserver_trans_id,
             acs_signed_content,
         } = self;
         Authentication {
@@ -256,7 +251,6 @@ impl AuthenticationUpdateInternal {
             challenge_request: challenge_request.or(source.challenge_request),
             acs_reference_number: acs_reference_number.or(source.acs_reference_number),
             acs_trans_id: acs_trans_id.or(source.acs_trans_id),
-            three_ds_server_trans_id: three_dsserver_trans_id.or(source.three_ds_server_trans_id),
             acs_signed_content: acs_signed_content.or(source.acs_signed_content),
             ..source
         }

--- a/crates/diesel_models/src/schema.rs
+++ b/crates/diesel_models/src/schema.rs
@@ -108,7 +108,6 @@ diesel::table! {
         challenge_request -> Nullable<Varchar>,
         acs_reference_number -> Nullable<Varchar>,
         acs_trans_id -> Nullable<Varchar>,
-        three_dsserver_trans_id -> Nullable<Varchar>,
         acs_signed_content -> Nullable<Varchar>,
         #[max_length = 64]
         profile_id -> Varchar,

--- a/crates/router/src/core/authentication/utils.rs
+++ b/crates/router/src/core/authentication/utils.rs
@@ -177,7 +177,6 @@ pub async fn create_new_authentication(
         challenge_request: None,
         acs_reference_number: None,
         acs_trans_id: None,
-        three_dsserver_trans_id: None,
         acs_signed_content: None,
         profile_id,
         payment_id,

--- a/crates/router/src/db/authentication.rs
+++ b/crates/router/src/db/authentication.rs
@@ -143,7 +143,6 @@ impl AuthenticationInterface for MockDb {
             challenge_request: authentication.challenge_request,
             acs_reference_number: authentication.acs_reference_number,
             acs_trans_id: authentication.acs_trans_id,
-            three_ds_server_trans_id: authentication.three_dsserver_trans_id,
             acs_signed_content: authentication.acs_signed_content,
             profile_id: authentication.profile_id,
             payment_id: authentication.payment_id,

--- a/crates/router/src/types/api/authentication.rs
+++ b/crates/router/src/types/api/authentication.rs
@@ -50,7 +50,7 @@ impl TryFrom<storage::Authentication> for AuthenticationResponse {
             challenge_request: authentication.challenge_request,
             acs_reference_number: authentication.acs_reference_number,
             acs_trans_id: authentication.acs_trans_id,
-            three_dsserver_trans_id: authentication.three_ds_server_trans_id,
+            three_dsserver_trans_id: authentication.threeds_server_transaction_id,
             acs_signed_content: authentication.acs_signed_content,
         })
     }

--- a/migrations/2024-05-08-111348_delete_unused_column_from_authentication/down.sql
+++ b/migrations/2024-05-08-111348_delete_unused_column_from_authentication/down.sql
@@ -1,0 +1,2 @@
+-- This file should undo anything in `up.sql`
+ALTER TABLE authentication ADD COLUMN three_dsserver_trans_id VARCHAR;

--- a/migrations/2024-05-08-111348_delete_unused_column_from_authentication/up.sql
+++ b/migrations/2024-05-08-111348_delete_unused_column_from_authentication/up.sql
@@ -1,0 +1,2 @@
+-- Your SQL goes here
+ALTER TABLE authentication DROP COLUMN three_dsserver_trans_id;


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
there are two fields in `authentication`(`three_ds_server_trans_id` and `threeds_server_transaction_id`) table that hold the same data. Removed `three_ds_server_trans_id` column which is not being populated at all. 

This caused confusion and as a result we were returning `three_ds_server_trans_id`. Which resulted in null being returned in `AuthenticationResponse` all the time.
Fixed that as well.

### Additional Changes

- [ ] This PR modifies the API contract
- [x] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Manual.
Create a merchant with netcetera authentication connector and checkout payment connector

1. create a payment with "request_external_three_ds_authentication": true,
```
curl --location 'http://localhost:8080/payments' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: dev_yWDRHoFLgGtQRwkccTm9nMENIESjKEgkxratJOAjLRUHDFp71Mzhy0OJguhBk47h' \
--data-raw '{
    "amount": 6540,
    "currency": "USD",
    "confirm": false,
    "capture_method": "automatic",
    "capture_on": "2022-09-10T10:11:12Z",
    "amount_to_capture": 6540,
    "customer_id": "StripeCustomer",
    "email": "guest@example.com",
    "name": "John Doe",
    "phone": "999999999",
    "phone_country_code": "+65",
    "description": "Its my first payment request",
    "authentication_type": "three_ds",
    "return_url": "https://duck.com",
    "billing": {
        "address": {
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "city": "San Fransico",
            "state": "California",
            "zip": "94122",
            "country": "US",
            "first_name": "PiX"
        },
        "phone": {
            "number": "123456789",
            "country_code": "12"
        }
    },
    "shipping": {
        "address": {
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "city": "San Fransico",
            "state": "California",
            "zip": "94122",
            "country": "US",
            "first_name": "PiX"
        },
        "phone": {
            "number": "123456789",
            "country_code": "12"
        }
    },
    "request_external_three_ds_authentication": true,
    "statement_descriptor_name": "joseph",
    "statement_descriptor_suffix": "JS",
    "metadata": {
        "udf1": "value1",
        "new_customer": "true",
        "login_date": "2019-09-10T10:11:12Z"
    }
}'
```
2. Confirm the payment
```
curl --location 'http://localhost:8080/payments/pay_CbBAoF959T5yIiPzc9JY/confirm' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: pk_dev_d9f3d219499e4867b7677eeb98e9d3f4' \
--data '{
    "browser_info": {
        "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Safari/537.36",
        "accept_header": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8",
        "language": "nl-NL",
        "color_depth": 24,
        "screen_height": 723,
        "screen_width": 1536,
        "time_zone": 0,
        "java_enabled": true,
        "java_script_enabled": true,
        "ip_address": "115.99.183.2"
    },
    "client_secret": "pay_CbBAoF959T5yIiPzc9JY_secret_9ymuISdrQEAm5Lwi1RzR",
    "payment_method": "card",
    "payment_method_data": {
        "card": {
            "card_number": "4929251897047956", 
            "card_exp_month": "10",
            "card_exp_year": "25",
            "card_holder_name": "joseph Doe",
            "card_cvc": "123"
        }
    }
}'
```
3. Do auth call.
```
curl --location 'http://localhost:8080/payments/pay_SLvW65GMYypubOUH4aGK/3ds/authentication' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: pk_dev_d9f3d219499e4867b7677eeb98e9d3f4' \
--data '{
    "client_secret": "pay_SLvW65GMYypubOUH4aGK_secret_ZPTWR1YANmOxEu6mdMUs",
    "device_channel": "BRW",
    "threeds_method_comp_ind": "N"
}'
```
Should get below response. (`three_dsserver_trans_id` will differ)
```
{
    "trans_status": "Y",
    "acs_url": null,
    "challenge_request": null,
    "acs_reference_number": null,
    "acs_trans_id": null,
    "three_dsserver_trans_id": "a3a75c67-4c3c-4335-ba31-60f9515dc532",
    "acs_signed_content": null
}
```


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
