### PR TITLE
refactor(db): Add TenantID field to sqlx and clickhouse struct

### DIFF
--- a/crates/analytics/src/clickhouse.rs
+++ b/crates/analytics/src/clickhouse.rs
@@ -31,9 +31,13 @@ use crate::{
 
 pub type ClickhouseResult<T> = error_stack::Result<T, ClickhouseError>;
 
+#[derive(Debug, serde::Deserialize)]
+pub struct TenantID(pub String);
+
 #[derive(Clone, Debug)]
 pub struct ClickhouseClient {
     pub config: Arc<ClickhouseConfig>,
+    pub tenant_id: TenantID
 }
 
 #[derive(Clone, Debug, serde::Deserialize)]

--- a/crates/analytics/src/sqlx.rs
+++ b/crates/analytics/src/sqlx.rs
@@ -28,9 +28,13 @@ use super::{
     },
 };
 
+#[derive(Debug, serde::Deserialize)]
+pub struct TenantID(pub String);
+
 #[derive(Debug, Clone)]
 pub struct SqlxClient {
     pool: Pool<Postgres>,
+    tenant_id: TenantID
 }
 
 impl Default for SqlxClient {
@@ -44,6 +48,7 @@ impl Default for SqlxClient {
             pool: PgPoolOptions::new()
                 .connect_lazy(&database_url)
                 .expect("SQLX Pool Creation failed"),
+            TenantID("default")
         }
     }
 }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->
#4521 

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
- Add TenantId field to the sqlx and click house struct
- pass tenantId as default to sqlx constructor 


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
