### PR TITLE
 Fix(connector): [BOA/CYBS] make rsync status optional

### DIFF
--- a/crates/router/src/connector/bankofamerica/transformers.rs
+++ b/crates/router/src/connector/bankofamerica/transformers.rs
@@ -2657,8 +2657,15 @@ pub struct RsyncApplicationInformation {
 }
 
 #[derive(Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum BankOfAmericaRsyncResponse {
+    RsyncApplicationResponse(Box<BankOfAmericaRsyncApplicationResponse>),
+    ErrorInformation(BankOfAmericaErrorInformationResponse),
+}
+
+#[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct BankOfAmericaRsyncResponse {
+pub struct BankOfAmericaRsyncApplicationResponse {
     id: String,
     application_information: RsyncApplicationInformation,
 }
@@ -2670,15 +2677,25 @@ impl TryFrom<types::RefundsResponseRouterData<api::RSync, BankOfAmericaRsyncResp
     fn try_from(
         item: types::RefundsResponseRouterData<api::RSync, BankOfAmericaRsyncResponse>,
     ) -> Result<Self, Self::Error> {
-        Ok(Self {
-            response: Ok(types::RefundsResponseData {
-                connector_refund_id: item.response.id,
-                refund_status: enums::RefundStatus::from(
-                    item.response.application_information.status,
-                ),
+        match item.response {
+            BankOfAmericaRsyncResponse::RsyncApplicationResponse(rsync_response) => Ok(Self {
+                response: Ok(types::RefundsResponseData {
+                    connector_refund_id: rsync_response.id,
+                    refund_status: enums::RefundStatus::from(
+                        rsync_response.application_information.status,
+                    ),
+                }),
+                ..item.data
             }),
-            ..item.data
-        })
+            BankOfAmericaRsyncResponse::ErrorInformation(error_response) => Ok(Self {
+                status: item.data.status,
+                response: Ok(types::RefundsResponseData {
+                    refund_status: common_enums::RefundStatus::Pending,
+                    connector_refund_id: error_response.id.clone(),
+                }),
+                ..item.data
+            }),
+        }
     }
 }
 

--- a/crates/router/src/connector/cybersource/transformers.rs
+++ b/crates/router/src/connector/cybersource/transformers.rs
@@ -2751,9 +2751,16 @@ pub struct RsyncApplicationInformation {
 
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct CybersourceRsyncResponse {
+pub struct CybersourceRsyncApplicationResponse {
     id: String,
     application_information: RsyncApplicationInformation,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum CybersourceRsyncResponse {
+    RsyncApplicationResponse(Box<CybersourceRsyncApplicationResponse>),
+    ErrorInformation(CybersourceErrorInformationResponse),
 }
 
 impl TryFrom<types::RefundsResponseRouterData<api::RSync, CybersourceRsyncResponse>>
@@ -2763,15 +2770,25 @@ impl TryFrom<types::RefundsResponseRouterData<api::RSync, CybersourceRsyncRespon
     fn try_from(
         item: types::RefundsResponseRouterData<api::RSync, CybersourceRsyncResponse>,
     ) -> Result<Self, Self::Error> {
-        Ok(Self {
-            response: Ok(types::RefundsResponseData {
-                connector_refund_id: item.response.id,
-                refund_status: enums::RefundStatus::from(
-                    item.response.application_information.status,
-                ),
+        match item.response {
+            CybersourceRsyncResponse::RsyncApplicationResponse(rsync_reponse) => Ok(Self {
+                response: Ok(types::RefundsResponseData {
+                    connector_refund_id: rsync_reponse.id,
+                    refund_status: enums::RefundStatus::from(
+                        rsync_reponse.application_information.status,
+                    ),
+                }),
+                ..item.data
             }),
-            ..item.data
-        })
+            CybersourceRsyncResponse::ErrorInformation(error_response) => Ok(Self {
+                status: item.data.status,
+                response: Ok(types::RefundsResponseData {
+                    refund_status: common_enums::RefundStatus::Pending,
+                    connector_refund_id: error_response.id.clone(),
+                }),
+                ..item.data
+            }),
+        }
     }
 }
 


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
BOA's Rsync response may or may not contain status.  But status is a mandatory field in the connector response, hence when the connector response do not contain status, it results in a de serialization error. 
This PR fixes the de-serialization error, by marking refund status as pending if connector do not send us the status. 
Hotfix for https://github.com/juspay/hyperswitch/pull/4570


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
1.Create a card payment with BOA
```
curl --location 'http://localhost:8080/payments' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key:""' \
--data-raw '{
    "amount": 100,
    "currency": "USD",
    "confirm": true,
    "capture_method": "automatic",
    "capture_on": "2022-09-10T10:11:12Z",
    "customer_id": "A",
    "email": "abcdef123@gmail.com",
    "name": "John Doe",
    "phone": "999999999",
    "phone_country_code": "+65",
    "description": "Its my first payment request",
    "authentication_type": "no_three_ds",
    "return_url": "https://google.com",
    "billing": {
        "address": {
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "city": "San Fransico",
            "state": "California",
            "zip": "94122",
            "country": "US",
            "first_name": "John",
            "last_name": "Doe"
        }
    },
    "browser_info": {
        "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Safari/537.36",
        "accept_header": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8",
        "language": "nl-NL",
        "color_depth": 24,
        "screen_height": 723,
        "screen_width": 1536,
        "time_zone": 0,
        "java_enabled": true,
        "java_script_enabled": true,
        "ip_address": "13.232.74.226"
    },
    "shipping": {
        "address": {
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "city": "San Fransico",
            "state": "California",
            "zip": "94122",
            "country": "IN",
            "first_name": "John",
            "last_name": "Doe"
        }
    },
    "statement_descriptor_name": "joseph",
    "statement_descriptor_suffix": "JS",
    "payment_method": "card",
    "payment_method_data": {
        "card": {
            "card_number":  "4622943127013705", 
            "card_exp_month": "10",
            "card_exp_year": "25",
            "card_holder_name": "joseph Doe",
            "card_cvc": "123"
        }
    },  
      "connector_metadata": {
            "noon": {
                "order_category": "pay"
            }
        },
    "metadata": {
        "city": "NY",
        "unit": "245",
        "account_name": "transaction_processing"
    }    
}'
```
Response
```
{
    "payment_id": "pay_CynccL5DmW1ETflUPxEa",
    "merchant_id": "merchant_1715083581",
    "status": "succeeded",
    "amount": 100,
    "net_amount": 100,
    "amount_capturable": 0,
    "amount_received": 100,
    "connector": "bankofamerica",
    "client_secret": "pay_CynccL5DmW1ETflUPxEa_secret_SBM9CrhhVKtnvPb3c0PN",
    "created": "2024-05-07T12:06:34.173Z",
    "currency": "USD",
    "customer_id": "A",
    "customer": {
        "id": "A",
        "name": "John Doe",
        "email": "abcdef123@gmail.com",
        "phone": "999999999",
        "phone_country_code": "+65"
    },
    "description": "Its my first payment request",
    "refunds": null,
    "disputes": null,
    "mandate_id": null,
    "mandate_data": null,
    "setup_future_usage": null,
    "off_session": null,
    "capture_on": null,
    "capture_method": "automatic",
    "payment_method": "card",
    "payment_method_data": {
        "card": {
            "last4": "3705",
            "card_type": null,
            "card_network": null,
            "card_issuer": null,
            "card_issuing_country": null,
            "card_isin": "462294",
            "card_extended_bin": null,
            "card_exp_month": "10",
            "card_exp_year": "25",
            "card_holder_name": "joseph Doe",
            "payment_checks": {
                "avs_response": {
                    "code": "Y",
                    "codeRaw": "Y"
                },
                "card_verification": {
                    "resultCode": "M",
                    "resultCodeRaw": "M"
                },
                "approval_code": "831000",
                "consumer_authentication_response": {
                    "code": "2",
                    "codeRaw": "2"
                },
                "cavv": null,
                "eci": null,
                "eci_raw": null
            },
            "authentication_data": {
                "retrieval_reference_number": "412812167299",
                "acs_transaction_id": null,
                "system_trace_audit_number": "167299"
            }
        },
        "billing": null
    },
    "payment_token": "token_4OB1T6AKesZztuDf8jlt",
    "shipping": {
        "address": {
            "city": "San Fransico",
            "country": "IN",
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "zip": "94122",
            "state": "California",
            "first_name": "John",
            "last_name": "Doe"
        },
        "phone": null,
        "email": null
    },
    "billing": {
        "address": {
            "city": "San Fransico",
            "country": "US",
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "zip": "94122",
            "state": "California",
            "first_name": "John",
            "last_name": "Doe"
        },
        "phone": null,
        "email": null
    },
    "order_details": null,
    "email": "abcdef123@gmail.com",
    "name": "John Doe",
    "phone": "999999999",
    "return_url": "https://google.com/",
    "authentication_type": "no_three_ds",
    "statement_descriptor_name": "joseph",
    "statement_descriptor_suffix": "JS",
    "next_action": null,
    "cancellation_reason": null,
    "error_code": null,
    "error_message": null,
    "unified_code": null,
    "unified_message": null,
    "payment_experience": null,
    "payment_method_type": null,
    "connector_label": null,
    "business_country": null,
    "business_label": "default",
    "business_sub_label": null,
    "allowed_payment_method_types": null,
    "ephemeral_key": {
        "customer_id": "A",
        "created_at": 1715083594,
        "expires": 1715087194,
        "secret": "epk_42b404783640408aa110028ca10a848c"
    },
    "manual_retry_allowed": false,
    "connector_transaction_id": "7150835957926310904953",
    "frm_message": null,
    "metadata": {
        "city": "NY",
        "unit": "245",
        "account_name": "transaction_processing"
    },
    "connector_metadata": {
        "apple_pay": null,
        "airwallex": null,
        "noon": {
            "order_category": "pay"
        }
    },
    "feature_metadata": null,
    "reference_id": "pay_CynccL5DmW1ETflUPxEa_1",
    "payment_link": null,
    "profile_id": "pro_T2wjq3SsGuXZ5fdUene6",
    "surcharge_details": null,
    "attempt_count": 1,
    "merchant_decision": null,
    "merchant_connector_id": "mca_otyt4b6GdbCisxI2tTTu",
    "incremental_authorization_allowed": null,
    "authorization_count": null,
    "incremental_authorizations": null,
    "external_authentication_details": null,
    "external_3ds_authentication_attempted": false,
    "expires_on": "2024-05-07T12:21:34.173Z",
    "fingerprint": null,
    "browser_info": {
        "language": "nl-NL",
        "time_zone": 0,
        "ip_address": "13.232.74.226",
        "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Safari/537.36",
        "color_depth": 24,
        "java_enabled": true,
        "screen_width": 1536,
        "accept_header": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8",
        "screen_height": 723,
        "java_script_enabled": true
    },
    "payment_method_id": null,
    "payment_method_status": null,
    "updated": "2024-05-07T12:06:36.806Z"
}
```

2. Refund the payment
```
curl --location 'http://localhost:8080/refunds' \
--header 'Content-Type: application/json' \
--header 'api-key: ""' \
--data '{
    "payment_id": "pay_CynccL5DmW1ETflUPxEa",
    "amount": 100,
    "reason": "Customer returned product",
    "refund_type": "instant",
    "metadata": {
        "udf1": "value1",
        "new_customer": "true",
        "login_date": "2019-09-10T10:11:12Z"
    }
}'
```
Response
```
{
    "refund_id": "ref_ycNxoYyhoEskxFyuUtjo",
    "payment_id": "pay_CynccL5DmW1ETflUPxEa",
    "amount": 100,
    "currency": "USD",
    "status": "pending",
    "reason": "Customer returned product",
    "metadata": {
        "udf1": "value1",
        "new_customer": "true",
        "login_date": "2019-09-10T10:11:12Z"
    },
    "error_message": null,
    "error_code": null,
    "created_at": "2024-05-07T12:08:16.183Z",
    "updated_at": "2024-05-07T12:08:16.183Z",
    "connector": "bankofamerica",
    "profile_id": "pro_T2wjq3SsGuXZ5fdUene6",
    "merchant_connector_id": "mca_otyt4b6GdbCisxI2tTTu"
}
```
3. Do a Rsync
```
curl --location 'http://localhost:8080/refunds/ref_ycNxoYyhoEskxFyuUtjo?force_sync=true' \
--header 'Accept: application/json' \
--header 'api-key:""'
```
Response - Should not give a De-serialization error
```{
    "refund_id": "ref_ycNxoYyhoEskxFyuUtjo",
    "payment_id": "pay_CynccL5DmW1ETflUPxEa",
    "amount": 100,
    "currency": "USD",
    "status": "pending",
    "reason": "Customer returned product",
    "metadata": {
        "udf1": "value1",
        "new_customer": "true",
        "login_date": "2019-09-10T10:11:12Z"
    },
    "error_message": null,
    "error_code": null,
    "created_at": "2024-05-07T12:08:16.183Z",
    "updated_at": "2024-05-07T12:08:16.183Z",
    "connector": "bankofamerica",
    "profile_id": "pro_T2wjq3SsGuXZ5fdUene6",
    "merchant_connector_id": "mca_otyt4b6GdbCisxI2tTTu"
}
```
4. Do a card payment with Cybersource
```
curl --location 'http://localhost:8080/payments' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: ""' \
--data-raw '{
    "amount": 100,
    "currency": "USD",
    "confirm": true,
    "business_country": "US",
    "business_label": "default",
    
    "capture_method": "automatic",
    "customer_id": "abc",
    "capture_on": "2022-09-10T10:11:12Z",
    "authentication_type": "no_three_ds",
    "return_url": "https://hs-payments-test.netlify.app/payments",
    "email": "arjun.karthik@juspay.in",
    "name": "John Doe",
    "phone": "999999999",
    "phone_country_code": "+65",
    "description": "Its my first payment request",
    "statement_descriptor_name": "Juspay",
    "statement_descriptor_suffix": "Router",
    "setup_future_usage": "off_session",
    "payment_method": "card",
    "payment_method_type": "credit",
    
    "payment_method_data": {
        "card": {
            
            "card_number": "4622943127013705",
            "card_exp_month": "12",
            "card_exp_year": "2030",
            "card_holder_name": "joseph Doe",
            "card_cvc": "838"
        }
    },
    "billing": {
        "address": {
            "line1": "1467",
            "line2": "CA",
            "line3": "Harrison Street",
            "city": "San Fransico",
            "state": "New York",
            "zip": "94122",
            "country": "US",
            "first_name": "joseph",
            "last_name": "Doe"
        },
        "phone": {
            "number": "8056594427",
            "country_code": "+91"
        }
    },
    "browser_info": {
        "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Safari/537.36",
        "accept_header": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8",
        "language": "nl-NL",
        "color_depth": 24,
        "screen_height": 723,
        "screen_width": 1536,
        "time_zone": 0,
        "java_enabled": true,
        "java_script_enabled": true,
        "ip_address": "125.0.0.1"
    },
    "metadata": {
        "order_details": {
            "product_name": "Apple iphone 15",
            "quantity": 1,
            "amount": 3200,
            "account_name": "transaction_processing"
        }
    }  
}'
``` 
Response
```
{
    "payment_id": "pay_ZtpG9t02Is8hmgg0Pt2k",
    "merchant_id": "merchant_1715085079",
    "status": "succeeded",
    "amount": 100,
    "net_amount": 100,
    "amount_capturable": 0,
    "amount_received": 100,
    "connector": "cybersource",
    "client_secret": "pay_ZtpG9t02Is8hmgg0Pt2k_secret_h4KlYF818tbvDdAFv2rU",
    "created": "2024-05-07T12:31:33.884Z",
    "currency": "USD",
    "customer_id": "abc",
    "customer": {
        "id": "abc",
        "name": "John Doe",
        "email": "arjun.karthik@juspay.in",
        "phone": "999999999",
        "phone_country_code": "+65"
    },
    "description": "Its my first payment request",
    "refunds": null,
    "disputes": null,
    "mandate_id": null,
    "mandate_data": null,
    "setup_future_usage": "off_session",
    "off_session": null,
    "capture_on": null,
    "capture_method": "automatic",
    "payment_method": "card",
    "payment_method_data": {
        "card": {
            "last4": "3705",
            "card_type": null,
            "card_network": null,
            "card_issuer": null,
            "card_issuing_country": null,
            "card_isin": "462294",
            "card_extended_bin": null,
            "card_exp_month": "12",
            "card_exp_year": "2030",
            "card_holder_name": "joseph Doe",
            "payment_checks": {
                "avs_response": {
                    "code": "Y",
                    "codeRaw": "Y"
                },
                "card_verification": null
            },
            "authentication_data": null
        },
        "billing": null
    },
    "payment_token": "token_QgMwzlAuhvZ8oZ0TyCnG",
    "shipping": null,
    "billing": {
        "address": {
            "city": "San Fransico",
            "country": "US",
            "line1": "1467",
            "line2": "CA",
            "line3": "Harrison Street",
            "zip": "94122",
            "state": "New York",
            "first_name": "joseph",
            "last_name": "Doe"
        },
        "phone": {
            "number": "8056594427",
            "country_code": "+91"
        },
        "email": null
    },
    "order_details": null,
    "email": "arjun.karthik@juspay.in",
    "name": "John Doe",
    "phone": "999999999",
    "return_url": "https://hs-payments-test.netlify.app/payments",
    "authentication_type": "no_three_ds",
    "statement_descriptor_name": "Juspay",
    "statement_descriptor_suffix": "Router",
    "next_action": null,
    "cancellation_reason": null,
    "error_code": null,
    "error_message": null,
    "unified_code": null,
    "unified_message": null,
    "payment_experience": null,
    "payment_method_type": "credit",
    "connector_label": "cybersource_US_default_default",
    "business_country": "US",
    "business_label": "default",
    "business_sub_label": null,
    "allowed_payment_method_types": null,
    "ephemeral_key": {
        "customer_id": "abc",
        "created_at": 1715085093,
        "expires": 1715088693,
        "secret": "epk_4fc527fec5034f52874e26668ccfd461"
    },
    "manual_retry_allowed": false,
    "connector_transaction_id": "7150850943306542603955",
    "frm_message": null,
    "metadata": {
        "order_details": {
            "amount": 3200,
            "quantity": 1,
            "account_name": "transaction_processing",
            "product_name": "Apple iphone 15"
        }
    },
    "connector_metadata": null,
    "feature_metadata": null,
    "reference_id": "pay_ZtpG9t02Is8hmgg0Pt2k_1",
    "payment_link": null,
    "profile_id": "pro_jy1hXETZpOTtyo48f2rP",
    "surcharge_details": null,
    "attempt_count": 1,
    "merchant_decision": null,
    "merchant_connector_id": "mca_mzXYICVAcgq5mCPlf4p9",
    "incremental_authorization_allowed": false,
    "authorization_count": null,
    "incremental_authorizations": null,
    "external_authentication_details": null,
    "external_3ds_authentication_attempted": false,
    "expires_on": "2024-05-07T12:46:33.884Z",
    "fingerprint": null,
    "browser_info": {
        "language": "nl-NL",
        "time_zone": 0,
        "ip_address": "125.0.0.1",
        "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Safari/537.36",
        "color_depth": 24,
        "java_enabled": true,
        "screen_width": 1536,
        "accept_header": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8",
        "screen_height": 723,
        "java_script_enabled": true
    },
    "payment_method_id": null,
    "payment_method_status": null,
    "updated": "2024-05-07T12:31:35.424Z"
}
```

5. Refund the payment
```
curl --location 'http://localhost:8080/refunds' \
--header 'Content-Type: application/json' \
--header 'api-key:""' \
--data '{
    "payment_id": "pay_ZtpG9t02Is8hmgg0Pt2k",
    "amount": 100,
    "reason": "Customer returned product",
    "refund_type": "instant",
    "metadata": {
        "udf1": "value1",
        "new_customer": "true",
        "login_date": "2019-09-10T10:11:12Z"
    }
}'
```
Response
```
{
    "refund_id": "ref_LhLapTLkO0lUxgROysYF",
    "payment_id": "pay_ZtpG9t02Is8hmgg0Pt2k",
    "amount": 100,
    "currency": "USD",
    "status": "pending",
    "reason": "Customer returned product",
    "metadata": {
        "udf1": "value1",
        "new_customer": "true",
        "login_date": "2019-09-10T10:11:12Z"
    },
    "error_message": null,
    "error_code": null,
    "created_at": "2024-05-07T12:32:35.452Z",
    "updated_at": "2024-05-07T12:32:35.452Z",
    "connector": "cybersource",
    "profile_id": "pro_jy1hXETZpOTtyo48f2rP",
    "merchant_connector_id": "mca_mzXYICVAcgq5mCPlf4p9"
}
```

6. Do a Rsync
```
curl --location 'http://localhost:8080/refunds/ref_ycNxoYyhoEskxFyuUtjo?force_sync=true' \
--header 'Accept: application/json' \
--header 'api-key: "" '
```
Response
```
{
    "refund_id": "ref_ycNxoYyhoEskxFyuUtjo",
    "payment_id": "pay_CynccL5DmW1ETflUPxEa",
    "amount": 100,
    "currency": "USD",
    "status": "pending",
    "reason": "Customer returned product",
    "metadata": {
        "udf1": "value1",
        "new_customer": "true",
        "login_date": "2019-09-10T10:11:12Z"
    },
    "error_message": null,
    "error_code": null,
    "created_at": "2024-05-07T12:08:16.183Z",
    "updated_at": "2024-05-07T12:08:16.183Z",
    "connector": "bankofamerica",
    "profile_id": "pro_T2wjq3SsGuXZ5fdUene6",
    "merchant_connector_id": "mca_otyt4b6GdbCisxI2tTTu"
}
```
__Note: there is no particular scenario where status is not sent in rsync connector response. This can happen randomly__


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
