### PR TITLE
fix(connector): [BAMBORA] Audit Fixes for Bambora

### DIFF
--- a/crates/connector_configs/toml/development.toml
+++ b/crates/connector_configs/toml/development.toml
@@ -385,26 +385,9 @@ merchant_secret="Source verification key"
   payment_method_type = "CartesBancaires"
 [[bambora.debit]]
   payment_method_type = "UnionPay"
-[[bambora.wallet]]
-  payment_method_type = "apple_pay"
-[[bambora.wallet]]
-  payment_method_type = "paypal"
 [bambora.connector_auth.BodyKey]
 api_key="Passcode"
 key1="Merchant Id"
-[bambora.connector_webhook_details]
-merchant_secret="Source verification key"
-[bambora.metadata.apple_pay.session_token_data]
-certificate="Merchant Certificate (Base64 Encoded)"
-certificate_keys="Merchant PrivateKey (Base64 Encoded)"
-merchant_identifier="Apple Merchant Identifier"
-display_name="Display Name"
-initiative="Domain"
-initiative_context="Domain Name"
-[bambora.metadata.apple_pay.payment_request_data]
-supported_networks=["visa","masterCard","amex","discover"]
-merchant_capabilities=["supports3DS"]
-label="apple"
 
 [bankofamerica]
 [[bankofamerica.credit]]

--- a/crates/connector_configs/toml/production.toml
+++ b/crates/connector_configs/toml/production.toml
@@ -403,27 +403,9 @@ merchant_config_currency="Currency"
   payment_method_type = "CartesBancaires"
 [[bambora.debit]]
   payment_method_type = "UnionPay"
-[[bambora.wallet]]
-  payment_method_type = "apple_pay"
-[[bambora.wallet]]
-  payment_method_type = "paypal"
 [bambora.connector_auth.BodyKey]
 api_key="Passcode"
 key1="Merchant Id"
-[bambora.connector_webhook_details]
-merchant_secret="Source verification key"
-
-[bambora.metadata.apple_pay.session_token_data]
-certificate="Merchant Certificate (Base64 Encoded)"
-certificate_keys="Merchant PrivateKey (Base64 Encoded)"
-merchant_identifier="Apple Merchant Identifier"
-display_name="Display Name"
-initiative="Domain"
-initiative_context="Domain Name"
-[bambora.metadata.apple_pay.payment_request_data]
-supported_networks=["visa","masterCard","amex","discover"]
-merchant_capabilities=["supports3DS"]
-label="apple"
 
 [bankofamerica]
 [[bankofamerica.credit]]

--- a/crates/connector_configs/toml/sandbox.toml
+++ b/crates/connector_configs/toml/sandbox.toml
@@ -385,26 +385,9 @@ merchant_secret="Source verification key"
   payment_method_type = "CartesBancaires"
 [[bambora.debit]]
   payment_method_type = "UnionPay"
-[[bambora.wallet]]
-  payment_method_type = "apple_pay"
-[[bambora.wallet]]
-  payment_method_type = "paypal"
 [bambora.connector_auth.BodyKey]
 api_key="Passcode"
 key1="Merchant Id"
-[bambora.connector_webhook_details]
-merchant_secret="Source verification key"
-[bambora.metadata.apple_pay.session_token_data]
-certificate="Merchant Certificate (Base64 Encoded)"
-certificate_keys="Merchant PrivateKey (Base64 Encoded)"
-merchant_identifier="Apple Merchant Identifier"
-display_name="Display Name"
-initiative="Domain"
-initiative_context="Domain Name"
-[bambora.metadata.apple_pay.payment_request_data]
-supported_networks=["visa","masterCard","amex","discover"]
-merchant_capabilities=["supports3DS"]
-label="apple"
 
 [bankofamerica]
 [[bankofamerica.credit]]

--- a/crates/router/src/connector/bambora.rs
+++ b/crates/router/src/connector/bambora.rs
@@ -10,10 +10,7 @@ use transformers as bambora;
 use super::utils::RefundsRequestData;
 use crate::{
     configs::settings,
-    connector::{
-        utils as connector_utils,
-        utils::{to_connector_meta, PaymentsAuthorizeRequestData, PaymentsSyncRequestData},
-    },
+    connector::{utils as connector_utils, utils::to_connector_meta},
     core::{
         errors::{self, CustomResult},
         payments,
@@ -35,6 +32,20 @@ use crate::{
 
 #[derive(Debug, Clone)]
 pub struct Bambora;
+
+impl api::Payment for Bambora {}
+impl api::PaymentToken for Bambora {}
+impl api::PaymentAuthorize for Bambora {}
+impl api::PaymentVoid for Bambora {}
+impl api::MandateSetup for Bambora {}
+impl api::ConnectorAccessToken for Bambora {}
+impl api::PaymentSync for Bambora {}
+impl api::PaymentCapture for Bambora {}
+impl api::PaymentSession for Bambora {}
+impl api::Refund for Bambora {}
+impl api::RefundExecute for Bambora {}
+impl api::RefundSync for Bambora {}
+impl api::PaymentsCompleteAuthorize for Bambora {}
 
 impl<Flow, Request, Response> ConnectorCommonExt<Flow, Request, Response> for Bambora
 where
@@ -103,8 +114,9 @@ impl ConnectorCommon for Bambora {
         Ok(ErrorResponse {
             status_code: res.status_code,
             code: response.code.to_string(),
-            message: response.message,
-            reason: Some(serde_json::to_string(&response.details).unwrap_or_default()),
+            message: serde_json::to_string(&response.details)
+                .unwrap_or(crate::consts::NO_ERROR_MESSAGE.to_string()),
+            reason: Some(response.message),
             attempt_status: None,
             connector_transaction_id: None,
         })
@@ -127,10 +139,6 @@ impl ConnectorValidation for Bambora {
     }
 }
 
-impl api::Payment for Bambora {}
-
-impl api::PaymentToken for Bambora {}
-
 impl
     ConnectorIntegration<
         api::PaymentMethodToken,
@@ -141,7 +149,17 @@ impl
     // Not Implemented (R)
 }
 
-impl api::MandateSetup for Bambora {}
+impl ConnectorIntegration<api::AccessTokenAuth, types::AccessTokenRequestData, types::AccessToken>
+    for Bambora
+{
+}
+
+impl ConnectorIntegration<api::Session, types::PaymentsSessionData, types::PaymentsResponseData>
+    for Bambora
+{
+    //TODO: implement sessions flow
+}
+
 impl
     ConnectorIntegration<
         api::SetupMandate,
@@ -165,7 +183,358 @@ impl
     }
 }
 
-impl api::PaymentVoid for Bambora {}
+impl ConnectorIntegration<api::Authorize, types::PaymentsAuthorizeData, types::PaymentsResponseData>
+    for Bambora
+{
+    fn get_headers(
+        &self,
+        req: &types::PaymentsAuthorizeRouterData,
+        connectors: &settings::Connectors,
+    ) -> CustomResult<Vec<(String, request::Maskable<String>)>, errors::ConnectorError> {
+        self.build_headers(req, connectors)
+    }
+
+    fn get_content_type(&self) -> &'static str {
+        self.common_get_content_type()
+    }
+
+    fn get_url(
+        &self,
+        _req: &types::PaymentsAuthorizeRouterData,
+        connectors: &settings::Connectors,
+    ) -> CustomResult<String, errors::ConnectorError> {
+        Ok(format!("{}{}", self.base_url(connectors), "/v1/payments"))
+    }
+
+    fn get_request_body(
+        &self,
+        req: &types::PaymentsAuthorizeRouterData,
+        _connectors: &settings::Connectors,
+    ) -> CustomResult<RequestContent, errors::ConnectorError> {
+        let connector_router_data = bambora::BamboraRouterData::try_from((
+            &self.get_currency_unit(),
+            req.request.currency,
+            req.request.amount,
+            req,
+        ))?;
+
+        let connector_req = bambora::BamboraPaymentsRequest::try_from(connector_router_data)?;
+        Ok(RequestContent::Json(Box::new(connector_req)))
+    }
+
+    fn build_request(
+        &self,
+        req: &types::PaymentsAuthorizeRouterData,
+        connectors: &settings::Connectors,
+    ) -> CustomResult<Option<services::Request>, errors::ConnectorError> {
+        Ok(Some(
+            services::RequestBuilder::new()
+                .method(services::Method::Post)
+                .url(&types::PaymentsAuthorizeType::get_url(
+                    self, req, connectors,
+                )?)
+                .attach_default_headers()
+                .headers(types::PaymentsAuthorizeType::get_headers(
+                    self, req, connectors,
+                )?)
+                .set_body(types::PaymentsAuthorizeType::get_request_body(
+                    self, req, connectors,
+                )?)
+                .build(),
+        ))
+    }
+
+    fn handle_response(
+        &self,
+        data: &types::PaymentsAuthorizeRouterData,
+        event_builder: Option<&mut ConnectorEvent>,
+        res: Response,
+    ) -> CustomResult<types::PaymentsAuthorizeRouterData, errors::ConnectorError> {
+        let response: bambora::BamboraResponse = res
+            .response
+            .parse_struct("PaymentIntentResponse")
+            .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
+        event_builder.map(|i| i.set_response_body(&response));
+        router_env::logger::info!(connector_response=?response);
+
+        types::RouterData::try_from(types::ResponseRouterData {
+            response,
+            data: data.clone(),
+            http_code: res.status_code,
+        })
+    }
+
+    fn get_error_response(
+        &self,
+        res: Response,
+        event_builder: Option<&mut ConnectorEvent>,
+    ) -> CustomResult<ErrorResponse, errors::ConnectorError> {
+        self.build_error_response(res, event_builder)
+    }
+}
+
+impl
+    ConnectorIntegration<
+        api::CompleteAuthorize,
+        types::CompleteAuthorizeData,
+        types::PaymentsResponseData,
+    > for Bambora
+{
+    fn get_headers(
+        &self,
+        req: &types::PaymentsCompleteAuthorizeRouterData,
+        connectors: &settings::Connectors,
+    ) -> CustomResult<Vec<(String, request::Maskable<String>)>, errors::ConnectorError> {
+        self.build_headers(req, connectors)
+    }
+
+    fn get_content_type(&self) -> &'static str {
+        self.common_get_content_type()
+    }
+
+    fn get_url(
+        &self,
+        req: &types::PaymentsCompleteAuthorizeRouterData,
+        connectors: &settings::Connectors,
+    ) -> CustomResult<String, errors::ConnectorError> {
+        let meta: bambora::BamboraMeta = to_connector_meta(req.request.connector_meta.clone())?;
+        Ok(format!(
+            "{}/v1/payments/{}{}",
+            self.base_url(connectors),
+            meta.three_d_session_data,
+            "/continue"
+        ))
+    }
+
+    fn get_request_body(
+        &self,
+        req: &types::PaymentsCompleteAuthorizeRouterData,
+        _connectors: &settings::Connectors,
+    ) -> CustomResult<RequestContent, errors::ConnectorError> {
+        let connector_req = bambora::BamboraThreedsContinueRequest::try_from(&req.request)?;
+
+        Ok(RequestContent::Json(Box::new(connector_req)))
+    }
+
+    fn build_request(
+        &self,
+        req: &types::PaymentsCompleteAuthorizeRouterData,
+        connectors: &settings::Connectors,
+    ) -> CustomResult<Option<services::Request>, errors::ConnectorError> {
+        let request = services::RequestBuilder::new()
+            .method(services::Method::Post)
+            .url(&types::PaymentsCompleteAuthorizeType::get_url(
+                self, req, connectors,
+            )?)
+            .headers(types::PaymentsCompleteAuthorizeType::get_headers(
+                self, req, connectors,
+            )?)
+            .set_body(types::PaymentsCompleteAuthorizeType::get_request_body(
+                self, req, connectors,
+            )?)
+            .build();
+        Ok(Some(request))
+    }
+
+    fn handle_response(
+        &self,
+        data: &types::PaymentsCompleteAuthorizeRouterData,
+        event_builder: Option<&mut ConnectorEvent>,
+        res: Response,
+    ) -> CustomResult<types::PaymentsCompleteAuthorizeRouterData, errors::ConnectorError> {
+        let response: bambora::BamboraPaymentsResponse = res
+            .response
+            .parse_struct("BamboraPaymentsResponse")
+            .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
+        event_builder.map(|i| i.set_response_body(&response));
+        router_env::logger::info!(connector_response=?response);
+
+        types::RouterData::try_from(types::ResponseRouterData {
+            response,
+            data: data.clone(),
+            http_code: res.status_code,
+        })
+        .change_context(errors::ConnectorError::ResponseHandlingFailed)
+    }
+
+    fn get_error_response(
+        &self,
+        res: Response,
+        event_builder: Option<&mut ConnectorEvent>,
+    ) -> CustomResult<ErrorResponse, errors::ConnectorError> {
+        self.build_error_response(res, event_builder)
+    }
+}
+
+impl ConnectorIntegration<api::PSync, types::PaymentsSyncData, types::PaymentsResponseData>
+    for Bambora
+{
+    fn get_headers(
+        &self,
+        req: &types::PaymentsSyncRouterData,
+        connectors: &settings::Connectors,
+    ) -> CustomResult<Vec<(String, request::Maskable<String>)>, errors::ConnectorError> {
+        self.build_headers(req, connectors)
+    }
+
+    fn get_content_type(&self) -> &'static str {
+        self.common_get_content_type()
+    }
+
+    fn get_url(
+        &self,
+        req: &types::PaymentsSyncRouterData,
+        connectors: &settings::Connectors,
+    ) -> CustomResult<String, errors::ConnectorError> {
+        let connector_payment_id = req
+            .request
+            .connector_transaction_id
+            .get_connector_transaction_id()
+            .change_context(errors::ConnectorError::MissingConnectorTransactionID)?;
+        Ok(format!(
+            "{}/v1/payments/{connector_payment_id}",
+            self.base_url(connectors),
+        ))
+    }
+
+    fn build_request(
+        &self,
+        req: &types::PaymentsSyncRouterData,
+        connectors: &settings::Connectors,
+    ) -> CustomResult<Option<services::Request>, errors::ConnectorError> {
+        Ok(Some(
+            services::RequestBuilder::new()
+                .method(services::Method::Get)
+                .url(&types::PaymentsSyncType::get_url(self, req, connectors)?)
+                .attach_default_headers()
+                .headers(types::PaymentsSyncType::get_headers(self, req, connectors)?)
+                .build(),
+        ))
+    }
+
+    fn get_error_response(
+        &self,
+        res: Response,
+        event_builder: Option<&mut ConnectorEvent>,
+    ) -> CustomResult<ErrorResponse, errors::ConnectorError> {
+        self.build_error_response(res, event_builder)
+    }
+
+    fn handle_response(
+        &self,
+        data: &types::PaymentsSyncRouterData,
+        event_builder: Option<&mut ConnectorEvent>,
+        res: Response,
+    ) -> CustomResult<types::PaymentsSyncRouterData, errors::ConnectorError> {
+        let response: bambora::BamboraPaymentsResponse = res
+            .response
+            .parse_struct("bambora PaymentsResponse")
+            .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
+
+        event_builder.map(|i| i.set_response_body(&response));
+        router_env::logger::info!(connector_response=?response);
+
+        types::RouterData::try_from(types::ResponseRouterData {
+            response,
+            data: data.clone(),
+            http_code: res.status_code,
+        })
+        .change_context(errors::ConnectorError::ResponseHandlingFailed)
+    }
+}
+
+impl ConnectorIntegration<api::Capture, types::PaymentsCaptureData, types::PaymentsResponseData>
+    for Bambora
+{
+    fn get_headers(
+        &self,
+        req: &types::PaymentsCaptureRouterData,
+        connectors: &settings::Connectors,
+    ) -> CustomResult<Vec<(String, request::Maskable<String>)>, errors::ConnectorError> {
+        self.build_headers(req, connectors)
+    }
+
+    fn get_content_type(&self) -> &'static str {
+        self.common_get_content_type()
+    }
+
+    fn get_url(
+        &self,
+        req: &types::PaymentsCaptureRouterData,
+        connectors: &settings::Connectors,
+    ) -> CustomResult<String, errors::ConnectorError> {
+        Ok(format!(
+            "{}/v1/payments/{}/completions",
+            self.base_url(connectors),
+            req.request.connector_transaction_id,
+        ))
+    }
+
+    fn get_request_body(
+        &self,
+        req: &types::PaymentsCaptureRouterData,
+        _connectors: &settings::Connectors,
+    ) -> CustomResult<RequestContent, errors::ConnectorError> {
+        let connector_router_data = bambora::BamboraRouterData::try_from((
+            &self.get_currency_unit(),
+            req.request.currency,
+            req.request.amount_to_capture,
+            req,
+        ))?;
+
+        let connector_req =
+            bambora::BamboraPaymentsCaptureRequest::try_from(connector_router_data)?;
+        Ok(RequestContent::Json(Box::new(connector_req)))
+    }
+
+    fn build_request(
+        &self,
+        req: &types::PaymentsCaptureRouterData,
+        connectors: &settings::Connectors,
+    ) -> CustomResult<Option<services::Request>, errors::ConnectorError> {
+        Ok(Some(
+            services::RequestBuilder::new()
+                .method(services::Method::Post)
+                .url(&types::PaymentsCaptureType::get_url(self, req, connectors)?)
+                .attach_default_headers()
+                .headers(types::PaymentsCaptureType::get_headers(
+                    self, req, connectors,
+                )?)
+                .set_body(self.get_request_body(req, connectors)?)
+                .build(),
+        ))
+    }
+
+    fn handle_response(
+        &self,
+        data: &types::PaymentsCaptureRouterData,
+        event_builder: Option<&mut ConnectorEvent>,
+        res: Response,
+    ) -> CustomResult<types::PaymentsCaptureRouterData, errors::ConnectorError> {
+        let response: bambora::BamboraPaymentsResponse = res
+            .response
+            .parse_struct("Bambora PaymentsResponse")
+            .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
+
+        event_builder.map(|i| i.set_response_body(&response));
+        router_env::logger::info!(connector_response=?response);
+
+        types::RouterData::try_from(types::ResponseRouterData {
+            response,
+            data: data.clone(),
+            http_code: res.status_code,
+        })
+        .change_context(errors::ConnectorError::ResponseHandlingFailed)
+    }
+
+    fn get_error_response(
+        &self,
+        res: Response,
+        event_builder: Option<&mut ConnectorEvent>,
+    ) -> CustomResult<ErrorResponse, errors::ConnectorError> {
+        self.build_error_response(res, event_builder)
+    }
+}
 
 impl ConnectorIntegration<api::Void, types::PaymentsCancelData, types::PaymentsResponseData>
     for Bambora
@@ -189,10 +558,9 @@ impl ConnectorIntegration<api::Void, types::PaymentsCancelData, types::PaymentsR
     ) -> CustomResult<String, errors::ConnectorError> {
         let connector_payment_id = req.request.connector_transaction_id.clone();
         Ok(format!(
-            "{}/v1/payments/{}{}",
+            "{}/v1/payments/{}/void",
             self.base_url(connectors),
             connector_payment_id,
-            "/void"
         ))
     }
 
@@ -243,7 +611,7 @@ impl ConnectorIntegration<api::Void, types::PaymentsCancelData, types::PaymentsR
         event_builder: Option<&mut ConnectorEvent>,
         res: Response,
     ) -> CustomResult<types::PaymentsCancelRouterData, errors::ConnectorError> {
-        let response: bambora::BamboraResponse = res
+        let response: bambora::BamboraPaymentsResponse = res
             .response
             .parse_struct("bambora PaymentsResponse")
             .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
@@ -251,14 +619,11 @@ impl ConnectorIntegration<api::Void, types::PaymentsCancelData, types::PaymentsR
         event_builder.map(|i| i.set_response_body(&response));
         router_env::logger::info!(connector_response=?response);
 
-        types::RouterData::try_from((
-            types::ResponseRouterData {
-                response,
-                data: data.clone(),
-                http_code: res.status_code,
-            },
-            bambora::PaymentFlow::Void,
-        ))
+        types::RouterData::try_from(types::ResponseRouterData {
+            response,
+            data: data.clone(),
+            http_code: res.status_code,
+        })
         .change_context(errors::ConnectorError::ResponseHandlingFailed)
     }
 
@@ -271,303 +636,22 @@ impl ConnectorIntegration<api::Void, types::PaymentsCancelData, types::PaymentsR
     }
 }
 
-impl api::ConnectorAccessToken for Bambora {}
-
-impl ConnectorIntegration<api::AccessTokenAuth, types::AccessTokenRequestData, types::AccessToken>
-    for Bambora
-{
-}
-
-impl api::PaymentSync for Bambora {}
-impl ConnectorIntegration<api::PSync, types::PaymentsSyncData, types::PaymentsResponseData>
-    for Bambora
-{
-    fn get_headers(
+impl services::ConnectorRedirectResponse for Bambora {
+    fn get_flow_type(
         &self,
-        req: &types::PaymentsSyncRouterData,
-        connectors: &settings::Connectors,
-    ) -> CustomResult<Vec<(String, request::Maskable<String>)>, errors::ConnectorError> {
-        self.build_headers(req, connectors)
-    }
-
-    fn get_content_type(&self) -> &'static str {
-        self.common_get_content_type()
-    }
-
-    fn get_url(
-        &self,
-        req: &types::PaymentsSyncRouterData,
-        connectors: &settings::Connectors,
-    ) -> CustomResult<String, errors::ConnectorError> {
-        let connector_payment_id = req
-            .request
-            .connector_transaction_id
-            .get_connector_transaction_id()
-            .change_context(errors::ConnectorError::MissingConnectorTransactionID)?;
-        Ok(format!(
-            "{}{}{}",
-            self.base_url(connectors),
-            "/v1/payments/",
-            connector_payment_id
-        ))
-    }
-
-    fn build_request(
-        &self,
-        req: &types::PaymentsSyncRouterData,
-        connectors: &settings::Connectors,
-    ) -> CustomResult<Option<services::Request>, errors::ConnectorError> {
-        Ok(Some(
-            services::RequestBuilder::new()
-                .method(services::Method::Get)
-                .url(&types::PaymentsSyncType::get_url(self, req, connectors)?)
-                .attach_default_headers()
-                .headers(types::PaymentsSyncType::get_headers(self, req, connectors)?)
-                .build(),
-        ))
-    }
-
-    fn get_error_response(
-        &self,
-        res: Response,
-        event_builder: Option<&mut ConnectorEvent>,
-    ) -> CustomResult<ErrorResponse, errors::ConnectorError> {
-        self.build_error_response(res, event_builder)
-    }
-
-    fn handle_response(
-        &self,
-        data: &types::PaymentsSyncRouterData,
-        event_builder: Option<&mut ConnectorEvent>,
-        res: Response,
-    ) -> CustomResult<types::PaymentsSyncRouterData, errors::ConnectorError> {
-        let response: bambora::BamboraResponse = res
-            .response
-            .parse_struct("bambora PaymentsResponse")
-            .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
-
-        event_builder.map(|i| i.set_response_body(&response));
-        router_env::logger::info!(connector_response=?response);
-
-        types::RouterData::try_from((
-            types::ResponseRouterData {
-                response,
-                data: data.clone(),
-                http_code: res.status_code,
-            },
-            get_payment_flow(data.request.is_auto_capture()?),
-        ))
-        .change_context(errors::ConnectorError::ResponseHandlingFailed)
+        _query_params: &str,
+        _json_payload: Option<serde_json::Value>,
+        action: services::PaymentAction,
+    ) -> CustomResult<payments::CallConnectorAction, errors::ConnectorError> {
+        match action {
+            services::PaymentAction::PSync
+            | services::PaymentAction::CompleteAuthorize
+            | services::PaymentAction::PaymentAuthenticateCompleteAuthorize => {
+                Ok(payments::CallConnectorAction::Trigger)
+            }
+        }
     }
 }
-
-impl api::PaymentCapture for Bambora {}
-impl ConnectorIntegration<api::Capture, types::PaymentsCaptureData, types::PaymentsResponseData>
-    for Bambora
-{
-    fn get_headers(
-        &self,
-        req: &types::PaymentsCaptureRouterData,
-        connectors: &settings::Connectors,
-    ) -> CustomResult<Vec<(String, request::Maskable<String>)>, errors::ConnectorError> {
-        self.build_headers(req, connectors)
-    }
-
-    fn get_content_type(&self) -> &'static str {
-        self.common_get_content_type()
-    }
-
-    fn get_url(
-        &self,
-        req: &types::PaymentsCaptureRouterData,
-        connectors: &settings::Connectors,
-    ) -> CustomResult<String, errors::ConnectorError> {
-        Ok(format!(
-            "{}{}{}{}",
-            self.base_url(connectors),
-            "/v1/payments/",
-            req.request.connector_transaction_id,
-            "/completions"
-        ))
-    }
-
-    fn get_request_body(
-        &self,
-        req: &types::PaymentsCaptureRouterData,
-        _connectors: &settings::Connectors,
-    ) -> CustomResult<RequestContent, errors::ConnectorError> {
-        let connector_router_data = bambora::BamboraRouterData::try_from((
-            &self.get_currency_unit(),
-            req.request.currency,
-            req.request.amount_to_capture,
-            req,
-        ))?;
-
-        let connector_req =
-            bambora::BamboraPaymentsCaptureRequest::try_from(connector_router_data)?;
-        Ok(RequestContent::Json(Box::new(connector_req)))
-    }
-
-    fn build_request(
-        &self,
-        req: &types::PaymentsCaptureRouterData,
-        connectors: &settings::Connectors,
-    ) -> CustomResult<Option<services::Request>, errors::ConnectorError> {
-        Ok(Some(
-            services::RequestBuilder::new()
-                .method(services::Method::Post)
-                .url(&types::PaymentsCaptureType::get_url(self, req, connectors)?)
-                .attach_default_headers()
-                .headers(types::PaymentsCaptureType::get_headers(
-                    self, req, connectors,
-                )?)
-                .set_body(self.get_request_body(req, connectors)?)
-                .build(),
-        ))
-    }
-
-    fn handle_response(
-        &self,
-        data: &types::PaymentsCaptureRouterData,
-        event_builder: Option<&mut ConnectorEvent>,
-        res: Response,
-    ) -> CustomResult<types::PaymentsCaptureRouterData, errors::ConnectorError> {
-        let response: bambora::BamboraResponse = res
-            .response
-            .parse_struct("Bambora PaymentsResponse")
-            .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
-
-        event_builder.map(|i| i.set_response_body(&response));
-        router_env::logger::info!(connector_response=?response);
-
-        types::RouterData::try_from((
-            types::ResponseRouterData {
-                response,
-                data: data.clone(),
-                http_code: res.status_code,
-            },
-            bambora::PaymentFlow::Capture,
-        ))
-        .change_context(errors::ConnectorError::ResponseHandlingFailed)
-    }
-
-    fn get_error_response(
-        &self,
-        res: Response,
-        event_builder: Option<&mut ConnectorEvent>,
-    ) -> CustomResult<ErrorResponse, errors::ConnectorError> {
-        self.build_error_response(res, event_builder)
-    }
-}
-
-impl api::PaymentSession for Bambora {}
-
-impl ConnectorIntegration<api::Session, types::PaymentsSessionData, types::PaymentsResponseData>
-    for Bambora
-{
-    //TODO: implement sessions flow
-}
-
-impl api::PaymentAuthorize for Bambora {}
-
-impl ConnectorIntegration<api::Authorize, types::PaymentsAuthorizeData, types::PaymentsResponseData>
-    for Bambora
-{
-    fn get_headers(
-        &self,
-        req: &types::PaymentsAuthorizeRouterData,
-        connectors: &settings::Connectors,
-    ) -> CustomResult<Vec<(String, request::Maskable<String>)>, errors::ConnectorError> {
-        self.build_headers(req, connectors)
-    }
-
-    fn get_content_type(&self) -> &'static str {
-        self.common_get_content_type()
-    }
-
-    fn get_url(
-        &self,
-        _req: &types::PaymentsAuthorizeRouterData,
-        connectors: &settings::Connectors,
-    ) -> CustomResult<String, errors::ConnectorError> {
-        Ok(format!("{}{}", self.base_url(connectors), "/v1/payments"))
-    }
-
-    fn get_request_body(
-        &self,
-        req: &types::PaymentsAuthorizeRouterData,
-        _connectors: &settings::Connectors,
-    ) -> CustomResult<RequestContent, errors::ConnectorError> {
-        let connector_router_data = bambora::BamboraRouterData::try_from((
-            &self.get_currency_unit(),
-            req.request.currency,
-            req.request.amount,
-            req,
-        ))?;
-
-        let connector_req = bambora::BamboraPaymentsRequest::try_from(connector_router_data)?;
-
-        Ok(RequestContent::Json(Box::new(connector_req)))
-    }
-
-    fn build_request(
-        &self,
-        req: &types::PaymentsAuthorizeRouterData,
-        connectors: &settings::Connectors,
-    ) -> CustomResult<Option<services::Request>, errors::ConnectorError> {
-        Ok(Some(
-            services::RequestBuilder::new()
-                .method(services::Method::Post)
-                .url(&types::PaymentsAuthorizeType::get_url(
-                    self, req, connectors,
-                )?)
-                .attach_default_headers()
-                .headers(types::PaymentsAuthorizeType::get_headers(
-                    self, req, connectors,
-                )?)
-                .set_body(types::PaymentsAuthorizeType::get_request_body(
-                    self, req, connectors,
-                )?)
-                .build(),
-        ))
-    }
-
-    fn handle_response(
-        &self,
-        data: &types::PaymentsAuthorizeRouterData,
-        event_builder: Option<&mut ConnectorEvent>,
-        res: Response,
-    ) -> CustomResult<types::PaymentsAuthorizeRouterData, errors::ConnectorError> {
-        let response: bambora::BamboraResponse = res
-            .response
-            .parse_struct("PaymentIntentResponse")
-            .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
-        event_builder.map(|i| i.set_response_body(&response));
-        router_env::logger::info!(connector_response=?response);
-
-        types::RouterData::try_from((
-            types::ResponseRouterData {
-                response,
-                data: data.clone(),
-                http_code: res.status_code,
-            },
-            get_payment_flow(data.request.is_auto_capture()?),
-        ))
-        .change_context(errors::ConnectorError::ResponseHandlingFailed)
-    }
-
-    fn get_error_response(
-        &self,
-        res: Response,
-        event_builder: Option<&mut ConnectorEvent>,
-    ) -> CustomResult<ErrorResponse, errors::ConnectorError> {
-        self.build_error_response(res, event_builder)
-    }
-}
-
-impl api::Refund for Bambora {}
-impl api::RefundExecute for Bambora {}
-impl api::RefundSync for Bambora {}
 
 impl ConnectorIntegration<api::Execute, types::RefundsData, types::RefundsResponseData>
     for Bambora
@@ -591,11 +675,9 @@ impl ConnectorIntegration<api::Execute, types::RefundsData, types::RefundsRespon
     ) -> CustomResult<String, errors::ConnectorError> {
         let connector_payment_id = req.request.connector_transaction_id.clone();
         Ok(format!(
-            "{}{}{}{}",
+            "{}/v1/payments/{}/returns",
             self.base_url(connectors),
-            "/v1/payments/",
             connector_payment_id,
-            "/returns"
         ))
     }
 
@@ -685,9 +767,8 @@ impl ConnectorIntegration<api::RSync, types::RefundsData, types::RefundsResponse
         let _connector_payment_id = req.request.connector_transaction_id.clone();
         let connector_refund_id = req.request.get_connector_refund_id()?;
         Ok(format!(
-            "{}{}{}",
+            "{}/v1/payments/{}",
             self.base_url(connectors),
-            "/v1/payments/",
             connector_refund_id
         ))
     }
@@ -759,126 +840,5 @@ impl api::IncomingWebhook for Bambora {
         _request: &api::IncomingWebhookRequestDetails<'_>,
     ) -> CustomResult<Box<dyn masking::ErasedMaskSerialize>, errors::ConnectorError> {
         Err(errors::ConnectorError::WebhooksNotImplemented).into_report()
-    }
-}
-
-pub fn get_payment_flow(is_auto_capture: bool) -> bambora::PaymentFlow {
-    if is_auto_capture {
-        bambora::PaymentFlow::Capture
-    } else {
-        bambora::PaymentFlow::Authorize
-    }
-}
-
-impl services::ConnectorRedirectResponse for Bambora {
-    fn get_flow_type(
-        &self,
-        _query_params: &str,
-        _json_payload: Option<serde_json::Value>,
-        action: services::PaymentAction,
-    ) -> CustomResult<payments::CallConnectorAction, errors::ConnectorError> {
-        match action {
-            services::PaymentAction::PSync | services::PaymentAction::CompleteAuthorize => {
-                Ok(payments::CallConnectorAction::Trigger)
-            }
-        }
-    }
-}
-
-impl api::PaymentsCompleteAuthorize for Bambora {}
-
-impl
-    ConnectorIntegration<
-        api::CompleteAuthorize,
-        types::CompleteAuthorizeData,
-        types::PaymentsResponseData,
-    > for Bambora
-{
-    fn get_headers(
-        &self,
-        req: &types::PaymentsCompleteAuthorizeRouterData,
-        connectors: &settings::Connectors,
-    ) -> CustomResult<Vec<(String, request::Maskable<String>)>, errors::ConnectorError> {
-        self.build_headers(req, connectors)
-    }
-
-    fn get_content_type(&self) -> &'static str {
-        self.common_get_content_type()
-    }
-
-    fn get_url(
-        &self,
-        req: &types::PaymentsCompleteAuthorizeRouterData,
-        connectors: &settings::Connectors,
-    ) -> CustomResult<String, errors::ConnectorError> {
-        let meta: bambora::BamboraMeta = to_connector_meta(req.request.connector_meta.clone())?;
-        Ok(format!(
-            "{}/v1/payments/{}{}",
-            self.base_url(connectors),
-            meta.three_d_session_data,
-            "/continue"
-        ))
-    }
-
-    fn get_request_body(
-        &self,
-        req: &types::PaymentsCompleteAuthorizeRouterData,
-        _connectors: &settings::Connectors,
-    ) -> CustomResult<RequestContent, errors::ConnectorError> {
-        let connector_req = bambora::BamboraThreedsContinueRequest::try_from(&req.request)?;
-
-        Ok(RequestContent::Json(Box::new(connector_req)))
-    }
-
-    fn build_request(
-        &self,
-        req: &types::PaymentsCompleteAuthorizeRouterData,
-        connectors: &settings::Connectors,
-    ) -> CustomResult<Option<services::Request>, errors::ConnectorError> {
-        let request = services::RequestBuilder::new()
-            .method(services::Method::Post)
-            .url(&types::PaymentsCompleteAuthorizeType::get_url(
-                self, req, connectors,
-            )?)
-            .headers(types::PaymentsCompleteAuthorizeType::get_headers(
-                self, req, connectors,
-            )?)
-            .set_body(types::PaymentsCompleteAuthorizeType::get_request_body(
-                self, req, connectors,
-            )?)
-            .build();
-        Ok(Some(request))
-    }
-
-    fn handle_response(
-        &self,
-        data: &types::PaymentsCompleteAuthorizeRouterData,
-        event_builder: Option<&mut ConnectorEvent>,
-        res: Response,
-    ) -> CustomResult<types::PaymentsCompleteAuthorizeRouterData, errors::ConnectorError> {
-        let response: bambora::BamboraResponse = res
-            .response
-            .parse_struct("Bambora PaymentsResponse")
-            .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
-        event_builder.map(|i| i.set_response_body(&response));
-        router_env::logger::info!(connector_response=?response);
-
-        types::RouterData::try_from((
-            types::ResponseRouterData {
-                response,
-                data: data.clone(),
-                http_code: res.status_code,
-            },
-            bambora::PaymentFlow::Capture,
-        ))
-        .change_context(errors::ConnectorError::ResponseHandlingFailed)
-    }
-
-    fn get_error_response(
-        &self,
-        res: Response,
-        event_builder: Option<&mut ConnectorEvent>,
-    ) -> CustomResult<ErrorResponse, errors::ConnectorError> {
-        self.build_error_response(res, event_builder)
     }
 }

--- a/crates/router/src/connector/bambora.rs
+++ b/crates/router/src/connector/bambora.rs
@@ -644,9 +644,7 @@ impl services::ConnectorRedirectResponse for Bambora {
         action: services::PaymentAction,
     ) -> CustomResult<payments::CallConnectorAction, errors::ConnectorError> {
         match action {
-            services::PaymentAction::PSync
-            | services::PaymentAction::CompleteAuthorize
-            | services::PaymentAction::PaymentAuthenticateCompleteAuthorize => {
+            services::PaymentAction::PSync | services::PaymentAction::CompleteAuthorize => {
                 Ok(payments::CallConnectorAction::Trigger)
             }
         }

--- a/crates/router/src/connector/bambora/transformers.rs
+++ b/crates/router/src/connector/bambora/transformers.rs
@@ -147,7 +147,7 @@ impl TryFrom<BamboraRouterData<&types::PaymentsAuthorizeRouterData>> for Bambora
         item: BamboraRouterData<&types::PaymentsAuthorizeRouterData>,
     ) -> Result<Self, Self::Error> {
         match item.router_data.request.payment_method_data.clone() {
-            domain::PaymentMethodData::Card(req_card) => {
+            api_models::payments::PaymentMethodData::Card(req_card) => {
                 let (three_ds, customer_ip) = match item.router_data.auth_type {
                     enums::AuthenticationType::ThreeDs => (
                         Some(ThreeDSecure {
@@ -184,19 +184,19 @@ impl TryFrom<BamboraRouterData<&types::PaymentsAuthorizeRouterData>> for Bambora
                     term_url: item.router_data.request.complete_authorize_url.clone(),
                 })
             }
-            domain::PaymentMethodData::CardRedirect(_)
-            | domain::PaymentMethodData::Wallet(_)
-            | domain::PaymentMethodData::PayLater(_)
-            | domain::PaymentMethodData::BankRedirect(_)
-            | domain::PaymentMethodData::BankDebit(_)
-            | domain::PaymentMethodData::BankTransfer(_)
-            | domain::PaymentMethodData::Crypto(_)
-            | domain::PaymentMethodData::MandatePayment
-            | domain::PaymentMethodData::Reward
-            | domain::PaymentMethodData::Upi(_)
-            | domain::PaymentMethodData::Voucher(_)
-            | domain::PaymentMethodData::GiftCard(_)
-            | domain::PaymentMethodData::CardToken(_) => {
+            api_models::payments::PaymentMethodData::CardRedirect(_)
+            | api_models::payments::PaymentMethodData::Wallet(_)
+            | api_models::payments::PaymentMethodData::PayLater(_)
+            | api_models::payments::PaymentMethodData::BankRedirect(_)
+            | api_models::payments::PaymentMethodData::BankDebit(_)
+            | api_models::payments::PaymentMethodData::BankTransfer(_)
+            | api_models::payments::PaymentMethodData::Crypto(_)
+            | api_models::payments::PaymentMethodData::MandatePayment
+            | api_models::payments::PaymentMethodData::Reward
+            | api_models::payments::PaymentMethodData::Upi(_)
+            | api_models::payments::PaymentMethodData::Voucher(_)
+            | api_models::payments::PaymentMethodData::GiftCard(_)
+            | api_models::payments::PaymentMethodData::CardToken(_) => {
                 Err(errors::ConnectorError::NotImplemented("Payment methods".to_string()).into())
             }
         }
@@ -475,6 +475,7 @@ impl<F>
                             serde_json::to_value(BamboraMeta {
                                 three_d_session_data: response.three_d_session_data.expose(),
                             })
+                            .into_report()
                             .change_context(errors::ConnectorError::ResponseHandlingFailed)?,
                         ),
                         network_txn_id: None,

--- a/crates/router/src/connector/bambora/transformers.rs
+++ b/crates/router/src/connector/bambora/transformers.rs
@@ -7,7 +7,8 @@ use serde::{Deserialize, Deserializer, Serialize};
 use crate::{
     connector::utils::{
         AddressDetailsData, BrowserInformationData, CardData as OtherCardData,
-        PaymentsAuthorizeRequestData, RouterData,
+        PaymentsAuthorizeRequestData, PaymentsCompleteAuthorizeRequestData,
+        PaymentsSyncRequestData, RouterData,
     },
     consts,
     core::errors,
@@ -146,17 +147,25 @@ impl TryFrom<BamboraRouterData<&types::PaymentsAuthorizeRouterData>> for Bambora
         item: BamboraRouterData<&types::PaymentsAuthorizeRouterData>,
     ) -> Result<Self, Self::Error> {
         match item.router_data.request.payment_method_data.clone() {
-            api_models::payments::PaymentMethodData::Card(req_card) => {
-                let three_ds = match item.router_data.auth_type {
-                    enums::AuthenticationType::ThreeDs => Some(ThreeDSecure {
-                        enabled: true,
-                        browser: get_browser_info(item.router_data)?,
-                        version: Some(2),
-                        auth_required: Some(true),
-                    }),
-                    enums::AuthenticationType::NoThreeDs => None,
+            domain::PaymentMethodData::Card(req_card) => {
+                let (three_ds, customer_ip) = match item.router_data.auth_type {
+                    enums::AuthenticationType::ThreeDs => (
+                        Some(ThreeDSecure {
+                            enabled: true,
+                            browser: get_browser_info(item.router_data)?,
+                            version: Some(2),
+                            auth_required: Some(true),
+                        }),
+                        Some(
+                            item.router_data
+                                .request
+                                .get_browser_info()?
+                                .get_ip_address()?,
+                        ),
+                    ),
+                    enums::AuthenticationType::NoThreeDs => (None, None),
                 };
-                let bambora_card = BamboraCard {
+                let card = BamboraCard {
                     name: item.router_data.get_billing_address()?.get_full_name()?,
                     expiry_year: req_card.get_card_expiry_year_2_digit()?,
                     number: req_card.card_number,
@@ -165,19 +174,31 @@ impl TryFrom<BamboraRouterData<&types::PaymentsAuthorizeRouterData>> for Bambora
                     three_d_secure: three_ds,
                     complete: item.router_data.request.is_auto_capture()?,
                 };
-                let browser_info = item.router_data.request.get_browser_info()?;
+
                 Ok(Self {
                     order_number: item.router_data.connector_request_reference_id.clone(),
                     amount: item.amount,
                     payment_method: PaymentMethod::Card,
-                    card: bambora_card,
-                    customer_ip: browser_info
-                        .ip_address
-                        .map(|ip_address| Secret::new(format!("{ip_address}"))),
+                    card,
+                    customer_ip,
                     term_url: item.router_data.request.complete_authorize_url.clone(),
                 })
             }
-            _ => Err(errors::ConnectorError::NotImplemented("Payment methods".to_string()).into()),
+            domain::PaymentMethodData::CardRedirect(_)
+            | domain::PaymentMethodData::Wallet(_)
+            | domain::PaymentMethodData::PayLater(_)
+            | domain::PaymentMethodData::BankRedirect(_)
+            | domain::PaymentMethodData::BankDebit(_)
+            | domain::PaymentMethodData::BankTransfer(_)
+            | domain::PaymentMethodData::Crypto(_)
+            | domain::PaymentMethodData::MandatePayment
+            | domain::PaymentMethodData::Reward
+            | domain::PaymentMethodData::Upi(_)
+            | domain::PaymentMethodData::Voucher(_)
+            | domain::PaymentMethodData::GiftCard(_)
+            | domain::PaymentMethodData::CardToken(_) => {
+                Err(errors::ConnectorError::NotImplemented("Payment methods".to_string()).into())
+            }
         }
     }
 }
@@ -208,88 +229,6 @@ impl TryFrom<&types::ConnectorAuthType> for BamboraAuthType {
             })
         } else {
             Err(errors::ConnectorError::FailedToObtainAuthType)?
-        }
-    }
-}
-
-pub enum PaymentFlow {
-    Authorize,
-    Capture,
-    Void,
-}
-
-// PaymentsResponse
-impl<F, T>
-    TryFrom<(
-        types::ResponseRouterData<F, BamboraResponse, T, types::PaymentsResponseData>,
-        PaymentFlow,
-    )> for types::RouterData<F, T, types::PaymentsResponseData>
-{
-    type Error = error_stack::Report<errors::ConnectorError>;
-    fn try_from(
-        data: (
-            types::ResponseRouterData<F, BamboraResponse, T, types::PaymentsResponseData>,
-            PaymentFlow,
-        ),
-    ) -> Result<Self, Self::Error> {
-        let flow = data.1;
-        let item = data.0;
-        match item.response {
-            BamboraResponse::NormalTransaction(pg_response) => Ok(Self {
-                status: match pg_response.approved.as_str() {
-                    "0" => match flow {
-                        PaymentFlow::Authorize => enums::AttemptStatus::AuthorizationFailed,
-                        PaymentFlow::Capture => enums::AttemptStatus::Failure,
-                        PaymentFlow::Void => enums::AttemptStatus::VoidFailed,
-                    },
-                    "1" => match flow {
-                        PaymentFlow::Authorize => enums::AttemptStatus::Authorized,
-                        PaymentFlow::Capture => enums::AttemptStatus::Charged,
-                        PaymentFlow::Void => enums::AttemptStatus::Voided,
-                    },
-                    &_ => Err(errors::ConnectorError::ResponseDeserializationFailed)?,
-                },
-                response: Ok(types::PaymentsResponseData::TransactionResponse {
-                    resource_id: types::ResponseId::ConnectorTransactionId(
-                        pg_response.id.to_string(),
-                    ),
-                    redirection_data: None,
-                    mandate_reference: None,
-                    connector_metadata: None,
-                    network_txn_id: None,
-                    connector_response_reference_id: Some(pg_response.order_number.to_string()),
-                    incremental_authorization_allowed: None,
-                }),
-                ..item.data
-            }),
-
-            BamboraResponse::ThreeDsResponse(response) => {
-                let value = url::form_urlencoded::parse(response.contents.as_bytes())
-                    .map(|(key, val)| [key, val].concat())
-                    .collect();
-                let redirection_data = Some(services::RedirectForm::Html { html_data: value });
-                Ok(Self {
-                    status: enums::AttemptStatus::AuthenticationPending,
-                    response: Ok(types::PaymentsResponseData::TransactionResponse {
-                        resource_id: types::ResponseId::NoResponseId,
-                        redirection_data,
-                        mandate_reference: None,
-                        connector_metadata: Some(
-                            serde_json::to_value(BamboraMeta {
-                                three_d_session_data: response.three_d_session_data.expose(),
-                            })
-                            .into_report()
-                            .change_context(errors::ConnectorError::ResponseHandlingFailed)?,
-                        ),
-                        network_txn_id: None,
-                        connector_response_reference_id: Some(
-                            item.data.connector_request_reference_id.to_string(),
-                        ),
-                        incremental_authorization_allowed: None,
-                    }),
-                    ..item.data
-                })
-            }
         }
     }
 }
@@ -457,7 +396,7 @@ pub enum PaymentMethod {
 // Capture
 #[derive(Default, Debug, Clone, Serialize, PartialEq)]
 pub struct BamboraPaymentsCaptureRequest {
-    amount: Option<f64>,
+    amount: f64,
     payment_method: PaymentMethod,
 }
 
@@ -469,8 +408,265 @@ impl TryFrom<BamboraRouterData<&types::PaymentsCaptureRouterData>>
         item: BamboraRouterData<&types::PaymentsCaptureRouterData>,
     ) -> Result<Self, Self::Error> {
         Ok(Self {
-            amount: Some(item.amount),
+            amount: item.amount,
             payment_method: PaymentMethod::Card,
+        })
+    }
+}
+
+impl<F>
+    TryFrom<
+        types::ResponseRouterData<
+            F,
+            BamboraResponse,
+            types::PaymentsAuthorizeData,
+            types::PaymentsResponseData,
+        >,
+    > for types::RouterData<F, types::PaymentsAuthorizeData, types::PaymentsResponseData>
+{
+    type Error = error_stack::Report<errors::ConnectorError>;
+    fn try_from(
+        item: types::ResponseRouterData<
+            F,
+            BamboraResponse,
+            types::PaymentsAuthorizeData,
+            types::PaymentsResponseData,
+        >,
+    ) -> Result<Self, Self::Error> {
+        match item.response {
+            BamboraResponse::NormalTransaction(pg_response) => Ok(Self {
+                status: if pg_response.approved.as_str() == "1" {
+                    match item.data.request.is_auto_capture()? {
+                        true => enums::AttemptStatus::Charged,
+                        false => enums::AttemptStatus::Authorized,
+                    }
+                } else {
+                    match item.data.request.is_auto_capture()? {
+                        true => enums::AttemptStatus::Failure,
+                        false => enums::AttemptStatus::AuthorizationFailed,
+                    }
+                },
+                response: Ok(types::PaymentsResponseData::TransactionResponse {
+                    resource_id: types::ResponseId::ConnectorTransactionId(
+                        pg_response.id.to_string(),
+                    ),
+                    redirection_data: None,
+                    mandate_reference: None,
+                    connector_metadata: None,
+                    network_txn_id: None,
+                    connector_response_reference_id: Some(pg_response.order_number.to_string()),
+                    incremental_authorization_allowed: None,
+                }),
+                ..item.data
+            }),
+
+            BamboraResponse::ThreeDsResponse(response) => {
+                let value = url::form_urlencoded::parse(response.contents.as_bytes())
+                    .map(|(key, val)| [key, val].concat())
+                    .collect();
+                let redirection_data = Some(services::RedirectForm::Html { html_data: value });
+                Ok(Self {
+                    status: enums::AttemptStatus::AuthenticationPending,
+                    response: Ok(types::PaymentsResponseData::TransactionResponse {
+                        resource_id: types::ResponseId::NoResponseId,
+                        redirection_data,
+                        mandate_reference: None,
+                        connector_metadata: Some(
+                            serde_json::to_value(BamboraMeta {
+                                three_d_session_data: response.three_d_session_data.expose(),
+                            })
+                            .change_context(errors::ConnectorError::ResponseHandlingFailed)?,
+                        ),
+                        network_txn_id: None,
+                        connector_response_reference_id: Some(
+                            item.data.connector_request_reference_id.to_string(),
+                        ),
+                        incremental_authorization_allowed: None,
+                    }),
+                    ..item.data
+                })
+            }
+        }
+    }
+}
+
+impl<F>
+    TryFrom<
+        types::ResponseRouterData<
+            F,
+            BamboraPaymentsResponse,
+            types::CompleteAuthorizeData,
+            types::PaymentsResponseData,
+        >,
+    > for types::RouterData<F, types::CompleteAuthorizeData, types::PaymentsResponseData>
+{
+    type Error = error_stack::Report<errors::ConnectorError>;
+    fn try_from(
+        item: types::ResponseRouterData<
+            F,
+            BamboraPaymentsResponse,
+            types::CompleteAuthorizeData,
+            types::PaymentsResponseData,
+        >,
+    ) -> Result<Self, Self::Error> {
+        Ok(Self {
+            status: if item.response.approved.as_str() == "1" {
+                match item.data.request.is_auto_capture()? {
+                    true => enums::AttemptStatus::Charged,
+                    false => enums::AttemptStatus::Authorized,
+                }
+            } else {
+                match item.data.request.is_auto_capture()? {
+                    true => enums::AttemptStatus::Failure,
+                    false => enums::AttemptStatus::AuthorizationFailed,
+                }
+            },
+            response: Ok(types::PaymentsResponseData::TransactionResponse {
+                resource_id: types::ResponseId::ConnectorTransactionId(
+                    item.response.id.to_string(),
+                ),
+                redirection_data: None,
+                mandate_reference: None,
+                connector_metadata: None,
+                network_txn_id: None,
+                connector_response_reference_id: Some(item.response.order_number.to_string()),
+                incremental_authorization_allowed: None,
+            }),
+            ..item.data
+        })
+    }
+}
+
+impl<F>
+    TryFrom<
+        types::ResponseRouterData<
+            F,
+            BamboraPaymentsResponse,
+            types::PaymentsSyncData,
+            types::PaymentsResponseData,
+        >,
+    > for types::RouterData<F, types::PaymentsSyncData, types::PaymentsResponseData>
+{
+    type Error = error_stack::Report<errors::ConnectorError>;
+    fn try_from(
+        item: types::ResponseRouterData<
+            F,
+            BamboraPaymentsResponse,
+            types::PaymentsSyncData,
+            types::PaymentsResponseData,
+        >,
+    ) -> Result<Self, Self::Error> {
+        Ok(Self {
+            status: match item.data.request.is_auto_capture()? {
+                true => {
+                    if item.response.approved.as_str() == "1" {
+                        enums::AttemptStatus::Charged
+                    } else {
+                        enums::AttemptStatus::Failure
+                    }
+                }
+                false => {
+                    if item.response.approved.as_str() == "1" {
+                        enums::AttemptStatus::Authorized
+                    } else {
+                        enums::AttemptStatus::AuthorizationFailed
+                    }
+                }
+            },
+            response: Ok(types::PaymentsResponseData::TransactionResponse {
+                resource_id: types::ResponseId::ConnectorTransactionId(
+                    item.response.id.to_string(),
+                ),
+                redirection_data: None,
+                mandate_reference: None,
+                connector_metadata: None,
+                network_txn_id: None,
+                connector_response_reference_id: Some(item.response.order_number.to_string()),
+                incremental_authorization_allowed: None,
+            }),
+            ..item.data
+        })
+    }
+}
+
+impl<F>
+    TryFrom<
+        types::ResponseRouterData<
+            F,
+            BamboraPaymentsResponse,
+            types::PaymentsCaptureData,
+            types::PaymentsResponseData,
+        >,
+    > for types::RouterData<F, types::PaymentsCaptureData, types::PaymentsResponseData>
+{
+    type Error = error_stack::Report<errors::ConnectorError>;
+    fn try_from(
+        item: types::ResponseRouterData<
+            F,
+            BamboraPaymentsResponse,
+            types::PaymentsCaptureData,
+            types::PaymentsResponseData,
+        >,
+    ) -> Result<Self, Self::Error> {
+        Ok(Self {
+            status: if item.response.approved.as_str() == "1" {
+                enums::AttemptStatus::Charged
+            } else {
+                enums::AttemptStatus::Failure
+            },
+            response: Ok(types::PaymentsResponseData::TransactionResponse {
+                resource_id: types::ResponseId::ConnectorTransactionId(
+                    item.response.id.to_string(),
+                ),
+                redirection_data: None,
+                mandate_reference: None,
+                connector_metadata: None,
+                network_txn_id: None,
+                connector_response_reference_id: Some(item.response.order_number.to_string()),
+                incremental_authorization_allowed: None,
+            }),
+            ..item.data
+        })
+    }
+}
+
+impl<F>
+    TryFrom<
+        types::ResponseRouterData<
+            F,
+            BamboraPaymentsResponse,
+            types::PaymentsCancelData,
+            types::PaymentsResponseData,
+        >,
+    > for types::RouterData<F, types::PaymentsCancelData, types::PaymentsResponseData>
+{
+    type Error = error_stack::Report<errors::ConnectorError>;
+    fn try_from(
+        item: types::ResponseRouterData<
+            F,
+            BamboraPaymentsResponse,
+            types::PaymentsCancelData,
+            types::PaymentsResponseData,
+        >,
+    ) -> Result<Self, Self::Error> {
+        Ok(Self {
+            status: if item.response.approved.as_str() == "1" {
+                enums::AttemptStatus::Voided
+            } else {
+                enums::AttemptStatus::VoidFailed
+            },
+            response: Ok(types::PaymentsResponseData::TransactionResponse {
+                resource_id: types::ResponseId::ConnectorTransactionId(
+                    item.response.id.to_string(),
+                ),
+                redirection_data: None,
+                mandate_reference: None,
+                connector_metadata: None,
+                network_txn_id: None,
+                connector_response_reference_id: Some(item.response.order_number.to_string()),
+                incremental_authorization_allowed: None,
+            }),
+            ..item.data
         })
     }
 }
@@ -550,10 +746,10 @@ impl TryFrom<types::RefundsResponseRouterData<api::Execute, RefundResponse>>
     fn try_from(
         item: types::RefundsResponseRouterData<api::Execute, RefundResponse>,
     ) -> Result<Self, Self::Error> {
-        let refund_status = match item.response.approved.as_str() {
-            "0" => enums::RefundStatus::Failure,
-            "1" => enums::RefundStatus::Success,
-            &_ => Err(errors::ConnectorError::ResponseDeserializationFailed)?,
+        let refund_status = if item.response.approved.as_str() == "1" {
+            enums::RefundStatus::Success
+        } else {
+            enums::RefundStatus::Failure
         };
         Ok(Self {
             response: Ok(types::RefundsResponseData {
@@ -572,10 +768,10 @@ impl TryFrom<types::RefundsResponseRouterData<api::RSync, RefundResponse>>
     fn try_from(
         item: types::RefundsResponseRouterData<api::RSync, RefundResponse>,
     ) -> Result<Self, Self::Error> {
-        let refund_status = match item.response.approved.as_str() {
-            "0" => enums::RefundStatus::Failure,
-            "1" => enums::RefundStatus::Success,
-            &_ => Err(errors::ConnectorError::ResponseDeserializationFailed)?,
+        let refund_status = if item.response.approved.as_str() == "1" {
+            enums::RefundStatus::Success
+        } else {
+            enums::RefundStatus::Failure
         };
         Ok(Self {
             response: Ok(types::RefundsResponseData {


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
ORIGINAL PR: https://github.com/juspay/hyperswitch/pull/4604
Following code improvements are done for connector Bambora:
- Optional fields that are being passed for payments request are removed
- 2XX and 4XX Error response are now handled properly
- Separate try_from are now used for all the flows
- Unwanted configs are removed
- Default case handling is removed

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

Following are the paths where you can find config files which have been updated:
1. `crates/connector_configs/toml/development.toml`
2. `crates/connector_configs/toml/sandbox.toml`
3. `crates/connector_configs/toml/production.toml`



## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
https://github.com/juspay/hyperswitch/issues/4605

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
All the payment flows need to be tested(except void) for cards(Non-3DS) via Bambora.
1. Payments (Automatic):
Request -
```
curl --location 'http://localhost:8080/payments' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: API_KEY_HERE' \
--data '{
    "amount": 2000,
    "currency": "USD",
    "confirm": true,
    "customer_id": "assdre1v",
    "authentication_type": "no_three_ds",
    "payment_method": "card",
    "payment_method_type": "credit",
    "payment_method_data": {
        "card": {
            "card_number": "4030000010001234",
            "card_exp_month": "10",
            "card_exp_year": "2024",
            "card_holder_name": "Sundari KK",
            "card_cvc": "123"
        }
    }
}'
```
Response -
```
{
    "payment_id": "pay_WLq2W1Lf6nDlkSVsTfXH",
    "merchant_id": "merchant_1714730521",
    "status": "succeeded",
    "amount": 2000,
    "net_amount": 2000,
    "amount_capturable": 0,
    "amount_received": 2000,
    "connector": "bambora",
    "client_secret": "pay_WLq2W1Lf6nDlkSVsTfXH_secret_AGkc7on7LPYnS4tzNDrh",
    "created": "2024-05-09T11:29:26.243Z",
    "currency": "USD",
    "customer_id": "assdre1v",
    "customer": {
        "id": "assdre1v",
        "name": null,
        "email": null,
        "phone": null,
        "phone_country_code": null
    },
    "description": null,
    "refunds": null,
    "disputes": null,
    "mandate_id": null,
    "mandate_data": null,
    "setup_future_usage": null,
    "off_session": null,
    "capture_on": null,
    "capture_method": null,
    "payment_method": "card",
    "payment_method_data": {
        "card": {
            "last4": "1234",
            "card_type": null,
            "card_network": null,
            "card_issuer": null,
            "card_issuing_country": null,
            "card_isin": "403000",
            "card_extended_bin": null,
            "card_exp_month": "10",
            "card_exp_year": "2024",
            "card_holder_name": "Sundari KK",
            "payment_checks": null,
            "authentication_data": null
        },
        "billing": null
    },
    "payment_token": null,
    "shipping": null,
    "billing": null,
    "order_details": null,
    "email": null,
    "name": null,
    "phone": null,
    "return_url": null,
    "authentication_type": "no_three_ds",
    "statement_descriptor_name": null,
    "statement_descriptor_suffix": null,
    "next_action": null,
    "cancellation_reason": null,
    "error_code": null,
    "error_message": null,
    "unified_code": null,
    "unified_message": null,
    "payment_experience": null,
    "payment_method_type": "credit",
    "connector_label": null,
    "business_country": null,
    "business_label": "default",
    "business_sub_label": null,
    "allowed_payment_method_types": null,
    "ephemeral_key": {
        "customer_id": "assdre1v",
        "created_at": 1715254166,
        "expires": 1715257766,
        "secret": "epk_1b0a796b1c1d4f2ebac92c20ba7f2381"
    },
    "manual_retry_allowed": false,
    "connector_transaction_id": "10004856",
    "frm_message": null,
    "metadata": null,
    "connector_metadata": null,
    "feature_metadata": null,
    "reference_id": "pay_WLq2W1Lf6nDlkSVsTfXH_1",
    "payment_link": null,
    "profile_id": "pro_l8ERwD92l71RbPpGZZz9",
    "surcharge_details": null,
    "attempt_count": 1,
    "merchant_decision": null,
    "merchant_connector_id": "mca_ybl21De1o5q31x82RpEj",
    "incremental_authorization_allowed": null,
    "authorization_count": null,
    "incremental_authorizations": null,
    "external_authentication_details": null,
    "external_3ds_authentication_attempted": false,
    "expires_on": "2024-05-09T11:44:26.243Z",
    "fingerprint": null,
    "browser_info": null,
    "payment_method_id": null,
    "payment_method_status": null,
    "updated": "2024-05-09T11:29:28.588Z"
}
```

2. Payments (Manual):
Request -
```
curl --location 'http://localhost:8080/payments' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: API_KEY_HERE' \
--data '{
    "amount": 2000,
    "currency": "USD",
    "confirm": true,
    "customer_id": "assdre1v",
    "capture_method": "manual",
    "authentication_type": "no_three_ds",
    "payment_method": "card",
    "payment_method_type": "credit",
    "payment_method_data": {
        "card": {
            "card_number": "4030000010001234",
            "card_exp_month": "10",
            "card_exp_year": "2024",
            "card_holder_name": "Sundari KK",
            "card_cvc": "123"
        }
    }
}'
```
Response -
```
{
    "payment_id": "pay_xHfLlrcSjSKeOPaw1GGz",
    "merchant_id": "merchant_1714730521",
    "status": "requires_capture",
    "amount": 2000,
    "net_amount": 2000,
    "amount_capturable": 2000,
    "amount_received": null,
    "connector": "bambora",
    "client_secret": "pay_xHfLlrcSjSKeOPaw1GGz_secret_wTB68iFSUs9LuEiSJy6O",
    "created": "2024-05-09T11:29:40.405Z",
    "currency": "USD",
    "customer_id": "assdre1v",
    "customer": {
        "id": "assdre1v",
        "name": null,
        "email": null,
        "phone": null,
        "phone_country_code": null
    },
    "description": null,
    "refunds": null,
    "disputes": null,
    "mandate_id": null,
    "mandate_data": null,
    "setup_future_usage": null,
    "off_session": null,
    "capture_on": null,
    "capture_method": "manual",
    "payment_method": "card",
    "payment_method_data": {
        "card": {
            "last4": "1234",
            "card_type": null,
            "card_network": null,
            "card_issuer": null,
            "card_issuing_country": null,
            "card_isin": "403000",
            "card_extended_bin": null,
            "card_exp_month": "10",
            "card_exp_year": "2024",
            "card_holder_name": "Sundari KK",
            "payment_checks": null,
            "authentication_data": null
        },
        "billing": null
    },
    "payment_token": null,
    "shipping": null,
    "billing": null,
    "order_details": null,
    "email": null,
    "name": null,
    "phone": null,
    "return_url": null,
    "authentication_type": "no_three_ds",
    "statement_descriptor_name": null,
    "statement_descriptor_suffix": null,
    "next_action": null,
    "cancellation_reason": null,
    "error_code": null,
    "error_message": null,
    "unified_code": null,
    "unified_message": null,
    "payment_experience": null,
    "payment_method_type": "credit",
    "connector_label": null,
    "business_country": null,
    "business_label": "default",
    "business_sub_label": null,
    "allowed_payment_method_types": null,
    "ephemeral_key": {
        "customer_id": "assdre1v",
        "created_at": 1715254180,
        "expires": 1715257780,
        "secret": "epk_28013d1f51344818865586555d178f34"
    },
    "manual_retry_allowed": false,
    "connector_transaction_id": "10004857",
    "frm_message": null,
    "metadata": null,
    "connector_metadata": null,
    "feature_metadata": null,
    "reference_id": "pay_xHfLlrcSjSKeOPaw1GGz_1",
    "payment_link": null,
    "profile_id": "pro_l8ERwD92l71RbPpGZZz9",
    "surcharge_details": null,
    "attempt_count": 1,
    "merchant_decision": null,
    "merchant_connector_id": "mca_ybl21De1o5q31x82RpEj",
    "incremental_authorization_allowed": null,
    "authorization_count": null,
    "incremental_authorizations": null,
    "external_authentication_details": null,
    "external_3ds_authentication_attempted": false,
    "expires_on": "2024-05-09T11:44:40.405Z",
    "fingerprint": null,
    "browser_info": null,
    "payment_method_id": null,
    "payment_method_status": null,
    "updated": "2024-05-09T11:29:42.247Z"
}
```

3. Payments (Capture):
Request - 
```
curl --location 'http://localhost:8080/payments/pay_Qjbk8kB5wduiuuBOvI2Y/capture' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: API_KEY_HERE' \
--data '{
    "amount_to_capture": 2000,
    "statement_descriptor_name": "Joseph",
    "statement_descriptor_suffix": "JS"
}'
```
Response - 
```
{
    "payment_id": "pay_xHfLlrcSjSKeOPaw1GGz",
    "merchant_id": "merchant_1714730521",
    "status": "succeeded",
    "amount": 2000,
    "net_amount": 2000,
    "amount_capturable": 0,
    "amount_received": 2000,
    "connector": "bambora",
    "client_secret": "pay_xHfLlrcSjSKeOPaw1GGz_secret_wTB68iFSUs9LuEiSJy6O",
    "created": "2024-05-09T11:29:40.405Z",
    "currency": "USD",
    "customer_id": "assdre1v",
    "customer": {
        "id": "assdre1v",
        "name": null,
        "email": null,
        "phone": null,
        "phone_country_code": null
    },
    "description": null,
    "refunds": null,
    "disputes": null,
    "mandate_id": null,
    "mandate_data": null,
    "setup_future_usage": null,
    "off_session": null,
    "capture_on": null,
    "capture_method": "manual",
    "payment_method": "card",
    "payment_method_data": {
        "card": {
            "last4": "1234",
            "card_type": null,
            "card_network": null,
            "card_issuer": null,
            "card_issuing_country": null,
            "card_isin": "403000",
            "card_extended_bin": null,
            "card_exp_month": "10",
            "card_exp_year": "2024",
            "card_holder_name": "Sundari KK",
            "payment_checks": null,
            "authentication_data": null
        },
        "billing": null
    },
    "payment_token": null,
    "shipping": null,
    "billing": null,
    "order_details": null,
    "email": null,
    "name": null,
    "phone": null,
    "return_url": null,
    "authentication_type": "no_three_ds",
    "statement_descriptor_name": null,
    "statement_descriptor_suffix": null,
    "next_action": null,
    "cancellation_reason": null,
    "error_code": null,
    "error_message": null,
    "unified_code": null,
    "unified_message": null,
    "payment_experience": null,
    "payment_method_type": "credit",
    "connector_label": null,
    "business_country": null,
    "business_label": "default",
    "business_sub_label": null,
    "allowed_payment_method_types": null,
    "ephemeral_key": null,
    "manual_retry_allowed": false,
    "connector_transaction_id": "10004858",
    "frm_message": null,
    "metadata": null,
    "connector_metadata": null,
    "feature_metadata": null,
    "reference_id": "pay_xHfLlrcSjSKeOPaw1GGz_1",
    "payment_link": null,
    "profile_id": "pro_l8ERwD92l71RbPpGZZz9",
    "surcharge_details": null,
    "attempt_count": 1,
    "merchant_decision": null,
    "merchant_connector_id": "mca_ybl21De1o5q31x82RpEj",
    "incremental_authorization_allowed": null,
    "authorization_count": null,
    "incremental_authorizations": null,
    "external_authentication_details": null,
    "external_3ds_authentication_attempted": false,
    "expires_on": "2024-05-09T11:44:40.405Z",
    "fingerprint": null,
    "browser_info": null,
    "payment_method_id": null,
    "payment_method_status": null,
    "updated": "2024-05-09T11:30:15.379Z"
}
```

4. Refunds:
Request - 
```
curl --location 'http://localhost:8080/refunds' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: API_KEY_HERE' \
--data '{
    "amount": 100,
    "payment_id": "pay_xHfLlrcSjSKeOPaw1GGz",
    "reason": "Customer returned product",
    "refund_type": "instant",
    "metadata": {
        "udf1": "value1",
        "new_customer": "true",
        "login_date": "2019-09-10T10:11:12Z"
    }
}'
```

Response:
```
{
    "refund_id": "ref_i2J7zKX1kzvU00IPSW2m",
    "payment_id": "pay_xHfLlrcSjSKeOPaw1GGz",
    "amount": 100,
    "currency": "USD",
    "status": "succeeded",
    "reason": "Customer returned product",
    "metadata": {
        "udf1": "value1",
        "new_customer": "true",
        "login_date": "2019-09-10T10:11:12Z"
    },
    "error_message": null,
    "error_code": null,
    "created_at": "2024-05-09T11:33:37.772Z",
    "updated_at": "2024-05-09T11:33:37.772Z",
    "connector": "bambora",
    "profile_id": "pro_l8ERwD92l71RbPpGZZz9",
    "merchant_connector_id": "mca_ybl21De1o5q31x82RpEj"
}
```

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
