### PR TITLE
Fix(router): fix QR data into image conversion

### DIFF
--- a/crates/router/src/utils.rs
+++ b/crates/router/src/utils.rs
@@ -185,7 +185,7 @@ impl QrImage {
         let image_data_source = format!(
             "{},{}",
             consts::QR_IMAGE_DATA_SOURCE_STRING,
-            consts::BASE64_ENGINE.encode(image_bytes.get_ref().get_ref())
+            consts::BASE64_ENGINE.encode(image_bytes.buffer())
         );
         Ok(Self {
             data: image_data_source,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
The QR code generation function, 'new_from_data', is not working as expected. It is returning an empty string instead of the encoded image URL , leading to the failure of PIX QR code generation.

Earlier 
<img width="339" alt="Screenshot 2024-05-10 at 12 18 52 PM" src="https://github.com/juspay/hyperswitch/assets/131388445/b9d78dd5-ec62-4a79-9587-b6b359f9d122">


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
1. Create a PIX payment with Adyen. In response we must get a valid base64 encoded QR Code data
```
curl --location 'http://localhost:8080/payments' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: dev_Q1XJ407yuiyLeM1BwpMrGJos9JzwwHHztSVIypS3zsMkIYQqf1W7HA2NZhFpZyL4' \
--data-raw '{
  "amount": 6540,
  "currency": "BRL",
  "confirm": true,
  "capture_method": "automatic",
  "capture_on": "2022-09-10T10:11:12Z",
  "amount_to_capture": 6540,
  "customer_id": "StripeCustomer",
  "email": "guest@example.com",
  "name": "John Doe",
  "phone": "999999999",
  "phone_country_code": "+1",
  "description": "Its my first payment request",
  "authentication_type": "no_three_ds",
  "return_url": "https://hs-payments-test.netlify.app/payments/",
      "payment_method": "bank_transfer",
    "payment_method_type": "pix",
    "payment_method_data": {
        "bank_transfer": {
            "pix": {}
        }
    }
}'
```
Response
```
{
    "payment_id": "pay_pES0gbesSS9LXecyuhd6",
    "merchant_id": "merchant_1715279316",
    "status": "requires_customer_action",
    "amount": 6540,
    "net_amount": 6540,
    "amount_capturable": 6540,
    "amount_received": null,
    "connector": "adyen",
    "client_secret": "pay_pES0gbesSS9LXecyuhd6_secret_Q3ma2x34cOKMp9h6OTRm",
    "created": "2024-05-10T06:20:26.315Z",
    "currency": "BRL",
    "customer_id": "StripeCustomer",
    "customer": {
        "id": "StripeCustomer",
        "name": "John Doe",
        "email": "guest@example.com",
        "phone": "999999999",
        "phone_country_code": "+1"
    },
    "description": "Its my first payment request",
    "refunds": null,
    "disputes": null,
    "mandate_id": null,
    "mandate_data": null,
    "setup_future_usage": null,
    "off_session": null,
    "capture_on": null,
    "capture_method": "automatic",
    "payment_method": "bank_transfer",
    "payment_method_data": {
        "bank_transfer": {},
        "billing": null
    },
    "payment_token": null,
    "shipping": null,
    "billing": null,
    "order_details": null,
    "email": "guest@example.com",
    "name": "John Doe",
    "phone": "999999999",
    "return_url": "https://hs-payments-test.netlify.app/payments/",
    "authentication_type": "no_three_ds",
    "statement_descriptor_name": null,
    "statement_descriptor_suffix": null,
    "next_action": {
        "type": "qr_code_information",
        "image_data_url": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUg**********",
        "display_to_timestamp": 1715325628000,
        "qr_code_url": "https://test.adyen.com/hpp/generateQRCodeImage.shtml?url=*********"
    },
    "cancellation_reason": null,
    "error_code": null,
    "error_message": null,
    "unified_code": null,
    "unified_message": null,
    "payment_experience": null,
    "payment_method_type": "pix",
    "connector_label": null,
    "business_country": null,
    "business_label": "default",
    "business_sub_label": null,
    "allowed_payment_method_types": null,
    "ephemeral_key": {
        "customer_id": "StripeCustomer",
        "created_at": 1715322026,
        "expires": 1715325626,
        "secret": "epk_eea7fdbbbeb645d28e1e0bd4a0905631"
    },
    "manual_retry_allowed": null,
    "connector_transaction_id": "MQ9886QMBZNKWPT5",
    "frm_message": null,
    "metadata": null,
    "connector_metadata": null,
    "feature_metadata": null,
    "reference_id": "MQ9886QMBZNKWPT5",
    "payment_link": null,
    "profile_id": "pro_10opqc1gzSgRKhUq7O1H",
    "surcharge_details": null,
    "attempt_count": 1,
    "merchant_decision": null,
    "merchant_connector_id": "mca_mbTo85IbSKeh3xAG84jr",
    "incremental_authorization_allowed": null,
    "authorization_count": null,
    "incremental_authorizations": null,
    "external_authentication_details": null,
    "external_3ds_authentication_attempted": false,
    "expires_on": "2024-05-10T06:35:26.315Z",
    "fingerprint": null,
    "browser_info": null,
    "payment_method_id": null,
    "payment_method_status": null,
    "updated": "2024-05-10T06:20:28.525Z"
}
```

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
