### PR TITLE
Ci(Cypress): Fix SaveCard Flow Test

### DIFF
--- a/cypress-tests/cypress/e2e/ConnectorTest/00013-SaveCardFlow.cy.js
+++ b/cypress-tests/cypress/e2e/ConnectorTest/00013-SaveCardFlow.cy.js
@@ -3,7 +3,7 @@ import confirmBody from "../../fixtures/confirm-body.json";
 import createPaymentBody from "../../fixtures/create-payment-body.json";
 import createConfirmPaymentBody from "../../fixtures/create-confirm-body.json";
 import customerCreateBody from "../../fixtures/create-customer-body.json";
-import SaveCardConfirmBody from "../../fixtures/save-card-confirm-body.json";
+import saveCardConfirmBody from "../../fixtures/save-card-confirm-body.json";
 import getConnectorDetails from "../ConnectorUtils/utils";
 import State from "../../utils/State";
 let globalState;
@@ -44,7 +44,7 @@ describe("Card - SaveCard payment flow test", () => {
 
       it ("confirm-save-card-payment-call-test", () => {
         let det = getConnectorDetails(globalState.get("connectorId"))["card_pm"]["SaveCardUseNo3DS"];
-        cy.saveCardConfirmCallTest(SaveCardConfirmBody,det,globalState);
+        cy.saveCardConfirmCallTest(saveCardConfirmBody,det,globalState);
       });
       
     });
@@ -75,7 +75,7 @@ describe("Card - SaveCard payment flow test", () => {
   
         it ("confirm-save-card-payment-call-test", () => {
           let det = getConnectorDetails(globalState.get("connectorId"))["card_pm"]["SaveCardUseNo3DS"];
-          cy.saveCardConfirmCallTest(SaveCardConfirmBody,det,globalState);
+          cy.saveCardConfirmCallTest(saveCardConfirmBody,det,globalState);
         });
         
         it("capture-call-test", () => {
@@ -110,7 +110,7 @@ describe("Card - SaveCard payment flow test", () => {
   
         it ("confirm-save-card-payment-call-test", () => {
           let det = getConnectorDetails(globalState.get("connectorId"))["card_pm"]["SaveCardUseNo3DS"];
-          cy.saveCardConfirmCallTest(SaveCardConfirmBody,det,globalState);
+          cy.saveCardConfirmCallTest(saveCardConfirmBody,det,globalState);
         });
         
         it("capture-call-test", () => {

--- a/cypress-tests/cypress/fixtures/create-payment-body.json
+++ b/cypress-tests/cypress/fixtures/create-payment-body.json
@@ -10,6 +10,7 @@
       "order_category": "applepay"
     }
   },
+
   "metadata": {
     "udf1": "value1",
     "new_customer": "true",

--- a/cypress-tests/cypress/fixtures/save-card-confirm-body.json
+++ b/cypress-tests/cypress/fixtures/save-card-confirm-body.json
@@ -2,5 +2,31 @@
   "client_secret": "{{client_secret}}",
   "payment_method": "card",
   "payment_token": "{{payment_token}}",
-  "card_cvc": "card_cvc"
+  "card_cvc": "card_cvc",
+  "billing": {
+    "address": {
+      "line1": "1467",
+      "line2": "Harrison Street",
+      "line3": "Harrison Street",
+      "city": "San Fransico",
+      "state": "California",
+      "zip": "94122",
+      "country": "US",
+      "first_name": "john",
+      "last_name": "doe"
+    }
+  },
+  "shipping": {
+    "address": {
+      "line1": "1467",
+      "line2": "Harrison Street",
+      "line3": "Harrison Street",
+      "city": "San Fransico",
+      "state": "California",
+      "zip": "94122",
+      "country": "US",
+      "first_name": "john",
+      "last_name": "doe"
+    }
+  }
 }

--- a/cypress-tests/cypress/support/commands.js
+++ b/cypress-tests/cypress/support/commands.js
@@ -154,7 +154,7 @@ Cypress.Commands.add("createPaymentIntentTest", (request, det, authentication_ty
     body: request,
   }).then((response) => {
     logRequestId(response.headers['x-request-id']);
-
+    console.log(response);
     expect(response.headers["content-type"]).to.include("application/json");
     expect(response.body).to.have.property("client_secret");
     const clientSecret = response.body.client_secret;
@@ -208,7 +208,7 @@ Cypress.Commands.add("confirmCallTest", (confirmBody, details, confirm, globalSt
     body: confirmBody,
   }).then((response) => {
     logRequestId(response.headers['x-request-id']);
-
+    console.log(response);
     expect(response.headers["content-type"]).to.include("application/json");
     globalState.set("paymentID", paymentIntentID);
     if (response.body.capture_method === "automatic") {
@@ -260,7 +260,7 @@ Cypress.Commands.add("createConfirmPaymentTest", (createConfirmPaymentBody, deta
     body: createConfirmPaymentBody,
   }).then((response) => {
     logRequestId(response.headers['x-request-id']);
-
+    console.log(response);
     expect(response.headers["content-type"]).to.include("application/json");
     expect(response.body).to.have.property("status");
     globalState.set("paymentAmount", createConfirmPaymentBody.amount);
@@ -297,7 +297,7 @@ Cypress.Commands.add("createConfirmPaymentTest", (createConfirmPaymentBody, deta
 // This is consequent saved card payment confirm call test(Using payment token)
 Cypress.Commands.add("saveCardConfirmCallTest", (SaveCardConfirmBody,det,globalState) => {
   const paymentIntentID = globalState.get("paymentID");
-  SaveCardConfirmBody.card_cvc = det.card_cvc;
+  SaveCardConfirmBody.card_cvc = det.card.card_cvc;
   SaveCardConfirmBody.payment_token = globalState.get("paymentToken");
   SaveCardConfirmBody.client_secret = globalState.get("clientSecret");
   console.log("conf conn ->" + globalState.get("connectorId"));
@@ -309,10 +309,11 @@ Cypress.Commands.add("saveCardConfirmCallTest", (SaveCardConfirmBody,det,globalS
       "api-key": globalState.get("publishableKey"),
     },
     body: SaveCardConfirmBody,
+
   })
     .then((response) => {
       logRequestId(response.headers['x-request-id']);
-
+      console.log(response);
       expect(response.headers["content-type"]).to.include("application/json");
       globalState.set("paymentID", paymentIntentID);
       if (response.body.capture_method === "automatic") {

--- a/cypress-tests/cypress/support/commands.js
+++ b/cypress-tests/cypress/support/commands.js
@@ -295,11 +295,11 @@ Cypress.Commands.add("createConfirmPaymentTest", (createConfirmPaymentBody, deta
 });
 
 // This is consequent saved card payment confirm call test(Using payment token)
-Cypress.Commands.add("saveCardConfirmCallTest", (SaveCardConfirmBody,det,globalState) => {
+Cypress.Commands.add("saveCardConfirmCallTest", (saveCardConfirmBody,det,globalState) => {
   const paymentIntentID = globalState.get("paymentID");
-  SaveCardConfirmBody.card_cvc = det.card.card_cvc;
-  SaveCardConfirmBody.payment_token = globalState.get("paymentToken");
-  SaveCardConfirmBody.client_secret = globalState.get("clientSecret");
+  saveCardConfirmBody.card_cvc = det.card.card_cvc;
+  saveCardConfirmBody.payment_token = globalState.get("paymentToken");
+  saveCardConfirmBody.client_secret = globalState.get("clientSecret");
   console.log("conf conn ->" + globalState.get("connectorId"));
   cy.request({
     method: "POST",
@@ -308,7 +308,7 @@ Cypress.Commands.add("saveCardConfirmCallTest", (SaveCardConfirmBody,det,globalS
       "Content-Type": "application/json",
       "api-key": globalState.get("publishableKey"),
     },
-    body: SaveCardConfirmBody,
+    body: saveCardConfirmBody,
 
   })
     .then((response) => {


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [x] CI/CD

## Description
SaveCard flow is failing in the pipeline for BOA,Cybersource,Adyen.It requires billing country,city. So Added the billing details in the confirmBody


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
Tested in cypress
BOA:
<img width="770" alt="Screenshot 2024-05-13 at 6 30 02 PM" src="https://github.com/juspay/hyperswitch/assets/118818938/a893528b-aa7c-4d93-99d5-d18ca3f63fa3">

Adyen
<img width="466" alt="Screenshot 2024-05-13 at 6 44 32 PM" src="https://github.com/juspay/hyperswitch/assets/118818938/35ab0e56-55a2-418b-bf8f-9be92a6ff9ab">



## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
