### PR TITLE
fix(core): use `realip_remote_addr` function to extract ip address

### DIFF
--- a/crates/router/src/routes/payments/helpers.rs
+++ b/crates/router/src/routes/payments/helpers.rs
@@ -2,7 +2,7 @@ use error_stack::ResultExt;
 
 use crate::{
     core::errors::{self, RouterResult},
-    headers, logger,
+    logger,
     types::{self, api},
     utils::{Encode, ValueExt},
 };
@@ -36,22 +36,22 @@ pub fn populate_ip_into_browser_info(
     // This header will contain multiple IP addresses for each ALB hop which has
     // a comma separated list of IP addresses: 'X.X.X.X, Y.Y.Y.Y, Z.Z.Z.Z'
     // The first one here will be the client IP which we want to retrieve
-    let ip_address_from_header = req.headers()
-        .get(headers::X_FORWARDED_FOR)
-        .map(|val| val.to_str())
-        .transpose()
-        .unwrap_or_else(|e| {
-            logger::error!(error=?e, message="failed to retrieve ip address from X-Forwarded-For header");
-            None
-        })
-        .and_then(|ips| ips.split(',').next());
+    let ip_address = req
+        .connection_info()
+        .realip_remote_addr()
+        .map(ToOwned::to_owned);
+
+    if ip_address.is_some() {
+        logger::debug!("Extracted ip address from request");
+    }
 
     browser_info.ip_address = browser_info.ip_address.or_else(|| {
-        ip_address_from_header
+        ip_address
+            .as_ref()
             .map(|ip| ip.parse())
             .transpose()
             .unwrap_or_else(|e| {
-                logger::error!(error=?e, message="failed to parse ip address from X-Forwarded-For");
+                logger::error!(error=?e, message="failed to parse ip address which is extracted from the request");
                 None
             })
     });
@@ -70,7 +70,7 @@ pub fn populate_ip_into_browser_info(
     {
         *req_ip = req_ip
             .clone()
-            .or_else(|| ip_address_from_header.map(|ip| masking::Secret::new(ip.to_string())));
+            .or_else(|| ip_address.map(|ip| masking::Secret::new(ip.to_string())));
     }
 
     let encoded = browser_info

--- a/crates/router/src/routes/payments/helpers.rs
+++ b/crates/router/src/routes/payments/helpers.rs
@@ -32,10 +32,6 @@ pub fn populate_ip_into_browser_info(
             ip_address: None,
         });
 
-    // Parse the IP Address from the "X-Forwarded-For" header
-    // This header will contain multiple IP addresses for each ALB hop which has
-    // a comma separated list of IP addresses: 'X.X.X.X, Y.Y.Y.Y, Z.Z.Z.Z'
-    // The first one here will be the client IP which we want to retrieve
     let ip_address = req
         .connection_info()
         .realip_remote_addr()


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix

## Description
<!-- Describe your changes in detail -->
Previously we were relying on the `X_FORWARDED_FOR` header value for extracting the ip address. This value would be available if there were proxies that populate this value. But if this has been done from the localhost or if there were no reverse proxies behind the application, then this header value would not be present. This has been fixed in this PR. 

We are using the `realip_remote_addr` function to extract the ip address from the request. This will look for the `X_FORWARDED_FOR` header, if not found, fallback to the socket ip address.


<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
- Confirm a payment and then check for the log line


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
