### PR TITLE
fix(Recon): make recon status optional in merchant account

### DIFF
--- a/crates/api_models/src/admin.rs
+++ b/crates/api_models/src/admin.rs
@@ -276,7 +276,7 @@ pub struct MerchantAccountResponse {
 
     /// Used to indicate the status of the recon module for a merchant account
     #[schema(value_type = ReconStatus, example = "not_requested")]
-    pub recon_status: enums::ReconStatus,
+    pub recon_status: Option<enums::ReconStatus>,
 }
 
 #[derive(Clone, Debug, Deserialize, ToSchema, Serialize)]

--- a/crates/api_models/src/recon.rs
+++ b/crates/api_models/src/recon.rs
@@ -17,5 +17,5 @@ pub struct ReconTokenResponse {
 
 #[derive(Debug, serde::Serialize)]
 pub struct ReconStatusResponse {
-    pub recon_status: enums::ReconStatus,
+    pub recon_status: Option<enums::ReconStatus>,
 }

--- a/crates/common_enums/src/enums.rs
+++ b/crates/common_enums/src/enums.rs
@@ -2261,7 +2261,6 @@ pub enum FrmSuggestion {
     Clone,
     Debug,
     Eq,
-    Default,
     Hash,
     PartialEq,
     serde::Deserialize,
@@ -2275,7 +2274,6 @@ pub enum FrmSuggestion {
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 pub enum ReconStatus {
-    #[default]
     NotRequested,
     Requested,
     Active,

--- a/crates/diesel_models/src/merchant_account.rs
+++ b/crates/diesel_models/src/merchant_account.rs
@@ -39,7 +39,7 @@ pub struct MerchantAccount {
     pub organization_id: String,
     pub is_recon_enabled: bool,
     pub default_profile: Option<String>,
-    pub recon_status: storage_enums::ReconStatus,
+    pub recon_status: Option<storage_enums::ReconStatus>,
     pub payment_link_config: Option<serde_json::Value>,
 }
 
@@ -69,7 +69,7 @@ pub struct MerchantAccountNew {
     pub organization_id: String,
     pub is_recon_enabled: bool,
     pub default_profile: Option<String>,
-    pub recon_status: storage_enums::ReconStatus,
+    pub recon_status: Option<storage_enums::ReconStatus>,
     pub payment_link_config: Option<serde_json::Value>,
 }
 
@@ -98,6 +98,6 @@ pub struct MerchantAccountUpdateInternal {
     pub organization_id: Option<String>,
     pub is_recon_enabled: bool,
     pub default_profile: Option<Option<String>>,
-    pub recon_status: storage_enums::ReconStatus,
+    pub recon_status: Option<storage_enums::ReconStatus>,
     pub payment_link_config: Option<serde_json::Value>,
 }

--- a/crates/diesel_models/src/schema.rs
+++ b/crates/diesel_models/src/schema.rs
@@ -631,7 +631,7 @@ diesel::table! {
         is_recon_enabled -> Bool,
         #[max_length = 64]
         default_profile -> Nullable<Varchar>,
-        recon_status -> ReconStatus,
+        recon_status -> Nullable<ReconStatus>,
         payment_link_config -> Nullable<Jsonb>,
     }
 }

--- a/crates/router/src/core/admin.rs
+++ b/crates/router/src/core/admin.rs
@@ -214,7 +214,7 @@ pub async fn create_merchant_account(
             organization_id,
             is_recon_enabled: false,
             default_profile: None,
-            recon_status: diesel_models::enums::ReconStatus::NotRequested,
+            recon_status: Some(diesel_models::enums::ReconStatus::NotRequested),
             payment_link_config: None,
         })
     }

--- a/crates/router/src/routes/recon.rs
+++ b/crates/router/src/routes/recon.rs
@@ -143,7 +143,7 @@ pub async fn send_recon_request(
     } else {
         Ok(service_api::ApplicationResponse::Json(
             recon_api::ReconStatusResponse {
-                recon_status: enums::ReconStatus::NotRequested,
+                recon_status: Some(enums::ReconStatus::NotRequested),
             },
         ))
     }

--- a/crates/router/src/types/domain/merchant_account.rs
+++ b/crates/router/src/types/domain/merchant_account.rs
@@ -44,7 +44,7 @@ pub struct MerchantAccount {
     pub organization_id: String,
     pub is_recon_enabled: bool,
     pub default_profile: Option<String>,
-    pub recon_status: diesel_models::enums::ReconStatus,
+    pub recon_status: Option<diesel_models::enums::ReconStatus>,
     pub payment_link_config: Option<serde_json::Value>,
 }
 
@@ -134,7 +134,7 @@ impl From<MerchantAccountUpdate> for MerchantAccountUpdateInternal {
                 ..Default::default()
             },
             MerchantAccountUpdate::ReconUpdate { recon_status } => Self {
-                recon_status,
+                recon_status: Some(recon_status),
                 ..Default::default()
             },
             MerchantAccountUpdate::UnsetDefaultProfile => Self {

--- a/migrations/2024-05-15-135034_make_recon_status_optional/down.sql
+++ b/migrations/2024-05-15-135034_make_recon_status_optional/down.sql
@@ -1,0 +1,4 @@
+-- This file should undo anything in `up.sql`
+
+ALTER TABLE merchant_account 
+ALTER COLUMN recon_status SET NOT NULL;

--- a/migrations/2024-05-15-135034_make_recon_status_optional/up.sql
+++ b/migrations/2024-05-15-135034_make_recon_status_optional/up.sql
@@ -1,0 +1,4 @@
+-- Your SQL goes here
+
+ALTER TABLE merchant_account 
+ALTER COLUMN recon_status DROP NOT NULL;


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Previously when merchant account is updated recon status is updating to `not_requested`. This PR makes recon status optional field so that even if we use default it will not update to not_requested. 

### Additional Changes

- [ ] This PR modifies the API contract
- [x] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->

Default value of recon status is not_requested. When we try to call merchant_update, it will update the recon status to not_requested every time. So to remove this default implementation make recon status optional, so it won't get updated every time we update merchant_account.

Steps to recreate this bug :

1) Create merchant_account
2) Update the recon status to active by calling /recon_update
3) call merchant_account_update - recon status will be updated to not_requested 

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Using Postman(yet to be added).

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
