### PR TITLE
feat(middleware): log content_length for 4xx

### DIFF
--- a/crates/router/src/connector/adyen.rs
+++ b/crates/router/src/connector/adyen.rs
@@ -231,7 +231,7 @@ impl ConnectorValidation for Adyen {
     fn validate_mandate_payment(
         &self,
         pm_type: Option<PaymentMethodType>,
-        pm_data: types::domain::payments::PaymentMethodData,
+        pm_data: domain::payments::PaymentMethodData,
     ) -> CustomResult<(), errors::ConnectorError> {
         let mandate_supported_pmd = std::collections::HashSet::from([
             PaymentMethodDataType::Card,

--- a/crates/router/src/connector/bambora/transformers.rs
+++ b/crates/router/src/connector/bambora/transformers.rs
@@ -26,7 +26,7 @@ impl<T> TryFrom<(&api::CurrencyUnit, enums::Currency, i64, T)> for BamboraRouter
     fn try_from(
         (currency_unit, currency, amount, item): (&api::CurrencyUnit, enums::Currency, i64, T),
     ) -> Result<Self, Self::Error> {
-        let amount = crate::connector::utils::get_amount_as_f64(currency_unit, amount, currency)?;
+        let amount = utils::get_amount_as_f64(currency_unit, amount, currency)?;
         Ok(Self {
             amount,
             router_data: item,

--- a/crates/router/src/connector/mifinity/transformers.rs
+++ b/crates/router/src/connector/mifinity/transformers.rs
@@ -13,22 +13,10 @@ pub struct MifinityRouterData<T> {
     pub router_data: T,
 }
 
-impl<T>
-    TryFrom<(
-        &api::CurrencyUnit,
-        enums::Currency,
-        i64,
-        T,
-    )> for MifinityRouterData<T>
-{
+impl<T> TryFrom<(&api::CurrencyUnit, enums::Currency, i64, T)> for MifinityRouterData<T> {
     type Error = error_stack::Report<errors::ConnectorError>;
     fn try_from(
-        (_currency_unit, _currency, amount, item): (
-            &api::CurrencyUnit,
-            enums::Currency,
-            i64,
-            T,
-        ),
+        (_currency_unit, _currency, amount, item): (&api::CurrencyUnit, enums::Currency, i64, T),
     ) -> Result<Self, Self::Error> {
         //Todo :  use utils to convert the amount to the type of amount that a connector accepts
         Ok(Self {

--- a/crates/router/src/connector/mifinity/transformers.rs
+++ b/crates/router/src/connector/mifinity/transformers.rs
@@ -15,8 +15,8 @@ pub struct MifinityRouterData<T> {
 
 impl<T>
     TryFrom<(
-        &types::api::CurrencyUnit,
-        types::storage::enums::Currency,
+        &api::CurrencyUnit,
+        enums::Currency,
         i64,
         T,
     )> for MifinityRouterData<T>
@@ -24,8 +24,8 @@ impl<T>
     type Error = error_stack::Report<errors::ConnectorError>;
     fn try_from(
         (_currency_unit, _currency, amount, item): (
-            &types::api::CurrencyUnit,
-            types::storage::enums::Currency,
+            &api::CurrencyUnit,
+            enums::Currency,
             i64,
             T,
         ),

--- a/crates/router/src/connector/multisafepay.rs
+++ b/crates/router/src/connector/multisafepay.rs
@@ -120,7 +120,7 @@ impl ConnectorValidation for Multisafepay {
 
     fn validate_mandate_payment(
         &self,
-        pm_type: Option<types::storage::enums::PaymentMethodType>,
+        pm_type: Option<enums::PaymentMethodType>,
         pm_data: types::domain::payments::PaymentMethodData,
     ) -> CustomResult<(), errors::ConnectorError> {
         let mandate_supported_pmd = std::collections::HashSet::from([

--- a/crates/router/src/connector/nexinets.rs
+++ b/crates/router/src/connector/nexinets.rs
@@ -159,7 +159,7 @@ impl ConnectorValidation for Nexinets {
 
     fn validate_mandate_payment(
         &self,
-        pm_type: Option<types::storage::enums::PaymentMethodType>,
+        pm_type: Option<enums::PaymentMethodType>,
         pm_data: types::domain::payments::PaymentMethodData,
     ) -> CustomResult<(), errors::ConnectorError> {
         let mandate_supported_pmd = std::collections::HashSet::from([

--- a/crates/router/src/connector/nuvei.rs
+++ b/crates/router/src/connector/nuvei.rs
@@ -90,7 +90,7 @@ impl ConnectorValidation for Nuvei {
 
     fn validate_mandate_payment(
         &self,
-        pm_type: Option<types::storage::enums::PaymentMethodType>,
+        pm_type: Option<enums::PaymentMethodType>,
         pm_data: types::domain::payments::PaymentMethodData,
     ) -> CustomResult<(), errors::ConnectorError> {
         let mandate_supported_pmd = std::collections::HashSet::from([PaymentMethodDataType::Card]);

--- a/crates/router/src/connector/payme.rs
+++ b/crates/router/src/connector/payme.rs
@@ -135,7 +135,7 @@ impl ConnectorValidation for Payme {
     fn validate_mandate_payment(
         &self,
         pm_type: Option<types::storage::enums::PaymentMethodType>,
-        pm_data: types::domain::payments::PaymentMethodData,
+        pm_data: domain::payments::PaymentMethodData,
     ) -> CustomResult<(), errors::ConnectorError> {
         let mandate_supported_pmd = std::collections::HashSet::from([
             PaymentMethodDataType::Card,

--- a/crates/router/src/connector/payone/transformers.rs
+++ b/crates/router/src/connector/payone/transformers.rs
@@ -13,22 +13,10 @@ pub struct PayoneRouterData<T> {
     pub router_data: T,
 }
 
-impl<T>
-    TryFrom<(
-        &api::CurrencyUnit,
-        enums::Currency,
-        i64,
-        T,
-    )> for PayoneRouterData<T>
-{
+impl<T> TryFrom<(&api::CurrencyUnit, enums::Currency, i64, T)> for PayoneRouterData<T> {
     type Error = error_stack::Report<errors::ConnectorError>;
     fn try_from(
-        (_currency_unit, _currency, amount, item): (
-            &api::CurrencyUnit,
-            enums::Currency,
-            i64,
-            T,
-        ),
+        (_currency_unit, _currency, amount, item): (&api::CurrencyUnit, enums::Currency, i64, T),
     ) -> Result<Self, Self::Error> {
         //Todo :  use utils to convert the amount to the type of amount that a connector accepts
         Ok(Self {

--- a/crates/router/src/connector/payone/transformers.rs
+++ b/crates/router/src/connector/payone/transformers.rs
@@ -15,8 +15,8 @@ pub struct PayoneRouterData<T> {
 
 impl<T>
     TryFrom<(
-        &types::api::CurrencyUnit,
-        types::storage::enums::Currency,
+        &api::CurrencyUnit,
+        enums::Currency,
         i64,
         T,
     )> for PayoneRouterData<T>
@@ -24,8 +24,8 @@ impl<T>
     type Error = error_stack::Report<errors::ConnectorError>;
     fn try_from(
         (_currency_unit, _currency, amount, item): (
-            &types::api::CurrencyUnit,
-            types::storage::enums::Currency,
+            &api::CurrencyUnit,
+            enums::Currency,
             i64,
             T,
         ),

--- a/crates/router/src/connector/stripe.rs
+++ b/crates/router/src/connector/stripe.rs
@@ -136,7 +136,7 @@ impl ConnectorValidation for Stripe {
     fn validate_mandate_payment(
         &self,
         pm_type: Option<types::storage::enums::PaymentMethodType>,
-        pm_data: types::domain::payments::PaymentMethodData,
+        pm_data: domain::payments::PaymentMethodData,
     ) -> CustomResult<(), errors::ConnectorError> {
         let mandate_supported_pmd = std::collections::HashSet::from([
             PaymentMethodDataType::Card,

--- a/crates/router/src/connector/utils.rs
+++ b/crates/router/src/connector/utils.rs
@@ -2448,9 +2448,7 @@ impl From<domain::payments::PaymentMethodData> for PaymentMethodDataType {
                     domain::CardRedirectData::Knet {} => Self::Knet,
                     domain::payments::CardRedirectData::Benefit {} => Self::Benefit,
                     domain::payments::CardRedirectData::MomoAtm {} => Self::MomoAtm,
-                    domain::payments::CardRedirectData::CardRedirect {} => {
-                        Self::CardRedirect
-                    }
+                    domain::payments::CardRedirectData::CardRedirect {} => Self::CardRedirect,
                 }
             }
             domain::payments::PaymentMethodData::Wallet(wallet_data) => match wallet_data {
@@ -2468,51 +2466,35 @@ impl From<domain::payments::PaymentMethodData> for PaymentMethodDataType {
                 }
                 domain::payments::WalletData::DanaRedirect {} => Self::DanaRedirect,
                 domain::payments::WalletData::GooglePay(_) => Self::GooglePay,
-                domain::payments::WalletData::GooglePayRedirect(_) => {
-                    Self::GooglePayRedirect
-                }
+                domain::payments::WalletData::GooglePayRedirect(_) => Self::GooglePayRedirect,
                 domain::payments::WalletData::GooglePayThirdPartySdk(_) => {
                     Self::GooglePayThirdPartySdk
                 }
                 domain::payments::WalletData::MbWayRedirect(_) => Self::MbWayRedirect,
-                domain::payments::WalletData::MobilePayRedirect(_) => {
-                    Self::MobilePayRedirect
-                }
+                domain::payments::WalletData::MobilePayRedirect(_) => Self::MobilePayRedirect,
                 domain::payments::WalletData::PaypalRedirect(_) => Self::PaypalRedirect,
                 domain::payments::WalletData::PaypalSdk(_) => Self::PaypalSdk,
                 domain::payments::WalletData::SamsungPay(_) => Self::SamsungPay,
                 domain::payments::WalletData::TwintRedirect {} => Self::TwintRedirect,
                 domain::payments::WalletData::VippsRedirect {} => Self::VippsRedirect,
                 domain::payments::WalletData::TouchNGoRedirect(_) => Self::TouchNGoRedirect,
-                domain::payments::WalletData::WeChatPayRedirect(_) => {
-                    Self::WeChatPayRedirect
-                }
+                domain::payments::WalletData::WeChatPayRedirect(_) => Self::WeChatPayRedirect,
                 domain::payments::WalletData::WeChatPayQr(_) => Self::WeChatPayQr,
                 domain::payments::WalletData::CashappQr(_) => Self::CashappQr,
                 domain::payments::WalletData::SwishQr(_) => Self::SwishQr,
             },
-            domain::payments::PaymentMethodData::PayLater(pay_later_data) => {
-                match pay_later_data {
-                    domain::payments::PayLaterData::KlarnaRedirect { .. } => {
-                        Self::KlarnaRedirect
-                    }
-                    domain::payments::PayLaterData::KlarnaSdk { .. } => Self::KlarnaSdk,
-                    domain::payments::PayLaterData::AffirmRedirect {} => {
-                        Self::AffirmRedirect
-                    }
-                    domain::payments::PayLaterData::AfterpayClearpayRedirect { .. } => {
-                        Self::AfterpayClearpayRedirect
-                    }
-                    domain::payments::PayLaterData::PayBrightRedirect {} => {
-                        Self::PayBrightRedirect
-                    }
-                    domain::payments::PayLaterData::WalleyRedirect {} => {
-                        Self::WalleyRedirect
-                    }
-                    domain::payments::PayLaterData::AlmaRedirect {} => Self::AlmaRedirect,
-                    domain::payments::PayLaterData::AtomeRedirect {} => Self::AtomeRedirect,
+            domain::payments::PaymentMethodData::PayLater(pay_later_data) => match pay_later_data {
+                domain::payments::PayLaterData::KlarnaRedirect { .. } => Self::KlarnaRedirect,
+                domain::payments::PayLaterData::KlarnaSdk { .. } => Self::KlarnaSdk,
+                domain::payments::PayLaterData::AffirmRedirect {} => Self::AffirmRedirect,
+                domain::payments::PayLaterData::AfterpayClearpayRedirect { .. } => {
+                    Self::AfterpayClearpayRedirect
                 }
-            }
+                domain::payments::PayLaterData::PayBrightRedirect {} => Self::PayBrightRedirect,
+                domain::payments::PayLaterData::WalleyRedirect {} => Self::WalleyRedirect,
+                domain::payments::PayLaterData::AlmaRedirect {} => Self::AlmaRedirect,
+                domain::payments::PayLaterData::AtomeRedirect {} => Self::AtomeRedirect,
+            },
             domain::payments::PaymentMethodData::BankRedirect(bank_redirect_data) => {
                 match bank_redirect_data {
                     domain::payments::BankRedirectData::BancontactCard { .. } => {
@@ -2524,9 +2506,9 @@ impl From<domain::payments::PaymentMethodData> for PaymentMethodDataType {
                     domain::payments::BankRedirectData::Giropay { .. } => Self::Giropay,
                     domain::payments::BankRedirectData::Ideal { .. } => Self::Ideal,
                     domain::payments::BankRedirectData::Interac { .. } => Self::Interac,
-                    domain::payments::BankRedirectData::OnlineBankingCzechRepublic {
-                        ..
-                    } => Self::OnlineBankingCzechRepublic,
+                    domain::payments::BankRedirectData::OnlineBankingCzechRepublic { .. } => {
+                        Self::OnlineBankingCzechRepublic
+                    }
                     domain::payments::BankRedirectData::OnlineBankingFinland { .. } => {
                         Self::OnlineBankingFinland
                     }
@@ -2536,12 +2518,8 @@ impl From<domain::payments::PaymentMethodData> for PaymentMethodDataType {
                     domain::payments::BankRedirectData::OnlineBankingSlovakia { .. } => {
                         Self::OnlineBankingSlovakia
                     }
-                    domain::payments::BankRedirectData::OpenBankingUk { .. } => {
-                        Self::OpenBankingUk
-                    }
-                    domain::payments::BankRedirectData::Przelewy24 { .. } => {
-                        Self::Przelewy24
-                    }
+                    domain::payments::BankRedirectData::OpenBankingUk { .. } => Self::OpenBankingUk,
+                    domain::payments::BankRedirectData::Przelewy24 { .. } => Self::Przelewy24,
                     domain::payments::BankRedirectData::Sofort { .. } => Self::Sofort,
                     domain::payments::BankRedirectData::Trustly { .. } => Self::Trustly,
                     domain::payments::BankRedirectData::OnlineBankingFpx { .. } => {
@@ -2554,18 +2532,10 @@ impl From<domain::payments::PaymentMethodData> for PaymentMethodDataType {
             }
             domain::payments::PaymentMethodData::BankDebit(bank_debit_data) => {
                 match bank_debit_data {
-                    domain::payments::BankDebitData::AchBankDebit { .. } => {
-                        Self::AchBankDebit
-                    }
-                    domain::payments::BankDebitData::SepaBankDebit { .. } => {
-                        Self::SepaBankDebit
-                    }
-                    domain::payments::BankDebitData::BecsBankDebit { .. } => {
-                        Self::BecsBankDebit
-                    }
-                    domain::payments::BankDebitData::BacsBankDebit { .. } => {
-                        Self::BacsBankDebit
-                    }
+                    domain::payments::BankDebitData::AchBankDebit { .. } => Self::AchBankDebit,
+                    domain::payments::BankDebitData::SepaBankDebit { .. } => Self::SepaBankDebit,
+                    domain::payments::BankDebitData::BecsBankDebit { .. } => Self::BecsBankDebit,
+                    domain::payments::BankDebitData::BacsBankDebit { .. } => Self::BacsBankDebit,
                 }
             }
             domain::payments::PaymentMethodData::BankTransfer(bank_transfer_data) => {
@@ -2579,9 +2549,9 @@ impl From<domain::payments::PaymentMethodData> for PaymentMethodDataType {
                     domain::payments::BankTransferData::BacsBankTransfer { .. } => {
                         Self::BacsBankTransfer
                     }
-                    domain::payments::BankTransferData::MultibancoBankTransfer {
-                        ..
-                    } => Self::MultibancoBankTransfer,
+                    domain::payments::BankTransferData::MultibancoBankTransfer { .. } => {
+                        Self::MultibancoBankTransfer
+                    }
                     domain::payments::BankTransferData::PermataBankTransfer { .. } => {
                         Self::PermataBankTransfer
                     }
@@ -2614,8 +2584,7 @@ impl From<domain::payments::PaymentMethodData> for PaymentMethodDataType {
             domain::payments::PaymentMethodData::MandatePayment => Self::MandatePayment,
             domain::payments::PaymentMethodData::Reward => Self::Reward,
             domain::payments::PaymentMethodData::Upi(_) => Self::Upi,
-            domain::payments::PaymentMethodData::Voucher(voucher_data) => match voucher_data
-            {
+            domain::payments::PaymentMethodData::Voucher(voucher_data) => match voucher_data {
                 domain::payments::VoucherData::Boleto(_) => Self::Boleto,
                 domain::payments::VoucherData::Efecty => Self::Efecty,
                 domain::payments::VoucherData::PagoEfectivo => Self::PagoEfectivo,

--- a/crates/router/src/connector/utils.rs
+++ b/crates/router/src/connector/utils.rs
@@ -2439,205 +2439,205 @@ pub enum PaymentMethodDataType {
     LocalBankTransfer,
 }
 
-impl From<types::domain::payments::PaymentMethodData> for PaymentMethodDataType {
-    fn from(pm_data: types::domain::payments::PaymentMethodData) -> Self {
+impl From<domain::payments::PaymentMethodData> for PaymentMethodDataType {
+    fn from(pm_data: domain::payments::PaymentMethodData) -> Self {
         match pm_data {
-            types::domain::payments::PaymentMethodData::Card(_) => Self::Card,
-            types::domain::payments::PaymentMethodData::CardRedirect(card_redirect_data) => {
+            domain::payments::PaymentMethodData::Card(_) => Self::Card,
+            domain::payments::PaymentMethodData::CardRedirect(card_redirect_data) => {
                 match card_redirect_data {
-                    types::domain::CardRedirectData::Knet {} => Self::Knet,
-                    types::domain::payments::CardRedirectData::Benefit {} => Self::Benefit,
-                    types::domain::payments::CardRedirectData::MomoAtm {} => Self::MomoAtm,
-                    types::domain::payments::CardRedirectData::CardRedirect {} => {
+                    domain::CardRedirectData::Knet {} => Self::Knet,
+                    domain::payments::CardRedirectData::Benefit {} => Self::Benefit,
+                    domain::payments::CardRedirectData::MomoAtm {} => Self::MomoAtm,
+                    domain::payments::CardRedirectData::CardRedirect {} => {
                         Self::CardRedirect
                     }
                 }
             }
-            types::domain::payments::PaymentMethodData::Wallet(wallet_data) => match wallet_data {
-                types::domain::payments::WalletData::AliPayQr(_) => Self::AliPayQr,
-                types::domain::payments::WalletData::AliPayRedirect(_) => Self::AliPayRedirect,
-                types::domain::payments::WalletData::AliPayHkRedirect(_) => Self::AliPayHkRedirect,
-                types::domain::payments::WalletData::MomoRedirect(_) => Self::MomoRedirect,
-                types::domain::payments::WalletData::KakaoPayRedirect(_) => Self::KakaoPayRedirect,
-                types::domain::payments::WalletData::GoPayRedirect(_) => Self::GoPayRedirect,
-                types::domain::payments::WalletData::GcashRedirect(_) => Self::GcashRedirect,
-                types::domain::payments::WalletData::ApplePay(_) => Self::ApplePay,
-                types::domain::payments::WalletData::ApplePayRedirect(_) => Self::ApplePayRedirect,
-                types::domain::payments::WalletData::ApplePayThirdPartySdk(_) => {
+            domain::payments::PaymentMethodData::Wallet(wallet_data) => match wallet_data {
+                domain::payments::WalletData::AliPayQr(_) => Self::AliPayQr,
+                domain::payments::WalletData::AliPayRedirect(_) => Self::AliPayRedirect,
+                domain::payments::WalletData::AliPayHkRedirect(_) => Self::AliPayHkRedirect,
+                domain::payments::WalletData::MomoRedirect(_) => Self::MomoRedirect,
+                domain::payments::WalletData::KakaoPayRedirect(_) => Self::KakaoPayRedirect,
+                domain::payments::WalletData::GoPayRedirect(_) => Self::GoPayRedirect,
+                domain::payments::WalletData::GcashRedirect(_) => Self::GcashRedirect,
+                domain::payments::WalletData::ApplePay(_) => Self::ApplePay,
+                domain::payments::WalletData::ApplePayRedirect(_) => Self::ApplePayRedirect,
+                domain::payments::WalletData::ApplePayThirdPartySdk(_) => {
                     Self::ApplePayThirdPartySdk
                 }
-                types::domain::payments::WalletData::DanaRedirect {} => Self::DanaRedirect,
-                types::domain::payments::WalletData::GooglePay(_) => Self::GooglePay,
-                types::domain::payments::WalletData::GooglePayRedirect(_) => {
+                domain::payments::WalletData::DanaRedirect {} => Self::DanaRedirect,
+                domain::payments::WalletData::GooglePay(_) => Self::GooglePay,
+                domain::payments::WalletData::GooglePayRedirect(_) => {
                     Self::GooglePayRedirect
                 }
-                types::domain::payments::WalletData::GooglePayThirdPartySdk(_) => {
+                domain::payments::WalletData::GooglePayThirdPartySdk(_) => {
                     Self::GooglePayThirdPartySdk
                 }
-                types::domain::payments::WalletData::MbWayRedirect(_) => Self::MbWayRedirect,
-                types::domain::payments::WalletData::MobilePayRedirect(_) => {
+                domain::payments::WalletData::MbWayRedirect(_) => Self::MbWayRedirect,
+                domain::payments::WalletData::MobilePayRedirect(_) => {
                     Self::MobilePayRedirect
                 }
-                types::domain::payments::WalletData::PaypalRedirect(_) => Self::PaypalRedirect,
-                types::domain::payments::WalletData::PaypalSdk(_) => Self::PaypalSdk,
-                types::domain::payments::WalletData::SamsungPay(_) => Self::SamsungPay,
-                types::domain::payments::WalletData::TwintRedirect {} => Self::TwintRedirect,
-                types::domain::payments::WalletData::VippsRedirect {} => Self::VippsRedirect,
-                types::domain::payments::WalletData::TouchNGoRedirect(_) => Self::TouchNGoRedirect,
-                types::domain::payments::WalletData::WeChatPayRedirect(_) => {
+                domain::payments::WalletData::PaypalRedirect(_) => Self::PaypalRedirect,
+                domain::payments::WalletData::PaypalSdk(_) => Self::PaypalSdk,
+                domain::payments::WalletData::SamsungPay(_) => Self::SamsungPay,
+                domain::payments::WalletData::TwintRedirect {} => Self::TwintRedirect,
+                domain::payments::WalletData::VippsRedirect {} => Self::VippsRedirect,
+                domain::payments::WalletData::TouchNGoRedirect(_) => Self::TouchNGoRedirect,
+                domain::payments::WalletData::WeChatPayRedirect(_) => {
                     Self::WeChatPayRedirect
                 }
-                types::domain::payments::WalletData::WeChatPayQr(_) => Self::WeChatPayQr,
-                types::domain::payments::WalletData::CashappQr(_) => Self::CashappQr,
-                types::domain::payments::WalletData::SwishQr(_) => Self::SwishQr,
+                domain::payments::WalletData::WeChatPayQr(_) => Self::WeChatPayQr,
+                domain::payments::WalletData::CashappQr(_) => Self::CashappQr,
+                domain::payments::WalletData::SwishQr(_) => Self::SwishQr,
             },
-            types::domain::payments::PaymentMethodData::PayLater(pay_later_data) => {
+            domain::payments::PaymentMethodData::PayLater(pay_later_data) => {
                 match pay_later_data {
-                    types::domain::payments::PayLaterData::KlarnaRedirect { .. } => {
+                    domain::payments::PayLaterData::KlarnaRedirect { .. } => {
                         Self::KlarnaRedirect
                     }
-                    types::domain::payments::PayLaterData::KlarnaSdk { .. } => Self::KlarnaSdk,
-                    types::domain::payments::PayLaterData::AffirmRedirect {} => {
+                    domain::payments::PayLaterData::KlarnaSdk { .. } => Self::KlarnaSdk,
+                    domain::payments::PayLaterData::AffirmRedirect {} => {
                         Self::AffirmRedirect
                     }
-                    types::domain::payments::PayLaterData::AfterpayClearpayRedirect { .. } => {
+                    domain::payments::PayLaterData::AfterpayClearpayRedirect { .. } => {
                         Self::AfterpayClearpayRedirect
                     }
-                    types::domain::payments::PayLaterData::PayBrightRedirect {} => {
+                    domain::payments::PayLaterData::PayBrightRedirect {} => {
                         Self::PayBrightRedirect
                     }
-                    types::domain::payments::PayLaterData::WalleyRedirect {} => {
+                    domain::payments::PayLaterData::WalleyRedirect {} => {
                         Self::WalleyRedirect
                     }
-                    types::domain::payments::PayLaterData::AlmaRedirect {} => Self::AlmaRedirect,
-                    types::domain::payments::PayLaterData::AtomeRedirect {} => Self::AtomeRedirect,
+                    domain::payments::PayLaterData::AlmaRedirect {} => Self::AlmaRedirect,
+                    domain::payments::PayLaterData::AtomeRedirect {} => Self::AtomeRedirect,
                 }
             }
-            types::domain::payments::PaymentMethodData::BankRedirect(bank_redirect_data) => {
+            domain::payments::PaymentMethodData::BankRedirect(bank_redirect_data) => {
                 match bank_redirect_data {
-                    types::domain::payments::BankRedirectData::BancontactCard { .. } => {
+                    domain::payments::BankRedirectData::BancontactCard { .. } => {
                         Self::BancontactCard
                     }
-                    types::domain::payments::BankRedirectData::Bizum {} => Self::Bizum,
-                    types::domain::payments::BankRedirectData::Blik { .. } => Self::Blik,
-                    types::domain::payments::BankRedirectData::Eps { .. } => Self::Eps,
-                    types::domain::payments::BankRedirectData::Giropay { .. } => Self::Giropay,
-                    types::domain::payments::BankRedirectData::Ideal { .. } => Self::Ideal,
-                    types::domain::payments::BankRedirectData::Interac { .. } => Self::Interac,
-                    types::domain::payments::BankRedirectData::OnlineBankingCzechRepublic {
+                    domain::payments::BankRedirectData::Bizum {} => Self::Bizum,
+                    domain::payments::BankRedirectData::Blik { .. } => Self::Blik,
+                    domain::payments::BankRedirectData::Eps { .. } => Self::Eps,
+                    domain::payments::BankRedirectData::Giropay { .. } => Self::Giropay,
+                    domain::payments::BankRedirectData::Ideal { .. } => Self::Ideal,
+                    domain::payments::BankRedirectData::Interac { .. } => Self::Interac,
+                    domain::payments::BankRedirectData::OnlineBankingCzechRepublic {
                         ..
                     } => Self::OnlineBankingCzechRepublic,
-                    types::domain::payments::BankRedirectData::OnlineBankingFinland { .. } => {
+                    domain::payments::BankRedirectData::OnlineBankingFinland { .. } => {
                         Self::OnlineBankingFinland
                     }
-                    types::domain::payments::BankRedirectData::OnlineBankingPoland { .. } => {
+                    domain::payments::BankRedirectData::OnlineBankingPoland { .. } => {
                         Self::OnlineBankingPoland
                     }
-                    types::domain::payments::BankRedirectData::OnlineBankingSlovakia { .. } => {
+                    domain::payments::BankRedirectData::OnlineBankingSlovakia { .. } => {
                         Self::OnlineBankingSlovakia
                     }
-                    types::domain::payments::BankRedirectData::OpenBankingUk { .. } => {
+                    domain::payments::BankRedirectData::OpenBankingUk { .. } => {
                         Self::OpenBankingUk
                     }
-                    types::domain::payments::BankRedirectData::Przelewy24 { .. } => {
+                    domain::payments::BankRedirectData::Przelewy24 { .. } => {
                         Self::Przelewy24
                     }
-                    types::domain::payments::BankRedirectData::Sofort { .. } => Self::Sofort,
-                    types::domain::payments::BankRedirectData::Trustly { .. } => Self::Trustly,
-                    types::domain::payments::BankRedirectData::OnlineBankingFpx { .. } => {
+                    domain::payments::BankRedirectData::Sofort { .. } => Self::Sofort,
+                    domain::payments::BankRedirectData::Trustly { .. } => Self::Trustly,
+                    domain::payments::BankRedirectData::OnlineBankingFpx { .. } => {
                         Self::OnlineBankingFpx
                     }
-                    types::domain::payments::BankRedirectData::OnlineBankingThailand { .. } => {
+                    domain::payments::BankRedirectData::OnlineBankingThailand { .. } => {
                         Self::OnlineBankingThailand
                     }
                 }
             }
-            types::domain::payments::PaymentMethodData::BankDebit(bank_debit_data) => {
+            domain::payments::PaymentMethodData::BankDebit(bank_debit_data) => {
                 match bank_debit_data {
-                    types::domain::payments::BankDebitData::AchBankDebit { .. } => {
+                    domain::payments::BankDebitData::AchBankDebit { .. } => {
                         Self::AchBankDebit
                     }
-                    types::domain::payments::BankDebitData::SepaBankDebit { .. } => {
+                    domain::payments::BankDebitData::SepaBankDebit { .. } => {
                         Self::SepaBankDebit
                     }
-                    types::domain::payments::BankDebitData::BecsBankDebit { .. } => {
+                    domain::payments::BankDebitData::BecsBankDebit { .. } => {
                         Self::BecsBankDebit
                     }
-                    types::domain::payments::BankDebitData::BacsBankDebit { .. } => {
+                    domain::payments::BankDebitData::BacsBankDebit { .. } => {
                         Self::BacsBankDebit
                     }
                 }
             }
-            types::domain::payments::PaymentMethodData::BankTransfer(bank_transfer_data) => {
+            domain::payments::PaymentMethodData::BankTransfer(bank_transfer_data) => {
                 match *bank_transfer_data {
-                    types::domain::payments::BankTransferData::AchBankTransfer { .. } => {
+                    domain::payments::BankTransferData::AchBankTransfer { .. } => {
                         Self::AchBankTransfer
                     }
-                    types::domain::payments::BankTransferData::SepaBankTransfer { .. } => {
+                    domain::payments::BankTransferData::SepaBankTransfer { .. } => {
                         Self::SepaBankTransfer
                     }
-                    types::domain::payments::BankTransferData::BacsBankTransfer { .. } => {
+                    domain::payments::BankTransferData::BacsBankTransfer { .. } => {
                         Self::BacsBankTransfer
                     }
-                    types::domain::payments::BankTransferData::MultibancoBankTransfer {
+                    domain::payments::BankTransferData::MultibancoBankTransfer {
                         ..
                     } => Self::MultibancoBankTransfer,
-                    types::domain::payments::BankTransferData::PermataBankTransfer { .. } => {
+                    domain::payments::BankTransferData::PermataBankTransfer { .. } => {
                         Self::PermataBankTransfer
                     }
-                    types::domain::payments::BankTransferData::BcaBankTransfer { .. } => {
+                    domain::payments::BankTransferData::BcaBankTransfer { .. } => {
                         Self::BcaBankTransfer
                     }
-                    types::domain::payments::BankTransferData::BniVaBankTransfer { .. } => {
+                    domain::payments::BankTransferData::BniVaBankTransfer { .. } => {
                         Self::BniVaBankTransfer
                     }
-                    types::domain::payments::BankTransferData::BriVaBankTransfer { .. } => {
+                    domain::payments::BankTransferData::BriVaBankTransfer { .. } => {
                         Self::BriVaBankTransfer
                     }
-                    types::domain::payments::BankTransferData::CimbVaBankTransfer { .. } => {
+                    domain::payments::BankTransferData::CimbVaBankTransfer { .. } => {
                         Self::CimbVaBankTransfer
                     }
-                    types::domain::payments::BankTransferData::DanamonVaBankTransfer { .. } => {
+                    domain::payments::BankTransferData::DanamonVaBankTransfer { .. } => {
                         Self::DanamonVaBankTransfer
                     }
-                    types::domain::payments::BankTransferData::MandiriVaBankTransfer { .. } => {
+                    domain::payments::BankTransferData::MandiriVaBankTransfer { .. } => {
                         Self::MandiriVaBankTransfer
                     }
-                    types::domain::payments::BankTransferData::Pix {} => Self::Pix,
-                    types::domain::payments::BankTransferData::Pse {} => Self::Pse,
-                    types::domain::payments::BankTransferData::LocalBankTransfer { .. } => {
+                    domain::payments::BankTransferData::Pix {} => Self::Pix,
+                    domain::payments::BankTransferData::Pse {} => Self::Pse,
+                    domain::payments::BankTransferData::LocalBankTransfer { .. } => {
                         Self::LocalBankTransfer
                     }
                 }
             }
-            types::domain::payments::PaymentMethodData::Crypto(_) => Self::Crypto,
-            types::domain::payments::PaymentMethodData::MandatePayment => Self::MandatePayment,
-            types::domain::payments::PaymentMethodData::Reward => Self::Reward,
-            types::domain::payments::PaymentMethodData::Upi(_) => Self::Upi,
-            types::domain::payments::PaymentMethodData::Voucher(voucher_data) => match voucher_data
+            domain::payments::PaymentMethodData::Crypto(_) => Self::Crypto,
+            domain::payments::PaymentMethodData::MandatePayment => Self::MandatePayment,
+            domain::payments::PaymentMethodData::Reward => Self::Reward,
+            domain::payments::PaymentMethodData::Upi(_) => Self::Upi,
+            domain::payments::PaymentMethodData::Voucher(voucher_data) => match voucher_data
             {
-                types::domain::payments::VoucherData::Boleto(_) => Self::Boleto,
-                types::domain::payments::VoucherData::Efecty => Self::Efecty,
-                types::domain::payments::VoucherData::PagoEfectivo => Self::PagoEfectivo,
-                types::domain::payments::VoucherData::RedCompra => Self::RedCompra,
-                types::domain::payments::VoucherData::RedPagos => Self::RedPagos,
-                types::domain::payments::VoucherData::Alfamart(_) => Self::Alfamart,
-                types::domain::payments::VoucherData::Indomaret(_) => Self::Indomaret,
-                types::domain::payments::VoucherData::Oxxo => Self::Oxxo,
-                types::domain::payments::VoucherData::SevenEleven(_) => Self::SevenEleven,
-                types::domain::payments::VoucherData::Lawson(_) => Self::Lawson,
-                types::domain::payments::VoucherData::MiniStop(_) => Self::MiniStop,
-                types::domain::payments::VoucherData::FamilyMart(_) => Self::FamilyMart,
-                types::domain::payments::VoucherData::Seicomart(_) => Self::Seicomart,
-                types::domain::payments::VoucherData::PayEasy(_) => Self::PayEasy,
+                domain::payments::VoucherData::Boleto(_) => Self::Boleto,
+                domain::payments::VoucherData::Efecty => Self::Efecty,
+                domain::payments::VoucherData::PagoEfectivo => Self::PagoEfectivo,
+                domain::payments::VoucherData::RedCompra => Self::RedCompra,
+                domain::payments::VoucherData::RedPagos => Self::RedPagos,
+                domain::payments::VoucherData::Alfamart(_) => Self::Alfamart,
+                domain::payments::VoucherData::Indomaret(_) => Self::Indomaret,
+                domain::payments::VoucherData::Oxxo => Self::Oxxo,
+                domain::payments::VoucherData::SevenEleven(_) => Self::SevenEleven,
+                domain::payments::VoucherData::Lawson(_) => Self::Lawson,
+                domain::payments::VoucherData::MiniStop(_) => Self::MiniStop,
+                domain::payments::VoucherData::FamilyMart(_) => Self::FamilyMart,
+                domain::payments::VoucherData::Seicomart(_) => Self::Seicomart,
+                domain::payments::VoucherData::PayEasy(_) => Self::PayEasy,
             },
-            types::domain::payments::PaymentMethodData::GiftCard(gift_card_data) => {
+            domain::payments::PaymentMethodData::GiftCard(gift_card_data) => {
                 match *gift_card_data {
-                    types::domain::payments::GiftCardData::Givex(_) => Self::Givex,
-                    types::domain::payments::GiftCardData::PaySafeCard {} => Self::PaySafeCar,
+                    domain::payments::GiftCardData::Givex(_) => Self::Givex,
+                    domain::payments::GiftCardData::PaySafeCard {} => Self::PaySafeCar,
                 }
             }
-            types::domain::payments::PaymentMethodData::CardToken(_) => Self::CardToken,
+            domain::payments::PaymentMethodData::CardToken(_) => Self::CardToken,
         }
     }
 }

--- a/crates/router/src/core/payments/helpers.rs
+++ b/crates/router/src/core/payments/helpers.rs
@@ -3090,7 +3090,7 @@ pub async fn insert_merchant_connector_creds_to_config(
             .serialize_and_set_key_with_expiry(
                 key.as_str(),
                 &encoded_data.peek(),
-                crate::consts::CONNECTOR_CREDS_TOKEN_TTL,
+                consts::CONNECTOR_CREDS_TOKEN_TTL,
             )
             .await
             .map_or_else(

--- a/crates/router/src/core/payments/transformers.rs
+++ b/crates/router/src/core/payments/transformers.rs
@@ -319,7 +319,7 @@ where
             Self {
                 verify_id: Some(data.payment_intent.payment_id),
                 merchant_id: Some(data.payment_intent.merchant_id),
-                client_secret: data.payment_intent.client_secret.map(masking::Secret::new),
+                client_secret: data.payment_intent.client_secret.map(Secret::new),
                 customer_id: customer.as_ref().map(|x| x.customer_id.clone()),
                 email: customer
                     .as_ref()
@@ -641,7 +641,7 @@ where
                 .set_amount_received(payment_intent.amount_captured)
                 .set_surcharge_details(surcharge_details)
                 .set_connector(routed_through)
-                .set_client_secret(payment_intent.client_secret.map(masking::Secret::new))
+                .set_client_secret(payment_intent.client_secret.map(Secret::new))
                 .set_created(Some(payment_intent.created_at))
                 .set_currency(currency.to_string())
                 .set_customer_id(customer.as_ref().map(|cus| cus.clone().customer_id))

--- a/crates/router/src/lib.rs
+++ b/crates/router/src/lib.rs
@@ -72,6 +72,7 @@ pub mod headers {
     pub const X_REQUEST_ID: &str = "X-Request-Id";
     pub const STRIPE_COMPATIBLE_WEBHOOK_SIGNATURE: &str = "Stripe-Signature";
     pub const STRIPE_COMPATIBLE_CONNECT_ACCOUNT: &str = "Stripe-Account";
+    pub const CONTENT_LENGTH: &str = "Content-Length";
 }
 
 pub mod pii {

--- a/crates/router/src/middleware.rs
+++ b/crates/router/src/middleware.rs
@@ -255,6 +255,7 @@ where
                 .into_iter()
                 .collect::<Result<Vec<bytes::Bytes>, actix_web::error::PayloadError>>()?;
             let bytes = payload.clone().concat().to_vec();
+            let bytes_length = bytes.len();
             // we are creating h1 payload manually from bytes, currently there's no way to create http2 payload with actix
             let (_, mut new_payload) = actix_http::h1::Payload::create(true);
             new_payload.unread_data(bytes.to_vec().clone().into());
@@ -281,7 +282,7 @@ where
                     .ok()
                     .flatten();
 
-                logger::info!("Content length: {content_length_header_string:?}");
+                logger::info!("Content length from header: {content_length_header_string:?}, Bytes length: {bytes_length}");
 
                 if !bytes.is_empty() {
                     let value_result: Result<serde_json::Value, serde_json::Error> =

--- a/crates/router/src/middleware.rs
+++ b/crates/router/src/middleware.rs
@@ -3,6 +3,8 @@ use router_env::{
     logger,
     tracing::{field::Empty, Instrument},
 };
+
+use crate::headers;
 /// Middleware to include request ID in response header.
 pub struct RequestId;
 
@@ -257,11 +259,30 @@ where
             let (_, mut new_payload) = actix_http::h1::Payload::create(true);
             new_payload.unread_data(bytes.to_vec().clone().into());
             let new_req = actix_web::dev::ServiceRequest::from_parts(http_req, new_payload.into());
+
+            let content_length_header = new_req
+                .headers()
+                .get(headers::CONTENT_LENGTH)
+                .map(ToOwned::to_owned);
             let response_fut = svc.call(new_req);
             let response = response_fut.await?;
             // Log the request_details when we receive 400 status from the application
             if response.status() == 400 {
                 let request_id = request_id_fut.await?.as_hyphenated().to_string();
+                let content_length_header_string = content_length_header
+                    .map(|content_length_header| {
+                        content_length_header.to_str().map(ToOwned::to_owned)
+                    })
+                    .transpose()
+                    .map_err(|error| {
+                        logger::warn!("Could not convert content length to string {error:?}");
+                        error
+                    })
+                    .ok()
+                    .flatten();
+
+                logger::info!("Content length: {content_length_header_string:?}");
+
                 if !bytes.is_empty() {
                     let value_result: Result<serde_json::Value, serde_json::Error> =
                         serde_json::from_slice(&bytes);

--- a/crates/router/src/routes/user.rs
+++ b/crates/router/src/routes/user.rs
@@ -642,7 +642,7 @@ pub async fn totp_begin(state: web::Data<AppState>, req: HttpRequest) -> HttpRes
         &req,
         (),
         |state, user, _, _| user_core::begin_totp(state, user),
-        &auth::SinglePurposeJWTAuth(common_enums::TokenPurpose::TOTP),
+        &auth::SinglePurposeJWTAuth(TokenPurpose::TOTP),
         api_locking::LockAction::NotApplicable,
     ))
     .await
@@ -660,7 +660,7 @@ pub async fn totp_verify(
         &req,
         json_payload.into_inner(),
         |state, user, req_body, _| user_core::verify_totp(state, user, req_body),
-        &auth::SinglePurposeJWTAuth(common_enums::TokenPurpose::TOTP),
+        &auth::SinglePurposeJWTAuth(TokenPurpose::TOTP),
         api_locking::LockAction::NotApplicable,
     ))
     .await

--- a/crates/router/src/routes/user.rs
+++ b/crates/router/src/routes/user.rs
@@ -507,7 +507,7 @@ pub async fn accept_invite_from_email(
             |state, user, req_payload, _| {
                 user_core::accept_invite_from_email_token_only_flow(state, user, req_payload)
             },
-            &auth::SinglePurposeJWTAuth(common_enums::TokenPurpose::AcceptInvitationFromEmail),
+            &auth::SinglePurposeJWTAuth(TokenPurpose::AcceptInvitationFromEmail),
             api_locking::LockAction::NotApplicable,
         ))
         .await
@@ -545,7 +545,7 @@ pub async fn verify_email(
             |state, user, req_payload, _| {
                 user_core::verify_email_token_only_flow(state, user, req_payload)
             },
-            &auth::SinglePurposeJWTAuth(common_enums::TokenPurpose::VerifyEmail),
+            &auth::SinglePurposeJWTAuth(TokenPurpose::VerifyEmail),
             api_locking::LockAction::NotApplicable,
         ))
         .await

--- a/crates/router/src/types/domain/address.rs
+++ b/crates/router/src/types/domain/address.rs
@@ -80,7 +80,7 @@ impl behaviour::Conversion for CustomerAddress {
                 .customer_id
                 .clone()
                 .ok_or(ValidationError::MissingRequiredField {
-                    field_name: "cutomer_id".to_string(),
+                    field_name: "customer_id".to_string(),
                 })?;
 
         let address = Address::convert_back(other, key).await?;

--- a/crates/router/tests/connectors/gpayments.rs
+++ b/crates/router/tests/connectors/gpayments.rs
@@ -4,6 +4,7 @@ use test_utils::connector_auth;
 use crate::utils::{self, ConnectorActions};
 
 #[derive(Clone, Copy)]
+#[allow(dead_code)]
 struct GpaymentsTest;
 impl ConnectorActions for GpaymentsTest {}
 impl utils::Connector for GpaymentsTest {

--- a/crates/router/tests/connectors/mifinity.rs
+++ b/crates/router/tests/connectors/mifinity.rs
@@ -93,7 +93,7 @@ async fn should_sync_authorized_payment() {
         .psync_retry_till_status_matches(
             enums::AttemptStatus::Authorized,
             Some(types::PaymentsSyncData {
-                connector_transaction_id: router::types::ResponseId::ConnectorTransactionId(
+                connector_transaction_id: types::ResponseId::ConnectorTransactionId(
                     txn_id.unwrap(),
                 ),
                 ..Default::default()
@@ -213,7 +213,7 @@ async fn should_sync_auto_captured_payment() {
         .psync_retry_till_status_matches(
             enums::AttemptStatus::Charged,
             Some(types::PaymentsSyncData {
-                connector_transaction_id: router::types::ResponseId::ConnectorTransactionId(
+                connector_transaction_id: types::ResponseId::ConnectorTransactionId(
                     txn_id.unwrap(),
                 ),
                 capture_method: Some(enums::CaptureMethod::Automatic),
@@ -303,7 +303,7 @@ async fn should_fail_payment_for_incorrect_cvc() {
     let response = CONNECTOR
         .make_payment(
             Some(types::PaymentsAuthorizeData {
-                payment_method_data: types::domain::PaymentMethodData::Card(domain::Card {
+                payment_method_data: domain::PaymentMethodData::Card(domain::Card {
                     card_cvc: Secret::new("12345".to_string()),
                     ..utils::CCardType::default().0
                 }),
@@ -325,7 +325,7 @@ async fn should_fail_payment_for_invalid_exp_month() {
     let response = CONNECTOR
         .make_payment(
             Some(types::PaymentsAuthorizeData {
-                payment_method_data: types::domain::PaymentMethodData::Card(domain::Card {
+                payment_method_data: domain::PaymentMethodData::Card(domain::Card {
                     card_exp_month: Secret::new("20".to_string()),
                     ..utils::CCardType::default().0
                 }),
@@ -347,7 +347,7 @@ async fn should_fail_payment_for_incorrect_expiry_year() {
     let response = CONNECTOR
         .make_payment(
             Some(types::PaymentsAuthorizeData {
-                payment_method_data: types::domain::PaymentMethodData::Card(domain::Card {
+                payment_method_data: domain::PaymentMethodData::Card(domain::Card {
                     card_exp_year: Secret::new("2000".to_string()),
                     ..utils::CCardType::default().0
                 }),

--- a/crates/router/tests/connectors/payone.rs
+++ b/crates/router/tests/connectors/payone.rs
@@ -93,7 +93,7 @@ async fn should_sync_authorized_payment() {
         .psync_retry_till_status_matches(
             enums::AttemptStatus::Authorized,
             Some(types::PaymentsSyncData {
-                connector_transaction_id: router::types::ResponseId::ConnectorTransactionId(
+                connector_transaction_id: types::ResponseId::ConnectorTransactionId(
                     txn_id.unwrap(),
                 ),
                 ..Default::default()
@@ -213,7 +213,7 @@ async fn should_sync_auto_captured_payment() {
         .psync_retry_till_status_matches(
             enums::AttemptStatus::Charged,
             Some(types::PaymentsSyncData {
-                connector_transaction_id: router::types::ResponseId::ConnectorTransactionId(
+                connector_transaction_id: types::ResponseId::ConnectorTransactionId(
                     txn_id.unwrap(),
                 ),
                 capture_method: Some(enums::CaptureMethod::Automatic),
@@ -303,7 +303,7 @@ async fn should_fail_payment_for_incorrect_cvc() {
     let response = CONNECTOR
         .make_payment(
             Some(types::PaymentsAuthorizeData {
-                payment_method_data: types::domain::PaymentMethodData::Card(domain::Card {
+                payment_method_data: domain::PaymentMethodData::Card(domain::Card {
                     card_cvc: Secret::new("12345".to_string()),
                     ..utils::CCardType::default().0
                 }),
@@ -325,7 +325,7 @@ async fn should_fail_payment_for_invalid_exp_month() {
     let response = CONNECTOR
         .make_payment(
             Some(types::PaymentsAuthorizeData {
-                payment_method_data: types::domain::PaymentMethodData::Card(domain::Card {
+                payment_method_data: domain::PaymentMethodData::Card(domain::Card {
                     card_exp_month: Secret::new("20".to_string()),
                     ..utils::CCardType::default().0
                 }),
@@ -347,7 +347,7 @@ async fn should_fail_payment_for_incorrect_expiry_year() {
     let response = CONNECTOR
         .make_payment(
             Some(types::PaymentsAuthorizeData {
-                payment_method_data: types::domain::PaymentMethodData::Card(domain::Card {
+                payment_method_data: domain::PaymentMethodData::Card(domain::Card {
                     card_exp_year: Secret::new("2000".to_string()),
                     ..utils::CCardType::default().0
                 }),


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Enhancement

## Description
<!-- Describe your changes in detail -->
In case of 4xx, we need to log the content length of the request from the `content-length` header. This PR adds that enhancement.

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
To provide better support for debugging issues related to missing fields.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
- Create a 4xx error and check for the content length log.
<img width="2055" alt="image" src="https://github.com/juspay/hyperswitch/assets/48803246/f3a1da9e-3afe-4dcd-87e7-f62a7bbf3df9">


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
