### PR TITLE
refactor(cache): remove `deref` impl on `Cache` type

### DIFF
--- a/crates/router/src/db/cache.rs
+++ b/crates/router/src/db/cache.rs
@@ -88,7 +88,7 @@ where
     Fut: futures::Future<Output = CustomResult<T, errors::StorageError>> + Send,
 {
     let data = fun().await?;
-    in_memory.async_map(|cache| cache.invalidate(key)).await;
+    in_memory.async_map(|cache| cache.remove(key)).await;
 
     let redis_conn = store
         .get_redis_conn()

--- a/crates/router/tests/cache.rs
+++ b/crates/router/tests/cache.rs
@@ -50,8 +50,14 @@ async fn invalidate_existing_cache_success() {
     let response_body = response.body().await;
     println!("invalidate Cache: {response:?} : {response_body:?}");
     assert_eq!(response.status(), awc::http::StatusCode::OK);
-    assert!(cache::CONFIG_CACHE.get(&cache_key).await.is_none());
-    assert!(cache::ACCOUNTS_CACHE.get(&cache_key).await.is_none());
+    assert!(cache::CONFIG_CACHE
+        .get_val::<String>(&cache_key)
+        .await
+        .is_none());
+    assert!(cache::ACCOUNTS_CACHE
+        .get_val::<String>(&cache_key)
+        .await
+        .is_none());
 }
 
 #[actix_web::test]

--- a/crates/storage_impl/src/redis/pub_sub.rs
+++ b/crates/storage_impl/src/redis/pub_sub.rs
@@ -60,16 +60,16 @@ impl PubSubInterface for redis_interface::RedisConnectionPool {
 
             let key = match key {
                 CacheKind::Config(key) => {
-                    CONFIG_CACHE.invalidate(key.as_ref()).await;
+                    CONFIG_CACHE.remove(key.as_ref()).await;
                     key
                 }
                 CacheKind::Accounts(key) => {
-                    ACCOUNTS_CACHE.invalidate(key.as_ref()).await;
+                    ACCOUNTS_CACHE.remove(key.as_ref()).await;
                     key
                 }
                 CacheKind::All(key) => {
-                    CONFIG_CACHE.invalidate(key.as_ref()).await;
-                    ACCOUNTS_CACHE.invalidate(key.as_ref()).await;
+                    CONFIG_CACHE.remove(key.as_ref()).await;
+                    ACCOUNTS_CACHE.remove(key.as_ref()).await;
                     key
                 }
             };


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Currently `Cache` is a type having inner value as `MokaCache`.
```
pub struct Cache {
    inner: MokaCache<String, Arc<dyn Cacheable>>,
}
```

There's a deref impl on this type which returns the inner `MokaCache`. We should instead have custom methods on `Cache` which calls the `MokaCache` methods instead of deref doing the job. There's already custom methods available on `Cache`. This PR refactors it to invoke these methods instead of calling it on the deref of `Cache`.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Basic sanity tests should suffice

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
