### PR TITLE
feat(cypress): add pix payment method to adyen

### DIFF
--- a/cypress-tests/cypress/e2e/ConnectorTest/00016-BankTransfers.cy.js
+++ b/cypress-tests/cypress/e2e/ConnectorTest/00016-BankTransfers.cy.js
@@ -1,0 +1,82 @@
+import confirmBody from "../../fixtures/confirm-body.json";
+import createPaymentBody from "../../fixtures/create-payment-body.json";
+import State from "../../utils/State";
+import getConnectorDetails from "../ConnectorUtils/utils";
+import * as utils from "../ConnectorUtils/utils";
+
+let globalState;
+
+describe("Bank Transfers", () => {
+  before("seed global state", () => {
+    cy.task("getGlobalState").then((state) => {
+      globalState = new State(state);
+      console.log("seeding globalState -> " + JSON.stringify(globalState));
+    });
+  });
+
+  after("flush global state", () => {
+    console.log("flushing globalState -> " + JSON.stringify(globalState));
+    cy.task("setGlobalState", globalState.data);
+  });
+
+  context("Bank transfer - Pix by Adyen forward flow", () => {
+    let should_continue = true; // variable that will be used to skip tests if a previous test fails
+
+    beforeEach(function () {
+      if (!should_continue) {
+        this.skip();
+      }
+    });
+
+    it("create-payment-call-test", () => {
+      let data = getConnectorDetails(globalState.get("connectorId"))[
+        "bank_transfer_pm"
+      ]["PaymentIntent"];
+      let req_data = data["Request"];
+      let res_data = data["Response"];
+      cy.createPaymentIntentTest(
+        createPaymentBody,
+        req_data,
+        res_data,
+        "three_ds",
+        "automatic",
+        globalState
+      );
+      if (should_continue)
+        should_continue = utils.should_continue_further(res_data);
+    });
+
+    it("payment_methods-call-test", () => {
+      cy.task("cli_log", "PM CALL ");
+      cy.paymentMethodsCallTest(globalState);
+    });
+
+    it("Confirm bank transfer", () => {
+      let data = getConnectorDetails(globalState.get("connectorId"))[
+        "bank_transfer_pm"
+      ]["Pix"];
+      let req_data = data["Request"];
+      let res_data = data["Response"];
+      cy.task("cli_log", "GLOBAL STATE -> " + JSON.stringify(globalState.data));
+      cy.confirmBankTransferCallTest(
+        confirmBody,
+        req_data,
+        res_data,
+        true,
+        globalState
+      );
+      if (should_continue)
+        should_continue = utils.should_continue_further(res_data);
+    });
+
+    it("Handle bank transfer redirection", () => {
+      let expected_redirection = confirmBody["return_url"];
+      let bank_transfer_payment_method_type = "pix";
+      cy.handleBankTransferRedirection(
+        globalState,
+        bank_transfer_payment_method_type,
+        expected_redirection
+      );
+    });
+  });
+});

--- a/cypress-tests/cypress/e2e/ConnectorUtils/Adyen.js
+++ b/cypress-tests/cypress/e2e/ConnectorUtils/Adyen.js
@@ -1,382 +1,394 @@
-
 const successfulNo3DSCardDetails = {
-    "card_number": "371449635398431",
-    "card_exp_month": "03",
-    "card_exp_year": "30",
-    "card_holder_name": "John Doe",
-    "card_cvc": "7373"
+  card_number: "371449635398431",
+  card_exp_month: "03",
+  card_exp_year: "30",
+  card_holder_name: "John Doe",
+  card_cvc: "7373",
 };
 
 const successfulThreeDSTestCardDetails = {
-    "card_number": "4917610000000000",
-    "card_exp_month": "03",
-    "card_exp_year": "30",
-    "card_holder_name": "Joseph Doe",
-    "card_cvc": "737"
+  card_number: "4917610000000000",
+  card_exp_month: "03",
+  card_exp_year: "30",
+  card_holder_name: "Joseph Doe",
+  card_cvc: "737",
 };
 
 export const connectorDetails = {
-card_pm:{
-    "PaymentIntent": {
-        "Request": {
-            "card": successfulNo3DSCardDetails,
-            "currency": "USD",
-            "customer_acceptance": null,
-            "setup_future_usage": "on_session"
+  card_pm: {
+    PaymentIntent: {
+      Request: {
+        card: successfulNo3DSCardDetails,
+        currency: "USD",
+        customer_acceptance: null,
+        setup_future_usage: "on_session",
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "requires_payment_method",
         },
-        "Response": {
-            "status": 200,
-            "body": {
-                "status": "requires_payment_method"
-            }
-        }
+      },
     },
     "3DSManualCapture": {
-        "Request": {
-            "card": successfulThreeDSTestCardDetails,
-            "currency": "USD",
-            "customer_acceptance": null,
-            "setup_future_usage": "on_session"
+      Request: {
+        card: successfulThreeDSTestCardDetails,
+        currency: "USD",
+        customer_acceptance: null,
+        setup_future_usage: "on_session",
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "processing",
         },
-        "Response": {
-            "status": 200,
-            "body": {
-                "status": "processing"
-            }
-        }
+      },
     },
     "3DSAutoCapture": {
-        "Request": {
-            "card": successfulThreeDSTestCardDetails,
-            "currency": "USD",
-            "customer_acceptance": null,
-            "setup_future_usage": "on_session"
+      Request: {
+        card: successfulThreeDSTestCardDetails,
+        currency: "USD",
+        customer_acceptance: null,
+        setup_future_usage: "on_session",
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "succeeded",
         },
-        "Response": {
-            "status": 200,
-            "body": {
-                "status": "succeeded"
-            }
-        }
+      },
     },
-    "No3DSManualCapture": {
-        "Request": {
-            "card": successfulNo3DSCardDetails,
-            "currency": "USD",
-            "customer_acceptance": null,
-            "setup_future_usage": "on_session"
+    No3DSManualCapture: {
+      Request: {
+        card: successfulNo3DSCardDetails,
+        currency: "USD",
+        customer_acceptance: null,
+        setup_future_usage: "on_session",
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "requires_capture",
         },
-        "Response": {
-            "status": 200,
-            "body": {
-                "status": "requires_capture"
-            }
-        }
+      },
     },
-    "No3DSAutoCapture": {
-        "Request": {
-            "card": successfulNo3DSCardDetails,
-            "currency": "USD",
-            "customer_acceptance": null,
-            "setup_future_usage": "on_session"
+    No3DSAutoCapture: {
+      Request: {
+        card: successfulNo3DSCardDetails,
+        currency: "USD",
+        customer_acceptance: null,
+        setup_future_usage: "on_session",
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "succeeded",
         },
-        "Response": {
-            "status": 200,
-            "body": {
-                "status": "succeeded"
-            }
-        }
+      },
     },
-    "Capture": {
-        "Request": {
-            "card": successfulNo3DSCardDetails,
-            "currency": "USD",
-            "customer_acceptance": null,
+    Capture: {
+      Request: {
+        card: successfulNo3DSCardDetails,
+        currency: "USD",
+        customer_acceptance: null,
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "processing",
+          amount: 6500,
+          amount_capturable: 6500,
+          amount_received: 0,
         },
-        "Response": {
-            "status": 200,
-            "body":{
-                "status": "processing",
-                "amount": 6500,
-                "amount_capturable": 6500,
-                "amount_received": 0,
+      },
+    },
 
-            }
-        }
-    },
-
-    "PartialCapture": {
-        "Request": {
+    PartialCapture: {
+      Request: {},
+      Response: {
+        status: 200,
+        body: {
+          status: "processing",
+          amount: 6500,
+          amount_capturable: 6500,
+          amount_received: 0,
         },
-        "Response": {
-            "status": 200,
-            "body": {
-                "status": "processing",
-                "amount": 6500,
-                "amount_capturable": 6500,
-                "amount_received": 0,
-            }
-
-        }
+      },
     },
-    "Void":{
-        "Request": {
+    Void: {
+      Request: {},
+      Response: {
+        status: 200,
+        body: {
+          status: "processing",
         },
-        "Response": {
-            "status": 200,
-            "body":{
-                status: "processing"
-    
-            }
-        }
+      },
     },
-    "Refund": {
-        "Request": {
-            
-            "currency": "USD",
-       
+    Refund: {
+      Request: {
+        currency: "USD",
+      },
+      Response: {
+        status: 400,
+        body: {
+          status: "pending",
         },
-        "Response": {
-            "status": 400,
-            "body": {
-                "status": "pending",
-            }
-
-        }
+      },
     },
-    "PartialRefund": {
-        "Request": {
-      
-            "currency": "USD",
-   
+    PartialRefund: {
+      Request: {
+        currency: "USD",
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "pending",
         },
-        "Response": {
-            "status": 200,
-            "body": {
-                "status": "pending",
-            }
-
-        }
+      },
     },
-    "SyncRefund": {
-        "Request": {
-      
-            "currency": "USD",
-   
+    SyncRefund: {
+      Request: {
+        currency: "USD",
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "pending",
         },
-        "Response": {
-            "status": 200,
-            "body": {
-                "status": "pending",
-            }
-
-        }
+      },
     },
-    "MandateSingleUse3DSAutoCapture": {
-        "Request": {
-            "card": successfulThreeDSTestCardDetails,
-            "currency": "USD",
-            "mandate_type": {
-                "single_use": {
-                    "amount": 8000,
-                    "currency": "USD"
-                }
-            }
+    MandateSingleUse3DSAutoCapture: {
+      Request: {
+        card: successfulThreeDSTestCardDetails,
+        currency: "USD",
+        mandate_type: {
+          single_use: {
+            amount: 8000,
+            currency: "USD",
+          },
         },
-        "Response": {
-            "status": 200,
-            "body": {
-                "status": "succeeded"
-            }
-        }
-        
-    },
-    "MandateSingleUse3DSManualCapture": {
-        "Request": {
-            "card": successfulThreeDSTestCardDetails,
-            "currency": "USD",
-            "mandate_type": {
-                "single_use": {
-                    "amount": 8000,
-                    "currency": "USD"
-                }
-            }
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "succeeded",
         },
-        "Response": {
-            "status": 200,
-            "body": {
-                "status": "requires_customer_action"
-            }
-        }
-        
+      },
     },
-    "MandateSingleUseNo3DSAutoCapture": {
-        "Request": {
-            "card": successfulNo3DSCardDetails,
-            "currency": "USD",
-            "mandate_type": {
-                "single_use": {
-                    "amount": 8000,
-                    "currency": "USD"
-                }
-            }
+    MandateSingleUse3DSManualCapture: {
+      Request: {
+        card: successfulThreeDSTestCardDetails,
+        currency: "USD",
+        mandate_type: {
+          single_use: {
+            amount: 8000,
+            currency: "USD",
+          },
         },
-        "Response": {
-            "status": 200,
-            "body": {
-                "status": "succeeded"
-             }
-        }
-    },
-    "MandateSingleUseNo3DSManualCapture": {
-        "Request": {
-            "card": successfulNo3DSCardDetails,
-            "currency": "USD",
-            "mandate_type": {
-                "single_use": {
-                    "amount": 8000,
-                    "currency": "USD"
-                }
-            }
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "requires_customer_action",
         },
-        "Response": {
-            "status": 200,
-            "body": {
-                "status": "processing"
-             }
-        }
+      },
     },
-    "MandateMultiUseNo3DSAutoCapture": {
-        "Request": {
-            "card": successfulNo3DSCardDetails,
-            "currency": "USD",
-            "mandate_type": {
-                "multi_use": {
-                    "amount": 8000,
-                    "currency": "USD"
-                }
-            }
+    MandateSingleUseNo3DSAutoCapture: {
+      Request: {
+        card: successfulNo3DSCardDetails,
+        currency: "USD",
+        mandate_type: {
+          single_use: {
+            amount: 8000,
+            currency: "USD",
+          },
         },
-        "Response": {
-            "status": 200,
-            "body": {
-                "status": "succeeded"
-            }
-        }
-    },
-    "MandateMultiUseNo3DSManualCapture": {
-        "Request": {
-            "card": successfulNo3DSCardDetails,
-            "currency": "USD",
-            "mandate_type": {
-                "multi_use": {
-                    "amount": 8000,
-                    "currency": "USD"
-                }
-            }
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "succeeded",
         },
-        "Response": {
-            "status": 200,
-            "body": {
-                "status": "requires_capture"
-            }
-        }
+      },
     },
-    "MandateMultiUse3DSAutoCapture": {
-        "Request": {
-            "card": successfulThreeDSTestCardDetails,
-            "currency": "USD",
-            "mandate_type": {
-                "multi_use": {
-                    "amount": 8000,
-                    "currency": "USD"
-                }
-            },
+    MandateSingleUseNo3DSManualCapture: {
+      Request: {
+        card: successfulNo3DSCardDetails,
+        currency: "USD",
+        mandate_type: {
+          single_use: {
+            amount: 8000,
+            currency: "USD",
+          },
         },
-        "Response": {
-            "status": 200,
-            "body": {
-                "status": "requires_capture"
-            }
-        }
-    },
-    "MandateMultiUse3DSManualCapture": {
-        "Request": {
-            "card": successfulThreeDSTestCardDetails,
-            "currency": "USD",
-            "mandate_type": {
-                "multi_use": {
-                    "amount": 8000,
-                    "currency": "USD"
-                }
-            },
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "processing",
         },
-        "Response": {
-            "status": 200,
-            "body": {
-                "status": "requires_capture"
-            }
-        }
+      },
     },
-    "ZeroAuthMandate": {
-        "Request": {
-            "card": successfulNo3DSCardDetails,
-            "currency": "USD",
-            "mandate_type": {
-                "single_use": {
-                    "amount": 8000,
-                    "currency": "USD"
-                }
-            }
+    MandateMultiUseNo3DSAutoCapture: {
+      Request: {
+        card: successfulNo3DSCardDetails,
+        currency: "USD",
+        mandate_type: {
+          multi_use: {
+            amount: 8000,
+            currency: "USD",
+          },
         },
-        "Response": {
-            "status": 200,
-            "body": {
-                "status": "succeeded"
-             }
-        }
-    },
-    "SaveCardUseNo3DSAutoCapture": {
-        "Request": {
-            "card": successfulNo3DSCardDetails,
-            "currency": "USD",
-            "setup_future_usage": "on_session",
-            "customer_acceptance": {
-                "acceptance_type": "offline",
-                "accepted_at": "1963-05-03T04:07:52.723Z",
-                "online": {
-                    "ip_address": "127.0.0.1",
-                    "user_agent": "amet irure esse"
-                }
-            },
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "succeeded",
         },
-        "Response": {
-            "status": 200,
-            "body": {
-                "status": "succeeded"
-            }
-        }
+      },
     },
-    "SaveCardUseNo3DSManualCapture": {
-        "Request": {
-            "card": successfulNo3DSCardDetails,
-            "currency": "USD",
-            "setup_future_usage": "on_session",
-            "customer_acceptance": {
-                "acceptance_type": "offline",
-                "accepted_at": "1963-05-03T04:07:52.723Z",
-                "online": {
-                    "ip_address": "127.0.0.1",
-                    "user_agent": "amet irure esse"
-                }
-            },
+    MandateMultiUseNo3DSManualCapture: {
+      Request: {
+        card: successfulNo3DSCardDetails,
+        currency: "USD",
+        mandate_type: {
+          multi_use: {
+            amount: 8000,
+            currency: "USD",
+          },
         },
-        "Response": {
-            "status": 200,
-            "body": {
-                "status": "requires_capture"
-            }
-        }
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "requires_capture",
+        },
+      },
     },
-}
-}; 
+    MandateMultiUse3DSAutoCapture: {
+      Request: {
+        card: successfulThreeDSTestCardDetails,
+        currency: "USD",
+        mandate_type: {
+          multi_use: {
+            amount: 8000,
+            currency: "USD",
+          },
+        },
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "requires_capture",
+        },
+      },
+    },
+    MandateMultiUse3DSManualCapture: {
+      Request: {
+        card: successfulThreeDSTestCardDetails,
+        currency: "USD",
+        mandate_type: {
+          multi_use: {
+            amount: 8000,
+            currency: "USD",
+          },
+        },
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "requires_capture",
+        },
+      },
+    },
+    ZeroAuthMandate: {
+      Request: {
+        card: successfulNo3DSCardDetails,
+        currency: "USD",
+        mandate_type: {
+          single_use: {
+            amount: 8000,
+            currency: "USD",
+          },
+        },
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "succeeded",
+        },
+      },
+    },
+    SaveCardUseNo3DSAutoCapture: {
+      Request: {
+        card: successfulNo3DSCardDetails,
+        currency: "USD",
+        setup_future_usage: "on_session",
+        customer_acceptance: {
+          acceptance_type: "offline",
+          accepted_at: "1963-05-03T04:07:52.723Z",
+          online: {
+            ip_address: "127.0.0.1",
+            user_agent: "amet irure esse",
+          },
+        },
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "succeeded",
+        },
+      },
+    },
+    SaveCardUseNo3DSManualCapture: {
+      Request: {
+        card: successfulNo3DSCardDetails,
+        currency: "USD",
+        setup_future_usage: "on_session",
+        customer_acceptance: {
+          acceptance_type: "offline",
+          accepted_at: "1963-05-03T04:07:52.723Z",
+          online: {
+            ip_address: "127.0.0.1",
+            user_agent: "amet irure esse",
+          },
+        },
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "requires_capture",
+        },
+      },
+    },
+  },
+  bank_transfer_pm: {
+    PaymentIntent: {
+      Request: {
+        currency: "BRL",
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "requires_payment_method",
+        },
+      },
+    },
+    Pix: {
+      Request: {
+        payment_method: "bank_transfer",
+        payment_method_type: "pix",
+        bank_transfer: {
+          pix: {},
+        },
+        currency: "BRL",
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "requires_customer_action",
+        },
+      },
+    },
+  },
+};

--- a/cypress-tests/cypress/fixtures/confirm-body.json
+++ b/cypress-tests/cypress/fixtures/confirm-body.json
@@ -1,20 +1,9 @@
 {
   "client_secret": "",
   "return_url": "https://hyperswitch.io",
-  "payment_method": "card",
   "confirm": true,
-  "payment_method_data": {
-    "card": {
-      "_comment": "these details are fetched from utils",
-      "card_number": "YourCardNumberHere",
-      "card_exp_month": "04",
-      "card_exp_year": "24",
-      "card_holder_name": "xyz",
-      "card_cvc": "424",
-      "card_issuer": "",
-      "card_network": "Visa"
-    }
-  },
+  "payment_method": "card",
+  "payment_method_data": {},
   "customer_acceptance": {
     "acceptance_type": "offline",
     "accepted_at": "1963-05-03T04:07:52.723Z",

--- a/cypress-tests/cypress/fixtures/create-connector-body.json
+++ b/cypress-tests/cypress/fixtures/create-connector-body.json
@@ -52,6 +52,18 @@
           "installment_payment_enabled": true
         }
       ]
+    },
+    {
+      "payment_method": "bank_transfer",
+      "payment_method_types": [
+        {
+          "payment_method_type": "pix",
+          "minimum_amount": 0,
+          "maximum_amount": 68607706,
+          "recurring_enabled": false,
+          "installment_payment_enabled": true
+        }
+      ]
     }
   ],
   "metadata": {

--- a/cypress-tests/package.json
+++ b/cypress-tests/package.json
@@ -9,5 +9,8 @@
     "cypress:ci": "npx cypress run --headless"
   },
   "author": "",
-  "license": "ISC"
+  "license": "ISC",
+  "dependencies": {
+    "jsqr": "^1.4.0"
+  }
 }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->

- Added Pix payment method type to Cypress
- Auto formatted by `prettier`
- Prettier library yet to be added in this PR
- Auto-formatting the entire cypress will be taken in a different PR once stabilised

```txt
connector: "adyen
payment_method: "bank_transfer"
payment_method_type: "pix"
```

Flow:

- Create a payment intent
- Confirm
- Validate QR

> [!NOTE]
> SDK says payment is `processing`, but on dashboard, even after `force_psync`, the status remains as `requires_customer_action`.
> One would also need to **login** to Adyen dashboard and manually move the status from offer to sale to move the payment status to `processing`
> Adyen login is behind a 2FA

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->

NIL

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

<img width="513" alt="image" src="https://github.com/juspay/hyperswitch/assets/69745008/fb635cc9-d0da-4ede-b321-996884647604">


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
