### PR TITLE
chore(docker-compose): specify `pull_policy` for hyperswitch services

### DIFF
--- a/docker-compose-development.yml
+++ b/docker-compose-development.yml
@@ -298,6 +298,7 @@ services:
 
   hyperswitch-control-center:
     image: juspaydotin/hyperswitch-control-center:latest
+    pull_policy: always
     networks:
       - router_net
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,6 +48,7 @@ services:
   ### Application services
   hyperswitch-server:
     image: juspaydotin/hyperswitch-router:standalone
+    pull_policy: always
     command: /local/bin/router -f /local/config/docker_compose.toml
     ports:
       - "8080:8080"
@@ -67,6 +68,7 @@ services:
 
   hyperswitch-producer:
     image: juspaydotin/hyperswitch-producer:standalone
+    pull_policy: always
     command: /local/bin/scheduler -f /local/config/docker_compose.toml
     networks:
       - router_net
@@ -84,6 +86,7 @@ services:
 
   hyperswitch-consumer:
     image: juspaydotin/hyperswitch-consumer:standalone
+    pull_policy: always
     command: /local/bin/scheduler -f /local/config/docker_compose.toml
     networks:
       - router_net
@@ -107,6 +110,7 @@ services:
 
   hyperswitch-drainer:
     image: juspaydotin/hyperswitch-drainer:standalone
+    pull_policy: always
     command: /local/bin/drainer -f /local/config/docker_compose.toml
     deploy:
       replicas: ${DRAINER_INSTANCE_COUNT:-1}
@@ -148,6 +152,7 @@ services:
   ### Control Center
   hyperswitch-control-center:
     image: juspaydotin/hyperswitch-control-center:latest
+    pull_policy: always
     ports:
       - "9000:9000"
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -338,7 +338,7 @@ services:
       JMX_PORT: 9997
       KAFKA_JMX_OPTS: -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname=kafka0 -Dcom.sun.management.jmxremote.rmi.port=9997
     profiles:
-      - analytics
+      - olap
     volumes:
       - ./monitoring/kafka-script.sh:/tmp/update_run.sh
     command: "bash -c 'if [ ! -f /tmp/update_run.sh ]; then echo \"ERROR: Did you forget the update_run.sh file that came with this docker-compose.yml file?\" && exit 1 ; else /tmp/update_run.sh && /etc/confluent/docker/run ; fi'"
@@ -353,7 +353,7 @@ services:
     depends_on:
       - kafka0
     profiles:
-      - analytics
+      - olap
     environment:
       KAFKA_CLUSTERS_0_NAME: local
       KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS: kafka0:29092
@@ -369,7 +369,7 @@ services:
     volumes:
       - ./crates/analytics/docs/clickhouse/scripts:/docker-entrypoint-initdb.d
     profiles:
-      - analytics
+      - olap
     ulimits:
       nofile:
         soft: 262144

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -381,6 +381,8 @@ services:
       - ./docker/fluentd/conf:/fluentd/etc
     networks:
       - router_net
+    profiles:
+      - olap
 
   opensearch:
     image: public.ecr.aws/opensearchproject/opensearch:1.3.14
@@ -394,6 +396,8 @@ services:
       - "9200:9200"
     networks:
       - router_net
+    profiles:
+      - olap
 
   opensearch-dashboards:
     image: opensearchproject/opensearch-dashboards:1.3.14
@@ -405,3 +409,5 @@ services:
       OPENSEARCH_HOSTS: '["https://opensearch:9200"]'
     networks:
       - router_net
+    profiles:
+      - olap


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
This PR adds a `pull_policy` field for hyperswitch services in the Docker Compose setup, so that the latest images are pulled from Docker Hub. In addition, this PR renames the `analytics` profile in the Docker Compose to `olap`, and moves the `fluentd`, `opensearch` and `opensearch-dashboards` services under the `olap` profile.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
This would ensure that the latest images from Docker Hub are pulled and run, even if the user has old images cached on their local system.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Running the Docker Compose setup locally with `docker compose up -d` and `docker compose --profile olap up -d` and verified that the intended containers come up.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
