### PR TITLE
docs: update Docker Compose setup guide to checkout `latest` tag

### DIFF
--- a/.github/workflows/release-stable-version.yml
+++ b/.github/workflows/release-stable-version.yml
@@ -118,7 +118,7 @@ jobs:
           echo "PREVIOUS_TAG=${PREVIOUS_TAG}" >> $GITHUB_ENV
           echo "NEXT_TAG=${NEXT_TAG}" >> $GITHUB_ENV
 
-        # We make use of GitHub API calls to create the tag to have signed tags
+        # We make use of GitHub API calls to create and update tags
       - name: Create SemVer tag
         shell: bash
         env:
@@ -131,6 +131,18 @@ jobs:
             --header 'X-GitHub-Api-Version: 2022-11-28' \
             '/repos/{owner}/{repo}/git/refs' \
             --raw-field "ref=refs/tags/${NEXT_TAG}" \
+            --raw-field 'sha=${{ github.sha }}'
+
+      - name: Update `latest` tag to point to newly created SemVer tag
+        shell: bash
+        env:
+          GH_TOKEN: ${{ steps.generate_app_token.outputs.token }}
+        run: |
+          gh api \
+            --method PATCH \
+            --header 'Accept: application/vnd.github+json' \
+            --header 'X-GitHub-Api-Version: 2022-11-28' \
+            '/repos/{owner}/{repo}/git/refs/tags/latest' \
             --raw-field 'sha=${{ github.sha }}'
 
       - name: Generate changelog

--- a/README.md
+++ b/README.md
@@ -75,10 +75,12 @@ The fastest and easiest way to try Hyperswitch is via our CDK scripts
 You can run Hyperswitch on your system using Docker Compose after cloning this repository:
 
 ```shell
+git clone --depth 1 --branch latest https://github.com/juspay/hyperswitch
+cd hyperswitch
 docker compose up -d
 ```
 
-This will start the payments router, the primary component within Hyperswitch.
+This will start the app server, web client and control center.
 
 Check out the [local setup guide][local-setup-guide] for a more comprehensive
 setup, which includes the [scheduler and monitoring services][docker-compose-scheduler-monitoring].

--- a/docs/try_local_system.md
+++ b/docs/try_local_system.md
@@ -36,7 +36,7 @@ Check the Table Of Contents to jump to the relevant section.
 2. Clone the repository and switch to the project directory:
 
    ```shell
-   git clone https://github.com/juspay/hyperswitch
+   git clone --depth 1 --branch latest https://github.com/juspay/hyperswitch
    cd hyperswitch
    ```
 
@@ -51,13 +51,13 @@ Check the Table Of Contents to jump to the relevant section.
    docker compose up -d
    ```
 
-   This should run the hyperswitch payments router, the primary component within
-   hyperswitch.
+   This should run the hyperswitch app server, web client and control center.
    Wait for the `migration_runner` container to finish installing `diesel_cli`
-   and running migrations (approximately 2 minutes) before proceeding further.
+   and running migrations (approximately 2 minutes), and for the
+   `hyperswitch-web` container to finish compiling before proceeding further.
    You can also choose to
    [run the scheduler and monitoring services](#run-the-scheduler-and-monitoring-services)
-   in addition to the payments router.
+   in addition to the app server, web client and control center.
 
 5. Verify that the server is up and running by hitting the health endpoint:
 


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [x] Documentation
- [x] CI/CD

## Description
<!-- Describe your changes in detail -->
This PR updates the release stable version workflow with a new step to update the `latest` tag to the newly created SemVer tag, and updates the Docker Compose setup guide to checkout the `latest` tag when cloning the repository.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
This would help prevent failures with starting the app server when running off of the `main` branch, specifically when a new enum variant has been introduced in the `main` branch, but is not available in the latest stable release. Checking out the latest stable release when running the Docker Compose setup would ensure that a compatible configuration file would be used, and thus reduce server startup failures.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
I've tested out the new step added in the stable release workflow by running the command locally, first by creating the `latest` tag manually to point to an old release, then by running the command to point to the latest stable release.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
