### PR TITLE
feat(router): send message_version and directory_server_id in next_action block of three_ds_data for external 3ds flow

### DIFF
--- a/crates/api_models/src/payments.rs
+++ b/crates/api_models/src/payments.rs
@@ -2955,6 +2955,10 @@ pub struct ThreeDsData {
     pub three_ds_method_details: ThreeDsMethodData,
     /// Poll config for a connector
     pub poll_config: PollConfigResponse,
+    /// Message Version
+    pub message_version: Option<String>,
+    /// Directory Server ID
+    pub directory_server_id: Option<String>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, serde::Serialize, ToSchema)]

--- a/crates/diesel_models/src/authentication.rs
+++ b/crates/diesel_models/src/authentication.rs
@@ -42,6 +42,7 @@ pub struct Authentication {
     pub profile_id: String,
     pub payment_id: Option<String>,
     pub merchant_connector_id: String,
+    pub directory_server_id: Option<String>,
 }
 
 impl Authentication {
@@ -86,6 +87,7 @@ pub struct AuthenticationNew {
     pub profile_id: String,
     pub payment_id: Option<String>,
     pub merchant_connector_id: String,
+    pub directory_server_id: Option<String>,
 }
 
 #[derive(Debug)]
@@ -101,6 +103,7 @@ pub enum AuthenticationUpdate {
         authentication_status: common_enums::AuthenticationStatus,
         acquirer_bin: Option<String>,
         acquirer_merchant_id: Option<String>,
+        directory_server_id: Option<String>,
     },
     AuthenticationUpdate {
         authentication_value: Option<String>,
@@ -159,6 +162,7 @@ pub struct AuthenticationUpdateInternal {
     pub acs_reference_number: Option<String>,
     pub acs_trans_id: Option<String>,
     pub acs_signed_content: Option<String>,
+    pub directory_server_id: Option<String>,
 }
 
 impl Default for AuthenticationUpdateInternal {
@@ -189,6 +193,7 @@ impl Default for AuthenticationUpdateInternal {
             acs_reference_number: Default::default(),
             acs_trans_id: Default::default(),
             acs_signed_content: Default::default(),
+            directory_server_id: Default::default(),
         }
     }
 }
@@ -221,6 +226,7 @@ impl AuthenticationUpdateInternal {
             acs_reference_number,
             acs_trans_id,
             acs_signed_content,
+            directory_server_id,
         } = self;
         Authentication {
             connector_authentication_id: connector_authentication_id
@@ -252,6 +258,7 @@ impl AuthenticationUpdateInternal {
             acs_reference_number: acs_reference_number.or(source.acs_reference_number),
             acs_trans_id: acs_trans_id.or(source.acs_trans_id),
             acs_signed_content: acs_signed_content.or(source.acs_signed_content),
+            directory_server_id: directory_server_id.or(source.directory_server_id),
             ..source
         }
     }
@@ -304,6 +311,7 @@ impl From<AuthenticationUpdate> for AuthenticationUpdateInternal {
                 authentication_status,
                 acquirer_bin,
                 acquirer_merchant_id,
+                directory_server_id,
             } => Self {
                 threeds_server_transaction_id: Some(threeds_server_transaction_id),
                 maximum_supported_version: Some(maximum_supported_3ds_version),
@@ -315,6 +323,7 @@ impl From<AuthenticationUpdate> for AuthenticationUpdateInternal {
                 authentication_status: Some(authentication_status),
                 acquirer_bin,
                 acquirer_merchant_id,
+                directory_server_id,
                 ..Default::default()
             },
             AuthenticationUpdate::AuthenticationUpdate {

--- a/crates/diesel_models/src/schema.rs
+++ b/crates/diesel_models/src/schema.rs
@@ -115,6 +115,8 @@ diesel::table! {
         payment_id -> Nullable<Varchar>,
         #[max_length = 128]
         merchant_connector_id -> Varchar,
+        #[max_length = 128]
+        directory_server_id -> Nullable<Varchar>,
     }
 }
 

--- a/crates/router/src/connector/netcetera/transformers.rs
+++ b/crates/router/src/connector/netcetera/transformers.rs
@@ -96,6 +96,9 @@ impl
                         three_ds_method_url,
                         message_version: maximum_supported_3ds_version,
                         connector_metadata: None,
+                        directory_server_id: card_range
+                            .as_ref()
+                            .and_then(|card_range| card_range.directory_server_id.clone()),
                     },
                 )
             }

--- a/crates/router/src/connector/threedsecureio/transformers.rs
+++ b/crates/router/src/connector/threedsecureio/transformers.rs
@@ -108,6 +108,7 @@ impl
                         )
                         .change_context(errors::ConnectorError::ParsingFailed)?,
                         connector_metadata: Some(connector_metadata),
+                        directory_server_id: None,
                     },
                 )
             }

--- a/crates/router/src/core/authentication/utils.rs
+++ b/crates/router/src/core/authentication/utils.rs
@@ -63,6 +63,7 @@ pub async fn update_trackers<F: Clone, Req>(
                 three_ds_method_url,
                 message_version,
                 connector_metadata,
+                directory_server_id,
             } => storage::AuthenticationUpdate::PreAuthenticationUpdate {
                 threeds_server_transaction_id,
                 maximum_supported_3ds_version,
@@ -77,6 +78,7 @@ pub async fn update_trackers<F: Clone, Req>(
                     .map(|acquirer_details| acquirer_details.acquirer_bin.clone()),
                 acquirer_merchant_id: acquirer_details
                     .map(|acquirer_details| acquirer_details.acquirer_merchant_id),
+                directory_server_id,
             },
             AuthenticationResponseData::AuthNResponse {
                 authn_flow_type,
@@ -181,6 +183,7 @@ pub async fn create_new_authentication(
         profile_id,
         payment_id,
         merchant_connector_id,
+        directory_server_id: None,
     };
     state
         .store

--- a/crates/router/src/core/payments/transformers.rs
+++ b/crates/router/src/core/payments/transformers.rs
@@ -600,6 +600,9 @@ where
                                                     three_ds_method_url: None,
                                             }),
                                             poll_config: api_models::payments::PollConfigResponse {poll_id: request_poll_id, delay_in_secs: poll_config.delay_in_secs, frequency: poll_config.frequency},
+                                            message_version: authentication.message_version.as_ref()
+                                            .map(|version| version.to_string()),
+                                            directory_server_id: authentication.directory_server_id.clone(),
                                         },
                                     })
                                 }else{

--- a/crates/router/src/db/authentication.rs
+++ b/crates/router/src/db/authentication.rs
@@ -147,6 +147,7 @@ impl AuthenticationInterface for MockDb {
             profile_id: authentication.profile_id,
             payment_id: authentication.payment_id,
             merchant_connector_id: authentication.merchant_connector_id,
+            directory_server_id: authentication.directory_server_id,
         };
         authentications.push(authentication.clone());
         Ok(authentication)

--- a/crates/router/src/types/authentication.rs
+++ b/crates/router/src/types/authentication.rs
@@ -18,6 +18,7 @@ pub enum AuthenticationResponseData {
         three_ds_method_url: Option<String>,
         message_version: common_utils::types::SemanticVersion,
         connector_metadata: Option<serde_json::Value>,
+        directory_server_id: Option<String>,
     },
     AuthNResponse {
         authn_flow_type: AuthNFlowType,

--- a/migrations/2024-05-21-075556_add_directory_server_id_in_authentication/down.sql
+++ b/migrations/2024-05-21-075556_add_directory_server_id_in_authentication/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE authentication DROP COLUMN IF EXISTS directory_server_id;

--- a/migrations/2024-05-21-075556_add_directory_server_id_in_authentication/up.sql
+++ b/migrations/2024-05-21-075556_add_directory_server_id_in_authentication/up.sql
@@ -1,0 +1,2 @@
+-- Your SQL goes here
+ALTER TABLE authentication ADD COLUMN IF NOT EXISTS directory_server_id VARCHAR(128);

--- a/openapi/openapi_spec.json
+++ b/openapi/openapi_spec.json
@@ -18329,6 +18329,16 @@
           },
           "poll_config": {
             "$ref": "#/components/schemas/PollConfigResponse"
+          },
+          "message_version": {
+            "type": "string",
+            "description": "Message Version",
+            "nullable": true
+          },
+          "directory_server_id": {
+            "type": "string",
+            "description": "Directory Server ID",
+            "nullable": true
           }
         }
       },


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
send message_version and directory_server_id in next_action block of three_ds_data for external 3ds flow
message_version and directory_server_id are required for mobile sdk to initiate the netcetera sdk


### Additional Changes

- [x] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
**Tested Manually**
1. Initiate 3DS Authentication with Netcetera and can see the newly added fields in next_action block for external 3DS
![image](https://github.com/juspay/hyperswitch/assets/56996463/cc35f510-ec0e-40c6-a9fc-736cf84bd08d)
![image](https://github.com/juspay/hyperswitch/assets/56996463/6e661107-de28-4dfc-9932-159189edfe0f)

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
