### PR TITLE
chore: move tracing to workspace deps and remove router_env as a dependency of redis_interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5365,11 +5365,11 @@ dependencies = [
  "error-stack",
  "fred",
  "futures 0.3.30",
- "router_env",
  "serde",
  "thiserror",
  "tokio 1.37.0",
  "tokio-stream",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,9 @@ package.edition = "2021"
 package.rust-version = "1.70"
 package.license = "Apache-2.0"
 
+[workspace.dependencies]
+tracing = { version = "0.1.40" }
+
 [profile.release]
 strip = true
 lto = true

--- a/crates/redis_interface/Cargo.toml
+++ b/crates/redis_interface/Cargo.toml
@@ -18,7 +18,8 @@ tokio-stream = {version = "0.1.15", features = ["sync"]}
 
 # First party crates
 common_utils = { version = "0.1.0", path = "../common_utils", features = ["async_ext"] }
-router_env = { version = "0.1.0", path = "../router_env", features = ["log_extra_implicit_fields", "log_custom_entries_to_extra"] }
+# router_env = { version = "0.1.0", path = "../router_env", features = ["log_extra_implicit_fields", "log_custom_entries_to_extra"] }
+tracing = { workspace = true }
 
 [dev-dependencies]
 tokio = { version = "1.37.0", features = ["macros", "rt-multi-thread"] }

--- a/crates/redis_interface/Cargo.toml
+++ b/crates/redis_interface/Cargo.toml
@@ -15,11 +15,10 @@ serde = { version = "1.0.197", features = ["derive"] }
 thiserror = "1.0.58"
 tokio = "1.37.0"
 tokio-stream = {version = "0.1.15", features = ["sync"]}
+tracing = { workspace = true }
 
 # First party crates
 common_utils = { version = "0.1.0", path = "../common_utils", features = ["async_ext"] }
-# router_env = { version = "0.1.0", path = "../router_env", features = ["log_extra_implicit_fields", "log_custom_entries_to_extra"] }
-tracing = { workspace = true }
 
 [dev-dependencies]
 tokio = { version = "1.37.0", features = ["macros", "rt-multi-thread"] }

--- a/crates/redis_interface/src/commands.rs
+++ b/crates/redis_interface/src/commands.rs
@@ -23,7 +23,7 @@ use fred::{
     },
 };
 use futures::StreamExt;
-use router_env::{instrument, logger, tracing};
+use tracing::instrument;
 
 use crate::{
     errors,
@@ -379,7 +379,7 @@ impl super::RedisConnectionPool {
                         Some(futures::stream::iter(v))
                     }
                     Err(err) => {
-                        logger::error!(?err);
+                        tracing::error!(?err);
                         None
                     }
                 }

--- a/crates/router_env/Cargo.toml
+++ b/crates/router_env/Cargo.toml
@@ -22,7 +22,7 @@ serde_path_to_error = "0.1.16"
 strum = { version = "0.26.2", features = ["derive"] }
 time = { version = "0.3.35", default-features = false, features = ["formatting"] }
 tokio = { version = "1.37.0" }
-tracing = { version = "0.1.40" }
+tracing = { workspace = true }
 tracing-actix-web = { version = "0.7.10", features = ["opentelemetry_0_19", "uuid_v7"], optional = true }
 tracing-appender = { version = "0.2.3" }
 tracing-attributes = "0.1.27"


### PR DESCRIPTION
…ndency for redis_interface

## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

This PR removes `router_env` as a dependency of `redis_interface` crate. To accomplish this we declare `tracing` as a workspace dependency and use that individually in `redis_interface` and `router_env`.

<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context

This is done to make `redis_interface` more self-sufficient and improve its usage as a autonomous dependency.

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?

This is dependency relocation, no domain logic or framework code was changed
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
