### PR TITLE
feat(constraint_graph): add size estimation functionality to the constraint graph

### DIFF
--- a/crates/hyperswitch_constraint_graph/src/dense_map.rs
+++ b/crates/hyperswitch_constraint_graph/src/dense_map.rs
@@ -1,5 +1,7 @@
 use std::{fmt, iter, marker::PhantomData, ops, slice, vec};
 
+use crate::types::{GetSize, Size};
+
 pub trait EntityId {
     fn get_id(&self) -> usize;
     fn with_id(id: usize) -> Self;
@@ -238,5 +240,14 @@ where
             data: Vec::from_iter(iter),
             _marker: PhantomData,
         }
+    }
+}
+
+impl<K, V> GetSize for DenseMap<K, V>
+where
+    V: GetSize,
+{
+    fn get_size(&self) -> Size {
+        self.data.get_size()
     }
 }

--- a/crates/hyperswitch_constraint_graph/src/graph.rs
+++ b/crates/hyperswitch_constraint_graph/src/graph.rs
@@ -7,9 +7,9 @@ use crate::{
     dense_map::DenseMap,
     error::{self, AnalysisTrace, GraphError},
     types::{
-        CheckingContext, CycleCheck, DomainId, DomainIdentifier, DomainInfo, Edge, EdgeId,
+        CheckingContext, CycleCheck, DomainId, DomainIdentifier, DomainInfo, Edge, EdgeId, GetSize,
         Memoization, Metadata, Node, NodeId, NodeType, NodeValue, Relation, RelationResolution,
-        Strength, ValueNode,
+        Size, Strength, ValueNode,
     },
 };
 
@@ -587,6 +587,20 @@ where
         }
 
         Ok(node_builder.build())
+    }
+}
+
+impl<'a, V> GetSize for ConstraintGraph<'a, V>
+where
+    V: ValueNode + GetSize,
+{
+    fn get_size(&self) -> Size {
+        self.domain.get_size()
+            + self.domain_identifier_map.get_size()
+            + self.nodes.get_size()
+            + self.edges.get_size()
+            + self.value_map.get_size()
+            + self.node_info.get_size()
     }
 }
 


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
This PR adds size estimation functionality to the constraint graph that allows one to estimate the amount of space the graph occupies in memory

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
Size estimation for constraint graphs would be useful for design and diagnostic purposes since they can become quite large.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
compiler-guided. No API tests required as this is a purely internal/test-focused feature.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
