### PR TITLE
feat(users): add support to verify 2FA using recovery code

### DIFF
--- a/config/config.example.toml
+++ b/config/config.example.toml
@@ -352,7 +352,7 @@ sts_role_session_name = "" # An identifier for the assumed role session, used to
 
 [user]
 password_validity_in_days = 90             # Number of days after which password should be updated
-two_factor_auth_expiry_in_secs = 60 * 5;   # Number of seconds after which 2FA should be done again if doing update/change from inside
+two_factor_auth_expiry_in_secs = 300    # Number of seconds after which 2FA should be done again if doing update/change from inside
 
 #tokenization configuration which describe token lifetime and payment method for specific connector
 [tokenization]

--- a/config/config.example.toml
+++ b/config/config.example.toml
@@ -351,7 +351,8 @@ email_role_arn = ""        # The amazon resource name ( arn ) of the role which 
 sts_role_session_name = "" # An identifier for the assumed role session, used to uniquely identify a session.
 
 [user]
-password_validity_in_days = 90        # Number of days after which password should be updated
+password_validity_in_days = 90             # Number of days after which password should be updated
+two_factor_auth_expiry_in_secs = 60 * 5;   # Number of seconds after which 2FA should be done again if doing update/change from inside
 
 #tokenization configuration which describe token lifetime and payment method for specific connector
 [tokenization]

--- a/config/deployments/integration_test.toml
+++ b/config/deployments/integration_test.toml
@@ -113,6 +113,7 @@ slack_invite_url = "https://join.slack.com/t/hyperswitch-io/shared_invite/zt-2aw
 
 [user]
 password_validity_in_days = 90
+two_factor_auth_expiry_in_secs = 60 * 5;
 
 [frm]
 enabled = true

--- a/config/deployments/integration_test.toml
+++ b/config/deployments/integration_test.toml
@@ -113,7 +113,7 @@ slack_invite_url = "https://join.slack.com/t/hyperswitch-io/shared_invite/zt-2aw
 
 [user]
 password_validity_in_days = 90
-two_factor_auth_expiry_in_secs = 60 * 5;
+two_factor_auth_expiry_in_secs = 300
 
 [frm]
 enabled = true

--- a/config/deployments/production.toml
+++ b/config/deployments/production.toml
@@ -120,6 +120,7 @@ slack_invite_url = "https://join.slack.com/t/hyperswitch-io/shared_invite/zt-2aw
 
 [user]
 password_validity_in_days = 90
+two_factor_auth_expiry_in_secs = 60 * 5;
 
 [frm]
 enabled = false

--- a/config/deployments/production.toml
+++ b/config/deployments/production.toml
@@ -120,7 +120,7 @@ slack_invite_url = "https://join.slack.com/t/hyperswitch-io/shared_invite/zt-2aw
 
 [user]
 password_validity_in_days = 90
-two_factor_auth_expiry_in_secs = 60 * 5;
+two_factor_auth_expiry_in_secs = 300
 
 [frm]
 enabled = false

--- a/config/deployments/sandbox.toml
+++ b/config/deployments/sandbox.toml
@@ -120,7 +120,7 @@ slack_invite_url = "https://join.slack.com/t/hyperswitch-io/shared_invite/zt-2aw
 
 [user]
 password_validity_in_days = 90
-two_factor_auth_expiry_in_secs = 60 * 5;
+two_factor_auth_expiry_in_secs = 300
 
 [frm]
 enabled = true

--- a/config/deployments/sandbox.toml
+++ b/config/deployments/sandbox.toml
@@ -120,6 +120,7 @@ slack_invite_url = "https://join.slack.com/t/hyperswitch-io/shared_invite/zt-2aw
 
 [user]
 password_validity_in_days = 90
+two_factor_auth_expiry_in_secs = 60 * 5;
 
 [frm]
 enabled = true

--- a/config/development.toml
+++ b/config/development.toml
@@ -269,6 +269,7 @@ sts_role_session_name = ""
 
 [user]
 password_validity_in_days = 90
+two_factor_auth_expiry_in_secs = 60 * 5;
 
 [bank_config.eps]
 stripe = { banks = "arzte_und_apotheker_bank,austrian_anadi_bank_ag,bank_austria,bankhaus_carl_spangler,bankhaus_schelhammer_und_schattera_ag,bawag_psk_ag,bks_bank_ag,brull_kallmus_bank_ag,btv_vier_lander_bank,capital_bank_grawe_gruppe_ag,dolomitenbank,easybank_ag,erste_bank_und_sparkassen,hypo_alpeadriabank_international_ag,hypo_noe_lb_fur_niederosterreich_u_wien,hypo_oberosterreich_salzburg_steiermark,hypo_tirol_bank_ag,hypo_vorarlberg_bank_ag,hypo_bank_burgenland_aktiengesellschaft,marchfelder_bank,oberbank_ag,raiffeisen_bankengruppe_osterreich,schoellerbank_ag,sparda_bank_wien,volksbank_gruppe,volkskreditbank_ag,vr_bank_braunau" }

--- a/config/development.toml
+++ b/config/development.toml
@@ -269,7 +269,7 @@ sts_role_session_name = ""
 
 [user]
 password_validity_in_days = 90
-two_factor_auth_expiry_in_secs = 60 * 5;
+two_factor_auth_expiry_in_secs = 300
 
 [bank_config.eps]
 stripe = { banks = "arzte_und_apotheker_bank,austrian_anadi_bank_ag,bank_austria,bankhaus_carl_spangler,bankhaus_schelhammer_und_schattera_ag,bawag_psk_ag,bks_bank_ag,brull_kallmus_bank_ag,btv_vier_lander_bank,capital_bank_grawe_gruppe_ag,dolomitenbank,easybank_ag,erste_bank_und_sparkassen,hypo_alpeadriabank_international_ag,hypo_noe_lb_fur_niederosterreich_u_wien,hypo_oberosterreich_salzburg_steiermark,hypo_tirol_bank_ag,hypo_vorarlberg_bank_ag,hypo_bank_burgenland_aktiengesellschaft,marchfelder_bank,oberbank_ag,raiffeisen_bankengruppe_osterreich,schoellerbank_ag,sparda_bank_wien,volksbank_gruppe,volkskreditbank_ag,vr_bank_braunau" }

--- a/config/docker_compose.toml
+++ b/config/docker_compose.toml
@@ -53,7 +53,7 @@ recon_admin_api_key = "recon_test_admin"
 
 [user]
 password_validity_in_days = 90
-two_factor_auth_expiry_in_secs = 60 * 5;
+two_factor_auth_expiry_in_secs = 300
 
 [locker]
 host = ""

--- a/config/docker_compose.toml
+++ b/config/docker_compose.toml
@@ -53,6 +53,7 @@ recon_admin_api_key = "recon_test_admin"
 
 [user]
 password_validity_in_days = 90
+two_factor_auth_expiry_in_secs = 60 * 5;
 
 [locker]
 host = ""

--- a/crates/api_models/src/events/user.rs
+++ b/crates/api_models/src/events/user.rs
@@ -17,7 +17,7 @@ use crate::user::{
     RecoveryCodes, ResetPasswordRequest, RotatePasswordRequest, SendVerifyEmailRequest,
     SignInResponse, SignUpRequest, SignUpWithMerchantIdRequest, SwitchMerchantIdRequest,
     TokenOrPayloadResponse, TokenResponse, UpdateUserAccountDetailsRequest, UserFromEmailRequest,
-    UserMerchantCreate, VerifyEmailRequest, VerifyTotpRequest,
+    UserMerchantCreate, VerifyAccessCodeRequest, VerifyEmailRequest, VerifyTotpRequest,
 };
 
 impl ApiEventMetric for DashboardEntryResponse {
@@ -75,6 +75,7 @@ common_utils::impl_misc_api_event_type!(
     TokenResponse,
     UserFromEmailRequest,
     BeginTotpResponse,
+    VerifyAccessCodeRequest,
     VerifyTotpRequest,
     RecoveryCodes
 );

--- a/crates/api_models/src/user.rs
+++ b/crates/api_models/src/user.rs
@@ -259,6 +259,11 @@ pub struct VerifyTotpRequest {
 }
 
 #[derive(Debug, serde::Deserialize, serde::Serialize)]
+pub struct VerifyAccessCodeRequest {
+    pub access_code: Secret<String>,
+}
+
+#[derive(Debug, serde::Deserialize, serde::Serialize)]
 pub struct RecoveryCodes {
     pub recovery_codes: Vec<Secret<String>>,
 }

--- a/crates/api_models/src/user.rs
+++ b/crates/api_models/src/user.rs
@@ -260,7 +260,7 @@ pub struct VerifyTotpRequest {
 
 #[derive(Debug, serde::Deserialize, serde::Serialize)]
 pub struct VerifyAccessCodeRequest {
-    pub access_code: Secret<String>,
+    pub recovery_code: Secret<String>,
 }
 
 #[derive(Debug, serde::Deserialize, serde::Serialize)]

--- a/crates/router/src/configs/settings.rs
+++ b/crates/router/src/configs/settings.rs
@@ -395,6 +395,7 @@ pub struct Secrets {
 #[derive(Debug, Clone, Default, Deserialize)]
 pub struct UserSettings {
     pub password_validity_in_days: u16,
+    pub two_factor_auth_expiry_in_secs: u64,
 }
 
 #[derive(Debug, Deserialize, Clone)]

--- a/crates/router/src/consts/user.rs
+++ b/crates/router/src/consts/user.rs
@@ -14,3 +14,4 @@ pub const MAX_PASSWORD_LENGTH: usize = 70;
 pub const MIN_PASSWORD_LENGTH: usize = 8;
 
 pub const TOTP_PREFIX: &str = "TOTP_";
+pub const REDIS_RECOVERY_CODE_PREFIX: &str = "RC_";

--- a/crates/router/src/core/errors/user.rs
+++ b/crates/router/src/core/errors/user.rs
@@ -72,6 +72,8 @@ pub enum UserErrors {
     InvalidTotp,
     #[error("TotpRequired")]
     TotpRequired,
+    #[error("InvalidRecoveryCode")]
+    InvalidRecoveryCode,
 }
 
 impl common_utils::errors::ErrorSwitch<api_models::errors::types::ApiErrorResponse> for UserErrors {
@@ -184,6 +186,9 @@ impl common_utils::errors::ErrorSwitch<api_models::errors::types::ApiErrorRespon
             Self::TotpRequired => {
                 AER::BadRequest(ApiError::new(sub_code, 38, self.get_error_message(), None))
             }
+            Self::InvalidRecoveryCode => {
+                AER::BadRequest(ApiError::new(sub_code, 39, self.get_error_message(), None))
+            }
         }
     }
 }
@@ -223,6 +228,7 @@ impl UserErrors {
             Self::TotpNotSetup => "TOTP not setup",
             Self::InvalidTotp => "Invalid TOTP",
             Self::TotpRequired => "TOTP required",
+            Self::InvalidRecoveryCode => "Invalid Recovery Code"
         }
     }
 }

--- a/crates/router/src/core/user.rs
+++ b/crates/router/src/core/user.rs
@@ -1794,7 +1794,7 @@ pub async fn verify_recovery_code(
         password::get_correct_recovery_code_index(req.recovery_code, recovery_codes.clone())?;
 
     if matching_index.is_none() {
-        return Err(UserErrors::InvalidCredentials.into());
+        return Err(UserErrors::InvalidRecoveryCode.into());
     }
 
     let mut updated_recovery_codes = recovery_codes;

--- a/crates/router/src/routes/app.rs
+++ b/crates/router/src/routes/app.rs
@@ -1212,7 +1212,7 @@ impl User {
             )
             .service(web::resource("/totp/begin").route(web::get().to(totp_begin)))
             .service(web::resource("/totp/verify").route(web::post().to(totp_verify)))
-            .service(web::resource("/recovery_code/verify").route(web::post().to(recovery_code_verify)))
+            .service(web::resource("/recovery_codes/verify").route(web::post().to(recovery_code_verify)))
             .service(
                 web::resource("/recovery_codes/generate")
                     .route(web::get().to(generate_recovery_codes)),

--- a/crates/router/src/routes/app.rs
+++ b/crates/router/src/routes/app.rs
@@ -1212,6 +1212,7 @@ impl User {
             )
             .service(web::resource("/totp/begin").route(web::get().to(totp_begin)))
             .service(web::resource("/totp/verify").route(web::post().to(totp_verify)))
+            .service(web::resource("/access_code/verify").route(web::post().to(access_code_verify)))
             .service(
                 web::resource("/recovery_codes/generate")
                     .route(web::get().to(generate_recovery_codes)),

--- a/crates/router/src/routes/app.rs
+++ b/crates/router/src/routes/app.rs
@@ -1212,7 +1212,7 @@ impl User {
             )
             .service(web::resource("/totp/begin").route(web::get().to(totp_begin)))
             .service(web::resource("/totp/verify").route(web::post().to(totp_verify)))
-            .service(web::resource("/access_code/verify").route(web::post().to(access_code_verify)))
+            .service(web::resource("/recovery_code/verify").route(web::post().to(recovery_code_verify)))
             .service(
                 web::resource("/recovery_codes/generate")
                     .route(web::get().to(generate_recovery_codes)),

--- a/crates/router/src/routes/lock_utils.rs
+++ b/crates/router/src/routes/lock_utils.rs
@@ -215,6 +215,7 @@ impl From<Flow> for ApiIdentifier {
             | Flow::UpdateUserAccountDetails
             | Flow::TotpBegin
             | Flow::TotpVerify
+            | Flow::AccessCodeVerify
             | Flow::GenerateRecoveryCodes => Self::User,
 
             Flow::ListRoles

--- a/crates/router/src/routes/user.rs
+++ b/crates/router/src/routes/user.rs
@@ -666,6 +666,24 @@ pub async fn totp_verify(
     .await
 }
 
+pub async fn access_code_verify(
+    state: web::Data<AppState>,
+    req: HttpRequest,
+    json_payload: web::Json<user_api::VerifyAccessCodeRequest>,
+) -> HttpResponse {
+    let flow = Flow::AccessCodeVerify;
+    Box::pin(api::server_wrap(
+        flow,
+        state.clone(),
+        &req,
+        json_payload.into_inner(),
+        |state, user, req_body, _| user_core::verify_access_code(state, user, req_body),
+        &auth::SinglePurposeJWTAuth(TokenPurpose::TOTP),
+        api_locking::LockAction::NotApplicable,
+    ))
+    .await
+}
+
 pub async fn generate_recovery_codes(state: web::Data<AppState>, req: HttpRequest) -> HttpResponse {
     let flow = Flow::GenerateRecoveryCodes;
     Box::pin(api::server_wrap(

--- a/crates/router/src/routes/user.rs
+++ b/crates/router/src/routes/user.rs
@@ -666,7 +666,7 @@ pub async fn totp_verify(
     .await
 }
 
-pub async fn access_code_verify(
+pub async fn recovery_code_verify(
     state: web::Data<AppState>,
     req: HttpRequest,
     json_payload: web::Json<user_api::VerifyAccessCodeRequest>,
@@ -677,7 +677,7 @@ pub async fn access_code_verify(
         state.clone(),
         &req,
         json_payload.into_inner(),
-        |state, user, req_body, _| user_core::verify_access_code(state, user, req_body),
+        |state, user, req_body, _| user_core::verify_recovery_code(state, user, req_body),
         &auth::SinglePurposeJWTAuth(TokenPurpose::TOTP),
         api_locking::LockAction::NotApplicable,
     ))

--- a/crates/router/src/types/domain/user.rs
+++ b/crates/router/src/types/domain/user.rs
@@ -930,6 +930,10 @@ impl UserFromStorage {
         self.0.totp_status
     }
 
+    pub fn get_recovery_codes(&self) -> Option<Vec<Secret<String>>> {
+        self.0.totp_recovery_codes.clone()
+    }
+
     pub async fn decrypt_and_get_totp_secret(
         &self,
         state: &AppState,

--- a/crates/router/src/utils/user/password.rs
+++ b/crates/router/src/utils/user/password.rs
@@ -40,6 +40,18 @@ pub fn is_correct_password(
     .change_context(UserErrors::InternalServerError)
 }
 
+pub fn get_correct_access_code_index(
+    candidate: Secret<String>,
+    access_codes: Vec<Secret<String>>,
+) -> CustomResult<Option<usize>, UserErrors> {
+    Ok(access_codes
+        .into_iter()
+        .map(|access_code| is_correct_password(candidate.clone(), access_code))
+        .collect::<Result<Vec<_>, _>>()?
+        .into_iter()
+        .position(|x| x))
+}
+
 pub fn get_temp_password() -> Secret<String> {
     let uuid_pass = uuid::Uuid::new_v4().to_string();
     let mut rng = rand::thread_rng();

--- a/crates/router/src/utils/user/password.rs
+++ b/crates/router/src/utils/user/password.rs
@@ -40,13 +40,13 @@ pub fn is_correct_password(
     .change_context(UserErrors::InternalServerError)
 }
 
-pub fn get_correct_access_code_index(
+pub fn get_correct_recovery_code_index(
     candidate: Secret<String>,
-    access_codes: Vec<Secret<String>>,
+    recovery_codes: Vec<Secret<String>>,
 ) -> CustomResult<Option<usize>, UserErrors> {
-    Ok(access_codes
+    Ok(recovery_codes
         .into_iter()
-        .map(|access_code| is_correct_password(candidate.clone(), access_code))
+        .map(|recovery_code| is_correct_password(candidate.clone(), recovery_code))
         .collect::<Result<Vec<_>, _>>()?
         .into_iter()
         .position(|x| x))

--- a/crates/router/src/utils/user/two_factor_auth.rs
+++ b/crates/router/src/utils/user/two_factor_auth.rs
@@ -55,7 +55,7 @@ fn expiry_to_i64(expiry: u64) -> UserResult<i64> {
     i64::try_from(expiry).change_context(UserErrors::InternalServerError)
 }
 
-pub async fn insert_access_code_in_redis(state: &AppState, user_id: &str) -> UserResult<()> {
+pub async fn insert_recovery_code_in_redis(state: &AppState, user_id: &str) -> UserResult<()> {
     let redis_conn = get_redis_connection(state)?;
     let key = format!("{}{}", consts::user::REDIS_RECOVERY_CODE_PREFIX, user_id);
     let expiry = expiry_to_i64(state.conf.user.two_factor_auth_expiry_in_secs)

--- a/crates/router/src/utils/user/two_factor_auth.rs
+++ b/crates/router/src/utils/user/two_factor_auth.rs
@@ -50,3 +50,18 @@ fn get_redis_connection(state: &AppState) -> UserResult<Arc<RedisConnectionPool>
         .change_context(UserErrors::InternalServerError)
         .attach_printable("Failed to get redis connection")
 }
+
+fn expiry_to_i64(expiry: u64) -> UserResult<i64> {
+    i64::try_from(expiry).change_context(UserErrors::InternalServerError)
+}
+
+pub async fn insert_access_code_in_redis(state: &AppState, user_id: &str) -> UserResult<()> {
+    let redis_conn = get_redis_connection(state)?;
+    let key = format!("{}{}", consts::user::REDIS_RECOVERY_CODE_PREFIX, user_id);
+    let expiry = expiry_to_i64(state.conf.user.two_factor_auth_expiry_in_secs)
+        .change_context(UserErrors::InternalServerError)?;
+    redis_conn
+        .set_key_with_expiry(key.as_str(), true, expiry)
+        .await
+        .change_context(UserErrors::InternalServerError)
+}

--- a/crates/router_env/src/logger/types.rs
+++ b/crates/router_env/src/logger/types.rs
@@ -406,6 +406,8 @@ pub enum Flow {
     TotpBegin,
     /// Verify TOTP
     TotpVerify,
+    /// Verify Access Code
+    AccessCodeVerify,
     /// Generate or Regenerate recovery codes
     GenerateRecoveryCodes,
     /// List initial webhook delivery attempts

--- a/loadtest/config/development.toml
+++ b/loadtest/config/development.toml
@@ -30,7 +30,7 @@ jwt_secret = "secret"
 
 [user]
 password_validity_in_days = 90
-two_factor_auth_expiry_in_secs = 60 * 5;
+two_factor_auth_expiry_in_secs = 300
 
 [locker]
 host = ""

--- a/loadtest/config/development.toml
+++ b/loadtest/config/development.toml
@@ -30,6 +30,7 @@ jwt_secret = "secret"
 
 [user]
 password_validity_in_days = 90
+two_factor_auth_expiry_in_secs = 60 * 5;
 
 [locker]
 host = ""


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
The PR adds support to verify 2FA using recovery code, in case TOTP is lost 

### Additional Changes

- [x] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
Closes [#4736](https://github.com/juspay/hyperswitch/issues/4736)


## How did you test it?
First Sigin for user for which 2FA is already set.
Then to verify 2FA:

Use the below curl to test it
```
curl --location 'http://localhost:8080/user/recovery_code/verify' \
--header 'Content-Type: application/json' \
--header 'Authorization: Bearer SPT' \
--header 'Cookie: Cookie_1=value' \
--data '{
    "recovery_code": "j4Az-W7Fk"
}'
```
If the recovery code is correct then response will be `200 ok`.
Else proper error would be thrown
```
{
    "error": {
        "type": "invalid_request",
        "message": "Invalid Recovery Code",
        "code": "UR_39"
    }
}
```



## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
