### PR TITLE
fix(payment_methods): mask the email address being logged in the `payment_method_list` response logs

### DIFF
--- a/crates/api_models/src/payment_methods.rs
+++ b/crates/api_models/src/payment_methods.rs
@@ -531,7 +531,7 @@ pub struct RequiredFieldInfo {
     #[schema(value_type = FieldType)]
     pub field_type: api_enums::FieldType,
 
-    pub value: Option<String>,
+    pub value: Option<masking::Secret<String, pii::EmailStrategy>>,
 }
 
 #[derive(Debug, Clone, serde::Serialize, ToSchema)]

--- a/crates/api_models/src/payment_methods.rs
+++ b/crates/api_models/src/payment_methods.rs
@@ -531,7 +531,8 @@ pub struct RequiredFieldInfo {
     #[schema(value_type = FieldType)]
     pub field_type: api_enums::FieldType,
 
-    pub value: Option<masking::Secret<String, pii::EmailStrategy>>,
+    #[schema(value_type = Option<String>)]
+    pub value: Option<masking::Secret<String>>,
 }
 
 #[derive(Debug, Clone, serde::Serialize, ToSchema)]

--- a/crates/router/src/core/payment_methods/cards.rs
+++ b/crates/router/src/core/payment_methods/cards.rs
@@ -2268,7 +2268,7 @@ pub async fn list_payment_methods(
                                             .as_ref()
                                             .and_then(|r| get_val(key.to_owned(), r));
                                         if let Some(s) = temp {
-                                            val.value = Some(s)
+                                            val.value = Some(s.into())
                                         };
                                     }
                                 }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
This pr is to mask the email address being logged in the payment method list response.


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
-> Create a merchant account and mca
-> Create a payment with confirm false
```
curl --location 'http://localhost:8080/account/payment_methods?client_secret=pay_jviyQiUsX9uHI99VXUlF_secret_lHrA6q5GKvNvd5a0blUQ' \
--header 'Accept: application/json' \
--header 'api-key: pk_dev_df002da8beb74682ac3e8677a4b82217'
```
in the below log we can see the email address being logged (this is without the changes in this pr)
<img width="1448" alt="image" src="https://github.com/juspay/hyperswitch/assets/83439957/0900eba7-09e0-4db7-95aa-bcd102cb49d6">

after the changes the email is being masked
<img width="1466" alt="image" src="https://github.com/juspay/hyperswitch/assets/83439957/67164e06-9953-4b17-83e1-3ccdad17d129">

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
