### PR TITLE
fix: include client columns in payment attempts response struct

### DIFF
--- a/crates/api_models/src/payments.rs
+++ b/crates/api_models/src/payments.rs
@@ -613,6 +613,10 @@ pub struct PaymentAttemptResponse {
     pub unified_code: Option<String>,
     /// error message unified across the connectors is received here if there was an error while calling connector
     pub unified_message: Option<String>,
+    /// Value passed in X-CLIENT-SOURCE header during payments confirm request by the client
+    pub client_source: Option<String>,
+    /// Value passed in X-CLIENT-VERSION header during payments confirm request by the client
+    pub client_version: Option<String>,
 }
 
 #[derive(

--- a/crates/router/src/types/transformers.rs
+++ b/crates/router/src/types/transformers.rs
@@ -931,6 +931,8 @@ impl ForeignFrom<storage::PaymentAttempt> for payments::PaymentAttemptResponse {
             reference_id: payment_attempt.connector_response_reference_id,
             unified_code: payment_attempt.unified_code,
             unified_message: payment_attempt.unified_message,
+            client_source: payment_attempt.client_source,
+            client_version: payment_attempt.client_version,
         }
     }
 }

--- a/openapi/openapi_spec.json
+++ b/openapi/openapi_spec.json
@@ -12526,6 +12526,16 @@
             "type": "string",
             "description": "error message unified across the connectors is received here if there was an error while calling connector",
             "nullable": true
+          },
+          "client_source": {
+            "type": "string",
+            "description": "Value passed in X-CLIENT-SOURCE header during payments confirm request by the client",
+            "nullable": true
+          },
+          "client_version": {
+            "type": "string",
+            "description": "Value passed in X-CLIENT-VERSION header during payments confirm request by the client",
+            "nullable": true
           }
         }
       },


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
This pull request introduces a modification to the **PaymentAttemptResponse** struct by adding two new fields: **client_source** and **client_version**. These fields are intended to provide additional context about the client making the payment attempt, which can be valuable for analytics, debugging, and improving overall user experience.

**client_source**: A string representing the source of the client making the payment attempt (e.g., "mobile_app", "web_app", "api_client").
**client_version**: A string indicating the version of the client making the payment attempt (e.g., "1.0.0", "2.3.1").

Added descriptions for **client_source** and **client_version** to ensure developers understand their purpose and usage.

**Backward Compatibility:**
This change is backward compatible as it only adds new fields without altering or removing existing ones. Clients that do not send these fields will continue to function as before, with default values for the new fields.

closes #4656 

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
1. Create a payment intent by passing **confirm: false**
```
curl --location 'localhost:8080/payments' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: api-key' \
--data-raw '{
  "amount": 6540,
  "currency": "USD",
  "confirm": false,
  "capture_method": "automatic",
  "capture_on": "2022-09-10T10:11:12Z",
  "amount_to_capture": 6540,
  "customer_id": "StripeCustomer",
  "email": "guest@example.com",
  "name": "John Doe",
  "phone": "999999999",
  "phone_country_code": "+1",
  "description": "Its my first payment request",
  "authentication_type": "no_three_ds",
  "return_url": "https://google.com",
  "payment_method": "card",
  "payment_method_type": "credit",
  "payment_method_data": {
    "card": {
      "card_number": "4242424242424242",
      "card_exp_month": "10",
      "card_exp_year": "25",
      "card_holder_name": "joseph Doe",
      "card_cvc": "123"
    }
  },
  "billing": {
    "address": {
      "line1": "1467",
      "line2": "Harrison Street",
      "line3": "Harrison Street",
      "city": "San Fransico",
      "state": "California",
      "zip": "94122",
      "country": "US",
      "first_name": "joseph",
      "last_name": "Doe"
    },
    "phone": {
      "number": "8056594427",
      "country_code": "+91"
    }
  },
  "shipping": {
    "address": {
      "line1": "1467",
      "line2": "Harrison Street",
      "line3": "Harrison Street",
      "city": "San Fransico",
      "state": "California",
      "zip": "94122",
      "country": "US",
      "first_name": "joseph",
      "last_name": "Doe"
    },
    "phone": {
      "number": "8056594427",
      "country_code": "+91"
    }
  },
  "statement_descriptor_name": "joseph",
  "statement_descriptor_suffix": "JS",
  "metadata": {
    "udf1": "value1",
    "new_customer": "true",
    "login_date": "2019-09-10T10:11:12Z"
  },
  "business_label": "food",
  "business_country": "US"
}'
```

2. Confirm the payment. Pass values for **client_source** and **client_version** in the headers

```
curl --location 'localhost:8080/payments/:payment_id/confirm' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'X-Client-Source: ExpressCheckout' \
--header 'X-Client-Version: 1.1.1' \
--header 'api-key: api-key' \
--data '{}'
```

3. Retrieve the payment with **expand_attempts=true**
```
curl --location 'localhost:8080/payments/:payment_id?expand_attempts=true' \
--header 'Accept: application/json' \
--header 'api-key: api-key'
```
<img width="832" alt="Screenshot 2024-05-28 at 3 19 47 PM" src="https://github.com/juspay/hyperswitch/assets/136090360/4cf43025-7a58-4377-ae64-31b03452d972">


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [x] I added unit tests for my changes where possible
