### PR TITLE
refactor(core): move router data response and request models to hyperswitch domain models crate

### DIFF
--- a/crates/hyperswitch_domain_models/src/lib.rs
+++ b/crates/hyperswitch_domain_models/src/lib.rs
@@ -7,6 +7,7 @@ pub mod payments;
 pub mod payouts;
 pub mod router_data;
 pub mod router_request_types;
+pub mod router_response_types;
 
 #[cfg(not(feature = "payouts"))]
 pub trait PayoutAttemptInterface {}

--- a/crates/hyperswitch_domain_models/src/router_request_types/authentication.rs
+++ b/crates/hyperswitch_domain_models/src/router_request_types/authentication.rs
@@ -8,29 +8,6 @@ use crate::{
     router_request_types::BrowserInformation,
 };
 
-#[derive(Debug, Clone)]
-pub enum AuthenticationResponseData {
-    PreAuthNResponse {
-        threeds_server_transaction_id: String,
-        maximum_supported_3ds_version: common_utils::types::SemanticVersion,
-        connector_authentication_id: String,
-        three_ds_method_data: Option<String>,
-        three_ds_method_url: Option<String>,
-        message_version: common_utils::types::SemanticVersion,
-        connector_metadata: Option<serde_json::Value>,
-    },
-    AuthNResponse {
-        authn_flow_type: AuthNFlowType,
-        authentication_value: Option<String>,
-        trans_status: common_enums::TransactionStatus,
-    },
-    PostAuthNResponse {
-        trans_status: common_enums::TransactionStatus,
-        authentication_value: Option<String>,
-        eci: Option<String>,
-    },
-}
-
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ChallengeParams {
     pub acs_url: Option<url::Url>,
@@ -94,8 +71,7 @@ impl AuthNFlowType {
 #[derive(Clone, Default, Debug)]
 pub struct PreAuthNRequestData {
     // card number
-    #[allow(dead_code)]
-    pub(crate) card_holder_account_number: CardNumber,
+    pub card_holder_account_number: CardNumber,
 }
 
 #[derive(Clone, Debug)]

--- a/crates/hyperswitch_domain_models/src/router_response_types.rs
+++ b/crates/hyperswitch_domain_models/src/router_response_types.rs
@@ -1,0 +1,234 @@
+pub mod disputes;
+pub mod fraud_check;
+use std::collections::HashMap;
+
+use common_utils::{request::Method, types::MinorUnit};
+pub use disputes::{AcceptDisputeResponse, DefendDisputeResponse, SubmitEvidenceResponse};
+
+use crate::router_request_types::{authentication::AuthNFlowType, ResponseId};
+#[derive(Debug, Clone)]
+pub struct RefundsResponseData {
+    pub connector_refund_id: String,
+    pub refund_status: common_enums::RefundStatus,
+    // pub amount_received: Option<i32>, // Calculation for amount received not in place yet
+}
+
+#[derive(Debug, Clone)]
+pub enum PaymentsResponseData {
+    TransactionResponse {
+        resource_id: ResponseId,
+        redirection_data: Option<RedirectForm>,
+        mandate_reference: Option<MandateReference>,
+        connector_metadata: Option<serde_json::Value>,
+        network_txn_id: Option<String>,
+        connector_response_reference_id: Option<String>,
+        incremental_authorization_allowed: Option<bool>,
+        charge_id: Option<String>,
+    },
+    MultipleCaptureResponse {
+        // pending_capture_id_list: Vec<String>,
+        capture_sync_response_list: HashMap<String, CaptureSyncResponse>,
+    },
+    SessionResponse {
+        session_token: api_models::payments::SessionToken,
+    },
+    SessionTokenResponse {
+        session_token: String,
+    },
+    TransactionUnresolvedResponse {
+        resource_id: ResponseId,
+        //to add more info on cypto response, like `unresolved` reason(overpaid, underpaid, delayed)
+        reason: Option<api_models::enums::UnresolvedResponseReason>,
+        connector_response_reference_id: Option<String>,
+    },
+    TokenizationResponse {
+        token: String,
+    },
+
+    ConnectorCustomerResponse {
+        connector_customer_id: String,
+    },
+
+    ThreeDSEnrollmentResponse {
+        enrolled_v2: bool,
+        related_transaction_id: Option<String>,
+    },
+    PreProcessingResponse {
+        pre_processing_id: PreprocessingResponseId,
+        connector_metadata: Option<serde_json::Value>,
+        session_token: Option<api_models::payments::SessionToken>,
+        connector_response_reference_id: Option<String>,
+    },
+    IncrementalAuthorizationResponse {
+        status: common_enums::AuthorizationStatus,
+        connector_authorization_id: Option<String>,
+        error_code: Option<String>,
+        error_message: Option<String>,
+    },
+}
+
+#[derive(serde::Serialize, Debug, Clone)]
+pub struct MandateReference {
+    pub connector_mandate_id: Option<String>,
+    pub payment_method_id: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub enum CaptureSyncResponse {
+    Success {
+        resource_id: ResponseId,
+        status: common_enums::AttemptStatus,
+        connector_response_reference_id: Option<String>,
+        amount: Option<MinorUnit>,
+    },
+    Error {
+        code: String,
+        message: String,
+        reason: Option<String>,
+        status_code: u16,
+        amount: Option<MinorUnit>,
+    },
+}
+
+impl CaptureSyncResponse {
+    pub fn get_amount_captured(&self) -> Option<MinorUnit> {
+        match self {
+            Self::Success { amount, .. } | Self::Error { amount, .. } => *amount,
+        }
+    }
+    pub fn get_connector_response_reference_id(&self) -> Option<String> {
+        match self {
+            Self::Success {
+                connector_response_reference_id,
+                ..
+            } => connector_response_reference_id.clone(),
+            Self::Error { .. } => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum PreprocessingResponseId {
+    PreProcessingId(String),
+    ConnectorTransactionId(String),
+}
+
+#[derive(Debug, Eq, PartialEq, Clone, serde::Serialize, serde::Deserialize)]
+pub enum RedirectForm {
+    Form {
+        endpoint: String,
+        method: Method,
+        form_fields: HashMap<String, String>,
+    },
+    Html {
+        html_data: String,
+    },
+    BlueSnap {
+        payment_fields_token: String, // payment-field-token
+    },
+    CybersourceAuthSetup {
+        access_token: String,
+        ddc_url: String,
+        reference_id: String,
+    },
+    CybersourceConsumerAuth {
+        access_token: String,
+        step_up_url: String,
+    },
+    Payme,
+    Braintree {
+        client_token: String,
+        card_token: String,
+        bin: String,
+    },
+    Nmi {
+        amount: String,
+        currency: common_enums::Currency,
+        public_key: masking::Secret<String>,
+        customer_vault_id: String,
+        order_id: String,
+    },
+}
+
+impl From<(url::Url, Method)> for RedirectForm {
+    fn from((mut redirect_url, method): (url::Url, Method)) -> Self {
+        let form_fields = HashMap::from_iter(
+            redirect_url
+                .query_pairs()
+                .map(|(key, value)| (key.to_string(), value.to_string())),
+        );
+
+        // Do not include query params in the endpoint
+        redirect_url.set_query(None);
+
+        Self::Form {
+            endpoint: redirect_url.to_string(),
+            method,
+            form_fields,
+        }
+    }
+}
+
+#[derive(Default, Clone, Debug)]
+pub struct UploadFileResponse {
+    pub provider_file_id: String,
+}
+#[derive(Clone, Debug)]
+pub struct RetrieveFileResponse {
+    pub file_data: Vec<u8>,
+}
+
+#[cfg(feature = "payouts")]
+#[derive(Clone, Debug, Default)]
+pub struct PayoutsResponseData {
+    pub status: Option<common_enums::PayoutStatus>,
+    pub connector_payout_id: String,
+    pub payout_eligible: Option<bool>,
+    pub should_add_next_step_to_process_tracker: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct VerifyWebhookSourceResponseData {
+    pub verify_webhook_status: VerifyWebhookStatus,
+}
+
+#[derive(Debug, Clone)]
+pub enum VerifyWebhookStatus {
+    SourceVerified,
+    SourceNotVerified,
+}
+
+#[derive(Debug, Clone)]
+pub struct MandateRevokeResponseData {
+    pub mandate_status: common_enums::MandateStatus,
+}
+
+#[derive(Debug, Clone)]
+pub enum AuthenticationResponseData {
+    PreAuthNResponse {
+        threeds_server_transaction_id: String,
+        maximum_supported_3ds_version: common_utils::types::SemanticVersion,
+        connector_authentication_id: String,
+        three_ds_method_data: Option<String>,
+        three_ds_method_url: Option<String>,
+        message_version: common_utils::types::SemanticVersion,
+        connector_metadata: Option<serde_json::Value>,
+        directory_server_id: Option<String>,
+    },
+    AuthNResponse {
+        authn_flow_type: AuthNFlowType,
+        authentication_value: Option<String>,
+        trans_status: common_enums::TransactionStatus,
+    },
+    PostAuthNResponse {
+        trans_status: common_enums::TransactionStatus,
+        authentication_value: Option<String>,
+        eci: Option<String>,
+    },
+}
+
+#[derive(Debug, Clone)]
+pub struct CompleteAuthorizeRedirectResponse {
+    pub params: Option<masking::Secret<String>>,
+    pub payload: Option<common_utils::pii::SecretSerdeValue>,
+}

--- a/crates/hyperswitch_domain_models/src/router_response_types/disputes.rs
+++ b/crates/hyperswitch_domain_models/src/router_response_types/disputes.rs
@@ -1,0 +1,17 @@
+#[derive(Default, Clone, Debug)]
+pub struct AcceptDisputeResponse {
+    pub dispute_status: api_models::enums::DisputeStatus,
+    pub connector_status: Option<String>,
+}
+
+#[derive(Default, Clone, Debug)]
+pub struct SubmitEvidenceResponse {
+    pub dispute_status: api_models::enums::DisputeStatus,
+    pub connector_status: Option<String>,
+}
+
+#[derive(Default, Debug, Clone)]
+pub struct DefendDisputeResponse {
+    pub dispute_status: api_models::enums::DisputeStatus,
+    pub connector_status: Option<String>,
+}

--- a/crates/hyperswitch_domain_models/src/router_response_types/fraud_check.rs
+++ b/crates/hyperswitch_domain_models/src/router_response_types/fraud_check.rs
@@ -1,0 +1,30 @@
+use serde::Serialize;
+
+use crate::router_response_types::ResponseId;
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(untagged)]
+pub enum FraudCheckResponseData {
+    TransactionResponse {
+        resource_id: ResponseId,
+        status: diesel_models::enums::FraudCheckStatus,
+        connector_metadata: Option<serde_json::Value>,
+        reason: Option<serde_json::Value>,
+        score: Option<i32>,
+    },
+    FulfillmentResponse {
+        order_id: String,
+        shipment_ids: Vec<String>,
+    },
+    RecordReturnResponse {
+        resource_id: ResponseId,
+        connector_metadata: Option<serde_json::Value>,
+        return_id: Option<String>,
+    },
+}
+
+impl common_utils::events::ApiEventMetric for FraudCheckResponseData {
+    fn get_api_event_type(&self) -> Option<common_utils::events::ApiEventsType> {
+        Some(common_utils::events::ApiEventsType::FraudCheck)
+    }
+}

--- a/crates/router/src/connector/adyen.rs
+++ b/crates/router/src/connector/adyen.rs
@@ -367,7 +367,7 @@ impl
     ) -> CustomResult<RequestContent, errors::ConnectorError> {
         let authorize_req = types::PaymentsAuthorizeRouterData::foreign_from((
             req,
-            types::PaymentsAuthorizeData::from(req),
+            types::PaymentsAuthorizeData::foreign_from(req),
         ));
         let connector_router_data = adyen::AdyenRouterData::try_from((
             &self.get_currency_unit(),

--- a/crates/router/src/connector/nuvei.rs
+++ b/crates/router/src/connector/nuvei.rs
@@ -539,7 +539,7 @@ impl ConnectorIntegration<api::Authorize, types::PaymentsAuthorizeData, types::P
         > = Box::new(&Self);
         let authorize_data = &types::PaymentsAuthorizeSessionTokenRouterData::foreign_from((
             &router_data.to_owned(),
-            types::AuthorizeSessionTokenData::from(&router_data),
+            types::AuthorizeSessionTokenData::foreign_from(&router_data),
         ));
         let resp = services::execute_connector_processing_step(
             app_state,

--- a/crates/router/src/connector/stripe/transformers.rs
+++ b/crates/router/src/connector/stripe/transformers.rs
@@ -2377,7 +2377,7 @@ impl<F, T>
         let status = enums::AttemptStatus::from(item.response.status);
 
         let response = if connector_util::is_payment_failure(status) {
-            types::PaymentsResponseData::try_from((
+            types::PaymentsResponseData::foreign_try_from((
                 &item.response.last_payment_error,
                 item.http_code,
                 item.response.id.clone(),
@@ -2558,7 +2558,7 @@ impl<F, T>
             .and_then(extract_payment_method_connector_response_from_latest_charge);
 
         let response = if connector_util::is_payment_failure(status) {
-            types::PaymentsResponseData::try_from((
+            types::PaymentsResponseData::foreign_try_from((
                 &item.response.payment_intent_fields.last_payment_error,
                 item.http_code,
                 item.response.id.clone(),
@@ -2639,7 +2639,7 @@ impl<F, T>
             .and_then(extract_payment_method_connector_response_from_latest_attempt);
 
         let response = if connector_util::is_payment_failure(status) {
-            types::PaymentsResponseData::try_from((
+            types::PaymentsResponseData::foreign_try_from((
                 &item.response.last_setup_error,
                 item.http_code,
                 item.response.id.clone(),
@@ -3910,9 +3910,9 @@ fn get_transaction_metadata(
     meta_data
 }
 
-impl TryFrom<(&Option<ErrorDetails>, u16, String)> for types::PaymentsResponseData {
+impl ForeignTryFrom<(&Option<ErrorDetails>, u16, String)> for types::PaymentsResponseData {
     type Error = types::ErrorResponse;
-    fn try_from(
+    fn foreign_try_from(
         (response, http_code, response_id): (&Option<ErrorDetails>, u16, String),
     ) -> Result<Self, Self::Error> {
         let (code, error_message) = match response {

--- a/crates/router/src/core/authentication/types.rs
+++ b/crates/router/src/core/authentication/types.rs
@@ -1,43 +1,13 @@
-use cards::CardNumber;
 use error_stack::{Report, ResultExt};
-use serde::{Deserialize, Serialize};
+pub use hyperswitch_domain_models::router_request_types::authentication::{
+    AcquirerDetails, ExternalThreeDSConnectorMetadata, PreAuthenticationData, ThreeDsMethodData,
+};
 
 use crate::{
-    core::{errors, payments},
+    core::errors,
     types::{storage, transformers::ForeignTryFrom},
     utils::OptionExt,
 };
-pub enum PreAuthenthenticationFlowInput<'a, F: Clone> {
-    PaymentAuthNFlow {
-        payment_data: &'a mut payments::PaymentData<F>,
-        should_continue_confirm_transaction: &'a mut bool,
-        card_number: CardNumber,
-    },
-    PaymentMethodAuthNFlow {
-        card_number: CardNumber,
-        other_fields: String, //should be expanded when implementation begins
-    },
-}
-
-pub enum PostAuthenthenticationFlowInput<'a, F: Clone> {
-    PaymentAuthNFlow {
-        payment_data: &'a mut payments::PaymentData<F>,
-        authentication: storage::Authentication,
-        should_continue_confirm_transaction: &'a mut bool,
-    },
-    PaymentMethodAuthNFlow {
-        other_fields: String, //should be expanded when implementation begins
-    },
-}
-
-#[derive(Clone, Debug)]
-pub struct PreAuthenticationData {
-    pub threeds_server_transaction_id: String,
-    pub message_version: common_utils::types::SemanticVersion,
-    pub acquirer_bin: Option<String>,
-    pub acquirer_merchant_id: Option<String>,
-    pub connector_metadata: Option<serde_json::Value>,
-}
 
 impl ForeignTryFrom<&storage::Authentication> for PreAuthenticationData {
     type Error = Report<errors::ApiErrorResponse>;
@@ -61,21 +31,4 @@ impl ForeignTryFrom<&storage::Authentication> for PreAuthenticationData {
             connector_metadata: authentication.connector_metadata.clone(),
         })
     }
-}
-
-#[derive(Clone, Default, Debug, Serialize, Deserialize)]
-pub struct ThreeDsMethodData {
-    pub three_ds_method_data_submission: bool,
-    pub three_ds_method_data: String,
-    pub three_ds_method_url: Option<String>,
-}
-#[derive(Clone, Default, Debug, Serialize, Deserialize)]
-pub struct AcquirerDetails {
-    pub acquirer_bin: String,
-    pub acquirer_merchant_id: String,
-}
-
-#[derive(Clone, Debug, Deserialize)]
-pub struct ExternalThreeDSConnectorMetadata {
-    pub pull_mechanism_for_external_3ds_enabled: Option<bool>,
 }

--- a/crates/router/src/core/payments/flows/authorize_flow.rs
+++ b/crates/router/src/core/payments/flows/authorize_flow.rs
@@ -1,11 +1,10 @@
 use async_trait::async_trait;
-use error_stack;
 
 // use router_env::tracing::Instrument;
 use super::{ConstructFlowSpecificData, Feature};
 use crate::{
     core::{
-        errors::{self, ConnectorErrorExt, RouterResult},
+        errors::{ConnectorErrorExt, RouterResult},
         mandate,
         payments::{
             self, access_token, customers, helpers, tokenization, transformers, PaymentData,
@@ -333,85 +332,5 @@ pub async fn authorize_preprocessing_steps<F: Clone>(
         Ok(authorize_router_data)
     } else {
         Ok(router_data.clone())
-    }
-}
-
-impl<F> TryFrom<&types::RouterData<F, types::PaymentsAuthorizeData, types::PaymentsResponseData>>
-    for types::ConnectorCustomerData
-{
-    type Error = error_stack::Report<errors::ApiErrorResponse>;
-
-    fn try_from(
-        data: &types::RouterData<F, types::PaymentsAuthorizeData, types::PaymentsResponseData>,
-    ) -> Result<Self, Self::Error> {
-        Ok(Self {
-            email: data.request.email.clone(),
-            payment_method_data: data.request.payment_method_data.clone(),
-            description: None,
-            phone: None,
-            name: data.request.customer_name.clone(),
-            preprocessing_id: data.preprocessing_id.clone(),
-        })
-    }
-}
-
-impl TryFrom<types::PaymentsAuthorizeData> for types::PaymentMethodTokenizationData {
-    type Error = error_stack::Report<errors::ApiErrorResponse>;
-
-    fn try_from(data: types::PaymentsAuthorizeData) -> Result<Self, Self::Error> {
-        Ok(Self {
-            payment_method_data: data.payment_method_data,
-            browser_info: data.browser_info,
-            currency: data.currency,
-            amount: Some(data.amount),
-        })
-    }
-}
-
-impl TryFrom<types::PaymentsAuthorizeData> for types::PaymentsPreProcessingData {
-    type Error = error_stack::Report<errors::ApiErrorResponse>;
-
-    fn try_from(data: types::PaymentsAuthorizeData) -> Result<Self, Self::Error> {
-        Ok(Self {
-            payment_method_data: Some(data.payment_method_data),
-            amount: Some(data.amount),
-            email: data.email,
-            currency: Some(data.currency),
-            payment_method_type: data.payment_method_type,
-            setup_mandate_details: data.setup_mandate_details,
-            capture_method: data.capture_method,
-            order_details: data.order_details,
-            router_return_url: data.router_return_url,
-            webhook_url: data.webhook_url,
-            complete_authorize_url: data.complete_authorize_url,
-            browser_info: data.browser_info,
-            surcharge_details: data.surcharge_details,
-            connector_transaction_id: None,
-            redirect_response: None,
-        })
-    }
-}
-
-impl TryFrom<types::CompleteAuthorizeData> for types::PaymentsPreProcessingData {
-    type Error = error_stack::Report<errors::ApiErrorResponse>;
-
-    fn try_from(data: types::CompleteAuthorizeData) -> Result<Self, Self::Error> {
-        Ok(Self {
-            payment_method_data: data.payment_method_data,
-            amount: Some(data.amount),
-            email: data.email,
-            currency: Some(data.currency),
-            payment_method_type: None,
-            setup_mandate_details: data.setup_mandate_details,
-            capture_method: data.capture_method,
-            order_details: None,
-            router_return_url: None,
-            webhook_url: None,
-            complete_authorize_url: data.complete_authorize_url,
-            browser_info: data.browser_info,
-            surcharge_details: None,
-            connector_transaction_id: data.connector_transaction_id,
-            redirect_response: data.redirect_response,
-        })
     }
 }

--- a/crates/router/src/core/payments/flows/complete_authorize_flow.rs
+++ b/crates/router/src/core/payments/flows/complete_authorize_flow.rs
@@ -3,13 +3,12 @@ use async_trait::async_trait;
 use super::{ConstructFlowSpecificData, Feature};
 use crate::{
     core::{
-        errors::{self, ConnectorErrorExt, RouterResult},
+        errors::{ConnectorErrorExt, RouterResult},
         payments::{self, access_token, helpers, transformers, PaymentData},
     },
     routes::{metrics, AppState},
     services,
     types::{self, api, domain, storage},
-    utils::OptionExt,
 };
 
 #[async_trait]
@@ -219,20 +218,5 @@ pub async fn complete_authorize_preprocessing_steps<F: Clone>(
         Ok(authorize_router_data)
     } else {
         Ok(router_data.clone())
-    }
-}
-
-impl TryFrom<types::CompleteAuthorizeData> for types::PaymentMethodTokenizationData {
-    type Error = error_stack::Report<errors::ApiErrorResponse>;
-
-    fn try_from(data: types::CompleteAuthorizeData) -> Result<Self, Self::Error> {
-        Ok(Self {
-            payment_method_data: data
-                .payment_method_data
-                .get_required_value("payment_method_data")?,
-            browser_info: data.browser_info,
-            currency: data.currency,
-            amount: Some(data.amount),
-        })
     }
 }

--- a/crates/router/src/core/payments/flows/setup_mandate_flow.rs
+++ b/crates/router/src/core/payments/flows/setup_mandate_flow.rs
@@ -3,7 +3,7 @@ use async_trait::async_trait;
 use super::{ConstructFlowSpecificData, Feature};
 use crate::{
     core::{
-        errors::{self, ConnectorErrorExt, RouterResult},
+        errors::{ConnectorErrorExt, RouterResult},
         mandate,
         payments::{
             self, access_token, customers, helpers, tokenization, transformers, PaymentData,
@@ -143,20 +143,6 @@ impl Feature<api::SetupMandate, types::SetupMandateRequestData> for types::Setup
     }
 }
 
-impl TryFrom<types::SetupMandateRequestData> for types::ConnectorCustomerData {
-    type Error = error_stack::Report<errors::ApiErrorResponse>;
-    fn try_from(data: types::SetupMandateRequestData) -> Result<Self, Self::Error> {
-        Ok(Self {
-            email: data.email,
-            payment_method_data: data.payment_method_data,
-            description: None,
-            phone: None,
-            name: None,
-            preprocessing_id: None,
-        })
-    }
-}
-
 impl mandate::MandateBehaviour for types::SetupMandateRequestData {
     fn get_amount(&self) -> i64 {
         0
@@ -185,18 +171,5 @@ impl mandate::MandateBehaviour for types::SetupMandateRequestData {
     }
     fn get_customer_acceptance(&self) -> Option<api_models::payments::CustomerAcceptance> {
         self.customer_acceptance.clone().map(From::from)
-    }
-}
-
-impl TryFrom<types::SetupMandateRequestData> for types::PaymentMethodTokenizationData {
-    type Error = error_stack::Report<errors::ApiErrorResponse>;
-
-    fn try_from(data: types::SetupMandateRequestData) -> Result<Self, Self::Error> {
-        Ok(Self {
-            payment_method_data: data.payment_method_data,
-            browser_info: None,
-            currency: data.currency,
-            amount: data.amount,
-        })
     }
 }

--- a/crates/router/src/core/payments/operations/payment_response.rs
+++ b/crates/router/src/core/payments/operations/payment_response.rs
@@ -1314,7 +1314,10 @@ fn response_to_capture_update(
         let capture =
             multiple_capture_data.get_capture_by_connector_capture_id(connector_capture_id);
         if let Some(capture) = capture {
-            capture_update_list.push((capture.clone(), capture_sync_response.try_into()?))
+            capture_update_list.push((
+                capture.clone(),
+                storage::CaptureUpdate::foreign_try_from(capture_sync_response)?,
+            ))
         } else {
             // connector_capture_id may not be populated in the captures table in some case
             // if so, we try to map the unmapped capture response and captures in DB.
@@ -1350,7 +1353,7 @@ fn get_capture_update_for_unmapped_capture_responses(
         {
             result.push((
                 capture.clone(),
-                storage::CaptureUpdate::try_from(capture_sync_response)?,
+                storage::CaptureUpdate::foreign_try_from(capture_sync_response)?,
             ))
         }
     }

--- a/crates/router/src/core/payments/transformers.rs
+++ b/crates/router/src/core/payments/transformers.rs
@@ -1617,10 +1617,12 @@ impl<F: Clone> TryFrom<PaymentAdditionalData<'_, F>> for types::SetupMandateRequ
     }
 }
 
-impl TryFrom<types::CaptureSyncResponse> for storage::CaptureUpdate {
+impl ForeignTryFrom<types::CaptureSyncResponse> for storage::CaptureUpdate {
     type Error = error_stack::Report<errors::ApiErrorResponse>;
 
-    fn try_from(capture_sync_response: types::CaptureSyncResponse) -> Result<Self, Self::Error> {
+    fn foreign_try_from(
+        capture_sync_response: types::CaptureSyncResponse,
+    ) -> Result<Self, Self::Error> {
         match capture_sync_response {
             types::CaptureSyncResponse::Success {
                 resource_id,

--- a/crates/router/src/core/payments/types.rs
+++ b/crates/router/src/core/payments/types.rs
@@ -9,7 +9,9 @@ use common_utils::{
 use diesel_models::business_profile::BusinessProfile;
 use error_stack::ResultExt;
 use hyperswitch_domain_models::payments::payment_attempt::PaymentAttempt;
-pub use hyperswitch_domain_models::router_request_types::{AuthenticationData, SurchargeDetails};
+pub use hyperswitch_domain_models::router_request_types::{
+    AuthenticationData, PaymentCharges, SurchargeDetails,
+};
 use redis_interface::errors::RedisError;
 use router_env::{instrument, tracing};
 
@@ -373,11 +375,4 @@ impl ForeignTryFrom<&storage::Authentication> for AuthenticationData {
             Err(errors::ApiErrorResponse::PaymentAuthenticationFailed { data: None }.into())
         }
     }
-}
-
-#[derive(Debug, serde::Deserialize, Clone)]
-pub struct PaymentCharges {
-    pub charge_type: api_models::enums::PaymentChargeType,
-    pub fees: i64,
-    pub transfer_account_id: String,
 }

--- a/crates/router/src/routes/fraud_check.rs
+++ b/crates/router/src/routes/fraud_check.rs
@@ -1,11 +1,9 @@
 use actix_web::{web, HttpRequest, HttpResponse};
-use common_utils::events::{ApiEventMetric, ApiEventsType};
 use router_env::Flow;
 
 use crate::{
     core::{api_locking, fraud_check as frm_core},
     services::{self, api},
-    types::fraud_check::FraudCheckResponseData,
     AppState,
 };
 
@@ -27,10 +25,4 @@ pub async fn frm_fulfillment(
         api_locking::LockAction::NotApplicable,
     ))
     .await
-}
-
-impl ApiEventMetric for FraudCheckResponseData {
-    fn get_api_event_type(&self) -> Option<ApiEventsType> {
-        Some(ApiEventsType::FraudCheck)
-    }
 }

--- a/crates/router/src/services/api.rs
+++ b/crates/router/src/services/api.rs
@@ -15,7 +15,6 @@ use actix_web::{
 };
 use api_models::enums::{CaptureMethod, PaymentMethodType};
 pub use client::{proxy_bypass_urls, ApiClient, MockApiClient, ProxyClient};
-use common_enums::Currency;
 pub use common_utils::request::{ContentType, Method, Request, RequestBuilder};
 use common_utils::{
     consts::X_HS_LATENCY,
@@ -23,7 +22,8 @@ use common_utils::{
     request::RequestContent,
 };
 use error_stack::{report, Report, ResultExt};
-use masking::{Maskable, PeekInterface, Secret};
+pub use hyperswitch_domain_models::router_response_types::RedirectForm;
+use masking::{Maskable, PeekInterface};
 use router_env::{instrument, tracing, tracing_actix_web::RequestId, Tag};
 use serde::Serialize;
 use serde_json::json;
@@ -899,62 +899,6 @@ pub enum PaymentAction {
 #[derive(Debug, Eq, PartialEq, Serialize)]
 pub struct ApplicationRedirectResponse {
     pub url: String,
-}
-
-#[derive(Debug, Eq, PartialEq, Clone, serde::Serialize, serde::Deserialize)]
-pub enum RedirectForm {
-    Form {
-        endpoint: String,
-        method: Method,
-        form_fields: HashMap<String, String>,
-    },
-    Html {
-        html_data: String,
-    },
-    BlueSnap {
-        payment_fields_token: String, // payment-field-token
-    },
-    CybersourceAuthSetup {
-        access_token: String,
-        ddc_url: String,
-        reference_id: String,
-    },
-    CybersourceConsumerAuth {
-        access_token: String,
-        step_up_url: String,
-    },
-    Payme,
-    Braintree {
-        client_token: String,
-        card_token: String,
-        bin: String,
-    },
-    Nmi {
-        amount: String,
-        currency: Currency,
-        public_key: Secret<String>,
-        customer_vault_id: String,
-        order_id: String,
-    },
-}
-
-impl From<(url::Url, Method)> for RedirectForm {
-    fn from((mut redirect_url, method): (url::Url, Method)) -> Self {
-        let form_fields = HashMap::from_iter(
-            redirect_url
-                .query_pairs()
-                .map(|(key, value)| (key.to_string(), value.to_string())),
-        );
-
-        // Do not include query params in the endpoint
-        redirect_url.set_query(None);
-
-        Self::Form {
-            endpoint: redirect_url.to_string(),
-            method,
-            form_fields,
-        }
-    }
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]

--- a/crates/router/src/types/authentication.rs
+++ b/crates/router/src/types/authentication.rs
@@ -1,127 +1,13 @@
-use cards::CardNumber;
-use common_utils::pii::Email;
-use serde::{Deserialize, Serialize};
-
-use super::{
-    api::{self, authentication},
-    domain, BrowserInformation, RouterData,
+pub use hyperswitch_domain_models::{
+    router_request_types::authentication::{
+        AcquirerDetails, AuthNFlowType, ChallengeParams, ConnectorAuthenticationRequestData,
+        ConnectorPostAuthenticationRequestData, PreAuthNRequestData, PreAuthenticationData,
+    },
+    router_response_types::AuthenticationResponseData,
 };
+
+use super::{api, RouterData};
 use crate::services;
-
-#[derive(Debug, Clone)]
-pub enum AuthenticationResponseData {
-    PreAuthNResponse {
-        threeds_server_transaction_id: String,
-        maximum_supported_3ds_version: common_utils::types::SemanticVersion,
-        connector_authentication_id: String,
-        three_ds_method_data: Option<String>,
-        three_ds_method_url: Option<String>,
-        message_version: common_utils::types::SemanticVersion,
-        connector_metadata: Option<serde_json::Value>,
-        directory_server_id: Option<String>,
-    },
-    AuthNResponse {
-        authn_flow_type: AuthNFlowType,
-        authentication_value: Option<String>,
-        trans_status: common_enums::TransactionStatus,
-    },
-    PostAuthNResponse {
-        trans_status: common_enums::TransactionStatus,
-        authentication_value: Option<String>,
-        eci: Option<String>,
-    },
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct ChallengeParams {
-    pub acs_url: Option<url::Url>,
-    pub challenge_request: Option<String>,
-    pub acs_reference_number: Option<String>,
-    pub acs_trans_id: Option<String>,
-    pub three_dsserver_trans_id: Option<String>,
-    pub acs_signed_content: Option<String>,
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub enum AuthNFlowType {
-    Challenge(Box<ChallengeParams>),
-    Frictionless,
-}
-
-impl AuthNFlowType {
-    pub fn get_acs_url(&self) -> Option<String> {
-        if let Self::Challenge(challenge_params) = self {
-            challenge_params.acs_url.as_ref().map(ToString::to_string)
-        } else {
-            None
-        }
-    }
-    pub fn get_challenge_request(&self) -> Option<String> {
-        if let Self::Challenge(challenge_params) = self {
-            challenge_params.challenge_request.clone()
-        } else {
-            None
-        }
-    }
-    pub fn get_acs_reference_number(&self) -> Option<String> {
-        if let Self::Challenge(challenge_params) = self {
-            challenge_params.acs_reference_number.clone()
-        } else {
-            None
-        }
-    }
-    pub fn get_acs_trans_id(&self) -> Option<String> {
-        if let Self::Challenge(challenge_params) = self {
-            challenge_params.acs_trans_id.clone()
-        } else {
-            None
-        }
-    }
-    pub fn get_acs_signed_content(&self) -> Option<String> {
-        if let Self::Challenge(challenge_params) = self {
-            challenge_params.acs_signed_content.clone()
-        } else {
-            None
-        }
-    }
-    pub fn get_decoupled_authentication_type(&self) -> common_enums::DecoupledAuthenticationType {
-        match self {
-            Self::Challenge(_) => common_enums::DecoupledAuthenticationType::Challenge,
-            Self::Frictionless => common_enums::DecoupledAuthenticationType::Frictionless,
-        }
-    }
-}
-
-#[derive(Clone, Default, Debug)]
-pub struct PreAuthNRequestData {
-    // card number
-    #[allow(dead_code)]
-    pub(crate) card_holder_account_number: CardNumber,
-}
-
-#[derive(Clone, Debug)]
-pub struct ConnectorAuthenticationRequestData {
-    pub payment_method_data: domain::PaymentMethodData,
-    pub billing_address: api_models::payments::Address,
-    pub shipping_address: Option<api_models::payments::Address>,
-    pub browser_details: Option<BrowserInformation>,
-    pub amount: Option<i64>,
-    pub currency: Option<common_enums::Currency>,
-    pub message_category: authentication::MessageCategory,
-    pub device_channel: api_models::payments::DeviceChannel,
-    pub pre_authentication_data: crate::core::authentication::types::PreAuthenticationData,
-    pub return_url: Option<String>,
-    pub sdk_information: Option<api_models::payments::SdkInformation>,
-    pub email: Option<Email>,
-    pub threeds_method_comp_ind: api_models::payments::ThreeDsCompletionIndicator,
-    pub three_ds_requestor_url: String,
-    pub webhook_url: String,
-}
-
-#[derive(Clone, Debug)]
-pub struct ConnectorPostAuthenticationRequestData {
-    pub threeds_server_transaction_id: String,
-}
 
 pub type PreAuthNRouterData =
     RouterData<api::PreAuthentication, PreAuthNRequestData, AuthenticationResponseData>;

--- a/crates/router/src/types/fraud_check.rs
+++ b/crates/router/src/types/fraud_check.rs
@@ -1,12 +1,14 @@
-pub use hyperswitch_domain_models::router_request_types::fraud_check::{
-    FraudCheckCheckoutData, FraudCheckFulfillmentData, FraudCheckRecordReturnData,
-    FraudCheckSaleData, FraudCheckTransactionData, RefundMethod,
+pub use hyperswitch_domain_models::{
+    router_request_types::fraud_check::{
+        FraudCheckCheckoutData, FraudCheckFulfillmentData, FraudCheckRecordReturnData,
+        FraudCheckSaleData, FraudCheckTransactionData, RefundMethod,
+    },
+    router_response_types::fraud_check::FraudCheckResponseData,
 };
 
 use crate::{
-    pii::Serialize,
     services,
-    types::{api, storage_enums, ErrorResponse, ResponseId, RouterData},
+    types::{api, ErrorResponse, RouterData},
 };
 
 pub type FrmSaleRouterData = RouterData<api::Sale, FraudCheckSaleData, FraudCheckResponseData>;
@@ -38,27 +40,6 @@ pub enum FrmResponse {
     Transaction(Result<FraudCheckResponseData, ErrorResponse>),
     Fulfillment(Result<FraudCheckResponseData, ErrorResponse>),
     RecordReturn(Result<FraudCheckResponseData, ErrorResponse>),
-}
-
-#[derive(Debug, Clone, Serialize)]
-#[serde(untagged)]
-pub enum FraudCheckResponseData {
-    TransactionResponse {
-        resource_id: ResponseId,
-        status: storage_enums::FraudCheckStatus,
-        connector_metadata: Option<serde_json::Value>,
-        reason: Option<serde_json::Value>,
-        score: Option<i32>,
-    },
-    FulfillmentResponse {
-        order_id: String,
-        shipment_ids: Vec<String>,
-    },
-    RecordReturnResponse {
-        resource_id: ResponseId,
-        connector_metadata: Option<serde_json::Value>,
-        return_id: Option<String>,
-    },
 }
 
 pub type FrmCheckoutRouterData =


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Moved all router_data response models and a few request models to hyperswitch domain models crate.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Checked if the code compiles successfully.


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
