### PR TITLE
fix: implement StrongEq for Vec<u8>

### DIFF
--- a/crates/masking/src/strong_secret.rs
+++ b/crates/masking/src/strong_secret.rs
@@ -117,3 +117,12 @@ impl StrongEq for String {
         bool::from(lhs.ct_eq(rhs))
     }
 }
+
+impl StrongEq for Vec<u8> {
+    fn strong_eq(&self, other: &Self) -> bool {
+        let lhs = &self;
+        let rhs = &other;
+
+        bool::from(lhs.ct_eq(rhs))
+    }
+}


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->
- [x] Enhancement

## Description
<!-- Describe your changes in detail -->
Implement `StrongEq` for `Vec<u8>`

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
Implement `StrongEq` for deriving `Eq` for `StrongSecret<Vec<u8>>`.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
NA. Testing is not needed, compiler guided.


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code