### PR TITLE
Fix(Cypress): Fixing 3DS payment failure in headless mode

### DIFF
--- a/cypress-tests/cypress.config.js
+++ b/cypress-tests/cypress.config.js
@@ -19,5 +19,7 @@ module.exports = {
     },
     experimentalRunAllSpecs: true
   },
-  chromeWebSecurity: false
+  chromeWebSecurity: false,
+  defaultCommandTimeout: 10000,
+  pageLoadTimeout: 20000
 };

--- a/cypress-tests/cypress/e2e/ConnectorTest/00008-RefundPayment.cy.js
+++ b/cypress-tests/cypress/e2e/ConnectorTest/00008-RefundPayment.cy.js
@@ -17,8 +17,8 @@ describe("Card - Refund flow test", () => {
     before("seed global state", () => {
 
         cy.task('getGlobalState').then((state) => {
-           globalState = new State(state);
-           console.log("seeding globalState -> " + JSON.stringify(globalState));
+          globalState = new State(state);
+          console.log("seeding globalState -> " + JSON.stringify(globalState));
         })
     
       })

--- a/cypress-tests/cypress/e2e/ConnectorTest/00008-RefundPayment.cy.js
+++ b/cypress-tests/cypress/e2e/ConnectorTest/00008-RefundPayment.cy.js
@@ -15,10 +15,10 @@ let globalState;
 describe("Card - Refund flow test", () => {
 
     before("seed global state", () => {
-  
+
         cy.task('getGlobalState').then((state) => {
-          globalState = new State(state);
-          console.log("seeding globalState -> " + JSON.stringify(globalState));
+           globalState = new State(state);
+           console.log("seeding globalState -> " + JSON.stringify(globalState));
         })
     
       })
@@ -26,7 +26,7 @@ describe("Card - Refund flow test", () => {
       afterEach("flush global state", () => {
         console.log("flushing globalState -> " + JSON.stringify(globalState));
         cy.task('setGlobalState', globalState.data);
-      })
+    })
 
     context("Card - Full Refund flow test for No-3DS", () => {
         let should_continue = true; // variable that will be used to skip tests if a previous test fails

--- a/cypress-tests/cypress/e2e/ConnectorTest/00008-RefundPayment.cy.js
+++ b/cypress-tests/cypress/e2e/ConnectorTest/00008-RefundPayment.cy.js
@@ -15,17 +15,18 @@ let globalState;
 describe("Card - Refund flow test", () => {
 
     before("seed global state", () => {
-
+  
         cy.task('getGlobalState').then((state) => {
-            globalState = new State(state);
-            console.log("seeding globalState -> " + JSON.stringify(globalState));
+          globalState = new State(state);
+          console.log("seeding globalState -> " + JSON.stringify(globalState));
         })
-    })
-
-    after("flush global state", () => {
+    
+      })
+    
+      afterEach("flush global state", () => {
         console.log("flushing globalState -> " + JSON.stringify(globalState));
         cy.task('setGlobalState', globalState.data);
-    })
+      })
 
     context("Card - Full Refund flow test for No-3DS", () => {
         let should_continue = true; // variable that will be used to skip tests if a previous test fails
@@ -528,6 +529,20 @@ describe("Card - Refund flow test", () => {
                 this.skip();
             }
         });
+      
+        before("seed global state", () => {
+      
+          cy.task('getGlobalState').then((state) => {
+            globalState = new State(state);
+            console.log("seeding globalState -> " + JSON.stringify(globalState));
+          })
+      
+        })
+      
+        afterEach("flush global state", () => {
+          console.log("flushing globalState -> " + JSON.stringify(globalState));
+          cy.task('setGlobalState', globalState.data);
+        })
 
         it("create-payment-call-test", () => {
             let data = getConnectorDetails(globalState.get("connectorId"))["card_pm"]["PaymentIntent"];
@@ -535,18 +550,16 @@ describe("Card - Refund flow test", () => {
             let res_data = data["Response"];
             cy.createPaymentIntentTest(createPaymentBody, req_data, res_data, "three_ds", "automatic", globalState);
             if(should_continue) should_continue = utils.should_continue_further(res_data);
-
-        });
-
-        it("payment_methods-call-test", () => {
+          });
+        
+          it("payment_methods-call-test", () => {
             cy.paymentMethodsCallTest(globalState);
-        });
-
-        it("Confirm 3DS", () => {
+          });
+        
+          it("Confirm 3DS", () => {
             let data = getConnectorDetails(globalState.get("connectorId"))["card_pm"]["3DSAutoCapture"];
             let req_data = data["Request"];
             let res_data = data["Response"];
-            console.log("det -> " + data.card);
             cy.confirmCallTest(confirmBody, req_data, res_data, true, globalState);
             if(should_continue) should_continue = utils.should_continue_further(res_data);
           });

--- a/cypress-tests/cypress/e2e/ConnectorTest/00015-ThreeDSManualCapture.cy.js
+++ b/cypress-tests/cypress/e2e/ConnectorTest/00015-ThreeDSManualCapture.cy.js
@@ -19,7 +19,7 @@ describe("Card - ThreeDS Manual payment flow test", () => {
       })
   
     })
-  
+
     afterEach("flush global state", () => {
       console.log("flushing globalState -> " + JSON.stringify(globalState));
       cy.task('setGlobalState', globalState.data);

--- a/cypress-tests/cypress/e2e/ConnectorTest/00015-ThreeDSManualCapture.cy.js
+++ b/cypress-tests/cypress/e2e/ConnectorTest/00015-ThreeDSManualCapture.cy.js
@@ -10,16 +10,19 @@ let globalState;
 
 describe("Card - ThreeDS Manual payment flow test", () => {
 
+  
     before("seed global state", () => {
-        cy.task('getGlobalState').then((state) => {
-            globalState = new State(state);
-            console.log("seeding globalState -> " + JSON.stringify(globalState));
-        })
+  
+      cy.task('getGlobalState').then((state) => {
+        globalState = new State(state);
+        console.log("seeding globalState -> " + JSON.stringify(globalState));
+      })
+  
     })
-
-    after("flush global state", () => {
-        console.log("flushing globalState -> " + JSON.stringify(globalState));
-        cy.task('setGlobalState', globalState.data);
+  
+    afterEach("flush global state", () => {
+      console.log("flushing globalState -> " + JSON.stringify(globalState));
+      cy.task('setGlobalState', globalState.data);
     })
 
     context("Card - ThreeDS Manual Full Capture payment flow test", () => {

--- a/cypress-tests/cypress/support/commands.js
+++ b/cypress-tests/cypress/support/commands.js
@@ -698,12 +698,13 @@ Cypress.Commands.add("revokeMandateCallTest", (globalState) => {
   });
 });
 
+
 Cypress.Commands.add("handleRedirection", (globalState, expected_redirection) => {
   let connectorId = globalState.get("connectorId");
   let expected_url = new URL(expected_redirection);
   let redirection_url = new URL(globalState.get("nextActionUrl"));
   cy.visit(redirection_url.href);
-  if (globalState.get("connectorId") == "adyen") {
+    if (globalState.get("connectorId") == "adyen") {
     cy.get('iframe')
       .its('0.contentDocument.body')
       .within((body) => {
@@ -713,7 +714,7 @@ Cypress.Commands.add("handleRedirection", (globalState, expected_redirection) =>
       })
   }
   else if (globalState.get("connectorId") === "cybersource" || globalState.get("connectorId") === "bankofamerica") {
-    cy.get('iframe')
+    cy.get('iframe', { timeout: 150000 })
       .its('0.contentDocument.body')
       .within((body) => {
         cy.get('input[type="text"]').click().type("1234");
@@ -734,8 +735,9 @@ Cypress.Commands.add("handleRedirection", (globalState, expected_redirection) =>
           })
       })
   }
+  
   else if (globalState.get("connectorId") === "stripe") {
-    cy.get('iframe')
+    cy.get('iframe', { timeout: 30000 })
       .its('0.contentDocument.body')
       .within((body) => {
         cy.get('iframe')
@@ -768,7 +770,6 @@ Cypress.Commands.add("handleRedirection", (globalState, expected_redirection) =>
       cy.window().its('location.origin').should('eq', expected_url);
     })
   }
-
 });
 
 Cypress.Commands.add("listCustomerPMCallTest", (globalState) => {

--- a/cypress-tests/cypress/support/commands.js
+++ b/cypress-tests/cypress/support/commands.js
@@ -704,7 +704,7 @@ Cypress.Commands.add("handleRedirection", (globalState, expected_redirection) =>
   let expected_url = new URL(expected_redirection);
   let redirection_url = new URL(globalState.get("nextActionUrl"));
   cy.visit(redirection_url.href);
-    if (globalState.get("connectorId") == "adyen") {
+  if (globalState.get("connectorId") == "adyen") {
     cy.get('iframe')
       .its('0.contentDocument.body')
       .within((body) => {

--- a/cypress-tests/cypress/support/commands.js
+++ b/cypress-tests/cypress/support/commands.js
@@ -714,7 +714,7 @@ Cypress.Commands.add("handleRedirection", (globalState, expected_redirection) =>
       })
   }
   else if (globalState.get("connectorId") === "cybersource" || globalState.get("connectorId") === "bankofamerica") {
-    cy.get('iframe', { timeout: 150000 })
+    cy.get('iframe', { timeout: 15000 })
       .its('0.contentDocument.body')
       .within((body) => {
         cy.get('input[type="text"]').click().type("1234");


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [x] CI/CD

## Description
3DS payments were failing in the refund test in Cypress headless mode. I added the timeout and properly configured the hooks to fetch the redirection URL correctly.


## Motivation and Context
To ensure the test runs successfully without any failures in the CI/CD pipeline.

## How did you test it?
 Tested locally in the headless mode
 
 Stripe
 
<img width="843" alt="Screenshot 2024-05-29 at 1 41 57 PM" src="https://github.com/juspay/hyperswitch/assets/118818938/b5737099-bf5c-4408-b598-77185c257411">

Cybersource
<img width="898" alt="Screenshot 2024-05-29 at 2 45 53 PM" src="https://github.com/juspay/hyperswitch/assets/118818938/63c7be7b-9b12-4312-8b55-26aa53fde86d">

NMI
<img width="807" alt="Screenshot 2024-05-29 at 3 09 28 PM" src="https://github.com/juspay/hyperswitch/assets/118818938/496d2212-0ceb-4fd8-8584-b507907f2521">

Adyen

<img width="852" alt="Screenshot 2024-05-29 at 3 17 36 PM" src="https://github.com/juspay/hyperswitch/assets/118818938/07722a6d-b771-4585-b618-944423c8c15b">



## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible

