### PR TITLE
feat(users): add support to reset totp

### DIFF
--- a/crates/router/src/core/user.rs
+++ b/crates/router/src/core/user.rs
@@ -1658,6 +1658,12 @@ pub async fn reset_totp(
         return Err(UserErrors::TotpNotSetup.into());
     }
 
+    if !tfa_utils::check_totp_in_redis(&state, &user_token.user_id).await?
+        && !tfa_utils::check_recovery_code_in_redis(&state, &user_token.user_id).await?
+    {
+        return Err(UserErrors::TwoFactorAuthRequired.into());
+    }
+
     let (secret, totp) =
         tfa_utils::generate_totp_and_insert_secret_in_redis(state, user_from_db).await?;
 

--- a/crates/router/src/core/user.rs
+++ b/crates/router/src/core/user.rs
@@ -1632,8 +1632,9 @@ pub async fn begin_totp(
         }));
     }
 
-    let (secret, totp) =
-        tfa_utils::generate_totp_and_insert_secret_in_redis(state, user_from_db).await?;
+    let totp = tfa_utils::generate_default_totp(user_from_db.get_email(), None)?;
+    let secret = totp.get_secret_base32().into();
+    tfa_utils::insert_totp_secret_in_redis(&state, &user_token.user_id, &secret).await?;
 
     Ok(ApplicationResponse::Json(user_api::BeginTotpResponse {
         secret: Some(user_api::TotpSecret {
@@ -1664,8 +1665,9 @@ pub async fn reset_totp(
         return Err(UserErrors::TwoFactorAuthRequired.into());
     }
 
-    let (secret, totp) =
-        tfa_utils::generate_totp_and_insert_secret_in_redis(state, user_from_db).await?;
+    let totp = tfa_utils::generate_default_totp(user_from_db.get_email(), None)?;
+    let secret = totp.get_secret_base32().into();
+    tfa_utils::insert_totp_secret_in_redis(&state, &user_token.user_id, &secret).await?;
 
     Ok(ApplicationResponse::Json(user_api::BeginTotpResponse {
         secret: Some(user_api::TotpSecret {

--- a/crates/router/src/core/user.rs
+++ b/crates/router/src/core/user.rs
@@ -1645,7 +1645,7 @@ pub async fn begin_totp(
 
 pub async fn reset_totp(
     state: AppState,
-    user_token: auth::UserFromSinglePurposeToken,
+    user_token: auth::UserFromToken,
 ) -> UserResponse<user_api::BeginTotpResponse> {
     let user_from_db: domain::UserFromStorage = state
         .store

--- a/crates/router/src/routes/app.rs
+++ b/crates/router/src/routes/app.rs
@@ -1217,6 +1217,7 @@ impl User {
                 .service(
                     web::scope("/totp")
                         .service(web::resource("/begin").route(web::get().to(totp_begin)))
+                        .service(web::resource("/reset").route(web::get().to(totp_reset)))
                         .service(
                             web::resource("/verify")
                                 .route(web::post().to(totp_verify))

--- a/crates/router/src/routes/lock_utils.rs
+++ b/crates/router/src/routes/lock_utils.rs
@@ -214,6 +214,7 @@ impl From<Flow> for ApiIdentifier {
             | Flow::VerifyEmailRequest
             | Flow::UpdateUserAccountDetails
             | Flow::TotpBegin
+            | Flow::TotpReset
             | Flow::TotpVerify
             | Flow::TotpUpdate
             | Flow::RecoveryCodeVerify

--- a/crates/router/src/routes/user.rs
+++ b/crates/router/src/routes/user.rs
@@ -656,7 +656,7 @@ pub async fn totp_reset(state: web::Data<AppState>, req: HttpRequest) -> HttpRes
         &req,
         (),
         |state, user, _, _| user_core::reset_totp(state, user),
-        &auth::SinglePurposeJWTAuth(TokenPurpose::TOTP),
+        &auth::DashboardNoPermissionAuth,
         api_locking::LockAction::NotApplicable,
     ))
     .await

--- a/crates/router/src/routes/user.rs
+++ b/crates/router/src/routes/user.rs
@@ -648,6 +648,20 @@ pub async fn totp_begin(state: web::Data<AppState>, req: HttpRequest) -> HttpRes
     .await
 }
 
+pub async fn totp_reset(state: web::Data<AppState>, req: HttpRequest) -> HttpResponse {
+    let flow = Flow::TotpReset;
+    Box::pin(api::server_wrap(
+        flow,
+        state.clone(),
+        &req,
+        (),
+        |state, user, _, _| user_core::reset_totp(state, user),
+        &auth::SinglePurposeJWTAuth(TokenPurpose::TOTP),
+        api_locking::LockAction::NotApplicable,
+    ))
+    .await
+}
+
 pub async fn totp_verify(
     state: web::Data<AppState>,
     req: HttpRequest,

--- a/crates/router/src/utils/user/two_factor_auth.rs
+++ b/crates/router/src/utils/user/two_factor_auth.rs
@@ -7,7 +7,6 @@ use crate::{
     consts,
     core::errors::{UserErrors, UserResult},
     routes::AppState,
-    types::domain::UserFromStorage,
 };
 
 pub fn generate_default_totp(
@@ -30,17 +29,6 @@ pub fn generate_default_totp(
         email.expose().expose(),
     )
     .change_context(UserErrors::InternalServerError)
-}
-
-pub async fn generate_totp_and_insert_secret_in_redis(
-    state: AppState,
-    user_from_db: UserFromStorage,
-) -> UserResult<(masking::Secret<String>, TOTP)> {
-    let totp = generate_default_totp(user_from_db.get_email(), None)?;
-    let secret = totp.get_secret_base32().into();
-    insert_totp_secret_in_redis(&state, user_from_db.get_user_id(), &secret).await?;
-
-    Ok((secret, totp))
 }
 
 pub async fn check_totp_in_redis(state: &AppState, user_id: &str) -> UserResult<bool> {

--- a/crates/router/src/utils/user/two_factor_auth.rs
+++ b/crates/router/src/utils/user/two_factor_auth.rs
@@ -7,6 +7,7 @@ use crate::{
     consts,
     core::errors::{UserErrors, UserResult},
     routes::AppState,
+    types::domain::UserFromStorage,
 };
 
 pub fn generate_default_totp(
@@ -29,6 +30,17 @@ pub fn generate_default_totp(
         email.expose().expose(),
     )
     .change_context(UserErrors::InternalServerError)
+}
+
+pub async fn generate_totp_and_insert_secret_in_redis(
+    state: AppState,
+    user_from_db: UserFromStorage,
+) -> UserResult<(masking::Secret<String>, TOTP)> {
+    let totp = generate_default_totp(user_from_db.get_email(), None)?;
+    let secret = totp.get_secret_base32().into();
+    insert_totp_secret_in_redis(&state, &user_from_db.get_user_id(), &secret).await?;
+
+    Ok((secret, totp))
 }
 
 pub async fn check_totp_in_redis(state: &AppState, user_id: &str) -> UserResult<bool> {

--- a/crates/router/src/utils/user/two_factor_auth.rs
+++ b/crates/router/src/utils/user/two_factor_auth.rs
@@ -38,7 +38,7 @@ pub async fn generate_totp_and_insert_secret_in_redis(
 ) -> UserResult<(masking::Secret<String>, TOTP)> {
     let totp = generate_default_totp(user_from_db.get_email(), None)?;
     let secret = totp.get_secret_base32().into();
-    insert_totp_secret_in_redis(&state, &user_from_db.get_user_id(), &secret).await?;
+    insert_totp_secret_in_redis(&state, user_from_db.get_user_id(), &secret).await?;
 
     Ok((secret, totp))
 }

--- a/crates/router_env/src/logger/types.rs
+++ b/crates/router_env/src/logger/types.rs
@@ -404,6 +404,8 @@ pub enum Flow {
     UserFromEmail,
     /// Begin TOTP
     TotpBegin,
+    // Reset TOTP
+    TotpReset,
     /// Verify TOTP
     TotpVerify,
     /// Update TOTP secret


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
Add support to reset TOTP

### Additional Changes

- [x] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
Closes [#4820](https://github.com/juspay/hyperswitch/issues/4820)


## How did you test it?
Use the curl to reset TOTP when it is already setup (from inside dashboard):
```
curl --location 'http://localhost:8080/user/2fa/totp/reset' \
--header 'Authorization: Bearer JWT' \
--header 'Cookie: Cookie_1=value'
```

Response:
```
{
    "secret": {
        "secret": "VERUDBNHLYZDGFTKNXY2VVP4EQ5GOBUB",
        "totp_url": "otpauth://totp/Hyperswitch:ver%40gmail.com?secret=VERUDBNHLYZDGFTKNXY2VVP4EQ5GOBUB&issuer=Hyperswitch"
    }
}
```
The Response can be used to generate new QR and reset TOTP.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
