### PR TITLE
chore: enable `clippy::large_futures` lint

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -6,6 +6,7 @@ rustflags = [
     "-Wclippy::expect_used",
     "-Wclippy::index_refutable_slice",
     "-Wclippy::indexing_slicing",
+    "-Wclippy::large_futures",
     "-Wclippy::match_on_vec_items",
     "-Wclippy::missing_panics_doc",
     "-Wclippy::out_of_bounds_indexing",

--- a/crates/router/src/core/disputes.rs
+++ b/crates/router/src/core/disputes.rs
@@ -358,12 +358,12 @@ pub async fn attach_evidence(
             })
         },
     )?;
-    let create_file_response = files::files_create_core(
+    let create_file_response = Box::pin(files::files_create_core(
         state.clone(),
         merchant_account,
         key_store,
         attach_evidence_request.create_file_request,
-    )
+    ))
     .await?;
     let file_id = match &create_file_response {
         services::ApplicationResponse::Json(res) => res.file_id.clone(),

--- a/crates/router/src/core/fraud_check.rs
+++ b/crates/router/src/core/fraud_check.rs
@@ -563,7 +563,7 @@ where
         frm_routing_algorithm.zip(frm_connector_label)
     {
         if let Some(frm_configs) = frm_configs.clone() {
-            let mut updated_frm_info = make_frm_data_and_fraud_check_operation(
+            let mut updated_frm_info = Box::pin(make_frm_data_and_fraud_check_operation(
                 db,
                 state,
                 merchant_account,
@@ -572,7 +572,7 @@ where
                 profile_id,
                 frm_configs.clone(),
                 customer,
-            )
+            ))
             .await?;
 
             if is_frm_enabled {

--- a/crates/router/src/core/payments/tokenization.rs
+++ b/crates/router/src/core/payments/tokenization.rs
@@ -660,14 +660,14 @@ pub async fn save_in_locker(
         .clone()
         .get_required_value("customer_id")?;
     match payment_method_request.card.clone() {
-        Some(card) => payment_methods::cards::add_card_to_locker(
+        Some(card) => Box::pin(payment_methods::cards::add_card_to_locker(
             state,
             payment_method_request,
             &card,
             &customer_id,
             merchant_account,
             None,
-        )
+        ))
         .await
         .change_context(errors::ApiErrorResponse::InternalServerError)
         .attach_printable("Add Card Failed"),

--- a/crates/router/src/core/refunds.rs
+++ b/crates/router/src/core/refunds.rs
@@ -725,7 +725,7 @@ pub async fn validate_and_create_refund(
         .await
     {
         Ok(refund) => {
-            schedule_refund_execution(
+            Box::pin(schedule_refund_execution(
                 state,
                 refund.clone(),
                 refund_type,
@@ -735,7 +735,7 @@ pub async fn validate_and_create_refund(
                 payment_intent,
                 creds_identifier,
                 charges,
-            )
+            ))
             .await?
         }
         Err(err) => {

--- a/crates/router/src/core/webhooks.rs
+++ b/crates/router/src/core/webhooks.rs
@@ -1070,7 +1070,7 @@ pub(crate) async fn create_event_and_trigger_outgoing_webhook(
     // may have an actix arbiter
     tokio::spawn(
         async move {
-            trigger_webhook_and_raise_event(
+            Box::pin(trigger_webhook_and_raise_event(
                 state,
                 business_profile,
                 &cloned_key_store,
@@ -1079,7 +1079,7 @@ pub(crate) async fn create_event_and_trigger_outgoing_webhook(
                 delivery_attempt,
                 Some(content),
                 process_tracker,
-            )
+            ))
             .await;
         }
         .in_current_span(),

--- a/crates/router/src/core/webhooks/webhook_events.rs
+++ b/crates/router/src/core/webhooks/webhook_events.rs
@@ -231,7 +231,7 @@ pub async fn retry_delivery_attempt(
         .change_context(errors::ApiErrorResponse::InternalServerError)
         .attach_printable("Failed to parse webhook event request information")?;
 
-    super::trigger_webhook_and_raise_event(
+    Box::pin(super::trigger_webhook_and_raise_event(
         state.clone(),
         business_profile,
         &key_store,
@@ -240,7 +240,7 @@ pub async fn retry_delivery_attempt(
         delivery_attempt,
         None,
         None,
-    )
+    ))
     .await;
 
     let updated_event = store

--- a/crates/router/src/routes/cards_info.rs
+++ b/crates/router/src/routes/cards_info.rs
@@ -41,7 +41,7 @@ pub async fn card_iin_info(
         Err(e) => return api::log_and_return_error_response(e),
     };
 
-    api::server_wrap(
+    Box::pin(api::server_wrap(
         Flow::CardsInfo,
         state,
         &req,
@@ -49,6 +49,6 @@ pub async fn card_iin_info(
         |state, auth, req, _| cards_info::retrieve_card_info(state, auth.merchant_account, req),
         &*auth,
         api_locking::LockAction::NotApplicable,
-    )
+    ))
     .await
 }

--- a/crates/router/src/routes/customers.rs
+++ b/crates/router/src/routes/customers.rs
@@ -52,7 +52,7 @@ pub async fn customers_retrieve(
         }
     };
 
-    api::server_wrap(
+    Box::pin(api::server_wrap(
         flow,
         state,
         &req,
@@ -60,7 +60,7 @@ pub async fn customers_retrieve(
         |state, auth, req, _| retrieve_customer(state, auth.merchant_account, auth.key_store, req),
         &*auth,
         api_locking::LockAction::NotApplicable,
-    )
+    ))
     .await
 }
 

--- a/crates/router/src/routes/disputes.rs
+++ b/crates/router/src/routes/disputes.rs
@@ -38,7 +38,7 @@ pub async fn retrieve_dispute(
     let dispute_id = dispute_types::DisputeId {
         dispute_id: path.into_inner(),
     };
-    api::server_wrap(
+    Box::pin(api::server_wrap(
         flow,
         state,
         &req,
@@ -50,7 +50,7 @@ pub async fn retrieve_dispute(
             req.headers(),
         ),
         api_locking::LockAction::NotApplicable,
-    )
+    ))
     .await
 }
 /// Disputes - List Disputes
@@ -85,7 +85,7 @@ pub async fn retrieve_disputes_list(
 ) -> HttpResponse {
     let flow = Flow::DisputesList;
     let payload = payload.into_inner();
-    api::server_wrap(
+    Box::pin(api::server_wrap(
         flow,
         state,
         &req,
@@ -97,7 +97,7 @@ pub async fn retrieve_disputes_list(
             req.headers(),
         ),
         api_locking::LockAction::NotApplicable,
-    )
+    ))
     .await
 }
 /// Disputes - Accept Dispute

--- a/crates/router/src/routes/mandates.rs
+++ b/crates/router/src/routes/mandates.rs
@@ -36,7 +36,7 @@ pub async fn get_mandate(
     let mandate_id = mandates::MandateId {
         mandate_id: path.into_inner(),
     };
-    api::server_wrap(
+    Box::pin(api::server_wrap(
         flow,
         state,
         &req,
@@ -46,7 +46,7 @@ pub async fn get_mandate(
         },
         &auth::ApiKeyAuth,
         api_locking::LockAction::NotApplicable,
-    )
+    ))
     .await
 }
 /// Mandates - Revoke Mandate

--- a/crates/router/src/routes/payment_link.rs
+++ b/crates/router/src/routes/payment_link.rs
@@ -112,7 +112,7 @@ pub async fn payments_link_list(
 ) -> impl Responder {
     let flow = Flow::PaymentLinkList;
     let payload = payload.into_inner();
-    api::server_wrap(
+    Box::pin(api::server_wrap(
         flow,
         state,
         &req,
@@ -120,7 +120,7 @@ pub async fn payments_link_list(
         |state, auth, payload, _| list_payment_link(state, auth.merchant_account, payload),
         &auth::ApiKeyAuth,
         api_locking::LockAction::NotApplicable,
-    )
+    ))
     .await
 }
 

--- a/crates/router/src/routes/payments.rs
+++ b/crates/router/src/routes/payments.rs
@@ -949,7 +949,7 @@ pub async fn payments_list(
 ) -> impl Responder {
     let flow = Flow::PaymentsList;
     let payload = payload.into_inner();
-    api::server_wrap(
+    Box::pin(api::server_wrap(
         flow,
         state,
         &req,
@@ -961,7 +961,7 @@ pub async fn payments_list(
             req.headers(),
         ),
         api_locking::LockAction::NotApplicable,
-    )
+    ))
     .await
 }
 #[instrument(skip_all, fields(flow = ?Flow::PaymentsList))]
@@ -973,7 +973,7 @@ pub async fn payments_list_by_filter(
 ) -> impl Responder {
     let flow = Flow::PaymentsList;
     let payload = payload.into_inner();
-    api::server_wrap(
+    Box::pin(api::server_wrap(
         flow,
         state,
         &req,
@@ -983,7 +983,7 @@ pub async fn payments_list_by_filter(
         },
         &auth::JWTAuth(Permission::PaymentRead),
         api_locking::LockAction::NotApplicable,
-    )
+    ))
     .await
 }
 #[instrument(skip_all, fields(flow = ?Flow::PaymentsList))]
@@ -995,7 +995,7 @@ pub async fn get_filters_for_payments(
 ) -> impl Responder {
     let flow = Flow::PaymentsList;
     let payload = payload.into_inner();
-    api::server_wrap(
+    Box::pin(api::server_wrap(
         flow,
         state,
         &req,
@@ -1005,7 +1005,7 @@ pub async fn get_filters_for_payments(
         },
         &auth::JWTAuth(Permission::PaymentRead),
         api_locking::LockAction::NotApplicable,
-    )
+    ))
     .await
 }
 
@@ -1016,7 +1016,7 @@ pub async fn get_payment_filters(
     req: actix_web::HttpRequest,
 ) -> impl Responder {
     let flow = Flow::PaymentsFilters;
-    api::server_wrap(
+    Box::pin(api::server_wrap(
         flow,
         state,
         &req,
@@ -1026,7 +1026,7 @@ pub async fn get_payment_filters(
         },
         &auth::JWTAuth(Permission::PaymentRead),
         api_locking::LockAction::NotApplicable,
-    )
+    ))
     .await
 }
 

--- a/crates/router/src/routes/poll.rs
+++ b/crates/router/src/routes/poll.rs
@@ -33,7 +33,7 @@ pub async fn retrieve_poll_status(
     let poll_id = PollId {
         poll_id: path.into_inner(),
     };
-    api::server_wrap(
+    Box::pin(api::server_wrap(
         flow,
         state,
         &req,
@@ -41,6 +41,6 @@ pub async fn retrieve_poll_status(
         |state, auth, req, _| poll::retrieve_poll_status(state, req, auth.merchant_account),
         &auth::PublishableKeyAuth,
         api_locking::LockAction::NotApplicable,
-    )
+    ))
     .await
 }

--- a/crates/router/src/routes/refunds.rs
+++ b/crates/router/src/routes/refunds.rs
@@ -182,7 +182,7 @@ pub async fn refunds_update(
     let flow = Flow::RefundsUpdate;
     let mut refund_update_req = json_payload.into_inner();
     refund_update_req.refund_id = path.into_inner();
-    api::server_wrap(
+    Box::pin(api::server_wrap(
         flow,
         state,
         &req,
@@ -190,7 +190,7 @@ pub async fn refunds_update(
         |state, auth, req, _| refund_update_core(state, auth.merchant_account, req),
         &auth::ApiKeyAuth,
         api_locking::LockAction::NotApplicable,
-    )
+    ))
     .await
 }
 /// Refunds - List
@@ -215,7 +215,7 @@ pub async fn refunds_list(
     payload: web::Json<api_models::refunds::RefundListRequest>,
 ) -> HttpResponse {
     let flow = Flow::RefundsList;
-    api::server_wrap(
+    Box::pin(api::server_wrap(
         flow,
         state,
         &req,
@@ -227,7 +227,7 @@ pub async fn refunds_list(
             req.headers(),
         ),
         api_locking::LockAction::NotApplicable,
-    )
+    ))
     .await
 }
 
@@ -253,7 +253,7 @@ pub async fn refunds_filter_list(
     payload: web::Json<api_models::payments::TimeRange>,
 ) -> HttpResponse {
     let flow = Flow::RefundsList;
-    api::server_wrap(
+    Box::pin(api::server_wrap(
         flow,
         state,
         &req,
@@ -265,7 +265,7 @@ pub async fn refunds_filter_list(
             req.headers(),
         ),
         api_locking::LockAction::NotApplicable,
-    )
+    ))
     .await
 }
 
@@ -286,7 +286,7 @@ pub async fn refunds_filter_list(
 #[cfg(feature = "olap")]
 pub async fn get_refunds_filters(state: web::Data<AppState>, req: HttpRequest) -> HttpResponse {
     let flow = Flow::RefundsFilters;
-    api::server_wrap(
+    Box::pin(api::server_wrap(
         flow,
         state,
         &req,
@@ -298,6 +298,6 @@ pub async fn get_refunds_filters(state: web::Data<AppState>, req: HttpRequest) -
             req.headers(),
         ),
         api_locking::LockAction::NotApplicable,
-    )
+    ))
     .await
 }

--- a/crates/router/src/routes/routing.rs
+++ b/crates/router/src/routes/routing.rs
@@ -259,7 +259,7 @@ pub async fn routing_update_default_config(
     json_payload: web::Json<Vec<routing_types::RoutableConnectorChoice>>,
     transaction_type: &enums::TransactionType,
 ) -> impl Responder {
-    oss_api::server_wrap(
+    Box::pin(oss_api::server_wrap(
         Flow::RoutingUpdateDefaultConfig,
         state,
         &req,
@@ -281,7 +281,7 @@ pub async fn routing_update_default_config(
         #[cfg(feature = "release")]
         &auth::JWTAuth(Permission::RoutingWrite),
         api_locking::LockAction::NotApplicable,
-    )
+    ))
     .await
 }
 
@@ -292,7 +292,7 @@ pub async fn routing_retrieve_default_config(
     req: HttpRequest,
     transaction_type: &enums::TransactionType,
 ) -> impl Responder {
-    oss_api::server_wrap(
+    Box::pin(oss_api::server_wrap(
         Flow::RoutingRetrieveDefaultConfig,
         state,
         &req,
@@ -309,7 +309,7 @@ pub async fn routing_retrieve_default_config(
         #[cfg(feature = "release")]
         &auth::JWTAuth(Permission::RoutingRead),
         api_locking::LockAction::NotApplicable,
-    )
+    ))
     .await
 }
 
@@ -573,7 +573,7 @@ pub async fn routing_retrieve_default_config_for_profiles(
     req: HttpRequest,
     transaction_type: &enums::TransactionType,
 ) -> impl Responder {
-    oss_api::server_wrap(
+    Box::pin(oss_api::server_wrap(
         Flow::RoutingRetrieveDefaultConfig,
         state,
         &req,
@@ -598,7 +598,7 @@ pub async fn routing_retrieve_default_config_for_profiles(
             req.headers(),
         ),
         api_locking::LockAction::NotApplicable,
-    )
+    ))
     .await
 }
 
@@ -615,7 +615,7 @@ pub async fn routing_update_default_config_for_profile(
         updated_config: json_payload.into_inner(),
         profile_id: path.into_inner(),
     };
-    oss_api::server_wrap(
+    Box::pin(oss_api::server_wrap(
         Flow::RoutingUpdateDefaultConfig,
         state,
         &req,
@@ -638,6 +638,6 @@ pub async fn routing_update_default_config_for_profile(
         #[cfg(feature = "release")]
         &auth::JWTAuth(Permission::RoutingWrite),
         api_locking::LockAction::NotApplicable,
-    )
+    ))
     .await
 }

--- a/crates/router/src/routes/webhook_events.rs
+++ b/crates/router/src/routes/webhook_events.rs
@@ -27,7 +27,7 @@ pub async fn list_initial_webhook_delivery_attempts(
         constraints,
     };
 
-    api::server_wrap(
+    Box::pin(api::server_wrap(
         flow,
         state,
         &req,
@@ -48,7 +48,7 @@ pub async fn list_initial_webhook_delivery_attempts(
             req.headers(),
         ),
         api_locking::LockAction::NotApplicable,
-    )
+    ))
     .await
 }
 
@@ -66,7 +66,7 @@ pub async fn list_webhook_delivery_attempts(
         initial_attempt_id,
     };
 
-    api::server_wrap(
+    Box::pin(api::server_wrap(
         flow,
         state,
         &req,
@@ -87,7 +87,7 @@ pub async fn list_webhook_delivery_attempts(
             req.headers(),
         ),
         api_locking::LockAction::NotApplicable,
-    )
+    ))
     .await
 }
 
@@ -105,7 +105,7 @@ pub async fn retry_webhook_delivery_attempt(
         event_id,
     };
 
-    api::server_wrap(
+    Box::pin(api::server_wrap(
         flow,
         state,
         &req,
@@ -126,6 +126,6 @@ pub async fn retry_webhook_delivery_attempt(
             req.headers(),
         ),
         api_locking::LockAction::NotApplicable,
-    )
+    ))
     .await
 }

--- a/crates/router/src/workflows/outgoing_webhook_retry.rs
+++ b/crates/router/src/workflows/outgoing_webhook_retry.rs
@@ -114,7 +114,7 @@ impl ProcessTrackerWorkflow<AppState> for OutgoingWebhookRetryWorkflow {
                     .peek()
                     .parse_struct("OutgoingWebhookRequestContent")?;
 
-                webhooks_core::trigger_webhook_and_raise_event(
+                Box::pin(webhooks_core::trigger_webhook_and_raise_event(
                     state.clone(),
                     business_profile,
                     &key_store,
@@ -123,7 +123,7 @@ impl ProcessTrackerWorkflow<AppState> for OutgoingWebhookRetryWorkflow {
                     delivery_attempt,
                     None,
                     Some(process),
-                )
+                ))
                 .await;
             }
 
@@ -168,7 +168,7 @@ impl ProcessTrackerWorkflow<AppState> for OutgoingWebhookRetryWorkflow {
                             errors::ProcessTrackerError::EApiErrorResponse
                         })?;
 
-                        webhooks_core::trigger_webhook_and_raise_event(
+                        Box::pin(webhooks_core::trigger_webhook_and_raise_event(
                             state.clone(),
                             business_profile,
                             &key_store,
@@ -177,7 +177,7 @@ impl ProcessTrackerWorkflow<AppState> for OutgoingWebhookRetryWorkflow {
                             delivery_attempt,
                             Some(content),
                             Some(process),
-                        )
+                        ))
                         .await;
                     }
                     // Resource status has changed since the event was created, finish task


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
This PR enables the `clippy::large_futures` lint and addresses warnings that arise due to the lint.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
Hopefully helps keep async functions which use a lot of stack space in check.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
N/A

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
