### PR TITLE
fix: include client_version and client_source in retried payments

### DIFF
--- a/crates/router/src/core/payments/helpers.rs
+++ b/crates/router/src/core/payments/helpers.rs
@@ -3579,8 +3579,8 @@ impl AttemptType {
             payment_method_billing_address_id: None,
             fingerprint_id: None,
             charge_id: None,
-            client_source: None,
-            client_version: None,
+            client_source: old_payment_attempt.client_source,
+            client_version: old_payment_attempt.client_version,
         }
     }
 

--- a/crates/router/src/core/payments/retry.rs
+++ b/crates/router/src/core/payments/retry.rs
@@ -510,7 +510,8 @@ pub fn make_new_payment_attempt(
         mandate_id: old_payment_attempt.mandate_id,
         browser_info: old_payment_attempt.browser_info,
         payment_token: old_payment_attempt.payment_token,
-
+        client_source: old_payment_attempt.client_source,
+        client_version: old_payment_attempt.client_version,
         created_at,
         modified_at,
         last_synced,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
This pull request addresses a bug where the client_source and client_version fields were not populated for payment attempts created via retry cases. This issue resulted in these fields being correctly displayed for the first payment attempt but missing in subsequent retry attempts.

**Issue:**

Problem: For the first payment attempt, the client_source and client_version fields were populated correctly. However, for subsequent payments made through retry mechanisms, these fields were not populated, leading to incomplete data in the PaymentAttemptResponse struct.

**Impact**: This caused inconsistencies in tracking the source and version of clients across different payment attempts, impacting analytics, debugging, and support.

**Backward Compatibility:**
This fix is backward compatible as it does not change the existing API or data structures but ensures that existing fields are correctly populated.

fixes https://github.com/juspay/hyperswitch/issues/4656


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

**1. Setup Two Connectors on Hyperswitch Control Center:**

Access the Hyperswitch Control Center.
Navigate to the "Connectors" section.
Configure two different payment connectors (Connector 1 and Connector 2).
Ensure both connectors are properly set up and enabled.

**2. Create a Payment Intent and Try Confirming It:**
Use the Hyperswitch API or dashboard to create a new payment intent.
Ensure to include the client_source and client_version fields in the request headers in the confirm request

**3. Produce a Retriable Error from Connector 1 so It Gets Retried with Connector 2:**
Simulate a retriable error on Connector 1 (e.g., by configuring Connector 1 to return a specific error code that triggers a retry).
Ensure that Hyperswitch handles the error and automatically retries the payment using Connector 2.

**4. Check the Values for client_source and client_version for Both Payment Attempts:**

Retrieve the payment intent by passing `?expand_attempts=true`
Verify that both the initial and retry payment attempts contain the client_source and client_version fields

**Attempt 1**
```
        {
            "attempt_id": "pay_Ycjp9242NLsL9UT2pQKS_1",
            "status": "failure",
            "amount": 6540,
            "currency": "USD",
            "connector": "cybersource",
            "error_message": "Authentication failed",
            "payment_method": "card",
            "connector_transaction_id": null,
            "capture_method": "automatic",
            "authentication_type": "no_three_ds",
            "cancellation_reason": null,
            "mandate_id": null,
            "error_code": "No error code",
            "payment_token": "token_FnzQEt8rNha2E4EzV7Va",
            "connector_metadata": null,
            "payment_experience": null,
            "payment_method_type": "credit",
            "reference_id": null,
            "unified_code": null,
            "unified_message": null,
            "client_source": "ExpressCheckout",
            "client_version": "1.1.1"
        }
```

**Attempt 2**
```
        {
            "attempt_id": "pay_Ycjp9242NLsL9UT2pQKS_2",
            "status": "charged",
            "amount": 6540,
            "currency": "USD",
            "connector": "stripe",
            "error_message": "null,
            "payment_method": "card",
            "connector_transaction_id": null,
            "capture_method": "automatic",
            "authentication_type": "no_three_ds",
            "cancellation_reason": null,
            "mandate_id": null,
            "error_code": "No error code",
            "payment_token": "token_FnzQEt8rNha2E4EzV7Va",
            "connector_metadata": null,
            "payment_experience": null,
            "payment_method_type": "credit",
            "reference_id": null,
            "unified_code": null,
            "unified_message": null,
            "client_source": "ExpressCheckout",
            "client_version": "1.1.1"
        }
```

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [x] I added unit tests for my changes where possible
