### PR TITLE
fix(connector): make few fields optional in struct NetceteraErrorDetails

### DIFF
--- a/crates/router/src/connector/netcetera.rs
+++ b/crates/router/src/connector/netcetera.rs
@@ -107,7 +107,7 @@ impl ConnectorCommon for Netcetera {
             status_code: res.status_code,
             code: response.error_details.error_code,
             message: response.error_details.error_description,
-            reason: Some(response.error_details.error_detail),
+            reason: response.error_details.error_detail,
             attempt_status: None,
             connector_transaction_id: None,
         })

--- a/crates/router/src/connector/netcetera/transformers.rs
+++ b/crates/router/src/connector/netcetera/transformers.rs
@@ -105,8 +105,8 @@ impl
             NetceteraPreAuthenticationResponse::Failure(error_response) => {
                 Err(types::ErrorResponse {
                     code: error_response.error_details.error_code,
-                    message: error_response.error_details.error_detail,
-                    reason: Some(error_response.error_details.error_description),
+                    message: error_response.error_details.error_description,
+                    reason: error_response.error_details.error_detail,
                     status_code: item.http_code,
                     attempt_status: None,
                     connector_transaction_id: None,
@@ -173,8 +173,8 @@ impl
             }
             NetceteraAuthenticationResponse::Error(error_response) => Err(types::ErrorResponse {
                 code: error_response.error_details.error_code,
-                message: error_response.error_details.error_detail,
-                reason: Some(error_response.error_details.error_description),
+                message: error_response.error_details.error_description,
+                reason: error_response.error_details.error_detail,
                 status_code: item.http_code,
                 attempt_status: None,
                 connector_transaction_id: None,
@@ -234,20 +234,20 @@ pub struct NetceteraErrorDetails {
     pub error_code: String,
 
     /// Code indicating the 3-D Secure component that identified the error.
-    pub error_component: String,
+    pub error_component: Option<String>,
 
     /// Text describing the problem identified.
     pub error_description: String,
 
     /// Additional detail regarding the problem identified.
-    pub error_detail: String,
+    pub error_detail: Option<String>,
 
     /// Universally unique identifier for the transaction assigned by the 3DS SDK.
     #[serde(rename = "sdkTransID")]
     pub sdk_trans_id: Option<String>,
 
     /// The Message Type that was identified as erroneous.
-    pub error_message_type: String,
+    pub error_message_type: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Few fields in netcetera error object that were marked required in the official api documentation were missing in api response body. This caused deserialization failure at hyperswitch. 

So made those fields optional.


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Manual.
Tested sanity of Netcetera Authentication Connector.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
