### PR TITLE
feat(auth): Create and use `SinglePurposeOrLoginTokenAuth`

### DIFF
--- a/crates/router/src/core/user.rs
+++ b/crates/router/src/core/user.rs
@@ -1228,11 +1228,11 @@ pub async fn create_merchant_account(
 
 pub async fn list_merchants_for_user(
     state: AppState,
-    user_from_token: Box<dyn auth::GetUserIdFromAuth>,
+    user_from_token: auth::UserFromSinglePurposeOrLoginToken,
 ) -> UserResponse<Vec<user_api::UserMerchantAccount>> {
     let user_roles = state
         .store
-        .list_user_roles_by_user_id(user_from_token.get_user_id().as_str())
+        .list_user_roles_by_user_id(user_from_token.user_id.as_str())
         .await
         .change_context(UserErrors::InternalServerError)?;
 
@@ -1679,7 +1679,7 @@ pub async fn reset_totp(
 
 pub async fn verify_totp(
     state: AppState,
-    user_token: auth::UserFromSinglePurposeToken,
+    user_token: auth::UserFromSinglePurposeOrLoginToken,
     req: user_api::VerifyTotpRequest,
 ) -> UserResponse<user_api::TokenResponse> {
     let user_from_db: domain::UserFromStorage = state
@@ -1780,7 +1780,7 @@ pub async fn update_totp(
 
 pub async fn generate_recovery_codes(
     state: AppState,
-    user_token: auth::UserFromSinglePurposeToken,
+    user_token: auth::UserFromSinglePurposeOrLoginToken,
 ) -> UserResponse<user_api::RecoveryCodes> {
     if !tfa_utils::check_totp_in_redis(&state, &user_token.user_id).await? {
         return Err(UserErrors::TotpRequired.into());
@@ -1812,7 +1812,7 @@ pub async fn generate_recovery_codes(
 
 pub async fn verify_recovery_code(
     state: AppState,
-    user_token: auth::UserFromSinglePurposeToken,
+    user_token: auth::UserFromSinglePurposeOrLoginToken,
     req: user_api::VerifyRecoveryCodeRequest,
 ) -> UserResponse<user_api::TokenResponse> {
     let user_from_db: domain::UserFromStorage = state

--- a/crates/router/src/routes/app.rs
+++ b/crates/router/src/routes/app.rs
@@ -1201,7 +1201,7 @@ impl User {
             // The route is utilized to select an invitation from a list of merchants in an intermediate state
             .service(
                 web::resource("/merchants_select/list")
-                    .route(web::get().to(list_merchants_for_user_with_spt)),
+                    .route(web::get().to(list_merchants_for_user)),
             )
             .service(web::resource("/permission_info").route(web::get().to(get_authorization_info)))
             .service(web::resource("/update").route(web::post().to(update_user_account_details)))

--- a/crates/router/src/routes/user.rs
+++ b/crates/router/src/routes/user.rs
@@ -318,24 +318,7 @@ pub async fn list_merchants_for_user(state: web::Data<AppState>, req: HttpReques
         &req,
         (),
         |state, user, _, _| user_core::list_merchants_for_user(state, user),
-        &auth::DashboardNoPermissionAuth,
-        api_locking::LockAction::NotApplicable,
-    ))
-    .await
-}
-
-pub async fn list_merchants_for_user_with_spt(
-    state: web::Data<AppState>,
-    req: HttpRequest,
-) -> HttpResponse {
-    let flow = Flow::UserMerchantAccountList;
-    Box::pin(api::server_wrap(
-        flow,
-        state,
-        &req,
-        (),
-        |state, user, _, _| user_core::list_merchants_for_user(state, user),
-        &auth::SinglePurposeJWTAuth(TokenPurpose::AcceptInvite),
+        &auth::SinglePurposeOrLoginTokenAuth(TokenPurpose::AcceptInvite, None),
         api_locking::LockAction::NotApplicable,
     ))
     .await
@@ -674,7 +657,7 @@ pub async fn totp_verify(
         &req,
         json_payload.into_inner(),
         |state, user, req_body, _| user_core::verify_totp(state, user, req_body),
-        &auth::SinglePurposeJWTAuth(TokenPurpose::TOTP),
+        &auth::SinglePurposeOrLoginTokenAuth(TokenPurpose::TOTP, None),
         api_locking::LockAction::NotApplicable,
     ))
     .await
@@ -692,7 +675,7 @@ pub async fn verify_recovery_code(
         &req,
         json_payload.into_inner(),
         |state, user, req_body, _| user_core::verify_recovery_code(state, user, req_body),
-        &auth::SinglePurposeJWTAuth(TokenPurpose::TOTP),
+        &auth::SinglePurposeOrLoginTokenAuth(TokenPurpose::TOTP, None),
         api_locking::LockAction::NotApplicable,
     ))
     .await
@@ -724,7 +707,7 @@ pub async fn generate_recovery_codes(state: web::Data<AppState>, req: HttpReques
         &req,
         (),
         |state, user, _, _| user_core::generate_recovery_codes(state, user),
-        &auth::SinglePurposeJWTAuth(TokenPurpose::TOTP),
+        &auth::SinglePurposeOrLoginTokenAuth(TokenPurpose::TOTP, None),
         api_locking::LockAction::NotApplicable,
     ))
     .await

--- a/crates/router/src/services/authentication.rs
+++ b/crates/router/src/services/authentication.rs
@@ -387,8 +387,11 @@ where
             return Err(errors::ApiErrorResponse::InvalidJwtToken.into());
         }
 
-        if payload.purpose.as_ref() == Some(&self.0) && payload.permission == self.1 {
-            Ok((
+        match (
+            payload.purpose.as_ref().map(|inner| inner == &self.0),
+            payload.permission == self.1,
+        ) {
+            (Some(true), _) | (None, true) => Ok((
                 UserFromSinglePurposeOrLoginToken {
                     user_id: payload.user_id.clone(),
                 },
@@ -397,9 +400,8 @@ where
                     purpose: payload.purpose,
                     permission: payload.permission,
                 },
-            ))
-        } else {
-            Err(errors::ApiErrorResponse::InvalidJwtToken.into())
+            )),
+            _ => Err(errors::ApiErrorResponse::InvalidJwtToken.into()),
         }
     }
 }

--- a/crates/router/src/services/authentication/blacklist.rs
+++ b/crates/router/src/services/authentication/blacklist.rs
@@ -5,9 +5,9 @@ use common_utils::date_time;
 use error_stack::ResultExt;
 use redis_interface::RedisConnectionPool;
 
-use super::AuthToken;
 #[cfg(feature = "olap")]
 use super::SinglePurposeToken;
+use super::{AuthToken, SinglePurposeOrLoginToken};
 #[cfg(feature = "email")]
 use crate::consts::{EMAIL_TOKEN_BLACKLIST_PREFIX, EMAIL_TOKEN_TIME_IN_SECS};
 use crate::{
@@ -159,6 +159,17 @@ impl BlackList for AuthToken {
 #[cfg(feature = "olap")]
 #[async_trait::async_trait]
 impl BlackList for SinglePurposeToken {
+    async fn check_in_blacklist<A>(&self, state: &A) -> RouterResult<bool>
+    where
+        A: AppStateInfo + Sync,
+    {
+        check_user_in_blacklist(state, &self.user_id, self.exp).await
+    }
+}
+
+#[cfg(feature = "olap")]
+#[async_trait::async_trait]
+impl BlackList for SinglePurposeOrLoginToken {
     async fn check_in_blacklist<A>(&self, state: &A) -> RouterResult<bool>
     where
         A: AppStateInfo + Sync,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
This PR adds new auth type `SinglePurposeOrLoginTokenAuth`, which will allow both SPTs and Login Tokens to be used as auth token for APIs.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
Closes #4829.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
1. Verify TOTP
	```
	curl --location 'http://localhost:8080/user/2fa/totp/verify' \
	--header 'Content-Type: application/json' \
	--header 'Authorization: Bearer SPT with purpose as TOTP' \
	--data '{
	    "totp": "597760"
	}'
	```
	```
	curl --location 'http://localhost:8080/user/2fa/totp/verify' \
	--header 'Content-Type: application/json' \
	--header 'Authorization: Bearer Login Token' \
	--data '{
	    "totp": "597760"
	}'
	```
	
	In both the cases this API should give 200 OK.

2. Verify Recovery Code
	```
	curl --location 'http://localhost:8080/user/2fa/recovery_code/verify' \
	--header 'Content-Type: application/json' \
	--header 'Authorization: Bearer SPT with purpose as TOTP' \
	--data '{
	    "recovery_code": "recovery_code"
	}'
	```
	```
	curl --location 'http://localhost:8080/user/2fa/recovery_code/verify' \
	--header 'Content-Type: application/json' \
	--header 'Authorization: Bearer Login Token' \
	--data '{
	    "recovery_code": "recovery_code"
	}'
	```

	In both the cases this API should give 200 OK.

3. Generate Recovery Codes
	```
	curl --location 'http://localhost:8080/user/2fa/recovery_code/generate' \
	--header 'Authorization: Bearer SPT with purpose as TOTP' \
	```
	```
	curl --location 'http://localhost:8080/user/2fa/recovery_code/generate' \
	--header 'Authorization: Bearer Login Token' \
	```
	In both the cases, API should respond like this
	```
	{
	    "recovery_codes": [
	        "w5fM-NLm0",
	        "TumH-oyXE",
	        "wDIr-zEmu",
	        "HZjm-e16M",
	        "Q4qB-MupL",
	        "5BtN-vRuY",
	        "4vG6-URGf",
	        "Dbq8-n5V1"
	    ]
	}
	```
4. Merchant select List
	```
	curl --location 'http://localhost:8080/user/merchants_select/list' \
	--header 'Authorization: Bearer SPT with Purpose as AcceptInvite'
	```
	```
	curl --location 'http://localhost:8080/user/merchants_select/list' \
	--header 'Authorization: Bearer Login Token'
	```
	In both the cases, API should respond like this
	```
	[
	    {
	        "merchant_id": "merchant_1681110944832",
	        "merchant_name": "sdjkfl",
	        "is_active": true,
	        "role_id": "merchant_admin",
	        "role_name": "admin",
	        "org_id": "org_LoNX0cc4lNZVgJrPV65QY"
	    },
	    {
	        "merchant_id": "merchant_1704717001",
	        "merchant_name": null,
	        "is_active": true,
	        "role_id": "merchant_customer_support",
	        "role_name": "customer_support",
	        "org_id": "org_7yULICVqnwmSX5PgW5zK"
	    }
	]
	```

5. Switch List
	```
	curl --location 'http://localhost:8080/user/switch/list' \
	--header 'Authorization: Bearer SPT with Purpose as AcceptInvite'
	```
	```
	curl --location 'http://localhost:8080/user/switch/list' \
	--header 'Authorization: Bearer Login Token'
	```
	In both the cases, API should respond like this
	```
	[
	    {
	        "merchant_id": "merchant_1681110944832",
	        "merchant_name": "sdjkfl",
	        "is_active": true,
	        "role_id": "merchant_admin",
	        "role_name": "admin",
	        "org_id": "org_LoNX0cc4lNZVgJrPV65QY"
	    },
	    {
	        "merchant_id": "merchant_1704717001",
	        "merchant_name": null,
	        "is_active": true,
	        "role_id": "merchant_customer_support",
	        "role_name": "customer_support",
	        "org_id": "org_7yULICVqnwmSX5PgW5zK"
	    }
	]
	```

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
