### PR TITLE
chore(cypress): remove logs that expose `globalState`

### DIFF
--- a/cypress-tests/cypress/e2e/ConnectorTest/00000-AccountCreate.cy.js
+++ b/cypress-tests/cypress/e2e/ConnectorTest/00000-AccountCreate.cy.js
@@ -9,11 +9,9 @@ describe("Account Create flow test", () => {
 
     cy.task('getGlobalState').then((state) => {
       globalState = new State(state);
-      console.log("seeding globalState -> " + JSON.stringify(globalState));
     })
   })
   after("flush global state", () => {
-    console.log("flushing globalState -> " + JSON.stringify(globalState));
     cy.task('setGlobalState', globalState.data);
   })
 

--- a/cypress-tests/cypress/e2e/ConnectorTest/00001-CustomerCreate.cy.js
+++ b/cypress-tests/cypress/e2e/ConnectorTest/00001-CustomerCreate.cy.js
@@ -9,11 +9,9 @@ describe("Customer Create flow test", () => {
 
         cy.task('getGlobalState').then((state) => {
             globalState = new State(state);
-            console.log("seeding globalState -> " + JSON.stringify(globalState));
         })
     })
     after("flush global state", () => {
-        console.log("flushing globalState -> " + JSON.stringify(globalState));
         cy.task('setGlobalState', globalState.data);
     })
     it("customer-create-call-test", () => {

--- a/cypress-tests/cypress/e2e/ConnectorTest/00002-ConnectorCreate.cy.js
+++ b/cypress-tests/cypress/e2e/ConnectorTest/00002-ConnectorCreate.cy.js
@@ -8,12 +8,10 @@ describe("Connector Account Create flow test", () => {
 
     cy.task('getGlobalState').then((state) => {
       globalState = new State(state);
-      console.log("seeding globalState -> " + JSON.stringify(globalState));
     })
   })
 
   after("flush global state", () => {
-    console.log("flushing globalState -> " + JSON.stringify(globalState));
     cy.task('setGlobalState', globalState.data);
   })
 

--- a/cypress-tests/cypress/e2e/ConnectorTest/00003-NoThreeDSAutoCapture.cy.js
+++ b/cypress-tests/cypress/e2e/ConnectorTest/00003-NoThreeDSAutoCapture.cy.js
@@ -13,12 +13,10 @@ describe("Card - NoThreeDS payment flow test", () => {
 
     cy.task('getGlobalState').then((state) => {
       globalState = new State(state);
-      console.log("seeding globalState -> " + JSON.stringify(globalState));
     })
   })
 
   after("flush global state", () => {
-    console.log("flushing globalState -> " + JSON.stringify(globalState));
     cy.task('setGlobalState', globalState.data);
   })
 
@@ -78,7 +76,5 @@ describe("Card - NoThreeDS payment flow test", () => {
     it("retrieve-payment-call-test", () => {
       cy.retrievePaymentCallTest(globalState);
     });
-
-
   });
 });

--- a/cypress-tests/cypress/e2e/ConnectorTest/00004-ThreeDSAutoCapture.cy.js
+++ b/cypress-tests/cypress/e2e/ConnectorTest/00004-ThreeDSAutoCapture.cy.js
@@ -19,16 +19,12 @@ describe("Card - ThreeDS payment flow test", () => {
 
     cy.task('getGlobalState').then((state) => {
       globalState = new State(state);
-      console.log("seeding globalState -> " + JSON.stringify(globalState));
-      cy.task('cli_log', "SEEDING GLOBAL STATE -> " + JSON.stringify(globalState));
     })
 
   })
 
   afterEach("flush global state", () => {
-    console.log("flushing globalState -> " + JSON.stringify(globalState));
     cy.task('setGlobalState', globalState.data);
-    cy.task('cli_log', " FLUSHING GLOBAL STATE -> " + JSON.stringify(globalState));
   })
 
 
@@ -41,7 +37,6 @@ describe("Card - ThreeDS payment flow test", () => {
   });
 
   it("payment_methods-call-test", () => {
-    cy.task('cli_log', "PM CALL ");
     cy.paymentMethodsCallTest(globalState);
   });
 
@@ -49,7 +44,6 @@ describe("Card - ThreeDS payment flow test", () => {
     let data = getConnectorDetails(globalState.get("connectorId"))["card_pm"]["3DSAutoCapture"];
     let req_data = data["Request"];
     let res_data = data["Response"];
-    cy.task('cli_log', "GLOBAL STATE -> " + JSON.stringify(globalState.data));
     cy.confirmCallTest(confirmBody, req_data, res_data, true, globalState);
     if(should_continue) should_continue = utils.should_continue_further(res_data);
   });

--- a/cypress-tests/cypress/e2e/ConnectorTest/00005-NoThreeDSManualCapture.cy.js
+++ b/cypress-tests/cypress/e2e/ConnectorTest/00005-NoThreeDSManualCapture.cy.js
@@ -14,12 +14,10 @@ describe("Card - NoThreeDS Manual payment flow test", () => {
 
         cy.task('getGlobalState').then((state) => {
             globalState = new State(state);
-            console.log("seeding globalState -> " + JSON.stringify(globalState));
         })
     })
 
     after("flush global state", () => {
-        console.log("flushing globalState -> " + JSON.stringify(globalState));
         cy.task('setGlobalState', globalState.data);
     })
 

--- a/cypress-tests/cypress/e2e/ConnectorTest/00006-VoidPayment.cy.js
+++ b/cypress-tests/cypress/e2e/ConnectorTest/00006-VoidPayment.cy.js
@@ -13,12 +13,10 @@ describe("Card - NoThreeDS Manual payment flow test", () => {
 
         cy.task('getGlobalState').then((state) => {
             globalState = new State(state);
-            console.log("seeding globalState -> " + JSON.stringify(globalState));
         })
     })
 
     after("flush global state", () => {
-        console.log("flushing globalState -> " + JSON.stringify(globalState));
         cy.task('setGlobalState', globalState.data);
     })
 

--- a/cypress-tests/cypress/e2e/ConnectorTest/00007-SyncPayment.cy.js
+++ b/cypress-tests/cypress/e2e/ConnectorTest/00007-SyncPayment.cy.js
@@ -19,12 +19,10 @@ describe("Card - Sync payment flow test", () => {
 
     cy.task('getGlobalState').then((state) => {
       globalState = new State(state);
-      console.log("seeding globalState -> " + JSON.stringify(globalState));
     })
   })
 
   after("flush global state", () => {
-    console.log("flushing globalState -> " + JSON.stringify(globalState));
     cy.task('setGlobalState', globalState.data);
   })
   it("create-payment-call-test", () => {

--- a/cypress-tests/cypress/e2e/ConnectorTest/00008-RefundPayment.cy.js
+++ b/cypress-tests/cypress/e2e/ConnectorTest/00008-RefundPayment.cy.js
@@ -18,13 +18,11 @@ describe("Card - Refund flow test", () => {
 
         cy.task('getGlobalState').then((state) => {
           globalState = new State(state);
-          console.log("seeding globalState -> " + JSON.stringify(globalState));
         })
     
       })
     
       afterEach("flush global state", () => {
-        console.log("flushing globalState -> " + JSON.stringify(globalState));
         cy.task('setGlobalState', globalState.data);
     })
 
@@ -534,13 +532,11 @@ describe("Card - Refund flow test", () => {
       
           cy.task('getGlobalState').then((state) => {
             globalState = new State(state);
-            console.log("seeding globalState -> " + JSON.stringify(globalState));
           })
       
         })
       
         afterEach("flush global state", () => {
-          console.log("flushing globalState -> " + JSON.stringify(globalState));
           cy.task('setGlobalState', globalState.data);
         })
 

--- a/cypress-tests/cypress/e2e/ConnectorTest/00009-SyncRefund.cy.js
+++ b/cypress-tests/cypress/e2e/ConnectorTest/00009-SyncRefund.cy.js
@@ -20,12 +20,10 @@ describe("Card - Sync Refund flow test", () => {
 
         cy.task('getGlobalState').then((state) => {
             globalState = new State(state);
-            console.log("seeding globalState -> " + JSON.stringify(globalState));
         })
     })
 
     after("flush global state", () => {
-        console.log("flushing globalState -> " + JSON.stringify(globalState));
         cy.task('setGlobalState', globalState.data);
     })
 

--- a/cypress-tests/cypress/e2e/ConnectorTest/00010-CreateSingleuseMandate.cy.js
+++ b/cypress-tests/cypress/e2e/ConnectorTest/00010-CreateSingleuseMandate.cy.js
@@ -13,12 +13,10 @@ describe("Card - SingleUse Mandates flow test", () => {
 
         cy.task('getGlobalState').then((state) => {
             globalState = new State(state);
-            console.log("seeding globalState -> " + JSON.stringify(globalState));
         })
     })
 
     after("flush global state", () => {
-        console.log("flushing globalState -> " + JSON.stringify(globalState));
         cy.task('setGlobalState', globalState.data);
     })
 

--- a/cypress-tests/cypress/e2e/ConnectorTest/00011-CreateMultiuseMandate.cy.js
+++ b/cypress-tests/cypress/e2e/ConnectorTest/00011-CreateMultiuseMandate.cy.js
@@ -13,12 +13,10 @@ describe("Card - MultiUse Mandates flow test", () => {
 
         cy.task('getGlobalState').then((state) => {
             globalState = new State(state);
-            console.log("seeding globalState -> " + JSON.stringify(globalState));
         })
     })
 
     after("flush global state", () => {
-        console.log("flushing globalState -> " + JSON.stringify(globalState));
         cy.task('setGlobalState', globalState.data);
     })
 

--- a/cypress-tests/cypress/e2e/ConnectorTest/00012-ListAndRevokeMandate.cy.js
+++ b/cypress-tests/cypress/e2e/ConnectorTest/00012-ListAndRevokeMandate.cy.js
@@ -13,12 +13,10 @@ describe("Card - SingleUse Mandates flow test", () => {
 
         cy.task('getGlobalState').then((state) => {
             globalState = new State(state);
-            console.log("seeding globalState -> " + JSON.stringify(globalState));
         })
     })
 
     after("flush global state", () => {
-        console.log("flushing globalState -> " + JSON.stringify(globalState));
         cy.task('setGlobalState', globalState.data);
     })
 

--- a/cypress-tests/cypress/e2e/ConnectorTest/00013-SaveCardFlow.cy.js
+++ b/cypress-tests/cypress/e2e/ConnectorTest/00013-SaveCardFlow.cy.js
@@ -15,7 +15,6 @@ describe("Card - SaveCard payment flow test", () => {
 
     cy.task('getGlobalState').then((state) => {
       globalState = new State(state);
-      console.log("seeding globalState -> " + JSON.stringify(globalState));
     })
   })
 

--- a/cypress-tests/cypress/e2e/ConnectorTest/00014-ZeroAuthMandate.cy.js
+++ b/cypress-tests/cypress/e2e/ConnectorTest/00014-ZeroAuthMandate.cy.js
@@ -12,12 +12,10 @@ describe("Card - SingleUse Mandates flow test", () => {
 
         cy.task('getGlobalState').then((state) => {
             globalState = new State(state);
-            console.log("seeding globalState -> " + JSON.stringify(globalState));
         })
     })
 
     after("flush global state", () => {
-        console.log("flushing globalState -> " + JSON.stringify(globalState));
         cy.task('setGlobalState', globalState.data);
     })
 

--- a/cypress-tests/cypress/e2e/ConnectorTest/00015-ThreeDSManualCapture.cy.js
+++ b/cypress-tests/cypress/e2e/ConnectorTest/00015-ThreeDSManualCapture.cy.js
@@ -15,13 +15,11 @@ describe("Card - ThreeDS Manual payment flow test", () => {
   
       cy.task('getGlobalState').then((state) => {
         globalState = new State(state);
-        console.log("seeding globalState -> " + JSON.stringify(globalState));
       })
   
     })
 
     afterEach("flush global state", () => {
-      console.log("flushing globalState -> " + JSON.stringify(globalState));
       cy.task('setGlobalState', globalState.data);
     })
 

--- a/cypress-tests/cypress/e2e/ConnectorTest/00016-BankTransfers.cy.js
+++ b/cypress-tests/cypress/e2e/ConnectorTest/00016-BankTransfers.cy.js
@@ -9,12 +9,10 @@ describe("Bank Transfers", () => {
   before("seed global state", () => {
     cy.task("getGlobalState").then((state) => {
       globalState = new State(state);
-      console.log("seeding globalState -> " + JSON.stringify(globalState));
     });
   });
 
   after("flush global state", () => {
-    console.log("flushing globalState -> " + JSON.stringify(globalState));
     cy.task("setGlobalState", globalState.data);
   });
 
@@ -46,7 +44,6 @@ describe("Bank Transfers", () => {
     });
 
     it("payment_methods-call-test", () => {
-      cy.task("cli_log", "PM CALL ");
       cy.paymentMethodsCallTest(globalState);
     });
 
@@ -56,7 +53,6 @@ describe("Bank Transfers", () => {
       ]["Pix"];
       let req_data = data["Request"];
       let res_data = data["Response"];
-      cy.task("cli_log", "GLOBAL STATE -> " + JSON.stringify(globalState.data));
       cy.confirmBankTransferCallTest(
         confirmBody,
         req_data,

--- a/cypress-tests/cypress/e2e/ConnectorTest/00017-BankRedirect.cy.js
+++ b/cypress-tests/cypress/e2e/ConnectorTest/00017-BankRedirect.cy.js
@@ -9,22 +9,15 @@ describe("Bank Redirect tests", () => {
   before("seed global state", () => {
     cy.task("getGlobalState").then((state) => {
       globalState = new State(state);
-      console.log("seeding globalState -> " + JSON.stringify(globalState));
     });
   });
 
   after("flush global state", () => {
-    console.log("flushing globalState -> " + JSON.stringify(globalState));
     cy.task("setGlobalState", globalState.data);
   });
 
   afterEach("flush global state", () => {
-    console.log("flushing globalState -> " + JSON.stringify(globalState));
     cy.task("setGlobalState", globalState.data);
-    cy.task(
-      "cli_log",
-      " FLUSHING GLOBAL STATE -> " + JSON.stringify(globalState)
-    );
   });
 
   context("Blik Create and Confirm flow test", () => {
@@ -55,7 +48,6 @@ describe("Bank Redirect tests", () => {
     });
 
     it("payment_methods-call-test", () => {
-      cy.task("cli_log", "PM CALL ");
       cy.paymentMethodsCallTest(globalState);
     });
 
@@ -65,7 +57,6 @@ describe("Bank Redirect tests", () => {
       ]["blik"];
       let req_data = data["Request"];
       let res_data = data["Response"];
-      cy.task("cli_log", "GLOBAL STATE -> " + JSON.stringify(globalState.data));
       cy.confirmBankRedirectCallTest(
         confirmBody,
         req_data,
@@ -105,7 +96,6 @@ describe("Bank Redirect tests", () => {
     });
 
     it("payment_methods-call-test", () => {
-      cy.task("cli_log", "PM CALL ");
       cy.paymentMethodsCallTest(globalState);
     });
 
@@ -115,7 +105,6 @@ describe("Bank Redirect tests", () => {
       ]["eps"];
       let req_data = data["Request"];
       let res_data = data["Response"];
-      cy.task("cli_log", "GLOBAL STATE -> " + JSON.stringify(globalState.data));
       cy.confirmBankRedirectCallTest(
         confirmBody,
         req_data,
@@ -167,7 +156,6 @@ describe("Bank Redirect tests", () => {
     });
 
     it("payment_methods-call-test", () => {
-      cy.task("cli_log", "PM CALL ");
       cy.paymentMethodsCallTest(globalState);
     });
 
@@ -177,7 +165,6 @@ describe("Bank Redirect tests", () => {
       ]["ideal"];
       let req_data = data["Request"];
       let res_data = data["Response"];
-      cy.task("cli_log", "GLOBAL STATE -> " + JSON.stringify(globalState.data));
       cy.confirmBankRedirectCallTest(
         confirmBody,
         req_data,
@@ -228,7 +215,6 @@ describe("Bank Redirect tests", () => {
     });
 
     it("payment_methods-call-test", () => {
-      cy.task("cli_log", "PM CALL ");
       cy.paymentMethodsCallTest(globalState);
     });
 
@@ -238,7 +224,6 @@ describe("Bank Redirect tests", () => {
       ]["giropay"];
       let req_data = data["Request"];
       let res_data = data["Response"];
-      cy.task("cli_log", "GLOBAL STATE -> " + JSON.stringify(globalState.data));
       cy.confirmBankRedirectCallTest(
         confirmBody,
         req_data,
@@ -289,7 +274,6 @@ describe("Bank Redirect tests", () => {
     });
 
     it("payment_methods-call-test", () => {
-      cy.task("cli_log", "PM CALL ");
       cy.paymentMethodsCallTest(globalState);
     });
 
@@ -299,7 +283,6 @@ describe("Bank Redirect tests", () => {
       ]["sofort"];
       let req_data = data["Request"];
       let res_data = data["Response"];
-      cy.task("cli_log", "GLOBAL STATE -> " + JSON.stringify(globalState.data));
       cy.confirmBankRedirectCallTest(
         confirmBody,
         req_data,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [x] CI/CD

## Description
<!-- Describe your changes in detail -->

This PR removes all the `console.log()`, `cy.task()` that exposes the `globalState`

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->

NIL


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->

To avoid possible exposure of admin api keys and other sensitive info.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

print statements should not affect flow of a test. it should just work as before.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
