### PR TITLE
refactor(connector): move AuthorizeSessionToken flow to core from execute_pretasks for nuvei and sqaure

### DIFF
--- a/crates/router/src/connector/nuvei.rs
+++ b/crates/router/src/connector/nuvei.rs
@@ -24,7 +24,7 @@ use crate::{
     services::{self, request, ConnectorIntegration, ConnectorValidation},
     types::{
         self,
-        api::{self, ConnectorCommon, ConnectorCommonExt, InitPayment},
+        api::{self, ConnectorCommon, ConnectorCommonExt},
         storage::enums,
         transformers::ForeignFrom,
         ErrorResponse, Response,
@@ -118,6 +118,7 @@ impl api::PaymentSync for Nuvei {}
 impl api::PaymentCapture for Nuvei {}
 impl api::PaymentSession for Nuvei {}
 impl api::PaymentAuthorize for Nuvei {}
+impl api::PaymentAuthorizeSessionToken for Nuvei {}
 impl api::Refund for Nuvei {}
 impl api::RefundExecute for Nuvei {}
 impl api::RefundSync for Nuvei {}
@@ -528,28 +529,6 @@ impl ConnectorIntegration<api::Authorize, types::PaymentsAuthorizeData, types::P
         router_data: &mut types::PaymentsAuthorizeRouterData,
         app_state: &crate::routes::AppState,
     ) -> CustomResult<(), errors::ConnectorError> {
-        let integ: Box<
-            &(dyn ConnectorIntegration<
-                api::AuthorizeSessionToken,
-                types::AuthorizeSessionTokenData,
-                types::PaymentsResponseData,
-            > + Send
-                  + Sync
-                  + 'static),
-        > = Box::new(&Self);
-        let authorize_data = &types::PaymentsAuthorizeSessionTokenRouterData::foreign_from((
-            &router_data.to_owned(),
-            types::AuthorizeSessionTokenData::foreign_from(&router_data),
-        ));
-        let resp = services::execute_connector_processing_step(
-            app_state,
-            integ,
-            authorize_data,
-            payments::CallConnectorAction::Trigger,
-            None,
-        )
-        .await?;
-        router_data.session_token = resp.session_token;
         let (enrolled_for_3ds, related_transaction_id) =
             match (router_data.auth_type, router_data.payment_method) {
                 (
@@ -558,7 +537,7 @@ impl ConnectorIntegration<api::Authorize, types::PaymentsAuthorizeData, types::P
                 ) => {
                     let integ: Box<
                         &(dyn ConnectorIntegration<
-                            InitPayment,
+                            api::InitPayment,
                             types::PaymentsAuthorizeData,
                             types::PaymentsResponseData,
                         > + Send
@@ -744,8 +723,12 @@ impl
     }
 }
 
-impl ConnectorIntegration<InitPayment, types::PaymentsAuthorizeData, types::PaymentsResponseData>
-    for Nuvei
+impl
+    ConnectorIntegration<
+        api::InitPayment,
+        types::PaymentsAuthorizeData,
+        types::PaymentsResponseData,
+    > for Nuvei
 {
     fn get_headers(
         &self,

--- a/crates/router/src/connector/square.rs
+++ b/crates/router/src/connector/square.rs
@@ -13,10 +13,7 @@ use super::utils::{self as super_utils, RefundsRequestData};
 use crate::{
     configs::settings,
     consts,
-    core::{
-        errors::{self, CustomResult},
-        payments,
-    },
+    core::errors::{self, CustomResult},
     events::connector_api_logs::ConnectorEvent,
     headers,
     services::{
@@ -27,7 +24,6 @@ use crate::{
     types::{
         self,
         api::{self, ConnectorCommon, ConnectorCommonExt},
-        transformers::ForeignFrom,
         ErrorResponse, Response,
     },
     utils::BytesExt,
@@ -41,6 +37,7 @@ impl api::PaymentSession for Square {}
 impl api::ConnectorAccessToken for Square {}
 impl api::MandateSetup for Square {}
 impl api::PaymentAuthorize for Square {}
+impl api::PaymentAuthorizeSessionToken for Square {}
 impl api::PaymentSync for Square {}
 impl api::PaymentCapture for Square {}
 impl api::PaymentVoid for Square {}
@@ -193,46 +190,6 @@ impl
         types::PaymentsResponseData,
     > for Square
 {
-    async fn execute_pretasks(
-        &self,
-        router_data: &mut types::TokenizationRouterData,
-        app_state: &crate::routes::AppState,
-    ) -> CustomResult<(), errors::ConnectorError> {
-        let integ: Box<
-            &(dyn ConnectorIntegration<
-                api::AuthorizeSessionToken,
-                types::AuthorizeSessionTokenData,
-                types::PaymentsResponseData,
-            > + Send
-                  + Sync
-                  + 'static),
-        > = Box::new(&Self);
-
-        let authorize_session_token_data = types::AuthorizeSessionTokenData {
-            connector_transaction_id: router_data.payment_id.clone(),
-            amount_to_capture: None,
-            currency: router_data.request.currency,
-            amount: router_data.request.amount,
-        };
-
-        let authorize_data = &types::PaymentsAuthorizeSessionTokenRouterData::foreign_from((
-            &router_data.to_owned(),
-            authorize_session_token_data,
-        ));
-
-        let resp = services::execute_connector_processing_step(
-            app_state,
-            integ,
-            authorize_data,
-            payments::CallConnectorAction::Trigger,
-            None,
-        )
-        .await?;
-
-        router_data.session_token = resp.session_token;
-        Ok(())
-    }
-
     fn get_headers(
         &self,
         _req: &types::TokenizationRouterData,

--- a/crates/router/src/core/payments.rs
+++ b/crates/router/src/core/payments.rs
@@ -1467,6 +1467,8 @@ where
         .add_access_token(state, &connector, merchant_account)
         .await?;
 
+    router_data = router_data.add_session_token(state, &connector).await?;
+
     let mut should_continue_further = access_token::update_router_data_with_access_token_result(
         &add_access_token_result,
         &mut router_data,

--- a/crates/router/src/core/payments/flows.rs
+++ b/crates/router/src/core/payments/flows.rs
@@ -64,6 +64,19 @@ pub trait Feature<F, T> {
         Self: Sized,
         dyn api::Connector: services::ConnectorIntegration<F, T, types::PaymentsResponseData>;
 
+    async fn add_session_token<'a>(
+        self,
+        _state: &AppState,
+        _connector: &api::ConnectorData,
+    ) -> RouterResult<Self>
+    where
+        F: Clone,
+        Self: Sized,
+        dyn api::Connector: services::ConnectorIntegration<F, T, types::PaymentsResponseData>,
+    {
+        Ok(self)
+    }
+
     async fn add_payment_method_token<'a>(
         &mut self,
         _state: &AppState,
@@ -2697,6 +2710,92 @@ default_imp_for_connector_authentication!(
     connector::Stax,
     connector::Stripe,
     connector::Shift4,
+    connector::Trustpay,
+    connector::Tsys,
+    connector::Volt,
+    connector::Wise,
+    connector::Worldline,
+    connector::Worldpay,
+    connector::Zen,
+    connector::Zsl
+);
+
+macro_rules! default_imp_for_authorize_session_token {
+    ($($path:ident::$connector:ident),*) => {
+        $( impl api::PaymentAuthorizeSessionToken for $path::$connector {}
+            impl
+            services::ConnectorIntegration<
+                api::AuthorizeSessionToken,
+                types::AuthorizeSessionTokenData,
+                types::PaymentsResponseData
+        > for $path::$connector
+        {}
+    )*
+    };
+}
+#[cfg(feature = "dummy_connector")]
+impl<const T: u8> api::PaymentAuthorizeSessionToken for connector::DummyConnector<T> {}
+#[cfg(feature = "dummy_connector")]
+impl<const T: u8>
+    services::ConnectorIntegration<
+        api::AuthorizeSessionToken,
+        types::AuthorizeSessionTokenData,
+        types::PaymentsResponseData,
+    > for connector::DummyConnector<T>
+{
+}
+default_imp_for_authorize_session_token!(
+    connector::Aci,
+    connector::Adyen,
+    connector::Airwallex,
+    connector::Authorizedotnet,
+    connector::Bambora,
+    connector::Bankofamerica,
+    connector::Billwerk,
+    connector::Bitpay,
+    connector::Bluesnap,
+    connector::Boku,
+    connector::Braintree,
+    connector::Cashtocode,
+    connector::Checkout,
+    connector::Cryptopay,
+    connector::Coinbase,
+    connector::Cybersource,
+    connector::Dlocal,
+    connector::Ebanx,
+    connector::Fiserv,
+    connector::Forte,
+    connector::Globalpay,
+    connector::Globepay,
+    connector::Gocardless,
+    connector::Gpayments,
+    connector::Helcim,
+    connector::Iatapay,
+    connector::Klarna,
+    connector::Mifinity,
+    connector::Mollie,
+    connector::Multisafepay,
+    connector::Netcetera,
+    connector::Nexinets,
+    connector::Nmi,
+    connector::Noon,
+    connector::Opayo,
+    connector::Opennode,
+    connector::Payeezy,
+    connector::Payme,
+    connector::Payone,
+    connector::Paypal,
+    connector::Payu,
+    connector::Placetopay,
+    connector::Powertranz,
+    connector::Prophetpay,
+    connector::Rapyd,
+    connector::Riskified,
+    connector::Signifyd,
+    connector::Stax,
+    connector::Stripe,
+    connector::Shift4,
+    connector::Threedsecureio,
     connector::Trustpay,
     connector::Tsys,
     connector::Volt,

--- a/crates/router/src/core/payments/flows/authorize_flow.rs
+++ b/crates/router/src/core/payments/flows/authorize_flow.rs
@@ -13,7 +13,7 @@ use crate::{
     logger,
     routes::{metrics, AppState},
     services,
-    types::{self, api, domain, storage},
+    types::{self, api, domain, storage, transformers::ForeignFrom},
 };
 
 #[async_trait]
@@ -98,6 +98,38 @@ impl Feature<api::Authorize, types::PaymentsAuthorizeData> for types::PaymentsAu
         merchant_account: &domain::MerchantAccount,
     ) -> RouterResult<types::AddAccessTokenResult> {
         access_token::add_access_token(state, connector, merchant_account, self).await
+    }
+
+    async fn add_session_token<'a>(
+        self,
+        state: &AppState,
+        connector: &api::ConnectorData,
+    ) -> RouterResult<Self>
+    where
+        Self: Sized,
+    {
+        let connector_integration: services::BoxedConnectorIntegration<
+            '_,
+            api::AuthorizeSessionToken,
+            types::AuthorizeSessionTokenData,
+            types::PaymentsResponseData,
+        > = connector.connector.get_connector_integration();
+        let authorize_data = &types::PaymentsAuthorizeSessionTokenRouterData::foreign_from((
+            &self,
+            types::AuthorizeSessionTokenData::foreign_from(&self),
+        ));
+        let resp = services::execute_connector_processing_step(
+            state,
+            connector_integration,
+            authorize_data,
+            payments::CallConnectorAction::Trigger,
+            None,
+        )
+        .await
+        .to_payment_failed_response()?;
+        let mut router_data = self;
+        router_data.session_token = resp.session_token;
+        Ok(router_data)
     }
 
     async fn add_payment_method_token<'a>(

--- a/crates/router/src/types.rs
+++ b/crates/router/src/types.rs
@@ -717,8 +717,8 @@ impl ForeignTryFrom<ConnectorAuthType> for AccessTokenRequestData {
     }
 }
 
-impl ForeignFrom<&&mut PaymentsAuthorizeRouterData> for AuthorizeSessionTokenData {
-    fn foreign_from(data: &&mut PaymentsAuthorizeRouterData) -> Self {
+impl ForeignFrom<&PaymentsAuthorizeRouterData> for AuthorizeSessionTokenData {
+    fn foreign_from(data: &PaymentsAuthorizeRouterData) -> Self {
         Self {
             amount_to_capture: data.amount_captured,
             currency: data.request.currency,

--- a/crates/router/src/types/api/payments.rs
+++ b/crates/router/src/types/api/payments.rs
@@ -77,6 +77,15 @@ pub trait PaymentAuthorize:
 {
 }
 
+pub trait PaymentAuthorizeSessionToken:
+    api::ConnectorIntegration<
+    AuthorizeSessionToken,
+    types::AuthorizeSessionTokenData,
+    types::PaymentsResponseData,
+>
+{
+}
+
 pub trait PaymentSync:
     api::ConnectorIntegration<PSync, types::PaymentsSyncData, types::PaymentsResponseData>
 {
@@ -161,6 +170,7 @@ pub trait Payment:
     api_types::ConnectorCommon
     + api_types::ConnectorValidation
     + PaymentAuthorize
+    + PaymentAuthorizeSessionToken
     + PaymentsCompleteAuthorize
     + PaymentSync
     + PaymentCapture


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
`AuthorizeSessionToken` flow was being called from `fn execute_pretasks()` of ConnectorIntegration<Authorize> for Nuvei and Sqaure connectors. Move this logic to core.


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->



## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Manual.
Ran the nuvei postman collection.

sanity of sqaure cannot be tested at this point since, it has an outdated integration.

<img width="1728" alt="Screenshot 2024-06-03 at 5 19 30 PM" src="https://github.com/juspay/hyperswitch/assets/61539176/f5fe9eed-bc59-4d0a-b59d-2cee0f3618ba">


<img width="1728" alt="image" src="https://github.com/juspay/hyperswitch/assets/61539176/3b7b66de-97a4-4766-a94c-bebd1caf4367">



## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
