### PR TITLE
Refactor(connector): added amount conversion framework for cryptopay

### DIFF
--- a/crates/common_utils/src/types.rs
+++ b/crates/common_utils/src/types.rs
@@ -565,6 +565,11 @@ impl StringMajorUnit {
             .ok_or(ParsingError::DecimalToI64ConversionFailure)?;
         Ok(MinorUnit::new(amount_i64))
     }
+
+    /// Get string amount from struct to be removed in future
+    pub fn get_amount_as_string(&self) -> String {
+        self.0.clone()
+    }
 }
 
 #[cfg(test)]

--- a/crates/router/src/connector/cryptopay.rs
+++ b/crates/router/src/connector/cryptopay.rs
@@ -1,13 +1,12 @@
 pub mod transformers;
 
-use std::fmt::Debug;
-
 use base64::Engine;
 use common_utils::{
     crypto::{self, GenerateDigest, SignMessage},
     date_time,
     ext_traits::ByteSliceExt,
     request::RequestContent,
+    types::{AmountConvertor, StringMajorUnit, StringMajorUnitForConnector},
 };
 use error_stack::ResultExt;
 use hex::encode;
@@ -36,8 +35,18 @@ use crate::{
     utils::BytesExt,
 };
 
-#[derive(Debug, Clone)]
-pub struct Cryptopay;
+#[derive(Clone)]
+pub struct Cryptopay {
+    amount_converter: &'static (dyn AmountConvertor<Output = StringMajorUnit> + Sync),
+}
+
+impl Cryptopay {
+    pub fn new() -> &'static Self {
+        &Self {
+            amount_converter: &StringMajorUnitForConnector,
+        }
+    }
+}
 
 impl api::Payment for Cryptopay {}
 impl api::PaymentSession for Cryptopay {}
@@ -123,7 +132,7 @@ where
             (headers::DATE.to_string(), date.into()),
             (
                 headers::CONTENT_TYPE.to_string(),
-                Self.get_content_type().to_string().into(),
+                self.get_content_type().to_string().into(),
             ),
         ];
         Ok(headers)
@@ -244,12 +253,12 @@ impl ConnectorIntegration<api::Authorize, types::PaymentsAuthorizeData, types::P
         req: &types::PaymentsAuthorizeRouterData,
         _connectors: &settings::Connectors,
     ) -> CustomResult<RequestContent, errors::ConnectorError> {
-        let connector_router_data = cryptopay::CryptopayRouterData::try_from((
-            &self.get_currency_unit(),
+        let amount = utils::convert_amount(
+            self.amount_converter,
+            req.request.minor_amount,
             req.request.currency,
-            req.request.amount,
-            req,
-        ))?;
+        )?;
+        let connector_router_data = cryptopay::CryptopayRouterData::try_from((amount, req))?;
         let connector_req = cryptopay::CryptopayPaymentsRequest::try_from(&connector_router_data)?;
         Ok(RequestContent::Json(Box::new(connector_req)))
     }
@@ -288,6 +297,14 @@ impl ConnectorIntegration<api::Authorize, types::PaymentsAuthorizeData, types::P
             .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
         event_builder.map(|i| i.set_response_body(&response));
         router_env::logger::info!(connector_response=?response);
+        let capture_amount_core = match response.data.price_amount {
+            Some(ref amount) => Some(utils::convert_back(
+                self.amount_converter,
+                amount.clone(),
+                data.request.currency,
+            )?),
+            None => None,
+        };
         types::RouterData::foreign_try_from((
             types::ResponseRouterData {
                 response,
@@ -295,6 +312,7 @@ impl ConnectorIntegration<api::Authorize, types::PaymentsAuthorizeData, types::P
                 http_code: res.status_code,
             },
             data.request.currency,
+            capture_amount_core,
         ))
     }
 
@@ -375,6 +393,14 @@ impl ConnectorIntegration<api::PSync, types::PaymentsSyncData, types::PaymentsRe
             .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
         event_builder.map(|i| i.set_response_body(&response));
         router_env::logger::info!(connector_response=?response);
+        let capture_amount_core = match response.data.price_amount {
+            Some(ref amount) => Some(utils::convert_back(
+                self.amount_converter,
+                amount.clone(),
+                data.request.currency,
+            )?),
+            None => None,
+        };
         types::RouterData::foreign_try_from((
             types::ResponseRouterData {
                 response,
@@ -382,6 +408,7 @@ impl ConnectorIntegration<api::PSync, types::PaymentsSyncData, types::PaymentsRe
                 http_code: res.status_code,
             },
             data.request.currency,
+            capture_amount_core,
         ))
     }
 

--- a/crates/router/src/types/api.rs
+++ b/crates/router/src/types/api.rs
@@ -328,7 +328,7 @@ impl ConnectorData {
                 enums::Connector::Cashtocode => Ok(Box::new(&connector::Cashtocode)),
                 enums::Connector::Checkout => Ok(Box::new(&connector::Checkout)),
                 enums::Connector::Coinbase => Ok(Box::new(&connector::Coinbase)),
-                enums::Connector::Cryptopay => Ok(Box::new(&connector::Cryptopay)),
+                enums::Connector::Cryptopay => Ok(Box::new(connector::Cryptopay::new())),
                 enums::Connector::Cybersource => Ok(Box::new(&connector::Cybersource)),
                 enums::Connector::Dlocal => Ok(Box::new(&connector::Dlocal)),
                 #[cfg(feature = "dummy_connector")]

--- a/crates/router/tests/connectors/cryptopay.rs
+++ b/crates/router/tests/connectors/cryptopay.rs
@@ -13,7 +13,7 @@ impl utils::Connector for CryptopayTest {
     fn get_data(&self) -> api::ConnectorData {
         use router::connector::Cryptopay;
         api::ConnectorData {
-            connector: Box::new(&Cryptopay),
+            connector: Box::new(Cryptopay::new()),
             connector_name: types::Connector::Cryptopay,
             get_token: api::GetToken::Connector,
             merchant_connector_id: None,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->
- [x] Refactoring


## Description
<!-- Describe your changes in detail -->
This Pr adds amount conversion framework to crptopay 

Note: Cryptopay uses String Major Unit

![Screenshot 2024-06-05 at 5 20 05 PM](https://github.com/juspay/hyperswitch/assets/26082680/9fe6a500-bfee-4af3-b080-7ca6b768af83)


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

Flows that needs to be tested

- Authorise 
- Payment Sync

### Authorise

```shell
curl --location 'http://localhost:8080/payments' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: dev_kSZpEJsK5Y8tOzCag256wb9v8esC0q3pEbEwRn0ZLTIF8RZVkTTCYr2NzLvC9fjS' \
--data-raw '{
    "amount": 65401,
    "currency": "USD",
    "confirm": true,
    "client_secret": "pay_CXM6qvgHR2mOA0pkjBxe_secret_wjGpNK93pVOhpNEnghcT",
    "payment_method": "crypto",
    "payment_method_type": "crypto_currency",
    "payment_experience": "redirect_to_url",
    "payment_method_data": {
        "crypto": {
            "pay_currency": "BTC"
        }
    },
    "browser_info": {
        "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.1.2 Safari/605.1.15",
        "accept_header": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8",
        "language": "en-US",
        "color_depth": 24,
        "screen_height": 1117,
        "screen_width": 1728,
        "time_zone": -330,
        "java_enabled": true,
        "java_script_enabled": true
    },
    "payment_type": "normal",
    "customer_id": "StripeCustomer1232345",
    "email": "guest@example.com",
    "name": "John Doe",
    "phone": "999999999",
    "phone_country_code": "+1",
    "description": "Its my first payment request",
    "authentication_type": "three_ds",
    "return_url": "https://google.com",
    "billing": {
        "address": {
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "city": "San Fransico",
            "state": "California",
            "zip": "94122",
            "country": "US",
            "first_name": "sundari"
        },
        "phone": {
            "number": "1233456789",
            "country_code": "+1"
        }
    },
    "shipping": {
        "address": {
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "city": "San Fransico",
            "state": "California",
            "zip": "94122",
            "country": "US",
            "first_name": "sundari"
        },
        "phone": {
            "number": "1233456789",
            "country_code": "+1"
        }
    } 
}
'
```
<img width="1725" alt="Screenshot 2024-06-06 at 3 06 28 PM" src="https://github.com/juspay/hyperswitch/assets/26082680/a71be73c-40a1-4f23-ac2d-6bd5432c729a">



## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
