### PR TITLE
refactor(connector): [Adyen] handle redirection error response

### DIFF
--- a/crates/router/src/connector/adyen/transformers.rs
+++ b/crates/router/src/connector/adyen/transformers.rs
@@ -3570,7 +3570,7 @@ pub fn get_redirection_error_response(
         message: response
             .refusal_reason
             .clone()
-            .unwrap_or_else(|| consts::NO_ERROR_CODE.to_string()),
+            .unwrap_or_else(|| consts::NO_ERROR_MESSAGE.to_string()),
         reason: response.refusal_reason,
         status_code,
         attempt_status: None,

--- a/crates/router/src/connector/adyen/transformers.rs
+++ b/crates/router/src/connector/adyen/transformers.rs
@@ -394,8 +394,9 @@ pub struct AdyenWebhookResponse {
 #[serde(rename_all = "camelCase")]
 pub struct RedirectionErrorResponse {
     result_code: AdyenStatus,
-    refusal_reason: String,
+    refusal_reason: Option<String>,
     psp_reference: Option<String>,
+    merchant_reference: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -3566,8 +3567,11 @@ pub fn get_redirection_error_response(
         storage_enums::AttemptStatus::foreign_from((is_manual_capture, response.result_code, pmt));
     let error = Some(types::ErrorResponse {
         code: status.to_string(),
-        message: response.refusal_reason.clone(),
-        reason: Some(response.refusal_reason),
+        message: response
+            .refusal_reason
+            .clone()
+            .unwrap_or_else(|| consts::NO_ERROR_CODE.to_string()),
+        reason: response.refusal_reason,
         status_code,
         attempt_status: None,
         connector_transaction_id: response.psp_reference.clone(),
@@ -3579,7 +3583,10 @@ pub fn get_redirection_error_response(
         mandate_reference: None,
         connector_metadata: None,
         network_txn_id: None,
-        connector_response_reference_id: None,
+        connector_response_reference_id: response
+            .merchant_reference
+            .clone()
+            .or(response.psp_reference),
         incremental_authorization_allowed: None,
         charge_id: None,
     };


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
1. Make refusal_reason optional as, we don't get it every time 
2. Capture `connector_response_reference_id` in error response.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
1. Create a Wechat Pay Payment via Adyen
```
{
  "amount": 6540,
  "currency": "EUR",
  "confirm": true,
  "capture_method": "automatic",
  "capture_on": "2022-09-10T10:11:12Z",
  "amount_to_capture": 6540,
  "customer_id": "StripeCustomer",
  "email": "guest@example.com",
  "name": "John Doe",
  "phone": "999999999",
  "phone_country_code": "+1",
  "description": "Its my first payment request",
  "authentication_type": "no_three_ds",
  "return_url": "https://webhook.site/6fed9c8b-2a57-43cc-9eb1-9629ff4d2f80",
  "payment_method": "wallet",
  "payment_method_type": "we_chat_pay",
  "payment_method_data": {
    "wallet": {
      "we_chat_pay_redirect": {}
    }
  }
}
```
Response
```
{
    "payment_id": "pay_6KG6neTgsPy7bXC80cQV",
    "merchant_id": "merchant_1717481738",
    "status": "requires_customer_action",
    "amount": 6540,
    "net_amount": 6540,
    "amount_capturable": 6540,
    "amount_received": null,
    "connector": "adyen",
    "client_secret": "pay_6KG6neTgsPy7bXC80cQV_secret_1L7jN6QnXyWlIxZxvKv7",
    "created": "2024-06-04T06:15:44.187Z",
    "currency": "EUR",
    "customer_id": "StripeCustomer",
    "customer": {
        "id": "StripeCustomer",
        "name": "John Doe",
        "email": "guest@example.com",
        "phone": "999999999",
        "phone_country_code": "+1"
    },
    "description": "Its my first payment request",
    "refunds": null,
    "disputes": null,
    "mandate_id": null,
    "mandate_data": null,
    "setup_future_usage": null,
    "off_session": null,
    "capture_on": null,
    "capture_method": "automatic",
    "payment_method": "wallet",
    "payment_method_data": {
        "wallet": {},
        "billing": null
    },
    "payment_token": null,
    "shipping": null,
    "billing": null,
    "order_details": null,
    "email": "guest@example.com",
    "name": "John Doe",
    "phone": "999999999",
    "return_url": "https://webhook.site/6fed9c8b-2a57-43cc-9eb1-9629ff4d2f80",
    "authentication_type": "no_three_ds",
    "statement_descriptor_name": null,
    "statement_descriptor_suffix": null,
    "next_action": {
        "type": "redirect_to_url",
        "redirect_to_url": "http://localhost:8080/payments/redirect/pay_6KG6neTgsPy7bXC80cQV/merchant_1717481738/pay_6KG6neTgsPy7bXC80cQV_1"
    },
    "cancellation_reason": null,
    "error_code": null,
    "error_message": null,
    "unified_code": null,
    "unified_message": null,
    "payment_experience": null,
    "payment_method_type": "we_chat_pay",
    "connector_label": null,
    "business_country": null,
    "business_label": "default",
    "business_sub_label": null,
    "allowed_payment_method_types": null,
    "ephemeral_key": {
        "customer_id": "StripeCustomer",
        "created_at": 1717481744,
        "expires": 1717485344,
        "secret": "epk_19eb29df5184401a8615fd5a7527e6e1"
    },
    "manual_retry_allowed": null,
    "connector_transaction_id": null,
    "frm_message": null,
    "metadata": null,
    "connector_metadata": null,
    "feature_metadata": null,
    "reference_id": null,
    "payment_link": null,
    "profile_id": "pro_MILIvVZe8eOaUMR9pBm2",
    "surcharge_details": null,
    "attempt_count": 1,
    "merchant_decision": null,
    "merchant_connector_id": "mca_HrEuBbUGiW4VshbH0okk",
    "incremental_authorization_allowed": null,
    "authorization_count": null,
    "incremental_authorizations": null,
    "external_authentication_details": null,
    "external_3ds_authentication_attempted": false,
    "expires_on": "2024-06-04T06:30:44.186Z",
    "fingerprint": null,
    "browser_info": null,
    "payment_method_id": null,
    "payment_method_status": null,
    "updated": "2024-06-04T06:15:45.290Z",
    "charges": null,
    "frm_metadata": null
}
```
After redirection Cancel the payment

_____________________________________________

Do a Psync 
```
curl --location 'http://localhost:8080/payments/{paymnet_id}' \
--header 'Accept: application/json' \
--header 'api-key: dev_17aeitdX6vfrJTgBaCE1kW4rosNKzmWudAbOIzKGfLfD2jpOzJ9gEgkPpqXlTV9v'
```
Response
```
{
    "payment_id": "pay_E4tNagBCjPirfKeftfkz",
    "merchant_id": "merchant_1717481738",
    "status": "cancelled",
    "amount": 6540,
    "net_amount": 6540,
    "amount_capturable": 0,
    "amount_received": null,
    "connector": "adyen",
    "client_secret": "pay_E4tNagBCjPirfKeftfkz_secret_88hDBcLQZ9FTgfgxwsOn",
    "created": "2024-06-04T06:36:57.016Z",
    "currency": "EUR",
    "customer_id": "StripeCustomer",
    "customer": {
        "id": "StripeCustomer",
        "name": "John Doe",
        "email": "guest@example.com",
        "phone": "999999999",
        "phone_country_code": "+1"
    },
    "description": "Its my first payment request",
    "refunds": null,
    "disputes": null,
    "mandate_id": null,
    "mandate_data": null,
    "setup_future_usage": null,
    "off_session": null,
    "capture_on": null,
    "capture_method": "automatic",
    "payment_method": "wallet",
    "payment_method_data": {
        "wallet": {},
        "billing": null
    },
    "payment_token": null,
    "shipping": null,
    "billing": null,
    "order_details": null,
    "email": "guest@example.com",
    "name": "John Doe",
    "phone": "999999999",
    "return_url": "https://webhook.site/6fed9c8b-2a57-43cc-9eb1-9629ff4d2f80",
    "authentication_type": "no_three_ds",
    "statement_descriptor_name": null,
    "statement_descriptor_suffix": null,
    "next_action": null,
    "cancellation_reason": null,
    "error_code": null,
    "error_message": null,
    "unified_code": null,
    "unified_message": null,
    "payment_experience": null,
    "payment_method_type": "we_chat_pay",
    "connector_label": null,
    "business_country": null,
    "business_label": "default",
    "business_sub_label": null,
    "allowed_payment_method_types": null,
    "ephemeral_key": null,
    "manual_retry_allowed": false,
    "connector_transaction_id": "ZNPGXG5PTX4K8ZT5",
    "frm_message": null,
    "metadata": null,
    "connector_metadata": null,
    "feature_metadata": null,
    "reference_id": "pay_E4tNagBCjPirfKeftfkz_1",
    "payment_link": null,
    "profile_id": "pro_MILIvVZe8eOaUMR9pBm2",
    "surcharge_details": null,
    "attempt_count": 1,
    "merchant_decision": null,
    "merchant_connector_id": "mca_HrEuBbUGiW4VshbH0okk",
    "incremental_authorization_allowed": null,
    "authorization_count": null,
    "incremental_authorizations": null,
    "external_authentication_details": null,
    "external_3ds_authentication_attempted": false,
    "expires_on": "2024-06-04T06:51:57.016Z",
    "fingerprint": null,
    "browser_info": null,
    "payment_method_id": null,
    "payment_method_status": null,
    "updated": "2024-06-04T06:37:06.703Z",
    "charges": null,
    "frm_metadata": null
}
```

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
