### PR TITLE
feat(connector): [BOA] Handle refund status 201

### DIFF
--- a/crates/router/src/connector/bankofamerica/transformers.rs
+++ b/crates/router/src/connector/bankofamerica/transformers.rs
@@ -2607,9 +2607,12 @@ impl<F> TryFrom<&BankOfAmericaRouterData<&types::RefundsRouterData<F>>>
     }
 }
 
-impl From<BankofamericaRefundStatus> for enums::RefundStatus {
-    fn from(item: BankofamericaRefundStatus) -> Self {
-        match item {
+impl From<BankOfAmericaRefundResponse> for enums::RefundStatus {
+    fn from(item: BankOfAmericaRefundResponse) -> Self {
+        let error_reason = item
+            .error_information
+            .and_then(|error_info| error_info.reason);
+        match item.status {
             BankofamericaRefundStatus::Succeeded | BankofamericaRefundStatus::Transmitted => {
                 Self::Success
             }
@@ -2617,11 +2620,18 @@ impl From<BankofamericaRefundStatus> for enums::RefundStatus {
             | BankofamericaRefundStatus::Failed
             | BankofamericaRefundStatus::Voided => Self::Failure,
             BankofamericaRefundStatus::Pending => Self::Pending,
+            BankofamericaRefundStatus::TwoZeroOne => {
+                if error_reason == Some("PROCESSOR_DECLINED".to_string()) {
+                    Self::Failure
+                } else {
+                    Self::Pending
+                }
+            }
         }
     }
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct BankOfAmericaRefundResponse {
     id: String,
@@ -2636,19 +2646,19 @@ impl TryFrom<types::RefundsResponseRouterData<api::Execute, BankOfAmericaRefundR
     fn try_from(
         item: types::RefundsResponseRouterData<api::Execute, BankOfAmericaRefundResponse>,
     ) -> Result<Self, Self::Error> {
-        let refund_status = enums::RefundStatus::from(item.response.status.clone());
+        let refund_status = enums::RefundStatus::from(item.response.clone());
         let response = if utils::is_refund_failure(refund_status) {
             Err(types::ErrorResponse::foreign_from((
                 &item.response.error_information,
                 &None,
                 None,
                 item.http_code,
-                item.response.id.clone(),
+                item.response.id,
             )))
         } else {
             Ok(types::RefundsResponseData {
                 connector_refund_id: item.response.id,
-                refund_status: enums::RefundStatus::from(item.response.status),
+                refund_status,
             })
         };
 
@@ -2668,6 +2678,8 @@ pub enum BankofamericaRefundStatus {
     Pending,
     Voided,
     Cancelled,
+    #[serde(rename = "201")]
+    TwoZeroOne,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -2697,8 +2709,26 @@ impl TryFrom<types::RefundsResponseRouterData<api::RSync, BankOfAmericaRsyncResp
             .and_then(|application_information| application_information.status)
         {
             Some(status) => {
-                let refund_status: common_enums::RefundStatus =
-                    enums::RefundStatus::from(status.clone());
+                let error_reason = item
+                    .response
+                    .error_information
+                    .clone()
+                    .and_then(|error_info| error_info.reason);
+                let refund_status = match status {
+                    BankofamericaRefundStatus::Succeeded
+                    | BankofamericaRefundStatus::Transmitted => enums::RefundStatus::Success,
+                    BankofamericaRefundStatus::Cancelled
+                    | BankofamericaRefundStatus::Failed
+                    | BankofamericaRefundStatus::Voided => enums::RefundStatus::Failure,
+                    BankofamericaRefundStatus::Pending => enums::RefundStatus::Pending,
+                    BankofamericaRefundStatus::TwoZeroOne => {
+                        if error_reason == Some("PROCESSOR_DECLINED".to_string()) {
+                            enums::RefundStatus::Failure
+                        } else {
+                            enums::RefundStatus::Pending
+                        }
+                    }
+                };
                 if utils::is_refund_failure(refund_status) {
                     if status == BankofamericaRefundStatus::Voided {
                         Err(types::ErrorResponse::foreign_from((


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
[ORIGINAL PR: https://github.com/juspay/hyperswitch/pull/4908 ]
Refund Status in Bankofamerica refund response is returning a new value 201 along with errorInformation.reason as PROCESSOR_DECLINED which is being handled now.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
https://github.com/juspay/hyperswitch/issues/4906

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
We are unable to recreate the status "201" on BOA sandbox and hence only normal refund flow should be tested.

Refund Request:
```
curl --location 'http://localhost:8080/refunds' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: API_KEY_HERE' \
--data '{
  "payment_id": "pay_O9ziXsg3MNqO3z40T5G7",
  "amount": 1404,
  "reason": "Coumer returned product",
  "refund_type": "instant",
  "metadata": {
    "udf1": "value1",
    "new_customer": "true",
    "login_date": "2019-09-10T10:11:12Z"
  }
}'
```

Refund Response:
```
{
    "refund_id": "ref_d6SrGxAWUP3qn0jbXeLJ",
    "payment_id": "pay_O9ziXsg3MNqO3z40T5G7",
    "amount": 1404,
    "currency": "USD",
    "status": "pending",
    "reason": "Coumer returned product",
    "metadata": {
        "udf1": "value1",
        "new_customer": "true",
        "login_date": "2019-09-10T10:11:12Z"
    },
    "error_message": null,
    "error_code": null,
    "created_at": "2024-06-07T08:48:26.104Z",
    "updated_at": "2024-06-07T08:48:26.104Z",
    "connector": "bankofamerica",
    "profile_id": "pro_p65lw9djOoJVaUd5BEwN",
    "merchant_connector_id": "mca_31kwy8X7BwWrWRLPDYe7",
    "charges": null
}
```

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
