### PR TITLE
refactor(connector): [CRYPTOPAY] amount conversion framework added

### DIFF
--- a/crates/common_utils/src/types.rs
+++ b/crates/common_utils/src/types.rs
@@ -541,6 +541,11 @@ impl StringMajorUnit {
             .ok_or(ParsingError::DecimalToI64ConversionFailure)?;
         Ok(MinorUnit::new(amount_i64))
     }
+
+    /// Get string amount from struct to be removed in future
+    pub fn get_amount_as_string(&self) -> String {
+        self.0.clone()
+    }
 }
 
 #[cfg(test)]

--- a/crates/common_utils/src/types.rs
+++ b/crates/common_utils/src/types.rs
@@ -541,11 +541,6 @@ impl StringMajorUnit {
             .ok_or(ParsingError::DecimalToI64ConversionFailure)?;
         Ok(MinorUnit::new(amount_i64))
     }
-
-    /// Get string amount from struct to be removed in future
-    pub fn get_amount_as_string(&self) -> String {
-        self.0.clone()
-    }
 }
 
 #[cfg(test)]

--- a/crates/router/src/connector/cryptopay.rs
+++ b/crates/router/src/connector/cryptopay.rs
@@ -311,7 +311,6 @@ impl ConnectorIntegration<api::Authorize, types::PaymentsAuthorizeData, types::P
                 data: data.clone(),
                 http_code: res.status_code,
             },
-            data.request.currency,
             capture_amount_core,
         ))
     }
@@ -407,7 +406,6 @@ impl ConnectorIntegration<api::PSync, types::PaymentsSyncData, types::PaymentsRe
                 data: data.clone(),
                 http_code: res.status_code,
             },
-            data.request.currency,
             capture_amount_core,
         ))
     }

--- a/crates/router/src/connector/cryptopay.rs
+++ b/crates/router/src/connector/cryptopay.rs
@@ -258,7 +258,7 @@ impl ConnectorIntegration<api::Authorize, types::PaymentsAuthorizeData, types::P
             req.request.minor_amount,
             req.request.currency,
         )?;
-        let connector_router_data = cryptopay::CryptopayRouterData::try_from((amount, req))?;
+        let connector_router_data = cryptopay::CryptopayRouterData::from((amount, req));
         let connector_req = cryptopay::CryptopayPaymentsRequest::try_from(&connector_router_data)?;
         Ok(RequestContent::Json(Box::new(connector_req)))
     }
@@ -297,7 +297,7 @@ impl ConnectorIntegration<api::Authorize, types::PaymentsAuthorizeData, types::P
             .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
         event_builder.map(|i| i.set_response_body(&response));
         router_env::logger::info!(connector_response=?response);
-        let capture_amount_core = match response.data.price_amount {
+        let capture_amount_in_minor_units = match response.data.price_amount {
             Some(ref amount) => Some(utils::convert_back(
                 self.amount_converter,
                 amount.clone(),
@@ -311,7 +311,7 @@ impl ConnectorIntegration<api::Authorize, types::PaymentsAuthorizeData, types::P
                 data: data.clone(),
                 http_code: res.status_code,
             },
-            capture_amount_core,
+            capture_amount_in_minor_units,
         ))
     }
 
@@ -392,7 +392,7 @@ impl ConnectorIntegration<api::PSync, types::PaymentsSyncData, types::PaymentsRe
             .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
         event_builder.map(|i| i.set_response_body(&response));
         router_env::logger::info!(connector_response=?response);
-        let capture_amount_core = match response.data.price_amount {
+        let capture_amount_in_minor_units = match response.data.price_amount {
             Some(ref amount) => Some(utils::convert_back(
                 self.amount_converter,
                 amount.clone(),
@@ -406,7 +406,7 @@ impl ConnectorIntegration<api::PSync, types::PaymentsSyncData, types::PaymentsRe
                 data: data.clone(),
                 http_code: res.status_code,
             },
-            capture_amount_core,
+            capture_amount_in_minor_units,
         ))
     }
 

--- a/crates/router/src/connector/cryptopay.rs
+++ b/crates/router/src/connector/cryptopay.rs
@@ -1,13 +1,12 @@
 pub mod transformers;
 
-use std::fmt::Debug;
-
 use base64::Engine;
 use common_utils::{
     crypto::{self, GenerateDigest, SignMessage},
     date_time,
     ext_traits::ByteSliceExt,
     request::RequestContent,
+    types::{AmountConvertor, StringMajorUnit, StringMajorUnitForConnector},
 };
 use error_stack::ResultExt;
 use hex::encode;
@@ -36,8 +35,18 @@ use crate::{
     utils::BytesExt,
 };
 
-#[derive(Debug, Clone)]
-pub struct Cryptopay;
+#[derive(Clone)]
+pub struct Cryptopay {
+    amount_converter: &'static (dyn AmountConvertor<Output = StringMajorUnit> + Sync),
+}
+
+impl Cryptopay {
+    pub fn new() -> &'static Self {
+        &Self {
+            amount_converter: &StringMajorUnitForConnector,
+        }
+    }
+}
 
 impl api::Payment for Cryptopay {}
 impl api::PaymentSession for Cryptopay {}
@@ -123,7 +132,7 @@ where
             (headers::DATE.to_string(), date.into()),
             (
                 headers::CONTENT_TYPE.to_string(),
-                Self.get_content_type().to_string().into(),
+                self.get_content_type().to_string().into(),
             ),
         ];
         Ok(headers)
@@ -244,12 +253,12 @@ impl ConnectorIntegration<api::Authorize, types::PaymentsAuthorizeData, types::P
         req: &types::PaymentsAuthorizeRouterData,
         _connectors: &settings::Connectors,
     ) -> CustomResult<RequestContent, errors::ConnectorError> {
-        let connector_router_data = cryptopay::CryptopayRouterData::try_from((
-            &self.get_currency_unit(),
+        let amount = utils::convert_amount(
+            self.amount_converter,
+            req.request.minor_amount,
             req.request.currency,
-            req.request.amount,
-            req,
-        ))?;
+        )?;
+        let connector_router_data = cryptopay::CryptopayRouterData::try_from((amount, req))?;
         let connector_req = cryptopay::CryptopayPaymentsRequest::try_from(&connector_router_data)?;
         Ok(RequestContent::Json(Box::new(connector_req)))
     }
@@ -288,6 +297,14 @@ impl ConnectorIntegration<api::Authorize, types::PaymentsAuthorizeData, types::P
             .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
         event_builder.map(|i| i.set_response_body(&response));
         router_env::logger::info!(connector_response=?response);
+        let capture_amount_core = match response.data.price_amount {
+            Some(ref amount) => Some(utils::convert_back(
+                self.amount_converter,
+                amount.clone(),
+                data.request.currency,
+            )?),
+            None => None,
+        };
         types::RouterData::foreign_try_from((
             types::ResponseRouterData {
                 response,
@@ -295,6 +312,7 @@ impl ConnectorIntegration<api::Authorize, types::PaymentsAuthorizeData, types::P
                 http_code: res.status_code,
             },
             data.request.currency,
+            capture_amount_core,
         ))
     }
 
@@ -375,6 +393,14 @@ impl ConnectorIntegration<api::PSync, types::PaymentsSyncData, types::PaymentsRe
             .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
         event_builder.map(|i| i.set_response_body(&response));
         router_env::logger::info!(connector_response=?response);
+        let capture_amount_core = match response.data.price_amount {
+            Some(ref amount) => Some(utils::convert_back(
+                self.amount_converter,
+                amount.clone(),
+                data.request.currency,
+            )?),
+            None => None,
+        };
         types::RouterData::foreign_try_from((
             types::ResponseRouterData {
                 response,
@@ -382,6 +408,7 @@ impl ConnectorIntegration<api::PSync, types::PaymentsSyncData, types::PaymentsRe
                 http_code: res.status_code,
             },
             data.request.currency,
+            capture_amount_core,
         ))
     }
 

--- a/crates/router/src/connector/cryptopay/transformers.rs
+++ b/crates/router/src/connector/cryptopay/transformers.rs
@@ -20,13 +20,12 @@ pub struct CryptopayRouterData<T> {
     pub router_data: T,
 }
 
-impl<T> TryFrom<(StringMajorUnit, T)> for CryptopayRouterData<T> {
-    type Error = error_stack::Report<errors::ConnectorError>;
-    fn try_from((amount, item): (StringMajorUnit, T)) -> Result<Self, Self::Error> {
-        Ok(Self {
+impl<T> From<(StringMajorUnit, T)> for CryptopayRouterData<T> {
+    fn from((amount, item): (StringMajorUnit, T)) -> Self {
+        Self {
             amount,
             router_data: item,
-        })
+        }
     }
 }
 
@@ -144,7 +143,7 @@ impl<F, T>
 {
     type Error = error_stack::Report<errors::ConnectorError>;
     fn foreign_try_from(
-        (item, amount_captured_core): (
+        (item, amount_captured_in_minor_units): (
             types::ResponseRouterData<F, CryptopayPaymentsResponse, T, types::PaymentsResponseData>,
             Option<MinorUnit>,
         ),
@@ -189,7 +188,7 @@ impl<F, T>
                 charge_id: None,
             })
         };
-        match amount_captured_core {
+        match amount_captured_in_minor_units {
             Some(minor_amount) => {
                 let amount_captured = Some(minor_amount.get_amount_as_i64());
                 Ok(Self {

--- a/crates/router/src/types/api.rs
+++ b/crates/router/src/types/api.rs
@@ -329,7 +329,7 @@ impl ConnectorData {
                 enums::Connector::Cashtocode => Ok(Box::new(&connector::Cashtocode)),
                 enums::Connector::Checkout => Ok(Box::new(&connector::Checkout)),
                 enums::Connector::Coinbase => Ok(Box::new(&connector::Coinbase)),
-                enums::Connector::Cryptopay => Ok(Box::new(&connector::Cryptopay)),
+                enums::Connector::Cryptopay => Ok(Box::new(connector::Cryptopay::new())),
                 enums::Connector::Cybersource => Ok(Box::new(&connector::Cybersource)),
                 enums::Connector::Dlocal => Ok(Box::new(&connector::Dlocal)),
                 #[cfg(feature = "dummy_connector")]

--- a/crates/router/tests/connectors/cryptopay.rs
+++ b/crates/router/tests/connectors/cryptopay.rs
@@ -13,7 +13,7 @@ impl utils::Connector for CryptopayTest {
     fn get_data(&self) -> api::ConnectorData {
         use router::connector::Cryptopay;
         api::ConnectorData {
-            connector: Box::new(&Cryptopay),
+            connector: Box::new(Cryptopay::new()),
             connector_name: types::Connector::Cryptopay,
             get_token: api::GetToken::Connector,
             merchant_connector_id: None,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
The conversion of a f64 base amount to i64 minor amount is causing parsing error in cryptopay. This needs to be fixed by using decimal type instead of f64.

Also this Pr adds amount conversion framework to Cryptopay
Note: Cryptopay uses String Major Unit
![image](https://github.com/juspay/hyperswitch/assets/41580413/54a9311f-6220-4675-a3c5-934ba6637c79)


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
https://github.com/juspay/hyperswitch/issues/4929

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
We need to test Cryptopay payments for various different amounts.

Request: 
```
curl --location 'http://localhost:8080/payments' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: API_KEY_HERE' \
--data-raw '{
    "amount": 115,
    "currency": "USD",
    "confirm": true,
    "email": "guest@example.com",
    "return_url": "https://google.com",
    "payment_method": "crypto",
    "payment_method_type": "crypto_currency",
    "payment_experience": "redirect_to_url",
    "payment_method_data": {
        "crypto": {
            "pay_currency": "LTC",
            "network": "litecoin"
        }
    }
}'
```

Response:
```
{
    "payment_id": "pay_6xbLnqQCFF6t23vtANeX",
    "merchant_id": "merchant_1717926706",
    "status": "requires_customer_action",
    "amount": 115,
    "net_amount": 115,
    "amount_capturable": 115,
    "amount_received": 115,
    "connector": "cryptopay",
    "client_secret": "pay_6xbLnqQCFF6t23vtANeX_secret_YIJnRmmD1hu2YhtJ3rpR",
    "created": "2024-06-10T10:02:23.598Z",
    "currency": "USD",
    "customer_id": null,
    "customer": null,
    "description": null,
    "refunds": null,
    "disputes": null,
    "mandate_id": null,
    "mandate_data": null,
    "setup_future_usage": null,
    "off_session": null,
    "capture_on": null,
    "capture_method": null,
    "payment_method": "crypto",
    "payment_method_data": {
        "crypto": {},
        "billing": null
    },
    "payment_token": null,
    "shipping": null,
    "billing": null,
    "order_details": null,
    "email": null,
    "name": null,
    "phone": null,
    "return_url": "https://google.com/",
    "authentication_type": "no_three_ds",
    "statement_descriptor_name": null,
    "statement_descriptor_suffix": null,
    "next_action": {
        "type": "redirect_to_url",
        "redirect_to_url": "http://localhost:8080/payments/redirect/pay_6xbLnqQCFF6t23vtANeX/merchant_1717926706/pay_6xbLnqQCFF6t23vtANeX_1"
    },
    "cancellation_reason": null,
    "error_code": null,
    "error_message": null,
    "unified_code": null,
    "unified_message": null,
    "payment_experience": "redirect_to_url",
    "payment_method_type": "crypto_currency",
    "connector_label": null,
    "business_country": null,
    "business_label": "default",
    "business_sub_label": null,
    "allowed_payment_method_types": null,
    "ephemeral_key": null,
    "manual_retry_allowed": null,
    "connector_transaction_id": "a31c8590-3fc7-495c-91f0-392c3aa65b26",
    "frm_message": null,
    "metadata": null,
    "connector_metadata": null,
    "feature_metadata": null,
    "reference_id": "pay_6xbLnqQCFF6t23vtANeX_1",
    "payment_link": null,
    "profile_id": "pro_kr0RocqcrWsWzyfCMsbV",
    "surcharge_details": null,
    "attempt_count": 1,
    "merchant_decision": null,
    "merchant_connector_id": "mca_cbz96DuLRCEdzUAd4syf",
    "incremental_authorization_allowed": null,
    "authorization_count": null,
    "incremental_authorizations": null,
    "external_authentication_details": null,
    "external_3ds_authentication_attempted": false,
    "expires_on": "2024-06-10T10:17:23.598Z",
    "fingerprint": null,
    "browser_info": null,
    "payment_method_id": null,
    "payment_method_status": null,
    "updated": "2024-06-10T10:02:24.390Z",
    "charges": null,
    "frm_metadata": null
}
```

Note: Specifically test for amount 115.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
