### PR TITLE
refactor: wrap the encryption and file storage interface client in appstate with `Arc` as opposed to `Box`

### DIFF
--- a/crates/drainer/src/settings.rs
+++ b/crates/drainer/src/settings.rs
@@ -31,7 +31,7 @@ pub struct CmdLineConf {
 #[derive(Clone)]
 pub struct AppState {
     pub conf: Arc<Settings<RawSecret>>,
-    pub encryption_client: Box<dyn EncryptionManagementInterface>,
+    pub encryption_client: Arc<dyn EncryptionManagementInterface>,
 }
 
 impl AppState {

--- a/crates/external_services/src/file_storage.rs
+++ b/crates/external_services/src/file_storage.rs
@@ -2,7 +2,10 @@
 //! Module for managing file storage operations with support for multiple storage schemes.
 //!
 
-use std::fmt::{Display, Formatter};
+use std::{
+    fmt::{Display, Formatter},
+    sync::Arc,
+};
 
 use common_utils::errors::CustomResult;
 
@@ -39,11 +42,11 @@ impl FileStorageConfig {
     }
 
     /// Retrieves the appropriate file storage client based on the file storage configuration.
-    pub async fn get_file_storage_client(&self) -> Box<dyn FileStorageInterface> {
+    pub async fn get_file_storage_client(&self) -> Arc<dyn FileStorageInterface> {
         match self {
             #[cfg(feature = "aws_s3")]
-            Self::AwsS3 { aws_s3 } => Box::new(aws_s3::AwsFileStorageClient::new(aws_s3).await),
-            Self::FileSystem => Box::new(file_system::FileSystem),
+            Self::AwsS3 { aws_s3 } => Arc::new(aws_s3::AwsFileStorageClient::new(aws_s3).await),
+            Self::FileSystem => Arc::new(file_system::FileSystem),
         }
     }
 }

--- a/crates/external_services/src/managers/encryption_management.rs
+++ b/crates/external_services/src/managers/encryption_management.rs
@@ -2,6 +2,8 @@
 //! Encryption management util module
 //!
 
+use std::sync::Arc;
+
 use common_utils::errors::CustomResult;
 use hyperswitch_interfaces::encryption_interface::{
     EncryptionError, EncryptionManagementInterface,
@@ -42,12 +44,12 @@ impl EncryptionManagementConfig {
     /// Retrieves the appropriate encryption client based on the configuration.
     pub async fn get_encryption_management_client(
         &self,
-    ) -> CustomResult<Box<dyn EncryptionManagementInterface>, EncryptionError> {
+    ) -> CustomResult<Arc<dyn EncryptionManagementInterface>, EncryptionError> {
         Ok(match self {
             #[cfg(feature = "aws_kms")]
-            Self::AwsKms { aws_kms } => Box::new(aws_kms::core::AwsKmsClient::new(aws_kms).await),
+            Self::AwsKms { aws_kms } => Arc::new(aws_kms::core::AwsKmsClient::new(aws_kms).await),
 
-            Self::NoEncryption => Box::new(NoEncryption),
+            Self::NoEncryption => Arc::new(NoEncryption),
         })
     }
 }

--- a/crates/router/src/routes/app.rs
+++ b/crates/router/src/routes/app.rs
@@ -82,7 +82,7 @@ pub struct SessionState {
     pub email_client: Arc<dyn EmailService>,
     #[cfg(feature = "olap")]
     pub pool: AnalyticsProvider,
-    pub file_storage_client: Box<dyn FileStorageInterface>,
+    pub file_storage_client: Arc<dyn FileStorageInterface>,
     pub request_id: Option<RequestId>,
     pub base_url: String,
     pub tenant: String,
@@ -144,8 +144,8 @@ pub struct AppState {
     #[cfg(feature = "olap")]
     pub opensearch_client: Arc<OpenSearchClient>,
     pub request_id: Option<RequestId>,
-    pub file_storage_client: Box<dyn FileStorageInterface>,
-    pub encryption_client: Box<dyn EncryptionManagementInterface>,
+    pub file_storage_client: Arc<dyn FileStorageInterface>,
+    pub encryption_client: Arc<dyn EncryptionManagementInterface>,
 }
 impl scheduler::SchedulerAppState for AppState {
     fn get_tenants(&self) -> Vec<String> {


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Currently, the encryption interface and file storage interface client is wrapped with `Box`. These clients live in `AppState`. Since state is cloned for each api handler, wrapping the clients in Arc will help in not cloning the actual internal data rather maintaining a counter on the single client instance.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Basic sanity testing should suffice

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
