### PR TITLE
feat(connector): [BOA/CYB] Make billTo fields optional

### DIFF
--- a/crates/router/src/connector/bankofamerica/transformers.rs
+++ b/crates/router/src/connector/bankofamerica/transformers.rs
@@ -489,43 +489,30 @@ fn build_bill_to(
     address_details: Option<&payments::Address>,
     email: pii::Email,
 ) -> Result<BillTo, error_stack::Report<errors::ConnectorError>> {
-    match address_details {
-        Some(address) => match &address.address {
-            Some(address) => Ok(BillTo {
-                first_name: address.first_name.clone(),
-                last_name: address.last_name.clone(),
-                address1: address.line1.clone(),
-                locality: address.city.clone(),
-                administrative_area: match address.to_state_code_as_optional() {
-                    Ok(state) => state,
-                    Err(_) => None,
-                },
-                postal_code: address.zip.clone(),
-                country: address.country,
+    let default_address = BillTo {
+        first_name: None,
+        last_name: None,
+        address1: None,
+        locality: None,
+        administrative_area: None,
+        postal_code: None,
+        country: None,
+        email: email.clone(),
+    };
+    Ok(address_details
+        .and_then(|addr| {
+            addr.address.as_ref().map(|addr| BillTo {
+                first_name: addr.first_name.clone(),
+                last_name: addr.last_name.clone(),
+                address1: addr.line1.clone(),
+                locality: addr.city.clone(),
+                administrative_area: addr.to_state_code_as_optional().ok().flatten(),
+                postal_code: addr.zip.clone(),
+                country: addr.country,
                 email,
-            }),
-            None => Ok(BillTo {
-                first_name: None,
-                last_name: None,
-                address1: None,
-                locality: None,
-                administrative_area: None,
-                postal_code: None,
-                country: None,
-                email,
-            }),
-        },
-        None => Ok(BillTo {
-            first_name: None,
-            last_name: None,
-            address1: None,
-            locality: None,
-            administrative_area: None,
-            postal_code: None,
-            country: None,
-            email,
-        }),
-    }
+            })
+        })
+        .unwrap_or(default_address))
 }
 
 impl From<CardIssuer> for String {

--- a/crates/router/src/connector/bankofamerica/transformers.rs
+++ b/crates/router/src/connector/bankofamerica/transformers.rs
@@ -260,15 +260,15 @@ pub struct Amount {
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct BillTo {
-    first_name: Secret<String>,
-    last_name: Secret<String>,
-    address1: Secret<String>,
-    locality: Secret<String>,
+    first_name: Option<Secret<String>>,
+    last_name: Option<Secret<String>>,
+    address1: Option<Secret<String>>,
+    locality: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     administrative_area: Option<Secret<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     postal_code: Option<Secret<String>>,
-    country: api_enums::CountryAlpha2,
+    country: Option<api_enums::CountryAlpha2>,
     email: pii::Email,
 }
 
@@ -442,47 +442,90 @@ impl<F, T>
 }
 
 // for bankofamerica each item in Billing is mandatory
+// fn build_bill_to(
+//     address_details: &payments::Address,
+//     email: pii::Email,
+// ) -> Result<BillTo, error_stack::Report<errors::ConnectorError>> {
+//     let address = address_details
+//         .address
+//         .as_ref()
+//         .ok_or_else(utils::missing_field_err("billing.address"))?;
+
+//     let country = address.get_country()?.to_owned();
+//     let first_name = address.get_first_name()?;
+
+//     let (administrative_area, postal_code) =
+//         if country == api_enums::CountryAlpha2::US || country == api_enums::CountryAlpha2::CA {
+//             let mut state = address.to_state_code()?.peek().clone();
+//             state.truncate(20);
+//             (
+//                 Some(Secret::from(state)),
+//                 Some(address.get_zip()?.to_owned()),
+//             )
+//         } else {
+//             let zip = address.zip.clone();
+//             let mut_state = address.state.clone().map(|state| state.expose());
+//             match mut_state {
+//                 Some(mut state) => {
+//                     state.truncate(20);
+//                     (Some(Secret::from(state)), zip)
+//                 }
+//                 None => (None, zip),
+//             }
+//         };
+//     Ok(BillTo {
+//         first_name: first_name.clone(),
+//         last_name: address.get_last_name().unwrap_or(first_name).clone(),
+//         address1: address.get_line1()?.to_owned(),
+//         locality: Secret::new(address.get_city()?.to_owned()),
+//         administrative_area,
+//         postal_code,
+//         country,
+//         email,
+//     })
+// }
+
 fn build_bill_to(
-    address_details: &payments::Address,
+    address_details: Option<&payments::Address>,
     email: pii::Email,
 ) -> Result<BillTo, error_stack::Report<errors::ConnectorError>> {
-    let address = address_details
-        .address
-        .as_ref()
-        .ok_or_else(utils::missing_field_err("billing.address"))?;
-
-    let country = address.get_country()?.to_owned();
-    let first_name = address.get_first_name()?;
-
-    let (administrative_area, postal_code) =
-        if country == api_enums::CountryAlpha2::US || country == api_enums::CountryAlpha2::CA {
-            let mut state = address.to_state_code()?.peek().clone();
-            state.truncate(20);
-            (
-                Some(Secret::from(state)),
-                Some(address.get_zip()?.to_owned()),
-            )
-        } else {
-            let zip = address.zip.clone();
-            let mut_state = address.state.clone().map(|state| state.expose());
-            match mut_state {
-                Some(mut state) => {
-                    state.truncate(20);
-                    (Some(Secret::from(state)), zip)
-                }
-                None => (None, zip),
-            }
-        };
-    Ok(BillTo {
-        first_name: first_name.clone(),
-        last_name: address.get_last_name().unwrap_or(first_name).clone(),
-        address1: address.get_line1()?.to_owned(),
-        locality: Secret::new(address.get_city()?.to_owned()),
-        administrative_area,
-        postal_code,
-        country,
-        email,
-    })
+    match address_details {
+        Some(address) => match &address.address {
+            Some(address) => Ok(BillTo {
+                first_name: address.first_name.clone(),
+                last_name: address.last_name.clone(),
+                address1: address.line1.clone(),
+                locality: address.city.clone(),
+                administrative_area: match address.to_state_code_as_optional() {
+                    Ok(state) => state,
+                    Err(_) => None,
+                },
+                postal_code: address.zip.clone(),
+                country: address.country,
+                email,
+            }),
+            None => Ok(BillTo {
+                first_name: None,
+                last_name: None,
+                address1: None,
+                locality: None,
+                administrative_area: None,
+                postal_code: None,
+                country: None,
+                email,
+            }),
+        },
+        None => Ok(BillTo {
+            first_name: None,
+            last_name: None,
+            address1: None,
+            locality: None,
+            administrative_area: None,
+            postal_code: None,
+            country: None,
+            email,
+        }),
+    }
 }
 
 impl From<CardIssuer> for String {
@@ -876,7 +919,7 @@ impl
         ),
     ) -> Result<Self, Self::Error> {
         let email = item.router_data.request.get_email()?;
-        let bill_to = build_bill_to(item.router_data.get_billing()?, email)?;
+        let bill_to = build_bill_to(item.router_data.get_optional_billing(), email)?;
         let order_information = OrderInformationWithBill::from((item, bill_to));
 
         let payment_information = PaymentInformation::try_from(&ccard)?;
@@ -939,7 +982,7 @@ impl
         ),
     ) -> Result<Self, Self::Error> {
         let email = item.router_data.request.get_email()?;
-        let bill_to = build_bill_to(item.router_data.get_billing()?, email)?;
+        let bill_to = build_bill_to(item.router_data.get_optional_billing(), email)?;
         let order_information = OrderInformationWithBill::from((item, Some(bill_to)));
         let payment_information = PaymentInformation::try_from(&ccard)?;
         let processing_information = ProcessingInformation::try_from((item, None, None))?;
@@ -976,7 +1019,7 @@ impl
         ),
     ) -> Result<Self, Self::Error> {
         let email = item.router_data.request.get_email()?;
-        let bill_to = build_bill_to(item.router_data.get_billing()?, email)?;
+        let bill_to = build_bill_to(item.router_data.get_optional_billing(), email)?;
         let order_information = OrderInformationWithBill::from((item, Some(bill_to)));
         let processing_information = ProcessingInformation::try_from((
             item,
@@ -1030,7 +1073,7 @@ impl
         ),
     ) -> Result<Self, Self::Error> {
         let email = item.router_data.request.get_email()?;
-        let bill_to = build_bill_to(item.router_data.get_billing()?, email)?;
+        let bill_to = build_bill_to(item.router_data.get_optional_billing(), email)?;
         let order_information = OrderInformationWithBill::from((item, Some(bill_to)));
         let payment_information = PaymentInformation::from(&google_pay_data);
         let processing_information =
@@ -1081,8 +1124,10 @@ impl TryFrom<&BankOfAmericaRouterData<&types::PaymentsAuthorizeRouterData>>
                                 },
                                 None => {
                                     let email = item.router_data.request.get_email()?;
-                                    let bill_to =
-                                        build_bill_to(item.router_data.get_billing()?, email)?;
+                                    let bill_to = build_bill_to(
+                                        item.router_data.get_optional_billing(),
+                                        email,
+                                    )?;
                                     let order_information: OrderInformationWithBill =
                                         OrderInformationWithBill::from((item, Some(bill_to)));
                                     let processing_information =
@@ -1897,7 +1942,7 @@ impl TryFrom<&BankOfAmericaRouterData<&types::PaymentsPreProcessingRouterData>>
                     .1
                     .to_string();
                 let email = item.router_data.request.get_email()?;
-                let bill_to = build_bill_to(item.router_data.get_billing()?, email)?;
+                let bill_to = build_bill_to(item.router_data.get_optional_billing(), email)?;
                 let order_information = OrderInformationWithBill {
                     amount_details,
                     bill_to: Some(bill_to),
@@ -3098,7 +3143,7 @@ impl TryFrom<&types::SetupMandateRouterData> for OrderInformationWithBill {
 
     fn try_from(item: &types::SetupMandateRouterData) -> Result<Self, Self::Error> {
         let email = item.request.get_email()?;
-        let bill_to = build_bill_to(item.get_billing()?, email)?;
+        let bill_to = build_bill_to(item.get_optional_billing(), email)?;
 
         Ok(Self {
             amount_details: Amount {

--- a/crates/router/src/connector/cybersource/transformers.rs
+++ b/crates/router/src/connector/cybersource/transformers.rs
@@ -65,7 +65,7 @@ impl TryFrom<&types::SetupMandateRouterData> for CybersourceZeroMandateRequest {
     type Error = error_stack::Report<errors::ConnectorError>;
     fn try_from(item: &types::SetupMandateRouterData) -> Result<Self, Self::Error> {
         let email = item.request.get_email()?;
-        let bill_to = build_bill_to(item.get_billing()?, email)?;
+        let bill_to = build_bill_to(item.get_optional_billing(), email)?;
 
         let order_information = OrderInformationWithBill {
             amount_details: Amount {
@@ -478,15 +478,15 @@ impl From<PaymentSolution> for String {
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct BillTo {
-    first_name: Secret<String>,
-    last_name: Secret<String>,
-    address1: Secret<String>,
-    locality: String,
+    first_name: Option<Secret<String>>,
+    last_name: Option<Secret<String>>,
+    address1: Option<Secret<String>>,
+    locality: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     administrative_area: Option<Secret<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     postal_code: Option<Secret<String>>,
-    country: api_enums::CountryAlpha2,
+    country: Option<api_enums::CountryAlpha2>,
     email: pii::Email,
 }
 
@@ -863,46 +863,46 @@ impl
 
 // for cybersource each item in Billing is mandatory
 fn build_bill_to(
-    address_details: &payments::Address,
+    address_details: Option<&payments::Address>,
     email: pii::Email,
 ) -> Result<BillTo, error_stack::Report<errors::ConnectorError>> {
-    let address = address_details
-        .address
-        .as_ref()
-        .ok_or_else(utils::missing_field_err("billing.address"))?;
-
-    let country = address.get_country()?.to_owned();
-    let first_name = address.get_first_name()?;
-
-    let (administrative_area, postal_code) =
-        if country == api_enums::CountryAlpha2::US || country == api_enums::CountryAlpha2::CA {
-            let mut state = address.to_state_code()?.peek().clone();
-            state.truncate(20);
-            (
-                Some(Secret::from(state)),
-                Some(address.get_zip()?.to_owned()),
-            )
-        } else {
-            let zip = address.zip.clone();
-            let mut_state = address.state.clone().map(|state| state.expose());
-            match mut_state {
-                Some(mut state) => {
-                    state.truncate(20);
-                    (Some(Secret::from(state)), zip)
-                }
-                None => (None, zip),
-            }
-        };
-    Ok(BillTo {
-        first_name: first_name.clone(),
-        last_name: address.get_last_name().unwrap_or(first_name).clone(),
-        address1: address.get_line1()?.to_owned(),
-        locality: address.get_city()?.to_owned(),
-        administrative_area,
-        postal_code,
-        country,
-        email,
-    })
+    match address_details {
+        Some(address) => match &address.address {
+            Some(address) => Ok(BillTo {
+                first_name: address.first_name.clone(),
+                last_name: address.last_name.clone(),
+                address1: address.line1.clone(),
+                locality: address.city.clone(),
+                administrative_area: match address.to_state_code_as_optional() {
+                    Ok(state) => state,
+                    Err(_) => None,
+                },
+                postal_code: address.zip.clone(),
+                country: address.country,
+                email,
+            }),
+            None => Ok(BillTo {
+                first_name: None,
+                last_name: None,
+                address1: None,
+                locality: None,
+                administrative_area: None,
+                postal_code: None,
+                country: None,
+                email,
+            }),
+        },
+        None => Ok(BillTo {
+            first_name: None,
+            last_name: None,
+            address1: None,
+            locality: None,
+            administrative_area: None,
+            postal_code: None,
+            country: None,
+            email,
+        }),
+    }
 }
 
 impl ForeignFrom<Value> for Vec<MerchantDefinedInformation> {
@@ -937,7 +937,7 @@ impl
         ),
     ) -> Result<Self, Self::Error> {
         let email = item.router_data.request.get_email()?;
-        let bill_to = build_bill_to(item.router_data.get_billing()?, email)?;
+        let bill_to = build_bill_to(item.router_data.get_optional_billing(), email)?;
         let order_information = OrderInformationWithBill::from((item, Some(bill_to)));
 
         let card_issuer = ccard.get_card_issuer();
@@ -1015,7 +1015,7 @@ impl
         ),
     ) -> Result<Self, Self::Error> {
         let email = item.router_data.request.get_email()?;
-        let bill_to = build_bill_to(item.router_data.get_billing()?, email)?;
+        let bill_to = build_bill_to(item.router_data.get_optional_billing(), email)?;
         let order_information = OrderInformationWithBill::from((item, bill_to));
 
         let card_issuer = ccard.get_card_issuer();
@@ -1096,7 +1096,7 @@ impl
         ),
     ) -> Result<Self, Self::Error> {
         let email = item.router_data.request.get_email()?;
-        let bill_to = build_bill_to(item.router_data.get_billing()?, email)?;
+        let bill_to = build_bill_to(item.router_data.get_optional_billing(), email)?;
         let order_information = OrderInformationWithBill::from((item, Some(bill_to)));
         let processing_information = ProcessingInformation::try_from((
             item,
@@ -1163,7 +1163,7 @@ impl
         ),
     ) -> Result<Self, Self::Error> {
         let email = item.router_data.request.get_email()?;
-        let bill_to = build_bill_to(item.router_data.get_billing()?, email)?;
+        let bill_to = build_bill_to(item.router_data.get_optional_billing(), email)?;
         let order_information = OrderInformationWithBill::from((item, Some(bill_to)));
 
         let payment_information =
@@ -1223,8 +1223,10 @@ impl TryFrom<&CybersourceRouterData<&types::PaymentsAuthorizeRouterData>>
                                 },
                                 None => {
                                     let email = item.router_data.request.get_email()?;
-                                    let bill_to =
-                                        build_bill_to(item.router_data.get_billing()?, email)?;
+                                    let bill_to = build_bill_to(
+                                        item.router_data.get_optional_billing(),
+                                        email,
+                                    )?;
                                     let order_information =
                                         OrderInformationWithBill::from((item, Some(bill_to)));
                                     let processing_information =
@@ -2212,7 +2214,7 @@ impl TryFrom<&CybersourceRouterData<&types::PaymentsPreProcessingRouterData>>
                     .1
                     .to_string();
                 let email = item.router_data.request.get_email()?;
-                let bill_to = build_bill_to(item.router_data.get_billing()?, email)?;
+                let bill_to = build_bill_to(item.router_data.get_optional_billing(), email)?;
                 let order_information = OrderInformationWithBill {
                     amount_details,
                     bill_to: Some(bill_to),

--- a/crates/router/src/connector/cybersource/transformers.rs
+++ b/crates/router/src/connector/cybersource/transformers.rs
@@ -909,43 +909,30 @@ fn build_bill_to(
     address_details: Option<&payments::Address>,
     email: pii::Email,
 ) -> Result<BillTo, error_stack::Report<errors::ConnectorError>> {
-    match address_details {
-        Some(address) => match &address.address {
-            Some(address) => Ok(BillTo {
-                first_name: address.first_name.clone(),
-                last_name: address.last_name.clone(),
-                address1: address.line1.clone(),
-                locality: address.city.clone(),
-                administrative_area: match address.to_state_code_as_optional() {
-                    Ok(state) => state,
-                    Err(_) => None,
-                },
-                postal_code: address.zip.clone(),
-                country: address.country,
+    let default_address = BillTo {
+        first_name: None,
+        last_name: None,
+        address1: None,
+        locality: None,
+        administrative_area: None,
+        postal_code: None,
+        country: None,
+        email: email.clone(),
+    };
+    Ok(address_details
+        .and_then(|addr| {
+            addr.address.as_ref().map(|addr| BillTo {
+                first_name: addr.first_name.clone(),
+                last_name: addr.last_name.clone(),
+                address1: addr.line1.clone(),
+                locality: addr.city.clone(),
+                administrative_area: addr.to_state_code_as_optional().ok().flatten(),
+                postal_code: addr.zip.clone(),
+                country: addr.country,
                 email,
-            }),
-            None => Ok(BillTo {
-                first_name: None,
-                last_name: None,
-                address1: None,
-                locality: None,
-                administrative_area: None,
-                postal_code: None,
-                country: None,
-                email,
-            }),
-        },
-        None => Ok(BillTo {
-            first_name: None,
-            last_name: None,
-            address1: None,
-            locality: None,
-            administrative_area: None,
-            postal_code: None,
-            country: None,
-            email,
-        }),
-    }
+            })
+        })
+        .unwrap_or(default_address))
 }
 
 impl ForeignFrom<Value> for Vec<MerchantDefinedInformation> {

--- a/crates/router/src/connector/cybersource/transformers.rs
+++ b/crates/router/src/connector/cybersource/transformers.rs
@@ -862,6 +862,49 @@ impl
 }
 
 // for cybersource each item in Billing is mandatory
+// fn build_bill_to(
+//     address_details: &payments::Address,
+//     email: pii::Email,
+// ) -> Result<BillTo, error_stack::Report<errors::ConnectorError>> {
+//     let address = address_details
+//         .address
+//         .as_ref()
+//         .ok_or_else(utils::missing_field_err("billing.address"))?;
+
+//     let country = address.get_country()?.to_owned();
+//     let first_name = address.get_first_name()?;
+
+//     let (administrative_area, postal_code) =
+//         if country == api_enums::CountryAlpha2::US || country == api_enums::CountryAlpha2::CA {
+//             let mut state = address.to_state_code()?.peek().clone();
+//             state.truncate(20);
+//             (
+//                 Some(Secret::from(state)),
+//                 Some(address.get_zip()?.to_owned()),
+//             )
+//         } else {
+//             let zip = address.zip.clone();
+//             let mut_state = address.state.clone().map(|state| state.expose());
+//             match mut_state {
+//                 Some(mut state) => {
+//                     state.truncate(20);
+//                     (Some(Secret::from(state)), zip)
+//                 }
+//                 None => (None, zip),
+//             }
+//         };
+//     Ok(BillTo {
+//         first_name: first_name.clone(),
+//         last_name: address.get_last_name().unwrap_or(first_name).clone(),
+//         address1: address.get_line1()?.to_owned(),
+//         locality: address.get_city()?.to_owned(),
+//         administrative_area,
+//         postal_code,
+//         country,
+//         email,
+//     })
+// }
+
 fn build_bill_to(
     address_details: Option<&payments::Address>,
     email: pii::Email,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Make billTo fields optional in connector BOA and Cybersource. This change is required for prod testing.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
https://github.com/juspay/hyperswitch/issues/4950

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Testing should be done for BOA and Cybersource. Payments should work if billing address is passed and payments should be failed at connector if billing address is not passed.

Failure Request:
```
curl --location 'http://localhost:8080/payments' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: dev_mF5ApaF7qylFyewcvRbsOVw9bhOUy2ufhC8MutbWQvLwNWWqX7CZGDPf5SnZ6KRE' \
--data-raw '{
    "amount": 101,
    "currency": "USD",
    "confirm": true,
    "customer_id": "mearX",
    "email": "guest@deepanshu.com",
    "return_url": "https://google.com",
    "payment_method": "card",
    "payment_method_type": "credit",
    "payment_method_data": {
        "card": {
            "card_number": "4111111111111111",
            "card_exp_month": "05",
            "card_exp_year": "25",
            "card_holder_name": "Bernard Eugine",
            "card_cvc": "123"
        }
    }
}'
```

Failure Response:
```
{
    "payment_id": "pay_7iL2BAQtdP07gisZ5lgy",
    "merchant_id": "merchant_1718024306",
    "status": "failed",
    "amount": 101,
    "net_amount": 101,
    "amount_capturable": 0,
    "amount_received": null,
    "connector": "bankofamerica",
    "client_secret": "pay_7iL2BAQtdP07gisZ5lgy_secret_aLewy2zRmIcXiVmgPRsZ",
    "created": "2024-06-11T12:11:53.042Z",
    "currency": "USD",
    "customer_id": "mearX",
    "customer": {
        "id": "mearX",
        "name": "John Doe",
        "email": "guest@deepanshu.com",
        "phone": "999999999",
        "phone_country_code": "+1"
    },
    "description": null,
    "refunds": null,
    "disputes": null,
    "mandate_id": null,
    "mandate_data": null,
    "setup_future_usage": null,
    "off_session": null,
    "capture_on": null,
    "capture_method": null,
    "payment_method": "card",
    "payment_method_data": {
        "card": {
            "last4": "1111",
            "card_type": null,
            "card_network": null,
            "card_issuer": null,
            "card_issuing_country": null,
            "card_isin": "411111",
            "card_extended_bin": null,
            "card_exp_month": "05",
            "card_exp_year": "25",
            "card_holder_name": "Bernard Eugine",
            "payment_checks": null,
            "authentication_data": null
        },
        "billing": null
    },
    "payment_token": "token_hlcvyB0Vp6vQJ2v4Uk5g",
    "shipping": null,
    "billing": null,
    "order_details": null,
    "email": "guest@deepanshu.com",
    "name": "John Doe",
    "phone": "999999999",
    "return_url": "https://google.com/",
    "authentication_type": "no_three_ds",
    "statement_descriptor_name": null,
    "statement_descriptor_suffix": null,
    "next_action": null,
    "cancellation_reason": null,
    "error_code": "MISSING_FIELD",
    "error_message": "Declined - The request is missing one or more fields, detailed_error_information: orderInformation.billTo.locality : MISSING_FIELD, orderInformation.billTo.address1 : MISSING_FIELD, orderInformation.billTo.country : MISSING_FIELD",
    "unified_code": null,
    "unified_message": null,
    "payment_experience": null,
    "payment_method_type": "credit",
    "connector_label": null,
    "business_country": null,
    "business_label": "default",
    "business_sub_label": null,
    "allowed_payment_method_types": null,
    "ephemeral_key": {
        "customer_id": "mearX",
        "created_at": 1718107912,
        "expires": 1718111512,
        "secret": "epk_8c55074dbcc94632811fe1bd02a06edb"
    },
    "manual_retry_allowed": true,
    "connector_transaction_id": null,
    "frm_message": null,
    "metadata": null,
    "connector_metadata": null,
    "feature_metadata": null,
    "reference_id": null,
    "payment_link": null,
    "profile_id": "pro_sjoiFN7MPB9SdG5Zr0iT",
    "surcharge_details": null,
    "attempt_count": 1,
    "merchant_decision": null,
    "merchant_connector_id": "mca_QxbSnL7xEEr3Wc2sODHD",
    "incremental_authorization_allowed": false,
    "authorization_count": null,
    "incremental_authorizations": null,
    "external_authentication_details": null,
    "external_3ds_authentication_attempted": false,
    "expires_on": "2024-06-11T12:26:53.041Z",
    "fingerprint": null,
    "browser_info": null,
    "payment_method_id": null,
    "payment_method_status": null,
    "updated": "2024-06-11T12:11:54.679Z",
    "charges": null,
    "frm_metadata": null
}
```

Success Request:
```
curl --location 'http://localhost:8080/payments' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: dev_mF5ApaF7qylFyewcvRbsOVw9bhOUy2ufhC8MutbWQvLwNWWqX7CZGDPf5SnZ6KRE' \
--data-raw '{
    "amount": 101,
    "currency": "USD",
    "confirm": true,
    "customer_id": "mearX",
    "email": "guest@deepanshu.com",
    "return_url": "https://google.com",
    "payment_method": "card",
    "payment_method_type": "credit",
    "payment_method_data": {
        "card": {
            "card_number": "4111111111111111",
            "card_exp_month": "05",
            "card_exp_year": "25",
            "card_holder_name": "Bernard Eugine",
            "card_cvc": "123"
        }
    },
    "billing": {
        "address": {
            "line1": "eqnkl",
            "city": "San Francisco",
            "state": "BC",
            "zip": "V2S 1A6",
            "country": "DE",
            "first_name": "John",
            "last_name": "Bond"
        }
    }
}'
```

Success Response:
```
{
    "payment_id": "pay_kRyRpMuXP8jqDMCkwWcI",
    "merchant_id": "merchant_1718024306",
    "status": "succeeded",
    "amount": 101,
    "net_amount": 101,
    "amount_capturable": 0,
    "amount_received": 101,
    "connector": "bankofamerica",
    "client_secret": "pay_kRyRpMuXP8jqDMCkwWcI_secret_kC4PSvgrobptzODtJgEn",
    "created": "2024-06-11T12:12:55.139Z",
    "currency": "USD",
    "customer_id": "mearX",
    "customer": {
        "id": "mearX",
        "name": "John Doe",
        "email": "guest@deepanshu.com",
        "phone": "999999999",
        "phone_country_code": "+1"
    },
    "description": null,
    "refunds": null,
    "disputes": null,
    "mandate_id": null,
    "mandate_data": null,
    "setup_future_usage": null,
    "off_session": null,
    "capture_on": null,
    "capture_method": null,
    "payment_method": "card",
    "payment_method_data": {
        "card": {
            "last4": "1111",
            "card_type": null,
            "card_network": null,
            "card_issuer": null,
            "card_issuing_country": null,
            "card_isin": "411111",
            "card_extended_bin": null,
            "card_exp_month": "05",
            "card_exp_year": "25",
            "card_holder_name": "Bernard Eugine",
            "payment_checks": {
                "avs_response": {
                    "code": "Y",
                    "codeRaw": "Y"
                },
                "card_verification": {
                    "resultCode": "M",
                    "resultCodeRaw": "M"
                },
                "approval_code": "831000",
                "consumer_authentication_response": {
                    "code": "2",
                    "codeRaw": "2"
                },
                "cavv": null,
                "eci": null,
                "eci_raw": null
            },
            "authentication_data": {
                "retrieval_reference_number": "416312127150",
                "acs_transaction_id": null,
                "system_trace_audit_number": "127150"
            }
        },
        "billing": null
    },
    "payment_token": "token_JLkgC0o4OvAPM1lxzecO",
    "shipping": null,
    "billing": {
        "address": {
            "city": "San Francisco",
            "country": "DE",
            "line1": "eqnkl",
            "line2": null,
            "line3": null,
            "zip": "V2S 1A6",
            "state": "BC",
            "first_name": "John",
            "last_name": "Bond"
        },
        "phone": null,
        "email": null
    },
    "order_details": null,
    "email": "guest@deepanshu.com",
    "name": "John Doe",
    "phone": "999999999",
    "return_url": "https://google.com/",
    "authentication_type": "no_three_ds",
    "statement_descriptor_name": null,
    "statement_descriptor_suffix": null,
    "next_action": null,
    "cancellation_reason": null,
    "error_code": null,
    "error_message": null,
    "unified_code": null,
    "unified_message": null,
    "payment_experience": null,
    "payment_method_type": "credit",
    "connector_label": null,
    "business_country": null,
    "business_label": "default",
    "business_sub_label": null,
    "allowed_payment_method_types": null,
    "ephemeral_key": {
        "customer_id": "mearX",
        "created_at": 1718107975,
        "expires": 1718111575,
        "secret": "epk_b51ed8a854734e3c96a4c702ce610921"
    },
    "manual_retry_allowed": false,
    "connector_transaction_id": "7181079753616046504951",
    "frm_message": null,
    "metadata": null,
    "connector_metadata": null,
    "feature_metadata": null,
    "reference_id": "pay_kRyRpMuXP8jqDMCkwWcI_1",
    "payment_link": null,
    "profile_id": "pro_sjoiFN7MPB9SdG5Zr0iT",
    "surcharge_details": null,
    "attempt_count": 1,
    "merchant_decision": null,
    "merchant_connector_id": "mca_QxbSnL7xEEr3Wc2sODHD",
    "incremental_authorization_allowed": null,
    "authorization_count": null,
    "incremental_authorizations": null,
    "external_authentication_details": null,
    "external_3ds_authentication_attempted": false,
    "expires_on": "2024-06-11T12:27:55.139Z",
    "fingerprint": null,
    "browser_info": null,
    "payment_method_id": null,
    "payment_method_status": null,
    "updated": "2024-06-11T12:12:56.234Z",
    "charges": null,
    "frm_metadata": null
}
```

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
