### PR TITLE
chore: address Rust 1.79 clippy lints

### DIFF
--- a/crates/analytics/src/query.rs
+++ b/crates/analytics/src/query.rs
@@ -317,6 +317,7 @@ impl std::fmt::Display for Order {
 //     "count",
 //     Order::Descending,
 // )
+#[allow(dead_code)]
 #[derive(Debug)]
 pub struct TopN {
     pub columns: String,

--- a/crates/router/src/connector/globalpay/response.rs
+++ b/crates/router/src/connector/globalpay/response.rs
@@ -378,27 +378,7 @@ pub enum GlobalpayPaymentStatus {
 }
 
 #[derive(Debug, Deserialize)]
-pub struct GlobalpayWebhoookResourceObject {
-    pub data: GlobalpayWebhookDataResource,
-}
-
-#[derive(Debug, Deserialize)]
-pub struct GlobalpayWebhookDataResource {
-    pub object: serde_json::Value,
-}
-
-#[derive(Debug, Deserialize)]
 pub struct GlobalpayWebhookObjectId {
-    pub id: String,
-}
-
-#[derive(Debug, Deserialize)]
-pub struct GlobalpayWebhookDataId {
-    pub object: GlobalpayWebhookObjectDataId,
-}
-
-#[derive(Debug, Deserialize)]
-pub struct GlobalpayWebhookObjectDataId {
     pub id: String,
 }
 

--- a/crates/router/tests/connectors/adyen.rs
+++ b/crates/router/tests/connectors/adyen.rs
@@ -83,7 +83,6 @@ impl AdyenTest {
         use common_utils::pii::Email;
 
         Some(PaymentInfo {
-            country: Some(api_models::enums::CountryAlpha2::NL),
             currency: Some(enums::Currency::EUR),
             address: Some(PaymentAddress::new(
                 None,

--- a/crates/router/tests/connectors/payme.rs
+++ b/crates/router/tests/connectors/payme.rs
@@ -68,7 +68,6 @@ fn get_default_payment_info() -> Option<utils::PaymentInfo> {
         return_url: None,
         connector_customer: None,
         payment_method_token: None,
-        country: None,
         currency: None,
         #[cfg(feature = "payouts")]
         payout_method_data: None,

--- a/crates/router/tests/connectors/square.rs
+++ b/crates/router/tests/connectors/square.rs
@@ -48,7 +48,6 @@ fn get_default_payment_info(payment_method_token: Option<String>) -> Option<util
         #[cfg(feature = "payouts")]
         payout_method_data: None,
         currency: None,
-        country: None,
     })
 }
 

--- a/crates/router/tests/connectors/stax.rs
+++ b/crates/router/tests/connectors/stax.rs
@@ -51,7 +51,6 @@ fn get_default_payment_info(
         #[cfg(feature = "payouts")]
         payout_method_data: None,
         currency: None,
-        country: None,
     })
 }
 

--- a/crates/router/tests/connectors/utils.rs
+++ b/crates/router/tests/connectors/utils.rs
@@ -51,7 +51,6 @@ pub struct PaymentInfo {
     #[cfg(feature = "payouts")]
     pub payout_method_data: Option<types::api::PayoutMethodData>,
     pub currency: Option<enums::Currency>,
-    pub country: Option<enums::CountryAlpha2>,
 }
 
 impl PaymentInfo {

--- a/crates/router/tests/connectors/wise.rs
+++ b/crates/router/tests/connectors/wise.rs
@@ -52,7 +52,6 @@ impl utils::Connector for WiseTest {
 impl WiseTest {
     fn get_payout_info() -> Option<PaymentInfo> {
         Some(PaymentInfo {
-            country: Some(api_models::enums::CountryAlpha2::NL),
             currency: Some(enums::Currency::GBP),
             address: Some(PaymentAddress::new(
                 None,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
This PR addresses the clippy lints occurring due to new rust version 1.79

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Basic sanity testing should suffice

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
