### PR TITLE
chore(docker-compose): pass correct configuration values for running SDK demo app 

### DIFF
--- a/docker-compose-development.yml
+++ b/docker-compose-development.yml
@@ -25,6 +25,12 @@ services:
       - POSTGRES_USER=db_user
       - POSTGRES_PASSWORD=db_pass
       - POSTGRES_DB=hyperswitch_db
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready"]
+      interval: 5s
+      retries: 3
+      start_period: 5s
+      timeout: 5s
 
   redis-standalone:
     image: redis:7
@@ -32,6 +38,12 @@ services:
       - router_net
     ports:
       - "6379:6379"
+    healthcheck:
+      test: ["CMD-SHELL", "redis-cli ping | grep '^PONG$'"]
+      interval: 5s
+      retries: 3
+      start_period: 5s
+      timeout: 5s
 
   migration_runner:
     image: rust:latest

--- a/docker-compose-development.yml
+++ b/docker-compose-development.yml
@@ -76,6 +76,11 @@ services:
     environment:
       - CARGO_HOME=/cargo_cache
       - CARGO_TARGET_DIR=/cargo_build_cache
+    depends_on:
+      pg:
+        condition: service_healthy
+      redis-standalone:
+        condition: service_healthy
     labels:
       logs: "promtail"
     healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,12 @@ services:
       - POSTGRES_USER=db_user
       - POSTGRES_PASSWORD=db_pass
       - POSTGRES_DB=hyperswitch_db
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready"]
+      interval: 5s
+      retries: 3
+      start_period: 5s
+      timeout: 5s
 
   redis-standalone:
     image: redis:7
@@ -27,6 +33,12 @@ services:
       - router_net
     ports:
       - "6379:6379"
+    healthcheck:
+      test: ["CMD-SHELL", "redis-cli ping | grep '^PONG$'"]
+      interval: 5s
+      retries: 3
+      start_period: 5s
+      timeout: 5s
 
   migration_runner:
     image: rust:latest
@@ -59,10 +71,10 @@ services:
       logs: "promtail"
     healthcheck:
       test: curl --fail http://localhost:8080/health || exit 1
-      interval: 10s
+      interval: 5s
       retries: 3
       start_period: 5s
-      timeout: 10s
+      timeout: 5s
 
   hyperswitch-producer:
     image: juspaydotin/hyperswitch-producer:standalone

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,6 +67,11 @@ services:
     volumes:
       - ./config:/local/config
       - ./files:/local/bin/files
+    depends_on:
+      pg:
+        condition: service_healthy
+      redis-standalone:
+        condition: service_healthy
     labels:
       logs: "promtail"
     healthcheck:
@@ -108,7 +113,7 @@ services:
       - SCHEDULER_FLOW=consumer
     depends_on:
       hyperswitch-server:
-        condition: service_started
+        condition: service_healthy
     labels:
       logs: "promtail"
     healthcheck:
@@ -133,7 +138,7 @@ services:
     restart: unless-stopped
     depends_on:
       hyperswitch-server:
-        condition: service_started
+        condition: service_healthy
     labels:
       logs: "promtail"
 
@@ -143,21 +148,25 @@ services:
       - "9050:9050"
       - "9060:9060"
       - "5252:5252"
+    networks:
+      - router_net
     build:
       context: ./docker
       dockerfile: web.Dockerfile
+    depends_on:
+      hyperswitch-server:
+        condition: service_healthy
     environment:
-      - HYPERSWITCH_PUBLISHABLE_KEY=${HYPERSWITCH_PUBLISHABLE_KEY:-PUBLISHABLE_KEY}
-      - HYPERSWITCH_SECRET_KEY=${HYPERSWITCH_SECRET_KEY:-SECRET_KEY}
-      - HYPERSWITCH_SERVER_URL=${HYPERSWITCH_SERVER_URL:-http://hyperswitch-server:8080}
-      - HYPERSWITCH_CLIENT_URL=${HYPERSWITCH_CLIENT_URL:-http://localhost:9050}
-      - SELF_SERVER_URL=${SELF_SERVER_URL:-http://localhost:5252}
-      - SDK_ENV=${SDK_ENV:-local}
-      - ENV_SDK_URL=${ENV_SDK_URL:-http://localhost:9050}
-      - ENV_BACKEND_URL=${ENV_BACKEND_URL:-http://localhost:8080}
-      - ENV_LOGGING_URL=${ENV_LOGGING_URL:-http://localhost:3100}
+      - HYPERSWITCH_PUBLISHABLE_KEY=placeholder_publishable_key
+      - HYPERSWITCH_SECRET_KEY=placeholder_api_key
+      - HYPERSWITCH_SERVER_URL=http://localhost:8080
+      - HYPERSWITCH_SERVER_URL_FOR_DEMO_APP=http://hyperswitch-server:8080
+      - HYPERSWITCH_CLIENT_URL=http://localhost:9050
+      - SELF_SERVER_URL=http://localhost:5252
+      - SDK_ENV=local
+      - ENV_LOGGING_URL=http://localhost:3100
     labels:  
-      logs: "promtail"  
+      logs: "promtail"
 
   ### Control Center
   hyperswitch-control-center:
@@ -170,7 +179,10 @@ services:
     volumes:
       - ./config/dashboard.toml:/tmp/dashboard-config.toml
     depends_on:
-      - hyperswitch-web
+      hyperswitch-server:
+        condition: service_healthy
+      hyperswitch-web:
+        condition: service_started
     labels:  
       logs: "promtail" 
 


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->

This PR includes the following changes to the Docker Compose setup:

- Adds health checks for PostgreSQL and Redis containers.
- Specifies the dependencies among services.
- Specifies the correct environment variables for the `hyperswitch-web` service so that the SDK demo app works correctly.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
More robust Docker Compose setup, and enabling the SDK demo app.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Locally, with the Docker Compose setup:

![Screenshot of locally running demo app](https://github.com/juspay/hyperswitch/assets/22217505/5d84d772-57b6-4cc9-a117-9b3adbd1c180)


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
