### PR TITLE
chore(ci): Add nix workflow

### DIFF
--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -1,0 +1,17 @@
+name: "CI Nix"
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+jobs:
+  checks:
+    runs-on: ${{ matrix.system }}
+    permissions:
+      contents: read
+    strategy:
+      matrix:
+        system: [ x86_64-linux, aarch64-darwin ]
+    steps:
+      - uses: actions/checkout@v4
+      - run: nixci --extra-access-tokens ${{ secrets.GITHUB_TOKEN }} build --systems "github:nix-systems/${{ matrix.system }}"

--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -14,4 +14,4 @@ jobs:
         system: [ x86_64-linux, aarch64-darwin ]
     steps:
       - uses: actions/checkout@v4
-      - run: nixci --extra-access-tokens ${{ secrets.GITHUB_TOKEN }} build --systems "github:nix-systems/${{ matrix.system }}"
+      - run: om ci --extra-access-tokens ${{ secrets.GITHUB_TOKEN }} run --systems "${{ matrix.system }}"


### PR DESCRIPTION
The builds will run on Juspay managed self-hosted runners (NixOS & nix-darwin machines in office).

## Motivation and Context

To make sure that `flake.nix` remains usable over time and works for users.

