### PR TITLE
fix(payment_methods): populate card fields while saving card again during metadata change condition

### DIFF
--- a/crates/router/src/core/payment_methods/cards.rs
+++ b/crates/router/src/core/payment_methods/cards.rs
@@ -653,9 +653,10 @@ pub async fn add_payment_method(
                     };
 
                     let updated_card = Some(api::CardDetailFromLocker {
-                        scheme: None,
+                        scheme: existing_pm.scheme.clone(),
                         last4_digits: Some(card.card_number.get_last4()),
-                        issuer_country: None,
+                        issuer_country: card.card_issuing_country,
+                        card_isin: Some(card.card_number.get_card_isin()),
                         card_number: Some(card.card_number),
                         expiry_month: Some(card.card_exp_month),
                         expiry_year: Some(card.card_exp_year),
@@ -663,10 +664,9 @@ pub async fn add_payment_method(
                         card_fingerprint: None,
                         card_holder_name: card.card_holder_name,
                         nick_name: card.nick_name,
-                        card_network: None,
-                        card_isin: None,
-                        card_issuer: None,
-                        card_type: None,
+                        card_network: card.card_network,
+                        card_issuer: card.card_issuer,
+                        card_type: card.card_type,
                         saved_to_locker: true,
                     });
 

--- a/crates/router/src/core/payment_methods/transformers.rs
+++ b/crates/router/src/core/payment_methods/transformers.rs
@@ -346,7 +346,7 @@ pub fn mk_add_card_response_hs(
     let card = api::CardDetailFromLocker {
         scheme: None,
         last4_digits: Some(last4_digits),
-        issuer_country: None,
+        issuer_country: card.card_issuing_country,
         card_number: Some(card.card_number.clone()),
         expiry_month: Some(card.card_exp_month.clone()),
         expiry_year: Some(card.card_exp_year.clone()),

--- a/crates/router/src/core/payments/tokenization.rs
+++ b/crates/router/src/core/payments/tokenization.rs
@@ -469,9 +469,10 @@ where
                                 };
 
                                 let updated_card = Some(CardDetailFromLocker {
-                                    scheme: None,
+                                    scheme: existing_pm.scheme.clone(),
                                     last4_digits: Some(card.card_number.get_last4()),
-                                    issuer_country: None,
+                                    issuer_country: card.card_issuing_country,
+                                    card_isin: Some(card.card_number.get_card_isin()),
                                     card_number: Some(card.card_number),
                                     expiry_month: Some(card.card_exp_month),
                                     expiry_year: Some(card.card_exp_year),
@@ -479,10 +480,9 @@ where
                                     card_fingerprint: None,
                                     card_holder_name: card.card_holder_name,
                                     nick_name: card.nick_name,
-                                    card_network: None,
-                                    card_isin: None,
-                                    card_issuer: None,
-                                    card_type: None,
+                                    card_network: card.card_network,
+                                    card_issuer: card.card_issuer,
+                                    card_type: card.card_type,
                                     saved_to_locker: true,
                                 });
 


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
When the same card is being saved with metadata changes, the other fields of card like `card_network`, `card_issuer`, `scheme`, `card_type`, `card_isin`, `card_issuing_country` were getting saved with hardcoded value as `None` instead of getting its value from the existing saved card. This PR fixes the issue

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
1. Save a card 

```
curl --location 'http://localhost:8080/payments' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: dev_bS3Uz99HdVusSOy9rHtZqcevmpHt9L4N6WvNt5d16SwBgz53crKKEd6pCMrvVVbH' \
--data-raw '{
    "amount": 499,
    "currency": "USD",
    "confirm": true,
    "capture_method": "automatic",
    "customer_id": "cus_6Syv31iU1EeDKyfN1U7O",
    "email": "guest@example.com",
    "customer_acceptance": {
        "acceptance_type": "online"
    },
    "payment_method": "card",
    "payment_method_type": "credit",
    "payment_method_data": {
        "card": {
            "card_number": "4242424242424242",
            "card_exp_month": "03",
            "card_exp_year": "2030",
            "card_holder_name": "Test Holder",
            "card_cvc": "737"
        }
    },
    "billing": {
        "address": {
            "city": "test",
            "country": "US",
            "line1": "here",
            "line2": "there",
            "line3": "anywhere",
            "zip": "560095",
            "state": "Washington",
            "first_name": "One",
            "last_name": "Two"
        },
        "phone": {
            "number": "1234567890",
            "country_code": "+1"
        },
        "email": "guest@example.com"
    },
    "authentication_type": "no_three_ds"
}'
```

2. Hit list customer payment methods and all the card fields like card_network, issuer country, scheme, etc should be listed.

![image](https://github.com/juspay/hyperswitch/assets/70657455/04daa5d4-a8fd-4994-8bb2-b99c17e4a6d5)

3. Save the same card again but with some different expiry.
4. Hit list customer payment methods and still the above fields has to be listed which was not the case before.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
