### PR TITLE
feat(router): add payment method type duplication check for `google_pay`

### DIFF
--- a/crates/router/src/core/payments/tokenization.rs
+++ b/crates/router/src/core/payments/tokenization.rs
@@ -532,12 +532,7 @@ where
                                 Ok(customer_payment_methods) => Ok(customer_payment_methods
                                     .iter()
                                     .find(|payment_method| {
-                                        payment_method.payment_method_type
-                                            == Some(api_models::enums::PaymentMethodType::ApplePay)
-                                            || payment_method.payment_method_type
-                                                == Some(
-                                                    api_models::enums::PaymentMethodType::GooglePay,
-                                                )
+                                        payment_method.payment_method_type == payment_method_type
                                     })
                                     .map(|pm| pm.payment_method_id.clone())),
                                 Err(error) => {

--- a/crates/router/src/core/payments/tokenization.rs
+++ b/crates/router/src/core/payments/tokenization.rs
@@ -515,7 +515,7 @@ where
                         }
                     },
                     None => {
-                        let customer_apple_pay_saved_pm_id_option = if payment_method_type
+                        let customer_saved_pm_id_option = if payment_method_type
                             == Some(api_models::enums::PaymentMethodType::ApplePay)
                             || payment_method_type
                                 == Some(api_models::enums::PaymentMethodType::GooglePay)
@@ -553,10 +553,8 @@ where
                             Ok(None)
                         }?;
 
-                        if let Some(customer_apple_pay_saved_pm_id) =
-                            customer_apple_pay_saved_pm_id_option
-                        {
-                            resp.payment_method_id = customer_apple_pay_saved_pm_id;
+                        if let Some(customer_saved_pm_id) = customer_saved_pm_id_option {
+                            resp.payment_method_id = customer_saved_pm_id;
                         } else {
                             let pm_metadata =
                                 create_payment_method_metadata(None, connector_token)?;

--- a/crates/router/src/core/payments/tokenization.rs
+++ b/crates/router/src/core/payments/tokenization.rs
@@ -517,6 +517,8 @@ where
                     None => {
                         let customer_apple_pay_saved_pm_id_option = if payment_method_type
                             == Some(api_models::enums::PaymentMethodType::ApplePay)
+                            || payment_method_type
+                                == Some(api_models::enums::PaymentMethodType::GooglePay)
                         {
                             match state
                                 .store
@@ -532,6 +534,10 @@ where
                                     .find(|payment_method| {
                                         payment_method.payment_method_type
                                             == Some(api_models::enums::PaymentMethodType::ApplePay)
+                                            || payment_method.payment_method_type
+                                                == Some(
+                                                    api_models::enums::PaymentMethodType::GooglePay,
+                                                )
                                     })
                                     .map(|pm| pm.payment_method_id.clone())),
                                 Err(error) => {


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Currently there is no duplication check for google pay and we will create a new payment method entry for every google pay payment CIT with `"setup_future_usage": "on_session"`. This is not the case in cards as locker handles the card duplication. Since we do not have a parameter handle duplication check for a google pay, we have to go with a approach of a customer can have only one saved google pay payment method.

In this approach we list all the saved payment method for a customer during every google pay CIT and check if any of them have the `payment_method_type` is `google_pay` if it is then we just return already saved `payment_method_id`.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
-> Create a merchant connector account with google pay enabled
-> Do a CIT with `setup_future_usage`
```
curl --location 'http://localhost:8080/payments' \
--header 'Accept: application/json' \
--header 'api-key: dev_rR35w9RzL1WW5hiDN7aF9jZbH6qHzAzW0nb9kB52KAnJDYc5EH3CakFbIje9MpYk' \
--header 'Content-Type: application/json' \
--data-raw '{
    "amount": 800,
    "currency": "USD",
    "confirm": true,
    "amount_to_capture": 800,
    "customer_id": "gpay_testing",
    "capture_method": "automatic",
    "capture_on": "2022-09-10T10:11:12Z",
    "authentication_type": "three_ds",
    "return_url": "https://google.com",
    "email": "something@gmail.com",
    "name": "Joseph Doe",
    "phone": "999999999",
    "phone_country_code": "+65",
    "description": "Its my first payment request",
    "statement_descriptor_name": "Juspay",
    "statement_descriptor_suffix": "Router",
    "payment_method": "wallet",
    "payment_method_type": "google_pay",
    "payment_method_data": {
        "wallet": {
            "google_pay": {
                "type": "CARD",
                "description": "Visa •••• 1111",
                "info": {
                    "card_network": "VISA",
                    "card_details": "1111"
                },
                "tokenization_data": {
                    "type": "PAYMENT_GATEWAY",
                    "token": "{\n  \"id\": \"tok_1PT1DcD5n    \"address_line2\": null,\n    \"address_state\": null,\n    \"address_zip\": null,\n    \"address,\n    \"exp_year\": 2026,\n    \"funding\": \"credit\",\n    \"last4\": \"1111\",\n    \"metadata\": {},\n    \"name\": null,\n    \"networks\": {\n      \"preferred\": null\n    },\n    \"tokenization_method\": \"android_pay\",\n    \"wallet\": null\n  },\n  \"client_ip\": \"209.85.198.162\",\n  \"created\": 1718713980,\n  \"livemode\": false,\n  \"type\": \"card\",\n  \"used\": false\n}"
                }
            }
        }
    },
    "setup_future_usage": "off_session",
    "customer_acceptance": {
        "acceptance_type": "offline",
        "accepted_at": "1963-05-03T04:07:52.723Z",
        "online": {
            "ip_address": "in sit",
            "user_agent": "amet irure esse"
        }
    },
    "billing": {
        "address": {
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "city": "San Fransico",
            "state": "California",
            "zip": "94122",
            "country": "US",
            "first_name": "joseph",
            "last_name": "Doe"
        },
        "phone": {
            "number": "8056594427",
            "country_code": "+91"
        }
    },
    "connector_metadata": {
        "noon": {
            "order_category": "pay"
        }
    }
}'
```
<img width="804" alt="image" src="https://github.com/juspay/hyperswitch/assets/83439957/b35b015e-d049-49fd-932f-aea4d421ca3a">

-> Perform the CIT again with same request payload and different google pay token
```
{
    "amount": 800,
    "currency": "USD",
    "confirm": true,
    "amount_to_capture": 800,
    "customer_id": "gpay_testing",
    "capture_method": "automatic",
    "capture_on": "2022-09-10T10:11:12Z",
    "authentication_type": "three_ds",
    "return_url": "https://google.com",
    "email": "something@gmail.com",
    "name": "Joseph Doe",
    "phone": "999999999",
    "phone_country_code": "+65",
    "description": "Its my first payment request",
    "statement_descriptor_name": "Juspay",
    "statement_descriptor_suffix": "Router",
    "payment_method": "wallet",
    "payment_method_type": "google_pay",
    "payment_method_data": {
        "wallet": {
            "google_pay": {
                "type": "CARD",
                "description": "Visa •••• 1111",
                "info": {
                    "card_network": "VISA",
                    "card_details": "1111"
                },
                "tokenization_data": {
                    "type": "PAYMENT_GATEWAY",
                    "token": "{\n  \"id\": \"tok_1PT1czD5R7gDAGffO2Mtj23f\",\n  \"object\": \"token\",\n  \"card\": {\n    \"id\": \"card_1PT1czD5R7gDAGffPGZqUPoL\",\n    \"object\": \"card\",\n    \"address_city\": null,\n    \"address_country\": null,\n    \"address_line1\": null,\n    \"address_line1_check\": null,\n    \"address_line2\": null,\n    \"address_state\": null,\n    \"address_zip\": null,\n    \"address_zip_check\": null,\n    \"brand\": \"Visa\",\n    \"country\": \"US\",\n    \"cvc_check\": null,\n    \"dynamic_last4\": \"1111\",\n    \"exp_month\": 12,\n    \"exp_year\": 2026,\n    \"funding\": \"credit\",\n    \"last4\": \"1111\",\n    \"metadata\": {},\n    \"name\": null,\n    \"networks\": {\n      \"preferred\": null\n    },\n    \"tokenization_method\": \"android_pay\",\n    \"wallet\": null\n  },\n  \"client_ip\": \"209.85.198.162\",\n  \"created\": 1718715553,\n  \"livemode\": false,\n  \"type\": \"card\",\n  \"used\": false\n}"
                }
            }
        }
    },
    "setup_future_usage": "off_session",
    "customer_acceptance": {
        "acceptance_type": "offline",
        "accepted_at": "1963-05-03T04:07:52.723Z",
        "online": {
            "ip_address": "in sit",
            "user_agent": "amet irure esse"
        }
    },
    "billing": {
        "address": {
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "city": "San Fransico",
            "state": "California",
            "zip": "94122",
            "country": "US",
            "first_name": "joseph",
            "last_name": "Doe"
        },
        "phone": {
            "number": "8056594427",
            "country_code": "+91"
        }
    },
    "connector_metadata": {
        "noon": {
            "order_category": "pay"
        }
    }
}
```
<img width="1077" alt="image" src="https://github.com/juspay/hyperswitch/assets/83439957/efe76f95-1253-4abd-b427-6f4dc4ec4021">


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
