### PR TITLE
ci(cypress): Fix payment method id for non supported connectors

### DIFF
--- a/cypress-tests/cypress/e2e/PaymentTest/00018-MandatesUsingPMID.cy.js
+++ b/cypress-tests/cypress/e2e/PaymentTest/00018-MandatesUsingPMID.cy.js
@@ -16,10 +16,8 @@ describe("Card - Mandates using Payment Method Id flow test", () => {
     });
   });
 
-  beforeEach(function () {
-    if (!should_continue) {
-      this.skip();
-    }
+  after("flush global state", () => {
+    cy.task("setGlobalState", globalState.data);
   });
 
   afterEach("flush global state", () => {
@@ -30,6 +28,13 @@ describe("Card - Mandates using Payment Method Id flow test", () => {
     "Card - NoThreeDS Create and Confirm Automatic CIT and MIT payment flow test",
     () => {
       let should_continue = true;
+
+      beforeEach(function () {
+        if (!should_continue) {
+          this.skip();
+        }
+      });
+      
       it("Create No 3DS Payment Intent", () => {
         let data = getConnectorDetails(globalState.get("connectorId"))[
           "card_pm"
@@ -80,6 +85,12 @@ describe("Card - Mandates using Payment Method Id flow test", () => {
     "Card - NoThreeDS Create and Confirm Manual CIT and MIT payment flow test",
     () => {
       let should_continue = true;
+
+      beforeEach(function () {
+        if (!should_continue) {
+          this.skip();
+        }
+      });
 
       it("Create No 3DS Payment Intent", () => {
         let data = getConnectorDetails(globalState.get("connectorId"))[
@@ -144,6 +155,12 @@ describe("Card - Mandates using Payment Method Id flow test", () => {
     () => {
       let should_continue = true;
 
+      beforeEach(function () {
+        if (!should_continue) {
+          this.skip();
+        }
+      });
+
       it("Confirm No 3DS CIT", () => {
         console.log("confirm -> " + globalState.get("connectorId"));
         let data = getConnectorDetails(globalState.get("connectorId"))[
@@ -179,6 +196,12 @@ describe("Card - Mandates using Payment Method Id flow test", () => {
     "Card - NoThreeDS Create + Confirm Manual CIT and MIT payment flow test",
     () => {
       let should_continue = true;
+
+      beforeEach(function () {
+        if (!should_continue) {
+          this.skip();
+        }
+      });
 
       it("Confirm No 3DS CIT", () => {
         console.log("confirm -> " + globalState.get("connectorId"));
@@ -253,6 +276,12 @@ describe("Card - Mandates using Payment Method Id flow test", () => {
     () => {
       let should_continue = true;
 
+      beforeEach(function () {
+        if (!should_continue) {
+          this.skip();
+        }
+      });
+
       it("Confirm 3DS CIT", () => {
         console.log("confirm -> " + globalState.get("connectorId"));
         let data = getConnectorDetails(globalState.get("connectorId"))[
@@ -293,6 +322,12 @@ describe("Card - Mandates using Payment Method Id flow test", () => {
     "Card - ThreeDS Create + Confirm Manual CIT and MIT payment flow",
     () => {
       let should_continue = true;
+
+      beforeEach(function () {
+        if (!should_continue) {
+          this.skip();
+        }
+      });
 
       it("Confirm 3DS CIT", () => {
         console.log("confirm -> " + globalState.get("connectorId"));

--- a/cypress-tests/cypress/e2e/PaymentUtils/Paypal.js
+++ b/cypress-tests/cypress/e2e/PaymentUtils/Paypal.js
@@ -1,3 +1,5 @@
+import { getCustomExchange } from "./Commons";
+
 const successfulNo3DSCardDetails = {
   card_number: "4012000033330026",
   card_exp_month: "01",
@@ -232,7 +234,7 @@ export const connectorDetails = {
     },
     MandateSingleUse3DSManualCapture: {
       Request: {
-       payment_method_data: {
+        payment_method_data: {
           card: successfulThreeDSTestCardDetails,
         },
         currency: "USD",
@@ -336,7 +338,7 @@ export const connectorDetails = {
           card: successfulThreeDSTestCardDetails,
         },
         currency: "USD",
-       mandate_data: multiUseMandateData,
+        mandate_data: multiUseMandateData,
       },
       Response: {
         status: 400,
@@ -541,6 +543,166 @@ export const connectorDetails = {
             code: "HE_03",
             reason: "debit mandate payment is not supported by paypal",
           },
+        },
+      },
+    },
+  },
+  bank_redirect_pm: {
+    PaymentIntent: getCustomExchange({
+      Request: {
+        currency: "EUR",
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "requires_payment_method",
+        },
+      },
+    }),
+    ideal: {
+      Request: {
+        payment_method: "bank_redirect",
+        payment_method_type: "ideal",
+        payment_method_data: {
+          bank_redirect: {
+            ideal: {
+              bank_name: "ing",
+            },
+          },
+        },
+        billing: {
+          address: {
+            line1: "1467",
+            line2: "Harrison Street",
+            line3: "Harrison Street",
+            city: "San Fransico",
+            state: "California",
+            zip: "94122",
+            country: "NL",
+            first_name: "joseph",
+            last_name: "Doe",
+          },
+          phone: {
+            number: "8056594427",
+            country_code: "+91",
+          },
+        },
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "requires_customer_action",
+        },
+      },
+    },
+    giropay: {
+      Request: {
+        payment_method: "bank_redirect",
+        payment_method_type: "giropay",
+        payment_method_data: {
+          bank_redirect: {
+            giropay: {
+              bank_name: "",
+              bank_account_bic: "",
+              bank_account_iban: "",
+            },
+          },
+        },
+        billing: {
+          address: {
+            line1: "1467",
+            line2: "Harrison Street",
+            line3: "Harrison Street",
+            city: "San Fransico",
+            state: "California",
+            zip: "94122",
+            country: "DE",
+            first_name: "joseph",
+            last_name: "Doe",
+          },
+          phone: {
+            number: "8056594427",
+            country_code: "+91",
+          },
+        },
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "requires_customer_action",
+        },
+      },
+    },
+    sofort: {
+      Request: {
+        payment_method: "bank_redirect",
+        payment_method_type: "sofort",
+        payment_method_data: {
+          bank_redirect: {
+            sofort: {
+              preferred_language: "en",
+            },
+          },
+        },
+        billing: {
+          address: {
+            line1: "1467",
+            line2: "Harrison Street",
+            line3: "Harrison Street",
+            city: "San Fransico",
+            state: "California",
+            zip: "94122",
+            country: "AT",
+            first_name: "joseph",
+            last_name: "Doe",
+          },
+          phone: {
+            number: "8056594427",
+            country_code: "+91",
+          },
+        },
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "failed",
+          error_code: "PERMISSION_DENIED",
+        },
+      },
+    },
+    eps: {
+      Request: {
+        payment_method: "bank_redirect",
+        payment_method_type: "eps",
+        payment_method_data: {
+          bank_redirect: {
+            eps: {
+              bank_name: "ing",
+            },
+          },
+        },
+        billing: {
+          address: {
+            line1: "1467",
+            line2: "Harrison Street",
+            line3: "Harrison Street",
+            city: "San Fransico",
+            state: "California",
+            zip: "94122",
+            country: "AT",
+            first_name: "joseph",
+            last_name: "Doe",
+          },
+          phone: {
+            number: "8056594427",
+            country_code: "+91",
+          },
+        },
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "requires_customer_action",
         },
       },
     },

--- a/cypress-tests/cypress/e2e/PaymentUtils/Trustpay.js
+++ b/cypress-tests/cypress/e2e/PaymentUtils/Trustpay.js
@@ -227,7 +227,7 @@ export const connectorDetails = {
           card: successfulThreeDSTestCardDetails,
         },
         currency: "USD",
-        mandate_data: singleUseMandateData, 
+        mandate_data: singleUseMandateData,
       },
       Response: {
         status: 400,
@@ -246,7 +246,7 @@ export const connectorDetails = {
           card: successfulThreeDSTestCardDetails,
         },
         currency: "USD",
-        mandate_data: singleUseMandateData, 
+        mandate_data: singleUseMandateData,
       },
       Response: {
         status: 400,
@@ -265,7 +265,7 @@ export const connectorDetails = {
           card: successfulNo3DSCardDetails,
         },
         currency: "USD",
-        mandate_data: singleUseMandateData, 
+        mandate_data: singleUseMandateData,
       },
       Response: {
         status: 400,
@@ -284,7 +284,7 @@ export const connectorDetails = {
           card: successfulNo3DSCardDetails,
         },
         currency: "USD",
-        mandate_data: singleUseMandateData, 
+        mandate_data: singleUseMandateData,
       },
       Response: {
         status: 400,
@@ -303,7 +303,7 @@ export const connectorDetails = {
           card: successfulNo3DSCardDetails,
         },
         currency: "USD",
-        mandate_data: multiUseMandateData, 
+        mandate_data: multiUseMandateData,
       },
       Response: {
         status: 400,
@@ -322,7 +322,7 @@ export const connectorDetails = {
           card: successfulNo3DSCardDetails,
         },
         currency: "USD",
-       mandate_data: multiUseMandateData,
+        mandate_data: multiUseMandateData,
       },
       Response: {
         status: 400,
@@ -485,7 +485,7 @@ export const connectorDetails = {
             type: "invalid_request",
             message: "Payment method type not supported",
             code: "HE_03",
-            reason: "debit mandate payment is not supported by trustpay",
+            reason: "manual is not supported by trustpay",
           },
         },
       },
@@ -542,7 +542,7 @@ export const connectorDetails = {
             type: "invalid_request",
             message: "Payment method type not supported",
             code: "HE_03",
-            reason: "debit mandate payment is not supported by trustpay",
+            reason: "manual is not supported by trustpay",
           },
         },
       },

--- a/cypress-tests/cypress/support/redirectionHandler.js
+++ b/cypress-tests/cypress/support/redirectionHandler.js
@@ -198,6 +198,24 @@ function bankRedirectRedirection(
       }
       verifyUrl = true;
       break;
+    case "paypal":
+      switch (payment_method_type) {
+        case "eps":
+          cy.get('button[name="Successful"][value="SUCCEEDED"]').click();
+          break;
+        case "ideal":
+          cy.get('button[name="Successful"][value="SUCCEEDED"]').click();
+          break;
+        case "giropay":
+          cy.get('button[name="Successful"][value="SUCCEEDED"]').click();
+          break;
+        default:
+          throw new Error(
+            `Unsupported payment method type: ${payment_method_type}`
+          );
+      }
+      verifyUrl = true;
+      break;
     case "stripe":
       switch (payment_method_type) {
         case "eps":

--- a/cypress-tests/cypress/support/redirectionHandler.js
+++ b/cypress-tests/cypress/support/redirectionHandler.js
@@ -264,13 +264,8 @@ function bankRedirectRedirection(
           cy.get("input#submitButton.btn.btn-primary").click();
           break;
         case "ideal":
-          cy.get("p").should(
-            "contain.text",
-            "Choose your iDeal Issuer Bank please"
-          );
-          cy.get("#issuerSearchInput").click();
-          cy.get("#issuerSearchInput").type("ING{enter}");
-          cy.get("#trustpay__selectIssuer_submit").click();
+          cy.contains("button", "Select your bank").click();
+          cy.get('[data-testid="ideal-box-bank-item-INGBNL2A"]').click();
           break;
         case "giropay":
           cy.get("._transactionId__header__iXVd_").should(


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
- Added hooks for payment method id mandates test cases as it was missed 
- Added bank redirect cases for Paypal 
- Fixed ideal bank redirect as UI has been changed

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
Test cases were failing for non supported connectors


## How did you test it?
Cypress:

- Trustpay 
<img width="738" alt="image" src="https://github.com/juspay/hyperswitch/assets/131246334/53310e6f-f2d3-4261-af8e-1bade03836ad">

- Stripe
<img width="728" alt="image" src="https://github.com/juspay/hyperswitch/assets/131246334/812391c6-c684-4219-bc78-6c2f30208fe1">

- Cybersource
<img width="728" alt="image" src="https://github.com/juspay/hyperswitch/assets/131246334/ba78a6ce-34ab-4284-a13d-f6a03af4dce5">

- Bankofamerica
<img width="728" alt="image" src="https://github.com/juspay/hyperswitch/assets/131246334/b95ba7e9-0f37-420f-9d7f-c6b866e3626a">

- nmi
<img width="728" alt="image" src="https://github.com/juspay/hyperswitch/assets/131246334/f0a67f5e-b91c-4b45-b7d5-eee56dc96603">

[2 failures are because of issue in sandbox , needs to be fixed ]

- adyen
<img width="728" alt="image" src="https://github.com/juspay/hyperswitch/assets/131246334/941ff39c-ed4c-4f1e-b3fd-5b6a81886d39">

- paypal
<img width="738" alt="image" src="https://github.com/juspay/hyperswitch/assets/131246334/01da447f-9e8d-4292-8ad5-822fbd8ccaad">


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
