### PR TITLE
fix(router): avoid considering pre-routing results during `perform_session_token_routing`

### DIFF
--- a/crates/router/src/core/payments.rs
+++ b/crates/router/src/core/payments.rs
@@ -3653,12 +3653,9 @@ pub async fn perform_session_token_routing<F>(
 where
     F: Clone,
 {
-
-    // Commenting out this code as `list_payment_method_api` and `perform_session_token_routing` 
-    // will happen in parallel the behaviour of the session call differ based on filters in 
+    // Commenting out this code as `list_payment_method_api` and `perform_session_token_routing`
+    // will happen in parallel the behaviour of the session call differ based on filters in
     // list_payment_method_api
-
-
 
     // let routing_info: Option<storage::PaymentRoutingInfo> = payment_data
     //     .payment_attempt

--- a/crates/router/src/core/payments.rs
+++ b/crates/router/src/core/payments.rs
@@ -3653,57 +3653,64 @@ pub async fn perform_session_token_routing<F>(
 where
     F: Clone,
 {
-    let routing_info: Option<storage::PaymentRoutingInfo> = payment_data
-        .payment_attempt
-        .straight_through_algorithm
-        .clone()
-        .map(|val| val.parse_value("PaymentRoutingInfo"))
-        .transpose()
-        .change_context(errors::ApiErrorResponse::InternalServerError)
-        .attach_printable("invalid payment routing info format found in payment attempt")?;
 
-    if let Some(storage::PaymentRoutingInfo {
-        pre_routing_results: Some(pre_routing_results),
-        ..
-    }) = routing_info
-    {
-        let mut payment_methods: rustc_hash::FxHashMap<
-            (String, enums::PaymentMethodType),
-            api::SessionConnectorData,
-        > = rustc_hash::FxHashMap::from_iter(connectors.iter().map(|c| {
-            (
-                (
-                    c.connector.connector_name.to_string(),
-                    c.payment_method_type,
-                ),
-                c.clone(),
-            )
-        }));
+    // Commenting out this code as `list_payment_method_api` and `perform_session_token_routing` 
+    // will happen in parallel the behaviour of the session call differ based on filters in 
+    // list_payment_method_api
 
-        let mut final_list: Vec<api::SessionConnectorData> = Vec::new();
-        for (routed_pm_type, pre_routing_choice) in pre_routing_results.into_iter() {
-            let routable_connector_list = match pre_routing_choice {
-                storage::PreRoutingConnectorChoice::Single(routable_connector) => {
-                    vec![routable_connector.clone()]
-                }
-                storage::PreRoutingConnectorChoice::Multiple(routable_connector_list) => {
-                    routable_connector_list.clone()
-                }
-            };
-            for routable_connector in routable_connector_list {
-                if let Some(session_connector_data) =
-                    payment_methods.remove(&(routable_connector.to_string(), routed_pm_type))
-                {
-                    final_list.push(session_connector_data);
-                    break;
-                }
-            }
-        }
 
-        if !final_list.is_empty() {
-            return Ok(final_list);
-        }
-    }
+
+    // let routing_info: Option<storage::PaymentRoutingInfo> = payment_data
+    //     .payment_attempt
+    //     .straight_through_algorithm
+    //     .clone()
+    //     .map(|val| val.parse_value("PaymentRoutingInfo"))
+    //     .transpose()
+    //     .change_context(errors::ApiErrorResponse::InternalServerError)
+    //     .attach_printable("invalid payment routing info format found in payment attempt")?;
+
+    // if let Some(storage::PaymentRoutingInfo {
+    //     pre_routing_results: Some(pre_routing_results),
+    //     ..
+    // }) = routing_info
+    // {
+    //     let mut payment_methods: rustc_hash::FxHashMap<
+    //         (String, enums::PaymentMethodType),
+    //         api::SessionConnectorData,
+    //     > = rustc_hash::FxHashMap::from_iter(connectors.iter().map(|c| {
+    //         (
+    //             (
+    //                 c.connector.connector_name.to_string(),
+    //                 c.payment_method_type,
+    //             ),
+    //             c.clone(),
+    //         )
+    //     }));
+
+    //     let mut final_list: Vec<api::SessionConnectorData> = Vec::new();
+    //     for (routed_pm_type, pre_routing_choice) in pre_routing_results.into_iter() {
+    //         let routable_connector_list = match pre_routing_choice {
+    //             storage::PreRoutingConnectorChoice::Single(routable_connector) => {
+    //                 vec![routable_connector.clone()]
+    //             }
+    //             storage::PreRoutingConnectorChoice::Multiple(routable_connector_list) => {
+    //                 routable_connector_list.clone()
+    //             }
+    //         };
+    //         for routable_connector in routable_connector_list {
+    //             if let Some(session_connector_data) =
+    //                 payment_methods.remove(&(routable_connector.to_string(), routed_pm_type))
+    //             {
+    //                 final_list.push(session_connector_data);
+    //                 break;
+    //             }
+    //         }
+    //     }
+
+    //     if !final_list.is_empty() {
+    //         return Ok(final_list);
+    //     }
+    // }
 
     let routing_enabled_pms = HashSet::from([
         enums::PaymentMethodType::GooglePay,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
avoid considering pre-routing results during `perform_session_token_routing`

As there is a logic to filter out the apple pay payment method if apple pay is already saved. But this should not be the save when performing the session token (`perform_session_token_routing`). 

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
-> Create mca with apple pay configured
-> Create payment with apple pay
```
{
    "amount": 650,
    "currency": "USD",
    "confirm": true,
    "business_country": "US",
    "business_label": "default",
    "amount_to_capture": 650,
    "customer_id": "test_fb",
    "capture_method": "automatic",
    "capture_on": "2022-09-10T10:11:12Z",
    "authentication_type": "three_ds",
    "return_url": "https://google.com",
    "email": "something@gmail.com",
    "name": "Joseph Doe",
    "phone": "999999999",
    "phone_country_code": "+65",
    "description": "Its my first payment request",
    "statement_descriptor_name": "Juspay",
    "statement_descriptor_suffix": "Router",
    "payment_method": "wallet",
    "payment_method_type": "apple_pay",
    "billing": {
        "address": {
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "city": "San Fransico",
            "state": "California",
            "zip": "94122",
            "country": "US",
            "first_name": "joseph",
            "last_name": "Doe"
        },
        "phone": {
            "number": "8056594427",
            "country_code": "+91"
        }
       
    },
    "payment_method_data": {
        "wallet": {
            "apple_pay": {
                "payment_data":"eyJkYXRhIjoiVnJnTm9mYXRRZEFIME1MTjZjd1VMazdIS09PdWIvUnMwbEtFOW1vWllvcFhSSXpGemM4VDJiMzlpWjdWSGVXK0YxZVFmY0V5OFJrWjMvcWRZQkVyaE4wK1BxL2pRZ2xpZFNUNlYzdXNwRHB6MlJGSWxYUWhiODJndmd5Y3hSb1R6MER4MDgwNzQ1MUJkN1RMUldyVWNlaVRvdEN4N041ZXFVcjM3UTJlZ2hTaExNOWtXVzAxSmIvT3FLM3RLTUhZaFZNRmE2alNaaHduMVU1NitpbXR5SDMvS1BpdlJlQ0ZxTUtFVmJiRFRyNmpzSDEyNWUwVmlOalBXYm1kVzZJZWU2RDR0cjk5VEhiSkhiWUJzaVdrMUROb29tS28zbHRVUjRkMTZwL09Cc2xTYUh6dnFTL2VrOGVCTDB4dTB3TkMyamx5OFpQUnVZNGRZL2gyS3U0VmprL1BpTWtJUnRNVGl3MTFZWExXUHFNamkvM1N1VDcxUEFnZllpQU4zZmxYK1Q5RmVZRE5yVmdSNWFyRGN3PT0iLCJzaWduYXR1cmUiOiJNSUFHQ1NxR1NJYjNEUUVIQXFDQU1JQUNBUUV4RFRBTEJnbGdoa2dCWlFNRUFnRXdnQVlKS29aSWh2Y05BUWNCQUFDZ2dEQ0NBK013Z2dPSW9BTUNBUUlDQ0JaalRJc09NRmNYTUFvR0NDcUdTTTQ5QkFNQ01Ib3hMakFzQmdOVkJBTU1KVUZ3Y0d4bElFRndjR3hwWTJGMGFXOXVJRWx1ZEdWbmNtRjBhVzl1SUVOQklDMGdSek14SmpBa0JnTlZCQXNNSFVGd2NHeGxJRU5sY25ScFptbGpZWFJwYjI0Z1FYVjBhRzl5YVhSNU1STXdFUVlEVlFRS0RBcEJjSEJzWlNCSmJtTXVNUXN3Q1FZRFZRUUdFd0pWVXpBZUZ3MHlOREEwTWpreE56UTNNamRhRncweU9UQTBNamd4TnpRM01qWmFNRjh4SlRBakJnTlZCQU1NSEdWall5MXpiWEF0WW5KdmEyVnlMWE5wWjI1ZlZVTTBMVkJTVDBReEZEQVNCZ05WQkFzTUMybFBVeUJUZVhOMFpXMXpNUk13RVFZRFZRUUtEQXBCY0hCc1pTQkpibU11TVFzd0NRWURWUVFHRXdKVlV6QlpNQk1HQnlxR1NNNDlBZ0VHQ0NxR1NNNDlBd0VIQTBJQUJNSVZkKzNyMXNleUlZOW8zWENRb1NHTng3QzlieXdvUFlSZ2xkbEs5S1ZCRzROQ0R0Z1I4MEIrZ3pNZkhGVEQ5K3N5SU5hNjFkVHY5SktKaVQ1OER4T2pnZ0lSTUlJQ0RUQU1CZ05WSFJNQkFmOEVBakFBTUI4R0ExVWRJd1FZTUJhQUZDUHlTY1JQaytUdkorYkU5aWhzUDZLNy9TNUxNRVVHQ0NzR0FRVUZCd0VCQkRrd056QTFCZ2dyQmdFRkJRY3dBWVlwYUhSMGNEb3ZMMjlqYzNBdVlYQndiR1V1WTI5dEwyOWpjM0F3TkMxaGNIQnNaV0ZwWTJFek1ESXdnZ0VkQmdOVkhTQUVnZ0VVTUlJQkVEQ0NBUXdHQ1NxR1NJYjNZMlFGQVRDQi9qQ0J3d1lJS3dZQkJRVUhBZ0l3Z2JZTWdiTlNaV3hwWVc1alpTQnZiaUIwYUdseklHTmxjblJwWm1sallYUmxJR0o1SUdGdWVTQndZWEowZVNCaGMzTjFiV1Z6SUdGalkyVndkR0Z1WTJVZ2IyWWdkR2hsSUhSb1pXNGdZWEJ3YkdsallXSnNaU0J6ZEdGdVpHRnlaQ0IwWlhKdGN5QmhibVFnWTI5dVpHbDBhVzl1Y3lCdlppQjFjMlVzSUdObGNuUnBabWxqWVhSbElIQnZiR2xqZVNCaGJtUWdZMlZ5ZEdsbWFXTmhkR2x2YmlCd2NtRmpkR2xqWlNCemRHRjBaVzFsYm5SekxqQTJCZ2dyQmdFRkJRY0NBUllxYUhSMGNEb3ZMM2QzZHk1aGNIQnNaUzVqYjIwdlkyVnlkR2xtYVdOaGRHVmhkWFJvYjNKcGRIa3ZNRFFHQTFVZEh3UXRNQ3N3S2FBbm9DV0dJMmgwZEhBNkx5OWpjbXd1WVhCd2JHVXVZMjl0TDJGd2NHeGxZV2xqWVRNdVkzSnNNQjBHQTFVZERnUVdCQlNVVjl0djFYU0Job21KZGk5K1Y0VUg1NXRZSkRBT0JnTlZIUThCQWY4RUJBTUNCNEF3RHdZSktvWklodmRqWkFZZEJBSUZBREFLQmdncWhrak9QUVFEQWdOSkFEQkdBaUVBeHZBanl5WVV1ekE0aUtGaW1ENGFrL0VGYjFENmVNMjV1a3lpUWN3VTRsNENJUUMrUE5EZjBXSkg5a2xFZFRnT25VVENLS0VJa0tPaDNISkxpMHk0aUpnWXZEQ0NBdTR3Z2dKMW9BTUNBUUlDQ0VsdEw3ODZtTnFYTUFvR0NDcUdTTTQ5QkFNQ01HY3hHekFaQmdOVkJBTU1Fa0Z3Y0d4bElGSnZiM1FnUTBFZ0xTQkhNekVtTUNRR0ExVUVDd3dkUVhCd2JHVWdRMlZ5ZEdsbWFXTmhkR2x2YmlCQmRYUm9iM0pwZEhreEV6QVJCZ05WQkFvTUNrRndjR3hsSUVsdVl5NHhDekFKQmdOVkJBWVRBbFZUTUI0WERURTBNRFV3TmpJek5EWXpNRm9YRFRJNU1EVXdOakl6TkRZek1Gb3dlakV1TUN3R0ExVUVBd3dsUVhCd2JHVWdRWEJ3YkdsallYUnBiMjRnU1c1MFpXZHlZWFJwYjI0Z1EwRWdMU0JITXpFbU1DUUdBMVVFQ3d3ZFFYQndiR1VnUTJWeWRHbG1hV05oZEdsdmJpQkJkWFJvYjNKcGRIa3hFekFSQmdOVkJBb01Da0Z3Y0d4bElFbHVZeTR4Q3pBSkJnTlZCQVlUQWxWVE1Ga3dFd1lIS29aSXpqMENBUVlJS29aSXpqMERBUWNEUWdBRThCY1JoQm5YWklYVkdsNGxnUWQyNklDaTc5NTdyazNnamZ4TGsrRXpWdFZtV3pXdUl0Q1hkZzBpVG51NkNQMTJGODZJeTNhN1puQyt5T2dwaFA5VVJhT0I5ekNCOURCR0JnZ3JCZ0VGQlFjQkFRUTZNRGd3TmdZSUt3WUJCUVVITUFHR0ttaDBkSEE2THk5dlkzTndMbUZ3Y0d4bExtTnZiUzl2WTNOd01EUXRZWEJ3YkdWeWIyOTBZMkZuTXpBZEJnTlZIUTRFRmdRVUkvSkp4RStUNU84bjVzVDJLR3cvb3J2OUxrc3dEd1lEVlIwVEFRSC9CQVV3QXdFQi96QWZCZ05WSFNNRUdEQVdnQlM3c042aFdET0ltcVNLbWQ2K3ZldXYyc3NrcXpBM0JnTlZIUjhFTURBdU1DeWdLcUFvaGlab2RIUndPaTh2WTNKc0xtRndjR3hsTG1OdmJTOWhjSEJzWlhKdmIzUmpZV2N6TG1OeWJEQU9CZ05WSFE4QkFmOEVCQU1DQVFZd0VBWUtLb1pJaHZkalpBWUNEZ1FDQlFBd0NnWUlLb1pJemowRUF3SURad0F3WkFJd09zOXlnMUVXbWJHRyt6WERWc3Bpdi9RWDdka1BkVTJpanI3eG5JRmVRcmVKK0pqM20xbWZtTlZCRFkrZDZjTCtBakF5TGRWRUliQ2pCWGRzWGZNNE81Qm4vUmQ4TENGdGxrL0djbW1DRW05VStIcDlHNW5MbXdtSklXRUdtUThKa2gwQUFER0NBWWt3Z2dHRkFnRUJNSUdHTUhveExqQXNCZ05WQkFNTUpVRndjR3hsSUVGd2NHeHBZMkYwYVc5dUlFbHVkR1ZuY21GMGFXOXVJRU5CSUMwZ1J6TXhKakFrQmdOVkJBc01IVUdWJsaWNLZXkiOiJNRmt3RXdZSEtvWkl6ajBDQVFZSUtvWkl6ajBEQVFjRFFnQUVZQTdEUmxFWjk4KzNYNjVnTWVEam5wVndOS1FxRytnTzhlQmJaUDBWVVNyOFZ3ckx5YXZ4cW9ua1dJc01ZemhVRVpJYjJjZGxYd3c0eGJFRis1S25uQT09IiwidHJhbnNhY3Rpb25JZCI6ImMxMTFjYzA1YzBkZjFiMjZmYTI3MjcwZDcyMjhmM2EzNDQ1ZTJhMDNiYTMyYjQ5NjI3ODEzNTVkYjc2M2VjNjMifSwidmVyc2lvbiI6IkVDX3YxIn0=",
                "payment_method": {
                    "display_name": "Visa 0326",
                    "network": "Mastercard",
                    "type": "debit"
                },
                "transaction_identifier": "55CC32D7BF7890B9064433F15B9F23F849CF84AFD01E4E65DD8ADE306300E9D8"
            }
        }
    }
     }
```
<img width="1057" alt="image" src="https://github.com/juspay/hyperswitch/assets/83439957/c6ebf1b6-6325-4c96-a923-2687e0acccb8">


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
