### PR TITLE
refactor(cache): allow publish method of redis to accept list of keys

### DIFF
--- a/crates/drainer/src/stream.rs
+++ b/crates/drainer/src/stream.rs
@@ -44,7 +44,7 @@ impl Store {
 
     pub async fn make_stream_available(&self, stream_name_flag: &str) -> errors::DrainerResult<()> {
         match self.redis_conn.delete_key(stream_name_flag).await {
-            Ok(redis::DelReply::KeyDeleted) => Ok(()),
+            Ok(redis::DelReply::KeyDeleted(_)) => Ok(()),
             Ok(redis::DelReply::KeyNotDeleted) => {
                 logger::error!("Tried to unlock a stream which is already unlocked");
                 Ok(())

--- a/crates/redis_interface/src/commands.rs
+++ b/crates/redis_interface/src/commands.rs
@@ -210,6 +210,22 @@ impl super::RedisConnectionPool {
     }
 
     #[instrument(level = "DEBUG", skip(self))]
+    pub async fn delete_keys(
+        &self,
+        keys: Vec<String>,
+    ) -> CustomResult<DelReply, errors::RedisError> {
+        let keys = keys
+            .iter()
+            .map(|key| self.add_prefix(key))
+            .collect::<Vec<_>>();
+
+        self.pool
+            .del(keys)
+            .await
+            .change_context(errors::RedisError::DeleteFailed)
+    }
+
+    #[instrument(level = "DEBUG", skip(self))]
     pub async fn set_key_with_expiry<V>(
         &self,
         key: &str,

--- a/crates/redis_interface/src/types.rs
+++ b/crates/redis_interface/src/types.rs
@@ -248,15 +248,17 @@ impl From<StreamCapTrim> for fred::types::XCapTrim {
 
 #[derive(Debug)]
 pub enum DelReply {
-    KeyDeleted,
+    KeyDeleted(i64),
     KeyNotDeleted, // Key not found
 }
 
 impl fred::types::FromRedis for DelReply {
     fn from_value(value: fred::types::RedisValue) -> Result<Self, fred::error::RedisError> {
         match value {
-            fred::types::RedisValue::Integer(1) => Ok(Self::KeyDeleted),
             fred::types::RedisValue::Integer(0) => Ok(Self::KeyNotDeleted),
+            fred::types::RedisValue::Integer(no_of_deleted_keys) => {
+                Ok(Self::KeyDeleted(no_of_deleted_keys))
+            }
             _ => Err(fred::error::RedisError::new(
                 fred::error::RedisErrorKind::Unknown,
                 "Unexpected del command reply",

--- a/crates/router/src/core/api_locking.rs
+++ b/crates/router/src/core/api_locking.rs
@@ -129,7 +129,7 @@ impl LockAction {
                     Ok(val) => {
                         if val == state.get_request_id() {
                             match redis_conn.delete_key(redis_locking_key.as_str()).await {
-                                Ok(redis::types::DelReply::KeyDeleted) => {
+                                Ok(redis::types::DelReply::KeyDeleted(_)) => {
                                     logger::info!("Lock freed for locking input {:?}", input);
                                     tracing::Span::current()
                                         .record("redis_lock_released", redis_locking_key);

--- a/crates/router/src/core/cache.rs
+++ b/crates/router/src/core/cache.rs
@@ -1,5 +1,5 @@
 use common_utils::errors::CustomResult;
-use error_stack::{report, ResultExt};
+use error_stack::ResultExt;
 use storage_impl::redis::cache::{publish_into_redact_channel, CacheKind};
 
 use super::errors;
@@ -10,19 +10,12 @@ pub async fn invalidate(
     key: &str,
 ) -> CustomResult<services::api::ApplicationResponse<serde_json::Value>, errors::ApiErrorResponse> {
     let store = state.store.as_ref();
-    let result = publish_into_redact_channel(
+    publish_into_redact_channel(
         store.get_cache_store().as_ref(),
         [CacheKind::All(key.into())],
     )
     .await
     .change_context(errors::ApiErrorResponse::InternalServerError)?;
 
-    // If the message was published to atleast one channel
-    // then return status Ok
-    if result > 0 {
-        Ok(services::api::ApplicationResponse::StatusOk)
-    } else {
-        Err(report!(errors::ApiErrorResponse::InternalServerError)
-            .attach_printable("Failed to invalidate cache"))
-    }
+    Ok(services::api::ApplicationResponse::StatusOk)
 }

--- a/crates/router/src/core/payment_methods/vault.rs
+++ b/crates/router/src/core/payment_methods/vault.rs
@@ -1086,7 +1086,7 @@ pub async fn delete_tokenized_data(
         let response = redis_conn.delete_key(redis_key.as_str()).await;
 
         match response {
-            Ok(redis_interface::DelReply::KeyDeleted) => Ok(()),
+            Ok(redis_interface::DelReply::KeyDeleted(_)) => Ok(()),
             Ok(redis_interface::DelReply::KeyNotDeleted) => {
                 Err(errors::ApiErrorResponse::InternalServerError)
                     .attach_printable("Token invalid or expired")

--- a/crates/router/src/db/api_keys.rs
+++ b/crates/router/src/db/api_keys.rs
@@ -102,9 +102,11 @@ impl ApiKeyInterface for Store {
                 "ApiKey of {_key_id} not found"
             ))))?;
 
-            cache::publish_and_redact(
+            cache::db_call_with_redact_and_publish(
                 self,
-                CacheKind::Accounts(api_key.hashed_api_key.into_inner().into()),
+                [CacheKind::Accounts(
+                    api_key.hashed_api_key.into_inner().into(),
+                )],
                 update_call,
             )
             .await
@@ -144,9 +146,11 @@ impl ApiKeyInterface for Store {
                         "ApiKey of {key_id} not found"
                     ))))?;
 
-            cache::publish_and_redact(
+            cache::db_call_with_redact_and_publish(
                 self,
-                CacheKind::Accounts(api_key.hashed_api_key.into_inner().into()),
+                [CacheKind::Accounts(
+                    api_key.hashed_api_key.into_inner().into(),
+                )],
                 delete_call,
             )
             .await
@@ -515,11 +519,11 @@ mod tests {
 
         let delete_call = || async { db.revoke_api_key(merchant_id, &api.key_id).await };
 
-        cache::publish_and_redact(
+        cache::db_call_with_redact_and_publish(
             &db,
-            CacheKind::Accounts(
+            [CacheKind::Accounts(
                 format!("{}_{}", merchant_id, hashed_api_key.clone().into_inner()).into(),
-            ),
+            )],
             delete_call,
         )
         .await

--- a/crates/router/src/db/merchant_connector_account.rs
+++ b/crates/router/src/db/merchant_connector_account.rs
@@ -440,7 +440,7 @@ impl MerchantConnectorAccountInterface for Store {
 
                 #[cfg(feature = "accounts_cache")]
                 // Redact all caches as any of might be used because of backwards compatibility
-                cache::publish_and_redact_multiple(
+                cache::db_call_with_redact_and_publish(
                     self,
                     [
                         cache::CacheKind::Accounts(
@@ -526,7 +526,7 @@ impl MerchantConnectorAccountInterface for Store {
         #[cfg(feature = "accounts_cache")]
         {
             // Redact all caches as any of might be used because of backwards compatibility
-            cache::publish_and_redact_multiple(
+            cache::db_call_with_redact_and_publish(
                 self,
                 [
                     cache::CacheKind::Accounts(
@@ -586,7 +586,7 @@ impl MerchantConnectorAccountInterface for Store {
                 "profile_id".to_string(),
             ))?;
 
-            cache::publish_and_redact_multiple(
+            cache::db_call_with_redact_and_publish(
                 self,
                 [
                     cache::CacheKind::Accounts(
@@ -1021,9 +1021,11 @@ mod merchant_connector_account_cache_tests {
             .await
         };
 
-        cache::publish_and_redact(
+        cache::db_call_with_redact_and_publish(
             &db,
-            CacheKind::Accounts(format!("{}_{}", merchant_id, connector_label).into()),
+            [CacheKind::Accounts(
+                format!("{}_{}", merchant_id, connector_label).into(),
+            )],
             delete_call,
         )
         .await

--- a/crates/router/src/db/merchant_key_store.rs
+++ b/crates/router/src/db/merchant_key_store.rs
@@ -128,9 +128,9 @@ impl MerchantKeyStoreInterface for Store {
         #[cfg(feature = "accounts_cache")]
         {
             let key_store_cache_key = format!("merchant_key_store_{}", merchant_id);
-            cache::publish_and_redact(
+            cache::db_call_with_redact_and_publish(
                 self,
-                CacheKind::Accounts(key_store_cache_key.into()),
+                [CacheKind::Accounts(key_store_cache_key.into())],
                 delete_func,
             )
             .await

--- a/crates/storage_impl/src/redis/pub_sub.rs
+++ b/crates/storage_impl/src/redis/pub_sub.rs
@@ -4,20 +4,19 @@ use error_stack::ResultExt;
 use redis_interface::{errors as redis_errors, PubsubInterface, RedisValue};
 use router_env::{logger, tracing::Instrument};
 
-use crate::redis::cache::{
-    CacheKey, CacheKind, ACCOUNTS_CACHE, CGRAPH_CACHE, CONFIG_CACHE, DECISION_MANAGER_CACHE,
-    ROUTING_CACHE, SURCHARGE_CACHE,
-};
+use crate::redis::cache::{self, CacheKind};
 
 #[async_trait::async_trait]
 pub trait PubSubInterface {
     async fn subscribe(&self, channel: &str) -> error_stack::Result<(), redis_errors::RedisError>;
 
-    async fn publish<'a>(
+    async fn publish<'a, K>(
         &self,
         channel: &str,
-        key: CacheKind<'a>,
-    ) -> error_stack::Result<usize, redis_errors::RedisError>;
+        keys: K,
+    ) -> error_stack::Result<usize, redis_errors::RedisError>
+    where
+        K: IntoIterator<Item = CacheKind<'a>> + Send;
 
     async fn on_message(&self) -> error_stack::Result<(), redis_errors::RedisError>;
 }
@@ -61,15 +60,32 @@ impl PubSubInterface for std::sync::Arc<redis_interface::RedisConnectionPool> {
     }
 
     #[inline]
-    async fn publish<'a>(
+    async fn publish<'a, K>(
         &self,
         channel: &str,
-        key: CacheKind<'a>,
-    ) -> error_stack::Result<usize, redis_errors::RedisError> {
+        keys: K,
+    ) -> error_stack::Result<usize, redis_errors::RedisError>
+    where
+        K: IntoIterator<Item = CacheKind<'a>> + Send,
+    {
+        let mut keys_to_be_published_to_redis = Vec::new();
+        for key in keys {
+            keys_to_be_published_to_redis.push(
+                RedisValue::from(key)
+                    .as_string()
+                    .ok_or(redis_errors::RedisError::PublishError)
+                    .attach_printable("Failed to convert RedisValue to String")?,
+            )
+        }
+        let serialized_keys = serde_json::json!(keys_to_be_published_to_redis).to_string();
+
         self.publisher
-            .publish(channel, RedisValue::from(key).into_inner())
+            .publish(
+                channel,
+                RedisValue::from_string(serialized_keys).into_inner(),
+            )
             .await
-            .change_context(redis_errors::RedisError::SubscribeError)
+            .change_context(redis_errors::RedisError::PublishError)
     }
 
     #[inline]
@@ -81,122 +97,20 @@ impl PubSubInterface for std::sync::Arc<redis_interface::RedisConnectionPool> {
             logger::debug!("Received message on channel: {channel_name}");
 
             match channel_name.as_str() {
-                super::cache::IMC_INVALIDATION_CHANNEL => {
-                    let key = match CacheKind::try_from(RedisValue::new(message.value))
-                        .change_context(redis_errors::RedisError::OnMessageError)
-                    {
-                        Ok(value) => value,
-                        Err(err) => {
-                            logger::error!(value_conversion_err=?err);
-                            continue;
-                        }
-                    };
+                cache::IMC_INVALIDATION_CHANNEL => {
+                    let keys_to_be_invalidated =
+                        match CacheKind::from_redis_value(RedisValue::new(message.value))
+                            .change_context(redis_errors::RedisError::OnMessageError)
+                        {
+                            Ok(value) => value,
+                            Err(err) => {
+                                logger::error!(value_conversion_err=?err);
+                                continue;
+                            }
+                        };
 
-                    let key = match key {
-                        CacheKind::Config(key) => {
-                            CONFIG_CACHE
-                                .remove(CacheKey {
-                                    key: key.to_string(),
-                                    prefix: self.key_prefix.clone(),
-                                })
-                                .await;
-                            key
-                        }
-                        CacheKind::Accounts(key) => {
-                            ACCOUNTS_CACHE
-                                .remove(CacheKey {
-                                    key: key.to_string(),
-                                    prefix: self.key_prefix.clone(),
-                                })
-                                .await;
-                            key
-                        }
-                        CacheKind::CGraph(key) => {
-                            CGRAPH_CACHE
-                                .remove(CacheKey {
-                                    key: key.to_string(),
-                                    prefix: self.key_prefix.clone(),
-                                })
-                                .await;
-                            key
-                        }
-                        CacheKind::Routing(key) => {
-                            ROUTING_CACHE
-                                .remove(CacheKey {
-                                    key: key.to_string(),
-                                    prefix: self.key_prefix.clone(),
-                                })
-                                .await;
-                            key
-                        }
-                        CacheKind::DecisionManager(key) => {
-                            DECISION_MANAGER_CACHE
-                                .remove(CacheKey {
-                                    key: key.to_string(),
-                                    prefix: self.key_prefix.clone(),
-                                })
-                                .await;
-                            key
-                        }
-                        CacheKind::Surcharge(key) => {
-                            SURCHARGE_CACHE
-                                .remove(CacheKey {
-                                    key: key.to_string(),
-                                    prefix: self.key_prefix.clone(),
-                                })
-                                .await;
-                            key
-                        }
-                        CacheKind::All(key) => {
-                            CONFIG_CACHE
-                                .remove(CacheKey {
-                                    key: key.to_string(),
-                                    prefix: self.key_prefix.clone(),
-                                })
-                                .await;
-                            ACCOUNTS_CACHE
-                                .remove(CacheKey {
-                                    key: key.to_string(),
-                                    prefix: self.key_prefix.clone(),
-                                })
-                                .await;
-                            CGRAPH_CACHE
-                                .remove(CacheKey {
-                                    key: key.to_string(),
-                                    prefix: self.key_prefix.clone(),
-                                })
-                                .await;
-                            ROUTING_CACHE
-                                .remove(CacheKey {
-                                    key: key.to_string(),
-                                    prefix: self.key_prefix.clone(),
-                                })
-                                .await;
-                            DECISION_MANAGER_CACHE
-                                .remove(CacheKey {
-                                    key: key.to_string(),
-                                    prefix: self.key_prefix.clone(),
-                                })
-                                .await;
-                            SURCHARGE_CACHE
-                                .remove(CacheKey {
-                                    key: key.to_string(),
-                                    prefix: self.key_prefix.clone(),
-                                })
-                                .await;
-
-                            key
-                        }
-                    };
-
-                    self.delete_key(key.as_ref())
-                        .await
-                        .map_err(|err| logger::error!("Error while deleting redis key: {err:?}"))
-                        .ok();
-
-                    logger::debug!(
-                        "Handled message on channel {channel_name} - Done invalidating {key}"
-                    );
+                    cache::invalidate_cache_entry(keys_to_be_invalidated, self.key_prefix.clone())
+                        .await;
                 }
                 _ => {
                     logger::debug!("Received message from unknown channel: {channel_name}");


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
This PR includes following refactors - 
* Currently, `publish` method of redis takes in only one key to publish to a channel. Instead it should take in a list of keys to be published as this will restrict calling the publish method only once rather than calling it once for every key. 
* Add a new method on redis interface to delete multiple keys
* Created three separate methods: one for handling database calls with Redis redaction and publishing to IMC invalidation channel, another for Redis redaction and publishing, and the last one solely for publishing. This hierarchy provides flexibility for clients to perform either comprehensive invalidation or targeted actions.
* In the redis subscriber logic, match on the channel name and perform the appropriate action

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
