### PR TITLE
fix(router): skip serialize if none for assurance_details_required in googlepay session response

### DIFF
--- a/crates/api_models/src/payments.rs
+++ b/crates/api_models/src/payments.rs
@@ -4110,6 +4110,7 @@ pub struct GpayAllowedMethodsParameters {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub billing_address_parameters: Option<GpayBillingAddressParameters>,
     /// Whether assurance details are required
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub assurance_details_required: Option<bool>,
 }
 


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
assurance_details_required being null in googlepay session response was causing issues in SDK, skip serialize if none for assurance_details_required in googlepay session response

parent pr - https://github.com/juspay/hyperswitch/pull/2744

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Tested Manually
1. There's no assurance_details_required field in metadata for googlepay, field is not shown in the response
![image](https://github.com/juspay/hyperswitch/assets/56996463/96ff2c0e-3bcc-4fee-b16f-f5356ee21012)

2. If there's assurance_details_required in metadata for googlepay, then the value is returned
![image](https://github.com/juspay/hyperswitch/assets/56996463/cae5358f-8dc7-4aee-ac65-e7a8d11b8b29)

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
