### PR TITLE
fix(analytics): using HashSet to represent the returned metrics

### DIFF
--- a/crates/analytics/src/active_payments/metrics.rs
+++ b/crates/analytics/src/active_payments/metrics.rs
@@ -1,9 +1,10 @@
+use std::collections::HashSet;
+
 use api_models::analytics::{
     active_payments::{ActivePaymentsMetrics, ActivePaymentsMetricsBucketIdentifier},
     Granularity,
 };
 use time::PrimitiveDateTime;
-use std::collections::HashSet;
 
 use crate::{
     query::{Aggregate, GroupByClause, ToSql, Window},

--- a/crates/analytics/src/active_payments/metrics.rs
+++ b/crates/analytics/src/active_payments/metrics.rs
@@ -3,6 +3,7 @@ use api_models::analytics::{
     Granularity,
 };
 use time::PrimitiveDateTime;
+use std::collections::HashSet;
 
 use crate::{
     query::{Aggregate, GroupByClause, ToSql, Window},
@@ -13,7 +14,7 @@ mod active_payments;
 
 use active_payments::ActivePayments;
 
-#[derive(Debug, PartialEq, Eq, serde::Deserialize)]
+#[derive(Debug, PartialEq, Eq, serde::Deserialize, Hash)]
 pub struct ActivePaymentsMetricRow {
     pub count: Option<i64>,
 }
@@ -31,7 +32,7 @@ where
         publishable_key: &str,
         pool: &T,
     ) -> MetricsResult<
-        Vec<(
+        HashSet<(
             ActivePaymentsMetricsBucketIdentifier,
             ActivePaymentsMetricRow,
         )>,
@@ -54,7 +55,7 @@ where
         publishable_key: &str,
         pool: &T,
     ) -> MetricsResult<
-        Vec<(
+        HashSet<(
             ActivePaymentsMetricsBucketIdentifier,
             ActivePaymentsMetricRow,
         )>,

--- a/crates/analytics/src/active_payments/metrics/active_payments.rs
+++ b/crates/analytics/src/active_payments/metrics/active_payments.rs
@@ -1,8 +1,9 @@
+use std::collections::HashSet;
+
 use api_models::analytics::{active_payments::ActivePaymentsMetricsBucketIdentifier, Granularity};
 use common_utils::errors::ReportSwitchExt;
 use error_stack::ResultExt;
 use time::PrimitiveDateTime;
-use std::collections::HashSet;
 
 use super::ActivePaymentsMetricRow;
 use crate::{

--- a/crates/analytics/src/active_payments/metrics/active_payments.rs
+++ b/crates/analytics/src/active_payments/metrics/active_payments.rs
@@ -2,6 +2,7 @@ use api_models::analytics::{active_payments::ActivePaymentsMetricsBucketIdentifi
 use common_utils::errors::ReportSwitchExt;
 use error_stack::ResultExt;
 use time::PrimitiveDateTime;
+use std::collections::HashSet;
 
 use super::ActivePaymentsMetricRow;
 use crate::{
@@ -28,7 +29,7 @@ where
         publishable_key: &str,
         pool: &T,
     ) -> MetricsResult<
-        Vec<(
+        HashSet<(
             ActivePaymentsMetricsBucketIdentifier,
             ActivePaymentsMetricRow,
         )>,
@@ -59,7 +60,7 @@ where
             .into_iter()
             .map(|i| Ok((ActivePaymentsMetricsBucketIdentifier::new(None), i)))
             .collect::<error_stack::Result<
-                Vec<(
+                HashSet<(
                     ActivePaymentsMetricsBucketIdentifier,
                     ActivePaymentsMetricRow,
                 )>,

--- a/crates/analytics/src/api_event/metrics.rs
+++ b/crates/analytics/src/api_event/metrics.rs
@@ -14,12 +14,13 @@ use crate::{
 mod api_count;
 pub mod latency;
 mod status_code_count;
+use std::collections::HashSet;
+
 use api_count::ApiCount;
 use latency::MaxLatency;
 use status_code_count::StatusCodeCount;
 
 use self::latency::LatencyAvg;
-use std::collections::HashSet;
 
 #[derive(Debug, PartialEq, Eq, serde::Deserialize, Hash)]
 pub struct ApiEventMetricRow {
@@ -93,7 +94,6 @@ where
                         pool,
                     )
                     .await
-
             }
             Self::StatusCodeCount => {
                 StatusCodeCount

--- a/crates/analytics/src/api_event/metrics.rs
+++ b/crates/analytics/src/api_event/metrics.rs
@@ -19,8 +19,9 @@ use latency::MaxLatency;
 use status_code_count::StatusCodeCount;
 
 use self::latency::LatencyAvg;
+use std::collections::HashSet;
 
-#[derive(Debug, PartialEq, Eq, serde::Deserialize)]
+#[derive(Debug, PartialEq, Eq, serde::Deserialize, Hash)]
 pub struct ApiEventMetricRow {
     pub latency: Option<u64>,
     pub api_count: Option<u64>,
@@ -46,7 +47,7 @@ where
         granularity: &Option<Granularity>,
         time_range: &TimeRange,
         pool: &T,
-    ) -> MetricsResult<Vec<(ApiEventMetricsBucketIdentifier, ApiEventMetricRow)>>;
+    ) -> MetricsResult<HashSet<(ApiEventMetricsBucketIdentifier, ApiEventMetricRow)>>;
 }
 
 #[async_trait::async_trait]
@@ -67,7 +68,7 @@ where
         granularity: &Option<Granularity>,
         time_range: &TimeRange,
         pool: &T,
-    ) -> MetricsResult<Vec<(ApiEventMetricsBucketIdentifier, ApiEventMetricRow)>> {
+    ) -> MetricsResult<HashSet<(ApiEventMetricsBucketIdentifier, ApiEventMetricRow)>> {
         match self {
             Self::Latency => {
                 MaxLatency
@@ -92,6 +93,7 @@ where
                         pool,
                     )
                     .await
+
             }
             Self::StatusCodeCount => {
                 StatusCodeCount

--- a/crates/analytics/src/api_event/metrics/api_count.rs
+++ b/crates/analytics/src/api_event/metrics/api_count.rs
@@ -1,10 +1,11 @@
+use std::collections::HashSet;
+
 use api_models::analytics::{
     api_event::{ApiEventDimensions, ApiEventFilters, ApiEventMetricsBucketIdentifier},
     Granularity, TimeRange,
 };
 use common_utils::errors::ReportSwitchExt;
 use error_stack::ResultExt;
-use std::collections::HashSet;
 use time::PrimitiveDateTime;
 
 use super::ApiEventMetricRow;

--- a/crates/analytics/src/api_event/metrics/api_count.rs
+++ b/crates/analytics/src/api_event/metrics/api_count.rs
@@ -4,6 +4,7 @@ use api_models::analytics::{
 };
 use common_utils::errors::ReportSwitchExt;
 use error_stack::ResultExt;
+use std::collections::HashSet;
 use time::PrimitiveDateTime;
 
 use super::ApiEventMetricRow;
@@ -33,7 +34,7 @@ where
         granularity: &Option<Granularity>,
         time_range: &TimeRange,
         pool: &T,
-    ) -> MetricsResult<Vec<(ApiEventMetricsBucketIdentifier, ApiEventMetricRow)>> {
+    ) -> MetricsResult<HashSet<(ApiEventMetricsBucketIdentifier, ApiEventMetricRow)>> {
         let mut query_builder: QueryBuilder<T> = QueryBuilder::new(AnalyticsCollection::ApiEvents);
 
         query_builder
@@ -98,7 +99,7 @@ where
                 ))
             })
             .collect::<error_stack::Result<
-                Vec<(ApiEventMetricsBucketIdentifier, ApiEventMetricRow)>,
+                HashSet<(ApiEventMetricsBucketIdentifier, ApiEventMetricRow)>,
                 crate::query::PostProcessingError,
             >>()
             .change_context(MetricsError::PostProcessingFailure)

--- a/crates/analytics/src/api_event/metrics/latency.rs
+++ b/crates/analytics/src/api_event/metrics/latency.rs
@@ -1,10 +1,11 @@
+use std::collections::HashSet;
+
 use api_models::analytics::{
     api_event::{ApiEventDimensions, ApiEventFilters, ApiEventMetricsBucketIdentifier},
     Granularity, TimeRange,
 };
 use common_utils::errors::ReportSwitchExt;
 use error_stack::ResultExt;
-use std::collections::HashSet;
 use time::PrimitiveDateTime;
 
 use super::ApiEventMetricRow;

--- a/crates/analytics/src/api_event/metrics/latency.rs
+++ b/crates/analytics/src/api_event/metrics/latency.rs
@@ -4,6 +4,7 @@ use api_models::analytics::{
 };
 use common_utils::errors::ReportSwitchExt;
 use error_stack::ResultExt;
+use std::collections::HashSet;
 use time::PrimitiveDateTime;
 
 use super::ApiEventMetricRow;
@@ -36,7 +37,7 @@ where
         granularity: &Option<Granularity>,
         time_range: &TimeRange,
         pool: &T,
-    ) -> MetricsResult<Vec<(ApiEventMetricsBucketIdentifier, ApiEventMetricRow)>> {
+    ) -> MetricsResult<HashSet<(ApiEventMetricsBucketIdentifier, ApiEventMetricRow)>> {
         let mut query_builder: QueryBuilder<T> = QueryBuilder::new(AnalyticsCollection::ApiEvents);
 
         query_builder
@@ -120,7 +121,7 @@ where
                 ))
             })
             .collect::<error_stack::Result<
-                Vec<(ApiEventMetricsBucketIdentifier, ApiEventMetricRow)>,
+                HashSet<(ApiEventMetricsBucketIdentifier, ApiEventMetricRow)>,
                 crate::query::PostProcessingError,
             >>()
             .change_context(MetricsError::PostProcessingFailure)

--- a/crates/analytics/src/api_event/metrics/status_code_count.rs
+++ b/crates/analytics/src/api_event/metrics/status_code_count.rs
@@ -4,6 +4,7 @@ use api_models::analytics::{
 };
 use common_utils::errors::ReportSwitchExt;
 use error_stack::ResultExt;
+use std::collections::HashSet;
 use time::PrimitiveDateTime;
 
 use super::ApiEventMetricRow;
@@ -33,7 +34,7 @@ where
         granularity: &Option<Granularity>,
         time_range: &TimeRange,
         pool: &T,
-    ) -> MetricsResult<Vec<(ApiEventMetricsBucketIdentifier, ApiEventMetricRow)>> {
+    ) -> MetricsResult<HashSet<(ApiEventMetricsBucketIdentifier, ApiEventMetricRow)>> {
         let mut query_builder: QueryBuilder<T> = QueryBuilder::new(AnalyticsCollection::ApiEvents);
 
         query_builder
@@ -95,7 +96,7 @@ where
                 ))
             })
             .collect::<error_stack::Result<
-                Vec<(ApiEventMetricsBucketIdentifier, ApiEventMetricRow)>,
+                HashSet<(ApiEventMetricsBucketIdentifier, ApiEventMetricRow)>,
                 crate::query::PostProcessingError,
             >>()
             .change_context(MetricsError::PostProcessingFailure)

--- a/crates/analytics/src/api_event/metrics/status_code_count.rs
+++ b/crates/analytics/src/api_event/metrics/status_code_count.rs
@@ -1,10 +1,11 @@
+use std::collections::HashSet;
+
 use api_models::analytics::{
     api_event::{ApiEventDimensions, ApiEventFilters, ApiEventMetricsBucketIdentifier},
     Granularity, TimeRange,
 };
 use common_utils::errors::ReportSwitchExt;
 use error_stack::ResultExt;
-use std::collections::HashSet;
 use time::PrimitiveDateTime;
 
 use super::ApiEventMetricRow;

--- a/crates/analytics/src/auth_events/metrics.rs
+++ b/crates/analytics/src/auth_events/metrics.rs
@@ -1,9 +1,10 @@
+use std::collections::HashSet;
+
 use api_models::analytics::{
     auth_events::{AuthEventMetrics, AuthEventMetricsBucketIdentifier},
     Granularity, TimeRange,
 };
 use time::PrimitiveDateTime;
-use std::collections::HashSet;
 
 use crate::{
     query::{Aggregate, GroupByClause, ToSql, Window},

--- a/crates/analytics/src/auth_events/metrics.rs
+++ b/crates/analytics/src/auth_events/metrics.rs
@@ -3,6 +3,7 @@ use api_models::analytics::{
     Granularity, TimeRange,
 };
 use time::PrimitiveDateTime;
+use std::collections::HashSet;
 
 use crate::{
     query::{Aggregate, GroupByClause, ToSql, Window},
@@ -27,7 +28,7 @@ use frictionless_flow_count::FrictionlessFlowCount;
 use frictionless_success_count::FrictionlessSuccessCount;
 use three_ds_sdk_count::ThreeDsSdkCount;
 
-#[derive(Debug, PartialEq, Eq, serde::Deserialize)]
+#[derive(Debug, PartialEq, Eq, serde::Deserialize, Hash)]
 pub struct AuthEventMetricRow {
     pub count: Option<i64>,
     pub time_bucket: Option<String>,
@@ -47,7 +48,7 @@ where
         granularity: &Option<Granularity>,
         time_range: &TimeRange,
         pool: &T,
-    ) -> MetricsResult<Vec<(AuthEventMetricsBucketIdentifier, AuthEventMetricRow)>>;
+    ) -> MetricsResult<HashSet<(AuthEventMetricsBucketIdentifier, AuthEventMetricRow)>>;
 }
 
 #[async_trait::async_trait]
@@ -67,7 +68,7 @@ where
         granularity: &Option<Granularity>,
         time_range: &TimeRange,
         pool: &T,
-    ) -> MetricsResult<Vec<(AuthEventMetricsBucketIdentifier, AuthEventMetricRow)>> {
+    ) -> MetricsResult<HashSet<(AuthEventMetricsBucketIdentifier, AuthEventMetricRow)>> {
         match self {
             Self::ThreeDsSdkCount => {
                 ThreeDsSdkCount

--- a/crates/analytics/src/auth_events/metrics/authentication_attempt_count.rs
+++ b/crates/analytics/src/auth_events/metrics/authentication_attempt_count.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use api_models::analytics::{
     auth_events::AuthEventMetricsBucketIdentifier, sdk_events::SdkEventNames, Granularity,
     TimeRange,
@@ -5,7 +7,6 @@ use api_models::analytics::{
 use common_utils::errors::ReportSwitchExt;
 use error_stack::ResultExt;
 use time::PrimitiveDateTime;
-use std::collections::HashSet;
 
 use super::AuthEventMetricRow;
 use crate::{

--- a/crates/analytics/src/auth_events/metrics/authentication_attempt_count.rs
+++ b/crates/analytics/src/auth_events/metrics/authentication_attempt_count.rs
@@ -5,6 +5,7 @@ use api_models::analytics::{
 use common_utils::errors::ReportSwitchExt;
 use error_stack::ResultExt;
 use time::PrimitiveDateTime;
+use std::collections::HashSet;
 
 use super::AuthEventMetricRow;
 use crate::{
@@ -32,7 +33,7 @@ where
         granularity: &Option<Granularity>,
         time_range: &TimeRange,
         pool: &T,
-    ) -> MetricsResult<Vec<(AuthEventMetricsBucketIdentifier, AuthEventMetricRow)>> {
+    ) -> MetricsResult<HashSet<(AuthEventMetricsBucketIdentifier, AuthEventMetricRow)>> {
         let mut query_builder: QueryBuilder<T> =
             QueryBuilder::new(AnalyticsCollection::SdkEventsAnalytics);
 
@@ -94,7 +95,7 @@ where
                 ))
             })
             .collect::<error_stack::Result<
-                Vec<(AuthEventMetricsBucketIdentifier, AuthEventMetricRow)>,
+                HashSet<(AuthEventMetricsBucketIdentifier, AuthEventMetricRow)>,
                 crate::query::PostProcessingError,
             >>()
             .change_context(MetricsError::PostProcessingFailure)

--- a/crates/analytics/src/auth_events/metrics/authentication_success_count.rs
+++ b/crates/analytics/src/auth_events/metrics/authentication_success_count.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use api_models::analytics::{
     auth_events::AuthEventMetricsBucketIdentifier, sdk_events::SdkEventNames, Granularity,
     TimeRange,
@@ -5,7 +7,6 @@ use api_models::analytics::{
 use common_utils::errors::ReportSwitchExt;
 use error_stack::ResultExt;
 use time::PrimitiveDateTime;
-use std::collections::HashSet;
 
 use super::AuthEventMetricRow;
 use crate::{

--- a/crates/analytics/src/auth_events/metrics/authentication_success_count.rs
+++ b/crates/analytics/src/auth_events/metrics/authentication_success_count.rs
@@ -5,6 +5,7 @@ use api_models::analytics::{
 use common_utils::errors::ReportSwitchExt;
 use error_stack::ResultExt;
 use time::PrimitiveDateTime;
+use std::collections::HashSet;
 
 use super::AuthEventMetricRow;
 use crate::{
@@ -32,7 +33,7 @@ where
         granularity: &Option<Granularity>,
         time_range: &TimeRange,
         pool: &T,
-    ) -> MetricsResult<Vec<(AuthEventMetricsBucketIdentifier, AuthEventMetricRow)>> {
+    ) -> MetricsResult<HashSet<(AuthEventMetricsBucketIdentifier, AuthEventMetricRow)>> {
         let mut query_builder: QueryBuilder<T> =
             QueryBuilder::new(AnalyticsCollection::SdkEventsAnalytics);
 
@@ -94,7 +95,7 @@ where
                 ))
             })
             .collect::<error_stack::Result<
-                Vec<(AuthEventMetricsBucketIdentifier, AuthEventMetricRow)>,
+                HashSet<(AuthEventMetricsBucketIdentifier, AuthEventMetricRow)>,
                 crate::query::PostProcessingError,
             >>()
             .change_context(MetricsError::PostProcessingFailure)

--- a/crates/analytics/src/auth_events/metrics/challenge_attempt_count.rs
+++ b/crates/analytics/src/auth_events/metrics/challenge_attempt_count.rs
@@ -5,6 +5,7 @@ use api_models::analytics::{
 use common_utils::errors::ReportSwitchExt;
 use error_stack::ResultExt;
 use time::PrimitiveDateTime;
+use std::collections::HashSet;
 
 use super::AuthEventMetricRow;
 use crate::{
@@ -32,7 +33,7 @@ where
         granularity: &Option<Granularity>,
         time_range: &TimeRange,
         pool: &T,
-    ) -> MetricsResult<Vec<(AuthEventMetricsBucketIdentifier, AuthEventMetricRow)>> {
+    ) -> MetricsResult<HashSet<(AuthEventMetricsBucketIdentifier, AuthEventMetricRow)>> {
         let mut query_builder: QueryBuilder<T> =
             QueryBuilder::new(AnalyticsCollection::ApiEventsAnalytics);
 
@@ -86,7 +87,7 @@ where
                 ))
             })
             .collect::<error_stack::Result<
-                Vec<(AuthEventMetricsBucketIdentifier, AuthEventMetricRow)>,
+                HashSet<(AuthEventMetricsBucketIdentifier, AuthEventMetricRow)>,
                 crate::query::PostProcessingError,
             >>()
             .change_context(MetricsError::PostProcessingFailure)

--- a/crates/analytics/src/auth_events/metrics/challenge_attempt_count.rs
+++ b/crates/analytics/src/auth_events/metrics/challenge_attempt_count.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use api_models::analytics::{
     auth_events::{AuthEventFlows, AuthEventMetricsBucketIdentifier},
     Granularity, TimeRange,
@@ -5,7 +7,6 @@ use api_models::analytics::{
 use common_utils::errors::ReportSwitchExt;
 use error_stack::ResultExt;
 use time::PrimitiveDateTime;
-use std::collections::HashSet;
 
 use super::AuthEventMetricRow;
 use crate::{

--- a/crates/analytics/src/auth_events/metrics/challenge_flow_count.rs
+++ b/crates/analytics/src/auth_events/metrics/challenge_flow_count.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use api_models::analytics::{
     auth_events::AuthEventMetricsBucketIdentifier, sdk_events::SdkEventNames, Granularity,
     TimeRange,
@@ -5,7 +7,6 @@ use api_models::analytics::{
 use common_utils::errors::ReportSwitchExt;
 use error_stack::ResultExt;
 use time::PrimitiveDateTime;
-use std::collections::HashSet;
 
 use super::AuthEventMetricRow;
 use crate::{

--- a/crates/analytics/src/auth_events/metrics/challenge_flow_count.rs
+++ b/crates/analytics/src/auth_events/metrics/challenge_flow_count.rs
@@ -5,6 +5,7 @@ use api_models::analytics::{
 use common_utils::errors::ReportSwitchExt;
 use error_stack::ResultExt;
 use time::PrimitiveDateTime;
+use std::collections::HashSet;
 
 use super::AuthEventMetricRow;
 use crate::{
@@ -32,7 +33,7 @@ where
         granularity: &Option<Granularity>,
         time_range: &TimeRange,
         pool: &T,
-    ) -> MetricsResult<Vec<(AuthEventMetricsBucketIdentifier, AuthEventMetricRow)>> {
+    ) -> MetricsResult<HashSet<(AuthEventMetricsBucketIdentifier, AuthEventMetricRow)>> {
         let mut query_builder: QueryBuilder<T> =
             QueryBuilder::new(AnalyticsCollection::SdkEventsAnalytics);
 
@@ -96,7 +97,7 @@ where
                 ))
             })
             .collect::<error_stack::Result<
-                Vec<(AuthEventMetricsBucketIdentifier, AuthEventMetricRow)>,
+                HashSet<(AuthEventMetricsBucketIdentifier, AuthEventMetricRow)>,
                 crate::query::PostProcessingError,
             >>()
             .change_context(MetricsError::PostProcessingFailure)

--- a/crates/analytics/src/auth_events/metrics/challenge_success_count.rs
+++ b/crates/analytics/src/auth_events/metrics/challenge_success_count.rs
@@ -5,6 +5,7 @@ use api_models::analytics::{
 use common_utils::errors::ReportSwitchExt;
 use error_stack::ResultExt;
 use time::PrimitiveDateTime;
+use std::collections::HashSet;
 
 use super::AuthEventMetricRow;
 use crate::{
@@ -32,7 +33,7 @@ where
         granularity: &Option<Granularity>,
         time_range: &TimeRange,
         pool: &T,
-    ) -> MetricsResult<Vec<(AuthEventMetricsBucketIdentifier, AuthEventMetricRow)>> {
+    ) -> MetricsResult<HashSet<(AuthEventMetricsBucketIdentifier, AuthEventMetricRow)>> {
         let mut query_builder: QueryBuilder<T> =
             QueryBuilder::new(AnalyticsCollection::ApiEventsAnalytics);
 
@@ -86,7 +87,7 @@ where
                 ))
             })
             .collect::<error_stack::Result<
-                Vec<(AuthEventMetricsBucketIdentifier, AuthEventMetricRow)>,
+                HashSet<(AuthEventMetricsBucketIdentifier, AuthEventMetricRow)>,
                 crate::query::PostProcessingError,
             >>()
             .change_context(MetricsError::PostProcessingFailure)

--- a/crates/analytics/src/auth_events/metrics/challenge_success_count.rs
+++ b/crates/analytics/src/auth_events/metrics/challenge_success_count.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use api_models::analytics::{
     auth_events::{AuthEventFlows, AuthEventMetricsBucketIdentifier},
     Granularity, TimeRange,
@@ -5,7 +7,6 @@ use api_models::analytics::{
 use common_utils::errors::ReportSwitchExt;
 use error_stack::ResultExt;
 use time::PrimitiveDateTime;
-use std::collections::HashSet;
 
 use super::AuthEventMetricRow;
 use crate::{

--- a/crates/analytics/src/auth_events/metrics/frictionless_flow_count.rs
+++ b/crates/analytics/src/auth_events/metrics/frictionless_flow_count.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use api_models::analytics::{
     auth_events::AuthEventMetricsBucketIdentifier, sdk_events::SdkEventNames, Granularity,
     TimeRange,
@@ -5,7 +7,6 @@ use api_models::analytics::{
 use common_utils::errors::ReportSwitchExt;
 use error_stack::ResultExt;
 use time::PrimitiveDateTime;
-use std::collections::HashSet;
 
 use super::AuthEventMetricRow;
 use crate::{

--- a/crates/analytics/src/auth_events/metrics/frictionless_flow_count.rs
+++ b/crates/analytics/src/auth_events/metrics/frictionless_flow_count.rs
@@ -5,6 +5,7 @@ use api_models::analytics::{
 use common_utils::errors::ReportSwitchExt;
 use error_stack::ResultExt;
 use time::PrimitiveDateTime;
+use std::collections::HashSet;
 
 use super::AuthEventMetricRow;
 use crate::{
@@ -32,7 +33,7 @@ where
         granularity: &Option<Granularity>,
         time_range: &TimeRange,
         pool: &T,
-    ) -> MetricsResult<Vec<(AuthEventMetricsBucketIdentifier, AuthEventMetricRow)>> {
+    ) -> MetricsResult<HashSet<(AuthEventMetricsBucketIdentifier, AuthEventMetricRow)>> {
         let mut query_builder: QueryBuilder<T> =
             QueryBuilder::new(AnalyticsCollection::SdkEventsAnalytics);
 
@@ -98,7 +99,7 @@ where
                 ))
             })
             .collect::<error_stack::Result<
-                Vec<(AuthEventMetricsBucketIdentifier, AuthEventMetricRow)>,
+                HashSet<(AuthEventMetricsBucketIdentifier, AuthEventMetricRow)>,
                 crate::query::PostProcessingError,
             >>()
             .change_context(MetricsError::PostProcessingFailure)

--- a/crates/analytics/src/auth_events/metrics/frictionless_success_count.rs
+++ b/crates/analytics/src/auth_events/metrics/frictionless_success_count.rs
@@ -5,6 +5,7 @@ use api_models::analytics::{
 use common_utils::errors::ReportSwitchExt;
 use error_stack::ResultExt;
 use time::PrimitiveDateTime;
+use std::collections::HashSet;
 
 use super::AuthEventMetricRow;
 use crate::{
@@ -32,7 +33,7 @@ where
         granularity: &Option<Granularity>,
         time_range: &TimeRange,
         pool: &T,
-    ) -> MetricsResult<Vec<(AuthEventMetricsBucketIdentifier, AuthEventMetricRow)>> {
+    ) -> MetricsResult<HashSet<(AuthEventMetricsBucketIdentifier, AuthEventMetricRow)>> {
         let mut query_builder: QueryBuilder<T> =
             QueryBuilder::new(AnalyticsCollection::ApiEventsAnalytics);
 
@@ -86,7 +87,7 @@ where
                 ))
             })
             .collect::<error_stack::Result<
-                Vec<(AuthEventMetricsBucketIdentifier, AuthEventMetricRow)>,
+                HashSet<(AuthEventMetricsBucketIdentifier, AuthEventMetricRow)>,
                 crate::query::PostProcessingError,
             >>()
             .change_context(MetricsError::PostProcessingFailure)

--- a/crates/analytics/src/auth_events/metrics/frictionless_success_count.rs
+++ b/crates/analytics/src/auth_events/metrics/frictionless_success_count.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use api_models::analytics::{
     auth_events::{AuthEventFlows, AuthEventMetricsBucketIdentifier},
     Granularity, TimeRange,
@@ -5,7 +7,6 @@ use api_models::analytics::{
 use common_utils::errors::ReportSwitchExt;
 use error_stack::ResultExt;
 use time::PrimitiveDateTime;
-use std::collections::HashSet;
 
 use super::AuthEventMetricRow;
 use crate::{

--- a/crates/analytics/src/auth_events/metrics/three_ds_sdk_count.rs
+++ b/crates/analytics/src/auth_events/metrics/three_ds_sdk_count.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use api_models::analytics::{
     auth_events::AuthEventMetricsBucketIdentifier, sdk_events::SdkEventNames, Granularity,
     TimeRange,
@@ -5,7 +7,6 @@ use api_models::analytics::{
 use common_utils::errors::ReportSwitchExt;
 use error_stack::ResultExt;
 use time::PrimitiveDateTime;
-use std::collections::HashSet;
 
 use super::AuthEventMetricRow;
 use crate::{

--- a/crates/analytics/src/auth_events/metrics/three_ds_sdk_count.rs
+++ b/crates/analytics/src/auth_events/metrics/three_ds_sdk_count.rs
@@ -5,6 +5,7 @@ use api_models::analytics::{
 use common_utils::errors::ReportSwitchExt;
 use error_stack::ResultExt;
 use time::PrimitiveDateTime;
+use std::collections::HashSet;
 
 use super::AuthEventMetricRow;
 use crate::{
@@ -32,7 +33,7 @@ where
         granularity: &Option<Granularity>,
         time_range: &TimeRange,
         pool: &T,
-    ) -> MetricsResult<Vec<(AuthEventMetricsBucketIdentifier, AuthEventMetricRow)>> {
+    ) -> MetricsResult<HashSet<(AuthEventMetricsBucketIdentifier, AuthEventMetricRow)>> {
         let mut query_builder: QueryBuilder<T> =
             QueryBuilder::new(AnalyticsCollection::SdkEventsAnalytics);
 
@@ -94,7 +95,7 @@ where
                 ))
             })
             .collect::<error_stack::Result<
-                Vec<(AuthEventMetricsBucketIdentifier, AuthEventMetricRow)>,
+                HashSet<(AuthEventMetricsBucketIdentifier, AuthEventMetricRow)>,
                 crate::query::PostProcessingError,
             >>()
             .change_context(MetricsError::PostProcessingFailure)

--- a/crates/analytics/src/disputes/metrics.rs
+++ b/crates/analytics/src/disputes/metrics.rs
@@ -13,6 +13,7 @@ use api_models::{
 };
 use diesel_models::enums as storage_enums;
 use time::PrimitiveDateTime;
+use std::collections::HashSet;
 
 use self::{
     dispute_status_metric::DisputeStatusMetric, total_amount_disputed::TotalAmountDisputed,
@@ -22,7 +23,7 @@ use crate::{
     query::{Aggregate, GroupByClause, ToSql, Window},
     types::{AnalyticsCollection, AnalyticsDataSource, DBEnumWrapper, LoadRow, MetricsResult},
 };
-#[derive(Debug, Eq, PartialEq, serde::Deserialize)]
+#[derive(Debug, Eq, PartialEq, serde::Deserialize, Hash)]
 pub struct DisputeMetricRow {
     pub dispute_stage: Option<DBEnumWrapper<storage_enums::DisputeStage>>,
     pub dispute_status: Option<DBEnumWrapper<storage_enums::DisputeStatus>>,
@@ -55,7 +56,7 @@ where
         granularity: &Option<Granularity>,
         time_range: &TimeRange,
         pool: &T,
-    ) -> MetricsResult<Vec<(DisputeMetricsBucketIdentifier, DisputeMetricRow)>>;
+    ) -> MetricsResult<HashSet<(DisputeMetricsBucketIdentifier, DisputeMetricRow)>>;
 }
 
 #[async_trait::async_trait]
@@ -76,7 +77,7 @@ where
         granularity: &Option<Granularity>,
         time_range: &TimeRange,
         pool: &T,
-    ) -> MetricsResult<Vec<(DisputeMetricsBucketIdentifier, DisputeMetricRow)>> {
+    ) -> MetricsResult<HashSet<(DisputeMetricsBucketIdentifier, DisputeMetricRow)>> {
         match self {
             Self::TotalAmountDisputed => {
                 TotalAmountDisputed::default()

--- a/crates/analytics/src/disputes/metrics.rs
+++ b/crates/analytics/src/disputes/metrics.rs
@@ -2,6 +2,8 @@ mod dispute_status_metric;
 mod total_amount_disputed;
 mod total_dispute_lost_amount;
 
+use std::collections::HashSet;
+
 use api_models::{
     analytics::{
         disputes::{
@@ -13,7 +15,6 @@ use api_models::{
 };
 use diesel_models::enums as storage_enums;
 use time::PrimitiveDateTime;
-use std::collections::HashSet;
 
 use self::{
     dispute_status_metric::DisputeStatusMetric, total_amount_disputed::TotalAmountDisputed,

--- a/crates/analytics/src/disputes/metrics/dispute_status_metric.rs
+++ b/crates/analytics/src/disputes/metrics/dispute_status_metric.rs
@@ -5,6 +5,7 @@ use api_models::analytics::{
 use common_utils::errors::ReportSwitchExt;
 use error_stack::ResultExt;
 use time::PrimitiveDateTime;
+use std::collections::HashSet;
 
 use super::DisputeMetricRow;
 use crate::{
@@ -32,7 +33,7 @@ where
         granularity: &Option<Granularity>,
         time_range: &TimeRange,
         pool: &T,
-    ) -> MetricsResult<Vec<(DisputeMetricsBucketIdentifier, DisputeMetricRow)>>
+    ) -> MetricsResult<HashSet<(DisputeMetricsBucketIdentifier, DisputeMetricRow)>>
     where
         T: AnalyticsDataSource + super::DisputeMetricAnalytics,
     {
@@ -111,7 +112,7 @@ where
                 ))
             })
             .collect::<error_stack::Result<
-                Vec<(DisputeMetricsBucketIdentifier, DisputeMetricRow)>,
+                HashSet<(DisputeMetricsBucketIdentifier, DisputeMetricRow)>,
                 crate::query::PostProcessingError,
             >>()
             .change_context(MetricsError::PostProcessingFailure)

--- a/crates/analytics/src/disputes/metrics/dispute_status_metric.rs
+++ b/crates/analytics/src/disputes/metrics/dispute_status_metric.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use api_models::analytics::{
     disputes::{DisputeDimensions, DisputeFilters, DisputeMetricsBucketIdentifier},
     Granularity, TimeRange,
@@ -5,7 +7,6 @@ use api_models::analytics::{
 use common_utils::errors::ReportSwitchExt;
 use error_stack::ResultExt;
 use time::PrimitiveDateTime;
-use std::collections::HashSet;
 
 use super::DisputeMetricRow;
 use crate::{

--- a/crates/analytics/src/disputes/metrics/total_amount_disputed.rs
+++ b/crates/analytics/src/disputes/metrics/total_amount_disputed.rs
@@ -5,6 +5,7 @@ use api_models::analytics::{
 use common_utils::errors::ReportSwitchExt;
 use error_stack::ResultExt;
 use time::PrimitiveDateTime;
+use std::collections::HashSet;
 
 use super::DisputeMetricRow;
 use crate::{
@@ -32,7 +33,7 @@ where
         granularity: &Option<Granularity>,
         time_range: &TimeRange,
         pool: &T,
-    ) -> MetricsResult<Vec<(DisputeMetricsBucketIdentifier, DisputeMetricRow)>>
+    ) -> MetricsResult<HashSet<(DisputeMetricsBucketIdentifier, DisputeMetricRow)>>
     where
         T: AnalyticsDataSource + super::DisputeMetricAnalytics,
     {
@@ -110,7 +111,7 @@ where
                     i,
                 ))
             })
-            .collect::<error_stack::Result<Vec<_>, crate::query::PostProcessingError>>()
+            .collect::<error_stack::Result<HashSet<_>, crate::query::PostProcessingError>>()
             .change_context(MetricsError::PostProcessingFailure)
     }
 }

--- a/crates/analytics/src/disputes/metrics/total_amount_disputed.rs
+++ b/crates/analytics/src/disputes/metrics/total_amount_disputed.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use api_models::analytics::{
     disputes::{DisputeDimensions, DisputeFilters, DisputeMetricsBucketIdentifier},
     Granularity, TimeRange,
@@ -5,7 +7,6 @@ use api_models::analytics::{
 use common_utils::errors::ReportSwitchExt;
 use error_stack::ResultExt;
 use time::PrimitiveDateTime;
-use std::collections::HashSet;
 
 use super::DisputeMetricRow;
 use crate::{

--- a/crates/analytics/src/disputes/metrics/total_dispute_lost_amount.rs
+++ b/crates/analytics/src/disputes/metrics/total_dispute_lost_amount.rs
@@ -5,6 +5,7 @@ use api_models::analytics::{
 use common_utils::errors::ReportSwitchExt;
 use error_stack::ResultExt;
 use time::PrimitiveDateTime;
+use std::collections::HashSet;
 
 use super::DisputeMetricRow;
 use crate::{
@@ -32,7 +33,7 @@ where
         granularity: &Option<Granularity>,
         time_range: &TimeRange,
         pool: &T,
-    ) -> MetricsResult<Vec<(DisputeMetricsBucketIdentifier, DisputeMetricRow)>>
+    ) -> MetricsResult<HashSet<(DisputeMetricsBucketIdentifier, DisputeMetricRow)>>
     where
         T: AnalyticsDataSource + super::DisputeMetricAnalytics,
     {
@@ -111,7 +112,7 @@ where
                     i,
                 ))
             })
-            .collect::<error_stack::Result<Vec<_>, crate::query::PostProcessingError>>()
+            .collect::<error_stack::Result<HashSet<_>, crate::query::PostProcessingError>>()
             .change_context(MetricsError::PostProcessingFailure)
     }
 }

--- a/crates/analytics/src/disputes/metrics/total_dispute_lost_amount.rs
+++ b/crates/analytics/src/disputes/metrics/total_dispute_lost_amount.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use api_models::analytics::{
     disputes::{DisputeDimensions, DisputeFilters, DisputeMetricsBucketIdentifier},
     Granularity, TimeRange,
@@ -5,7 +7,6 @@ use api_models::analytics::{
 use common_utils::errors::ReportSwitchExt;
 use error_stack::ResultExt;
 use time::PrimitiveDateTime;
-use std::collections::HashSet;
 
 use super::DisputeMetricRow;
 use crate::{

--- a/crates/analytics/src/lib.rs
+++ b/crates/analytics/src/lib.rs
@@ -31,8 +31,7 @@ pub use types::AnalyticsDomain;
 pub mod lambda_utils;
 pub mod utils;
 
-use std::collections::HashSet;
-use std::sync::Arc;
+use std::{collections::HashSet, sync::Arc};
 
 use api_models::analytics::{
     active_payments::{ActivePaymentsMetrics, ActivePaymentsMetricsBucketIdentifier},

--- a/crates/analytics/src/lib.rs
+++ b/crates/analytics/src/lib.rs
@@ -31,6 +31,7 @@ pub use types::AnalyticsDomain;
 pub mod lambda_utils;
 pub mod utils;
 
+use std::collections::HashSet;
 use std::sync::Arc;
 
 use api_models::analytics::{
@@ -113,7 +114,7 @@ impl AnalyticsProvider {
         filters: &PaymentFilters,
         granularity: &Option<Granularity>,
         time_range: &TimeRange,
-    ) -> types::MetricsResult<Vec<(PaymentMetricsBucketIdentifier, PaymentMetricRow)>> {
+    ) -> types::MetricsResult<HashSet<(PaymentMetricsBucketIdentifier, PaymentMetricRow)>> {
         // Metrics to get the fetch time for each payment metric
         metrics::request::record_operation_time(
             async {
@@ -327,7 +328,7 @@ impl AnalyticsProvider {
         filters: &PaymentIntentFilters,
         granularity: &Option<Granularity>,
         time_range: &TimeRange,
-    ) -> types::MetricsResult<Vec<(PaymentIntentMetricsBucketIdentifier, PaymentIntentMetricRow)>>
+    ) -> types::MetricsResult<HashSet<(PaymentIntentMetricsBucketIdentifier, PaymentIntentMetricRow)>>
     {
         // Metrics to get the fetch time for each payment intent metric
         metrics::request::record_operation_time(
@@ -432,7 +433,7 @@ impl AnalyticsProvider {
         filters: &RefundFilters,
         granularity: &Option<Granularity>,
         time_range: &TimeRange,
-    ) -> types::MetricsResult<Vec<(RefundMetricsBucketIdentifier, RefundMetricRow)>> {
+    ) -> types::MetricsResult<HashSet<(RefundMetricsBucketIdentifier, RefundMetricRow)>> {
         // Metrics to get the fetch time for each refund metric
         metrics::request::record_operation_time(
             async {
@@ -532,7 +533,7 @@ impl AnalyticsProvider {
         filters: &DisputeFilters,
         granularity: &Option<Granularity>,
         time_range: &TimeRange,
-    ) -> types::MetricsResult<Vec<(DisputeMetricsBucketIdentifier, DisputeMetricRow)>> {
+    ) -> types::MetricsResult<HashSet<(DisputeMetricsBucketIdentifier, DisputeMetricRow)>> {
         // Metrics to get the fetch time for each refund metric
         metrics::request::record_operation_time(
             async {
@@ -632,7 +633,7 @@ impl AnalyticsProvider {
         filters: &SdkEventFilters,
         granularity: &Option<Granularity>,
         time_range: &TimeRange,
-    ) -> types::MetricsResult<Vec<(SdkEventMetricsBucketIdentifier, SdkEventMetricRow)>> {
+    ) -> types::MetricsResult<HashSet<(SdkEventMetricsBucketIdentifier, SdkEventMetricRow)>> {
         match self {
             Self::Sqlx(_pool) => Err(report!(MetricsError::NotImplemented)),
             Self::Clickhouse(pool) => {
@@ -669,7 +670,7 @@ impl AnalyticsProvider {
         merchant_id: &str,
         publishable_key: &str,
     ) -> types::MetricsResult<
-        Vec<(
+        HashSet<(
             ActivePaymentsMetricsBucketIdentifier,
             ActivePaymentsMetricRow,
         )>,
@@ -696,7 +697,7 @@ impl AnalyticsProvider {
         publishable_key: &str,
         granularity: &Option<Granularity>,
         time_range: &TimeRange,
-    ) -> types::MetricsResult<Vec<(AuthEventMetricsBucketIdentifier, AuthEventMetricRow)>> {
+    ) -> types::MetricsResult<HashSet<(AuthEventMetricsBucketIdentifier, AuthEventMetricRow)>> {
         match self {
             Self::Sqlx(_pool) => Err(report!(MetricsError::NotImplemented)),
             Self::Clickhouse(pool) => {
@@ -727,7 +728,7 @@ impl AnalyticsProvider {
         filters: &ApiEventFilters,
         granularity: &Option<Granularity>,
         time_range: &TimeRange,
-    ) -> types::MetricsResult<Vec<(ApiEventMetricsBucketIdentifier, ApiEventMetricRow)>> {
+    ) -> types::MetricsResult<HashSet<(ApiEventMetricsBucketIdentifier, ApiEventMetricRow)>> {
         match self {
             Self::Sqlx(_pool) => Err(report!(MetricsError::NotImplemented)),
             Self::Clickhouse(ckh_pool)

--- a/crates/analytics/src/payment_intents/core.rs
+++ b/crates/analytics/src/payment_intents/core.rs
@@ -1,5 +1,5 @@
 #![allow(dead_code)]
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use api_models::analytics::{
     payment_intents::{
@@ -34,7 +34,7 @@ pub enum TaskType {
     MetricTask(
         PaymentIntentMetrics,
         CustomResult<
-            Vec<(PaymentIntentMetricsBucketIdentifier, PaymentIntentMetricRow)>,
+            HashSet<(PaymentIntentMetricsBucketIdentifier, PaymentIntentMetricRow)>,
             AnalyticsError,
         >,
     ),

--- a/crates/analytics/src/payment_intents/filters.rs
+++ b/crates/analytics/src/payment_intents/filters.rs
@@ -1,5 +1,3 @@
-use std::collections::HashSet;
-
 use api_models::analytics::{payment_intents::PaymentIntentDimensions, Granularity, TimeRange};
 use common_utils::errors::ReportSwitchExt;
 use diesel_models::enums::{Currency, IntentStatus};
@@ -21,7 +19,7 @@ pub async fn get_payment_intent_filter_for_dimension<T>(
     merchant: &String,
     time_range: &TimeRange,
     pool: &T,
-) -> FiltersResult<HashSet<PaymentIntentFilterRow>>
+) -> FiltersResult<Vec<PaymentIntentFilterRow>>
 where
     T: AnalyticsDataSource + PaymentIntentFilterAnalytics,
     PrimitiveDateTime: ToSql<T>,
@@ -44,18 +42,14 @@ where
 
     query_builder.set_distinct();
 
-    let result: Vec<PaymentIntentFilterRow> = query_builder
+    query_builder
         .execute_query::<PaymentIntentFilterRow, _>(pool)
         .await
         .change_context(FiltersError::QueryBuildingError)?
-        .change_context(FiltersError::QueryExecutionFailure)?;
-
-    let result_set: HashSet<PaymentIntentFilterRow> = result.into_iter().collect();
-
-    Ok(result_set)
+        .change_context(FiltersError::QueryExecutionFailure)
 }
 
-#[derive(Debug, serde::Serialize, Eq, PartialEq, serde::Deserialize, Hash)]
+#[derive(Debug, serde::Serialize, Eq, PartialEq, serde::Deserialize)]
 pub struct PaymentIntentFilterRow {
     pub status: Option<DBEnumWrapper<IntentStatus>>,
     pub currency: Option<DBEnumWrapper<Currency>>,

--- a/crates/analytics/src/payment_intents/filters.rs
+++ b/crates/analytics/src/payment_intents/filters.rs
@@ -1,9 +1,10 @@
+use std::collections::HashSet;
+
 use api_models::analytics::{payment_intents::PaymentIntentDimensions, Granularity, TimeRange};
 use common_utils::errors::ReportSwitchExt;
 use diesel_models::enums::{Currency, IntentStatus};
 use error_stack::ResultExt;
 use time::PrimitiveDateTime;
-use std::collections::HashSet;
 
 use crate::{
     query::{Aggregate, GroupByClause, QueryBuilder, QueryFilter, ToSql, Window},

--- a/crates/analytics/src/payment_intents/metrics.rs
+++ b/crates/analytics/src/payment_intents/metrics.rs
@@ -7,6 +7,7 @@ use api_models::analytics::{
 };
 use diesel_models::enums as storage_enums;
 use time::PrimitiveDateTime;
+use std::collections::HashSet;
 
 use crate::{
     query::{Aggregate, GroupByClause, ToSql, Window},
@@ -23,7 +24,7 @@ use smart_retried_amount::SmartRetriedAmount;
 use successful_smart_retries::SuccessfulSmartRetries;
 use total_smart_retries::TotalSmartRetries;
 
-#[derive(Debug, PartialEq, Eq, serde::Deserialize)]
+#[derive(Debug, PartialEq, Eq, serde::Deserialize, Hash)]
 pub struct PaymentIntentMetricRow {
     pub status: Option<DBEnumWrapper<storage_enums::IntentStatus>>,
     pub currency: Option<DBEnumWrapper<storage_enums::Currency>>,
@@ -50,7 +51,7 @@ where
         granularity: &Option<Granularity>,
         time_range: &TimeRange,
         pool: &T,
-    ) -> MetricsResult<Vec<(PaymentIntentMetricsBucketIdentifier, PaymentIntentMetricRow)>>;
+    ) -> MetricsResult<HashSet<(PaymentIntentMetricsBucketIdentifier, PaymentIntentMetricRow)>>;
 }
 
 #[async_trait::async_trait]
@@ -71,7 +72,7 @@ where
         granularity: &Option<Granularity>,
         time_range: &TimeRange,
         pool: &T,
-    ) -> MetricsResult<Vec<(PaymentIntentMetricsBucketIdentifier, PaymentIntentMetricRow)>> {
+    ) -> MetricsResult<HashSet<(PaymentIntentMetricsBucketIdentifier, PaymentIntentMetricRow)>> {
         match self {
             Self::SuccessfulSmartRetries => {
                 SuccessfulSmartRetries

--- a/crates/analytics/src/payment_intents/metrics.rs
+++ b/crates/analytics/src/payment_intents/metrics.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use api_models::analytics::{
     payment_intents::{
         PaymentIntentDimensions, PaymentIntentFilters, PaymentIntentMetrics,
@@ -7,7 +9,6 @@ use api_models::analytics::{
 };
 use diesel_models::enums as storage_enums;
 use time::PrimitiveDateTime;
-use std::collections::HashSet;
 
 use crate::{
     query::{Aggregate, GroupByClause, ToSql, Window},
@@ -72,7 +73,8 @@ where
         granularity: &Option<Granularity>,
         time_range: &TimeRange,
         pool: &T,
-    ) -> MetricsResult<HashSet<(PaymentIntentMetricsBucketIdentifier, PaymentIntentMetricRow)>> {
+    ) -> MetricsResult<HashSet<(PaymentIntentMetricsBucketIdentifier, PaymentIntentMetricRow)>>
+    {
         match self {
             Self::SuccessfulSmartRetries => {
                 SuccessfulSmartRetries

--- a/crates/analytics/src/payment_intents/metrics/payment_intent_count.rs
+++ b/crates/analytics/src/payment_intents/metrics/payment_intent_count.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use api_models::analytics::{
     payment_intents::{
         PaymentIntentDimensions, PaymentIntentFilters, PaymentIntentMetricsBucketIdentifier,
@@ -7,7 +9,6 @@ use api_models::analytics::{
 use common_utils::errors::ReportSwitchExt;
 use error_stack::ResultExt;
 use time::PrimitiveDateTime;
-use std::collections::HashSet;
 
 use super::PaymentIntentMetricRow;
 use crate::{
@@ -36,7 +37,8 @@ where
         granularity: &Option<Granularity>,
         time_range: &TimeRange,
         pool: &T,
-    ) -> MetricsResult<HashSet<(PaymentIntentMetricsBucketIdentifier, PaymentIntentMetricRow)>> {
+    ) -> MetricsResult<HashSet<(PaymentIntentMetricsBucketIdentifier, PaymentIntentMetricRow)>>
+    {
         let mut query_builder: QueryBuilder<T> =
             QueryBuilder::new(AnalyticsCollection::PaymentIntent);
 

--- a/crates/analytics/src/payment_intents/metrics/payment_intent_count.rs
+++ b/crates/analytics/src/payment_intents/metrics/payment_intent_count.rs
@@ -7,6 +7,7 @@ use api_models::analytics::{
 use common_utils::errors::ReportSwitchExt;
 use error_stack::ResultExt;
 use time::PrimitiveDateTime;
+use std::collections::HashSet;
 
 use super::PaymentIntentMetricRow;
 use crate::{
@@ -35,7 +36,7 @@ where
         granularity: &Option<Granularity>,
         time_range: &TimeRange,
         pool: &T,
-    ) -> MetricsResult<Vec<(PaymentIntentMetricsBucketIdentifier, PaymentIntentMetricRow)>> {
+    ) -> MetricsResult<HashSet<(PaymentIntentMetricsBucketIdentifier, PaymentIntentMetricRow)>> {
         let mut query_builder: QueryBuilder<T> =
             QueryBuilder::new(AnalyticsCollection::PaymentIntent);
 
@@ -113,7 +114,7 @@ where
                 ))
             })
             .collect::<error_stack::Result<
-                Vec<(PaymentIntentMetricsBucketIdentifier, PaymentIntentMetricRow)>,
+                HashSet<(PaymentIntentMetricsBucketIdentifier, PaymentIntentMetricRow)>,
                 crate::query::PostProcessingError,
             >>()
             .change_context(MetricsError::PostProcessingFailure)

--- a/crates/analytics/src/payment_intents/metrics/smart_retried_amount.rs
+++ b/crates/analytics/src/payment_intents/metrics/smart_retried_amount.rs
@@ -10,6 +10,7 @@ use api_models::{
 use common_utils::errors::ReportSwitchExt;
 use error_stack::ResultExt;
 use time::PrimitiveDateTime;
+use std::collections::HashSet;
 
 use super::PaymentIntentMetricRow;
 use crate::{
@@ -41,7 +42,7 @@ where
         granularity: &Option<Granularity>,
         time_range: &TimeRange,
         pool: &T,
-    ) -> MetricsResult<Vec<(PaymentIntentMetricsBucketIdentifier, PaymentIntentMetricRow)>> {
+    ) -> MetricsResult<HashSet<(PaymentIntentMetricsBucketIdentifier, PaymentIntentMetricRow)>> {
         let mut query_builder: QueryBuilder<T> =
             QueryBuilder::new(AnalyticsCollection::PaymentIntent);
 
@@ -123,7 +124,7 @@ where
                 ))
             })
             .collect::<error_stack::Result<
-                Vec<(PaymentIntentMetricsBucketIdentifier, PaymentIntentMetricRow)>,
+                HashSet<(PaymentIntentMetricsBucketIdentifier, PaymentIntentMetricRow)>,
                 crate::query::PostProcessingError,
             >>()
             .change_context(MetricsError::PostProcessingFailure)

--- a/crates/analytics/src/payment_intents/metrics/smart_retried_amount.rs
+++ b/crates/analytics/src/payment_intents/metrics/smart_retried_amount.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use api_models::{
     analytics::{
         payment_intents::{
@@ -10,7 +12,6 @@ use api_models::{
 use common_utils::errors::ReportSwitchExt;
 use error_stack::ResultExt;
 use time::PrimitiveDateTime;
-use std::collections::HashSet;
 
 use super::PaymentIntentMetricRow;
 use crate::{
@@ -42,7 +43,8 @@ where
         granularity: &Option<Granularity>,
         time_range: &TimeRange,
         pool: &T,
-    ) -> MetricsResult<HashSet<(PaymentIntentMetricsBucketIdentifier, PaymentIntentMetricRow)>> {
+    ) -> MetricsResult<HashSet<(PaymentIntentMetricsBucketIdentifier, PaymentIntentMetricRow)>>
+    {
         let mut query_builder: QueryBuilder<T> =
             QueryBuilder::new(AnalyticsCollection::PaymentIntent);
 

--- a/crates/analytics/src/payment_intents/metrics/successful_smart_retries.rs
+++ b/crates/analytics/src/payment_intents/metrics/successful_smart_retries.rs
@@ -10,6 +10,7 @@ use api_models::{
 use common_utils::errors::ReportSwitchExt;
 use error_stack::ResultExt;
 use time::PrimitiveDateTime;
+use std::collections::HashSet;
 
 use super::PaymentIntentMetricRow;
 use crate::{
@@ -41,7 +42,7 @@ where
         granularity: &Option<Granularity>,
         time_range: &TimeRange,
         pool: &T,
-    ) -> MetricsResult<Vec<(PaymentIntentMetricsBucketIdentifier, PaymentIntentMetricRow)>> {
+    ) -> MetricsResult<HashSet<(PaymentIntentMetricsBucketIdentifier, PaymentIntentMetricRow)>> {
         let mut query_builder: QueryBuilder<T> =
             QueryBuilder::new(AnalyticsCollection::PaymentIntent);
 
@@ -122,7 +123,7 @@ where
                 ))
             })
             .collect::<error_stack::Result<
-                Vec<(PaymentIntentMetricsBucketIdentifier, PaymentIntentMetricRow)>,
+                HashSet<(PaymentIntentMetricsBucketIdentifier, PaymentIntentMetricRow)>,
                 crate::query::PostProcessingError,
             >>()
             .change_context(MetricsError::PostProcessingFailure)

--- a/crates/analytics/src/payment_intents/metrics/successful_smart_retries.rs
+++ b/crates/analytics/src/payment_intents/metrics/successful_smart_retries.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use api_models::{
     analytics::{
         payment_intents::{
@@ -10,7 +12,6 @@ use api_models::{
 use common_utils::errors::ReportSwitchExt;
 use error_stack::ResultExt;
 use time::PrimitiveDateTime;
-use std::collections::HashSet;
 
 use super::PaymentIntentMetricRow;
 use crate::{
@@ -42,7 +43,8 @@ where
         granularity: &Option<Granularity>,
         time_range: &TimeRange,
         pool: &T,
-    ) -> MetricsResult<HashSet<(PaymentIntentMetricsBucketIdentifier, PaymentIntentMetricRow)>> {
+    ) -> MetricsResult<HashSet<(PaymentIntentMetricsBucketIdentifier, PaymentIntentMetricRow)>>
+    {
         let mut query_builder: QueryBuilder<T> =
             QueryBuilder::new(AnalyticsCollection::PaymentIntent);
 

--- a/crates/analytics/src/payment_intents/metrics/total_smart_retries.rs
+++ b/crates/analytics/src/payment_intents/metrics/total_smart_retries.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use api_models::analytics::{
     payment_intents::{
         PaymentIntentDimensions, PaymentIntentFilters, PaymentIntentMetricsBucketIdentifier,
@@ -7,7 +9,6 @@ use api_models::analytics::{
 use common_utils::errors::ReportSwitchExt;
 use error_stack::ResultExt;
 use time::PrimitiveDateTime;
-use std::collections::HashSet;
 
 use super::PaymentIntentMetricRow;
 use crate::{
@@ -39,7 +40,8 @@ where
         granularity: &Option<Granularity>,
         time_range: &TimeRange,
         pool: &T,
-    ) -> MetricsResult<HashSet<(PaymentIntentMetricsBucketIdentifier, PaymentIntentMetricRow)>> {
+    ) -> MetricsResult<HashSet<(PaymentIntentMetricsBucketIdentifier, PaymentIntentMetricRow)>>
+    {
         let mut query_builder: QueryBuilder<T> =
             QueryBuilder::new(AnalyticsCollection::PaymentIntent);
 

--- a/crates/analytics/src/payment_intents/metrics/total_smart_retries.rs
+++ b/crates/analytics/src/payment_intents/metrics/total_smart_retries.rs
@@ -7,6 +7,7 @@ use api_models::analytics::{
 use common_utils::errors::ReportSwitchExt;
 use error_stack::ResultExt;
 use time::PrimitiveDateTime;
+use std::collections::HashSet;
 
 use super::PaymentIntentMetricRow;
 use crate::{
@@ -38,7 +39,7 @@ where
         granularity: &Option<Granularity>,
         time_range: &TimeRange,
         pool: &T,
-    ) -> MetricsResult<Vec<(PaymentIntentMetricsBucketIdentifier, PaymentIntentMetricRow)>> {
+    ) -> MetricsResult<HashSet<(PaymentIntentMetricsBucketIdentifier, PaymentIntentMetricRow)>> {
         let mut query_builder: QueryBuilder<T> =
             QueryBuilder::new(AnalyticsCollection::PaymentIntent);
 
@@ -117,7 +118,7 @@ where
                 ))
             })
             .collect::<error_stack::Result<
-                Vec<(PaymentIntentMetricsBucketIdentifier, PaymentIntentMetricRow)>,
+                HashSet<(PaymentIntentMetricsBucketIdentifier, PaymentIntentMetricRow)>,
                 crate::query::PostProcessingError,
             >>()
             .change_context(MetricsError::PostProcessingFailure)

--- a/crates/analytics/src/payments/core.rs
+++ b/crates/analytics/src/payments/core.rs
@@ -1,5 +1,5 @@
 #![allow(dead_code)]
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use api_models::analytics::{
     payments::{
@@ -34,7 +34,7 @@ use crate::{
 pub enum TaskType {
     MetricTask(
         PaymentMetrics,
-        CustomResult<Vec<(PaymentMetricsBucketIdentifier, PaymentMetricRow)>, AnalyticsError>,
+        CustomResult<HashSet<(PaymentMetricsBucketIdentifier, PaymentMetricRow)>, AnalyticsError>,
     ),
     DistributionTask(
         PaymentDistributions,

--- a/crates/analytics/src/payments/filters.rs
+++ b/crates/analytics/src/payments/filters.rs
@@ -1,9 +1,11 @@
+use std::collections::HashSet;
+
 use api_models::analytics::{payments::PaymentDimensions, Granularity, TimeRange};
 use common_utils::errors::ReportSwitchExt;
 use diesel_models::enums::{AttemptStatus, AuthenticationType, Currency};
 use error_stack::ResultExt;
 use time::PrimitiveDateTime;
-use std::collections::HashSet;
+
 use crate::{
     query::{Aggregate, GroupByClause, QueryBuilder, QueryFilter, ToSql, Window},
     types::{
@@ -51,8 +53,6 @@ where
     let result_set: HashSet<FilterRow> = result.into_iter().collect();
 
     Ok(result_set)
-
-    
 }
 
 #[derive(Debug, serde::Serialize, Eq, PartialEq, serde::Deserialize, Hash)]

--- a/crates/analytics/src/payments/metrics.rs
+++ b/crates/analytics/src/payments/metrics.rs
@@ -1,10 +1,11 @@
+use std::collections::HashSet;
+
 use api_models::analytics::{
     payments::{PaymentDimensions, PaymentFilters, PaymentMetrics, PaymentMetricsBucketIdentifier},
     Granularity, TimeRange,
 };
 use diesel_models::enums as storage_enums;
 use time::PrimitiveDateTime;
-use std::collections::HashSet;
 
 use crate::{
     query::{Aggregate, GroupByClause, ToSql, Window},

--- a/crates/analytics/src/payments/metrics.rs
+++ b/crates/analytics/src/payments/metrics.rs
@@ -4,6 +4,7 @@ use api_models::analytics::{
 };
 use diesel_models::enums as storage_enums;
 use time::PrimitiveDateTime;
+use std::collections::HashSet;
 
 use crate::{
     query::{Aggregate, GroupByClause, ToSql, Window},
@@ -27,7 +28,7 @@ use success_rate::PaymentSuccessRate;
 
 use self::retries_count::RetriesCount;
 
-#[derive(Debug, PartialEq, Eq, serde::Deserialize)]
+#[derive(Debug, PartialEq, Eq, serde::Deserialize, Hash)]
 pub struct PaymentMetricRow {
     pub currency: Option<DBEnumWrapper<storage_enums::Currency>>,
     pub status: Option<DBEnumWrapper<storage_enums::AttemptStatus>>,
@@ -60,7 +61,7 @@ where
         granularity: &Option<Granularity>,
         time_range: &TimeRange,
         pool: &T,
-    ) -> MetricsResult<Vec<(PaymentMetricsBucketIdentifier, PaymentMetricRow)>>;
+    ) -> MetricsResult<HashSet<(PaymentMetricsBucketIdentifier, PaymentMetricRow)>>;
 }
 
 #[async_trait::async_trait]
@@ -81,7 +82,7 @@ where
         granularity: &Option<Granularity>,
         time_range: &TimeRange,
         pool: &T,
-    ) -> MetricsResult<Vec<(PaymentMetricsBucketIdentifier, PaymentMetricRow)>> {
+    ) -> MetricsResult<HashSet<(PaymentMetricsBucketIdentifier, PaymentMetricRow)>> {
         match self {
             Self::PaymentSuccessRate => {
                 PaymentSuccessRate

--- a/crates/analytics/src/payments/metrics/avg_ticket_size.rs
+++ b/crates/analytics/src/payments/metrics/avg_ticket_size.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use api_models::analytics::{
     payments::{PaymentDimensions, PaymentFilters, PaymentMetricsBucketIdentifier},
     Granularity, TimeRange,
@@ -6,7 +8,6 @@ use common_utils::errors::ReportSwitchExt;
 use diesel_models::enums as storage_enums;
 use error_stack::ResultExt;
 use time::PrimitiveDateTime;
-use std::collections::HashSet;
 
 use super::{PaymentMetric, PaymentMetricRow};
 use crate::{

--- a/crates/analytics/src/payments/metrics/avg_ticket_size.rs
+++ b/crates/analytics/src/payments/metrics/avg_ticket_size.rs
@@ -6,6 +6,7 @@ use common_utils::errors::ReportSwitchExt;
 use diesel_models::enums as storage_enums;
 use error_stack::ResultExt;
 use time::PrimitiveDateTime;
+use std::collections::HashSet;
 
 use super::{PaymentMetric, PaymentMetricRow};
 use crate::{
@@ -34,7 +35,7 @@ where
         granularity: &Option<Granularity>,
         time_range: &TimeRange,
         pool: &T,
-    ) -> MetricsResult<Vec<(PaymentMetricsBucketIdentifier, PaymentMetricRow)>> {
+    ) -> MetricsResult<HashSet<(PaymentMetricsBucketIdentifier, PaymentMetricRow)>> {
         let mut query_builder: QueryBuilder<T> = QueryBuilder::new(AnalyticsCollection::Payment);
 
         for dim in dimensions.iter() {
@@ -130,7 +131,7 @@ where
                 ))
             })
             .collect::<error_stack::Result<
-                Vec<(PaymentMetricsBucketIdentifier, PaymentMetricRow)>,
+                HashSet<(PaymentMetricsBucketIdentifier, PaymentMetricRow)>,
                 crate::query::PostProcessingError,
             >>()
             .change_context(MetricsError::PostProcessingFailure)

--- a/crates/analytics/src/payments/metrics/connector_success_rate.rs
+++ b/crates/analytics/src/payments/metrics/connector_success_rate.rs
@@ -5,6 +5,7 @@ use api_models::analytics::{
 use common_utils::errors::ReportSwitchExt;
 use error_stack::ResultExt;
 use time::PrimitiveDateTime;
+use std::collections::HashSet;
 
 use super::PaymentMetricRow;
 use crate::{
@@ -36,7 +37,7 @@ where
         granularity: &Option<Granularity>,
         time_range: &TimeRange,
         pool: &T,
-    ) -> MetricsResult<Vec<(PaymentMetricsBucketIdentifier, PaymentMetricRow)>> {
+    ) -> MetricsResult<HashSet<(PaymentMetricsBucketIdentifier, PaymentMetricRow)>> {
         let mut query_builder: QueryBuilder<T> = QueryBuilder::new(AnalyticsCollection::Payment);
         let mut dimensions = dimensions.to_vec();
 
@@ -124,7 +125,7 @@ where
                 ))
             })
             .collect::<error_stack::Result<
-                Vec<(PaymentMetricsBucketIdentifier, PaymentMetricRow)>,
+                HashSet<(PaymentMetricsBucketIdentifier, PaymentMetricRow)>,
                 crate::query::PostProcessingError,
             >>()
             .change_context(MetricsError::PostProcessingFailure)

--- a/crates/analytics/src/payments/metrics/connector_success_rate.rs
+++ b/crates/analytics/src/payments/metrics/connector_success_rate.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use api_models::analytics::{
     payments::{PaymentDimensions, PaymentFilters, PaymentMetricsBucketIdentifier},
     Granularity, TimeRange,
@@ -5,7 +7,6 @@ use api_models::analytics::{
 use common_utils::errors::ReportSwitchExt;
 use error_stack::ResultExt;
 use time::PrimitiveDateTime;
-use std::collections::HashSet;
 
 use super::PaymentMetricRow;
 use crate::{

--- a/crates/analytics/src/payments/metrics/payment_count.rs
+++ b/crates/analytics/src/payments/metrics/payment_count.rs
@@ -5,6 +5,7 @@ use api_models::analytics::{
 use common_utils::errors::ReportSwitchExt;
 use error_stack::ResultExt;
 use time::PrimitiveDateTime;
+use std::collections::HashSet;
 
 use super::PaymentMetricRow;
 use crate::{
@@ -33,7 +34,7 @@ where
         granularity: &Option<Granularity>,
         time_range: &TimeRange,
         pool: &T,
-    ) -> MetricsResult<Vec<(PaymentMetricsBucketIdentifier, PaymentMetricRow)>> {
+    ) -> MetricsResult<HashSet<(PaymentMetricsBucketIdentifier, PaymentMetricRow)>> {
         let mut query_builder: QueryBuilder<T> = QueryBuilder::new(AnalyticsCollection::Payment);
 
         for dim in dimensions.iter() {
@@ -115,7 +116,7 @@ where
                     i,
                 ))
             })
-            .collect::<error_stack::Result<Vec<_>, crate::query::PostProcessingError>>()
+            .collect::<error_stack::Result<HashSet<_>, crate::query::PostProcessingError>>()
             .change_context(MetricsError::PostProcessingFailure)
     }
 }

--- a/crates/analytics/src/payments/metrics/payment_count.rs
+++ b/crates/analytics/src/payments/metrics/payment_count.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use api_models::analytics::{
     payments::{PaymentDimensions, PaymentFilters, PaymentMetricsBucketIdentifier},
     Granularity, TimeRange,
@@ -5,7 +7,6 @@ use api_models::analytics::{
 use common_utils::errors::ReportSwitchExt;
 use error_stack::ResultExt;
 use time::PrimitiveDateTime;
-use std::collections::HashSet;
 
 use super::PaymentMetricRow;
 use crate::{

--- a/crates/analytics/src/payments/metrics/payment_processed_amount.rs
+++ b/crates/analytics/src/payments/metrics/payment_processed_amount.rs
@@ -6,6 +6,7 @@ use common_utils::errors::ReportSwitchExt;
 use diesel_models::enums as storage_enums;
 use error_stack::ResultExt;
 use time::PrimitiveDateTime;
+use std::collections::HashSet;
 
 use super::PaymentMetricRow;
 use crate::{
@@ -34,7 +35,7 @@ where
         granularity: &Option<Granularity>,
         time_range: &TimeRange,
         pool: &T,
-    ) -> MetricsResult<Vec<(PaymentMetricsBucketIdentifier, PaymentMetricRow)>> {
+    ) -> MetricsResult<HashSet<(PaymentMetricsBucketIdentifier, PaymentMetricRow)>> {
         let mut query_builder: QueryBuilder<T> = QueryBuilder::new(AnalyticsCollection::Payment);
 
         for dim in dimensions.iter() {
@@ -124,7 +125,7 @@ where
                 ))
             })
             .collect::<error_stack::Result<
-                Vec<(PaymentMetricsBucketIdentifier, PaymentMetricRow)>,
+                HashSet<(PaymentMetricsBucketIdentifier, PaymentMetricRow)>,
                 crate::query::PostProcessingError,
             >>()
             .change_context(MetricsError::PostProcessingFailure)

--- a/crates/analytics/src/payments/metrics/payment_processed_amount.rs
+++ b/crates/analytics/src/payments/metrics/payment_processed_amount.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use api_models::analytics::{
     payments::{PaymentDimensions, PaymentFilters, PaymentMetricsBucketIdentifier},
     Granularity, TimeRange,
@@ -6,7 +8,6 @@ use common_utils::errors::ReportSwitchExt;
 use diesel_models::enums as storage_enums;
 use error_stack::ResultExt;
 use time::PrimitiveDateTime;
-use std::collections::HashSet;
 
 use super::PaymentMetricRow;
 use crate::{

--- a/crates/analytics/src/payments/metrics/payment_success_count.rs
+++ b/crates/analytics/src/payments/metrics/payment_success_count.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use api_models::analytics::{
     payments::{PaymentDimensions, PaymentFilters, PaymentMetricsBucketIdentifier},
     Granularity, TimeRange,
@@ -6,7 +8,6 @@ use common_utils::errors::ReportSwitchExt;
 use diesel_models::enums as storage_enums;
 use error_stack::ResultExt;
 use time::PrimitiveDateTime;
-use std::collections::HashSet;
 
 use super::PaymentMetricRow;
 use crate::{

--- a/crates/analytics/src/payments/metrics/payment_success_count.rs
+++ b/crates/analytics/src/payments/metrics/payment_success_count.rs
@@ -6,6 +6,7 @@ use common_utils::errors::ReportSwitchExt;
 use diesel_models::enums as storage_enums;
 use error_stack::ResultExt;
 use time::PrimitiveDateTime;
+use std::collections::HashSet;
 
 use super::PaymentMetricRow;
 use crate::{
@@ -34,7 +35,7 @@ where
         granularity: &Option<Granularity>,
         time_range: &TimeRange,
         pool: &T,
-    ) -> MetricsResult<Vec<(PaymentMetricsBucketIdentifier, PaymentMetricRow)>> {
+    ) -> MetricsResult<HashSet<(PaymentMetricsBucketIdentifier, PaymentMetricRow)>> {
         let mut query_builder: QueryBuilder<T> = QueryBuilder::new(AnalyticsCollection::Payment);
 
         for dim in dimensions.iter() {
@@ -123,7 +124,7 @@ where
                 ))
             })
             .collect::<error_stack::Result<
-                Vec<(PaymentMetricsBucketIdentifier, PaymentMetricRow)>,
+                HashSet<(PaymentMetricsBucketIdentifier, PaymentMetricRow)>,
                 crate::query::PostProcessingError,
             >>()
             .change_context(MetricsError::PostProcessingFailure)

--- a/crates/analytics/src/payments/metrics/retries_count.rs
+++ b/crates/analytics/src/payments/metrics/retries_count.rs
@@ -8,6 +8,7 @@ use api_models::{
 use common_utils::errors::ReportSwitchExt;
 use error_stack::ResultExt;
 use time::PrimitiveDateTime;
+use std::collections::HashSet;
 
 use super::PaymentMetricRow;
 use crate::{
@@ -39,7 +40,7 @@ where
         granularity: &Option<Granularity>,
         time_range: &TimeRange,
         pool: &T,
-    ) -> MetricsResult<Vec<(PaymentMetricsBucketIdentifier, PaymentMetricRow)>> {
+    ) -> MetricsResult<HashSet<(PaymentMetricsBucketIdentifier, PaymentMetricRow)>> {
         let mut query_builder: QueryBuilder<T> =
             QueryBuilder::new(AnalyticsCollection::PaymentIntent);
         query_builder
@@ -119,7 +120,7 @@ where
                 ))
             })
             .collect::<error_stack::Result<
-                Vec<(PaymentMetricsBucketIdentifier, PaymentMetricRow)>,
+                HashSet<(PaymentMetricsBucketIdentifier, PaymentMetricRow)>,
                 crate::query::PostProcessingError,
             >>()
             .change_context(MetricsError::PostProcessingFailure)

--- a/crates/analytics/src/payments/metrics/retries_count.rs
+++ b/crates/analytics/src/payments/metrics/retries_count.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use api_models::{
     analytics::{
         payments::{PaymentDimensions, PaymentFilters, PaymentMetricsBucketIdentifier},
@@ -8,7 +10,6 @@ use api_models::{
 use common_utils::errors::ReportSwitchExt;
 use error_stack::ResultExt;
 use time::PrimitiveDateTime;
-use std::collections::HashSet;
 
 use super::PaymentMetricRow;
 use crate::{

--- a/crates/analytics/src/payments/metrics/success_rate.rs
+++ b/crates/analytics/src/payments/metrics/success_rate.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use api_models::analytics::{
     payments::{PaymentDimensions, PaymentFilters, PaymentMetricsBucketIdentifier},
     Granularity, TimeRange,
@@ -5,7 +7,6 @@ use api_models::analytics::{
 use common_utils::errors::ReportSwitchExt;
 use error_stack::ResultExt;
 use time::PrimitiveDateTime;
-use std::collections::HashSet;
 
 use super::PaymentMetricRow;
 use crate::{

--- a/crates/analytics/src/payments/metrics/success_rate.rs
+++ b/crates/analytics/src/payments/metrics/success_rate.rs
@@ -5,6 +5,7 @@ use api_models::analytics::{
 use common_utils::errors::ReportSwitchExt;
 use error_stack::ResultExt;
 use time::PrimitiveDateTime;
+use std::collections::HashSet;
 
 use super::PaymentMetricRow;
 use crate::{
@@ -33,7 +34,7 @@ where
         granularity: &Option<Granularity>,
         time_range: &TimeRange,
         pool: &T,
-    ) -> MetricsResult<Vec<(PaymentMetricsBucketIdentifier, PaymentMetricRow)>> {
+    ) -> MetricsResult<HashSet<(PaymentMetricsBucketIdentifier, PaymentMetricRow)>> {
         let mut query_builder: QueryBuilder<T> = QueryBuilder::new(AnalyticsCollection::Payment);
         let mut dimensions = dimensions.to_vec();
 
@@ -119,7 +120,7 @@ where
                 ))
             })
             .collect::<error_stack::Result<
-                Vec<(PaymentMetricsBucketIdentifier, PaymentMetricRow)>,
+                HashSet<(PaymentMetricsBucketIdentifier, PaymentMetricRow)>,
                 crate::query::PostProcessingError,
             >>()
             .change_context(MetricsError::PostProcessingFailure)

--- a/crates/analytics/src/refunds/metrics.rs
+++ b/crates/analytics/src/refunds/metrics.rs
@@ -19,7 +19,9 @@ use crate::{
     query::{Aggregate, GroupByClause, ToSql, Window},
     types::{AnalyticsCollection, AnalyticsDataSource, DBEnumWrapper, LoadRow, MetricsResult},
 };
-#[derive(Debug, Eq, PartialEq, serde::Deserialize)]
+use std::collections::HashSet;
+
+#[derive(Debug, Eq, PartialEq, serde::Deserialize, Hash)]
 pub struct RefundMetricRow {
     pub currency: Option<DBEnumWrapper<storage_enums::Currency>>,
     pub refund_status: Option<DBEnumWrapper<storage_enums::RefundStatus>>,
@@ -53,7 +55,7 @@ where
         granularity: &Option<Granularity>,
         time_range: &TimeRange,
         pool: &T,
-    ) -> MetricsResult<Vec<(RefundMetricsBucketIdentifier, RefundMetricRow)>>;
+    ) -> MetricsResult<HashSet<(RefundMetricsBucketIdentifier, RefundMetricRow)>>;
 }
 
 #[async_trait::async_trait]
@@ -74,7 +76,7 @@ where
         granularity: &Option<Granularity>,
         time_range: &TimeRange,
         pool: &T,
-    ) -> MetricsResult<Vec<(RefundMetricsBucketIdentifier, RefundMetricRow)>> {
+    ) -> MetricsResult<HashSet<(RefundMetricsBucketIdentifier, RefundMetricRow)>> {
         match self {
             Self::RefundSuccessRate => {
                 RefundSuccessRate::default()

--- a/crates/analytics/src/refunds/metrics.rs
+++ b/crates/analytics/src/refunds/metrics.rs
@@ -10,6 +10,8 @@ mod refund_count;
 mod refund_processed_amount;
 mod refund_success_count;
 mod refund_success_rate;
+use std::collections::HashSet;
+
 use refund_count::RefundCount;
 use refund_processed_amount::RefundProcessedAmount;
 use refund_success_count::RefundSuccessCount;
@@ -19,7 +21,6 @@ use crate::{
     query::{Aggregate, GroupByClause, ToSql, Window},
     types::{AnalyticsCollection, AnalyticsDataSource, DBEnumWrapper, LoadRow, MetricsResult},
 };
-use std::collections::HashSet;
 
 #[derive(Debug, Eq, PartialEq, serde::Deserialize, Hash)]
 pub struct RefundMetricRow {

--- a/crates/analytics/src/refunds/metrics/refund_count.rs
+++ b/crates/analytics/src/refunds/metrics/refund_count.rs
@@ -5,6 +5,7 @@ use api_models::analytics::{
 use common_utils::errors::ReportSwitchExt;
 use error_stack::ResultExt;
 use time::PrimitiveDateTime;
+use std::collections::HashSet;
 
 use super::RefundMetricRow;
 use crate::{
@@ -33,7 +34,7 @@ where
         granularity: &Option<Granularity>,
         time_range: &TimeRange,
         pool: &T,
-    ) -> MetricsResult<Vec<(RefundMetricsBucketIdentifier, RefundMetricRow)>> {
+    ) -> MetricsResult<HashSet<(RefundMetricsBucketIdentifier, RefundMetricRow)>> {
         let mut query_builder: QueryBuilder<T> = QueryBuilder::new(AnalyticsCollection::Refund);
 
         for dim in dimensions.iter() {
@@ -111,7 +112,7 @@ where
                     i,
                 ))
             })
-            .collect::<error_stack::Result<Vec<_>, crate::query::PostProcessingError>>()
+            .collect::<error_stack::Result<HashSet<_>, crate::query::PostProcessingError>>()
             .change_context(MetricsError::PostProcessingFailure)
     }
 }

--- a/crates/analytics/src/refunds/metrics/refund_count.rs
+++ b/crates/analytics/src/refunds/metrics/refund_count.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use api_models::analytics::{
     refunds::{RefundDimensions, RefundFilters, RefundMetricsBucketIdentifier},
     Granularity, TimeRange,
@@ -5,7 +7,6 @@ use api_models::analytics::{
 use common_utils::errors::ReportSwitchExt;
 use error_stack::ResultExt;
 use time::PrimitiveDateTime;
-use std::collections::HashSet;
 
 use super::RefundMetricRow;
 use crate::{

--- a/crates/analytics/src/refunds/metrics/refund_processed_amount.rs
+++ b/crates/analytics/src/refunds/metrics/refund_processed_amount.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use api_models::analytics::{
     refunds::{RefundDimensions, RefundFilters, RefundMetricsBucketIdentifier},
     Granularity, TimeRange,
@@ -6,7 +8,6 @@ use common_utils::errors::ReportSwitchExt;
 use diesel_models::enums as storage_enums;
 use error_stack::ResultExt;
 use time::PrimitiveDateTime;
-use std::collections::HashSet;
 
 use super::RefundMetricRow;
 use crate::{

--- a/crates/analytics/src/refunds/metrics/refund_processed_amount.rs
+++ b/crates/analytics/src/refunds/metrics/refund_processed_amount.rs
@@ -6,6 +6,7 @@ use common_utils::errors::ReportSwitchExt;
 use diesel_models::enums as storage_enums;
 use error_stack::ResultExt;
 use time::PrimitiveDateTime;
+use std::collections::HashSet;
 
 use super::RefundMetricRow;
 use crate::{
@@ -33,7 +34,7 @@ where
         granularity: &Option<Granularity>,
         time_range: &TimeRange,
         pool: &T,
-    ) -> MetricsResult<Vec<(RefundMetricsBucketIdentifier, RefundMetricRow)>>
+    ) -> MetricsResult<HashSet<(RefundMetricsBucketIdentifier, RefundMetricRow)>>
     where
         T: AnalyticsDataSource + super::RefundMetricAnalytics,
     {
@@ -117,7 +118,7 @@ where
                     i,
                 ))
             })
-            .collect::<error_stack::Result<Vec<_>, crate::query::PostProcessingError>>()
+            .collect::<error_stack::Result<HashSet<_>, crate::query::PostProcessingError>>()
             .change_context(MetricsError::PostProcessingFailure)
     }
 }

--- a/crates/analytics/src/refunds/metrics/refund_success_count.rs
+++ b/crates/analytics/src/refunds/metrics/refund_success_count.rs
@@ -6,6 +6,7 @@ use common_utils::errors::ReportSwitchExt;
 use diesel_models::enums as storage_enums;
 use error_stack::ResultExt;
 use time::PrimitiveDateTime;
+use std::collections::HashSet;
 
 use super::RefundMetricRow;
 use crate::{
@@ -34,7 +35,7 @@ where
         granularity: &Option<Granularity>,
         time_range: &TimeRange,
         pool: &T,
-    ) -> MetricsResult<Vec<(RefundMetricsBucketIdentifier, RefundMetricRow)>>
+    ) -> MetricsResult<HashSet<(RefundMetricsBucketIdentifier, RefundMetricRow)>>
     where
         T: AnalyticsDataSource + super::RefundMetricAnalytics,
     {
@@ -115,7 +116,7 @@ where
                 ))
             })
             .collect::<error_stack::Result<
-                Vec<(RefundMetricsBucketIdentifier, RefundMetricRow)>,
+                HashSet<(RefundMetricsBucketIdentifier, RefundMetricRow)>,
                 crate::query::PostProcessingError,
             >>()
             .change_context(MetricsError::PostProcessingFailure)

--- a/crates/analytics/src/refunds/metrics/refund_success_count.rs
+++ b/crates/analytics/src/refunds/metrics/refund_success_count.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use api_models::analytics::{
     refunds::{RefundDimensions, RefundFilters, RefundMetricsBucketIdentifier},
     Granularity, TimeRange,
@@ -6,7 +8,6 @@ use common_utils::errors::ReportSwitchExt;
 use diesel_models::enums as storage_enums;
 use error_stack::ResultExt;
 use time::PrimitiveDateTime;
-use std::collections::HashSet;
 
 use super::RefundMetricRow;
 use crate::{

--- a/crates/analytics/src/refunds/metrics/refund_success_rate.rs
+++ b/crates/analytics/src/refunds/metrics/refund_success_rate.rs
@@ -5,6 +5,7 @@ use api_models::analytics::{
 use common_utils::errors::ReportSwitchExt;
 use error_stack::ResultExt;
 use time::PrimitiveDateTime;
+use std::collections::HashSet;
 
 use super::RefundMetricRow;
 use crate::{
@@ -32,7 +33,7 @@ where
         granularity: &Option<Granularity>,
         time_range: &TimeRange,
         pool: &T,
-    ) -> MetricsResult<Vec<(RefundMetricsBucketIdentifier, RefundMetricRow)>>
+    ) -> MetricsResult<HashSet<(RefundMetricsBucketIdentifier, RefundMetricRow)>>
     where
         T: AnalyticsDataSource + super::RefundMetricAnalytics,
     {
@@ -110,7 +111,7 @@ where
                 ))
             })
             .collect::<error_stack::Result<
-                Vec<(RefundMetricsBucketIdentifier, RefundMetricRow)>,
+                HashSet<(RefundMetricsBucketIdentifier, RefundMetricRow)>,
                 crate::query::PostProcessingError,
             >>()
             .change_context(MetricsError::PostProcessingFailure)

--- a/crates/analytics/src/refunds/metrics/refund_success_rate.rs
+++ b/crates/analytics/src/refunds/metrics/refund_success_rate.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use api_models::analytics::{
     refunds::{RefundDimensions, RefundFilters, RefundMetricsBucketIdentifier},
     Granularity, TimeRange,
@@ -5,7 +7,6 @@ use api_models::analytics::{
 use common_utils::errors::ReportSwitchExt;
 use error_stack::ResultExt;
 use time::PrimitiveDateTime;
-use std::collections::HashSet;
 
 use super::RefundMetricRow;
 use crate::{

--- a/crates/analytics/src/sdk_events/metrics.rs
+++ b/crates/analytics/src/sdk_events/metrics.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use api_models::analytics::{
     sdk_events::{
         SdkEventDimensions, SdkEventFilters, SdkEventMetrics, SdkEventMetricsBucketIdentifier,
@@ -5,7 +7,6 @@ use api_models::analytics::{
     Granularity, TimeRange,
 };
 use time::PrimitiveDateTime;
-use std::collections::HashSet;
 
 use crate::{
     query::{Aggregate, GroupByClause, ToSql, Window},

--- a/crates/analytics/src/sdk_events/metrics.rs
+++ b/crates/analytics/src/sdk_events/metrics.rs
@@ -5,6 +5,7 @@ use api_models::analytics::{
     Granularity, TimeRange,
 };
 use time::PrimitiveDateTime;
+use std::collections::HashSet;
 
 use crate::{
     query::{Aggregate, GroupByClause, ToSql, Window},
@@ -29,7 +30,7 @@ use payment_methods_call_count::PaymentMethodsCallCount;
 use sdk_initiated_count::SdkInitiatedCount;
 use sdk_rendered_count::SdkRenderedCount;
 
-#[derive(Debug, PartialEq, Eq, serde::Deserialize)]
+#[derive(Debug, PartialEq, Eq, serde::Deserialize, Hash)]
 pub struct SdkEventMetricRow {
     pub total: Option<bigdecimal::BigDecimal>,
     pub count: Option<i64>,
@@ -57,7 +58,7 @@ where
         granularity: &Option<Granularity>,
         time_range: &TimeRange,
         pool: &T,
-    ) -> MetricsResult<Vec<(SdkEventMetricsBucketIdentifier, SdkEventMetricRow)>>;
+    ) -> MetricsResult<HashSet<(SdkEventMetricsBucketIdentifier, SdkEventMetricRow)>>;
 }
 
 #[async_trait::async_trait]
@@ -78,7 +79,7 @@ where
         granularity: &Option<Granularity>,
         time_range: &TimeRange,
         pool: &T,
-    ) -> MetricsResult<Vec<(SdkEventMetricsBucketIdentifier, SdkEventMetricRow)>> {
+    ) -> MetricsResult<HashSet<(SdkEventMetricsBucketIdentifier, SdkEventMetricRow)>> {
         match self {
             Self::PaymentAttempts => {
                 PaymentAttempts

--- a/crates/analytics/src/sdk_events/metrics/average_payment_time.rs
+++ b/crates/analytics/src/sdk_events/metrics/average_payment_time.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use api_models::analytics::{
     sdk_events::{
         SdkEventDimensions, SdkEventFilters, SdkEventMetricsBucketIdentifier, SdkEventNames,
@@ -7,7 +9,6 @@ use api_models::analytics::{
 use common_utils::errors::ReportSwitchExt;
 use error_stack::ResultExt;
 use time::PrimitiveDateTime;
-use std::collections::HashSet;
 
 use super::SdkEventMetricRow;
 use crate::{

--- a/crates/analytics/src/sdk_events/metrics/average_payment_time.rs
+++ b/crates/analytics/src/sdk_events/metrics/average_payment_time.rs
@@ -7,6 +7,7 @@ use api_models::analytics::{
 use common_utils::errors::ReportSwitchExt;
 use error_stack::ResultExt;
 use time::PrimitiveDateTime;
+use std::collections::HashSet;
 
 use super::SdkEventMetricRow;
 use crate::{
@@ -35,7 +36,7 @@ where
         granularity: &Option<Granularity>,
         time_range: &TimeRange,
         pool: &T,
-    ) -> MetricsResult<Vec<(SdkEventMetricsBucketIdentifier, SdkEventMetricRow)>> {
+    ) -> MetricsResult<HashSet<(SdkEventMetricsBucketIdentifier, SdkEventMetricRow)>> {
         let mut query_builder: QueryBuilder<T> =
             QueryBuilder::new(AnalyticsCollection::SdkEventsAnalytics);
         let dimensions = dimensions.to_vec();
@@ -116,7 +117,7 @@ where
                 ))
             })
             .collect::<error_stack::Result<
-                Vec<(SdkEventMetricsBucketIdentifier, SdkEventMetricRow)>,
+                HashSet<(SdkEventMetricsBucketIdentifier, SdkEventMetricRow)>,
                 crate::query::PostProcessingError,
             >>()
             .change_context(MetricsError::PostProcessingFailure)

--- a/crates/analytics/src/sdk_events/metrics/load_time.rs
+++ b/crates/analytics/src/sdk_events/metrics/load_time.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use api_models::analytics::{
     sdk_events::{
         SdkEventDimensions, SdkEventFilters, SdkEventMetricsBucketIdentifier, SdkEventNames,
@@ -7,7 +9,6 @@ use api_models::analytics::{
 use common_utils::errors::ReportSwitchExt;
 use error_stack::ResultExt;
 use time::PrimitiveDateTime;
-use std::collections::HashSet;
 
 use super::SdkEventMetricRow;
 use crate::{

--- a/crates/analytics/src/sdk_events/metrics/load_time.rs
+++ b/crates/analytics/src/sdk_events/metrics/load_time.rs
@@ -7,6 +7,7 @@ use api_models::analytics::{
 use common_utils::errors::ReportSwitchExt;
 use error_stack::ResultExt;
 use time::PrimitiveDateTime;
+use std::collections::HashSet;
 
 use super::SdkEventMetricRow;
 use crate::{
@@ -35,7 +36,7 @@ where
         granularity: &Option<Granularity>,
         time_range: &TimeRange,
         pool: &T,
-    ) -> MetricsResult<Vec<(SdkEventMetricsBucketIdentifier, SdkEventMetricRow)>> {
+    ) -> MetricsResult<HashSet<(SdkEventMetricsBucketIdentifier, SdkEventMetricRow)>> {
         let mut query_builder: QueryBuilder<T> =
             QueryBuilder::new(AnalyticsCollection::SdkEventsAnalytics);
         let dimensions = dimensions.to_vec();
@@ -116,7 +117,7 @@ where
                 ))
             })
             .collect::<error_stack::Result<
-                Vec<(SdkEventMetricsBucketIdentifier, SdkEventMetricRow)>,
+                HashSet<(SdkEventMetricsBucketIdentifier, SdkEventMetricRow)>,
                 crate::query::PostProcessingError,
             >>()
             .change_context(MetricsError::PostProcessingFailure)

--- a/crates/analytics/src/sdk_events/metrics/payment_attempts.rs
+++ b/crates/analytics/src/sdk_events/metrics/payment_attempts.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use api_models::analytics::{
     sdk_events::{
         SdkEventDimensions, SdkEventFilters, SdkEventMetricsBucketIdentifier, SdkEventNames,
@@ -7,7 +9,6 @@ use api_models::analytics::{
 use common_utils::errors::ReportSwitchExt;
 use error_stack::ResultExt;
 use time::PrimitiveDateTime;
-use std::collections::HashSet;
 
 use super::SdkEventMetricRow;
 use crate::{

--- a/crates/analytics/src/sdk_events/metrics/payment_attempts.rs
+++ b/crates/analytics/src/sdk_events/metrics/payment_attempts.rs
@@ -7,6 +7,7 @@ use api_models::analytics::{
 use common_utils::errors::ReportSwitchExt;
 use error_stack::ResultExt;
 use time::PrimitiveDateTime;
+use std::collections::HashSet;
 
 use super::SdkEventMetricRow;
 use crate::{
@@ -35,7 +36,7 @@ where
         granularity: &Option<Granularity>,
         time_range: &TimeRange,
         pool: &T,
-    ) -> MetricsResult<Vec<(SdkEventMetricsBucketIdentifier, SdkEventMetricRow)>> {
+    ) -> MetricsResult<HashSet<(SdkEventMetricsBucketIdentifier, SdkEventMetricRow)>> {
         let mut query_builder: QueryBuilder<T> =
             QueryBuilder::new(AnalyticsCollection::SdkEventsAnalytics);
         let dimensions = dimensions.to_vec();
@@ -111,7 +112,7 @@ where
                 ))
             })
             .collect::<error_stack::Result<
-                Vec<(SdkEventMetricsBucketIdentifier, SdkEventMetricRow)>,
+                HashSet<(SdkEventMetricsBucketIdentifier, SdkEventMetricRow)>,
                 crate::query::PostProcessingError,
             >>()
             .change_context(MetricsError::PostProcessingFailure)

--- a/crates/analytics/src/sdk_events/metrics/payment_data_filled_count.rs
+++ b/crates/analytics/src/sdk_events/metrics/payment_data_filled_count.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use api_models::analytics::{
     sdk_events::{
         SdkEventDimensions, SdkEventFilters, SdkEventMetricsBucketIdentifier, SdkEventNames,
@@ -7,7 +9,6 @@ use api_models::analytics::{
 use common_utils::errors::ReportSwitchExt;
 use error_stack::ResultExt;
 use time::PrimitiveDateTime;
-use std::collections::HashSet;
 
 use super::SdkEventMetricRow;
 use crate::{

--- a/crates/analytics/src/sdk_events/metrics/payment_data_filled_count.rs
+++ b/crates/analytics/src/sdk_events/metrics/payment_data_filled_count.rs
@@ -7,6 +7,7 @@ use api_models::analytics::{
 use common_utils::errors::ReportSwitchExt;
 use error_stack::ResultExt;
 use time::PrimitiveDateTime;
+use std::collections::HashSet;
 
 use super::SdkEventMetricRow;
 use crate::{
@@ -35,7 +36,7 @@ where
         granularity: &Option<Granularity>,
         time_range: &TimeRange,
         pool: &T,
-    ) -> MetricsResult<Vec<(SdkEventMetricsBucketIdentifier, SdkEventMetricRow)>> {
+    ) -> MetricsResult<HashSet<(SdkEventMetricsBucketIdentifier, SdkEventMetricRow)>> {
         let mut query_builder: QueryBuilder<T> =
             QueryBuilder::new(AnalyticsCollection::SdkEventsAnalytics);
         let dimensions = dimensions.to_vec();
@@ -111,7 +112,7 @@ where
                 ))
             })
             .collect::<error_stack::Result<
-                Vec<(SdkEventMetricsBucketIdentifier, SdkEventMetricRow)>,
+                HashSet<(SdkEventMetricsBucketIdentifier, SdkEventMetricRow)>,
                 crate::query::PostProcessingError,
             >>()
             .change_context(MetricsError::PostProcessingFailure)

--- a/crates/analytics/src/sdk_events/metrics/payment_method_selected_count.rs
+++ b/crates/analytics/src/sdk_events/metrics/payment_method_selected_count.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use api_models::analytics::{
     sdk_events::{
         SdkEventDimensions, SdkEventFilters, SdkEventMetricsBucketIdentifier, SdkEventNames,
@@ -7,7 +9,6 @@ use api_models::analytics::{
 use common_utils::errors::ReportSwitchExt;
 use error_stack::ResultExt;
 use time::PrimitiveDateTime;
-use std::collections::HashSet;
 
 use super::SdkEventMetricRow;
 use crate::{

--- a/crates/analytics/src/sdk_events/metrics/payment_method_selected_count.rs
+++ b/crates/analytics/src/sdk_events/metrics/payment_method_selected_count.rs
@@ -7,6 +7,7 @@ use api_models::analytics::{
 use common_utils::errors::ReportSwitchExt;
 use error_stack::ResultExt;
 use time::PrimitiveDateTime;
+use std::collections::HashSet;
 
 use super::SdkEventMetricRow;
 use crate::{
@@ -35,7 +36,7 @@ where
         granularity: &Option<Granularity>,
         time_range: &TimeRange,
         pool: &T,
-    ) -> MetricsResult<Vec<(SdkEventMetricsBucketIdentifier, SdkEventMetricRow)>> {
+    ) -> MetricsResult<HashSet<(SdkEventMetricsBucketIdentifier, SdkEventMetricRow)>> {
         let mut query_builder: QueryBuilder<T> =
             QueryBuilder::new(AnalyticsCollection::SdkEventsAnalytics);
         let dimensions = dimensions.to_vec();
@@ -111,7 +112,7 @@ where
                 ))
             })
             .collect::<error_stack::Result<
-                Vec<(SdkEventMetricsBucketIdentifier, SdkEventMetricRow)>,
+                HashSet<(SdkEventMetricsBucketIdentifier, SdkEventMetricRow)>,
                 crate::query::PostProcessingError,
             >>()
             .change_context(MetricsError::PostProcessingFailure)

--- a/crates/analytics/src/sdk_events/metrics/payment_methods_call_count.rs
+++ b/crates/analytics/src/sdk_events/metrics/payment_methods_call_count.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use api_models::analytics::{
     sdk_events::{
         SdkEventDimensions, SdkEventFilters, SdkEventMetricsBucketIdentifier, SdkEventNames,
@@ -7,7 +9,6 @@ use api_models::analytics::{
 use common_utils::errors::ReportSwitchExt;
 use error_stack::ResultExt;
 use time::PrimitiveDateTime;
-use std::collections::HashSet;
 
 use super::SdkEventMetricRow;
 use crate::{

--- a/crates/analytics/src/sdk_events/metrics/payment_methods_call_count.rs
+++ b/crates/analytics/src/sdk_events/metrics/payment_methods_call_count.rs
@@ -7,6 +7,7 @@ use api_models::analytics::{
 use common_utils::errors::ReportSwitchExt;
 use error_stack::ResultExt;
 use time::PrimitiveDateTime;
+use std::collections::HashSet;
 
 use super::SdkEventMetricRow;
 use crate::{
@@ -35,7 +36,7 @@ where
         granularity: &Option<Granularity>,
         time_range: &TimeRange,
         pool: &T,
-    ) -> MetricsResult<Vec<(SdkEventMetricsBucketIdentifier, SdkEventMetricRow)>> {
+    ) -> MetricsResult<HashSet<(SdkEventMetricsBucketIdentifier, SdkEventMetricRow)>> {
         let mut query_builder: QueryBuilder<T> =
             QueryBuilder::new(AnalyticsCollection::SdkEventsAnalytics);
         let dimensions = dimensions.to_vec();
@@ -119,7 +120,7 @@ where
                 ))
             })
             .collect::<error_stack::Result<
-                Vec<(SdkEventMetricsBucketIdentifier, SdkEventMetricRow)>,
+                HashSet<(SdkEventMetricsBucketIdentifier, SdkEventMetricRow)>,
                 crate::query::PostProcessingError,
             >>()
             .change_context(MetricsError::PostProcessingFailure)

--- a/crates/analytics/src/sdk_events/metrics/sdk_initiated_count.rs
+++ b/crates/analytics/src/sdk_events/metrics/sdk_initiated_count.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use api_models::analytics::{
     sdk_events::{
         SdkEventDimensions, SdkEventFilters, SdkEventMetricsBucketIdentifier, SdkEventNames,
@@ -7,7 +9,6 @@ use api_models::analytics::{
 use common_utils::errors::ReportSwitchExt;
 use error_stack::ResultExt;
 use time::PrimitiveDateTime;
-use std::collections::HashSet;
 
 use super::SdkEventMetricRow;
 use crate::{

--- a/crates/analytics/src/sdk_events/metrics/sdk_initiated_count.rs
+++ b/crates/analytics/src/sdk_events/metrics/sdk_initiated_count.rs
@@ -7,6 +7,7 @@ use api_models::analytics::{
 use common_utils::errors::ReportSwitchExt;
 use error_stack::ResultExt;
 use time::PrimitiveDateTime;
+use std::collections::HashSet;
 
 use super::SdkEventMetricRow;
 use crate::{
@@ -35,7 +36,7 @@ where
         granularity: &Option<Granularity>,
         time_range: &TimeRange,
         pool: &T,
-    ) -> MetricsResult<Vec<(SdkEventMetricsBucketIdentifier, SdkEventMetricRow)>> {
+    ) -> MetricsResult<HashSet<(SdkEventMetricsBucketIdentifier, SdkEventMetricRow)>> {
         let mut query_builder: QueryBuilder<T> =
             QueryBuilder::new(AnalyticsCollection::SdkEventsAnalytics);
         let dimensions = dimensions.to_vec();
@@ -111,7 +112,7 @@ where
                 ))
             })
             .collect::<error_stack::Result<
-                Vec<(SdkEventMetricsBucketIdentifier, SdkEventMetricRow)>,
+                HashSet<(SdkEventMetricsBucketIdentifier, SdkEventMetricRow)>,
                 crate::query::PostProcessingError,
             >>()
             .change_context(MetricsError::PostProcessingFailure)

--- a/crates/analytics/src/sdk_events/metrics/sdk_rendered_count.rs
+++ b/crates/analytics/src/sdk_events/metrics/sdk_rendered_count.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use api_models::analytics::{
     sdk_events::{
         SdkEventDimensions, SdkEventFilters, SdkEventMetricsBucketIdentifier, SdkEventNames,
@@ -7,7 +9,6 @@ use api_models::analytics::{
 use common_utils::errors::ReportSwitchExt;
 use error_stack::ResultExt;
 use time::PrimitiveDateTime;
-use std::collections::HashSet;
 
 use super::SdkEventMetricRow;
 use crate::{

--- a/crates/analytics/src/sdk_events/metrics/sdk_rendered_count.rs
+++ b/crates/analytics/src/sdk_events/metrics/sdk_rendered_count.rs
@@ -7,6 +7,7 @@ use api_models::analytics::{
 use common_utils::errors::ReportSwitchExt;
 use error_stack::ResultExt;
 use time::PrimitiveDateTime;
+use std::collections::HashSet;
 
 use super::SdkEventMetricRow;
 use crate::{
@@ -35,7 +36,7 @@ where
         granularity: &Option<Granularity>,
         time_range: &TimeRange,
         pool: &T,
-    ) -> MetricsResult<Vec<(SdkEventMetricsBucketIdentifier, SdkEventMetricRow)>> {
+    ) -> MetricsResult<HashSet<(SdkEventMetricsBucketIdentifier, SdkEventMetricRow)>> {
         let mut query_builder: QueryBuilder<T> =
             QueryBuilder::new(AnalyticsCollection::SdkEventsAnalytics);
         let dimensions = dimensions.to_vec();
@@ -111,7 +112,7 @@ where
                 ))
             })
             .collect::<error_stack::Result<
-                Vec<(SdkEventMetricsBucketIdentifier, SdkEventMetricRow)>,
+                HashSet<(SdkEventMetricsBucketIdentifier, SdkEventMetricRow)>,
                 crate::query::PostProcessingError,
             >>()
             .change_context(MetricsError::PostProcessingFailure)

--- a/crates/analytics/src/types.rs
+++ b/crates/analytics/src/types.rs
@@ -44,7 +44,7 @@ pub enum TableEngine {
     BasicTree,
 }
 
-#[derive(Debug, serde::Serialize, serde::Deserialize, Eq, PartialEq)]
+#[derive(Debug, serde::Serialize, serde::Deserialize, Eq, PartialEq, Hash)]
 #[serde(transparent)]
 pub struct DBEnumWrapper<T: FromStr + Display>(pub T);
 

--- a/crates/api_models/src/analytics/refunds.rs
+++ b/crates/api_models/src/analytics/refunds.rs
@@ -10,6 +10,7 @@ use crate::{enums::Currency, refunds::RefundStatus};
     Copy,
     Debug,
     Default,
+    Hash,
     Eq,
     PartialEq,
     serde::Serialize,

--- a/crates/common_enums/src/enums.rs
+++ b/crates/common_enums/src/enums.rs
@@ -25,6 +25,7 @@ pub mod diesel_exports {
     Copy,
     Debug,
     Default,
+    Hash,
     Eq,
     PartialEq,
     serde::Deserialize,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Used hashset instead of vector for representing the returned metrics

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
Currently we return a vector of results this causes an mismatch warning if the order is changed,
instead we should use a HashSet to store & compare these values.



## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Using curl requests, expected normal behaviour while perfoming payments, refunds, etc
```bash
curl --location 'http://localhost:8080/payments' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: dev_IG9ateOUhGE0KLFEItNN1tsJXcr5M62N7zlbtOlUtStTfPpzSomswbQa4aO2k1B4' \
--data-raw '{
  "amount": 6540,
  "currency": "USD",
  "confirm": true,
  "capture_method": "automatic",
  "capture_on": "2022-09-10T10:11:12Z",
  "amount_to_capture": 6540,
  "customer_id": "StripeCustomer",
  "email": "guest@example.com",
  "name": "John Doe",
  "phone": "999999999",
  "phone_country_code": "+1",
  "description": "Its my first payment request",
  "authentication_type": "no_three_ds",
  "return_url": "https://google.com",
  "payment_method": "card",
  "payment_method_type": "credit",
  "payment_method_data": {
    "card": {
      "card_number": "4242424242424242",
      "card_exp_month": "10",
      "card_exp_year": "25",
      "card_holder_name": "joseph Doe",
      "card_cvc": "123"
    }
  },
  "billing": {
    "address": {
      "line1": "1467",
      "line2": "Harrison Street",
      "line3": "Harrison Street",
      "city": "San Fransico",
      "state": "California",
      "zip": "94122",
      "country": "US",
      "first_name": "joseph",
      "last_name": "Doe"
    },
    "phone": {
      "number": "8056594427",
      "country_code": "+91"
    }
  },
  "shipping": {
    "address": {
      "line1": "1467",
      "line2": "Harrison Street",
      "line3": "Harrison Street",
      "city": "San Fransico",
      "state": "California",
      "zip": "94122",
      "country": "US",
      "first_name": "joseph",
      "last_name": "Doe"
    },
    "phone": {
      "number": "8056594427",
      "country_code": "+91"
    }
  },
  "statement_descriptor_name": "joseph",
  "statement_descriptor_suffix": "JS",
  "metadata": {
    "data2": "camel",
    "new_customer": "true",
    "login_date": "2019-09-10T10:11:12Z"
  }
}'
```
<img width="1288" alt="Screenshot 2024-07-04 at 7 42 57 PM" src="https://github.com/juspay/hyperswitch/assets/83278309/e06f5709-d8ca-4fbc-a4ce-64059bf8088e">
<img width="640" alt="Screenshot 2024-07-04 at 7 43 31 PM" src="https://github.com/juspay/hyperswitch/assets/83278309/0edcffbc-004f-4df8-bb8b-d98a34ec88f2">

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
