### PR TITLE
feat(payments): add audit events for PaymentStart update

### DIFF
--- a/crates/router/src/core/payments/operations/payment_start.rs
+++ b/crates/router/src/core/payments/operations/payment_start.rs
@@ -13,6 +13,7 @@ use crate::{
         payments::{helpers, operations, CustomerDetails, PaymentAddress, PaymentData},
     },
     db::StorageInterface,
+    events::audit_events::{AuditEvent, AuditEventType},
     routes::{app::ReqState, SessionState},
     services,
     types::{
@@ -224,6 +225,11 @@ impl<F: Clone> UpdateTracker<F, PaymentData<F>, api::PaymentsStartRequest> for P
     where
         F: 'b + Send,
     {
+        _req_state
+            .event_context
+            .event(AuditEvent::new(AuditEventType::PaymentStart))
+            .with(payment_data.to_event())
+            .emit();
         Ok((Box::new(self), payment_data))
     }
 }

--- a/crates/router/src/events/audit_events.rs
+++ b/crates/router/src/events/audit_events.rs
@@ -9,6 +9,7 @@ pub enum AuditEventType {
     Error {
         error_message: String,
     },
+    PaymentStart,
     PaymentCreated,
     ConnectorDecided,
     ConnectorCalled,
@@ -56,6 +57,7 @@ impl Event for AuditEvent {
     fn identifier(&self) -> String {
         let event_type = match &self.event_type {
             AuditEventType::Error { .. } => "error",
+            AuditEventType::PaymentStart => "payment_start",
             AuditEventType::PaymentCreated => "payment_created",
             AuditEventType::PaymentConfirm { .. } => "payment_confirm",
             AuditEventType::ConnectorDecided => "connector_decided",


### PR DESCRIPTION
## Type of Change


- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
update the paymentstart implementation of updatetracker to generate an event


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

Add audit events for PaymentStart update
following files have been changed:
crates/router/src/core/payments/operations/patment_start.rs
crates/router/src/events/audit_events.rs


## Motivation and Context

#4681 

## How did you test it?



## Checklist


- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
