### PR TITLE
feat(router): pass fields to indicate if the customer address details to be connector from wallets

### DIFF
--- a/api-reference/openapi_spec.json
+++ b/api-reference/openapi_spec.json
@@ -14278,6 +14278,16 @@
             "type": "boolean",
             "description": "flag to indicate whether to perform external 3ds authentication",
             "example": true
+          },
+          "collect_shipping_details_from_wallets": {
+            "type": "boolean",
+            "description": "flag that indicates whether to collect shipping details from wallets or from the customer",
+            "nullable": true
+          },
+          "collect_billing_details_from_wallets": {
+            "type": "boolean",
+            "description": "flag that indicates whether to collect billing details from wallets or from the customer",
+            "nullable": true
           }
         }
       },

--- a/crates/api_models/src/payment_methods.rs
+++ b/crates/api_models/src/payment_methods.rs
@@ -796,10 +796,10 @@ pub struct PaymentMethodListResponse {
     #[schema(example = true)]
     pub request_external_three_ds_authentication: bool,
 
-    /// flag to indicate whether to collect shipping details from wallets or customer
+    /// flag that indicates whether to collect shipping details from wallets or from the customer
     pub collect_shipping_details_from_wallets: Option<bool>,
 
-    /// flag to indicate whether to collect billing details from wallets or customer
+    /// flag that indicates whether to collect billing details from wallets or from the customer
     pub collect_billing_details_from_wallets: Option<bool>,
 }
 

--- a/crates/api_models/src/payment_methods.rs
+++ b/crates/api_models/src/payment_methods.rs
@@ -795,6 +795,12 @@ pub struct PaymentMethodListResponse {
     /// flag to indicate whether to perform external 3ds authentication
     #[schema(example = true)]
     pub request_external_three_ds_authentication: bool,
+
+    /// flag to indicate whether to collect shipping details from wallets or customer
+    pub collect_shipping_details_from_wallets: Option<bool>,
+
+    /// flag to indicate whether to collect billing details from wallets or customer
+    pub collect_billing_details_from_wallets: Option<bool>,
 }
 
 #[derive(Eq, PartialEq, Hash, Debug, serde::Deserialize, ToSchema)]

--- a/crates/router/src/core/payment_methods/cards.rs
+++ b/crates/router/src/core/payment_methods/cards.rs
@@ -2703,14 +2703,14 @@ pub async fn list_payment_methods(
         if let Some((payment_attempt, payment_intent, business_profile)) = payment_attempt
             .as_ref()
             .zip(payment_intent)
-            .zip(business_profile)
+            .zip(business_profile.as_ref())
             .map(|((pa, pi), bp)| (pa, pi, bp))
         {
             Box::pin(call_surcharge_decision_management(
                 state,
                 &merchant_account,
                 &key_store,
-                &business_profile,
+                business_profile,
                 payment_attempt,
                 payment_intent,
                 billing_address,
@@ -2720,6 +2720,14 @@ pub async fn list_payment_methods(
         } else {
             api_surcharge_decision_configs::MerchantSurchargeConfigs::default()
         };
+
+    let collect_shipping_details_from_wallets = business_profile
+        .as_ref()
+        .and_then(|bp| bp.collect_shipping_details_from_wallet_connector);
+
+    let collect_billing_details_from_wallets = business_profile
+        .as_ref()
+        .and_then(|bp| bp.collect_billing_details_from_wallet_connector);
     Ok(services::ApplicationResponse::Json(
         api::PaymentMethodListResponse {
             redirect_url: merchant_account.return_url,
@@ -2756,6 +2764,8 @@ pub async fn list_payment_methods(
                 .unwrap_or_default(),
             currency,
             request_external_three_ds_authentication,
+            collect_shipping_details_from_wallets,
+            collect_billing_details_from_wallets,
         },
     ))
 }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Currently there are two fields which indicate if the customer address needs to be collected form the wallets like apple pay or google pay. And those fields are `collect_shipping_details_from_wallet_connector` and `collect_billing_details_from_wallet_connector`, and the same fields needs to be sent to sdk so that they can make the required decisions based on it.

### Additional Changes

- [x] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
-> Create stripe mca
-> For the specific business profile set the below fields as ture
```
curl --location 'http://localhost:8080/account/merchant_1720165673/business_profile/pro_6Rcn7QpBhEJ1M76tiD4w' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: admin' \
--data '{
    "collect_shipping_details_from_wallet_connector": false,
    "collect_billing_details_from_wallet_connector": false
}'
```
-> Create a payment with confirm false
```
{
  "amount": 10000,
  "currency": "USD",
  "capture_method": "automatic",
  "authentication_type": "no_three_ds",
  "confirm": false,
  "customer_id": "aaa"
}
```
-> Make session call
```
curl --location 'http://localhost:8080/payments/session_tokens' \
--header 'Content-Type: application/json' \
--header 'api-key: pk_dev_05af5b5c33c54c33a8b11c3e77b99cc8' \
--data '{
    "payment_id": "pay_xmrt6KKS0Vvye7OO1sIn",
    "wallets": [],
    "client_secret": "pay_xmrt6KKS0Vvye7OO1sIn_secret_8WAX2eYNDT4y5QfWrjL9"
}'
```
Both shipping and billing will be false in the apple pay and google pay session token
<img width="1183" alt="image" src="https://github.com/juspay/hyperswitch/assets/83439957/3db3ce79-de35-484b-9de2-a37b083e4d69">

-> Do merchant payment method list
```
curl --location 'http://localhost:8080/account/payment_methods?client_secret=pay_xmrt6KKS0Vvye7OO1sIn_secret_8WAX2eYNDT4y5QfWrjL9' \
--header 'Accept: application/json' \
--header 'api-key: pk_dev_05af5b5c33c54c33a8b11c3e77b99cc8'
```
<img width="1172" alt="image" src="https://github.com/juspay/hyperswitch/assets/83439957/a917f21d-4eae-43aa-920c-1f059f77b5ab">

-> Now set the fields in the business profile with the below curl
```
curl --location 'http://localhost:8080/account/merchant_1720167317/business_profile/pro_VPeQOAs890a2r3IrsqCW' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: test_admin' \
--data '{
    "collect_shipping_details_from_wallet_connector": true,
    "collect_billing_details_from_wallet_connector": true
}'
```
<img width="1172" alt="image" src="https://github.com/juspay/hyperswitch/assets/83439957/d07bbc05-4af6-4bc3-92fe-1040b1b765bd">

-> Create a payment with confirm false
-> Do a session call and the apple pay and the google pay should contain the billing and shipping fields
<img width="1199" alt="image" src="https://github.com/juspay/hyperswitch/assets/83439957/7486af2f-506c-4859-a051-0986f77a77ce">

-> Now make payment methods list
<img width="1165" alt="image" src="https://github.com/juspay/hyperswitch/assets/83439957/9346efbc-47e4-4c54-a08a-e8278ffdb33b">


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
