### PR TITLE
fix(payments_create): save the `customer_id` in payments create

### DIFF
--- a/crates/api_models/src/payments.rs
+++ b/crates/api_models/src/payments.rs
@@ -626,7 +626,7 @@ mod payments_request_test {
     }
 
     #[test]
-    fn test_ivalid_case_where_customer_id_is_passed_in_both_places() {
+    fn test_invalid_case_where_customer_id_is_passed_in_both_places() {
         let customer_id = generate_customer_id_of_default_length();
         let another_customer_id = generate_customer_id_of_default_length();
 

--- a/crates/api_models/src/payments.rs
+++ b/crates/api_models/src/payments.rs
@@ -569,7 +569,7 @@ impl PaymentsRequest {
                 .then_some("phone_country_code and customer.phone_country_code"),
             ]
             .into_iter()
-            .filter_map(|invalid_fields| invalid_fields)
+            .flatten()
             .collect::<Vec<_>>();
 
             if invalid_fields.is_empty() {

--- a/crates/router/src/core/payments/helpers.rs
+++ b/crates/router/src/core/payments/helpers.rs
@@ -1471,6 +1471,23 @@ pub fn validate_max_amount(
     }
 }
 
+/// Check whether the customer information that is sent in the root of payments request
+/// and in the customer object are same, if the values mismatch return an error
+pub fn validate_customer_information(
+    request: &api_models::payments::PaymentsRequest,
+) -> RouterResult<()> {
+    if let Some(mismatched_fields) = request.validate_customer_details_in_request() {
+        let mismatched_fields = mismatched_fields.join(", ");
+        Err(errors::ApiErrorResponse::PreconditionFailed {
+            message: format!(
+                "The field names `{mismatched_fields}` sent in both places is ambiguous"
+            ),
+        })?
+    } else {
+        Ok(())
+    }
+}
+
 /// Get the customer details from customer field if present
 /// or from the individual fields in `PaymentsRequest`
 #[instrument(skip_all)]

--- a/crates/router/src/core/payments/helpers.rs
+++ b/crates/router/src/core/payments/helpers.rs
@@ -513,7 +513,7 @@ pub async fn get_token_pm_type_mandate_details(
                             &payment_method_info.merchant_id,
                             &merchant_account.merchant_id,
                             &payment_method_info.customer_id,
-                            &customer_id,
+                            customer_id,
                         )?;
 
                         (

--- a/crates/router/src/core/payments/helpers.rs
+++ b/crates/router/src/core/payments/helpers.rs
@@ -451,7 +451,7 @@ pub async fn get_token_pm_type_mandate_details(
     merchant_account: &domain::MerchantAccount,
     merchant_key_store: &domain::MerchantKeyStore,
     payment_method_id: Option<String>,
-    customer_id: &Option<id_type::CustomerId>,
+    payment_intent_customer_id: Option<&id_type::CustomerId>,
 ) -> RouterResult<MandateGenericData> {
     let mandate_data = request.mandate_data.clone().map(MandateData::foreign_from);
     let (
@@ -505,7 +505,8 @@ pub async fn get_token_pm_type_mandate_details(
                             .to_not_found_response(
                                 errors::ApiErrorResponse::PaymentMethodNotFound,
                             )?;
-                        let customer_id = get_customer_id_from_payment_request(request)
+                        let customer_id = request
+                            .get_customer_id()
                             .get_required_value("customer_id")?;
 
                         verify_mandate_details_for_recurring_payments(
@@ -552,10 +553,9 @@ pub async fn get_token_pm_type_mandate_details(
                         || request.payment_method_type
                             == Some(api_models::enums::PaymentMethodType::GooglePay)
                     {
-                        let payment_request_customer_id =
-                            get_customer_id_from_payment_request(request);
+                        let payment_request_customer_id = request.get_customer_id();
                         if let Some(customer_id) =
-                            &payment_request_customer_id.or(customer_id.clone())
+                            payment_request_customer_id.or(payment_intent_customer_id)
                         {
                             let customer_saved_pm_option = match state
                                 .store
@@ -711,10 +711,10 @@ pub async fn get_token_for_recurring_mandate(
         .map(|pi| pi.amount.get_amount_as_i64());
     let original_payment_authorized_currency =
         original_payment_intent.clone().and_then(|pi| pi.currency);
-    let customer = get_customer_id_from_payment_request(req).get_required_value("customer_id")?;
+    let customer = req.get_customer_id().get_required_value("customer_id")?;
 
     let payment_method_id = {
-        if mandate.customer_id != customer {
+        if &mandate.customer_id != customer {
             Err(report!(errors::ApiErrorResponse::PreconditionFailed {
                 message: "customer_id must match mandate customer_id".into()
             }))?
@@ -1453,25 +1453,6 @@ pub async fn get_customer_from_details<F: Clone>(
     }
 }
 
-// Checks if the inner values of two options are not equal and throws appropriate error
-fn validate_options_for_inequality<T: PartialEq>(
-    first_option: Option<&T>,
-    second_option: Option<&T>,
-    field_name: &str,
-) -> Result<(), errors::ApiErrorResponse> {
-    fp_utils::when(
-        first_option
-            .zip(second_option)
-            .map(|(value1, value2)| value1 != value2)
-            .unwrap_or(false),
-        || {
-            Err(errors::ApiErrorResponse::PreconditionFailed {
-                message: format!("The field name `{field_name}` sent in both places is ambiguous"),
-            })
-        },
-    )
-}
-
 pub fn validate_max_amount(
     amount: api_models::payments::Amount,
 ) -> CustomResult<(), errors::ApiErrorResponse> {
@@ -1490,58 +1471,13 @@ pub fn validate_max_amount(
     }
 }
 
-// Checks if the customer details are passed in both places
-// If so, raise an error
-pub fn validate_customer_details_in_request(
-    request: &api_models::payments::PaymentsRequest,
-) -> Result<(), errors::ApiErrorResponse> {
-    if let Some(customer_details) = request.customer.as_ref() {
-        validate_options_for_inequality(
-            request.customer_id.as_ref(),
-            Some(&customer_details.id),
-            "customer_id",
-        )?;
-
-        validate_options_for_inequality(
-            request.email.as_ref(),
-            customer_details.email.as_ref(),
-            "email",
-        )?;
-
-        validate_options_for_inequality(
-            request.name.as_ref(),
-            customer_details.name.as_ref(),
-            "name",
-        )?;
-
-        validate_options_for_inequality(
-            request.phone.as_ref(),
-            customer_details.phone.as_ref(),
-            "phone",
-        )?;
-
-        validate_options_for_inequality(
-            request.phone_country_code.as_ref(),
-            customer_details.phone_country_code.as_ref(),
-            "phone_country_code",
-        )?;
-    }
-
-    Ok(())
-}
-
 /// Get the customer details from customer field if present
 /// or from the individual fields in `PaymentsRequest`
 #[instrument(skip_all)]
 pub fn get_customer_details_from_request(
     request: &api_models::payments::PaymentsRequest,
 ) -> CustomerDetails {
-    let customer_id = request
-        .customer
-        .as_ref()
-        .map(|customer_details| &customer_details.id)
-        .or(request.customer_id.as_ref())
-        .map(ToOwned::to_owned);
+    let customer_id = request.get_customer_id().map(ToOwned::to_owned);
 
     let customer_name = request
         .customer
@@ -1574,16 +1510,6 @@ pub fn get_customer_details_from_request(
         phone: customer_phone,
         phone_country_code: customer_phone_code,
     }
-}
-
-fn get_customer_id_from_payment_request(
-    request: &api_models::payments::PaymentsRequest,
-) -> Option<id_type::CustomerId> {
-    request
-        .customer
-        .as_ref()
-        .map(|customer| customer.id.clone())
-        .or(request.customer_id.clone())
 }
 
 pub async fn get_connector_default(
@@ -4079,8 +4005,8 @@ pub fn validate_customer_access(
     auth_flow: services::AuthFlow,
     request: &api::PaymentsRequest,
 ) -> Result<(), errors::ApiErrorResponse> {
-    if auth_flow == services::AuthFlow::Client && request.customer_id.is_some() {
-        let is_same_customer = request.customer_id == payment_intent.customer_id;
+    if auth_flow == services::AuthFlow::Client && request.get_customer_id().is_some() {
+        let is_same_customer = request.get_customer_id() == payment_intent.customer_id.as_ref();
         if !is_same_customer {
             Err(errors::ApiErrorResponse::GenericUnauthorized {
                 message: "Unauthorised access to update customer".to_string(),

--- a/crates/router/src/core/payments/operations/payment_confirm.rs
+++ b/crates/router/src/core/payments/operations/payment_confirm.rs
@@ -1353,10 +1353,11 @@ impl<F: Send + Clone> ValidateRequest<F, api::PaymentsRequest> for PaymentConfir
         BoxedOperation<'b, F, api::PaymentsRequest>,
         operations::ValidateResult<'a>,
     )> {
-        if let Some(mismatched_field) = request.validate_customer_details_in_request() {
+        if let Some(mismatched_fields) = request.validate_customer_details_in_request() {
+            let mismatched_fields = mismatched_fields.join(", ");
             Err(errors::ApiErrorResponse::PreconditionFailed {
                 message: format!(
-                    "The field name `{mismatched_field}` sent in both places is ambiguous"
+                    "The field name `{mismatched_fields}` sent in both places is ambiguous"
                 ),
             })?
         }

--- a/crates/router/src/core/payments/operations/payment_confirm.rs
+++ b/crates/router/src/core/payments/operations/payment_confirm.rs
@@ -1353,14 +1353,7 @@ impl<F: Send + Clone> ValidateRequest<F, api::PaymentsRequest> for PaymentConfir
         BoxedOperation<'b, F, api::PaymentsRequest>,
         operations::ValidateResult<'a>,
     )> {
-        if let Some(mismatched_fields) = request.validate_customer_details_in_request() {
-            let mismatched_fields = mismatched_fields.join(", ");
-            Err(errors::ApiErrorResponse::PreconditionFailed {
-                message: format!(
-                    "The field name `{mismatched_fields}` sent in both places is ambiguous"
-                ),
-            })?
-        }
+        helpers::validate_customer_information(request)?;
 
         if let Some(amount) = request.amount {
             helpers::validate_max_amount(amount)?;

--- a/crates/router/src/core/payments/operations/payment_create.rs
+++ b/crates/router/src/core/payments/operations/payment_create.rs
@@ -684,14 +684,7 @@ impl<F: Send + Clone> ValidateRequest<F, api::PaymentsRequest> for PaymentCreate
         BoxedOperation<'b, F, api::PaymentsRequest>,
         operations::ValidateResult<'a>,
     )> {
-        if let Some(mismatched_fields) = request.validate_customer_details_in_request() {
-            let mismatched_fields = mismatched_fields.join(", ");
-            Err(errors::ApiErrorResponse::PreconditionFailed {
-                message: format!(
-                    "The field name `{mismatched_fields}` sent in both places is ambiguous"
-                ),
-            })?
-        }
+        helpers::validate_customer_information(request)?;
 
         if let Some(amount) = request.amount {
             helpers::validate_max_amount(amount)?;

--- a/crates/router/src/core/payments/operations/payment_create.rs
+++ b/crates/router/src/core/payments/operations/payment_create.rs
@@ -136,7 +136,7 @@ impl<F: Send + Clone> GetTracker<F, PaymentData<F>, api::PaymentsRequest> for Pa
             merchant_account,
             merchant_key_store,
             None,
-            &request.customer_id,
+            None,
         )
         .await?;
 
@@ -684,7 +684,14 @@ impl<F: Send + Clone> ValidateRequest<F, api::PaymentsRequest> for PaymentCreate
         BoxedOperation<'b, F, api::PaymentsRequest>,
         operations::ValidateResult<'a>,
     )> {
-        helpers::validate_customer_details_in_request(request)?;
+        if let Some(mismatched_field) = request.validate_customer_details_in_request() {
+            Err(errors::ApiErrorResponse::PreconditionFailed {
+                message: format!(
+                    "The field name `{mismatched_field}` sent in both places is ambiguous"
+                ),
+            })?
+        }
+
         if let Some(amount) = request.amount {
             helpers::validate_max_amount(amount)?;
         }
@@ -749,11 +756,7 @@ impl<F: Send + Clone> ValidateRequest<F, api::PaymentsRequest> for PaymentCreate
 
             helpers::validate_customer_id_mandatory_cases(
                 request.setup_future_usage.is_some(),
-                request
-                    .customer
-                    .as_ref()
-                    .map(|customer| &customer.id)
-                    .or(request.customer_id.as_ref()),
+                request.get_customer_id(),
             )?;
         }
 
@@ -1066,7 +1069,7 @@ impl PaymentCreate {
             .await;
 
         // Derivation of directly supplied Customer data in our Payment Create Request
-        let raw_customer_details = if request.customer_id.is_none()
+        let raw_customer_details = if request.get_customer_id().is_none()
             && (request.name.is_some()
                 || request.email.is_some()
                 || request.phone.is_some()
@@ -1115,7 +1118,7 @@ impl PaymentCreate {
             ),
             order_details,
             amount_captured: None,
-            customer_id: None,
+            customer_id: request.get_customer_id().cloned(),
             connector_id: None,
             allowed_payment_method_types,
             connector_metadata,
@@ -1149,10 +1152,10 @@ impl PaymentCreate {
         state: &SessionState,
         merchant_account: &domain::MerchantAccount,
     ) -> Option<ephemeral_key::EphemeralKey> {
-        match request.customer_id.clone() {
+        match request.get_customer_id() {
             Some(customer_id) => helpers::make_ephemeral_key(
                 state.clone(),
-                customer_id,
+                customer_id.clone(),
                 merchant_account.merchant_id.clone(),
             )
             .await

--- a/crates/router/src/core/payments/operations/payment_create.rs
+++ b/crates/router/src/core/payments/operations/payment_create.rs
@@ -684,10 +684,11 @@ impl<F: Send + Clone> ValidateRequest<F, api::PaymentsRequest> for PaymentCreate
         BoxedOperation<'b, F, api::PaymentsRequest>,
         operations::ValidateResult<'a>,
     )> {
-        if let Some(mismatched_field) = request.validate_customer_details_in_request() {
+        if let Some(mismatched_fields) = request.validate_customer_details_in_request() {
+            let mismatched_fields = mismatched_fields.join(", ");
             Err(errors::ApiErrorResponse::PreconditionFailed {
                 message: format!(
-                    "The field name `{mismatched_field}` sent in both places is ambiguous"
+                    "The field name `{mismatched_fields}` sent in both places is ambiguous"
                 ),
             })?
         }

--- a/crates/router/src/core/payments/operations/payment_update.rs
+++ b/crates/router/src/core/payments/operations/payment_update.rs
@@ -807,14 +807,7 @@ impl<F: Send + Clone> ValidateRequest<F, api::PaymentsRequest> for PaymentUpdate
         BoxedOperation<'b, F, api::PaymentsRequest>,
         operations::ValidateResult<'a>,
     )> {
-        if let Some(mismatched_fields) = request.validate_customer_details_in_request() {
-            let mismatched_fields = mismatched_fields.join(", ");
-            Err(errors::ApiErrorResponse::PreconditionFailed {
-                message: format!(
-                    "The field name `{mismatched_fields}` sent in both places is ambiguous"
-                ),
-            })?
-        }
+        helpers::validate_customer_information(request)?;
 
         if let Some(amount) = request.amount {
             helpers::validate_max_amount(amount)?;

--- a/crates/router/src/core/payments/operations/payment_update.rs
+++ b/crates/router/src/core/payments/operations/payment_update.rs
@@ -151,7 +151,7 @@ impl<F: Send + Clone> GetTracker<F, PaymentData<F>, api::PaymentsRequest> for Pa
             merchant_account,
             key_store,
             None,
-            &payment_intent.customer_id,
+            payment_intent.customer_id.as_ref(),
         )
         .await?;
         helpers::validate_amount_to_capture_and_capture_method(Some(&payment_attempt), request)?;
@@ -807,7 +807,14 @@ impl<F: Send + Clone> ValidateRequest<F, api::PaymentsRequest> for PaymentUpdate
         BoxedOperation<'b, F, api::PaymentsRequest>,
         operations::ValidateResult<'a>,
     )> {
-        helpers::validate_customer_details_in_request(request)?;
+        if let Some(mismatched_field) = request.validate_customer_details_in_request() {
+            Err(errors::ApiErrorResponse::PreconditionFailed {
+                message: format!(
+                    "The field name `{mismatched_field}` sent in both places is ambiguous"
+                ),
+            })?
+        }
+
         if let Some(amount) = request.amount {
             helpers::validate_max_amount(amount)?;
         }

--- a/crates/router/src/core/payments/operations/payment_update.rs
+++ b/crates/router/src/core/payments/operations/payment_update.rs
@@ -807,10 +807,11 @@ impl<F: Send + Clone> ValidateRequest<F, api::PaymentsRequest> for PaymentUpdate
         BoxedOperation<'b, F, api::PaymentsRequest>,
         operations::ValidateResult<'a>,
     )> {
-        if let Some(mismatched_field) = request.validate_customer_details_in_request() {
+        if let Some(mismatched_fields) = request.validate_customer_details_in_request() {
+            let mismatched_fields = mismatched_fields.join(", ");
             Err(errors::ApiErrorResponse::PreconditionFailed {
                 message: format!(
-                    "The field name `{mismatched_field}` sent in both places is ambiguous"
+                    "The field name `{mismatched_fields}` sent in both places is ambiguous"
                 ),
             })?
         }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix

## Description
<!-- Describe your changes in detail -->
In case we receive a 4xx when creating the payment before calling the connector, we do not save the `customer_id` in payment intent. This PR fixes it

This PR also includes changes to ensure that `customer_id` is always taken from both the places in the PaymentsRequest. The root `customer_id` and `customer.id` field.


<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
- Create a merchant account
```bash
curl --location 'http://localhost:8080/accounts' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: test_admin' \
--data '{
    "merchant_id": "merchant_1720593206"
}'
```

- Create an api key
```bash
curl --location 'http://localhost:8080/api_keys/merchant_1720593134' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: test_admin' \
--data '{
  "name": "API Key 1",
  "description": null,
  "expiration": "2038-01-19T03:14:08.000Z"
}'
```

- Create a payment
```bash
curl --location 'http://localhost:8080/payments' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: dev_RMV9h1z6QVqWHW9B7LBRl6peSokwQ7go96pfAjehuGZDGiwlenKAbgtyqUlXny9J' \
--data '{
    "amount": 0,
    "payment_id": "pay_1720593248",
    "customer_id": "cus_123",
    "currency": "USD",
    "confirm": true,
    "payment_type": "setup_mandate",
    "payment_method": "card",
    "payment_method_data": {
        "card": {
            "card_number": "4111111111111111",
            "card_exp_month": "10",
            "card_exp_year": "25",
            "card_holder_name": "joseph Doe",
            "card_cvc": "123"
        }
    }
}'
```
Fails with the error message
```json
{
    "error": {
        "type": "invalid_request",
        "message": "No eligible connector was found for the current payment method configuration",
        "code": "HE_04"
    }
}
```

- Check in the database whether `customer_id` is updated
<img width="1014" alt="image" src="https://github.com/juspay/hyperswitch/assets/48803246/a83fce74-2aa9-4670-b074-d1ea77bb3e14">


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
