### PR TITLE
fix(router): fixed integrity check failures in case of 3ds flow in sync flow

### DIFF
--- a/crates/hyperswitch_domain_models/src/router_request_types.rs
+++ b/crates/hyperswitch_domain_models/src/router_request_types.rs
@@ -84,8 +84,6 @@ pub struct SyncIntegrityObject {
     pub amount: Option<MinorUnit>,
     /// Sync currency
     pub currency: Option<storage_enums::Currency>,
-    /// Sync capture amount in case of automatic capture
-    pub captured_amount: Option<MinorUnit>,
 }
 
 #[derive(Debug, serde::Deserialize, Clone)]
@@ -384,7 +382,6 @@ pub struct PaymentsSyncData {
 
     pub amount: MinorUnit,
     pub integrity_object: Option<SyncIntegrityObject>,
-    pub captured_amount: Option<MinorUnit>,
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/hyperswitch_interfaces/src/integrity.rs
+++ b/crates/hyperswitch_interfaces/src/integrity.rs
@@ -140,11 +140,19 @@ impl FlowIntegrity for RefundIntegrityObject {
         let mut mismatched_fields = Vec::new();
 
         if req_integrity_object.currency != res_integrity_object.currency {
-            mismatched_fields.push("currency".to_string());
+            mismatched_fields.push(format_mismatch(
+                "currency",
+                &req_integrity_object.currency.to_string(),
+                &res_integrity_object.currency.to_string(),
+            ));
         }
 
         if req_integrity_object.refund_amount != res_integrity_object.refund_amount {
-            mismatched_fields.push("refund_amount".to_string());
+            mismatched_fields.push(format_mismatch(
+                "refund_amount",
+                &req_integrity_object.refund_amount.to_string(),
+                &res_integrity_object.refund_amount.to_string(),
+            ));
         }
 
         if mismatched_fields.is_empty() {
@@ -170,11 +178,19 @@ impl FlowIntegrity for AuthoriseIntegrityObject {
         let mut mismatched_fields = Vec::new();
 
         if req_integrity_object.amount != res_integrity_object.amount {
-            mismatched_fields.push("amount".to_string());
+            mismatched_fields.push(format_mismatch(
+                "amount",
+                &req_integrity_object.amount.to_string(),
+                &res_integrity_object.amount.to_string(),
+            ));
         }
 
         if req_integrity_object.currency != res_integrity_object.currency {
-            mismatched_fields.push("currency".to_string());
+            mismatched_fields.push(format_mismatch(
+                "currency",
+                &req_integrity_object.currency.to_string(),
+                &res_integrity_object.currency.to_string(),
+            ));
         }
 
         if mismatched_fields.is_empty() {
@@ -200,29 +216,28 @@ impl FlowIntegrity for SyncIntegrityObject {
         let mut mismatched_fields = Vec::new();
 
         res_integrity_object
-            .captured_amount
-            .zip(req_integrity_object.captured_amount)
-            .map(|tup| {
-                if tup.0 != tup.1 {
-                    mismatched_fields.push("captured_amount".to_string());
-                }
-            });
-
-        res_integrity_object
             .amount
             .zip(req_integrity_object.amount)
-            .map(|tup| {
-                if tup.0 != tup.1 {
-                    mismatched_fields.push("amount".to_string());
+            .map(|(res_amount, req_amount)| {
+                if res_amount != req_amount {
+                    mismatched_fields.push(format_mismatch(
+                        "amount",
+                        &req_amount.to_string(),
+                        &res_amount.to_string(),
+                    ));
                 }
             });
 
         res_integrity_object
             .currency
             .zip(req_integrity_object.currency)
-            .map(|tup| {
-                if tup.0 != tup.1 {
-                    mismatched_fields.push("currency".to_string());
+            .map(|(res_currency, req_currency)| {
+                if res_currency != req_currency {
+                    mismatched_fields.push(format_mismatch(
+                        "currency",
+                        &req_currency.to_string(),
+                        &res_currency.to_string(),
+                    ));
                 }
             });
 
@@ -251,14 +266,22 @@ impl FlowIntegrity for CaptureIntegrityObject {
         res_integrity_object
             .capture_amount
             .zip(req_integrity_object.capture_amount)
-            .map(|tup| {
-                if tup.0 != tup.1 {
-                    mismatched_fields.push("capture_amount".to_string());
+            .map(|(res_amount, req_amount)| {
+                if res_amount != req_amount {
+                    mismatched_fields.push(format_mismatch(
+                        "capture_amount",
+                        &req_amount.to_string(),
+                        &res_amount.to_string(),
+                    ));
                 }
             });
 
         if req_integrity_object.currency != res_integrity_object.currency {
-            mismatched_fields.push("currency".to_string());
+            mismatched_fields.push(format_mismatch(
+                "currency",
+                &req_integrity_object.currency.to_string(),
+                &res_integrity_object.currency.to_string(),
+            ));
         }
 
         if mismatched_fields.is_empty() {
@@ -322,7 +345,10 @@ impl GetIntegrityObject<SyncIntegrityObject> for PaymentsSyncData {
         SyncIntegrityObject {
             amount: Some(self.amount),
             currency: Some(self.currency),
-            captured_amount: self.captured_amount,
         }
     }
+}
+
+fn format_mismatch(field: &str, expected: &str, found: &str) -> String {
+    format!("{} expected {} but found {}", field, expected, found)
 }

--- a/crates/hyperswitch_interfaces/src/integrity.rs
+++ b/crates/hyperswitch_interfaces/src/integrity.rs
@@ -349,6 +349,7 @@ impl GetIntegrityObject<SyncIntegrityObject> for PaymentsSyncData {
     }
 }
 
+#[inline]
 fn format_mismatch(field: &str, expected: &str, found: &str) -> String {
     format!("{} expected {} but found {}", field, expected, found)
 }

--- a/crates/router/src/connector/stripe.rs
+++ b/crates/router/src/connector/stripe.rs
@@ -842,7 +842,6 @@ impl
                     self.amount_converter,
                     response.amount,
                     response.currency.clone(),
-                    response.amount_received,
                 )?;
 
                 event_builder.map(|i| i.set_response_body(&response));

--- a/crates/router/src/connector/utils.rs
+++ b/crates/router/src/connector/utils.rs
@@ -2914,21 +2914,15 @@ pub fn get_sync_integrity_object<T>(
     amount_convertor: &dyn AmountConvertor<Output = T>,
     amount: T,
     currency: String,
-    captured_amount: Option<T>,
 ) -> Result<SyncIntegrityObject, error_stack::Report<errors::ConnectorError>> {
     let currency_enum = enums::Currency::from_str(currency.to_uppercase().as_str())
         .change_context(errors::ConnectorError::ParsingFailed)?;
     let amount_in_minor_unit =
         convert_back_amount_to_minor_units(amount_convertor, amount, currency_enum)?;
 
-    let capture_amount_in_minor_unit = captured_amount
-        .map(|amount| convert_back_amount_to_minor_units(amount_convertor, amount, currency_enum))
-        .transpose()?;
-
     Ok(SyncIntegrityObject {
         amount: Some(amount_in_minor_unit),
         currency: Some(currency_enum),
-        captured_amount: capture_amount_in_minor_unit,
     })
 }
 

--- a/crates/router/src/core/payments/transformers.rs
+++ b/crates/router/src/core/payments/transformers.rs
@@ -1372,7 +1372,7 @@ impl<F: Clone> TryFrom<PaymentAdditionalData<'_, F>> for types::PaymentsSyncData
             .as_ref()
             .map(|surcharge_details| surcharge_details.final_amount)
             .unwrap_or(payment_data.amount.into());
-        let captured_amount = payment_data.payment_intent.amount_captured;
+        let captured_amount = Some(payment_data.payment_attempt.net_amount);
         Ok(Self {
             amount,
             integrity_object: None,

--- a/crates/router/src/core/payments/transformers.rs
+++ b/crates/router/src/core/payments/transformers.rs
@@ -1372,7 +1372,6 @@ impl<F: Clone> TryFrom<PaymentAdditionalData<'_, F>> for types::PaymentsSyncData
             .as_ref()
             .map(|surcharge_details| surcharge_details.final_amount)
             .unwrap_or(payment_data.amount.into());
-        let captured_amount = Some(payment_data.payment_attempt.net_amount);
         Ok(Self {
             amount,
             integrity_object: None,
@@ -1395,7 +1394,6 @@ impl<F: Clone> TryFrom<PaymentAdditionalData<'_, F>> for types::PaymentsSyncData
             payment_method_type: payment_data.payment_attempt.payment_method_type,
             currency: payment_data.currency,
             payment_experience: payment_data.payment_attempt.payment_experience,
-            captured_amount,
         })
     }
 }

--- a/crates/router/tests/connectors/bambora.rs
+++ b/crates/router/tests/connectors/bambora.rs
@@ -114,7 +114,6 @@ async fn should_sync_authorized_payment() {
                 payment_experience: None,
                 integrity_object: None,
                 amount: MinorUnit::new(100),
-                captured_amount: None,
             }),
             None,
         )
@@ -234,7 +233,6 @@ async fn should_sync_auto_captured_payment() {
                 payment_experience: None,
                 integrity_object: None,
                 amount: MinorUnit::new(100),
-                captured_amount: None,
             }),
             None,
         )

--- a/crates/router/tests/connectors/forte.rs
+++ b/crates/router/tests/connectors/forte.rs
@@ -163,7 +163,6 @@ async fn should_sync_authorized_payment() {
                 payment_experience: None,
                 integrity_object: None,
                 amount: MinorUnit::new(100),
-                captured_amount: None,
             }),
             get_default_payment_info(),
         )

--- a/crates/router/tests/connectors/nexinets.rs
+++ b/crates/router/tests/connectors/nexinets.rs
@@ -130,7 +130,6 @@ async fn should_sync_authorized_payment() {
                 payment_experience: None,
                 integrity_object: None,
                 amount: MinorUnit::new(100),
-                captured_amount: None,
             }),
             None,
         )

--- a/crates/router/tests/connectors/paypal.rs
+++ b/crates/router/tests/connectors/paypal.rs
@@ -147,7 +147,6 @@ async fn should_sync_authorized_payment() {
                 payment_experience: None,
                 integrity_object: None,
                 amount: MinorUnit::new(100),
-                captured_amount: None,
             }),
             get_default_payment_info(),
         )
@@ -349,7 +348,6 @@ async fn should_sync_auto_captured_payment() {
                 payment_experience: None,
                 amount: MinorUnit::new(100),
                 integrity_object: None,
-                captured_amount: None,
             }),
             get_default_payment_info(),
         )

--- a/crates/router/tests/connectors/utils.rs
+++ b/crates/router/tests/connectors/utils.rs
@@ -1000,7 +1000,6 @@ impl Default for PaymentSyncType {
             payment_experience: None,
             amount: MinorUnit::new(100),
             integrity_object: None,
-            captured_amount: None,
         };
         Self(data)
     }

--- a/crates/router/tests/connectors/zen.rs
+++ b/crates/router/tests/connectors/zen.rs
@@ -108,7 +108,6 @@ async fn should_sync_authorized_payment() {
                 payment_experience: None,
                 amount: MinorUnit::new(100),
                 integrity_object: None,
-                captured_amount: None,
             }),
             None,
         )
@@ -228,7 +227,6 @@ async fn should_sync_auto_captured_payment() {
                 payment_experience: None,
                 amount: MinorUnit::new(100),
                 integrity_object: None,
-                captured_amount: None,
             }),
             None,
         )


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix

## Description
<!-- Describe your changes in detail -->
we have implemented integrity checks for stripe, we have implemented integrity in authorise, sync, capture and refund, refund sync

but, where in sync flow we check amount, currency and amount_captured.

the bug is in 3ds flow, where after the transaction is completed we do a sync with the connector, but our trackers are not updated at this point.

In 3ds transaction we rely on connector sync to update our trackers, since integrity checks happens with data before post update trackers we were comparing MinorUnit(0) our amount captured to Some(MinorUnit(x)) amount received by the connector.

due, to this there was a data mismatch issue, which led to integrity check failure.


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

```
curl --location 'http://localhost:8080/payments' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: dev_GBcnEyXku3rLhERWs4Lb5EVGFWWmVxRIC9vbpDa3QYoVcsjxdQEkMpXo1s8beKnD' \
--data-raw '
{
    "amount": 600,
    "currency": "USD",
    "payment_link": true,
    "capture_on": "2022-09-10T10:11:12Z",
    "customer_id": "stripesavecard_1234",
    "email": "guest@example.com",
    "name": "John Doe",
    "phone": "999999999",
    "phone_country_code": "+65",
    "description": "Its my first payment request",
    "authentication_type": "three_ds",
    "return_url": "https://google.com",
    "setup_future_usage": "on_session",
    "customer_acceptance": {
        "acceptance_type": "offline",
        "accepted_at": "1963-05-03T04:07:52.723Z",
        "online": {
            "ip_address": "127.0.0.1",
            "user_agent": "amet irure esse"
        }
    },
    "billing": {
        "address": {
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "city": "San Fransico",
            "state": "California",
            "zip": "94122",
            "country": "US",
            "first_name": "joseph",
            "last_name": "Doe"
        },
        "phone": {
            "number": "8056594427",
            "country_code": "+91"
        }
    },
    "shipping": {
        "address": {
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "city": "San Fransico",
            "state": "California",
            "zip": "94122",
            "country": "US",
            "first_name": "joseph",
            "last_name": "Doe"
        },
        "phone": {
            "number": "8056594427",
            "country_code": "+91"
        }
    },
    "routing": {
        "type": "single",
        "data": "stripe"
    },
    "statement_descriptor_name": "joseph",
    "statement_descriptor_suffix": "JS",
    "metadata": {
        "udf1": "value1",
        "new_customer": "true",
        "login_date": "2019-09-10T10:11:12Z"
    },
    "session_expiry": 2423545,
    "payment_link_config": {
        "theme": "#3B845E",
        "logo": "https://i.pinimg.com/736x/4d/83/5c/4d835ca8aafbbb15f84d07d926fda473.jpg",
        "seller_name": "sahkal",
        "sdk_layout": "spaced_accordion",
        
        "enabled_saved_payment_method":true
    }
}'
```

Do, 3ds transaction with stripe it should pass.

https://github.com/juspay/hyperswitch/assets/26082680/c55e37a3-7464-4a6f-8c26-81842bc50914




## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
