### PR TITLE
fix(router): fail refund with bad request error for duplicate refund_id in refunds create flow

### DIFF
--- a/crates/router/src/core/refunds.rs
+++ b/crates/router/src/core/refunds.rs
@@ -836,13 +836,7 @@ pub async fn validate_and_create_refund(
         }
         Err(err) => {
             if err.current_context().is_db_unique_violation() {
-                db.find_refund_by_merchant_id_refund_id(
-                    merchant_account.merchant_id.as_str(),
-                    refund_id.as_str(),
-                    merchant_account.storage_scheme,
-                )
-                .await
-                .to_not_found_response(errors::ApiErrorResponse::RefundNotFound)?
+                Err(errors::ApiErrorResponse::DuplicateRefundRequest)?
             } else {
                 return Err(err)
                     .change_context(errors::ApiErrorResponse::RefundNotFound)


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
fail refund with bad request error for duplicate refund_id in refunds create flow


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Tested Manually
Create a refund with duplicate refund_id, it should fail with Bad request error
![image](https://github.com/juspay/hyperswitch/assets/56996463/aeb6a7ea-d551-4a5a-bf1a-5c9a1c08bbcd)

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
