### PR TITLE
refactor: use `Debug` impl instead of `Display` impl for logging errors

### DIFF
--- a/crates/common_utils/src/macros.rs
+++ b/crates/common_utils/src/macros.rs
@@ -65,7 +65,7 @@ macro_rules! fallback_reverse_lookup_not_found {
         match $a {
             Ok(res) => res,
             Err(err) => {
-                router_env::logger::error!(reverse_lookup_fallback = %err);
+                router_env::logger::error!(reverse_lookup_fallback = ?err);
                 match err.current_context() {
                     errors::StorageError::ValueNotFound(_) => return $b,
                     errors::StorageError::DatabaseError(data_err) => {

--- a/crates/drainer/src/handler.rs
+++ b/crates/drainer/src/handler.rs
@@ -154,13 +154,13 @@ impl Handler {
 pub async fn redis_error_receiver(rx: oneshot::Receiver<()>, shutdown_channel: mpsc::Sender<()>) {
     match rx.await {
         Ok(_) => {
-            logger::error!("The redis server failed ");
+            logger::error!("The redis server failed");
             let _ = shutdown_channel.send(()).await.map_err(|err| {
                 logger::error!("Failed to send signal to the shutdown channel {err}")
             });
         }
         Err(err) => {
-            logger::error!("Channel receiver error{err}");
+            logger::error!("Channel receiver error {err}");
         }
     }
 }

--- a/crates/router/src/bin/scheduler.rs
+++ b/crates/router/src/bin/scheduler.rs
@@ -328,7 +328,7 @@ impl ProcessTrackerWorkflows<routes::SessionState> for WorkflowRunner {
             {
                 Ok(_) => (),
                 Err(error) => {
-                    logger::error!(%error, "Failed while handling error");
+                    logger::error!(?error, "Failed while handling error");
                     let status = state
                         .get_db()
                         .as_scheduler()
@@ -337,8 +337,12 @@ impl ProcessTrackerWorkflows<routes::SessionState> for WorkflowRunner {
                             business_status::GLOBAL_FAILURE,
                         )
                         .await;
-                    if let Err(err) = status {
-                        logger::error!(%err, "Failed while performing database operation: {}", business_status::GLOBAL_FAILURE);
+                    if let Err(error) = status {
+                        logger::error!(
+                            ?error,
+                            "Failed while performing database operation: {}",
+                            business_status::GLOBAL_FAILURE
+                        );
                     }
                 }
             },

--- a/crates/router/src/core/blocklist/utils.rs
+++ b/crates/router/src/core/blocklist/utils.rs
@@ -74,9 +74,9 @@ pub async fn toggle_blocklist_guard_for_merchant(
                 .change_context(errors::ApiErrorResponse::InternalServerError)
                 .attach_printable("Error enabling the blocklist guard")?;
         }
-        Err(e) => {
-            logger::error!(error=?e);
-            Err(e)
+        Err(error) => {
+            logger::error!(?error);
+            Err(error)
                 .change_context(errors::ApiErrorResponse::InternalServerError)
                 .attach_printable("Error enabling the blocklist guard")?;
         }
@@ -323,8 +323,8 @@ where
         .await
         .attach_printable("error in pm fingerprint creation")
         .map_or_else(
-            |err| {
-                logger::error!(error=?err);
+            |error| {
+                logger::error!(?error);
                 None
             },
             Some,
@@ -469,8 +469,8 @@ pub async fn generate_payment_fingerprint(
             .await
             .attach_printable("error in pm fingerprint creation")
             .map_or_else(
-                |err| {
-                    logger::error!(error=?err);
+                |error| {
+                    logger::error!(?error);
                     None
                 },
                 Some,

--- a/crates/router/src/core/payments.rs
+++ b/crates/router/src/core/payments.rs
@@ -2183,24 +2183,33 @@ fn check_apple_pay_metadata(
                     api_models::payments::ApplePayCombinedMetadata::Simplified { .. } => {
                         domain::ApplePayFlow::Simplified(payments_api::PaymentProcessingDetails {
                             payment_processing_certificate: state
-                            .conf
-                            .applepay_decrypt_keys
-                            .get_inner()
-                            .apple_pay_ppc
-                            .clone(),
+                                .conf
+                                .applepay_decrypt_keys
+                                .get_inner()
+                                .apple_pay_ppc
+                                .clone(),
                             payment_processing_certificate_key: state
-                            .conf
-                            .applepay_decrypt_keys
-                            .get_inner()
-                            .apple_pay_ppc_key
-                            .clone(),
-                         })
+                                .conf
+                                .applepay_decrypt_keys
+                                .get_inner()
+                                .apple_pay_ppc_key
+                                .clone(),
+                        })
                     }
-                    api_models::payments::ApplePayCombinedMetadata::Manual { payment_request_data: _, session_token_data } => {
-                        if let Some(manual_payment_processing_details_at) = session_token_data.payment_processing_details_at {
+                    api_models::payments::ApplePayCombinedMetadata::Manual {
+                        payment_request_data: _,
+                        session_token_data,
+                    } => {
+                        if let Some(manual_payment_processing_details_at) =
+                            session_token_data.payment_processing_details_at
+                        {
                             match manual_payment_processing_details_at {
-                                payments_api::PaymentProcessingDetailsAt::Hyperswitch(payment_processing_details) => domain::ApplePayFlow::Simplified(payment_processing_details),
-                                payments_api::PaymentProcessingDetailsAt::Connector => domain::ApplePayFlow::Manual,
+                                payments_api::PaymentProcessingDetailsAt::Hyperswitch(
+                                    payment_processing_details,
+                                ) => domain::ApplePayFlow::Simplified(payment_processing_details),
+                                payments_api::PaymentProcessingDetailsAt::Connector => {
+                                    domain::ApplePayFlow::Manual
+                                }
                             }
                         } else {
                             domain::ApplePayFlow::Manual

--- a/crates/router/src/core/payments.rs
+++ b/crates/router/src/core/payments.rs
@@ -2172,9 +2172,9 @@ fn check_apple_pay_metadata(
                             )
                         })
                 })
-                .map_err(
-                    |error| logger::warn!(%error, "Failed to Parse Value to ApplepaySessionTokenData"),
-                );
+                .map_err(|error| {
+                    logger::warn!(?error, "Failed to Parse Value to ApplepaySessionTokenData")
+                });
 
             parsed_metadata.ok().map(|metadata| match metadata {
                 api_models::payments::ApplepaySessionTokenMetadata::ApplePayCombined(

--- a/crates/router/src/core/payments/helpers.rs
+++ b/crates/router/src/core/payments/helpers.rs
@@ -1922,7 +1922,7 @@ pub async fn retrieve_card_with_permanent_token(
             .map(|card_brand| enums::CardNetwork::from_str(&card_brand))
             .transpose()
             .map_err(|e| {
-                logger::error!("Failed to parse card network {}", e);
+                logger::error!("Failed to parse card network {e:?}");
             })
             .ok()
             .flatten(),
@@ -5035,8 +5035,8 @@ pub async fn config_skip_saving_wallet_at_connector(
                 .change_context(errors::ApiErrorResponse::InternalServerError)
                 .attach_printable("skip_save_wallet_at_connector config parsing failed")?,
         ),
-        Err(err) => {
-            logger::error!("{err}");
+        Err(error) => {
+            logger::error!(?error);
             None
         }
     })

--- a/crates/router/src/core/payments/retry.rs
+++ b/crates/router/src/core/payments/retry.rs
@@ -540,8 +540,8 @@ pub async fn config_should_call_gsm(db: &dyn StorageInterface, merchant_id: &Str
         .await;
     match config {
         Ok(conf) => conf.config == "true",
-        Err(err) => {
-            logger::error!("{err}");
+        Err(error) => {
+            logger::error!(?error);
             false
         }
     }

--- a/crates/router/src/core/payments/transformers.rs
+++ b/crates/router/src/core/payments/transformers.rs
@@ -1016,7 +1016,7 @@ impl ForeignFrom<(storage::PaymentIntent, storage::PaymentAttempt)> for api::Pay
                 match data.parse_value("PaymentMethodDataResponseWithBilling") {
                     Ok(parsed_data) => Some(parsed_data),
                     Err(e) => {
-                        router_env::logger::error!("Failed to parse 'PaymentMethodDataResponseWithBilling' from payment method data. Error: {}", e);
+                        router_env::logger::error!("Failed to parse 'PaymentMethodDataResponseWithBilling' from payment method data. Error: {e:?}");
                         None
                     }
                 }

--- a/crates/router/src/core/payouts/retry.rs
+++ b/crates/router/src/core/payouts/retry.rs
@@ -334,8 +334,8 @@ pub async fn config_should_call_gsm_payout(
         .await;
     match config {
         Ok(conf) => conf.config == "true",
-        Err(err) => {
-            logger::error!("{err}");
+        Err(error) => {
+            logger::error!(?error);
             false
         }
     }

--- a/crates/router/src/core/pm_auth.rs
+++ b/crates/router/src/core/pm_auth.rs
@@ -338,8 +338,8 @@ async fn store_bank_details_in_payment_methods(
                     .attach_printable("Failed to deserialize Payment Method Auth config")
             })
             .transpose()
-            .unwrap_or_else(|err| {
-                logger::error!(error=?err);
+            .unwrap_or_else(|error| {
+                logger::error!(?error);
                 None
             })
             .and_then(|pmd| match pmd {

--- a/crates/router/src/core/refunds.rs
+++ b/crates/router/src/core/refunds.rs
@@ -1452,7 +1452,7 @@ pub async fn get_refund_sync_process_schedule_time(
     let mapping = match redis_mapping {
         Ok(x) => x,
         Err(err) => {
-            logger::error!("Error: while getting connector mapping: {}", err);
+            logger::error!("Error: while getting connector mapping: {err:?}");
             process_data::ConnectorPTMapping::default()
         }
     };

--- a/crates/router/src/core/user.rs
+++ b/crates/router/src/core/user.rs
@@ -386,7 +386,7 @@ pub async fn change_password(
 
     let _ = auth::blacklist::insert_user_in_blacklist(&state, user.get_user_id())
         .await
-        .map_err(|e| logger::error!(?e));
+        .map_err(|error| logger::error!(?error));
 
     #[cfg(not(feature = "email"))]
     {
@@ -398,7 +398,7 @@ pub async fn change_password(
                 diesel_models::enums::DashboardMetadata::IsChangePasswordRequired,
             )
             .await
-            .map_err(|e| logger::error!("Error while deleting dashboard metadata {}", e))
+            .map_err(|e| logger::error!("Error while deleting dashboard metadata {e:?}"))
             .ok();
     }
 
@@ -479,7 +479,7 @@ pub async fn rotate_password(
 
     let _ = auth::blacklist::insert_user_in_blacklist(&state, &user.user_id)
         .await
-        .map_err(|e| logger::error!(?e));
+        .map_err(|error| logger::error!(?error));
 
     auth::cookies::remove_cookie_response()
 }
@@ -534,15 +534,15 @@ pub async fn reset_password_token_only_flow(
                 storage_user::UserUpdate::VerifyUser,
             )
             .await
-            .map_err(|e| logger::error!(?e));
+            .map_err(|error| logger::error!(?error));
     }
 
     let _ = auth::blacklist::insert_email_token_in_blacklist(&state, &token)
         .await
-        .map_err(|e| logger::error!(?e));
+        .map_err(|error| logger::error!(?error));
     let _ = auth::blacklist::insert_user_in_blacklist(&state, &user.user_id)
         .await
-        .map_err(|e| logger::error!(?e));
+        .map_err(|error| logger::error!(?error));
 
     auth::cookies::remove_cookie_response()
 }
@@ -592,10 +592,10 @@ pub async fn reset_password(
 
     let _ = auth::blacklist::insert_email_token_in_blacklist(&state, &token)
         .await
-        .map_err(|e| logger::error!(?e));
+        .map_err(|error| logger::error!(?error));
     let _ = auth::blacklist::insert_user_in_blacklist(&state, &user.user_id)
         .await
-        .map_err(|e| logger::error!(?e));
+        .map_err(|error| logger::error!(?error));
 
     auth::cookies::remove_cookie_response()
 }
@@ -997,7 +997,7 @@ pub async fn accept_invite_from_email(
 
     let _ = auth::blacklist::insert_email_token_in_blacklist(&state, &token)
         .await
-        .map_err(|e| logger::error!(?e));
+        .map_err(|error| logger::error!(?error));
 
     let user_from_db: domain::UserFromStorage = state
         .global_store
@@ -1075,12 +1075,12 @@ pub async fn accept_invite_from_email_token_only_flow(
                 storage_user::UserUpdate::VerifyUser,
             )
             .await
-            .map_err(|e| logger::error!(?e));
+            .map_err(|error| logger::error!(?error));
     }
 
     let _ = auth::blacklist::insert_email_token_in_blacklist(&state, &token)
         .await
-        .map_err(|e| logger::error!(?e));
+        .map_err(|error| logger::error!(?error));
 
     let current_flow = domain::CurrentFlow::new(
         user_token,
@@ -1489,7 +1489,7 @@ pub async fn verify_email(
 
     let _ = auth::blacklist::insert_email_token_in_blacklist(&state, &token)
         .await
-        .map_err(|e| logger::error!(?e));
+        .map_err(|error| logger::error!(?error));
 
     let response = signin_strategy.get_signin_response(&state).await?;
     let token = utils::user::get_token_from_signin_response(&response);
@@ -1535,7 +1535,7 @@ pub async fn verify_email_token_only_flow(
 
     let _ = auth::blacklist::insert_email_token_in_blacklist(&state, &token)
         .await
-        .map_err(|e| logger::error!(?e));
+        .map_err(|error| logger::error!(?error));
 
     let current_flow = domain::CurrentFlow::new(user_token, domain::SPTFlow::VerifyEmail.into())?;
     let next_flow = current_flow.next(user_from_db, &state).await?;
@@ -1867,14 +1867,14 @@ pub async fn update_totp(
 
     let _ = tfa_utils::delete_totp_secret_from_redis(&state, &user_token.user_id)
         .await
-        .map_err(|e| logger::error!(?e));
+        .map_err(|error| logger::error!(?error));
 
     // This is not the main task of this API, so we don't throw error if this fails.
     // Any following API which requires TOTP will throw error if TOTP is not set in redis
     // and FE will ask user to enter TOTP again
     let _ = tfa_utils::insert_totp_in_redis(&state, &user_token.user_id)
         .await
-        .map_err(|e| logger::error!(?e));
+        .map_err(|error| logger::error!(?error));
 
     Ok(ApplicationResponse::StatusOk)
 }

--- a/crates/router/src/core/user_role.rs
+++ b/crates/router/src/core/user_role.rs
@@ -186,7 +186,7 @@ pub async fn accept_invitation(
             )
             .await
             .map_err(|e| {
-                logger::error!("Error while accepting invitation {}", e);
+                logger::error!("Error while accepting invitation {e:?}");
             })
             .ok()
     }))
@@ -216,7 +216,7 @@ pub async fn merchant_select(
             )
             .await
             .map_err(|e| {
-                logger::error!("Error while accepting invitation {}", e);
+                logger::error!("Error while accepting invitation {e:?}");
             })
             .ok()
     }))
@@ -270,7 +270,7 @@ pub async fn merchant_select_token_only_flow(
             )
             .await
             .map_err(|e| {
-                logger::error!("Error while accepting invitation {}", e);
+                logger::error!("Error while accepting invitation {e:?}");
             })
             .ok()
     }))

--- a/crates/router/src/db/merchant_connector_account.rs
+++ b/crates/router/src/db/merchant_connector_account.rs
@@ -476,9 +476,9 @@ impl MerchantConnectorAccountInterface for Store {
                         // -> it is not possible to write a `From` impl to convert the `diesel::result::Error` to `error_stack::Report<StorageError>`
                         //    because of Rust's orphan rules
                         router_env::logger::error!(
-                        ?error,
-                        "DB transaction for updating multiple merchant connector account failed"
-                    );
+                            ?error,
+                            "DB transaction for updating multiple merchant connector account failed"
+                        );
                         errors::StorageError::DatabaseConnectionError
                     })?;
                 }

--- a/crates/router/src/lib.rs
+++ b/crates/router/src/lib.rs
@@ -270,7 +270,7 @@ pub async fn receiver_for_error(rx: oneshot::Receiver<()>, mut server: impl Stop
             server.stop_server().await;
         }
         Err(err) => {
-            logger::error!("Channel receiver error{err}");
+            logger::error!("Channel receiver error: {err}");
         }
     }
 }

--- a/crates/router/src/routes/payments.rs
+++ b/crates/router/src/routes/payments.rs
@@ -595,8 +595,11 @@ pub async fn payments_connector_session(
 
     let header_payload = match HeaderPayload::foreign_try_from(req.headers()) {
         Ok(headers) => headers,
-        Err(err) => {
-            logger::error!(?err, "Failed to get headers in payments_connector_session");
+        Err(error) => {
+            logger::error!(
+                ?error,
+                "Failed to get headers in payments_connector_session"
+            );
             HeaderPayload::default()
         }
     };

--- a/crates/router/src/routes/payments/helpers.rs
+++ b/crates/router/src/routes/payments/helpers.rs
@@ -46,8 +46,11 @@ pub fn populate_ip_into_browser_info(
             .as_ref()
             .map(|ip| ip.parse())
             .transpose()
-            .unwrap_or_else(|e| {
-                logger::error!(error=?e, message="failed to parse ip address which is extracted from the request");
+            .unwrap_or_else(|error| {
+                logger::error!(
+                    ?error,
+                    "failed to parse ip address which is extracted from the request"
+                );
                 None
             })
     });

--- a/crates/router/src/services/api.rs
+++ b/crates/router/src/services/api.rs
@@ -1192,8 +1192,8 @@ pub fn http_response_json_with_headers<T: body::MessageBody + 'static>(
         }
         let mut header_value = match HeaderValue::from_str(header_value.as_str()) {
             Ok(header_value) => header_value,
-            Err(e) => {
-                logger::error!(?e);
+            Err(error) => {
+                logger::error!(?error);
                 return http_server_error_json_response("Something Went Wrong");
             }
         };

--- a/crates/router/src/services/authentication.rs
+++ b/crates/router/src/services/authentication.rs
@@ -790,10 +790,10 @@ where
 {
     let token = match get_cookie_from_header(headers).and_then(cookies::parse_cookie) {
         Ok(cookies) => cookies,
-        Err(e) => {
+        Err(error) => {
             let token = get_jwt_from_authorization_header(headers);
             if token.is_err() {
-                logger::error!(?e);
+                logger::error!(?error);
             }
             token?.to_owned()
         }

--- a/crates/router/src/services/authorization.rs
+++ b/crates/router/src/services/authorization.rs
@@ -31,7 +31,7 @@ where
 
     if let Ok(permissions) = get_permissions_from_cache(state, &token.role_id)
         .await
-        .map_err(|e| logger::error!("Failed to get permissions from cache {}", e))
+        .map_err(|e| logger::error!("Failed to get permissions from cache {e:?}"))
     {
         return Ok(permissions);
     }
@@ -45,7 +45,7 @@ where
 
     set_permissions_in_cache(state, &token.role_id, &permissions, cache_ttl)
         .await
-        .map_err(|e| logger::error!("Failed to set permissions in cache {}", e))
+        .map_err(|e| logger::error!("Failed to set permissions in cache {e:?}"))
         .ok();
     Ok(permissions)
 }

--- a/crates/router/src/workflows/api_key_expiry.rs
+++ b/crates/router/src/workflows/api_key_expiry.rs
@@ -69,15 +69,17 @@ impl ProcessTrackerWorkflow<SessionState> for ApiKeyExpiryWorkflow {
             .ok_or(errors::ProcessTrackerError::EApiErrorResponse)?;
 
         let email_contents = ApiKeyExpiryReminder {
-            recipient_email: UserEmail::from_pii_email(email_id).map_err(|err| {
-                logger::error!(%err,"Failed to convert recipient's email to UserEmail from pii::Email");
+            recipient_email: UserEmail::from_pii_email(email_id).map_err(|error| {
+                logger::error!(
+                    ?error,
+                    "Failed to convert recipient's email to UserEmail from pii::Email"
+                );
                 errors::ProcessTrackerError::EApiErrorResponse
             })?,
             subject: "API Key Expiry Notice",
             expires_in: *expires_in,
             api_key_name,
             prefix,
-
         };
 
         state

--- a/crates/scheduler/src/db/queue.rs
+++ b/crates/scheduler/src/db/queue.rs
@@ -91,7 +91,7 @@ impl QueueInterface for Store {
 
                 #[allow(unused_must_use)]
                 Err(error) => {
-                    logger::error!(error=?error.current_context());
+                    logger::error!(?error);
                     conn.delete_key(lock_key).await;
                     false
                 }
@@ -101,7 +101,7 @@ impl QueueInterface for Store {
                 false
             }
             Err(error) => {
-                logger::error!(error=%error.current_context(), %tag, "Error while locking");
+                logger::error!(?error, %tag, "Error while locking");
                 false
             }
         })
@@ -112,7 +112,7 @@ impl QueueInterface for Store {
         Ok(match is_lock_released {
             Ok(_del_reply) => true,
             Err(error) => {
-                logger::error!(error=%error.current_context(), %tag, "Error while releasing lock");
+                logger::error!(?error, %tag, "Error while releasing lock");
                 false
             }
         })

--- a/crates/scheduler/src/errors.rs
+++ b/crates/scheduler/src/errors.rs
@@ -101,7 +101,7 @@ impl<T: PTError + std::fmt::Debug + std::fmt::Display> From<error_stack::Report<
     for ProcessTrackerError
 {
     fn from(error: error_stack::Report<T>) -> Self {
-        logger::error!(error=%error.current_context());
+        logger::error!(?error);
         error.current_context().to_pt_error()
     }
 }

--- a/crates/scheduler/src/producer.rs
+++ b/crates/scheduler/src/producer.rs
@@ -76,7 +76,7 @@ where
                             // Intentionally not propagating error to caller.
                             // Any errors that occur in the producer flow must be handled here only, as
                             // this is the topmost level function which is concerned with the producer flow.
-                            error!(%error);
+                            error!(?error);
                         }
                     }
                 }

--- a/crates/scheduler/src/utils.rs
+++ b/crates/scheduler/src/utils.rs
@@ -34,7 +34,7 @@ where
         let result = update_status_and_append(state, flow, batch).await;
         match result {
             Ok(_) => (),
-            Err(error) => logger::error!(error=%error.current_context()),
+            Err(error) => logger::error!(?error),
         }
     }
     Ok(())
@@ -64,7 +64,7 @@ where
                     },
                 )
                 .await.map_or_else(|error| {
-                    logger::error!(error=%error.current_context(),"Error while updating process status");
+                    logger::error!(?error, "Error while updating process status");
                     Err(error.change_context(errors::ProcessTrackerError::ProcessUpdateFailed))
                 }, |count| {
                     logger::debug!("Updated status of {count} processes");
@@ -81,15 +81,15 @@ where
                     Ok(())
                 }
                 Err(error) => {
-                    logger::error!(error=%error.current_context(),"Error while reinitializing processes");
+                    logger::error!(?error, "Error while reinitializing processes");
                     Err(error.change_context(errors::ProcessTrackerError::ProcessUpdateFailed))
                 }
             }
         }
         _ => {
-            let error_msg = format!("Unexpected scheduler flow {flow:?}");
-            logger::error!(error = %error_msg);
-            Err(report!(errors::ProcessTrackerError::UnexpectedFlow).attach_printable(error_msg))
+            let error = format!("Unexpected scheduler flow {flow:?}");
+            logger::error!(%error);
+            Err(report!(errors::ProcessTrackerError::UnexpectedFlow).attach_printable(error))
         }
     }?;
 
@@ -115,7 +115,7 @@ where
                     },
                 )
                 .await.map_or_else(|error| {
-                    logger::error!(error=%error.current_context(),"Error while updating process status");
+                    logger::error!(?error, "Error while updating process status");
                     Err(error.change_context(errors::ProcessTrackerError::ProcessUpdateFailed))
                 }, |count| {
                     logger::debug!("Updated status of {count} processes");
@@ -275,7 +275,7 @@ pub fn add_histogram_metrics(
     #[warn(clippy::option_map_unit_fn)]
     if let Some((schedule_time, runner)) = task.schedule_time.as_ref().zip(task.runner.as_ref()) {
         let pickup_schedule_delta = (*pickup_time - *schedule_time).as_seconds_f64();
-        logger::error!(%pickup_schedule_delta, "<- Time delta for scheduled tasks");
+        logger::error!("Time delta for scheduled tasks: {pickup_schedule_delta} seconds");
         let runner_name = runner.clone();
         metrics::CONSUMER_STATS.record(
             &metrics::CONTEXT,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->

This PR updates the error logs to use the `Debug` implementation instead of the `Display` implementation to log errors. This would print the entire error reports (in case of `error_stack::Report`) instead of just the latest error raised in the report.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
This would help developers debug failures better.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Sanity testing done via Postman.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
