### PR TITLE
refactor(connector): make the `original_authorized_amount` optional for MITs with `connector_mandate_details`

### DIFF
--- a/crates/router/src/connector/cybersource/transformers.rs
+++ b/crates/router/src/connector/cybersource/transformers.rs
@@ -631,7 +631,8 @@ impl
                         .map(|network| network.to_lowercase())
                         .as_deref()
                     {
-                        Some("discover") => {
+                        //This is to make original_authorized_amount mandatory for discover card networks in NetworkMandateId flow
+                        Some("004") => {
                             let original_amount = Some(
                                 item.router_data
                                     .get_recurring_mandate_payment_data()?

--- a/crates/router/src/connector/cybersource/transformers.rs
+++ b/crates/router/src/connector/cybersource/transformers.rs
@@ -588,12 +588,30 @@ impl
                 Some(payments::MandateReferenceId::ConnectorMandateId(_)) => {
                     let original_amount = item
                         .router_data
-                        .get_recurring_mandate_payment_data()?
-                        .get_original_payment_amount()?;
+                        .recurring_mandate_payment_data
+                        .as_ref()
+                        .and_then(|recurring_mandate_payment_data| {
+                            recurring_mandate_payment_data.original_payment_authorized_amount
+                        });
+
                     let original_currency = item
                         .router_data
-                        .get_recurring_mandate_payment_data()?
-                        .get_original_payment_currency()?;
+                        .recurring_mandate_payment_data
+                        .as_ref()
+                        .and_then(|recurring_mandate_payment_data| {
+                            recurring_mandate_payment_data.original_payment_authorized_currency
+                        });
+
+                    let original_authorized_amount = match original_amount.zip(original_currency) {
+                        Some((original_amount, original_currency)) => {
+                            Some(utils::get_amount_as_string(
+                                &api::CurrencyUnit::Base,
+                                original_amount,
+                                original_currency,
+                            )?)
+                        }
+                        None => None,
+                    };
                     (
                         None,
                         None,
@@ -601,11 +619,7 @@ impl
                             initiator: None,
                             merchant_intitiated_transaction: Some(MerchantInitiatedTransaction {
                                 reason: None,
-                                original_authorized_amount: Some(utils::get_amount_as_string(
-                                    &api::CurrencyUnit::Base,
-                                    original_amount,
-                                    original_currency,
-                                )?),
+                                original_authorized_amount,
                                 previous_transaction_id: None,
                             }),
                         }),
@@ -652,12 +666,11 @@ impl
                             (original_amount, original_currency)
                         }
                     };
-
-                    let original_authorized_amount = match (original_amount, original_currency) {
-                        (Some(original_amount), Some(original_currency)) => Some(
+                    let original_authorized_amount = match original_amount.zip(original_currency) {
+                        Some((original_amount, original_currency)) => Some(
                             utils::to_currency_base_unit(original_amount, original_currency)?,
                         ),
-                        _ => None,
+                        None => None,
                     };
                     commerce_indicator = "recurring".to_string();
                     (


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
During the MITs with the `connector_mandate_details`  the `original_authorized_amount` is made optional.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
-> Create cybersource merchant connector account
-> Create mandate
```
curl --location 'http://localhost:8080/payments' \
--header 'Accept: application/json' \
--header 'api-key: dev_FZ5RdQNZ944E16z8uT6DrqlkCa2TsEnGBFxdFu6uuNgbwi68PJlvfpYGXmqLFlJa' \
--header 'Content-Type: application/json' \
--data-raw '{
    "amount": 1000,
    "currency": "USD",
    "confirm": true,
    "capture_method": "automatic",
    "capture_on": "2022-09-10T10:11:12Z",
    "customer_id": "cu_1720965634",
    "email": "guest@example.com",
    "name": "John Doe",
    "phone": "999999999",
    "phone_country_code": "+65",
    "description": "Its my first payment request",
    "authentication_type": "no_three_ds",
    "return_url": "https://google.com",
    "payment_method": "card",
    "payment_method_type": "credit",
    "payment_method_data": {
        "card": {
            "card_number": "4111111111111111",
            "card_exp_month": "03",
            "card_exp_year": "2030",
            "card_holder_name": "name name",
            "card_cvc": "737"
        }
    },
    "setup_future_usage": "off_session",
    "customer_acceptance": {
        "acceptance_type": "offline",
        "accepted_at": "1963-05-03T04:07:52.723Z",
        "online": {
            "ip_address": "in sit",
            "user_agent": "amet irure esse"
        }
    },
    "billing": {
        "address": {
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "city": "San Fransico",
            "state": "California",
            "zip": "94122",
            "country": "US",
            "first_name": "PiX",
            "last_name": "ss"
        }
    },
    "shipping": {
        "address": {
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "city": "San Fransico",
            "state": "California",
            "zip": "94122",
            "country": "US",
            "first_name": "John",
            "last_name": "Doe"
        },
        "phone": {
            "number": "8056594427",
            "country_code": "+91"
        }
    },
    "browser_info": {
        "user_agent": "Mozilla\/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/70.0.3538.110 Safari\/537.36",
        "accept_header": "text\/html,application\/xhtml+xml,application\/xml;q=0.9,image\/webp,image\/apng,*\/*;q=0.8",
        "language": "nl-NL",
        "color_depth": 24,
        "screen_height": 723,
        "screen_width": 1536,
        "time_zone": 0,
        "java_enabled": true,
        "java_script_enabled": true,
        "ip_address": "125.0.0.1"
    },
    "statement_descriptor_name": "joseph",
    "statement_descriptor_suffix": "JS",
    "metadata": {},
    "order_details": [
        {
            "product_name": "Apple iphone 15",
            "quantity": 1,
            "amount": 0,
            "account_name": "transaction_processing"
        }
    ]
}'
```
<img width="888" alt="image" src="https://github.com/user-attachments/assets/389fcc01-0039-44c7-91c9-b86ee56c881c">

<img width="1451" alt="image" src="https://github.com/user-attachments/assets/5c2fdd4b-8996-49f2-903e-234540d4f1c1">

-> Create a payment with confirm false
```
curl --location 'http://localhost:8080/payments' \
--header 'Accept: application/json' \
--header 'api-key: dev_FZ5RdQNZ944E16z8uT6DrqlkCa2TsEnGBFxdFu6uuNgbwi68PJlvfpYGXmqLFlJa' \
--header 'Content-Type: application/json' \
--data '{
    "amount": 10000,
    "currency": "USD",
    "capture_method": "automatic",
    "authentication_type": "no_three_ds",
    "confirm": false,
    "off_session": true,
    "customer_id": "cu_1720964758"
}'
```
<img width="860" alt="image" src="https://github.com/user-attachments/assets/de232b18-1d27-4932-9b6e-ca71af7fb407">

-> List payment methods with client_secret
```
curl --location 'http://localhost:8080/customers/payment_methods?client_secret=pay_bkfuNbw8xifVm7NLOOyt_secret_xZOreIvw2iJPM39q7u6d' \
--header 'Accept: application/json' \
--header 'api-key: pk_dev_a4f83cc1e4d345ae8fc5ccf9db82cc2b'
```
<img width="931" alt="image" src="https://github.com/user-attachments/assets/e4d3d692-9f9c-4859-a66e-6044427f62de">
 
 -> Confirm the payment with the above listed token
 ```
 curl --location 'http://localhost:8080/payments/pay_bkfuNbw8xifVm7NLOOyt/confirm' \
--header 'api-key: pk_dev_a4f83cc1e4d345ae8fc5ccf9db82cc2b' \
--header 'Content-Type: application/json' \
--data '{
    "payment_token": "token_s5u8wLyMPGvKIRmV6EfU",
    "client_secret": "pay_bkfuNbw8xifVm7NLOOyt_secret_xZOreIvw2iJPM39q7u6d",
    "payment_method": "card",
    "billing": {
        "address": {
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "city": "San Fransico",
            "state": "California",
            "zip": "94122",
            "country": "US",
            "first_name": "PiX",
            "last_name": "ss"
        }
    }
}'
 ```
 
<img width="886" alt="image" src="https://github.com/user-attachments/assets/f82652d9-41dc-47a7-b850-74ebd6738f98">

-> Make the `"original_payment_authorized_currency": "USD"` and `"original_payment_authorized_amount": 1000,` null for testing
<img width="1317" alt="image" src="https://github.com/user-attachments/assets/6a9e4ad3-912c-4a2a-8478-a8093c2e2567">

-> List payment methods for customer and make a payment, verified original_authorized_amount being sent as null form logs
<img width="968" alt="image" src="https://github.com/user-attachments/assets/55fcb911-31a6-42e8-b6b2-480e4e4a676f">|
<img width="926" alt="image" src="https://github.com/user-attachments/assets/e049f880-5e6f-4dbd-a3dd-c642b123805b">
<img width="1274" alt="image" src="https://github.com/user-attachments/assets/c746bd9c-d4c8-4337-8b58-a1781bbd23f0">
<img width="1263" alt="image" src="https://github.com/user-attachments/assets/f5af7f82-5ebd-4d85-a9c2-ff0c80a558cb">


-> Perform the same steps with `Discover` card
<img width="1119" alt="image" src="https://github.com/user-attachments/assets/ee588fbb-02b9-4b60-b60b-46e0a5a42b66">
<img width="1047" alt="image" src="https://github.com/user-attachments/assets/0ec70da9-db9f-4d58-888e-75c9daabc1f5">
<img width="957" alt="image" src="https://github.com/user-attachments/assets/047060ec-75dc-4651-8631-f19bf5ff3eef">

<img width="1263" alt="image" src="https://github.com/user-attachments/assets/630f2e1e-485e-4da7-93f8-ad813a529436">
<img width="1268" alt="image" src="https://github.com/user-attachments/assets/3e8e0b68-2db7-4aac-9895-fe75f265cfa7">
<img width="861" alt="image" src="https://github.com/user-attachments/assets/bdc71789-45bb-41af-9732-1f669b53a31e">




## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
