### PR TITLE
fix(connector): [AUTHORIZEDOTNET] Populate error reason for failure transactions

### DIFF
--- a/crates/router/src/connector/authorizedotnet/transformers.rs
+++ b/crates/router/src/connector/authorizedotnet/transformers.rs
@@ -1061,7 +1061,7 @@ impl<F, T>
                     errors.iter().next().map(|error| types::ErrorResponse {
                         code: error.error_code.clone(),
                         message: error.error_text.clone(),
-                        reason: None,
+                        reason: Some(error.error_text.clone()),
                         status_code: item.http_code,
                         attempt_status: None,
                         connector_transaction_id: Some(transaction_response.transaction_id.clone()),
@@ -1158,7 +1158,7 @@ impl<F, T>
                     errors.iter().next().map(|error| types::ErrorResponse {
                         code: error.error_code.clone(),
                         message: error.error_text.clone(),
-                        reason: None,
+                        reason: Some(error.error_text.clone()),
                         status_code: item.http_code,
                         attempt_status: None,
                         connector_transaction_id: Some(transaction_response.transaction_id.clone()),
@@ -1305,7 +1305,7 @@ impl<F> TryFrom<types::RefundsResponseRouterData<F, AuthorizedotnetRefundRespons
             errors.first().map(|error| types::ErrorResponse {
                 code: error.error_code.clone(),
                 message: error.error_text.clone(),
-                reason: None,
+                reason: Some(error.error_text.clone()),
                 status_code: item.http_code,
                 attempt_status: None,
                 connector_transaction_id: Some(transaction_response.transaction_id.clone()),
@@ -1587,7 +1587,7 @@ fn get_err_response(
     Ok(types::ErrorResponse {
         code: response_message.code.clone(),
         message: response_message.text.clone(),
-        reason: None,
+        reason: Some(response_message.text.clone()),
         status_code,
         attempt_status: None,
         connector_transaction_id: None,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
ORIGINAL PR: https://github.com/juspay/hyperswitch/pull/5319
Error reason is now being populated for failure transactions for connector authorizedotnet.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
https://github.com/juspay/hyperswitch/issues/5318

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Zip code should be passed as 46282 to generate failure scenario for connector authorizedotnet.
Request:
```
curl --location 'http://localhost:8080/payments' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: dev_Rjm1odUMbdX57oOLZNQzZtoYOEAo8ZAi1QHZzV79JIkJPnM8ffypLayUJW9rGX7a' \
--data '{
    "amount": 1232,
    "currency": "USD",
    "confirm": true,
    "customer_id": "Strustomewwr",
    "payment_method": "card",
    "payment_method_type": "credit",
    "payment_method_data": {
        "card": {
            "card_number": "4111111111111111",
            "card_exp_month": "02",
            "card_exp_year": "35",
            "card_holder_name": "John Doe",
            "card_cvc": "123"
        }
    },
    "billing": {
        "address": {
            "first_name": "John",
            "last_name": "Doe",
            "line1": "Harrison Street",
            "city": "San Francisco",
            "state": "California",
            "zip": "46282",
            "country": "US"
        }
    }
}'
```

Response:
```
{
    "payment_id": "pay_xQm2HqZbnK99JszUaE3A",
    "merchant_id": "merchant_1717672514",
    "status": "failed",
    "amount": 1232,
    "net_amount": 1232,
    "amount_capturable": 0,
    "amount_received": null,
    "connector": "authorizedotnet",
    "client_secret": "pay_xQm2HqZbnK99JszUaE3A_secret_wgPiZJagTyGg9F4I9Oae",
    "created": "2024-07-15T07:34:53.450Z",
    "currency": "USD",
    "customer_id": "Strustomewwr",
    "customer": {
        "id": "Strustomewwr",
        "name": null,
        "email": null,
        "phone": null,
        "phone_country_code": null
    },
    "description": null,
    "refunds": null,
    "disputes": null,
    "mandate_id": null,
    "mandate_data": null,
    "setup_future_usage": null,
    "off_session": null,
    "capture_on": null,
    "capture_method": null,
    "payment_method": "card",
    "payment_method_data": {
        "card": {
            "last4": "1111",
            "card_type": null,
            "card_network": null,
            "card_issuer": null,
            "card_issuing_country": null,
            "card_isin": "411111",
            "card_extended_bin": null,
            "card_exp_month": "02",
            "card_exp_year": "35",
            "card_holder_name": "John Doe",
            "payment_checks": null,
            "authentication_data": null
        },
        "billing": null
    },
    "payment_token": null,
    "shipping": null,
    "billing": {
        "address": {
            "city": "San Francisco",
            "country": "US",
            "line1": "Harrison Street",
            "line2": null,
            "line3": null,
            "zip": "46282",
            "state": "California",
            "first_name": "John",
            "last_name": "Doe"
        },
        "phone": null,
        "email": null
    },
    "order_details": null,
    "email": null,
    "name": null,
    "phone": null,
    "return_url": null,
    "authentication_type": "no_three_ds",
    "statement_descriptor_name": null,
    "statement_descriptor_suffix": null,
    "next_action": null,
    "cancellation_reason": null,
    "error_code": "2",
    "error_message": "This transaction has been declined.",
    "unified_code": null,
    "unified_message": null,
    "payment_experience": null,
    "payment_method_type": "credit",
    "connector_label": null,
    "business_country": null,
    "business_label": "default",
    "business_sub_label": null,
    "allowed_payment_method_types": null,
    "ephemeral_key": {
        "customer_id": "Strustomewwr",
        "created_at": 1721028893,
        "expires": 1721032493,
        "secret": "epk_cd28e31ba4eb48c6b01595b2d007b8b0"
    },
    "manual_retry_allowed": true,
    "connector_transaction_id": "80022007717",
    "frm_message": null,
    "metadata": null,
    "connector_metadata": null,
    "feature_metadata": null,
    "reference_id": null,
    "payment_link": null,
    "profile_id": "pro_ND2WwoC6VijcO2bwzCNZ",
    "surcharge_details": null,
    "attempt_count": 1,
    "merchant_decision": null,
    "merchant_connector_id": "mca_UvqVahz5mptFO2F5hXP4",
    "incremental_authorization_allowed": false,
    "authorization_count": null,
    "incremental_authorizations": null,
    "external_authentication_details": null,
    "external_3ds_authentication_attempted": false,
    "expires_on": "2024-07-15T07:49:53.449Z",
    "fingerprint": null,
    "browser_info": null,
    "payment_method_id": null,
    "payment_method_status": null,
    "updated": "2024-07-15T07:34:55.849Z",
    "charges": null,
    "frm_metadata": null,
    "merchant_order_reference_id": null
}
```
The error reason should be populated for the failed payment in the payment_attempt table.
<img width="701" alt="Screenshot 2024-07-15 at 1 10 26 PM" src="https://github.com/user-attachments/assets/68a21fc6-9416-47f4-9158-3b11c6f62f15">


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
