### PR TITLE
fix: use encrypt api for all encryption and decryption

### DIFF
--- a/crates/hyperswitch_domain_models/src/merchant_account.rs
+++ b/crates/hyperswitch_domain_models/src/merchant_account.rs
@@ -14,7 +14,7 @@ use error_stack::ResultExt;
 use masking::{PeekInterface, Secret};
 use router_env::logger;
 
-use crate::type_encryption::{decrypt, AsyncLift};
+use crate::type_encryption::{decrypt_optional, AsyncLift};
 
 #[derive(Clone, Debug, serde::Serialize)]
 pub struct MerchantAccount {
@@ -220,11 +220,15 @@ impl super::behaviour::Conversion for MerchantAccount {
                 redirect_to_merchant_with_http_post: item.redirect_to_merchant_with_http_post,
                 merchant_name: item
                     .merchant_name
-                    .async_lift(|inner| decrypt(state, inner, identifier.clone(), key.peek()))
+                    .async_lift(|inner| {
+                        decrypt_optional(state, inner, identifier.clone(), key.peek())
+                    })
                     .await?,
                 merchant_details: item
                     .merchant_details
-                    .async_lift(|inner| decrypt(state, inner, identifier.clone(), key.peek()))
+                    .async_lift(|inner| {
+                        decrypt_optional(state, inner, identifier.clone(), key.peek())
+                    })
                     .await?,
                 webhook_details: item.webhook_details,
                 sub_merchants_enabled: item.sub_merchants_enabled,

--- a/crates/hyperswitch_domain_models/src/merchant_key_store.rs
+++ b/crates/hyperswitch_domain_models/src/merchant_key_store.rs
@@ -1,5 +1,5 @@
 use common_utils::{
-    crypto::{Encryptable, GcmAes256},
+    crypto::Encryptable,
     custom_serde, date_time,
     errors::{CustomResult, ValidationError},
     types::keymanager::{Identifier, KeyManagerState},
@@ -8,7 +8,7 @@ use error_stack::ResultExt;
 use masking::{PeekInterface, Secret};
 use time::PrimitiveDateTime;
 
-use crate::type_encryption::TypeEncryption;
+use crate::type_encryption::decrypt;
 
 #[derive(Clone, Debug, serde::Serialize)]
 pub struct MerchantKeyStore {
@@ -41,7 +41,7 @@ impl super::behaviour::Conversion for MerchantKeyStore {
     {
         let identifier = Identifier::Merchant(item.merchant_id.clone());
         Ok(Self {
-            key: Encryptable::decrypt_via_api(state, item.key, identifier, key.peek(), GcmAes256)
+            key: decrypt(state, item.key, identifier, key.peek())
                 .await
                 .change_context(ValidationError::InvalidValue {
                     message: "Failed while decrypting customer data".to_string(),

--- a/crates/hyperswitch_domain_models/src/payments/payment_attempt.rs
+++ b/crates/hyperswitch_domain_models/src/payments/payment_attempt.rs
@@ -15,7 +15,7 @@ use super::PaymentIntent;
 use crate::{
     behaviour, errors,
     mandates::{MandateDataType, MandateDetails},
-    type_encryption::{decrypt, AsyncLift},
+    type_encryption::{decrypt_optional, AsyncLift},
     ForeignIDRef, RemoteStorageObject,
 };
 
@@ -552,7 +552,7 @@ impl behaviour::Conversion for PaymentIntent {
     {
         async {
             let inner_decrypt = |inner| {
-                decrypt(
+                decrypt_optional(
                     state,
                     inner,
                     common_utils::types::keymanager::Identifier::Merchant(key_store_ref_id.clone()),

--- a/crates/router/src/core/admin.rs
+++ b/crates/router/src/core/admin.rs
@@ -111,7 +111,10 @@ pub async fn create_merchant_account(
     req: api::MerchantAccountCreate,
 ) -> RouterResponse<api::MerchantAccountResponse> {
     #[cfg(feature = "keymanager_create")]
-    use common_utils::keymanager;
+    use {
+        base64::Engine,
+        common_utils::{keymanager, types::keymanager::EncryptionTransferRequest},
+    };
 
     let db = state.store.as_ref();
 
@@ -124,13 +127,13 @@ pub async fn create_merchant_account(
     let key_manager_state = &(&state).into();
     let merchant_id = req.get_merchant_reference_id().get_string_repr().to_owned();
     let identifier = km_types::Identifier::Merchant(merchant_id.clone());
-
     #[cfg(feature = "keymanager_create")]
     {
-        keymanager::create_key_in_key_manager(
+        keymanager::transfer_key_to_key_manager(
             key_manager_state,
-            km_types::EncryptionCreateRequest {
+            EncryptionTransferRequest {
                 identifier: identifier.clone(),
+                key: consts::BASE64_ENGINE.encode(key),
             },
         )
         .await

--- a/crates/router/src/core/payments/operations/payment_confirm.rs
+++ b/crates/router/src/core/payments/operations/payment_confirm.rs
@@ -39,7 +39,7 @@ use crate::{
     types::{
         self,
         api::{self, ConnectorCallType, PaymentIdTypeExt},
-        domain::{self, types::decrypt},
+        domain::{self, types::decrypt_optional},
         storage::{self, enums as storage_enums},
     },
     utils::{self, OptionExt},
@@ -1084,7 +1084,7 @@ impl<F: Clone> UpdateTracker<F, PaymentData<F>, api::PaymentsRequest> for Paymen
             let key = key_store.key.get_inner().peek();
 
             let card_detail_from_locker: Option<api::CardDetailFromLocker> =
-                decrypt::<serde_json::Value, masking::WithType>(
+                decrypt_optional::<serde_json::Value, masking::WithType>(
                     key_manager_state,
                     pm.payment_method_data.clone(),
                     Identifier::Merchant(key_store.merchant_id.clone()),

--- a/crates/router/src/core/payments/operations/payment_create.rs
+++ b/crates/router/src/core/payments/operations/payment_create.rs
@@ -13,7 +13,7 @@ use error_stack::{self, ResultExt};
 use hyperswitch_domain_models::{
     mandates::{MandateData, MandateDetails},
     payments::{payment_attempt::PaymentAttempt, payment_intent::CustomerData},
-    type_encryption::decrypt,
+    type_encryption::decrypt_optional,
 };
 use masking::{ExposeInterface, PeekInterface, Secret};
 use router_derive::PaymentOperation;
@@ -847,7 +847,7 @@ impl PaymentCreate {
             additional_pm_data = payment_method_info
                 .as_ref()
                 .async_map(|pm_info| async {
-                    decrypt::<serde_json::Value, masking::WithType>(
+                    decrypt_optional::<serde_json::Value, masking::WithType>(
                         &state.into(),
                         pm_info.payment_method_data.clone(),
                         Identifier::Merchant(key_store.merchant_id.clone()),

--- a/crates/router/src/core/pm_auth.rs
+++ b/crates/router/src/core/pm_auth.rs
@@ -45,7 +45,7 @@ use crate::{
     services::{pm_auth as pm_auth_services, ApplicationResponse},
     types::{
         self,
-        domain::{self, types::decrypt},
+        domain::{self, types::decrypt_optional},
         storage,
         transformers::ForeignTryFrom,
     },
@@ -327,7 +327,7 @@ async fn store_bank_details_in_payment_methods(
 
     for pm in payment_methods {
         if pm.payment_method == Some(enums::PaymentMethod::BankDebit) {
-            let bank_details_pm_data = decrypt::<serde_json::Value, masking::WithType>(
+            let bank_details_pm_data = decrypt_optional::<serde_json::Value, masking::WithType>(
                 &(&state).into(),
                 pm.payment_method_data.clone(),
                 Identifier::Merchant(key_store.merchant_id.clone()),

--- a/crates/router/src/core/webhooks/outgoing.rs
+++ b/crates/router/src/core/webhooks/outgoing.rs
@@ -7,7 +7,7 @@ use api_models::{
 use common_utils::{ext_traits::Encode, request::RequestContent, types::keymanager::Identifier};
 use diesel_models::process_tracker::business_status;
 use error_stack::{report, ResultExt};
-use hyperswitch_domain_models::type_encryption::decrypt;
+use hyperswitch_domain_models::type_encryption::decrypt_optional;
 use masking::{ExposeInterface, Mask, PeekInterface, Secret};
 use router_env::{
     instrument,
@@ -575,7 +575,7 @@ pub(crate) async fn get_outgoing_webhook_request(
 
         let transformed_outgoing_webhook = WebhookType::from(outgoing_webhook);
         let payment_response_hash_key = business_profile.payment_response_hash_key.clone();
-        let custom_headers = decrypt::<serde_json::Value, masking::WithType>(
+        let custom_headers = decrypt_optional::<serde_json::Value, masking::WithType>(
             &state.into(),
             business_profile
                 .outgoing_webhook_custom_http_headers

--- a/crates/router/src/types/api/admin.rs
+++ b/crates/router/src/types/api/admin.rs
@@ -13,7 +13,9 @@ use common_utils::{
     types::keymanager::Identifier,
 };
 use error_stack::{report, ResultExt};
-use hyperswitch_domain_models::{merchant_key_store::MerchantKeyStore, type_encryption::decrypt};
+use hyperswitch_domain_models::{
+    merchant_key_store::MerchantKeyStore, type_encryption::decrypt_optional,
+};
 use masking::{ExposeInterface, PeekInterface, Secret};
 
 use crate::{
@@ -92,24 +94,25 @@ pub async fn business_profile_response(
     item: storage::business_profile::BusinessProfile,
     key_store: &MerchantKeyStore,
 ) -> Result<BusinessProfileResponse, error_stack::Report<errors::ParsingError>> {
-    let outgoing_webhook_custom_http_headers = decrypt::<serde_json::Value, masking::WithType>(
-        &state.into(),
-        item.outgoing_webhook_custom_http_headers.clone(),
-        Identifier::Merchant(key_store.merchant_id.clone()),
-        key_store.key.get_inner().peek(),
-    )
-    .await
-    .change_context(errors::ParsingError::StructParseFailure(
-        "Outgoing webhook custom HTTP headers",
-    ))
-    .attach_printable("Failed to decrypt outgoing webhook custom HTTP headers")?
-    .map(|decrypted_value| {
-        decrypted_value
-            .into_inner()
-            .expose()
-            .parse_value::<HashMap<String, String>>("HashMap<String,String>")
-    })
-    .transpose()?;
+    let outgoing_webhook_custom_http_headers =
+        decrypt_optional::<serde_json::Value, masking::WithType>(
+            &state.into(),
+            item.outgoing_webhook_custom_http_headers.clone(),
+            Identifier::Merchant(key_store.merchant_id.clone()),
+            key_store.key.get_inner().peek(),
+        )
+        .await
+        .change_context(errors::ParsingError::StructParseFailure(
+            "Outgoing webhook custom HTTP headers",
+        ))
+        .attach_printable("Failed to decrypt outgoing webhook custom HTTP headers")?
+        .map(|decrypted_value| {
+            decrypted_value
+                .into_inner()
+                .expose()
+                .parse_value::<HashMap<String, String>>("HashMap<String,String>")
+        })
+        .transpose()?;
 
     Ok(BusinessProfileResponse {
         merchant_id: item.merchant_id,

--- a/crates/router/src/types/domain/types.rs
+++ b/crates/router/src/types/domain/types.rs
@@ -1,7 +1,7 @@
 use common_utils::types::keymanager::KeyManagerState;
 pub use hyperswitch_domain_models::type_encryption::{
-    batch_decrypt, batch_encrypt, decrypt, encrypt, encrypt_optional, AsyncLift, Lift,
-    TypeEncryption,
+    batch_decrypt, batch_encrypt, decrypt, decrypt_optional, encrypt, encrypt_optional, AsyncLift,
+    Lift,
 };
 
 impl From<&crate::SessionState> for KeyManagerState {

--- a/crates/router/src/types/domain/user.rs
+++ b/crates/router/src/types/domain/user.rs
@@ -6,8 +6,6 @@ use api_models::{
 use common_enums::TokenPurpose;
 #[cfg(not(feature = "v2"))]
 use common_utils::id_type;
-#[cfg(feature = "keymanager_create")]
-use common_utils::types::keymanager::EncryptionCreateRequest;
 use common_utils::{
     crypto::Encryptable, errors::CustomResult, new_type::MerchantName, pii,
     types::keymanager::Identifier,
@@ -25,6 +23,8 @@ use once_cell::sync::Lazy;
 use rand::distributions::{Alphanumeric, DistString};
 use router_env::env;
 use unicode_segmentation::UnicodeSegmentation;
+#[cfg(feature = "keymanager_create")]
+use {base64::Engine, common_utils::types::keymanager::EncryptionTransferRequest};
 
 use crate::{
     consts,
@@ -975,6 +975,19 @@ impl UserFromStorage {
                 .change_context(UserErrors::InternalServerError)
                 .attach_printable("Unable to generate aes 256 key")?;
 
+            #[cfg(feature = "keymanager_create")]
+            {
+                common_utils::keymanager::transfer_key_to_key_manager(
+                    key_manager_state,
+                    EncryptionTransferRequest {
+                        identifier: Identifier::User(self.get_user_id().to_string()),
+                        key: consts::BASE64_ENGINE.encode(key),
+                    },
+                )
+                .await
+                .change_context(UserErrors::InternalServerError)?;
+            }
+
             let key_store = UserKeyStore {
                 user_id: self.get_user_id().to_string(),
                 key: domain_types::encrypt(
@@ -987,18 +1000,6 @@ impl UserFromStorage {
                 .change_context(UserErrors::InternalServerError)?,
                 created_at: common_utils::date_time::now(),
             };
-
-            #[cfg(feature = "keymanager_create")]
-            {
-                common_utils::keymanager::create_key_in_key_manager(
-                    key_manager_state,
-                    EncryptionCreateRequest {
-                        identifier: Identifier::User(key_store.user_id.clone()),
-                    },
-                )
-                .await
-                .change_context(UserErrors::InternalServerError)?;
-            }
 
             state
                 .global_store
@@ -1039,7 +1040,7 @@ impl UserFromStorage {
             .await
             .change_context(UserErrors::InternalServerError)?;
 
-        Ok(domain_types::decrypt::<String, masking::WithType>(
+        Ok(domain_types::decrypt_optional::<String, masking::WithType>(
             key_manager_state,
             self.0.totp_secret.clone(),
             Identifier::User(user_key_store.user_id.clone()),

--- a/crates/router/src/types/domain/user_key_store.rs
+++ b/crates/router/src/types/domain/user_key_store.rs
@@ -1,16 +1,14 @@
 use common_utils::{
-    crypto::{Encryptable, GcmAes256},
+    crypto::Encryptable,
     date_time,
     types::keymanager::{Identifier, KeyManagerState},
 };
 use error_stack::ResultExt;
+use hyperswitch_domain_models::type_encryption::decrypt;
 use masking::{PeekInterface, Secret};
 use time::PrimitiveDateTime;
 
-use crate::{
-    errors::{CustomResult, ValidationError},
-    types::domain::types::TypeEncryption,
-};
+use crate::errors::{CustomResult, ValidationError};
 
 #[derive(Clone, Debug, serde::Serialize)]
 pub struct UserKeyStore {
@@ -43,7 +41,7 @@ impl super::behaviour::Conversion for UserKeyStore {
     {
         let identifier = Identifier::User(item.user_id.clone());
         Ok(Self {
-            key: Encryptable::decrypt_via_api(state, item.key, identifier, key.peek(), GcmAes256)
+            key: decrypt(state, item.key, identifier, key.peek())
                 .await
                 .change_context(ValidationError::InvalidValue {
                     message: "Failed while decrypting customer data".to_string(),

--- a/crates/router/src/utils/user.rs
+++ b/crates/router/src/utils/user.rs
@@ -283,7 +283,7 @@ pub async fn decrypt_oidc_private_config(
     .change_context(UserErrors::InternalServerError)
     .attach_printable("Failed to decode DEK")?;
 
-    let private_config = domain::types::decrypt::<serde_json::Value, masking::WithType>(
+    let private_config = domain::types::decrypt_optional::<serde_json::Value, masking::WithType>(
         &state.into(),
         encrypted_config,
         Identifier::UserAuth(id),


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
encrypt/decrypt should happen only via encryption service and DEK should be same in application and encryption service


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
encrypt/decrypt should happen only via encryption service and DEK should be same in application and encryption service


## How did you test it?
Changes can be verified only through logs. Look for "Fall back to Application Encryption" or "Fall back to Application Decryption" in the logs post deployment after running below tests. If logs are present encryption/decryption failed with encryption service and fall back to the application encryption which has to be investigated.

Test with merchant created before the changes deployed
1. Create Payment
2. Retrieve Payment
3. Create Refund
4. Retrieve Payment
Test with merchant created after the changes deployed
1. Create Merchant
2. Create API Key
3. Create MCA
4. Create Payment
6. Retrieve Payment
7. Create Refund
8. Retrieve Payment
Requires sanity on all the flows


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
