### PR TITLE
fix: use the default configuration when multitenancy is disabled

### DIFF
--- a/config/development.toml
+++ b/config/development.toml
@@ -698,10 +698,6 @@ sdk_eligible_payment_methods = "card"
 
 [multitenancy]
 enabled = false
-global_tenant = { schema = "public", redis_key_prefix = "" }
-
-[multitenancy.tenants]
-public = { name = "hyperswitch", base_url = "http://localhost:8080", schema = "public", redis_key_prefix = "", clickhouse_database = "default"}
 
 [user_auth_methods]
 encryption_key = "A8EF32E029BC3342E54BF2E172A4D7AA43E8EF9D2C3A624A9F04E2EF79DC698F"

--- a/config/docker_compose.toml
+++ b/config/docker_compose.toml
@@ -526,10 +526,6 @@ sdk_eligible_payment_methods = "card"
 
 [multitenancy]
 enabled = false
-global_tenant = { schema = "public", redis_key_prefix = "" }
-
-[multitenancy.tenants]
-public = { name = "hyperswitch", base_url = "http://localhost:8080", schema = "public", redis_key_prefix = "", clickhouse_database = "default" }
 
 [user_auth_methods]
 encryption_key = "A8EF32E029BC3342E54BF2E172A4D7AA43E8EF9D2C3A624A9F04E2EF79DC698F"

--- a/crates/router/src/configs/defaults.rs
+++ b/crates/router/src/configs/defaults.rs
@@ -8918,6 +8918,35 @@ impl Default for super::settings::RequiredFields {
     }
 }
 
+impl Default for super::settings::TenantConfig {
+    fn default() -> Self {
+        Self(HashMap::from([(
+            String::from("public"),
+            super::settings::Tenant::default(),
+        )]))
+    }
+}
+
+impl Default for super::settings::Tenant {
+    fn default() -> Self {
+        Self {
+            name: String::from("hyperswitch"),
+            base_url: String::from("http://localhost:8080"),
+            schema: String::from("public"),
+            redis_key_prefix: String::default(),
+            clickhouse_database: String::from("default"),
+        }
+    }
+}
+
+impl Default for super::settings::GlobalTenant {
+    fn default() -> Self {
+        Self {
+            schema: String::from("public"),
+            redis_key_prefix: String::default(),
+        }
+    }
+}
 #[allow(clippy::derivable_impls)]
 impl Default for super::settings::ApiKeys {
     fn default() -> Self {

--- a/crates/router/src/configs/settings.rs
+++ b/crates/router/src/configs/settings.rs
@@ -133,6 +133,7 @@ pub struct Settings<S: SecretState> {
 }
 
 #[derive(Debug, Deserialize, Clone, Default)]
+#[serde(default)]
 pub struct Multitenancy {
     pub tenants: TenantConfig,
     pub enabled: bool,
@@ -156,11 +157,11 @@ pub struct DecisionConfig {
     pub base_url: String,
 }
 
-#[derive(Debug, Deserialize, Clone, Default)]
+#[derive(Debug, Deserialize, Clone, Eq, PartialEq)]
 #[serde(transparent)]
 pub struct TenantConfig(pub HashMap<String, Tenant>);
 
-#[derive(Debug, Deserialize, Clone, Default)]
+#[derive(Debug, Deserialize, Clone, Eq, PartialEq)]
 pub struct Tenant {
     pub name: String,
     pub base_url: String,
@@ -184,7 +185,7 @@ impl storage_impl::config::ClickHouseConfig for Tenant {
     }
 }
 
-#[derive(Debug, Deserialize, Clone, Default)]
+#[derive(Debug, Deserialize, Clone, Eq, PartialEq)]
 pub struct GlobalTenant {
     pub schema: String,
     pub redis_key_prefix: String,
@@ -815,6 +816,7 @@ impl Settings<SecuredSecret> {
             .map_err(|err| ApplicationError::InvalidConfigurationValueError(err.into()))?;
         self.generic_link.payment_method_collect.validate()?;
         self.generic_link.payout_link.validate()?;
+        self.multitenancy.validate()?;
         Ok(())
     }
 }

--- a/crates/router/src/configs/validations.rs
+++ b/crates/router/src/configs/validations.rs
@@ -192,3 +192,20 @@ impl super::settings::GenericLinkEnvConfig {
         })
     }
 }
+
+impl super::settings::Multitenancy {
+    pub fn validate(&self) -> Result<(), ApplicationError> {
+        use common_utils::fp_utils::when;
+
+        when(
+            self.enabled
+                && self.tenants.clone() == super::settings::TenantConfig::default()
+                && self.global_tenant.clone() == super::settings::GlobalTenant::default(),
+            || {
+                Err(ApplicationError::InvalidConfigurationValueError(
+                    "Tenant configs are missing for the application".into(),
+                ))
+            },
+        )
+    }
+}

--- a/loadtest/config/development.toml
+++ b/loadtest/config/development.toml
@@ -346,7 +346,4 @@ keys = "user-agent"
 
 [multitenancy]
 enabled = false
-global_tenant = { schema = "public", redis_key_prefix = "" }
 
-[multitenancy.tenants]
-public = { name = "hyperswitch", base_url = "http://localhost:8080", schema = "public", redis_key_prefix = "", clickhouse_database = "default"}


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->
- [x] Enhancement

## Description
<!-- Describe your changes in detail -->
This supports application to take default configuration for multitenancy in case if it's disabled

### Additional Changes
- [x] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
This supports application to take default configuration for multitenancy in case if it's disabled. If it's enabled you need to provide explicit tenant configuration

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
1. When multi tenancy is disabled  and no explicit  tenant configuration is provided in the config. Server will run by taking the default values
2. When multi tenancy is enabled and no explicit tenant configuration is provided in the config. Server startup will throw this error
![Screenshot 2024-07-24 at 3 30 12 PM](https://github.com/user-attachments/assets/c4f9495a-9bf5-424b-bb41-644aff94378d)


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code