### PR TITLE
 ci: obtain files modified from PR instead of git diff

### DIFF
--- a/.github/workflows/CI-pr.yml
+++ b/.github/workflows/CI-pr.yml
@@ -101,10 +101,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: "Fetch base branch"
-        shell: bash
-        run: git fetch origin $GITHUB_BASE_REF --depth 1
-
       - name: Install mold linker
         uses: rui314/setup-mold@v1
         if: ${{ runner.os == 'Linux' }}
@@ -204,10 +200,6 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.ref }}
           token: ${{ steps.generate_token.outputs.token }}
-
-      - name: "Fetch base branch"
-        shell: bash
-        run: git fetch origin $GITHUB_BASE_REF --depth 1
 
       - name: Install mold linker
         uses: rui314/setup-mold@v1

--- a/.github/workflows/CI-pr.yml
+++ b/.github/workflows/CI-pr.yml
@@ -146,6 +146,8 @@ jobs:
 
       - name: Cargo hack
         shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: just ci_hack
 
   # cargo-deny:
@@ -269,6 +271,8 @@ jobs:
 
       - name: Run cargo check
         shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: just ci_hack
 
   typos:

--- a/scripts/ci-checks.sh
+++ b/scripts/ci-checks.sh
@@ -24,7 +24,7 @@ if [[ "${GITHUB_EVENT_NAME:-}" == 'pull_request' ]]; then
       --header 'Accept: application/vnd.github+json' \
       --header 'X-GitHub-Api-Version: 2022-11-28' \
       --paginate \
-      "https://api.github.com/repos/juspay/hyperswitch/pulls/${pull_request_number}/files" \
+      "https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls/${pull_request_number}/files" \
       --jq '.[].filename'
   )"
 

--- a/scripts/ci-checks.sh
+++ b/scripts/ci-checks.sh
@@ -16,29 +16,37 @@ PACKAGES_CHECKED=()
 PACKAGES_SKIPPED=()
 
 # If we are running this on a pull request, then only check for packages that are modified
-if [[ -n "${GITHUB_BASE_REF:-}" ]]; then
+if [[ "${GITHUB_EVENT_NAME:-}" == 'pull_request' ]]; then
+  # Obtain the pull request number and files modified in the pull request
+  pull_request_number="$(jq --raw-output '.pull_request.number' "${GITHUB_EVENT_PATH}")"
+  files_modified="$(
+    gh api \
+      --header 'Accept: application/vnd.github+json' \
+      --header 'X-GitHub-Api-Version: 2022-11-28' \
+      --paginate \
+      "https://api.github.com/repos/juspay/hyperswitch/pulls/${pull_request_number}/files" \
+      --jq '.[].filename'
+  )"
+
   while IFS= read -r package_name; do
-    # Obtain comma-separated list of transitive workspace dependencies for each workspace member
+    # Obtain pipe-separated list of transitive workspace dependencies for each workspace member
     change_paths="$(cargo tree --all-features --no-dedupe --prefix none --package "${package_name}" \
       | grep 'crates/' \
       | sort --unique \
-      | awk --field-separator ' ' '{ printf "crates/%s\n", $1 }' | paste -d ',' -s -)"
-
-    # Store change paths in an array by splitting `change_paths` by comma
-    IFS=',' read -ra change_paths <<< "${change_paths}"
+      | awk --field-separator ' ' '{ printf "crates/%s\n", $1 }' | paste -d '|' -s -)"
 
     # A package must be checked if any of its transitive dependencies (or itself) has been modified
-    if git diff --exit-code --quiet "origin/${GITHUB_BASE_REF}" -- "${change_paths[@]}"; then
-      printf '::debug::Skipping `%s` since none of these paths were modified: %s\n' "${package_name}" "${change_paths[*]}"
-      PACKAGES_SKIPPED+=("${package_name}")
-    else
-      printf '::debug::Checking `%s` since at least one of these paths was modified: %s\n' "${package_name}" "${change_paths[*]}"
+    if grep --quiet --extended-regexp "^(${change_paths})" <<< "${files_modified}"; then
+      printf '::debug::Checking `%s` since at least one of these paths was modified: %s\n' "${package_name}" "${change_paths[*]//|/ }"
       PACKAGES_CHECKED+=("${package_name}")
+    else
+      printf '::debug::Skipping `%s` since none of these paths were modified: %s\n' "${package_name}" "${change_paths[*]//|/ }"
+      PACKAGES_SKIPPED+=("${package_name}")
     fi
   done <<< "${workspace_members}"
   printf '::notice::Packages checked: %s; Packages skipped: %s\n' "${PACKAGES_CHECKED[*]}" "${PACKAGES_SKIPPED[*]}"
 
-  packages_checked=$(printf '%s\n' "${PACKAGES_CHECKED[@]}" | jq -R . | jq -s .)
+  packages_checked="$(jq --compact-output --null-input '$ARGS.positional' --args -- "${PACKAGES_CHECKED[@]}")"
 
   crates_with_features="$(cargo metadata --format-version 1 --no-deps \
     | jq \
@@ -92,7 +100,7 @@ while IFS= read -r crate && [[ -n "${crate}" ]]; do
   all_commands+=("$command")
 done <<< "${crates_without_v1_feature}"
 
-if (( ${#all_commands[@]} == 0 )); then
+if ((${#all_commands[@]} == 0)); then
   echo "There are no commands to be be executed"
   exit 0
 fi


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [x] CI/CD

## Description
<!-- Describe your changes in detail -->
This PR updates the CI check script to obtain the modified files from the PR instead of via `git diff`, since obtaining it from the PR would give us more accurate results.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
Using `git diff` to obtain the diff of files modified can result in incorrect diffs, specifically if the base branch has had recent commits which modify Rust code, while the PR itself does not modify any Rust code. In such situations, taking a `git diff` would report that the PR involves Rust code changes, since `origin/main` (for example) reflects the latest state of the `main` branch, but not when the PR was last synced with the `main` branch.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Test commits on this PR branch.

1. When no code files were modified ([commit `0c973de`](https://github.com/juspay/hyperswitch/pull/5436/commits/0c973de8018dfc52da787fb7a7c47a1c1d9a78c9)), no checks were run:
   Run: https://github.com/juspay/hyperswitch/actions/runs/10084188861/job/27882446903
   ![Screenshot of no checks run](https://github.com/user-attachments/assets/6217f43a-3b3d-494a-ad0f-3573d775e24b)

2. When a file was created in the `euclid` crate ([commit `a06e506`](https://github.com/juspay/hyperswitch/pull/5436/commits/a06e5060d8874cf34db8a80d999a46dd8b579b20)), the dependent crates would have been checked:
   Run: https://github.com/juspay/hyperswitch/actions/runs/10084324676/job/27882883011
   ![Screenshot of packages depending on `euclid` being checked](https://github.com/user-attachments/assets/5ad79f70-5149-4e99-b8e3-d7a5dc150b5d)


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
