### PR TITLE
fix: use application decryption by default for decrypting merchant and user DEK

### DIFF
--- a/crates/hyperswitch_domain_models/src/merchant_key_store.rs
+++ b/crates/hyperswitch_domain_models/src/merchant_key_store.rs
@@ -61,7 +61,7 @@ impl super::behaviour::Conversion for MerchantKeyStore {
     }
 }
 
-/// This is a temprory function to decrypt the merchant key store within application
+/// This is a temporary function to decrypt the merchant key store within application
 /// Since key in merchant key store is encrypted with master key in the application, decrypt can't be done with key manager service.
 /// Once application merchant key store is deprecated, this method should be removed.
 async fn decrypt_merchant_key_store(

--- a/crates/hyperswitch_domain_models/src/type_encryption.rs
+++ b/crates/hyperswitch_domain_models/src/type_encryption.rs
@@ -990,7 +990,7 @@ where
     }
 }
 
-mod metrics {
+pub mod metrics {
     use router_env::{counter_metric, global_meter, histogram_metric, metrics_context, once_cell};
 
     metrics_context!(CONTEXT);

--- a/crates/hyperswitch_domain_models/src/type_encryption.rs
+++ b/crates/hyperswitch_domain_models/src/type_encryption.rs
@@ -69,6 +69,10 @@ mod encrypt {
             crypt_algo: V,
         ) -> CustomResult<Self, errors::CryptoError>;
 
+        /// Note to developer: While deprecating/removing this method please make sure
+        /// to remove own decrypt implementation of Merchant keystore and User keystore
+        /// crates/router/src/types/domain/user_key_store.rs
+        /// crates/hyperswitch_domain_models/src/merchant_key_store.rs
         async fn decrypt(
             encrypted_data: Encryption,
             key: &[u8],
@@ -986,7 +990,7 @@ where
     }
 }
 
-pub(crate) mod metrics {
+mod metrics {
     use router_env::{counter_metric, global_meter, histogram_metric, metrics_context, once_cell};
 
     metrics_context!(CONTEXT);

--- a/crates/router/src/types/domain/user_key_store.rs
+++ b/crates/router/src/types/domain/user_key_store.rs
@@ -63,7 +63,7 @@ impl super::behaviour::Conversion for UserKeyStore {
     }
 }
 
-/// This is a temprory function to decrypt the user key store within application
+/// This is a temporary function to decrypt the user key store within application
 /// Since key in user key store is encrypted with master key in the application, decrypt can't be done with key manager service.
 /// Once application user key store is deprecated, this method should be removed.
 async fn decrypt_user_key_store(


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
Merchant and User DEK's were encrypted with Master key in the application. Keymanager service doesn't have context about Master key, So decryption of the DEK will always fail in the Keymanager service. To overcome this User & Merchant DEK's should be decrypted by the application itself, till the time both key stores were deprecated.


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
decryption of DEK always fails in the keymanager service since both were encrypted with master key in the application. Unnecessary decryption failure should be avoided


## How did you test it?
Manual testing


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
