### PR TITLE
refactor(connector): added amount conversion framework for Boku

### DIFF
--- a/crates/router/src/connector/boku.rs
+++ b/crates/router/src/connector/boku.rs
@@ -1,6 +1,10 @@
 pub mod transformers;
 
-use common_utils::{ext_traits::XmlExt, request::RequestContent, types::{AmountConvertor, MinorUnitForConnector, MinorUnit}};
+use common_utils::{
+    ext_traits::XmlExt,
+    request::RequestContent,
+    types::{AmountConvertor, MinorUnit, MinorUnitForConnector},
+};
 use diesel_models::enums;
 use error_stack::{report, Report, ResultExt};
 use masking::{ExposeInterface, PeekInterface, Secret, WithType};
@@ -505,7 +509,6 @@ impl ConnectorIntegration<api::Execute, types::RefundsData, types::RefundsRespon
         req: &types::RefundsRouterData<api::Execute>,
         _connectors: &settings::Connectors,
     ) -> CustomResult<RequestContent, errors::ConnectorError> {
-
         let refund_amount = connector_utils::convert_amount(
             self.amount_converter,
             req.request.minor_refund_amount,

--- a/crates/router/src/connector/boku.rs
+++ b/crates/router/src/connector/boku.rs
@@ -1,7 +1,6 @@
 pub mod transformers;
-use std::fmt::Debug;
 
-use common_utils::{ext_traits::XmlExt, request::RequestContent};
+use common_utils::{ext_traits::XmlExt, request::RequestContent, types::{AmountConvertor, MinorUnitForConnector, MinorUnit}};
 use diesel_models::enums;
 use error_stack::{report, Report, ResultExt};
 use masking::{ExposeInterface, PeekInterface, Secret, WithType};
@@ -32,8 +31,18 @@ use crate::{
     utils::{BytesExt, OptionExt},
 };
 
-#[derive(Debug, Clone)]
-pub struct Boku;
+#[derive(Clone)]
+pub struct Boku {
+    amount_converter: &'static (dyn AmountConvertor<Output = MinorUnit> + Sync),
+}
+
+impl Boku {
+    pub fn new() -> &'static Self {
+        &Self {
+            amount_converter: &MinorUnitForConnector,
+        }
+    }
+}
 
 impl api::Payment for Boku {}
 impl api::PaymentSession for Boku {}
@@ -231,7 +240,14 @@ impl ConnectorIntegration<api::Authorize, types::PaymentsAuthorizeData, types::P
         req: &types::PaymentsAuthorizeRouterData,
         _connectors: &settings::Connectors,
     ) -> CustomResult<RequestContent, errors::ConnectorError> {
-        let connector_req = boku::BokuPaymentsRequest::try_from(req)?;
+        let amount = connector_utils::convert_amount(
+            self.amount_converter,
+            req.request.minor_amount,
+            req.request.currency,
+        )?;
+
+        let connector_router_data = boku::BokuRouterData::from((amount, req));
+        let connector_req = boku::BokuPaymentsRequest::try_from(&connector_router_data)?;
         Ok(RequestContent::Xml(Box::new(connector_req)))
     }
 
@@ -489,7 +505,15 @@ impl ConnectorIntegration<api::Execute, types::RefundsData, types::RefundsRespon
         req: &types::RefundsRouterData<api::Execute>,
         _connectors: &settings::Connectors,
     ) -> CustomResult<RequestContent, errors::ConnectorError> {
-        let connector_req = boku::BokuRefundRequest::try_from(req)?;
+
+        let refund_amount = connector_utils::convert_amount(
+            self.amount_converter,
+            req.request.minor_refund_amount,
+            req.request.currency,
+        )?;
+
+        let connector_router_data = boku::BokuRouterData::from((refund_amount, req));
+        let connector_req = boku::BokuRefundRequest::try_from(&connector_router_data)?;
         Ok(RequestContent::Xml(Box::new(connector_req)))
     }
 

--- a/crates/router/src/connector/boku/transformers.rs
+++ b/crates/router/src/connector/boku/transformers.rs
@@ -1,5 +1,6 @@
 use std::fmt;
 
+use common_utils::types::MinorUnit;
 use masking::Secret;
 use serde::{Deserialize, Serialize};
 use url::Url;
@@ -12,6 +13,21 @@ use crate::{
     types::{self, api, domain, storage::enums},
 };
 
+#[derive(Debug, Serialize)]
+pub struct BokuRouterData<T> {
+    pub amount: MinorUnit,
+    pub router_data: T,
+}
+
+impl<T> From<(MinorUnit, T)> for BokuRouterData<T> {
+    fn from((amount, router_data): (MinorUnit, T)) -> Self {
+        Self {
+            amount,
+            router_data,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum BokuPaymentsRequest {
@@ -21,7 +37,7 @@ pub enum BokuPaymentsRequest {
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct SingleChargeData {
-    total_amount: i64,
+    total_amount: MinorUnit,
     currency: String,
     country: String,
     merchant_id: Secret<String>,
@@ -74,10 +90,10 @@ struct BokuHostedData {
     forward_url: String,
 }
 
-impl TryFrom<&types::PaymentsAuthorizeRouterData> for BokuPaymentsRequest {
+impl TryFrom<&BokuRouterData<&types::PaymentsAuthorizeRouterData>> for BokuPaymentsRequest {
     type Error = error_stack::Report<errors::ConnectorError>;
-    fn try_from(item: &types::PaymentsAuthorizeRouterData) -> Result<Self, Self::Error> {
-        match item.request.payment_method_data.clone() {
+    fn try_from(item: &BokuRouterData<&types::PaymentsAuthorizeRouterData>) -> Result<Self, Self::Error> {
+        match item.router_data.request.payment_method_data.clone() {
             domain::PaymentMethodData::Wallet(wallet_data) => Self::try_from((item, &wallet_data)),
             domain::PaymentMethodData::Card(_)
             | domain::PaymentMethodData::CardRedirect(_)
@@ -102,12 +118,13 @@ impl TryFrom<&types::PaymentsAuthorizeRouterData> for BokuPaymentsRequest {
     }
 }
 
-impl TryFrom<(&types::PaymentsAuthorizeRouterData, &domain::WalletData)> for BokuPaymentsRequest {
+impl TryFrom<(&BokuRouterData<&types::PaymentsAuthorizeRouterData>, &domain::WalletData)> for BokuPaymentsRequest {
     type Error = error_stack::Report<errors::ConnectorError>;
     fn try_from(
-        value: (&types::PaymentsAuthorizeRouterData, &domain::WalletData),
+        value: (&BokuRouterData<&types::PaymentsAuthorizeRouterData>, &domain::WalletData),
     ) -> Result<Self, Self::Error> {
-        let (item, wallet_data) = value;
+        let (item_router_data, wallet_data) = value;
+        let item = item_router_data.router_data;
         let address = item.get_billing_address()?;
         let country = address.get_country()?.to_string();
         let payment_method = get_wallet_type(wallet_data)?;
@@ -115,7 +132,7 @@ impl TryFrom<(&types::PaymentsAuthorizeRouterData, &domain::WalletData)> for Bok
         let auth_type = BokuAuthType::try_from(&item.connector_auth_type)?;
         let merchant_item_description = item.get_description()?;
         let payment_data = SingleChargeData {
-            total_amount: item.request.amount,
+            total_amount: item_router_data.amount,
             currency: item.request.currency.to_string(),
             country,
             merchant_id: auth_type.merchant_id,
@@ -320,7 +337,7 @@ fn get_psync_response(
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename = "refund-charge-request")]
 pub struct BokuRefundRequest {
-    refund_amount: i64,
+    refund_amount: MinorUnit,
     merchant_id: Secret<String>,
     merchant_request_id: String,
     merchant_refund_id: Secret<String>,
@@ -341,16 +358,16 @@ impl fmt::Display for BokuRefundReasonCode {
     }
 }
 
-impl<F> TryFrom<&types::RefundsRouterData<F>> for BokuRefundRequest {
+impl<F> TryFrom<&BokuRouterData<&types::RefundsRouterData<F>>> for BokuRefundRequest {
     type Error = error_stack::Report<errors::ConnectorError>;
-    fn try_from(item: &types::RefundsRouterData<F>) -> Result<Self, Self::Error> {
-        let auth_type = BokuAuthType::try_from(&item.connector_auth_type)?;
+    fn try_from(item: &BokuRouterData<&types::RefundsRouterData<F>>) -> Result<Self, Self::Error> {
+        let auth_type = BokuAuthType::try_from(&item.router_data.connector_auth_type)?;
         let payment_data = Self {
-            refund_amount: item.request.refund_amount,
+            refund_amount: item.amount,
             merchant_id: auth_type.merchant_id,
-            merchant_refund_id: Secret::new(item.request.refund_id.to_string()),
+            merchant_refund_id: Secret::new(item.router_data.request.refund_id.to_string()),
             merchant_request_id: Uuid::new_v4().to_string(),
-            charge_id: item.request.connector_transaction_id.to_string(),
+            charge_id: item.router_data.request.connector_transaction_id.to_string(),
             reason_code: BokuRefundReasonCode::NonFulfillment.to_string(),
         };
 

--- a/crates/router/src/connector/boku/transformers.rs
+++ b/crates/router/src/connector/boku/transformers.rs
@@ -92,7 +92,9 @@ struct BokuHostedData {
 
 impl TryFrom<&BokuRouterData<&types::PaymentsAuthorizeRouterData>> for BokuPaymentsRequest {
     type Error = error_stack::Report<errors::ConnectorError>;
-    fn try_from(item: &BokuRouterData<&types::PaymentsAuthorizeRouterData>) -> Result<Self, Self::Error> {
+    fn try_from(
+        item: &BokuRouterData<&types::PaymentsAuthorizeRouterData>,
+    ) -> Result<Self, Self::Error> {
         match item.router_data.request.payment_method_data.clone() {
             domain::PaymentMethodData::Wallet(wallet_data) => Self::try_from((item, &wallet_data)),
             domain::PaymentMethodData::Card(_)
@@ -118,10 +120,18 @@ impl TryFrom<&BokuRouterData<&types::PaymentsAuthorizeRouterData>> for BokuPayme
     }
 }
 
-impl TryFrom<(&BokuRouterData<&types::PaymentsAuthorizeRouterData>, &domain::WalletData)> for BokuPaymentsRequest {
+impl
+    TryFrom<(
+        &BokuRouterData<&types::PaymentsAuthorizeRouterData>,
+        &domain::WalletData,
+    )> for BokuPaymentsRequest
+{
     type Error = error_stack::Report<errors::ConnectorError>;
     fn try_from(
-        value: (&BokuRouterData<&types::PaymentsAuthorizeRouterData>, &domain::WalletData),
+        value: (
+            &BokuRouterData<&types::PaymentsAuthorizeRouterData>,
+            &domain::WalletData,
+        ),
     ) -> Result<Self, Self::Error> {
         let (item_router_data, wallet_data) = value;
         let item = item_router_data.router_data;
@@ -367,7 +377,11 @@ impl<F> TryFrom<&BokuRouterData<&types::RefundsRouterData<F>>> for BokuRefundReq
             merchant_id: auth_type.merchant_id,
             merchant_refund_id: Secret::new(item.router_data.request.refund_id.to_string()),
             merchant_request_id: Uuid::new_v4().to_string(),
-            charge_id: item.router_data.request.connector_transaction_id.to_string(),
+            charge_id: item
+                .router_data
+                .request
+                .connector_transaction_id
+                .to_string(),
             reason_code: BokuRefundReasonCode::NonFulfillment.to_string(),
         };
 

--- a/crates/router/src/types/api.rs
+++ b/crates/router/src/types/api.rs
@@ -321,7 +321,7 @@ impl ConnectorData {
                 enums::Connector::Bluesnap => {
                     Ok(ConnectorEnum::Old(Box::new(connector::Bluesnap::new())))
                 }
-                enums::Connector::Boku => Ok(ConnectorEnum::Old(Box::new(&connector::Boku))),
+                enums::Connector::Boku => Ok(ConnectorEnum::Old(Box::new(connector::Boku::new()))),
                 enums::Connector::Braintree => {
                     Ok(ConnectorEnum::Old(Box::new(&connector::Braintree)))
                 }

--- a/crates/router/tests/connectors/boku.rs
+++ b/crates/router/tests/connectors/boku.rs
@@ -14,7 +14,7 @@ impl utils::Connector for BokuTest {
             Box::new(Boku::new()),
             types::Connector::Boku,
             types::api::GetToken::Connector,
-        None,
+            None,
         )
     }
 

--- a/crates/router/tests/connectors/boku.rs
+++ b/crates/router/tests/connectors/boku.rs
@@ -11,10 +11,10 @@ impl utils::Connector for BokuTest {
     fn get_data(&self) -> types::api::ConnectorData {
         use router::connector::Boku;
         utils::construct_connector_data_old(
-            Box::new(&Boku),
+            Box::new(Boku::new()),
             types::Connector::Boku,
             types::api::GetToken::Connector,
-            None,
+        None,
         )
     }
 


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->
- [x] Refactoring

## Description
<!-- Describe your changes in detail -->
This PR do changes to Boku connector for framework amount conversions and Boku accepts the amount in MinorUnit

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
https://github.com/juspay/hyperswitch-cloud/issues/6128


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
We do not have sandbox credential for this connector

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
