### PR TITLE
ci(cypress): Added shipping address test cases for PML

### DIFF
--- a/cypress-tests/cypress/e2e/PaymentMethodListTest/00000-PaymentMethodListTests.cy.js
+++ b/cypress-tests/cypress/e2e/PaymentMethodListTest/00000-PaymentMethodListTests.cy.js
@@ -400,7 +400,7 @@ describe("Payment Method list using Constraint Graph flow tests", () => {
   context(
     `
    MCA1 -> Stripe configured with card credit\n
-   MCA1 -> Cybersource configured with card credit = { currency = "USD" }\n
+   MCA2 -> Cybersource configured with card credit = { currency = "USD" }\n
    Payment is done with currency as USD and no billing address\n
    The resultant Payment Method list should have both\n
    Stripe and cybersource for credit\n

--- a/cypress-tests/cypress/e2e/PaymentMethodListTest/00000-PaymentMethodListTests.cy.js
+++ b/cypress-tests/cypress/e2e/PaymentMethodListTest/00000-PaymentMethodListTests.cy.js
@@ -15,11 +15,6 @@ import getConnectorDetails from "../PaymentMethodListUtils/Utils";
 
 let globalState;
 describe("Payment Method list using Constraint Graph flow tests", () => {
-  // Testing for scenario:
-  // MCA1 -> Stripe configured with ideal = { country = "NL", currency = "EUR" }
-  // MCA2 -> Cybersource configured with credit = { currency = "USD" }
-  // Payment is done with currency as EUR and no billing address
-  // The resultant Payment Method list should only have ideal with stripe
   context(
     `
     MCA1 -> Stripe configured with ideal = { country = "NL", currency = "EUR" }\n
@@ -96,11 +91,6 @@ describe("Payment Method list using Constraint Graph flow tests", () => {
     }
   );
 
-  // Testing for scenario:
-  // MCA1 -> Stripe configured with ideal = { country = "NL", currency = "EUR" }
-  // MCA2 -> Cybersource configured with credit = { currency = "USD" }
-  // Payment is done with currency as INR and no billing address
-  // The resultant Payment Method list shouldn't have any payment method
   context(
     `
     MCA1 -> Stripe configured with ideal = { country = "NL", currency = "EUR" }\n
@@ -177,11 +167,6 @@ describe("Payment Method list using Constraint Graph flow tests", () => {
     }
   );
 
-  // Testing for scenario:
-  // MCA1 -> Stripe configured with credit = { country = "US" }
-  // MCA2 -> Cybersource configured with credit = { country = "US" }
-  // Payment is done with country as US and currency as USD
-  // The resultant Payment Method list should have both Stripe and cybersource
   context(
     `
    MCA1 -> Stripe configured with credit = { country = "US" }\n
@@ -258,11 +243,6 @@ describe("Payment Method list using Constraint Graph flow tests", () => {
     }
   );
 
-  // Testing for scenario:
-  // MCA1 -> Stripe configured with ideal = { country = "NL", currency = "EUR" }
-  // MCA2 -> Cybersource configured with ideal = { country = "NL", currency = "EUR" }
-  // Payment is done with country as US and currency as EUR
-  // The resultant Payment Method list shouldn't have anything
   context(
     `
     MCA1 -> Stripe configured with ideal = { country = "NL", currency = "EUR" }\n
@@ -339,13 +319,6 @@ describe("Payment Method list using Constraint Graph flow tests", () => {
     }
   );
 
-  // Testing for scenario:
-  // MCA1 -> Stripe configured with card credit no configs present
-  // MCA1 -> Cybersource configured with card credit = { currency = "USD" }
-  // and ideal (default config present as = { country = "NL", currency = "EUR" } )
-  // Payment is done with country as IN and currency as USD
-  // The resultant Payment Method list should have
-  // Stripe and cybersource both for credit and none for ideal
   context(
     `
     MCA1 -> Stripe configured with card credit no configs present\n
@@ -424,12 +397,6 @@ describe("Payment Method list using Constraint Graph flow tests", () => {
     }
   );
 
-  // Testing for scenario:
-  // MCA1 -> Stripe configured with card credit
-  // MCA1 -> Cybersource configured with card credit = { currency = "USD" }
-  // Payment is done with currency as USD and no billing address
-  // The resultant Payment Method list should have
-  // Stripe and cybersource both for credit
   context(
     `
    MCA1 -> Stripe configured with card credit\n

--- a/cypress-tests/cypress/e2e/PaymentMethodListTest/00000-PaymentMethodListTests.cy.js
+++ b/cypress-tests/cypress/e2e/PaymentMethodListTest/00000-PaymentMethodListTests.cy.js
@@ -316,7 +316,7 @@ describe("Payment Method list using Constraint Graph flow tests", () => {
         let res_data = data["Response"];
 
         cy.createPaymentIntentTest(
-          create_payment_body_with_currency_country("EUR", "US"),
+          create_payment_body_with_currency_country("EUR", "US", "US"),
           req_data,
           res_data,
           "no_three_ds",
@@ -401,7 +401,7 @@ describe("Payment Method list using Constraint Graph flow tests", () => {
         let res_data = data["Response"];
 
         cy.createPaymentIntentTest(
-          create_payment_body_with_currency_country("USD", "IN"),
+          create_payment_body_with_currency_country("USD", "IN", "IN"),
           req_data,
           res_data,
           "no_three_ds",
@@ -417,6 +417,165 @@ describe("Payment Method list using Constraint Graph flow tests", () => {
             "PmListWithCreditTwoConnector"
           ];
         cy.paymentMethodListTestTwoConnectorsForOnePaymentMethodCredit(
+          data,
+          globalState
+        );
+      });
+    }
+  );
+
+  // Testing for scenario:
+  // MCA1 -> Stripe configured with card credit
+  // MCA1 -> Cybersource configured with card credit = { currency = "USD" }
+  // Payment is done with currency as USD and no billing address
+  // The resultant Payment Method list should have
+  // Stripe and cybersource both for credit
+  context(
+    `
+   MCA1 -> Stripe configured with card credit\n
+   MCA1 -> Cybersource configured with card credit = { currency = "USD" }\n
+   Payment is done with currency as USD and no billing address\n
+   The resultant Payment Method list should have both\n
+   Stripe and cybersource for credit\n
+     `,
+    () => {
+      before("seed global state", () => {
+        cy.task("getGlobalState").then((state) => {
+          globalState = new State(state);
+        });
+      });
+
+      after("flush global state", () => {
+        cy.task("setGlobalState", globalState.data);
+      });
+
+      it("merchant-create-call-test", () => {
+        cy.merchantCreateCallTest(merchantCreateBody, globalState);
+      });
+
+      it("api-key-create-call-test", () => {
+        cy.apiKeyCreateTest(apiKeyCreateBody, globalState);
+      });
+
+      // stripe connector create with card credit enabled
+      it("connector-create-call-test", () => {
+        cy.createNamedConnectorCallTest(
+          createConnectorBody,
+          card_credit_enabled,
+          globalState,
+          "stripe"
+        );
+      });
+
+      // cybersource connector create with card credit 
+      it("connector-create-call-test", () => {
+        cy.createNamedConnectorCallTest(
+          createConnectorBody,
+          card_credit_enabled,
+          globalState,
+          "cybersource"
+        );
+      });
+
+      // creating payment with currency as USD and billing address as IN
+      it("create-payment-call-test", () => {
+        let data = getConnectorDetails("stripe")["pm_list"]["PaymentIntent"];
+        let req_data = data["RequestCurrencyUSD"];
+        let res_data = data["Response"];
+
+        cy.createPaymentIntentTest(
+          create_payment_body_with_currency("USD"),
+          req_data,
+          res_data,
+          "no_three_ds",
+          "automatic",
+          globalState
+        );
+      });
+
+      // payment method list which should have credit with stripe and cybersource and no ideal
+      it("payment-method-list-call-test", () => {
+        let data =
+          getConnectorDetails("stripe")["pm_list"]["PmListResponse"][
+            "PmListWithCreditTwoConnector"
+          ];
+        cy.paymentMethodListTestTwoConnectorsForOnePaymentMethodCredit(
+          data,
+          globalState
+        );
+      });
+    }
+  );
+
+  context(
+    `
+    MCA1 -> Stripe configured with ideal = { country = "NL", currency = "EUR" }\n
+    MCA2 -> Cybersource configured with credit = { currency = "USD" }\n
+    Payment is done with currency as EUR and billing country as NL , shipping country as US\n
+    The resultant Payment Method list should only have ideal with stripe\n
+    `,
+    () => {
+      before("seed global state", () => {
+        cy.task("getGlobalState").then((state) => {
+          globalState = new State(state);
+        });
+      });
+
+      after("flush global state", () => {
+        cy.task("setGlobalState", globalState.data);
+      });
+
+      it("merchant-create-call-test", () => {
+        cy.merchantCreateCallTest(merchantCreateBody, globalState);
+      });
+
+      it("api-key-create-call-test", () => {
+        cy.apiKeyCreateTest(apiKeyCreateBody, globalState);
+      });
+
+      // stripe connector create with ideal enabled
+      it("connector-create-call-test", () => {
+        cy.createNamedConnectorCallTest(
+          createConnectorBody,
+          bank_redirect_ideal_enabled,
+          globalState,
+          "stripe"
+        );
+      });
+
+      // cybersource connector create with card credit enabled
+      it("connector-create-call-test", () => {
+        cy.createNamedConnectorCallTest(
+          createConnectorBody,
+          card_credit_enabled,
+          globalState,
+          "cybersource"
+        );
+      });
+
+      // creating payment with currency as EUR and no billing address
+      it("create-payment-call-test", () => {
+        let data = getConnectorDetails("stripe")["pm_list"]["PaymentIntent"];
+        let req_data = data["RequestCurrencyEUR"];
+        let res_data = data["Response"];
+
+        cy.createPaymentIntentTest(
+          create_payment_body_with_currency_country("EUR", "NL", "US"),
+          req_data,
+          res_data,
+          "no_three_ds",
+          "automatic",
+          globalState
+        );
+      });
+
+      // payment method list which should only have ideal with stripe
+      it("payment-method-list-call-test", () => {
+        let data =
+          getConnectorDetails("stripe")["pm_list"]["PmListResponse"][
+            "PmListWithStripeForIdeal"
+          ];
+        cy.paymentMethodListTestLessThanEqualToOnePaymentMethod(
           data,
           globalState
         );

--- a/cypress-tests/cypress/e2e/PaymentMethodListUtils/Commons.js
+++ b/cypress-tests/cypress/e2e/PaymentMethodListUtils/Commons.js
@@ -160,7 +160,7 @@ export const create_payment_body_with_currency_country = (
       last_name: "Joseph",
     },
     phone: {
-      number: "9888888888",
+      number: "9123456789",
       country_code: "+91",
     },
     email: "example@example.com",

--- a/cypress-tests/cypress/e2e/PaymentMethodListUtils/Commons.js
+++ b/cypress-tests/cypress/e2e/PaymentMethodListUtils/Commons.js
@@ -114,7 +114,8 @@ export const bank_redirect_ideal_and_credit_enabled = [
 
 export const create_payment_body_with_currency_country = (
   currency,
-  billingCountry
+  billingCountry,
+  shippingCountry
 ) => ({
   currency: currency,
   amount: 6500,
@@ -142,6 +143,24 @@ export const create_payment_body_with_currency_country = (
     },
     phone: {
       number: "8056594427",
+      country_code: "+91",
+    },
+    email: "example@example.com",
+  },
+  shipping: {
+    address: {
+      line1: "130",
+      line2: "Koramangala",
+      line3: "Ramnagar",
+      city: "Bengaluru",
+      state: "Karnataka",
+      zip: "560011",
+      country: shippingCountry, // Shipping country from parameter
+      first_name: "John",
+      last_name: "Joseph",
+    },
+    phone: {
+      number: "9888888888",
       country_code: "+91",
     },
     email: "example@example.com",

--- a/cypress-tests/cypress/e2e/PaymentMethodListUtils/Commons.js
+++ b/cypress-tests/cypress/e2e/PaymentMethodListUtils/Commons.js
@@ -142,7 +142,7 @@ export const create_payment_body_with_currency_country = (
       last_name: "Doe",
     },
     phone: {
-      number: "8056594427",
+      number: "9123456789",
       country_code: "+91",
     },
     email: "example@example.com",


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
Added shipping address test cases for payment method list in cypress automation


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
Shipping address test cases wasn't present in the cypress automation 

## How did you test it?
Cypress
- PML alone
<img width="684" alt="image" src="https://github.com/user-attachments/assets/2fe3bbe0-6d54-488d-bfe6-3fcffe7bafb5">

- Stripe
<img width="731" alt="image" src="https://github.com/user-attachments/assets/06b52c9f-b172-44a2-bfb5-5b7a1df2b598">

- Cybersource
<img width="684" alt="image" src="https://github.com/user-attachments/assets/31bad49a-5896-483c-a6bd-afcff3912bb2">

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
