### PR TITLE
fix(payment_link): move redirection fn to global scope for open links

### DIFF
--- a/crates/router/src/core/payment_link/payment_link_initiate/payment_link_initiator.js
+++ b/crates/router/src/core/payment_link/payment_link_initiate/payment_link_initiator.js
@@ -68,15 +68,15 @@ function initializeSDK() {
   setTimeout(() => {
     document.body.removeChild(shimmer);
   }, 500);
+}
 
-  /**
-   * Use - redirect to /payment_link/status
-   */
-  function redirectToStatus() {
-    var arr = window.location.pathname.split("/");
-    arr.splice(0, 2);
-    arr.unshift("status");
-    arr.unshift("payment_link");
-    window.location.href = window.location.origin + "/" + arr.join("/");
-  }
+/**
+ * Use - redirect to /payment_link/status
+ */
+function redirectToStatus() {
+  var arr = window.location.pathname.split("/");
+  arr.splice(0, 2);
+  arr.unshift("status");
+  arr.unshift("payment_link");
+  window.location.href = window.location.origin + "/" + arr.join("/");
 }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
Described in https://github.com/juspay/hyperswitch/issues/5495


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->

## How did you test it?
<details>
<summary>1. Create non 3DS open payment link</summary>
curl --location 'https://sandbox.hyperswitch.io/payments' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: API_KEY' \
--data-raw '{
    "customer_id": "cus_05845u0qSuOENDnHLqTl",
    "amount": 100,
    "currency": "USD",
    "payment_link": true,
    "authentication_type": "no_three_ds",
    "connector": [
        "stripe"
    ],
    "billing": {
        "address": {
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "city": "San Fransico",
            "state": "CA",
            "zip": "94122",
            "country": "US",
            "first_name": "John",
            "last_name": "Doe"
        },
        "phone": {
            "number": "8056594427",
            "country_code": "+91"
        }
    },
    "email": "john.doe@example.com",
    "session_expiry": 1000000,
    "return_url": "https://google.com",
    "payment_link_config": {
        "theme": "#14356f",
        "logo": "https://hyperswitch.io/favicon.ico",
        "seller_name": "HyperSwitch Inc."
    }
}'
</details>

Complete the payment, and wait for redirection


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
