### PR TITLE
feat(router): add accept language header middleware 

### DIFF
--- a/config/deployments/integration_test.toml
+++ b/config/deployments/integration_test.toml
@@ -350,7 +350,7 @@ outgoing_enabled = true
 connectors_with_webhook_source_verification_call = "paypal"         # List of connectors which has additional source verification api-call
 
 [unmasked_headers]
-keys = "user-agent"
+keys = "accept-language,user-agent"
 
 [saved_payment_methods]
 sdk_eligible_payment_methods = "card"

--- a/config/deployments/production.toml
+++ b/config/deployments/production.toml
@@ -369,7 +369,7 @@ outgoing_enabled = true
 connectors_with_webhook_source_verification_call = "paypal"     # List of connectors which has additional source verification api-call
 
 [unmasked_headers]
-keys = "user-agent"
+keys = "accept-language,user-agent"
 
 [saved_payment_methods]
 sdk_eligible_payment_methods = "card"

--- a/config/deployments/sandbox.toml
+++ b/config/deployments/sandbox.toml
@@ -373,7 +373,7 @@ outgoing_enabled = true
 connectors_with_webhook_source_verification_call = "paypal"        # List of connectors which has additional source verification api-call
 
 [unmasked_headers]
-keys = "user-agent"
+keys = "accept-language,user-agent"
 
 [saved_payment_methods]
 sdk_eligible_payment_methods = "card"

--- a/config/development.toml
+++ b/config/development.toml
@@ -676,7 +676,7 @@ enabled = true
 file_storage_backend = "file_system"
 
 [unmasked_headers]
-keys = "user-agent"
+keys = "accept-language,user-agent"
 
 [opensearch]
 host = "https://localhost:9200"

--- a/config/docker_compose.toml
+++ b/config/docker_compose.toml
@@ -504,7 +504,7 @@ source = "logs"
 file_storage_backend = "file_system"
 
 [unmasked_headers]
-keys = "user-agent"
+keys = "accept-language,user-agent"
 
 [opensearch]
 host = "https://opensearch:9200"

--- a/crates/router/Cargo.toml
+++ b/crates/router/Cargo.toml
@@ -18,7 +18,7 @@ keymanager_create = []
 keymanager_mtls = ["reqwest/rustls-tls", "common_utils/keymanager_mtls"]
 encryption_service = ["hyperswitch_domain_models/encryption_service", "common_utils/encryption_service"]
 frm = ["api_models/frm", "hyperswitch_domain_models/frm", "hyperswitch_connectors/frm", "hyperswitch_interfaces/frm"]
-stripe = ["dep:serde_qs"]
+stripe = []
 release = ["stripe", "email", "accounts_cache", "kv_store", "vergen", "recon", "external_services/aws_kms", "external_services/aws_s3", "keymanager_mtls", "keymanager_create", "encryption_service"]
 oltp = ["storage_impl/oltp"]
 kv_store = ["scheduler/kv_store"]
@@ -96,7 +96,7 @@ rustls-pemfile = "2"
 serde = { version = "1.0.197", features = ["derive"] }
 serde_json = "1.0.115"
 serde_path_to_error = "0.1.16"
-serde_qs = { version = "0.12.0", optional = true }
+serde_qs = "0.12.0"
 serde_repr = "0.1.19"
 serde_urlencoded = "0.7.1"
 serde_with = "3.7.0"

--- a/crates/router/src/lib.rs
+++ b/crates/router/src/lib.rs
@@ -341,6 +341,7 @@ pub fn get_application_builder(
         .wrap(cors::cors(cors))
         // this middleware works only for Http1.1 requests
         .wrap(middleware::Http400RequestDetailsLogger)
+        .wrap(middleware::AddAcceptLanguageHeader)
         .wrap(middleware::LogSpanInitializer)
         .wrap(router_env::tracing_actix_web::TracingLogger::default())
 }

--- a/crates/router/src/middleware.rs
+++ b/crates/router/src/middleware.rs
@@ -382,7 +382,7 @@ where
             if let Some(locale) = locale_param.locale {
                 req.headers_mut().insert(
                     http::header::ACCEPT_LANGUAGE,
-                    http::HeaderValue::from_str(&locale.to_string())?,
+                    http::HeaderValue::from_str(&locale)?,
                 );
             } else if accept_language_header.is_none() {
                 req.headers_mut().insert(

--- a/crates/router/src/middleware.rs
+++ b/crates/router/src/middleware.rs
@@ -367,9 +367,7 @@ where
         let svc = self.service.clone();
         Box::pin(async move {
             let query_params = req.query_string();
-            let locale_param = query_params
-            .split('&')
-            .find_map(|param| {
+            let locale_param = query_params.split('&').find_map(|param| {
                 let mut split = param.split('=');
                 if let (Some(key), Some(value)) = (split.next(), split.next()) {
                     if key == "locale" {
@@ -378,7 +376,8 @@ where
                 }
                 None
             });
-            let accept_language_header = req.headers().get(actix_web::http::header::ACCEPT_LANGUAGE);
+            let accept_language_header =
+                req.headers().get(actix_web::http::header::ACCEPT_LANGUAGE);
             if let Some(locale) = locale_param {
                 req.headers_mut().insert(
                     http::header::HeaderName::from_static("accept-language"),
@@ -395,5 +394,4 @@ where
             Ok(response)
         })
     }
-    
 }

--- a/crates/router/src/middleware.rs
+++ b/crates/router/src/middleware.rs
@@ -366,6 +366,10 @@ where
     fn call(&self, mut req: actix_web::dev::ServiceRequest) -> Self::Future {
         let svc = self.service.clone();
         Box::pin(async move {
+            #[derive(serde::Deserialize)]
+            struct LocaleQueryParam {
+                locale: Option<String>,
+            }
             let query_params = req.query_string();
             let locale_param =
                 serde_qs::from_str::<LocaleQueryParam>(query_params).map_err(|error| {
@@ -374,16 +378,15 @@ where
                         error
                     ))
                 })?;
-            let accept_language_header =
-                req.headers().get(actix_web::http::header::ACCEPT_LANGUAGE);
+            let accept_language_header = req.headers().get(http::header::ACCEPT_LANGUAGE);
             if let Some(locale) = locale_param.locale {
                 req.headers_mut().insert(
-                    http::header::HeaderName::from_static("accept-language"),
+                    http::header::ACCEPT_LANGUAGE,
                     http::HeaderValue::from_str(&locale.to_string())?,
                 );
             } else if accept_language_header.is_none() {
                 req.headers_mut().insert(
-                    http::header::HeaderName::from_static("accept-language"),
+                    http::header::ACCEPT_LANGUAGE,
                     http::HeaderValue::from_static("en"),
                 );
             }
@@ -392,9 +395,4 @@ where
             Ok(response)
         })
     }
-}
-
-#[derive(serde::Deserialize)]
-pub struct LocaleQueryParam {
-    locale: Option<String>,
 }

--- a/loadtest/config/development.toml
+++ b/loadtest/config/development.toml
@@ -342,7 +342,7 @@ client_secret = ""
 partner_id = ""
 
 [unmasked_headers]
-keys = "user-agent"
+keys = "accept-language,user-agent"
 
 [multitenancy]
 enabled = false


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
 add accept language header middleware .
Case 1 : when query parameter locale is present it should overwrite the Accept-Language headers in the middleware for api request.
Case 2: If query parameter is not present then if request have Accept-Language headers, do nothing.

Case 3 : Incase if both query param & header is not present we should add new header Accept-Language header with default value "en".

This feature is meant to be used by internal api's, We will not suggest merchant to send query parameter . SDK will pass this headers to backend to perform backend loaclization. Will consume this header input and perform backend localization in future.
### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
create any api request to hyperswitch with query params locale this should add accept-language header in the request. you can check this in the logs.

```
curl --location 'http://localhost:8080/accounts?locale=en' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: test_admin' \
--data-raw '{
    "merchant_id": "merchant_1722496591",
    "locker_id": "m0010",
    "merchant_name": "NewAge Retailer",
    "merchant_details": {
        "primary_contact_person": "John Test",
        "primary_email": "JohnTest@test.com",
        "primary_phone": "sunt laborum",
        "secondary_contact_person": "John Test2",
        "secondary_email": "JohnTest2@test.com",
        "secondary_phone": "cillum do dolor id",
        "website": "www.example.com",
        "about_business": "Online Retail with a wide selection of organic products for North America",
        "address": {
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "city": "San Fransico",
            "state": "California",
            "zip": "94122",
            "country": "US"
        }
    },
    "return_url": "https://google.com/success",
    "webhook_details": {
        "webhook_url": "https://enz8u459xx5j.x.pipedream.net/",
        "webhook_version": "1.0.1",
        "webhook_username": "ekart_retail",
        "webhook_password": "password_ekart@123",
        "payment_created_enabled": true,
        "payment_succeeded_enabled": true,
        "payment_failed_enabled": true
    },
    "sub_merchants_enabled": false,
    "metadata": {
        "account_name": "transaction_processing",
        "city": "NY",
        "unit": "245"
    }
}'
```

<img width="941" alt="Screenshot 2024-08-01 at 12 47 27 PM" src="https://github.com/user-attachments/assets/9deaae39-8db8-4335-befd-ca4c8dc312c7">


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [X] I formatted the code `cargo +nightly fmt --all`
- [X] I addressed lints thrown by `cargo clippy`
- [X] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
