### PR TITLE
fix(open_payment_links): send displaySavedPaymentMethods as false explicitly for open payment links

### DIFF
--- a/crates/router/src/core/payment_link/payment_link_initiate/payment_link_initiator.js
+++ b/crates/router/src/core/payment_link/payment_link_initiate/payment_link_initiator.js
@@ -41,6 +41,7 @@ function initializeSDK() {
 
   var unifiedCheckoutOptions = {
     displaySavedPaymentMethodsCheckbox: false,
+    displaySavedPaymentMethods: false,
     layout: {
       type: type, //accordion , tabs, spaced accordion
       spacedAccordionItems: paymentDetails.sdk_layout === "spaced_accordion",


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
This PR adds an argument to be sent to the SDK for open payment links. This field controls the listing of SPMs for a given customer. Default value is `true` in SDK, needs to be sent as `false` explicitly during SDK integration

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
Bug fixes; open link is not behaving as expected

## How did you test it?
<details>
<summary>1. Create non 3DS open payment link with an existing customer</summary>
curl --location 'https://sandbox.hyperswitch.io/payments' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: API_KEY' \
--data-raw '{
    "customer_id": "cus_05845u0qSuOENDnHLqTl",
    "amount": 100,
    "currency": "USD",
    "payment_link": true,
    "authentication_type": "no_three_ds",
    "connector": [
        "stripe"
    ],
    "billing": {
        "address": {
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "city": "San Fransico",
            "state": "CA",
            "zip": "94122",
            "country": "US",
            "first_name": "John",
            "last_name": "Doe"
        },
        "phone": {
            "number": "8056594427",
            "country_code": "+91"
        }
    },
    "email": "john.doe@example.com",
    "session_expiry": 1000000,
    "return_url": "https://google.com",
    "payment_link_config": {
        "theme": "#14356f",
        "logo": "https://hyperswitch.io/favicon.ico",
        "seller_name": "HyperSwitch Inc."
    }
}'
</details>

SPMs should not be displayed in the payment link


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
