### PR TITLE
fix: [CYBERSOURCE] Update status handling for AuthorizedPendingReview

### DIFF
--- a/crates/router/src/connector/cybersource/transformers.rs
+++ b/crates/router/src/connector/cybersource/transformers.rs
@@ -1730,8 +1730,7 @@ pub enum CybersourceIncrementalAuthorizationStatus {
 impl ForeignFrom<(CybersourcePaymentStatus, bool)> for enums::AttemptStatus {
     fn foreign_from((status, capture): (CybersourcePaymentStatus, bool)) -> Self {
         match status {
-            CybersourcePaymentStatus::Authorized
-            | CybersourcePaymentStatus::AuthorizedPendingReview => {
+            CybersourcePaymentStatus::Authorized => {
                 if capture {
                     // Because Cybersource will return Payment Status as Authorized even in AutoCapture Payment
                     Self::Charged
@@ -1762,7 +1761,8 @@ impl ForeignFrom<(CybersourcePaymentStatus, bool)> for enums::AttemptStatus {
             CybersourcePaymentStatus::PendingReview
             | CybersourcePaymentStatus::StatusNotReceived
             | CybersourcePaymentStatus::Challenge
-            | CybersourcePaymentStatus::Accepted => Self::Pending,
+            | CybersourcePaymentStatus::Accepted
+            | CybersourcePaymentStatus::AuthorizedPendingReview => Self::Pending,
         }
     }
 }

--- a/crates/router/src/connector/cybersource/transformers.rs
+++ b/crates/router/src/connector/cybersource/transformers.rs
@@ -1738,13 +1738,6 @@ impl ForeignFrom<(CybersourcePaymentStatus, bool)> for enums::AttemptStatus {
                     Self::Authorized
                 }
             }
-            CybersourcePaymentStatus::Pending => {
-                if capture {
-                    Self::Charged
-                } else {
-                    Self::Pending
-                }
-            }
             CybersourcePaymentStatus::Succeeded | CybersourcePaymentStatus::Transmitted => {
                 Self::Charged
             }
@@ -1762,6 +1755,7 @@ impl ForeignFrom<(CybersourcePaymentStatus, bool)> for enums::AttemptStatus {
             | CybersourcePaymentStatus::StatusNotReceived
             | CybersourcePaymentStatus::Challenge
             | CybersourcePaymentStatus::Accepted
+            | CybersourcePaymentStatus::Pending
             | CybersourcePaymentStatus::AuthorizedPendingReview => Self::Pending,
         }
     }
@@ -1770,8 +1764,8 @@ impl ForeignFrom<(CybersourcePaymentStatus, bool)> for enums::AttemptStatus {
 impl From<CybersourceIncrementalAuthorizationStatus> for common_enums::AuthorizationStatus {
     fn from(item: CybersourceIncrementalAuthorizationStatus) -> Self {
         match item {
-            CybersourceIncrementalAuthorizationStatus::Authorized
-            | CybersourceIncrementalAuthorizationStatus::AuthorizedPendingReview => Self::Success,
+            CybersourceIncrementalAuthorizationStatus::Authorized => Self::Success,
+            CybersourceIncrementalAuthorizationStatus::AuthorizedPendingReview => Self::Processing,
             CybersourceIncrementalAuthorizationStatus::Declined => Self::Failure,
         }
     }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
The status mapping for AuthorizedPendingReview status from Cybersource is updated. These payments will now be marked as pending.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
https://github.com/juspay/hyperswitch/issues/5535

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
For testing this PR, we need to generate a AVS mismatch error at Cybersource which should mark the payment as failure. For triggering this one needs to enable strong fraud checks on cybersource dashboard before starting testing.
Request:
```
curl --location 'http://localhost:8080/payments' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: dev_yvZV0B0RAfH0T1djPkbJicPaQJ34DgMFFpLJiHLs7z4qaC2jZoYx0HPGKSyHRUhh' \
--data-raw '{
  "amount": 1404,
  "currency": "USD",
  "confirm": true,
  "capture_method": "automatic",
  "capture_on": "2022-09-10T10:11:12Z",
  "customer_id": "CustomerX",
  "email": "guest@example.com",
  "authentication_type": "no_three_ds",
  "return_url": "https://google.com",
  "payment_method": "card",
  "payment_method_type": "credit",
  "payment_method_data": {
    "card": {
      "card_number": "4111111111111111",
      "card_exp_month": "12",
      "card_exp_year": "30",
      "card_holder_name": "joseph Doe",
      "card_cvc": "029"
    }
  },
  "billing": {
    "address": {
      "line1": "cq",
      "city": "San Francisco",
      "state": "California",
      "zip": "46205",
      "country": "US",
      "first_name": "joseph",
      "last_name": "doe"
    },
    "phone": {
      "number": "32674512965",
      "country_code": "+1"
    }
  }
}'
```

Response:
```
{
    "payment_id": "pay_ZtjVn6KUxEosbBZOhvNN",
    "merchant_id": "merchant_1722938867",
    "status": "failed",
    "amount": 1404,
    "net_amount": 1404,
    "amount_capturable": 0,
    "amount_received": null,
    "connector": "cybersource",
    "client_secret": "pay_ZtjVn6KUxEosbBZOhvNN_secret_YmMWhOrVkWp06v2iNSGl",
    "created": "2024-08-06T10:07:50.672Z",
    "currency": "USD",
    "customer_id": "CustomerX",
    "customer": {
        "id": "CustomerX",
        "name": null,
        "email": "guest@example.com",
        "phone": null,
        "phone_country_code": null
    },
    "description": null,
    "refunds": null,
    "disputes": null,
    "mandate_id": null,
    "mandate_data": null,
    "setup_future_usage": null,
    "off_session": null,
    "capture_on": null,
    "capture_method": "automatic",
    "payment_method": "card",
    "payment_method_data": {
        "card": {
            "last4": "1111",
            "card_type": null,
            "card_network": null,
            "card_issuer": null,
            "card_issuing_country": null,
            "card_isin": "411111",
            "card_extended_bin": null,
            "card_exp_month": "12",
            "card_exp_year": "30",
            "card_holder_name": "joseph Doe",
            "payment_checks": null,
            "authentication_data": null
        },
        "billing": null
    },
    "payment_token": "token_IjZz7k1LftFf7BgrFpY5",
    "shipping": null,
    "billing": {
        "address": {
            "city": "San Francisco",
            "country": "US",
            "line1": "cq",
            "line2": null,
            "line3": null,
            "zip": "46205",
            "state": "California",
            "first_name": "joseph",
            "last_name": "doe"
        },
        "phone": {
            "number": "32674512965",
            "country_code": "+1"
        },
        "email": null
    },
    "order_details": null,
    "email": "guest@example.com",
    "name": null,
    "phone": null,
    "return_url": "https://google.com/",
    "authentication_type": "no_three_ds",
    "statement_descriptor_name": null,
    "statement_descriptor_suffix": null,
    "next_action": null,
    "cancellation_reason": null,
    "error_code": "DECISION_PROFILE_REJECT",
    "error_message": "The order has been rejected by Decision Manager, detailed_error_information: , avs_message:  , Fraud Score - Reject",
    "unified_code": null,
    "unified_message": null,
    "payment_experience": null,
    "payment_method_type": "credit",
    "connector_label": null,
    "business_country": null,
    "business_label": "default",
    "business_sub_label": null,
    "allowed_payment_method_types": null,
    "ephemeral_key": {
        "customer_id": "CustomerX",
        "created_at": 1722938870,
        "expires": 1722942470,
        "secret": "epk_c534fe4fad5547b4bfb826e8362bb866"
    },
    "manual_retry_allowed": true,
    "connector_transaction_id": "7229388724956351804953",
    "frm_message": null,
    "metadata": null,
    "connector_metadata": null,
    "feature_metadata": null,
    "reference_id": null,
    "payment_link": null,
    "profile_id": "pro_3YFGXQeOfEAs2FFhVeRs",
    "surcharge_details": null,
    "attempt_count": 1,
    "merchant_decision": null,
    "merchant_connector_id": "mca_HYrS5VsIUooY6QtCwWY8",
    "incremental_authorization_allowed": false,
    "authorization_count": null,
    "incremental_authorizations": null,
    "external_authentication_details": null,
    "external_3ds_authentication_attempted": false,
    "expires_on": "2024-08-06T10:22:50.672Z",
    "fingerprint": null,
    "browser_info": null,
    "payment_method_id": null,
    "payment_method_status": null,
    "updated": "2024-08-06T10:07:53.892Z",
    "charges": null,
    "frm_metadata": null,
    "merchant_order_reference_id": null
}
```

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
