### PR TITLE
ci(cypress): Add off-session save card flows

### DIFF
--- a/cypress-tests/cypress/e2e/PaymentTest/00013-SaveCardFlow.cy.js
+++ b/cypress-tests/cypress/e2e/PaymentTest/00013-SaveCardFlow.cy.js
@@ -313,7 +313,6 @@ describe("Card - SaveCard payment flow test", () => {
         ]["SaveCardUseNo3DSAutoCaptureOffSession"];
         let req_data = data["Request"];
         let res_data = data["Response"];
-        console.log(res_data);
         cy.createConfirmPaymentTest(
           fixtures.createConfirmPaymentBody,
           req_data,

--- a/cypress-tests/cypress/e2e/PaymentTest/00013-SaveCardFlow.cy.js
+++ b/cypress-tests/cypress/e2e/PaymentTest/00013-SaveCardFlow.cy.js
@@ -3,6 +3,7 @@ import State from "../../utils/State";
 import getConnectorDetails, * as utils from "../PaymentUtils/Utils";
 
 let globalState;
+let saveCardBody;
 
 describe("Card - SaveCard payment flow test", () => {
   before("seed global state", () => {
@@ -11,12 +12,17 @@ describe("Card - SaveCard payment flow test", () => {
     });
   });
 
+  after("flush global state", () => {
+    cy.task("setGlobalState", globalState.data);
+  });
+
   context(
-    "Save card for NoThreeDS automatic capture payment- Create+Confirm",
+    "Save card for NoThreeDS automatic capture payment- Create+Confirm[on_session]",
     () => {
       let should_continue = true; // variable that will be used to skip tests if a previous test fails
 
       beforeEach(function () {
+        saveCardBody = Cypress._.cloneDeep(fixtures.saveCardConfirmBody);
         if (!should_continue) {
           this.skip();
         }
@@ -77,7 +83,7 @@ describe("Card - SaveCard payment flow test", () => {
         let req_data = data["Request"];
         let res_data = data["Response"];
         cy.saveCardConfirmCallTest(
-          fixtures.saveCardConfirmBody,
+          saveCardBody,
           req_data,
           res_data,
           globalState
@@ -89,11 +95,12 @@ describe("Card - SaveCard payment flow test", () => {
   );
 
   context(
-    "Save card for NoThreeDS manual full capture payment- Create+Confirm",
+    "Save card for NoThreeDS manual full capture payment- Create+Confirm[on_session]",
     () => {
       let should_continue = true; // variable that will be used to skip tests if a previous test fails
 
       beforeEach(function () {
+        saveCardBody = Cypress._.cloneDeep(fixtures.saveCardConfirmBody);
         if (!should_continue) {
           this.skip();
         }
@@ -154,7 +161,7 @@ describe("Card - SaveCard payment flow test", () => {
         let req_data = data["Request"];
         let res_data = data["Response"];
         cy.saveCardConfirmCallTest(
-          fixtures.saveCardConfirmBody,
+          saveCardBody,
           req_data,
           res_data,
           globalState
@@ -187,11 +194,12 @@ describe("Card - SaveCard payment flow test", () => {
   );
 
   context(
-    "Save card for NoThreeDS manual partial capture payment- Create + Confirm",
+    "Save card for NoThreeDS manual partial capture payment- Create + Confirm[on_session]",
     () => {
       let should_continue = true; // variable that will be used to skip tests if a previous test fails
 
       beforeEach(function () {
+        saveCardBody = Cypress._.cloneDeep(fixtures.saveCardConfirmBody);
         if (!should_continue) {
           this.skip();
         }
@@ -252,7 +260,7 @@ describe("Card - SaveCard payment flow test", () => {
         let req_data = data["Request"];
         let res_data = data["Response"];
         cy.saveCardConfirmCallTest(
-          fixtures.saveCardConfirmBody,
+          saveCardBody,
           req_data,
           res_data,
           globalState
@@ -279,6 +287,205 @@ describe("Card - SaveCard payment flow test", () => {
         );
         if (should_continue)
           should_continue = utils.should_continue_further(res_data);
+      });
+    }
+  );
+
+  context(
+    "Save card for NoThreeDS automatic capture payment[off_session]",
+    () => {
+      let should_continue = true; // variable that will be used to skip tests if a previous test fails
+
+      beforeEach(function () {
+        saveCardBody = Cypress._.cloneDeep(fixtures.saveCardConfirmBody);
+        if (!should_continue) {
+          this.skip();
+        }
+      });
+
+      it("customer-create-call-test", () => {
+        cy.createCustomerCallTest(fixtures.customerCreateBody, globalState);
+      });
+
+      it("create+confirm-payment-call-test", () => {
+        let data = getConnectorDetails(globalState.get("connectorId"))[
+          "card_pm"
+        ]["SaveCardUseNo3DSAutoCaptureOffSession"];
+        let req_data = data["Request"];
+        let res_data = data["Response"];
+        console.log(res_data);
+        cy.createConfirmPaymentTest(
+          fixtures.createConfirmPaymentBody,
+          req_data,
+          res_data,
+          "no_three_ds",
+          "automatic",
+          globalState
+        );
+        if (should_continue)
+          should_continue = utils.should_continue_further(res_data);
+      });
+
+      it("retrieve-payment-call-test", () => {
+        cy.retrievePaymentCallTest(globalState);
+      });
+
+      it("retrieve-customerPM-call-test", () => {
+        cy.listCustomerPMCallTest(globalState);
+      });
+
+      it("create-payment-call-test", () => {
+        let data = getConnectorDetails(globalState.get("connectorId"))[
+          "card_pm"
+        ]["PaymentIntentOffSession"];
+        let req_data = data["Request"];
+        let res_data = data["Response"];
+        cy.createPaymentIntentTest(
+          fixtures.createPaymentBody,
+          req_data,
+          res_data,
+          "no_three_ds",
+          "automatic",
+          globalState
+        );
+        if (should_continue)
+          should_continue = utils.should_continue_further(res_data);
+      });
+
+      it("confirm-save-card-payment-call-test", () => {
+        let data = getConnectorDetails(globalState.get("connectorId"))[
+          "card_pm"
+        ]["SaveCardConfirmAutoCaptureOffSession"];
+        let req_data = data["Request"];
+        let res_data = data["Response"];
+
+        cy.saveCardConfirmCallTest(
+          saveCardBody,
+          req_data,
+          res_data,
+          globalState
+        );
+        if (should_continue)
+          should_continue = utils.should_continue_further(res_data);
+      });
+    }
+  );
+
+  context(
+    "Save card for NoThreeDS manual capture payment- Create+Confirm[off_session]",
+    () => {
+      let should_continue = true; // variable that will be used to skip tests if a previous test fails
+
+      beforeEach(function () {
+        saveCardBody = Cypress._.cloneDeep(fixtures.saveCardConfirmBody);
+        if (!should_continue) {
+          this.skip();
+        }
+      });
+
+      it("customer-create-call-test", () => {
+        cy.createCustomerCallTest(fixtures.customerCreateBody, globalState);
+      });
+
+      it("create+confirm-payment-call-test", () => {
+        let data = getConnectorDetails(globalState.get("connectorId"))[
+          "card_pm"
+        ]["SaveCardUseNo3DSManualCaptureOffSession"];
+        let req_data = data["Request"];
+        let res_data = data["Response"];
+        cy.createConfirmPaymentTest(
+          fixtures.createConfirmPaymentBody,
+          req_data,
+          res_data,
+          "no_three_ds",
+          "manual",
+          globalState
+        );
+        if (should_continue)
+          should_continue = utils.should_continue_further(res_data);
+      });
+
+      it("retrieve-payment-call-test", () => {
+        cy.retrievePaymentCallTest(globalState);
+      });
+      it("capture-call-test", () => {
+        let data = getConnectorDetails(globalState.get("connectorId"))[
+          "card_pm"
+        ]["Capture"];
+        let req_data = data["Request"];
+        let res_data = data["Response"];
+        cy.captureCallTest(
+          fixtures.captureBody,
+          req_data,
+          res_data,
+          6500,
+          globalState
+        );
+        if (should_continue)
+          should_continue = utils.should_continue_further(res_data);
+      });
+
+      it("retrieve-customerPM-call-test", () => {
+        cy.listCustomerPMCallTest(globalState);
+      });
+
+      it("create-payment-call-test", () => {
+        let data = getConnectorDetails(globalState.get("connectorId"))[
+          "card_pm"
+        ]["PaymentIntentOffSession"];
+        let req_data = data["Request"];
+        let res_data = data["Response"];
+        cy.createPaymentIntentTest(
+          fixtures.createPaymentBody,
+          req_data,
+          res_data,
+          "no_three_ds",
+          "manual",
+          globalState
+        );
+        if (should_continue)
+          should_continue = utils.should_continue_further(res_data);
+      });
+
+      it("confirm-save-card-payment-call-test", () => {
+        let data = getConnectorDetails(globalState.get("connectorId"))[
+          "card_pm"
+        ]["SaveCardConfirmManualCaptureOffSession"];
+        let req_data = data["Request"];
+        let res_data = data["Response"];
+        cy.saveCardConfirmCallTest(
+          saveCardBody,
+          req_data,
+          res_data,
+          globalState
+        );
+        if (should_continue)
+          should_continue = utils.should_continue_further(res_data);
+      });
+
+      it("retrieve-payment-call-test", () => {
+        cy.retrievePaymentCallTest(globalState);
+      });
+
+      it("capture-call-test", () => {
+        let data = getConnectorDetails(globalState.get("connectorId"))[
+          "card_pm"
+        ]["Capture"];
+        let req_data = data["Request"];
+        let res_data = data["Response"];
+        cy.captureCallTest(
+          fixtures.captureBody,
+          req_data,
+          res_data,
+          6500,
+          globalState
+        );
+        if (should_continue)
+          should_continue = utils.should_continue_further(res_data);
+      });
+
+      it("retrieve-payment-call-test", () => {
+        cy.retrievePaymentCallTest(globalState);
       });
     }
   );

--- a/cypress-tests/cypress/e2e/PaymentTest/00013-SaveCardFlow.cy.js
+++ b/cypress-tests/cypress/e2e/PaymentTest/00013-SaveCardFlow.cy.js
@@ -32,7 +32,7 @@ describe("Card - SaveCard payment flow test", () => {
         cy.createCustomerCallTest(fixtures.customerCreateBody, globalState);
       });
 
-      it.only("create+confirm-payment-call-test", () => {
+      it("create+confirm-payment-call-test", () => {
         let data = getConnectorDetails(globalState.get("connectorId"))[
           "card_pm"
         ]["SaveCardUseNo3DSAutoCapture"];

--- a/cypress-tests/cypress/e2e/PaymentTest/00013-SaveCardFlow.cy.js
+++ b/cypress-tests/cypress/e2e/PaymentTest/00013-SaveCardFlow.cy.js
@@ -32,7 +32,7 @@ describe("Card - SaveCard payment flow test", () => {
         cy.createCustomerCallTest(fixtures.customerCreateBody, globalState);
       });
 
-      it("create+confirm-payment-call-test", () => {
+      it.only("create+confirm-payment-call-test", () => {
         let data = getConnectorDetails(globalState.get("connectorId"))[
           "card_pm"
         ]["SaveCardUseNo3DSAutoCapture"];
@@ -292,7 +292,7 @@ describe("Card - SaveCard payment flow test", () => {
   );
 
   context(
-    "Save card for NoThreeDS automatic capture payment[off_session]",
+    "Save card for NoThreeDS automatic capture payment [off_session]",
     () => {
       let should_continue = true; // variable that will be used to skip tests if a previous test fails
 

--- a/cypress-tests/cypress/e2e/PaymentTest/00013-SaveCardFlow.cy.js
+++ b/cypress-tests/cypress/e2e/PaymentTest/00013-SaveCardFlow.cy.js
@@ -17,7 +17,7 @@ describe("Card - SaveCard payment flow test", () => {
   });
 
   context(
-    "Save card for NoThreeDS automatic capture payment- Create+Confirm[on_session]",
+    "Save card for NoThreeDS automatic capture payment- Create+Confirm [on_session]",
     () => {
       let should_continue = true; // variable that will be used to skip tests if a previous test fails
 
@@ -95,7 +95,7 @@ describe("Card - SaveCard payment flow test", () => {
   );
 
   context(
-    "Save card for NoThreeDS manual full capture payment- Create+Confirm[on_session]",
+    "Save card for NoThreeDS manual full capture payment- Create+Confirm [on_session]",
     () => {
       let should_continue = true; // variable that will be used to skip tests if a previous test fails
 
@@ -194,7 +194,7 @@ describe("Card - SaveCard payment flow test", () => {
   );
 
   context(
-    "Save card for NoThreeDS manual partial capture payment- Create + Confirm[on_session]",
+    "Save card for NoThreeDS manual partial capture payment- Create + Confirm [on_session]",
     () => {
       let should_continue = true; // variable that will be used to skip tests if a previous test fails
 
@@ -371,7 +371,7 @@ describe("Card - SaveCard payment flow test", () => {
   );
 
   context(
-    "Save card for NoThreeDS manual capture payment- Create+Confirm[off_session]",
+    "Save card for NoThreeDS manual capture payment- Create+Confirm [off_session]",
     () => {
       let should_continue = true; // variable that will be used to skip tests if a previous test fails
 

--- a/cypress-tests/cypress/e2e/PaymentUtils/Adyen.js
+++ b/cypress-tests/cypress/e2e/PaymentUtils/Adyen.js
@@ -69,6 +69,23 @@ export const connectorDetails = {
         },
       },
     },
+    PaymentIntentOffSession: {
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulNo3DSCardDetails,
+        },
+        currency: "USD",
+        customer_acceptance: null,
+        setup_future_usage: "off_session",
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "requires_payment_method",
+        },
+      },
+    },
     "3DSManualCapture": {
       Request: {
         payment_method: "card",
@@ -379,6 +396,78 @@ export const connectorDetails = {
         },
       },
     },
+    SaveCardUseNo3DSAutoCaptureOffSession: {
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulNo3DSCardDetails,
+        },
+        currency: "USD",
+        setup_future_usage: "off_session",
+        customer_acceptance: {
+          acceptance_type: "offline",
+          accepted_at: "1963-05-03T04:07:52.723Z",
+          online: {
+            ip_address: "127.0.0.1",
+            user_agent: "amet irure esse",
+          },
+        },
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "succeeded",
+        },
+      },
+    },
+    SaveCardUseNo3DSManualCaptureOffSession: {
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulNo3DSCardDetails,
+        },
+        currency: "USD",
+        setup_future_usage: "off_session",
+        customer_acceptance: {
+          acceptance_type: "offline",
+          accepted_at: "1963-05-03T04:07:52.723Z",
+          online: {
+            ip_address: "127.0.0.1",
+            user_agent: "amet irure esse",
+          },
+        },
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "requires_capture",
+        },
+      },
+    },
+    SaveCardConfirmAutoCaptureOffSession: {
+      Request: {
+        currency: "USD",
+        setup_future_usage: "off_session",
+      },
+      Response: {
+        status: 200,
+        body: {
+         status: "succeeded"
+        },
+      },
+    },
+    SaveCardConfirmManualCaptureOffSession: {
+      Request: {
+        currency: "USD",
+        setup_future_usage: "off_session",
+      },
+      Response: {
+        status: 200,
+        body: {
+          status:"requires_capture"
+      },
+    },
+  },
     SaveCardUseNo3DSManualCapture: {
       Request: {
         payment_method: "card",

--- a/cypress-tests/cypress/e2e/PaymentUtils/Adyen.js
+++ b/cypress-tests/cypress/e2e/PaymentUtils/Adyen.js
@@ -71,10 +71,6 @@ export const connectorDetails = {
     },
     PaymentIntentOffSession: {
       Request: {
-        payment_method: "card",
-        payment_method_data: {
-          card: successfulNo3DSCardDetails,
-        },
         currency: "USD",
         customer_acceptance: null,
         setup_future_usage: "off_session",

--- a/cypress-tests/cypress/e2e/PaymentUtils/Adyen.js
+++ b/cypress-tests/cypress/e2e/PaymentUtils/Adyen.js
@@ -398,7 +398,6 @@ export const connectorDetails = {
         payment_method_data: {
           card: successfulNo3DSCardDetails,
         },
-        currency: "USD",
         setup_future_usage: "off_session",
         customer_acceptance: {
           acceptance_type: "offline",
@@ -422,7 +421,6 @@ export const connectorDetails = {
         payment_method_data: {
           card: successfulNo3DSCardDetails,
         },
-        currency: "USD",
         setup_future_usage: "off_session",
         customer_acceptance: {
           acceptance_type: "offline",
@@ -442,28 +440,26 @@ export const connectorDetails = {
     },
     SaveCardConfirmAutoCaptureOffSession: {
       Request: {
-        currency: "USD",
         setup_future_usage: "off_session",
       },
       Response: {
         status: 200,
         body: {
-         status: "succeeded"
+          status: "succeeded",
         },
       },
     },
     SaveCardConfirmManualCaptureOffSession: {
       Request: {
-        currency: "USD",
         setup_future_usage: "off_session",
       },
       Response: {
         status: 200,
         body: {
-          status:"requires_capture"
+          status: "requires_capture",
+        },
       },
     },
-  },
     SaveCardUseNo3DSManualCapture: {
       Request: {
         payment_method: "card",

--- a/cypress-tests/cypress/e2e/PaymentUtils/BankOfAmerica.js
+++ b/cypress-tests/cypress/e2e/PaymentUtils/BankOfAmerica.js
@@ -67,6 +67,23 @@ export const connectorDetails = {
         },
       },
     },
+    PaymentIntentOffSession: {
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulNo3DSCardDetails,
+        },
+        currency: "USD",
+        customer_acceptance: null,
+        setup_future_usage: "off_session",
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "requires_payment_method",
+        },
+      },
+    },
     "3DSManualCapture": {
       Request: {
         payment_method: "card",
@@ -391,6 +408,78 @@ export const connectorDetails = {
         },
       },
     },
+    SaveCardUseNo3DSAutoCaptureOffSession: {
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulNo3DSCardDetails,
+        },
+        currency: "USD",
+        setup_future_usage: "off_session",
+        customer_acceptance: {
+          acceptance_type: "offline",
+          accepted_at: "1963-05-03T04:07:52.723Z",
+          online: {
+            ip_address: "127.0.0.1",
+            user_agent: "amet irure esse",
+          },
+        },
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "succeeded",
+        },
+      },
+    },
+    SaveCardUseNo3DSManualCaptureOffSession: {
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulNo3DSCardDetails,
+        },
+        currency: "USD",
+        setup_future_usage: "off_session",
+        customer_acceptance: {
+          acceptance_type: "offline",
+          accepted_at: "1963-05-03T04:07:52.723Z",
+          online: {
+            ip_address: "127.0.0.1",
+            user_agent: "amet irure esse",
+          },
+        },
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "requires_capture",
+        },
+      },
+    },
+    SaveCardConfirmAutoCaptureOffSession: {
+      Request: {
+        currency: "USD",
+        setup_future_usage: "off_session",
+      },
+      Response: {
+        status: 200,
+        body: {
+         status: "succeeded"
+        },
+      },
+    },
+    SaveCardConfirmManualCaptureOffSession: {
+      Request: {
+        currency: "USD",
+        setup_future_usage: "off_session",
+      },
+      Response: {
+        status: 200,
+        body: {
+          status:"requires_capture"
+      },
+    },
+  },
     SaveCardUseNo3DSManualCapture: {
       Request: {
         payment_method: "card",

--- a/cypress-tests/cypress/e2e/PaymentUtils/BankOfAmerica.js
+++ b/cypress-tests/cypress/e2e/PaymentUtils/BankOfAmerica.js
@@ -410,7 +410,6 @@ export const connectorDetails = {
         payment_method_data: {
           card: successfulNo3DSCardDetails,
         },
-        currency: "USD",
         setup_future_usage: "off_session",
         customer_acceptance: {
           acceptance_type: "offline",
@@ -434,7 +433,6 @@ export const connectorDetails = {
         payment_method_data: {
           card: successfulNo3DSCardDetails,
         },
-        currency: "USD",
         setup_future_usage: "off_session",
         customer_acceptance: {
           acceptance_type: "offline",
@@ -454,28 +452,26 @@ export const connectorDetails = {
     },
     SaveCardConfirmAutoCaptureOffSession: {
       Request: {
-        currency: "USD",
         setup_future_usage: "off_session",
       },
       Response: {
         status: 200,
         body: {
-         status: "succeeded"
+          status: "succeeded",
         },
       },
     },
     SaveCardConfirmManualCaptureOffSession: {
       Request: {
-        currency: "USD",
         setup_future_usage: "off_session",
       },
       Response: {
         status: 200,
         body: {
-          status:"requires_capture"
+          status: "requires_capture",
+        },
       },
     },
-  },
     SaveCardUseNo3DSManualCapture: {
       Request: {
         payment_method: "card",

--- a/cypress-tests/cypress/e2e/PaymentUtils/BankOfAmerica.js
+++ b/cypress-tests/cypress/e2e/PaymentUtils/BankOfAmerica.js
@@ -69,10 +69,6 @@ export const connectorDetails = {
     },
     PaymentIntentOffSession: {
       Request: {
-        payment_method: "card",
-        payment_method_data: {
-          card: successfulNo3DSCardDetails,
-        },
         currency: "USD",
         customer_acceptance: null,
         setup_future_usage: "off_session",

--- a/cypress-tests/cypress/e2e/PaymentUtils/Commons.js
+++ b/cypress-tests/cypress/e2e/PaymentUtils/Commons.js
@@ -671,7 +671,7 @@ export const connectorDetails = {
           },
         },
       },
-          }),
+    }),
     PartialRefund: getCustomExchange({
       Request: {
         payment_method: "card",
@@ -806,7 +806,6 @@ export const connectorDetails = {
         payment_method_data: {
           card: successfulNo3DSCardDetails,
         },
-        currency: "USD",
         setup_future_usage: "off_session",
         customer_acceptance: {
           acceptance_type: "offline",
@@ -824,7 +823,6 @@ export const connectorDetails = {
         payment_method_data: {
           card: successfulNo3DSCardDetails,
         },
-        currency: "USD",
         setup_future_usage: "off_session",
         customer_acceptance: {
           acceptance_type: "offline",
@@ -838,13 +836,11 @@ export const connectorDetails = {
     }),
     SaveCardConfirmAutoCaptureOffSession: getCustomExchange({
       Request: {
-        currency: "USD",
         setup_future_usage: "off_session",
       },
     }),
     SaveCardConfirmManualCaptureOffSession: getCustomExchange({
       Request: {
-        currency: "USD",
         setup_future_usage: "off_session",
       },
     }),

--- a/cypress-tests/cypress/e2e/PaymentUtils/Commons.js
+++ b/cypress-tests/cypress/e2e/PaymentUtils/Commons.js
@@ -563,6 +563,17 @@ export const connectorDetails = {
         },
       },
     }),
+    PaymentIntentOffSession: getCustomExchange({
+      Request: {
+        currency: "USD",
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "requires_payment_method",
+        },
+      },
+    }),
     "3DSManualCapture": getCustomExchange({
       Request: {
         payment_method: "card",
@@ -660,7 +671,7 @@ export const connectorDetails = {
           },
         },
       },
-    }),
+          }),
     PartialRefund: getCustomExchange({
       Request: {
         payment_method: "card",
@@ -787,6 +798,54 @@ export const connectorDetails = {
             user_agent: "amet irure esse",
           },
         },
+      },
+    }),
+    SaveCardUseNo3DSAutoCaptureOffSession: getCustomExchange({
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulNo3DSCardDetails,
+        },
+        currency: "USD",
+        setup_future_usage: "off_session",
+        customer_acceptance: {
+          acceptance_type: "offline",
+          accepted_at: "1963-05-03T04:07:52.723Z",
+          online: {
+            ip_address: "127.0.0.1",
+            user_agent: "amet irure esse",
+          },
+        },
+      },
+    }),
+    SaveCardUseNo3DSManualCaptureOffSession: getCustomExchange({
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulNo3DSCardDetails,
+        },
+        currency: "USD",
+        setup_future_usage: "off_session",
+        customer_acceptance: {
+          acceptance_type: "offline",
+          accepted_at: "1963-05-03T04:07:52.723Z",
+          online: {
+            ip_address: "127.0.0.1",
+            user_agent: "amet irure esse",
+          },
+        },
+      },
+    }),
+    SaveCardConfirmAutoCaptureOffSession: getCustomExchange({
+      Request: {
+        currency: "USD",
+        setup_future_usage: "off_session",
+      },
+    }),
+    SaveCardConfirmManualCaptureOffSession: getCustomExchange({
+      Request: {
+        currency: "USD",
+        setup_future_usage: "off_session",
       },
     }),
     SaveCardUseNo3DSManualCapture: getCustomExchange({

--- a/cypress-tests/cypress/e2e/PaymentUtils/Cybersource.js
+++ b/cypress-tests/cypress/e2e/PaymentUtils/Cybersource.js
@@ -69,10 +69,6 @@ export const connectorDetails = {
     },
     PaymentIntentOffSession: {
       Request: {
-        payment_method: "card",
-        payment_method_data: {
-          card: successfulNo3DSCardDetails,
-        },
         currency: "USD",
         customer_acceptance: null,
         setup_future_usage: "off_session",

--- a/cypress-tests/cypress/e2e/PaymentUtils/Cybersource.js
+++ b/cypress-tests/cypress/e2e/PaymentUtils/Cybersource.js
@@ -410,7 +410,6 @@ export const connectorDetails = {
         payment_method_data: {
           card: successfulNo3DSCardDetails,
         },
-        currency: "USD",
         setup_future_usage: "off_session",
         customer_acceptance: {
           acceptance_type: "offline",
@@ -434,7 +433,6 @@ export const connectorDetails = {
         payment_method_data: {
           card: successfulNo3DSCardDetails,
         },
-        currency: "USD",
         setup_future_usage: "off_session",
         customer_acceptance: {
           acceptance_type: "offline",
@@ -454,7 +452,6 @@ export const connectorDetails = {
     },
     SaveCardConfirmAutoCaptureOffSession: {
       Request: {
-        currency: "USD",
         setup_future_usage: "off_session",
       },
       Response: {
@@ -466,7 +463,6 @@ export const connectorDetails = {
     },
     SaveCardConfirmManualCaptureOffSession: {
       Request: {
-        currency: "USD",
         setup_future_usage: "off_session",
       },
       Response: {

--- a/cypress-tests/cypress/e2e/PaymentUtils/Cybersource.js
+++ b/cypress-tests/cypress/e2e/PaymentUtils/Cybersource.js
@@ -67,6 +67,23 @@ export const connectorDetails = {
         },
       },
     },
+    PaymentIntentOffSession: {
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulNo3DSCardDetails,
+        },
+        currency: "USD",
+        customer_acceptance: null,
+        setup_future_usage: "off_session",
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "requires_payment_method",
+        },
+      },
+    },
     "3DSManualCapture": {
       Request: {
         payment_method: "card",
@@ -147,10 +164,10 @@ export const connectorDetails = {
       Response: {
         status: 200,
         body: {
-          status: "succeeded",
+          status: "processing",
           amount: 6500,
-          amount_capturable: 0,
-          amount_received: 6500,
+          amount_capturable: 6500,
+          amount_received: null,
         },
       },
     },
@@ -159,10 +176,10 @@ export const connectorDetails = {
       Response: {
         status: 200,
         body: {
-          status: "partially_captured",
+          status: "processing",
           amount: 6500,
-          amount_capturable: 0,
-          amount_received: 100,
+          amount_capturable: 6500,
+          amount_received: null,
         },
       },
     },
@@ -388,6 +405,78 @@ export const connectorDetails = {
         status: 200,
         body: {
           status: "succeeded",
+        },
+      },
+    },
+    SaveCardUseNo3DSAutoCaptureOffSession: {
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulNo3DSCardDetails,
+        },
+        currency: "USD",
+        setup_future_usage: "off_session",
+        customer_acceptance: {
+          acceptance_type: "offline",
+          accepted_at: "1963-05-03T04:07:52.723Z",
+          online: {
+            ip_address: "127.0.0.1",
+            user_agent: "amet irure esse",
+          },
+        },
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "succeeded",
+        },
+      },
+    },
+    SaveCardUseNo3DSManualCaptureOffSession: {
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulNo3DSCardDetails,
+        },
+        currency: "USD",
+        setup_future_usage: "off_session",
+        customer_acceptance: {
+          acceptance_type: "offline",
+          accepted_at: "1963-05-03T04:07:52.723Z",
+          online: {
+            ip_address: "127.0.0.1",
+            user_agent: "amet irure esse",
+          },
+        },
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "requires_capture",
+        },
+      },
+    },
+    SaveCardConfirmAutoCaptureOffSession: {
+      Request: {
+        currency: "USD",
+        setup_future_usage: "off_session",
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "succeeded",
+        },
+      },
+    },
+    SaveCardConfirmManualCaptureOffSession: {
+      Request: {
+        currency: "USD",
+        setup_future_usage: "off_session",
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "requires_capture",
         },
       },
     },

--- a/cypress-tests/cypress/e2e/PaymentUtils/Stripe.js
+++ b/cypress-tests/cypress/e2e/PaymentUtils/Stripe.js
@@ -69,6 +69,23 @@ export const connectorDetails = {
         },
       },
     },
+    PaymentIntentOffSession: {
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulNo3DSCardDetails,
+        },
+        currency: "USD",
+        customer_acceptance: null,
+        setup_future_usage: "off_session",
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "requires_payment_method",
+        },
+      },
+    },
     "3DSManualCapture": {
       Request: {
         payment_method: "card",
@@ -438,6 +455,82 @@ export const connectorDetails = {
         status: 200,
         body: {
           status: "succeeded",
+        },
+      },
+    },
+    SaveCardUseNo3DSAutoCaptureOffSession: {
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulNo3DSCardDetails,
+        },
+        currency: "USD",
+        setup_future_usage: "off_session",
+        customer_acceptance: {
+          acceptance_type: "offline",
+          accepted_at: "1963-05-03T04:07:52.723Z",
+          online: {
+            ip_address: "127.0.0.1",
+            user_agent: "amet irure esse",
+          },
+        },
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "succeeded",
+        },
+      },
+    },
+    SaveCardUseNo3DSManualCaptureOffSession: {
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulNo3DSCardDetails,
+        },
+        currency: "USD",
+        setup_future_usage: "off_session",
+        customer_acceptance: {
+          acceptance_type: "offline",
+          accepted_at: "1963-05-03T04:07:52.723Z",
+          online: {
+            ip_address: "127.0.0.1",
+            user_agent: "amet irure esse",
+          },
+        },
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "requires_capture",
+        },
+      },
+    },
+    SaveCardConfirmAutoCaptureOffSession: {
+      Request: {
+        currency: "USD",
+        setup_future_usage: "off_session",
+      },
+      Response: {
+        status: 200,
+        body: {
+          error_code: "No error code",
+          error_message:
+            "You cannot confirm with `off_session=true` when `setup_future_usage` is also set on the PaymentIntent. The customer needs to be on-session to perform the steps which may be required to set up the PaymentMethod for future usage. Please confirm this PaymentIntent with your customer on-session.",
+        },
+      },
+    },
+    SaveCardConfirmManualCaptureOffSession: {
+      Request: {
+        currency: "USD",
+        setup_future_usage: "off_session",
+      },
+      Response: {
+        status: 200,
+        body: {
+          error_code: "No error code",
+          error_message:
+            "You cannot confirm with `off_session=true` when `setup_future_usage` is also set on the PaymentIntent. The customer needs to be on-session to perform the steps which may be required to set up the PaymentMethod for future usage. Please confirm this PaymentIntent with your customer on-session.",
         },
       },
     },

--- a/cypress-tests/cypress/e2e/PaymentUtils/Stripe.js
+++ b/cypress-tests/cypress/e2e/PaymentUtils/Stripe.js
@@ -460,7 +460,6 @@ export const connectorDetails = {
         payment_method_data: {
           card: successfulNo3DSCardDetails,
         },
-        currency: "USD",
         setup_future_usage: "off_session",
         customer_acceptance: {
           acceptance_type: "offline",
@@ -484,7 +483,6 @@ export const connectorDetails = {
         payment_method_data: {
           card: successfulNo3DSCardDetails,
         },
-        currency: "USD",
         setup_future_usage: "off_session",
         customer_acceptance: {
           acceptance_type: "offline",
@@ -504,7 +502,6 @@ export const connectorDetails = {
     },
     SaveCardConfirmAutoCaptureOffSession: {
       Request: {
-        currency: "USD",
         setup_future_usage: "off_session",
       },
       Response: {
@@ -518,7 +515,6 @@ export const connectorDetails = {
     },
     SaveCardConfirmManualCaptureOffSession: {
       Request: {
-        currency: "USD",
         setup_future_usage: "off_session",
       },
       Response: {

--- a/cypress-tests/cypress/e2e/PaymentUtils/Stripe.js
+++ b/cypress-tests/cypress/e2e/PaymentUtils/Stripe.js
@@ -71,10 +71,6 @@ export const connectorDetails = {
     },
     PaymentIntentOffSession: {
       Request: {
-        payment_method: "card",
-        payment_method_data: {
-          card: successfulNo3DSCardDetails,
-        },
         currency: "USD",
         customer_acceptance: null,
         setup_future_usage: "off_session",

--- a/cypress-tests/cypress/fixtures/save-card-confirm-body.json
+++ b/cypress-tests/cypress/fixtures/save-card-confirm-body.json
@@ -2,7 +2,6 @@
   "client_secret": "{{client_secret}}",
   "payment_method": "card",
   "payment_token": "{{payment_token}}",
-  "card_cvc": "card_cvc",
   "billing": {
     "address": {
       "line1": "1467",

--- a/cypress-tests/cypress/support/commands.js
+++ b/cypress-tests/cypress/support/commands.js
@@ -1250,7 +1250,9 @@ Cypress.Commands.add(
   "saveCardConfirmCallTest",
   (saveCardConfirmBody, req_data, res_data, globalState) => {
     const paymentIntentID = globalState.get("paymentID");
-    saveCardConfirmBody.card_cvc = req_data.payment_method_data.card.card_cvc;
+    if (req_data.setup_future_usage === "on_session"){
+      saveCardConfirmBody.card_cvc = req_data.payment_method_data.card.card_cvc;
+    }
     saveCardConfirmBody.payment_token = globalState.get("paymentToken");
     saveCardConfirmBody.client_secret = globalState.get("clientSecret");
     cy.request({


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
This PR adds up some more test cases for save card flows i.e., recurring payment using payment token 


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
NIL
## How did you test it?
Cypress:

- STRIPE
<img width="711" alt="stripe" src="https://github.com/user-attachments/assets/9b094550-4053-4baf-9459-1c7103b93d53">

- cybersource
<img width="711" alt="cybersource" src="https://github.com/user-attachments/assets/372b5801-b573-4cd3-8bbc-5f0653e40051">



## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
