### PR TITLE
fix(docker): currency enum fix for docker config

### DIFF
--- a/config/docker_compose.toml
+++ b/config/docker_compose.toml
@@ -557,7 +557,7 @@ merchant_name = "HyperSwitch"
 card = "credit,debit"
 
 [payout_method_filters.adyenplatform]
-sepa = { country = "ES,SK,AT,NL,DE,BE,FR,FI,PT,IE,EE,LT,LV,IT,CZ,DE,HU,NO,PL,SE,GB,CH", currency = "EUR,CZK,DKK,HUF,NOR,PLN,SEK,GBP,CHF" }
+sepa = { country = "ES,SK,AT,NL,DE,BE,FR,FI,PT,IE,EE,LT,LV,IT,CZ,DE,HU,NO,PL,SE,GB,CH", currency = "EUR,CZK,DKK,HUF,NOK,PLN,SEK,GBP,CHF" }
 
 [payout_method_filters.stripe]
 ach = { country = "US", currency = "USD" }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
This PR fixes the following bug 
```
2024-08-08 21:08:07 thread 'main' panicked at crates/router/src/bin/router.rs:16:10:
2024-08-08 21:08:07 Unable to construct application configuration: Application configuration error
2024-08-08 21:08:07 ├╴at crates/router/src/configs/settings.rs:759:14
2024-08-08 21:08:07 │
2024-08-08 21:08:07 ╰─▶ payout_method_filters.adyenplatform.sepa.currency: Some errors occurred:
2024-08-08 21:08:07     Unable to deserialize `NOR` as `common_enums::enums::Currency`: Matching variant not found
2024-08-08 21:08:07     ├╴at crates/router/src/configs/settings.rs:758:14
2024-08-08 21:08:07     ╰╴Unable to deserialize application configuration
2024-08-08 21:08:07 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
