### PR TITLE
fix(router): return missing required filed error when a domain is missing during apple pay session call

### DIFF
--- a/crates/router/src/core/payments/flows/session_flow.rs
+++ b/crates/router/src/core/payments/flows/session_flow.rs
@@ -411,10 +411,8 @@ async fn create_applepay_session_token(
                             "Retry apple pay session call with the merchant configured domain {error:?}"
                         );
                         let merchant_configured_domain = merchant_configured_domain_optional
-                            .ok_or(errors::ApiErrorResponse::InternalServerError)
-                            .attach_printable(
-                                "Failed to get initiative_context for apple pay session call retry",
-                            )?;
+                            .get_required_value("apple pay domain")
+                            .attach_printable("Failed to get domain for apple pay session call")?;
                         let apple_pay_retry_session_request =
                             payment_types::ApplepaySessionRequest {
                                 initiative_context: merchant_configured_domain,
@@ -496,15 +494,16 @@ fn get_session_request_for_manual_apple_pay(
     session_token_data: payment_types::SessionTokenInfo,
     merchant_domain: Option<String>,
 ) -> RouterResult<payment_types::ApplepaySessionRequest> {
-    let initiative_context = session_token_data
-        .initiative_context
-        .ok_or(errors::ApiErrorResponse::InternalServerError)
-        .attach_printable("Failed to get initiative_context for apple pay session call")?;
+    let initiative_context = merchant_domain
+        .or_else(|| session_token_data.initiative_context.clone())
+        .get_required_value("apple pay domain")
+        .attach_printable("Failed to get domain for apple pay session call")?;
+
     Ok(payment_types::ApplepaySessionRequest {
         merchant_identifier: session_token_data.merchant_identifier.clone(),
         display_name: session_token_data.display_name.clone(),
         initiative: session_token_data.initiative.to_string(),
-        initiative_context: merchant_domain.unwrap_or(initiative_context),
+        initiative_context,
     })
 }
 


### PR DESCRIPTION


## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Reference issue for the feature https://github.com/juspay/hyperswitch/issues/5354

As described in the above issue the apple pay domain needs to be fetched dynamically by the sdk and to be sent in the session request header. When sdk fails to send which is not expected to happen, we try to get the domain that merchant has configured in the merchant connector account. Now ff merchant has not configured a domain it will result in an `InternalServerError` instead it should be missing required filed.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
