### PR TITLE
chore: run pml independently

### DIFF
--- a/cypress-tests/cypress/support/commands.js
+++ b/cypress-tests/cypress/support/commands.js
@@ -1250,7 +1250,7 @@ Cypress.Commands.add(
   "saveCardConfirmCallTest",
   (saveCardConfirmBody, req_data, res_data, globalState) => {
     const paymentIntentID = globalState.get("paymentID");
-    if (req_data.setup_future_usage === "on_session"){
+    if (req_data.setup_future_usage === "on_session") {
       saveCardConfirmBody.card_cvc = req_data.payment_method_data.card.card_cvc;
     }
     saveCardConfirmBody.payment_token = globalState.get("paymentToken");

--- a/cypress-tests/package.json
+++ b/cypress-tests/package.json
@@ -9,6 +9,7 @@
     "cypress:ci": "npx cypress run --headless",
     "cypress:payments": "cypress run --headless --spec 'cypress/e2e/PaymentTest/**/*'",
     "cypress:payouts": "cypress run --headless --spec 'cypress/e2e/PayoutTest/**/*'",
+    "cypress:payment-method-list": "cypress run --headless --spec 'cypress/e2e/PaymentMethodListTest/**/*'",
     "cypress:routing": "cypress run --headless --spec 'cypress/e2e/RoutingTest/**/*'"
   },
   "author": "",


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [x] Dependency updates
- [ ] Documentation
- [x] CI/CD

## Description
<!-- Describe your changes in detail -->

This PR enables running PML independently.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->

Needed.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

Execute:
```
export CYPRESS_CONNECTOR="wellsfargo" && npm run cypress:payment-method-list
```

![image](https://github.com/user-attachments/assets/ca5dac12-3379-4b1e-9021-4b9ff914fb8d)

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `prettier . --write`
- [ ] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
