### PR TITLE
fix(docs): fix typo in try_local_system.md

### DIFF
--- a/docs/try_local_system.md
+++ b/docs/try_local_system.md
@@ -493,13 +493,7 @@ Once you're done with setting up the dependencies, proceed with
 
    Run the migrations
 
-   - If you have just installed
-
-   ```shell
-   just migrate
-   ```
-
-   - Using the diesel-cli command
+   - If you have just installed just migrate using the diesel-cli command
 
    ```shell
    diesel migration run


### PR DESCRIPTION
I think this was a typo in the documentation. I'm not sure what should it be replaced with. I appreciate any suggestion for improving it.
