### PR TITLE
feat(router): [cybersource] add disable_avs and disable_cvn flag in connector metadata 

### DIFF
--- a/crates/connector_configs/toml/development.toml
+++ b/crates/connector_configs/toml/development.toml
@@ -1217,6 +1217,8 @@ key1="Merchant ID"
 api_secret="Shared Secret"
 [cybersource.connector_webhook_details]
 merchant_secret="Source verification key"
+[cybersource.metadata]
+disable_avs = "Disable AVS check"
 
 [[cybersource.metadata.apple_pay]]
 name="certificate"

--- a/crates/connector_configs/toml/development.toml
+++ b/crates/connector_configs/toml/development.toml
@@ -1219,6 +1219,7 @@ api_secret="Shared Secret"
 merchant_secret="Source verification key"
 [cybersource.metadata]
 disable_avs = "Disable AVS check"
+disable_cvn = "Disable CVN check"
 
 [[cybersource.metadata.apple_pay]]
 name="certificate"

--- a/crates/connector_configs/toml/production.toml
+++ b/crates/connector_configs/toml/production.toml
@@ -1032,6 +1032,8 @@ key1="Merchant ID"
 api_secret="Shared Secret"
 [cybersource.connector_webhook_details]
 merchant_secret="Source verification key"
+[cybersource.metadata]
+disable_avs = "Disable AVS check"
 
 [[cybersource.metadata.apple_pay]]
 name="certificate"

--- a/crates/connector_configs/toml/production.toml
+++ b/crates/connector_configs/toml/production.toml
@@ -1034,6 +1034,7 @@ api_secret="Shared Secret"
 merchant_secret="Source verification key"
 [cybersource.metadata]
 disable_avs = "Disable AVS check"
+disable_cvn = "Disable CVN check"
 
 [[cybersource.metadata.apple_pay]]
 name="certificate"

--- a/crates/connector_configs/toml/sandbox.toml
+++ b/crates/connector_configs/toml/sandbox.toml
@@ -1217,6 +1217,8 @@ key1="Merchant ID"
 api_secret="Shared Secret"
 [cybersource.connector_webhook_details]
 merchant_secret="Source verification key"
+[cybersource.metadata]
+disable_avs = "Disable AVS check"
 
 [[cybersource.metadata.apple_pay]]
 name="certificate"

--- a/crates/connector_configs/toml/sandbox.toml
+++ b/crates/connector_configs/toml/sandbox.toml
@@ -1219,6 +1219,7 @@ api_secret="Shared Secret"
 merchant_secret="Source verification key"
 [cybersource.metadata]
 disable_avs = "Disable AVS check"
+disable_cvn = "Disable CVN check"
 
 [[cybersource.metadata.apple_pay]]
 name="certificate"

--- a/crates/router/src/connector/cybersource/transformers.rs
+++ b/crates/router/src/connector/cybersource/transformers.rs
@@ -729,7 +729,12 @@ impl
                 None => (None, None, None),
             }
         } else {
-            (None, None, None)
+            (None, None, Some(CybersourceAuthorizationOptions {
+                initiator: None,
+                merchant_intitiated_transaction: None,
+                ignore_avs_result : connector_merchant_config.disable_avs,
+                ignore_cv_result: connector_merchant_config.disable_cvn,
+            }))
         };
         // this logic is for external authenticated card
         let commerce_indicator_for_external_authentication = item

--- a/crates/router/src/connector/cybersource/transformers.rs
+++ b/crates/router/src/connector/cybersource/transformers.rs
@@ -93,9 +93,9 @@ impl TryFrom<&types::SetupMandateRouterData> for CybersourceZeroMandateRequest {
             },
             bill_to: Some(bill_to),
         };
-        let connector_merchant_config = CybersourceConnectorMetadataObject::try_from(&item.connector_meta_data)?;
-        
-            
+        let connector_merchant_config =
+            CybersourceConnectorMetadataObject::try_from(&item.connector_meta_data)?;
+
         let (action_list, action_token_types, authorization_options) = (
             Some(vec![CybersourceActionsList::TokenCreate]),
             Some(vec![
@@ -109,7 +109,7 @@ impl TryFrom<&types::SetupMandateRouterData> for CybersourceZeroMandateRequest {
                     stored_credential_used: None,
                 }),
                 merchant_intitiated_transaction: None,
-                ignore_avs_result : connector_merchant_config.disable_avs,
+                ignore_avs_result: connector_merchant_config.disable_avs,
                 ignore_cv_result: connector_merchant_config.disable_cvn,
             }),
         );
@@ -572,8 +572,8 @@ impl
             .unwrap_or("internet")
             .to_string();
 
-        let connector_merchant_config = CybersourceConnectorMetadataObject::try_from(&item.router_data.connector_meta_data)?;
-
+        let connector_merchant_config =
+            CybersourceConnectorMetadataObject::try_from(&item.router_data.connector_meta_data)?;
 
         let (action_list, action_token_types, authorization_options) = if item
             .router_data
@@ -603,7 +603,7 @@ impl
                         credential_stored_on_file: Some(true),
                         stored_credential_used: None,
                     }),
-                    ignore_avs_result : connector_merchant_config.disable_avs,
+                    ignore_avs_result: connector_merchant_config.disable_avs,
                     ignore_cv_result: connector_merchant_config.disable_cvn,
                     merchant_intitiated_transaction: None,
                 }),
@@ -653,7 +653,7 @@ impl
                                 original_authorized_amount,
                                 previous_transaction_id: None,
                             }),
-                            ignore_avs_result : connector_merchant_config.disable_avs,
+                            ignore_avs_result: connector_merchant_config.disable_avs,
                             ignore_cv_result: connector_merchant_config.disable_cvn,
                         }),
                     )
@@ -721,7 +721,7 @@ impl
                                 original_authorized_amount,
                                 previous_transaction_id: Some(Secret::new(network_transaction_id)),
                             }),
-                            ignore_avs_result : connector_merchant_config.disable_avs,
+                            ignore_avs_result: connector_merchant_config.disable_avs,
                             ignore_cv_result: connector_merchant_config.disable_cvn,
                         }),
                     )
@@ -825,7 +825,8 @@ impl
             &CybersourceConsumerAuthValidateResponse,
         ),
     ) -> Result<Self, Self::Error> {
-        let connector_merchant_config = CybersourceConnectorMetadataObject::try_from(&item.router_data.connector_meta_data)?;
+        let connector_merchant_config =
+            CybersourceConnectorMetadataObject::try_from(&item.router_data.connector_meta_data)?;
 
         let (action_list, action_token_types, authorization_options) = if item
             .router_data
@@ -849,7 +850,7 @@ impl
                         stored_credential_used: None,
                     }),
                     merchant_intitiated_transaction: None,
-                    ignore_avs_result : connector_merchant_config.disable_avs,
+                    ignore_avs_result: connector_merchant_config.disable_avs,
                     ignore_cv_result: connector_merchant_config.disable_cvn,
                 }),
             )
@@ -1623,8 +1624,8 @@ impl TryFrom<&CybersourceRouterData<&types::PaymentsIncrementalAuthorizationRout
     fn try_from(
         item: &CybersourceRouterData<&types::PaymentsIncrementalAuthorizationRouterData>,
     ) -> Result<Self, Self::Error> {
-        let connector_merchant_config = CybersourceConnectorMetadataObject::try_from(&item.router_data.connector_meta_data)?;
-
+        let connector_merchant_config =
+            CybersourceConnectorMetadataObject::try_from(&item.router_data.connector_meta_data)?;
 
         Ok(Self {
             processing_information: ProcessingInformation {
@@ -1641,7 +1642,7 @@ impl TryFrom<&CybersourceRouterData<&types::PaymentsIncrementalAuthorizationRout
                         previous_transaction_id: None,
                         original_authorized_amount: None,
                     }),
-                    ignore_avs_result : connector_merchant_config.disable_avs,
+                    ignore_avs_result: connector_merchant_config.disable_avs,
                     ignore_cv_result: connector_merchant_config.disable_cvn,
                 }),
                 commerce_indicator: String::from("internet"),

--- a/crates/router/src/connector/cybersource/transformers.rs
+++ b/crates/router/src/connector/cybersource/transformers.rs
@@ -54,6 +54,22 @@ impl<T> TryFrom<(&api::CurrencyUnit, enums::Currency, i64, T)> for CybersourceRo
     }
 }
 
+#[derive(Debug, Default, Serialize, Deserialize)]
+pub struct CybersourceConnectorMetadataObject {
+    pub disable_avs: Option<bool>,
+}
+
+impl TryFrom<&Option<pii::SecretSerdeValue>> for CybersourceConnectorMetadataObject {
+    type Error = error_stack::Report<errors::ConnectorError>;
+    fn try_from(meta_data: &Option<pii::SecretSerdeValue>) -> Result<Self, Self::Error> {
+        let metadata = utils::to_connector_meta_from_secret::<Self>(meta_data.clone())
+            .change_context(errors::ConnectorError::InvalidConnectorConfig {
+                config: "metadata",
+            })?;
+        Ok(metadata)
+    }
+}
+
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CybersourceZeroMandateRequest {
@@ -76,6 +92,8 @@ impl TryFrom<&types::SetupMandateRouterData> for CybersourceZeroMandateRequest {
             },
             bill_to: Some(bill_to),
         };
+        let ignore_avs_result =
+            CybersourceConnectorMetadataObject::try_from(&item.connector_meta_data)?.disable_avs;
         let (action_list, action_token_types, authorization_options) = (
             Some(vec![CybersourceActionsList::TokenCreate]),
             Some(vec![
@@ -89,6 +107,7 @@ impl TryFrom<&types::SetupMandateRouterData> for CybersourceZeroMandateRequest {
                     stored_credential_used: None,
                 }),
                 merchant_intitiated_transaction: None,
+                ignore_avs_result,
             }),
         );
 
@@ -310,6 +329,7 @@ pub enum CybersourceActionsTokenType {
 pub struct CybersourceAuthorizationOptions {
     initiator: Option<CybersourcePaymentInitiator>,
     merchant_intitiated_transaction: Option<MerchantInitiatedTransaction>,
+    ignore_avs_result: Option<bool>,
 }
 
 #[derive(Debug, Serialize)]
@@ -548,6 +568,10 @@ impl
             .unwrap_or("internet")
             .to_string();
 
+        let ignore_avs_result =
+            CybersourceConnectorMetadataObject::try_from(&item.router_data.connector_meta_data)?
+                .disable_avs;
+
         let (action_list, action_token_types, authorization_options) = if item
             .router_data
             .request
@@ -576,6 +600,7 @@ impl
                         credential_stored_on_file: Some(true),
                         stored_credential_used: None,
                     }),
+                    ignore_avs_result,
                     merchant_intitiated_transaction: None,
                 }),
             )
@@ -624,6 +649,7 @@ impl
                                 original_authorized_amount,
                                 previous_transaction_id: None,
                             }),
+                            ignore_avs_result,
                         }),
                     )
                 }
@@ -690,6 +716,7 @@ impl
                                 original_authorized_amount,
                                 previous_transaction_id: Some(Secret::new(network_transaction_id)),
                             }),
+                            ignore_avs_result,
                         }),
                     )
                 }
@@ -778,19 +805,23 @@ fn get_commerce_indicator_for_external_authentication(
 }
 
 impl
-    From<(
+    TryFrom<(
         &CybersourceRouterData<&types::PaymentsCompleteAuthorizeRouterData>,
         Option<PaymentSolution>,
         &CybersourceConsumerAuthValidateResponse,
     )> for ProcessingInformation
 {
-    fn from(
+    type Error = error_stack::Report<errors::ConnectorError>;
+    fn try_from(
         (item, solution, three_ds_data): (
             &CybersourceRouterData<&types::PaymentsCompleteAuthorizeRouterData>,
             Option<PaymentSolution>,
             &CybersourceConsumerAuthValidateResponse,
         ),
-    ) -> Self {
+    ) -> Result<Self, Self::Error> {
+        let ignore_avs_result =
+            CybersourceConnectorMetadataObject::try_from(&item.router_data.connector_meta_data)?
+                .disable_avs;
         let (action_list, action_token_types, authorization_options) = if item
             .router_data
             .request
@@ -813,12 +844,13 @@ impl
                         stored_credential_used: None,
                     }),
                     merchant_intitiated_transaction: None,
+                    ignore_avs_result,
                 }),
             )
         } else {
             (None, None, None)
         };
-        Self {
+        Ok(Self {
             capture: Some(matches!(
                 item.router_data.request.capture_method,
                 Some(enums::CaptureMethod::Automatic) | None
@@ -832,7 +864,7 @@ impl
                 .indicator
                 .to_owned()
                 .unwrap_or(String::from("internet")),
-        }
+        })
     }
 }
 
@@ -1100,7 +1132,7 @@ impl
             })?;
 
         let processing_information =
-            ProcessingInformation::from((item, None, &three_ds_info.three_ds_data));
+            ProcessingInformation::try_from((item, None, &three_ds_info.three_ds_data))?;
 
         let consumer_authentication_information = Some(CybersourceConsumerAuthInformation {
             ucaf_collection_indicator: three_ds_info.three_ds_data.ucaf_collection_indicator,
@@ -1585,6 +1617,10 @@ impl TryFrom<&CybersourceRouterData<&types::PaymentsIncrementalAuthorizationRout
     fn try_from(
         item: &CybersourceRouterData<&types::PaymentsIncrementalAuthorizationRouterData>,
     ) -> Result<Self, Self::Error> {
+        let ignore_avs_result =
+            CybersourceConnectorMetadataObject::try_from(&item.router_data.connector_meta_data)?
+                .disable_avs;
+
         Ok(Self {
             processing_information: ProcessingInformation {
                 action_list: None,
@@ -1600,6 +1636,7 @@ impl TryFrom<&CybersourceRouterData<&types::PaymentsIncrementalAuthorizationRout
                         previous_transaction_id: None,
                         original_authorized_amount: None,
                     }),
+                    ignore_avs_result,
                 }),
                 commerce_indicator: String::from("internet"),
                 capture: None,

--- a/crates/router/src/connector/cybersource/transformers.rs
+++ b/crates/router/src/connector/cybersource/transformers.rs
@@ -729,12 +729,16 @@ impl
                 None => (None, None, None),
             }
         } else {
-            (None, None, Some(CybersourceAuthorizationOptions {
-                initiator: None,
-                merchant_intitiated_transaction: None,
-                ignore_avs_result : connector_merchant_config.disable_avs,
-                ignore_cv_result: connector_merchant_config.disable_cvn,
-            }))
+            (
+                None,
+                None,
+                Some(CybersourceAuthorizationOptions {
+                    initiator: None,
+                    merchant_intitiated_transaction: None,
+                    ignore_avs_result: connector_merchant_config.disable_avs,
+                    ignore_cv_result: connector_merchant_config.disable_cvn,
+                }),
+            )
         };
         // this logic is for external authenticated card
         let commerce_indicator_for_external_authentication = item

--- a/crates/router/src/core/admin.rs
+++ b/crates/router/src/core/admin.rs
@@ -1335,6 +1335,9 @@ impl<'a> ConnectorAuthTypeAndMetadataValidation<'a> {
             }
             api_enums::Connector::Cybersource => {
                 cybersource::transformers::CybersourceAuthType::try_from(self.auth_type)?;
+                cybersource::transformers::CybersourceConnectorMetadataObject::try_from(
+                    self.connector_meta_data,
+                )?;
                 Ok(())
             }
             api_enums::Connector::Datatrans => {


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
When `disable_avs` is enabled, avs result will be ignored by Cybersource. 
When `disable_cvn` is enabled, cvn result will be ignored by Cybersource.
```
  "metadata": {
        "disable_avs": true,
       "disable_cvn": true,
}
```
> Note:  These flags are not effective in sandbox

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Can't be tested as avs check is only done in production env
Sanity 
1. Create a payment with cards
```
curl --location 'http://localhost:8080/payments' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: dev_aQxPOtk3HOI1YMCSh71XowkHSKeKmfYLoakbfXuAMxlEIX93sCOenDWzBySirGhl' \
--data-raw '{
    "amount": 1000,
    "currency": "USD",
    "confirm": true,
    "capture_method": "automatic",
    "capture_on": "2022-09-10T10:11:12Z",
    "customer_id": "testCus_15",
    "email": "guest@example.com",
    "name": "John Doe",
    "phone": "999999999",
    "phone_country_code": "+1",
    "description": "Its my first payment request",
    "authentication_type": "no_three_ds",
    "return_url": "https://duck.com",
    "payment_method": "card",
    "payment_method_type": "credit",
    "payment_method_data": {
        "card": {
            "card_number":  "4242424242424242", 
            "card_exp_month": "10",
            "card_exp_year": "25",
            "card_holder_name": "joseph Doe",
            "card_cvc": "123"
        }
    },
    "billing": {
        "address": {
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "city": "San Fransico",
            "state": "California",
            "zip": "94122",
            "country": "US",
            "first_name": "Rayan",
            "last_name": "Doe"
        },
        "phone": {
            "number": "9123456789",
            "country_code": "+91"
        }
    },
    "shipping": {
        "address": {
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "city": "San Fransico",
            "state": "California",
            "zip": "94122",
            "country": "US",
            "first_name": "Rayan",
            "last_name": "Doe"
        },
        "phone": {
            "number": "9123456789",
            "country_code": "+91"
        }
    },
    "statement_descriptor_name": "joseph",
    "statement_descriptor_suffix": "JS"
    ,"setup_future_usage": "off_session",
    
    "customer_acceptance": {
        "acceptance_type": "offline",
        "accepted_at": "1963-05-03T04:07:52.723Z",
        "online": {
            "ip_address": "13.232.74.226",
            "user_agent": "amet irure esse"
        }
    }
}'
```
Response
```
{
    "payment_id": "pay_CTH8cvEA9uDUnxqkYI6R",
    "merchant_id": "postman_merchant_GHAction_dc98950e-5985-4b6f-8ecf-2d848efb7c96",
    "status": "succeeded",
    "amount": 1000,
    "net_amount": 1000,
    "amount_capturable": 0,
    "amount_received": 1000,
    "connector": "cybersource",
    "client_secret": "pay_CTH8cvEA9uDUnxqkYI6R_secret_c68ZqG1gWbFqJ4P9do7F",
    "created": "2024-08-22T10:28:13.027Z",
    "currency": "USD",
    "customer_id": "testCus_15",
    "customer": {
        "id": "testCus_15",
        "name": "John Doe",
        "email": "guest@example.com",
        "phone": "999999999",
        "phone_country_code": "+1"
    },
    "description": "Its my first payment request",
    "refunds": null,
    "disputes": null,
    "mandate_id": null,
    "mandate_data": null,
    "setup_future_usage": "off_session",
    "off_session": null,
    "capture_on": null,
    "capture_method": "automatic",
    "payment_method": "card",
    "payment_method_data": {
        "card": {
            "last4": "4242",
            "card_type": null,
            "card_network": null,
            "card_issuer": null,
            "card_issuing_country": null,
            "card_isin": "424242",
            "card_extended_bin": null,
            "card_exp_month": "10",
            "card_exp_year": "25",
            "card_holder_name": null,
            "payment_checks": {
                "avs_response": {
                    "code": "Y",
                    "codeRaw": "Y"
                },
                "card_verification": null
            },
            "authentication_data": null
        },
        "billing": null
    },
    "payment_token": "token_s2Wbe6sOlerqSYuKrxbG",
    "shipping": {
        "address": {
            "city": "San Fransico",
            "country": "US",
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "zip": "94122",
            "state": "California",
            "first_name": "Rayan",
            "last_name": "Doe"
        },
        "phone": {
            "number": "9123456789",
            "country_code": "+91"
        },
        "email": null
    },
    "billing": {
        "address": {
            "city": "San Fransico",
            "country": "US",
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "zip": "94122",
            "state": "California",
            "first_name": "Rayan",
            "last_name": "Doe"
        },
        "phone": {
            "number": "9123456789",
            "country_code": "+91"
        },
        "email": null
    },
    "order_details": null,
    "email": "guest@example.com",
    "name": "John Doe",
    "phone": "999999999",
    "return_url": "https://duck.com/",
    "authentication_type": "no_three_ds",
    "statement_descriptor_name": "joseph",
    "statement_descriptor_suffix": "JS",
    "next_action": null,
    "cancellation_reason": null,
    "error_code": null,
    "error_message": null,
    "unified_code": null,
    "unified_message": null,
    "payment_experience": null,
    "payment_method_type": "credit",
    "connector_label": null,
    "business_country": null,
    "business_label": "default",
    "business_sub_label": null,
    "allowed_payment_method_types": null,
    "ephemeral_key": {
        "customer_id": "testCus_15",
        "created_at": 1724322492,
        "expires": 1724326092,
        "secret": "epk_0ef28df9d88e4c32bc08c3b9e60223bb"
    },
    "manual_retry_allowed": false,
    "connector_transaction_id": "7243224942556544504953",
    "frm_message": null,
    "metadata": null,
    "connector_metadata": null,
    "feature_metadata": null,
    "reference_id": "pay_CTH8cvEA9uDUnxqkYI6R_1",
    "payment_link": null,
    "profile_id": "pro_Ligu65tAS9PRvV6cl8jY",
    "surcharge_details": null,
    "attempt_count": 1,
    "merchant_decision": null,
    "merchant_connector_id": "mca_3DSxDdq9eyzOw3X6xF9S",
    "incremental_authorization_allowed": false,
    "authorization_count": null,
    "incremental_authorizations": null,
    "external_authentication_details": null,
    "external_3ds_authentication_attempted": false,
    "expires_on": "2024-08-22T10:43:13.027Z",
    "fingerprint": null,
    "browser_info": null,
    "payment_method_id": "pm_dhvsNUBwSqlD9W6dpj10",
    "payment_method_status": null,
    "updated": "2024-08-22T10:28:16.613Z",
    "charges": null,
    "frm_metadata": null,
    "merchant_order_reference_id": null
}
```


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
