### PR TITLE
chore: create v2 route for organization

### DIFF
--- a/api-reference-v2/api-reference/organization/organization--create.mdx
+++ b/api-reference-v2/api-reference/organization/organization--create.mdx
@@ -1,0 +1,3 @@
+---
+openapi: post /v2/organization
+---

--- a/api-reference-v2/api-reference/organization/organization--retrieve.mdx
+++ b/api-reference-v2/api-reference/organization/organization--retrieve.mdx
@@ -1,0 +1,3 @@
+---
+openapi: get /v2/organization/{organization_id}
+---

--- a/api-reference-v2/api-reference/organization/organization--update.mdx
+++ b/api-reference-v2/api-reference/organization/organization--update.mdx
@@ -1,0 +1,3 @@
+---
+openapi: put /v2/organization/{organization_id}
+---

--- a/api-reference-v2/mint.json
+++ b/api-reference-v2/mint.json
@@ -35,6 +35,14 @@
       ]
     },
     {
+      "group": "Organization",
+      "pages": [
+        "api-reference/organization/organization--create",
+        "api-reference/organization/organization--retrieve",
+        "api-reference/organization/organization--update"
+      ]
+    },
+    {
       "group": "Merchant Account",
       "pages": [
         "api-reference/merchant-account/merchant-account--create",

--- a/api-reference-v2/openapi_spec.json
+++ b/api-reference-v2/openapi_spec.json
@@ -10286,17 +10286,6 @@
           {
             "type": "object",
             "required": [
-              "paypal"
-            ],
-            "properties": {
-              "paypal": {
-                "type": "object"
-              }
-            }
-          },
-          {
-            "type": "object",
-            "required": [
               "bank_redirect"
             ],
             "properties": {

--- a/api-reference-v2/openapi_spec.json
+++ b/api-reference-v2/openapi_spec.json
@@ -20,7 +20,7 @@
     }
   ],
   "paths": {
-    "/organization": {
+    "/v2/organization": {
       "post": {
         "tags": [
           "Organization"
@@ -67,7 +67,7 @@
         ]
       }
     },
-    "/organization/{organization_id}": {
+    "/v2/organization/{organization_id}": {
       "get": {
         "tags": [
           "Organization"

--- a/crates/openapi/src/routes/organization.rs
+++ b/crates/openapi/src/routes/organization.rs
@@ -43,7 +43,8 @@ pub async fn organization_create() {}
 )]
 pub async fn organization_retrieve() {}
 
-#[cfg(feature = "v1")]/// Organization - Update
+#[cfg(feature = "v1")]
+/// Organization - Update
 ///
 /// Create a new organization for .
 #[utoipa::path(
@@ -69,7 +70,6 @@ pub async fn organization_retrieve() {}
     security(("admin_api_key" = []))
 )]
 pub async fn organization_update() {}
-
 
 #[cfg(feature = "v2")]
 /// Organization - Create

--- a/crates/openapi/src/routes/organization.rs
+++ b/crates/openapi/src/routes/organization.rs
@@ -1,4 +1,4 @@
-#[cfg(any(feature = "v1", feature = "v2"))]
+#[cfg(feature = "v1")]
 /// Organization - Create
 ///
 /// Create a new organization
@@ -25,7 +25,7 @@
 )]
 pub async fn organization_create() {}
 
-#[cfg(any(feature = "v1", feature = "v2"))]
+#[cfg(feature = "v1")]
 /// Organization - Retrieve
 ///
 /// Retrieve an existing organization
@@ -43,13 +43,86 @@ pub async fn organization_create() {}
 )]
 pub async fn organization_retrieve() {}
 
-#[cfg(any(feature = "v1", feature = "v2"))]
-/// Organization - Update
+#[cfg(feature = "v1")]/// Organization - Update
 ///
 /// Create a new organization for .
 #[utoipa::path(
     put,
     path = "/organization/{organization_id}",
+    request_body(
+        content = OrganizationRequest,
+        examples(
+            (
+                "Update organization_name of the organization" = (
+                    value = json!({"organization_name": "organization_abcd"})
+                )
+            ),
+        )
+    ),
+    params (("organization_id" = String, Path, description = "The unique identifier for the Organization")),
+    responses(
+        (status = 200, description = "Organization Created", body =OrganizationResponse),
+        (status = 400, description = "Invalid data")
+    ),
+    tag = "Organization",
+    operation_id = "Update an Organization",
+    security(("admin_api_key" = []))
+)]
+pub async fn organization_update() {}
+
+
+#[cfg(feature = "v2")]
+/// Organization - Create
+///
+/// Create a new organization
+#[utoipa::path(
+    post,
+    path = "/v2/organization",
+    request_body(
+        content = OrganizationRequest,
+        examples(
+            (
+                "Create an organization with organization_name" = (
+                    value = json!({"organization_name": "organization_abc"})
+                )
+            ),
+        )
+    ),
+    responses(
+        (status = 200, description = "Organization Created", body =OrganizationResponse),
+        (status = 400, description = "Invalid data")
+    ),
+    tag = "Organization",
+    operation_id = "Create an Organization",
+    security(("admin_api_key" = []))
+)]
+pub async fn organization_create() {}
+
+#[cfg(feature = "v2")]
+/// Organization - Retrieve
+///
+/// Retrieve an existing organization
+#[utoipa::path(
+    get,
+    path = "/v2/organization/{organization_id}",
+    params (("organization_id" = String, Path, description = "The unique identifier for the Organization")),
+    responses(
+        (status = 200, description = "Organization Created", body =OrganizationResponse),
+        (status = 400, description = "Invalid data")
+    ),
+    tag = "Organization",
+    operation_id = "Retrieve an Organization",
+    security(("admin_api_key" = []))
+)]
+pub async fn organization_retrieve() {}
+
+#[cfg(feature = "v2")]
+/// Organization - Update
+///
+/// Create a new organization for .
+#[utoipa::path(
+    put,
+    path = "/v2/organization/{organization_id}",
     request_body(
         content = OrganizationRequest,
         examples(

--- a/crates/router/src/routes/app.rs
+++ b/crates/router/src/routes/app.rs
@@ -1159,7 +1159,7 @@ impl Organization {
 #[cfg(all(feature = "v2", feature = "olap", feature = "merchant_account_v2"))]
 impl Organization {
     pub fn server(state: AppState) -> Scope {
-        web::scope("v2/organization")
+        web::scope("/v2/organization")
             .app_data(web::Data::new(state))
             .service(web::resource("").route(web::post().to(organization_create)))
             .service(

--- a/crates/router/src/routes/app.rs
+++ b/crates/router/src/routes/app.rs
@@ -1137,10 +1137,29 @@ impl Blocklist {
 
 #[cfg(feature = "olap")]
 pub struct Organization;
-#[cfg(feature = "olap")]
+
+#[cfg(all(
+    feature = "olap",
+    any(feature = "v1", feature = "v2"),
+    not(feature = "merchant_account_v2")
+))]
 impl Organization {
     pub fn server(state: AppState) -> Scope {
         web::scope("/organization")
+            .app_data(web::Data::new(state))
+            .service(web::resource("").route(web::post().to(organization_create)))
+            .service(
+                web::resource("/{id}")
+                    .route(web::get().to(organization_retrieve))
+                    .route(web::put().to(organization_update)),
+            )
+    }
+}
+
+#[cfg(all(feature = "v2", feature = "olap", feature = "merchant_account_v2"))]
+impl Organization {
+    pub fn server(state: AppState) -> Scope {
+        web::scope("v2/organization")
             .app_data(web::Data::new(state))
             .service(web::resource("").route(web::post().to(organization_create)))
             .service(


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Added new v2 routes for organization endpoint. And generated open api spec and mintlify docs.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Ran `mintlify dev` to render the newly added routes.
<img width="1728" alt="Screenshot 2024-08-23 at 9 33 34 AM" src="https://github.com/user-attachments/assets/20af0e71-76ea-4bd0-9135-1d1bf96db7c9">

Postman screenshots.
1. Create.
<img width="1728" alt="Screenshot 2024-08-23 at 3 19 27 PM" src="https://github.com/user-attachments/assets/4436d183-2ca2-4478-a306-b5ebeeda0816">

2. Retrieve
<img width="1728" alt="Screenshot 2024-08-23 at 3 19 32 PM" src="https://github.com/user-attachments/assets/ec19f603-af86-4480-a73f-0f5ef979eabf">

3. Update
<img width="1728" alt="Screenshot 2024-08-23 at 3 19 37 PM" src="https://github.com/user-attachments/assets/eee8551a-7a78-4b76-882b-6c6ba7b9ac75">



## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
