### PR TITLE
feat(database): add profile & organisation id to transaction tables

### DIFF
--- a/crates/analytics/docs/clickhouse/scripts/disputes.sql
+++ b/crates/analytics/docs/clickhouse/scripts/disputes.sql
@@ -20,6 +20,7 @@ CREATE TABLE dispute_queue (
     `evidence` Nullable(String),
     `profile_id` Nullable(String),
     `merchant_connector_id` Nullable(String),
+    `organization_id` String,
     `sign_flag` Int8
 ) ENGINE = Kafka SETTINGS kafka_broker_list = 'kafka0:29092',
 kafka_topic_list = 'hyperswitch-dispute-events',
@@ -50,6 +51,7 @@ CREATE TABLE dispute (
     `profile_id` Nullable(String),
     `merchant_connector_id` Nullable(String),
     `inserted_at` DateTime DEFAULT now() CODEC(T64, LZ4),
+    `organization_id` String,
     `sign_flag` Int8,
     INDEX connectorIndex connector TYPE bloom_filter GRANULARITY 1,
     INDEX disputeStatusIndex dispute_status TYPE bloom_filter GRANULARITY 1,
@@ -80,6 +82,7 @@ CREATE MATERIALIZED VIEW dispute_mv TO dispute (
     `evidence` Nullable(String),
     `profile_id` Nullable(String),
     `merchant_connector_id` Nullable(String),
+    `organization_id` String,
     `inserted_at` DateTime64(3),
     `sign_flag` Int8
 ) AS
@@ -105,6 +108,7 @@ SELECT
     evidence,
     profile_id,
     merchant_connector_id,
+    organization_id,
     now() AS inserted_at,
     sign_flag
 FROM

--- a/crates/analytics/docs/clickhouse/scripts/payment_attempts.sql
+++ b/crates/analytics/docs/clickhouse/scripts/payment_attempts.sql
@@ -40,6 +40,8 @@ CREATE TABLE payment_attempt_queue (
     `mandate_data` Nullable(String),
     `client_source` LowCardinality(Nullable(String)),
     `client_version` LowCardinality(Nullable(String)),
+    `organization_id` String,
+    `profile_id` String,
     `sign_flag` Int8
 ) ENGINE = Kafka SETTINGS kafka_broker_list = 'kafka0:29092',
 kafka_topic_list = 'hyperswitch-payment-attempt-events',
@@ -90,6 +92,8 @@ CREATE TABLE payment_attempts (
     `inserted_at` DateTime DEFAULT now() CODEC(T64, LZ4),
     `client_source` LowCardinality(Nullable(String)),
     `client_version` LowCardinality(Nullable(String)),
+    `organization_id` String,
+    `profile_id` String,
     `sign_flag` Int8,
     INDEX connectorIndex connector TYPE bloom_filter GRANULARITY 1,
     INDEX paymentMethodIndex payment_method TYPE bloom_filter GRANULARITY 1,
@@ -143,6 +147,8 @@ CREATE MATERIALIZED VIEW payment_attempt_mv TO payment_attempts (
     `inserted_at` DateTime64(3),
     `client_source` LowCardinality(Nullable(String)),
     `client_version` LowCardinality(Nullable(String)),
+    `organization_id` String,
+    `profile_id` String,
     `sign_flag` Int8
 ) AS
 SELECT
@@ -188,6 +194,8 @@ SELECT
     now() AS inserted_at,
     client_source,
     client_version,
+    organization_id,
+    profile_id,
     sign_flag
 FROM
     payment_attempt_queue

--- a/crates/analytics/docs/clickhouse/scripts/payment_intents.sql
+++ b/crates/analytics/docs/clickhouse/scripts/payment_intents.sql
@@ -23,6 +23,7 @@ CREATE TABLE payment_intents_queue
     `modified_at` DateTime CODEC(T64, LZ4),
     `created_at` DateTime CODEC(T64, LZ4),
     `last_synced` Nullable(DateTime) CODEC(T64, LZ4),
+    `organization_id` String,
     `sign_flag` Int8
 ) ENGINE = Kafka SETTINGS kafka_broker_list = 'kafka0:29092',
 kafka_topic_list = 'hyperswitch-payment-intent-events',
@@ -56,6 +57,7 @@ CREATE TABLE payment_intents
     `created_at` DateTime DEFAULT now() CODEC(T64, LZ4),
     `last_synced` Nullable(DateTime) CODEC(T64, LZ4),
     `inserted_at` DateTime DEFAULT now() CODEC(T64, LZ4),
+    `organization_id` String,
     `sign_flag` Int8,
     INDEX connectorIndex connector_id TYPE bloom_filter GRANULARITY 1,
     INDEX currencyIndex currency TYPE bloom_filter GRANULARITY 1,
@@ -93,6 +95,7 @@ CREATE MATERIALIZED VIEW payment_intents_mv TO payment_intents
     `created_at` DateTime64(3),
     `last_synced` Nullable(DateTime64(3)),
     `inserted_at` DateTime64(3),
+    `organization_id` String,
     `sign_flag` Int8
 ) AS
 SELECT
@@ -120,5 +123,6 @@ SELECT
     created_at,
     last_synced,
     now() AS inserted_at,
+    organization_id,
     sign_flag
 FROM payment_intents_queue;

--- a/crates/analytics/docs/clickhouse/scripts/refunds.sql
+++ b/crates/analytics/docs/clickhouse/scripts/refunds.sql
@@ -21,6 +21,8 @@ CREATE TABLE refund_queue (
     `refund_error_code` Nullable(String),
     `created_at` DateTime,
     `modified_at` DateTime,
+    `organization_id` String,
+    `profile_id` String,
     `sign_flag` Int8
 ) ENGINE = Kafka SETTINGS kafka_broker_list = 'kafka0:29092',
 kafka_topic_list = 'hyperswitch-refund-events',
@@ -52,6 +54,8 @@ CREATE TABLE refunds (
     `created_at` DateTime DEFAULT now() CODEC(T64, LZ4),
     `modified_at` DateTime DEFAULT now() CODEC(T64, LZ4),
     `inserted_at` DateTime DEFAULT now() CODEC(T64, LZ4),
+    `organization_id` String,
+    `profile_id` String,
     `sign_flag` Int8,
     INDEX connectorIndex connector TYPE bloom_filter GRANULARITY 1,
     INDEX refundTypeIndex refund_type TYPE bloom_filter GRANULARITY 1,
@@ -85,6 +89,8 @@ CREATE MATERIALIZED VIEW refund_mv TO refunds (
     `created_at` DateTime64(3),
     `modified_at` DateTime64(3),
     `inserted_at` DateTime64(3),
+    `organization_id` String,
+    `profile_id` String,
     `sign_flag` Int8
 ) AS
 SELECT
@@ -111,6 +117,8 @@ SELECT
     created_at,
     modified_at,
     now() AS inserted_at,
+    organization_id,
+    profile_id,
     sign_flag
 FROM
     refund_queue

--- a/crates/diesel_models/src/dispute.rs
+++ b/crates/diesel_models/src/dispute.rs
@@ -30,6 +30,7 @@ pub struct DisputeNew {
     pub profile_id: Option<String>,
     pub merchant_connector_id: Option<String>,
     pub dispute_amount: i64,
+    pub organization_id: String,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Identifiable, Queryable, Selectable)]
@@ -59,6 +60,7 @@ pub struct Dispute {
     pub profile_id: Option<String>,
     pub merchant_connector_id: Option<String>,
     pub dispute_amount: i64,
+    pub organization_id: String,
 }
 
 #[derive(Debug)]

--- a/crates/diesel_models/src/payment_attempt.rs
+++ b/crates/diesel_models/src/payment_attempt.rs
@@ -78,6 +78,8 @@ pub struct PaymentAttempt {
     pub client_source: Option<String>,
     pub client_version: Option<String>,
     pub customer_acceptance: Option<pii::SecretSerdeValue>,
+    pub profile_id: String,
+    pub organization_id: String,
 }
 
 #[cfg(all(any(feature = "v1", feature = "v2"), not(feature = "payment_v2")))]
@@ -149,6 +151,8 @@ pub struct PaymentAttempt {
     pub client_source: Option<String>,
     pub client_version: Option<String>,
     pub customer_acceptance: Option<pii::SecretSerdeValue>,
+    pub profile_id: String,
+    pub organization_id: String,
 }
 
 impl PaymentAttempt {
@@ -231,6 +235,8 @@ pub struct PaymentAttemptNew {
     pub client_source: Option<String>,
     pub client_version: Option<String>,
     pub customer_acceptance: Option<pii::SecretSerdeValue>,
+    pub profile_id: String,
+    pub organization_id: String,
 }
 
 impl PaymentAttemptNew {

--- a/crates/diesel_models/src/payment_intent.rs
+++ b/crates/diesel_models/src/payment_intent.rs
@@ -69,6 +69,7 @@ pub struct PaymentIntent {
     pub merchant_order_reference_id: Option<String>,
     pub shipping_details: Option<Encryption>,
     pub is_payment_processor_token_flow: Option<bool>,
+    pub organization_id: String,
 }
 
 #[cfg(all(any(feature = "v1", feature = "v2"), not(feature = "payment_v2")))]
@@ -130,6 +131,7 @@ pub struct PaymentIntent {
     pub merchant_order_reference_id: Option<String>,
     pub shipping_details: Option<Encryption>,
     pub is_payment_processor_token_flow: Option<bool>,
+    pub organization_id: String,
 }
 
 #[derive(
@@ -190,6 +192,7 @@ pub struct PaymentIntentNew {
     pub merchant_order_reference_id: Option<String>,
     pub shipping_details: Option<Encryption>,
     pub is_payment_processor_token_flow: Option<bool>,
+    pub organization_id: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/diesel_models/src/refund.rs
+++ b/crates/diesel_models/src/refund.rs
@@ -50,6 +50,7 @@ pub struct Refund {
     pub updated_by: String,
     pub merchant_connector_id: Option<String>,
     pub charges: Option<ChargeRefunds>,
+    pub organization_id: String,
 }
 
 #[derive(
@@ -92,6 +93,7 @@ pub struct RefundNew {
     pub updated_by: String,
     pub merchant_connector_id: Option<String>,
     pub charges: Option<ChargeRefunds>,
+    pub organization_id: String,
 }
 
 impl Default for RefundNew {
@@ -122,6 +124,7 @@ impl Default for RefundNew {
             updated_by: Default::default(),
             merchant_connector_id: Default::default(),
             charges: Default::default(),
+            organization_id: Default::default(),
         }
     }
 }

--- a/crates/diesel_models/src/schema.rs
+++ b/crates/diesel_models/src/schema.rs
@@ -370,6 +370,8 @@ diesel::table! {
         #[max_length = 32]
         merchant_connector_id -> Nullable<Varchar>,
         dispute_amount -> Int8,
+        #[max_length = 32]
+        organization_id -> Varchar,
     }
 }
 
@@ -826,6 +828,10 @@ diesel::table! {
         #[max_length = 64]
         client_version -> Nullable<Varchar>,
         customer_acceptance -> Nullable<Jsonb>,
+        #[max_length = 64]
+        profile_id -> Varchar,
+        #[max_length = 32]
+        organization_id -> Varchar,
     }
 }
 
@@ -901,6 +907,8 @@ diesel::table! {
         merchant_order_reference_id -> Nullable<Varchar>,
         shipping_details -> Nullable<Bytea>,
         is_payment_processor_token_flow -> Nullable<Bool>,
+        #[max_length = 32]
+        organization_id -> Varchar,
     }
 }
 
@@ -1145,6 +1153,8 @@ diesel::table! {
         #[max_length = 32]
         merchant_connector_id -> Nullable<Varchar>,
         charges -> Nullable<Jsonb>,
+        #[max_length = 32]
+        organization_id -> Varchar,
     }
 }
 

--- a/crates/diesel_models/src/user/sample_data.rs
+++ b/crates/diesel_models/src/user/sample_data.rs
@@ -80,6 +80,8 @@ pub struct PaymentAttemptBatchNew {
     pub client_source: Option<String>,
     pub client_version: Option<String>,
     pub customer_acceptance: Option<common_utils::pii::SecretSerdeValue>,
+    pub profile_id: String,
+    pub organization_id: String,
 }
 
 #[allow(dead_code)]
@@ -144,6 +146,8 @@ impl PaymentAttemptBatchNew {
             client_source: self.client_source,
             client_version: self.client_version,
             customer_acceptance: self.customer_acceptance,
+            profile_id: self.profile_id,
+            organization_id: self.organization_id,
         }
     }
 }

--- a/crates/hyperswitch_domain_models/src/payments.rs
+++ b/crates/hyperswitch_domain_models/src/payments.rs
@@ -43,7 +43,7 @@ pub struct PaymentIntent {
     pub allowed_payment_method_types: Option<serde_json::Value>,
     pub connector_metadata: Option<serde_json::Value>,
     pub feature_metadata: Option<serde_json::Value>,
-    pub attempt_count: i16,
+    pub attempt_count: i16, 
     pub profile_id: Option<String>,
     pub payment_link_id: Option<String>,
     // Denotes the action(approve or reject) taken by merchant in case of manual review.
@@ -67,4 +67,5 @@ pub struct PaymentIntent {
     pub merchant_order_reference_id: Option<String>,
     pub shipping_details: Option<Encryptable<Secret<serde_json::Value>>>,
     pub is_payment_processor_token_flow: Option<bool>,
+    pub organization_id: String,
 }

--- a/crates/hyperswitch_domain_models/src/payments.rs
+++ b/crates/hyperswitch_domain_models/src/payments.rs
@@ -43,7 +43,7 @@ pub struct PaymentIntent {
     pub allowed_payment_method_types: Option<serde_json::Value>,
     pub connector_metadata: Option<serde_json::Value>,
     pub feature_metadata: Option<serde_json::Value>,
-    pub attempt_count: i16, 
+    pub attempt_count: i16,
     pub profile_id: Option<String>,
     pub payment_link_id: Option<String>,
     // Denotes the action(approve or reject) taken by merchant in case of manual review.

--- a/crates/hyperswitch_domain_models/src/payments/payment_attempt.rs
+++ b/crates/hyperswitch_domain_models/src/payments/payment_attempt.rs
@@ -181,6 +181,8 @@ pub struct PaymentAttempt {
     pub client_source: Option<String>,
     pub client_version: Option<String>,
     pub customer_acceptance: Option<pii::SecretSerdeValue>,
+    pub profile_id: String,
+    pub organization_id: String,
 }
 
 impl PaymentAttempt {
@@ -271,6 +273,8 @@ pub struct PaymentAttemptNew {
     pub client_source: Option<String>,
     pub client_version: Option<String>,
     pub customer_acceptance: Option<pii::SecretSerdeValue>,
+    pub profile_id: String,
+    pub organization_id: String,
 }
 
 impl PaymentAttemptNew {
@@ -742,6 +746,7 @@ impl behaviour::Conversion for PaymentIntent {
             merchant_order_reference_id: self.merchant_order_reference_id,
             shipping_details: self.shipping_details.map(Encryption::from),
             is_payment_processor_token_flow: self.is_payment_processor_token_flow,
+            organization_id: self.organization_id,
         })
     }
 
@@ -825,6 +830,7 @@ impl behaviour::Conversion for PaymentIntent {
                     .async_lift(inner_decrypt)
                     .await?,
                 is_payment_processor_token_flow: storage_model.is_payment_processor_token_flow,
+                organization_id: storage_model.organization_id,
             })
         }
         .await
@@ -883,6 +889,7 @@ impl behaviour::Conversion for PaymentIntent {
             merchant_order_reference_id: self.merchant_order_reference_id,
             shipping_details: self.shipping_details.map(Encryption::from),
             is_payment_processor_token_flow: self.is_payment_processor_token_flow,
+            organization_id: self.organization_id
         })
     }
 }

--- a/crates/hyperswitch_domain_models/src/payments/payment_attempt.rs
+++ b/crates/hyperswitch_domain_models/src/payments/payment_attempt.rs
@@ -889,7 +889,7 @@ impl behaviour::Conversion for PaymentIntent {
             merchant_order_reference_id: self.merchant_order_reference_id,
             shipping_details: self.shipping_details.map(Encryption::from),
             is_payment_processor_token_flow: self.is_payment_processor_token_flow,
-            organization_id: self.organization_id
+            organization_id: self.organization_id,
         })
     }
 }

--- a/crates/hyperswitch_domain_models/src/payments/payment_intent.rs
+++ b/crates/hyperswitch_domain_models/src/payments/payment_intent.rs
@@ -23,7 +23,7 @@ pub trait PaymentIntentInterface {
         merchant_key_store: &MerchantKeyStore,
         storage_scheme: storage_enums::MerchantStorageScheme,
     ) -> error_stack::Result<PaymentIntent, errors::StorageError>;
-
+ 
     async fn insert_payment_intent(
         &self,
         state: &KeyManagerState,
@@ -144,6 +144,7 @@ pub struct PaymentIntentNew {
     pub billing_details: Option<Encryptable<Secret<serde_json::Value>>>,
     pub shipping_details: Option<Encryptable<Secret<serde_json::Value>>>,
     pub is_payment_processor_token_flow: Option<bool>,
+    pub organization_id: String,
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/crates/hyperswitch_domain_models/src/payments/payment_intent.rs
+++ b/crates/hyperswitch_domain_models/src/payments/payment_intent.rs
@@ -23,7 +23,7 @@ pub trait PaymentIntentInterface {
         merchant_key_store: &MerchantKeyStore,
         storage_scheme: storage_enums::MerchantStorageScheme,
     ) -> error_stack::Result<PaymentIntent, errors::StorageError>;
- 
+
     async fn insert_payment_intent(
         &self,
         state: &KeyManagerState,

--- a/crates/router/src/core/payments/helpers.rs
+++ b/crates/router/src/core/payments/helpers.rs
@@ -3752,6 +3752,8 @@ impl AttemptType {
             client_source: old_payment_attempt.client_source,
             client_version: old_payment_attempt.client_version,
             customer_acceptance: old_payment_attempt.customer_acceptance,
+            organization_id: old_payment_attempt.organization_id,
+            profile_id: old_payment_attempt.profile_id,
         }
     }
 

--- a/crates/router/src/core/payments/operations/payment_create.rs
+++ b/crates/router/src/core/payments/operations/payment_create.rs
@@ -308,7 +308,7 @@ impl<F: Send + Clone> GetTracker<F, PaymentData<F>, api::PaymentsRequest> for Pa
         let (payment_attempt_new, additional_payment_data) = Self::make_payment_attempt(
             &payment_id,
             merchant_id,
-            &merchant_account.organization_id, 
+            &merchant_account.organization_id,
             money,
             payment_method,
             payment_method_type,
@@ -317,7 +317,7 @@ impl<F: Send + Clone> GetTracker<F, PaymentData<F>, api::PaymentsRequest> for Pa
             state,
             payment_method_billing_address
                 .as_ref()
-                .map(|address| address.address_id.clone()), 
+                .map(|address| address.address_id.clone()),
             &payment_method_info,
             merchant_key_store,
             profile_id,
@@ -1250,7 +1250,10 @@ impl PaymentCreate {
             merchant_order_reference_id: request.merchant_order_reference_id.clone(),
             shipping_details,
             is_payment_processor_token_flow,
-            organization_id: merchant_account.organization_id.get_string_repr().to_string(),
+            organization_id: merchant_account
+                .organization_id
+                .get_string_repr()
+                .to_string(),
         })
     }
 

--- a/crates/router/src/core/payments/operations/payment_create.rs
+++ b/crates/router/src/core/payments/operations/payment_create.rs
@@ -308,6 +308,7 @@ impl<F: Send + Clone> GetTracker<F, PaymentData<F>, api::PaymentsRequest> for Pa
         let (payment_attempt_new, additional_payment_data) = Self::make_payment_attempt(
             &payment_id,
             merchant_id,
+            &merchant_account.organization_id, 
             money,
             payment_method,
             payment_method_type,
@@ -316,7 +317,7 @@ impl<F: Send + Clone> GetTracker<F, PaymentData<F>, api::PaymentsRequest> for Pa
             state,
             payment_method_billing_address
                 .as_ref()
-                .map(|address| address.address_id.clone()),
+                .map(|address| address.address_id.clone()), 
             &payment_method_info,
             merchant_key_store,
             profile_id,
@@ -874,6 +875,7 @@ impl PaymentCreate {
     pub async fn make_payment_attempt(
         payment_id: &str,
         merchant_id: &common_utils::id_type::MerchantId,
+        organization_id: &common_utils::id_type::OrganizationId,
         money: (api::Amount, enums::Currency),
         payment_method: Option<enums::PaymentMethod>,
         payment_method_type: Option<enums::PaymentMethodType>,
@@ -1065,6 +1067,8 @@ impl PaymentCreate {
                     .change_context(errors::ApiErrorResponse::InternalServerError)
                     .attach_printable("Failed to serialize customer_acceptance")?
                     .map(Secret::new),
+                organization_id: organization_id.get_string_repr().to_string(),
+                profile_id,
             },
             additional_pm_data,
         ))
@@ -1246,6 +1250,7 @@ impl PaymentCreate {
             merchant_order_reference_id: request.merchant_order_reference_id.clone(),
             shipping_details,
             is_payment_processor_token_flow,
+            organization_id: merchant_account.organization_id.get_string_repr().to_string(),
         })
     }
 

--- a/crates/router/src/core/user/sample_data.rs
+++ b/crates/router/src/core/user/sample_data.rs
@@ -19,7 +19,7 @@ pub async fn generate_sample_data_for_user(
     req: SampleDataRequest,
     _req_state: ReqState,
 ) -> SampleDataApiResponse<()> {
-    let sample_data = generate_sample_data(&state, req, &user_from_token.merchant_id).await?;
+    let sample_data = generate_sample_data(&state, req, &user_from_token.merchant_id, &user_from_token.org_id).await?;
 
     let key_store = state
         .store

--- a/crates/router/src/core/user/sample_data.rs
+++ b/crates/router/src/core/user/sample_data.rs
@@ -19,7 +19,13 @@ pub async fn generate_sample_data_for_user(
     req: SampleDataRequest,
     _req_state: ReqState,
 ) -> SampleDataApiResponse<()> {
-    let sample_data = generate_sample_data(&state, req, &user_from_token.merchant_id, &user_from_token.org_id).await?;
+    let sample_data = generate_sample_data(
+        &state,
+        req,
+        &user_from_token.merchant_id,
+        &user_from_token.org_id,
+    )
+    .await?;
 
     let key_store = state
         .store

--- a/crates/router/src/core/webhooks/incoming.rs
+++ b/crates/router/src/core/webhooks/incoming.rs
@@ -907,6 +907,7 @@ async fn get_or_update_dispute_object(
     option_dispute: Option<diesel_models::dispute::Dispute>,
     dispute_details: api::disputes::DisputePayload,
     merchant_id: &common_utils::id_type::MerchantId,
+    organization_id: &common_utils::id_type::OrganizationId,
     payment_attempt: &hyperswitch_domain_models::payments::payment_attempt::PaymentAttempt,
     event_type: webhooks::IncomingWebhookEvent,
     business_profile: &domain::BusinessProfile,
@@ -940,6 +941,7 @@ async fn get_or_update_dispute_object(
                 evidence: None,
                 merchant_connector_id: payment_attempt.merchant_connector_id.clone(),
                 dispute_amount: dispute_details.amount.parse::<i64>().unwrap_or(0),
+                organization_id: organization_id.get_string_repr().to_owned(),
             };
             state
                 .store
@@ -1391,6 +1393,7 @@ async fn disputes_incoming_webhook_flow(
             option_dispute,
             dispute_details,
             merchant_account.get_id(),
+            &merchant_account.organization_id,
             &payment_attempt,
             event_type,
             &business_profile,

--- a/crates/router/src/db/dispute.rs
+++ b/crates/router/src/db/dispute.rs
@@ -170,6 +170,7 @@ impl DisputeInterface for MockDb {
             evidence,
             merchant_connector_id: dispute.merchant_connector_id,
             dispute_amount: dispute.dispute_amount,
+            organization_id: dispute.organization_id,
         };
 
         locked_disputes.push(new_dispute.clone());

--- a/crates/router/src/db/refund.rs
+++ b/crates/router/src/db/refund.rs
@@ -398,6 +398,7 @@ mod storage {
                         updated_by: new.updated_by.clone(),
                         merchant_connector_id: new.merchant_connector_id.clone(),
                         charges: new.charges.clone(),
+                        organization_id: new.organization_id.clone(),
                     };
 
                     let field = format!(
@@ -859,6 +860,7 @@ impl RefundInterface for MockDb {
             updated_by: new.updated_by,
             merchant_connector_id: new.merchant_connector_id,
             charges: new.charges,
+            organization_id: new.organization_id,
         };
         refunds.push(refund.clone());
         Ok(refund)

--- a/crates/router/src/services/kafka/dispute.rs
+++ b/crates/router/src/services/kafka/dispute.rs
@@ -32,7 +32,7 @@ pub struct KafkaDispute<'a> {
     pub evidence: &'a Secret<serde_json::Value>,
     pub profile_id: Option<&'a String>,
     pub merchant_connector_id: Option<&'a String>,
-    pub organization_id: &'a String
+    pub organization_id: &'a String,
 }
 
 impl<'a> KafkaDispute<'a> {
@@ -59,7 +59,7 @@ impl<'a> KafkaDispute<'a> {
             evidence: &dispute.evidence,
             profile_id: dispute.profile_id.as_ref(),
             merchant_connector_id: dispute.merchant_connector_id.as_ref(),
-            organization_id: &dispute.organization_id
+            organization_id: &dispute.organization_id,
         }
     }
 }
@@ -78,4 +78,3 @@ impl<'a> super::KafkaMessage for KafkaDispute<'a> {
         crate::events::EventType::Dispute
     }
 }
- 

--- a/crates/router/src/services/kafka/dispute.rs
+++ b/crates/router/src/services/kafka/dispute.rs
@@ -32,6 +32,7 @@ pub struct KafkaDispute<'a> {
     pub evidence: &'a Secret<serde_json::Value>,
     pub profile_id: Option<&'a String>,
     pub merchant_connector_id: Option<&'a String>,
+    pub organization_id: &'a String
 }
 
 impl<'a> KafkaDispute<'a> {
@@ -58,6 +59,7 @@ impl<'a> KafkaDispute<'a> {
             evidence: &dispute.evidence,
             profile_id: dispute.profile_id.as_ref(),
             merchant_connector_id: dispute.merchant_connector_id.as_ref(),
+            organization_id: &dispute.organization_id
         }
     }
 }
@@ -76,3 +78,4 @@ impl<'a> super::KafkaMessage for KafkaDispute<'a> {
         crate::events::EventType::Dispute
     }
 }
+ 

--- a/crates/router/src/services/kafka/dispute_event.rs
+++ b/crates/router/src/services/kafka/dispute_event.rs
@@ -33,6 +33,7 @@ pub struct KafkaDisputeEvent<'a> {
     pub evidence: &'a Secret<serde_json::Value>,
     pub profile_id: Option<&'a String>,
     pub merchant_connector_id: Option<&'a String>,
+    pub organization_id: &'a String
 }
 
 impl<'a> KafkaDisputeEvent<'a> {
@@ -59,6 +60,7 @@ impl<'a> KafkaDisputeEvent<'a> {
             evidence: &dispute.evidence,
             profile_id: dispute.profile_id.as_ref(),
             merchant_connector_id: dispute.merchant_connector_id.as_ref(),
+            organization_id: &dispute.organization_id
         }
     }
 }

--- a/crates/router/src/services/kafka/dispute_event.rs
+++ b/crates/router/src/services/kafka/dispute_event.rs
@@ -33,7 +33,7 @@ pub struct KafkaDisputeEvent<'a> {
     pub evidence: &'a Secret<serde_json::Value>,
     pub profile_id: Option<&'a String>,
     pub merchant_connector_id: Option<&'a String>,
-    pub organization_id: &'a String
+    pub organization_id: &'a String,
 }
 
 impl<'a> KafkaDisputeEvent<'a> {
@@ -60,7 +60,7 @@ impl<'a> KafkaDisputeEvent<'a> {
             evidence: &dispute.evidence,
             profile_id: dispute.profile_id.as_ref(),
             merchant_connector_id: dispute.merchant_connector_id.as_ref(),
-            organization_id: &dispute.organization_id
+            organization_id: &dispute.organization_id,
         }
     }
 }

--- a/crates/router/src/services/kafka/payment_attempt.rs
+++ b/crates/router/src/services/kafka/payment_attempt.rs
@@ -54,6 +54,8 @@ pub struct KafkaPaymentAttempt<'a> {
     pub mandate_data: Option<&'a MandateDetails>,
     pub client_source: Option<&'a String>,
     pub client_version: Option<&'a String>,
+    pub profile_id: &'a String,
+    pub organization_id: &'a String
 }
 
 impl<'a> KafkaPaymentAttempt<'a> {
@@ -100,6 +102,8 @@ impl<'a> KafkaPaymentAttempt<'a> {
             mandate_data: attempt.mandate_data.as_ref(),
             client_source: attempt.client_source.as_ref(),
             client_version: attempt.client_version.as_ref(),
+            profile_id: &attempt.profile_id,
+            organization_id: &attempt.organization_id,
         }
     }
 }

--- a/crates/router/src/services/kafka/payment_attempt.rs
+++ b/crates/router/src/services/kafka/payment_attempt.rs
@@ -55,7 +55,7 @@ pub struct KafkaPaymentAttempt<'a> {
     pub client_source: Option<&'a String>,
     pub client_version: Option<&'a String>,
     pub profile_id: &'a String,
-    pub organization_id: &'a String
+    pub organization_id: &'a String,
 }
 
 impl<'a> KafkaPaymentAttempt<'a> {

--- a/crates/router/src/services/kafka/payment_attempt_event.rs
+++ b/crates/router/src/services/kafka/payment_attempt_event.rs
@@ -56,7 +56,7 @@ pub struct KafkaPaymentAttemptEvent<'a> {
     pub client_source: Option<&'a String>,
     pub client_version: Option<&'a String>,
     pub profile_id: &'a String,
-    pub organization_id: &'a String
+    pub organization_id: &'a String,
 }
 
 impl<'a> KafkaPaymentAttemptEvent<'a> {
@@ -68,7 +68,7 @@ impl<'a> KafkaPaymentAttemptEvent<'a> {
             status: attempt.status,
             amount: attempt.amount,
             currency: attempt.currency,
-            save_to_locker: attempt.save_to_locker, 
+            save_to_locker: attempt.save_to_locker,
             connector: attempt.connector.as_ref(),
             error_message: attempt.error_message.as_ref(),
             offer_amount: attempt.offer_amount,

--- a/crates/router/src/services/kafka/payment_attempt_event.rs
+++ b/crates/router/src/services/kafka/payment_attempt_event.rs
@@ -55,6 +55,8 @@ pub struct KafkaPaymentAttemptEvent<'a> {
     pub mandate_data: Option<&'a MandateDetails>,
     pub client_source: Option<&'a String>,
     pub client_version: Option<&'a String>,
+    pub profile_id: &'a String,
+    pub organization_id: &'a String
 }
 
 impl<'a> KafkaPaymentAttemptEvent<'a> {
@@ -66,7 +68,7 @@ impl<'a> KafkaPaymentAttemptEvent<'a> {
             status: attempt.status,
             amount: attempt.amount,
             currency: attempt.currency,
-            save_to_locker: attempt.save_to_locker,
+            save_to_locker: attempt.save_to_locker, 
             connector: attempt.connector.as_ref(),
             error_message: attempt.error_message.as_ref(),
             offer_amount: attempt.offer_amount,
@@ -101,6 +103,8 @@ impl<'a> KafkaPaymentAttemptEvent<'a> {
             mandate_data: attempt.mandate_data.as_ref(),
             client_source: attempt.client_source.as_ref(),
             client_version: attempt.client_version.as_ref(),
+            profile_id: &attempt.profile_id,
+            organization_id: &attempt.organization_id,
         }
     }
 }

--- a/crates/router/src/services/kafka/payment_intent.rs
+++ b/crates/router/src/services/kafka/payment_intent.rs
@@ -40,7 +40,7 @@ pub struct KafkaPaymentIntent<'a> {
     pub customer_email: Option<HashedString<pii::EmailStrategy>>,
     pub feature_metadata: Option<&'a Value>,
     pub merchant_order_reference_id: Option<&'a String>,
-    pub organization_id: &'a String
+    pub organization_id: &'a String,
 }
 
 impl<'a> KafkaPaymentIntent<'a> {
@@ -97,4 +97,3 @@ impl<'a> super::KafkaMessage for KafkaPaymentIntent<'a> {
         crate::events::EventType::PaymentIntent
     }
 }
- 

--- a/crates/router/src/services/kafka/payment_intent.rs
+++ b/crates/router/src/services/kafka/payment_intent.rs
@@ -40,6 +40,7 @@ pub struct KafkaPaymentIntent<'a> {
     pub customer_email: Option<HashedString<pii::EmailStrategy>>,
     pub feature_metadata: Option<&'a Value>,
     pub merchant_order_reference_id: Option<&'a String>,
+    pub organization_id: &'a String
 }
 
 impl<'a> KafkaPaymentIntent<'a> {
@@ -82,6 +83,7 @@ impl<'a> KafkaPaymentIntent<'a> {
                 .map(|email| HashedString::from(Secret::new(email.to_string()))),
             feature_metadata: intent.feature_metadata.as_ref(),
             merchant_order_reference_id: intent.merchant_order_reference_id.as_ref(),
+            organization_id: &intent.organization_id,
         }
     }
 }
@@ -95,3 +97,4 @@ impl<'a> super::KafkaMessage for KafkaPaymentIntent<'a> {
         crate::events::EventType::PaymentIntent
     }
 }
+ 

--- a/crates/router/src/services/kafka/payment_intent_event.rs
+++ b/crates/router/src/services/kafka/payment_intent_event.rs
@@ -41,7 +41,7 @@ pub struct KafkaPaymentIntentEvent<'a> {
     pub customer_email: Option<HashedString<pii::EmailStrategy>>,
     pub feature_metadata: Option<&'a Value>,
     pub merchant_order_reference_id: Option<&'a String>,
-    pub organization_id: &'a String
+    pub organization_id: &'a String,
 }
 
 impl<'a> KafkaPaymentIntentEvent<'a> {
@@ -84,7 +84,7 @@ impl<'a> KafkaPaymentIntentEvent<'a> {
                 .map(|email| HashedString::from(Secret::new(email.to_string()))),
             feature_metadata: intent.feature_metadata.as_ref(),
             merchant_order_reference_id: intent.merchant_order_reference_id.as_ref(),
-            organization_id: &intent.organization_id
+            organization_id: &intent.organization_id,
         }
     }
 }

--- a/crates/router/src/services/kafka/payment_intent_event.rs
+++ b/crates/router/src/services/kafka/payment_intent_event.rs
@@ -41,6 +41,7 @@ pub struct KafkaPaymentIntentEvent<'a> {
     pub customer_email: Option<HashedString<pii::EmailStrategy>>,
     pub feature_metadata: Option<&'a Value>,
     pub merchant_order_reference_id: Option<&'a String>,
+    pub organization_id: &'a String
 }
 
 impl<'a> KafkaPaymentIntentEvent<'a> {
@@ -83,6 +84,7 @@ impl<'a> KafkaPaymentIntentEvent<'a> {
                 .map(|email| HashedString::from(Secret::new(email.to_string()))),
             feature_metadata: intent.feature_metadata.as_ref(),
             merchant_order_reference_id: intent.merchant_order_reference_id.as_ref(),
+            organization_id: &intent.organization_id
         }
     }
 }

--- a/crates/router/src/services/kafka/refund.rs
+++ b/crates/router/src/services/kafka/refund.rs
@@ -29,7 +29,7 @@ pub struct KafkaRefund<'a> {
     pub refund_reason: Option<&'a String>,
     pub refund_error_code: Option<&'a String>,
     pub profile_id: Option<&'a String>,
-    pub organization_id: &'a String
+    pub organization_id: &'a String,
 }
 
 impl<'a> KafkaRefund<'a> {

--- a/crates/router/src/services/kafka/refund.rs
+++ b/crates/router/src/services/kafka/refund.rs
@@ -28,6 +28,8 @@ pub struct KafkaRefund<'a> {
     pub attempt_id: &'a String,
     pub refund_reason: Option<&'a String>,
     pub refund_error_code: Option<&'a String>,
+    pub profile_id: Option<&'a String>,
+    pub organization_id: &'a String
 }
 
 impl<'a> KafkaRefund<'a> {
@@ -55,6 +57,8 @@ impl<'a> KafkaRefund<'a> {
             attempt_id: &refund.attempt_id,
             refund_reason: refund.refund_reason.as_ref(),
             refund_error_code: refund.refund_error_code.as_ref(),
+            profile_id: refund.profile_id.as_ref(),
+            organization_id: &refund.organization_id,
         }
     }
 }

--- a/crates/router/src/services/kafka/refund_event.rs
+++ b/crates/router/src/services/kafka/refund_event.rs
@@ -30,7 +30,7 @@ pub struct KafkaRefundEvent<'a> {
     pub refund_reason: Option<&'a String>,
     pub refund_error_code: Option<&'a String>,
     pub profile_id: Option<&'a String>,
-    pub organization_id: &'a String
+    pub organization_id: &'a String,
 }
 
 impl<'a> KafkaRefundEvent<'a> {

--- a/crates/router/src/services/kafka/refund_event.rs
+++ b/crates/router/src/services/kafka/refund_event.rs
@@ -29,6 +29,8 @@ pub struct KafkaRefundEvent<'a> {
     pub attempt_id: &'a String,
     pub refund_reason: Option<&'a String>,
     pub refund_error_code: Option<&'a String>,
+    pub profile_id: Option<&'a String>,
+    pub organization_id: &'a String
 }
 
 impl<'a> KafkaRefundEvent<'a> {
@@ -56,6 +58,8 @@ impl<'a> KafkaRefundEvent<'a> {
             attempt_id: &refund.attempt_id,
             refund_reason: refund.refund_reason.as_ref(),
             refund_error_code: refund.refund_error_code.as_ref(),
+            profile_id: refund.profile_id.as_ref(),
+            organization_id: &refund.organization_id,
         }
     }
 }

--- a/crates/router/src/utils/user/sample_data.rs
+++ b/crates/router/src/utils/user/sample_data.rs
@@ -253,7 +253,7 @@ pub async fn generate_sample_data(
             merchant_order_reference_id: Default::default(),
             shipping_details: None,
             is_payment_processor_token_flow: None,
-            organization_id: org_id.get_string_repr().to_string()
+            organization_id: org_id.get_string_repr().to_string(),
         };
         let payment_attempt = PaymentAttemptBatchNew {
             attempt_id: attempt_id.clone(),
@@ -332,7 +332,7 @@ pub async fn generate_sample_data(
             client_version: None,
             customer_acceptance: None,
             profile_id: String::from("sample_data_profile"),
-            organization_id: org_id.get_string_repr().to_string()
+            organization_id: org_id.get_string_repr().to_string(),
         };
 
         let refund = if refunds_count < number_of_refunds && !is_failed_payment {
@@ -368,7 +368,7 @@ pub async fn generate_sample_data(
                 updated_by: merchant_from_db.storage_scheme.to_string(),
                 merchant_connector_id: payment_attempt.merchant_connector_id.clone(),
                 charges: None,
-                organization_id: org_id.get_string_repr().to_string()
+                organization_id: org_id.get_string_repr().to_string(),
             })
         } else {
             None

--- a/crates/router/src/utils/user/sample_data.rs
+++ b/crates/router/src/utils/user/sample_data.rs
@@ -20,6 +20,7 @@ pub async fn generate_sample_data(
     state: &SessionState,
     req: SampleDataRequest,
     merchant_id: &id_type::MerchantId,
+    org_id: &id_type::OrganizationId,
 ) -> SampleDataResult<Vec<(PaymentIntent, PaymentAttemptBatchNew, Option<RefundNew>)>> {
     let sample_data_size: usize = req.record.unwrap_or(100);
     let key_manager_state = &state.into();
@@ -252,6 +253,7 @@ pub async fn generate_sample_data(
             merchant_order_reference_id: Default::default(),
             shipping_details: None,
             is_payment_processor_token_flow: None,
+            organization_id: org_id.get_string_repr().to_string()
         };
         let payment_attempt = PaymentAttemptBatchNew {
             attempt_id: attempt_id.clone(),
@@ -329,6 +331,8 @@ pub async fn generate_sample_data(
             client_source: None,
             client_version: None,
             customer_acceptance: None,
+            profile_id: String::from("sample_data_profile"),
+            organization_id: org_id.get_string_repr().to_string()
         };
 
         let refund = if refunds_count < number_of_refunds && !is_failed_payment {
@@ -364,6 +368,7 @@ pub async fn generate_sample_data(
                 updated_by: merchant_from_db.storage_scheme.to_string(),
                 merchant_connector_id: payment_attempt.merchant_connector_id.clone(),
                 charges: None,
+                organization_id: org_id.get_string_repr().to_string()
             })
         } else {
             None

--- a/crates/storage_impl/src/mock_db/payment_attempt.rs
+++ b/crates/storage_impl/src/mock_db/payment_attempt.rs
@@ -158,6 +158,8 @@ impl PaymentAttemptInterface for MockDb {
             client_source: payment_attempt.client_source,
             client_version: payment_attempt.client_version,
             customer_acceptance: payment_attempt.customer_acceptance,
+            organization_id: payment_attempt.organization_id,
+            profile_id: payment_attempt.profile_id,
         };
         payment_attempts.push(payment_attempt.clone());
         Ok(payment_attempt)

--- a/crates/storage_impl/src/payments/payment_attempt.rs
+++ b/crates/storage_impl/src/payments/payment_attempt.rs
@@ -419,6 +419,8 @@ impl<T: DatabaseStore> PaymentAttemptInterface for KVRouterStore<T> {
                     client_source: payment_attempt.client_source.clone(),
                     client_version: payment_attempt.client_version.clone(),
                     customer_acceptance: payment_attempt.customer_acceptance.clone(),
+                    organization_id: payment_attempt.organization_id.clone(),
+                    profile_id: payment_attempt.profile_id.clone(),
                 };
 
                 let field = format!("pa_{}", created_attempt.attempt_id);
@@ -1356,6 +1358,8 @@ impl DataModelExt for PaymentAttempt {
             client_source: self.client_source,
             client_version: self.client_version,
             customer_acceptance: self.customer_acceptance,
+            organization_id: self.organization_id,
+            profile_id: self.profile_id,
         }
     }
 
@@ -1423,6 +1427,8 @@ impl DataModelExt for PaymentAttempt {
             client_source: storage_model.client_source,
             client_version: storage_model.client_version,
             customer_acceptance: storage_model.customer_acceptance,
+            organization_id: storage_model.organization_id,
+            profile_id: storage_model.profile_id,
         }
     }
 }
@@ -1495,8 +1501,10 @@ impl DataModelExt for PaymentAttemptNew {
             fingerprint_id: self.fingerprint_id,
             charge_id: self.charge_id,
             client_source: self.client_source,
-            client_version: self.client_version,
+             client_version: self.client_version,
             customer_acceptance: self.customer_acceptance,
+            organization_id: self.organization_id,
+            profile_id: self.profile_id,
         }
     }
 
@@ -1563,6 +1571,8 @@ impl DataModelExt for PaymentAttemptNew {
             client_source: storage_model.client_source,
             client_version: storage_model.client_version,
             customer_acceptance: storage_model.customer_acceptance,
+            organization_id: storage_model.organization_id,
+            profile_id: storage_model.profile_id,
         }
     }
 }

--- a/crates/storage_impl/src/payments/payment_attempt.rs
+++ b/crates/storage_impl/src/payments/payment_attempt.rs
@@ -1501,7 +1501,7 @@ impl DataModelExt for PaymentAttemptNew {
             fingerprint_id: self.fingerprint_id,
             charge_id: self.charge_id,
             client_source: self.client_source,
-             client_version: self.client_version,
+            client_version: self.client_version,
             customer_acceptance: self.customer_acceptance,
             organization_id: self.organization_id,
             profile_id: self.profile_id,

--- a/migrations/2024-08-20-112035_add-profile-id-to-txn-tables/down.sql
+++ b/migrations/2024-08-20-112035_add-profile-id-to-txn-tables/down.sql
@@ -1,0 +1,20 @@
+-- This file should undo anything in `up.sql`
+-- Remove profile_id from payment_attempt table
+ALTER TABLE payment_attempt
+DROP COLUMN IF EXISTS profile_id;
+
+-- Remove organization_id from payment_attempt table
+ALTER TABLE payment_attempt
+DROP COLUMN IF EXISTS organization_id;
+
+-- Remove organization_id from payment_intent table
+ALTER TABLE payment_intent
+DROP COLUMN IF EXISTS organization_id;
+
+-- Remove organization_id from refund table
+ALTER TABLE refund
+DROP COLUMN IF EXISTS organization_id;
+
+-- Remove organization_id from dispute table
+ALTER TABLE dispute
+DROP COLUMN IF EXISTS organization_id;

--- a/migrations/2024-08-20-112035_add-profile-id-to-txn-tables/up.sql
+++ b/migrations/2024-08-20-112035_add-profile-id-to-txn-tables/up.sql
@@ -1,0 +1,19 @@
+-- Your SQL goes here
+ALTER TABLE payment_attempt
+ADD COLUMN IF NOT EXISTS profile_id VARCHAR(64) NOT NULL DEFAULT 'default_profile';
+
+-- Add organization_id to payment_attempt table
+ALTER TABLE payment_attempt
+ADD COLUMN IF NOT EXISTS organization_id VARCHAR(32) NOT NULL DEFAULT 'default_org';
+
+-- Add organization_id to payment_intent table
+ALTER TABLE payment_intent
+ADD COLUMN IF NOT EXISTS organization_id VARCHAR(32) NOT NULL DEFAULT 'default_org';
+
+-- Add organization_id to refund table
+ALTER TABLE refund
+ADD COLUMN IF NOT EXISTS organization_id VARCHAR(32) NOT NULL DEFAULT 'default_org';
+
+-- Add organization_id to dispute table
+ALTER TABLE dispute
+ADD COLUMN IF NOT EXISTS organization_id VARCHAR(32) NOT NULL DEFAULT 'default_org';


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Add organisation id for 
- payment intents
- payment attempts
- refunds
- disputes
add profile id for payment attempts

Add the above fields in clickhouse & kafka as well

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->

Adding these fields to provide better authentication guards

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
<img width="975" alt="image" src="https://github.com/user-attachments/assets/dcb1ff45-4771-4382-9f97-36039abb9ef2">

Check for the added columns in pgweb/grafana

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
