### PR TITLE
ci(cypress): Handle failures for trustpay bank-redirects

### DIFF
--- a/cypress-tests/cypress/e2e/PaymentUtils/Trustpay.js
+++ b/cypress-tests/cypress/e2e/PaymentUtils/Trustpay.js
@@ -321,7 +321,8 @@ export const connectorDetails = {
       Response: {
         status: 200,
         body: {
-          status: "requires_customer_action",
+          status: "failed",
+          error_code: "1133001",
         },
       },
     },

--- a/cypress-tests/cypress/e2e/PaymentUtils/Trustpay.js
+++ b/cypress-tests/cypress/e2e/PaymentUtils/Trustpay.js
@@ -323,6 +323,8 @@ export const connectorDetails = {
         body: {
           status: "failed",
           error_code: "1133001",
+          error_message:
+            "Giropay payments are not enabled in Project 4107608031",
         },
       },
     },

--- a/cypress-tests/cypress/support/redirectionHandler.js
+++ b/cypress-tests/cypress/support/redirectionHandler.js
@@ -247,10 +247,9 @@ function bankRedirectRedirection(
           break;
         case "ideal":
           cy.contains("button", "Select your bank").click();
-          cy.get('[data-testid="ideal-box-bank-item-INGBNL2A-content"]')
-            .should("be.visible")
-            .click();
-
+          cy.get(
+            'button[data-testid="bank-item"][id="bank-item-INGBNL2A"]'
+          ).click();
           break;
         case "giropay":
           cy.get("._transactionId__header__iXVd_").should(


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [x] CI/CD

## Description
- Giropay is deprecated from trustpay hence added error message
- Fixed elements changes for ideal redirection flow


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
Test cases were failing


## How did you test it?
Cypress

<img width="585" alt="image" src="https://github.com/user-attachments/assets/5c96fc50-1fc4-4c08-b410-e9c2cb5a23d1">

Note : Failed test cases are not related to these changes , this will be picked up by @Gnanasundari24 
## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
