### PR TITLE
fix(cypress): fix cypress throwing error when `connectorId` is not passed and miscellaneous fixes

### DIFF
--- a/cypress-tests/cypress.config.js
+++ b/cypress-tests/cypress.config.js
@@ -4,7 +4,7 @@ const path = require("path");
 
 let globalState;
 // Fetch from environment variable
-const connectorId = process.env.CYPRESS_CONNECTOR;
+const connectorId = process.env.CYPRESS_CONNECTOR || "service";
 const reportName = process.env.REPORT_NAME || `${connectorId}_report`;
 
 module.exports = defineConfig({

--- a/cypress-tests/cypress/e2e/PaymentUtils/Commons.js
+++ b/cypress-tests/cypress/e2e/PaymentUtils/Commons.js
@@ -20,11 +20,13 @@ function normalise(input) {
     // Add more known exceptions here
   };
 
-  if (exceptions[input.toLowerCase()]) {
-    return exceptions[input.toLowerCase()];
-  } else {
-    return input;
+  if (typeof input !== "string") {
+    const spec_name = Cypress.spec.name.split("-")[1].split(".")[0];
+    return `${spec_name}`;
   }
+
+  const lowerCaseInput = input.toLowerCase();
+  return exceptions[lowerCaseInput] || input;
 }
 
 const successfulNo3DSCardDetails = {

--- a/cypress-tests/cypress/e2e/PaymentUtils/Fiservemea.js
+++ b/cypress-tests/cypress/e2e/PaymentUtils/Fiservemea.js
@@ -1,164 +1,163 @@
 const successfulNo3DSCardDetails = {
-    card_number: "5204740000001002",
-    card_exp_month: "10",
-    card_exp_year: "24",
-    card_holder_name: "Joseph Doe",
-    card_cvc: "002",
-  };
-  
-  export const connectorDetails = {
-    card_pm: {
-      PaymentIntent: {
-        Request: {
-          payment_method: "card",
-          payment_method_data: {
-            card: successfulNo3DSCardDetails,
-          },
-          currency: "EUR",
-          customer_acceptance: null,
-          setup_future_usage: "on_session",
+  card_number: "5204740000001002",
+  card_exp_month: "10",
+  card_exp_year: "24",
+  card_holder_name: "Joseph Doe",
+  card_cvc: "002",
+};
+
+export const connectorDetails = {
+  card_pm: {
+    PaymentIntent: {
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulNo3DSCardDetails,
         },
-        Response: {
-          status: 200,
-          body: {
-            status: "requires_payment_method",
-          },
+        currency: "EUR",
+        customer_acceptance: null,
+        setup_future_usage: "on_session",
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "requires_payment_method",
         },
       },
-      No3DSManualCapture: {
-        Request: {
-          payment_method: "card",
-          payment_method_data: {
-            card: successfulNo3DSCardDetails,
-          },
-          currency: "EUR",
-          customer_acceptance: null,
-          setup_future_usage: "on_session",
+    },
+    No3DSManualCapture: {
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulNo3DSCardDetails,
         },
-        Response: {
-          status: 200,
-          body: {
-            status: "requires_capture",
-          },
+        currency: "EUR",
+        customer_acceptance: null,
+        setup_future_usage: "on_session",
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "requires_capture",
         },
       },
-      No3DSAutoCapture: {
-        Request: {
-          payment_method: "card",
-          payment_method_data: {
-            card: successfulNo3DSCardDetails,
-          },
-          currency: "EUR",
-          customer_acceptance: null,
-          setup_future_usage: "on_session",
+    },
+    No3DSAutoCapture: {
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulNo3DSCardDetails,
         },
-        Response: {
-          status: 200,
-          body: {
-            status: "succeeded",
-          },
+        currency: "EUR",
+        customer_acceptance: null,
+        setup_future_usage: "on_session",
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "succeeded",
         },
       },
-      Capture: {
-        Request: {
-          payment_method: "card",
-          payment_method_data: {
-            card: successfulNo3DSCardDetails,
-          },
-          currency: "EUR",
-          customer_acceptance: null,
+    },
+    Capture: {
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulNo3DSCardDetails,
         },
-        Response: {
-          status: 200,
-          body: {
-            status: "succeeded",
-            amount: 6500,
-            amount_capturable: 0,
-            amount_received: 6500,
-          },
+        currency: "EUR",
+        customer_acceptance: null,
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "succeeded",
+          amount: 6500,
+          amount_capturable: 0,
+          amount_received: 6500,
         },
       },
-      PartialCapture: {
-        Request: {},
-        Response: {
-          status: 200,
-          body: {
-            status: "partially_captured",
-            amount: 6500,
-            amount_capturable: 0,
-            amount_received: 100,
-          },
+    },
+    PartialCapture: {
+      Request: {},
+      Response: {
+        status: 200,
+        body: {
+          status: "partially_captured",
+          amount: 6500,
+          amount_capturable: 0,
+          amount_received: 100,
         },
       },
-      Void: {
-        Request: {},
-        Response: {
-          status: 200,
-          body: {
-            status: "cancelled",
-          },
+    },
+    Void: {
+      Request: {},
+      Response: {
+        status: 200,
+        body: {
+          status: "cancelled",
         },
       },
-      Refund: {
-        Request: {
-          payment_method: "card",
-          payment_method_data: {
-            card: successfulNo3DSCardDetails,
-          },
-          currency: "EUR",
-          customer_acceptance: null,
+    },
+    Refund: {
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulNo3DSCardDetails,
         },
-        Response: {
-          status: 200,
-          body: {
-            status: "succeeded",
-          },
+        currency: "EUR",
+        customer_acceptance: null,
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "succeeded",
         },
       },
-      PartialRefund: {
-        Request: {
-          payment_method: "card",
-          payment_method_data: {
-            card: successfulNo3DSCardDetails,
-          },
-          currency: "EUR",
-          customer_acceptance: null,
+    },
+    PartialRefund: {
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulNo3DSCardDetails,
         },
-        Response: {
-          status: 200,
-          body: {
-            status: "succeeded",
-          },
+        currency: "EUR",
+        customer_acceptance: null,
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "succeeded",
         },
       },
-      SyncRefund: {
-        Request: {
-          payment_method: "card",
-          payment_method_data: {
-            card: successfulNo3DSCardDetails,
-          },
-          currency: "EUR",
-          customer_acceptance: null,
+    },
+    SyncRefund: {
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulNo3DSCardDetails,
         },
-        Response: {
-          status: 200,
-          body: {
-            status: "succeeded",
-          },
+        currency: "EUR",
+        customer_acceptance: null,
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "succeeded",
         },
       },
-      ZeroAuthMandate: {
-        Response: {
-          status: 501,
-          body: {
-            error: {
-              type: "invalid_request",
-              message: "Setup Mandate flow for Fiservemea is not implemented",
-              code: "IR_00",
-            },
+    },
+    ZeroAuthMandate: {
+      Response: {
+        status: 501,
+        body: {
+          error: {
+            type: "invalid_request",
+            message: "Setup Mandate flow for Fiservemea is not implemented",
+            code: "IR_00",
           },
         },
       },
     },
-  };
-  
+  },
+};

--- a/cypress-tests/cypress/e2e/RoutingTest/00002-RuleBasedRouting.cy.js
+++ b/cypress-tests/cypress/e2e/RoutingTest/00002-RuleBasedRouting.cy.js
@@ -21,8 +21,6 @@ describe("Rule Based Routing Test", () => {
       let res_data = data["Response"];
 
       cy.createJWTToken(req_data, res_data, globalState);
-      if (should_continue)
-        should_continue = utils.should_continue_further(res_data);
     });
 
     it("merchant retrieve call", () => {

--- a/cypress-tests/cypress/support/commands.js
+++ b/cypress-tests/cypress/support/commands.js
@@ -324,7 +324,6 @@ Cypress.Commands.add(
               "merchantConnectorId",
               response.body.merchant_connector_id
             );
-            globalState.set("connectorId", connectorName);
           } else {
             cy.task(
               "cli_log",
@@ -392,7 +391,6 @@ Cypress.Commands.add(
               "merchantConnectorId",
               response.body.merchant_connector_id
             );
-            globalState.set("connectorId", response.body.connector_name);
           } else {
             cy.task(
               "cli_log",
@@ -461,7 +459,6 @@ Cypress.Commands.add(
             expect(globalState.get("connectorId")).to.equal(
               response.body.connector_name
             );
-            globalState.set("connectorId", response.body.connector_name);
             globalState.set(
               "merchantConnectorId",
               response.body.merchant_connector_id
@@ -2124,7 +2121,6 @@ Cypress.Commands.add(
       expect(response.headers["content-type"]).to.include("application/json");
 
       if (response.status === 200) {
-        globalState.set("connectorId", response.body.connector_name);
         expect(response.body).to.have.property("id");
         globalState.set("routingConfigId", response.body.id);
         for (const key in res_data.body) {
@@ -2184,10 +2180,6 @@ Cypress.Commands.add(
       expect(response.headers["content-type"]).to.include("application/json");
 
       if (response.status === 200) {
-        if (globalState.get("connectorId") === undefined) {
-          globalState.set("connectorId", response.body.connector_name);
-        }
-
         expect(response.body.id).to.equal(routing_config_id);
         for (const key in res_data.body) {
           expect(res_data.body[key]).to.equal(response.body[key]);

--- a/cypress-tests/cypress/support/commands.js
+++ b/cypress-tests/cypress/support/commands.js
@@ -324,6 +324,7 @@ Cypress.Commands.add(
               "merchantConnectorId",
               response.body.merchant_connector_id
             );
+            globalState.set("connectorId", connectorName);
           } else {
             cy.task(
               "cli_log",
@@ -391,6 +392,7 @@ Cypress.Commands.add(
               "merchantConnectorId",
               response.body.merchant_connector_id
             );
+            globalState.set("connectorId", response.body.connector_name);
           } else {
             cy.task(
               "cli_log",
@@ -459,6 +461,7 @@ Cypress.Commands.add(
             expect(globalState.get("connectorId")).to.equal(
               response.body.connector_name
             );
+            globalState.set("connectorId", response.body.connector_name);
             globalState.set(
               "merchantConnectorId",
               response.body.merchant_connector_id
@@ -2121,6 +2124,7 @@ Cypress.Commands.add(
       expect(response.headers["content-type"]).to.include("application/json");
 
       if (response.status === 200) {
+        globalState.set("connectorId", response.body.connector_name);
         expect(response.body).to.have.property("id");
         globalState.set("routingConfigId", response.body.id);
         for (const key in res_data.body) {
@@ -2180,6 +2184,10 @@ Cypress.Commands.add(
       expect(response.headers["content-type"]).to.include("application/json");
 
       if (response.status === 200) {
+        if (globalState.get("connectorId") === undefined) {
+          globalState.set("connectorId", response.body.connector_name);
+        }
+
         expect(response.body.id).to.equal(routing_config_id);
         for (const key in res_data.body) {
           expect(res_data.body[key]).to.equal(response.body[key]);

--- a/cypress-tests/package-lock.json
+++ b/cypress-tests/package-lock.json
@@ -12,7 +12,7 @@
         "prettier": "^3.3.2"
       },
       "devDependencies": {
-        "cypress": "^13.13.3",
+        "cypress": "13.14.0",
         "cypress-mochawesome-reporter": "^3.8.2",
         "jsqr": "^1.4.0"
       }
@@ -722,11 +722,12 @@
       }
     },
     "node_modules/cypress": {
-      "version": "13.13.3",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.13.3.tgz",
-      "integrity": "sha512-hUxPrdbJXhUOTzuML+y9Av7CKoYznbD83pt8g3klgpioEha0emfx4WNIuVRx0C76r0xV2MIwAW9WYiXfVJYFQw==",
+      "version": "13.14.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.14.0.tgz",
+      "integrity": "sha512-r0+nhd033x883YL6068futewUsl02Q7rWiinyAAIBDW/OOTn+UMILWgNuCiY3vtJjd53efOqq5R9dctQk/rKiw==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "MIT",
       "dependencies": {
         "@cypress/request": "^3.0.1",
         "@cypress/xvfb": "^1.2.4",

--- a/cypress-tests/package-lock.json
+++ b/cypress-tests/package-lock.json
@@ -12,7 +12,7 @@
         "prettier": "^3.3.2"
       },
       "devDependencies": {
-        "cypress": "13.14.0",
+        "cypress": "^13.14.1",
         "cypress-mochawesome-reporter": "^3.8.2",
         "jsqr": "^1.4.0"
       }
@@ -722,9 +722,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "13.14.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.14.0.tgz",
-      "integrity": "sha512-r0+nhd033x883YL6068futewUsl02Q7rWiinyAAIBDW/OOTn+UMILWgNuCiY3vtJjd53efOqq5R9dctQk/rKiw==",
+      "version": "13.14.1",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.14.1.tgz",
+      "integrity": "sha512-Wo+byPmjps66hACEH5udhXINEiN3qS3jWNGRzJOjrRJF3D0+YrcP2LVB1T7oYaVQM/S+eanqEvBWYc8cf7Vcbg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",

--- a/cypress-tests/package.json
+++ b/cypress-tests/package.json
@@ -15,7 +15,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "cypress": "^13.14.0",
+    "cypress": "^13.14.1",
     "cypress-mochawesome-reporter": "^3.8.2",
     "jsqr": "^1.4.0"
   },

--- a/cypress-tests/package.json
+++ b/cypress-tests/package.json
@@ -15,7 +15,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "cypress": "^13.13.3",
+    "cypress": "^13.14.0",
     "cypress-mochawesome-reporter": "^3.8.2",
     "jsqr": "^1.4.0"
   },


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [x] CI/CD

## Description
<!-- Describe your changes in detail -->

- This PR aims to fix Cypress throwing error when the `connectorId` is `undefined`. This would occur when `routing` and `payment method list` tests were being run directly without passing the `connectorId` which is in fact redundant
  - As for `reports`, we now pass `service` as prefix without which it takes `undefined` as connector name which is not intended and for CI, reportName is considered from `env`
- This PR also addresses one of the issue with `routing` test by removing `should_continue` flag  where Cypress would throw an error stating  it to be not defined
- In addition to that, we now set the `connectorId` in `globalState` during connector create call to address occasional unintended issues where it would not get updated properly
- Bumped Cypress version to `v13.14.0` from `v13.13.3`
- Lints

> [!NOTE]
> Changes have been split into different commits for ease of reviewing.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->

NIL

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

|PML|ROUTING|
|-|-|
|<img width="760" alt="image" src="https://github.com/user-attachments/assets/dbac6d30-5ba4-447f-be36-5137d0813296">|<img width="727" alt="image" src="https://github.com/user-attachments/assets/0044c6dc-9f6d-4896-9fca-1a489725e375">|
| `npm run cypress:payment-method-list`|`npm run cypress:routing`|

> [!NOTE]
> Routing tests now throw one less error.
> PML and Routing tests now run without user needing to pass `CYPRESS_CONNECTOR` as `env`

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `prettier . --write`
- [ ] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
