### PR TITLE
fix(router): send post message to window.parent instead of window.top in external 3ds flow

### DIFF
--- a/crates/router/src/core/utils.rs
+++ b/crates/router/src/core/utils.rs
@@ -1240,7 +1240,7 @@ pub fn get_html_redirect_response_for_external_authentication(
                                     try {{
                                         // if inside iframe, send post message to parent for redirection
                                         if (window.self !== window.parent) {{
-                                            window.top.postMessage({{poll_status: poll_status_data}}, '*')
+                                            window.parent.postMessage({{poll_status: poll_status_data}}, '*')
                                         // if parent, redirect self to return_url
                                         }} else {{
                                             window.location.href = return_url
@@ -1248,7 +1248,7 @@ pub fn get_html_redirect_response_for_external_authentication(
                                     }}
                                     catch(err) {{
                                         // if error occurs, send post message to parent and wait for 10 secs to redirect. if doesn't redirect, redirect self to return_url
-                                        window.top.postMessage({{poll_status: poll_status_data}}, '*')
+                                        window.parent.postMessage({{poll_status: poll_status_data}}, '*')
                                         setTimeout(function() {{
                                             window.location.href = return_url
                                         }}, 10000);
@@ -1270,7 +1270,7 @@ pub fn get_html_redirect_response_for_external_authentication(
                                     try {{
                                         // if inside iframe, send post message to parent for redirection
                                         if (window.self !== window.parent) {{
-                                            window.top.postMessage({{openurl_if_required: return_url}}, '*')
+                                            window.parent.postMessage({{openurl_if_required: return_url}}, '*')
                                         // if parent, redirect self to return_url
                                         }} else {{
                                             window.location.href = return_url
@@ -1278,7 +1278,7 @@ pub fn get_html_redirect_response_for_external_authentication(
                                     }}
                                     catch(err) {{
                                         // if error occurs, send post message to parent and wait for 10 secs to redirect. if doesn't redirect, redirect self to return_url
-                                        window.top.postMessage({{openurl_if_required: return_url}}, '*')
+                                        window.parent.postMessage({{openurl_if_required: return_url}}, '*')
                                         setTimeout(function() {{
                                             window.location.href = return_url
                                         }}, 10000);


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
send post message to window.parent instead of window.top in external 3ds flow

SDK is making a change of adding an event listener at the parent, this approach is more fault tolerant and SDK would be handling the redirection from post message even when during an architecture / design change in SDK

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Sanity External 3DS payment using Netcetera <> Cybersource

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
