### PR TITLE
chore: make kms decryption optional if partial auth not enabled

### DIFF
--- a/crates/router/src/configs/secrets_transformers.rs
+++ b/crates/router/src/configs/secrets_transformers.rs
@@ -115,6 +115,9 @@ impl SecretsHandler for settings::ApiKeys {
         let expiry_reminder_days = api_keys.expiry_reminder_days.clone();
 
         #[cfg(feature = "partial-auth")]
+        let enable_partial_auth = api_keys.enable_partial_auth;
+
+        #[cfg(feature = "partial-auth")]
         let (checksum_auth_context, checksum_auth_key) = {
             if enable_partial_auth {
                 let checksum_auth_context = secret_management_client
@@ -128,8 +131,6 @@ impl SecretsHandler for settings::ApiKeys {
                 (String::new().into(), String::new().into())
             }
         };
-        #[cfg(feature = "partial-auth")]
-        let enable_partial_auth = api_keys.enable_partial_auth;
 
         Ok(value.transition_state(|_| Self {
             hash_key,

--- a/crates/router/src/configs/secrets_transformers.rs
+++ b/crates/router/src/configs/secrets_transformers.rs
@@ -115,14 +115,19 @@ impl SecretsHandler for settings::ApiKeys {
         let expiry_reminder_days = api_keys.expiry_reminder_days.clone();
 
         #[cfg(feature = "partial-auth")]
-        let checksum_auth_context = secret_management_client
-            .get_secret(api_keys.checksum_auth_context.clone())
-            .await?;
-        #[cfg(feature = "partial-auth")]
-        let checksum_auth_key = secret_management_client
-            .get_secret(api_keys.checksum_auth_key.clone())
-            .await?;
-
+        let (checksum_auth_context, checksum_auth_key) = {
+            if enable_partial_auth {
+                let checksum_auth_context = secret_management_client
+                    .get_secret(api_keys.checksum_auth_context.clone())
+                    .await?;
+                let checksum_auth_key = secret_management_client
+                    .get_secret(api_keys.checksum_auth_key.clone())
+                    .await?;
+                (checksum_auth_context, checksum_auth_key)
+            } else {
+                (String::new().into(), String::new().into())
+            }
+        };
         #[cfg(feature = "partial-auth")]
         let enable_partial_auth = api_keys.enable_partial_auth;
 


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description


Putting the checksum kms decryption under the runtime feature flag


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
it was a fix for an issue that happened on integ deployment the other day. No testing is required


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
