### PR TITLE
fix(cypress): `api_key` check in cypress

### DIFF
--- a/cypress-tests/cypress/support/commands.js
+++ b/cypress-tests/cypress/support/commands.js
@@ -253,7 +253,7 @@ Cypress.Commands.add("apiKeyListCall", (globalState) => {
           .and.not.empty;
       } else if (base_url.includes("localhost")) {
         expect(response.body[key]).to.have.property("key_id").include("dev_")
-          .and;
+          .and.not.empty;
       }
       expect(response.body[key].merchant_id).to.equal(merchant_id);
     }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [x] CI/CD

## Description
<!-- Describe your changes in detail -->

This PR fixes minor issue with respect to how api key validation is done in Cypress.  
The implementation was not complete and would fail in local (`dev_`).

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->

NIL

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

No tests needed. It is just that, when running in local, the API Key should get validated properly.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `prettier . --write`
- [ ] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
