### PR TITLE
fix(docker): add `version_feature_set` build arg with default as `v1` in wasm build dockerfile

### DIFF
--- a/docker/wasm-build.Dockerfile
+++ b/docker/wasm-build.Dockerfile
@@ -2,6 +2,7 @@ FROM rust:latest as builder
 
 ARG RUN_ENV=sandbox
 ARG EXTRA_FEATURES=""
+ARG VERSION_FEATURE_SET="v1"
 
 RUN apt-get update \
     && apt-get install -y clang libssl-dev pkg-config
@@ -18,7 +19,7 @@ ENV env=$env
 COPY . .
 RUN echo env
 RUN cargo install wasm-pack
-RUN wasm-pack build --target web --out-dir /tmp/wasm --out-name euclid crates/euclid_wasm -- --features ${RUN_ENV},${EXTRA_FEATURES}
+RUN wasm-pack build --target web --out-dir /tmp/wasm --out-name euclid crates/euclid_wasm -- --features ${VERSION_FEATURE_SET},${RUN_ENV},${EXTRA_FEATURES}
 
 FROM scratch
 


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
It is now required to either enable v1 or v2 feature while building wasm
This PR adds `version_feature_set` build arg with default as `v1` in wasm build dockerfile


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Built locally
![image](https://github.com/user-attachments/assets/ebdaafcd-8b53-48bb-b502-cacbf70b3074)

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
