### PR TITLE
fix(process): add process tracker support for instant refunds

### DIFF
--- a/crates/router/src/compatibility/stripe/refunds.rs
+++ b/crates/router/src/compatibility/stripe/refunds.rs
@@ -100,7 +100,7 @@ pub async fn refund_retrieve_with_gateway_creds(
                 None,
                 auth.key_store,
                 refund_request,
-                refunds::refund_retrieve_core,
+                refunds::refund_retrieve_core_with_refund_id,
             )
         },
         &auth::HeaderAuth(auth::ApiKeyAuth),
@@ -143,7 +143,7 @@ pub async fn refund_retrieve(
                 None,
                 auth.key_store,
                 refund_request,
-                refunds::refund_retrieve_core,
+                refunds::refund_retrieve_core_with_refund_id,
             )
         },
         &auth::HeaderAuth(auth::ApiKeyAuth),

--- a/crates/router/src/core/webhooks/incoming.rs
+++ b/crates/router/src/core/webhooks/incoming.rs
@@ -820,7 +820,7 @@ async fn refunds_incoming_webhook_flow(
         .to_not_found_response(errors::ApiErrorResponse::WebhookResourceNotFound)
         .attach_printable_lazy(|| format!("Failed while updating refund: refund_id: {refund_id}"))?
     } else {
-        Box::pin(refunds::refund_retrieve_core(
+        Box::pin(refunds::refund_retrieve_core_with_refund_id(
             state.clone(),
             merchant_account.clone(),
             None,

--- a/crates/router/src/routes/refunds.rs
+++ b/crates/router/src/routes/refunds.rs
@@ -103,7 +103,7 @@ pub async fn refunds_retrieve(
                 auth.profile_id,
                 auth.key_store,
                 refund_request,
-                refund_retrieve_core,
+                refund_retrieve_core_with_refund_id,
             )
         },
         auth::auth_type(
@@ -155,7 +155,7 @@ pub async fn refunds_retrieve_with_body(
                 auth.profile_id,
                 auth.key_store,
                 req,
-                refund_retrieve_core,
+                refund_retrieve_core_with_refund_id,
             )
         },
         &auth::HeaderAuth(auth::ApiKeyAuth),

--- a/crates/router/src/workflows/outgoing_webhook_retry.rs
+++ b/crates/router/src/workflows/outgoing_webhook_retry.rs
@@ -347,7 +347,7 @@ async fn get_outgoing_webhook_content_and_event_type(
             disputes::retrieve_dispute,
             mandate::get_mandate,
             payments::{payments_core, CallConnectorAction, PaymentStatus},
-            refunds::refund_retrieve_core,
+            refunds::refund_retrieve_core_with_refund_id,
         },
         services::{ApplicationResponse, AuthFlow},
         types::{
@@ -415,7 +415,7 @@ async fn get_outgoing_webhook_content_and_event_type(
                 merchant_connector_details: None,
             };
 
-            let refund = Box::pin(refund_retrieve_core(
+            let refund = Box::pin(refund_retrieve_core_with_refund_id(
                 state,
                 merchant_account,
                 None,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
This PR 
1. Adds process tracker support for instant refunds
2. Fix mapping refund_id to internal_refund_id


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
1. Create an instant refund with Braintree
```
curl --location 'http://localhost:8080/refunds' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: dev_TDO8FwbwbQCasgvL5qiuYqCFVhWyTBUdBFA8usraNSQekdO51E9BKsiikwfVDyAR' \
--data '{"payment_id":"pay_013aoRNHHbBWEbGoKUTJ","amount":600,"reason":"Customer returned product","refund_type":"instant","metadata":{"udf1":"value1","new_customer":"true","login_date":"2019-09-10T10:11:12Z"}}'
```
2.  Wait for the process tracker to update the status
Process_tracker
![Screenshot 2024-09-05 at 7 00 08 PM](https://github.com/user-attachments/assets/f2dbfbf9-4988-4611-a9db-8ccc71f64718)
![Screenshot 2024-09-05 at 6 59 39 PM](https://github.com/user-attachments/assets/fcbf5f67-0ac2-46a2-af2c-35f3affb0c95)



## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
