### PR TITLE
feat(analytics): Revert api_event metrics and filters back to merchant_id authentication

### DIFF
--- a/crates/analytics/src/api_event/core.rs
+++ b/crates/analytics/src/api_event/core.rs
@@ -68,7 +68,8 @@ pub async fn get_filters(
             AnalyticsProvider::Clickhouse(ckh_pool)
             | AnalyticsProvider::CombinedSqlx(_, ckh_pool)
             | AnalyticsProvider::CombinedCkh(_, ckh_pool) => {
-                get_api_event_filter_for_dimension(dim, merchant_id, &req.time_range, ckh_pool).await
+                get_api_event_filter_for_dimension(dim, merchant_id, &req.time_range, ckh_pool)
+                    .await
             }
         }
         .switch()?

--- a/crates/analytics/src/api_event/filters.rs
+++ b/crates/analytics/src/api_event/filters.rs
@@ -4,7 +4,6 @@ use error_stack::ResultExt;
 use time::PrimitiveDateTime;
 
 use crate::{
-    enums::AuthInfo,
     query::{Aggregate, GroupByClause, QueryBuilder, QueryFilter, ToSql, Window},
     types::{AnalyticsCollection, AnalyticsDataSource, FiltersError, FiltersResult, LoadRow},
 };
@@ -13,7 +12,7 @@ pub trait ApiEventFilterAnalytics: LoadRow<ApiEventFilter> {}
 
 pub async fn get_api_event_filter_for_dimension<T>(
     dimension: ApiEventDimensions,
-    auth: &AuthInfo,
+    merchant_id: &common_utils::id_type::MerchantId,
     time_range: &TimeRange,
     pool: &T,
 ) -> FiltersResult<Vec<ApiEventFilter>>
@@ -33,7 +32,9 @@ where
         .attach_printable("Error filtering time range")
         .switch()?;
 
-    auth.set_filter_clause(&mut query_builder).switch()?;
+    query_builder
+        .add_filter_clause("merchant_id", merchant_id)
+        .switch()?;
 
     query_builder.set_distinct();
 

--- a/crates/analytics/src/api_event/metrics.rs
+++ b/crates/analytics/src/api_event/metrics.rs
@@ -7,7 +7,6 @@ use api_models::analytics::{
 use time::PrimitiveDateTime;
 
 use crate::{
-    enums::AuthInfo,
     query::{Aggregate, GroupByClause, ToSql, Window},
     types::{AnalyticsCollection, AnalyticsDataSource, LoadRow, MetricsResult},
 };
@@ -44,7 +43,7 @@ where
     async fn load_metrics(
         &self,
         dimensions: &[ApiEventDimensions],
-        auth: &AuthInfo,
+        merchant_id: &common_utils::id_type::MerchantId,
         filters: &ApiEventFilters,
         granularity: &Option<Granularity>,
         time_range: &TimeRange,
@@ -65,7 +64,7 @@ where
     async fn load_metrics(
         &self,
         dimensions: &[ApiEventDimensions],
-        auth: &AuthInfo,
+        merchant_id: &common_utils::id_type::MerchantId,
         filters: &ApiEventFilters,
         granularity: &Option<Granularity>,
         time_range: &TimeRange,
@@ -74,17 +73,17 @@ where
         match self {
             Self::Latency => {
                 MaxLatency
-                    .load_metrics(dimensions, auth, filters, granularity, time_range, pool)
+                    .load_metrics(dimensions, merchant_id, filters, granularity, time_range, pool)
                     .await
             }
             Self::ApiCount => {
                 ApiCount
-                    .load_metrics(dimensions, auth, filters, granularity, time_range, pool)
+                    .load_metrics(dimensions, merchant_id, filters, granularity, time_range, pool)
                     .await
             }
             Self::StatusCodeCount => {
                 StatusCodeCount
-                    .load_metrics(dimensions, auth, filters, granularity, time_range, pool)
+                    .load_metrics(dimensions, merchant_id, filters, granularity, time_range, pool)
                     .await
             }
         }

--- a/crates/analytics/src/api_event/metrics.rs
+++ b/crates/analytics/src/api_event/metrics.rs
@@ -73,17 +73,38 @@ where
         match self {
             Self::Latency => {
                 MaxLatency
-                    .load_metrics(dimensions, merchant_id, filters, granularity, time_range, pool)
+                    .load_metrics(
+                        dimensions,
+                        merchant_id,
+                        filters,
+                        granularity,
+                        time_range,
+                        pool,
+                    )
                     .await
             }
             Self::ApiCount => {
                 ApiCount
-                    .load_metrics(dimensions, merchant_id, filters, granularity, time_range, pool)
+                    .load_metrics(
+                        dimensions,
+                        merchant_id,
+                        filters,
+                        granularity,
+                        time_range,
+                        pool,
+                    )
                     .await
             }
             Self::StatusCodeCount => {
                 StatusCodeCount
-                    .load_metrics(dimensions, merchant_id, filters, granularity, time_range, pool)
+                    .load_metrics(
+                        dimensions,
+                        merchant_id,
+                        filters,
+                        granularity,
+                        time_range,
+                        pool,
+                    )
                     .await
             }
         }

--- a/crates/analytics/src/api_event/metrics/api_count.rs
+++ b/crates/analytics/src/api_event/metrics/api_count.rs
@@ -10,7 +10,6 @@ use time::PrimitiveDateTime;
 
 use super::ApiEventMetricRow;
 use crate::{
-    enums::AuthInfo,
     query::{Aggregate, GroupByClause, QueryBuilder, QueryFilter, SeriesBucket, ToSql, Window},
     types::{AnalyticsCollection, AnalyticsDataSource, MetricsError, MetricsResult},
 };
@@ -31,7 +30,7 @@ where
     async fn load_metrics(
         &self,
         _dimensions: &[ApiEventDimensions],
-        auth: &AuthInfo,
+        merchant_id: &common_utils::id_type::MerchantId,
         filters: &ApiEventFilters,
         granularity: &Option<Granularity>,
         time_range: &TimeRange,
@@ -70,7 +69,9 @@ where
                 .switch()?;
         }
 
-        auth.set_filter_clause(&mut query_builder).switch()?;
+        query_builder
+            .add_filter_clause("merchant_id", merchant_id)
+            .switch()?;
 
         time_range
             .set_filter_clause(&mut query_builder)

--- a/crates/analytics/src/api_event/metrics/latency.rs
+++ b/crates/analytics/src/api_event/metrics/latency.rs
@@ -10,7 +10,6 @@ use time::PrimitiveDateTime;
 
 use super::ApiEventMetricRow;
 use crate::{
-    enums::AuthInfo,
     query::{
         Aggregate, FilterTypes, GroupByClause, QueryBuilder, QueryFilter, SeriesBucket, ToSql,
         Window,
@@ -34,7 +33,7 @@ where
     async fn load_metrics(
         &self,
         _dimensions: &[ApiEventDimensions],
-        auth: &AuthInfo,
+        merchant_id: &common_utils::id_type::MerchantId,
         filters: &ApiEventFilters,
         granularity: &Option<Granularity>,
         time_range: &TimeRange,
@@ -77,7 +76,9 @@ where
 
         filters.set_filter_clause(&mut query_builder).switch()?;
 
-        auth.set_filter_clause(&mut query_builder).switch()?;
+        query_builder
+            .add_filter_clause("merchant_id", merchant_id)
+            .switch()?;
 
         time_range
             .set_filter_clause(&mut query_builder)

--- a/crates/analytics/src/api_event/metrics/status_code_count.rs
+++ b/crates/analytics/src/api_event/metrics/status_code_count.rs
@@ -10,7 +10,6 @@ use time::PrimitiveDateTime;
 
 use super::ApiEventMetricRow;
 use crate::{
-    enums::AuthInfo,
     query::{Aggregate, GroupByClause, QueryBuilder, QueryFilter, SeriesBucket, ToSql, Window},
     types::{AnalyticsCollection, AnalyticsDataSource, MetricsError, MetricsResult},
 };
@@ -31,7 +30,7 @@ where
     async fn load_metrics(
         &self,
         _dimensions: &[ApiEventDimensions],
-        auth: &AuthInfo,
+        merchant_id: &common_utils::id_type::MerchantId,
         filters: &ApiEventFilters,
         granularity: &Option<Granularity>,
         time_range: &TimeRange,
@@ -48,7 +47,9 @@ where
 
         filters.set_filter_clause(&mut query_builder).switch()?;
 
-        auth.set_filter_clause(&mut query_builder).switch()?;
+        query_builder
+            .add_filter_clause("merchant_id", merchant_id)
+            .switch()?;
 
         time_range
             .set_filter_clause(&mut query_builder)

--- a/crates/analytics/src/lib.rs
+++ b/crates/analytics/src/lib.rs
@@ -828,7 +828,7 @@ impl AnalyticsProvider {
         &self,
         metric: &ApiEventMetrics,
         dimensions: &[ApiEventDimensions],
-        auth: &AuthInfo,
+        merchant_id: &common_utils::id_type::MerchantId,
         filters: &ApiEventFilters,
         granularity: &Option<Granularity>,
         time_range: &TimeRange,
@@ -840,7 +840,7 @@ impl AnalyticsProvider {
             | Self::CombinedSqlx(_, ckh_pool) => {
                 // Since API events are ckh only use ckh here
                 metric
-                    .load_metrics(dimensions, auth, filters, granularity, time_range, ckh_pool)
+                    .load_metrics(dimensions, merchant_id, filters, granularity, time_range, ckh_pool)
                     .await
             }
         }

--- a/crates/analytics/src/lib.rs
+++ b/crates/analytics/src/lib.rs
@@ -840,7 +840,14 @@ impl AnalyticsProvider {
             | Self::CombinedSqlx(_, ckh_pool) => {
                 // Since API events are ckh only use ckh here
                 metric
-                    .load_metrics(dimensions, merchant_id, filters, granularity, time_range, ckh_pool)
+                    .load_metrics(
+                        dimensions,
+                        merchant_id,
+                        filters,
+                        granularity,
+                        time_range,
+                        ckh_pool,
+                    )
                     .await
             }
         }

--- a/crates/router/src/analytics.rs
+++ b/crates/router/src/analytics.rs
@@ -1638,9 +1638,13 @@ pub mod routes {
             &req,
             payload,
             |state, auth: AuthenticationData, req, _| async move {
-                analytics::api_event::get_api_event_metrics(&state.pool, auth.merchant_account.get_id(), req)
-                    .await
-                    .map(ApplicationResponse::Json)
+                analytics::api_event::get_api_event_metrics(
+                    &state.pool,
+                    auth.merchant_account.get_id(),
+                    req,
+                )
+                .await
+                .map(ApplicationResponse::Json)
             },
             &auth::JWTAuth(Permission::Analytics),
             api_locking::LockAction::NotApplicable,

--- a/crates/router/src/analytics.rs
+++ b/crates/router/src/analytics.rs
@@ -215,14 +215,6 @@ pub mod routes {
                                         .route(web::post().to(get_org_dispute_filters)),
                                 )
                                 .service(
-                                    web::resource("filters/api_events")
-                                        .route(web::post().to(get_org_api_event_filters)),
-                                )
-                                .service(
-                                    web::resource("metrics/api_events")
-                                        .route(web::post().to(get_org_api_events_metrics)),
-                                )
-                                .service(
                                     web::resource("report/dispute")
                                         .route(web::post().to(generate_org_dispute_report)),
                                 )
@@ -255,14 +247,6 @@ pub mod routes {
                                 .service(
                                     web::resource("filters/refunds")
                                         .route(web::post().to(get_profile_refund_filters)),
-                                )
-                                .service(
-                                    web::resource("metrics/api_events")
-                                        .route(web::post().to(get_profile_api_events_metrics)),
-                                )
-                                .service(
-                                    web::resource("filters/api_events")
-                                        .route(web::post().to(get_profile_api_event_filters)),
                                 )
                                 .service(
                                     web::resource("metrics/disputes")
@@ -1654,92 +1638,7 @@ pub mod routes {
             &req,
             payload,
             |state, auth: AuthenticationData, req, _| async move {
-                let org_id = auth.merchant_account.get_org_id();
-                let merchant_id = auth.merchant_account.get_id();
-                let auth: AuthInfo = AuthInfo::MerchantLevel {
-                    org_id: org_id.clone(),
-                    merchant_ids: vec![merchant_id.clone()],
-                };
-                analytics::api_event::get_api_event_metrics(&state.pool, &auth, req)
-                    .await
-                    .map(ApplicationResponse::Json)
-            },
-            &auth::JWTAuth(Permission::Analytics),
-            api_locking::LockAction::NotApplicable,
-        ))
-        .await
-    }
-
-    /// # Panics
-    ///
-    /// Panics if `json_payload` array does not contain one `GetApiEventMetricRequest` element.
-    pub async fn get_org_api_events_metrics(
-        state: web::Data<AppState>,
-        req: actix_web::HttpRequest,
-        json_payload: web::Json<[GetApiEventMetricRequest; 1]>,
-    ) -> impl Responder {
-        // safety: This shouldn't panic owing to the data type
-        #[allow(clippy::expect_used)]
-        let payload = json_payload
-            .into_inner()
-            .to_vec()
-            .pop()
-            .expect("Couldn't get GetApiEventMetricRequest");
-        let flow = AnalyticsFlow::GetApiEventMetrics;
-        Box::pin(api::server_wrap(
-            flow,
-            state.clone(),
-            &req,
-            payload,
-            |state, auth: AuthenticationData, req, _| async move {
-                let org_id = auth.merchant_account.get_org_id();
-                let auth: AuthInfo = AuthInfo::OrgLevel {
-                    org_id: org_id.clone(),
-                };
-                analytics::api_event::get_api_event_metrics(&state.pool, &auth, req)
-                    .await
-                    .map(ApplicationResponse::Json)
-            },
-            &auth::JWTAuth(Permission::Analytics),
-            api_locking::LockAction::NotApplicable,
-        ))
-        .await
-    }
-
-    /// # Panics
-    ///
-    /// Panics if `json_payload` array does not contain one `GetApiEventMetricRequest` element.
-    pub async fn get_profile_api_events_metrics(
-        state: web::Data<AppState>,
-        req: actix_web::HttpRequest,
-        json_payload: web::Json<[GetApiEventMetricRequest; 1]>,
-    ) -> impl Responder {
-        // safety: This shouldn't panic owing to the data type
-        #[allow(clippy::expect_used)]
-        let payload = json_payload
-            .into_inner()
-            .to_vec()
-            .pop()
-            .expect("Couldn't get GetApiEventMetricRequest");
-        let flow = AnalyticsFlow::GetApiEventMetrics;
-        Box::pin(api::server_wrap(
-            flow,
-            state.clone(),
-            &req,
-            payload,
-            |state, auth: AuthenticationData, req, _| async move {
-                let org_id = auth.merchant_account.get_org_id();
-                let merchant_id = auth.merchant_account.get_id();
-                let profile_id = auth
-                    .profile_id
-                    .ok_or(report!(UserErrors::JwtProfileIdMissing))
-                    .change_context(AnalyticsError::AccessForbiddenError)?;
-                let auth: AuthInfo = AuthInfo::ProfileLevel {
-                    org_id: org_id.clone(),
-                    merchant_id: merchant_id.clone(),
-                    profile_ids: vec![profile_id.clone()],
-                };
-                analytics::api_event::get_api_event_metrics(&state.pool, &auth, req)
+                analytics::api_event::get_api_event_metrics(&state.pool, auth.merchant_account.get_id(), req)
                     .await
                     .map(ApplicationResponse::Json)
             },
@@ -1761,72 +1660,7 @@ pub mod routes {
             &req,
             json_payload.into_inner(),
             |state, auth: AuthenticationData, req, _| async move {
-                let org_id = auth.merchant_account.get_org_id();
-                let merchant_id = auth.merchant_account.get_id();
-                let auth: AuthInfo = AuthInfo::MerchantLevel {
-                    org_id: org_id.clone(),
-                    merchant_ids: vec![merchant_id.clone()],
-                };
-                analytics::api_event::get_filters(&state.pool, req, &auth)
-                    .await
-                    .map(ApplicationResponse::Json)
-            },
-            &auth::JWTAuth(Permission::Analytics),
-            api_locking::LockAction::NotApplicable,
-        ))
-        .await
-    }
-
-    pub async fn get_org_api_event_filters(
-        state: web::Data<AppState>,
-        req: actix_web::HttpRequest,
-        json_payload: web::Json<GetApiEventFiltersRequest>,
-    ) -> impl Responder {
-        let flow = AnalyticsFlow::GetApiEventFilters;
-        Box::pin(api::server_wrap(
-            flow,
-            state.clone(),
-            &req,
-            json_payload.into_inner(),
-            |state, auth: AuthenticationData, req, _| async move {
-                let org_id = auth.merchant_account.get_org_id();
-                let auth: AuthInfo = AuthInfo::OrgLevel {
-                    org_id: org_id.clone(),
-                };
-                analytics::api_event::get_filters(&state.pool, req, &auth)
-                    .await
-                    .map(ApplicationResponse::Json)
-            },
-            &auth::JWTAuth(Permission::Analytics),
-            api_locking::LockAction::NotApplicable,
-        ))
-        .await
-    }
-
-    pub async fn get_profile_api_event_filters(
-        state: web::Data<AppState>,
-        req: actix_web::HttpRequest,
-        json_payload: web::Json<GetApiEventFiltersRequest>,
-    ) -> impl Responder {
-        let flow = AnalyticsFlow::GetApiEventFilters;
-        Box::pin(api::server_wrap(
-            flow,
-            state.clone(),
-            &req,
-            json_payload.into_inner(),
-            |state, auth: AuthenticationData, req, _| async move {
-                let org_id = auth.merchant_account.get_org_id();
-                let merchant_id = auth.merchant_account.get_id();
-                let profile_id = auth
-                    .profile_id
-                    .ok_or(report!(UserErrors::JwtProfileIdMissing))
-                    .change_context(AnalyticsError::AccessForbiddenError)?;
-                let auth: AuthInfo = AuthInfo::ProfileLevel {
-                    org_id: org_id.clone(),
-                    merchant_id: merchant_id.clone(),
-                    profile_ids: vec![profile_id.clone()],
-                };
-                analytics::api_event::get_filters(&state.pool, req, &auth)
+                analytics::api_event::get_filters(&state.pool, req, auth.merchant_account.get_id())
                     .await
                     .map(ApplicationResponse::Json)
             },


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Previously modified api_event_metrics and api_event_filters to authenticate through AuthInfo where there are MerchantLevel, ProfileLevel and OrgLevel authentication. ([https://github.com/juspay/hyperswitch/pull/5729](https://github.com/juspay/hyperswitch/pull/5729))

But ApiEvents table is not populated with `organization_id` and `profile_id`, hence reverting back.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
Fix the issues on sandbox analytics related to api_events.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Spoke with dashboard team and removed the following api endpoints:
- /analytics/v1/profile/metrics/api_events
- /analytics/v1/profile/filters/api_events
- /analytics/v1/org/metrics/api_events
- /analytics/v1/org/filters/api_events

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
