### PR TITLE
chore: address Rust 1.81.0 clippy lints

### DIFF
--- a/crates/drainer/src/health_check.rs
+++ b/crates/drainer/src/health_check.rs
@@ -170,7 +170,7 @@ impl HealthCheckInterface for Store {
         logger::debug!("Redis set_key was successful");
 
         redis_conn
-            .get_key("test_key")
+            .get_key::<()>("test_key")
             .await
             .change_context(HealthCheckRedisError::GetFailed)?;
 

--- a/crates/router/src/connector/globalpay.rs
+++ b/crates/router/src/connector/globalpay.rs
@@ -1017,12 +1017,11 @@ impl api::IncomingWebhook for Globalpay {
         &self,
         request: &api::IncomingWebhookRequestDetails<'_>,
     ) -> CustomResult<Box<dyn masking::ErasedMaskSerialize>, errors::ConnectorError> {
-        let details = std::str::from_utf8(request.body)
-            .change_context(errors::ConnectorError::WebhookBodyDecodingFailed)?;
-
         Ok(Box::new(
-            serde_json::from_str::<GlobalpayPaymentsResponse>(details)
-                .change_context(errors::ConnectorError::WebhookResourceObjectNotFound)?,
+            request
+                .body
+                .parse_struct::<GlobalpayPaymentsResponse>("GlobalpayPaymentsResponse")
+                .change_context(errors::ConnectorError::WebhookBodyDecodingFailed)?,
         ))
     }
 }

--- a/crates/router/src/connector/globalpay.rs
+++ b/crates/router/src/connector/globalpay.rs
@@ -1019,9 +1019,11 @@ impl api::IncomingWebhook for Globalpay {
     ) -> CustomResult<Box<dyn masking::ErasedMaskSerialize>, errors::ConnectorError> {
         let details = std::str::from_utf8(request.body)
             .change_context(errors::ConnectorError::WebhookBodyDecodingFailed)?;
-        Ok(Box::new(serde_json::from_str(details).change_context(
-            errors::ConnectorError::WebhookResourceObjectNotFound,
-        )?))
+
+        Ok(Box::new(
+            serde_json::from_str::<GlobalpayPaymentsResponse>(details)
+                .change_context(errors::ConnectorError::WebhookResourceObjectNotFound)?,
+        ))
     }
 }
 

--- a/crates/router/src/core/health_check.rs
+++ b/crates/router/src/core/health_check.rs
@@ -52,7 +52,7 @@ impl HealthCheckInterface for app::SessionState {
         logger::debug!("Redis set_key was successful");
 
         redis_conn
-            .get_key("test_key")
+            .get_key::<()>("test_key")
             .await
             .change_context(errors::HealthCheckRedisError::GetFailed)?;
 

--- a/crates/router/src/core/payment_methods/surcharge_decision_configs.rs
+++ b/crates/router/src/core/payment_methods/surcharge_decision_configs.rs
@@ -88,11 +88,10 @@ impl SurchargeSource {
                         )
                     })
                     .transpose()?
-                    .map(|surcharge_details| {
+                    .inspect(|surcharge_details| {
                         let (surcharge_metadata, surcharge_key) = surcharge_metadata_and_key;
                         surcharge_metadata
                             .insert_surcharge_details(surcharge_key, surcharge_details.clone());
-                        surcharge_details
                     }))
             }
             Self::Predetermined(request_surcharge_details) => Ok(Some(

--- a/crates/router/src/core/payments.rs
+++ b/crates/router/src/core/payments.rs
@@ -145,7 +145,7 @@ where
         .to_validate_request()?
         .validate_request(&req, &merchant_account)?;
 
-    tracing::Span::current().record("payment_id", &format!("{}", validate_result.payment_id));
+    tracing::Span::current().record("payment_id", format!("{}", validate_result.payment_id));
 
     let operations::GetTrackerResponse {
         operation,

--- a/crates/router_env/tests/env.rs
+++ b/crates/router_env/tests/env.rs
@@ -25,7 +25,7 @@ async fn basic() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 
 #[cfg(feature = "vergen")]
 #[tokio::test]
-async fn env_macro() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+async fn env_macro() {
     println!("version : {:?}", env::version!());
     println!("build : {:?}", env::build!());
     println!("commit : {:?}", env::commit!());
@@ -35,6 +35,4 @@ async fn env_macro() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     assert!(!env::build!().is_empty());
     assert!(!env::commit!().is_empty());
     // assert!(env::platform!().len() > 0);
-
-    Ok(())
 }

--- a/crates/storage_impl/src/redis/kv_store.rs
+++ b/crates/storage_impl/src/redis/kv_store.rs
@@ -259,12 +259,11 @@ where
 
     result
         .await
-        .map(|result| {
+        .inspect(|_| {
             logger::debug!(kv_operation= %operation, status="success");
             let keyvalue = router_env::opentelemetry::KeyValue::new("operation", operation.clone());
 
             metrics::KV_OPERATION_SUCCESSFUL.add(&metrics::CONTEXT, 1, &[keyvalue]);
-            result
         })
         .inspect_err(|err| {
             logger::error!(kv_operation = %operation, status="error", error = ?err);

--- a/crates/storage_impl/src/redis/pub_sub.rs
+++ b/crates/storage_impl/src/redis/pub_sub.rs
@@ -30,7 +30,7 @@ impl PubSubInterface for std::sync::Arc<redis_interface::RedisConnectionPool> {
         self.subscriber.manage_subscriptions();
 
         self.subscriber
-            .subscribe(channel)
+            .subscribe::<(), &str>(channel)
             .await
             .change_context(redis_errors::RedisError::SubscribeError)?;
 


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [x] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
This PR addresses the clippy lints occurring due to new rust version 1.81.0

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
This PR addresses clippy lint due to new rust version. So basic sanity testing should suffice.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
