### PR TITLE
fix: fix `status_code` being logged as string instead of number in logs

### DIFF
--- a/crates/router/src/core/webhooks/outgoing.rs
+++ b/crates/router/src/core/webhooks/outgoing.rs
@@ -889,7 +889,7 @@ async fn error_response_handler(
     );
 
     let error = report!(errors::WebhooksFlowError::NotReceivedByMerchant);
-    logger::warn!(?error, ?delivery_attempt, ?status_code, %log_message);
+    logger::warn!(?error, ?delivery_attempt, status_code, %log_message);
 
     if let ScheduleWebhookRetry::WithProcessTracker(process_tracker) = schedule_webhook_retry {
         // Schedule a retry attempt for webhook delivery

--- a/crates/router/src/services/api.rs
+++ b/crates/router/src/services/api.rs
@@ -383,11 +383,11 @@ pub async fn call_connector_api(
             let status_code = resp.status().as_u16();
             let elapsed_time = current_time.elapsed();
             logger::info!(
-                headers=?headers,
-                url=?url,
-                status_code=?status_code,
+                ?headers,
+                url,
+                status_code,
                 flow=?flow_name,
-                elapsed_time=?elapsed_time
+                ?elapsed_time
             );
         }
         Err(err) => {


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->

This PR fixes a bug with the `status_code` field being logged as a string instead of a number in JSON logs. This was primarily happening in two functions: `router::services::api::call_connector_api()` and `router::core::webhooks::outgoing::error_response_handler()`. 

The bug occurred due to the `Debug` implementation of the field being used to log the values (with the `?` sigil). Using the `%` sigil to use the `Display` implementation to log the status code also caused the same problem. The fix was to not provide any sigil (`?` or `%`) and let `tracing` automatically format the status code.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->

This PR fixes a bug with status codes being sometimes logged as strings, which also caused issues with Elasticsearch being unable to index the field correctly.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

1. Create a successful payment using Postman (basically any request that includes a connector call).

2. Search logs, filtering by the request ID and searching for `call_connector_api`.

   Previously, the status code was logged as a string:

   ![Screenshot of status code logged as string](https://github.com/user-attachments/assets/ebc1b501-bd31-4510-b506-5f61a4aca53b)

   With this fix, the status code is correctly logged as a number:

   ![Screenshot of status code logged as number](https://github.com/user-attachments/assets/4ebd0190-ddd7-494a-8f1a-0d787c230dcf)

   As part of this change, the `url` field in the log message also loses one set of double quotes (and is no longer escaped as a result).

3. If the webhook URL is configured incorrectly in the business profile (such that the URL returns a non-2xx status code when a webhook is sent) and the payment created triggers a webhook, then the error log should also have the status code logged as a number (logs can be filtered with request ID and the message `Ignoring error when sending webhook to merchant`):

   Before:

   ![Screenshot of outgoing webhook status code logged as string](https://github.com/user-attachments/assets/2dc0be3e-b10e-4ffd-9ddd-c5964708ea69)

   After:

   ![Screenshot of outgoing webhook status code logged as number](https://github.com/user-attachments/assets/471bd3f3-37ae-401b-9e1d-0768fdb8afdd)


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
