### PR TITLE
chore: remove Connectors enum dependency from ConnectorIntegrationV2 trait

### DIFF
--- a/crates/hyperswitch_interfaces/src/connector_integration_v2.rs
+++ b/crates/hyperswitch_interfaces/src/connector_integration_v2.rs
@@ -9,8 +9,7 @@ use router_env::metrics::add_attributes;
 use serde_json::json;
 
 use crate::{
-    api::CaptureSyncMethod, configs::Connectors, errors,
-    events::connector_api_logs::ConnectorEvent, metrics, types,
+    api::CaptureSyncMethod, errors, events::connector_api_logs::ConnectorEvent, metrics, types,
 };
 
 /// alias for Box of a type that implements trait ConnectorIntegrationV2
@@ -47,7 +46,6 @@ pub trait ConnectorIntegrationV2<Flow, ResourceCommonData, Req, Resp>:
     fn get_headers(
         &self,
         _req: &RouterDataV2<Flow, ResourceCommonData, Req, Resp>,
-        _connectors: &Connectors,
     ) -> CustomResult<Vec<(String, Maskable<String>)>, errors::ConnectorError> {
         Ok(vec![])
     }
@@ -66,7 +64,6 @@ pub trait ConnectorIntegrationV2<Flow, ResourceCommonData, Req, Resp>:
     fn get_url(
         &self,
         _req: &RouterDataV2<Flow, ResourceCommonData, Req, Resp>,
-        _connectors: &Connectors,
     ) -> CustomResult<String, errors::ConnectorError> {
         Ok(String::new())
     }
@@ -75,7 +72,6 @@ pub trait ConnectorIntegrationV2<Flow, ResourceCommonData, Req, Resp>:
     fn get_request_body(
         &self,
         _req: &RouterDataV2<Flow, ResourceCommonData, Req, Resp>,
-        _connectors: &Connectors,
     ) -> CustomResult<RequestContent, errors::ConnectorError> {
         Ok(RequestContent::Json(Box::new(json!(r#"{}"#))))
     }
@@ -92,7 +88,6 @@ pub trait ConnectorIntegrationV2<Flow, ResourceCommonData, Req, Resp>:
     fn build_request_v2(
         &self,
         _req: &RouterDataV2<Flow, ResourceCommonData, Req, Resp>,
-        _connectors: &Connectors,
     ) -> CustomResult<Option<Request>, errors::ConnectorError> {
         metrics::UNIMPLEMENTED_FLOW.add(
             &metrics::CONTEXT,

--- a/crates/router/src/services/connector_integration_interface.rs
+++ b/crates/router/src/services/connector_integration_interface.rs
@@ -570,7 +570,7 @@ where
             }
             ConnectorIntegrationEnum::New(new_integration) => {
                 let new_router_data = ResourceCommonData::from_old_router_data(req)?;
-                new_integration.build_request_v2(&new_router_data, connectors)
+                new_integration.build_request_v2(&new_router_data)
             }
         }
     }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Main branch PR https://github.com/juspay/hyperswitch/pull/5840


Currently few functions in ConnectorIntegrationV2 trait accepts enum Connectors as argument. This prevents the trait from being used outside the repository (through connector_integration module).


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Checked if the code compiled successfully.




## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
