### PR TITLE
fix(router): return `collect_billing_details_from_wallet_connector` if `always_collect_billing_details_from_wallet_connector ` is false in merchant payment method list

### DIFF
--- a/crates/router/src/core/payment_methods/cards.rs
+++ b/crates/router/src/core/payment_methods/cards.rs
@@ -3652,23 +3652,29 @@ pub async fn list_payment_methods(
             api_surcharge_decision_configs::MerchantSurchargeConfigs::default()
         };
 
-    let collect_shipping_details_from_wallets = business_profile
-        .as_ref()
-        .and_then(|business_profile| {
-            business_profile.always_collect_shipping_details_from_wallet_connector
-        })
-        .or(business_profile.as_ref().and_then(|business_profile| {
-            business_profile.collect_shipping_details_from_wallet_connector
-        }));
+    let collect_shipping_details_from_wallets =
+        business_profile.as_ref().and_then(|business_profile| {
+            if business_profile
+                .always_collect_shipping_details_from_wallet_connector
+                .unwrap_or(false)
+            {
+                business_profile.always_collect_shipping_details_from_wallet_connector
+            } else {
+                business_profile.collect_shipping_details_from_wallet_connector
+            }
+        });
 
-    let collect_billing_details_from_wallets = business_profile
-        .as_ref()
-        .and_then(|business_profile| {
-            business_profile.always_collect_billing_details_from_wallet_connector
-        })
-        .or(business_profile.as_ref().and_then(|business_profile| {
-            business_profile.collect_billing_details_from_wallet_connector
-        }));
+    let collect_billing_details_from_wallets =
+        business_profile.as_ref().and_then(|business_profile| {
+            if business_profile
+                .always_collect_billing_details_from_wallet_connector
+                .unwrap_or(false)
+            {
+                business_profile.always_collect_billing_details_from_wallet_connector
+            } else {
+                business_profile.collect_billing_details_from_wallet_connector
+            }
+        });
 
     Ok(services::ApplicationResponse::Json(
         api::PaymentMethodListResponse {


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
1. `collect_billing_details_from_wallets` field should be made true if either of `always_collect_billing_details_from_wallet_connector` ` collect_billing_details_from_wallet_connector` 
2. `collect_shipping_details_from_wallets` field should be made true if either of `always_collect_shipping_details_from_wallet_connector` ` collect_shipping_details_from_wallet_connector` 

So that the sdk gets to know that the address details needs to be collected from apple pay and not from the customers

Main branch pr https://github.com/juspay/hyperswitch/pull/5854

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
