### PR TITLE
refactor: return optional request body from build_request_v2 in ConnectorIntegrationV2 trait

### DIFF
--- a/crates/common_utils/src/request.rs
+++ b/crates/common_utils/src/request.rs
@@ -152,6 +152,11 @@ impl RequestBuilder {
         self
     }
 
+    pub fn set_optional_body<T: Into<RequestContent>>(mut self, body: Option<T>) -> Self {
+        body.map(|body| self.body.replace(body.into()));
+        self
+    }
+
     pub fn set_body<T: Into<RequestContent>>(mut self, body: T) -> Self {
         self.body.replace(body.into());
         self

--- a/crates/hyperswitch_interfaces/src/connector_integration_v2.rs
+++ b/crates/hyperswitch_interfaces/src/connector_integration_v2.rs
@@ -1,7 +1,7 @@
 //! definition of the new connector integration trait
 use common_utils::{
     errors::CustomResult,
-    request::{Method, Request, RequestContent},
+    request::{Method, Request, RequestBuilder, RequestContent},
 };
 use hyperswitch_domain_models::{router_data::ErrorResponse, router_data_v2::RouterDataV2};
 use masking::Maskable;
@@ -65,6 +65,11 @@ pub trait ConnectorIntegrationV2<Flow, ResourceCommonData, Req, Resp>:
         &self,
         _req: &RouterDataV2<Flow, ResourceCommonData, Req, Resp>,
     ) -> CustomResult<String, errors::ConnectorError> {
+        metrics::UNIMPLEMENTED_FLOW.add(
+            &metrics::CONTEXT,
+            1,
+            &add_attributes([("connector", self.id())]),
+        );
         Ok(String::new())
     }
 
@@ -72,8 +77,8 @@ pub trait ConnectorIntegrationV2<Flow, ResourceCommonData, Req, Resp>:
     fn get_request_body(
         &self,
         _req: &RouterDataV2<Flow, ResourceCommonData, Req, Resp>,
-    ) -> CustomResult<RequestContent, errors::ConnectorError> {
-        Ok(RequestContent::Json(Box::new(json!(r#"{}"#))))
+    ) -> CustomResult<Option<RequestContent>, errors::ConnectorError> {
+        Ok(None)
     }
 
     /// returns form data
@@ -87,14 +92,19 @@ pub trait ConnectorIntegrationV2<Flow, ResourceCommonData, Req, Resp>:
     /// builds the request and returns it
     fn build_request_v2(
         &self,
-        _req: &RouterDataV2<Flow, ResourceCommonData, Req, Resp>,
+        req: &RouterDataV2<Flow, ResourceCommonData, Req, Resp>,
     ) -> CustomResult<Option<Request>, errors::ConnectorError> {
-        metrics::UNIMPLEMENTED_FLOW.add(
-            &metrics::CONTEXT,
-            1,
-            &add_attributes([("connector", self.id())]),
-        );
-        Ok(None)
+        Ok(Some(
+            RequestBuilder::new()
+                .method(self.get_http_method())
+                .url(self.get_url(req)?.as_str())
+                .attach_default_headers()
+                .headers(self.get_headers(req)?)
+                .set_optional_body(self.get_request_body(req)?)
+                .add_certificate(self.get_certificate(req)?)
+                .add_certificate_key(self.get_certificate_key(req)?)
+                .build(),
+        ))
     }
 
     /// accepts the raw api response and decodes it
@@ -167,7 +177,7 @@ pub trait ConnectorIntegrationV2<Flow, ResourceCommonData, Req, Resp>:
     fn get_certificate(
         &self,
         _req: &RouterDataV2<Flow, ResourceCommonData, Req, Resp>,
-    ) -> CustomResult<Option<String>, errors::ConnectorError> {
+    ) -> CustomResult<Option<masking::Secret<String>>, errors::ConnectorError> {
         Ok(None)
     }
 
@@ -175,7 +185,7 @@ pub trait ConnectorIntegrationV2<Flow, ResourceCommonData, Req, Resp>:
     fn get_certificate_key(
         &self,
         _req: &RouterDataV2<Flow, ResourceCommonData, Req, Resp>,
-    ) -> CustomResult<Option<String>, errors::ConnectorError> {
+    ) -> CustomResult<Option<masking::Secret<String>>, errors::ConnectorError> {
         Ok(None)
     }
 }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Main PR https://github.com/juspay/hyperswitch/pull/5865
Currenlty fn get_request_body in ConnectorIntegrationV2 trait returns RequestContent type. Modified it to return Option<RequestContent>.
This needs to be done since most flows with http get call don't need any RequestBody.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Checked if code compiled successfully.




## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
