### PR TITLE
revert: feat(router): mask keys in connector_account_details for merchant_connector_response in mca retrieve flow

### DIFF
--- a/crates/hyperswitch_domain_models/src/router_data.rs
+++ b/crates/hyperswitch_domain_models/src/router_data.rs
@@ -7,7 +7,7 @@ use common_utils::{
     types::MinorUnit,
 };
 use error_stack::ResultExt;
-use masking::{ExposeInterface, Secret};
+use masking::Secret;
 
 use crate::{payment_address::PaymentAddress, payment_method_data};
 
@@ -135,74 +135,6 @@ impl ConnectorAuthType {
             .change_context(common_utils::errors::ParsingError::StructParseFailure(
                 "ConnectorAuthType",
             ))
-    }
-
-    // show only first and last two digits of the key and mask others with *
-    // mask the entire key if it's length is less than or equal to 4
-    fn mask_key(&self, key: String) -> Secret<String> {
-        let key_len = key.len();
-        let masked_key = if key_len <= 4 {
-            "*".repeat(key_len)
-        } else {
-            // Show the first two and last two characters, mask the rest with '*'
-            let mut masked_key = String::new();
-            let key_len = key.len();
-            // Iterate through characters by their index
-            for (index, character) in key.chars().enumerate() {
-                if index < 2 || index >= key_len - 2 {
-                    masked_key.push(character); // Keep the first two and last two characters
-                } else {
-                    masked_key.push('*'); // Mask the middle characters
-                }
-            }
-            masked_key
-        };
-        Secret::new(masked_key)
-    }
-
-    // Mask the keys in the auth_type
-    pub fn get_masked_keys(&self) -> Self {
-        match self {
-            Self::TemporaryAuth => Self::TemporaryAuth,
-            Self::NoKey => Self::NoKey,
-            Self::HeaderKey { api_key } => Self::HeaderKey {
-                api_key: self.mask_key(api_key.clone().expose()),
-            },
-            Self::BodyKey { api_key, key1 } => Self::BodyKey {
-                api_key: self.mask_key(api_key.clone().expose()),
-                key1: self.mask_key(key1.clone().expose()),
-            },
-            Self::SignatureKey {
-                api_key,
-                key1,
-                api_secret,
-            } => Self::SignatureKey {
-                api_key: self.mask_key(api_key.clone().expose()),
-                key1: self.mask_key(key1.clone().expose()),
-                api_secret: self.mask_key(api_secret.clone().expose()),
-            },
-            Self::MultiAuthKey {
-                api_key,
-                key1,
-                api_secret,
-                key2,
-            } => Self::MultiAuthKey {
-                api_key: self.mask_key(api_key.clone().expose()),
-                key1: self.mask_key(key1.clone().expose()),
-                api_secret: self.mask_key(api_secret.clone().expose()),
-                key2: self.mask_key(key2.clone().expose()),
-            },
-            Self::CurrencyAuthKey { auth_key_map } => Self::CurrencyAuthKey {
-                auth_key_map: auth_key_map.clone(),
-            },
-            Self::CertificateAuth {
-                certificate,
-                private_key,
-            } => Self::CertificateAuth {
-                certificate: self.mask_key(certificate.clone().expose()),
-                private_key: self.mask_key(private_key.clone().expose()),
-            },
-        }
     }
 }
 


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
revert mask keys in connector_account_details for merchant_connector_response in mca retrieve flow - https://github.com/juspay/hyperswitch/pull/5848
This reverts commit 71b52024c296548156cd80950010a2f1266906fb.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Tested Manually
MCA create & retrieve to see api keys are not masked
Sanity payments, captures & refunds

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
