### PR TITLE
fix(user_roles): Populate `profile_id` from token in update user role API

### DIFF
--- a/crates/router/src/core/user_role.rs
+++ b/crates/router/src/core/user_role.rs
@@ -119,7 +119,7 @@ pub async fn update_user_role(
             user_to_be_updated.get_user_id(),
             &user_from_token.org_id,
             &user_from_token.merchant_id,
-            None,
+            user_from_token.profile_id.as_ref(),
             UserRoleVersion::V2,
         )
         .await
@@ -165,7 +165,7 @@ pub async fn update_user_role(
                 user_to_be_updated.get_user_id(),
                 &user_from_token.org_id,
                 &user_from_token.merchant_id,
-                None,
+                user_from_token.profile_id.as_ref(),
                 UserRoleUpdate::UpdateRole {
                     role_id: req.role_id.clone(),
                     modified_by: user_from_token.user_id.clone(),
@@ -184,7 +184,7 @@ pub async fn update_user_role(
             user_to_be_updated.get_user_id(),
             &user_from_token.org_id,
             &user_from_token.merchant_id,
-            None,
+            user_from_token.profile_id.as_ref(),
             UserRoleVersion::V1,
         )
         .await
@@ -230,7 +230,7 @@ pub async fn update_user_role(
                 user_to_be_updated.get_user_id(),
                 &user_from_token.org_id,
                 &user_from_token.merchant_id,
-                None,
+                user_from_token.profile_id.as_ref(),
                 UserRoleUpdate::UpdateRole {
                     role_id: req.role_id.clone(),
                     modified_by: user_from_token.user_id,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Currently, profile level user_roles are not being updated. This PR fixes it.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
Closes #5906.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
```
curl 'http://localhost:8080/user/user/update_role' \
  -H 'authorization: Bearer JWT' \
  --data-raw '{"email":"email","role_id":"profile_iam_admin"}'
```
Response: 200 OK.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
