### PR TITLE
fix(merchant_account_v2): remove compatible_connector field in metadata

### DIFF
--- a/crates/api_models/src/admin.rs
+++ b/crates/api_models/src/admin.rs
@@ -188,7 +188,7 @@ pub struct MerchantAccountCreate {
 
     /// Metadata is useful for storing additional, unstructured information about the merchant account.
     #[schema(value_type = Option<Object>, example = r#"{ "city": "NY", "unit": "245" }"#)]
-    pub metadata: Option<MerchantAccountMetadata>,
+    pub metadata: Option<pii::SecretSerdeValue>,
 
     /// The id of the organization to which the merchant belongs to. Please use the organization endpoint to create an organization
     #[schema(value_type = String, max_length = 64, min_length = 1, example = "org_q98uSGAYbjEwqs0mJwnz")]
@@ -207,15 +207,6 @@ impl MerchantAccountCreate {
         self.merchant_details
             .as_ref()
             .map(|merchant_details| merchant_details.encode_to_value().map(Secret::new))
-            .transpose()
-    }
-
-    pub fn get_metadata_as_secret(
-        &self,
-    ) -> CustomResult<Option<pii::SecretSerdeValue>, errors::ParsingError> {
-        self.metadata
-            .as_ref()
-            .map(|metadata| metadata.encode_to_value().map(Secret::new))
             .transpose()
     }
 

--- a/crates/router/src/core/admin.rs
+++ b/crates/router/src/core/admin.rs
@@ -606,12 +606,6 @@ impl MerchantAccountCreateBridge for api::MerchantAccountCreate {
         let publishable_key = create_merchant_publishable_key();
         let db = &*state.store;
 
-        let metadata = self.get_metadata_as_secret().change_context(
-            errors::ApiErrorResponse::InvalidDataValue {
-                field_name: "metadata",
-            },
-        )?;
-
         let merchant_details = self.get_merchant_details_as_secret().change_context(
             errors::ApiErrorResponse::InvalidDataValue {
                 field_name: "merchant_details",
@@ -659,7 +653,7 @@ impl MerchantAccountCreateBridge for api::MerchantAccountCreate {
                         })
                         .await?,
                     publishable_key,
-                    metadata,
+                    metadata: self.metadata,
                     storage_scheme: MerchantStorageScheme::PostgresOnly,
                     created_at: date_time::now(),
                     modified_at: date_time::now(),


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix

## Description
<!-- Describe your changes in detail -->
This PR fixes a bug in MerchantAccountV2 where metadata was being populated with the key `compatible_connector`. 

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
- Create an organization
```bash
curl --location 'http://localhost:8080/v2/organization' \
--header 'Content-Type: application/json' \
--header 'api-key: test_admin' \
--data '{
    "organization_name": "my_org"
}'
```

- Create a merchant account
```bash
curl --location 'http://localhost:8080/v2/merchant_accounts' \
--header 'Content-Type: application/json' \
--header 'api-key: test_admin' \
--data '{
    "merchant_name": "cloth_seller",
    "organization_id": "org_5MhtBgZ9IknBUQaChQu0",
    "metadata": {
        "key1": "value"
    }
}'
```

- Check the metadata
```json
{
    "id": "cloth_seller_RBou3QbmnnmCMUZ0sjv6",
    "merchant_name": "cloth_seller",
    "merchant_details": null,
    "publishable_key": "pk_dev_d983e4d01058478c8780d1ad4f611295",
    "metadata": {
        "key1": "value"
    },
    "organization_id": "org_5MhtBgZ9IknBUQaChQu0",
    "recon_status": "not_requested"
}
```

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
