### PR TITLE
fix(connector): [DEUTSCHE] Trim spaces in IBAN

### DIFF
--- a/crates/hyperswitch_connectors/src/connectors/deutschebank/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/deutschebank/transformers.rs
@@ -155,7 +155,7 @@ impl TryFrom<&DeutschebankRouterData<&PaymentsAuthorizeRouterData>>
                             Ok(Self::MandatePost(DeutschebankMandatePostRequest {
                                 approval_by: DeutschebankSEPAApproval::Click,
                                 email_address: item.router_data.request.get_email()?,
-                                iban,
+                                iban: Secret::from(iban.peek().replace(" ", "")),
                                 first_name: billing_address.get_first_name()?.clone(),
                                 last_name: billing_address.get_last_name()?.clone(),
                             }))
@@ -313,7 +313,7 @@ impl
                                 PaymentMethodData::BankDebit(BankDebitData::SepaBankDebit {
                                     iban,
                                     ..
-                                }) => Ok(iban),
+                                }) => Ok(Secret::from(iban.peek().replace(" ", ""))),
                                 _ => Err(errors::ConnectorError::MissingRequiredField {
                                     field_name:
                                         "payment_method_data.bank_debit.sepa_bank_debit.iban"
@@ -470,7 +470,7 @@ impl TryFrom<&DeutschebankRouterData<&PaymentsCompleteAuthorizeRouterData>>
                     means_of_payment: DeutschebankMeansOfPayment {
                         bank_account: DeutschebankBankAccount {
                             account_holder,
-                            iban,
+                            iban: Secret::from(iban.peek().replace(" ", "")),
                         },
                     },
                     mandate: {


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Trim the spaces in IBAN before sending it in SEPA Mandate Post and Direct Debit requests for Deutsche Bank.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
https://github.com/juspay/hyperswitch/issues/5976

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Request:
```
curl --location 'http://localhost:8080/payments' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: dev_2QpEeK0ByPRkb2DPBxHfad4i1WxQO3hZSuVzlFcg9mTrLFUHRpGfE0SCuQwZjGEb' \
--data '{
    "amount": 9000,
    "currency": "EUR",
    "confirm": true,
    "profile_id": "pro_EuXuxP2KVO0m1tlDWSau",
    "customer_id": "customer123",
    "payment_method": "bank_debit",
    "payment_method_type": "sepa",
    "payment_method_data": {
        "bank_debit": {
            "sepa_bank_debit": {
                "iban": "DE87 1234 5678 1234 5678 90"
            }
        }
    },
    "billing": {
        "address": {
            "first_name": "joseph",
            "last_name": "doe"
        }
    },
    "customer_acceptance": {
        "acceptance_type": "offline"
    },
    "setup_future_usage": "off_session"
}'
```
Response:
```
{
    "payment_id": "pay_THxTbiKwV1xv7Tmkqe8I",
    "merchant_id": "merchant_1725539597",
    "status": "requires_customer_action",
    "amount": 9000,
    "net_amount": 9000,
    "amount_capturable": 9000,
    "amount_received": null,
    "connector": "deutschebank",
    "client_secret": "pay_THxTbiKwV1xv7Tmkqe8I_secret_hx91jywe0lywBW5UrLb0",
    "created": "2024-09-20T11:05:32.884Z",
    "currency": "EUR",
    "customer_id": "customer123",
    "customer": {
        "id": "customer123",
        "name": "John Doe",
        "email": "something@example.com",
        "phone": "9999999999",
        "phone_country_code": "+1"
    },
    "description": null,
    "refunds": null,
    "disputes": null,
    "mandate_id": null,
    "mandate_data": null,
    "setup_future_usage": "off_session",
    "off_session": null,
    "capture_on": null,
    "capture_method": null,
    "payment_method": "bank_debit",
    "payment_method_data": {
        "bank_debit": {
            "sepa": {
                "iban": "DE87 **** **** **** **78 90",
                "bank_account_holder_name": null
            }
        },
        "billing": null
    },
    "payment_token": "token_LBU2etjaOq7pdJhAPHMk",
    "shipping": null,
    "billing": {
        "address": {
            "city": null,
            "country": null,
            "line1": null,
            "line2": null,
            "line3": null,
            "zip": null,
            "state": null,
            "first_name": "joseph",
            "last_name": "doe"
        },
        "phone": null,
        "email": null
    },
    "order_details": null,
    "email": "something@example.com",
    "name": "John Doe",
    "phone": "9999999999",
    "return_url": null,
    "authentication_type": "no_three_ds",
    "statement_descriptor_name": null,
    "statement_descriptor_suffix": null,
    "next_action": {
        "type": "redirect_to_url",
        "redirect_to_url": "http://localhost:8080/payments/redirect/pay_THxTbiKwV1xv7Tmkqe8I/merchant_1725539597/pay_THxTbiKwV1xv7Tmkqe8I_1"
    },
    "cancellation_reason": null,
    "error_code": null,
    "error_message": null,
    "unified_code": null,
    "unified_message": null,
    "payment_experience": null,
    "payment_method_type": "sepa",
    "connector_label": null,
    "business_country": null,
    "business_label": "default",
    "business_sub_label": null,
    "allowed_payment_method_types": null,
    "ephemeral_key": {
        "customer_id": "customer123",
        "created_at": 1726830332,
        "expires": 1726833932,
        "secret": "epk_fb2f1bbac4204fc2841fd2b74a295fa0"
    },
    "manual_retry_allowed": null,
    "connector_transaction_id": null,
    "frm_message": null,
    "metadata": null,
    "connector_metadata": null,
    "feature_metadata": null,
    "reference_id": null,
    "payment_link": null,
    "profile_id": "pro_EuXuxP2KVO0m1tlDWSau",
    "surcharge_details": null,
    "attempt_count": 1,
    "merchant_decision": null,
    "merchant_connector_id": "mca_MZAsrTowXuzpeXl4DMj2",
    "incremental_authorization_allowed": null,
    "authorization_count": null,
    "incremental_authorizations": null,
    "external_authentication_details": null,
    "external_3ds_authentication_attempted": false,
    "expires_on": "2024-09-20T11:20:32.884Z",
    "fingerprint": null,
    "browser_info": null,
    "payment_method_id": "pm_R9MnbGoavSYoxTmxMiS2",
    "payment_method_status": null,
    "updated": "2024-09-20T11:05:35.073Z",
    "charges": null,
    "frm_metadata": null,
    "merchant_order_reference_id": null,
    "order_tax_amount": null
}
```

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
