### PR TITLE
fix: log detailed error reports during deep health check failures

### DIFF
--- a/config/docker_compose.toml
+++ b/config/docker_compose.toml
@@ -503,7 +503,7 @@ database_name = "default"
 [analytics.sqlx]
 username = "db_user"
 password = "db_pass"
-host = "localhost"
+host = "pg"
 port = 5432
 dbname = "hyperswitch_db"
 pool_size = 5

--- a/crates/drainer/src/health_check.rs
+++ b/crates/drainer/src/health_check.rs
@@ -72,11 +72,14 @@ pub async fn deep_health_check_func(
 
     logger::debug!("Database health check begin");
 
-    let db_status = store.health_check_db().await.map(|_| true).map_err(|err| {
-        error_stack::report!(HealthCheckError::DbError {
-            message: err.to_string()
-        })
-    })?;
+    let db_status = store
+        .health_check_db()
+        .await
+        .map(|_| true)
+        .map_err(|error| {
+            let message = error.to_string();
+            error.change_context(HealthCheckError::DbError { message })
+        })?;
 
     logger::debug!("Database health check end");
 
@@ -86,10 +89,9 @@ pub async fn deep_health_check_func(
         .health_check_redis(&conf.into_inner())
         .await
         .map(|_| true)
-        .map_err(|err| {
-            error_stack::report!(HealthCheckError::RedisError {
-                message: err.to_string()
-            })
+        .map_err(|error| {
+            let message = error.to_string();
+            error.change_context(HealthCheckError::RedisError { message })
         })?;
 
     logger::debug!("Redis health check end");

--- a/crates/router/src/routes/health.rs
+++ b/crates/router/src/routes/health.rs
@@ -48,10 +48,11 @@ async fn deep_health_check_func(
 
     logger::debug!("Database health check begin");
 
-    let db_status = state.health_check_db().await.map_err(|err| {
-        error_stack::report!(errors::ApiErrorResponse::HealthCheckError {
+    let db_status = state.health_check_db().await.map_err(|error| {
+        let message = error.to_string();
+        error.change_context(errors::ApiErrorResponse::HealthCheckError {
             component: "Database",
-            message: err.to_string()
+            message,
         })
     })?;
 
@@ -59,10 +60,11 @@ async fn deep_health_check_func(
 
     logger::debug!("Redis health check begin");
 
-    let redis_status = state.health_check_redis().await.map_err(|err| {
-        error_stack::report!(errors::ApiErrorResponse::HealthCheckError {
+    let redis_status = state.health_check_redis().await.map_err(|error| {
+        let message = error.to_string();
+        error.change_context(errors::ApiErrorResponse::HealthCheckError {
             component: "Redis",
-            message: err.to_string()
+            message,
         })
     })?;
 
@@ -70,10 +72,11 @@ async fn deep_health_check_func(
 
     logger::debug!("Locker health check begin");
 
-    let locker_status = state.health_check_locker().await.map_err(|err| {
-        error_stack::report!(errors::ApiErrorResponse::HealthCheckError {
+    let locker_status = state.health_check_locker().await.map_err(|error| {
+        let message = error.to_string();
+        error.change_context(errors::ApiErrorResponse::HealthCheckError {
             component: "Locker",
-            message: err.to_string()
+            message,
         })
     })?;
 
@@ -82,10 +85,11 @@ async fn deep_health_check_func(
     logger::debug!("Analytics health check begin");
 
     #[cfg(feature = "olap")]
-    let analytics_status = state.health_check_analytics().await.map_err(|err| {
-        error_stack::report!(errors::ApiErrorResponse::HealthCheckError {
+    let analytics_status = state.health_check_analytics().await.map_err(|error| {
+        let message = error.to_string();
+        error.change_context(errors::ApiErrorResponse::HealthCheckError {
             component: "Analytics",
-            message: err.to_string()
+            message,
         })
     })?;
 
@@ -94,10 +98,11 @@ async fn deep_health_check_func(
     logger::debug!("Opensearch health check begin");
 
     #[cfg(feature = "olap")]
-    let opensearch_status = state.health_check_opensearch().await.map_err(|err| {
-        error_stack::report!(errors::ApiErrorResponse::HealthCheckError {
+    let opensearch_status = state.health_check_opensearch().await.map_err(|error| {
+        let message = error.to_string();
+        error.change_context(errors::ApiErrorResponse::HealthCheckError {
             component: "Opensearch",
-            message: err.to_string()
+            message,
         })
     })?;
 
@@ -105,10 +110,11 @@ async fn deep_health_check_func(
 
     logger::debug!("Outgoing Request health check begin");
 
-    let outgoing_check = state.health_check_outgoing().await.map_err(|err| {
-        error_stack::report!(errors::ApiErrorResponse::HealthCheckError {
+    let outgoing_check = state.health_check_outgoing().await.map_err(|error| {
+        let message = error.to_string();
+        error.change_context(errors::ApiErrorResponse::HealthCheckError {
             component: "Outgoing Request",
-            message: err.to_string()
+            message,
         })
     })?;
 


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->

This PR updates the deep health check error propagation code to build the error reports instead of constructing new errors. As a result of this change, we should now have detailed error reports being logged when there are deep health check failures (which were absent previously).

In addition, this PR fixes the sqlx analytics host name in the Docker Compose config file.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [x] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->

This PR fixes the sqlx analytics host name in the `config/docker_compose.toml` file.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->

Having detailed error reports during deep health check failures should help debug issues better.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

1. I intentionally typo'd the sqlx analytics host name in the `config/development.toml` file, which causes a deep health check failure when the endpoint is accessed.

2. Next, hit the deep health check endpoint:

   ```shell
   curl --include 'http://localhost:8080/health/ready'
   ```

   We obtain an internal server error, because of the typo earlier.

   Previously, the error log didn't contain much useful information:

   ![Screenshot of previous error message](https://github.com/user-attachments/assets/7484b6da-b6d0-488c-96c5-2ffa44e03167)

   Now, the error log includes the complete error report:

   ![Screenshot of detailed error report](https://github.com/user-attachments/assets/02918ea4-e57d-4a82-b6de-21e04961fb15)

We may not be able test this behavior on our hosted environments, since most of the things tested by the deep health check have been set up correctly.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
