### PR TITLE
fix(core): Update pm details in Psync response

### DIFF
--- a/crates/router/src/core/payments/transformers.rs
+++ b/crates/router/src/core/payments/transformers.rs
@@ -778,37 +778,18 @@ where
         .as_ref()
         .map(ToString::to_string)
         .unwrap_or("".to_owned());
-    let additional_payment_method_data: Option<api_models::payments::AdditionalPaymentData> =
-    match payment_data.get_payment_method_data(){
-        Some(payment_method_data) => match payment_method_data{
-            hyperswitch_domain_models::payment_method_data::PaymentMethodData::Card(_) |
-            hyperswitch_domain_models::payment_method_data::PaymentMethodData::CardRedirect(_) |
-            hyperswitch_domain_models::payment_method_data::PaymentMethodData::Wallet(_) |
-            hyperswitch_domain_models::payment_method_data::PaymentMethodData::PayLater(_) |
-            hyperswitch_domain_models::payment_method_data::PaymentMethodData::BankRedirect(_) |
-            hyperswitch_domain_models::payment_method_data::PaymentMethodData::BankDebit(_) |
-            hyperswitch_domain_models::payment_method_data::PaymentMethodData::BankTransfer(_) |
-            hyperswitch_domain_models::payment_method_data::PaymentMethodData::Crypto(_) |
-            hyperswitch_domain_models::payment_method_data::PaymentMethodData::MandatePayment |
-            hyperswitch_domain_models::payment_method_data::PaymentMethodData::Reward |
-            hyperswitch_domain_models::payment_method_data::PaymentMethodData::RealTimePayment(_) |
-            hyperswitch_domain_models::payment_method_data::PaymentMethodData::Upi(_) |
-            hyperswitch_domain_models::payment_method_data::PaymentMethodData::Voucher(_) |
-            hyperswitch_domain_models::payment_method_data::PaymentMethodData::GiftCard(_) |
-            hyperswitch_domain_models::payment_method_data::PaymentMethodData::CardToken(_) |
-            hyperswitch_domain_models::payment_method_data::PaymentMethodData::OpenBanking(_)  => {payment_attempt
-                .payment_method_data
-                .clone()
-                .map(|data| data.parse_value("payment_method_data"))
-                .transpose()
-                .change_context(errors::ApiErrorResponse::InvalidDataValue {
-                    field_name: "payment_method_data",
-                })?},
-            hyperswitch_domain_models::payment_method_data::PaymentMethodData::NetworkToken(_) => None,
-        }
-        None => None
 
-        };
+    let additional_payment_method_data: Option<api_models::payments::AdditionalPaymentData> =
+        payment_attempt
+            .payment_method_data
+            .clone()
+            .and_then(|data| match data {
+                serde_json::Value::Null => None, // This is to handle the case when the payment_method_data is null
+                _ => Some(data.parse_value("AdditionalPaymentData")),
+            })
+            .transpose()
+            .change_context(errors::ApiErrorResponse::InternalServerError)
+            .attach_printable("Failed to parse the AdditionalPaymentData from payment_attempt.payment_method_data")?;
 
     let surcharge_details =
         payment_attempt


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
pr on oss main - [#6003](https://github.com/juspay/hyperswitch/pull/6003)
Currently, in Psync response, payment_method_data is being none. Updated the Psync response with pm data.
For network token pm data will be none, since we are not storing additional pm data in attempt.
For other payment methods,  it will continue to function as it did previously.


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
payment curl - 
```{
    "amount": 6540,
    "currency": "USD",
    "confirm": true,
    "capture_method": "automatic",
    "capture_on": "2022-09-10T10:11:12Z",
    "amount_to_capture": 6540,
    "customer_id": "StripeCustomer",
    "email": "guest@example.com",
    "name": "John Doe",
    "phone": "999999999",
    "phone_country_code": "+1",
    "description": "Its my first payment request",
    "authentication_type": "no_three_ds",
    "return_url": "https://duck.com/",
    "payment_method": "card",
    "payment_method_data": {
        "card": {
            "card_number": "4242424242424242",
            "card_exp_month": "10",
            "card_exp_year": "25",
            "card_holder_name": "joseph Doe",
            "card_cvc": "123"
        }
    },
    "billing": {
        "address": {
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "city": "San Fransico",
            "state": "California",
            "zip": "94122",
            "country": "US",
            "first_name": "sundari"
        }
    },
    "shipping": {
        "address": {
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "city": "San Fransico",
            "state": "California",
            "zip": "94122",
            "country": "US",
            "first_name": "sundari"
        }
    },
    "statement_descriptor_name": "joseph",
    "statement_descriptor_suffix": "JS",
    "metadata": {
        "udf1": "value1",
        "new_customer": "true",
        "login_date": "2019-09-10T10:11:12Z"
    },
    "routing": {
        "type": "single",
        "data": "stripe"
    }
    
}```
test cases - make a successful payment, pm data should be displayed in the response
PaymentsCreate - 
<img width="702" alt="Screenshot 2024-09-24 at 1 54 01 PM" src="https://github.com/user-attachments/assets/cb4635ef-95c9-4127-aa67-25f1b372efd3">

 PSync - 
<img width="710" alt="Screenshot 2024-09-24 at 1 54 16 PM" src="https://github.com/user-attachments/assets/1fb845e8-da1a-4257-af73-0cdce5171d56">

Save Card flow - 
<img width="763" alt="Screenshot 2024-09-24 at 1 54 30 PM" src="https://github.com/user-attachments/assets/2c2dde1c-f841-47b5-9d76-a4fcd48d5204">



## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
