### PR TITLE
fix(config): dont read cert and url if keymanager is disabled

### DIFF
--- a/config/development.toml
+++ b/config/development.toml
@@ -13,7 +13,7 @@ use_xray_generator = false
 bg_metrics_collection_interval_in_secs = 15
 
 [key_manager]
-url = "http://localhost:5000"
+enabled = false
 
 # TODO: Update database credentials before running application
 [master_database]

--- a/crates/common_utils/src/types/keymanager.rs
+++ b/crates/common_utils/src/types/keymanager.rs
@@ -25,7 +25,7 @@ use crate::{
 
 #[derive(Debug, Clone)]
 pub struct KeyManagerState {
-    pub enabled: Option<bool>,
+    pub enabled: bool,
     pub url: String,
     pub client_idle_timeout: Option<u64>,
     #[cfg(feature = "km_forward_x_request_id")]

--- a/crates/hyperswitch_domain_models/src/type_encryption.rs
+++ b/crates/hyperswitch_domain_models/src/type_encryption.rs
@@ -101,7 +101,7 @@ mod encrypt {
     fn is_encryption_service_enabled(_state: &KeyManagerState) -> bool {
         #[cfg(feature = "encryption_service")]
         {
-            _state.enabled.unwrap_or_default()
+            _state.enabled
         }
         #[cfg(not(feature = "encryption_service"))]
         {

--- a/crates/router/src/configs/defaults.rs
+++ b/crates/router/src/configs/defaults.rs
@@ -12461,16 +12461,3 @@ pub fn get_shipping_required_fields() -> HashMap<String, RequiredFieldInfo> {
         ),
     ])
 }
-
-impl Default for super::settings::KeyManagerConfig {
-    fn default() -> Self {
-        Self {
-            enabled: None,
-            url: String::from("localhost:5000"),
-            #[cfg(feature = "keymanager_mtls")]
-            ca: String::default().into(),
-            #[cfg(feature = "keymanager_mtls")]
-            cert: String::default().into(),
-        }
-    }
-}

--- a/crates/router/src/configs/secrets_transformers.rs
+++ b/crates/router/src/configs/secrets_transformers.rs
@@ -232,14 +232,22 @@ impl SecretsHandler for settings::KeyManagerConfig {
         let keyconfig = value.get_inner();
 
         #[cfg(feature = "keymanager_mtls")]
-        let ca = _secret_management_client
-            .get_secret(keyconfig.ca.clone())
-            .await?;
+        let ca = if keyconfig.enabled {
+            _secret_management_client
+                .get_secret(keyconfig.ca.clone())
+                .await?
+        } else {
+            keyconfig.ca.clone()
+        };
 
         #[cfg(feature = "keymanager_mtls")]
-        let cert = _secret_management_client
-            .get_secret(keyconfig.cert.clone())
-            .await?;
+        let cert = if keyconfig.enabled {
+            _secret_management_client
+                .get_secret(keyconfig.cert.clone())
+                .await?
+        } else {
+            keyconfig.ca.clone()
+        };
 
         Ok(value.transition_state(|keyconfig| Self {
             #[cfg(feature = "keymanager_mtls")]

--- a/crates/router/src/configs/settings.rs
+++ b/crates/router/src/configs/settings.rs
@@ -213,9 +213,10 @@ pub struct KvConfig {
     pub soft_kill: Option<bool>,
 }
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Clone, Default)]
+#[serde(default)]
 pub struct KeyManagerConfig {
-    pub enabled: Option<bool>,
+    pub enabled: bool,
     pub url: String,
     #[cfg(feature = "keymanager_mtls")]
     pub cert: Secret<String>,
@@ -858,6 +859,8 @@ impl Settings<SecuredSecret> {
             .as_ref()
             .map(|x| x.get_inner().validate())
             .transpose()?;
+
+        self.key_manager.get_inner().validate()?;
 
         Ok(())
     }

--- a/crates/router/src/configs/validations.rs
+++ b/crates/router/src/configs/validations.rs
@@ -222,3 +222,25 @@ impl super::settings::NetworkTokenizationService {
         })
     }
 }
+
+impl super::settings::KeyManagerConfig {
+    pub fn validate(&self) -> Result<(), ApplicationError> {
+        use common_utils::fp_utils::when;
+
+        #[cfg(feature = "keymanager_mtls")]
+        when(
+            self.enabled && (self.ca.is_default_or_empty() || self.cert.is_default_or_empty()),
+            || {
+                Err(ApplicationError::InvalidConfigurationValueError(
+                    "Invalid CA or Certificate for Keymanager.".into(),
+                ))
+            },
+        )?;
+
+        when(self.enabled && self.url.is_default_or_empty(), || {
+            Err(ApplicationError::InvalidConfigurationValueError(
+                "Invalid URL for Keymanager".into(),
+            ))
+        })
+    }
+}


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->
- [x] Enhancement

## Description
<!-- Describe your changes in detail -->
This fixes unnecessary failure when url and cert for the keymanager is not provided in the config but keymanager is disabled.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
If the keymanager is disabled in the config, there's no reason to provide `url` and `cert` for keymanager since they won't be used. This PR adds a check which checks if keymanager is enabled and only fail for these configs missing if keymanager is enabled

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
This cannot be tested on any environment


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code