### PR TITLE
fix: env added for hyperswitch-web

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -162,6 +162,7 @@ services:
       - SELF_SERVER_URL=http://localhost:5252
       - SDK_ENV=local
       - ENV_LOGGING_URL=http://localhost:3103
+      - ENV_BACKEND_URL=http://localhost:8080
     labels:
       logs: "promtail"
 


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
In docker for hyperswitch-web we were facing that it's always pointing to beta.hyperswitch.io as ENV_BACKEND_URL was not getting passed.


Hotfix for - https://github.com/juspay/hyperswitch/pull/6113


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
Via checking HyperLoader.js file at 9050 port.


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
