### PR TITLE
fix(user_roles): Send only same and below Entity Level Users in List Users API

### DIFF
--- a/crates/router/src/core/user_role.rs
+++ b/crates/router/src/core/user_role.rs
@@ -736,6 +736,16 @@ pub async fn list_users_in_lineage(
         }
     };
 
+    // This filtering is needed because for org level users in V1, merchant_id is present.
+    // Due to this, we get org level users in merchant level users list.
+    let user_roles_set = user_roles_set
+        .into_iter()
+        .filter_map(|user_role| {
+            let (_entity_id, entity_type) = user_role.get_entity_id_and_type()?;
+            (entity_type <= requestor_role_info.get_entity_type()).then_some(user_role)
+        })
+        .collect::<HashSet<_>>();
+
     let mut email_map = state
         .global_store
         .find_users_by_user_ids(


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
- Send only same and below Entity Level Users in List Users API.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
Closes [#6146](https://github.com/juspay/hyperswitch/issues/6146).

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
```
curl 'http://localhost:8080/user/user/v2/list' \
  -H 'authorization: Bearer JWT' \
```
This API when called with merchant level users, should send org level users in response. Can be tested via control center.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
