### PR TITLE
feat(router): add amount conversion framework for connectors

### DIFF
--- a/crates/router/src/connector/nuvei.rs
+++ b/crates/router/src/connector/nuvei.rs
@@ -7,6 +7,7 @@ use ::common_utils::{
     errors::ReportSwitchExt,
     ext_traits::{BytesExt, ValueExt},
     request::RequestContent,
+    types::{AmountConvertor, StringMajorUnit, StringMajorUnitForConnector},
 };
 use error_stack::ResultExt;
 use masking::ExposeInterface;
@@ -32,7 +33,16 @@ use crate::{
 };
 
 #[derive(Debug, Clone)]
-pub struct Nuvei;
+pub struct Nuvei{
+    amount_converter: &'static (dyn AmountConvertor<Output = StringMajorUnit> + Sync),
+};
+impl Nuvei {
+    pub fn new() -> &'static Self {
+        &Self {
+            amount_converter: &StringMajorUnitForConnector,
+        }
+    }
+}
 
 impl<Flow, Request, Response> ConnectorCommonExt<Flow, Request, Response> for Nuvei
 where
@@ -268,7 +278,13 @@ impl ConnectorIntegration<api::Void, types::PaymentsCancelData, types::PaymentsR
         req: &types::PaymentsCancelRouterData,
         _connectors: &settings::Connectors,
     ) -> CustomResult<RequestContent, errors::ConnectorError> {
-        let connector_req = nuvei::NuveiPaymentFlowRequest::try_from(req)?;
+        let amount = connector_utils::convert_amount(
+            self.amount_converter,
+            req.request.minor_amount,
+            req.request.currency,
+        )?;
+        let connector_router_data = nuvei::NuveiRouterData::try_from((amount, req))?;
+        let connector_req = nuvei::NuveiPaymentFlowRequest::try_from(&connector_router_data)?;
         Ok(RequestContent::Json(Box::new(connector_req)))
     }
 
@@ -437,7 +453,13 @@ impl ConnectorIntegration<api::Capture, types::PaymentsCaptureData, types::Payme
         req: &types::PaymentsCaptureRouterData,
         _connectors: &settings::Connectors,
     ) -> CustomResult<RequestContent, errors::ConnectorError> {
-        let connector_req = nuvei::NuveiPaymentFlowRequest::try_from(req)?;
+        let amount = connector_utils::convert_amount(
+            self.amount_converter,
+            req.request.minor_amount,
+            req.request.currency,
+        )?;
+        let connector_router_data = nuvei::NuveiRouterData::try_from((amount, req))?;
+        let connector_req = nuvei::NuveiPaymentFlowRequest::try_from(&connector_router_data)?;
         Ok(RequestContent::Json(Box::new(connector_req)))
     }
 
@@ -798,7 +820,13 @@ impl ConnectorIntegration<api::Execute, types::RefundsData, types::RefundsRespon
         req: &types::RefundsRouterData<api::Execute>,
         _connectors: &settings::Connectors,
     ) -> CustomResult<RequestContent, errors::ConnectorError> {
-        let connector_req = nuvei::NuveiPaymentFlowRequest::try_from(req)?;
+            let refund_amount = connector_utils::convert_amount(
+            self.amount_converter,
+            req.request.minor_amount,
+            req.request.currency,
+        )?;
+        let connector_router_data = nuvei::NuveiRouterData::try_from((amount, req))?;
+        let connector_req = nuvei::NuveiPaymentFlowRequest::try_from(&connector_router_data)?;
         Ok(RequestContent::Json(Box::new(connector_req)))
     }
 

--- a/crates/router/src/connector/nuvei/transformers.rs
+++ b/crates/router/src/connector/nuvei/transformers.rs
@@ -4,6 +4,7 @@ use common_utils::{
     ext_traits::Encode,
     fp_utils,
     pii::{Email, IpAddress},
+    types::StringMajorUnit,
 };
 use error_stack::ResultExt;
 use hyperswitch_domain_models::mandates::{MandateData, MandateDataType};
@@ -22,6 +23,22 @@ use crate::{
     types::{self, api, domain, storage::enums, transformers::ForeignTryFrom, BrowserInformation},
     utils::OptionExt,
 };
+
+#[derive(Debug, Serialize)]
+pub struct NuveiRouterData<T> {
+    pub amount: StringMajorUnit,
+    pub router_data: T,
+}
+
+impl<T> TryFrom<(StringMajorUnit, T)> for NuveiRouterData<T> {
+    type Error = error_stack::Report<errors::ConnectorError>;
+    fn try_from((amount, item): (StringMajorUnit, T)) -> Result<Self, Self::Error> {
+        Ok(Self {
+            amount,
+            router_data: item,
+        })
+    }
+}
 
 trait NuveiAuthorizePreprocessingCommon {
     fn get_browser_info(&self) -> Option<BrowserInformation>;
@@ -193,7 +210,7 @@ pub struct NuveiPaymentsRequest {
     pub merchant_id: Secret<String>,
     pub merchant_site_id: Secret<String>,
     pub client_request_id: Secret<String>,
-    pub amount: String,
+    pub amount: StringMajorUnit,
     pub currency: diesel_models::enums::Currency,
     /// This ID uniquely identifies your consumer/user in your system.
     pub user_token_id: Option<Email>,
@@ -222,7 +239,7 @@ pub struct NuveiInitPaymentRequest {
     pub merchant_id: Secret<String>,
     pub merchant_site_id: Secret<String>,
     pub client_request_id: String,
-    pub amount: String,
+    pub amount: StringMajorUnit,
     pub currency: String,
     pub payment_option: PaymentOption,
     pub checksum: Secret<String>,
@@ -236,7 +253,7 @@ pub struct NuveiPaymentFlowRequest {
     pub merchant_id: Secret<String>,
     pub merchant_site_id: Secret<String>,
     pub client_request_id: String,
-    pub amount: String,
+    pub amount: StringMajorUnit,
     pub currency: diesel_models::enums::Currency,
     pub related_transaction_id: Option<String>,
     pub checksum: Secret<String>,
@@ -1299,7 +1316,7 @@ impl TryFrom<NuveiPaymentRequestData> for NuveiPaymentFlowRequest {
 
 #[derive(Debug, Clone, Default)]
 pub struct NuveiPaymentRequestData {
-    pub amount: String,
+    pub amount: StringMajorUnit,
     pub currency: diesel_models::enums::Currency,
     pub related_transaction_id: Option<String>,
     pub client_request_id: String,

--- a/crates/router/src/types/api.rs
+++ b/crates/router/src/types/api.rs
@@ -455,7 +455,7 @@ impl ConnectorData {
                 enums::Connector::Novalnet => {
                     Ok(ConnectorEnum::Old(Box::new(connector::Novalnet::new())))
                 }
-                enums::Connector::Nuvei => Ok(ConnectorEnum::Old(Box::new(&connector::Nuvei))),
+                enums::Connector::Nuvei => Ok(ConnectorEnum::Old(Box::new(&connector::Nuvei::new()))),
                 enums::Connector::Opennode => {
                     Ok(ConnectorEnum::Old(Box::new(&connector::Opennode)))
                 }

--- a/crates/router/tests/connectors/nuvei.rs
+++ b/crates/router/tests/connectors/nuvei.rs
@@ -16,7 +16,7 @@ impl utils::Connector for NuveiTest {
     fn get_data(&self) -> types::api::ConnectorData {
         use router::connector::Nuvei;
         utils::construct_connector_data_old(
-            Box::new(&Nuvei),
+            Box::new(&Nuvei::new()),
             types::Connector::Nuvei,
             types::api::GetToken::Connector,
             None,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
This feature introduces a new `Unit` struct along with the MinorUnit type to standardize amount handling across all connectors within the application. The primary objective is to centralize the conversion logic within the core framework, eliminating the need for each connector to handle its own conversion.

By standardizing the format and placing the conversion logic in one location, this change simplifies the codebase and reduces potential inconsistencies in how amounts are managed across different connectors. Each connector can now simply invoke the convert function to receive amounts in their required format, based on their documentation.

This update will make future modifications and bug fixes easier to implement, as all amount conversions are now handled by a single, unified system.

fixes #6023 







## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
