### PR TITLE
chore(router): use proper spelling in cloneable

### DIFF
--- a/crates/router/src/services/api.rs
+++ b/crates/router/src/services/api.rs
@@ -496,7 +496,7 @@ pub async fn send_request(
         ))
     };
 
-    // We cannot clone the request type, because it has Form trait which is not clonable. So we are cloning the request builder here.
+    // We cannot clone the request type, because it has Form trait which is not cloneable. So we are cloning the request builder here.
     let cloned_send_request = request.try_clone().map(|cloned_request| async {
         cloned_request
             .send()
@@ -570,7 +570,7 @@ pub async fn send_request(
                     .await
                 }
                 None => {
-                    logger::info!("Retrying request due to connection closed before message could complete failed as request is not clonable");
+                    logger::info!("Retrying request due to connection closed before message could complete failed as request is not cloneable");
                     Err(error)
                 }
             }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->

While working on #6191 (cf. #5917) I noticed that the CI is reporting this spelling issue. Some more of the CI jobs failed:
- https://github.com/juspay/hyperswitch/actions/runs/11135615914/job/30945965216,
- https://github.com/juspay/hyperswitch/actions/runs/11123807888/job/30908038374,
- https://github.com/juspay/hyperswitch/actions/runs/11123440265/job/30906897289,
- https://github.com/juspay/hyperswitch/actions/runs/11123158701/job/30906005608.

Fixes #6195.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Manually checked against a dictionary, cf. https://en.wiktionary.org/wiki/clonable#English vs. https://en.wiktionary.org/wiki/cloneable

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
