### PR TITLE
feat(cypress): execute cypress tests in parallel

### DIFF
--- a/.github/workflows/cypress-tests-runner.yml
+++ b/.github/workflows/cypress-tests-runner.yml
@@ -13,8 +13,8 @@ concurrency:
 env:
   CARGO_INCREMENTAL: 0
   CARGO_NET_RETRY: 10
-  PAYMENTS: "adyen bankofamerica bluesnap cybersource iatapay nmi paypal stripe trustpay"
-  PAYOUTS: "adyen adyenplatform wise"
+  PAYMENTS: "bluesnap cybersource stripe"
+  PAYOUTS: "adyen wise"
   RUST_BACKTRACE: short
   RUSTUP_MAX_RETRIES: 10
   RUN_TESTS: ${{ ((github.event_name == 'pull_request') && (github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name)) || (github.event_name == 'merge_group')}}

--- a/.github/workflows/cypress-tests-runner.yml
+++ b/.github/workflows/cypress-tests-runner.yml
@@ -194,9 +194,6 @@ jobs:
 
           kill "${{ env.PID }}"
 
-          ls -la cypres-tests/cypress/reports
-          tree -a cypres-tests/cypress/reports 
-
       - name: Upload Cypress test results
         if: env.RUN_TESTS == 'true' && failure()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/cypress-tests-runner.yml
+++ b/.github/workflows/cypress-tests-runner.yml
@@ -13,8 +13,8 @@ concurrency:
 env:
   CARGO_INCREMENTAL: 0
   CARGO_NET_RETRY: 10
-  PAYMENTS_CONNECTORS: "bluesnap cybersource stripe"
-  PAYOUTS_CONNECTORS: "adyen wise"
+  PAYMENTS_CONNECTORS: "stripe"
+  PAYOUTS_CONNECTORS: "wise"
   RUST_BACKTRACE: short
   RUSTUP_MAX_RETRIES: 10
   RUN_TESTS: ${{ ((github.event_name == 'pull_request') && (github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name)) || (github.event_name == 'merge_group')}}

--- a/.github/workflows/cypress-tests-runner.yml
+++ b/.github/workflows/cypress-tests-runner.yml
@@ -13,8 +13,8 @@ concurrency:
 env:
   CARGO_INCREMENTAL: 0
   CARGO_NET_RETRY: 10
-  PAYMENTS: "bluesnap cybersource stripe"
-  PAYOUTS: "adyen wise"
+  PAYMENTS_CONNECTORS: "bluesnap cybersource stripe"
+  PAYOUTS_CONNECTORS: "adyen wise"
   RUST_BACKTRACE: short
   RUSTUP_MAX_RETRIES: 10
   RUN_TESTS: ${{ ((github.event_name == 'pull_request') && (github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name)) || (github.event_name == 'merge_group')}}

--- a/.github/workflows/cypress-tests-runner.yml
+++ b/.github/workflows/cypress-tests-runner.yml
@@ -190,7 +190,7 @@ jobs:
           ROUTER__SERVER__WORKERS: 4
         shell: bash -leuo pipefail {0}
         run: |
-          . scripts/execute_cypress.sh --parallel
+          . scripts/execute_cypress.sh --parallel 3
 
           kill "${{ env.PID }}"
 

--- a/.github/workflows/cypress-tests-runner.yml
+++ b/.github/workflows/cypress-tests-runner.yml
@@ -13,7 +13,8 @@ concurrency:
 env:
   CARGO_INCREMENTAL: 0
   CARGO_NET_RETRY: 10
-  CONNECTORS: stripe
+  PAYMENTS: "adyen bankofamerica bluesnap cybersource iatapay nmi paypal stripe trustpay"
+  PAYOUTS: "adyen adyenplatform wise"
   RUST_BACKTRACE: short
   RUSTUP_MAX_RETRIES: 10
   RUN_TESTS: ${{ ((github.event_name == 'pull_request') && (github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name)) || (github.event_name == 'merge_group')}}
@@ -186,29 +187,10 @@ jobs:
         if: ${{ env.RUN_TESTS == 'true' }}
         env:
           CYPRESS_BASEURL: "http://localhost:8080"
+          ROUTER__SERVER__WORKERS: 4
         shell: bash -leuo pipefail {0}
         run: |
-          cd cypress-tests
-
-          RED='\033[0;31m'
-          RESET='\033[0m'
-
-          failed_connectors=()
-
-          for connector in $(echo "${CONNECTORS}" | tr "," "\n"); do
-            echo "${connector}"
-            for service in "payments" "payouts"; do
-              if ! ROUTER__SERVER__WORKERS=4 CYPRESS_CONNECTOR="${connector}" npm run cypress:"${service}"; then
-                failed_connectors+=("${connector}-${service}")
-              fi
-            done
-          done
-
-          if [ ${#failed_connectors[@]} -gt 0 ]; then
-            echo -e "${RED}One or more connectors failed to run:${RESET}"
-            printf '%s\n' "${failed_connectors[@]}"
-            exit 1
-          fi
+          . scripts/execute_cypress.sh --parallel
 
           kill "${{ env.PID }}"
 

--- a/.github/workflows/cypress-tests-runner.yml
+++ b/.github/workflows/cypress-tests-runner.yml
@@ -69,7 +69,7 @@ jobs:
           CONNECTOR_AUTH_PASSPHRASE: ${{ secrets.CONNECTOR_AUTH_PASSPHRASE }}
           CONNECTOR_CREDS_S3_BUCKET_URI: ${{ secrets.CONNECTOR_CREDS_S3_BUCKET_URI}}
           DESTINATION_FILE_NAME: "creds.json.gpg"
-          S3_SOURCE_FILE_NAME: "f64157fe-a8f7-43a8-a268-b17e9a8c305f.json.gpg"
+          S3_SOURCE_FILE_NAME: "5a3f7679-445e-4621-86c5-39bd8d26b7c5.json.gpg"
         shell: bash
         run: |
           mkdir -p ".github/secrets" ".github/test"

--- a/.github/workflows/cypress-tests-runner.yml
+++ b/.github/workflows/cypress-tests-runner.yml
@@ -194,6 +194,9 @@ jobs:
 
           kill "${{ env.PID }}"
 
+          ls -la cypres-tests/cypress/reports
+          tree -a cypres-tests/cypress/reports 
+
       - name: Upload Cypress test results
         if: env.RUN_TESTS == 'true' && failure()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/cypress-tests-runner.yml
+++ b/.github/workflows/cypress-tests-runner.yml
@@ -200,6 +200,5 @@ jobs:
         with:
           name: cypress-test-results
           path: |
-            cypress-tests/cypress/reports/*.json
-            cypress-tests/cypress/reports/*.html
+            cypress-tests/cypress/reports/
           retention-days: 1

--- a/cypress-tests/cypress.config.js
+++ b/cypress-tests/cypress.config.js
@@ -5,6 +5,7 @@ const path = require("path");
 let globalState;
 // Fetch from environment variable
 const connectorId = process.env.CYPRESS_CONNECTOR || "service";
+const screenshotsFolderName = `screenshots/${connectorId}`;
 const reportName = process.env.REPORT_NAME || `${connectorId}_report`;
 
 module.exports = defineConfig({
@@ -25,36 +26,12 @@ module.exports = defineConfig({
           return null;
         },
       });
-      on("after:screenshot", (details) => {
-        // Full path to the screenshot file
-        const screenshotPath = details.path;
-
-        // Extract filename without extension
-        const name = path.basename(
-          screenshotPath,
-          path.extname(screenshotPath)
-        );
-
-        // Define a new name with a connectorId
-        const newName = `[${connectorId}] ${name}.png`;
-        const newPath = path.join(path.dirname(screenshotPath), newName);
-
-        return fs
-          .rename(screenshotPath, newPath)
-          .then(() => {
-            console.log("Screenshot renamed successfully");
-            return { path: newPath };
-          })
-          .catch((err) => {
-            console.error("Failed to rename screenshot:", err);
-          });
-      });
     },
     experimentalRunAllSpecs: true,
 
     reporter: "cypress-mochawesome-reporter",
     reporterOptions: {
-      reportDir: "cypress/reports",
+      reportDir: `cypress/reports/${connectorId}`,
       reportFilename: reportName,
       reportPageTitle: `[${connectorId}] Cypress test report`,
       embeddedScreenshots: true,
@@ -66,4 +43,6 @@ module.exports = defineConfig({
   chromeWebSecurity: false,
   defaultCommandTimeout: 10000,
   pageLoadTimeout: 20000,
+
+  screenshotsFolder: screenshotsFolderName,
 });

--- a/cypress-tests/readme.md
+++ b/cypress-tests/readme.md
@@ -72,6 +72,32 @@ To run test cases, follow these steps:
    npm run cypress:routing
    ```
 
+In order to run cypress tests against multiple connectors at a time:
+
+1. Set up `.env` file that exports necessary info:
+
+   ```env
+   export DEBUG=cypress:cli
+
+   export CYPRESS_ADMINAPIKEY='admin_api_key'
+   export CYPRESS_BASEURL='base_url'
+   export CYPRESS_CONNECTOR_AUTH_FILE_PATH="path/to/creds.json"
+
+   export PAYMENTS=("payment_connector_1" "payment_connector_2" "payment_connector_3" "payment_connector_4")
+   export PAYOUTS=("payout_connector_1" "payout_connector_2" "payout_connector_3")
+   export PAYMENT_METHOD_LIST=()
+   export ROUTING=()
+   ```
+
+2. In terminal, execute:
+
+   ```shell
+   source .env
+   . scripts/execute_cypress.sh
+   ```
+
+   Optionally, `--parallel <jobs (integer)>` can be passed to run cypress tests in parallel. By default, when `parallel` command is passed, it will be run in batches of `5`.
+
 > [!NOTE]
 > To learn about how creds file should be structured, refer to the [example.creds.json](#example-credsjson) section below.
 
@@ -157,10 +183,7 @@ Cypress.Commands.add("listMandateCallTest", (globalState) => {
     if (xRequestId) {
       cy.task("cli_log", "x-request-id ->> " + xRequestId);
     } else {
-      cy.task(
-        "cli_log",
-        "x-request-id is not available in the response headers"
-      );
+      cy.task("cli_log", "x-request-id is not available in the response headers");
     }
     expect(response.headers["content-type"]).to.include("application/json");
     console.log(response.body);

--- a/cypress-tests/readme.md
+++ b/cypress-tests/readme.md
@@ -83,17 +83,17 @@ In order to run cypress tests against multiple connectors at a time:
    export CYPRESS_BASEURL='base_url'
    export CYPRESS_CONNECTOR_AUTH_FILE_PATH="path/to/creds.json"
 
-   export PAYMENTS=("payment_connector_1" "payment_connector_2" "payment_connector_3" "payment_connector_4")
-   export PAYOUTS=("payout_connector_1" "payout_connector_2" "payout_connector_3")
-   export PAYMENT_METHOD_LIST=()
-   export ROUTING=()
+   export PAYMENTS="payment_connector_1 payment_connector_2 payment_connector_3 payment_connector_4"
+   export PAYOUTS="payout_connector_1 payout_connector_2 payout_connector_3"
+   export PAYMENT_METHOD_LIST=""
+   export ROUTING=""
    ```
 
 2. In terminal, execute:
 
    ```shell
    source .env
-   . scripts/execute_cypress.sh
+   scripts/execute_cypress.sh
    ```
 
    Optionally, `--parallel <jobs (integer)>` can be passed to run cypress tests in parallel. By default, when `parallel` command is passed, it will be run in batches of `5`.

--- a/cypress-tests/readme.md
+++ b/cypress-tests/readme.md
@@ -83,8 +83,8 @@ In order to run cypress tests against multiple connectors at a time:
    export CYPRESS_BASEURL='base_url'
    export CYPRESS_CONNECTOR_AUTH_FILE_PATH="path/to/creds.json"
 
-   export PAYMENTS="payment_connector_1 payment_connector_2 payment_connector_3 payment_connector_4"
-   export PAYOUTS="payout_connector_1 payout_connector_2 payout_connector_3"
+   export PAYMENTS_CONNECTORS="payment_connector_1 payment_connector_2 payment_connector_3 payment_connector_4"
+   export PAYOUTS_CONNECTORS="payout_connector_1 payout_connector_2 payout_connector_3"
    export PAYMENT_METHOD_LIST=""
    export ROUTING=""
    ```

--- a/cypress-tests/readme.md
+++ b/cypress-tests/readme.md
@@ -27,10 +27,16 @@ To run test cases, follow these steps:
 2. Install Cypress and its dependencies to `cypress-tests` directory by running the following command:
 
    ```shell
-   npm install
+   npm ci
    ```
 
-3. Set environment variables for cypress
+3. Insert data to `cards_info` table in `hyperswitch_db`
+
+   ```shell
+   psql --host=localhost --port=5432 --username=db_user --dbname=hyperswitch_db --command "\copy cards_info FROM '.github/data/cards_info.csv' DELIMITER ',' CSV HEADER;"
+   ```
+
+4. Set environment variables for cypress
 
    ```shell
    export CYPRESS_CONNECTOR="connector_id"
@@ -40,7 +46,7 @@ To run test cases, follow these steps:
    export CYPRESS_CONNECTOR_AUTH_FILE_PATH="path/to/creds.json"
    ```
 
-4. Run Cypress test cases
+5. Run Cypress test cases
 
    To run the tests in interactive mode run the following command
 

--- a/scripts/execute_cypress.sh
+++ b/scripts/execute_cypress.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -euo pipefail
+set -o nounset -euo pipefail -o errexit
 
 # define colors
 RESET='\033[0m'

--- a/scripts/execute_cypress.sh
+++ b/scripts/execute_cypress.sh
@@ -111,6 +111,10 @@ function check_dependencies() {
   fi
 }
 
+function cleanup() {
+  unset PAYMENTS PAYOUTS PAYMENT_METHOD_LIST ROUTING
+}
+
 function main() {
   local command="${1:-}"
   local jobs="${2:-5}"
@@ -135,6 +139,8 @@ function main() {
       run_tests 1
       ;;
   esac
+
+  cleanup
 }
 
 # Execute the main function with passed arguments

--- a/scripts/execute_cypress.sh
+++ b/scripts/execute_cypress.sh
@@ -129,7 +129,7 @@ function cleanup() {
 # Main function
 function main() {
   local command="${1:-}"
-  local jobs="${2:-5}"
+  local jobs="${2:-4}"
 
   # Ensure script runs from 'cypress-tests' directory
   if [[ "$(basename "$PWD")" != "cypress-tests" ]]; then

--- a/scripts/execute_cypress.sh
+++ b/scripts/execute_cypress.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
-set -o nounset -euo pipefail -o errexit
+
+# Exit immediately if a command exits with a non-zero status,
+# Treat unset variables as an error, and prevent errors in a pipeline from being masked
+set -euo pipefail
 
 # define colors
 RESET='\033[0m'

--- a/scripts/execute_cypress.sh
+++ b/scripts/execute_cypress.sh
@@ -52,9 +52,9 @@ function command_exists() {
 
 # Function to execute Cypress tests
 function execute_test() {
-  local connector="${1}"
-  local service="${2}"
-  local tmp_file="${3}"
+  local connector="$1"
+  local service="$2"
+  local tmp_file="$3"
 
   print_color "YELLOW" "Executing tests for ${service} with connector ${connector}..."
 
@@ -75,10 +75,11 @@ function run_tests() {
   trap 'rm -f "$tmp_file"' EXIT
 
   for service in "${connector_map[@]}"; do
-    declare -n connectors="${service}"
+    # Use indirect reference to get the array by service name
+    declare -n connectors="$service"
 
     if [[ ${#connectors[@]} -eq 0 ]]; then
-      # A service level test i.e., payment method list or routing
+      # Service-level test (e.g., payment-method-list or routing)
       [[ $service == "payment_method_list" ]] && service="payment-method-list"
 
       echo "Running ${service} tests without connectors..."
@@ -105,6 +106,7 @@ function run_tests() {
   fi
 }
 
+# Function to check and install dependencies
 function check_dependencies() {
   # parallel and npm are mandatory dependencies. exit the script if not found.
   local dependencies=("parallel" "npm")
@@ -124,6 +126,7 @@ function cleanup() {
   unset PAYMENTS PAYOUTS PAYMENT_METHOD_LIST ROUTING
 }
 
+# Main function
 function main() {
   local command="${1:-}"
   local jobs="${2:-5}"
@@ -140,7 +143,7 @@ function main() {
   check_dependencies
   read_service_arrays
 
-  case "${command}" in
+  case "$command" in
     --parallel | -p)
       print_color "YELLOW" "WARNING: Running Cypress tests in parallel is more resource-intensive!"
       # At present, parallel execution is limited to batch of 4 to not run out of memory

--- a/scripts/execute_cypress.sh
+++ b/scripts/execute_cypress.sh
@@ -4,7 +4,6 @@ set -o nounset -euo pipefail -o errexit
 # define colors
 RESET='\033[0m'
 RED='\033[0;31m'
-GREEN='\033[0;32m'
 YELLOW='\033[0;33m]'
 
 # Define arrays for services, etc.
@@ -67,7 +66,7 @@ function run_tests() {
       # A service level test i.e., payment method list or routing
       [[ $service == "payment_method_list" ]] && service="payment-method-list"
 
-      echo "${GREEN}Running ${service} tests without connectors...${RESET}"
+      echo "Running ${service} tests without connectors..."
       export REPORT_NAME="${service}_report"
 
       if ! npm run "cypress:${service}"; then
@@ -75,7 +74,7 @@ function run_tests() {
       fi
     else
       # Connector test, i.e., payments or payouts
-      echo -e "${GREEN}Running tests for service: '${service}'\nWith connectors: [${connectors[*]}] in batch of ${jobs}..${RESET}."
+      echo -e "Running tests for service: '${service}'\nWith connectors: [${connectors[*]}] in batch of ${jobs}..."
 
       # Capture the output of execute_test
       echo "${connectors[@]}" | tr ' ' '\n' | parallel --jobs "${jobs}" execute_test {} "${service}" "${tmp_file}"

--- a/scripts/execute_cypress.sh
+++ b/scripts/execute_cypress.sh
@@ -1,0 +1,128 @@
+#!/bin/bash
+set -euo pipefail
+
+# define colors
+RESET='\033[0m'
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m]'
+
+# Define arrays for services, etc.
+# Read service arrays from environment variables or use default empty arrays
+read -r -a payments <<< "${PAYMENTS[@]}"
+read -r -a payouts <<< "${PAYOUTS[@]:-}"
+read -r -a payment_method_list <<< "${PAYMENT_METHOD_LIST[@]:-}"
+read -r -a routing <<< "${ROUTING[@]:-}"
+
+connector_map=("payments" "payouts")
+
+# Check if PAYMENT_METHOD_LIST is exported (even as empty)
+if [[ -n "${PAYMENT_METHOD_LIST+x}" ]]; then
+  connector_map+=("payment_method_list")
+fi
+
+# Check if ROUTING is exported (even as empty)
+if [[ -n "${ROUTING+x}" ]]; then
+  connector_map+=("routing")
+fi
+
+failed_connectors=()
+
+# Function to check if a command exists
+function command_exists() {
+  local cmd="${1}"
+  command -v "${cmd}" > /dev/null 2>&1
+}
+
+# Function to execute Cypress tests
+function execute_test() {
+  local connector="${1}"
+  local service="${2}"
+  echo "Executing tests for ${service} with connector ${connector}..."
+
+  export REPORT_NAME="${service}_${connector}_report"
+  if ! CYPRESS_CONNECTOR="$connector" npm run "cypress:$service"; then
+    failed_connectors+=("${connector}-${service}")
+  fi
+}
+
+export -f execute_test
+
+# Function to run tests
+function run_tests() {
+  local jobs="${1:-1}"
+  local tasks=()
+
+  for service in "${connector_map[@]}"; do
+    declare -n connectors="${service}"
+
+    if [[ ${#connectors[@]} -eq 0 ]]; then
+      # A service level test i.e., payment method list or routing
+      [[ $service == "payment_method_list" ]] && service="payment-method-list"
+
+      echo "${GREEN}Running ${service} tests without connectors...${RESET}"
+      export REPORT_NAME="${service}_report"
+
+      if ! npm run "cypress:${service}"; then
+        failed_connectors+=("${service}")
+      fi
+    else
+      # Connector test, i.e., payments or payouts
+      echo -e "${GREEN}Running tests for service: '${service}'\nWith connectors: [${connectors[*]}] in batch of ${jobs}..${RESET}."
+      echo "${connectors[@]}" | tr ' ' '\n' | parallel --jobs "${jobs}" execute_test {} "${service}"
+    fi
+  done
+
+  if [ ${#failed_connectors[@]} -gt 0 ]; then
+    echo -e "${RED}One or more connectors failed to run:${RESET}"
+    printf '%s\n' "${failed_connectors[@]}"
+    exit 1
+  fi
+}
+
+function check_dependencies() {
+  # parallel and npm are mandatory dependencies. exit the script if not found.
+  # Check if gnu-parallel exist
+  if ! command_exists 'parallel'; then
+    echo "${RED}ERROR: GNU Parallel is not installed!${RESET}"
+    exit 1
+  fi
+
+  # Check if npm is installed
+  if ! command_exists 'npm'; then
+    echo "${RED}ERROR: NPM is not installed!${RESET}"
+    exit 1
+  else
+    # Re-install packages just so that they're intact
+    npm ci
+  fi
+}
+
+function main() {
+  local command="${1:-}"
+  local jobs="${2:-5}"
+
+  if [[ $(basename "$(pwd)") != "cypress-tests" ]]; then
+    echo "Changing directory to 'cypress-tests'..."
+    cd cypress-tests || {
+      echo "${RED}ERROR: Directory 'cypress-tests' not found!${RESET}"
+      exit 1
+    }
+  fi
+
+  check_dependencies
+
+  case "${command}" in
+    --parallel | -p)
+      # At present, parallel execution is limited to batch of 5 to not run out of memory
+      echo "${YELLOW}WARNING: Running Cypress tests in parallel is more resource intensive!${RESET}"
+      run_tests "${jobs}"
+      ;;
+    *)
+      run_tests 1
+      ;;
+  esac
+}
+
+# Execute the main function with passed arguments
+main "$@"

--- a/scripts/execute_cypress.sh
+++ b/scripts/execute_cypress.sh
@@ -107,20 +107,17 @@ function run_tests() {
 
 function check_dependencies() {
   # parallel and npm are mandatory dependencies. exit the script if not found.
-  # Check if gnu-parallel exist
-  if ! command_exists 'parallel'; then
-    echo "${RED}ERROR: GNU Parallel is not installed!${RESET}"
-    exit 1
-  fi
+  local dependencies=("parallel" "npm")
 
-  # Check if npm is installed
-  if ! command_exists 'npm'; then
-    echo "${RED}ERROR: NPM is not installed!${RESET}"
-    exit 1
-  else
-    # Re-install packages just so that they're intact
-    npm ci
-  fi
+  for cmd in "${dependencies[@]}"; do
+    if ! command_exists "$cmd"; then
+      print_color "RED" "ERROR: ${cmd^} is not installed!"
+      exit 1
+    fi
+  done
+
+  # Install npm packages
+  npm ci
 }
 
 function cleanup() {

--- a/scripts/execute_cypress.sh
+++ b/scripts/execute_cypress.sh
@@ -28,17 +28,26 @@ declare -A services=(
   ["ROUTING"]="routing"
 )
 
-# Loop through the associative array and check if each service is exported
-for var in "${!services[@]}"; do
-  if [[ -n "${!var+x}" ]]; then
-    connector_map+=("${services[$var]}")
-  fi
-done
+# Function to read service arrays from environment variables
+function read_service_arrays() {
+  # Loop through the associative array and check if each service is exported
+  for var in "${!services[@]}"; do
+    if [[ -n "${!var+x}" ]]; then
+      connector_map+=("${services[$var]}")
+    fi
+  done
+}
+
+# Function to print messages in color
+function print_color() {
+  local color="$1"
+  local message="$2"
+  echo -e "${color}${message}${RESET}"
+}
 
 # Function to check if a command exists
 function command_exists() {
-  local cmd="${1}"
-  command -v "${cmd}" > /dev/null 2>&1
+  command -v "$1" > /dev/null 2>&1
 }
 
 # Function to execute Cypress tests
@@ -131,6 +140,7 @@ function main() {
   fi
 
   check_dependencies
+  read_service_arrays
 
   case "${command}" in
     --parallel | -p)

--- a/scripts/execute_cypress.sh
+++ b/scripts/execute_cypress.sh
@@ -8,25 +8,30 @@ GREEN='\033[0;32m'
 YELLOW='\033[0;33m]'
 
 # Define arrays for services, etc.
-# Read service arrays from environment variables or use default empty arrays
+# Read service arrays from environment variables
 read -r -a payments <<< "${PAYMENTS[@]}"
-read -r -a payouts <<< "${PAYOUTS[@]:-}"
-read -r -a payment_method_list <<< "${PAYMENT_METHOD_LIST[@]:-}"
-read -r -a routing <<< "${ROUTING[@]:-}"
+read -r -a payouts <<< "${PAYOUTS[@]}"
+read -r -a payment_method_list <<< "${PAYMENT_METHOD_LIST[@]}"
+read -r -a routing <<< "${ROUTING[@]}"
 
-connector_map=("payments" "payouts")
-
-# Check if PAYMENT_METHOD_LIST is exported (even as empty)
-if [[ -n "${PAYMENT_METHOD_LIST+x}" ]]; then
-  connector_map+=("payment_method_list")
-fi
-
-# Check if ROUTING is exported (even as empty)
-if [[ -n "${ROUTING+x}" ]]; then
-  connector_map+=("routing")
-fi
-
+# define arrays
+connector_map=()
 failed_connectors=()
+
+# Define an associative array to map environment variables to service names
+declare -A services=(
+  ["PAYMENTS"]="payments"
+  ["PAYOUTS"]="payouts"
+  ["PAYMENT_METHOD_LIST"]="payment_method_list"
+  ["ROUTING"]="routing"
+)
+
+# Loop through the associative array and check if each service is exported
+for var in "${!services[@]}"; do
+  if [[ -n "${!var+x}" ]]; then
+    connector_map+=("${services[$var]}")
+  fi
+done
 
 # Function to check if a command exists
 function command_exists() {

--- a/scripts/execute_cypress.sh
+++ b/scripts/execute_cypress.sh
@@ -56,7 +56,7 @@ function execute_test() {
   local service="${2}"
   local tmp_file="${3}"
 
-  echo -e "Executing tests for ${service} with connector ${connector}..."
+  print_color "YELLOW" "Executing tests for ${service} with connector ${connector}..."
 
   export REPORT_NAME="${service}_${connector}_report"
   if ! CYPRESS_CONNECTOR="$connector" npm run "cypress:$service"; then
@@ -88,11 +88,11 @@ function run_tests() {
         echo "${service}" >> "$tmp_file"
       fi
     else
-      # Connector test, i.e., payments or payouts
-      echo -e "Running tests for service: '${service}'\nWith connectors: [${connectors[*]}] in batch of ${jobs}..."
+      # Connector-specific tests (e.g., payments or payouts)
+      print_color "YELLOW" "Running tests for service: '${service}' with connectors: [${connectors[*]}] in batches of ${jobs}..."
 
-      # Capture the output of execute_test
-      echo "${connectors[@]}" | tr ' ' '\n' | parallel --jobs "${jobs}" execute_test {} "${service}" "${tmp_file}"
+      # Execute tests in parallel
+      printf '%s\n' "${connectors[@]}" | parallel --jobs "${jobs}" execute_test {} "${service}" "${tmp_file}"
     fi
   done
 
@@ -131,10 +131,11 @@ function main() {
   local command="${1:-}"
   local jobs="${2:-5}"
 
-  if [[ $(basename "$(pwd)") != "cypress-tests" ]]; then
-    echo "Changing directory to 'cypress-tests'..."
+  # Ensure script runs from 'cypress-tests' directory
+  if [[ "$(basename "$PWD")" != "cypress-tests" ]]; then
+    print_color "YELLOW" "Changing directory to 'cypress-tests'..."
     cd cypress-tests || {
-      echo "${RED}ERROR: Directory 'cypress-tests' not found!${RESET}"
+      print_color "RED" "ERROR: Directory 'cypress-tests' not found!"
       exit 1
     }
   fi
@@ -144,9 +145,9 @@ function main() {
 
   case "${command}" in
     --parallel | -p)
-      # At present, parallel execution is limited to batch of 5 to not run out of memory
-      echo "${YELLOW}WARNING: Running Cypress tests in parallel is more resource intensive!${RESET}"
-      run_tests "${jobs}"
+      print_color "YELLOW" "WARNING: Running Cypress tests in parallel is more resource-intensive!"
+      # At present, parallel execution is limited to batch of 4 to not run out of memory
+      run_tests "$jobs"
       ;;
     *)
       run_tests 1

--- a/scripts/execute_cypress.sh
+++ b/scripts/execute_cypress.sh
@@ -158,7 +158,7 @@ function cleanup() {
 # Main function
 function main() {
   local command="${1:-}"
-  local jobs="${2:-4}"
+  local jobs="${2:-5}"
 
   # Ensure script runs from 'cypress-tests' directory
   if [[ "$(basename "$PWD")" != "cypress-tests" ]]; then

--- a/scripts/execute_cypress.sh
+++ b/scripts/execute_cypress.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 # Exit immediately if a command exits with a non-zero status,
-# Treat unset variables as an error, and prevent errors in a pipeline from being masked
 set -euo pipefail
 
 # Initialize tmp_file globally
@@ -91,7 +90,6 @@ function run_tests() {
   trap 'cleanup' EXIT
 
   for service in "${connector_map[@]}"; do
-    # Use indirect reference to get the array by service name
     declare -n connectors="$service"
 
     if [[ ${#connectors[@]} -eq 0 ]]; then
@@ -179,7 +177,8 @@ function main() {
   case "$command" in
     --parallel | -p)
       print_color "yellow" "WARNING: Running Cypress tests in parallel is more resource-intensive!"
-      # At present, parallel execution is limited to batch of 4 to not run out of memory
+      # At present, parallel execution is limited to batch of 4 by default to not run out of memory
+      # But can be scaled up by passing the value as an argument
       run_tests "$jobs"
       ;;
     *)

--- a/scripts/execute_cypress.sh
+++ b/scripts/execute_cypress.sh
@@ -9,8 +9,8 @@ tmp_file=""
 # Read service arrays from environment variables
 read -r -a payments <<< "${PAYMENTS_CONNECTORS[@]:-}"
 read -r -a payouts <<< "${PAYOUTS_CONNECTORS[@]:-}"
-read -r payment_method_list <<< "${PAYMENT_METHOD_LIST:-}"
-read -r routing <<< "${ROUTING:-}"
+read -r -a payment_method_list <<< "${PAYMENT_METHOD_LIST[@]:-}"
+read -r -a routing <<< "${ROUTING[@]:-}"
 
 # Define arrays
 connector_map=()

--- a/scripts/execute_cypress.sh
+++ b/scripts/execute_cypress.sh
@@ -1,6 +1,5 @@
 #! /usr/bin/env bash
 
-# Exit immediately if a command exits with a non-zero status,
 set -euo pipefail
 
 # Initialize tmp_file globally
@@ -176,7 +175,7 @@ function main() {
   case "$command" in
     --parallel | -p)
       print_color "yellow" "WARNING: Running Cypress tests in parallel is more resource-intensive!"
-      # At present, parallel execution is limited to batch of 4 by default to not run out of memory
+      # At present, parallel execution is restricted to not run out of memory
       # But can be scaled up by passing the value as an argument
       run_tests "$jobs"
       ;;

--- a/scripts/execute_cypress.sh
+++ b/scripts/execute_cypress.sh
@@ -52,7 +52,7 @@ function command_exists() {
 function read_service_arrays() {
   # Loop through the associative array and check if each service is exported
   for var in "${!services[@]}"; do
-    if [[ -n "${!var:-}" ]]; then
+    if [[ -n "${!var+x}" ]]; then
       connector_map+=("${services[$var]}")
     else
       print_color "yellow" "Environment variable ${var} is not set. Skipping..."

--- a/scripts/execute_cypress.sh
+++ b/scripts/execute_cypress.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#! /usr/bin/env bash
 
 # Exit immediately if a command exits with a non-zero status,
 set -euo pipefail
@@ -8,8 +8,8 @@ tmp_file=""
 
 # Define arrays for services, etc.
 # Read service arrays from environment variables
-read -r -a payments <<< "${PAYMENTS[@]:-}"
-read -r -a payouts <<< "${PAYOUTS[@]:-}"
+read -r -a payments <<< "${PAYMENTS_CONNECTORS[@]:-}"
+read -r -a payouts <<< "${PAYOUTS_CONNECTORS[@]:-}"
 read -r -a payment_method_list <<< "${PAYMENT_METHOD_LIST[@]:-}"
 read -r -a routing <<< "${ROUTING[@]:-}"
 
@@ -19,8 +19,8 @@ failed_connectors=()
 
 # Define an associative array to map environment variables to service names
 declare -A services=(
-  ["PAYMENTS"]="payments"
-  ["PAYOUTS"]="payouts"
+  ["PAYMENTS_CONNECTORS"]="payments"
+  ["PAYOUTS_CONNECTORS"]="payouts"
   ["PAYMENT_METHOD_LIST"]="payment_method_list"
   ["ROUTING"]="routing"
 )

--- a/scripts/execute_cypress.sh
+++ b/scripts/execute_cypress.sh
@@ -150,7 +150,6 @@ function cleanup() {
   if [[ -d "cypress-tests" ]]; then
     cd - || return
   fi
-  unset PAYMENTS PAYOUTS PAYMENT_METHOD_LIST ROUTING
 
   if [[ -n "${tmp_file}" && -f "${tmp_file}" ]]; then
     rm -f "${tmp_file}"

--- a/scripts/execute_cypress.sh
+++ b/scripts/execute_cypress.sh
@@ -9,8 +9,8 @@ tmp_file=""
 # Read service arrays from environment variables
 read -r -a payments <<< "${PAYMENTS_CONNECTORS[@]:-}"
 read -r -a payouts <<< "${PAYOUTS_CONNECTORS[@]:-}"
-read -r -a payment_method_list <<< "${PAYMENT_METHOD_LIST[@]:-}"
-read -r -a routing <<< "${ROUTING[@]:-}"
+read -r payment_method_list <<< "${PAYMENT_METHOD_LIST:-}"
+read -r routing <<< "${ROUTING:-}"
 
 # Define arrays
 connector_map=()

--- a/scripts/execute_cypress.sh
+++ b/scripts/execute_cypress.sh
@@ -1,5 +1,6 @@
 #! /usr/bin/env bash
 
+set -x
 set -euo pipefail
 
 # Initialize tmp_file globally
@@ -186,3 +187,4 @@ function main() {
 
 # Execute the main function with passed arguments
 main "$@"
+set +x

--- a/scripts/execute_cypress.sh
+++ b/scripts/execute_cypress.sh
@@ -1,6 +1,5 @@
 #! /usr/bin/env bash
 
-set -x
 set -euo pipefail
 
 # Initialize tmp_file globally
@@ -187,4 +186,3 @@ function main() {
 
 # Execute the main function with passed arguments
 main "$@"
-set +x

--- a/scripts/execute_cypress.sh
+++ b/scripts/execute_cypress.sh
@@ -90,14 +90,7 @@ function run_tests() {
   for service in "${connector_map[@]}"; do
     declare -n connectors="$service"
 
-    # Check if 'connectors' is an array
-    if [[ $(declare -p connectors 2> /dev/null) =~ "declare -a" ]]; then
-      # Connector-specific tests (e.g., payments or payouts)
-      print_color "yellow" "Running tests for service: '${service}' with connectors: [${connectors[*]}] in batches of ${jobs}..."
-
-      # Execute tests in parallel
-      printf '%s\n' "${connectors[@]}" | parallel --jobs "${jobs}" execute_test {} "${service}" "${tmp_file}"
-    else
+    if [[ ${#connectors[@]} -eq 0 ]]; then
       # Service-level test (e.g., payment-method-list or routing)
       [[ $service == "payment_method_list" ]] && service="payment-method-list"
 
@@ -107,6 +100,12 @@ function run_tests() {
       if ! npm run "cypress:${service}"; then
         echo "${service}" >> "${tmp_file}"
       fi
+    else
+      # Connector-specific tests (e.g., payments or payouts)
+      print_color "yellow" "Running tests for service: '${service}' with connectors: [${connectors[*]}] in batches of ${jobs}..."
+
+      # Execute tests in parallel
+      printf '%s\n' "${connectors[@]}" | parallel --jobs "${jobs}" execute_test {} "${service}" "${tmp_file}"
     fi
   done
 

--- a/scripts/execute_cypress.sh
+++ b/scripts/execute_cypress.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-set -x
 # Exit immediately if a command exits with a non-zero status,
 # Treat unset variables as an error, and prevent errors in a pipeline from being masked
 set -euo pipefail
@@ -191,5 +190,3 @@ function main() {
 
 # Execute the main function with passed arguments
 main "$@"
-
-set +x

--- a/scripts/execute_cypress.sh
+++ b/scripts/execute_cypress.sh
@@ -57,7 +57,6 @@ function read_service_arrays() {
     fi
   done
 }
-export -f read_service_arrays
 
 # Function to execute Cypress tests
 function execute_test() {

--- a/scripts/execute_cypress.sh
+++ b/scripts/execute_cypress.sh
@@ -147,7 +147,7 @@ function check_dependencies() {
 function cleanup() {
   print_color "yellow" "Cleaning up..."
   if [[ -d "cypress-tests" ]]; then
-    cd - || return
+    cd -
   fi
 
   if [[ -n "${tmp_file}" && -f "${tmp_file}" ]]; then


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [x] CI/CD

## Description
<!-- Describe your changes in detail -->

This PR makes it possible for us to run Cypress tests in parallel by leveraging `gnu-parallel`.
At present, we'll only be running against 5 connectors namely,
- payments: bluesnap, cybersource, stripe
- payouts: adyen and wise

w.r.t pml and other connectors, there are some failures within the tests that needs to be addressed.

>[!IMPORTANT]
> Cypress in parallel is resource heavy and running it in batch of 3+ will result in unintended consequences like abrupt failures due to resource limitation.

Running Cypress tests in parallel also puts up a challenge where when a specific test fails for 2 connectors at the same time, test against both the connectors stops abruptly. This is because of the file name conflict as we not have the privilege to change the names of the screenshots while capturing but only after the screenshot is captured.

To address this, the format of screenshot has been changed where screenshot directories are changed based on the connectors (just because we now have the privilege to change directories in real time).

Also, a similar issue with reports have also been addressed.

Documentation has been updated to address the usage of `scripts/execute_cypress.sh` script.
In short,

```sh
source .env
scripts/execute_cypress.sh --parallel <jobs_count>
```

>[!NOTE]
> make sure that service variables (PAYMENTS, PAYOUTS, PAYMENT_METHOD_LIST, ROUTING) is exported along with CYPRESS env variables in the `.env` file. Check README for more info.
> if `--parallel` is not passed, tests will run in sequential manner by setting jobs to `1`

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->

When Cypress tests are run in sequential, it takes about `1h10m+` to run against `10+` prod connectors. With `parallel`, we'll bring that down to nearly `15m`.

This should close https://github.com/juspay/hyperswitch/issues/5914

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

Tested locally:

These are known failures.

<img width="576" alt="image" src="https://github.com/user-attachments/assets/12788d3f-f816-4395-9799-316546595823">

The ones that passed is `Stripe` and hence it is not in `failed_connector` list.

https://github.com/juspay/hyperswitch/actions/runs/11177572035/job/31077505520?pr=6225
https://github.com/juspay/hyperswitch/actions/runs/11384335020/job/31673789059

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `prettier . --write`
- [ ] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
