### PR TITLE
refactor(routing): add admin api key as auth for toggling dynamic routing

### DIFF
--- a/api-reference/openapi_spec.json
+++ b/api-reference/openapi_spec.json
@@ -23615,17 +23615,6 @@
           }
         }
       },
-      "ToggleSuccessBasedRoutingPath": {
-        "type": "object",
-        "required": [
-          "profile_id"
-        ],
-        "properties": {
-          "profile_id": {
-            "type": "string"
-          }
-        }
-      },
       "ToggleSuccessBasedRoutingQuery": {
         "type": "object",
         "required": [

--- a/crates/api_models/src/routing.rs
+++ b/crates/api_models/src/routing.rs
@@ -555,11 +555,6 @@ pub struct ToggleSuccessBasedRoutingWrapper {
     pub status: bool,
 }
 
-#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, ToSchema)]
-pub struct ToggleSuccessBasedRoutingPath {
-    #[schema(value_type = String)]
-    pub profile_id: common_utils::id_type::ProfileId,
-}
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, ToSchema)]
 pub struct SuccessBasedRoutingConfig {
     pub params: Option<Vec<SuccessBasedRoutingConfigParams>>,

--- a/crates/api_models/src/routing.rs
+++ b/crates/api_models/src/routing.rs
@@ -550,6 +550,7 @@ pub struct SuccessBasedRoutingUpdateConfigQuery {
 
 #[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
 pub struct ToggleSuccessBasedRoutingWrapper {
+    pub merchant_id: common_utils::id_type::MerchantId,
     pub profile_id: common_utils::id_type::ProfileId,
     pub status: bool,
 }

--- a/crates/openapi/src/openapi.rs
+++ b/crates/openapi/src/openapi.rs
@@ -575,7 +575,6 @@ Never share your secret api keys. Keep them guarded and secure.
         api_models::routing::SuccessBasedRoutingConfigBody,
         api_models::routing::CurrentBlockThreshold,
         api_models::routing::SuccessBasedRoutingUpdateConfigQuery,
-        api_models::routing::ToggleSuccessBasedRoutingPath,
         api_models::routing::ast::RoutableChoiceKind,
         api_models::enums::RoutableConnectors,
         api_models::routing::ast::ProgramConnectorSelection,

--- a/crates/router/src/routes/routing.rs
+++ b/crates/router/src/routes/routing.rs
@@ -1010,7 +1010,7 @@ pub async fn toggle_success_based_routing(
             )
         },
         auth::auth_type(
-            &auth::HeaderAuth(auth::ApiKeyAuth),
+            &auth::HeaderAuth(auth::AdminApiAuth),
             &auth::JWTAuthProfileFromRoute {
                 profile_id: wrapper.profile_id,
                 required_permission: Permission::RoutingWrite,

--- a/crates/router/src/routes/routing.rs
+++ b/crates/router/src/routes/routing.rs
@@ -985,32 +985,33 @@ pub async fn toggle_success_based_routing(
     state: web::Data<AppState>,
     req: HttpRequest,
     query: web::Query<api_models::routing::ToggleSuccessBasedRoutingQuery>,
-    path: web::Path<routing_types::ToggleSuccessBasedRoutingPath>,
+    path: web::Path<(
+        common_utils::id_type::MerchantId,
+        common_utils::id_type::ProfileId,
+    )>,
 ) -> impl Responder {
     let flow = Flow::ToggleDynamicRouting;
+    let (merchant_id, profile_id) = path.into_inner();
     let wrapper = routing_types::ToggleSuccessBasedRoutingWrapper {
         status: query.into_inner().status,
-        profile_id: path.into_inner().profile_id,
+        merchant_id,
+        profile_id,
     };
     Box::pin(oss_api::server_wrap(
         flow,
         state,
         &req,
         wrapper.clone(),
-        |state,
-         auth: auth::AuthenticationData,
-         wrapper: routing_types::ToggleSuccessBasedRoutingWrapper,
-         _| {
+        |state, _, wrapper: routing_types::ToggleSuccessBasedRoutingWrapper, _| {
             routing::toggle_success_based_routing(
                 state,
-                auth.merchant_account,
-                auth.key_store,
                 wrapper.status,
                 wrapper.profile_id,
+                wrapper.merchant_id,
             )
         },
         auth::auth_type(
-            &auth::HeaderAuth(auth::AdminApiAuth),
+            &auth::AdminApiAuth,
             &auth::JWTAuthProfileFromRoute {
                 profile_id: wrapper.profile_id,
                 required_permission: Permission::RoutingWrite,

--- a/crates/router/src/routes/routing.rs
+++ b/crates/router/src/routes/routing.rs
@@ -1012,7 +1012,8 @@ pub async fn toggle_success_based_routing(
         },
         auth::auth_type(
             &auth::AdminApiAuth,
-            &auth::JWTAuthProfileFromRoute {
+            &auth::JWTAuthProfileAndMerchantFromRoute {
+                merchant_id: wrapper.merchant_id,
                 profile_id: wrapper.profile_id,
                 required_permission: Permission::RoutingWrite,
                 minimum_entity_level: EntityType::Profile,

--- a/crates/router/src/services/authentication.rs
+++ b/crates/router/src/services/authentication.rs
@@ -1467,6 +1467,48 @@ pub struct JWTAuthProfileFromRoute {
     pub required_permission: Permission,
     pub minimum_entity_level: EntityType,
 }
+#[async_trait]
+impl<A> AuthenticateAndFetch<(), A> for JWTAuthProfileFromRoute
+where
+    A: SessionStateInfo + Sync,
+{
+    async fn authenticate_and_fetch(
+        &self,
+        request_headers: &HeaderMap,
+        state: &A,
+    ) -> RouterResult<((), AuthenticationType)> {
+        let payload = parse_jwt_payload::<A, AuthToken>(request_headers, state).await?;
+        if payload.check_in_blacklist(state).await? {
+            return Err(errors::ApiErrorResponse::InvalidJwtToken.into());
+        }
+
+        let role_info = authorization::get_role_info(state, &payload).await?;
+        authorization::check_permission(&self.required_permission, &role_info)?;
+        authorization::check_entity(self.minimum_entity_level, &role_info)?;
+
+        if let Some(ref payload_profile_id) = payload.profile_id {
+            if *payload_profile_id != self.profile_id {
+                return Err(report!(errors::ApiErrorResponse::InvalidJwtToken));
+            } else {
+                Ok((
+                    (),
+                    AuthenticationType::MerchantJwt {
+                        merchant_id: payload.merchant_id.clone(),
+                        user_id: Some(payload.user_id),
+                    },
+                ))
+            }
+        } else {
+            Ok((
+                (),
+                AuthenticationType::MerchantJwt {
+                    merchant_id: payload.merchant_id.clone(),
+                    user_id: Some(payload.user_id),
+                },
+            ))
+        }
+    }
+}
 
 #[async_trait]
 impl<A> AuthenticateAndFetch<AuthenticationData, A> for JWTAuthProfileFromRoute


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
add admin api key as auth for toggling dynamic routing

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
