### PR TITLE
refactor(connector): add amount conversion framework to Shift4

### DIFF
--- a/crates/router/src/connector/shift4.rs
+++ b/crates/router/src/connector/shift4.rs
@@ -2,7 +2,11 @@ pub mod transformers;
 
 use std::fmt::Debug;
 
-use common_utils::{ext_traits::ByteSliceExt, request::RequestContent};
+use common_utils::{
+    ext_traits::ByteSliceExt,
+    request::RequestContent,
+    types::{MinorUnit, StringMinorUnitForConnector},
+};
 use diesel_models::enums;
 use error_stack::{report, ResultExt};
 use transformers as shift4;
@@ -27,8 +31,18 @@ use crate::{
     utils::BytesExt,
 };
 
-#[derive(Debug, Clone)]
-pub struct Shift4;
+#[derive(Clone)]
+pub struct Shift4 {
+    amount_converter: &'static (dyn AmountConverter<Output = MinorUnit> + Sync),
+}
+
+impl Shift4 {
+    pub fn new() -> &'static Self {
+        &Self {
+            amount_converter: &StringMinorUnitForConnector,
+        }
+    }
+}
 
 impl<Flow, Request, Response> ConnectorCommonExt<Flow, Request, Response> for Shift4
 where

--- a/crates/router/src/connector/shift4/transformers.rs
+++ b/crates/router/src/connector/shift4/transformers.rs
@@ -23,7 +23,6 @@ trait Shift4AuthorizePreprocessingCommon {
     fn get_router_return_url(&self) -> Option<String>;
     fn get_email_optional(&self) -> Option<pii::Email>;
     fn get_complete_authorize_url(&self) -> Option<String>;
-    fn get_amount_required(&self) -> Result<i64, Error>;
     fn get_currency_required(&self) -> Result<diesel_models::enums::Currency, Error>;
     fn get_payment_method_data_required(&self) -> Result<domain::PaymentMethodData, Error>;
 }
@@ -50,10 +49,6 @@ impl Shift4AuthorizePreprocessingCommon for types::PaymentsAuthorizeData {
 
     fn get_complete_authorize_url(&self) -> Option<String> {
         self.complete_authorize_url.clone()
-    }
-
-    fn get_amount_required(&self) -> Result<i64, error_stack::Report<errors::ConnectorError>> {
-        Ok(self.amount)
     }
 
     fn get_currency_required(
@@ -83,10 +78,6 @@ impl Shift4AuthorizePreprocessingCommon for types::PaymentsPreProcessingData {
 
     fn get_complete_authorize_url(&self) -> Option<String> {
         self.complete_authorize_url.clone()
-    }
-
-    fn get_amount_required(&self) -> Result<i64, Error> {
-        self.get_amount()
     }
 
     fn get_currency_required(&self) -> Result<diesel_models::enums::Currency, Error> {

--- a/crates/router/src/types/api.rs
+++ b/crates/router/src/types/api.rs
@@ -473,7 +473,9 @@ impl ConnectorData {
                     Ok(ConnectorEnum::Old(Box::new(connector::Razorpay::new())))
                 }
                 enums::Connector::Rapyd => Ok(ConnectorEnum::Old(Box::new(&connector::Rapyd))),
-                enums::Connector::Shift4 => Ok(ConnectorEnum::Old(Box::new(&connector::Shift4))),
+                enums::Connector::Shift4 => {
+                    Ok(ConnectorEnum::Old(Box::new(connector::Shift4::new())))
+                }
                 enums::Connector::Square => Ok(ConnectorEnum::Old(Box::new(&connector::Square))),
                 enums::Connector::Stax => Ok(ConnectorEnum::Old(Box::new(&connector::Stax))),
                 enums::Connector::Stripe => {

--- a/crates/router/tests/connectors/shift4.rs
+++ b/crates/router/tests/connectors/shift4.rs
@@ -15,7 +15,7 @@ impl utils::Connector for Shift4Test {
     fn get_data(&self) -> types::api::ConnectorData {
         use router::connector::Shift4;
         utils::construct_connector_data_old(
-            Box::new(&Shift4),
+            Box::new(Shift4::new()),
             types::Connector::Shift4,
             types::api::GetToken::Connector,
             None,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [X] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
This PR adds amount conversion framework to Shift4, for sending to connector.
Resolves #6122 

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
