### PR TITLE
refactor(cypress): get amount from connector fixture in CaptureCallTest

### DIFF
--- a/cypress-tests/cypress/e2e/PaymentTest/00005-NoThreeDSManualCapture.cy.js
+++ b/cypress-tests/cypress/e2e/PaymentTest/00005-NoThreeDSManualCapture.cy.js
@@ -81,7 +81,6 @@ describe("Card - NoThreeDS Manual payment flow test", () => {
           fixtures.captureBody,
           req_data,
           res_data,
-          6500,
           globalState
         );
         if (should_continue)
@@ -137,7 +136,6 @@ describe("Card - NoThreeDS Manual payment flow test", () => {
           fixtures.captureBody,
           req_data,
           res_data,
-          6500,
           globalState
         );
         if (should_continue)
@@ -217,7 +215,6 @@ describe("Card - NoThreeDS Manual payment flow test", () => {
             fixtures.captureBody,
             req_data,
             res_data,
-            100,
             globalState
           );
           if (should_continue)
@@ -273,7 +270,6 @@ describe("Card - NoThreeDS Manual payment flow test", () => {
             fixtures.captureBody,
             req_data,
             res_data,
-            100,
             globalState
           );
           if (should_continue)

--- a/cypress-tests/cypress/e2e/PaymentTest/00008-RefundPayment.cy.js
+++ b/cypress-tests/cypress/e2e/PaymentTest/00008-RefundPayment.cy.js
@@ -408,7 +408,6 @@ describe("Card - Refund flow - No 3DS", () => {
         fixtures.captureBody,
         req_data,
         res_data,
-        6500,
         globalState
       );
       if (should_continue)
@@ -513,7 +512,6 @@ describe("Card - Refund flow - No 3DS", () => {
         fixtures.captureBody,
         req_data,
         res_data,
-        6500,
         globalState
       );
       if (should_continue)
@@ -637,7 +635,6 @@ describe("Card - Refund flow - No 3DS", () => {
         fixtures.captureBody,
         req_data,
         res_data,
-        100,
         globalState
       );
       if (should_continue)
@@ -742,7 +739,6 @@ describe("Card - Refund flow - No 3DS", () => {
         fixtures.captureBody,
         req_data,
         res_data,
-        100,
         globalState
       );
       if (should_continue)
@@ -1284,7 +1280,6 @@ describe("Card - Refund flow - 3DS", () => {
         fixtures.captureBody,
         req_data,
         res_data,
-        6500,
         globalState
       );
       if (should_continue)
@@ -1392,7 +1387,6 @@ describe("Card - Refund flow - 3DS", () => {
         fixtures.captureBody,
         req_data,
         res_data,
-        6500,
         globalState
       );
       if (should_continue)
@@ -1516,7 +1510,6 @@ describe("Card - Refund flow - 3DS", () => {
         fixtures.captureBody,
         req_data,
         res_data,
-        100,
         globalState
       );
       if (should_continue)
@@ -1624,7 +1617,6 @@ describe("Card - Refund flow - 3DS", () => {
         fixtures.captureBody,
         req_data,
         res_data,
-        100,
         globalState
       );
       if (should_continue)

--- a/cypress-tests/cypress/e2e/PaymentTest/00010-CreateSingleuseMandate.cy.js
+++ b/cypress-tests/cypress/e2e/PaymentTest/00010-CreateSingleuseMandate.cy.js
@@ -104,7 +104,6 @@ describe("Card - SingleUse Mandates flow test", () => {
           fixtures.captureBody,
           req_data,
           res_data,
-          6500,
           globalState
         );
         if (should_continue)
@@ -132,7 +131,6 @@ describe("Card - SingleUse Mandates flow test", () => {
           fixtures.captureBody,
           req_data,
           res_data,
-          6500,
           globalState
         );
         if (should_continue)
@@ -189,7 +187,6 @@ describe("Card - SingleUse Mandates flow test", () => {
           fixtures.captureBody,
           req_data,
           res_data,
-          6500,
           globalState
         );
         if (should_continue)

--- a/cypress-tests/cypress/e2e/PaymentTest/00011-CreateMultiuseMandate.cy.js
+++ b/cypress-tests/cypress/e2e/PaymentTest/00011-CreateMultiuseMandate.cy.js
@@ -113,7 +113,6 @@ describe("Card - MultiUse Mandates flow test", () => {
           fixtures.captureBody,
           req_data,
           res_data,
-          6500,
           globalState
         );
         if (should_continue)
@@ -141,7 +140,6 @@ describe("Card - MultiUse Mandates flow test", () => {
           fixtures.captureBody,
           req_data,
           res_data,
-          6500,
           globalState
         );
         if (should_continue)
@@ -169,7 +167,6 @@ describe("Card - MultiUse Mandates flow test", () => {
           fixtures.captureBody,
           req_data,
           res_data,
-          6500,
           globalState
         );
         if (should_continue)
@@ -222,7 +219,6 @@ describe("Card - MultiUse Mandates flow test", () => {
           fixtures.captureBody,
           req_data,
           res_data,
-          6500,
           globalState
         );
         if (should_continue)

--- a/cypress-tests/cypress/e2e/PaymentTest/00013-SaveCardFlow.cy.js
+++ b/cypress-tests/cypress/e2e/PaymentTest/00013-SaveCardFlow.cy.js
@@ -184,7 +184,6 @@ describe("Card - SaveCard payment flow test", () => {
           fixtures.captureBody,
           req_data,
           res_data,
-          6500,
           globalState
         );
         if (should_continue)
@@ -282,7 +281,6 @@ describe("Card - SaveCard payment flow test", () => {
           fixtures.captureBody,
           req_data,
           res_data,
-          100,
           globalState
         );
         if (should_continue)
@@ -417,7 +415,6 @@ describe("Card - SaveCard payment flow test", () => {
           fixtures.captureBody,
           req_data,
           res_data,
-          6500,
           globalState
         );
         if (should_continue)
@@ -476,7 +473,6 @@ describe("Card - SaveCard payment flow test", () => {
           fixtures.captureBody,
           req_data,
           res_data,
-          6500,
           globalState
         );
         if (should_continue)

--- a/cypress-tests/cypress/e2e/PaymentTest/00015-ThreeDSManualCapture.cy.js
+++ b/cypress-tests/cypress/e2e/PaymentTest/00015-ThreeDSManualCapture.cy.js
@@ -80,7 +80,7 @@ describe("Card - ThreeDS Manual payment flow test", () => {
         ]["Capture"];
         let req_data = data["Request"];
         let res_data = data["Response"];
-        cy.captureCallTest(captureBody, req_data, res_data, 6500, globalState);
+        cy.captureCallTest(captureBody, req_data, res_data, globalState);
         if (should_continue)
           should_continue = utils.should_continue_further(res_data);
       });
@@ -133,7 +133,7 @@ describe("Card - ThreeDS Manual payment flow test", () => {
         ]["Capture"];
         let req_data = data["Request"];
         let res_data = data["Response"];
-        cy.captureCallTest(captureBody, req_data, res_data, 6500, globalState);
+        cy.captureCallTest(captureBody, req_data, res_data, globalState);
         if (should_continue)
           should_continue = utils.should_continue_further(res_data);
       });
@@ -210,7 +210,7 @@ describe("Card - ThreeDS Manual payment flow test", () => {
           ]["PartialCapture"];
           let req_data = data["Request"];
           let res_data = data["Response"];
-          cy.captureCallTest(captureBody, req_data, res_data, 100, globalState);
+          cy.captureCallTest(captureBody, req_data, res_data, globalState);
           if (should_continue)
             should_continue = utils.should_continue_further(res_data);
         });
@@ -263,7 +263,7 @@ describe("Card - ThreeDS Manual payment flow test", () => {
           ]["PartialCapture"];
           let req_data = data["Request"];
           let res_data = data["Response"];
-          cy.captureCallTest(captureBody, req_data, res_data, 100, globalState);
+          cy.captureCallTest(captureBody, req_data, res_data, globalState);
           if (should_continue)
             should_continue = utils.should_continue_further(res_data);
         });

--- a/cypress-tests/cypress/e2e/PaymentTest/00018-MandatesUsingPMID.cy.js
+++ b/cypress-tests/cypress/e2e/PaymentTest/00018-MandatesUsingPMID.cy.js
@@ -140,7 +140,6 @@ describe("Card - Mandates using Payment Method Id flow test", () => {
           fixtures.captureBody,
           req_data,
           res_data,
-          6500,
           globalState
         );
         if (should_continue)
@@ -257,7 +256,6 @@ describe("Card - Mandates using Payment Method Id flow test", () => {
           fixtures.captureBody,
           req_data,
           res_data,
-          6500,
           globalState
         );
         if (should_continue)
@@ -285,7 +283,6 @@ describe("Card - Mandates using Payment Method Id flow test", () => {
           fixtures.captureBody,
           req_data,
           res_data,
-          6500,
           globalState
         );
         if (should_continue)
@@ -313,7 +310,6 @@ describe("Card - Mandates using Payment Method Id flow test", () => {
           fixtures.captureBody,
           req_data,
           res_data,
-          6500,
           globalState
         );
         if (should_continue)
@@ -430,7 +426,6 @@ describe("Card - Mandates using Payment Method Id flow test", () => {
           fixtures.captureBody,
           req_data,
           res_data,
-          6500,
           globalState
         );
         if (should_continue)

--- a/cypress-tests/cypress/e2e/PaymentTest/00020-Variations.cy.js
+++ b/cypress-tests/cypress/e2e/PaymentTest/00020-Variations.cy.js
@@ -277,7 +277,6 @@ describe("Corner cases", () => {
         fixtures.captureBody,
         req_data,
         res_data,
-        65000,
         globalState
       );
 
@@ -342,7 +341,6 @@ describe("Corner cases", () => {
         fixtures.captureBody,
         req_data,
         res_data,
-        65000,
         globalState
       );
 
@@ -538,7 +536,6 @@ describe("Corner cases", () => {
         fixtures.captureBody,
         req_data,
         res_data,
-        65000,
         globalState
       );
 
@@ -722,7 +719,6 @@ describe("Corner cases", () => {
         fixtures.captureBody,
         req_data,
         res_data,
-        6500,
         globalState
       );
       if (should_continue)

--- a/cypress-tests/cypress/e2e/PaymentUtils/Commons.js
+++ b/cypress-tests/cypress/e2e/PaymentUtils/Commons.js
@@ -1197,16 +1197,15 @@ export const connectorDetails = {
       },
     },
     CaptureGreaterAmount: {
-      Request: {
         Request: {
           payment_method: "card",
           payment_method_data: {
             card: successfulNo3DSCardDetails,
           },
           currency: "USD",
+          amount_to_capture: 65000,
           customer_acceptance: null,
         },
-      },
       Response: {
         status: 400,
         body: {
@@ -1219,16 +1218,15 @@ export const connectorDetails = {
       },
     },
     CaptureCapturedAmount: getCustomExchange({
-      Request: {
         Request: {
           payment_method: "card",
           payment_method_data: {
             card: successfulNo3DSCardDetails,
           },
           currency: "USD",
+          amount: 6500,
           customer_acceptance: null,
         },
-      },
       Response: {
         status: 400,
         body: {

--- a/cypress-tests/cypress/e2e/PaymentUtils/Paypal.js
+++ b/cypress-tests/cypress/e2e/PaymentUtils/Paypal.js
@@ -21,6 +21,7 @@ export const connectorDetails = {
     PaymentIntent: {
       Request: {
         currency: "USD",
+        amount: 6500,
         customer_acceptance: null,
         setup_future_usage: "on_session",
       },
@@ -38,6 +39,7 @@ export const connectorDetails = {
           card: successfulThreeDSTestCardDetails,
         },
         currency: "USD",
+        amount: 6500,
         customer_acceptance: null,
         setup_future_usage: "on_session",
       },
@@ -74,6 +76,7 @@ export const connectorDetails = {
           card: successfulNo3DSCardDetails,
         },
         currency: "USD",
+        amount: 6500,
         customer_acceptance: null,
         setup_future_usage: "on_session",
       },
@@ -108,6 +111,8 @@ export const connectorDetails = {
           card: successfulNo3DSCardDetails,
         },
         currency: "USD",
+        amount: 6500,
+        amount_to_capture: 6500,
         customer_acceptance: null,
       },
       Response: {
@@ -121,7 +126,9 @@ export const connectorDetails = {
       },
     },
     PartialCapture: {
-      Request: {},
+      Request: {
+        amount_to_capture: 100,
+      },
       Response: {
         status: 200,
         body: {

--- a/cypress-tests/cypress/support/commands.js
+++ b/cypress-tests/cypress/support/commands.js
@@ -1451,9 +1451,12 @@ Cypress.Commands.add(
 
 Cypress.Commands.add(
   "captureCallTest",
-  (requestBody, req_data, res_data, amount_to_capture, globalState) => {
+  (requestBody, req_data, res_data, globalState) => {
     const payment_id = globalState.get("paymentID");
-    requestBody.amount_to_capture = amount_to_capture;
+    // requestBody.amount_to_capture = amount_to_capture;
+    for (const key in req_data) {
+      requestBody[key] = req_data[key];
+    }
     cy.request({
       method: "POST",
       url: `${globalState.get("baseUrl")}/payments/${payment_id}/capture`,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Removed amount_to_capture parameter from CaptureCallTest.
The amount is now taken from connector specific fixtures.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
Some connectors have a limit to the amount they support. So instead of one hardcoded value for each connector we need a connector specific amount.


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
<img width="734" alt="Screenshot 2024-10-10 at 3 27 28 PM" src="https://github.com/user-attachments/assets/2ff59b21-a713-4513-8d23-109e409fc80c">

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
