### PR TITLE
fix: Set headers as optional in ob flows

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -56,6 +56,7 @@ crates/euclid @juspay/hyperswitch-routing
 crates/euclid_macros @juspay/hyperswitch-routing
 crates/euclid_wasm @juspay/hyperswitch-routing
 crates/kgraph_utils @juspay/hyperswitch-routing
+crates/pm_auth @juspay/hyperswitch-routing
 crates/router/src/routes/routing.rs @juspay/hyperswitch-routing
 crates/router/src/core/routing @juspay/hyperswitch-routing
 crates/router/src/core/routing.rs @juspay/hyperswitch-routing

--- a/crates/api_models/src/pm_auth.rs
+++ b/crates/api_models/src/pm_auth.rs
@@ -14,9 +14,6 @@ pub struct LinkTokenCreateRequest {
     pub payment_id: id_type::PaymentId, // payment_id to be passed in req body for redis pm_auth connector name fetch
     pub payment_method: PaymentMethod,  // payment_method to be used for filtering pm_auth connector
     pub payment_method_type: PaymentMethodType, // payment_method_type to be used for filtering pm_auth connector
-    pub client_platform: Option<api_enums::ClientPlatform>, // Client Platform to perform platform based processing
-    pub android_package_name: Option<String>, // Android Package name to be sent for Android platform
-    pub redirect_uri: Option<String>, // Merchant redirect_uri to be sent in case of IOS platform
 }
 
 #[derive(Debug, Clone, serde::Serialize)]

--- a/crates/api_models/src/pm_auth.rs
+++ b/crates/api_models/src/pm_auth.rs
@@ -4,8 +4,6 @@ use common_utils::{
     id_type, impl_api_event_type,
 };
 
-use crate::enums as api_enums;
-
 #[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
 #[serde(rename_all = "snake_case")]
 pub struct LinkTokenCreateRequest {

--- a/crates/api_models/src/pm_auth.rs
+++ b/crates/api_models/src/pm_auth.rs
@@ -14,7 +14,7 @@ pub struct LinkTokenCreateRequest {
     pub payment_id: id_type::PaymentId, // payment_id to be passed in req body for redis pm_auth connector name fetch
     pub payment_method: PaymentMethod,  // payment_method to be used for filtering pm_auth connector
     pub payment_method_type: PaymentMethodType, // payment_method_type to be used for filtering pm_auth connector
-    pub client_platform: api_enums::ClientPlatform, // Client Platform to perform platform based processing
+    pub client_platform: Option<api_enums::ClientPlatform>, // Client Platform to perform platform based processing
     pub android_package_name: Option<String>, // Android Package name to be sent for Android platform
     pub redirect_uri: Option<String>, // Merchant redirect_uri to be sent in case of IOS platform
 }

--- a/crates/pm_auth/src/connector/plaid/transformers.rs
+++ b/crates/pm_auth/src/connector/plaid/transformers.rs
@@ -45,28 +45,20 @@ impl TryFrom<&types::LinkTokenRouterData> for PlaidLinkTokenRequest {
                 )?,
             },
             android_package_name: match item.request.client_platform {
-                api_models::enums::ClientPlatform::Android => {
-                    Some(item.request.android_package_name.clone().ok_or(
-                        errors::ConnectorError::MissingRequiredField {
-                            field_name: "android_package_name",
-                        },
-                    )?)
+                Some(api_models::enums::ClientPlatform::Android) => {
+                    item.request.android_package_name.clone()
                 }
-                api_models::enums::ClientPlatform::Ios
-                | api_models::enums::ClientPlatform::Web
-                | api_models::enums::ClientPlatform::Unknown => None,
+                Some(api_models::enums::ClientPlatform::Ios)
+                | Some(api_models::enums::ClientPlatform::Web)
+                | Some(api_models::enums::ClientPlatform::Unknown)
+                | None => None,
             },
             redirect_uri: match item.request.client_platform {
-                api_models::enums::ClientPlatform::Ios => {
-                    Some(item.request.redirect_uri.clone().ok_or(
-                        errors::ConnectorError::MissingRequiredField {
-                            field_name: "redirect_uri",
-                        },
-                    )?)
-                }
-                api_models::enums::ClientPlatform::Android
-                | api_models::enums::ClientPlatform::Web
-                | api_models::enums::ClientPlatform::Unknown => None,
+                Some(api_models::enums::ClientPlatform::Ios) => item.request.redirect_uri.clone(),
+                Some(api_models::enums::ClientPlatform::Android)
+                | Some(api_models::enums::ClientPlatform::Web)
+                | Some(api_models::enums::ClientPlatform::Unknown)
+                | None => None,
             },
         })
     }

--- a/crates/pm_auth/src/types.rs
+++ b/crates/pm_auth/src/types.rs
@@ -25,7 +25,7 @@ pub struct LinkTokenRequest {
     pub country_codes: Option<Vec<String>>,
     pub language: Option<String>,
     pub user_info: Option<id_type::CustomerId>,
-    pub client_platform: api_enums::ClientPlatform,
+    pub client_platform: Option<api_enums::ClientPlatform>,
     pub android_package_name: Option<String>,
     pub redirect_uri: Option<String>,
 }

--- a/crates/router/src/connector/plaid/transformers.rs
+++ b/crates/router/src/connector/plaid/transformers.rs
@@ -163,21 +163,15 @@ impl TryFrom<&types::PaymentsPostProcessingRouterData> for PlaidLinkTokenRequest
         match item.request.payment_method_data {
             domain::PaymentMethodData::OpenBanking(ref data) => match data {
                 domain::OpenBankingData::OpenBankingPIS { .. } => {
-                    let headers = item.header_payload.clone().ok_or(
-                        errors::ConnectorError::MissingRequiredField {
-                            field_name: "header_payload",
-                        },
-                    )?;
+                    let headers = item.header_payload.clone();
 
-                    let platform = headers.x_client_platform.ok_or(
-                        errors::ConnectorError::MissingRequiredField {
-                            field_name: "x_client_platform",
-                        },
-                    )?;
+                    let platform = headers
+                        .as_ref()
+                        .and_then(|headers| headers.x_client_platform.clone());
 
                     let (is_android, is_ios) = match platform {
-                        common_enums::ClientPlatform::Android => (true, false),
-                        common_enums::ClientPlatform::Ios => (false, true),
+                        Some(common_enums::ClientPlatform::Android) => (true, false),
+                        Some(common_enums::ClientPlatform::Ios) => (false, true),
                         _ => (false, false),
                     };
 
@@ -208,20 +202,16 @@ impl TryFrom<&types::PaymentsPostProcessingRouterData> for PlaidLinkTokenRequest
                                 .ok_or(errors::ConnectorError::MissingConnectorTransactionID)?,
                         },
                         android_package_name: if is_android {
-                            Some(headers.x_app_id.ok_or(
-                                errors::ConnectorError::MissingRequiredField {
-                                    field_name: "x-app-id",
-                                },
-                            )?)
+                            headers
+                                .as_ref()
+                                .and_then(|headers| headers.x_app_id.clone())
                         } else {
                             None
                         },
                         redirect_uri: if is_ios {
-                            Some(headers.x_redirect_uri.ok_or(
-                                errors::ConnectorError::MissingRequiredField {
-                                    field_name: "x_redirect_uri",
-                                },
-                            )?)
+                            headers
+                                .as_ref()
+                                .and_then(|headers| headers.x_redirect_uri.clone())
                         } else {
                             None
                         },

--- a/crates/router/src/core/pm_auth.rs
+++ b/crates/router/src/core/pm_auth.rs
@@ -51,7 +51,7 @@ pub async fn create_link_token(
     merchant_account: domain::MerchantAccount,
     key_store: domain::MerchantKeyStore,
     payload: api_models::pm_auth::LinkTokenCreateRequest,
-    headers: api_models::payments::HeaderPayload,
+    headers: Option<api_models::payments::HeaderPayload>,
 ) -> RouterResponse<api_models::pm_auth::LinkTokenCreateResponse> {
     let db = &*state.store;
 
@@ -166,9 +166,13 @@ pub async fn create_link_token(
             )?]),
             language: payload.language,
             user_info: payment_intent.and_then(|pi| pi.customer_id),
-            client_platform: headers.x_client_platform,
-            android_package_name: headers.x_app_id,
-            redirect_uri: headers.x_redirect_uri,
+            client_platform: headers
+                .as_ref()
+                .and_then(|header| header.x_client_platform.clone()),
+            android_package_name: headers.as_ref().and_then(|header| header.x_app_id.clone()),
+            redirect_uri: headers
+                .as_ref()
+                .and_then(|header| header.x_redirect_uri.clone()),
         },
         response: Ok(pm_auth_types::LinkTokenResponse {
             link_token: "".to_string(),
@@ -212,7 +216,7 @@ pub async fn create_link_token(
     _merchant_account: domain::MerchantAccount,
     _key_store: domain::MerchantKeyStore,
     _payload: api_models::pm_auth::LinkTokenCreateRequest,
-    _headers: api_models::payments::HeaderPayload,
+    _headers: Option<api_models::payments::HeaderPayload>,
 ) -> RouterResponse<api_models::pm_auth::LinkTokenCreateResponse> {
     todo!()
 }

--- a/crates/router/src/core/pm_auth.rs
+++ b/crates/router/src/core/pm_auth.rs
@@ -51,6 +51,7 @@ pub async fn create_link_token(
     merchant_account: domain::MerchantAccount,
     key_store: domain::MerchantKeyStore,
     payload: api_models::pm_auth::LinkTokenCreateRequest,
+    headers: api_models::payments::HeaderPayload,
 ) -> RouterResponse<api_models::pm_auth::LinkTokenCreateResponse> {
     let db = &*state.store;
 
@@ -165,9 +166,9 @@ pub async fn create_link_token(
             )?]),
             language: payload.language,
             user_info: payment_intent.and_then(|pi| pi.customer_id),
-            client_platform: payload.client_platform,
-            android_package_name: payload.android_package_name,
-            redirect_uri: payload.redirect_uri,
+            client_platform: headers.x_client_platform,
+            android_package_name: headers.x_app_id,
+            redirect_uri: headers.x_redirect_uri,
         },
         response: Ok(pm_auth_types::LinkTokenResponse {
             link_token: "".to_string(),

--- a/crates/router/src/core/pm_auth.rs
+++ b/crates/router/src/core/pm_auth.rs
@@ -212,6 +212,7 @@ pub async fn create_link_token(
     _merchant_account: domain::MerchantAccount,
     _key_store: domain::MerchantKeyStore,
     _payload: api_models::pm_auth::LinkTokenCreateRequest,
+    _headers: api_models::payments::HeaderPayload,
 ) -> RouterResponse<api_models::pm_auth::LinkTokenCreateResponse> {
     todo!()
 }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Make header data to consume in open banking flows as optional.


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Test all open banking flows (PM auth and Payment initiation)
Refer to this PR - https://github.com/juspay/hyperswitch/pull/3952

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
