### PR TITLE
feat(connector): [fiuu] Add support for payment and refund webhooks

### DIFF
--- a/crates/connector_configs/toml/development.toml
+++ b/crates/connector_configs/toml/development.toml
@@ -4186,3 +4186,6 @@ placeholder="Enter Payment Processing Details At"
 required=true
 type="Radio"
 options=["Connector","Hyperswitch"]
+
+[fiuu.connector_webhook_details]
+merchant_secret="Source verification key"

--- a/crates/connector_configs/toml/production.toml
+++ b/crates/connector_configs/toml/production.toml
@@ -3183,3 +3183,6 @@ placeholder="Enter Payment Processing Details At"
 required=true
 type="Radio"
 options=["Connector","Hyperswitch"]
+
+[fiuu.connector_webhook_details]
+merchant_secret="Source verification key"

--- a/crates/connector_configs/toml/sandbox.toml
+++ b/crates/connector_configs/toml/sandbox.toml
@@ -4180,3 +4180,6 @@ placeholder="Enter Payment Processing Details At"
 required=true
 type="Radio"
 options=["Connector","Hyperswitch"]
+
+[fiuu.connector_webhook_details]
+merchant_secret="Source verification key"

--- a/crates/hyperswitch_connectors/src/connectors/fiuu.rs
+++ b/crates/hyperswitch_connectors/src/connectors/fiuu.rs
@@ -4,12 +4,13 @@ use std::collections::HashMap;
 
 use common_enums::{CaptureMethod, PaymentMethodType};
 use common_utils::{
+    crypto::{self, GenerateDigest},
     errors::{self as common_errors, CustomResult},
-    ext_traits::BytesExt,
+    ext_traits::{ByteSliceExt, BytesExt},
     request::{Method, Request, RequestBuilder, RequestContent},
     types::{AmountConvertor, StringMajorUnit, StringMajorUnitForConnector},
 };
-use error_stack::{report, ResultExt};
+use error_stack::ResultExt;
 use hyperswitch_domain_models::{
     router_data::{AccessToken, ErrorResponse, RouterData},
     router_flow_types::{
@@ -36,11 +37,11 @@ use hyperswitch_interfaces::{
     types::{self, Response},
     webhooks,
 };
-use masking::Secret;
+use masking::{ExposeInterface, PeekInterface, Secret};
 use reqwest::multipart::Form;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use transformers as fiuu;
+use transformers::{self as fiuu, FiuuWebhooksResponse};
 
 use crate::{constants::headers, types::ResponseRouterData, utils};
 
@@ -48,10 +49,12 @@ fn parse_response<T>(data: &[u8]) -> Result<T, errors::ConnectorError>
 where
     T: for<'de> Deserialize<'de>,
 {
+    router_env::logger::debug!("response parsing.....");
     let response_str = String::from_utf8(data.to_vec()).map_err(|e| {
         router_env::logger::error!("Error in Deserializing Response Data: {:?}", e);
         errors::ConnectorError::ResponseDeserializationFailed
     })?;
+    router_env::logger::debug!("response parsing : {:?}", response_str);
 
     let mut json = serde_json::Map::new();
     let mut miscellaneous: HashMap<String, Secret<String>> = HashMap::new();
@@ -354,15 +357,43 @@ impl ConnectorIntegration<PSync, PaymentsSyncData, PaymentsResponseData> for Fiu
         event_builder: Option<&mut ConnectorEvent>,
         res: Response,
     ) -> CustomResult<PaymentsSyncRouterData, errors::ConnectorError> {
-        let response: fiuu::FiuuPaymentSyncResponse = parse_response(&res.response)?;
-        event_builder.map(|i| i.set_response_body(&response));
-        router_env::logger::info!(connector_response=?response);
-
-        RouterData::try_from(ResponseRouterData {
-            response,
-            data: data.clone(),
-            http_code: res.status_code,
-        })
+        match res.headers {
+            Some(headers) => {
+                let content_header = utils::get_http_header("Content-type", &headers)
+                    .attach_printable("Missing content type in headers")
+                    .change_context(errors::ConnectorError::ResponseHandlingFailed)?;
+                let response: fiuu::FiuuPaymentResponse = if content_header
+                    == "text/plain;charset=UTF-8"
+                {
+                    parse_response(&res.response)
+                } else {
+                    Err(errors::ConnectorError::ResponseDeserializationFailed)
+                        .attach_printable(format!("Expected content type to be text/plain;charset=UTF-8 , but received different content type as {content_header} in response"))?
+                }?;
+                event_builder.map(|i| i.set_response_body(&response));
+                router_env::logger::info!(connector_response=?response);
+                RouterData::try_from(ResponseRouterData {
+                    response,
+                    data: data.clone(),
+                    http_code: res.status_code,
+                })
+                .change_context(errors::ConnectorError::ResponseHandlingFailed)
+            }
+            None => {
+                let response: fiuu::FiuuPaymentResponse = res
+                    .response
+                    .parse_struct("fiuu::FiuuPaymentResponse")
+                    .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
+                event_builder.map(|i| i.set_response_body(&response));
+                router_env::logger::info!(connector_response=?response);
+                RouterData::try_from(ResponseRouterData {
+                    response,
+                    data: data.clone(),
+                    http_code: res.status_code,
+                })
+                .change_context(errors::ConnectorError::ResponseHandlingFailed)
+            }
+        }
     }
 
     fn get_error_response(
@@ -652,24 +683,184 @@ impl ConnectorIntegration<RSync, RefundsData, RefundsResponseData> for Fiuu {
 
 #[async_trait::async_trait]
 impl webhooks::IncomingWebhook for Fiuu {
-    fn get_webhook_object_reference_id(
+    fn get_webhook_source_verification_algorithm(
         &self,
         _request: &webhooks::IncomingWebhookRequestDetails<'_>,
+    ) -> CustomResult<Box<dyn crypto::VerifySignature + Send>, errors::ConnectorError> {
+        Ok(Box::new(crypto::Md5))
+    }
+
+    fn get_webhook_source_verification_signature(
+        &self,
+        request: &webhooks::IncomingWebhookRequestDetails<'_>,
+        _connector_webhook_secrets: &api_models::webhooks::ConnectorWebhookSecrets,
+    ) -> CustomResult<Vec<u8>, errors::ConnectorError> {
+        let header = utils::get_header_key_value("content-type", request.headers)?;
+        let resource: FiuuWebhooksResponse = if header == "application/x-www-form-urlencoded" {
+            serde_urlencoded::from_bytes::<FiuuWebhooksResponse>(request.body)
+                .change_context(errors::ConnectorError::WebhookBodyDecodingFailed)?
+        } else {
+            request
+                .body
+                .parse_struct("fiuu::FiuuWebhooksResponse")
+                .change_context(errors::ConnectorError::WebhookBodyDecodingFailed)?
+        };
+
+        let signature = match resource {
+            FiuuWebhooksResponse::FiuuWebhookPaymentResponse(webhooks_payment_response) => {
+                webhooks_payment_response.skey
+            }
+            FiuuWebhooksResponse::FiuuWebhookRefundResponse(webhooks_refunds_response) => {
+                webhooks_refunds_response.signature
+            }
+        };
+        hex::decode(signature.expose())
+            .change_context(errors::ConnectorError::WebhookVerificationSecretInvalid)
+    }
+
+    fn get_webhook_source_verification_message(
+        &self,
+        request: &webhooks::IncomingWebhookRequestDetails<'_>,
+        _merchant_id: &common_utils::id_type::MerchantId,
+        connector_webhook_secrets: &api_models::webhooks::ConnectorWebhookSecrets,
+    ) -> CustomResult<Vec<u8>, errors::ConnectorError> {
+        let header = utils::get_header_key_value("content-type", request.headers)?;
+        let resource: FiuuWebhooksResponse = if header == "application/x-www-form-urlencoded" {
+            serde_urlencoded::from_bytes::<FiuuWebhooksResponse>(request.body)
+                .change_context(errors::ConnectorError::WebhookBodyDecodingFailed)?
+        } else {
+            request
+                .body
+                .parse_struct("fiuu::FiuuWebhooksResponse")
+                .change_context(errors::ConnectorError::WebhookBodyDecodingFailed)?
+        };
+        let verification_message = match resource {
+            FiuuWebhooksResponse::FiuuWebhookPaymentResponse(webhooks_payment_response) => {
+                let key0 = format!(
+                    "{}{}{}{}{}{}",
+                    webhooks_payment_response.tran_id,
+                    webhooks_payment_response.order_id,
+                    webhooks_payment_response.status,
+                    webhooks_payment_response.domain.clone().peek(),
+                    webhooks_payment_response.amount.get_amount_as_string(),
+                    webhooks_payment_response.currency
+                );
+                let md5_key0 = hex::encode(
+                    crypto::Md5
+                        .generate_digest(key0.as_bytes())
+                        .change_context(errors::ConnectorError::RequestEncodingFailed)?,
+                );
+                let key1 = format!(
+                    "{}{}{}{}{}",
+                    webhooks_payment_response.paydate,
+                    webhooks_payment_response.domain.peek(),
+                    md5_key0,
+                    webhooks_payment_response.appcode.peek(),
+                    String::from_utf8_lossy(&connector_webhook_secrets.secret)
+                );
+                key1
+            }
+            FiuuWebhooksResponse::FiuuWebhookRefundResponse(webhooks_refunds_response) => {
+                format!(
+                    "{}{:?}{}{}{}{}{}{}",
+                    webhooks_refunds_response.refund_type,
+                    webhooks_refunds_response.merchant_id.peek(),
+                    webhooks_refunds_response.ref_id,
+                    webhooks_refunds_response.refund_id,
+                    webhooks_refunds_response.txn_id,
+                    webhooks_refunds_response.amount.get_amount_as_string(),
+                    webhooks_refunds_response.status,
+                    String::from_utf8_lossy(&connector_webhook_secrets.secret)
+                )
+            }
+        };
+        Ok(verification_message.as_bytes().to_vec())
+    }
+
+    fn get_webhook_object_reference_id(
+        &self,
+        request: &webhooks::IncomingWebhookRequestDetails<'_>,
     ) -> CustomResult<api_models::webhooks::ObjectReferenceId, errors::ConnectorError> {
-        Err(report!(errors::ConnectorError::WebhooksNotImplemented))
+        let header = utils::get_header_key_value("content-type", request.headers)?;
+        let resource: FiuuWebhooksResponse = if header == "application/x-www-form-urlencoded" {
+            serde_urlencoded::from_bytes::<FiuuWebhooksResponse>(request.body)
+                .change_context(errors::ConnectorError::WebhookBodyDecodingFailed)?
+        } else {
+            request
+                .body
+                .parse_struct("fiuu::FiuuWebhooksResponse")
+                .change_context(errors::ConnectorError::WebhookBodyDecodingFailed)?
+        };
+        let resource_id = match resource {
+            FiuuWebhooksResponse::FiuuWebhookPaymentResponse(webhooks_payment_response) => {
+                api_models::webhooks::ObjectReferenceId::PaymentId(
+                    api_models::payments::PaymentIdType::PaymentAttemptId(
+                        webhooks_payment_response.order_id,
+                    ),
+                )
+            }
+            FiuuWebhooksResponse::FiuuWebhookRefundResponse(webhooks_refunds_response) => {
+                api_models::webhooks::ObjectReferenceId::RefundId(
+                    api_models::webhooks::RefundIdType::ConnectorRefundId(
+                        webhooks_refunds_response.refund_id,
+                    ),
+                )
+            }
+        };
+        Ok(resource_id)
     }
 
     fn get_webhook_event_type(
         &self,
-        _request: &webhooks::IncomingWebhookRequestDetails<'_>,
+        request: &webhooks::IncomingWebhookRequestDetails<'_>,
     ) -> CustomResult<api_models::webhooks::IncomingWebhookEvent, errors::ConnectorError> {
-        Err(report!(errors::ConnectorError::WebhooksNotImplemented))
+        let header = utils::get_header_key_value("content-type", request.headers)?;
+        let resource: FiuuWebhooksResponse = if header == "application/x-www-form-urlencoded" {
+            serde_urlencoded::from_bytes::<FiuuWebhooksResponse>(request.body)
+                .change_context(errors::ConnectorError::WebhookBodyDecodingFailed)?
+        } else {
+            request
+                .body
+                .parse_struct("fiuu::FiuuWebhooksResponse")
+                .change_context(errors::ConnectorError::WebhookBodyDecodingFailed)?
+        };
+
+        match resource {
+            FiuuWebhooksResponse::FiuuWebhookPaymentResponse(webhooks_payment_response) => Ok(
+                api_models::webhooks::IncomingWebhookEvent::from(webhooks_payment_response.status),
+            ),
+            FiuuWebhooksResponse::FiuuWebhookRefundResponse(webhooks_refunds_response) => Ok(
+                api_models::webhooks::IncomingWebhookEvent::from(webhooks_refunds_response.status),
+            ),
+        }
     }
 
     fn get_webhook_resource_object(
         &self,
-        _request: &webhooks::IncomingWebhookRequestDetails<'_>,
+        request: &webhooks::IncomingWebhookRequestDetails<'_>,
     ) -> CustomResult<Box<dyn masking::ErasedMaskSerialize>, errors::ConnectorError> {
-        Err(report!(errors::ConnectorError::WebhooksNotImplemented))
+        let header = utils::get_header_key_value("content-type", request.headers)?;
+        let payload: FiuuWebhooksResponse = if header == "application/x-www-form-urlencoded" {
+            serde_urlencoded::from_bytes::<FiuuWebhooksResponse>(request.body)
+                .change_context(errors::ConnectorError::WebhookBodyDecodingFailed)?
+        } else {
+            request
+                .body
+                .parse_struct("fiuu::FiuuWebhooksResponse")
+                .change_context(errors::ConnectorError::WebhookBodyDecodingFailed)?
+        };
+
+        match payload.clone() {
+            FiuuWebhooksResponse::FiuuWebhookPaymentResponse(webhook_payment_response) => Ok(
+                Box::new(fiuu::FiuuPaymentResponse::FiuuWebhooksPaymentResponse(
+                    webhook_payment_response,
+                )),
+            ),
+            FiuuWebhooksResponse::FiuuWebhookRefundResponse(webhook_refund_response) => Ok(
+                Box::new(fiuu::FiuuRefundSyncResponse::Webhook(
+                    webhook_refund_response,
+                )),
+            ),
+        }
     }
 }

--- a/crates/hyperswitch_connectors/src/connectors/fiuu.rs
+++ b/crates/hyperswitch_connectors/src/connectors/fiuu.rs
@@ -761,7 +761,7 @@ impl webhooks::IncomingWebhook for Fiuu {
             }
             FiuuWebhooksResponse::FiuuWebhookRefundResponse(webhooks_refunds_response) => {
                 format!(
-                    "{}{:?}{}{}{}{}{}{}",
+                    "{}{}{}{}{}{}{}{}",
                     webhooks_refunds_response.refund_type,
                     webhooks_refunds_response.merchant_id.peek(),
                     webhooks_refunds_response.ref_id,

--- a/crates/hyperswitch_connectors/src/connectors/fiuu/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/fiuu/transformers.rs
@@ -27,7 +27,7 @@ use hyperswitch_domain_models::{
         PaymentsSyncRouterData, RefundSyncRouterData, RefundsRouterData,
     },
 };
-use hyperswitch_interfaces::errors;
+use hyperswitch_interfaces::{consts, errors};
 use masking::{PeekInterface, Secret};
 use serde::{Deserialize, Serialize};
 use strum::Display;
@@ -43,7 +43,7 @@ use crate::{
         PaymentsSyncResponseRouterData, RefundsResponseRouterData, ResponseRouterData,
     },
     unimplemented_payment_method,
-    utils::{self, ApplePayDecrypt, PaymentsAuthorizeRequestData, QrImage, RouterData as _},
+    utils::{self, ApplePayDecrypt, PaymentsAuthorizeRequestData, QrImage, RefundsRequestData, RouterData as _},
 };
 
 pub struct FiuuRouterData<T> {
@@ -645,9 +645,9 @@ impl<F>
                     let status = match non_threeds_data.status.as_str() {
                         "00" => {
                             if item.data.request.is_auto_capture()? {
-                                Ok(enums::AttemptStatus::Charged)
+                                Ok(enums::AttemptStatus::Pending)
                             } else {
-                                Ok(enums::AttemptStatus::Authorized)
+                                Ok(enums::AttemptStatus::Pending)
                             }
                         }
                         "11" => Ok(enums::AttemptStatus::Failure),
@@ -706,6 +706,8 @@ pub struct FiuuRefundRequest {
     pub txn_id: String,
     pub amount: StringMajorUnit,
     pub signature: Secret<String>,
+    #[serde(rename = "notify_url")]
+    pub notify_url: Option<Url>,
 }
 #[derive(Debug, Serialize, Display)]
 pub enum RefundType {
@@ -734,6 +736,7 @@ impl TryFrom<&FiuuRouterData<&RefundsRouterData<Execute>>> for FiuuRefundRequest
                 RefundType::Partial,
                 txn_amount.get_amount_as_string()
             ))?,
+            notify_url: Some(Url::parse(&item.router_data.request.get_webhook_url()?).change_context(errors::ConnectorError::RequestEncodingFailed)?),
         })
     }
 }
@@ -801,6 +804,13 @@ pub struct FiuuPaymentSyncRequest {
     tx_id: String,
     domain: String,
     skey: Secret<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(untagged)]
+pub enum FiuuPaymentResponse {
+    FiuuPaymentSyncResponse(FiuuPaymentSyncResponse),
+    FiuuWebhooksPaymentResponse(FiuuWebhooksPaymentResponse),
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -874,44 +884,103 @@ impl TryFrom<&PaymentsSyncRouterData> for FiuuPaymentSyncRequest {
     }
 }
 
-impl TryFrom<PaymentsSyncResponseRouterData<FiuuPaymentSyncResponse>> for PaymentsSyncRouterData {
+impl TryFrom<PaymentsSyncResponseRouterData<FiuuPaymentResponse>> for PaymentsSyncRouterData {
     type Error = Report<errors::ConnectorError>;
     fn try_from(
-        item: PaymentsSyncResponseRouterData<FiuuPaymentSyncResponse>,
+        item: PaymentsSyncResponseRouterData<FiuuPaymentResponse>,
     ) -> Result<Self, Self::Error> {
-        let stat_name = item.response.stat_name;
-        let stat_code = item.response.stat_code.clone();
-        let status = enums::AttemptStatus::try_from(FiuuSyncStatus {
-            stat_name,
-            stat_code,
-        })?;
-        let error_response = if status == enums::AttemptStatus::Failure {
-            Some(ErrorResponse {
-                status_code: item.http_code,
-                code: item.response.stat_code.to_string(),
-                message: item.response.stat_name.clone().to_string(),
-                reason: Some(item.response.stat_name.clone().to_string()),
-                attempt_status: Some(enums::AttemptStatus::Failure),
-                connector_transaction_id: None,
-            })
-        } else {
-            None
-        };
-        let payments_response_data = PaymentsResponseData::TransactionResponse {
-            resource_id: item.data.request.connector_transaction_id.clone(),
-            redirection_data: None,
-            mandate_reference: None,
-            connector_metadata: None,
-            network_txn_id: None,
-            connector_response_reference_id: None,
-            incremental_authorization_allowed: None,
-            charge_id: None,
-        };
-        Ok(Self {
-            status,
-            response: error_response.map_or_else(|| Ok(payments_response_data), Err),
-            ..item.data
-        })
+        match item.response {
+            FiuuPaymentResponse::FiuuPaymentSyncResponse(response) => {
+                let stat_name = response.stat_name;
+                let stat_code = response.stat_code.clone();
+                let status = enums::AttemptStatus::try_from(FiuuSyncStatus {
+                    stat_name,
+                    stat_code,
+                })?;
+                let error_response = if status == enums::AttemptStatus::Failure {
+                    Some(ErrorResponse {
+                        status_code: item.http_code,
+                        code: response.stat_code.to_string(),
+                        message: response.stat_name.clone().to_string(),
+                        reason: Some(response.stat_name.clone().to_string()),
+                        attempt_status: Some(enums::AttemptStatus::Failure),
+                        connector_transaction_id: None,
+                    })
+                } else {
+                    None
+                };
+                let payments_response_data = PaymentsResponseData::TransactionResponse {
+                    resource_id: item.data.request.connector_transaction_id.clone(),
+                    redirection_data: None,
+                    mandate_reference: None,
+                    connector_metadata: None,
+                    network_txn_id: None,
+                    connector_response_reference_id: None,
+                    incremental_authorization_allowed: None,
+                    charge_id: None,
+                };
+                Ok(Self {
+                    status,
+                    response: error_response.map_or_else(|| Ok(payments_response_data), Err),
+                    ..item.data
+                })
+            }
+            FiuuPaymentResponse::FiuuWebhooksPaymentResponse(response) => {
+                let status = enums::AttemptStatus::try_from(FiuuWebhookStatus{
+                    capture_method : item.data.request.capture_method,
+                    status: response.status,
+                })?;
+                let error_response = if status == enums::AttemptStatus::Failure {
+                    Some(ErrorResponse {
+                        status_code: item.http_code,
+                        code: response.error_code.clone().unwrap_or(consts::NO_ERROR_CODE.to_owned()),
+                        message: response.error_code.clone().unwrap_or(consts::NO_ERROR_MESSAGE.to_owned()),
+                        reason: response.error_desc.clone(),
+                        attempt_status: Some(enums::AttemptStatus::Failure),
+                        connector_transaction_id: None,
+                    })
+                } else {
+                    None
+                };
+                let payments_response_data = PaymentsResponseData::TransactionResponse {
+                    resource_id: item.data.request.connector_transaction_id.clone(),
+                    redirection_data: None,
+                    mandate_reference: None,
+                    connector_metadata: None,
+                    network_txn_id: None,
+                    connector_response_reference_id: None,
+                    incremental_authorization_allowed: None,
+                    charge_id: None,
+                };
+                Ok(Self {
+                    status,
+                    response: error_response.map_or_else(|| Ok(payments_response_data), Err),
+                    ..item.data
+                })
+            },
+        }
+    }
+}
+
+pub struct FiuuWebhookStatus{
+    pub capture_method : Option<CaptureMethod>,
+    pub status : FiuuPaymentWebhookStatus
+}
+
+impl TryFrom<FiuuWebhookStatus> for enums::AttemptStatus {
+    type Error = Report<errors::ConnectorError>;
+    fn try_from(webhook_status : FiuuWebhookStatus) -> Result<Self,Self::Error> {
+        match webhook_status.status{
+            FiuuPaymentWebhookStatus::Success => match webhook_status.capture_method{
+                Some(CaptureMethod::Automatic) => Ok(enums::AttemptStatus::Charged),
+                Some(CaptureMethod::Manual) => Ok(enums::AttemptStatus::Authorized),
+                _=> Err(errors::ConnectorError::UnexpectedResponseError(
+                    bytes::Bytes::from(webhook_status.status.to_string()),
+                ))?,
+            },
+            FiuuPaymentWebhookStatus::Failure => Ok(enums::AttemptStatus::Failure),
+            FiuuPaymentWebhookStatus::Pending => Ok(enums::AttemptStatus::AuthenticationPending),
+        }
     }
 }
 
@@ -1203,6 +1272,7 @@ impl TryFrom<&RefundSyncRouterData> for FiuuRefundSyncRequest {
 pub enum FiuuRefundSyncResponse {
     Success(Vec<RefundData>),
     Error(FiuuErrorResponse),
+    Webhook(FiuuWebhooksRefundResponse),
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -1257,6 +1327,15 @@ impl TryFrom<RefundsResponseRouterData<RSync, FiuuRefundSyncResponse>>
                     ..item.data
                 })
             }
+            FiuuRefundSyncResponse::Webhook(fiuu_webhooks_refund_response) => {
+                Ok(Self{
+                    response: Ok(RefundsResponseData {
+                        connector_refund_id : fiuu_webhooks_refund_response.refund_id,
+                        refund_status : enums::RefundStatus::from(fiuu_webhooks_refund_response.status.clone())
+                    }),
+                    ..item.data
+                })
+            },
         }
     }
 }
@@ -1292,5 +1371,131 @@ pub fn get_qr_metadata(
             .change_context(errors::ConnectorError::ResponseHandlingFailed)
     } else {
         Ok(None)
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+#[serde(untagged)]
+pub enum FiuuWebhooksResponse {
+    FiuuWebhookPaymentResponse(FiuuWebhooksPaymentResponse),
+    FiuuWebhookRefundResponse(FiuuWebhooksRefundResponse),
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct FiuuWebhooksPaymentResponse {
+    pub skey: Secret<String>,
+    pub status: FiuuPaymentWebhookStatus,
+    #[serde(rename = "orderid")]
+    pub order_id: String,
+    #[serde(rename = "tranID")]
+    pub tran_id: String,
+    pub nbcb: String,
+    pub amount: StringMajorUnit,
+    pub currency: String,
+    pub domain: Secret<String>,
+    pub appcode: Secret<String>,
+    pub paydate: String,
+    pub channel: String, 
+    pub error_desc: Option<String>,
+    pub error_code: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+#[serde(rename_all = "PascalCase")]
+pub struct FiuuWebhooksRefundResponse {
+    pub refund_type: FiuuWebhooksRefundType,
+    #[serde(rename = "MerchantID")]
+    pub merchant_id: Secret<String>,
+    #[serde(rename = "RefID")]
+    pub ref_id: String,
+    #[serde(rename = "RefundID")]
+    pub refund_id: String,
+    #[serde(rename = "TxnID")]
+    pub txn_id: String,
+    pub amount: StringMajorUnit,
+    pub status: FiuuRefundsWebhookStatus,
+    pub signature: Secret<String>,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone, strum::Display)]
+pub enum FiuuRefundsWebhookStatus {
+    #[serde(rename = "00")]
+    RefundSuccess,
+    #[serde(rename = "11")]
+    RefundFailure,
+    #[serde(rename = "22")]
+    RefundPending,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone, strum::Display)]
+pub enum FiuuWebhooksRefundType {
+    P,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct FiuuWebhookSignauture {
+    pub skey: Secret<String>,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct FiuuWebhookResourceId {
+    pub skey: Secret<String>,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct FiuWebhookEvent {
+    pub status: FiuuPaymentWebhookStatus,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone, strum::Display)]
+pub enum FiuuPaymentWebhookStatus {
+    #[strum(serialize = "00")]
+    #[serde(rename = "00")]
+    Success,
+    #[strum(serialize = "11")]
+    #[serde(rename = "11")]
+    Failure,
+    #[strum(serialize = "22")]
+    #[serde(rename = "22")]
+    Pending,
+}
+
+impl From<FiuuPaymentWebhookStatus> for StatCode {
+    fn from(value: FiuuPaymentWebhookStatus) -> Self {
+        match value {
+            FiuuPaymentWebhookStatus::Success => Self::Success,
+            FiuuPaymentWebhookStatus::Failure => Self::Failure,
+            FiuuPaymentWebhookStatus::Pending => Self::Pending,
+        }
+    }
+}
+
+impl From<FiuuPaymentWebhookStatus> for api_models::webhooks::IncomingWebhookEvent {
+    fn from(value: FiuuPaymentWebhookStatus) -> Self {
+        match value {
+            FiuuPaymentWebhookStatus::Success => Self::PaymentIntentSuccess,
+            FiuuPaymentWebhookStatus::Failure => Self::PaymentIntentFailure,
+            FiuuPaymentWebhookStatus::Pending => Self::PaymentIntentProcessing,
+        }
+    }
+}
+
+impl From<FiuuRefundsWebhookStatus> for api_models::webhooks::IncomingWebhookEvent {
+    fn from(value: FiuuRefundsWebhookStatus) -> Self {
+        match value {
+            FiuuRefundsWebhookStatus::RefundSuccess => Self::RefundSuccess,
+            FiuuRefundsWebhookStatus::RefundFailure => Self::RefundFailure,
+            FiuuRefundsWebhookStatus::RefundPending => Self::EventNotSupported,
+        }
+    }
+}
+
+impl From<FiuuRefundsWebhookStatus> for enums::RefundStatus {
+    fn from(value: FiuuRefundsWebhookStatus) -> Self {
+        match value {
+            FiuuRefundsWebhookStatus::RefundFailure => Self::Failure,
+            FiuuRefundsWebhookStatus::RefundSuccess => Self::Success,
+            FiuuRefundsWebhookStatus::RefundPending => Self::Pending,
+        }
     }
 }

--- a/crates/hyperswitch_connectors/src/connectors/fiuu/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/fiuu/transformers.rs
@@ -1431,10 +1431,13 @@ pub struct FiuuWebhooksRefundResponse {
 
 #[derive(Debug, Deserialize, Serialize, Clone, strum::Display)]
 pub enum FiuuRefundsWebhookStatus {
+    #[strum(serialize = "00")]
     #[serde(rename = "00")]
     RefundSuccess,
+    #[strum(serialize = "11")]
     #[serde(rename = "11")]
     RefundFailure,
+    #[strum(serialize = "22")]
     #[serde(rename = "22")]
     RefundPending,
 }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Add support for payment and refund webhooks

note: Needs dashboard wasm deployment to test in sandbox.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [x] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

Test cases : 

**Payment Webhooks**

<details>
<summary>Create payment(curl ) </summary>

```
curl --location 'http://localhost:8080/payments' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: dev_b8UHhFyzeGg5ftn9f6oGstBF6gWmxtrCpvWaj6KL7dj9NSBeSmHS9q9Mg5UU7d7O' \
--data-raw '{
    "amount":100,
    "currency": "MYR",
    "confirm": true,
    "payment_link" : false,
    "capture_method": "automatic",
    "capture_on": "2022-09-10T10:11:12Z",
    "amount_to_capture": 100,
    "customer_id": "StripeCustomer",
    "email": "guest@example.com",
    "name": "John Doe",
    "phone": "999999999",
    "phone_country_code": "+1",
    "description": "Its my first payment request",
    "authentication_type": "no_three_ds",
    
    "return_url": "https://google.com",
    "payment_method": "card",
    "payment_method_type": "credit",
    "payment_method_data": {
        "card": {
            "card_number": "5105105105105100",
            "card_exp_month": "12",
            "card_exp_year": "2030",
            "card_holder_name": "Max Mustermann",
            "card_cvc": "444"
        }
    },
    "billing": {
        "address": {
            "line1": "1467",
            "line2": "CA",
            "line3": "CA",
            "city": "Musterhausen",
            "state": "California",
            "zip": "12345",
            "country": "MY",
            "first_name": "Max",
            "last_name": "Mustermann"
        },
        "email": "test@novalnet.de",
        "phone": {
            "number": "8056594427",
            "country_code": "+91"
        }
    },
    "shipping": {
        "address": {
            "line1": "Musterstr",
            "line2": "CA",
            "line3": "CA",
            "city": "Musterhausen",
            "state": "California",
            "zip": "94122",
            "country": "MY",
            "first_name": "joseph",
            "last_name": "Doe"
        },
        "phone": {
            "number": "8056594427",
            "country_code": "+91"
        }
    },
    "browser_info": {
        "user_agent": "Mozilla\/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/70.0.3538.110 Safari\/537.36",
        "accept_header": "text\/html,application\/xhtml+xml,application\/xml;q=0.9,image\/webp,image\/apng,\/;q=0.8",
        "language": "nl-NL",
        "color_depth": 24,
        "ip_address": "103.77.139.95",
        "screen_height": 723,
        "screen_width": 1536,
        "time_zone": 0,
        "java_enabled": true,
        "java_script_enabled": true
    },
    
    "statement_descriptor_name": "joseph",
    "statement_descriptor_suffix": "JS",
    "metadata": {
        "udf1": "value1",
        "new_customer": "true",
        "login_date": "2019-09-10T10:11:12Z"
    }
}'
```

response 

```
{
    "payment_id": "pay_Im39Mej9j58nwAHKDNyd",
    "merchant_id": "merchant_1728366259",
    "status": "processing",
    "amount": 100,
    "net_amount": 100,
    "amount_capturable": 0,
    "amount_received": null,
    "connector": "fiuu",
    "client_secret": "pay_Im39Mej9j58nwAHKDNyd_secret_ASusk2VbfGl5hwOMrRjD",
    "created": "2024-10-15T08:25:44.957Z",
    "currency": "MYR",
    "customer_id": "StripeCustomer",
    "customer": {
        "id": "StripeCustomer",
        "name": "John Doe",
        "email": "guest@example.com",
        "phone": "999999999",
        "phone_country_code": "+1"
    },
    "description": "Its my first payment request",
    "refunds": null,
    "disputes": null,
    "mandate_id": null,
    "mandate_data": null,
    "setup_future_usage": null,
    "off_session": null,
    "capture_on": null,
    "capture_method": "automatic",
    "payment_method": "card",
    "payment_method_data": {
        "card": {
            "last4": "5100",
            "card_type": null,
            "card_network": null,
            "card_issuer": null,
            "card_issuing_country": null,
            "card_isin": "510510",
            "card_extended_bin": null,
            "card_exp_month": "12",
            "card_exp_year": "2030",
            "card_holder_name": null,
            "payment_checks": null,
            "authentication_data": null
        },
        "billing": null
    },
    "payment_token": null,
    "shipping": {
        "address": {
            "city": "Musterhausen",
            "country": "MY",
            "line1": "Musterstr",
            "line2": "CA",
            "line3": "CA",
            "zip": "94122",
            "state": "California",
            "first_name": "joseph",
            "last_name": "Doe"
        },
        "phone": {
            "number": "8056594427",
            "country_code": "+91"
        },
        "email": null
    },
    "billing": {
        "address": {
            "city": "Musterhausen",
            "country": "MY",
            "line1": "1467",
            "line2": "CA",
            "line3": "CA",
            "zip": "12345",
            "state": "California",
            "first_name": "Max",
            "last_name": "Mustermann"
        },
        "phone": {
            "number": "8056594427",
            "country_code": "+91"
        },
        "email": "test@novalnet.de"
    },
    "order_details": null,
    "email": "guest@example.com",
    "name": "John Doe",
    "phone": "999999999",
    "return_url": "https://google.com/",
    "authentication_type": "no_three_ds",
    "statement_descriptor_name": "joseph",
    "statement_descriptor_suffix": "JS",
    "next_action": null,
    "cancellation_reason": null,
    "error_code": null,
    "error_message": null,
    "unified_code": null,
    "unified_message": null,
    "payment_experience": null,
    "payment_method_type": "credit",
    "connector_label": null,
    "business_country": null,
    "business_label": "default",
    "business_sub_label": null,
    "allowed_payment_method_types": null,
    "ephemeral_key": {
        "customer_id": "StripeCustomer",
        "created_at": 1728980744,
        "expires": 1728984344,
        "secret": "epk_db79053f1d12419496081948424ed1ad"
    },
    "manual_retry_allowed": false,
    "connector_transaction_id": "30886384",
    "frm_message": null,
    "metadata": {
        "udf1": "value1",
        "login_date": "2019-09-10T10:11:12Z",
        "new_customer": "true"
    },
    "connector_metadata": null,
    "feature_metadata": null,
    "reference_id": null,
    "payment_link": null,
    "profile_id": "pro_OQKAbm8s3bQTKQbYxfnj",
    "surcharge_details": null,
    "attempt_count": 1,
    "merchant_decision": null,
    "merchant_connector_id": "mca_8Am6c072Z9KWAA9lCKds",
    "incremental_authorization_allowed": null,
    "authorization_count": null,
    "incremental_authorizations": null,
    "external_authentication_details": null,
    "external_3ds_authentication_attempted": false,
    "expires_on": "2024-10-15T08:40:44.957Z",
    "fingerprint": null,
    "browser_info": {
        "language": "nl-NL",
        "time_zone": 0,
        "ip_address": "103.77.139.95",
        "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Safari/537.36",
        "color_depth": 24,
        "java_enabled": true,
        "screen_width": 1536,
        "accept_header": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,/;q=0.8",
        "screen_height": 723,
        "java_script_enabled": true
    },
    "payment_method_id": null,
    "payment_method_status": null,
    "updated": "2024-10-15T08:25:53.397Z",
    "charges": null,
    "frm_metadata": null,
    "merchant_order_reference_id": null,
    "order_tax_amount": null,
    "connector_mandate_id": null
}
```

</details>

<details> <summary>  source verification = true & status update in db  </summary>

<img width="959" alt="Screenshot 2024-10-15 at 1 56 38 PM" src="https://github.com/user-attachments/assets/7ef28978-0688-4210-858e-6a40fda24aee">

<img width="945" alt="Screenshot 2024-10-15 at 1 57 37 PM" src="https://github.com/user-attachments/assets/ac20c41d-3c13-4783-ad2c-e42cdedce013">

</details>
With source verification false, it should call the connector psync and update the status .

**Refund Webhooks** 

With source verification true it will update status as above.
<details> 

Refund Webhooks 
<summary>refund create </summary>

```
curl --location 'http://localhost:8080/refunds' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: dev_b8UHhFyzeGg5ftn9f6oGstBF6gWmxtrCpvWaj6KL7dj9NSBeSmHS9q9Mg5UU7d7O' \
--data '{
    "payment_id": "pay_k21bxXbtTb3h8593OqOa",
    "amount": 100,
    "reason": "Customer returned product",
    "refund_type": "instant",
    "metadata": {
        "udf1": "value1",
        "new_customer": "true",
        "login_date": "2019-09-10T10:11:12Z"
    }
}'
```
</details>
       


 
<details>

<summary>refund webhook logs </summary>

 For  source verification = false

<img width="649" alt="Screenshot 2024-10-15 at 1 31 30 PM" src="https://github.com/user-attachments/assets/f473cdef-9856-4861-b479-2432d9b3673a">

<img width="664" alt="Screenshot 2024-10-15 at 1 32 04 PM" src="https://github.com/user-attachments/assets/0fe98d08-6344-4a8f-93e0-f3e2e6d5a44d">

</details>

<details>

<summary>Status update in DB</summary>

<img width="668" alt="Screenshot 2024-10-15 at 1 38 10 PM" src="https://github.com/user-attachments/assets/13c4add5-138a-4852-a102-2ffb8301bb6f">

</details>

Behaviour when source verification is false it will call the connector(Psync) and update the status



## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
