### PR TITLE
fix: replace deprecated backticks with $(...) for command substitution

### DIFF
--- a/INSTALL_dependencies.sh
+++ b/INSTALL_dependencies.sh
@@ -37,7 +37,7 @@ set -o nounset
 
 # utilities
 # convert semver to comparable integer
-if [[ $(id -u) -ne 0 ]]; then
+if [[ "$(id -u)" -ne 0 ]]; then
     print_info "requires sudo"
     SUDO=sudo
 else
@@ -45,10 +45,10 @@ else
 fi
 
 ver () {
-    printf "%03d%03d%03d%03d" $(echo "$1" | tr '.' ' ')
+    printf "%03d%03d%03d%03d" "$(echo "$1" | tr '.' ' ')";
 }
 
-PROGNAME=$(basename $0)
+PROGNAME="$(basename $0)"
 print_info () {
     echo -e "$PROGNAME: $*"
 }
@@ -125,10 +125,10 @@ if command -v cargo > /dev/null; then
 
     need_cmd rustc
 
-    RUST_VERSION=$(rustc -V | cut -d " " -f 2)
+    RUST_VERSION="$(rustc -V | cut -d " " -f 2)"
 
-    _HAVE_VERSION=$(ver ${RUST_VERSION})
-    _NEED_VERSION=$(ver ${RUST_MSRV})
+    _HAVE_VERSION="$(ver ${RUST_VERSION})"
+    _NEED_VERSION="$(ver ${RUST_MSRV})"
 
     print_info "Found rust version \"${RUST_VERSION}\". MSRV is \"${RUST_MSRV}\""
 

--- a/INSTALL_dependencies.sh
+++ b/INSTALL_dependencies.sh
@@ -37,7 +37,7 @@ set -o nounset
 
 # utilities
 # convert semver to comparable integer
-if [[ `id -u` -ne 0 ]]; then
+if [[ $(id -u) -ne 0 ]]; then
     print_info "requires sudo"
     SUDO=sudo
 else
@@ -45,10 +45,10 @@ else
 fi
 
 ver () {
-    printf "%03d%03d%03d%03d" `echo "$1" | tr '.' ' '`;
+    printf "%03d%03d%03d%03d" $(echo "$1" | tr '.' ' ')
 }
 
-PROGNAME=`basename $0`
+PROGNAME=$(basename $0)
 print_info () {
     echo -e "$PROGNAME: $*"
 }
@@ -125,10 +125,10 @@ if command -v cargo > /dev/null; then
 
     need_cmd rustc
 
-    RUST_VERSION=`rustc -V | cut -d " " -f 2`
+    RUST_VERSION=$(rustc -V | cut -d " " -f 2)
 
-    _HAVE_VERSION=`ver ${RUST_VERSION}`
-    _NEED_VERSION=`ver ${RUST_MSRV}`
+    _HAVE_VERSION=$(ver ${RUST_VERSION})
+    _NEED_VERSION=$(ver ${RUST_MSRV})
 
     print_info "Found rust version \"${RUST_VERSION}\". MSRV is \"${RUST_MSRV}\""
 
@@ -166,7 +166,7 @@ install_dep () {
     $INSTALL_CMD $*
 }
 
-if [[ ! -x "`command -v psql`" ]] || [[ ! -x "`command -v redis-server`" ]] ; then
+if [[ ! -x "$(command -v psql)" ]] || [[ ! -x "$(command -v redis-server)" ]] ; then
     print_info "Missing dependencies. Trying to install"
 
     # java has an apt which seems to mess up when we look for apt

--- a/aws/hyperswitch_aws_setup.sh
+++ b/aws/hyperswitch_aws_setup.sh
@@ -38,11 +38,11 @@ echo "Creating Security Group for Application..."
 
 export EC2_SG="application-sg"
 
-echo $(aws ec2 create-security-group \
+echo "$(aws ec2 create-security-group \
 --region $REGION \
 --group-name $EC2_SG \
 --description "Security Group for Hyperswitch EC2 instance" \
---tag-specifications "ResourceType=security-group,Tags=[{Key=ManagedBy,Value=hyperswitch}]")
+--tag-specifications "ResourceType=security-group,Tags=[{Key=ManagedBy,Value=hyperswitch}]")"
 
 export APP_SG_ID=$(aws ec2 describe-security-groups --group-names $EC2_SG --region $REGION --output text --query 'SecurityGroups[0].GroupId')
 
@@ -50,23 +50,23 @@ echo "Security Group for Application CREATED.\n"
 
 echo "Creating Security Group ingress for port 80..."
 
-echo $(aws ec2 authorize-security-group-ingress \
+echo "$(aws ec2 authorize-security-group-ingress \
 --group-id $APP_SG_ID \
 --protocol tcp \
 --port 80 \
 --cidr 0.0.0.0/0 \
---region $REGION)
+--region $REGION)"
 
 echo "Security Group ingress for port 80 CREATED.\n"
 
 echo "Creating Security Group ingress for port 22..."
 
-echo $(aws ec2 authorize-security-group-ingress \
+echo "$(aws ec2 authorize-security-group-ingress \
 --group-id $APP_SG_ID \
 --protocol tcp \
 --port 22 \
 --cidr 0.0.0.0/0 \
---region $REGION)
+--region $REGION)"
 
 echo "Security Group ingress for port 22 CREATED.\n"
 
@@ -76,11 +76,11 @@ echo "Security Group ingress for port 22 CREATED.\n"
 echo "Creating Security Group for Elasticache..."
 
 export REDIS_GROUP_NAME=redis-sg
-echo $(aws ec2 create-security-group \
+echo "$(aws ec2 create-security-group \
 --group-name $REDIS_GROUP_NAME \
 --description "SG attached to elasticache" \
 --tag-specifications "ResourceType=security-group,Tags=[{Key=ManagedBy,Value=hyperswitch}]" \
---region $REGION)
+--region $REGION)"
 
 echo "Security Group for Elasticache CREATED.\n"
 
@@ -89,12 +89,12 @@ echo "Creating Inbound rules for Redis..."
 export REDIS_SG_ID=$(aws ec2 describe-security-groups --group-names $REDIS_GROUP_NAME --region $REGION --output text --query 'SecurityGroups[0].GroupId')
 
 # CREATE INBOUND RULES
-echo $(aws ec2 authorize-security-group-ingress \
+echo "$(aws ec2 authorize-security-group-ingress \
 --group-id $REDIS_SG_ID \
 --protocol tcp \
 --port 6379 \
 --source-group $EC2_SG \
---region $REGION)
+--region $REGION)"
 
 echo "Inbound rules for Redis CREATED.\n"
 
@@ -103,11 +103,11 @@ echo "Inbound rules for Redis CREATED.\n"
 echo "Creating Security Group for RDS..."
 
 export RDS_GROUP_NAME=rds-sg
-echo $(aws ec2 create-security-group \
+echo "$(aws ec2 create-security-group \
 --group-name $RDS_GROUP_NAME \
 --description "SG attached to RDS" \
 --tag-specifications "ResourceType=security-group,Tags=[{Key=ManagedBy,Value=hyperswitch}]" \
---region $REGION)
+--region $REGION)"
 
 echo "Security Group for RDS CREATED.\n"
 
@@ -116,21 +116,21 @@ echo "Creating Inbound rules for RDS..."
 export RDS_SG_ID=$(aws ec2 describe-security-groups --group-names $RDS_GROUP_NAME --region $REGION --output text --query 'SecurityGroups[0].GroupId')
 
 # CREATE INBOUND RULES
-echo $(aws ec2 authorize-security-group-ingress \
+echo "$(aws ec2 authorize-security-group-ingress \
 --group-id $RDS_SG_ID \
 --protocol tcp \
 --port 5432 \
 --source-group $EC2_SG \
---region $REGION)
+--region $REGION)"
 
 echo "Inbound rules for RDS CREATED.\n"
 
-echo $(aws ec2 authorize-security-group-ingress \
+echo "$(aws ec2 authorize-security-group-ingress \
     --group-id $RDS_SG_ID \
     --protocol tcp \
     --port 5432 \
     --cidr 0.0.0.0/0 \
-    --region $REGION)
+    --region $REGION)"
 
 echo "Inbound rules for RDS (from any IP) CREATED.\n"
 
@@ -138,7 +138,7 @@ echo "Creating Elasticache with Redis engine..."
 
 export CACHE_CLUSTER_ID=hyperswitch-cluster
 
-echo $(aws elasticache create-cache-cluster \
+echo "$(aws elasticache create-cache-cluster \
 --cache-cluster-id $CACHE_CLUSTER_ID \
 --cache-node-type cache.t3.medium \
 --engine redis \
@@ -146,14 +146,14 @@ echo $(aws elasticache create-cache-cluster \
 --security-group-ids $REDIS_SG_ID \
 --engine-version 7.0 \
 --tags "Key=ManagedBy,Value=hyperswitch" \
---region $REGION)
+--region $REGION)"
 
 echo "Elasticache with Redis engine CREATED.\n"
 
 echo "Creating RDS with PSQL..."
 
 export DB_INSTANCE_ID=hyperswitch-db
-echo $(aws rds create-db-instance  \
+echo "$(aws rds create-db-instance  \
     --db-instance-identifier $DB_INSTANCE_ID\
     --db-instance-class db.t3.micro \
     --engine postgres \
@@ -164,7 +164,7 @@ echo $(aws rds create-db-instance  \
     --region $REGION \
     --db-name hyperswitch_db \
     --tags "Key=ManagedBy,Value=hyperswitch" \
-    --vpc-security-group-ids $RDS_SG_ID)
+    --vpc-security-group-ids $RDS_SG_ID)"
 
 echo "RDS with PSQL CREATED.\n"
 
@@ -306,17 +306,17 @@ echo "EC2 instance launched.\n"
 
 echo "Add Tags to EC2 instance..."
 
-echo $(aws ec2 create-tags \
+echo "$(aws ec2 create-tags \
 --resources $HYPERSWITCH_INSTANCE_ID \
 --tags "Key=Name,Value=hyperswitch-router" \
---region $REGION)
+--region $REGION)"
 
 echo "Tag added to EC2 instance.\n"
 
-echo $(aws ec2 create-tags \
+echo "$(aws ec2 create-tags \
 --resources $HYPERSWITCH_INSTANCE_ID \
 --tags "Key=ManagedBy,Value=hyperswitch" \
---region $REGION)
+--region $REGION)"
 
 echo "ManagedBy tag added to EC2 instance.\n"
 

--- a/aws/hyperswitch_aws_setup.sh
+++ b/aws/hyperswitch_aws_setup.sh
@@ -38,12 +38,11 @@ echo "Creating Security Group for Application..."
 
 export EC2_SG="application-sg"
 
-echo `(aws ec2 create-security-group \
+echo $(aws ec2 create-security-group \
 --region $REGION \
 --group-name $EC2_SG \
 --description "Security Group for Hyperswitch EC2 instance" \
---tag-specifications "ResourceType=security-group,Tags=[{Key=ManagedBy,Value=hyperswitch}]" \
-)`
+--tag-specifications "ResourceType=security-group,Tags=[{Key=ManagedBy,Value=hyperswitch}]")
 
 export APP_SG_ID=$(aws ec2 describe-security-groups --group-names $EC2_SG --region $REGION --output text --query 'SecurityGroups[0].GroupId')
 
@@ -51,24 +50,23 @@ echo "Security Group for Application CREATED.\n"
 
 echo "Creating Security Group ingress for port 80..."
 
-echo `aws ec2 authorize-security-group-ingress \
+echo $(aws ec2 authorize-security-group-ingress \
 --group-id $APP_SG_ID \
 --protocol tcp \
 --port 80 \
 --cidr 0.0.0.0/0 \
---region $REGION`
+--region $REGION)
 
 echo "Security Group ingress for port 80 CREATED.\n"
 
-
 echo "Creating Security Group ingress for port 22..."
 
-echo `aws ec2 authorize-security-group-ingress \
+echo $(aws ec2 authorize-security-group-ingress \
 --group-id $APP_SG_ID \
 --protocol tcp \
 --port 22 \
 --cidr 0.0.0.0/0 \
---region $REGION`
+--region $REGION)
 
 echo "Security Group ingress for port 22 CREATED.\n"
 
@@ -78,11 +76,11 @@ echo "Security Group ingress for port 22 CREATED.\n"
 echo "Creating Security Group for Elasticache..."
 
 export REDIS_GROUP_NAME=redis-sg
-echo `aws ec2 create-security-group \
+echo $(aws ec2 create-security-group \
 --group-name $REDIS_GROUP_NAME \
 --description "SG attached to elasticache" \
 --tag-specifications "ResourceType=security-group,Tags=[{Key=ManagedBy,Value=hyperswitch}]" \
---region $REGION`
+--region $REGION)
 
 echo "Security Group for Elasticache CREATED.\n"
 
@@ -91,12 +89,12 @@ echo "Creating Inbound rules for Redis..."
 export REDIS_SG_ID=$(aws ec2 describe-security-groups --group-names $REDIS_GROUP_NAME --region $REGION --output text --query 'SecurityGroups[0].GroupId')
 
 # CREATE INBOUND RULES
-echo `aws ec2 authorize-security-group-ingress \
+echo $(aws ec2 authorize-security-group-ingress \
 --group-id $REDIS_SG_ID \
 --protocol tcp \
 --port 6379 \
 --source-group $EC2_SG \
---region $REGION`
+--region $REGION)
 
 echo "Inbound rules for Redis CREATED.\n"
 
@@ -105,11 +103,11 @@ echo "Inbound rules for Redis CREATED.\n"
 echo "Creating Security Group for RDS..."
 
 export RDS_GROUP_NAME=rds-sg
-echo `aws ec2 create-security-group \
+echo $(aws ec2 create-security-group \
 --group-name $RDS_GROUP_NAME \
 --description "SG attached to RDS" \
 --tag-specifications "ResourceType=security-group,Tags=[{Key=ManagedBy,Value=hyperswitch}]" \
---region $REGION`
+--region $REGION)
 
 echo "Security Group for RDS CREATED.\n"
 
@@ -118,21 +116,21 @@ echo "Creating Inbound rules for RDS..."
 export RDS_SG_ID=$(aws ec2 describe-security-groups --group-names $RDS_GROUP_NAME --region $REGION --output text --query 'SecurityGroups[0].GroupId')
 
 # CREATE INBOUND RULES
-echo `aws ec2 authorize-security-group-ingress \
+echo $(aws ec2 authorize-security-group-ingress \
 --group-id $RDS_SG_ID \
 --protocol tcp \
 --port 5432 \
 --source-group $EC2_SG \
---region $REGION`
+--region $REGION)
 
 echo "Inbound rules for RDS CREATED.\n"
 
-echo `aws ec2 authorize-security-group-ingress \
+echo $(aws ec2 authorize-security-group-ingress \
     --group-id $RDS_SG_ID \
     --protocol tcp \
     --port 5432 \
     --cidr 0.0.0.0/0 \
-    --region $REGION`
+    --region $REGION)
 
 echo "Inbound rules for RDS (from any IP) CREATED.\n"
 
@@ -140,7 +138,7 @@ echo "Creating Elasticache with Redis engine..."
 
 export CACHE_CLUSTER_ID=hyperswitch-cluster
 
-echo `aws elasticache create-cache-cluster \
+echo $(aws elasticache create-cache-cluster \
 --cache-cluster-id $CACHE_CLUSTER_ID \
 --cache-node-type cache.t3.medium \
 --engine redis \
@@ -148,14 +146,14 @@ echo `aws elasticache create-cache-cluster \
 --security-group-ids $REDIS_SG_ID \
 --engine-version 7.0 \
 --tags "Key=ManagedBy,Value=hyperswitch" \
---region $REGION`
+--region $REGION)
 
 echo "Elasticache with Redis engine CREATED.\n"
 
 echo "Creating RDS with PSQL..."
 
 export DB_INSTANCE_ID=hyperswitch-db
-echo `aws rds create-db-instance  \
+echo $(aws rds create-db-instance  \
     --db-instance-identifier $DB_INSTANCE_ID\
     --db-instance-class db.t3.micro \
     --engine postgres \
@@ -166,7 +164,7 @@ echo `aws rds create-db-instance  \
     --region $REGION \
     --db-name hyperswitch_db \
     --tags "Key=ManagedBy,Value=hyperswitch" \
-    --vpc-security-group-ids $RDS_SG_ID`
+    --vpc-security-group-ids $RDS_SG_ID)
 
 echo "RDS with PSQL CREATED.\n"
 
@@ -308,17 +306,17 @@ echo "EC2 instance launched.\n"
 
 echo "Add Tags to EC2 instance..."
 
-echo `aws ec2 create-tags \
+echo $(aws ec2 create-tags \
 --resources $HYPERSWITCH_INSTANCE_ID \
 --tags "Key=Name,Value=hyperswitch-router" \
---region $REGION`
+--region $REGION)
 
 echo "Tag added to EC2 instance.\n"
 
-echo `aws ec2 create-tags \
+echo $(aws ec2 create-tags \
 --resources $HYPERSWITCH_INSTANCE_ID \
 --tags "Key=ManagedBy,Value=hyperswitch" \
---region $REGION`
+--region $REGION)
 
 echo "ManagedBy tag added to EC2 instance.\n"
 

--- a/aws/hyperswitch_cleanup_setup.sh
+++ b/aws/hyperswitch_cleanup_setup.sh
@@ -45,7 +45,7 @@ for cluster_arn in $ALL_ELASTIC_CACHE; do
     if [[ $? -eq 0 ]]; then
         echo -n "Delete $cluster_id (Y/n)? "
         if yes_or_no; then
-            echo $(aws elasticache delete-cache-cluster --region $REGION --cache-cluster-id $cluster_id)
+            echo "$(aws elasticache delete-cache-cluster --region $REGION --cache-cluster-id $cluster_id)"
         fi
     fi
 done
@@ -59,7 +59,7 @@ echo -n "Deleting ( $ALL_KEY_PAIRS ) key pairs? (Y/n)?"
 
 if yes_or_no; then
     for KEY_ID in $ALL_KEY_PAIRS; do
-        echo $(aws ec2 delete-key-pair --key-pair-id $KEY_ID --region $REGION)
+        echo "$(aws ec2 delete-key-pair --key-pair-id $KEY_ID --region $REGION)"
     done
 fi
 
@@ -78,7 +78,7 @@ echo -n "Terminating ( $ALL_INSTANCES ) instances? (Y/n)?"
 
 if yes_or_no; then
     for INSTANCE_ID in $ALL_INSTANCES; do
-        echo $(aws ec2 terminate-instances --instance-ids $INSTANCE_ID --region $REGION)
+        echo "$(aws ec2 terminate-instances --instance-ids $INSTANCE_ID --region $REGION)"
     done
 fi
 
@@ -105,15 +105,15 @@ for resource_id in $ALL_DB_RESOURCES; do
 
             echo -n "Create a snapshot before deleting ( $DB_INSTANCE_ID ) the database (Y/n)? "
             if yes_or_no; then
-                echo $(aws rds delete-db-instance \
+                echo "$(aws rds delete-db-instance \
                     --db-instance-identifier $DB_INSTANCE_ID \
    --region $REGION \
-                    --final-db-snapshot-identifier hyperswitch-db-snapshot-$(date +%s))
+                    --final-db-snapshot-identifier hyperswitch-db-snapshot-$(date +%s))"
             else
-                echo $(aws rds delete-db-instance \
+                echo "$(aws rds delete-db-instance \
          --region $REGION \
                     --db-instance-identifier $DB_INSTANCE_ID \
-                    --skip-final-snapshot)
+                    --skip-final-snapshot)"
             fi
         fi
     fi

--- a/aws/hyperswitch_cleanup_setup.sh
+++ b/aws/hyperswitch_cleanup_setup.sh
@@ -45,7 +45,7 @@ for cluster_arn in $ALL_ELASTIC_CACHE; do
     if [[ $? -eq 0 ]]; then
         echo -n "Delete $cluster_id (Y/n)? "
         if yes_or_no; then
-            echo `aws elasticache delete-cache-cluster --region $REGION --cache-cluster-id $cluster_id`
+            echo $(aws elasticache delete-cache-cluster --region $REGION --cache-cluster-id $cluster_id)
         fi
     fi
 done
@@ -59,7 +59,7 @@ echo -n "Deleting ( $ALL_KEY_PAIRS ) key pairs? (Y/n)?"
 
 if yes_or_no; then
     for KEY_ID in $ALL_KEY_PAIRS; do
-        echo `aws ec2 delete-key-pair --key-pair-id $KEY_ID --region $REGION`
+        echo $(aws ec2 delete-key-pair --key-pair-id $KEY_ID --region $REGION)
     done
 fi
 
@@ -78,7 +78,7 @@ echo -n "Terminating ( $ALL_INSTANCES ) instances? (Y/n)?"
 
 if yes_or_no; then
     for INSTANCE_ID in $ALL_INSTANCES; do
-        echo `aws ec2 terminate-instances --instance-ids $INSTANCE_ID --region $REGION`
+        echo $(aws ec2 terminate-instances --instance-ids $INSTANCE_ID --region $REGION)
     done
 fi
 
@@ -105,15 +105,15 @@ for resource_id in $ALL_DB_RESOURCES; do
 
             echo -n "Create a snapshot before deleting ( $DB_INSTANCE_ID ) the database (Y/n)? "
             if yes_or_no; then
-                echo `aws rds delete-db-instance \
+                echo $(aws rds delete-db-instance \
                     --db-instance-identifier $DB_INSTANCE_ID \
    --region $REGION \
-                    --final-db-snapshot-identifier hyperswitch-db-snapshot-`date +%s``
+                    --final-db-snapshot-identifier hyperswitch-db-snapshot-$(date +%s))
             else
-                echo `aws rds delete-db-instance \
+                echo $(aws rds delete-db-instance \
          --region $REGION \
                     --db-instance-identifier $DB_INSTANCE_ID \
-                    --skip-final-snapshot`
+                    --skip-final-snapshot)
             fi
         fi
     fi

--- a/scripts/add_connector.sh
+++ b/scripts/add_connector.sh
@@ -8,7 +8,7 @@ function find_prev_connector() {
     # Add new connector to existing list and sort it
     connectors=(aci adyen adyenplatform airwallex applepay authorizedotnet bambora bamboraapac bankofamerica billwerk bitpay bluesnap boku braintree cashtocode checkout coinbase cryptopay cybersource datatrans deutschebank digitalvirgo dlocal dummyconnector ebanx fiserv fiservemea fiuu forte globalpay globepay gocardless gpayments helcim iatapay itaubank klarna mifinity mollie multisafepay netcetera nexinets nexixpay noon novalnet nuvei opayo opennode paybox payeezy payme payone paypal payu placetopay plaid powertranz prophetpay rapyd razorpay shift4 square stax stripe taxjar threedsecureio thunes trustpay tsys volt wellsfargo wellsfargopayout wise worldline worldpay zsl "$1")
     IFS=$'\n' sorted=($(sort <<<"${connectors[*]}")); unset IFS
-    res=$(echo ${sorted[@]})
+    res="$(echo ${sorted[@]})"
     sed -i'' -e "s/^    connectors=.*/    connectors=($res \"\$1\")/" $self.tmp
     for i in "${!sorted[@]}"; do
     if [ "${sorted[$i]}" = "$1" ] && [ $i != "0" ]; then

--- a/scripts/add_connector.sh
+++ b/scripts/add_connector.sh
@@ -8,7 +8,7 @@ function find_prev_connector() {
     # Add new connector to existing list and sort it
     connectors=(aci adyen adyenplatform airwallex applepay authorizedotnet bambora bamboraapac bankofamerica billwerk bitpay bluesnap boku braintree cashtocode checkout coinbase cryptopay cybersource datatrans deutschebank digitalvirgo dlocal dummyconnector ebanx fiserv fiservemea fiuu forte globalpay globepay gocardless gpayments helcim iatapay itaubank klarna mifinity mollie multisafepay netcetera nexinets nexixpay noon novalnet nuvei opayo opennode paybox payeezy payme payone paypal payu placetopay plaid powertranz prophetpay rapyd razorpay shift4 square stax stripe taxjar threedsecureio thunes trustpay tsys volt wellsfargo wellsfargopayout wise worldline worldpay zsl "$1")
     IFS=$'\n' sorted=($(sort <<<"${connectors[*]}")); unset IFS
-    res=`echo ${sorted[@]}`
+    res=$(echo ${sorted[@]})
     sed -i'' -e "s/^    connectors=.*/    connectors=($res \"\$1\")/" $self.tmp
     for i in "${!sorted[@]}"; do
     if [ "${sorted[$i]}" = "$1" ] && [ $i != "0" ]; then


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Use $(...) notation instead of legacy `...` in the shell files.
Removes the use of deprecated backticks notation (cf. [SC2006](https://www.shellcheck.net/wiki/SC2006)).


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->

Fixes https://github.com/juspay/hyperswitch/issues/6271

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
