### PR TITLE
refactor(connector): Add amount conversion framework to Zen

### DIFF
--- a/crates/router/src/types/api.rs
+++ b/crates/router/src/types/api.rs
@@ -518,7 +518,7 @@ impl ConnectorData {
                 // enums::Connector::Wellsfargopayout => {
                 //     Ok(Box::new(connector::Wellsfargopayout::new()))
                 // }
-                enums::Connector::Zen => Ok(ConnectorEnum::Old(Box::new(&connector::Zen))),
+                enums::Connector::Zen => Ok(ConnectorEnum::Old(Box::new(connector::Zen::new()))),
                 enums::Connector::Zsl => Ok(ConnectorEnum::Old(Box::new(&connector::Zsl))),
                 enums::Connector::Plaid => {
                     Ok(ConnectorEnum::Old(Box::new(connector::Plaid::new())))

--- a/crates/router/tests/connectors/zen.rs
+++ b/crates/router/tests/connectors/zen.rs
@@ -18,7 +18,7 @@ impl utils::Connector for ZenTest {
     fn get_data(&self) -> types::api::ConnectorData {
         use router::connector::Zen;
         utils::construct_connector_data_old(
-            Box::new(&Zen),
+            Box::new(Zen::new()),
             types::Connector::Zen,
             types::api::GetToken::Connector,
             None,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
This PR does amount conversion changes for Zen Connector and it accepts the amount in MinorUnit

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->

Fixes #6138 


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
