### PR TITLE
feat(nix): add support for running external services through services-flake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -268,4 +268,4 @@ creds.json
 /.direnv
 
 # Nix services data
-data
+/data

--- a/.gitignore
+++ b/.gitignore
@@ -266,3 +266,6 @@ node_modules/
 creds.json
 
 /.direnv
+
+# Nix services data
+data

--- a/.gitignore
+++ b/.gitignore
@@ -264,3 +264,5 @@ node_modules/
 
 # cypress credentials
 creds.json
+
+/.direnv

--- a/docs/try_local_system.md
+++ b/docs/try_local_system.md
@@ -176,9 +176,9 @@ A Nix development environment simplifies the setup of required project dependenc
 
 ### Install nix
 
-We recommend that you install Nix using [the DetSys nix-installer](https://nixos.asia/en/install), which automatically enables flakes.
+We recommend that you install Nix using [the DetSys nix-installer][detsys-nixos-installer], which automatically enables flakes.
 
-As an **optional** next step, if you are interested in using Nix to manage your dotfiles and local packages, you can setup [nixos-unified-template](https://github.com/juspay/nixos-unified-template#on-non-nixos).
+As an **optional** next step, if you are interested in using Nix to manage your dotfiles and local packages, you can setup [nixos-unified-template][nixos-unified-template-repo].
 
 ### Using external services through Nix
 
@@ -722,3 +722,5 @@ To explore more of our APIs, please check the remaining folders in the
 [refunds-create]: https://www.postman.com/hyperswitch/workspace/hyperswitch-development/request/25176162-4d1315c6-ac61-4411-8f7d-15d4e4e736a1
 [refunds-retrieve]: https://www.postman.com/hyperswitch/workspace/hyperswitch-development/request/25176162-137d6260-24f7-4752-9e69-26b61b83df0d
 [connector-specific-details]: https://docs.google.com/spreadsheets/d/e/2PACX-1vQWHLza9m5iO4Ol-tEBx22_Nnq8Mb3ISCWI53nrinIGLK8eHYmHGnvXFXUXEut8AFyGyI9DipsYaBLG/pubhtml?gid=748960791&single=true
+[detsys-nixos-installer]: https://nixos.asia/en/install
+[nixos-unified-template-repo]: https://github.com/juspay/nixos-unified-template#on-non-nixos

--- a/docs/try_local_system.md
+++ b/docs/try_local_system.md
@@ -176,39 +176,9 @@ A Nix development environment simplifies the setup of required project dependenc
 
 ### Install nix
 
-Nix can be installed in numerous ways. If you're new to Nix, use the recommended approach. However, you're free to choose the way you'd like to have nix installed on your device. The aim is to have nix installed with `flakes` support.
+We recommend that you install Nix using [the DetSys nix-installer](https://nixos.asia/en/install), which automatically enables flakes.
 
-#### 1. Using nixos-unified-template [recommended]
-
-*nixos-unified-template* provides an unified Nix configuration template for managing user applications and using `flakes`.
-
-- Head to [nixos-unified-template](https://github.com/juspay/nixos-unified-template?tab=readme-ov-file#on-non-nixos) and follow the instructions.
-
-#### 2. Using nix-installer [minimal]
-
-*nix-installer* provides a quick and reliable way of installing Nix with `flakes`.
-
-- Head to [nix-installer](https://github.com/DeterminateSystems/nix-installer) and follow the instructions.
-
-#### 3. Using a standard nix installation or using NixOS
-
-Nix's standard installation does not include `flakes` by default as it's an experimental feature. You will need to enable it manually.
-
-- Install Nix via multi-user setup
-
-   ```shell
-   sh <(curl -L https://nixos.org/nix/install)
-   ```
-
-- Add below line to your `~/.config/nix/nix.conf` or `/etc/nix/nix.conf`
-
-   ```
-   experimental-features = nix-command flakes
-   ```
-
-- References
-   - Install Nix - https://nixos.org/download/
-   - Enable flakes - https://nixos.wiki/wiki/Flakes#Other_Distros.2C_without_Home-Manager
+As an **optional** next step, if you are interested in using Nix to manage your dotfiles and local packages, you can setup [nixos-unified-template](https://github.com/juspay/nixos-unified-template#on-non-nixos).
 
 ### Using external services through Nix
 

--- a/docs/try_local_system.md
+++ b/docs/try_local_system.md
@@ -15,6 +15,10 @@ Check the Table Of Contents to jump to the relevant section.
 - [Run hyperswitch using Docker Compose](#run-hyperswitch-using-docker-compose)
   - [Running additional services](#running-additional-services)
 - [Set up a development environment using Docker Compose](#set-up-a-development-environment-using-docker-compose)
+- [Set up a Nix development environment](#set-up-a-nix-development-environment)
+   - [Install Nix](#install-nix)
+   - [Using external services through Nix](#using-external-services-through-nix)
+   - [Logging into a Nix development environment (coming soon)](#logging-into-a-nix-development-environment)
 - [Set up a Rust environment and other dependencies](#set-up-a-rust-environment-and-other-dependencies)
   - [Set up dependencies on Ubuntu-based systems](#set-up-dependencies-on-ubuntu-based-systems)
   - [Set up dependencies on Windows (Ubuntu on WSL2)](#set-up-dependencies-on-windows-ubuntu-on-wsl2)
@@ -165,6 +169,46 @@ Once the services have been confirmed to be up and running, you can proceed with
 
    If the command returned a `200 OK` status code, proceed with
    [trying out our APIs](#try-out-our-apis).
+
+## Set up a Nix development environment
+
+A Nix development environment allows for easily setting up the required dependencies and external services. This is available for MacOS, Linux and WSL2 users.
+
+### Install nix
+
+Nix can be installed in numerous ways. If you're new here, and don't have Nix installed on your device, use the recommended approach. You're free to choose the way you'd like to have nix installed on your device.
+
+#### 1. Using nixos-unified-template [recommended]
+
+*nixos-unified-template* provides an unified Nix configuration template for managing user applications, and using `flakes`.
+
+- Head to [nixos-unified-template](https://github.com/juspay/nixos-unified-template?tab=readme-ov-file#on-non-nixos) and follow the instructions.
+
+#### 2. Using nix-installer [minimal]
+
+*nix-installer* provides a faster and reliable way of installing Nix along with `flakes`.
+
+- Head to [nix-installer](https://github.com/DeterminateSystems/nix-installer) and follow the instructions.
+
+#### 3. Using a standard nix installation or using NixOS
+
+Nix's standard installation does not include `flakes` by default as it's an experimental feature. Nix needs to be configured to use the experimenal feature!
+
+- Install Nix via multi-user installation
+
+   ```
+   sh <(curl -L https://nixos.org/nix/install)
+   ```
+
+- Add below line to your `~/.config/nix/nix.conf` or `/etc/nix/nix.conf`
+
+   ```
+   experimental-features = nix-command flakes
+   ```
+
+- References
+   - Install Nix - https://nixos.org/download/
+   - Enable flakes - https://nixos.wiki/wiki/Flakes#Other_Distros.2C_without_Home-Manager
 
 ## Set up a Rust environment and other dependencies
 

--- a/docs/try_local_system.md
+++ b/docs/try_local_system.md
@@ -18,7 +18,7 @@ Check the Table Of Contents to jump to the relevant section.
 - [Set up a Nix development environment](#set-up-a-nix-development-environment)
    - [Install Nix](#install-nix)
    - [Using external services through Nix](#using-external-services-through-nix)
-   - [Logging into a Nix development environment (coming soon)](#logging-into-a-nix-development-environment)
+   - [Develop in a Nix environment (coming soon)](#develop-in-a-nix-environment-coming-soon)
 - [Set up a Rust environment and other dependencies](#set-up-a-rust-environment-and-other-dependencies)
   - [Set up dependencies on Ubuntu-based systems](#set-up-dependencies-on-ubuntu-based-systems)
   - [Set up dependencies on Windows (Ubuntu on WSL2)](#set-up-dependencies-on-windows-ubuntu-on-wsl2)
@@ -192,11 +192,11 @@ Nix can be installed in numerous ways. If you're new here, and don't have Nix in
 
 #### 3. Using a standard nix installation or using NixOS
 
-Nix's standard installation does not include `flakes` by default as it's an experimental feature. Nix needs to be configured to use the experimenal feature!
+Nix's standard installation does not include `flakes` by default as it's an experimental feature. It needs to be configured to use the experimenal feature.
 
 - Install Nix via multi-user installation
 
-   ```
+   ```shell
    sh <(curl -L https://nixos.org/nix/install)
    ```
 
@@ -209,6 +209,34 @@ Nix's standard installation does not include `flakes` by default as it's an expe
 - References
    - Install Nix - https://nixos.org/download/
    - Enable flakes - https://nixos.wiki/wiki/Flakes#Other_Distros.2C_without_Home-Manager
+
+### Using external services through Nix
+
+Once you have Nix installed on your system, we can start the external services using flakes. More services will be added soon!
+
+- Run below command in hyperswitch directory
+
+   ```shell
+   nix run .#ext-services
+   ```
+
+This will run below services using `process-compose`
+- Postgres
+   - Create DB used by the application
+   - Create an user to be used by the application
+- Redis
+
+### Develop in a Nix environment (coming soon)
+
+Nix development environment ensures all the required project dependencies, including both the tools and services are available without having to install any of the dependencies manually.
+
+Run below command in hyperswitch directory
+
+   ```shell
+   nix develop
+   ```
+
+This is a work in progress, and not all the commands might be available in this environment.
 
 ## Set up a Rust environment and other dependencies
 

--- a/docs/try_local_system.md
+++ b/docs/try_local_system.md
@@ -172,29 +172,29 @@ Once the services have been confirmed to be up and running, you can proceed with
 
 ## Set up a Nix development environment
 
-A Nix development environment allows for easily setting up the required dependencies and external services. This is available for MacOS, Linux and WSL2 users.
+A Nix development environment simplifies the setup of required project dependencies. This is available for MacOS, Linux and WSL2 users.
 
 ### Install nix
 
-Nix can be installed in numerous ways. If you're new here, and don't have Nix installed on your device, use the recommended approach. You're free to choose the way you'd like to have nix installed on your device.
+Nix can be installed in numerous ways. If you're new to Nix, use the recommended approach. However, you're free to choose the way you'd like to have nix installed on your device. The aim is to have nix installed with `flakes` support.
 
 #### 1. Using nixos-unified-template [recommended]
 
-*nixos-unified-template* provides an unified Nix configuration template for managing user applications, and using `flakes`.
+*nixos-unified-template* provides an unified Nix configuration template for managing user applications and using `flakes`.
 
 - Head to [nixos-unified-template](https://github.com/juspay/nixos-unified-template?tab=readme-ov-file#on-non-nixos) and follow the instructions.
 
 #### 2. Using nix-installer [minimal]
 
-*nix-installer* provides a faster and reliable way of installing Nix along with `flakes`.
+*nix-installer* provides a quick and reliable way of installing Nix with `flakes`.
 
 - Head to [nix-installer](https://github.com/DeterminateSystems/nix-installer) and follow the instructions.
 
 #### 3. Using a standard nix installation or using NixOS
 
-Nix's standard installation does not include `flakes` by default as it's an experimental feature. It needs to be configured to use the experimenal feature.
+Nix's standard installation does not include `flakes` by default as it's an experimental feature. You will need to enable it manually.
 
-- Install Nix via multi-user installation
+- Install Nix via multi-user setup
 
    ```shell
    sh <(curl -L https://nixos.org/nix/install)
@@ -212,7 +212,7 @@ Nix's standard installation does not include `flakes` by default as it's an expe
 
 ### Using external services through Nix
 
-Once you have Nix installed on your system, we can start the external services using flakes. More services will be added soon!
+Once Nix is installed, you can use it to manage external services via `flakes`. More services will be added soon.
 
 - Run below command in hyperswitch directory
 
@@ -220,15 +220,14 @@ Once you have Nix installed on your system, we can start the external services u
    nix run .#ext-services
    ```
 
-This will run below services using `process-compose`
-- Postgres
-   - Create DB used by the application
-   - Create an user to be used by the application
+This will start the following services using `process-compose`
+- PostgreSQL
+   - Creates database and an user to be used by the application
 - Redis
 
 ### Develop in a Nix environment (coming soon)
 
-Nix development environment ensures all the required project dependencies, including both the tools and services are available without having to install any of the dependencies manually.
+Nix development environment ensures all the required project dependencies, including both the tools and services are readily available, eliminating the need for manual setup.
 
 Run below command in hyperswitch directory
 
@@ -236,7 +235,7 @@ Run below command in hyperswitch directory
    nix develop
    ```
 
-This is a work in progress, and not all the commands might be available in this environment.
+**NOTE:** This is a work in progress, and only a selected commands are available at the moment. Look in `flake.nix` (hyperswitch-shell) for a full list of packages.
 
 ## Set up a Rust environment and other dependencies
 

--- a/flake.lock
+++ b/flake.lock
@@ -107,11 +107,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1676569297,
-        "narHash": "sha256-2n4C4H3/U+3YbDrQB6xIw7AaLdFISCCFwOkcETAigqU=",
+        "lastModified": 1728888510,
+        "narHash": "sha256-nsNdSldaAyu6PE3YUA+YQLqUDJh+gRbBooMMekZJwvI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ac1f5b72a9e95873d1de0233fddcb56f99884b37",
+        "rev": "a3c0b3b21515f74fd2665903d4ce6bc4dc81c77c",
         "type": "github"
       },
       "original": {
@@ -137,12 +137,29 @@
         "type": "github"
       }
     },
+    "process-compose-flake": {
+      "locked": {
+        "lastModified": 1728868941,
+        "narHash": "sha256-yEMzxZfy+EE9gSqn++SyZeAVHXYupFT8Wyf99Z/CXXU=",
+        "owner": "Platonic-Systems",
+        "repo": "process-compose-flake",
+        "rev": "29301aec92d73c9b075fcfd06a6fb18665bfe6b5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Platonic-Systems",
+        "repo": "process-compose-flake",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "cargo2nix": "cargo2nix",
         "flake-parts": "flake-parts",
         "nixpkgs": "nixpkgs_2",
-        "rust-overlay": "rust-overlay_2"
+        "process-compose-flake": "process-compose-flake",
+        "rust-overlay": "rust-overlay_2",
+        "services-flake": "services-flake"
       }
     },
     "rust-overlay": {
@@ -185,6 +202,21 @@
       "original": {
         "owner": "oxalica",
         "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "services-flake": {
+      "locked": {
+        "lastModified": 1728811751,
+        "narHash": "sha256-IrwycNtt6jxJGCi+QJ8Bbzt9flg0vNeGLAR0KBbj4a8=",
+        "owner": "juspay",
+        "repo": "services-flake",
+        "rev": "e9f663036f3b1b1a12b0f136628ef93a8be92443",
+        "type": "github"
+      },
+      "original": {
+        "owner": "juspay",
+        "repo": "services-flake",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -31,7 +31,6 @@
           devShells.default = pkgs.mkShell {
             name = "hyperswitch-shell";
             packages = with pkgs; [
-              fd
               just
               nixd
               openssl

--- a/flake.nix
+++ b/flake.nix
@@ -8,10 +8,14 @@
     # TODO: Move away from these to https://github.com/juspay/rust-flake
     cargo2nix.url = "github:cargo2nix/cargo2nix/release-0.11.0";
     rust-overlay.url = "github:oxalica/rust-overlay";
+
+    process-compose-flake.url = "github:Platonic-Systems/process-compose-flake";
+    services-flake.url = "github:juspay/services-flake";
   };
 
   outputs = inputs:
     inputs.flake-parts.lib.mkFlake { inherit inputs; } {
+      imports = [ inputs.process-compose-flake.flakeModule ];
       systems = inputs.nixpkgs.lib.systems.flakeExposed;
       perSystem = { self', pkgs, lib, system, ... }:
         let
@@ -27,10 +31,11 @@
           devShells.default = pkgs.mkShell {
             name = "hyperswitch-shell";
             packages = with pkgs; [
+              fd
+              just
+              nixd
               openssl
               pkg-config
-              exa
-              fd
               rust-bin.stable.${rustVersion}.default
             ] ++ lib.optionals stdenv.isDarwin [
               # arch might have issue finding these libs.
@@ -38,6 +43,36 @@
               frameworks.Foundation
             ];
           };
+
+          /* For running external services
+              - Redis
+              - Postgres
+          */
+          process-compose."ext-services" =
+            let 
+              developmentToml = lib.importTOML ./config/development.toml;
+              databaseName = developmentToml.master_database.dbname;
+              databaseUser = developmentToml.master_database.username;
+              databasePass = developmentToml.master_database.password;
+            in
+            {
+              imports = [ inputs.services-flake.processComposeModules.default ];
+              services.redis."r1".enable = true;
+              /* Postgres
+                  - Create an user and grant all privileges
+                  - Create a database
+              */
+              services.postgres."p1" = {
+                enable = true;
+                initialScript = {
+                  before = "CREATE USER ${databaseUser} WITH PASSWORD '${databasePass}' SUPERUSER CREATEDB CREATEROLE INHERIT LOGIN;";
+                  after = "GRANT ALL PRIVILEGES ON DATABASE ${databaseName} to ${databaseUser};";
+                };
+                initialDatabases = [
+                  { name = databaseName; }
+                ];
+              };
+            };
         };
     };
 }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
Described in #57 

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
Removes dependency on brew for installing and managing external services - redis and Postgres.

## How did you test it?
Locally.

- Make sure nix is installed
- `nix run .#ext-services`

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
