### PR TITLE
fix(payments): total count issue for card-network filter

### DIFF
--- a/crates/api_models/src/payments.rs
+++ b/crates/api_models/src/payments.rs
@@ -4585,6 +4585,7 @@ impl PaymentListFilterConstraints {
             && self.payment_method_type.is_none()
             && self.authentication_type.is_none()
             && self.merchant_connector_id.is_none()
+            && self.card_network.is_none()
     }
 }
 

--- a/crates/diesel_models/src/query/payment_attempt.rs
+++ b/crates/diesel_models/src/query/payment_attempt.rs
@@ -382,6 +382,7 @@ impl PaymentAttempt {
         payment_method_type: Option<Vec<enums::PaymentMethodType>>,
         authentication_type: Option<Vec<enums::AuthenticationType>>,
         merchant_connector_id: Option<Vec<common_utils::id_type::MerchantConnectorAccountId>>,
+        card_network: Option<Vec<enums::CardNetwork>>,
     ) -> StorageResult<i64> {
         let mut filter = <Self as HasTable>::table()
             .count()
@@ -404,6 +405,9 @@ impl PaymentAttempt {
         }
         if let Some(merchant_connector_id) = merchant_connector_id {
             filter = filter.filter(dsl::merchant_connector_id.eq_any(merchant_connector_id))
+        }
+        if let Some(card_network) = card_network {
+            filter = filter.filter(dsl::card_network.eq_any(card_network))
         }
 
         router_env::logger::debug!(query = %debug_query::<Pg, _>(&filter).to_string());

--- a/crates/hyperswitch_domain_models/src/payments/payment_attempt.rs
+++ b/crates/hyperswitch_domain_models/src/payments/payment_attempt.rs
@@ -159,6 +159,7 @@ pub trait PaymentAttemptInterface {
         payment_method_type: Option<Vec<storage_enums::PaymentMethodType>>,
         authentication_type: Option<Vec<storage_enums::AuthenticationType>>,
         merchant_connector_id: Option<Vec<id_type::MerchantConnectorAccountId>>,
+        card_network: Option<Vec<storage_enums::CardNetwork>>,
         storage_scheme: storage_enums::MerchantStorageScheme,
     ) -> error_stack::Result<i64, errors::StorageError>;
 }

--- a/crates/router/src/core/payments.rs
+++ b/crates/router/src/core/payments.rs
@@ -3888,6 +3888,7 @@ pub async fn apply_filters_on_payments(
                     constraints.payment_method_type,
                     constraints.authentication_type,
                     constraints.merchant_connector_id,
+                    constraints.card_network,
                     merchant.storage_scheme,
                 )
                 .await

--- a/crates/router/src/db/kafka_store.rs
+++ b/crates/router/src/db/kafka_store.rs
@@ -1601,6 +1601,7 @@ impl PaymentAttemptInterface for KafkaStore {
         payment_method_type: Option<Vec<common_enums::PaymentMethodType>>,
         authentication_type: Option<Vec<common_enums::AuthenticationType>>,
         merchant_connector_id: Option<Vec<id_type::MerchantConnectorAccountId>>,
+        card_network: Option<Vec<common_enums::CardNetwork>>,
         storage_scheme: MerchantStorageScheme,
     ) -> CustomResult<i64, errors::DataStorageError> {
         self.diesel_store
@@ -1612,6 +1613,7 @@ impl PaymentAttemptInterface for KafkaStore {
                 payment_method_type,
                 authentication_type,
                 merchant_connector_id,
+                card_network,
                 storage_scheme,
             )
             .await

--- a/crates/storage_impl/src/mock_db/payment_attempt.rs
+++ b/crates/storage_impl/src/mock_db/payment_attempt.rs
@@ -52,6 +52,7 @@ impl PaymentAttemptInterface for MockDb {
         _payment_method_type: Option<Vec<common_enums::PaymentMethodType>>,
         _authentication_type: Option<Vec<common_enums::AuthenticationType>>,
         _merchanat_connector_id: Option<Vec<common_utils::id_type::MerchantConnectorAccountId>>,
+        _card_network: Option<Vec<storage_enums::CardNetwork>>,
         _storage_scheme: storage_enums::MerchantStorageScheme,
     ) -> CustomResult<i64, StorageError> {
         Err(StorageError::MockDbError)?

--- a/crates/storage_impl/src/payments/payment_attempt.rs
+++ b/crates/storage_impl/src/payments/payment_attempt.rs
@@ -406,6 +406,7 @@ impl<T: DatabaseStore> PaymentAttemptInterface for RouterStore<T> {
         payment_method_type: Option<Vec<common_enums::PaymentMethodType>>,
         authentication_type: Option<Vec<common_enums::AuthenticationType>>,
         merchant_connector_id: Option<Vec<common_utils::id_type::MerchantConnectorAccountId>>,
+        card_network: Option<Vec<common_enums::CardNetwork>>,
         _storage_scheme: MerchantStorageScheme,
     ) -> CustomResult<i64, errors::StorageError> {
         let conn = self
@@ -429,6 +430,7 @@ impl<T: DatabaseStore> PaymentAttemptInterface for RouterStore<T> {
             payment_method_type,
             authentication_type,
             merchant_connector_id,
+            card_network,
         )
         .await
         .map_err(|er| {
@@ -1291,6 +1293,7 @@ impl<T: DatabaseStore> PaymentAttemptInterface for KVRouterStore<T> {
         payment_method_type: Option<Vec<common_enums::PaymentMethodType>>,
         authentication_type: Option<Vec<common_enums::AuthenticationType>>,
         merchant_connector_id: Option<Vec<common_utils::id_type::MerchantConnectorAccountId>>,
+        card_network: Option<Vec<common_enums::CardNetwork>>,
         storage_scheme: MerchantStorageScheme,
     ) -> CustomResult<i64, errors::StorageError> {
         self.router_store
@@ -1302,6 +1305,7 @@ impl<T: DatabaseStore> PaymentAttemptInterface for KVRouterStore<T> {
                 payment_method_type,
                 authentication_type,
                 merchant_connector_id,
+                card_network,
                 storage_scheme,
             )
             .await


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
The total count in the payments response was incorrect when the card-network filter was applied. With this PR, the count will now be accurately filtered as well.


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Request : 
```
curl 'http://localhost:8080/payments/list' \
  -H 'authorization: Bearer JWT token' \
  -H 'sec-ch-ua: "Google Chrome";v="129", "Not=A?Brand";v="8", "Chromium";v="129"' \
  -H 'sec-ch-ua-mobile: ?0' \
  -H 'sec-ch-ua-platform: "macOS"' \
  --data-raw '{"offset":0,"limit":50,"start_time":"2024-09-21T18:30:00Z","card_network":["Visa"]}'
```

Response 
Lets say the total number of payments are 50 , when you apply filter the total_count and count should come as the filtered number . For Eg: When card-network filter = Visa , then the count = 4 and total_count =4
```
{
    "count": 4,
    "total_count": 4,
    "data": [
        {
            "payment_id": "test_RoHcgHs3m6ZsJ0Y5MEMU",
            "merchant_id": "merchant_1729190909",
            "status": "failed",
            "amount": 10200,
            "net_amount": 10200,
            "shipping_cost": null,
            "amount_capturable": 0,
            "amount_received": null,
            "connector": "stripe_test",
            "client_secret": "test_RoHcgHs3m6ZsJ0Y5MEMU_secret_wQHDmUUPatRIfmY8P8VO",
            "created": "2024-10-22T00:08:58.000Z",
            "currency": "USD",
            "customer_id": "hs-dashboard-user",
            "customer": null,
            "description": "This is a sample payment",
            "refunds": null,
            "disputes": null,
            "mandate_id": null,
            "mandate_data": null,
            "setup_future_usage": null,
            "off_session": null,
            "capture_on": null,
            "capture_method": null,
            "payment_method": "card",
            "payment_method_data": null,
            "payment_token": null,
            "shipping": null,
            "billing": null,
            "order_details": null,
            "email": null,
            "name": null,
            "phone": null,
            "return_url": null,
            "authentication_type": "three_ds",
            "statement_descriptor_name": null,
            "statement_descriptor_suffix": null,
            "next_action": null,
            "cancellation_reason": null,
            "error_code": null,
            "error_message": null,
            "unified_code": null,
            "unified_message": null,
            "payment_experience": null,
            "payment_method_type": "credit",
            "connector_label": null,
            "business_country": null,
            "business_label": "default",
            "business_sub_label": null,
            "allowed_payment_method_types": null,
            "ephemeral_key": null,
            "manual_retry_allowed": null,
            "connector_transaction_id": "test_RoHcgHs3m6ZsJ0Y5MEMU_1",
            "frm_message": null,
            "metadata": null,
            "connector_metadata": null,
            "feature_metadata": null,
            "reference_id": null,
            "payment_link": null,
            "profile_id": "pro_lqOYR8GAg2uTrz5WaqA5",
            "surcharge_details": null,
            "attempt_count": 1,
            "merchant_decision": null,
            "merchant_connector_id": null,
            "incremental_authorization_allowed": null,
            "authorization_count": null,
            "incremental_authorizations": null,
            "external_authentication_details": null,
            "external_3ds_authentication_attempted": null,
            "expires_on": null,
            "fingerprint": null,
            "browser_info": null,
            "payment_method_id": null,
            "payment_method_status": null,
            "updated": null,
            "charges": null,
            "frm_metadata": null,
            "merchant_order_reference_id": null,
            "order_tax_amount": null,
            "connector_mandate_id": null
        },
        {
            "payment_id": "test_EEe6rS8Mkv2vVDxZWowp",
            "merchant_id": "merchant_1729190909",
            "status": "succeeded",
            "amount": 18600,
            "net_amount": 18600,
            "shipping_cost": null,
            "amount_capturable": 0,
            "amount_received": null,
            "connector": "stripe_test",
            "client_secret": "test_EEe6rS8Mkv2vVDxZWowp_secret_fvEF0uo7CYqPOgasFSrQ",
            "created": "2024-10-21T02:51:29.000Z",
            "currency": "USD",
            "customer_id": "hs-dashboard-user",
            "customer": null,
            "description": "This is a sample payment",
            "refunds": null,
            "disputes": null,
            "mandate_id": null,
            "mandate_data": null,
            "setup_future_usage": null,
            "off_session": null,
            "capture_on": null,
            "capture_method": null,
            "payment_method": "card",
            "payment_method_data": null,
            "payment_token": null,
            "shipping": null,
            "billing": null,
            "order_details": null,
            "email": null,
            "name": null,
            "phone": null,
            "return_url": null,
            "authentication_type": "three_ds",
            "statement_descriptor_name": null,
            "statement_descriptor_suffix": null,
            "next_action": null,
            "cancellation_reason": null,
            "error_code": null,
            "error_message": null,
            "unified_code": null,
            "unified_message": null,
            "payment_experience": null,
            "payment_method_type": "debit",
            "connector_label": null,
            "business_country": null,
            "business_label": "default",
            "business_sub_label": null,
            "allowed_payment_method_types": null,
            "ephemeral_key": null,
            "manual_retry_allowed": null,
            "connector_transaction_id": "test_EEe6rS8Mkv2vVDxZWowp_1",
            "frm_message": null,
            "metadata": null,
            "connector_metadata": null,
            "feature_metadata": null,
            "reference_id": null,
            "payment_link": null,
            "profile_id": "pro_lqOYR8GAg2uTrz5WaqA5",
            "surcharge_details": null,
            "attempt_count": 1,
            "merchant_decision": null,
            "merchant_connector_id": null,
            "incremental_authorization_allowed": null,
            "authorization_count": null,
            "incremental_authorizations": null,
            "external_authentication_details": null,
            "external_3ds_authentication_attempted": null,
            "expires_on": null,
            "fingerprint": null,
            "browser_info": null,
            "payment_method_id": null,
            "payment_method_status": null,
            "updated": null,
            "charges": null,
            "frm_metadata": null,
            "merchant_order_reference_id": null,
            "order_tax_amount": null,
            "connector_mandate_id": null
        },
        {
            "payment_id": "test_46x3ZcQVz6U9RtJitDO4",
            "merchant_id": "merchant_1729190909",
            "status": "succeeded",
            "amount": 18200,
            "net_amount": 18200,
            "shipping_cost": null,
            "amount_capturable": 0,
            "amount_received": null,
            "connector": "stripe_test",
            "client_secret": "test_46x3ZcQVz6U9RtJitDO4_secret_hrOArvzAKBpwXvShhHo4",
            "created": "2024-10-20T18:06:38.000Z",
            "currency": "USD",
            "customer_id": "hs-dashboard-user",
            "customer": null,
            "description": "This is a sample payment",
            "refunds": null,
            "disputes": null,
            "mandate_id": null,
            "mandate_data": null,
            "setup_future_usage": null,
            "off_session": null,
            "capture_on": null,
            "capture_method": null,
            "payment_method": "card",
            "payment_method_data": null,
            "payment_token": null,
            "shipping": null,
            "billing": null,
            "order_details": null,
            "email": null,
            "name": null,
            "phone": null,
            "return_url": null,
            "authentication_type": "three_ds",
            "statement_descriptor_name": null,
            "statement_descriptor_suffix": null,
            "next_action": null,
            "cancellation_reason": null,
            "error_code": null,
            "error_message": null,
            "unified_code": null,
            "unified_message": null,
            "payment_experience": null,
            "payment_method_type": "credit",
            "connector_label": null,
            "business_country": null,
            "business_label": "default",
            "business_sub_label": null,
            "allowed_payment_method_types": null,
            "ephemeral_key": null,
            "manual_retry_allowed": null,
            "connector_transaction_id": "test_46x3ZcQVz6U9RtJitDO4_1",
            "frm_message": null,
            "metadata": null,
            "connector_metadata": null,
            "feature_metadata": null,
            "reference_id": null,
            "payment_link": null,
            "profile_id": "pro_lqOYR8GAg2uTrz5WaqA5",
            "surcharge_details": null,
            "attempt_count": 1,
            "merchant_decision": null,
            "merchant_connector_id": null,
            "incremental_authorization_allowed": null,
            "authorization_count": null,
            "incremental_authorizations": null,
            "external_authentication_details": null,
            "external_3ds_authentication_attempted": null,
            "expires_on": null,
            "fingerprint": null,
            "browser_info": null,
            "payment_method_id": null,
            "payment_method_status": null,
            "updated": null,
            "charges": null,
            "frm_metadata": null,
            "merchant_order_reference_id": null,
            "order_tax_amount": null,
            "connector_mandate_id": null
        },
        {
            "payment_id": "test_pghhoGT9kuPuXf2yopXO",
            "merchant_id": "merchant_1729190909",
            "status": "succeeded",
            "amount": 11800,
            "net_amount": 11800,
            "shipping_cost": null,
            "amount_capturable": 0,
            "amount_received": null,
            "connector": "paypal_test",
            "client_secret": "test_pghhoGT9kuPuXf2yopXO_secret_R0uu1JcxCBN1UFyMDVal",
            "created": "2024-10-16T05:26:35.000Z",
            "currency": "USD",
            "customer_id": "hs-dashboard-user",
            "customer": null,
            "description": "This is a sample payment",
            "refunds": null,
            "disputes": null,
            "mandate_id": null,
            "mandate_data": null,
            "setup_future_usage": null,
            "off_session": null,
            "capture_on": null,
            "capture_method": null,
            "payment_method": "card",
            "payment_method_data": null,
            "payment_token": null,
            "shipping": null,
            "billing": null,
            "order_details": null,
            "email": null,
            "name": null,
            "phone": null,
            "return_url": null,
            "authentication_type": "no_three_ds",
            "statement_descriptor_name": null,
            "statement_descriptor_suffix": null,
            "next_action": null,
            "cancellation_reason": null,
            "error_code": null,
            "error_message": null,
            "unified_code": null,
            "unified_message": null,
            "payment_experience": null,
            "payment_method_type": "credit",
            "connector_label": null,
            "business_country": null,
            "business_label": "default",
            "business_sub_label": null,
            "allowed_payment_method_types": null,
            "ephemeral_key": null,
            "manual_retry_allowed": null,
            "connector_transaction_id": "test_pghhoGT9kuPuXf2yopXO_1",
            "frm_message": null,
            "metadata": null,
            "connector_metadata": null,
            "feature_metadata": null,
            "reference_id": null,
            "payment_link": null,
            "profile_id": "pro_lqOYR8GAg2uTrz5WaqA5",
            "surcharge_details": null,
            "attempt_count": 1,
            "merchant_decision": null,
            "merchant_connector_id": null,
            "incremental_authorization_allowed": null,
            "authorization_count": null,
            "incremental_authorizations": null,
            "external_authentication_details": null,
            "external_3ds_authentication_attempted": null,
            "expires_on": null,
            "fingerprint": null,
            "browser_info": null,
            "payment_method_id": null,
            "payment_method_status": null,
            "updated": null,
            "charges": null,
            "frm_metadata": null,
            "merchant_order_reference_id": null,
            "order_tax_amount": null,
            "connector_mandate_id": null
        }
    ]
}
```


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
