### PR TITLE
fix(payment_methods): fix merchant payment method list to retain a mca based on connector_name and mca_id

### DIFF
--- a/crates/api_models/src/payment_methods.rs
+++ b/crates/api_models/src/payment_methods.rs
@@ -1217,12 +1217,14 @@ pub struct ResponsePaymentMethodIntermediate {
     pub card_networks: Option<Vec<api_enums::CardNetwork>>,
     pub payment_method: api_enums::PaymentMethod,
     pub connector: String,
+    pub merchant_connector_id: String,
 }
 
 impl ResponsePaymentMethodIntermediate {
     pub fn new(
         pm_type: RequestPaymentMethodTypes,
         connector: String,
+        merchant_connector_id: String,
         pm: api_enums::PaymentMethod,
     ) -> Self {
         Self {
@@ -1231,6 +1233,7 @@ impl ResponsePaymentMethodIntermediate {
             card_networks: pm_type.card_networks,
             payment_method: pm,
             connector,
+            merchant_connector_id,
         }
     }
 }

--- a/crates/router/src/core/payment_methods/cards.rs
+++ b/crates/router/src/core/payment_methods/cards.rs
@@ -3031,6 +3031,15 @@ pub async fn list_payment_methods(
                             .connector
                             .connector_name
                             .to_string()
+                        && first_routable_connector
+                            .connector
+                            .merchant_connector_id
+                            .as_ref()
+                            .map(|merchant_connector_id| {
+                                *merchant_connector_id.get_string_repr()
+                                    == intermediate.merchant_connector_id
+                            })
+                            .unwrap_or_default()
                 } else {
                     false
                 }
@@ -4068,6 +4077,7 @@ pub async fn filter_payment_methods(
                         let response_pm_type = ResponsePaymentMethodIntermediate::new(
                             payment_method_object,
                             connector.clone(),
+                            mca_id.get_string_repr().to_string(),
                             payment_method,
                         );
                         resp.push(response_pm_type);

--- a/crates/router/src/core/payment_methods/cards.rs
+++ b/crates/router/src/core/payment_methods/cards.rs
@@ -2980,6 +2980,7 @@ pub async fn list_payment_methods(
             api_enums::PaymentMethodType::ApplePay,
             api_enums::PaymentMethodType::Klarna,
             api_enums::PaymentMethodType::Paypal,
+            api_enums::PaymentMethodType::SamsungPay,
         ]);
 
         let mut chosen = Vec::<api::SessionConnectorData>::new();

--- a/crates/router/src/core/payments.rs
+++ b/crates/router/src/core/payments.rs
@@ -5298,7 +5298,10 @@ where
             let routing_choice = choice
                 .first()
                 .ok_or(errors::ApiErrorResponse::InternalServerError)?;
-            if connector_data.connector.connector_name == routing_choice.connector.connector_name {
+            if connector_data.connector.connector_name == routing_choice.connector.connector_name
+                && connector_data.connector.merchant_connector_id
+                    == routing_choice.connector.merchant_connector_id
+            {
                 final_list.push(connector_data);
             }
         }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
Earlier a connector was occurring twice while doing a session token call for wallets. This PR fixes merchant payment method list to retain a mca based on connector_name and mca_id. So that with every distinct mca_id the connector is listed just once for wallets.


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?

- Create a MA and an MCA(with wallets enabled)
- Create an payment_intent 
```
Intent Response
{
    "payment_id": "pay_NHWegNguTfDH9hxuVj1m",
    "merchant_id": "merchant_1729514766",
    "status": "requires_payment_method",
    "amount": 8500,
    "net_amount": 8500,
    "shipping_cost": null,
    "amount_capturable": 0,
    "amount_received": null,
    "connector": null,
    "client_secret": "pay_NHWegNguTfDH9hxuVj1m_secret_YgCdjC1ZMbdqGBmOOoTP",
    "created": "2024-10-21T13:11:49.384Z",
    "currency": "USD",
    "customer_id": "CustomerX777",
    "customer": {
        "id": "CustomerX777",
        "name": "Joseph Doe",
        "email": "something@gmail.com",
        "phone": "999999999",
        "phone_country_code": "+65"
    },
    "description": "Its my first payment request",
    "refunds": null,
    "disputes": null,
    "mandate_id": null,
    "mandate_data": null,
    "setup_future_usage": "off_session",
    "off_session": null,
    "capture_on": null,
    "capture_method": "automatic",
    "payment_method": null,
    "payment_method_data": null,
    "payment_token": null,
    "shipping": {
        "address": {
            "city": "San Fransico",
            "country": "US",
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "zip": "94122",
            "state": "California",
            "first_name": "joseph",
            "last_name": "Doe"
        },
        "phone": {
            "number": "8056594427",
            "country_code": "+91"
        },
        "email": null
    },
    "billing": {
        "address": {
            "city": "San Fransico",
            "country": "US",
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "zip": "94122",
            "state": "California",
            "first_name": "joseph",
            "last_name": "Doe"
        },
        "phone": {
            "number": "8056594427",
            "country_code": "+91"
        },
        "email": null
    },
    "order_details": null,
    "email": "something@gmail.com",
    "name": "Joseph Doe",
    "phone": "999999999",
    "return_url": "https://google.com/",
    "authentication_type": "three_ds",
    "statement_descriptor_name": null,
    "statement_descriptor_suffix": null,
    "next_action": null,
    "cancellation_reason": null,
    "error_code": null,
    "error_message": null,
    "unified_code": null,
    "unified_message": null,
    "payment_experience": null,
    "payment_method_type": null,
    "connector_label": null,
    "business_country": null,
    "business_label": "default",
    "business_sub_label": null,
    "allowed_payment_method_types": null,
    "ephemeral_key": {
        "customer_id": "CustomerX777",
        "created_at": 1729516309,
        "expires": 1729519909,
        "secret": "epk_f7a7e71ac7b246b490d5cc31cb55e5d4"
    },
    "manual_retry_allowed": null,
    "connector_transaction_id": null,
    "frm_message": null,
    "metadata": null,
    "connector_metadata": {
        "apple_pay": null,
        "airwallex": null,
        "noon": {
            "order_category": "pay"
        }
    },
    "feature_metadata": null,
    "reference_id": null,
    "payment_link": null,
    "profile_id": "pro_M3DqjrGVffJASyys4npr",
    "surcharge_details": null,
    "attempt_count": 1,
    "merchant_decision": null,
    "merchant_connector_id": null,
    "incremental_authorization_allowed": null,
    "authorization_count": null,
    "incremental_authorizations": null,
    "external_authentication_details": null,
    "external_3ds_authentication_attempted": false,
    "expires_on": "2024-10-21T13:26:49.384Z",
    "fingerprint": null,
    "browser_info": null,
    "payment_method_id": null,
    "payment_method_status": null,
    "updated": "2024-10-21T13:11:49.418Z",
    "charges": null,
    "frm_metadata": null,
    "merchant_order_reference_id": null,
    "order_tax_amount": null,
    "connector_mandate_id": null
}
```

- Do a PML call, for the wallets the mca should be listed once for the wallets that support session token flow

```
Merchant PML response
{
    "redirect_url": "https://google.com/success",
    "currency": "USD",
    "payment_methods": [
        {
            "payment_method": "wallet",
            "payment_method_types": [
                {
                    "payment_method_type": "paypal",
                    "payment_experience": [
                        {
                            "payment_experience_type": "redirect_to_url",
                            "eligible_connectors": [
                                "stripe"
                            ]
                        }
                    ],
                    "card_networks": null,
                    "bank_names": null,
                    "bank_debits": null,
                    "bank_transfers": null,
                    "required_fields": null,
                    "surcharge_details": null,
                    "pm_auth_connector": null
                },
                {
                    "payment_method_type": "google_pay",
                    "payment_experience": [
                        {
                            "payment_experience_type": "invoke_sdk_client",
                            "eligible_connectors": [
                                "stripe"
                            ]
                        }
                    ],
                    "card_networks": null,
                    "bank_names": null,
                    "bank_debits": null,
                    "bank_transfers": null,
                    "required_fields": {},
                    "surcharge_details": null,
                    "pm_auth_connector": null
                },
                {
                    "payment_method_type": "samsung_pay",
                    "payment_experience": [
                        {
                            "payment_experience_type": "invoke_sdk_client",
                            "eligible_connectors": [
                                "stripe",
                                "stripe"
                            ]
                        }
                    ],
                    "card_networks": null,
                    "bank_names": null,
                    "bank_debits": null,
                    "bank_transfers": null,
                    "required_fields": null,
                    "surcharge_details": null,
                    "pm_auth_connector": null
                },
                {
                    "payment_method_type": "apple_pay",
                    "payment_experience": [
                        {
                            "payment_experience_type": "invoke_sdk_client",
                            "eligible_connectors": [
                                "stripe"
                            ]
                        }
                    ],
                    "card_networks": null,
                    "bank_names": null,
                    "bank_debits": null,
                    "bank_transfers": null,
                    "required_fields": {},
                    "surcharge_details": null,
                    "pm_auth_connector": null
                }
            ]
        }
    ],
    "mandate_payment": null,
    "merchant_name": "NewAge Retailer",
    "show_surcharge_breakup_screen": false,
    "payment_type": "new_mandate",
    "request_external_three_ds_authentication": false,
    "collect_shipping_details_from_wallets": false,
    "collect_billing_details_from_wallets": false,
    "is_tax_calculation_enabled": false
}
```

 - Create a MA and 2 same MCA
 - Create a payment_intent
 - Create a session token, only one google_pay will appear
 ```
 curl --location 'http://localhost:8080/payments/session_tokens' \
--header 'Content-Type: application/json' \
--header 'x-client-platform: ios' \
--header 'api-key: pk_dev_385274838f7c4d66b6571c32756827d6' \
--data '{
    "payment_id": "pay_NUmAgcew9X7W8yyBBsIK",
    "wallets":[],
    "client_secret": "pay_NUmAgcew9X7W8yyBBsIK_secret_DdDRx8PnhQznkCnVfY99"
}'
```
```
{
    "payment_id": "pay_NUmAgcew9X7W8yyBBsIK",
    "client_secret": "pay_NUmAgcew9X7W8yyBBsIK_secret_DdDRx8PnhQznkCnVfY99",
    "session_token": [
        {
            "wallet_name": "google_pay",
            "merchant_info": {
                "merchant_name": "S7"
            },
            "shipping_address_required": false,
            "email_required": false,
            "shipping_address_parameters": {
                "phone_number_required": false
            },
            "allowed_payment_methods": [
                {
                    "type": "CARD",
                    "parameters": {
                        "allowed_auth_methods": [
                            "PAN_ONLY",
                            "CRYPTOGRAM_3DS"
                        ],
                        "allowed_card_networks": [
                            "AMEX",
                            "DISCOVER",
                            "INTERAC",
                            "JCB",
                            "MASTERCARD",
                            "VISA"
                        ],
                        "billing_address_required": false
                    },
                    "tokenization_specification": {
                        "type": "PAYMENT_GATEWAY",
                        "parameters": {
                            "gateway": "stripe",
                            "stripe:version": "2018-10-31",
                            "stripe:publishableKey": "pk_test_51Msk2GAGHc77EJXX78h549SX2uaOnEkUYqBfjcoD05PIpAnDkYxMn8nQ4d19im85NQuX4Z6WDyHaUw2fFTPBWsIY00Wa7oNerO"
                        }
                    }
                }
            ],
            "transaction_info": {
                "country_code": "US",
                "currency_code": "USD",
                "total_price_status": "Final",
                "total_price": "85.00"
            },
            "delayed_session_token": false,
            "connector": "stripe",
            "sdk_next_action": {
                "next_action": "confirm"
            },
            "secrets": null
        }
    ]
}
```
## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
