### PR TITLE
feat(cypress-test): include worldpay's request / response structure for test suite

### DIFF
--- a/cypress-tests/cypress/e2e/PaymentTest/00006-VoidPayment.cy.js
+++ b/cypress-tests/cypress/e2e/PaymentTest/00006-VoidPayment.cy.js
@@ -67,7 +67,7 @@ describe("Card - NoThreeDS Manual payment flow test", () => {
 
     it("void-call-test", () => {
       let data = getConnectorDetails(globalState.get("connectorId"))["card_pm"][
-        "Void"
+        "VoidAfterConfirm"
       ];
       let req_data = data["Request"];
       let res_data = data["Response"];
@@ -178,7 +178,7 @@ describe("Card - NoThreeDS Manual payment flow test", () => {
       it("void-call-test", () => {
         let data = getConnectorDetails(globalState.get("connectorId"))[
           "card_pm"
-        ]["Void"];
+        ]["VoidAfterConfirm"];
         let req_data = data["Request"];
         let res_data = data["Response"];
         cy.voidCallTest(fixtures.voidBody, req_data, res_data, globalState);

--- a/cypress-tests/cypress/e2e/PaymentTest/00013-SaveCardFlow.cy.js
+++ b/cypress-tests/cypress/e2e/PaymentTest/00013-SaveCardFlow.cy.js
@@ -37,7 +37,7 @@ describe("Card - SaveCard payment flow test", () => {
           "card_pm"
         ]["SaveCardUseNo3DSAutoCapture"];
         let req_data = data["Request"];
-        let res_data = data["Response"];
+        let res_data = data["ResponseCustom"] ? data["ResponseCustom"] : data["Response"];
         cy.createConfirmPaymentTest(
           fixtures.createConfirmPaymentBody,
           req_data,
@@ -115,7 +115,7 @@ describe("Card - SaveCard payment flow test", () => {
           "card_pm"
         ]["SaveCardUseNo3DSAutoCapture"];
         let req_data = data["Request"];
-        let res_data = data["Response"];
+        let res_data = data["ResponseCustom"] ? data["ResponseCustom"] : data["Response"];
         cy.createConfirmPaymentTest(
           fixtures.createConfirmPaymentBody,
           req_data,
@@ -214,7 +214,7 @@ describe("Card - SaveCard payment flow test", () => {
           "card_pm"
         ]["SaveCardUseNo3DSAutoCapture"];
         let req_data = data["Request"];
-        let res_data = data["Response"];
+        let res_data = data["ResponseCustom"] ? data["ResponseCustom"] : data["Response"];
         cy.createConfirmPaymentTest(
           fixtures.createConfirmPaymentBody,
           req_data,
@@ -312,7 +312,7 @@ describe("Card - SaveCard payment flow test", () => {
           "card_pm"
         ]["SaveCardUseNo3DSAutoCaptureOffSession"];
         let req_data = data["Request"];
-        let res_data = data["Response"];
+        let res_data = data["ResponseCustom"] ? data["ResponseCustom"] : data["Response"];
         cy.createConfirmPaymentTest(
           fixtures.createConfirmPaymentBody,
           req_data,

--- a/cypress-tests/cypress/e2e/PaymentTest/00013-SaveCardFlow.cy.js
+++ b/cypress-tests/cypress/e2e/PaymentTest/00013-SaveCardFlow.cy.js
@@ -47,10 +47,11 @@ describe("Card - SaveCard payment flow test", () => {
           globalState
         );
         if (should_continue) {
-          // Don't continue if payment status is processing
+          // Don't continue if payment status is processing during auto capture
           // Payment data is tokenized only after payment is successful
-          let notProcessing = globalState.get("paymentStatus") != "processing";
-          should_continue = notProcessing && utils.should_continue_further(res_data);
+          let notProcessing = res_data?.body?.status != "processing";
+          should_continue =
+            notProcessing && utils.should_continue_further(res_data);
         }
       });
 

--- a/cypress-tests/cypress/e2e/PaymentTest/00013-SaveCardFlow.cy.js
+++ b/cypress-tests/cypress/e2e/PaymentTest/00013-SaveCardFlow.cy.js
@@ -37,7 +37,7 @@ describe("Card - SaveCard payment flow test", () => {
           "card_pm"
         ]["SaveCardUseNo3DSAutoCapture"];
         let req_data = data["Request"];
-        let res_data = data["ResponseCustom"] ? data["ResponseCustom"] : data["Response"];
+        let res_data = data["Response"];
         cy.createConfirmPaymentTest(
           fixtures.createConfirmPaymentBody,
           req_data,
@@ -46,8 +46,12 @@ describe("Card - SaveCard payment flow test", () => {
           "automatic",
           globalState
         );
-        if (should_continue)
-          should_continue = utils.should_continue_further(res_data);
+        if (should_continue) {
+          // Don't continue if payment status is processing
+          // Payment data is tokenized only after payment is successful
+          let notProcessing = globalState.get("paymentStatus") != "processing";
+          should_continue = notProcessing && utils.should_continue_further(res_data);
+        }
       });
 
       it("retrieve-payment-call-test", () => {
@@ -115,7 +119,7 @@ describe("Card - SaveCard payment flow test", () => {
           "card_pm"
         ]["SaveCardUseNo3DSAutoCapture"];
         let req_data = data["Request"];
-        let res_data = data["ResponseCustom"] ? data["ResponseCustom"] : data["Response"];
+        let res_data = data["Response"];
         cy.createConfirmPaymentTest(
           fixtures.createConfirmPaymentBody,
           req_data,
@@ -214,7 +218,7 @@ describe("Card - SaveCard payment flow test", () => {
           "card_pm"
         ]["SaveCardUseNo3DSAutoCapture"];
         let req_data = data["Request"];
-        let res_data = data["ResponseCustom"] ? data["ResponseCustom"] : data["Response"];
+        let res_data = data["Response"];
         cy.createConfirmPaymentTest(
           fixtures.createConfirmPaymentBody,
           req_data,
@@ -312,7 +316,7 @@ describe("Card - SaveCard payment flow test", () => {
           "card_pm"
         ]["SaveCardUseNo3DSAutoCaptureOffSession"];
         let req_data = data["Request"];
-        let res_data = data["ResponseCustom"] ? data["ResponseCustom"] : data["Response"];
+        let res_data = data["Response"];
         cy.createConfirmPaymentTest(
           fixtures.createConfirmPaymentBody,
           req_data,

--- a/cypress-tests/cypress/e2e/PaymentTest/00020-Variations.cy.js
+++ b/cypress-tests/cypress/e2e/PaymentTest/00020-Variations.cy.js
@@ -463,8 +463,9 @@ describe("Corner cases", () => {
       let data = getConnectorDetails(globalState.get("connectorId"))["card_pm"][
         "Void"
       ];
+      let commonData = getConnectorDetails(globalState.get("commons"))["card_pm"]["Void"];
       let req_data = data["Request"];
-      let res_data = data["ResponseCustom"];
+      let res_data = utils.getConnectorFlowDetails(data, commonData, "ResponseCustom");
       cy.voidCallTest(fixtures.voidBody, req_data, res_data, globalState);
 
       if (should_continue)
@@ -594,8 +595,9 @@ describe("Corner cases", () => {
       let data = getConnectorDetails(globalState.get("connectorId"))["card_pm"][
         "Refund"
       ];
+      let commonData = getConnectorDetails(globalState.get("commons"))["card_pm"]["Refund"];
       let req_data = data["Request"];
-      let res_data = data["ResponseCustom"];
+      let res_data = utils.getConnectorFlowDetails(data, commonData, "ResponseCustom");
       cy.refundCallTest(
         fixtures.refundBody,
         req_data,
@@ -656,8 +658,9 @@ describe("Corner cases", () => {
       let data = getConnectorDetails(globalState.get("connectorId"))["card_pm"][
         "Refund"
       ];
+      let commonData = getConnectorDetails(globalState.get("commons"))["card_pm"]["Refund"];
       let req_data = data["Request"];
-      let res_data = data["ResponseCustom"];
+      let res_data = utils.getConnectorFlowDetails(data, commonData, "ResponseCustom");
       cy.refundCallTest(
         fixtures.refundBody,
         req_data,

--- a/cypress-tests/cypress/e2e/PaymentTest/00020-Variations.cy.js
+++ b/cypress-tests/cypress/e2e/PaymentTest/00020-Variations.cy.js
@@ -331,7 +331,8 @@ describe("Corner cases", () => {
     });
 
     it("Capture call", () => {
-      let data = getConnectorDetails(globalState.get("commons"))["card_pm"][
+      let connectorId = globalState.get("connectorId");
+      let data = getConnectorDetails(connectorId === "worldpay" ? connectorId : globalState.get("commons"))["card_pm"][
         "CaptureCapturedAmount"
       ];
 
@@ -396,7 +397,8 @@ describe("Corner cases", () => {
     });
 
     it("Confirm call", () => {
-      let data = getConnectorDetails(globalState.get("commons"))["card_pm"][
+      let connectorId = globalState.get("connectorId");
+      let data = getConnectorDetails(connectorId === "worldpay" ? connectorId : globalState.get("commons"))["card_pm"][
         "ConfirmSuccessfulPayment"
       ];
       let req_data = data["Request"];
@@ -461,7 +463,8 @@ describe("Corner cases", () => {
 
     it("Void call", () => {
       // `commons` here is intentionally used as we need to pass `ResponseCustom`
-      let data = getConnectorDetails(globalState.get("commons"))["card_pm"][
+      let connectorId = globalState.get("connectorId");
+      let data = getConnectorDetails(connectorId === "worldpay" ? connectorId : globalState.get("commons"))["card_pm"][
         "Void"
       ];
       let req_data = data["Request"];
@@ -593,7 +596,8 @@ describe("Corner cases", () => {
 
     it("Refund call", () => {
       // `commons` here is intentionally used as we need to pass `ResponseCustom`
-      let data = getConnectorDetails(globalState.get("commons"))["card_pm"][
+      let connectorId = globalState.get("connectorId");
+      let data = getConnectorDetails(connectorId === "worldpay" ? connectorId : globalState.get("commons"))["card_pm"][
         "Refund"
       ];
       let req_data = data["Request"];
@@ -656,7 +660,8 @@ describe("Corner cases", () => {
 
     it("Refund call", () => {
       // `commons` here is intentionally used as we need to pass `ResponseCustom`
-      let data = getConnectorDetails(globalState.get("commons"))["card_pm"][
+      let connectorId = globalState.get("connectorId");
+      let data = getConnectorDetails(connectorId === "worldpay" ? connectorId : globalState.get("commons"))["card_pm"][
         "Refund"
       ];
       let req_data = data["Request"];

--- a/cypress-tests/cypress/e2e/PaymentTest/00020-Variations.cy.js
+++ b/cypress-tests/cypress/e2e/PaymentTest/00020-Variations.cy.js
@@ -460,7 +460,6 @@ describe("Corner cases", () => {
     });
 
     it("Void call", () => {
-      // `commons` here is intentionally used as we need to pass `ResponseCustom`
       let data = getConnectorDetails(globalState.get("connectorId"))["card_pm"][
         "Void"
       ];
@@ -592,7 +591,6 @@ describe("Corner cases", () => {
     });
 
     it("Refund call", () => {
-      // `commons` here is intentionally used as we need to pass `ResponseCustom`
       let data = getConnectorDetails(globalState.get("connectorId"))["card_pm"][
         "Refund"
       ];
@@ -655,7 +653,6 @@ describe("Corner cases", () => {
     });
 
     it("Refund call", () => {
-      // `commons` here is intentionally used as we need to pass `ResponseCustom`
       let data = getConnectorDetails(globalState.get("connectorId"))["card_pm"][
         "Refund"
       ];

--- a/cypress-tests/cypress/e2e/PaymentTest/00020-Variations.cy.js
+++ b/cypress-tests/cypress/e2e/PaymentTest/00020-Variations.cy.js
@@ -331,8 +331,7 @@ describe("Corner cases", () => {
     });
 
     it("Capture call", () => {
-      let connectorId = globalState.get("connectorId");
-      let data = getConnectorDetails(connectorId === "worldpay" ? connectorId : globalState.get("commons"))["card_pm"][
+      let data = getConnectorDetails(globalState.get("connectorId"))["card_pm"][
         "CaptureCapturedAmount"
       ];
 
@@ -397,8 +396,7 @@ describe("Corner cases", () => {
     });
 
     it("Confirm call", () => {
-      let connectorId = globalState.get("connectorId");
-      let data = getConnectorDetails(connectorId === "worldpay" ? connectorId : globalState.get("commons"))["card_pm"][
+      let data = getConnectorDetails(globalState.get("connectorId"))["card_pm"][
         "ConfirmSuccessfulPayment"
       ];
       let req_data = data["Request"];
@@ -463,8 +461,7 @@ describe("Corner cases", () => {
 
     it("Void call", () => {
       // `commons` here is intentionally used as we need to pass `ResponseCustom`
-      let connectorId = globalState.get("connectorId");
-      let data = getConnectorDetails(connectorId === "worldpay" ? connectorId : globalState.get("commons"))["card_pm"][
+      let data = getConnectorDetails(globalState.get("connectorId"))["card_pm"][
         "Void"
       ];
       let req_data = data["Request"];
@@ -596,8 +593,7 @@ describe("Corner cases", () => {
 
     it("Refund call", () => {
       // `commons` here is intentionally used as we need to pass `ResponseCustom`
-      let connectorId = globalState.get("connectorId");
-      let data = getConnectorDetails(connectorId === "worldpay" ? connectorId : globalState.get("commons"))["card_pm"][
+      let data = getConnectorDetails(globalState.get("connectorId"))["card_pm"][
         "Refund"
       ];
       let req_data = data["Request"];
@@ -660,8 +656,7 @@ describe("Corner cases", () => {
 
     it("Refund call", () => {
       // `commons` here is intentionally used as we need to pass `ResponseCustom`
-      let connectorId = globalState.get("connectorId");
-      let data = getConnectorDetails(connectorId === "worldpay" ? connectorId : globalState.get("commons"))["card_pm"][
+      let data = getConnectorDetails(globalState.get("connectorId"))["card_pm"][
         "Refund"
       ];
       let req_data = data["Request"];

--- a/cypress-tests/cypress/e2e/PaymentUtils/Commons.js
+++ b/cypress-tests/cypress/e2e/PaymentUtils/Commons.js
@@ -666,6 +666,27 @@ export const connectorDetails = {
         },
       },
     }),
+    VoidAfterConfirm: getCustomExchange({
+      Request: {},
+      Response: {
+        status: 200,
+        body: {
+          status: "cancelled",
+          capture_method: "manual",
+        },
+      },
+      ResponseCustom: {
+        status: 400,
+        body: {
+          error: {
+            type: "invalid_request",
+            message:
+              "You cannot cancel this payment because it has status succeeded",
+            code: "IR_16",
+          },
+        },
+      },
+    }),
     Refund: getCustomExchange({
       Request: {
         payment_method: "card",

--- a/cypress-tests/cypress/e2e/PaymentUtils/Paybox.js
+++ b/cypress-tests/cypress/e2e/PaymentUtils/Paybox.js
@@ -401,29 +401,6 @@ export const connectorDetails = {
         },
       },
     },
-    CaptureCapturedAmount: {
-      Request: {
-        Request: {
-          payment_method: "card",
-          payment_method_data: {
-            card: successfulNo3DSCardDetails,
-          },
-          currency: "EUR",
-          customer_acceptance: null,
-        },
-      },
-      Response: {
-        status: 400,
-        body: {
-          error: {
-            type: "invalid_request",
-            message:
-              "This Payment could not be captured because it has a payment.status of succeeded. The expected state is requires_capture, partially_captured_and_capturable, processing",
-            code: "IR_14",
-          },
-        },
-      },
-    },
     ConfirmSuccessfulPayment: {
       Request: {
         payment_method: "card",

--- a/cypress-tests/cypress/e2e/PaymentUtils/Utils.js
+++ b/cypress-tests/cypress/e2e/PaymentUtils/Utils.js
@@ -19,6 +19,7 @@ import { connectorDetails as stripeConnectorDetails } from "./Stripe.js";
 import { connectorDetails as trustpayConnectorDetails } from "./Trustpay.js";
 import { connectorDetails as wellsfargoConnectorDetails } from "./WellsFargo.js";
 import { connectorDetails as fiuuConnectorDetails } from "./Fiuu.js";
+import { connectorDetails as worldpayConnectorDetails } from "./WorldPay.js";
 
 const connectorDetails = {
   adyen: adyenConnectorDetails,
@@ -39,6 +40,7 @@ const connectorDetails = {
   datatrans: datatransConnectorDetails,
   wellsfargo: wellsfargoConnectorDetails,
   fiuu: fiuuConnectorDetails,
+  worldpay: worldpayConnectorDetails,
 };
 
 export default function getConnectorDetails(connectorId) {

--- a/cypress-tests/cypress/e2e/PaymentUtils/Utils.js
+++ b/cypress-tests/cypress/e2e/PaymentUtils/Utils.js
@@ -48,6 +48,11 @@ export default function getConnectorDetails(connectorId) {
   return x;
 }
 
+export function getConnectorFlowDetails(connectorData, commonData, key) {
+  let data = connectorData[key] === undefined ? commonData[key] : connectorData[key];
+  return data;
+}
+
 function mergeDetails(connectorId) {
   const connectorData = getValueByKey(connectorDetails, connectorId);
   const fallbackData = getValueByKey(connectorDetails, "commons");

--- a/cypress-tests/cypress/e2e/PaymentUtils/WorldPay.js
+++ b/cypress-tests/cypress/e2e/PaymentUtils/WorldPay.js
@@ -1,0 +1,508 @@
+
+const billing = {
+  address: {
+    line1: "1467",
+    line2: "Harrison Street",
+    line3: "Harrison Street",
+    city: "San Fransico",
+    state: "CA",
+    zip: "94122",
+    country: "US",
+    first_name: "John",
+    last_name: "Doe"
+  }
+};
+
+const browser_info = {
+  "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Safari/537.36",
+  "accept_header": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8",
+  "language": "nl-NL",
+  "color_depth": 24,
+  "screen_height": 723,
+  "screen_width": 1536,
+  "time_zone": 0,
+  "java_enabled": true,
+  "java_script_enabled": true,
+  "ip_address": "127.0.0.1"
+};
+
+const successfulNo3DSCardDetails = {
+  card_number: "4242424242424242",
+  card_exp_month: "10",
+  card_exp_year: "2030",
+  card_holder_name: "morino",
+  card_cvc: "737",
+};
+
+const successfulThreeDSTestCardDetails = {
+  card_number: "4000000000001091",
+  card_exp_month: "10",
+  card_exp_year: "2030",
+  card_holder_name: "morino",
+  card_cvc: "737",
+};
+
+const payment_method_data_no3ds = {
+  card: {
+    last4: "4242",
+    card_type: null,
+    card_network: null,
+    card_issuer: null,
+    card_issuing_country: null,
+    card_isin: "424242",
+    card_extended_bin: null,
+    card_exp_month: "10",
+    card_exp_year: "2030",
+    card_holder_name: null,
+    payment_checks: null,
+    authentication_data: null
+  },
+  billing: null
+};
+
+const payment_method_data_3ds = {
+  card: {
+    last4: "1091",
+    card_type: null,
+    card_network: null,
+    card_issuer: null,
+    card_issuing_country: null,
+    card_isin: "400000",
+    card_extended_bin: null,
+    card_exp_month: "10",
+    card_exp_year: "2030",
+    card_holder_name: null,
+    payment_checks: null,
+    authentication_data: null
+  },
+  billing: null
+};
+
+const singleUseMandateData = {
+  customer_acceptance: {
+    acceptance_type: "offline",
+    accepted_at: "1963-05-03T04:07:52.723Z",
+    online: {
+      ip_address: "125.0.0.1",
+      user_agent: "amet irure esse",
+    },
+  },
+  mandate_type: {
+    single_use: {
+      amount: 8000,
+      currency: "USD",
+    },
+  },
+};
+
+export const connectorDetails = {
+  card_pm: {
+    PaymentIntent: {
+      Request: {
+        currency: "USD",
+        customer_acceptance: null,
+        setup_future_usage: "on_session",
+      }, Response: {
+        status: 200,
+        body: {
+          status: "requires_payment_method",
+          setup_future_usage: "on_session",
+        },
+      },
+    },
+    No3DSManualCapture: {
+      Request: {
+        payment_method: "card",
+        payment_method_type: "debit",
+        payment_method_data: {
+          card: successfulNo3DSCardDetails,
+        },
+        currency: "USD",
+        customer_acceptance: null,
+        setup_future_usage: "on_session",
+        billing: billing,
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "requires_capture",
+          payment_method: "card",
+          payment_method_type: "debit",
+          attempt_count: 1,
+          payment_method_data: payment_method_data_no3ds,
+        },
+      },
+    },
+    No3DSAutoCapture: {
+      Request: {
+        payment_method: "card",
+        payment_method_type: "debit",
+        payment_method_data: {
+          card: successfulNo3DSCardDetails,
+        },
+        currency: "USD",
+        customer_acceptance: null,
+        setup_future_usage: "on_session",
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "processing",
+          payment_method: "card",
+          payment_method_type: "debit",
+          attempt_count: 1,
+          payment_method_data: payment_method_data_no3ds,
+        },
+      },
+    },
+    Capture: {
+      Request: {
+        payment_method: "card",
+        payment_method_type: "debit",
+        payment_method_data: {
+          card: successfulNo3DSCardDetails,
+        },
+        currency: "USD",
+        customer_acceptance: null,
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "processing",
+          amount: 6500,
+          amount_capturable: 6500,
+        },
+      },
+    },
+    PartialCapture: {
+      Request: {
+        payment_method: "card",
+        payment_method_type: "debit",
+        payment_method_data: {
+          card: successfulNo3DSCardDetails,
+        },
+        currency: "USD",
+        customer_acceptance: null,
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "processing",
+          amount: 6500,
+          amount_capturable: 6500,
+        },
+      },
+    },
+    Void: {
+      Request: {},
+      Response: {
+        status: 200,
+        body: {
+          status: "cancelled",
+        },
+      },
+      ResponseCustom: {
+        body: {
+          type: "invalid_request",
+          message: "You cannot cancel this payment because it has status processing",
+          code: "IR_16",
+        }
+      }
+    },
+    VoidAfterConfirm: {
+      Request: {},
+      Response: {
+        status: 200,
+        body: {
+          status: "processing",
+        },
+      },
+    },
+    SaveCardUseNo3DSManualCapture: {
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulNo3DSCardDetails,
+        },
+        currency: "USD",
+        setup_future_usage: "on_session",
+        customer_acceptance: {
+          acceptance_type: "offline",
+          accepted_at: "1963-05-03T04:07:52.723Z",
+          online: {
+            ip_address: "127.0.0.1",
+            user_agent: "amet irure esse",
+          },
+        },
+      },
+      Response: {
+        status: 400,
+        body: {
+          error: {
+            type: "invalid_request",
+            message: "Missing required param: payment_method_data",
+            code: "IR_04"
+          }
+        },
+      },
+      ResponseCustom: {
+        status: 200,
+        body: {
+          status: "processing"
+        },
+      }
+    },
+    SaveCardUseNo3DSAutoCapture: {
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulNo3DSCardDetails,
+        },
+        currency: "USD",
+        setup_future_usage: "on_session",
+        browser_info,
+        customer_acceptance: {
+          acceptance_type: "offline",
+          accepted_at: "1963-05-03T04:07:52.723Z",
+          online: {
+            ip_address: "127.0.0.1",
+            user_agent: "amet irure esse",
+          },
+        },
+      },
+      Response: {
+        status: 400,
+        body: {
+          error: {
+            type: "invalid_request",
+            message: "Missing required param: payment_method_data",
+            code: "IR_04"
+          }
+        },
+      },
+      ResponseCustom: {
+        status: 200,
+        body: {
+          status: "processing"
+        },
+      }
+    },
+    // SaveCardUseNo3DSAutoCaptureOffSession: {
+    //     Request: {
+    //         payment_method: "card",
+    //         payment_method_data: {
+    //             card: successfulNo3DSCardDetails,
+    //         },
+    //         setup_future_usage: "off_session",
+    //         customer_acceptance: {
+    //             acceptance_type: "offline",
+    //             accepted_at: "1963-05-03T04:07:52.723Z",
+    //             online: {
+    //                 ip_address: "127.0.0.1",
+    //                 user_agent: "amet irure esse",
+    //             },
+    //         },
+    //     },
+    //     Response: {
+    //         status: 200,
+    //         body: {
+    //             status: "processing",
+    //         },
+    //     },
+    // },
+    // SaveCardConfirmAutoCaptureOffSession: {
+    //     Request: {
+    //         setup_future_usage: "off_session",
+    //     },
+    //     Response: {
+    //         status: 400,
+    //         body: {
+    //             type: "invalid_request",
+    //             message: "Missing required param: payment_method_data",
+    //             code: "IR_19",
+    //         },
+    //     },
+    // },
+    // SaveCardConfirmManualCaptureOffSession: {
+    //     Request: {
+    //         setup_future_usage: "off_session",
+    //     },
+    //     Response: {
+    //         status: 400,
+    //         body: {
+    //             error: {
+    //                 type: "invalid_request",
+    //                 message: "Payment method type not supported",
+    //                 code: "IR_19",
+    //                 reason: "debit mandate payment is not supported by worldpay"
+    //             }
+    //         },
+    //     },
+    // },
+
+    /**
+     * Variation cases
+     */
+    CaptureCapturedAmount: {
+      Request: {
+        Request: {
+          payment_method: "card",
+          payment_method_data: {
+            card: successfulNo3DSCardDetails,
+          },
+          currency: "EUR",
+          customer_acceptance: null,
+        },
+      },
+      Response: {
+        status: 400,
+        body: {
+          error: {
+            type: "invalid_request",
+            message:
+              "This Payment could not be captured because it has a capture_method of automatic. The expected state is manual_multiple",
+            code: "IR_14",
+          },
+        },
+      },
+    },
+    ConfirmSuccessfulPayment: {
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulNo3DSCardDetails,
+        },
+        currency: "USD",
+        customer_acceptance: null,
+      },
+      Response: {
+        status: 400,
+        body: {
+          error: {
+            type: "invalid_request",
+            message:
+              "You cannot confirm this payment because it has status processing",
+            code: "IR_16",
+          },
+        },
+      },
+    },
+
+    /**
+     * Not implemented or not ready for running test cases
+     * - 3DS
+     * - Refunds
+     */
+    "3DSManualCapture": {
+      Request: {
+        payment_method: "card",
+        payment_method_type: "debit",
+        payment_method_data: {
+          card: successfulThreeDSTestCardDetails,
+        },
+        currency: "USD",
+        customer_acceptance: null,
+        setup_future_usage: "on_session",
+        browser_info,
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "requires_customer_action",
+          setup_future_usage: "on_session",
+          payment_method_data: payment_method_data_3ds,
+        },
+      },
+    },
+    "3DSAutoCapture": {
+      Request: {
+        payment_method: "card",
+        payment_method_type: "debit",
+        payment_method_data: {
+          card: successfulThreeDSTestCardDetails,
+        },
+        currency: "USD",
+        customer_acceptance: null,
+        setup_future_usage: "on_session",
+        browser_info,
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "requires_customer_action",
+          setup_future_usage: "on_session",
+          payment_method_data: payment_method_data_3ds,
+        },
+      },
+    },
+    Refund: {
+      Request: {},
+      Response: {
+        body: {
+          error: {
+            type: "invalid_request",
+            message: "This Payment could not be refund because it has a status of processing. The expected state is succeeded, partially_captured",
+            code: "IR_14"
+          }
+        }
+      },
+      ResponseCustom: {
+        status: 400,
+        body: {
+          error: {
+            type: "invalid_request",
+            message: "This Payment could not be refund because it has a status of processing. The expected state is succeeded, partially_captured",
+            code: "IR_14",
+          },
+        },
+      },
+    },
+    PartialRefund: {
+      Request: {},
+      Response: {
+        body: {
+          error: {
+            type: "invalid_request",
+            message: "This Payment could not be refund because it has a status of processing. The expected state is succeeded, partially_captured",
+            code: "IR_14"
+          }
+        }
+      }
+    },
+    SyncRefund: {
+      Request: {},
+      Response: {
+        body: {
+          error: {
+            type: "invalid_request",
+            message: "Refund does not exist in our records.",
+            code: "HE_02"
+          }
+        }
+      }
+    },
+    ZeroAuthMandate: {
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulNo3DSCardDetails,
+        },
+        currency: "USD",
+        mandate_data: singleUseMandateData,
+      },
+      Response: {
+        body: {
+          error: {
+            type: "invalid_request",
+            message: "Setup Mandate flow for Worldpay is not implemented",
+            code: "IR_00"
+          }
+        },
+      },
+    },
+  },
+
+  /**
+   * Everything below this line is not supported by WP, but need to provide details for running the test cases
+   */
+}

--- a/cypress-tests/cypress/e2e/PaymentUtils/WorldPay.js
+++ b/cypress-tests/cypress/e2e/PaymentUtils/WorldPay.js
@@ -287,58 +287,48 @@ export const connectorDetails = {
         },
       }
     },
-    // SaveCardUseNo3DSAutoCaptureOffSession: {
-    //     Request: {
-    //         payment_method: "card",
-    //         payment_method_data: {
-    //             card: successfulNo3DSCardDetails,
-    //         },
-    //         setup_future_usage: "off_session",
-    //         customer_acceptance: {
-    //             acceptance_type: "offline",
-    //             accepted_at: "1963-05-03T04:07:52.723Z",
-    //             online: {
-    //                 ip_address: "127.0.0.1",
-    //                 user_agent: "amet irure esse",
-    //             },
-    //         },
-    //     },
-    //     Response: {
-    //         status: 200,
-    //         body: {
-    //             status: "processing",
-    //         },
-    //     },
-    // },
-    // SaveCardConfirmAutoCaptureOffSession: {
-    //     Request: {
-    //         setup_future_usage: "off_session",
-    //     },
-    //     Response: {
-    //         status: 400,
-    //         body: {
-    //             type: "invalid_request",
-    //             message: "Missing required param: payment_method_data",
-    //             code: "IR_19",
-    //         },
-    //     },
-    // },
-    // SaveCardConfirmManualCaptureOffSession: {
-    //     Request: {
-    //         setup_future_usage: "off_session",
-    //     },
-    //     Response: {
-    //         status: 400,
-    //         body: {
-    //             error: {
-    //                 type: "invalid_request",
-    //                 message: "Payment method type not supported",
-    //                 code: "IR_19",
-    //                 reason: "debit mandate payment is not supported by worldpay"
-    //             }
-    //         },
-    //     },
-    // },
+    "3DSManualCapture": {
+      Request: {
+        payment_method: "card",
+        payment_method_type: "debit",
+        payment_method_data: {
+          card: successfulThreeDSTestCardDetails,
+        },
+        currency: "USD",
+        customer_acceptance: null,
+        setup_future_usage: "on_session",
+        browser_info,
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "requires_customer_action",
+          setup_future_usage: "on_session",
+          payment_method_data: payment_method_data_3ds,
+        },
+      },
+    },
+    "3DSAutoCapture": {
+      Request: {
+        payment_method: "card",
+        payment_method_type: "debit",
+        payment_method_data: {
+          card: successfulThreeDSTestCardDetails,
+        },
+        currency: "USD",
+        customer_acceptance: null,
+        setup_future_usage: "on_session",
+        browser_info,
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "requires_customer_action",
+          setup_future_usage: "on_session",
+          payment_method_data: payment_method_data_3ds,
+        },
+      },
+    },
 
     /**
      * Variation cases
@@ -390,51 +380,9 @@ export const connectorDetails = {
 
     /**
      * Not implemented or not ready for running test cases
-     * - 3DS
      * - Refunds
+     * - Mandates
      */
-    "3DSManualCapture": {
-      Request: {
-        payment_method: "card",
-        payment_method_type: "debit",
-        payment_method_data: {
-          card: successfulThreeDSTestCardDetails,
-        },
-        currency: "USD",
-        customer_acceptance: null,
-        setup_future_usage: "on_session",
-        browser_info,
-      },
-      Response: {
-        status: 200,
-        body: {
-          status: "requires_customer_action",
-          setup_future_usage: "on_session",
-          payment_method_data: payment_method_data_3ds,
-        },
-      },
-    },
-    "3DSAutoCapture": {
-      Request: {
-        payment_method: "card",
-        payment_method_type: "debit",
-        payment_method_data: {
-          card: successfulThreeDSTestCardDetails,
-        },
-        currency: "USD",
-        customer_acceptance: null,
-        setup_future_usage: "on_session",
-        browser_info,
-      },
-      Response: {
-        status: 200,
-        body: {
-          status: "requires_customer_action",
-          setup_future_usage: "on_session",
-          payment_method_data: payment_method_data_3ds,
-        },
-      },
-    },
     Refund: {
       Request: {},
       Response: {
@@ -501,8 +449,4 @@ export const connectorDetails = {
       },
     },
   },
-
-  /**
-   * Everything below this line is not supported by WP, but need to provide details for running the test cases
-   */
 }

--- a/cypress-tests/cypress/e2e/PaymentUtils/WorldPay.js
+++ b/cypress-tests/cypress/e2e/PaymentUtils/WorldPay.js
@@ -45,10 +45,10 @@ const successfulThreeDSTestCardDetails = {
 const payment_method_data_no3ds = {
   card: {
     last4: "4242",
-    card_type: null,
-    card_network: null,
-    card_issuer: null,
-    card_issuing_country: null,
+    card_type: "CREDIT",
+    card_network: "Visa",
+    card_issuer: "STRIPE PAYMENTS UK LIMITED",
+    card_issuing_country: "UNITEDKINGDOM",
     card_isin: "424242",
     card_extended_bin: null,
     card_exp_month: "10",
@@ -63,10 +63,10 @@ const payment_method_data_no3ds = {
 const payment_method_data_3ds = {
   card: {
     last4: "1091",
-    card_type: null,
-    card_network: null,
-    card_issuer: null,
-    card_issuing_country: null,
+    card_type: "Visa",
+    card_network: "Visa",
+    card_issuer: "INTL HDQTRS-CENTER OWNED",
+    card_issuing_country: "UNITEDSTATES",
     card_isin: "400000",
     card_extended_bin: null,
     card_exp_month: "10",

--- a/cypress-tests/cypress/e2e/PaymentUtils/WorldPay.js
+++ b/cypress-tests/cypress/e2e/PaymentUtils/WorldPay.js
@@ -63,7 +63,7 @@ const payment_method_data_no3ds = {
 const payment_method_data_3ds = {
   card: {
     last4: "1091",
-    card_type: "Visa",
+    card_type: "CREDIT",
     card_network: "Visa",
     card_issuer: "INTL HDQTRS-CENTER OWNED",
     card_issuing_country: "UNITEDSTATES",
@@ -245,12 +245,6 @@ export const connectorDetails = {
           }
         },
       },
-      ResponseCustom: {
-        status: 200,
-        body: {
-          status: "processing"
-        },
-      }
     },
     SaveCardUseNo3DSAutoCapture: {
       Request: {
@@ -271,16 +265,6 @@ export const connectorDetails = {
         },
       },
       Response: {
-        status: 400,
-        body: {
-          error: {
-            type: "invalid_request",
-            message: "Missing required param: payment_method_data",
-            code: "IR_04"
-          }
-        },
-      },
-      ResponseCustom: {
         status: 200,
         body: {
           status: "processing"

--- a/cypress-tests/cypress/fixtures/create-connector-body.json
+++ b/cypress-tests/cypress/fixtures/create-connector-body.json
@@ -13,6 +13,7 @@
   "metadata": {
     "city": "NY",
     "unit": "245",
-    "endpoint_prefix": "AD"
+    "endpoint_prefix": "AD",
+    "merchant_name": "Cypress Test"
   }
 }

--- a/cypress-tests/cypress/support/commands.js
+++ b/cypress-tests/cypress/support/commands.js
@@ -1297,7 +1297,6 @@ Cypress.Commands.add(
       if (response.status === 200) {
         globalState.set("paymentAmount", createConfirmPaymentBody.amount);
         globalState.set("paymentID", response.body.payment_id);
-        globalState.set("paymentStatus", response.body.status);
         expect(response.body.connector, "connector").to.equal(
           globalState.get("connectorId")
         );

--- a/cypress-tests/cypress/support/commands.js
+++ b/cypress-tests/cypress/support/commands.js
@@ -1297,6 +1297,7 @@ Cypress.Commands.add(
       if (response.status === 200) {
         globalState.set("paymentAmount", createConfirmPaymentBody.amount);
         globalState.set("paymentID", response.body.payment_id);
+        globalState.set("paymentStatus", response.body.status);
         expect(response.body.connector, "connector").to.equal(
           globalState.get("connectorId")
         );

--- a/cypress-tests/cypress/support/redirectionHandler.js
+++ b/cypress-tests/cypress/support/redirectionHandler.js
@@ -343,7 +343,19 @@ function threeDsRedirection(redirection_url, expected_url, connectorId) {
         cy.get("#outcomeSelect").select("Approve").should("have.value", "Y");
         cy.get('button[type="submit"]').click();
       });
-  } else {
+  } else if (connectorId === "worldpay") {
+    cy.get("iframe", { timeout: WAIT_TIME })
+      .its("0.contentDocument.body")
+      .within(() => {
+        cy.get('form[name="cardholderInput"]', { timeout: WAIT_TIME })
+          .should("exist")
+          .then(() => {
+            cy.get('input[name="challengeDataEntry"]').click().type("1234");
+            cy.get('input[value="SUBMIT"]').click();
+          })
+      });
+  }
+  else {
     // If connectorId is neither of adyen, trustpay, nmi, stripe, bankofamerica or cybersource, wait for 10 seconds
     cy.wait(WAIT_TIME);
   }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [x] CI/CD

## Description
Described in #6316 point # 4 (read comments)


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
Helps in sanity testing of Worldpay connector.


## How did you test it?
Locally using `npm run cypress:payments`
<img width="842" alt="Screenshot 2024-10-24 at 11 17 11 AM" src="https://github.com/user-attachments/assets/a9a96e67-e251-428a-9a80-087a06dad32a">

## Checklist
<!-- Put an `x` in the boxes that apply -->


- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
