### PR TITLE
chore: consolidated UserStatus enum into common_enums

### DIFF
--- a/crates/api_models/src/user.rs
+++ b/crates/api_models/src/user.rs
@@ -1,10 +1,9 @@
 use std::fmt::Debug;
 
-use common_enums::{EntityType, TokenPurpose};
+use common_enums::{EntityType, TokenPurpose, UserStatus};
 use common_utils::{crypto::OptionalEncryptableName, id_type, pii};
 use masking::Secret;
 
-use crate::user_role::UserStatus;
 pub mod dashboard_metadata;
 #[cfg(feature = "dummy_connector")]
 pub mod sample_data;

--- a/crates/api_models/src/user_role.rs
+++ b/crates/api_models/src/user_role.rs
@@ -34,12 +34,6 @@ pub struct UpdateUserRoleRequest {
     pub role_id: String,
 }
 
-#[derive(Debug, serde::Serialize)]
-pub enum UserStatus {
-    Active,
-    InvitationSent,
-}
-
 #[derive(Debug, serde::Deserialize, serde::Serialize)]
 pub struct DeleteUserRoleRequest {
     pub email: pii::Email,

--- a/crates/common_enums/src/enums.rs
+++ b/crates/common_enums/src/enums.rs
@@ -3424,3 +3424,24 @@ pub enum ConnectorMandateStatus {
     /// Indicates that the connector mandate  is not active and hence cannot be used for payments.
     Inactive,
 }
+
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Default,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    strum::Display,
+    strum::EnumString,
+)]
+#[router_derive::diesel_enum(storage_type = "db_enum")]
+#[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "snake_case")]
+pub enum UserStatus {
+    Active,
+    #[default]
+    InvitationSent,
+}

--- a/crates/diesel_models/src/enums.rs
+++ b/crates/diesel_models/src/enums.rs
@@ -224,27 +224,6 @@ pub enum FraudCheckLastStep {
     Clone,
     Copy,
     Debug,
-    Default,
-    Eq,
-    PartialEq,
-    serde::Serialize,
-    serde::Deserialize,
-    strum::Display,
-    strum::EnumString,
-)]
-#[diesel_enum(storage_type = "db_enum")]
-#[serde(rename_all = "snake_case")]
-#[strum(serialize_all = "snake_case")]
-pub enum UserStatus {
-    Active,
-    #[default]
-    InvitationSent,
-}
-
-#[derive(
-    Clone,
-    Copy,
-    Debug,
     Eq,
     PartialEq,
     serde::Deserialize,

--- a/crates/diesel_models/src/query/user_role.rs
+++ b/crates/diesel_models/src/query/user_role.rs
@@ -1,4 +1,5 @@
 use async_bb8_diesel::AsyncRunQueryDsl;
+use common_enums::UserStatus;
 use common_utils::id_type;
 use diesel::{
     associations::HasTable, debug_query, pg::Pg, result::Error as DieselError,
@@ -7,11 +8,7 @@ use diesel::{
 use error_stack::{report, ResultExt};
 
 use crate::{
-    enums::{UserRoleVersion, UserStatus},
-    errors,
-    query::generics,
-    schema::user_roles::dsl,
-    user_role::*,
+    enums::UserRoleVersion, errors, query::generics, schema::user_roles::dsl, user_role::*,
     PgPooledConn, StorageResult,
 };
 

--- a/crates/diesel_models/src/user_role.rs
+++ b/crates/diesel_models/src/user_role.rs
@@ -1,6 +1,6 @@
 use std::hash::Hash;
 
-use common_enums::EntityType;
+use common_enums::{EntityType, UserStatus};
 use common_utils::{consts, id_type};
 use diesel::{AsChangeset, Identifiable, Insertable, Queryable, Selectable};
 use time::PrimitiveDateTime;
@@ -15,7 +15,7 @@ pub struct UserRole {
     pub merchant_id: Option<id_type::MerchantId>,
     pub role_id: String,
     pub org_id: Option<id_type::OrganizationId>,
-    pub status: enums::UserStatus,
+    pub status: UserStatus,
     pub created_by: String,
     pub last_modified_by: String,
     pub created_at: PrimitiveDateTime,
@@ -78,7 +78,7 @@ pub struct UserRoleNew {
     pub merchant_id: Option<id_type::MerchantId>,
     pub role_id: String,
     pub org_id: Option<id_type::OrganizationId>,
-    pub status: enums::UserStatus,
+    pub status: UserStatus,
     pub created_by: String,
     pub last_modified_by: String,
     pub created_at: PrimitiveDateTime,
@@ -93,7 +93,7 @@ pub struct UserRoleNew {
 #[diesel(table_name = user_roles)]
 pub struct UserRoleUpdateInternal {
     role_id: Option<String>,
-    status: Option<enums::UserStatus>,
+    status: Option<UserStatus>,
     last_modified_by: Option<String>,
     last_modified: PrimitiveDateTime,
 }
@@ -101,7 +101,7 @@ pub struct UserRoleUpdateInternal {
 #[derive(Clone)]
 pub enum UserRoleUpdate {
     UpdateStatus {
-        status: enums::UserStatus,
+        status: UserStatus,
         modified_by: String,
     },
     UpdateRole {

--- a/crates/router/src/core/user.rs
+++ b/crates/router/src/core/user.rs
@@ -7,12 +7,12 @@ use api_models::{
     payments::RedirectionResponse,
     user::{self as user_api, InviteMultipleUserResponse, NameIdUnit},
 };
-use common_enums::EntityType;
+use common_enums::{EntityType, UserStatus};
 use common_utils::{type_name, types::keymanager::Identifier};
 #[cfg(feature = "email")]
 use diesel_models::user_role::UserRoleUpdate;
 use diesel_models::{
-    enums::{TotpStatus, UserRoleVersion, UserStatus},
+    enums::{TotpStatus, UserRoleVersion},
     organization::OrganizationBridge,
     user as storage_user,
     user_authentication_method::{UserAuthenticationMethodNew, UserAuthenticationMethodUpdate},

--- a/crates/router/src/core/user_role.rs
+++ b/crates/router/src/core/user_role.rs
@@ -1,10 +1,9 @@
 use std::collections::{HashMap, HashSet};
 
 use api_models::{user as user_api, user_role as user_role_api};
+use common_enums::UserStatus;
 use diesel_models::{
-    enums::{UserRoleVersion, UserStatus},
-    organization::OrganizationBridge,
-    user_role::UserRoleUpdate,
+    enums::UserRoleVersion, organization::OrganizationBridge, user_role::UserRoleUpdate,
 };
 use error_stack::{report, ResultExt};
 use masking::Secret;

--- a/crates/router/src/db/user_role.rs
+++ b/crates/router/src/db/user_role.rs
@@ -1,8 +1,6 @@
+use common_enums::UserStatus;
 use common_utils::id_type;
-use diesel_models::{
-    enums::{self, UserStatus},
-    user_role as storage,
-};
+use diesel_models::{enums, user_role as storage};
 use error_stack::{report, ResultExt};
 use router_env::{instrument, tracing};
 

--- a/crates/router/src/types/domain/user.rs
+++ b/crates/router/src/types/domain/user.rs
@@ -3,13 +3,13 @@ use std::{collections::HashSet, ops, str::FromStr};
 use api_models::{
     admin as admin_api, organization as api_org, user as user_api, user_role as user_role_api,
 };
-use common_enums::EntityType;
+use common_enums::{EntityType, UserStatus};
 use common_utils::{
     crypto::Encryptable, id_type, new_type::MerchantName, pii, type_name,
     types::keymanager::Identifier,
 };
 use diesel_models::{
-    enums::{TotpStatus, UserRoleVersion, UserStatus},
+    enums::{TotpStatus, UserRoleVersion},
     organization::{self as diesel_org, Organization, OrganizationBridge},
     user as storage_user,
     user_role::{UserRole, UserRoleNew},
@@ -1010,7 +1010,7 @@ impl UserFromStorage {
     }
 }
 
-impl ForeignFrom<UserStatus> for user_role_api::UserStatus {
+impl ForeignFrom<UserStatus> for UserStatus {
     fn foreign_from(value: UserStatus) -> Self {
         match value {
             UserStatus::Active => Self::Active,

--- a/crates/router/src/types/domain/user/decision_manager.rs
+++ b/crates/router/src/types/domain/user/decision_manager.rs
@@ -1,5 +1,5 @@
-use common_enums::TokenPurpose;
-use diesel_models::{enums::UserStatus, user_role::UserRole};
+use common_enums::{TokenPurpose, UserStatus};
+use diesel_models::user_role::UserRole;
 use error_stack::{report, ResultExt};
 use masking::Secret;
 

--- a/crates/router/src/utils/user_role.rs
+++ b/crates/router/src/utils/user_role.rs
@@ -1,9 +1,9 @@
 use std::{cmp, collections::HashSet};
 
-use common_enums::{EntityType, PermissionGroup};
+use common_enums::{EntityType, PermissionGroup, UserStatus};
 use common_utils::id_type;
 use diesel_models::{
-    enums::{UserRoleVersion, UserStatus},
+    enums::UserRoleVersion,
     user_role::{UserRole, UserRoleUpdate},
 };
 use error_stack::{report, Report, ResultExt};


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [x] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
This PR consolidates the `UserStatus` enum across the project into the `common_enums` file.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
Fixes #5967 

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
