### PR TITLE
fix(analytics): add dynamic limit by clause in failure reasons metric query

### DIFF
--- a/crates/analytics/src/payments/metrics/sessionized_metrics/failure_reasons.rs
+++ b/crates/analytics/src/payments/metrics/sessionized_metrics/failure_reasons.rs
@@ -148,17 +148,20 @@ where
             .attach_printable("Error adding order by clause")
             .switch()?;
 
-        for dim in dimensions.iter() {
-            if dim != &PaymentDimensions::ErrorReason {
-                outer_query_builder
-                    .add_order_by_clause(dim, Order::Ascending)
-                    .attach_printable("Error adding order by clause")
-                    .switch()?;
-            }
+        let filtered_dimensions: Vec<&PaymentDimensions> = dimensions
+            .iter()
+            .filter(|&&dim| dim != PaymentDimensions::ErrorReason)
+            .collect();
+
+        for dim in &filtered_dimensions {
+            outer_query_builder
+                .add_order_by_clause(*dim, Order::Ascending)
+                .attach_printable("Error adding order by clause")
+                .switch()?;
         }
 
         outer_query_builder
-            .set_limit_by(5, &[PaymentDimensions::Connector])
+            .set_limit_by(5, &filtered_dimensions)
             .attach_printable("Error adding limit clause")
             .switch()?;
 


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
- Currently, the `limit by` clause in query_builder of `failure_reasons` metric has only `connector` hardcoded.
- Changed this behaviour to enable dynamic addition of `group` by fields to the `limit by` clause as well.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
Prevent errors when connector is not passed as a group by and also provide dynamic combination of error_reason with other filters like connector, payment_method, payment_method_type, etc.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Hit the curl:
```bash
curl --location 'http://localhost:8080/analytics/v1/org/metrics/payments' \
--header 'Accept: */*' \
--header 'Accept-Language: en-US,en;q=0.9' \
--header 'Connection: keep-alive' \
--header 'Content-Type: application/json' \
--header 'Origin: http://localhost:9000' \
--header 'Referer: http://localhost:9000/' \
--header 'Sec-Fetch-Dest: empty' \
--header 'Sec-Fetch-Mode: cors' \
--header 'Sec-Fetch-Site: same-site' \
--header 'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36' \
--header 'api-key: test_admin' \
--header 'authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoiNTQ5ZTNkMmItMTY5Yi00NzUzLWJmNTQtZDcxMTM2YjRiN2JkIiwibWVyY2hhbnRfaWQiOiJtZXJjaGFudF8xNzI2MDQ2MzI4Iiwicm9sZV9pZCI6Im9yZ19hZG1pbiIsImV4cCI6MTczMDI2NjUwMCwib3JnX2lkIjoib3JnX1ZwU0hPanNZZkR2YWJWWUpnQ0FKIiwicHJvZmlsZV9pZCI6InByb192NXNGb0hlODBPZWlVbElvbm9jTSJ9.p6u5u3k6-80GBh7_0Kri9VmIvZc3h2bx48UEQraeLA8' \
--header 'sec-ch-ua: "Chromium";v="128", "Not;A=Brand";v="24", "Google Chrome";v="128"' \
--header 'sec-ch-ua-mobile: ?0' \
--header 'sec-ch-ua-platform: "macOS"' \
--data '[
    {
        "timeRange": {
            "startTime": "2024-09-11T18:30:00Z",
            "endTime": "2024-10-30T09:22:00Z"
        },
        "groupByNames": [
            "connector", "payment_method", "payment_method_type", "error_reason"
        ],
        "filters": {
            "merchant_id": ["merchant_1726046328"]
        },
        "source": "BATCH",
        "metrics": [
            "failure_reasons"
        ],
        "delta": true
    }
]'
```
Sample response:
```bash
{
    "queryData": [
        {
            "payment_success_rate": null,
            "payment_count": null,
            "payment_success_count": null,
            "payment_processed_amount": 0,
            "payment_processed_count": null,
            "payment_processed_amount_without_smart_retries": 0,
            "payment_processed_count_without_smart_retries": null,
            "avg_ticket_size": null,
            "payment_error_message": null,
            "retries_count": null,
            "retries_amount_processed": 0,
            "connector_success_rate": null,
            "payments_success_rate_distribution": null,
            "payments_success_rate_distribution_without_smart_retries": null,
            "payments_failure_rate_distribution": null,
            "payments_failure_rate_distribution_without_smart_retries": null,
            "failure_reason_count": 1,
            "failure_reason_count_without_smart_retries": 1,
            "currency": null,
            "status": null,
            "connector": "stripe_test",
            "authentication_type": null,
            "payment_method": "card",
            "payment_method_type": "credit",
            "client_source": null,
            "client_version": null,
            "profile_id": null,
            "card_network": null,
            "merchant_id": null,
            "card_last_4": null,
            "card_issuer": null,
            "error_reason": "TEST FAILURE - 1",
            "time_range": {
                "start_time": "2024-09-11T18:30:00.000Z",
                "end_time": "2024-10-30T09:22:00.000Z"
            },
            "time_bucket": "2024-09-11 18:30:00"
        }
    ],
    "metaData": [
        {
            "total_payment_processed_amount": 0,
            "total_payment_processed_amount_without_smart_retries": 0,
            "total_payment_processed_count": 0,
            "total_payment_processed_count_without_smart_retries": 0,
            "total_failure_reasons_count": 1,
            "total_failure_reasons_count_without_smart_retries": 1
        }
    ]
}
```

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
