### PR TITLE
feat(events): Add payment reject audit events

### DIFF
--- a/crates/router/src/core/payments/operations/payment_reject.rs
+++ b/crates/router/src/core/payments/operations/payment_reject.rs
@@ -265,8 +265,8 @@ impl<F: Clone> UpdateTracker<F, PaymentData<F>, PaymentsCancelRequest> for Payme
             )
             .await
             .to_not_found_response(errors::ApiErrorResponse::PaymentNotFound)?;
-        let error_code = payment_data.payment_attempt.error_code;
-        let error_message = payment_data.payment_attempt.error_message;
+        let error_code = payment_data.payment_attempt.error_code.clone();
+        let error_message = payment_data.payment_attempt.error_message.clone();
         req_state
             .event_context
             .event(AuditEvent::new(AuditEventType::PaymentReject {

--- a/crates/router/src/events/audit_events.rs
+++ b/crates/router/src/events/audit_events.rs
@@ -33,7 +33,10 @@ pub enum AuditEventType {
     },
     PaymentApprove,
     PaymentCreate,
-    PaymentReject,
+    PaymentReject {
+        error_code: Option<String>,
+        error_message: Option<String>,
+    },
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -75,7 +78,7 @@ impl Event for AuditEvent {
             AuditEventType::PaymentUpdate { .. } => "payment_update",
             AuditEventType::PaymentApprove { .. } => "payment_approve",
             AuditEventType::PaymentCreate { .. } => "payment_create",
-            AuditEventType::PaymentReject => "payment_rejected",
+            AuditEventType::PaymentReject { .. } => "payment_rejected",
         };
         format!(
             "{event_type}-{}",

--- a/crates/router/src/events/audit_events.rs
+++ b/crates/router/src/events/audit_events.rs
@@ -33,6 +33,7 @@ pub enum AuditEventType {
     },
     PaymentApprove,
     PaymentCreate,
+    PaymentReject,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -74,6 +75,7 @@ impl Event for AuditEvent {
             AuditEventType::PaymentUpdate { .. } => "payment_update",
             AuditEventType::PaymentApprove { .. } => "payment_approve",
             AuditEventType::PaymentCreate { .. } => "payment_create",
+            AuditEventType::PaymentReject => "payment_rejected",
         };
         format!(
             "{event_type}-{}",


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [X] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Pass along request_state to payment_core
Modify the UpdateTracker trait to accept request state
Modify the PaymentReject implementation of UpdateTracker to generate an event


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->
Files changed
1. `crates/router/src/core/payments/operations/payment_reject.rs`
2. `crates/router/src/events/audit_events.rs`
## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
Resolves #4669 

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
This requires FRM related flows to be tested, and may not be tested locally.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [X] I formatted the code `cargo +nightly fmt --all`
- [X] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
