### PR TITLE
fix(router): get apple pay certificates only from metadata during the session call

### DIFF
--- a/crates/router/src/core/payments/flows/session_flow.rs
+++ b/crates/router/src/core/payments/flows/session_flow.rs
@@ -189,20 +189,11 @@ async fn create_applepay_session_token(
         )
     } else {
         // Get the apple pay metadata
-        let connector_apple_pay_wallet_details =
-            helpers::get_applepay_metadata(router_data.connector_wallets_details.clone())
-                .map_err(|error| {
-                    logger::debug!(
-                        "Apple pay connector wallets details parsing failed in create_applepay_session_token {:?}",
-                        error
-                    )
-                })
-                .ok();
-
-        let apple_pay_metadata = match connector_apple_pay_wallet_details {
-            Some(apple_pay_wallet_details) => apple_pay_wallet_details,
-            None => helpers::get_applepay_metadata(router_data.connector_meta_data.clone())?,
-        };
+        let apple_pay_metadata =
+            helpers::get_applepay_metadata(router_data.connector_meta_data.clone())
+                .attach_printable(
+                    "Failed to to fetch apple pay certificates during session call",
+                )?;
 
         // Get payment request data , apple pay session request and merchant keys
         let (

--- a/crates/router/src/core/payments/helpers.rs
+++ b/crates/router/src/core/payments/helpers.rs
@@ -4984,7 +4984,6 @@ where
 
     let connector_data_list = if is_apple_pay_simplified_flow(
         merchant_connector_account_type.get_metadata(),
-
         merchant_connector_account_type
             .get_connector_name()
             .as_ref(),

--- a/crates/router/src/core/payments/helpers.rs
+++ b/crates/router/src/core/payments/helpers.rs
@@ -4788,32 +4788,17 @@ pub fn validate_customer_access(
 
 pub fn is_apple_pay_simplified_flow(
     connector_metadata: Option<pii::SecretSerdeValue>,
-    connector_wallets_details: Option<pii::SecretSerdeValue>,
     connector_name: Option<&String>,
 ) -> CustomResult<bool, errors::ApiErrorResponse> {
-    let connector_apple_pay_wallet_details =
-        get_applepay_metadata(connector_wallets_details)
-            .map_err(|error| {
-                logger::debug!(
-                    "Apple pay connector wallets details parsing failed for {:?} in is_apple_pay_simplified_flow {:?}",
-                    connector_name,
-                    error
-                )
-            })
-            .ok();
-
-    let option_apple_pay_metadata = match connector_apple_pay_wallet_details {
-        Some(apple_pay_wallet_details) => Some(apple_pay_wallet_details),
-        None => get_applepay_metadata(connector_metadata)
-            .map_err(|error| {
-                logger::debug!(
-                "Apple pay metadata parsing failed for {:?} in is_apple_pay_simplified_flow {:?}",
+    let option_apple_pay_metadata = get_applepay_metadata(connector_metadata)
+        .map_err(|error| {
+            logger::info!(
+                "Apple pay metadata parsing for {:?} in is_apple_pay_simplified_flow {:?}",
                 connector_name,
                 error
             )
-            })
-            .ok(),
-    };
+        })
+        .ok();
 
     // return true only if the apple flow type is simplified
     Ok(matches!(
@@ -4999,7 +4984,7 @@ where
 
     let connector_data_list = if is_apple_pay_simplified_flow(
         merchant_connector_account_type.get_metadata(),
-        merchant_connector_account_type.get_connector_wallets_details(),
+
         merchant_connector_account_type
             .get_connector_name()
             .as_ref(),
@@ -5027,10 +5012,6 @@ where
         for merchant_connector_account in profile_specific_merchant_connector_account_list {
             if is_apple_pay_simplified_flow(
                 merchant_connector_account.metadata.clone(),
-                merchant_connector_account
-                    .connector_wallets_details
-                    .as_deref()
-                    .cloned(),
                 Some(&merchant_connector_account.connector_name),
             )? {
                 let connector_data = api::ConnectorData::get_connector_by_name(


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Currently we have apple pay certificates being stored in the `metadata` as well as `connector_wallet_details` when a merchant connector account is created. During the session call we try to get the certificates from the `connector_wallet_details` if it fails we try to get it from `metadata`. 

Currently when apple pay certificates are being updated with the merchant connector update call only the metadata is being updated. Because of this `connector_wallet_details` will still have the old data using which we make the session call.

In order to fix it, this pr contains the changes to get the `apple pay certificates` from the `metadata` only as it will have the latest updated data. In subsequent pr mca update inconsistency will be handled.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
-> Create merchant connector account with apple pay enabled (pass the certificates only in the metadata)
-> Create a payment with confirm false
```
curl --location 'http://localhost:8080/payments' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: dev_1mlXU5snhPhX9lzhh489Hafi6psrvNuTYGqgB7IWO10tUN81hYwfxqr54iHN9LqM' \
--data-raw '{
    "amount": 6100,
    "currency": "USD",
    "confirm": false,
    "business_country": "US",
    "business_label": "default",
    "amount_to_capture": 6100,
    "capture_method": "automatic",
    "capture_on": "2022-09-10T10:11:12Z",
    "return_url": "https://google.com",
    "email": "something@gmail.com",
    "name": "Joseph Doe",
    "phone": "999999999",
    "phone_country_code": "+65",
    "description": "Its my first payment request",
    "statement_descriptor_name": "Juspay",
    "statement_descriptor_suffix": "Router",
    "billing": {
        "address": {
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "city": "San Fransico",
            "state": "California",
            "zip": "94122",
            "country": "US",
            "first_name": "joseph",
            "last_name": "Doe"
        },
        "phone": {
            "number": "8056594427",
            "country_code": "+91"
        }
    }
}'
```
```
{
    "payment_id": "pay_13yS6rPTfz2flIVwTdOD",
    "merchant_id": "merchant_1731058139",
    "status": "requires_payment_method",
    "amount": 6100,
    "net_amount": 6100,
    "shipping_cost": null,
    "amount_capturable": 0,
    "amount_received": null,
    "connector": null,
    "client_secret": "pay_13yS6rPTfz2flIVwTdOD_secret_LDRqGrN0l1Oepne0sswI",
    "created": "2024-11-08T09:29:43.101Z",
    "currency": "USD",
    "customer_id": null,
    "customer": {
        "id": null,
        "name": "Joseph Doe",
        "email": "something@gmail.com",
        "phone": "999999999",
        "phone_country_code": "+65"
    },
    "description": "Its my first payment request",
    "refunds": null,
    "disputes": null,
    "mandate_id": null,
    "mandate_data": null,
    "setup_future_usage": null,
    "off_session": null,
    "capture_on": null,
    "capture_method": "automatic",
    "payment_method": null,
    "payment_method_data": null,
    "payment_token": null,
    "shipping": null,
    "billing": {
        "address": {
            "city": "San Fransico",
            "country": "US",
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "zip": "94122",
            "state": "California",
            "first_name": "joseph",
            "last_name": "Doe"
        },
        "phone": {
            "number": "8056594427",
            "country_code": "+91"
        },
        "email": null
    },
    "order_details": null,
    "email": null,
    "name": null,
    "phone": null,
    "return_url": "https://google.com/",
    "authentication_type": null,
    "statement_descriptor_name": "Juspay",
    "statement_descriptor_suffix": "Router",
    "next_action": null,
    "cancellation_reason": null,
    "error_code": null,
    "error_message": null,
    "unified_code": null,
    "unified_message": null,
    "payment_experience": null,
    "payment_method_type": null,
    "connector_label": null,
    "business_country": "US",
    "business_label": "default",
    "business_sub_label": null,
    "allowed_payment_method_types": null,
    "ephemeral_key": null,
    "manual_retry_allowed": null,
    "connector_transaction_id": null,
    "frm_message": null,
    "metadata": null,
    "connector_metadata": null,
    "feature_metadata": null,
    "reference_id": null,
    "payment_link": null,
    "profile_id": "pro_qk2Nf6soRabKK4PTZPI7",
    "surcharge_details": null,
    "attempt_count": 1,
    "merchant_decision": null,
    "merchant_connector_id": null,
    "incremental_authorization_allowed": null,
    "authorization_count": null,
    "incremental_authorizations": null,
    "external_authentication_details": null,
    "external_3ds_authentication_attempted": false,
    "expires_on": "2024-11-08T09:44:43.101Z",
    "fingerprint": null,
    "browser_info": null,
    "payment_method_id": null,
    "payment_method_status": null,
    "updated": "2024-11-08T09:29:43.156Z",
    "charges": null,
    "frm_metadata": null,
    "merchant_order_reference_id": null,
    "order_tax_amount": null,
    "connector_mandate_id": null
}
```
-> Make a session call
```
curl --location 'http://localhost:8080/payments/session_tokens' \
--header 'Content-Type: application/json' \
--header 'api-key: pk_dev_8f588c72e93146fd85d7888b57813cae' \
--data '{
    "payment_id": "pay_13yS6rPTfz2flIVwTdOD",
    "wallets": [],
    "client_secret": "pay_13yS6rPTfz2flIVwTdOD_secret_LDRqGrN0l1Oepne0sswI"
}'
```
```
{
    "payment_id": "pay_9dkYqqMjqhB6HVEdmtH8",
    "client_secret": "pay_9dkYqqMjqhB6HVEdmtH8_secret_yLYrfUXwlbhz1WTcwAZ0",
    "session_token": [
        {
            "wallet_name": "google_pay",
            "merchant_info": {
                "merchant_name": "Stripe"
            },
            "shipping_address_required": false,
            "email_required": false,
            "shipping_address_parameters": {
                "phone_number_required": false
            },
            "allowed_payment_methods": [
                {
                    "type": "CARD",
                    "parameters": {
                        "allowed_auth_methods": [
                            "PAN_ONLY",
                            "CRYPTOGRAM_3DS"
                        ],
                        "allowed_card_networks": [
                            "AMEX",
                            "DISCOVER",
                            "INTERAC",
                            "JCB",
                            "MASTERCARD",
                            "VISA"
                        ],
                        "billing_address_required": false
                    },
                    "tokenization_specification": {
                        "type": "PAYMENT_GATEWAY",
                        "parameters": {
                            "gateway": "stripe",
                            "stripe:version": "2018-10-31",
                            "stripe:publishableKey": "pk_test_51Msk2GAGHc77EJXX78h549SX2uaOnEkUYqBfjcoD05PIpAnDkYxMn8nQ4d19im85NQuX4Z6WDyHaUw2fFTPBWsIY00Wa7oNerO"
                        }
                    }
                }
            ],
            "transaction_info": {
                "country_code": "US",
                "currency_code": "USD",
                "total_price_status": "Final",
                "total_price": "61.00"
            },
            "delayed_session_token": false,
            "connector": "cybersource",
            "sdk_next_action": {
                "next_action": "confirm"
            },
            "secrets": null
        },
        {
            "wallet_name": "samsung_pay",
            "version": "2",
            "service_id": "49400558c67f4a97b3925f",
            "order_number": "pay-9dkYqqMjqhB6HVEdmtH8",
            "merchant": {
                "name": "Hyperswitch",
                "url": null,
                "country_code": "IN"
            },
            "amount": {
                "option": "FORMAT_TOTAL_PRICE_ONLY",
                "currency_code": "USD",
                "total": "61.00"
            },
            "protocol": "PROTOCOL3DS",
            "allowed_brands": [
                "visa",
                "masterCard",
                "amex",
                "discover"
            ]
        },
        {
            "wallet_name": "apple_pay",
            "session_token_data": {
                "epoch_timestamp": 1731058299555,
                "expires_at": 1731061899555,
                "merchant_session_identifier": "SSH56D7E29D55C14575B8A72585526E9989_7E0DD1295E42A30B376B18CB4E6B9B9FB4C5E36B3EDF9FB0DEA51F9419420173",
                "nonce": "bee270b5",
                "merchant_identifier": "A73398AA267417BF8F26F7168B22908662D517F8FF2FC31C76CBF7511F572AB8",
                "domain_name": "hyperswitch-demo-store.netlify.app",
                "display_name": "Shankar",
                "signature": "308006092a864886f70d010702a0803080020101310d300b0609608648016503040201308006092a864886f70d0107010000a080308203e330820388a003020102020816634c8b0e305717300a06082a8648ce3d040302307a312e302c06035504030c254170706c65204170706c69636174696f6e20496e746567726174696f6e204341202d20473331263024060355040b0c1d4170706c652043657274696669636174696f6e20417574686f7269747931133011060355040a0c0a4170706c6520496e632e310b3009060355040613025553301e170d3234303432393137343732375a170d3239303432383137343732365a305f3125302306035504030c1c6563632d736d702d62726f6b65722d7369676e5f5543342d50524f4431143012060355040b0c0b694f532053797374656d7331133011060355040a0c0a4170706c6520496e632e310b30090603550406130255533059301306072a8648ce3d020106082a8648ce3d03010703420004c21577edebd6c7b2218f68dd7090a1218dc7b0bd6f2c283d846095d94af4a5411b83420ed811f3407e83331f1c54c3f7eb3220d6bad5d4eff49289893e7c0f13a38202113082020d300c0603551d130101ff04023000301f0603551d2304183016801423f249c44f93e4ef27e6c4f6286c3fa2bbfd2e4b304506082b0601050507010104393037303506082b060105050730018629687474703a2f2f6f6373702e6170706c652e636f6d2f6f63737030342d6170706c65616963613330323082011d0603551d2004820114308201103082010c06092a864886f7636405013081fe3081c306082b060105050702023081b60c81b352656c69616e6365206f6e207468697320636572746966696361746520627920616e7920706172747920617373756d657320616363657074616e6365206f6620746865207468656e206170706c696361626c65207374616e64617264207465726d7320616e6420636f6e646974696f6e73206f66207573652c20636572746966696361746520706f6c69637920616e642063657274696669636174696f6e2070726163746963652073746174656d656e74732e303606082b06010505070201162a687474703a2f2f7777772e6170706c652e636f6d2f6365727469666963617465617574686f726974792f30340603551d1f042d302b3029a027a0258623687474703a2f2f63726c2e6170706c652e636f6d2f6170706c6561696361332e63726c301d0603551d0e041604149457db6fd57481868989762f7e578507e79b5824300e0603551d0f0101ff040403020780300f06092a864886f76364061d04020500300a06082a8648ce3d0403020349003046022100c6f023cb2614bb303888a162983e1a93f1056f50fa78cdb9ba4ca241cc14e25e022100be3cd0dfd16247f6494475380e9d44c228a10890a3a1dc724b8b4cb8889818bc308202ee30820275a0030201020208496d2fbf3a98da97300a06082a8648ce3d0403023067311b301906035504030c124170706c6520526f6f74204341202d20473331263024060355040b0c1d4170706c652043657274696669636174696f6e20417574686f7269747931133011060355040a0c0a4170706c6520496e632e310b3009060355040613025553301e170d3134303530363233343633305a170d3239303530363233343633305a307a312e302c06035504030c254170706c65204170706c69636174696f6e20496e746567726174696f6e204341202d20473331263024060355040b0c1d4170706c652043657274696669636174696f6e20417574686f7269747931133011060355040a0c0a4170706c6520496e632e310b30090603550406130255533059301306072a8648ce3d020106082a8648ce3d03010703420004f017118419d76485d51a5e25810776e880a2efde7bae4de08dfc4b93e13356d5665b35ae22d097760d224e7bba08fd7617ce88cb76bb6670bec8e82984ff5445a381f73081f4304606082b06010505070101043a3038303606082b06010505073001862a687474703a2f2f6f6373702e6170706c652e636f6d2f6f63737030342d6170706c65726f6f7463616733301d0603551d0e0416041423f249c44f93e4ef27e6c4f6286c3fa2bbfd2e4b300f0603551d130101ff040530030101ff301f0603551d23041830168014bbb0dea15833889aa48a99debebdebafdacb24ab30370603551d1f0430302e302ca02aa0288626687474703a2f2f63726c2e6170706c652e636f6d2f6170706c65726f6f74636167332e63726c300e0603551d0f0101ff0404030201063010060a2a864886f7636406020e04020500300a06082a8648ce3d040302036700306402303acf7283511699b186fb35c356ca62bff417edd90f754da28ebef19c815e42b789f898f79b599f98d5410d8f9de9c2fe0230322dd54421b0a305776c5df3383b9067fd177c2c216d964fc6726982126f54f87a7d1b99cb9b0989216106990f09921d00003182018830820184020101308186307a312e302c06035504030c254170706c65204170706c69636174696f6e20496e746567726174696f6e204341202d20473331263024060355040b0c1d4170706c652043657274696669636174696f6e20417574686f7269747931133011060355040a0c0a4170706c6520496e632e310b3009060355040613025553020816634c8b0e305717300b0609608648016503040201a08193301806092a864886f70d010903310b06092a864886f70d010701301c06092a864886f70d010905310f170d3234313130383039333133395a302806092a864886f70d010934311b3019300b0609608648016503040201a10a06082a8648ce3d040302302f06092a864886f70d01090431220420a43222765aad8e37be22057b06a5ff6b4a889b86eb254c8388ecfeb483bd2d20300a06082a8648ce3d04030204473045022005d15b2d109fff00c1f25743f54b973fc0868648bdfde0a53cb08c1b9f618dca022100b68baa956928c8ef13aeadf335868abefabd1ca358e546901d0a53961018187d000000000000",
                "operational_analytics_identifier": "Shankar:A73398AA267417BF8F26F7168B22908662D517F8FF2FC31C76CBF7511F572AB8",
                "retries": 0,
                "psp_id": "A73398AA267417BF8F26F7168B22908662D517F8FF2FC31C76CBF7511F572AB8"
            },
            "payment_request_data": {
                "country_code": "US",
                "currency_code": "USD",
                "total": {
                    "label": "applepay",
                    "type": "final",
                    "amount": "61.00"
                },
                "merchant_capabilities": [
                    "supports3DS"
                ],
                "supported_networks": [
                    "visa",
                    "masterCard",
                    "amex",
                    "discover"
                ],
                "merchant_identifier": "merchant.test.fb"
            },
            "connector": "cybersource",
            "delayed_session_token": false,
            "sdk_next_action": {
                "next_action": "confirm"
            },
            "connector_reference_id": null,
            "connector_sdk_public_key": null,
            "connector_merchant_id": null
        }
    ]
}
```

-> Now update the mca with different apple pay session data and make the session call
```
{
    "payment_id": "pay_9dkYqqMjqhB6HVEdmtH8",
    "client_secret": "pay_9dkYqqMjqhB6HVEdmtH8_secret_yLYrfUXwlbhz1WTcwAZ0",
    "session_token": [
        {
            "wallet_name": "google_pay",
            "merchant_info": {
                "merchant_name": "Stripe"
            },
            "shipping_address_required": false,
            "email_required": false,
            "shipping_address_parameters": {
                "phone_number_required": false
            },
            "allowed_payment_methods": [
                {
                    "type": "CARD",
                    "parameters": {
                        "allowed_auth_methods": [
                            "PAN_ONLY",
                            "CRYPTOGRAM_3DS"
                        ],
                        "allowed_card_networks": [
                            "AMEX",
                            "DISCOVER",
                            "INTERAC",
                            "JCB",
                            "MASTERCARD",
                            "VISA"
                        ],
                        "billing_address_required": false
                    },
                    "tokenization_specification": {
                        "type": "PAYMENT_GATEWAY",
                        "parameters": {
                            "gateway": "stripe",
                            "stripe:version": "2018-10-31",
                            "stripe:publishableKey": "pk_test_51Msk2GAGHc77EJXX78h549SX2uaOnEkUYqBfjcoD05PIpAnDkYxMn8nQ4d19im85NQuX4Z6WDyHaUw2fFTPBWsIY00Wa7oNerO"
                        }
                    }
                }
            ],
            "transaction_info": {
                "country_code": "US",
                "currency_code": "USD",
                "total_price_status": "Final",
                "total_price": "61.00"
            },
            "delayed_session_token": false,
            "connector": "cybersource",
            "sdk_next_action": {
                "next_action": "confirm"
            },
            "secrets": null
        },
        {
            "wallet_name": "apple_pay",
            "session_token_data": {
                "epoch_timestamp": 1731058447406,
                "expires_at": 1731062047406,
                "merchant_session_identifier": "SSH9AE703AD4E89431CA6995DEB16AECED6_A0E617ED4A56A343E07C6E1255BD4098423B3A8E1243236462D07B14B4A0F7C3",
                "nonce": "1ccfd4d4",
                "merchant_identifier": "A73398AA267417BF8F26F7168B22908662D517F8FF2FC31C76CBF7511F572AB8",
                "domain_name": "hyperswitch-demo-store.netlify.app",
                "display_name": "hyperswitch",
                "signature": "308006092a864886f70d010702a0803080020101310d300b0609608648016503040201308006092a864886f70d0107010000a080308203e330820388a003020102020816634c8b0e305717300a06082a8648ce3d040302307a312e302c06035504030c254170706c65204170706c69636174696f6e20496e746567726174696f6e204341202d20473331263024060355040b0c1d4170706c652043657274696669636174696f6e20417574686f7269747931133011060355040a0c0a4170706c6520496e632e310b3009060355040613025553301e170d3234303432393137343732375a170d3239303432383137343732365a305f3125302306035504030c1c6563632d736d702d62726f6b65722d7369676e5f5543342d50524f4431143012060355040b0c0b694f532053797374656d7331133011060355040a0c0a4170706c6520496e632e310b30090603550406130255533059301306072a8648ce3d020106082a8648ce3d03010703420004c21577edebd6c7b2218f68dd7090a1218dc7b0bd6f2c283d846095d94af4a5411b83420ed811f3407e83331f1c54c3f7eb3220d6bad5d4eff49289893e7c0f13a38202113082020d300c0603551d130101ff04023000301f0603551d2304183016801423f249c44f93e4ef27e6c4f6286c3fa2bbfd2e4b304506082b0601050507010104393037303506082b060105050730018629687474703a2f2f6f6373702e6170706c652e636f6d2f6f63737030342d6170706c65616963613330323082011d0603551d2004820114308201103082010c06092a864886f7636405013081fe3081c306082b060105050702023081b60c81b352656c69616e6365206f6e207468697320636572746966696361746520627920616e7920706172747920617373756d657320616363657074616e6365206f6620746865207468656e206170706c696361626c65207374616e64617264207465726d7320616e6420636f6e646974696f6e73206f66207573652c20636572746966696361746520706f6c69637920616e642063657274696669636174696f6e2070726163746963652073746174656d656e74732e303606082b06010505070201162a687474703a2f2f7777772e6170706c652e636f6d2f6365727469666963617465617574686f726974792f30340603551d1f042d302b3029a027a0258623687474703a2f2f63726c2e6170706c652e636f6d2f6170706c6561696361332e63726c301d0603551d0e041604149457db6fd57481868989762f7e578507e79b5824300e0603551d0f0101ff040403020780300f06092a864886f76364061d04020500300a06082a8648ce3d0403020349003046022100c6f023cb2614bb303888a162983e1a93f1056f50fa78cdb9ba4ca241cc14e25e022100be3cd0dfd16247f6494475380e9d44c228a10890a3a1dc724b8b4cb8889818bc308202ee30820275a0030201020208496d2fbf3a98da97300a06082a8648ce3d0403023067311b301906035504030c124170706c6520526f6f74204341202d20473331263024060355040b0c1d4170706c652043657274696669636174696f6e20417574686f7269747931133011060355040a0c0a4170706c6520496e632e310b3009060355040613025553301e170d3134303530363233343633305a170d3239303530363233343633305a307a312e302c06035504030c254170706c65204170706c69636174696f6e20496e746567726174696f6e204341202d20473331263024060355040b0c1d4170706c652043657274696669636174696f6e20417574686f7269747931133011060355040a0c0a4170706c6520496e632e310b30090603550406130255533059301306072a8648ce3d020106082a8648ce3d03010703420004f017118419d76485d51a5e25810776e880a2efde7bae4de08dfc4b93e13356d5665b35ae22d097760d224e7bba08fd7617ce88cb76bb6670bec8e82984ff5445a381f73081f4304606082b06010505070101043a3038303606082b06010505073001862a687474703a2f2f6f6373702e6170706c652e636f6d2f6f63737030342d6170706c65726f6f7463616733301d0603551d0e0416041423f249c44f93e4ef27e6c4f6286c3fa2bbfd2e4b300f0603551d130101ff040530030101ff301f0603551d23041830168014bbb0dea15833889aa48a99debebdebafdacb24ab30370603551d1f0430302e302ca02aa0288626687474703a2f2f63726c2e6170706c652e636f6d2f6170706c65726f6f74636167332e63726c300e0603551d0f0101ff0404030201063010060a2a864886f7636406020e04020500300a06082a8648ce3d040302036700306402303acf7283511699b186fb35c356ca62bff417edd90f754da28ebef19c815e42b789f898f79b599f98d5410d8f9de9c2fe0230322dd54421b0a305776c5df3383b9067fd177c2c216d964fc6726982126f54f87a7d1b99cb9b0989216106990f09921d00003182018830820184020101308186307a312e302c06035504030c254170706c65204170706c69636174696f6e20496e746567726174696f6e204341202d20473331263024060355040b0c1d4170706c652043657274696669636174696f6e20417574686f7269747931133011060355040a0c0a4170706c6520496e632e310b3009060355040613025553020816634c8b0e305717300b0609608648016503040201a08193301806092a864886f70d010903310b06092a864886f70d010701301c06092a864886f70d010905310f170d3234313130383039333430375a302806092a864886f70d010934311b3019300b0609608648016503040201a10a06082a8648ce3d040302302f06092a864886f70d01090431220420aba73465373dde2c582d797f825db72d3cc16bde7b453859381fbe56ea62a66b300a06082a8648ce3d040302044730450221008c76d246dbd8929261aea7a0035b005213d065c8a3ac66339e66ecacdfc589e202200360ac83bb14a1954cfe02f0aef3213d3310a3fef863894bb47e21cea2a39631000000000000",
                "operational_analytics_identifier": "hyperswitch:A73398AA267417BF8F26F7168B22908662D517F8FF2FC31C76CBF7511F572AB8",
                "retries": 0,
                "psp_id": "A73398AA267417BF8F26F7168B22908662D517F8FF2FC31C76CBF7511F572AB8"
            },
            "payment_request_data": {
                "country_code": "US",
                "currency_code": "USD",
                "total": {
                    "label": "applepay",
                    "type": "final",
                    "amount": "61.00"
                },
                "merchant_capabilities": [
                    "supports3DS"
                ],
                "supported_networks": [
                    "visa",
                    "masterCard",
                    "amex",
                    "discover"
                ],
                "merchant_identifier": "merchant.test.fb"
            },
            "connector": "cybersource",
            "delayed_session_token": false,
            "sdk_next_action": {
                "next_action": "confirm"
            },
            "connector_reference_id": null,
            "connector_sdk_public_key": null,
            "connector_merchant_id": null
        }
    ]
}
```

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
