### PR TITLE
fix(router): get apple pay certificates only from metadata during the session call

### DIFF
--- a/crates/router/src/core/payments/flows/session_flow.rs
+++ b/crates/router/src/core/payments/flows/session_flow.rs
@@ -189,20 +189,11 @@ async fn create_applepay_session_token(
         )
     } else {
         // Get the apple pay metadata
-        let connector_apple_pay_wallet_details =
-            helpers::get_applepay_metadata(router_data.connector_wallets_details.clone())
-                .map_err(|error| {
-                    logger::debug!(
-                        "Apple pay connector wallets details parsing failed in create_applepay_session_token {:?}",
-                        error
-                    )
-                })
-                .ok();
-
-        let apple_pay_metadata = match connector_apple_pay_wallet_details {
-            Some(apple_pay_wallet_details) => apple_pay_wallet_details,
-            None => helpers::get_applepay_metadata(router_data.connector_meta_data.clone())?,
-        };
+        let apple_pay_metadata =
+            helpers::get_applepay_metadata(router_data.connector_meta_data.clone())
+                .attach_printable(
+                    "Failed to to fetch apple pay certificates during session call",
+                )?;
 
         // Get payment request data , apple pay session request and merchant keys
         let (


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
