### PR TITLE
refactor(routing): remove payment_id from dynamic_routing metrics

### DIFF
--- a/crates/router/src/core/routing/helpers.rs
+++ b/crates/router/src/core/routing/helpers.rs
@@ -760,7 +760,6 @@ pub async fn push_metrics_with_update_window_for_success_based_routing(
                         payment_attempt.profile_id.get_string_repr()
                     ),
                 ),
-                ("merchant_connector_id", merchant_connector_id.to_string()),
                 (
                     "success_based_routing_connector",
                     first_success_based_connector.to_string(),

--- a/crates/router/src/core/routing/helpers.rs
+++ b/crates/router/src/core/routing/helpers.rs
@@ -753,18 +753,14 @@ pub async fn push_metrics_with_update_window_for_success_based_routing(
             &add_attributes([
                 ("tenant", state.tenant.tenant_id.clone()),
                 (
-                    "merchant_id",
-                    payment_attempt.merchant_id.get_string_repr().to_string(),
-                ),
-                (
-                    "profile_id",
-                    payment_attempt.profile_id.get_string_repr().to_string(),
+                    "merchant_profile_id",
+                    format!(
+                        "{}{}",
+                        payment_attempt.merchant_id.get_string_repr().to_string(),
+                        payment_attempt.profile_id.get_string_repr().to_string()
+                    ),
                 ),
                 ("merchant_connector_id", merchant_connector_id.to_string()),
-                (
-                    "payment_id",
-                    payment_attempt.payment_id.get_string_repr().to_string(),
-                ),
                 (
                     "success_based_routing_connector",
                     first_success_based_connector.to_string(),

--- a/crates/router/src/core/routing/helpers.rs
+++ b/crates/router/src/core/routing/helpers.rs
@@ -756,8 +756,8 @@ pub async fn push_metrics_with_update_window_for_success_based_routing(
                     "merchant_profile_id",
                     format!(
                         "{}:{}",
-                        payment_attempt.merchant_id.get_string_repr().to_string(),
-                        payment_attempt.profile_id.get_string_repr().to_string()
+                        payment_attempt.merchant_id.get_string_repr(),
+                        payment_attempt.profile_id.get_string_repr()
                     ),
                 ),
                 ("merchant_connector_id", merchant_connector_id.to_string()),

--- a/crates/router/src/core/routing/helpers.rs
+++ b/crates/router/src/core/routing/helpers.rs
@@ -733,7 +733,7 @@ pub async fn push_metrics_with_update_window_for_success_based_routing(
             .label
             .to_string();
 
-        let (first_success_based_connector, merchant_connector_id) = first_success_based_connector_label
+        let (first_success_based_connector, _) = first_success_based_connector_label
             .split_once(':')
             .ok_or(errors::ApiErrorResponse::InternalServerError)
             .attach_printable(format!(

--- a/crates/router/src/core/routing/helpers.rs
+++ b/crates/router/src/core/routing/helpers.rs
@@ -755,7 +755,7 @@ pub async fn push_metrics_with_update_window_for_success_based_routing(
                 (
                     "merchant_profile_id",
                     format!(
-                        "{}{}",
+                        "{}:{}",
                         payment_attempt.merchant_id.get_string_repr().to_string(),
                         payment_attempt.profile_id.get_string_repr().to_string()
                     ),


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
This will remove payment_id from being pushed to dynamic_routing metrics

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
This can be tested on SBX in the dynamic_routing Dashboard present on grafana dashboard,
There shouldn't be payment_id and the merchant_id should be merged with profile_id

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
