### PR TITLE
refactor(core): add profile_id for default_fallback api

### DIFF
--- a/crates/router/src/core/routing.rs
+++ b/crates/router/src/core/routing.rs
@@ -917,10 +917,9 @@ pub async fn retrieve_default_routing_config(
 ) -> RouterResponse<Vec<routing_types::RoutableConnectorChoice>> {
     metrics::ROUTING_RETRIEVE_DEFAULT_CONFIG.add(&metrics::CONTEXT, 1, &[]);
     let db = state.store.as_ref();
-    let id = profile_id.map(|profile_id| 
-        profile_id.get_string_repr().to_owned())
-        .unwrap_or_else(|| 
-            merchant_account.get_id().get_string_repr().to_string());
+    let id = profile_id
+        .map(|profile_id| profile_id.get_string_repr().to_owned())
+        .unwrap_or_else(|| merchant_account.get_id().get_string_repr().to_string());
 
     helpers::get_merchant_default_config(db, &id, transaction_type)
         .await

--- a/crates/router/src/core/routing.rs
+++ b/crates/router/src/core/routing.rs
@@ -909,26 +909,26 @@ pub async fn retrieve_default_fallback_algorithm_for_profile(
 }
 
 #[cfg(feature = "v1")]
-
 pub async fn retrieve_default_routing_config(
     state: SessionState,
-    merchant_account: domain::MerchantAccount,
+    profile_id: common_utils::id_type::ProfileId,
     transaction_type: &enums::TransactionType,
 ) -> RouterResponse<Vec<routing_types::RoutableConnectorChoice>> {
     metrics::ROUTING_RETRIEVE_DEFAULT_CONFIG.add(&metrics::CONTEXT, 1, &[]);
     let db = state.store.as_ref();
 
-    helpers::get_merchant_default_config(
-        db,
-        merchant_account.get_id().get_string_repr(),
-        transaction_type,
-    )
-    .await
-    .map(|conn_choice| {
-        metrics::ROUTING_RETRIEVE_DEFAULT_CONFIG_SUCCESS_RESPONSE.add(&metrics::CONTEXT, 1, &[]);
-        service_api::ApplicationResponse::Json(conn_choice)
-    })
+    helpers::get_merchant_default_config(db, profile_id.get_string_repr(), transaction_type)
+        .await
+        .map(|conn_choice| {
+            metrics::ROUTING_RETRIEVE_DEFAULT_CONFIG_SUCCESS_RESPONSE.add(
+                &metrics::CONTEXT,
+                1,
+                &[],
+            );
+            service_api::ApplicationResponse::Json(conn_choice)
+        })
 }
+
 #[cfg(feature = "v2")]
 pub async fn retrieve_routing_config_under_profile(
     state: SessionState,

--- a/crates/router/src/core/routing.rs
+++ b/crates/router/src/core/routing.rs
@@ -914,7 +914,9 @@ pub async fn retrieve_default_routing_config(
     profile_id: Option<common_utils::id_type::ProfileId>,
     transaction_type: &enums::TransactionType,
 ) -> RouterResponse<Vec<routing_types::RoutableConnectorChoice>> {
-    let profile_id = profile_id.ok_or(errors::ApiErrorResponse::GenericNotFoundError { message: "profile_id not found".to_string() })?;
+    let profile_id = profile_id.ok_or(errors::ApiErrorResponse::GenericNotFoundError {
+        message: "profile_id not found".to_string(),
+    })?;
     metrics::ROUTING_RETRIEVE_DEFAULT_CONFIG.add(&metrics::CONTEXT, 1, &[]);
     let db = state.store.as_ref();
 

--- a/crates/router/src/core/routing.rs
+++ b/crates/router/src/core/routing.rs
@@ -917,23 +917,12 @@ pub async fn retrieve_default_routing_config(
 ) -> RouterResponse<Vec<routing_types::RoutableConnectorChoice>> {
     metrics::ROUTING_RETRIEVE_DEFAULT_CONFIG.add(&metrics::CONTEXT, 1, &[]);
     let db = state.store.as_ref();
-    if let Some(profile_id) = profile_id {
-        helpers::get_merchant_default_config(db, profile_id.get_string_repr(), transaction_type)
-            .await
-            .map(|conn_choice| {
-                metrics::ROUTING_RETRIEVE_DEFAULT_CONFIG_SUCCESS_RESPONSE.add(
-                    &metrics::CONTEXT,
-                    1,
-                    &[],
-                );
-                service_api::ApplicationResponse::Json(conn_choice)
-            })
-    } else {
-        helpers::get_merchant_default_config(
-            db,
-            merchant_account.get_id().get_string_repr(),
-            transaction_type,
-        )
+    let id = profile_id.map(|profile_id| 
+        profile_id.get_string_repr().to_owned())
+        .unwrap_or_else(|| 
+            merchant_account.get_id().get_string_repr().to_string());
+
+    helpers::get_merchant_default_config(db, &id, transaction_type)
         .await
         .map(|conn_choice| {
             metrics::ROUTING_RETRIEVE_DEFAULT_CONFIG_SUCCESS_RESPONSE.add(
@@ -943,7 +932,6 @@ pub async fn retrieve_default_routing_config(
             );
             service_api::ApplicationResponse::Json(conn_choice)
         })
-    }
 }
 
 #[cfg(feature = "v2")]

--- a/crates/router/src/core/routing.rs
+++ b/crates/router/src/core/routing.rs
@@ -911,9 +911,10 @@ pub async fn retrieve_default_fallback_algorithm_for_profile(
 #[cfg(feature = "v1")]
 pub async fn retrieve_default_routing_config(
     state: SessionState,
-    profile_id: common_utils::id_type::ProfileId,
+    profile_id: Option<common_utils::id_type::ProfileId>,
     transaction_type: &enums::TransactionType,
 ) -> RouterResponse<Vec<routing_types::RoutableConnectorChoice>> {
+    let profile_id = profile_id.ok_or(errors::ApiErrorResponse::GenericNotFoundError { message: "profile_id not found".to_string() })?;
     metrics::ROUTING_RETRIEVE_DEFAULT_CONFIG.add(&metrics::CONTEXT, 1, &[]);
     let db = state.store.as_ref();
 

--- a/crates/router/src/core/routing.rs
+++ b/crates/router/src/core/routing.rs
@@ -919,17 +919,21 @@ pub async fn retrieve_default_routing_config(
     let db = state.store.as_ref();
     if let Some(profile_id) = profile_id {
         helpers::get_merchant_default_config(db, profile_id.get_string_repr(), transaction_type)
-        .await
-        .map(|conn_choice| {
-            metrics::ROUTING_RETRIEVE_DEFAULT_CONFIG_SUCCESS_RESPONSE.add(
-                &metrics::CONTEXT,
-                1,
-                &[],
-            );
-            service_api::ApplicationResponse::Json(conn_choice)
-        })
+            .await
+            .map(|conn_choice| {
+                metrics::ROUTING_RETRIEVE_DEFAULT_CONFIG_SUCCESS_RESPONSE.add(
+                    &metrics::CONTEXT,
+                    1,
+                    &[],
+                );
+                service_api::ApplicationResponse::Json(conn_choice)
+            })
     } else {
-        helpers::get_merchant_default_config(db, merchant_account.get_id().get_string_repr(), transaction_type)
+        helpers::get_merchant_default_config(
+            db,
+            merchant_account.get_id().get_string_repr(),
+            transaction_type,
+        )
         .await
         .map(|conn_choice| {
             metrics::ROUTING_RETRIEVE_DEFAULT_CONFIG_SUCCESS_RESPONSE.add(

--- a/crates/router/src/routes/app.rs
+++ b/crates/router/src/routes/app.rs
@@ -759,22 +759,14 @@ impl Routing {
                 },
             )))
             .service(
-                web::resource("/default")
-                    .route(web::get().to(|state, req| {
-                        routing::routing_retrieve_default_config(
-                            state,
-                            req,
-                            &TransactionType::Payment,
-                        )
-                    }))
-                    .route(web::post().to(|state, req, payload| {
-                        routing::routing_update_default_config(
-                            state,
-                            req,
-                            payload,
-                            &TransactionType::Payment,
-                        )
-                    })),
+                web::resource("/default").route(web::post().to(|state, req, payload| {
+                    routing::routing_update_default_config(
+                        state,
+                        req,
+                        payload,
+                        &TransactionType::Payment,
+                    )
+                })),
             )
             .service(
                 web::resource("/deactivate").route(web::post().to(|state, req, payload| {
@@ -794,8 +786,8 @@ impl Routing {
                     .route(web::delete().to(routing::delete_surcharge_decision_manager_config)),
             )
             .service(
-                web::resource("/default/profile/{profile_id}").route(web::post().to(
-                    |state, req, path, payload| {
+                web::resource("/default/profile/{profile_id}")
+                    .route(web::post().to(|state, req, path, payload| {
                         routing::routing_update_default_config_for_profile(
                             state,
                             req,
@@ -803,17 +795,15 @@ impl Routing {
                             payload,
                             &TransactionType::Payment,
                         )
-                    },
-                )),
-            )
-            .service(
-                web::resource("/default/profile").route(web::get().to(|state, req| {
-                    routing::routing_retrieve_default_config_for_profiles(
-                        state,
-                        req,
-                        &TransactionType::Payment,
-                    )
-                })),
+                    }))
+                    .route(web::get().to(|state, req, path| {
+                        routing::routing_retrieve_default_config(
+                            state,
+                            req,
+                            path,
+                            &TransactionType::Payment,
+                        )
+                    })),
             );
 
         #[cfg(feature = "payouts")]
@@ -861,11 +851,12 @@ impl Routing {
                     },
                 )))
                 .service(
-                    web::resource("/payouts/default")
-                        .route(web::get().to(|state, req| {
+                    web::resource("/payouts/default/{profile_id}")
+                        .route(web::get().to(|state, req, path| {
                             routing::routing_retrieve_default_config(
                                 state,
                                 req,
+                                path,
                                 &TransactionType::Payout,
                             )
                         }))

--- a/crates/router/src/routes/app.rs
+++ b/crates/router/src/routes/app.rs
@@ -759,15 +759,14 @@ impl Routing {
                 },
             )))
             .service(
-                web::resource("/default")
-                    .route(web::post().to(|state, req, payload| {
-                        routing::routing_update_default_config(
-                            state,
-                            req,
-                            payload,
-                            &TransactionType::Payment,
-                        )
-                    })),
+                web::resource("/default").route(web::post().to(|state, req, payload| {
+                    routing::routing_update_default_config(
+                        state,
+                        req,
+                        payload,
+                        &TransactionType::Payment,
+                    )
+                })),
             )
             .service(
                 web::resource("/deactivate").route(web::post().to(|state, req, payload| {
@@ -800,13 +799,8 @@ impl Routing {
                 )),
             )
             .service(
-                web::resource("/default/profile").route(web::get().to(
-                    |state, req| {
-                    routing::routing_retrieve_default_config(
-                        state,
-                        req,
-                        &TransactionType::Payment,
-                    )
+                web::resource("/default/profile").route(web::get().to(|state, req| {
+                    routing::routing_retrieve_default_config(state, req, &TransactionType::Payment)
                 })),
             );
 

--- a/crates/router/src/routes/app.rs
+++ b/crates/router/src/routes/app.rs
@@ -759,14 +759,15 @@ impl Routing {
                 },
             )))
             .service(
-                web::resource("/default").route(web::post().to(|state, req, payload| {
-                    routing::routing_update_default_config(
-                        state,
-                        req,
-                        payload,
-                        &TransactionType::Payment,
-                    )
-                })),
+                web::resource("/default")
+                    .route(web::post().to(|state, req, payload| {
+                        routing::routing_update_default_config(
+                            state,
+                            req,
+                            payload,
+                            &TransactionType::Payment,
+                        )
+                    })),
             )
             .service(
                 web::resource("/deactivate").route(web::post().to(|state, req, payload| {
@@ -786,8 +787,8 @@ impl Routing {
                     .route(web::delete().to(routing::delete_surcharge_decision_manager_config)),
             )
             .service(
-                web::resource("/default/profile/{profile_id}")
-                    .route(web::post().to(|state, req, path, payload| {
+                web::resource("/default/profile/{profile_id}").route(web::post().to(
+                    |state, req, path, payload| {
                         routing::routing_update_default_config_for_profile(
                             state,
                             req,
@@ -795,15 +796,18 @@ impl Routing {
                             payload,
                             &TransactionType::Payment,
                         )
-                    }))
-                    .route(web::get().to(|state, req, path| {
-                        routing::routing_retrieve_default_config(
-                            state,
-                            req,
-                            path,
-                            &TransactionType::Payment,
-                        )
-                    })),
+                    },
+                )),
+            )
+            .service(
+                web::resource("/default/profile").route(web::get().to(
+                    |state, req| {
+                    routing::routing_retrieve_default_config(
+                        state,
+                        req,
+                        &TransactionType::Payment,
+                    )
+                })),
             );
 
         #[cfg(feature = "payouts")]
@@ -851,12 +855,11 @@ impl Routing {
                     },
                 )))
                 .service(
-                    web::resource("/payouts/default/{profile_id}")
-                        .route(web::get().to(|state, req, path| {
+                    web::resource("/payouts/default")
+                        .route(web::get().to(|state, req| {
                             routing::routing_retrieve_default_config(
                                 state,
                                 req,
-                                path,
                                 &TransactionType::Payout,
                             )
                         }))

--- a/crates/router/src/routes/routing.rs
+++ b/crates/router/src/routes/routing.rs
@@ -565,7 +565,7 @@ pub async fn routing_retrieve_default_config(
         &req,
         (),
         |state, auth: auth::AuthenticationData, _, _| {
-            routing::retrieve_default_routing_config(state, auth.profile_id, transaction_type)
+            routing::retrieve_default_routing_config(state, auth.profile_id, auth.merchant_account, transaction_type)
         },
         &auth::JWTAuth {
             permission: Permission::ProfileRoutingRead,

--- a/crates/router/src/routes/routing.rs
+++ b/crates/router/src/routes/routing.rs
@@ -565,7 +565,12 @@ pub async fn routing_retrieve_default_config(
         &req,
         (),
         |state, auth: auth::AuthenticationData, _, _| {
-            routing::retrieve_default_routing_config(state, auth.profile_id, auth.merchant_account, transaction_type)
+            routing::retrieve_default_routing_config(
+                state,
+                auth.profile_id,
+                auth.merchant_account,
+                transaction_type,
+            )
         },
         &auth::JWTAuth {
             permission: Permission::ProfileRoutingRead,

--- a/crates/router/src/routes/routing.rs
+++ b/crates/router/src/routes/routing.rs
@@ -557,27 +557,31 @@ pub async fn routing_retrieve_default_config(
 pub async fn routing_retrieve_default_config(
     state: web::Data<AppState>,
     req: HttpRequest,
+    path: web::Path<common_utils::id_type::ProfileId>,
     transaction_type: &enums::TransactionType,
 ) -> impl Responder {
+    let path = path.into_inner();
     Box::pin(oss_api::server_wrap(
         Flow::RoutingRetrieveDefaultConfig,
         state,
         &req,
-        (),
-        |state, auth: auth::AuthenticationData, _, _| {
-            routing::retrieve_default_routing_config(state, auth.merchant_account, transaction_type)
+        path.clone(),
+        |state, _, profile_id, _| {
+            routing::retrieve_default_routing_config(state, profile_id, transaction_type)
         },
         #[cfg(not(feature = "release"))]
         auth::auth_type(
             &auth::HeaderAuth(auth::ApiKeyAuth),
-            &auth::JWTAuth {
-                permission: Permission::ProfileRoutingRead,
+            &auth::JWTAuthProfileFromRoute {
+                profile_id: path,
+                required_permission: Permission::ProfileRoutingRead,
             },
             req.headers(),
         ),
         #[cfg(feature = "release")]
-        &auth::JWTAuth {
-            permission: Permission::ProfileRoutingRead,
+        &auth::JWTAuthProfileFromRoute {
+            profile_id: path,
+            required_permission: Permission::ProfileRoutingRead,
         },
         api_locking::LockAction::NotApplicable,
     ))


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
This will refactor the route `routing/default/profile`
Previously the output for this route was the default fallback connectors from all the profiles, 
After this refactor it will have the fallback connectors only for the mentioned profile. If the `profile_id` is provided by the authentication layer, if not it will behave as previous by taking the `merchant_id` from auth layer.

Moreover we have removed 2 routes from backed as these were not being used(Dahboard as well as internal apis), hence were redundant.
GET `routing/default`
POST `routing/default`

### Additional Changes

- [x] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
Required by our Dashboard to move the api's under profile level

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
```
curl --location 'http://127.0.0.1:8080/routing/default/profile' \
--header 'Authorization: Bearer token
```
This should have the connectors from the mentioned profile only.
```
[
    {
        "connector": "bankofamerica",
        "merchant_connector_id": "mca_ADICIF9zh09TjnpUgusU"
    }
]
```

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
