### PR TITLE
feat(cypress): add test case for incorrect and empty card types

### DIFF
--- a/cypress-tests/cypress/e2e/PaymentTest/00021-Variations.cy.js
+++ b/cypress-tests/cypress/e2e/PaymentTest/00021-Variations.cy.js
@@ -145,6 +145,40 @@ describe("Corner cases", () => {
       );
     });
 
+    it("[Payment] Incorrect card type", () => {
+      let data = getConnectorDetails(globalState.get("commons"))["card_pm"][
+        "IncorrectCardType"
+      ];
+      let req_data = data["Request"];
+      let res_data = data["Response"];
+
+      cy.createConfirmPaymentTest(
+        paymentIntentBody,
+        req_data,
+        res_data,
+        "no_three_ds",
+        "automatic",
+        globalState
+      );
+    });
+
+    it("[Payment] Empty card type", () => {
+      let data = getConnectorDetails(globalState.get("commons"))["card_pm"][
+        "EmptyCardType"
+      ];
+      let req_data = data["Request"];
+      let res_data = data["Response"];
+
+      cy.createConfirmPaymentTest(
+        paymentIntentBody,
+        req_data,
+        res_data,
+        "no_three_ds",
+        "automatic",
+        globalState
+      );
+    });
+
     it("[Payment] Invalid `amount_to_capture`", () => {
       let data = getConnectorDetails(globalState.get("commons"))["card_pm"][
         "InvalidAmountToCapture"

--- a/cypress-tests/cypress/e2e/PaymentUtils/Commons.js
+++ b/cypress-tests/cypress/e2e/PaymentUtils/Commons.js
@@ -1229,6 +1229,79 @@ export const connectorDetails = {
         },
       },
     },
+    IncorrectCardType: {
+      Request: {
+        currency: "USD",
+        payment_method: "card",
+        payment_method_type: "debit",
+        setup_future_usage: "off_session",
+        confirm: true,
+        billing: {
+          address: {
+            line1: "1467",
+            line2: "Harrison Street",
+            line3: "Harrison Street",
+            city: "San Fransico",
+            state: "California",
+            zip: "94122",
+            country: "BR",
+            first_name: "john",
+            last_name: "doe",
+          },
+        },
+        payment_method_data: {
+          card: {
+            card_number: "4242424242424242",
+            card_exp_month: "01",
+            card_exp_year: "2034",
+            card_holder_name: "joseph Doe",
+            card_cvc: "123",
+          },
+        },
+      },
+      Response: {
+        status: 200,
+        body: {
+          payment_method_type: "credit",
+        },
+      },
+    },
+    EmptyCardType: {
+      Request: {
+        currency: "USD",
+        payment_method: "card",
+        setup_future_usage: "off_session",
+        confirm: true,
+        billing: {
+          address: {
+            line1: "1467",
+            line2: "Harrison Street",
+            line3: "Harrison Street",
+            city: "San Fransico",
+            state: "California",
+            zip: "94122",
+            country: "BR",
+            first_name: "john",
+            last_name: "doe",
+          },
+        },
+        payment_method_data: {
+          card: {
+            card_number: "4242424242424242",
+            card_exp_month: "01",
+            card_exp_year: "2034",
+            card_holder_name: "joseph Doe",
+            card_cvc: "123",
+          },
+        },
+      },
+      Response: {
+        status: 200,
+        body: {
+          payment_method_type: "credit",
+        },
+      },
+    },
     InvalidAmountToCapture: {
       Request: {
         currency: "USD",


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
Test cases for #6512 


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
Adds test cases for card types.


## How did you test it?
Locally.

![image](https://github.com/user-attachments/assets/3def75e5-bc0b-4ac5-9eaa-61abd028f4b1)



## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
