### PR TITLE
ci(cypress): Fix Iatapay Zero Auth Mandates Flow

### DIFF
--- a/cypress-tests/cypress/e2e/PaymentUtils/Iatapay.js
+++ b/cypress-tests/cypress/e2e/PaymentUtils/Iatapay.js
@@ -1,3 +1,11 @@
+const successfulNo3DSCardDetails = {
+  card_number: "4111111111111111",
+  card_exp_month: "03",
+  card_exp_year: "30",
+  card_holder_name: "John Doe",
+  card_cvc: "737",
+};
+
 export const connectorDetails = {
   bank_redirect_pm: {
     Ideal: {
@@ -35,6 +43,40 @@ export const connectorDetails = {
   },
   card_pm: {
     ZeroAuthMandate: {
+      Response: {
+        status: 501,
+        body: {
+          error: {
+            type: "invalid_request",
+            message: "Setup Mandate flow for Iatapay is not implemented",
+            code: "IR_00",
+          },
+        },
+      },
+    },
+    ZeroAuthPaymentIntent: {
+      Request: {
+        amount: 0,
+        setup_future_usage: "off_session",
+        currency: "USD",
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "requires_payment_method",
+          setup_future_usage: "off_session",
+        },
+      },
+    },
+    ZeroAuthConfirmPayment: {
+      Request: {
+        payment_type: "setup_mandate",
+        payment_method: "card",
+        payment_method_type: "credit",
+        payment_method_data: {
+          card: successfulNo3DSCardDetails,
+        },
+      },
       Response: {
         status: 501,
         body: {


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [x] CI/CD

## Description
Handled zero auth mandates for Iatapay connector in cypress automation


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
Zero auth payments test cases were failing for Iatapay

## How did you test it?

- Iatapay
<img width="710" alt="image" src="https://github.com/user-attachments/assets/268d1aae-9cbd-49c9-bdd5-93e9dd72890d">


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
