### PR TITLE
feat(connector): [Novalnet] Add support for disputes 

### DIFF
--- a/crates/hyperswitch_connectors/src/connectors/novalnet.rs
+++ b/crates/hyperswitch_connectors/src/connectors/novalnet.rs
@@ -37,7 +37,7 @@ use hyperswitch_interfaces::{
         ConnectorValidation,
     },
     configs::Connectors,
-    errors,
+    disputes, errors,
     events::connector_api_logs::ConnectorEvent,
     types::{self, Response},
     webhooks,
@@ -876,5 +876,45 @@ impl webhooks::IncomingWebhook for Novalnet {
         let notif = get_webhook_object_from_body(request.body)
             .change_context(errors::ConnectorError::WebhookResourceObjectNotFound)?;
         Ok(Box::new(notif))
+    }
+
+    fn get_dispute_details(
+        &self,
+        request: &webhooks::IncomingWebhookRequestDetails<'_>,
+    ) -> CustomResult<disputes::DisputePayload, errors::ConnectorError> {
+        let notif: transformers::NovalnetWebhookNotificationResponse =
+            get_webhook_object_from_body(request.body)
+                .change_context(errors::ConnectorError::WebhookBodyDecodingFailed)?;
+        let (amount, currency, reason, reason_code) = match notif.transaction {
+            novalnet::NovalnetWebhookTransactionData::CaptureTransactionData(data) => {
+                (data.amount, data.currency, None, None)
+            }
+            novalnet::NovalnetWebhookTransactionData::CancelTransactionData(data) => {
+                (data.amount, data.currency, None, None)
+            }
+
+            novalnet::NovalnetWebhookTransactionData::RefundsTransactionData(data) => {
+                (data.amount, data.currency, None, None)
+            }
+
+            novalnet::NovalnetWebhookTransactionData::SyncTransactionData(data) => {
+                (data.amount, data.currency, data.reason, data.reason_code)
+            }
+        };
+
+        let dispute_status =
+            novalnet::get_novalnet_dispute_status(notif.event.event_type).to_string();
+        Ok(disputes::DisputePayload {
+            amount: novalnet::option_to_result(amount)?.to_string(),
+            currency: novalnet::option_to_result(currency)?.to_string(),
+            dispute_stage: api_models::enums::DisputeStage::Dispute,
+            connector_dispute_id: notif.event.tid.to_string(),
+            connector_reason: reason,
+            connector_reason_code: reason_code,
+            challenge_required_by: None,
+            connector_status: dispute_status,
+            created_at: None,
+            updated_at: None,
+        })
     }
 }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [X] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
Added dispute support for novalnet.  Novalnet supports 2 webhook events for disputes
1. Chargeback 
2. Representment (dispute won)

Novalnet does not support emails/webhooks for Arbitration and Pre-Arbitration stages. 


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
https://github.com/juspay/hyperswitch-cloud

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

Tested locally with dispute webhook simulators given in novalnet documentation
**Chargeback webhook simulator:** https://developer.novalnet.com/asynchronousnotification/parameterspassed?payment=chargeback_creditcard_chargeback#parameter-list
**Representment webhook simulator:** https://developer.novalnet.com/asynchronousnotification/parameterspassed?payment=credit_creditcard_representment#parameter-list

**Chargeback webhook output**
<img width="1304" alt="Screenshot 2024-11-13 at 18 57 33" src="https://github.com/user-attachments/assets/5595648d-4fca-46e8-90d6-8921b94f11e0">

**Representment webhook output**
<img width="1304" alt="Screenshot 2024-11-13 at 18 59 13" src="https://github.com/user-attachments/assets/a8364b0f-daef-4a02-ad72-930dc6d3c64c">


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [X] I formatted the code `cargo +nightly fmt --all`
- [X] I addressed lints thrown by `cargo clippy`
- [X] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
