### PR TITLE
fix(analytics): fix `authentication_type` and `card_last_4` fields serialization for payment_intent_filters

### DIFF
--- a/crates/api_models/src/analytics/payment_intents.rs
+++ b/crates/api_models/src/analytics/payment_intents.rs
@@ -63,11 +63,15 @@ pub enum PaymentIntentDimensions {
     Currency,
     ProfileId,
     Connector,
+    #[strum(serialize = "authentication_type")]
+    #[serde(rename = "authentication_type")]
     AuthType,
     PaymentMethod,
     PaymentMethodType,
     CardNetwork,
     MerchantId,
+    #[strum(serialize = "card_last_4")]
+    #[serde(rename = "card_last_4")]
     CardLast4,
     CardIssuer,
     ErrorReason,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
There is a serialization issue for `card_last_4` and `authentication_type` fields when filters are getting applied for `PaymentIntentFilters`.
`card_last_4` was being processed as `card_last4` .
`auth_type` is being used to add the filters and not serialized into `Authentication_type`.

Made the changes to properly serialize `card_last_4` and `authentication_type` filters for `PaymentIntentFilters` now.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->

Fix the filters issue for some fields for Payment Intents.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
`authentication_type`:
Hit the curl for any metric of payment_intents (sessionized metrics):
```bash
curl --location 'http://localhost:8080/analytics/v2/org/metrics/payments' \
--header 'Accept: */*' \
--header 'Accept-Language: en-US,en;q=0.9' \
--header 'Connection: keep-alive' \
--header 'Content-Type: application/json' \
--header 'Origin: http://localhost:9000' \
--header 'QueryType: SingleStatTimeseries' \
--header 'Referer: http://localhost:9000/' \
--header 'Sec-Fetch-Dest: empty' \
--header 'Sec-Fetch-Mode: cors' \
--header 'Sec-Fetch-Site: same-site' \
--header 'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36' \
--header 'api-key: dev_LZcIA7XeMpnK5satp4CDvjcnHCaeKTBcosyuBBJaknZu1odhFo96cwS0nSdfzuJF' \
--header 'authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoiNTQ5ZTNkMmItMTY5Yi00NzUzLWJmNTQtZDcxMTM2YjRiN2JkIiwibWVyY2hhbnRfaWQiOiJtZXJjaGFudF8xNzI2MDQ2MzI4Iiwicm9sZV9pZCI6Im9yZ19hZG1pbiIsImV4cCI6MTczMjA4NzM4Miwib3JnX2lkIjoib3JnX1ZwU0hPanNZZkR2YWJWWUpnQ0FKIiwicHJvZmlsZV9pZCI6InByb192NXNGb0hlODBPZWlVbElvbm9jTSIsInRlbmFudF9pZCI6InB1YmxpYyJ9.3bV2aTF7uFAtELFBuKe-_hIZHY35Zv5ij51F-slCYIg' \
--header 'sec-ch-ua: "Chromium";v="128", "Not;A=Brand";v="24", "Google Chrome";v="128"' \
--header 'sec-ch-ua-mobile: ?0' \
--header 'sec-ch-ua-platform: "macOS"' \
--data '[
    {
        "timeRange": {
            "startTime": "2024-10-14T18:30:00Z",
            "endTime": "2024-10-22T15:24:00Z"
        },
        "groupByNames": [
            "currency"
        ],
        "filters": {
            "auth_type": [
                "no_three_ds"
            ]
        },
        "timeSeries": {
            "granularity": "G_ONEDAY"
        },
        "mode": "ORDER",
        "source": "BATCH",
        "metrics": [
            "sessionized_payment_processed_amount"
        ]
    }
]'
```
You can see the `authentication_type` filter that is getting applied in the query.
![Screenshot 2024-11-18 at 4 18 39 PM](https://github.com/user-attachments/assets/76815e78-8e10-4fbd-bda5-d96dcae51a01)

`card_last_4`:
Hit the curl for any metric of payment_intents (sessionized metrics):
```bash
curl --location 'http://localhost:8080/analytics/v2/org/metrics/payments' \
--header 'Accept: */*' \
--header 'Accept-Language: en-US,en;q=0.9' \
--header 'Connection: keep-alive' \
--header 'Content-Type: application/json' \
--header 'Origin: http://localhost:9000' \
--header 'QueryType: SingleStatTimeseries' \
--header 'Referer: http://localhost:9000/' \
--header 'Sec-Fetch-Dest: empty' \
--header 'Sec-Fetch-Mode: cors' \
--header 'Sec-Fetch-Site: same-site' \
--header 'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36' \
--header 'api-key: dev_LZcIA7XeMpnK5satp4CDvjcnHCaeKTBcosyuBBJaknZu1odhFo96cwS0nSdfzuJF' \
--header 'authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoiNTQ5ZTNkMmItMTY5Yi00NzUzLWJmNTQtZDcxMTM2YjRiN2JkIiwibWVyY2hhbnRfaWQiOiJtZXJjaGFudF8xNzI2MDQ2MzI4Iiwicm9sZV9pZCI6Im9yZ19hZG1pbiIsImV4cCI6MTczMjA4NzM4Miwib3JnX2lkIjoib3JnX1ZwU0hPanNZZkR2YWJWWUpnQ0FKIiwicHJvZmlsZV9pZCI6InByb192NXNGb0hlODBPZWlVbElvbm9jTSIsInRlbmFudF9pZCI6InB1YmxpYyJ9.3bV2aTF7uFAtELFBuKe-_hIZHY35Zv5ij51F-slCYIg' \
--header 'sec-ch-ua: "Chromium";v="128", "Not;A=Brand";v="24", "Google Chrome";v="128"' \
--header 'sec-ch-ua-mobile: ?0' \
--header 'sec-ch-ua-platform: "macOS"' \
--data '[
    {
        "timeRange": {
            "startTime": "2024-10-14T18:30:00Z",
            "endTime": "2024-10-22T15:24:00Z"
        },
        "groupByNames": [
            "currency"
        ],
        "filters": {
            "card_last_4": [
                "4242"
            ]
        },
        "timeSeries": {
            "granularity": "G_ONEDAY"
        },
        "mode": "ORDER",
        "source": "BATCH",
        "metrics": [
            "sessionized_payment_processed_amount"
        ]
    }
]'
```
You can see the `card_last_4` filter that is getting applied in the query.
![image](https://github.com/user-attachments/assets/8cd1f47b-0bb0-466a-8aac-632742c67612)


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
