### PR TITLE
fix(connector): [Adyen]fix error code and message for webhooks response

### DIFF
--- a/crates/router/src/connector/adyen/transformers.rs
+++ b/crates/router/src/connector/adyen/transformers.rs
@@ -3404,7 +3404,10 @@ pub fn get_adyen_response(
 > {
     let status =
         storage_enums::AttemptStatus::foreign_from((is_capture_manual, response.result_code, pmt));
-    let error = if response.refusal_reason.is_some() || response.refusal_reason_code.is_some() {
+    let error = if response.refusal_reason.is_some()
+        || response.refusal_reason_code.is_some()
+        || status == storage_enums::AttemptStatus::Failure
+    {
         Some(types::ErrorResponse {
             code: response
                 .refusal_reason_code
@@ -3467,7 +3470,10 @@ pub fn get_webhook_response(
         is_capture_manual,
         response.status.clone(),
     ))?;
-    let error = if response.refusal_reason.is_some() || response.refusal_reason_code.is_some() {
+    let error = if response.refusal_reason.is_some()
+        || response.refusal_reason_code.is_some()
+        || status == storage_enums::AttemptStatus::Failure
+    {
         Some(types::ErrorResponse {
             code: response
                 .refusal_reason_code
@@ -3533,7 +3539,10 @@ pub fn get_redirection_response(
         response.result_code.clone(),
         pmt,
     ));
-    let error = if response.refusal_reason.is_some() || response.refusal_reason_code.is_some() {
+    let error = if response.refusal_reason.is_some()
+        || response.refusal_reason_code.is_some()
+        || status == storage_enums::AttemptStatus::Failure
+    {
         Some(types::ErrorResponse {
             code: response
                 .refusal_reason_code
@@ -3605,7 +3614,10 @@ pub fn get_present_to_shopper_response(
         response.result_code.clone(),
         pmt,
     ));
-    let error = if response.refusal_reason.is_some() || response.refusal_reason_code.is_some() {
+    let error = if response.refusal_reason.is_some()
+        || response.refusal_reason_code.is_some()
+        || status == storage_enums::AttemptStatus::Failure
+    {
         Some(types::ErrorResponse {
             code: response
                 .refusal_reason_code
@@ -3663,7 +3675,10 @@ pub fn get_qr_code_response(
         response.result_code.clone(),
         pmt,
     ));
-    let error = if response.refusal_reason.is_some() || response.refusal_reason_code.is_some() {
+    let error = if response.refusal_reason.is_some()
+        || response.refusal_reason_code.is_some()
+        || status == storage_enums::AttemptStatus::Failure
+    {
         Some(types::ErrorResponse {
             code: response
                 .refusal_reason_code
@@ -4431,6 +4446,14 @@ pub struct AdyenIncomingWebhook {
 
 impl From<AdyenNotificationRequestItemWH> for AdyenWebhookResponse {
     fn from(notif: AdyenNotificationRequestItemWH) -> Self {
+        let (refusal_reason, refusal_reason_code) = if !is_success_scenario(notif.success.clone()) {
+            (
+                notif.reason.or(Some(consts::NO_ERROR_MESSAGE.to_string())),
+                Some(consts::NO_ERROR_CODE.to_string()),
+            )
+        } else {
+            (None, None)
+        };
         Self {
             transaction_id: notif.psp_reference,
             payment_reference: notif.original_reference,
@@ -4489,8 +4512,8 @@ impl From<AdyenNotificationRequestItemWH> for AdyenWebhookResponse {
                 currency: notif.amount.currency,
             }),
             merchant_reference_id: notif.merchant_reference,
-            refusal_reason: None,
-            refusal_reason_code: None,
+            refusal_reason,
+            refusal_reason_code,
             event_code: notif.event_code,
         }
     }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
For adyen incase of reponse update with webhooks,  we are hardcoding error code and message to none and while propagating checking whether error code & message is some, This pr fixes this bug .

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Make 3ds payment via adyen and cancel it in adyen simulator. block the redirect response in the browser so that payment is updated via webhook. Do a retrieve call error code & error message should be updated as per below response 

```
{
    "payment_id": "pay_xaWbqtvgCc8CuBKaMXmp",
    "merchant_id": "merchant_1731937042",
    "status": "failed",
    "amount": 2957000,
    "net_amount": 2957000,
    "shipping_cost": null,
    "amount_capturable": 0,
    "amount_received": null,
    "connector": "adyen",
    "client_secret": "pay_xaWbqtvgCc8CuBKaMXmp_secret_WZ701MiltGrC0FjAoOEB",
    "created": "2024-11-18T19:11:13.043Z",
    "currency": "AUD",
    "customer_id": null,
    "customer": {
        "id": null,
        "name": "John Doe",
        "email": "example@gmail.com",
        "phone": "999999999",
        "phone_country_code": "+1"
    },
    "description": "Its my first payment request",
    "refunds": null,
    "disputes": null,
    "mandate_id": null,
    "mandate_data": null,
    "setup_future_usage": null,
    "off_session": null,
    "capture_on": null,
    "capture_method": null,
    "payment_method": "card",
    "payment_method_data": {
        "card": {
            "last4": "0000",
            "card_type": null,
            "card_network": null,
            "card_issuer": null,
            "card_issuing_country": null,
            "card_isin": "491761",
            "card_extended_bin": null,
            "card_exp_month": "03",
            "card_exp_year": "30",
            "card_holder_name": null,
            "payment_checks": null,
            "authentication_data": null
        },
        "billing": {
            "address": {
                "city": "San Fransico",
                "country": "US",
                "line1": "1467",
                "line2": "CA",
                "line3": null,
                "zip": "94122",
                "state": "California",
                "first_name": null,
                "last_name": null
            },
            "phone": null,
            "email": null
        }
    },
    "payment_token": null,
    "shipping": null,
    "billing": null,
    "order_details": [
        {
            "brand": null,
            "amount": 110,
            "category": null,
            "quantity": 1,
            "product_id": null,
            "product_name": "Tea",
            "product_type": null,
            "sub_category": null,
            "product_img_link": "https://thumbs.dreamstime.com/b/indian-tea-spices-masala-chai-33827904.jpg",
            "product_tax_code": null,
            "requires_shipping": null
        },
        {
            "brand": null,
            "amount": 110,
            "category": null,
            "quantity": 1,
            "product_id": null,
            "product_name": "Tea",
            "product_type": null,
            "sub_category": null,
            "product_img_link": "https://thumbs.dreamstime.com/b/indian-tea-spices-masala-chai-33827904.jpg",
            "product_tax_code": null,
            "requires_shipping": null
        },
        {
            "brand": null,
            "amount": 110,
            "category": null,
            "quantity": 1,
            "product_id": null,
            "product_name": "Tea",
            "product_type": null,
            "sub_category": null,
            "product_img_link": "https://thumbs.dreamstime.com/b/indian-tea-spices-masala-chai-33827904.jpg",
            "product_tax_code": null,
            "requires_shipping": null
        }
    ],
    "email": null,
    "name": null,
    "phone": null,
    "return_url": "https://google.com/",
    "authentication_type": "no_three_ds",
    "statement_descriptor_name": null,
    "statement_descriptor_suffix": null,
    "next_action": null,
    "cancellation_reason": null,
    "error_code": "No error code",
    "error_message": "3D Not Authenticated",
    "unified_code": "UE_9000",
    "unified_message": "Something went wrong",
    "payment_experience": null,
    "payment_method_type": "credit",
    "connector_label": null,
    "business_country": null,
    "business_label": "default",
    "business_sub_label": null,
    "allowed_payment_method_types": null,
    "ephemeral_key": null,
    "manual_retry_allowed": true,
    "connector_transaction_id": "D254SLB5MMXNK375",
    "frm_message": null,
    "metadata": {
        "udf1": "value1",
        "login_date": "2019-09-10T10:11:12Z",
        "new_customer": "true"
    },
    "connector_metadata": null,
    "feature_metadata": null,
    "reference_id": "D254SLB5MMXNK375",
    "payment_link": null,
    "profile_id": "pro_dLWAHRDzKNSc5ukPbEJS",
    "surcharge_details": null,
    "attempt_count": 1,
    "merchant_decision": null,
    "merchant_connector_id": "mca_yMtIhWzBgAVAL8coVpvK",
    "incremental_authorization_allowed": false,
    "authorization_count": null,
    "incremental_authorizations": null,
    "external_authentication_details": null,
    "external_3ds_authentication_attempted": false,
    "expires_on": "2024-11-18T19:26:13.043Z",
    "fingerprint": null,
    "browser_info": {
        "language": "en-GB",
        "time_zone": -330,
        "ip_address": "208.127.127.193",
        "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36 Edg/126.0.0.0",
        "color_depth": 24,
        "java_enabled": true,
        "screen_width": 1280,
        "accept_header": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8",
        "screen_height": 720,
        "java_script_enabled": true
    },
    "payment_method_id": null,
    "payment_method_status": null,
    "updated": "2024-11-18T19:12:55.108Z",
    "charges": null,
    "frm_metadata": null,
    "merchant_order_reference_id": null,
    "order_tax_amount": null,
    "connector_mandate_id": null
}
```

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
