### PR TITLE
ci(cypress): Add Noon Connector

### DIFF
--- a/cypress-tests/cypress/e2e/PaymentUtils/Commons.js
+++ b/cypress-tests/cypress/e2e/PaymentUtils/Commons.js
@@ -18,6 +18,7 @@ function normalise(input) {
     paypal: "Paypal",
     wellsfargo: "Wellsfargo",
     fiuu: "Fiuu",
+    noon: "Noon"
     // Add more known exceptions here
   };
 

--- a/cypress-tests/cypress/e2e/PaymentUtils/Noon.js
+++ b/cypress-tests/cypress/e2e/PaymentUtils/Noon.js
@@ -484,6 +484,7 @@ export const connectorDetails = {
       Request: {
         amount: 0,
         setup_future_usage: "off_session",
+        currency: "AED",
       },
       Response: {
         status: 200,

--- a/cypress-tests/cypress/e2e/PaymentUtils/Noon.js
+++ b/cypress-tests/cypress/e2e/PaymentUtils/Noon.js
@@ -165,7 +165,9 @@ export const connectorDetails = {
         payment_method_data: {
           card: successfulThreeDSTestCardDetails,
         },
+        currency: "AED",
         customer_acceptance: null,
+        connector_metadata: connectorMetadata,
         setup_future_usage: "on_session",
       },
       Response: {

--- a/cypress-tests/cypress/e2e/PaymentUtils/Noon.js
+++ b/cypress-tests/cypress/e2e/PaymentUtils/Noon.js
@@ -73,7 +73,7 @@ const payment_method_data_no3ds = {
     card_isin: "424242",
     card_extended_bin: null,
     card_exp_month: "01",
-    card_exp_year: "25",
+    card_exp_year: "30",
     card_holder_name: null,
     payment_checks: {
       avs_response: {
@@ -97,7 +97,7 @@ const payment_method_data_3ds = {
     card_isin: "400000",
     card_extended_bin: null,
     card_exp_month: "01",
-    card_exp_year: "25",
+    card_exp_year: "30",
     card_holder_name: null,
     payment_checks: null,
     authentication_data: null,

--- a/cypress-tests/cypress/e2e/PaymentUtils/Noon.js
+++ b/cypress-tests/cypress/e2e/PaymentUtils/Noon.js
@@ -1,0 +1,690 @@
+const successfulNo3DSCardDetails = {
+  card_number: "4242424242424242",
+  card_exp_month: "01",
+  card_exp_year: "25",
+  card_holder_name: "joseph Doe",
+  card_cvc: "123",
+};
+
+const successfulThreeDSTestCardDetails = {
+  card_number: "4000000000001091",
+  card_exp_month: "01",
+  card_exp_year: "25",
+  card_holder_name: "joseph Doe",
+  card_cvc: "123",
+};
+
+const customerAcceptance = {
+  acceptance_type: "offline",
+  accepted_at: "1963-05-03T04:07:52.723Z",
+  online: {
+    ip_address: "125.0.0.1",
+    user_agent: "amet irure esse",
+  },
+};
+
+const connectorMetadata = {
+  noon: {
+    order_category: "pay",
+  },
+};
+
+const singleUseMandateData = {
+  customer_acceptance: {
+    acceptance_type: "offline",
+    accepted_at: "1963-05-03T04:07:52.723Z",
+    online: {
+      ip_address: "125.0.0.1",
+      user_agent: "amet irure esse",
+    },
+  },
+  mandate_type: {
+    single_use: {
+      amount: 8000,
+      currency: "USD",
+    },
+  },
+};
+
+const multiUseMandateData = {
+  customer_acceptance: {
+    acceptance_type: "offline",
+    accepted_at: "1963-05-03T04:07:52.723Z",
+    online: {
+      ip_address: "125.0.0.1",
+      user_agent: "amet irure esse",
+    },
+  },
+  mandate_type: {
+    multi_use: {
+      amount: 8000,
+      currency: "USD",
+    },
+  },
+};
+
+const payment_method_data_no3ds = {
+  card: {
+    last4: "4242",
+    card_type: "CREDIT",
+    card_network: "Visa",
+    card_issuer: "STRIPE PAYMENTS UK LIMITED",
+    card_issuing_country: "UNITEDKINGDOM",
+    card_isin: "424242",
+    card_extended_bin: null,
+    card_exp_month: "01",
+    card_exp_year: "25",
+    card_holder_name: null,
+    payment_checks: {
+      avs_response: {
+        code: "Y",
+        codeRaw: "Y",
+      },
+      card_verification: null,
+    },
+    authentication_data: null,
+  },
+  billing: null,
+};
+
+const payment_method_data_3ds = {
+  card: {
+    last4: "1091",
+    card_type: "CREDIT",
+    card_network: "Visa",
+    card_issuer: "INTL HDQTRS-CENTER OWNED",
+    card_issuing_country: "UNITEDSTATES",
+    card_isin: "400000",
+    card_extended_bin: null,
+    card_exp_month: "01",
+    card_exp_year: "25",
+    card_holder_name: null,
+    payment_checks: null,
+    authentication_data: null,
+  },
+  billing: null,
+};
+
+export const connectorDetails = {
+  card_pm: {
+    PaymentIntent: {
+      Request: {
+        currency: "AED",
+        customer_acceptance: null,
+        setup_future_usage: "on_session",
+        connector_metadata: connectorMetadata,
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "requires_payment_method",
+          setup_future_usage: "on_session",
+        },
+      },
+    },
+    PaymentIntentOffSession: {
+      Request: {
+        currency: "AED",
+        amount: 6500,
+        authentication_type: "no_three_ds",
+        customer_acceptance: null,
+        setup_future_usage: "off_session",
+        connector_metadata: connectorMetadata,
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "requires_payment_method",
+          setup_future_usage: "off_session",
+        },
+      },
+    },
+    "3DSManualCapture": {
+      Request: {
+        payment_method: "card",
+        currency: "AED",
+        payment_method_data: {
+          card: successfulThreeDSTestCardDetails,
+        },
+        customer_acceptance: null,
+        setup_future_usage: "on_session",
+        connector_metadata: connectorMetadata,
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "requires_customer_action",
+          setup_future_usage: "on_session",
+          payment_method_data: payment_method_data_3ds,
+        },
+      },
+    },
+    "3DSAutoCapture": {
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulThreeDSTestCardDetails,
+        },
+        customer_acceptance: null,
+        setup_future_usage: "on_session",
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "requires_customer_action",
+          setup_future_usage: "on_session",
+          payment_method_data: payment_method_data_3ds,
+        },
+      },
+    },
+    No3DSManualCapture: {
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulNo3DSCardDetails,
+        },
+        connector_metadata: connectorMetadata,
+        customer_acceptance: null,
+        currency: "AED",
+        setup_future_usage: "on_session",
+      },
+      Response: {
+        status: 200,
+        trigger_skip: true,
+        body: {
+          status: "requires_customer_action",
+        },
+      },
+    },
+    No3DSAutoCapture: {
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulNo3DSCardDetails,
+        },
+        connector_metadata: connectorMetadata,
+        currency: "AED",
+        customer_acceptance: null,
+        setup_future_usage: "on_session",
+      },
+      Response: {
+        status: 200,
+        trigger_skip: true,
+        body: {
+          status: "requires_customer_action",
+        },
+      },
+    },
+    Capture: {
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulNo3DSCardDetails,
+        },
+        customer_acceptance: null,
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "succeeded",
+          amount: 6500,
+          amount_capturable: 0,
+          amount_received: 6500,
+        },
+      },
+    },
+    PartialCapture: {
+      Request: {},
+      Response: {
+        status: 200,
+        body: {
+          status: "partially_captured",
+          amount: 6500,
+          amount_capturable: 0,
+        },
+      },
+    },
+    Void: {
+      Request: {},
+      Response: {
+        status: 200,
+        body: {
+          status: "cancelled",
+        },
+      },
+    },
+    Refund: {
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulNo3DSCardDetails,
+        },
+        currency: "AED",
+        customer_acceptance: null,
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "succeeded",
+        },
+      },
+    },
+    manualPaymentRefund: {
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulNo3DSCardDetails,
+        },
+        currency: "AED",
+        customer_acceptance: null,
+      },
+      Response: {
+        status: 200,
+        trigger_skip: true,
+        body: {
+          status: "failed",
+        },
+      },
+    },
+    manualPaymentPartialRefund: {
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulNo3DSCardDetails,
+        },
+        customer_acceptance: null,
+      },
+      Response: {
+        status: 200,
+        trigger_skip: true,
+        body: {
+          status: "failed",
+        },
+      },
+    },
+    PartialRefund: {
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulNo3DSCardDetails,
+        },
+        customer_acceptance: null,
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "succeeded",
+        },
+      },
+    },
+    SyncRefund: {
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulNo3DSCardDetails,
+        },
+        customer_acceptance: null,
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "succeeded",
+        },
+      },
+    },
+    MandateSingleUse3DSAutoCapture: {
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulThreeDSTestCardDetails,
+        },
+        connector_metadata: connectorMetadata,
+        mandate_data: singleUseMandateData,
+      },
+      Response: {
+        status: 200,
+        trigger_skip: true,
+        body: {
+          status: "requires_customer_action",
+        },
+      },
+    },
+    MandateSingleUse3DSManualCapture: {
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulThreeDSTestCardDetails,
+        },
+        mandate_data: singleUseMandateData,
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "requires_customer_action",
+        },
+      },
+    },
+    MandateSingleUseNo3DSAutoCapture: {
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulNo3DSCardDetails,
+        },
+        currency: "AED",
+        mandate_data: singleUseMandateData,
+        connector_metadata: connectorMetadata,
+      },
+      Response: {
+        status: 200,
+        trigger_skip: true,
+        body: {
+          status: "requires_customer_action",
+        },
+      },
+    },
+    MandateSingleUseNo3DSManualCapture: {
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulNo3DSCardDetails,
+        },
+        currency: "AED",
+        mandate_data: singleUseMandateData,
+        connector_metadata: connectorMetadata,
+      },
+      Response: {
+        status: 200,
+        trigger_skip: true,
+        body: {
+          status: "requires_customer_action",
+        },
+      },
+    },
+    MandateMultiUseNo3DSAutoCapture: {
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulNo3DSCardDetails,
+        },
+        currency: "AED",
+        mandate_data: multiUseMandateData,
+        connector_metadata: connectorMetadata,
+      },
+      Response: {
+        status: 200,
+        trigger_skip: true,
+        body: {
+          status: "requires_customer_action",
+        },
+      },
+    },
+    MandateMultiUseNo3DSManualCapture: {
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulNo3DSCardDetails,
+        },
+        currency: "AED",
+        mandate_data: multiUseMandateData,
+        connector_metadata: connectorMetadata,
+      },
+      Response: {
+        status: 200,
+        trigger_skip: true,
+        body: {
+          status: "requires_customer_action",
+        },
+      },
+    },
+    MandateMultiUse3DSAutoCapture: {
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulThreeDSTestCardDetails,
+        },
+        mandate_data: multiUseMandateData,
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "requires_capture",
+        },
+      },
+    },
+    MandateMultiUse3DSManualCapture: {
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulThreeDSTestCardDetails,
+        },
+        mandate_data: multiUseMandateData,
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "requires_capture",
+        },
+      },
+    },
+    ZeroAuthMandate: {
+      Response: {
+        status: 501,
+        body: {
+          error: {
+            type: "invalid_request",
+            message: "Setup Mandate flow for Noon is not implemented",
+            code: "IR_00",
+          },
+        },
+      },
+    },
+    ZeroAuthPaymentIntent: {
+      Request: {
+        amount: 0,
+        setup_future_usage: "off_session",
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "requires_payment_method",
+          setup_future_usage: "off_session",
+        },
+      },
+    },
+    ZeroAuthConfirmPayment: {
+      Request: {
+        payment_type: "setup_mandate",
+        payment_method: "card",
+        payment_method_type: "credit",
+        payment_method_data: {
+          card: successfulNo3DSCardDetails,
+        },
+      },
+      Response: {
+        status: 501,
+        body: {
+          error: {
+            type: "invalid_request",
+            message: "Setup Mandate flow for Noon is not implemented",
+            code: "IR_00",
+          },
+        },
+      },
+    },
+    SaveCardUseNo3DSAutoCapture: {
+      Request: {
+        payment_method: "card",
+        payment_method_type: "debit",
+        payment_method_data: {
+          card: successfulNo3DSCardDetails,
+        },
+        currency: "AED",
+        setup_future_usage: "on_session",
+        customer_acceptance: customerAcceptance,
+        connector_metadata: connectorMetadata,
+      },
+      Response: {
+        status: 200,
+        trigger_skip: true,
+        body: {
+          status: "requires_customer_action",
+        },
+      },
+    },
+    SaveCardUseNo3DSAutoCaptureOffSession: {
+      Request: {
+        payment_method: "card",
+        payment_method_type: "debit",
+        payment_method_data: {
+          card: successfulNo3DSCardDetails,
+        },
+        setup_future_usage: "off_session",
+        customer_acceptance: customerAcceptance,
+      },
+      Response: {
+        status: 200,
+        trigger_skip: true,
+        body: {
+          status: "requires_customer_action",
+        },
+      },
+    },
+    SaveCardUseNo3DSManualCaptureOffSession: {
+      Request: {
+        payment_method: "card",
+        payment_method_type: "debit",
+        payment_method_data: {
+          card: successfulNo3DSCardDetails,
+        },
+        setup_future_usage: "off_session",
+        customer_acceptance: customerAcceptance,
+        connector_metadata: connectorMetadata,
+      },
+      Response: {
+        status: 200,
+        trigger_skip: true,
+        body: {
+          status: "requires_customer_action",
+        },
+      },
+    },
+    SaveCardConfirmAutoCaptureOffSession: {
+      Request: {
+        setup_future_usage: "off_session",
+      },
+      Response: {
+        status: 200,
+        trigger_skip: true,
+        body: {
+          status: "requires_customer_action",
+        },
+      },
+    },
+    SaveCardConfirmManualCaptureOffSession: {
+      Request: {
+        setup_future_usage: "off_session",
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "requires_customer_action",
+        },
+      },
+    },
+    SaveCardUseNo3DSManualCapture: {
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulNo3DSCardDetails,
+        },
+        setup_future_usage: "on_session",
+        customer_acceptance: customerAcceptance,
+      },
+      Response: {
+        status: 200,
+        trigger_skip: true,
+        body: {
+          status: "requires_customer_action",
+        },
+      },
+    },
+    PaymentMethodIdMandateNo3DSAutoCapture: {
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulNo3DSCardDetails,
+        },
+        currency: "AED",
+        mandate_data: null,
+        customer_acceptance: customerAcceptance,
+        connector_metadata: connectorMetadata,
+      },
+      Response: {
+        status: 200,
+        trigger_skip: true,
+        body: {
+          status: "requires_customer_action",
+        },
+      },
+    },
+    PaymentMethodIdMandateNo3DSManualCapture: {
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulNo3DSCardDetails,
+        },
+        currency: "AED",
+        mandate_data: null,
+        customer_acceptance: customerAcceptance,
+        connector_metadata: connectorMetadata,
+      },
+      Response: {
+        status: 200,
+        trigger_skip: true,
+        body: {
+          status: "requires_customer_action",
+        },
+      },
+    },
+    PaymentMethodIdMandate3DSAutoCapture: {
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulThreeDSTestCardDetails,
+        },
+        currency: "AED",
+        mandate_data: null,
+        authentication_type: "three_ds",
+        customer_acceptance: customerAcceptance,
+        connector_metadata: connectorMetadata,
+      },
+      Response: {
+        status: 200,
+        trigger_skip: true,
+        body: {
+          status: "requires_customer_action",
+        },
+      },
+    },
+    PaymentMethodIdMandate3DSManualCapture: {
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulThreeDSTestCardDetails,
+        },
+        currency: "AED",
+        mandate_data: null,
+        authentication_type: "three_ds",
+        customer_acceptance: customerAcceptance,
+        connector_metadata: connectorMetadata,
+      },
+      Response: {
+        status: 200,
+        trigger_skip: true,
+        body: {
+          status: "requires_customer_action",
+        },
+      },
+    },
+  },
+};

--- a/cypress-tests/cypress/e2e/PaymentUtils/Noon.js
+++ b/cypress-tests/cypress/e2e/PaymentUtils/Noon.js
@@ -1,7 +1,7 @@
 const successfulNo3DSCardDetails = {
   card_number: "4242424242424242",
   card_exp_month: "01",
-  card_exp_year: "25",
+  card_exp_year: "30",
   card_holder_name: "joseph Doe",
   card_cvc: "123",
 };
@@ -9,7 +9,7 @@ const successfulNo3DSCardDetails = {
 const successfulThreeDSTestCardDetails = {
   card_number: "4000000000001091",
   card_exp_month: "01",
-  card_exp_year: "25",
+  card_exp_year: "30",
   card_holder_name: "joseph Doe",
   card_cvc: "123",
 };

--- a/cypress-tests/cypress/e2e/PaymentUtils/Utils.js
+++ b/cypress-tests/cypress/e2e/PaymentUtils/Utils.js
@@ -12,6 +12,7 @@ import { connectorDetails as iatapayConnectorDetails } from "./Iatapay.js";
 import { connectorDetails as itaubankConnectorDetails } from "./ItauBank.js";
 import { connectorDetails as nexixpayConnectorDetails } from "./Nexixpay.js";
 import { connectorDetails as nmiConnectorDetails } from "./Nmi.js";
+import { connectorDetails as noonConnectorDetails } from "./Noon.js";
 import { connectorDetails as novalnetConnectorDetails } from "./Novalnet.js";
 import { connectorDetails as payboxConnectorDetails } from "./Paybox.js";
 import { connectorDetails as paypalConnectorDetails } from "./Paypal.js";
@@ -43,6 +44,7 @@ const connectorDetails = {
   wellsfargo: wellsfargoConnectorDetails,
   fiuu: fiuuConnectorDetails,
   worldpay: worldpayConnectorDetails,
+  noon: noonConnectorDetails,
 };
 
 export default function getConnectorDetails(connectorId) {


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [x] CI/CD

## Description
Add Noon Connector for Cypress Automation
Note : Noon supports only 3ds payments , so all the no_three_ds payments are skipped  

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
Noon connector was not available in the cypress automation


## How did you test it?
<img width="710" alt="image" src="https://github.com/user-attachments/assets/88aec323-824c-49e3-b51e-67d469c9826a">


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
