### PR TITLE
fix(analytics): remove first_attempt group by in Payment Intent old metrics

### DIFF
--- a/crates/analytics/src/payment_intents/metrics/payment_processed_amount.rs
+++ b/crates/analytics/src/payment_intents/metrics/payment_processed_amount.rs
@@ -59,10 +59,6 @@ where
             })
             .switch()?;
 
-        query_builder
-            .add_select_column("attempt_count == 1 as first_attempt")
-            .switch()?;
-
         query_builder.add_select_column("currency").switch()?;
 
         query_builder
@@ -101,11 +97,6 @@ where
                 .attach_printable("Error grouping by dimensions")
                 .switch()?;
         }
-
-        query_builder
-            .add_group_by_clause("attempt_count")
-            .attach_printable("Error grouping by attempt_count")
-            .switch()?;
 
         query_builder
             .add_group_by_clause("currency")

--- a/crates/analytics/src/payment_intents/metrics/payments_success_rate.rs
+++ b/crates/analytics/src/payment_intents/metrics/payments_success_rate.rs
@@ -58,10 +58,6 @@ where
             .switch()?;
 
         query_builder
-            .add_select_column("(attempt_count == 1) as first_attempt".to_string())
-            .switch()?;
-
-        query_builder
             .add_select_column(Aggregate::Min {
                 field: "created_at",
                 alias: Some("start_bucket"),
@@ -89,11 +85,6 @@ where
                 .attach_printable("Error grouping by dimensions")
                 .switch()?;
         }
-
-        query_builder
-            .add_group_by_clause("first_attempt")
-            .attach_printable("Error grouping by first_attempt")
-            .switch()?;
 
         if let Some(granularity) = granularity.as_ref() {
             granularity

--- a/crates/analytics/src/payment_intents/metrics/sessionized_metrics/payment_processed_amount.rs
+++ b/crates/analytics/src/payment_intents/metrics/sessionized_metrics/payment_processed_amount.rs
@@ -59,7 +59,7 @@ where
             .switch()?;
 
         query_builder
-            .add_select_column("attempt_count == 1 as first_attempt")
+            .add_select_column("(attempt_count = 1) as first_attempt")
             .switch()?;
         query_builder.add_select_column("currency").switch()?;
         query_builder
@@ -98,8 +98,8 @@ where
         }
 
         query_builder
-            .add_group_by_clause("attempt_count")
-            .attach_printable("Error grouping by attempt_count")
+            .add_group_by_clause("first_attempt")
+            .attach_printable("Error grouping by first_attempt")
             .switch()?;
         query_builder
             .add_group_by_clause("currency")

--- a/crates/analytics/src/payment_intents/metrics/sessionized_metrics/payments_distribution.rs
+++ b/crates/analytics/src/payment_intents/metrics/sessionized_metrics/payments_distribution.rs
@@ -59,7 +59,7 @@ where
             .switch()?;
 
         query_builder
-            .add_select_column("attempt_count == 1 as first_attempt")
+            .add_select_column("(attempt_count = 1) as first_attempt")
             .switch()?;
 
         query_builder

--- a/crates/analytics/src/payment_intents/metrics/sessionized_metrics/payments_success_rate.rs
+++ b/crates/analytics/src/payment_intents/metrics/sessionized_metrics/payments_success_rate.rs
@@ -58,7 +58,7 @@ where
             .switch()?;
 
         query_builder
-            .add_select_column("(attempt_count == 1) as first_attempt".to_string())
+            .add_select_column("(attempt_count = 1) as first_attempt".to_string())
             .switch()?;
 
         query_builder

--- a/crates/analytics/src/payment_intents/metrics/sessionized_metrics/smart_retried_amount.rs
+++ b/crates/analytics/src/payment_intents/metrics/sessionized_metrics/smart_retried_amount.rs
@@ -60,7 +60,7 @@ where
             .switch()?;
 
         query_builder
-            .add_select_column("attempt_count == 1 as first_attempt")
+            .add_select_column("(attempt_count = 1) as first_attempt")
             .switch()?;
 
         query_builder.add_select_column("currency").switch()?;
@@ -105,7 +105,7 @@ where
             .switch()?;
         query_builder
             .add_group_by_clause("currency")
-            .attach_printable("Error grouping by first_attempt")
+            .attach_printable("Error grouping by currency")
             .switch()?;
         if let Some(granularity) = granularity.as_ref() {
             granularity

--- a/crates/analytics/src/payment_intents/metrics/smart_retried_amount.rs
+++ b/crates/analytics/src/payment_intents/metrics/smart_retried_amount.rs
@@ -59,9 +59,6 @@ where
             })
             .switch()?;
 
-        query_builder
-            .add_select_column("attempt_count == 1 as first_attempt")
-            .switch()?;
         query_builder.add_select_column("currency").switch()?;
         query_builder
             .add_select_column(Aggregate::Min {
@@ -98,10 +95,6 @@ where
                 .switch()?;
         }
 
-        query_builder
-            .add_group_by_clause("first_attempt")
-            .attach_printable("Error grouping by first_attempt")
-            .switch()?;
         query_builder
             .add_group_by_clause("currency")
             .attach_printable("Error grouping by currency")


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
`first_attempt` as a group by is getting added internally in the queries as it is required by the new PaymentIntent based metrics for Analytics V2 Dashboard.

The logic was added for the existing older metrics as well for PaymentIntents on the older dashboard, and is failing when using sqlx as the Pool.

Need to remove the logic for adding `first_attempt` as a group_by in the older metrics, and also tweak the manner in which this is getting added as a group_by in the new metrics.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
Fix the error when using older metrics on the old dashboard (PaymentIntent based metrics)

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Hit the curls to test the various metrics.
Sessionized_metrics should be tested only on clickhouse.
Older metricss can be tested on both sqlx and clickhouse.
```bash
curl --location 'http://localhost:8080/analytics/v2/org/metrics/payments' \
--header 'Accept: */*' \
--header 'Accept-Language: en-US,en;q=0.9' \
--header 'Connection: keep-alive' \
--header 'Content-Type: application/json' \
--header 'Origin: http://localhost:9000' \
--header 'QueryType: SingleStatTimeseries' \
--header 'Referer: http://localhost:9000/' \
--header 'Sec-Fetch-Dest: empty' \
--header 'Sec-Fetch-Mode: cors' \
--header 'Sec-Fetch-Site: same-site' \
--header 'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36' \
--header 'api-key: dev_LZcIA7XeMpnK5satp4CDvjcnHCaeKTBcosyuBBJaknZu1odhFo96cwS0nSdfzuJF' \
--header 'authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoiNTQ5ZTNkMmItMTY5Yi00NzUzLWJmNTQtZDcxMTM2YjRiN2JkIiwibWVyY2hhbnRfaWQiOiJtZXJjaGFudF8xNzI2MDQ2MzI4Iiwicm9sZV9pZCI6Im9yZ19hZG1pbiIsImV4cCI6MTczMjI3OTExOSwib3JnX2lkIjoib3JnX1ZwU0hPanNZZkR2YWJWWUpnQ0FKIiwicHJvZmlsZV9pZCI6InByb192NXNGb0hlODBPZWlVbElvbm9jTSIsInRlbmFudF9pZCI6InB1YmxpYyJ9.c3u-icFmoDrNwBzR5Av3IiK-tNktGLZarVxSqg3-LgY' \
--header 'sec-ch-ua: "Chromium";v="128", "Not;A=Brand";v="24", "Google Chrome";v="128"' \
--header 'sec-ch-ua-mobile: ?0' \
--header 'sec-ch-ua-platform: "macOS"' \
--data '[
    {
        "timeRange": {
            "startTime": "2024-11-14T18:30:00Z",
            "endTime": "2024-11-22T15:24:00Z"
        },
        "mode": "ORDER",
        "source": "BATCH",
        "metrics": [
            "smart_retried_amount",
            "payments_success_rate",
            "payment_processed_amount",
            "sessionized_smart_retried_amount",
            "sessionized_payments_success_rate",
            "sessionized_payment_processed_amount",
            "sessionized_payments_distribution"
        ]
    }
]'
```
API should not fail, and should give out response as expected.
```json
{
    "queryData": [
        {
            "successful_smart_retries": null,
            "total_smart_retries": null,
            "smart_retried_amount": 0,
            "smart_retried_amount_in_usd": null,
            "smart_retried_amount_without_smart_retries": 0,
            "smart_retried_amount_without_smart_retries_in_usd": null,
            "payment_intent_count": null,
            "successful_payments": 15,
            "successful_payments_without_smart_retries": 7,
            "total_payments": 15,
            "payments_success_rate": 100.0,
            "payments_success_rate_without_smart_retries": 46.666666666666664,
            "payment_processed_amount": 0,
            "payment_processed_amount_in_usd": null,
            "payment_processed_count": null,
            "payment_processed_amount_without_smart_retries": 0,
            "payment_processed_amount_without_smart_retries_in_usd": null,
            "payment_processed_count_without_smart_retries": null,
            "payments_success_rate_distribution_without_smart_retries": 87.5,
            "payments_failure_rate_distribution_without_smart_retries": 0.0,
            "status": null,
            "currency": null,
            "profile_id": null,
            "connector": null,
            "auth_type": null,
            "payment_method": null,
            "payment_method_type": null,
            "card_network": null,
            "merchant_id": null,
            "card_last_4": null,
            "card_issuer": null,
            "error_reason": null,
            "time_range": {
                "start_time": "2024-11-14T18:30:00.000Z",
                "end_time": "2024-11-22T15:24:00.000Z"
            },
            "time_bucket": "2024-11-14 18:30:00"
        },
        {
            "successful_smart_retries": null,
            "total_smart_retries": null,
            "smart_retried_amount": 0,
            "smart_retried_amount_in_usd": 0,
            "smart_retried_amount_without_smart_retries": 0,
            "smart_retried_amount_without_smart_retries_in_usd": 0,
            "payment_intent_count": null,
            "successful_payments": null,
            "successful_payments_without_smart_retries": null,
            "total_payments": null,
            "payments_success_rate": null,
            "payments_success_rate_without_smart_retries": null,
            "payment_processed_amount": 40000,
            "payment_processed_amount_in_usd": 40000,
            "payment_processed_count": 4,
            "payment_processed_amount_without_smart_retries": 20000,
            "payment_processed_amount_without_smart_retries_in_usd": 20000,
            "payment_processed_count_without_smart_retries": 2,
            "payments_success_rate_distribution_without_smart_retries": null,
            "payments_failure_rate_distribution_without_smart_retries": null,
            "status": null,
            "currency": "USD",
            "profile_id": null,
            "connector": null,
            "auth_type": null,
            "payment_method": null,
            "payment_method_type": null,
            "card_network": null,
            "merchant_id": null,
            "card_last_4": null,
            "card_issuer": null,
            "error_reason": null,
            "time_range": {
                "start_time": "2024-11-14T18:30:00.000Z",
                "end_time": "2024-11-22T15:24:00.000Z"
            },
            "time_bucket": "2024-11-14 18:30:00"
        },
        {
            "successful_smart_retries": null,
            "total_smart_retries": null,
            "smart_retried_amount": 0,
            "smart_retried_amount_in_usd": 0,
            "smart_retried_amount_without_smart_retries": 0,
            "smart_retried_amount_without_smart_retries_in_usd": 0,
            "payment_intent_count": null,
            "successful_payments": null,
            "successful_payments_without_smart_retries": null,
            "total_payments": null,
            "payments_success_rate": null,
            "payments_success_rate_without_smart_retries": null,
            "payment_processed_amount": 110000,
            "payment_processed_amount_in_usd": 1302,
            "payment_processed_count": 11,
            "payment_processed_amount_without_smart_retries": 50000,
            "payment_processed_amount_without_smart_retries_in_usd": 591,
            "payment_processed_count_without_smart_retries": 5,
            "payments_success_rate_distribution_without_smart_retries": null,
            "payments_failure_rate_distribution_without_smart_retries": null,
            "status": null,
            "currency": "INR",
            "profile_id": null,
            "connector": null,
            "auth_type": null,
            "payment_method": null,
            "payment_method_type": null,
            "card_network": null,
            "merchant_id": null,
            "card_last_4": null,
            "card_issuer": null,
            "error_reason": null,
            "time_range": {
                "start_time": "2024-11-14T18:30:00.000Z",
                "end_time": "2024-11-22T15:24:00.000Z"
            },
            "time_bucket": "2024-11-14 18:30:00"
        }
    ],
    "metaData": [
        {
            "total_success_rate": 100.0,
            "total_success_rate_without_smart_retries": 46.666666666666664,
            "total_smart_retried_amount": 0,
            "total_smart_retried_amount_without_smart_retries": 0,
            "total_payment_processed_amount": 150000,
            "total_payment_processed_amount_without_smart_retries": 70000,
            "total_smart_retried_amount_in_usd": 0,
            "total_smart_retried_amount_without_smart_retries_in_usd": 0,
            "total_payment_processed_amount_in_usd": 41302,
            "total_payment_processed_amount_without_smart_retries_in_usd": 20591,
            "total_payment_processed_count": 15,
            "total_payment_processed_count_without_smart_retries": 7
        }
    ]
}
```
## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
