### PR TITLE
feat(payments): add merchant order ref id filter

### DIFF
--- a/crates/api_models/src/payments.rs
+++ b/crates/api_models/src/payments.rs
@@ -4923,7 +4923,7 @@ pub struct PaymentListFilterConstraints {
     pub order: Order,
     /// The List of all the card networks to filter payments list
     pub card_network: Option<Vec<enums::CardNetwork>>,
-    /// The identifier for merchnat order reference id
+    /// The identifier for merchant order reference id
     pub merchant_order_reference_id: Option<String>,
 }
 

--- a/crates/api_models/src/payments.rs
+++ b/crates/api_models/src/payments.rs
@@ -4923,6 +4923,8 @@ pub struct PaymentListFilterConstraints {
     pub order: Order,
     /// The List of all the card networks to filter payments list
     pub card_network: Option<Vec<enums::CardNetwork>>,
+    /// The identifier for merchnat order reference id
+    pub merchant_order_reference_id: Option<String>,
 }
 
 impl PaymentListFilterConstraints {

--- a/crates/hyperswitch_domain_models/src/payments/payment_intent.rs
+++ b/crates/hyperswitch_domain_models/src/payments/payment_intent.rs
@@ -1002,6 +1002,7 @@ pub struct PaymentIntentListParams {
     pub limit: Option<u32>,
     pub order: api_models::payments::Order,
     pub card_network: Option<Vec<storage_enums::CardNetwork>>,
+    pub merchant_order_reference_id: Option<String>,
 }
 
 impl From<api_models::payments::PaymentListConstraints> for PaymentIntentFetchConstraints {
@@ -1036,6 +1037,7 @@ impl From<api_models::payments::PaymentListConstraints> for PaymentIntentFetchCo
             limit: Some(std::cmp::min(limit, PAYMENTS_LIST_MAX_LIMIT_V1)),
             order: Default::default(),
             card_network: None,
+            merchant_order_reference_id: None,
         }))
     }
 }
@@ -1061,6 +1063,7 @@ impl From<common_utils::types::TimeRange> for PaymentIntentFetchConstraints {
             limit: None,
             order: Default::default(),
             card_network: None,
+            merchant_order_reference_id: None,
         }))
     }
 }
@@ -1084,6 +1087,7 @@ impl From<api_models::payments::PaymentListFilterConstraints> for PaymentIntentF
             merchant_connector_id,
             order,
             card_network,
+            merchant_order_reference_id,
         } = value;
         if let Some(payment_intent_id) = payment_id {
             Self::Single { payment_intent_id }
@@ -1107,6 +1111,7 @@ impl From<api_models::payments::PaymentListFilterConstraints> for PaymentIntentF
                 limit: Some(std::cmp::min(limit, PAYMENTS_LIST_MAX_LIMIT_V2)),
                 order,
                 card_network,
+                merchant_order_reference_id,
             }))
         }
     }

--- a/crates/router/src/types/storage/dispute.rs
+++ b/crates/router/src/types/storage/dispute.rs
@@ -1,6 +1,6 @@
 use async_bb8_diesel::AsyncRunQueryDsl;
 use common_utils::errors::CustomResult;
-use diesel::{associations::HasTable, ExpressionMethods, QueryDsl};
+use diesel::{associations::HasTable, BoolExpressionMethods, ExpressionMethods, QueryDsl};
 pub use diesel_models::dispute::{Dispute, DisputeNew, DisputeUpdate};
 use diesel_models::{errors, query::generics::db_metrics, schema::dispute::dsl};
 use error_stack::ResultExt;
@@ -43,9 +43,11 @@ impl DisputeDbExt for Dispute {
             &dispute_list_constraints.dispute_id,
         ) {
             search_by_payment_or_dispute_id = true;
-            filter = filter
-                .filter(dsl::payment_id.eq(payment_id.to_owned()))
-                .or_filter(dsl::dispute_id.eq(dispute_id.to_owned()));
+            filter = filter.filter(
+                dsl::payment_id
+                    .eq(payment_id.to_owned())
+                    .or(dsl::dispute_id.eq(dispute_id.to_owned())),
+            );
         };
 
         if !search_by_payment_or_dispute_id {

--- a/crates/router/src/types/storage/refund.rs
+++ b/crates/router/src/types/storage/refund.rs
@@ -1,7 +1,7 @@
 use api_models::payments::AmountFilter;
 use async_bb8_diesel::AsyncRunQueryDsl;
 use common_utils::errors::CustomResult;
-use diesel::{associations::HasTable, ExpressionMethods, QueryDsl};
+use diesel::{associations::HasTable, BoolExpressionMethods, ExpressionMethods, QueryDsl};
 pub use diesel_models::refund::{
     Refund, RefundCoreWorkflow, RefundNew, RefundUpdate, RefundUpdateInternal,
 };
@@ -67,8 +67,11 @@ impl RefundDbExt for Refund {
         ) {
             search_by_pay_or_ref_id = true;
             filter = filter
-                .filter(dsl::payment_id.eq(pid.to_owned()))
-                .or_filter(dsl::refund_id.eq(ref_id.to_owned()))
+                .filter(
+                    dsl::payment_id
+                        .eq(pid.to_owned())
+                        .or(dsl::refund_id.eq(ref_id.to_owned())),
+                )
                 .limit(limit)
                 .offset(offset);
         };
@@ -228,9 +231,11 @@ impl RefundDbExt for Refund {
             &refund_list_details.refund_id,
         ) {
             search_by_pay_or_ref_id = true;
-            filter = filter
-                .filter(dsl::payment_id.eq(pid.to_owned()))
-                .or_filter(dsl::refund_id.eq(ref_id.to_owned()));
+            filter = filter.filter(
+                dsl::payment_id
+                    .eq(pid.to_owned())
+                    .or(dsl::refund_id.eq(ref_id.to_owned())),
+            );
         };
 
         if !search_by_pay_or_ref_id {

--- a/crates/storage_impl/src/payments/payment_intent.rs
+++ b/crates/storage_impl/src/payments/payment_intent.rs
@@ -871,6 +871,12 @@ impl<T: DatabaseStore> PaymentIntentInterface for crate::RouterStore<T> {
                     query = query.filter(pi_dsl::customer_id.eq(customer_id.clone()));
                 }
 
+                if let Some(merchant_order_reference_id) = &params.merchant_order_reference_id {
+                    query = query.filter(
+                        pi_dsl::merchant_order_reference_id.eq(merchant_order_reference_id.clone()),
+                    )
+                }
+
                 if let Some(profile_id) = &params.profile_id {
                     query = query.filter(pi_dsl::profile_id.eq_any(profile_id.clone()));
                 }
@@ -1040,6 +1046,11 @@ impl<T: DatabaseStore> PaymentIntentInterface for crate::RouterStore<T> {
             PaymentIntentFetchConstraints::List(params) => {
                 if let Some(customer_id) = &params.customer_id {
                     query = query.filter(pi_dsl::customer_id.eq(customer_id.clone()));
+                }
+                if let Some(merchant_order_reference_id) = &params.merchant_order_reference_id {
+                    query = query.filter(
+                        pi_dsl::merchant_order_reference_id.eq(merchant_order_reference_id.clone()),
+                    )
                 }
                 if let Some(profile_id) = &params.profile_id {
                     query = query.filter(pi_dsl::profile_id.eq_any(profile_id.clone()));


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
The PR
- Add merchant order reference id filter for payments list
- Fix bug for search by refund id (or payment_id), using `or` instead of `or_filter`. Earlier we were searching in whole list, ignoring the filter previously applied in the query.
However this was the only case for when we were searching dynamically for ids, it can be payment or refund id. It was producing correct result when searching for only payment id or only refund id. 

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
Closes [#6629](https://github.com/juspay/hyperswitch/issues/6629)


## How did you test it?
Merchant Order filter is working as expected
Request
```
curl --location 'http://localhost:8080/payments/list' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'Authorization: Bearer JWT' \
--data '{
    "merchant_order_reference_id": "test"
}'
```
Response:
```
{
    "count": 1,
    "total_count": 1,
    "data": [
        {
            "payment_id": "test_rkAjUPAeyOVH0V1JPBcg",
            "merchant_id": "merchant_1732182386",
            "status": "succeeded",
            "amount": 19900,
            "net_amount": 19900,
            "shipping_cost": null,
            "amount_capturable": 0,
            "amount_received": null,
            "connector": "stripe_test",
            "client_secret": "test_rkAjUPAeyOVH0V1JPBcg_secret_s8xZQVITYn3CT5RKTiUj",
            "created": "2024-11-20T22:30:10.000Z",
            "currency": "USD",
            "customer_id": "hs-dashboard-user",
            "customer": null,
            "description": "This is a sample payment",
            "refunds": null,
            "disputes": null,
            "mandate_id": null,
            "mandate_data": null,
            "setup_future_usage": null,
            "off_session": null,
            "capture_on": null,
            "capture_method": null,
            "payment_method": "card",
            "payment_method_data": null,
            "payment_token": null,
            "shipping": null,
            "billing": null,
            "order_details": null,
            "email": null,
            "name": null,
            "phone": null,
            "return_url": null,
            "authentication_type": "three_ds",
            "statement_descriptor_name": null,
            "statement_descriptor_suffix": null,
            "next_action": null,
            "cancellation_reason": null,
            "error_code": null,
            "error_message": null,
            "unified_code": null,
            "unified_message": null,
            "payment_experience": null,
            "payment_method_type": "debit",
            "connector_label": null,
            "business_country": null,
            "business_label": "default",
            "business_sub_label": null,
            "allowed_payment_method_types": null,
            "ephemeral_key": null,
            "manual_retry_allowed": null,
            "connector_transaction_id": "test_rkAjUPAeyOVH0V1JPBcg_1",
            "frm_message": null,
            "metadata": null,
            "connector_metadata": null,
            "feature_metadata": null,
            "reference_id": null,
            "payment_link": null,
            "profile_id": "pro_7J9fiPceBUM7IMdb045X",
            "surcharge_details": null,
            "attempt_count": 1,
            "merchant_decision": null,
            "merchant_connector_id": null,
            "incremental_authorization_allowed": null,
            "authorization_count": null,
            "incremental_authorizations": null,
            "external_authentication_details": null,
            "external_3ds_authentication_attempted": null,
            "expires_on": null,
            "fingerprint": null,
            "browser_info": null,
            "payment_method_id": null,
            "payment_method_status": null,
            "updated": null,
            "charges": null,
            "frm_metadata": null,
            "merchant_order_reference_id": "test",
            "order_tax_amount": null,
            "connector_mandate_id": null
        }
    ]
}
```
In refunds list when dynamically searching for both payment_id and refund_id, we are getting correct result now
```
curl --location 'http://localhost:8080/refunds/list' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'Authorization: Bearer JWT' \
--data '{
    "refund_id": "test_LlBBfgQbHHJfQxsoLiyT",
    "payment_id": "test_LlBBfgQbHHJfQxsoLiyT"
    
}'
```
Response:
```
{
    "count": 0,
    "total_count": 0,
    "data": []
}
```

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
