### PR TITLE
feat(refunds): Trigger refund outgoing webhooks in create and retrieve refund flows

### DIFF
--- a/crates/router/src/core/refunds.rs
+++ b/crates/router/src/core/refunds.rs
@@ -366,7 +366,7 @@ pub async fn trigger_refund_to_gateway(
     utils::trigger_refund_outgoing_webhook(
         state,
         merchant_account,
-        response.clone().foreign_into(),
+        &response,
         payment_attempt.profile_id.clone(),
         key_store,
     )
@@ -491,17 +491,6 @@ pub async fn refund_retrieve_core(
     } else {
         Ok(refund)
     }?;
-
-    utils::trigger_refund_outgoing_webhook(
-        &state,
-        &merchant_account,
-        response.clone().foreign_into(),
-        payment_attempt.profile_id.clone(),
-        &key_store,
-    )
-    .await
-    .map_err(|error| logger::warn!(refunds_outgoing_webhook_error=?error))
-    .ok();
 
     Ok(response)
 }
@@ -690,6 +679,16 @@ pub async fn sync_refund_with_gateway(
                 refund.refund_id
             )
         })?;
+    utils::trigger_refund_outgoing_webhook(
+        &state,
+        &merchant_account,
+        &response,
+        payment_attempt.profile_id.clone(),
+        &key_store,
+    )
+    .await
+    .map_err(|error| logger::warn!(refunds_outgoing_webhook_error=?error))
+    .ok();
     Ok(response)
 }
 

--- a/crates/router/src/core/refunds.rs
+++ b/crates/router/src/core/refunds.rs
@@ -363,6 +363,16 @@ pub async fn trigger_refund_to_gateway(
                 refund.refund_id
             )
         })?;
+    utils::trigger_refund_outgoing_webhook(
+        state,
+        merchant_account,
+        response.clone().foreign_into(),
+        payment_attempt.profile_id.clone(),
+        key_store,
+    )
+    .await
+    .map_err(|error| logger::warn!(refunds_outgoing_webhook_error=?error))
+    .ok();
     Ok(response)
 }
 
@@ -481,6 +491,17 @@ pub async fn refund_retrieve_core(
     } else {
         Ok(refund)
     }?;
+
+    utils::trigger_refund_outgoing_webhook(
+        &state,
+        &merchant_account,
+        response.clone().foreign_into(),
+        payment_attempt.profile_id.clone(),
+        &key_store,
+    )
+    .await
+    .map_err(|error| logger::warn!(refunds_outgoing_webhook_error=?error))
+    .ok();
 
     Ok(response)
 }

--- a/crates/router/src/types/transformers.rs
+++ b/crates/router/src/types/transformers.rs
@@ -576,18 +576,6 @@ impl ForeignTryFrom<payments::PaymentMethodData> for api_enums::PaymentMethod {
     }
 }
 
-impl ForeignFrom<storage_enums::RefundStatus> for Option<storage_enums::EventType> {
-    fn foreign_from(value: storage_enums::RefundStatus) -> Self {
-        match value {
-            storage_enums::RefundStatus::Success => Some(storage_enums::EventType::RefundSucceeded),
-            storage_enums::RefundStatus::Failure => Some(storage_enums::EventType::RefundFailed),
-            api_enums::RefundStatus::ManualReview
-            | api_enums::RefundStatus::Pending
-            | api_enums::RefundStatus::TransactionFailure => None,
-        }
-    }
-}
-
 impl ForeignFrom<api_models::refunds::RefundStatus> for Option<storage_enums::EventType> {
     fn foreign_from(value: api_models::refunds::RefundStatus) -> Self {
         match value {

--- a/crates/router/src/types/transformers.rs
+++ b/crates/router/src/types/transformers.rs
@@ -576,17 +576,14 @@ impl ForeignTryFrom<payments::PaymentMethodData> for api_enums::PaymentMethod {
     }
 }
 
-impl ForeignFrom<api_models::refunds::RefundStatus> for Option<storage_enums::EventType> {
-    fn foreign_from(value: api_models::refunds::RefundStatus) -> Self {
+impl ForeignFrom<storage_enums::RefundStatus> for Option<storage_enums::EventType> {
+    fn foreign_from(value: storage_enums::RefundStatus) -> Self {
         match value {
-            api_models::refunds::RefundStatus::Succeeded => {
-                Some(storage_enums::EventType::RefundSucceeded)
-            }
-            api_models::refunds::RefundStatus::Failed => {
-                Some(storage_enums::EventType::RefundFailed)
-            }
-            api_models::refunds::RefundStatus::Review
-            | api_models::refunds::RefundStatus::Pending => None,
+            storage_enums::RefundStatus::Success => Some(storage_enums::EventType::RefundSucceeded),
+            storage_enums::RefundStatus::Failure => Some(storage_enums::EventType::RefundFailed),
+            api_enums::RefundStatus::ManualReview
+            | api_enums::RefundStatus::Pending
+            | api_enums::RefundStatus::TransactionFailure => None,
         }
     }
 }

--- a/crates/router/src/types/transformers.rs
+++ b/crates/router/src/types/transformers.rs
@@ -588,6 +588,21 @@ impl ForeignFrom<storage_enums::RefundStatus> for Option<storage_enums::EventTyp
     }
 }
 
+impl ForeignFrom<api_models::refunds::RefundStatus> for Option<storage_enums::EventType> {
+    fn foreign_from(value: api_models::refunds::RefundStatus) -> Self {
+        match value {
+            api_models::refunds::RefundStatus::Succeeded => {
+                Some(storage_enums::EventType::RefundSucceeded)
+            }
+            api_models::refunds::RefundStatus::Failed => {
+                Some(storage_enums::EventType::RefundFailed)
+            }
+            api_models::refunds::RefundStatus::Review
+            | api_models::refunds::RefundStatus::Pending => None,
+        }
+    }
+}
+
 impl ForeignFrom<storage_enums::PayoutStatus> for Option<storage_enums::EventType> {
     fn foreign_from(value: storage_enums::PayoutStatus) -> Self {
         match value {

--- a/crates/router/src/utils.rs
+++ b/crates/router/src/utils.rs
@@ -1323,3 +1323,14 @@ pub async fn trigger_refund_outgoing_webhook(
     }
     Ok(())
 }
+
+#[cfg(feature = "v2")]
+pub async fn trigger_refund_outgoing_webhook(
+    state: &SessionState,
+    merchant_account: &domain::MerchantAccount,
+    refund_response: api_models::refunds::RefundResponse,
+    profile_id: id_type::ProfileId,
+    key_store: &domain::MerchantKeyStore,
+) -> RouterResult<()> {
+    todo!()
+}

--- a/crates/router/src/utils.rs
+++ b/crates/router/src/utils.rs
@@ -1270,3 +1270,56 @@ pub async fn flatten_join_error<T>(handle: Handle<T>) -> RouterResult<T> {
             .attach_printable("Join Error"),
     }
 }
+
+pub async fn trigger_refund_outgoing_webhook(
+    state: &SessionState,
+    merchant_account: &domain::MerchantAccount,
+    refund_response: api_models::refunds::RefundResponse,
+    profile_id: id_type::ProfileId,
+    key_store: &domain::MerchantKeyStore,
+) -> RouterResult<()> {
+    let refund_status = refund_response.status;
+    if matches!(
+        refund_status,
+        api_models::refunds::RefundStatus::Succeeded | api_models::refunds::RefundStatus::Failed
+    ) {
+        let key_manager_state = &(state).into();
+        let refund_id = refund_response.refund_id.clone();
+        let business_profile = state
+            .store
+            .find_business_profile_by_profile_id(key_manager_state, key_store, &profile_id)
+            .await
+            .to_not_found_response(errors::ApiErrorResponse::ProfileNotFound {
+                id: profile_id.get_string_repr().to_owned(),
+            })?;
+        let event_type: Option<enums::EventType> =
+            ForeignFrom::foreign_from(refund_response.status);
+        let cloned_state = state.clone();
+        let cloned_key_store = key_store.clone();
+        let cloned_merchant_account = merchant_account.clone();
+        let primary_object_created_at = refund_response.created_at;
+        if let Some(outgoing_event_type) = event_type {
+            tokio::spawn(
+                async move {
+                    Box::pin(webhooks_core::create_event_and_trigger_outgoing_webhook(
+                        cloned_state,
+                        cloned_merchant_account,
+                        business_profile,
+                        &cloned_key_store,
+                        outgoing_event_type,
+                        diesel_models::enums::EventClass::Refunds,
+                        refund_id.to_string(),
+                        diesel_models::enums::EventObjectType::RefundDetails,
+                        webhooks::OutgoingWebhookContent::RefundDetails(Box::new(refund_response)),
+                        primary_object_created_at,
+                    ))
+                    .await
+                }
+                .in_current_span(),
+            );
+        } else {
+            logger::warn!("Outgoing webhook not sent because of missing event type status mapping");
+        };
+    }
+    Ok(())
+}

--- a/crates/router/src/utils.rs
+++ b/crates/router/src/utils.rs
@@ -1334,7 +1334,7 @@ pub async fn trigger_refund_outgoing_webhook(
 pub async fn trigger_refund_outgoing_webhook(
     state: &SessionState,
     merchant_account: &domain::MerchantAccount,
-    refund: &diesel_models::refund,
+    refund: &diesel_models::Refund,
     profile_id: id_type::ProfileId,
     key_store: &domain::MerchantKeyStore,
 ) -> RouterResult<()> {

--- a/crates/router/src/utils.rs
+++ b/crates/router/src/utils.rs
@@ -1271,6 +1271,7 @@ pub async fn flatten_join_error<T>(handle: Handle<T>) -> RouterResult<T> {
     }
 }
 
+#[cfg(feature = "v1")]
 pub async fn trigger_refund_outgoing_webhook(
     state: &SessionState,
     merchant_account: &domain::MerchantAccount,

--- a/crates/router/src/utils.rs
+++ b/crates/router/src/utils.rs
@@ -11,7 +11,6 @@ pub mod user;
 pub mod user_role;
 #[cfg(feature = "olap")]
 pub mod verify_connector;
-use crate::types::transformers::ForeignInto;
 use std::fmt::Debug;
 
 use api_models::{
@@ -60,7 +59,10 @@ use crate::{
     logger,
     routes::{metrics, SessionState},
     services,
-    types::{self, domain, transformers::ForeignFrom},
+    types::{
+        self, domain,
+        transformers::{ForeignFrom, ForeignInto},
+    },
 };
 
 pub mod error_parser {


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Trigger refund outgoing webhooks in create and retrieve refund flows. 

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Test cases : 
1) Create a refund without configuring incoming webhooks, this should trigger outgoing webhook to merchant
2) If possible create a refund with processing and update the status by force sync, Upon status update it should trigger outgoing webhook to merchant.
Refund created with webhooks configured with immediate status = 'success' 

<img width="1164" alt="Screenshot 2024-11-22 at 5 56 59 PM" src="https://github.com/user-attachments/assets/233f00db-1150-4d58-8f1d-4fc4904feb13">

outgoing webhook triggered for the same event.
<img width="1674" alt="Screenshot 2024-11-22 at 5 57 52 PM" src="https://github.com/user-attachments/assets/c20d998d-0b7e-458e-90d7-a3fdbc765dbb">


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
