### PR TITLE
fix(analytics): fix first_attempt filter value parsing for Payments

### DIFF
--- a/crates/analytics/src/query.rs
+++ b/crates/analytics/src/query.rs
@@ -459,7 +459,11 @@ impl<T: AnalyticsDataSource> ToSql<T> for common_utils::id_type::CustomerId {
 
 impl<T: AnalyticsDataSource> ToSql<T> for bool {
     fn to_sql(&self, _table_engine: &TableEngine) -> error_stack::Result<String, ParsingError> {
-        Ok(self.to_string().to_owned())
+        Ok(if *self {
+            "1".to_string()
+        } else {
+            "0".to_string()
+        })
     }
 }
 

--- a/crates/analytics/src/query.rs
+++ b/crates/analytics/src/query.rs
@@ -459,11 +459,8 @@ impl<T: AnalyticsDataSource> ToSql<T> for common_utils::id_type::CustomerId {
 
 impl<T: AnalyticsDataSource> ToSql<T> for bool {
     fn to_sql(&self, _table_engine: &TableEngine) -> error_stack::Result<String, ParsingError> {
-        Ok(if *self {
-            "1".to_string()
-        } else {
-            "0".to_string()
-        })
+        let flag = *self;
+        Ok(i8::from(flag).to_string())
     }
 }
 


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Fixes this issue: [https://github.com/juspay/hyperswitch-cloud/issues/7580](https://github.com/juspay/hyperswitch-cloud/issues/7580)
- `first_attempt` filter takes in `true` or `false` as variants.
- But while it is getting applied in the query, it is being converted into a string:
`'true'` or `'false'`

This works on latest clickhouse versions, but fails on the older clickhouse versions, with the error:
```error
DB::Exception: Cannot convert string false to type Bool: While processing (first_attempt IN ('false'))
```

Now, internally converting `'true'` to `'1'` and `'false'` to `'0'` to fix the issue, and this gets accepted in both the versions.

The query which was previously running was:
```bash
SELECT connector, status, sum(sign_flag) as count, first_attempt, min(created_at) as start_bucket, max(created_at) as end_bucket FROM sessionizer_payment_attempts WHERE ( first_attempt IN ('false') AND organization_id = 'org_id' AND created_at >= '1731803400' AND created_at <= '1732577400' ) GROUP BY connector, status, first_attempt HAVING sum(sign_flag) >= '1'
```

Now the query which will run is:
```bash
SELECT connector, status, sum(sign_flag) as count, first_attempt, min(created_at) as start_bucket, max(created_at) as end_bucket FROM sessionizer_payment_attempts WHERE ( first_attempt IN ('0') AND organization_id = 'org_id' AND created_at >= '1731803400' AND created_at <= '1732577400' ) GROUP BY connector, status, first_attempt HAVING sum(sign_flag) >= '1'
```


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->

Fix the issue: [https://github.com/juspay/hyperswitch/issues/6666](https://github.com/juspay/hyperswitch/issues/6666)
## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

Hit the curl with first_attempt filter containing either `true` or `false`:
```bash
curl --location 'http://localhost:8080/analytics/v1/org/metrics/payments' \
--header 'Accept: */*' \
--header 'Accept-Language: en-US,en;q=0.9' \
--header 'Connection: keep-alive' \
--header 'Content-Type: application/json' \
--header 'Origin: http://localhost:9000' \
--header 'Referer: http://localhost:9000/' \
--header 'Sec-Fetch-Dest: empty' \
--header 'Sec-Fetch-Mode: cors' \
--header 'Sec-Fetch-Site: same-site' \
--header 'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36' \
--header 'api-key: test_admin' \
--header 'authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoiNTQ5ZTNkMmItMTY5Yi00NzUzLWJmNTQtZDcxMTM2YjRiN2JkIiwibWVyY2hhbnRfaWQiOiJtZXJjaGFudF8xNzI2MDQ2MzI4Iiwicm9sZV9pZCI6Im9yZ19hZG1pbiIsImV4cCI6MTczMjc5Mjk0OCwib3JnX2lkIjoib3JnX1ZwU0hPanNZZkR2YWJWWUpnQ0FKIiwicHJvZmlsZV9pZCI6InByb192NXNGb0hlODBPZWlVbElvbm9jTSIsInRlbmFudF9pZCI6InB1YmxpYyJ9.Q5ruAj8DwAp5XDj1ktFhma4aZXAHSZBmRSw_EnPk4HE' \
--header 'sec-ch-ua: "Chromium";v="128", "Not;A=Brand";v="24", "Google Chrome";v="128"' \
--header 'sec-ch-ua-mobile: ?0' \
--header 'sec-ch-ua-platform: "macOS"' \
--data '[
    {
        "timeRange": {
            "startTime": "2024-11-17T00:30:00Z",
            "endTime": "2024-11-25T23:30:00Z"
        },
        "groupByNames": [
            "connector"
        ],
        "filters":{
            "first_attempt": [false]
        },
        "source": "BATCH",
        "metrics": [
            "payments_distribution"
        ],
        "delta": true
    }
]'
```
Response:
```json
{
    "queryData": [
        {
            "payment_success_rate": null,
            "payment_count": null,
            "payment_success_count": null,
            "payment_processed_amount": 0,
            "payment_processed_amount_in_usd": null,
            "payment_processed_count": null,
            "payment_processed_amount_without_smart_retries": 0,
            "payment_processed_amount_without_smart_retries_usd": null,
            "payment_processed_count_without_smart_retries": null,
            "avg_ticket_size": null,
            "payment_error_message": null,
            "retries_count": null,
            "retries_amount_processed": 0,
            "connector_success_rate": null,
            "payments_success_rate_distribution": 100.0,
            "payments_success_rate_distribution_without_smart_retries": null,
            "payments_success_rate_distribution_with_only_retries": 100.0,
            "payments_failure_rate_distribution": 0.0,
            "payments_failure_rate_distribution_without_smart_retries": null,
            "payments_failure_rate_distribution_with_only_retries": 0.0,
            "failure_reason_count": 0,
            "failure_reason_count_without_smart_retries": 0,
            "currency": null,
            "status": null,
            "connector": "stripe_test",
            "authentication_type": null,
            "payment_method": null,
            "payment_method_type": null,
            "client_source": null,
            "client_version": null,
            "profile_id": null,
            "card_network": null,
            "merchant_id": null,
            "card_last_4": null,
            "card_issuer": null,
            "error_reason": null,
            "time_range": {
                "start_time": "2024-11-17T00:30:00.000Z",
                "end_time": "2024-11-25T23:30:00.000Z"
            },
            "time_bucket": "2024-11-17 00:30:00"
        }
    ],
    "metaData": [
        {
            "total_payment_processed_amount": 0,
            "total_payment_processed_amount_in_usd": 0,
            "total_payment_processed_amount_without_smart_retries": 0,
            "total_payment_processed_amount_without_smart_retries_usd": 0,
            "total_payment_processed_count": 0,
            "total_payment_processed_count_without_smart_retries": 0,
            "total_failure_reasons_count": 0,
            "total_failure_reasons_count_without_smart_retries": 0
        }
    ]
}
```
If smart retries are made, then these fields will show null:
```json
"payments_success_rate_distribution_without_smart_retries": null,
"payments_failure_rate_distribution_without_smart_retries": null,
```

And these fields will have some value:
```json
"payments_success_rate_distribution_with_only_retries": 100.0,
"payments_failure_rate_distribution_with_only_retries": 0.0,
```

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/591a1b3f-ced4-4fb4-a16d-1ddc246ad5c1">
<img width="1726" alt="image" src="https://github.com/user-attachments/assets/eea88a15-41c6-4998-b2a5-7485c3aebf75">

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
