### PR TITLE
fix(core): add payment_id as query param in merchant return url

### DIFF
--- a/crates/router/src/core/payments/helpers.rs
+++ b/crates/router/src/core/payments/helpers.rs
@@ -2948,11 +2948,13 @@ pub fn make_merchant_url_with_response(
         .ok_or(errors::ApiErrorResponse::InternalServerError)
         .attach_printable("Expected client secret to be `Some`")?;
 
+    let payment_id = redirection_response.payment_id.get_string_repr().to_owned();
     let merchant_url_with_response = if business_profile.redirect_to_merchant_with_http_post {
         url::Url::parse_with_params(
             url,
             &[
                 ("status", status_check.to_string()),
+                ("payment_id", payment_id),
                 (
                     "payment_intent_client_secret",
                     payment_client_secret.peek().to_string(),
@@ -2971,6 +2973,7 @@ pub fn make_merchant_url_with_response(
             url,
             &[
                 ("status", status_check.to_string()),
+                ("payment_id", payment_id),
                 (
                     "payment_intent_client_secret",
                     payment_client_secret.peek().to_string(),


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
hotfix pr for https://github.com/juspay/hyperswitch/pull/6665

Currently in payment link after redirection in case of non 3ds,  we return to  merchant url with following query params
-  payment id, status
But for non 3ds we return to merchant url with following query params
- status , client secret, manual_retry_allowed

Inorder to have consistency across all return response to merchant adding payment_id to 3ds/redirection like bank redirects response url.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Create 3ds transaction upon returning to merchant url redirection url should have payment id .

<img width="1501" alt="Screenshot 2024-11-26 at 6 37 03 PM" src="https://github.com/user-attachments/assets/685e6545-8ed8-4865-989d-81eeeac191ea">

Create 3ds failure transaction it should have the payment id in the response
<img width="1534" alt="Screenshot 2024-11-26 at 6 41 52 PM" src="https://github.com/user-attachments/assets/04a82a40-64ca-4063-a381-a1763f3e6cdc">

Create any other redirection payment method scenarios.- tested this locally with online banking fpx for fiuu.
```
{
    "amount": 1000,
    "currency": "MYR",
    "amount_to_capture": 1000,
    "confirm": false,
    "payment_link" : true,
    // "profile_id" : "{{profile_id}}",
    "capture_method": "automatic",
    "payment_method": "bank_redirect",
    "payment_method_type": "online_banking_fpx",
    "return_url": "https://google.com",
    "payment_method_data": {
        "bank_redirect": {
            "online_banking_fpx": {
                "issuer": "bank_islam"
            }
        }
    }
}
```
<img width="1385" alt="Screenshot 2024-11-26 at 6 44 05 PM" src="https://github.com/user-attachments/assets/c19c9ead-8c19-4dea-9a69-10cfb925524b">

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
