### PR TITLE
refactor(currency_conversion): release redis lock if api call fails

### DIFF
--- a/crates/router/src/utils/currency.rs
+++ b/crates/router/src/utils/currency.rs
@@ -237,9 +237,7 @@ async fn successive_fetch_and_save_forex(
                     logger::error!(?error);
                     let secondary_api_rates = fallback_fetch_forex_rates(state).await;
                     match secondary_api_rates {
-                        Ok(rates) => {
-                            Ok(successive_save_data_to_redis_local(state, rates).await?)
-                        },
+                        Ok(rates) => Ok(successive_save_data_to_redis_local(state, rates).await?),
                         Err(error) => stale_redis_data.ok_or({
                             logger::error!(?error);
                             release_redis_lock(state).await?;

--- a/crates/router/src/utils/currency.rs
+++ b/crates/router/src/utils/currency.rs
@@ -262,7 +262,7 @@ async fn successive_save_data_to_redis_local(
         .await
         .async_and_then(|_rates| release_redis_lock(state))
         .await
-        .async_and_then(|_val|  save_forex_to_local(forex.clone()))
+        .async_and_then(|_val| save_forex_to_local(forex.clone()))
         .await
         .map_or_else(
             |error| {
@@ -348,7 +348,9 @@ async fn fetch_forex_rates(
         .json::<ForexResponse>()
         .await
         .change_context(ForexCacheError::ParsingError)
-        .attach_printable("Unable to parse response received from primary api into ForexResponse")?;
+        .attach_printable(
+            "Unable to parse response received from primary api into ForexResponse",
+        )?;
 
     logger::info!("{:?}", forex_response);
 
@@ -407,7 +409,9 @@ pub async fn fallback_fetch_forex_rates(
         .json::<FallbackForexResponse>()
         .await
         .change_context(ForexCacheError::ParsingError)
-        .attach_printable("Unable to parse response received from falback api into ForexResponse")?;
+        .attach_printable(
+            "Unable to parse response received from falback api into ForexResponse",
+        )?;
 
     logger::info!("{:?}", fallback_forex_response);
     let mut conversions: HashMap<enums::Currency, CurrencyFactors> = HashMap::new();


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Refactors for currency conversion which invlolves:
-> Better error propagation
-> Redis lock realease, if data isn't fetched from api, so that the other subsequent calls donot fail.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
Reqired for analytics

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Scenarios tested:
1. No api_keys provided: call returned error and redis key was deleted after being set.
2. fallback api_key provided: call returned forex rates and lock was also released.
3. primary api_key provided: call returned forex rates and lock was also released.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
