### PR TITLE
fix(users): Check lineage across entities in invite

### DIFF
--- a/crates/router/src/core/user.rs
+++ b/crates/router/src/core/user.rs
@@ -669,7 +669,7 @@ async fn handle_existing_user_invitation(
             limit: Some(1),
         })
         .await
-        .is_ok_and(|data| data.len() > 0)
+        .is_ok_and(|data| data.is_empty().not())
     {
         return Err(UserErrors::UserExists.into());
     }

--- a/crates/router/src/core/user.rs
+++ b/crates/router/src/core/user.rs
@@ -642,6 +642,38 @@ async fn handle_existing_user_invitation(
         return Err(UserErrors::UserExists.into());
     }
 
+    let (org_id, merchant_id, profile_id) = match role_info.get_entity_type() {
+        EntityType::Organization => (Some(&user_from_token.org_id), None, None),
+        EntityType::Merchant => (
+            Some(&user_from_token.org_id),
+            Some(&user_from_token.merchant_id),
+            None,
+        ),
+        EntityType::Profile => (
+            Some(&user_from_token.org_id),
+            Some(&user_from_token.merchant_id),
+            Some(&user_from_token.profile_id),
+        ),
+    };
+
+    if state
+        .global_store
+        .list_user_roles_by_user_id(ListUserRolesByUserIdPayload {
+            user_id: invitee_user_from_db.get_user_id(),
+            org_id,
+            merchant_id,
+            profile_id,
+            entity_id: None,
+            version: None,
+            status: None,
+            limit: Some(1),
+        })
+        .await
+        .is_ok_and(|data| data.len() > 0)
+    {
+        return Err(UserErrors::UserExists.into());
+    }
+
     let user_role = domain::NewUserRole {
         user_id: invitee_user_from_db.get_user_id().to_owned(),
         role_id: request.role_id.clone(),


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Currently in invites we don't check if user exists across entities.
This will be a problem when inviting a user with higher entity from different lineage.
This PR fixes it.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->

Closes #6679.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
1. Invite a user in a specific (org, merchant, profile) combination.
2. Create a new profile in the same merchant account and switch to it.
3. Invite the same user as merchant level user. This should be stopped by API.


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
