### PR TITLE
refactor(core): add error handling wrapper to wehbook

### DIFF
--- a/crates/api_models/src/connector_enums.rs
+++ b/crates/api_models/src/connector_enums.rs
@@ -278,6 +278,9 @@ impl Connector {
     pub fn is_pre_processing_required_before_authorize(&self) -> bool {
         matches!(self, Self::Airwallex)
     }
+    pub fn should_acknowledge_webhook_for_resource_not_found_errors(&self) -> bool {
+        matches!(self, Self::Adyenplatform)
+    }
     #[cfg(feature = "dummy_connector")]
     pub fn validate_dummy_connector_enabled(
         &self,

--- a/crates/hyperswitch_connectors/src/connectors/cashtocode.rs
+++ b/crates/hyperswitch_connectors/src/connectors/cashtocode.rs
@@ -30,7 +30,7 @@ use hyperswitch_interfaces::{
     errors,
     events::connector_api_logs::ConnectorEvent,
     types::{PaymentsAuthorizeType, Response},
-    webhooks,
+    webhooks::{self, IncomingWebhookFlowError},
 };
 use masking::{Mask, PeekInterface, Secret};
 use transformers as cashtocode;
@@ -420,6 +420,7 @@ impl webhooks::IncomingWebhook for Cashtocode {
     fn get_webhook_api_response(
         &self,
         request: &webhooks::IncomingWebhookRequestDetails<'_>,
+        _error_kind: Option<IncomingWebhookFlowError>,
     ) -> CustomResult<ApplicationResponse<serde_json::Value>, errors::ConnectorError> {
         let status = "EXECUTED".to_string();
         let obj: transformers::CashtocodePaymentsSyncResponse = request

--- a/crates/hyperswitch_connectors/src/connectors/worldline.rs
+++ b/crates/hyperswitch_connectors/src/connectors/worldline.rs
@@ -41,7 +41,7 @@ use hyperswitch_interfaces::{
         PaymentsAuthorizeType, PaymentsCaptureType, PaymentsSyncType, PaymentsVoidType,
         RefundExecuteType, RefundSyncType, Response,
     },
-    webhooks,
+    webhooks::{self, IncomingWebhookFlowError},
 };
 use masking::{ExposeInterface, Mask, PeekInterface};
 use ring::hmac;
@@ -814,6 +814,7 @@ impl webhooks::IncomingWebhook for Worldline {
     fn get_webhook_api_response(
         &self,
         request: &webhooks::IncomingWebhookRequestDetails<'_>,
+        _error_kind: Option<IncomingWebhookFlowError>,
     ) -> CustomResult<
         hyperswitch_domain_models::api::ApplicationResponse<serde_json::Value>,
         errors::ConnectorError,

--- a/crates/hyperswitch_connectors/src/connectors/zen.rs
+++ b/crates/hyperswitch_connectors/src/connectors/zen.rs
@@ -41,7 +41,7 @@ use hyperswitch_interfaces::{
     errors,
     events::connector_api_logs::ConnectorEvent,
     types::{PaymentsAuthorizeType, PaymentsSyncType, RefundExecuteType, RefundSyncType, Response},
-    webhooks::{IncomingWebhook, IncomingWebhookRequestDetails},
+    webhooks::{IncomingWebhook, IncomingWebhookFlowError, IncomingWebhookRequestDetails},
 };
 use masking::{Mask, PeekInterface, Secret};
 use transformers::{self as zen, ZenPaymentStatus, ZenWebhookTxnType};
@@ -671,6 +671,7 @@ impl IncomingWebhook for Zen {
     fn get_webhook_api_response(
         &self,
         _request: &IncomingWebhookRequestDetails<'_>,
+        _error_kind: Option<IncomingWebhookFlowError>,
     ) -> CustomResult<ApplicationResponse<serde_json::Value>, errors::ConnectorError> {
         Ok(ApplicationResponse::Json(serde_json::json!({
             "status": "ok"

--- a/crates/hyperswitch_connectors/src/connectors/zsl.rs
+++ b/crates/hyperswitch_connectors/src/connectors/zsl.rs
@@ -36,7 +36,7 @@ use hyperswitch_interfaces::{
     errors,
     events::connector_api_logs::ConnectorEvent,
     types::{self, Response},
-    webhooks::{IncomingWebhook, IncomingWebhookRequestDetails},
+    webhooks::{IncomingWebhook, IncomingWebhookFlowError, IncomingWebhookRequestDetails},
 };
 use masking::{ExposeInterface, Secret};
 use transformers::{self as zsl, get_status};
@@ -442,6 +442,7 @@ impl IncomingWebhook for Zsl {
     fn get_webhook_api_response(
         &self,
         _request: &IncomingWebhookRequestDetails<'_>,
+        _error_kind: Option<IncomingWebhookFlowError>,
     ) -> CustomResult<ApplicationResponse<serde_json::Value>, errors::ConnectorError> {
         Ok(ApplicationResponse::TextPlain("CALLBACK-OK".to_string()))
     }

--- a/crates/hyperswitch_interfaces/src/webhooks.rs
+++ b/crates/hyperswitch_interfaces/src/webhooks.rs
@@ -2,7 +2,9 @@
 
 use common_utils::{crypto, errors::CustomResult, ext_traits::ValueExt};
 use error_stack::ResultExt;
-use hyperswitch_domain_models::api::ApplicationResponse;
+use hyperswitch_domain_models::{
+    api::ApplicationResponse, errors::api_error_response::ApiErrorResponse,
+};
 use masking::{ExposeInterface, Secret};
 
 use crate::{api::ConnectorCommon, errors};
@@ -20,6 +22,30 @@ pub struct IncomingWebhookRequestDetails<'a> {
     pub body: &'a [u8],
     /// query_params
     pub query_params: String,
+}
+
+/// IncomingWebhookFlowError enum defining the error type for incoming webhook
+#[derive(Debug)]
+pub enum IncomingWebhookFlowError {
+    /// Resource not found for the webhook
+    ResourceNotFound,
+    /// Internal error for the webhook
+    InternalError,
+}
+
+impl From<&ApiErrorResponse> for IncomingWebhookFlowError {
+    fn from(api_error_response: &ApiErrorResponse) -> Self {
+        match api_error_response {
+            ApiErrorResponse::WebhookResourceNotFound
+            | ApiErrorResponse::DisputeNotFound { .. }
+            | ApiErrorResponse::PayoutNotFound
+            | ApiErrorResponse::MandateNotFound
+            | ApiErrorResponse::PaymentNotFound
+            | ApiErrorResponse::RefundNotFound
+            | ApiErrorResponse::AuthenticationNotFound { .. } => Self::ResourceNotFound,
+            _ => Self::InternalError,
+        }
+    }
 }
 
 /// Trait defining incoming webhook
@@ -203,6 +229,7 @@ pub trait IncomingWebhook: ConnectorCommon + Sync {
     fn get_webhook_api_response(
         &self,
         _request: &IncomingWebhookRequestDetails<'_>,
+        _error_kind: Option<IncomingWebhookFlowError>,
     ) -> CustomResult<ApplicationResponse<serde_json::Value>, errors::ConnectorError> {
         Ok(ApplicationResponse::StatusOk)
     }

--- a/crates/router/src/connector/adyen.rs
+++ b/crates/router/src/connector/adyen.rs
@@ -7,6 +7,7 @@ use common_utils::{
 };
 use diesel_models::{enums as storage_enums, enums};
 use error_stack::{report, ResultExt};
+use hyperswitch_interfaces::webhooks::IncomingWebhookFlowError;
 use masking::{ExposeInterface, Secret};
 use ring::hmac;
 use router_env::{instrument, tracing};
@@ -1880,6 +1881,7 @@ impl api::IncomingWebhook for Adyen {
     fn get_webhook_api_response(
         &self,
         _request: &api::IncomingWebhookRequestDetails<'_>,
+        _error_kind: Option<IncomingWebhookFlowError>,
     ) -> CustomResult<services::api::ApplicationResponse<serde_json::Value>, errors::ConnectorError>
     {
         Ok(services::api::ApplicationResponse::TextPlain(

--- a/crates/router/src/connector/braintree.rs
+++ b/crates/router/src/connector/braintree.rs
@@ -10,6 +10,7 @@ use common_utils::{
 };
 use diesel_models::enums;
 use error_stack::{report, Report, ResultExt};
+use hyperswitch_interfaces::webhooks::IncomingWebhookFlowError;
 use masking::{ExposeInterface, PeekInterface, Secret};
 use ring::hmac;
 use sha1::{Digest, Sha1};
@@ -980,6 +981,7 @@ impl api::IncomingWebhook for Braintree {
     fn get_webhook_api_response(
         &self,
         _request: &api::IncomingWebhookRequestDetails<'_>,
+        _error_kind: Option<IncomingWebhookFlowError>,
     ) -> CustomResult<services::api::ApplicationResponse<serde_json::Value>, errors::ConnectorError>
     {
         Ok(services::api::ApplicationResponse::TextPlain(

--- a/crates/router/src/core/webhooks/incoming_v2.rs
+++ b/crates/router/src/core/webhooks/incoming_v2.rs
@@ -192,7 +192,7 @@ async fn incoming_webhooks_core<W: types::OutgoingWebhookType>(
             );
 
             let response = connector
-                .get_webhook_api_response(&request_details)
+                .get_webhook_api_response(&request_details, None)
                 .switch()
                 .attach_printable("Failed while early return in case of event type parsing")?;
 
@@ -367,7 +367,7 @@ async fn incoming_webhooks_core<W: types::OutgoingWebhookType>(
     };
 
     let response = connector
-        .get_webhook_api_response(&request_details)
+        .get_webhook_api_response(&request_details, None)
         .switch()
         .attach_printable("Could not get incoming webhook api response from connector")?;
 

--- a/crates/router/src/services/connector_integration_interface.rs
+++ b/crates/router/src/services/connector_integration_interface.rs
@@ -1,7 +1,8 @@
 use common_utils::{crypto, errors::CustomResult, request::Request};
 use hyperswitch_domain_models::{router_data::RouterData, router_data_v2::RouterDataV2};
 use hyperswitch_interfaces::{
-    authentication::ExternalAuthenticationPayload, connector_integration_v2::ConnectorIntegrationV2,
+    authentication::ExternalAuthenticationPayload,
+    connector_integration_v2::ConnectorIntegrationV2, webhooks::IncomingWebhookFlowError,
 };
 
 use super::{BoxedConnectorIntegrationV2, ConnectorValidation};
@@ -279,11 +280,12 @@ impl api::IncomingWebhook for ConnectorEnum {
     fn get_webhook_api_response(
         &self,
         request: &IncomingWebhookRequestDetails<'_>,
+        error_kind: Option<IncomingWebhookFlowError>,
     ) -> CustomResult<services_api::ApplicationResponse<serde_json::Value>, errors::ConnectorError>
     {
         match self {
-            Self::Old(connector) => connector.get_webhook_api_response(request),
-            Self::New(connector) => connector.get_webhook_api_response(request),
+            Self::Old(connector) => connector.get_webhook_api_response(request, error_kind),
+            Self::New(connector) => connector.get_webhook_api_response(request, error_kind),
         }
     }
 


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
In webhook, for specific connectors, we want to consume every webhook that arrives even if a error occurs while processing. This is done to keep the webhook channel open with the connector. 
In this pr, a error wrapper is introduced to handle this logic where based on connector, we choose whether to send error or not.

Note: Hotfix pr against #6636 

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

Tested through Postman:
- Create a MCA (Adyenplatform):
- Setup webhook endpoint in dashboard (Adyenplatform):
- Create a payout:
```
{
    "amount": 100,
    "currency": "EUR",
    "customer_id": "sakilcust",
    "email": "payout_customer@example.com",
    "phone": "999999999",
    "phone_country_code": "+65",
    "description": "Its my first payout request",
    "payout_type": "bank",
    "priority": "instant",
    "payout_method_data": {
        "bank": {
            "iban": "DE89370400440532013000"
        }
    },
    "billing": {
        "address": {
            "line1": "Raadhuisplein",
            "line2": "92",
            "city": "Hoogeveen",
            "state": "FL",
            "zip": "7901 BW",
            "country": "NL",
            "first_name": "John",
            "last_name": "Doe"
        },
        "phone": {
            "number": "0650242319",
            "country_code": "+31"
        }
    },
    "entity_type": "Individual",
    "recurring": true,
    "confirm": true,
    "auto_fulfill": true
}
```
- You should receive webhook for the following payout to the endpoint mentioned during merchant creation

Case 2:
- Setup `ngrok` to intercept webhook
- Create a payout (same body as above)
- delete the `payout_attempt` from the payout_attempt table against the generated `payout_id`
- See the log in ngrok for response sent to the adyenplatform
- The status should be 200 with `x-http-code` present in headers

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
