### PR TITLE
refactor(router): [ZSL] remove partially capture status

### DIFF
--- a/crates/hyperswitch_connectors/src/connectors/zsl/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/zsl/transformers.rs
@@ -414,20 +414,10 @@ impl<F> TryFrom<ResponseRouterData<F, ZslWebhookResponse, PaymentsSyncData, Paym
             .consr_paid_amt
             .parse::<i64>()
             .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
-        let txn_amount = item
-            .response
-            .txn_amt
-            .parse::<i64>()
-            .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
-        let status = if txn_amount > paid_amount {
-            enums::AttemptStatus::PartialCharged
-        } else {
-            enums::AttemptStatus::Charged
-        };
 
         if item.response.status == "0" {
             Ok(Self {
-                status,
+                status: enums::AttemptStatus::Charged,
                 amount_captured: Some(paid_amount),
                 response: Ok(PaymentsResponseData::TransactionResponse {
                     resource_id: ResponseId::ConnectorTransactionId(item.response.txn_id.clone()),


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Currently, in case of underpayment we are mapping the payment status as `partially captured` with the changes of this PR. We will map the underpayment status as `succeeded` and provide information about the amount actually captured 


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Webhooks cannot be tested in ZSL sandbox.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
