### PR TITLE
fix(openapi): Revert Standardise API naming scheme for V2 Dashboard Changes

### DIFF
--- a/crates/router/src/routes/app.rs
+++ b/crates/router/src/routes/app.rs
@@ -2003,7 +2003,7 @@ impl User {
                 )
                 .service(web::resource("/verify_email").route(web::post().to(user::verify_email)))
                 .service(
-                    web::resource("/v2/verify-email").route(web::post().to(user::verify_email)),
+                    web::resource("/v2/verify_email").route(web::post().to(user::verify_email)),
                 )
                 .service(
                     web::resource("/verify_email_request")
@@ -2057,7 +2057,7 @@ impl User {
                                         .route(web::post().to(user_role::accept_invitations_v2)),
                                 )
                                 .service(
-                                    web::resource("/pre-auth").route(
+                                    web::resource("/pre_auth").route(
                                         web::post().to(user_role::accept_invitations_pre_auth),
                                     ),
                                 ),


### PR DESCRIPTION
Reverts part of juspay/hyperswitch#6510

This PR also changed the dashboard related APIs, which doesn't come under the V2 changes that team is doing. As this is not a backwards compatible change, dashboard is breaking. Revert the dashboard API related changes.