### PR TITLE
fix(connector): adyen - propagate connector mandate details in incoming webhooks

### DIFF
--- a/crates/router/src/connector/adyen.rs
+++ b/crates/router/src/connector/adyen.rs
@@ -1908,6 +1908,27 @@ impl api::IncomingWebhook for Adyen {
             updated_at: notif.event_date,
         })
     }
+
+    fn get_mandate_details(
+        &self,
+        request: &api::IncomingWebhookRequestDetails<'_>,
+    ) -> CustomResult<
+        Option<hyperswitch_domain_models::router_flow_types::ConnectorMandateDetails>,
+        errors::ConnectorError,
+    > {
+        let notif = get_webhook_object_from_body(request.body)
+            .change_context(errors::ConnectorError::WebhookBodyDecodingFailed)?;
+        let mandate_reference =
+            notif
+                .additional_data
+                .recurring_detail_reference
+                .map(|mandate_id| {
+                    hyperswitch_domain_models::router_flow_types::ConnectorMandateDetails {
+                        connector_mandate_id: mandate_id.clone(),
+                    }
+                });
+        Ok(mandate_reference)
+    }
 }
 
 impl api::Dispute for Adyen {}

--- a/crates/router/src/connector/adyen/transformers.rs
+++ b/crates/router/src/connector/adyen/transformers.rs
@@ -4263,6 +4263,9 @@ pub struct AdyenAdditionalDataWH {
     pub chargeback_reason_code: Option<String>,
     #[serde(default, with = "common_utils::custom_serde::iso8601::option")]
     pub defense_period_ends_at: Option<PrimitiveDateTime>,
+    /// Enable recurring details in dashboard to receive this ID, https://docs.adyen.com/online-payments/tokenization/create-and-use-tokens#test-and-go-live
+    #[serde(rename = "recurring.recurringDetailReference")]
+    pub recurring_detail_reference: Option<Secret<String>>,
 }
 
 #[derive(Debug, Deserialize)]


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
Described in the linked #6719 

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
Ensures mandate details are stored for Adyen.

## How did you test it?
Since this is an intermittent scenario, webhooks flow was tested locally by disabling propagation of mandate details during PSync flow for Adyen.

`connector_mandate_details` is populate post receiving the webhooks
<img width="1341" alt="Screenshot 2024-12-02 at 8 30 39 PM" src="https://github.com/user-attachments/assets/e488b0e1-e7cf-45a5-b706-cfe77ff50a85">


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
