### PR TITLE
ci(Cypress): Add testcase for newline in address

### DIFF
--- a/cypress-tests/cypress/e2e/PaymentUtils/Cybersource.js
+++ b/cypress-tests/cypress/e2e/PaymentUtils/Cybersource.js
@@ -189,6 +189,23 @@ export const connectorDetails = {
         currency: "USD",
         customer_acceptance: null,
         setup_future_usage: "on_session",
+        billing: {
+          address: {
+            line1: "1467",
+            line2: "Harrison Street\nApt 101",
+            line3: "Harrison Street\nApt 101",
+            city: "San Fransico\n city",
+            state: "California",
+            zip: "94122",
+            country: "NL",
+            first_name: "joseph",
+            last_name: "Doe",
+          },
+          phone: {
+            number: "9123456789",
+            country_code: "+91",
+          },
+        },
       },
       Response: {
         status: 200,

--- a/cypress-tests/cypress/e2e/PaymentUtils/Cybersource.js
+++ b/cypress-tests/cypress/e2e/PaymentUtils/Cybersource.js
@@ -90,6 +90,24 @@ const payment_method_data_3ds = {
   billing: null,
 };
 
+const billing_with_newline = {
+  address: {
+    line1: "1467",
+    line2: "Harrison Street\nApt 101",
+    line3: "Harrison Street\nApt 101",
+    city: "San Fransico\n city",
+    state: "California",
+    zip: "94122",
+    country: "NL",
+    first_name: "joseph",
+    last_name: "Doe",
+  },
+  phone: {
+    number: "9123456789",
+    country_code: "+91",
+  },
+};
+
 export const connectorDetails = {
   card_pm: {
     PaymentIntent: {
@@ -189,23 +207,7 @@ export const connectorDetails = {
         currency: "USD",
         customer_acceptance: null,
         setup_future_usage: "on_session",
-        billing: {
-          address: {
-            line1: "1467",
-            line2: "Harrison Street\nApt 101",
-            line3: "Harrison Street\nApt 101",
-            city: "San Fransico\n city",
-            state: "California",
-            zip: "94122",
-            country: "NL",
-            first_name: "joseph",
-            last_name: "Doe",
-          },
-          phone: {
-            number: "9123456789",
-            country_code: "+91",
-          },
-        },
+        billing: billing_with_newline,
       },
       Response: {
         status: 200,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [x] CI/CD

## Description
There is a bug fix for cybersource where the billing address contains new line then the payments are getting failed. To address that in automation have added billling address with newlinw in confirm call and expecting succeeded in the response.



## Motivation and Context
To enhance the testcase

## How did you test it?
<img width="1055" alt="Screenshot 2024-12-02 at 5 07 37 PM" src="https://github.com/user-attachments/assets/5f021fa4-fa98-4c1a-99fd-1d1f2749dc30">


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
