### PR TITLE
consume connector error message for 2xx errors for DeutscheBank

### DIFF
--- a/crates/hyperswitch_connectors/src/connectors/deutschebank/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/deutschebank/transformers.rs
@@ -5,7 +5,7 @@ use common_utils::{ext_traits::ValueExt, pii::Email, types::MinorUnit};
 use error_stack::ResultExt;
 use hyperswitch_domain_models::{
     payment_method_data::{BankDebitData, PaymentMethodData},
-    router_data::{AccessToken, ConnectorAuthType, RouterData},
+    router_data::{AccessToken, ConnectorAuthType, ErrorResponse, RouterData},
     router_flow_types::{
         payments::{Authorize, Capture, CompleteAuthorize, PSync},
         refunds::{Execute, RSync},
@@ -263,6 +263,21 @@ pub struct DeutschebankMandatePostResponse {
     state: Option<DeutschebankSEPAMandateStatus>,
 }
 
+fn get_error_response(error_code: String, error_reason: String, status_code: u16) -> ErrorResponse {
+    ErrorResponse {
+        code: error_code.to_string(),
+        message: error_reason.clone(),
+        reason: Some(error_reason),
+        status_code,
+        attempt_status: None,
+        connector_transaction_id: None,
+    }
+}
+
+fn is_response_success(rc: String) -> bool {
+    rc == "0"
+}
+
 impl
     TryFrom<
         ResponseRouterData<
@@ -286,16 +301,16 @@ impl
             Some(date) => date.chars().take(10).collect(),
             None => time::OffsetDateTime::now_utc().date().to_string(),
         };
-        match item.response.reference.clone() {
-            Some(reference) => Ok(Self {
-                status: if item.response.rc == "0" {
-                    match item.response.state.clone() {
-                        Some(state) => common_enums::AttemptStatus::from(state),
-                        None => common_enums::AttemptStatus::Failure,
-                    }
-                } else {
-                    common_enums::AttemptStatus::Failure
-                },
+        let response_code = item.response.rc.clone();
+        let is_response_success = is_response_success(response_code.clone());
+
+        match (
+            item.response.reference.clone(),
+            item.response.state.clone(),
+            is_response_success,
+        ) {
+            (Some(reference), Some(state), true) => Ok(Self {
+                status: common_enums::AttemptStatus::from(state),
                 response: Ok(PaymentsResponseData::TransactionResponse {
                     resource_id: ResponseId::NoResponseId,
                     redirection_data: Box::new(Some(RedirectForm::Form {
@@ -340,10 +355,20 @@ impl
                 }),
                 ..item.data
             }),
-            None => Ok(Self {
-                status: common_enums::AttemptStatus::Failure,
-                ..item.data
-            }),
+            _ => {
+                let error_reason = item.response.message.clone();
+                let response = Err(get_error_response(
+                    response_code.clone(),
+                    error_reason,
+                    item.http_code,
+                ));
+
+                Ok(Self {
+                    status: common_enums::AttemptStatus::Failure,
+                    response,
+                    ..item.data
+                })
+            }
         }
     }
 }
@@ -367,27 +392,41 @@ impl
             PaymentsResponseData,
         >,
     ) -> Result<Self, Self::Error> {
-        Ok(Self {
-            status: if item.response.rc == "0" {
-                match item.data.request.is_auto_capture()? {
+        let response_code = item.response.rc.clone();
+        let is_response_success = is_response_success(response_code.clone());
+
+        if is_response_success {
+            Ok(Self {
+                status: match item.data.request.is_auto_capture()? {
                     true => common_enums::AttemptStatus::Charged,
                     false => common_enums::AttemptStatus::Authorized,
-                }
-            } else {
-                common_enums::AttemptStatus::Failure
-            },
-            response: Ok(PaymentsResponseData::TransactionResponse {
-                resource_id: ResponseId::ConnectorTransactionId(item.response.tx_id),
-                redirection_data: Box::new(None),
-                mandate_reference: Box::new(None),
-                connector_metadata: None,
-                network_txn_id: None,
-                connector_response_reference_id: None,
-                incremental_authorization_allowed: None,
-                charge_id: None,
-            }),
-            ..item.data
-        })
+                },
+                response: Ok(PaymentsResponseData::TransactionResponse {
+                    resource_id: ResponseId::ConnectorTransactionId(item.response.tx_id),
+                    redirection_data: Box::new(None),
+                    mandate_reference: Box::new(None),
+                    connector_metadata: None,
+                    network_txn_id: None,
+                    connector_response_reference_id: None,
+                    incremental_authorization_allowed: None,
+                    charge_id: None,
+                }),
+                ..item.data
+            })
+        } else {
+            let error_reason = item.response.message.clone();
+            let response = Err(get_error_response(
+                response_code.clone(),
+                error_reason,
+                item.http_code,
+            ));
+
+            Ok(Self {
+                status: common_enums::AttemptStatus::Failure,
+                response,
+                ..item.data
+            })
+        }
     }
 }
 
@@ -570,27 +609,41 @@ impl
             PaymentsResponseData,
         >,
     ) -> Result<Self, Self::Error> {
-        Ok(Self {
-            status: if item.response.rc == "0" {
-                match item.data.request.is_auto_capture()? {
+        let response_code = item.response.rc.clone();
+        let is_response_success = is_response_success(response_code.clone());
+
+        if is_response_success {
+            Ok(Self {
+                status: match item.data.request.is_auto_capture()? {
                     true => common_enums::AttemptStatus::Charged,
                     false => common_enums::AttemptStatus::Authorized,
-                }
-            } else {
-                common_enums::AttemptStatus::Failure
-            },
-            response: Ok(PaymentsResponseData::TransactionResponse {
-                resource_id: ResponseId::ConnectorTransactionId(item.response.tx_id),
-                redirection_data: Box::new(None),
-                mandate_reference: Box::new(None),
-                connector_metadata: None,
-                network_txn_id: None,
-                connector_response_reference_id: None,
-                incremental_authorization_allowed: None,
-                charge_id: None,
-            }),
-            ..item.data
-        })
+                },
+                response: Ok(PaymentsResponseData::TransactionResponse {
+                    resource_id: ResponseId::ConnectorTransactionId(item.response.tx_id),
+                    redirection_data: Box::new(None),
+                    mandate_reference: Box::new(None),
+                    connector_metadata: None,
+                    network_txn_id: None,
+                    connector_response_reference_id: None,
+                    incremental_authorization_allowed: None,
+                    charge_id: None,
+                }),
+                ..item.data
+            })
+        } else {
+            let error_reason = item.response.message.clone();
+            let response = Err(get_error_response(
+                response_code.clone(),
+                error_reason,
+                item.http_code,
+            ));
+
+            Ok(Self {
+                status: common_enums::AttemptStatus::Failure,
+                response,
+                ..item.data
+            })
+        }
     }
 }
 
@@ -637,24 +690,38 @@ impl
             PaymentsResponseData,
         >,
     ) -> Result<Self, Self::Error> {
-        Ok(Self {
-            response: Ok(PaymentsResponseData::TransactionResponse {
-                resource_id: ResponseId::ConnectorTransactionId(item.response.tx_id),
-                redirection_data: Box::new(None),
-                mandate_reference: Box::new(None),
-                connector_metadata: None,
-                network_txn_id: None,
-                connector_response_reference_id: None,
-                incremental_authorization_allowed: None,
-                charge_id: None,
-            }),
-            status: if item.response.rc == "0" {
-                common_enums::AttemptStatus::Charged
-            } else {
-                common_enums::AttemptStatus::Failure
-            },
-            ..item.data
-        })
+        let response_code = item.response.rc.clone();
+        let is_response_success = is_response_success(response_code.clone());
+
+        if is_response_success {
+            Ok(Self {
+                status: common_enums::AttemptStatus::Charged,
+                response: Ok(PaymentsResponseData::TransactionResponse {
+                    resource_id: ResponseId::ConnectorTransactionId(item.response.tx_id),
+                    redirection_data: Box::new(None),
+                    mandate_reference: Box::new(None),
+                    connector_metadata: None,
+                    network_txn_id: None,
+                    connector_response_reference_id: None,
+                    incremental_authorization_allowed: None,
+                    charge_id: None,
+                }),
+                ..item.data
+            })
+        } else {
+            let error_reason = item.response.message.clone();
+            let response = Err(get_error_response(
+                response_code.clone(),
+                error_reason,
+                item.http_code,
+            ));
+
+            Ok(Self {
+                status: common_enums::AttemptStatus::Failure,
+                response,
+                ..item.data
+            })
+        }
     }
 }
 
@@ -677,7 +744,10 @@ impl
             PaymentsResponseData,
         >,
     ) -> Result<Self, Self::Error> {
-        let status = if item.response.rc == "0" {
+        let response_code = item.response.rc.clone();
+        let is_response_success = is_response_success(response_code.clone());
+
+        let status = if is_response_success {
             item.response
                 .tx_action
                 .and_then(|tx_action| match tx_action {
@@ -699,6 +769,20 @@ impl
             Some(common_enums::AttemptStatus::Failure)
         };
         match status {
+            Some(common_enums::AttemptStatus::Failure) => {
+                let error_reason = item.response.message.clone();
+                let response = Err(get_error_response(
+                    response_code.clone(),
+                    error_reason,
+                    item.http_code,
+                ));
+
+                Ok(Self {
+                    status: common_enums::AttemptStatus::Failure,
+                    response,
+                    ..item.data
+                })
+            }
             Some(status) => Ok(Self {
                 status,
                 ..item.data
@@ -729,14 +813,28 @@ impl TryFrom<PaymentsCancelResponseRouterData<DeutschebankPaymentsResponse>>
     fn try_from(
         item: PaymentsCancelResponseRouterData<DeutschebankPaymentsResponse>,
     ) -> Result<Self, Self::Error> {
-        Ok(Self {
-            status: if item.response.rc == "0" {
-                common_enums::AttemptStatus::Voided
-            } else {
-                common_enums::AttemptStatus::VoidFailed
-            },
-            ..item.data
-        })
+        let response_code = item.response.rc.clone();
+        let is_response_success = is_response_success(response_code.clone());
+
+        if is_response_success {
+            Ok(Self {
+                status: common_enums::AttemptStatus::Voided,
+                ..item.data
+            })
+        } else {
+            let error_reason = item.response.message.clone();
+            let response = Err(get_error_response(
+                response_code.clone(),
+                error_reason,
+                item.http_code,
+            ));
+
+            Ok(Self {
+                status: common_enums::AttemptStatus::VoidFailed,
+                response,
+                ..item.data
+            })
+        }
     }
 }
 
@@ -763,17 +861,31 @@ impl TryFrom<RefundsResponseRouterData<Execute, DeutschebankPaymentsResponse>>
     fn try_from(
         item: RefundsResponseRouterData<Execute, DeutschebankPaymentsResponse>,
     ) -> Result<Self, Self::Error> {
-        Ok(Self {
-            response: Ok(RefundsResponseData {
-                connector_refund_id: item.response.tx_id,
-                refund_status: if item.response.rc == "0" {
-                    enums::RefundStatus::Success
-                } else {
-                    enums::RefundStatus::Failure
-                },
-            }),
-            ..item.data
-        })
+        let response_code = item.response.rc.clone();
+        let is_response_success = is_response_success(response_code.clone());
+
+        if is_response_success {
+            Ok(Self {
+                response: Ok(RefundsResponseData {
+                    connector_refund_id: item.response.tx_id,
+                    refund_status: enums::RefundStatus::Success,
+                }),
+                ..item.data
+            })
+        } else {
+            let error_reason = item.response.message.clone();
+            let response = Err(get_error_response(
+                response_code.clone(),
+                error_reason,
+                item.http_code,
+            ));
+
+            Ok(Self {
+                status: common_enums::AttemptStatus::Failure,
+                response,
+                ..item.data
+            })
+        }
     }
 }
 
@@ -784,7 +896,10 @@ impl TryFrom<RefundsResponseRouterData<RSync, DeutschebankPaymentsResponse>>
     fn try_from(
         item: RefundsResponseRouterData<RSync, DeutschebankPaymentsResponse>,
     ) -> Result<Self, Self::Error> {
-        let status = if item.response.rc == "0" {
+        let response_code = item.response.rc.clone();
+        let is_response_success = is_response_success(response_code.clone());
+
+        let status = if is_response_success {
             item.response
                 .tx_action
                 .and_then(|tx_action| match tx_action {
@@ -803,7 +918,22 @@ impl TryFrom<RefundsResponseRouterData<RSync, DeutschebankPaymentsResponse>>
         } else {
             Some(enums::RefundStatus::Failure)
         };
+
         match status {
+            Some(enums::RefundStatus::Failure) => {
+                let error_reason = item.response.message.clone();
+                let response = Err(get_error_response(
+                    response_code.clone(),
+                    error_reason,
+                    item.http_code,
+                ));
+
+                Ok(Self {
+                    status: common_enums::AttemptStatus::Failure,
+                    response,
+                    ..item.data
+                })
+            }
             Some(refund_status) => Ok(Self {
                 response: Ok(RefundsResponseData {
                     refund_status,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [X] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
 Consuming error message given by connector in case of 2xx errors, because it is currently not handled for 2xx errors. Error message is only consumed for 4xx and 5xx.




### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Tested manually using Postman
[Test Doc](https://docs.google.com/document/d/1DUUcWRbLXbaJWoxt1Rfn7s1rByJiMKouHXIk2VAONHk/edit?usp=sharing)


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [X] I formatted the code `cargo +nightly fmt --all`
- [X] I addressed lints thrown by `cargo clippy`
- [X] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
