### PR TITLE
feat(webhooks): adyen - consume and update connector's network_transaction_id in payment_methods

### DIFF
--- a/crates/diesel_models/src/payment_method.rs
+++ b/crates/diesel_models/src/payment_method.rs
@@ -654,7 +654,8 @@ impl From<PaymentMethodUpdate> for PaymentMethodUpdateInternal {
                 connector_mandate_details,
                 network_transaction_id,
             } => Self {
-                network_transaction_id: network_transaction_id.map(|network_transaction_id| network_transaction_id.expose()),
+                network_transaction_id: network_transaction_id
+                    .map(|network_transaction_id| network_transaction_id.expose()),
                 connector_mandate_details,
                 last_modified: common_utils::date_time::now(),
                 status: None,

--- a/crates/diesel_models/src/payment_method.rs
+++ b/crates/diesel_models/src/payment_method.rs
@@ -253,6 +253,10 @@ pub enum PaymentMethodUpdate {
         network_token_locker_id: Option<String>,
         network_token_payment_method_data: Option<Encryption>,
     },
+    ConnectorNetworkTransactionIdAndMandateDetailsUpdate {
+        network_transaction_id: Option<String>,
+        connector_mandate_details: Option<serde_json::Value>,
+    },
 }
 
 #[cfg(all(feature = "v2", feature = "payment_methods_v2"))]
@@ -645,6 +649,26 @@ impl From<PaymentMethodUpdate> for PaymentMethodUpdateInternal {
                 network_token_requestor_reference_id,
                 network_token_locker_id,
                 network_token_payment_method_data,
+            },
+            PaymentMethodUpdate::ConnectorNetworkTransactionIdAndMandateDetailsUpdate {
+                connector_mandate_details,
+                network_transaction_id,
+            } => Self {
+                network_transaction_id,
+                connector_mandate_details,
+                last_modified: common_utils::date_time::now(),
+                status: None,
+                metadata: None,
+                payment_method_data: None,
+                last_used_at: None,
+                locker_id: None,
+                payment_method: None,
+                updated_by: None,
+                payment_method_issuer: None,
+                payment_method_type: None,
+                network_token_requestor_reference_id: None,
+                network_token_locker_id: None,
+                network_token_payment_method_data: None,
             },
         }
     }

--- a/crates/diesel_models/src/payment_method.rs
+++ b/crates/diesel_models/src/payment_method.rs
@@ -254,8 +254,8 @@ pub enum PaymentMethodUpdate {
         network_token_payment_method_data: Option<Encryption>,
     },
     ConnectorNetworkTransactionIdAndMandateDetailsUpdate {
+        connector_mandate_details: Option<pii::SecretSerdeValue>,
         network_transaction_id: Option<Secret<String>>,
-        connector_mandate_details: Option<serde_json::Value>,
     },
 }
 
@@ -654,9 +654,8 @@ impl From<PaymentMethodUpdate> for PaymentMethodUpdateInternal {
                 connector_mandate_details,
                 network_transaction_id,
             } => Self {
-                network_transaction_id: network_transaction_id
-                    .map(|network_transaction_id| network_transaction_id.expose()),
-                connector_mandate_details,
+                connector_mandate_details: connector_mandate_details.map(|mandate_details| mandate_details.expose()),
+                network_transaction_id: network_transaction_id.map(|txn_id| txn_id.expose()),
                 last_modified: common_utils::date_time::now(),
                 status: None,
                 metadata: None,

--- a/crates/diesel_models/src/payment_method.rs
+++ b/crates/diesel_models/src/payment_method.rs
@@ -654,7 +654,8 @@ impl From<PaymentMethodUpdate> for PaymentMethodUpdateInternal {
                 connector_mandate_details,
                 network_transaction_id,
             } => Self {
-                connector_mandate_details: connector_mandate_details.map(|mandate_details| mandate_details.expose()),
+                connector_mandate_details: connector_mandate_details
+                    .map(|mandate_details| mandate_details.expose()),
                 network_transaction_id: network_transaction_id.map(|txn_id| txn_id.expose()),
                 last_modified: common_utils::date_time::now(),
                 status: None,

--- a/crates/diesel_models/src/payment_method.rs
+++ b/crates/diesel_models/src/payment_method.rs
@@ -7,7 +7,7 @@ use diesel::{AsChangeset, Identifiable, Insertable, Queryable, Selectable};
     any(feature = "v1", feature = "v2"),
     not(feature = "payment_methods_v2")
 ))]
-use masking::Secret;
+use masking::{ExposeInterface, Secret};
 use serde::{Deserialize, Serialize};
 use time::PrimitiveDateTime;
 
@@ -254,7 +254,7 @@ pub enum PaymentMethodUpdate {
         network_token_payment_method_data: Option<Encryption>,
     },
     ConnectorNetworkTransactionIdAndMandateDetailsUpdate {
-        network_transaction_id: Option<String>,
+        network_transaction_id: Option<Secret<String>>,
         connector_mandate_details: Option<serde_json::Value>,
     },
 }
@@ -654,7 +654,7 @@ impl From<PaymentMethodUpdate> for PaymentMethodUpdateInternal {
                 connector_mandate_details,
                 network_transaction_id,
             } => Self {
-                network_transaction_id,
+                network_transaction_id: network_transaction_id.map(|network_transaction_id| network_transaction_id.expose()),
                 connector_mandate_details,
                 last_modified: common_utils::date_time::now(),
                 status: None,

--- a/crates/hyperswitch_domain_models/src/router_flow_types/webhooks.rs
+++ b/crates/hyperswitch_domain_models/src/router_flow_types/webhooks.rs
@@ -7,3 +7,15 @@ pub struct VerifyWebhookSource;
 pub struct ConnectorMandateDetails {
     pub connector_mandate_id: masking::Secret<String>,
 }
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ConnectorNetworkTxnId(masking::Secret<String>);
+
+impl ConnectorNetworkTxnId {
+    pub fn new(txn_id: masking::Secret<String>) -> Self {
+        Self(txn_id)
+    }
+    pub fn get_id(&self) -> &masking::Secret<String> {
+        &self.0
+    }
+}

--- a/crates/hyperswitch_interfaces/src/webhooks.rs
+++ b/crates/hyperswitch_interfaces/src/webhooks.rs
@@ -264,4 +264,15 @@ pub trait IncomingWebhook: ConnectorCommon + Sync {
     > {
         Ok(None)
     }
+
+    /// fn get_network_txn_id
+    fn get_network_txn_id(
+        &self,
+        _request: &IncomingWebhookRequestDetails<'_>,
+    ) -> CustomResult<
+        Option<hyperswitch_domain_models::router_flow_types::ConnectorNetworkTxnId>,
+        errors::ConnectorError,
+    > {
+        Ok(None)
+    }
 }

--- a/crates/router/src/connector/adyen.rs
+++ b/crates/router/src/connector/adyen.rs
@@ -1929,6 +1929,27 @@ impl api::IncomingWebhook for Adyen {
                 });
         Ok(mandate_reference)
     }
+
+    fn get_network_txn_id(
+        &self,
+        request: &api::IncomingWebhookRequestDetails<'_>,
+    ) -> CustomResult<
+        Option<hyperswitch_domain_models::router_flow_types::ConnectorNetworkTxnId>,
+        errors::ConnectorError,
+    > {
+        let notif = get_webhook_object_from_body(request.body)
+            .change_context(errors::ConnectorError::WebhookBodyDecodingFailed)?;
+        let optional_network_txn_id =
+            notif
+                .additional_data
+                .network_tx_reference
+                .map(|network_txn_id| {
+                    hyperswitch_domain_models::router_flow_types::ConnectorNetworkTxnId::new(
+                        network_txn_id,
+                    )
+                });
+        Ok(optional_network_txn_id)
+    }
 }
 
 impl api::Dispute for Adyen {}

--- a/crates/router/src/connector/adyen/transformers.rs
+++ b/crates/router/src/connector/adyen/transformers.rs
@@ -4264,6 +4264,7 @@ pub struct AdyenAdditionalDataWH {
     /// Enable recurring details in dashboard to receive this ID, https://docs.adyen.com/online-payments/tokenization/create-and-use-tokens#test-and-go-live
     #[serde(rename = "recurring.recurringDetailReference")]
     pub recurring_detail_reference: Option<Secret<String>>,
+    pub network_tx_reference: Option<Secret<String>>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/router/src/core/webhooks/incoming.rs
+++ b/crates/router/src/core/webhooks/incoming.rs
@@ -1928,7 +1928,7 @@ async fn update_connector_mandate_details(
                 };
 
             let pm_update = diesel_models::PaymentMethodUpdate::ConnectorNetworkTransactionIdAndMandateDetailsUpdate {
-                connector_mandate_details: updated_connector_mandate_details.map(|mandate_details| masking::Secret::new(mandate_details)),
+                connector_mandate_details: updated_connector_mandate_details.map(masking::Secret::new),
                 network_transaction_id: webhook_connector_network_transaction_id
                     .map(|webhook_network_transaction_id| webhook_network_transaction_id.get_id().clone()),
             };

--- a/crates/router/src/core/webhooks/incoming.rs
+++ b/crates/router/src/core/webhooks/incoming.rs
@@ -1845,85 +1845,88 @@ async fn update_connector_mandate_details(
                 .to_not_found_response(errors::ApiErrorResponse::PaymentMethodNotFound)?;
 
             // Update connector's mandate details
-            let updated_connector_mandate_details =
-                if let Some(webhook_mandate_details) = webhook_connector_mandate_details {
-                    let mandate_details = payment_method_info
-                        .connector_mandate_details
-                        .clone()
-                        .map(|val| {
-                            val.parse_value::<diesel_models::PaymentsMandateReference>(
-                                "PaymentsMandateReference",
-                            )
-                        })
-                        .transpose()
-                        .change_context(errors::ApiErrorResponse::InternalServerError)
-                        .attach_printable("Failed to deserialize to Payment Mandate Reference")?;
+            let updated_connector_mandate_details = if let Some(webhook_mandate_details) =
+                webhook_connector_mandate_details
+            {
+                let mandate_details = payment_method_info
+                    .connector_mandate_details
+                    .clone()
+                    .map(|val| {
+                        val.parse_value::<diesel_models::PaymentsMandateReference>(
+                            "PaymentsMandateReference",
+                        )
+                    })
+                    .transpose()
+                    .change_context(errors::ApiErrorResponse::InternalServerError)
+                    .attach_printable("Failed to deserialize to Payment Mandate Reference")?;
 
-                    let merchant_connector_account_id = payment_attempt
-                        .merchant_connector_id
-                        .clone()
-                        .get_required_value("merchant_connector_id")?;
+                let merchant_connector_account_id = payment_attempt
+                    .merchant_connector_id
+                    .clone()
+                    .get_required_value("merchant_connector_id")?;
 
-                    if mandate_details
-                        .as_ref()
-                        .map(|details: &diesel_models::PaymentsMandateReference| {
-                            !details.0.contains_key(&merchant_connector_account_id)
-                        })
-                        .unwrap_or(true)
-                    {
-                        // Update the payment attempt to maintain consistency across tables.
-                        let (mandate_metadata, connector_mandate_request_reference_id) =
-                            payment_attempt
-                                .connector_mandate_detail
-                                .as_ref()
-                                .map(|details| {
-                                    (
-                                        details.mandate_metadata.clone(),
-                                        details.connector_mandate_request_reference_id.clone(),
-                                    )
-                                })
-                                .unwrap_or((None, None));
+                if mandate_details
+                    .as_ref()
+                    .map(|details: &diesel_models::PaymentsMandateReference| {
+                        !details.0.contains_key(&merchant_connector_account_id)
+                    })
+                    .unwrap_or(true)
+                {
+                    // Update the payment attempt to maintain consistency across tables.
+                    let (mandate_metadata, connector_mandate_request_reference_id) =
+                        payment_attempt
+                            .connector_mandate_detail
+                            .as_ref()
+                            .map(|details| {
+                                (
+                                    details.mandate_metadata.clone(),
+                                    details.connector_mandate_request_reference_id.clone(),
+                                )
+                            })
+                            .unwrap_or((None, None));
 
-                        let connector_mandate_reference_id = ConnectorMandateReferenceId {
-                            connector_mandate_id: Some(
-                                webhook_mandate_details
-                                    .connector_mandate_id
-                                    .peek()
-                                    .to_string(),
-                            ),
-                            payment_method_id: Some(payment_method_id.to_string()),
-                            mandate_metadata,
-                            connector_mandate_request_reference_id,
+                    let connector_mandate_reference_id = ConnectorMandateReferenceId {
+                        connector_mandate_id: Some(
+                            webhook_mandate_details
+                                .connector_mandate_id
+                                .peek()
+                                .to_string(),
+                        ),
+                        payment_method_id: Some(payment_method_id.to_string()),
+                        mandate_metadata,
+                        connector_mandate_request_reference_id,
+                    };
+
+                    let attempt_update =
+                        storage::PaymentAttemptUpdate::ConnectorMandateDetailUpdate {
+                            connector_mandate_detail: Some(connector_mandate_reference_id),
+                            updated_by: merchant_account.storage_scheme.to_string(),
                         };
 
-                        let attempt_update =
-                            storage::PaymentAttemptUpdate::ConnectorMandateDetailUpdate {
-                                connector_mandate_detail: Some(connector_mandate_reference_id),
-                                updated_by: merchant_account.storage_scheme.to_string(),
-                            };
+                    state
+                        .store
+                        .update_payment_attempt_with_attempt_id(
+                            payment_attempt.clone(),
+                            attempt_update,
+                            merchant_account.storage_scheme,
+                        )
+                        .await
+                        .to_not_found_response(errors::ApiErrorResponse::PaymentNotFound)?;
 
-                        state
-                            .store
-                            .update_payment_attempt_with_attempt_id(
-                                payment_attempt.clone(),
-                                attempt_update,
-                                merchant_account.storage_scheme,
-                            )
-                            .await
-                            .to_not_found_response(errors::ApiErrorResponse::PaymentNotFound)?;
-
-                        insert_mandate_details(
-                            &payment_attempt,
-                            &webhook_mandate_details,
-                            mandate_details,
-                        )?
-                    } else {
-                        logger::info!("Skipping connector mandate details update since they are already present.");
-                        None
-                    }
+                    insert_mandate_details(
+                        &payment_attempt,
+                        &webhook_mandate_details,
+                        mandate_details,
+                    )?
                 } else {
+                    logger::info!(
+                        "Skipping connector mandate details update since they are already present."
+                    );
                     None
-                };
+                }
+            } else {
+                None
+            };
 
             let pm_update = diesel_models::PaymentMethodUpdate::ConnectorNetworkTransactionIdAndMandateDetailsUpdate {
                 connector_mandate_details: updated_connector_mandate_details,

--- a/crates/router/src/core/webhooks/incoming.rs
+++ b/crates/router/src/core/webhooks/incoming.rs
@@ -1930,7 +1930,7 @@ async fn update_connector_mandate_details(
             let pm_update = diesel_models::PaymentMethodUpdate::ConnectorNetworkTransactionIdAndMandateDetailsUpdate {
                 connector_mandate_details: updated_connector_mandate_details,
                 network_transaction_id: webhook_connector_network_transaction_id
-                    .map(|webhook_network_transaction_id| webhook_network_transaction_id.get_id().peek().clone()),
+                    .map(|webhook_network_transaction_id| webhook_network_transaction_id.get_id().clone()),
             };
 
             state

--- a/crates/router/src/core/webhooks/incoming.rs
+++ b/crates/router/src/core/webhooks/incoming.rs
@@ -1845,88 +1845,87 @@ async fn update_connector_mandate_details(
                 .to_not_found_response(errors::ApiErrorResponse::PaymentMethodNotFound)?;
 
             // Update connector's mandate details
-            let updated_connector_mandate_details = if let Some(webhook_mandate_details) =
-                webhook_connector_mandate_details
-            {
-                let mandate_details = payment_method_info
-                    .connector_mandate_details
-                    .clone()
-                    .map(|val| {
-                        val.parse_value::<diesel_models::PaymentsMandateReference>(
-                            "PaymentsMandateReference",
-                        )
-                    })
-                    .transpose()
-                    .change_context(errors::ApiErrorResponse::InternalServerError)
-                    .attach_printable("Failed to deserialize to Payment Mandate Reference")?;
+            let updated_connector_mandate_details =
+                if let Some(webhook_mandate_details) = webhook_connector_mandate_details {
+                    let mandate_details = payment_method_info
+                        .connector_mandate_details
+                        .clone()
+                        .map(|val| {
+                            val.parse_value::<diesel_models::PaymentsMandateReference>(
+                                "PaymentsMandateReference",
+                            )
+                        })
+                        .transpose()
+                        .change_context(errors::ApiErrorResponse::InternalServerError)
+                        .attach_printable("Failed to deserialize to Payment Mandate Reference")?;
 
-                let merchant_connector_account_id = payment_attempt
-                    .merchant_connector_id
-                    .clone()
-                    .get_required_value("merchant_connector_id")?;
+                    let merchant_connector_account_id = payment_attempt
+                        .merchant_connector_id
+                        .clone()
+                        .get_required_value("merchant_connector_id")?;
 
-                if mandate_details
-                    .as_ref()
-                    .map(|details: &diesel_models::PaymentsMandateReference| {
-                        !details.0.contains_key(&merchant_connector_account_id)
-                    })
-                    .unwrap_or(true)
-                {
-                    // Update the payment attempt to maintain consistency across tables.
-                    let (mandate_metadata, connector_mandate_request_reference_id) =
-                        payment_attempt
-                            .connector_mandate_detail
-                            .as_ref()
-                            .map(|details| {
-                                (
-                                    details.mandate_metadata.clone(),
-                                    details.connector_mandate_request_reference_id.clone(),
-                                )
-                            })
-                            .unwrap_or((None, None));
+                    if mandate_details
+                        .as_ref()
+                        .map(|details: &diesel_models::PaymentsMandateReference| {
+                            !details.0.contains_key(&merchant_connector_account_id)
+                        })
+                        .unwrap_or(true)
+                    {
+                        // Update the payment attempt to maintain consistency across tables.
+                        let (mandate_metadata, connector_mandate_request_reference_id) =
+                            payment_attempt
+                                .connector_mandate_detail
+                                .as_ref()
+                                .map(|details| {
+                                    (
+                                        details.mandate_metadata.clone(),
+                                        details.connector_mandate_request_reference_id.clone(),
+                                    )
+                                })
+                                .unwrap_or((None, None));
 
-                    let connector_mandate_reference_id = ConnectorMandateReferenceId {
-                        connector_mandate_id: Some(
-                            webhook_mandate_details
-                                .connector_mandate_id
-                                .peek()
-                                .to_string(),
-                        ),
-                        payment_method_id: Some(payment_method_id.to_string()),
-                        mandate_metadata,
-                        connector_mandate_request_reference_id,
-                    };
-
-                    let attempt_update =
-                        storage::PaymentAttemptUpdate::ConnectorMandateDetailUpdate {
-                            connector_mandate_detail: Some(connector_mandate_reference_id),
-                            updated_by: merchant_account.storage_scheme.to_string(),
+                        let connector_mandate_reference_id = ConnectorMandateReferenceId {
+                            connector_mandate_id: Some(
+                                webhook_mandate_details
+                                    .connector_mandate_id
+                                    .peek()
+                                    .to_string(),
+                            ),
+                            payment_method_id: Some(payment_method_id.to_string()),
+                            mandate_metadata,
+                            connector_mandate_request_reference_id,
                         };
 
-                    state
-                        .store
-                        .update_payment_attempt_with_attempt_id(
-                            payment_attempt.clone(),
-                            attempt_update,
-                            merchant_account.storage_scheme,
-                        )
-                        .await
-                        .to_not_found_response(errors::ApiErrorResponse::PaymentNotFound)?;
+                        let attempt_update =
+                            storage::PaymentAttemptUpdate::ConnectorMandateDetailUpdate {
+                                connector_mandate_detail: Some(connector_mandate_reference_id),
+                                updated_by: merchant_account.storage_scheme.to_string(),
+                            };
 
-                    insert_mandate_details(
-                        &payment_attempt,
-                        &webhook_mandate_details,
-                        mandate_details,
-                    )?
-                } else {
-                    logger::info!(
+                        state
+                            .store
+                            .update_payment_attempt_with_attempt_id(
+                                payment_attempt.clone(),
+                                attempt_update,
+                                merchant_account.storage_scheme,
+                            )
+                            .await
+                            .to_not_found_response(errors::ApiErrorResponse::PaymentNotFound)?;
+
+                        insert_mandate_details(
+                            &payment_attempt,
+                            &webhook_mandate_details,
+                            mandate_details,
+                        )?
+                    } else {
+                        logger::info!(
                         "Skipping connector mandate details update since they are already present."
                     );
+                        None
+                    }
+                } else {
                     None
-                }
-            } else {
-                None
-            };
+                };
 
             let pm_update = diesel_models::PaymentMethodUpdate::ConnectorNetworkTransactionIdAndMandateDetailsUpdate {
                 connector_mandate_details: updated_connector_mandate_details,

--- a/crates/router/src/core/webhooks/incoming.rs
+++ b/crates/router/src/core/webhooks/incoming.rs
@@ -1928,7 +1928,7 @@ async fn update_connector_mandate_details(
                 };
 
             let pm_update = diesel_models::PaymentMethodUpdate::ConnectorNetworkTransactionIdAndMandateDetailsUpdate {
-                connector_mandate_details: updated_connector_mandate_details,
+                connector_mandate_details: updated_connector_mandate_details.map(|mandate_details| masking::Secret::new(mandate_details)),
                 network_transaction_id: webhook_connector_network_transaction_id
                     .map(|webhook_network_transaction_id| webhook_network_transaction_id.get_id().clone()),
             };

--- a/crates/router/src/core/webhooks/incoming.rs
+++ b/crates/router/src/core/webhooks/incoming.rs
@@ -1824,152 +1824,145 @@ async fn update_connector_mandate_details(
             "Could not find connector network transaction id in incoming webhook body",
         )?;
 
-    match (
-        webhook_connector_mandate_details.as_ref(),
-        webhook_connector_network_transaction_id.as_ref(),
-    ) {
-        // Either one OR both of the fields are present
-        (Some(_), Some(_)) | (Some(_), None) | (None, Some(_)) => {
-            let payment_attempt = get_payment_attempt_from_object_reference_id(
-                state,
-                object_ref_id,
-                merchant_account,
-            )
-            .await?;
-            if let Some(ref payment_method_id) = payment_attempt.payment_method_id {
-                let key_manager_state = &state.into();
-                let payment_method_info = state
-                    .store
-                    .find_payment_method(
-                        key_manager_state,
-                        key_store,
-                        payment_method_id,
-                        merchant_account.storage_scheme,
-                    )
-                    .await
-                    .to_not_found_response(errors::ApiErrorResponse::PaymentMethodNotFound)?;
+    // Either one OR both of the fields are present
+    if (webhook_connector_mandate_details.is_some()
+        || webhook_connector_network_transaction_id.is_some())
+    {
+        let payment_attempt =
+            get_payment_attempt_from_object_reference_id(state, object_ref_id, merchant_account)
+                .await?;
+        if let Some(ref payment_method_id) = payment_attempt.payment_method_id {
+            let key_manager_state = &state.into();
+            let payment_method_info = state
+                .store
+                .find_payment_method(
+                    key_manager_state,
+                    key_store,
+                    payment_method_id,
+                    merchant_account.storage_scheme,
+                )
+                .await
+                .to_not_found_response(errors::ApiErrorResponse::PaymentMethodNotFound)?;
 
-                // Update connector's mandate details
-                if let Some(webhook_mandate_details) = webhook_connector_mandate_details {
-                    let mandate_details = payment_method_info
-                        .connector_mandate_details
-                        .clone()
-                        .map(|val| {
-                            val.parse_value::<diesel_models::PaymentsMandateReference>(
-                                "PaymentsMandateReference",
-                            )
-                        })
-                        .transpose()
-                        .change_context(errors::ApiErrorResponse::InternalServerError)
-                        .attach_printable("Failed to deserialize to Payment Mandate Reference")?;
+            // Update connector's mandate details
+            if let Some(webhook_mandate_details) = webhook_connector_mandate_details {
+                let mandate_details = payment_method_info
+                    .connector_mandate_details
+                    .clone()
+                    .map(|val| {
+                        val.parse_value::<diesel_models::PaymentsMandateReference>(
+                            "PaymentsMandateReference",
+                        )
+                    })
+                    .transpose()
+                    .change_context(errors::ApiErrorResponse::InternalServerError)
+                    .attach_printable("Failed to deserialize to Payment Mandate Reference")?;
 
-                    let merchant_connector_account_id = payment_attempt
-                        .merchant_connector_id
-                        .clone()
-                        .get_required_value("merchant_connector_id")?;
+                let merchant_connector_account_id = payment_attempt
+                    .merchant_connector_id
+                    .clone()
+                    .get_required_value("merchant_connector_id")?;
 
-                    if mandate_details
-                        .as_ref()
-                        .map(|details: &diesel_models::PaymentsMandateReference| {
-                            !details.0.contains_key(&merchant_connector_account_id)
-                        })
-                        .unwrap_or(true)
-                    {
-                        let updated_connector_mandate_details = insert_mandate_details(
-                            &payment_attempt,
-                            &webhook_mandate_details,
-                            mandate_details,
-                        )?;
-                        let pm_update =
-                            diesel_models::PaymentMethodUpdate::ConnectorMandateDetailsUpdate {
-                                connector_mandate_details: updated_connector_mandate_details,
-                            };
-
-                        state
-                            .store
-                            .update_payment_method(
-                                key_manager_state,
-                                key_store,
-                                payment_method_info.clone(),
-                                pm_update,
-                                merchant_account.storage_scheme,
-                            )
-                            .await
-                            .change_context(errors::ApiErrorResponse::InternalServerError)
-                            .attach_printable("Failed to update payment method in db")?;
-
-                        // Update the payment attempt to maintain consistency across tables.
-                        let (mandate_metadata, connector_mandate_request_reference_id) =
-                            payment_attempt
-                                .connector_mandate_detail
-                                .as_ref()
-                                .map(|details| {
-                                    (
-                                        details.mandate_metadata.clone(),
-                                        details.connector_mandate_request_reference_id.clone(),
-                                    )
-                                })
-                                .unwrap_or((None, None));
-
-                        let connector_mandate_reference_id = ConnectorMandateReferenceId {
-                            connector_mandate_id: Some(
-                                webhook_mandate_details
-                                    .connector_mandate_id
-                                    .peek()
-                                    .to_string(),
-                            ),
-                            payment_method_id: Some(payment_method_id.to_string()),
-                            mandate_metadata,
-                            connector_mandate_request_reference_id,
-                        };
-
-                        let attempt_update =
-                            storage::PaymentAttemptUpdate::ConnectorMandateDetailUpdate {
-                                connector_mandate_detail: Some(connector_mandate_reference_id),
-                                updated_by: merchant_account.storage_scheme.to_string(),
-                            };
-
-                        state
-                            .store
-                            .update_payment_attempt_with_attempt_id(
-                                payment_attempt.clone(),
-                                attempt_update,
-                                merchant_account.storage_scheme,
-                            )
-                            .await
-                            .to_not_found_response(errors::ApiErrorResponse::PaymentNotFound)?;
-                    } else {
-                        logger::info!("Skipping connector mandate details update since they are already present.");
-                    }
-                }
-
-                // Update connector's network transaction id
-                if let Some(webhook_network_transaction_id) =
-                    webhook_connector_network_transaction_id
+                if mandate_details
+                    .as_ref()
+                    .map(|details: &diesel_models::PaymentsMandateReference| {
+                        !details.0.contains_key(&merchant_connector_account_id)
+                    })
+                    .unwrap_or(true)
                 {
-                    let payment_method_update =
-                        diesel_models::PaymentMethodUpdate::NetworkTransactionIdAndStatusUpdate {
-                            network_transaction_id: Some(
-                                webhook_network_transaction_id.get_id().peek().clone(),
-                            ),
-                            status: None,
+                    let updated_connector_mandate_details = insert_mandate_details(
+                        &payment_attempt,
+                        &webhook_mandate_details,
+                        mandate_details,
+                    )?;
+                    let pm_update =
+                        diesel_models::PaymentMethodUpdate::ConnectorMandateDetailsUpdate {
+                            connector_mandate_details: updated_connector_mandate_details,
                         };
+
                     state
                         .store
                         .update_payment_method(
                             key_manager_state,
                             key_store,
-                            payment_method_info,
-                            payment_method_update,
+                            payment_method_info.clone(),
+                            pm_update,
                             merchant_account.storage_scheme,
                         )
                         .await
                         .change_context(errors::ApiErrorResponse::InternalServerError)
                         .attach_printable("Failed to update payment method in db")?;
+
+                    // Update the payment attempt to maintain consistency across tables.
+                    let (mandate_metadata, connector_mandate_request_reference_id) =
+                        payment_attempt
+                            .connector_mandate_detail
+                            .as_ref()
+                            .map(|details| {
+                                (
+                                    details.mandate_metadata.clone(),
+                                    details.connector_mandate_request_reference_id.clone(),
+                                )
+                            })
+                            .unwrap_or((None, None));
+
+                    let connector_mandate_reference_id = ConnectorMandateReferenceId {
+                        connector_mandate_id: Some(
+                            webhook_mandate_details
+                                .connector_mandate_id
+                                .peek()
+                                .to_string(),
+                        ),
+                        payment_method_id: Some(payment_method_id.to_string()),
+                        mandate_metadata,
+                        connector_mandate_request_reference_id,
+                    };
+
+                    let attempt_update =
+                        storage::PaymentAttemptUpdate::ConnectorMandateDetailUpdate {
+                            connector_mandate_detail: Some(connector_mandate_reference_id),
+                            updated_by: merchant_account.storage_scheme.to_string(),
+                        };
+
+                    state
+                        .store
+                        .update_payment_attempt_with_attempt_id(
+                            payment_attempt.clone(),
+                            attempt_update,
+                            merchant_account.storage_scheme,
+                        )
+                        .await
+                        .to_not_found_response(errors::ApiErrorResponse::PaymentNotFound)?;
+                } else {
+                    logger::info!(
+                        "Skipping connector mandate details update since they are already present."
+                    );
                 }
             }
+
+            // Update connector's network transaction id
+            if let Some(webhook_network_transaction_id) = webhook_connector_network_transaction_id {
+                let payment_method_update =
+                    diesel_models::PaymentMethodUpdate::NetworkTransactionIdAndStatusUpdate {
+                        network_transaction_id: Some(
+                            webhook_network_transaction_id.get_id().peek().clone(),
+                        ),
+                        status: None,
+                    };
+                state
+                    .store
+                    .update_payment_method(
+                        key_manager_state,
+                        key_store,
+                        payment_method_info,
+                        payment_method_update,
+                        merchant_account.storage_scheme,
+                    )
+                    .await
+                    .change_context(errors::ApiErrorResponse::InternalServerError)
+                    .attach_printable("Failed to update payment method in db")?;
+            }
         }
-        _ => (),
     }
     Ok(())
 }

--- a/crates/router/src/core/webhooks/incoming.rs
+++ b/crates/router/src/core/webhooks/incoming.rs
@@ -1825,8 +1825,8 @@ async fn update_connector_mandate_details(
         )?;
 
     // Either one OR both of the fields are present
-    if (webhook_connector_mandate_details.is_some()
-        || webhook_connector_network_transaction_id.is_some())
+    if webhook_connector_mandate_details.is_some()
+        || webhook_connector_network_transaction_id.is_some()
     {
         let payment_attempt =
             get_payment_attempt_from_object_reference_id(state, object_ref_id, merchant_account)
@@ -1845,123 +1845,104 @@ async fn update_connector_mandate_details(
                 .to_not_found_response(errors::ApiErrorResponse::PaymentMethodNotFound)?;
 
             // Update connector's mandate details
-            if let Some(webhook_mandate_details) = webhook_connector_mandate_details {
-                let mandate_details = payment_method_info
-                    .connector_mandate_details
-                    .clone()
-                    .map(|val| {
-                        val.parse_value::<diesel_models::PaymentsMandateReference>(
-                            "PaymentsMandateReference",
-                        )
-                    })
-                    .transpose()
-                    .change_context(errors::ApiErrorResponse::InternalServerError)
-                    .attach_printable("Failed to deserialize to Payment Mandate Reference")?;
-
-                let merchant_connector_account_id = payment_attempt
-                    .merchant_connector_id
-                    .clone()
-                    .get_required_value("merchant_connector_id")?;
-
-                if mandate_details
-                    .as_ref()
-                    .map(|details: &diesel_models::PaymentsMandateReference| {
-                        !details.0.contains_key(&merchant_connector_account_id)
-                    })
-                    .unwrap_or(true)
-                {
-                    let updated_connector_mandate_details = insert_mandate_details(
-                        &payment_attempt,
-                        &webhook_mandate_details,
-                        mandate_details,
-                    )?;
-                    let pm_update =
-                        diesel_models::PaymentMethodUpdate::ConnectorMandateDetailsUpdate {
-                            connector_mandate_details: updated_connector_mandate_details,
-                        };
-
-                    state
-                        .store
-                        .update_payment_method(
-                            key_manager_state,
-                            key_store,
-                            payment_method_info.clone(),
-                            pm_update,
-                            merchant_account.storage_scheme,
-                        )
-                        .await
+            let updated_connector_mandate_details =
+                if let Some(webhook_mandate_details) = webhook_connector_mandate_details {
+                    let mandate_details = payment_method_info
+                        .connector_mandate_details
+                        .clone()
+                        .map(|val| {
+                            val.parse_value::<diesel_models::PaymentsMandateReference>(
+                                "PaymentsMandateReference",
+                            )
+                        })
+                        .transpose()
                         .change_context(errors::ApiErrorResponse::InternalServerError)
-                        .attach_printable("Failed to update payment method in db")?;
+                        .attach_printable("Failed to deserialize to Payment Mandate Reference")?;
 
-                    // Update the payment attempt to maintain consistency across tables.
-                    let (mandate_metadata, connector_mandate_request_reference_id) =
-                        payment_attempt
-                            .connector_mandate_detail
-                            .as_ref()
-                            .map(|details| {
-                                (
-                                    details.mandate_metadata.clone(),
-                                    details.connector_mandate_request_reference_id.clone(),
-                                )
-                            })
-                            .unwrap_or((None, None));
+                    let merchant_connector_account_id = payment_attempt
+                        .merchant_connector_id
+                        .clone()
+                        .get_required_value("merchant_connector_id")?;
 
-                    let connector_mandate_reference_id = ConnectorMandateReferenceId {
-                        connector_mandate_id: Some(
-                            webhook_mandate_details
-                                .connector_mandate_id
-                                .peek()
-                                .to_string(),
-                        ),
-                        payment_method_id: Some(payment_method_id.to_string()),
-                        mandate_metadata,
-                        connector_mandate_request_reference_id,
-                    };
+                    if mandate_details
+                        .as_ref()
+                        .map(|details: &diesel_models::PaymentsMandateReference| {
+                            !details.0.contains_key(&merchant_connector_account_id)
+                        })
+                        .unwrap_or(true)
+                    {
+                        // Update the payment attempt to maintain consistency across tables.
+                        let (mandate_metadata, connector_mandate_request_reference_id) =
+                            payment_attempt
+                                .connector_mandate_detail
+                                .as_ref()
+                                .map(|details| {
+                                    (
+                                        details.mandate_metadata.clone(),
+                                        details.connector_mandate_request_reference_id.clone(),
+                                    )
+                                })
+                                .unwrap_or((None, None));
 
-                    let attempt_update =
-                        storage::PaymentAttemptUpdate::ConnectorMandateDetailUpdate {
-                            connector_mandate_detail: Some(connector_mandate_reference_id),
-                            updated_by: merchant_account.storage_scheme.to_string(),
+                        let connector_mandate_reference_id = ConnectorMandateReferenceId {
+                            connector_mandate_id: Some(
+                                webhook_mandate_details
+                                    .connector_mandate_id
+                                    .peek()
+                                    .to_string(),
+                            ),
+                            payment_method_id: Some(payment_method_id.to_string()),
+                            mandate_metadata,
+                            connector_mandate_request_reference_id,
                         };
 
-                    state
-                        .store
-                        .update_payment_attempt_with_attempt_id(
-                            payment_attempt.clone(),
-                            attempt_update,
-                            merchant_account.storage_scheme,
-                        )
-                        .await
-                        .to_not_found_response(errors::ApiErrorResponse::PaymentNotFound)?;
-                } else {
-                    logger::info!(
-                        "Skipping connector mandate details update since they are already present."
-                    );
-                }
-            }
+                        let attempt_update =
+                            storage::PaymentAttemptUpdate::ConnectorMandateDetailUpdate {
+                                connector_mandate_detail: Some(connector_mandate_reference_id),
+                                updated_by: merchant_account.storage_scheme.to_string(),
+                            };
 
-            // Update connector's network transaction id
-            if let Some(webhook_network_transaction_id) = webhook_connector_network_transaction_id {
-                let payment_method_update =
-                    diesel_models::PaymentMethodUpdate::NetworkTransactionIdAndStatusUpdate {
-                        network_transaction_id: Some(
-                            webhook_network_transaction_id.get_id().peek().clone(),
-                        ),
-                        status: None,
-                    };
-                state
-                    .store
-                    .update_payment_method(
-                        key_manager_state,
-                        key_store,
-                        payment_method_info,
-                        payment_method_update,
-                        merchant_account.storage_scheme,
-                    )
-                    .await
-                    .change_context(errors::ApiErrorResponse::InternalServerError)
-                    .attach_printable("Failed to update payment method in db")?;
-            }
+                        state
+                            .store
+                            .update_payment_attempt_with_attempt_id(
+                                payment_attempt.clone(),
+                                attempt_update,
+                                merchant_account.storage_scheme,
+                            )
+                            .await
+                            .to_not_found_response(errors::ApiErrorResponse::PaymentNotFound)?;
+
+                        insert_mandate_details(
+                            &payment_attempt,
+                            &webhook_mandate_details,
+                            mandate_details,
+                        )?
+                    } else {
+                        logger::info!("Skipping connector mandate details update since they are already present.");
+                        None
+                    }
+                } else {
+                    None
+                };
+
+            let pm_update = diesel_models::PaymentMethodUpdate::ConnectorNetworkTransactionIdAndMandateDetailsUpdate {
+                connector_mandate_details: updated_connector_mandate_details,
+                network_transaction_id: webhook_connector_network_transaction_id
+                    .map(|webhook_network_transaction_id| webhook_network_transaction_id.get_id().peek().clone()),
+            };
+
+            state
+                .store
+                .update_payment_method(
+                    key_manager_state,
+                    key_store,
+                    payment_method_info,
+                    pm_update,
+                    merchant_account.storage_scheme,
+                )
+                .await
+                .change_context(errors::ApiErrorResponse::InternalServerError)
+                .attach_printable("Failed to update payment method in db")?;
         }
     }
     Ok(())

--- a/crates/router/src/core/webhooks/incoming.rs
+++ b/crates/router/src/core/webhooks/incoming.rs
@@ -1817,114 +1817,159 @@ async fn update_connector_mandate_details(
         .switch()
         .attach_printable("Could not find connector mandate details in incoming webhook body")?;
 
-    if let Some(webhook_mandate_details) = webhook_connector_mandate_details {
-        let payment_attempt =
-            get_payment_attempt_from_object_reference_id(state, object_ref_id, merchant_account)
-                .await?;
+    let webhook_connector_network_transaction_id = connector
+        .get_network_txn_id(request_details)
+        .switch()
+        .attach_printable(
+            "Could not find connector network transaction id in incoming webhook body",
+        )?;
 
-        if let Some(ref payment_method_id) = payment_attempt.payment_method_id {
-            let key_manager_state = &state.into();
-            let payment_method_info = state
-                .store
-                .find_payment_method(
-                    key_manager_state,
-                    key_store,
-                    payment_method_id,
-                    merchant_account.storage_scheme,
-                )
-                .await
-                .to_not_found_response(errors::ApiErrorResponse::PaymentMethodNotFound)?;
-
-            let mandate_details = payment_method_info
-                .connector_mandate_details
-                .clone()
-                .map(|val| {
-                    val.parse_value::<diesel_models::PaymentsMandateReference>(
-                        "PaymentsMandateReference",
-                    )
-                })
-                .transpose()
-                .change_context(errors::ApiErrorResponse::InternalServerError)
-                .attach_printable("Failed to deserialize to Payment Mandate Reference")?;
-
-            let merchant_connector_account_id = payment_attempt
-                .merchant_connector_id
-                .clone()
-                .get_required_value("merchant_connector_id")?;
-
-            if mandate_details
-                .as_ref()
-                .map(|details: &diesel_models::PaymentsMandateReference| {
-                    !details.0.contains_key(&merchant_connector_account_id)
-                })
-                .unwrap_or(true)
-            {
-                let updated_connector_mandate_details = insert_mandate_details(
-                    &payment_attempt,
-                    &webhook_mandate_details,
-                    mandate_details,
-                )?;
-                let pm_update = diesel_models::PaymentMethodUpdate::ConnectorMandateDetailsUpdate {
-                    connector_mandate_details: updated_connector_mandate_details,
-                };
-
-                state
+    match (
+        webhook_connector_mandate_details.as_ref(),
+        webhook_connector_network_transaction_id.as_ref(),
+    ) {
+        // Either one OR both of the fields are present
+        (Some(_), Some(_)) | (Some(_), None) | (None, Some(_)) => {
+            let payment_attempt = get_payment_attempt_from_object_reference_id(
+                state,
+                object_ref_id,
+                merchant_account,
+            )
+            .await?;
+            if let Some(ref payment_method_id) = payment_attempt.payment_method_id {
+                let key_manager_state = &state.into();
+                let payment_method_info = state
                     .store
-                    .update_payment_method(
+                    .find_payment_method(
                         key_manager_state,
                         key_store,
-                        payment_method_info,
-                        pm_update,
+                        payment_method_id,
                         merchant_account.storage_scheme,
                     )
                     .await
-                    .change_context(errors::ApiErrorResponse::InternalServerError)
-                    .attach_printable("Failed to update payment method in db")?;
-                // Update the payment attempt to maintain consistency across tables.
+                    .to_not_found_response(errors::ApiErrorResponse::PaymentMethodNotFound)?;
 
-                let (mandate_metadata, connector_mandate_request_reference_id) = payment_attempt
-                    .connector_mandate_detail
-                    .as_ref()
-                    .map(|details| {
-                        (
-                            details.mandate_metadata.clone(),
-                            details.connector_mandate_request_reference_id.clone(),
+                // Update connector's mandate details
+                if let Some(webhook_mandate_details) = webhook_connector_mandate_details {
+                    let mandate_details = payment_method_info
+                        .connector_mandate_details
+                        .clone()
+                        .map(|val| {
+                            val.parse_value::<diesel_models::PaymentsMandateReference>(
+                                "PaymentsMandateReference",
+                            )
+                        })
+                        .transpose()
+                        .change_context(errors::ApiErrorResponse::InternalServerError)
+                        .attach_printable("Failed to deserialize to Payment Mandate Reference")?;
+
+                    let merchant_connector_account_id = payment_attempt
+                        .merchant_connector_id
+                        .clone()
+                        .get_required_value("merchant_connector_id")?;
+
+                    if mandate_details
+                        .as_ref()
+                        .map(|details: &diesel_models::PaymentsMandateReference| {
+                            !details.0.contains_key(&merchant_connector_account_id)
+                        })
+                        .unwrap_or(true)
+                    {
+                        let updated_connector_mandate_details = insert_mandate_details(
+                            &payment_attempt,
+                            &webhook_mandate_details,
+                            mandate_details,
+                        )?;
+                        let pm_update =
+                            diesel_models::PaymentMethodUpdate::ConnectorMandateDetailsUpdate {
+                                connector_mandate_details: updated_connector_mandate_details,
+                            };
+
+                        state
+                            .store
+                            .update_payment_method(
+                                key_manager_state,
+                                key_store,
+                                payment_method_info.clone(),
+                                pm_update,
+                                merchant_account.storage_scheme,
+                            )
+                            .await
+                            .change_context(errors::ApiErrorResponse::InternalServerError)
+                            .attach_printable("Failed to update payment method in db")?;
+
+                        // Update the payment attempt to maintain consistency across tables.
+                        let (mandate_metadata, connector_mandate_request_reference_id) =
+                            payment_attempt
+                                .connector_mandate_detail
+                                .as_ref()
+                                .map(|details| {
+                                    (
+                                        details.mandate_metadata.clone(),
+                                        details.connector_mandate_request_reference_id.clone(),
+                                    )
+                                })
+                                .unwrap_or((None, None));
+
+                        let connector_mandate_reference_id = ConnectorMandateReferenceId {
+                            connector_mandate_id: Some(
+                                webhook_mandate_details
+                                    .connector_mandate_id
+                                    .peek()
+                                    .to_string(),
+                            ),
+                            payment_method_id: Some(payment_method_id.to_string()),
+                            mandate_metadata,
+                            connector_mandate_request_reference_id,
+                        };
+
+                        let attempt_update =
+                            storage::PaymentAttemptUpdate::ConnectorMandateDetailUpdate {
+                                connector_mandate_detail: Some(connector_mandate_reference_id),
+                                updated_by: merchant_account.storage_scheme.to_string(),
+                            };
+
+                        state
+                            .store
+                            .update_payment_attempt_with_attempt_id(
+                                payment_attempt.clone(),
+                                attempt_update,
+                                merchant_account.storage_scheme,
+                            )
+                            .await
+                            .to_not_found_response(errors::ApiErrorResponse::PaymentNotFound)?;
+                    } else {
+                        logger::info!("Skipping connector mandate details update since they are already present.");
+                    }
+                }
+
+                // Update connector's network transaction id
+                if let Some(webhook_network_transaction_id) =
+                    webhook_connector_network_transaction_id
+                {
+                    let payment_method_update =
+                        diesel_models::PaymentMethodUpdate::NetworkTransactionIdAndStatusUpdate {
+                            network_transaction_id: Some(
+                                webhook_network_transaction_id.get_id().peek().clone(),
+                            ),
+                            status: None,
+                        };
+                    state
+                        .store
+                        .update_payment_method(
+                            key_manager_state,
+                            key_store,
+                            payment_method_info,
+                            payment_method_update,
+                            merchant_account.storage_scheme,
                         )
-                    })
-                    .unwrap_or((None, None));
-
-                let connector_mandate_reference_id = ConnectorMandateReferenceId {
-                    connector_mandate_id: Some(
-                        webhook_mandate_details
-                            .connector_mandate_id
-                            .peek()
-                            .to_string(),
-                    ),
-                    payment_method_id: Some(payment_method_id.to_string()),
-                    mandate_metadata,
-                    connector_mandate_request_reference_id,
-                };
-
-                let attempt_update = storage::PaymentAttemptUpdate::ConnectorMandateDetailUpdate {
-                    connector_mandate_detail: Some(connector_mandate_reference_id),
-                    updated_by: merchant_account.storage_scheme.to_string(),
-                };
-
-                state
-                    .store
-                    .update_payment_attempt_with_attempt_id(
-                        payment_attempt.clone(),
-                        attempt_update,
-                        merchant_account.storage_scheme,
-                    )
-                    .await
-                    .to_not_found_response(errors::ApiErrorResponse::PaymentNotFound)?;
-            } else {
-                logger::info!(
-                    "Skipping connector mandate details update since they are already present."
-                );
+                        .await
+                        .change_context(errors::ApiErrorResponse::InternalServerError)
+                        .attach_printable("Failed to update payment method in db")?;
+                }
             }
         }
+        _ => (),
     }
     Ok(())
 }

--- a/crates/router/src/services/connector_integration_interface.rs
+++ b/crates/router/src/services/connector_integration_interface.rs
@@ -321,6 +321,19 @@ impl api::IncomingWebhook for ConnectorEnum {
             Self::New(connector) => connector.get_mandate_details(request),
         }
     }
+
+    fn get_network_txn_id(
+        &self,
+        request: &IncomingWebhookRequestDetails<'_>,
+    ) -> CustomResult<
+        Option<hyperswitch_domain_models::router_flow_types::ConnectorNetworkTxnId>,
+        errors::ConnectorError,
+    > {
+        match self {
+            Self::Old(connector) => connector.get_network_txn_id(request),
+            Self::New(connector) => connector.get_network_txn_id(request),
+        }
+    }
 }
 
 impl api::ConnectorTransactionId for ConnectorEnum {


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
Described in #6719 

This PR introduces below changes
- `get_network_txn_id` fn in IncomingWebhook trait
- implement this new fn for Adyen for retrieving the network txn ID
- consume this fn in core flows for updating `network_transaction_id` in `payment_methods` table

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
Helps persist network transaction IDs for connectors in case it was not present in Authorize or Capture responses but instead sent in the webhook!

## How did you test it?
- Ensure Adyen is configured in HS, along with webhooks!
- Ensure `network_tx_reference` (field in Adyen) is not returned in Authorize or Capture response
- This field should be populated in DB once webhooks are received (provided this field was also returned)

`network_transaction_id` is populated after receiving webhooks
<img width="1258" alt="Screenshot 2024-12-04 at 4 45 43 PM" src="https://github.com/user-attachments/assets/1caeb9cd-fd77-4b40-8aa5-01226c65c6b9">


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
