### PR TITLE
fix(api_models): Fix `wasm` build problems caused by `actix-multipart`

### DIFF
--- a/crates/api_models/Cargo.toml
+++ b/crates/api_models/Cargo.toml
@@ -21,7 +21,7 @@ v2 = ["common_utils/v2", "customer_v2"]
 customer_v2 = ["common_utils/customer_v2"]
 payment_methods_v2 = ["common_utils/payment_methods_v2"]
 dynamic_routing = []
-theme = ["dep:actix-web", "dep:actix-multipart"]
+control_center_theme = ["dep:actix-web", "dep:actix-multipart"]
 
 [dependencies]
 actix-multipart = { version = "0.6.1", optional = true }

--- a/crates/api_models/Cargo.toml
+++ b/crates/api_models/Cargo.toml
@@ -21,7 +21,7 @@ v2 = ["common_utils/v2", "customer_v2"]
 customer_v2 = ["common_utils/customer_v2"]
 payment_methods_v2 = ["common_utils/payment_methods_v2"]
 dynamic_routing = []
-themes = ["dep:actix-web", "dep:actix-multipart"]
+theme = ["dep:actix-web", "dep:actix-multipart"]
 
 [dependencies]
 actix-multipart = { version = "0.6.1", optional = true }

--- a/crates/api_models/Cargo.toml
+++ b/crates/api_models/Cargo.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 license.workspace = true
 
 [features]
-errors = ["dep:reqwest"]
+errors = ["dep:actix-web", "dep:reqwest"]
 dummy_connector = ["euclid/dummy_connector", "common_enums/dummy_connector"]
 detailed_errors = []
 payouts = ["common_enums/payouts"]
@@ -21,10 +21,11 @@ v2 = ["common_utils/v2", "customer_v2"]
 customer_v2 = ["common_utils/customer_v2"]
 payment_methods_v2 = ["common_utils/payment_methods_v2"]
 dynamic_routing = []
+themes = ["dep:actix-web", "dep:actix-multipart"]
 
 [dependencies]
-actix-multipart = "0.6.1"
-actix-web = "4.5.1"
+actix-multipart = { version = "0.6.1", optional = true }
+actix-web = { version = "4.5.1", optional = true }
 error-stack = "0.4.1"
 indexmap = "2.3.0"
 mime = "0.3.17"

--- a/crates/api_models/src/events/user.rs
+++ b/crates/api_models/src/events/user.rs
@@ -2,7 +2,7 @@ use common_utils::events::{ApiEventMetric, ApiEventsType};
 
 #[cfg(feature = "dummy_connector")]
 use crate::user::sample_data::SampleDataRequest;
-#[cfg(feature = "theme")]
+#[cfg(feature = "control_center_theme")]
 use crate::user::theme::{
     CreateThemeRequest, GetThemeResponse, UpdateThemeRequest, UploadFileRequest,
 };
@@ -69,7 +69,7 @@ common_utils::impl_api_event_type!(
     )
 );
 
-#[cfg(feature = "theme")]
+#[cfg(feature = "control_center_theme")]
 common_utils::impl_api_event_type!(
     Miscellaneous,
     (

--- a/crates/api_models/src/events/user.rs
+++ b/crates/api_models/src/events/user.rs
@@ -2,11 +2,14 @@ use common_utils::events::{ApiEventMetric, ApiEventsType};
 
 #[cfg(feature = "dummy_connector")]
 use crate::user::sample_data::SampleDataRequest;
+#[cfg(feature = "themes")]
+use crate::user::theme::{
+    CreateThemeRequest, GetThemeResponse, UpdateThemeRequest, UploadFileRequest,
+};
 use crate::user::{
     dashboard_metadata::{
         GetMetaDataRequest, GetMetaDataResponse, GetMultipleMetaDataPayload, SetMetaDataRequest,
     },
-    theme::{CreateThemeRequest, GetThemeResponse, UpdateThemeRequest, UploadFileRequest},
     AcceptInviteFromEmailRequest, AuthSelectRequest, AuthorizeResponse, BeginTotpResponse,
     ChangePasswordRequest, ConnectAccountRequest, CreateInternalUserRequest,
     CreateUserAuthenticationMethodRequest, ForgotPasswordRequest, GetSsoAuthUrlRequest,
@@ -62,7 +65,14 @@ common_utils::impl_api_event_type!(
         UpdateUserAuthenticationMethodRequest,
         GetSsoAuthUrlRequest,
         SsoSignInRequest,
-        AuthSelectRequest,
+        AuthSelectRequest
+    )
+);
+
+#[cfg(feature = "themes")]
+common_utils::impl_api_event_type!(
+    Miscellaneous,
+    (
         GetThemeResponse,
         UploadFileRequest,
         CreateThemeRequest,

--- a/crates/api_models/src/events/user.rs
+++ b/crates/api_models/src/events/user.rs
@@ -2,7 +2,7 @@ use common_utils::events::{ApiEventMetric, ApiEventsType};
 
 #[cfg(feature = "dummy_connector")]
 use crate::user::sample_data::SampleDataRequest;
-#[cfg(feature = "themes")]
+#[cfg(feature = "theme")]
 use crate::user::theme::{
     CreateThemeRequest, GetThemeResponse, UpdateThemeRequest, UploadFileRequest,
 };

--- a/crates/api_models/src/events/user.rs
+++ b/crates/api_models/src/events/user.rs
@@ -69,7 +69,7 @@ common_utils::impl_api_event_type!(
     )
 );
 
-#[cfg(feature = "themes")]
+#[cfg(feature = "theme")]
 common_utils::impl_api_event_type!(
     Miscellaneous,
     (

--- a/crates/api_models/src/user.rs
+++ b/crates/api_models/src/user.rs
@@ -8,7 +8,7 @@ use crate::user_role::UserStatus;
 pub mod dashboard_metadata;
 #[cfg(feature = "dummy_connector")]
 pub mod sample_data;
-#[cfg(feature = "theme")]
+#[cfg(feature = "control_center_theme")]
 pub mod theme;
 
 #[derive(serde::Deserialize, Debug, Clone, serde::Serialize)]

--- a/crates/api_models/src/user.rs
+++ b/crates/api_models/src/user.rs
@@ -8,6 +8,7 @@ use crate::user_role::UserStatus;
 pub mod dashboard_metadata;
 #[cfg(feature = "dummy_connector")]
 pub mod sample_data;
+#[cfg(feature = "themes")]
 pub mod theme;
 
 #[derive(serde::Deserialize, Debug, Clone, serde::Serialize)]

--- a/crates/api_models/src/user.rs
+++ b/crates/api_models/src/user.rs
@@ -8,7 +8,7 @@ use crate::user_role::UserStatus;
 pub mod dashboard_metadata;
 #[cfg(feature = "dummy_connector")]
 pub mod sample_data;
-#[cfg(feature = "themes")]
+#[cfg(feature = "theme")]
 pub mod theme;
 
 #[derive(serde::Deserialize, Debug, Clone, serde::Serialize)]

--- a/crates/router/Cargo.toml
+++ b/crates/router/Cargo.toml
@@ -124,7 +124,7 @@ x509-parser = "0.16.0"
 # First party crates
 
 analytics = { version = "0.1.0", path = "../analytics", optional = true, default-features = false }
-api_models = { version = "0.1.0", path = "../api_models", features = ["errors", "themes"] }
+api_models = { version = "0.1.0", path = "../api_models", features = ["errors", "theme"] }
 cards = { version = "0.1.0", path = "../cards" }
 common_enums = { version = "0.1.0", path = "../common_enums" }
 common_utils = { version = "0.1.0", path = "../common_utils", features = ["signals", "async_ext", "logs", "metrics", "keymanager", "encryption_service"] }

--- a/crates/router/Cargo.toml
+++ b/crates/router/Cargo.toml
@@ -124,7 +124,7 @@ x509-parser = "0.16.0"
 # First party crates
 
 analytics = { version = "0.1.0", path = "../analytics", optional = true, default-features = false }
-api_models = { version = "0.1.0", path = "../api_models", features = ["errors"] }
+api_models = { version = "0.1.0", path = "../api_models", features = ["errors", "themes"] }
 cards = { version = "0.1.0", path = "../cards" }
 common_enums = { version = "0.1.0", path = "../common_enums" }
 common_utils = { version = "0.1.0", path = "../common_utils", features = ["signals", "async_ext", "logs", "metrics", "keymanager", "encryption_service"] }

--- a/crates/router/Cargo.toml
+++ b/crates/router/Cargo.toml
@@ -124,7 +124,7 @@ x509-parser = "0.16.0"
 # First party crates
 
 analytics = { version = "0.1.0", path = "../analytics", optional = true, default-features = false }
-api_models = { version = "0.1.0", path = "../api_models", features = ["errors", "theme"] }
+api_models = { version = "0.1.0", path = "../api_models", features = ["errors", "control_center_theme"] }
 cards = { version = "0.1.0", path = "../cards" }
 common_enums = { version = "0.1.0", path = "../common_enums" }
 common_utils = { version = "0.1.0", path = "../common_utils", features = ["signals", "async_ext", "logs", "metrics", "keymanager", "encryption_service"] }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Wasm build is failing because of adding `actix-multipart` dependency in `api-models`.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
Closes #6748.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Checked by building `wasm` locally. It worked.
![Image from Jeeva Ramachandran via Slack](https://github.com/user-attachments/assets/966948cb-ff45-4d02-b885-f878d59ae90d)

No need to run any other tests as this is an internal change.


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
