### PR TITLE
refactor(enums): recon - include ReconOps variant in PermissionsGroup for backwards compatibility with data in DB

### DIFF
--- a/crates/common_enums/src/enums.rs
+++ b/crates/common_enums/src/enums.rs
@@ -2826,10 +2826,9 @@ pub enum PermissionGroup {
     ReconReportsView,
     ReconReportsManage,
     ReconOpsView,
-    // Alias is added for backward compatibility with database
-    // TODO: Remove alias post migration
-    #[serde(alias = "recon_ops")]
     ReconOpsManage,
+    // TODO: To be deprecated, make sure DB is migrated before removing
+    ReconOps,
 }
 
 #[derive(Clone, Debug, serde::Serialize, PartialEq, Eq, Hash, strum::EnumIter)]

--- a/crates/router/src/services/authorization/info.rs
+++ b/crates/router/src/services/authorization/info.rs
@@ -43,7 +43,7 @@ fn get_group_description(group: PermissionGroup) -> &'static str {
         PermissionGroup::ReconReportsView => "View and access reconciliation reports and analytics",
         PermissionGroup::ReconReportsManage => "Manage reconciliation reports",
         PermissionGroup::ReconOpsView => "View and access reconciliation operations",
-        PermissionGroup::ReconOpsManage => "Manage reconciliation operations",
+        PermissionGroup::ReconOpsManage | PermissionGroup::ReconOps => "Manage reconciliation operations",
     }
 }
 

--- a/crates/router/src/services/authorization/permission_groups.rs
+++ b/crates/router/src/services/authorization/permission_groups.rs
@@ -33,6 +33,7 @@ impl PermissionGroupExt for PermissionGroup {
             | Self::OrganizationManage
             | Self::AccountManage
             | Self::ReconOpsManage
+            | Self::ReconOps
             | Self::ReconReportsManage => PermissionScope::Write,
         }
     }
@@ -49,7 +50,7 @@ impl PermissionGroupExt for PermissionGroup {
             | Self::MerchantDetailsManage
             | Self::AccountView
             | Self::AccountManage => ParentGroup::Account,
-            Self::ReconOpsView | Self::ReconOpsManage => ParentGroup::ReconOps,
+            Self::ReconOpsView | Self::ReconOpsManage | Self::ReconOps => ParentGroup::ReconOps,
             Self::ReconReportsView | Self::ReconReportsManage => ParentGroup::ReconReports,
         }
     }
@@ -81,7 +82,7 @@ impl PermissionGroupExt for PermissionGroup {
             }
 
             Self::ReconOpsView => vec![Self::ReconOpsView],
-            Self::ReconOpsManage => vec![Self::ReconOpsView, Self::ReconOpsManage],
+            Self::ReconOpsManage | Self::ReconOps => vec![Self::ReconOpsView, Self::ReconOpsManage],
 
             Self::ReconReportsView => vec![Self::ReconReportsView],
             Self::ReconReportsManage => vec![Self::ReconReportsView, Self::ReconReportsManage],


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
This PR introduces a new variant - `ReconOps` in the `PermissionGroup` enum for deserializing the custom recon related roles in the existing DB.

**Why?**
In `PermissionGroup` enum, `ReconOps` was recently renamed to `ReconOpsManage`. These values are serialized and stored in DB in case custom roles are created. For existing custom recon related roles, this would be stored as `recon_ops` in the DB. Application would expect this to be `recon_ops_manage` leading to deserialization failures.

This cannot be solved using serde's alias or strum's serialize attributes. **Why?** using strum's serialize attribute will expect the DB to always have `recon_ops` - application will always store this as `recon_ops_manage` in the new builds. Serde's alias attribute is not taken into account for DB enums or texts - which depends on FromStr impls.

**Solution**
- Add a dummy variant `ReconOps` and treat it as `ReconOpsManage` in the application.
- Run migrations in DB once this build is rolled out
- Delete the redundant variants once the data is migrated

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
Helps maintain backward compatibility for recon related custom roles with DB.

## How did you test it?
Performing backwards compatibility with DB and application
- Ensure existing DB has `recon_ops` in custom roles
- Fetch roles using the new application

Current behavior (if custom recon roles are present in DB, and new application is used)
<img width="744" alt="Screenshot 2024-12-06 at 6 13 38 PM" src="https://github.com/user-attachments/assets/8b407de8-e616-49fb-828c-3b25e0ba5b42">
<img width="1258" alt="Screenshot 2024-12-06 at 6 15 26 PM" src="https://github.com/user-attachments/assets/f50d6db5-a367-4665-8b2c-f65e7ad95d91">

Updated behavior for the same case
<img width="696" alt="Screenshot 2024-12-06 at 6 18 05 PM" src="https://github.com/user-attachments/assets/fee2ce67-79ec-4ecb-95b0-4964b506d88d">

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
