### PR TITLE
ci(cypress): Add shipping cost test case

### DIFF
--- a/cypress-tests/cypress/e2e/PaymentTest/00004-NoThreeDSAutoCapture.cy.js
+++ b/cypress-tests/cypress/e2e/PaymentTest/00004-NoThreeDSAutoCapture.cy.js
@@ -96,4 +96,52 @@ describe("Card - NoThreeDS payment flow test", () => {
       cy.retrievePaymentCallTest(globalState, data);
     });
   });
+
+   context("Card-NoThreeDS payment with shipping cost", () => {
+     let shouldContinue = true; // variable that will be used to skip tests if a previous test fails
+
+     beforeEach(function () {
+       if (!shouldContinue) {
+         this.skip();
+       }
+     });
+
+     it("create-payment-call-test", () => {
+       const data = getConnectorDetails(globalState.get("connectorId"))[
+         "card_pm"
+       ]["PaymentIntentWithShippingCost"];
+
+       cy.createPaymentIntentTest(
+         fixtures.createPaymentBody,
+         data,
+         "no_three_ds",
+         "automatic",
+         globalState
+       );
+
+       if (shouldContinue) shouldContinue = utils.should_continue_further(data);
+     });
+
+     it("payment_methods-call-test", () => {
+       cy.paymentMethodsCallTest(globalState);
+     });
+
+     it("Confirm No 3DS", () => {
+       const data = getConnectorDetails(globalState.get("connectorId"))[
+         "card_pm"
+       ]["PaymentConfirmWithShippingCost"];
+
+       cy.confirmCallTest(fixtures.confirmBody, data, true, globalState);
+
+       if (shouldContinue) shouldContinue = utils.should_continue_further(data);
+     });
+
+     it("retrieve-payment-call-test", () => {
+       const data = getConnectorDetails(globalState.get("connectorId"))[
+         "card_pm"
+       ]["PaymentConfirmWithShippingCost"];
+
+       cy.retrievePaymentCallTest(globalState, data);
+     });
+   });
 });

--- a/cypress-tests/cypress/e2e/PaymentTest/00004-NoThreeDSAutoCapture.cy.js
+++ b/cypress-tests/cypress/e2e/PaymentTest/00004-NoThreeDSAutoCapture.cy.js
@@ -97,51 +97,51 @@ describe("Card - NoThreeDS payment flow test", () => {
     });
   });
 
-   context("Card-NoThreeDS payment with shipping cost", () => {
-     let shouldContinue = true; // variable that will be used to skip tests if a previous test fails
+  context("Card-NoThreeDS payment with shipping cost", () => {
+    let shouldContinue = true; // variable that will be used to skip tests if a previous test fails
 
-     beforeEach(function () {
-       if (!shouldContinue) {
-         this.skip();
-       }
-     });
+    beforeEach(function () {
+      if (!shouldContinue) {
+        this.skip();
+      }
+    });
 
-     it("create-payment-call-test", () => {
-       const data = getConnectorDetails(globalState.get("connectorId"))[
-         "card_pm"
-       ]["PaymentIntentWithShippingCost"];
+    it("create-payment-call-test", () => {
+      const data = getConnectorDetails(globalState.get("connectorId"))[
+        "card_pm"
+      ]["PaymentIntentWithShippingCost"];
 
-       cy.createPaymentIntentTest(
-         fixtures.createPaymentBody,
-         data,
-         "no_three_ds",
-         "automatic",
-         globalState
-       );
+      cy.createPaymentIntentTest(
+        fixtures.createPaymentBody,
+        data,
+        "no_three_ds",
+        "automatic",
+        globalState
+      );
 
-       if (shouldContinue) shouldContinue = utils.should_continue_further(data);
-     });
+      if (shouldContinue) shouldContinue = utils.should_continue_further(data);
+    });
 
-     it("payment_methods-call-test", () => {
-       cy.paymentMethodsCallTest(globalState);
-     });
+    it("payment_methods-call-test", () => {
+      cy.paymentMethodsCallTest(globalState);
+    });
 
-     it("Confirm No 3DS", () => {
-       const data = getConnectorDetails(globalState.get("connectorId"))[
-         "card_pm"
-       ]["PaymentConfirmWithShippingCost"];
+    it("Confirm No 3DS", () => {
+      const data = getConnectorDetails(globalState.get("connectorId"))[
+        "card_pm"
+      ]["PaymentConfirmWithShippingCost"];
 
-       cy.confirmCallTest(fixtures.confirmBody, data, true, globalState);
+      cy.confirmCallTest(fixtures.confirmBody, data, true, globalState);
 
-       if (shouldContinue) shouldContinue = utils.should_continue_further(data);
-     });
+      if (shouldContinue) shouldContinue = utils.should_continue_further(data);
+    });
 
-     it("retrieve-payment-call-test", () => {
-       const data = getConnectorDetails(globalState.get("connectorId"))[
-         "card_pm"
-       ]["PaymentConfirmWithShippingCost"];
+    it("retrieve-payment-call-test", () => {
+      const data = getConnectorDetails(globalState.get("connectorId"))[
+        "card_pm"
+      ]["PaymentConfirmWithShippingCost"];
 
-       cy.retrievePaymentCallTest(globalState, data);
-     });
-   });
+      cy.retrievePaymentCallTest(globalState, data);
+    });
+  });
 });

--- a/cypress-tests/cypress/e2e/PaymentUtils/Adyen.js
+++ b/cypress-tests/cypress/e2e/PaymentUtils/Adyen.js
@@ -89,7 +89,7 @@ export const connectorDetails = {
         status: 200,
         body: {
           status: "requires_payment_method",
-          shipping: 50,
+          shipping_cost: 50,
           amount: 6500,
         },
       },

--- a/cypress-tests/cypress/e2e/PaymentUtils/Adyen.js
+++ b/cypress-tests/cypress/e2e/PaymentUtils/Adyen.js
@@ -89,6 +89,8 @@ export const connectorDetails = {
         status: 200,
         body: {
           status: "requires_payment_method",
+          shipping: 50,
+          amount: 6500,
         },
       },
     },
@@ -107,6 +109,8 @@ export const connectorDetails = {
           status: "succeeded",
           shipping_cost: 50,
           amount_received: 6550,
+          amount: 6500,
+          net_amount: 6550,
         },
       },
     },

--- a/cypress-tests/cypress/e2e/PaymentUtils/Adyen.js
+++ b/cypress-tests/cypress/e2e/PaymentUtils/Adyen.js
@@ -80,6 +80,36 @@ export const connectorDetails = {
         },
       },
     },
+    PaymentIntentWithShippingCost: {
+      Request: {
+        currency: "USD",
+        shipping_cost: 50,
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "requires_payment_method",
+        },
+      },
+    },
+    PaymentConfirmWithShippingCost: {
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulNo3DSCardDetails,
+        },
+        customer_acceptance: null,
+        setup_future_usage: "on_session",
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "succeeded",
+          shipping_cost: 50,
+          amount_received: 6550,
+        },
+      },
+    },
     "3DSManualCapture": {
       Request: {
         payment_method: "card",

--- a/cypress-tests/cypress/e2e/PaymentUtils/BankOfAmerica.js
+++ b/cypress-tests/cypress/e2e/PaymentUtils/BankOfAmerica.js
@@ -87,6 +87,8 @@ export const connectorDetails = {
         status: 200,
         body: {
           status: "requires_payment_method",
+          amount: 6500,
+          shipping_cost: 50,
         },
       },
     },
@@ -105,6 +107,8 @@ export const connectorDetails = {
           status: "succeeded",
           shipping_cost: 50,
           amount_received: 6550,
+          amount: 6500,
+          net_amount: 6550,
         },
       },
     },

--- a/cypress-tests/cypress/e2e/PaymentUtils/BankOfAmerica.js
+++ b/cypress-tests/cypress/e2e/PaymentUtils/BankOfAmerica.js
@@ -78,6 +78,36 @@ export const connectorDetails = {
         },
       },
     },
+    PaymentIntentWithShippingCost: {
+      Request: {
+        currency: "USD",
+        shipping_cost: 50,
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "requires_payment_method",
+        },
+      },
+    },
+    PaymentConfirmWithShippingCost: {
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulNo3DSCardDetails,
+        },
+        customer_acceptance: null,
+        setup_future_usage: "on_session",
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "succeeded",
+          shipping_cost: 50,
+          amount_received: 6550,
+        },
+      },
+    },
     "3DSManualCapture": {
       Request: {
         payment_method: "card",

--- a/cypress-tests/cypress/e2e/PaymentUtils/Bluesnap.js
+++ b/cypress-tests/cypress/e2e/PaymentUtils/Bluesnap.js
@@ -32,12 +32,15 @@ export const connectorDetails = {
     PaymentIntentWithShippingCost: {
       Request: {
         currency: "USD",
+        amount: 6500,
         shipping_cost: 50,
       },
       Response: {
         status: 200,
         body: {
           status: "requires_payment_method",
+          amount: 6500,
+          shipping_cost: 50,
         },
       },
     },
@@ -56,6 +59,8 @@ export const connectorDetails = {
           status: "succeeded",
           shipping_cost: 50,
           amount_received: 6550,
+          amount: 6500,
+          net_amount: 6550,
         },
       },
     },

--- a/cypress-tests/cypress/e2e/PaymentUtils/Bluesnap.js
+++ b/cypress-tests/cypress/e2e/PaymentUtils/Bluesnap.js
@@ -29,6 +29,36 @@ export const connectorDetails = {
         },
       },
     },
+    PaymentIntentWithShippingCost: {
+      Request: {
+        currency: "USD",
+        shipping_cost: 50,
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "requires_payment_method",
+        },
+      },
+    },
+    PaymentConfirmWithShippingCost: {
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulNo3DSCardDetails,
+        },
+        customer_acceptance: null,
+        setup_future_usage: "on_session",
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "succeeded",
+          shipping_cost: 50,
+          amount_received: 6550,
+        },
+      },
+    },
     "3DSManualCapture": {
       Configs: {
         TRIGGER_SKIP: true,

--- a/cypress-tests/cypress/e2e/PaymentUtils/Checkout.js
+++ b/cypress-tests/cypress/e2e/PaymentUtils/Checkout.js
@@ -47,6 +47,8 @@ export const connectorDetails = {
         status: 200,
         body: {
           status: "requires_payment_method",
+          shipping_cost: 50,
+          amount: 6500,
         },
       },
     },
@@ -64,6 +66,7 @@ export const connectorDetails = {
         body: {
           status: "processing",
           shipping_cost: 50,
+          amount: 6500,
         },
       },
     },

--- a/cypress-tests/cypress/e2e/PaymentUtils/Checkout.js
+++ b/cypress-tests/cypress/e2e/PaymentUtils/Checkout.js
@@ -38,6 +38,35 @@ export const connectorDetails = {
         },
       },
     },
+    PaymentIntentWithShippingCost: {
+      Request: {
+        currency: "USD",
+        shipping_cost: 50,
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "requires_payment_method",
+        },
+      },
+    },
+    PaymentConfirmWithShippingCost: {
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulNo3DSCardDetails,
+        },
+        customer_acceptance: null,
+        setup_future_usage: "on_session",
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "processing",
+          shipping_cost: 50,
+        },
+      },
+    },
     "3DSManualCapture": {
       Request: {
         payment_method: "card",

--- a/cypress-tests/cypress/e2e/PaymentUtils/Commons.js
+++ b/cypress-tests/cypress/e2e/PaymentUtils/Commons.js
@@ -661,14 +661,6 @@ export const connectorDetails = {
         customer_acceptance: null,
         setup_future_usage: "on_session",
       },
-      Response: {
-        status: 200,
-        body: {
-          status: "succeeded",
-          shipping_cost: 50,
-          amount_received: 6550,
-        },
-      },
     }),
     "3DSManualCapture": getCustomExchange({
       Request: {

--- a/cypress-tests/cypress/e2e/PaymentUtils/Commons.js
+++ b/cypress-tests/cypress/e2e/PaymentUtils/Commons.js
@@ -640,6 +640,37 @@ export const connectorDetails = {
         },
       },
     }),
+    PaymentIntentWithShippingCost: getCustomExchange({
+      Request: {
+        currency: "USD",
+        shipping_cost: 50,
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "requires_payment_method",
+        },
+      },
+    }),
+    PaymentConfirmWithShippingCost: getCustomExchange({
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulNo3DSCardDetails,
+        },
+        currency: "USD",
+        customer_acceptance: null,
+        setup_future_usage: "on_session",
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "succeeded",
+          shipping_cost: 50,
+          amount_received: 6550,
+        },
+      },
+    }),
     "3DSManualCapture": getCustomExchange({
       Request: {
         payment_method: "card",

--- a/cypress-tests/cypress/e2e/PaymentUtils/Commons.js
+++ b/cypress-tests/cypress/e2e/PaymentUtils/Commons.js
@@ -658,7 +658,6 @@ export const connectorDetails = {
         payment_method_data: {
           card: successfulNo3DSCardDetails,
         },
-        currency: "USD",
         customer_acceptance: null,
         setup_future_usage: "on_session",
       },

--- a/cypress-tests/cypress/e2e/PaymentUtils/Commons.js
+++ b/cypress-tests/cypress/e2e/PaymentUtils/Commons.js
@@ -651,6 +651,8 @@ export const connectorDetails = {
         status: 200,
         body: {
           status: "requires_payment_method",
+          shipping_cost: 50,
+          amount: 6500,
         },
       },
     }),

--- a/cypress-tests/cypress/e2e/PaymentUtils/Commons.js
+++ b/cypress-tests/cypress/e2e/PaymentUtils/Commons.js
@@ -637,6 +637,8 @@ export const connectorDetails = {
         status: 200,
         body: {
           status: "requires_payment_method",
+          shipping_cost: 50,
+          amount: 6500,
         },
       },
     }),

--- a/cypress-tests/cypress/e2e/PaymentUtils/Cybersource.js
+++ b/cypress-tests/cypress/e2e/PaymentUtils/Cybersource.js
@@ -155,6 +155,8 @@ export const connectorDetails = {
         status: 200,
         body: {
           status: "requires_payment_method",
+          shipping_cost: 50,
+          amount: 6500,
         },
       },
     },
@@ -173,6 +175,8 @@ export const connectorDetails = {
           status: "succeeded",
           shipping_cost: 50,
           amount_received: 6550,
+          amount: 6500,
+          net_amount: 6550,
         },
       },
     },

--- a/cypress-tests/cypress/e2e/PaymentUtils/Cybersource.js
+++ b/cypress-tests/cypress/e2e/PaymentUtils/Cybersource.js
@@ -128,6 +128,36 @@ export const connectorDetails = {
         },
       },
     },
+    PaymentIntentWithShippingCost: {
+      Request: {
+        currency: "USD",
+        shipping_cost: 50,
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "requires_payment_method",
+        },
+      },
+    },
+    PaymentConfirmWithShippingCost: {
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulNo3DSCardDetails,
+        },
+        customer_acceptance: null,
+        setup_future_usage: "on_session",
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "succeeded",
+          shipping_cost: 50,
+          amount_received: 6550,
+        },
+      },
+    },
     "3DSManualCapture": {
       Configs: {
         CONNECTOR_CREDENTIAL: {

--- a/cypress-tests/cypress/e2e/PaymentUtils/Nmi.js
+++ b/cypress-tests/cypress/e2e/PaymentUtils/Nmi.js
@@ -47,6 +47,8 @@ export const connectorDetails = {
         status: 200,
         body: {
           status: "requires_payment_method",
+          shipping_cost: 50,
+          amount: 6500,
         },
       },
     },
@@ -64,6 +66,7 @@ export const connectorDetails = {
         body: {
           status: "processing",
           shipping_cost: 50,
+          amount: 6500,
         },
       },
     },

--- a/cypress-tests/cypress/e2e/PaymentUtils/Nmi.js
+++ b/cypress-tests/cypress/e2e/PaymentUtils/Nmi.js
@@ -38,6 +38,35 @@ export const connectorDetails = {
         },
       },
     },
+    PaymentIntentWithShippingCost: {
+      Request: {
+        currency: "USD",
+        shipping_cost: 50,
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "requires_payment_method",
+        },
+      },
+    },
+    PaymentConfirmWithShippingCost: {
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulNo3DSCardDetails,
+        },
+        customer_acceptance: null,
+        setup_future_usage: "on_session",
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "processing",
+          shipping_cost: 50,
+        },
+      },
+    },
     "3DSManualCapture": {
       Request: {
         payment_method: "card",

--- a/cypress-tests/cypress/e2e/PaymentUtils/Noon.js
+++ b/cypress-tests/cypress/e2e/PaymentUtils/Noon.js
@@ -115,6 +115,35 @@ export const connectorDetails = {
         },
       },
     },
+    PaymentIntentWithShippingCost: {
+      Request: {
+        currency: "AED",
+        shipping_cost: 50,
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "requires_payment_method",
+        },
+      },
+    },
+    PaymentConfirmWithShippingCost: {
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulNo3DSCardDetails,
+        },
+        customer_acceptance: null,
+        setup_future_usage: "on_session",
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "requires_customer_action",
+          shipping_cost: 50,
+        },
+      },
+    },
     "3DSManualCapture": {
       Request: {
         payment_method: "card",

--- a/cypress-tests/cypress/e2e/PaymentUtils/Noon.js
+++ b/cypress-tests/cypress/e2e/PaymentUtils/Noon.js
@@ -124,6 +124,8 @@ export const connectorDetails = {
         status: 200,
         body: {
           status: "requires_payment_method",
+          shipping_cost: 50,
+          amount: 6500,
         },
       },
     },
@@ -141,6 +143,7 @@ export const connectorDetails = {
         body: {
           status: "requires_customer_action",
           shipping_cost: 50,
+          amount: 6500,
         },
       },
     },

--- a/cypress-tests/cypress/e2e/PaymentUtils/Paypal.js
+++ b/cypress-tests/cypress/e2e/PaymentUtils/Paypal.js
@@ -57,6 +57,8 @@ export const connectorDetails = {
         status: 200,
         body: {
           status: "requires_payment_method",
+          shipping_cost: 50,
+          amount: 6500,
         },
       },
     },

--- a/cypress-tests/cypress/e2e/PaymentUtils/Paypal.js
+++ b/cypress-tests/cypress/e2e/PaymentUtils/Paypal.js
@@ -48,6 +48,37 @@ export const connectorDetails = {
         },
       },
     },
+    PaymentIntentWithShippingCost: {
+      Request: {
+        currency: "USD",
+        shipping_cost: 50,
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "requires_payment_method",
+        },
+      },
+    },
+    PaymentConfirmWithShippingCost: {
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulNo3DSCardDetails,
+        },
+        customer_acceptance: null,
+        setup_future_usage: "on_session",
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "failed",
+          error_code: "AMOUNT_MISMATCH",
+          error_message:
+            "description - Should equal item_total + tax_total + shipping + handling + insurance - shipping_discount - discount., value - 65.50, field - value;",
+        },
+      },
+    },
     "3DSManualCapture": {
       Configs: {
         TRIGGER_SKIP: true,

--- a/cypress-tests/cypress/e2e/PaymentUtils/Stripe.js
+++ b/cypress-tests/cypress/e2e/PaymentUtils/Stripe.js
@@ -150,6 +150,8 @@ export const connectorDetails = {
         status: 200,
         body: {
           status: "requires_payment_method",
+          shipping_cost: 50,
+          amount: 6500,
         },
       },
     },
@@ -168,6 +170,8 @@ export const connectorDetails = {
           status: "succeeded",
           shipping_cost: 50,
           amount_received: 6550,
+          amount: 6500,
+          net_amount: 6550,
         },
       },
     },

--- a/cypress-tests/cypress/e2e/PaymentUtils/Stripe.js
+++ b/cypress-tests/cypress/e2e/PaymentUtils/Stripe.js
@@ -141,6 +141,36 @@ export const connectorDetails = {
         },
       },
     },
+    PaymentIntentWithShippingCost: {
+      Request: {
+        currency: "USD",
+        shipping_cost: 50,
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "requires_payment_method",
+        },
+      },
+    },
+    PaymentConfirmWithShippingCost: {
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulNo3DSCardDetails,
+        },
+        customer_acceptance: null,
+        setup_future_usage: "on_session",
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "succeeded",
+          shipping_cost: 50,
+          amount_received: 6550,
+        },
+      },
+    },
     "3DSManualCapture": {
       Request: {
         payment_method: "card",

--- a/cypress-tests/cypress/e2e/PaymentUtils/Trustpay.js
+++ b/cypress-tests/cypress/e2e/PaymentUtils/Trustpay.js
@@ -54,6 +54,36 @@ export const connectorDetails = {
         },
       },
     }),
+    PaymentIntentWithShippingCost: {
+      Request: {
+        currency: "USD",
+        shipping_cost: 50,
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "requires_payment_method",
+        },
+      },
+    },
+    PaymentConfirmWithShippingCost: {
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulNo3DSCardDetails,
+        },
+        customer_acceptance: null,
+        setup_future_usage: "on_session",
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "succeeded",
+          shipping_cost: 50,
+          amount_received: 6550,
+        },
+      },
+    },
     "3DSAutoCapture": {
       Configs: {
         CONNECTOR_CREDENTIAL: {

--- a/cypress-tests/cypress/e2e/PaymentUtils/Trustpay.js
+++ b/cypress-tests/cypress/e2e/PaymentUtils/Trustpay.js
@@ -63,6 +63,8 @@ export const connectorDetails = {
         status: 200,
         body: {
           status: "requires_payment_method",
+          shipping_cost: 50,
+          amount: 6500,
         },
       },
     },
@@ -81,6 +83,8 @@ export const connectorDetails = {
           status: "succeeded",
           shipping_cost: 50,
           amount_received: 6550,
+          amount: 6500,
+          net_amount: 6550,
         },
       },
     },

--- a/cypress-tests/cypress/support/commands.js
+++ b/cypress-tests/cypress/support/commands.js
@@ -1079,7 +1079,7 @@ Cypress.Commands.add(
           createPaymentBody.setup_future_usage,
           "setup_future_usage"
         ).to.equal(response.body.setup_future_usage);
-      // If 'shipping_cost' is not included in the request, the 'amount' in 'createPaymentBody' should match the 'amount_capturable' in the response.
+        // If 'shipping_cost' is not included in the request, the 'amount' in 'createPaymentBody' should match the 'amount_capturable' in the response.
         if (typeof createPaymentBody?.shipping_cost === "undefined") {
           expect(createPaymentBody.amount, "amount_capturable").to.equal(
             response.body.amount_capturable

--- a/cypress-tests/cypress/support/commands.js
+++ b/cypress-tests/cypress/support/commands.js
@@ -1079,7 +1079,8 @@ Cypress.Commands.add(
           createPaymentBody.setup_future_usage,
           "setup_future_usage"
         ).to.equal(response.body.setup_future_usage);
-        if (createPaymentBody.shipping_cost === undefined) {
+      // If 'shipping_cost' is not included in the request, the 'amount' in 'createPaymentBody' should match the 'amount_capturable' in the response.
+        if (typeof createPaymentBody?.shipping_cost === "undefined") {
           expect(createPaymentBody.amount, "amount_capturable").to.equal(
             response.body.amount_capturable
           );

--- a/cypress-tests/cypress/support/commands.js
+++ b/cypress-tests/cypress/support/commands.js
@@ -1079,9 +1079,16 @@ Cypress.Commands.add(
           createPaymentBody.setup_future_usage,
           "setup_future_usage"
         ).to.equal(response.body.setup_future_usage);
-        expect(createPaymentBody.amount, "amount_capturable").to.equal(
-          response.body.amount_capturable
-        );
+        if (!createPaymentBody.hasOwnProperty("shipping_cost")) {
+          expect(createPaymentBody.amount, "amount_capturable").to.equal(
+            response.body.amount_capturable
+          );
+        } else {
+          expect(
+            createPaymentBody.amount + createPaymentBody.shipping_cost,
+            "amount_capturable"
+          ).to.equal(response.body.amount_capturable);
+        }
         expect(response.body.amount_received, "amount_received").to.be.oneOf([
           0,
           null,

--- a/cypress-tests/cypress/support/commands.js
+++ b/cypress-tests/cypress/support/commands.js
@@ -1079,7 +1079,7 @@ Cypress.Commands.add(
           createPaymentBody.setup_future_usage,
           "setup_future_usage"
         ).to.equal(response.body.setup_future_usage);
-        if (!createPaymentBody.hasOwnProperty("shipping_cost")) {
+        if (createPaymentBody.shipping_cost === undefined) {
           expect(createPaymentBody.amount, "amount_capturable").to.equal(
             response.body.amount_capturable
           );


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [x] CI/CD

## Description
Add Shipping Cost test case for cypress automation

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
Currently Test case was not present 

## How did you test it?
Cypress 
<img width="602" alt="image" src="https://github.com/user-attachments/assets/f6f26932-d6b4-4d0a-8312-461839417f35">


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
