### PR TITLE
feat(payments): [Payment links] Add locale case fix

### DIFF
--- a/crates/router/src/core/payment_link/locale.js
+++ b/crates/router/src/core/payment_link/locale.js
@@ -3,11 +3,11 @@ The languages supported by locale.js are:
  1) English (en)
  2) Hebrew (he)
  3) French (fr)
- 4) British English (en_GB)
+ 4) British English (en_gb)
  5) Arabic (ar)
  6) Japanese (ja)
  7) German (de)
- 8) Belgian French (fr_BE)
+ 8) Belgian French (fr_be)
  9) Spanish (es)
  10) Catalan (ca)
  11) Portuguese (pt)
@@ -17,7 +17,7 @@ The languages supported by locale.js are:
  15) Swedish (sv)
  16) Russian (ru)
  17) Chinese (zh)
- 19) Traditional Chinese (zh_Hant)
+ 19) Traditional Chinese (zh_hant)
 */
 const locales = {
     en: {
@@ -113,7 +113,7 @@ const locales = {
       errorCode: "Code d'erreur",
       errorMessage: "Message d'erreur"
     },
-    en_GB: {
+    en_gb: {
       expiresOn: "Link expires on: ",
       refId: "Ref Id: ",
       requestedBy: "Requested by ",
@@ -238,7 +238,7 @@ const locales = {
       errorCode: "Fehlercode",
       errorMessage: "Fehlermeldung"
     },
-    fr_BE: {
+    fr_be: {
       expiresOn: "Le lien expire le: ",
       refId: "ID de référence: ",
       requestedBy: "Demandé par ",
@@ -550,7 +550,7 @@ const locales = {
       errorCode: "错误代码",
       errorMessage: "错误信息"
     },
-    zh_Hant: {
+    zh_hant: {
       expiresOn: "連結到期日期：",
       refId: "參考編號：",
       requestedBy: "請求者 ",
@@ -584,6 +584,7 @@ const locales = {
   };
 
   function getTranslations(locale_str) {
-    var locale = locale_str || 'en'; // defaults if locale is not present in payment details.
+    var fallback_locale = 'en';
+    var locale = locale_str.toLowerCase().replace(/-/g, "_") || fallback_locale; // defaults if locale is not present in payment details.
     return locales[locale] || locales['en']; // defaults if locale is not implemented in locales.
   }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
Changed locale case to snakecase for  `const locale`  object for payment_link. Currently the object has keys in snake case but since Accept-Language is not passed in snakecase, payment_link is not able to render the translated data but shows data in english (fallback language).


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
(Need to run both hyperswitch-web and hyperswitch locally to test)

<details>
<summary>1. Update `allowed_domains` in business profile (Expand to see details)</summary>

``` 
curl --location 'http://localhost:8080/account/merchant_1733317126/business_profile/pro_I5CYJ8tVS6OHA1GMcXaW' \
--header 'Content-Type: application/json' \
--header 'api-key: test_admin' \
--data '{
    "payment_link_config": {
        "allowed_domains": [
            "*"
        ],
        "enabled_saved_payment_method": true,
        "hide_card_nickname_field" : true
    }
}'

```
</details>
<details>
<summary>2. Create a payment link with Accept-Language header as "zh-Hant" </summary>

cURL
`curl --location --request POST 'http://localhost:8080/payments' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: dev_9ujhlj2TyCy27k37JtCmZZMbTLKVVebPRTtPcWE1okFjsngoqlZEaw4nQtX1zClT' \
--header 'Accept-Language: zh-Hant' \
--data-raw '{
    "amount": 100,
    "currency": "USD",
    "payment_link": true,
    "connector": [
        "novalnet"
    ],
    "session_expiry": 1000000,
    "return_url": "http://127.0.0.1:5500/src/pl_iframe.html",
    "payment_link_config": {
        "theme": "#14356f",
        "logo": "https://logosandtypes.com/wp-content/uploads/2020/08/zurich.svg",
        "seller_name": "Zurich Inc.",
        "show_card_form_by_default": false
    }
}'`

Response of /payments 
```
{
    "payment_id": "pay_rlQ6zFFw7dlEd87TcGlY",
    "merchant_id": "merchant_1733317126",
    "status": "requires_payment_method",
    "amount": 100,
    "net_amount": 100,
    "shipping_cost": null,
    "amount_capturable": 100,
    "amount_received": null,
    "connector": null,
    "client_secret": "pay_rlQ6zFFw7dlEd87TcGlY_secret_l4amc98ygqRSMdN5bmQQ",
    "created": "2024-12-04T13:35:45.977Z",
    "currency": "USD",
    "customer_id": null,
    "customer": null,
    "description": null,
    "refunds": null,
    "disputes": null,
    "mandate_id": null,
    "mandate_data": null,
    "setup_future_usage": null,
    "off_session": null,
    "capture_on": null,
    "capture_method": null,
    "payment_method": null,
    "payment_method_data": null,
    "payment_token": null,
    "shipping": null,
    "billing": null,
    "order_details": null,
    "email": null,
    "name": null,
    "phone": null,
    "return_url": "http://127.0.0.1:5500/src/pl_iframe.html",
    "authentication_type": null,
    "statement_descriptor_name": null,
    "statement_descriptor_suffix": null,
    "next_action": null,
    "cancellation_reason": null,
    "error_code": null,
    "error_message": null,
    "unified_code": null,
    "unified_message": null,
    "payment_experience": null,
    "payment_method_type": null,
    "connector_label": null,
    "business_country": null,
    "business_label": "default",
    "business_sub_label": null,
    "allowed_payment_method_types": null,
    "ephemeral_key": null,
    "manual_retry_allowed": null,
    "connector_transaction_id": null,
    "frm_message": null,
    "metadata": null,
    "connector_metadata": null,
    "feature_metadata": null,
    "reference_id": null,
    "payment_link": {
        "link": "http://localhost:8080/payment_link/merchant_1733317126/pay_rlQ6zFFw7dlEd87TcGlY?locale=zh-Hant",
        "secure_link": "http://localhost:8080/payment_link/s/merchant_1733317126/pay_rlQ6zFFw7dlEd87TcGlY?locale=zh-Hant",
        "payment_link_id": "plink_ALMUnvEV9mgsuHTex9UQ"
    },
    "profile_id": "pro_I5CYJ8tVS6OHA1GMcXaW",
    "surcharge_details": null,
    "attempt_count": 1,
    "merchant_decision": null,
    "merchant_connector_id": null,
    "incremental_authorization_allowed": null,
    "authorization_count": null,
    "incremental_authorizations": null,
    "external_authentication_details": null,
    "external_3ds_authentication_attempted": false,
    "expires_on": "2024-12-16T03:22:25.579Z",
    "fingerprint": null,
    "browser_info": null,
    "payment_method_id": null,
    "payment_method_status": null,
    "updated": "2024-12-04T13:35:47.150Z",
    "charges": null,
    "frm_metadata": null,
    "merchant_order_reference_id": null,
    "order_tax_amount": null,
    "connector_mandate_id": null
}
```
</details>

3. Screenshots
Open the secure payment link (`secure_link` in API response) in an iframe for validating the functionality. For checking payment_link simply click on the payment_link (`payment_link` in API response)


### Expected Behavior (After code changes)

Payment_link should be able to render the text according to the `Accept-Language ` header passed  (here `Accept-Language `  = 'zh-Hant')
<img width="1589" alt="Screenshot 2024-12-10 at 17 45 03" src="https://github.com/user-attachments/assets/30ab2e21-e83d-40c8-9f08-95a6c1019e96">


### Current Behavior

Payment_link is not able to render the text according to the `Accept-Language ` header passed  (here `Accept-Language `  = 'zh-Hant')
<img width="1589" alt="Screenshot 2024-12-10 at 17 58 32" src="https://github.com/user-attachments/assets/7e9998ca-8561-48f4-90a8-c696e217c258">


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [X] I formatted the code `cargo +nightly fmt --all`
- [X] I addressed lints thrown by `cargo clippy`
- [X] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
