### PR TITLE
ci(cypress): Add testcases for unified error code and message

### DIFF
--- a/cypress-tests/cypress/e2e/PaymentTest/00022-Variations.cy.js
+++ b/cypress-tests/cypress/e2e/PaymentTest/00022-Variations.cy.js
@@ -673,4 +673,52 @@ describe("Corner cases", () => {
       );
     });
   });
+  context("Card-NoThreeDS fail payment flow test", () => {
+    let shouldContinue = true; // variable that will be used to skip tests if a previous test fails
+
+    before("seed global state", () => {
+      cy.task("getGlobalState").then((state) => {
+        globalState = new State(state);
+      });
+    });
+
+    after("flush global state", () => {
+      cy.task("setGlobalState", globalState.data);
+    });
+
+    beforeEach(function () {
+      if (!shouldContinue) {
+        this.skip();
+      }
+    });
+
+    it("create-payment-call-test", () => {
+      const data = getConnectorDetails(globalState.get("connectorId"))[
+        "card_pm"
+      ]["PaymentIntent"];
+
+      cy.createPaymentIntentTest(
+        fixtures.createPaymentBody,
+        data,
+        "no_three_ds",
+        "automatic",
+        globalState
+      );
+
+      if (shouldContinue) shouldContinue = utils.should_continue_further(data);
+    });
+
+    it("Confirm No 3DS", () => {
+      const data = getConnectorDetails(globalState.get("connectorId"))[
+        "card_pm"
+      ]["No3DSFailPayment"];
+
+      cy.confirmCallTest(fixtures.confirmBody, data, true, globalState);
+      if (shouldContinue) shouldContinue = utils.should_continue_further(data);
+    });
+
+    it("retrieve-payment-call-test", () => {
+      cy.retrievePaymentCallTest(globalState);
+    });
+  });
 });

--- a/cypress-tests/cypress/e2e/PaymentUtils/Adyen.js
+++ b/cypress-tests/cypress/e2e/PaymentUtils/Adyen.js
@@ -16,6 +16,14 @@ const successfulThreeDSTestCardDetails = {
   card_cvc: "737",
 };
 
+const failedNo3DSCardDetails = {
+  card_number: "4242424242424242",
+  card_exp_month: "01",
+  card_exp_year: "25",
+  card_holder_name: "joseph Doe",
+  card_cvc: "123",
+};
+
 const singleUseMandateData = {
   customer_acceptance: {
     acceptance_type: "offline",
@@ -179,6 +187,27 @@ export const connectorDetails = {
         status: 200,
         body: {
           status: "succeeded",
+        },
+      },
+    },
+    No3DSFailPayment: {
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: failedNo3DSCardDetails,
+        },
+        currency: "USD",
+        customer_acceptance: null,
+        setup_future_usage: "on_session",
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "failed",
+          error_code: "2",
+          error_message: "Refused",
+          unified_code: "UE_9000",
+          unified_message: "Something went wrong",
         },
       },
     },

--- a/cypress-tests/cypress/e2e/PaymentUtils/Adyen.js
+++ b/cypress-tests/cypress/e2e/PaymentUtils/Adyen.js
@@ -196,7 +196,6 @@ export const connectorDetails = {
         payment_method_data: {
           card: failedNo3DSCardDetails,
         },
-        currency: "USD",
         customer_acceptance: null,
         setup_future_usage: "on_session",
       },

--- a/cypress-tests/cypress/e2e/PaymentUtils/Commons.js
+++ b/cypress-tests/cypress/e2e/PaymentUtils/Commons.js
@@ -710,6 +710,21 @@ export const connectorDetails = {
         setup_future_usage: "on_session",
       },
     }),
+    No3DSFailPayment: getCustomExchange({
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulNo3DSCardDetails,
+        },
+        currency: "USD",
+        customer_acceptance: null,
+        setup_future_usage: "on_session",
+      },
+      Response: {
+        status: 200,
+        body: {},
+      },
+    }),
     Capture: getCustomExchange({
       Request: {
         payment_method: "card",

--- a/cypress-tests/cypress/e2e/PaymentUtils/Commons.js
+++ b/cypress-tests/cypress/e2e/PaymentUtils/Commons.js
@@ -716,7 +716,6 @@ export const connectorDetails = {
         payment_method_data: {
           card: successfulNo3DSCardDetails,
         },
-        currency: "USD",
         customer_acceptance: null,
         setup_future_usage: "on_session",
       },

--- a/cypress-tests/cypress/e2e/PaymentUtils/Stripe.js
+++ b/cypress-tests/cypress/e2e/PaymentUtils/Stripe.js
@@ -268,7 +268,6 @@ export const connectorDetails = {
         payment_method_data: {
           card: failedNo3DSCardDetails,
         },
-        currency: "USD",
         customer_acceptance: null,
         setup_future_usage: "on_session",
       },

--- a/cypress-tests/cypress/e2e/PaymentUtils/Stripe.js
+++ b/cypress-tests/cypress/e2e/PaymentUtils/Stripe.js
@@ -16,6 +16,14 @@ const successfulThreeDSTestCardDetails = {
   card_cvc: "737",
 };
 
+const failedNo3DSCardDetails = {
+  card_number: "4000000000000002",
+  card_exp_month: "01",
+  card_exp_year: "25",
+  card_holder_name: "joseph Doe",
+  card_cvc: "123",
+};
+
 const singleUseMandateData = {
   customer_acceptance: {
     acceptance_type: "offline",
@@ -251,6 +259,28 @@ export const connectorDetails = {
           payment_method: "card",
           attempt_count: 1,
           payment_method_data: payment_method_data_no3ds,
+        },
+      },
+    },
+    No3DSFailPayment: {
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: failedNo3DSCardDetails,
+        },
+        currency: "USD",
+        customer_acceptance: null,
+        setup_future_usage: "on_session",
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "failed",
+          error_code: "card_declined",
+          error_message:
+            "message - Your card was declined., decline_code - generic_decline",
+          unified_code: "UE_9000",
+          unified_message: "Something went wrong",
         },
       },
     },


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [x] CI/CD

## Description

 Added the testcases for unified error code and error message for stripe and adyen connector. And added failure payments testcases.


## How did you test it?

Stripe
<img width="729" alt="Screenshot 2024-12-10 at 7 58 49 PM" src="https://github.com/user-attachments/assets/1b7cc860-4d07-4891-b839-08749bb850d0">

Adyen
<img width="730" alt="Screenshot 2024-12-10 at 8 01 29 PM" src="https://github.com/user-attachments/assets/4c72db4f-206f-4467-9af2-b31a149e3c07">



## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
