### PR TITLE
refactor(constraint_graph): revert handle for cases where setup_future_usage is null in payments is null in payments

### DIFF
--- a/crates/router/src/core/payment_methods/cards.rs
+++ b/crates/router/src/core/payment_methods/cards.rs
@@ -4558,12 +4558,6 @@ pub async fn filter_payment_methods(
                     if payment_attempt
                         .and_then(|attempt| attempt.mandate_details.as_ref())
                         .is_some()
-                        || payment_intent
-                            .and_then(|intent| intent.setup_future_usage)
-                            .map(|future_usage| {
-                                future_usage == common_enums::FutureUsage::OffSession
-                            })
-                            .unwrap_or(false)
                     {
                         context_values.push(dir::DirValue::PaymentType(
                             euclid::enums::PaymentType::NewMandate,
@@ -4582,14 +4576,7 @@ pub async fn filter_payment_methods(
 
                     payment_attempt
                         .map(|attempt| {
-                            attempt.mandate_data.is_none()
-                                && attempt.mandate_details.is_none()
-                                && payment_intent
-                                    .and_then(|intent| intent.setup_future_usage)
-                                    .map(|future_usage| {
-                                        future_usage == common_enums::FutureUsage::OnSession
-                                    })
-                                    .unwrap_or(false)
+                            attempt.mandate_data.is_none() && attempt.mandate_details.is_none()
                         })
                         .and_then(|res| {
                             res.then(|| {

--- a/crates/router/src/core/payment_methods/utils.rs
+++ b/crates/router/src/core/payment_methods/utils.rs
@@ -429,20 +429,16 @@ fn construct_supported_connectors_for_update_mandate_node(
         }
     }
 
-    if !agg_nodes.is_empty() {
-        Ok(Some(
-            builder
-                .make_any_aggregator(
-                    &agg_nodes,
-                    Some("any node for card and non card pm"),
-                    None::<()>,
-                    Some(domain_id),
-                )
-                .map_err(KgraphError::GraphConstructionError)?,
-        ))
-    } else {
-        Ok(None)
-    }
+    Ok(Some(
+        builder
+            .make_any_aggregator(
+                &agg_nodes,
+                Some("any node for card and non card pm"),
+                None::<()>,
+                Some(domain_id),
+            )
+            .map_err(KgraphError::GraphConstructionError)?,
+    ))
 }
 
 fn construct_supported_connectors_for_mandate_node(


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
This will make the `mandate_payments` acceptable even when `setup_future_usage` is null in payments.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
