### PR TITLE
fix(connector): 5xx error for Volt Payment Sync

### DIFF
--- a/crates/hyperswitch_connectors/src/connectors/volt/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/volt/transformers.rs
@@ -341,7 +341,8 @@ impl<F, T> TryFrom<ResponseRouterData<F, VoltPaymentsResponseData, T, PaymentsRe
     ) -> Result<Self, Self::Error> {
         match item.response {
             VoltPaymentsResponseData::PsyncResponse(payment_response) => {
-                let status = get_attempt_status((payment_response.status.clone(), item.data.status));
+                let status =
+                    get_attempt_status((payment_response.status.clone(), item.data.status));
                 Ok(Self {
                     status,
                     response: if is_payment_failure(status) {

--- a/crates/hyperswitch_connectors/src/connectors/volt/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/volt/transformers.rs
@@ -235,22 +235,27 @@ impl TryFrom<&ConnectorAuthType> for VoltAuthType {
     }
 }
 
-impl From<VoltPaymentStatus> for enums::AttemptStatus {
-    fn from(item: VoltPaymentStatus) -> Self {
-        match item {
-            VoltPaymentStatus::Received | VoltPaymentStatus::Settled => Self::Charged,
-            VoltPaymentStatus::Completed | VoltPaymentStatus::DelayedAtBank => Self::Pending,
-            VoltPaymentStatus::NewPayment
-            | VoltPaymentStatus::BankRedirect
-            | VoltPaymentStatus::AwaitingCheckoutAuthorisation => Self::AuthenticationPending,
-            VoltPaymentStatus::RefusedByBank
-            | VoltPaymentStatus::RefusedByRisk
-            | VoltPaymentStatus::NotReceived
-            | VoltPaymentStatus::ErrorAtBank
-            | VoltPaymentStatus::CancelledByUser
-            | VoltPaymentStatus::AbandonedByUser
-            | VoltPaymentStatus::Failed => Self::Failure,
+fn get_attempt_status(
+    (item, current_status): (VoltPaymentStatus, enums::AttemptStatus),
+) -> enums::AttemptStatus {
+    match item {
+        VoltPaymentStatus::Received | VoltPaymentStatus::Settled => enums::AttemptStatus::Charged,
+        VoltPaymentStatus::Completed | VoltPaymentStatus::DelayedAtBank => {
+            enums::AttemptStatus::Pending
         }
+        VoltPaymentStatus::NewPayment
+        | VoltPaymentStatus::BankRedirect
+        | VoltPaymentStatus::AwaitingCheckoutAuthorisation => {
+            enums::AttemptStatus::AuthenticationPending
+        }
+        VoltPaymentStatus::RefusedByBank
+        | VoltPaymentStatus::RefusedByRisk
+        | VoltPaymentStatus::NotReceived
+        | VoltPaymentStatus::ErrorAtBank
+        | VoltPaymentStatus::CancelledByUser
+        | VoltPaymentStatus::AbandonedByUser
+        | VoltPaymentStatus::Failed => enums::AttemptStatus::Failure,
+        VoltPaymentStatus::Unknown => current_status,
     }
 }
 
@@ -309,6 +314,7 @@ pub enum VoltPaymentStatus {
     AbandonedByUser,
     Failed,
     Settled,
+    Unknown,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -335,7 +341,7 @@ impl<F, T> TryFrom<ResponseRouterData<F, VoltPaymentsResponseData, T, PaymentsRe
     ) -> Result<Self, Self::Error> {
         match item.response {
             VoltPaymentsResponseData::PsyncResponse(payment_response) => {
-                let status = enums::AttemptStatus::from(payment_response.status.clone());
+                let status = get_attempt_status((payment_response.status.clone(), item.data.status));
                 Ok(Self {
                     status,
                     response: if is_payment_failure(status) {


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
- 5xx error for Volt Payment Sync, for PaymentStatus. We received a new status `UNKNOWN`. 
- Adding `UNKNOWN` status to Psync Payment Status and mapping it with previous status to avoid deserialization error.


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
- Create a Payment using Volt connector
```
curl --location 'http://localhost:8080/payments' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: ___' \
--data-raw '{
    "amount": 8000,
    "currency": "EUR",
    "confirm": true,
      "capture_method": "automatic",
      "capture_on": "2022-09-10T10:11:12Z",
      "amount_to_capture": 8000,
    "customer_id": "StripeCustomer",
    "email": "guest@example.com",
    "name": "John Doe",
    "phone": "999999999",
    "phone_country_code": "+1",
    "description": "Its my first payment request",
      "authentication_type": "no_three_ds",
    "return_url": "https://www.google.com/",
    "payment_method": "bank_redirect",
    "payment_method_type": "open_banking_uk",
    "payment_method_data": {
        "bank_redirect": {
            "open_banking_uk": {
            }
        }
    },
    "billing": {
        "address": {
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "city": "San Fransico",
            "state": "California",
            "zip": "94122",
            "country": "DE",
            "first_name": "joseph",
            "last_name": "Doe"
        },
        "phone": {
            "number": "8056594427",
            "country_code": "+91"
        }
    },
    "shipping": {
        "address": {
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "city": "San Fransico",
            "state": "California",
            "zip": "94122",
            "country": "DE",
            "first_name": "joseph",
            "last_name": "Doe"
        },
        "phone": {
            "number": "8056594427",
            "country_code": "+91"
        }
    },
    "statement_descriptor_name": "joseph",
    "statement_descriptor_suffix": "JS",
    "metadata": {
        "udf1": "value1",
        "new_customer": "true",
        "login_date": "2019-09-10T10:11:12Z"
    },
    "profile_id": "pro_BAjOZ9EktLxLMBgVACoU"
}
'
```
Response
```
{
    "payment_id": "pay_aWNvDHbGqOHdT0ZPe0vA",
    "merchant_id": "merchant_1734340438",
    "status": "requires_customer_action",
    "amount": 8000,
    "net_amount": 8000,
    "shipping_cost": null,
    "amount_capturable": 8000,
    "amount_received": null,
    "connector": "volt",
    "client_secret": "pay_aWNvDHbGqOHdT0ZPe0vA_secret_2u06MEoR7rPRhvY89GSx",
    "created": "2024-12-16T09:14:56.795Z",
    "currency": "EUR",
    "customer_id": "StripeCustomer",
    "customer": {
        "id": "StripeCustomer",
        "name": "John Doe",
        "email": "guest@example.com",
        "phone": "999999999",
        "phone_country_code": "+1"
    },
    "description": "Its my first payment request",
    "refunds": null,
    "disputes": null,
    "mandate_id": null,
    "mandate_data": null,
    "setup_future_usage": null,
    "off_session": null,
    "capture_on": null,
    "capture_method": "automatic",
    "payment_method": "bank_redirect",
    "payment_method_data": {
        "bank_redirect": {
            "type": "BankRedirectResponse",
            "bank_name": null
        },
        "billing": null
    },
    "payment_token": null,
    "shipping": {
        "address": {
            "city": "San Fransico",
            "country": "DE",
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "zip": "94122",
            "state": "California",
            "first_name": "joseph",
            "last_name": "Doe"
        },
        "phone": {
            "number": "8056594427",
            "country_code": "+91"
        },
        "email": null
    },
    "billing": {
        "address": {
            "city": "San Fransico",
            "country": "DE",
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "zip": "94122",
            "state": "California",
            "first_name": "joseph",
            "last_name": "Doe"
        },
        "phone": {
            "number": "8056594427",
            "country_code": "+91"
        },
        "email": null
    },
    "order_details": null,
    "email": "guest@example.com",
    "name": "John Doe",
    "phone": "999999999",
    "return_url": "https://www.google.com/",
    "authentication_type": "no_three_ds",
    "statement_descriptor_name": "joseph",
    "statement_descriptor_suffix": "JS",
    "next_action": {
        "type": "redirect_to_url",
        "redirect_to_url": "http://localhost:8080/payments/redirect/pay_aWNvDHbGqOHdT0ZPe0vA/merchant_1734340438/pay_aWNvDHbGqOHdT0ZPe0vA_1"
    },
    "cancellation_reason": null,
    "error_code": null,
    "error_message": null,
    "unified_code": null,
    "unified_message": null,
    "payment_experience": null,
    "payment_method_type": "open_banking_uk",
    "connector_label": null,
    "business_country": null,
    "business_label": "default",
    "business_sub_label": null,
    "allowed_payment_method_types": null,
    "ephemeral_key": {
        "customer_id": "StripeCustomer",
        "created_at": 1734340496,
        "expires": 1734344096,
        "secret": "epk_642e604b1a53491fa262726bf1c7e3bc"
    },
    "manual_retry_allowed": null,
    "connector_transaction_id": "87a41138-a92e-47b4-916b-586fa9343ded",
    "frm_message": null,
    "metadata": {
        "udf1": "value1",
        "login_date": "2019-09-10T10:11:12Z",
        "new_customer": "true"
    },
    "connector_metadata": null,
    "feature_metadata": null,
    "reference_id": "87a41138-a92e-47b4-916b-586fa9343ded",
    "payment_link": null,
    "profile_id": "pro_BAjOZ9EktLxLMBgVACoU",
    "surcharge_details": null,
    "attempt_count": 1,
    "merchant_decision": null,
    "merchant_connector_id": "mca_Oi38wo3zd8gwyQQRU2bd",
    "incremental_authorization_allowed": null,
    "authorization_count": null,
    "incremental_authorizations": null,
    "external_authentication_details": null,
    "external_3ds_authentication_attempted": false,
    "expires_on": "2024-12-16T09:29:56.795Z",
    "fingerprint": null,
    "browser_info": null,
    "payment_method_id": null,
    "payment_method_status": null,
    "updated": "2024-12-16T09:14:59.866Z",
    "split_payments": null,
    "frm_metadata": null,
    "merchant_order_reference_id": null,
    "order_tax_amount": null,
    "connector_mandate_id": null
}
```
Complete Payment using redirection link

2. Do a Psync
```
curl --location 'http://localhost:8080/payments/pay_aWNvDHbGqOHdT0ZPe0vA?force_sync=true' \
--header 'Accept: application/json' \
--header 'api-key: __'
```
Response
```
{
    "payment_id": "pay_aWNvDHbGqOHdT0ZPe0vA",
    "merchant_id": "merchant_1734340438",
    "status": "succeeded",
    "amount": 8000,
    "net_amount": 8000,
    "shipping_cost": null,
    "amount_capturable": 0,
    "amount_received": 8000,
    "connector": "volt",
    "client_secret": "pay_aWNvDHbGqOHdT0ZPe0vA_secret_2u06MEoR7rPRhvY89GSx",
    "created": "2024-12-16T09:14:56.795Z",
    "currency": "EUR",
    "customer_id": "StripeCustomer",
    "customer": {
        "id": "StripeCustomer",
        "name": "John Doe",
        "email": "guest@example.com",
        "phone": "999999999",
        "phone_country_code": "+1"
    },
    "description": "Its my first payment request",
    "refunds": null,
    "disputes": null,
    "mandate_id": null,
    "mandate_data": null,
    "setup_future_usage": null,
    "off_session": null,
    "capture_on": null,
    "capture_method": "automatic",
    "payment_method": "bank_redirect",
    "payment_method_data": {
        "bank_redirect": {
            "type": "BankRedirectResponse",
            "bank_name": null
        },
        "billing": null
    },
    "payment_token": null,
    "shipping": {
        "address": {
            "city": "San Fransico",
            "country": "DE",
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "zip": "94122",
            "state": "California",
            "first_name": "joseph",
            "last_name": "Doe"
        },
        "phone": {
            "number": "8056594427",
            "country_code": "+91"
        },
        "email": null
    },
    "billing": {
        "address": {
            "city": "San Fransico",
            "country": "DE",
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "zip": "94122",
            "state": "California",
            "first_name": "joseph",
            "last_name": "Doe"
        },
        "phone": {
            "number": "8056594427",
            "country_code": "+91"
        },
        "email": null
    },
    "order_details": null,
    "email": "guest@example.com",
    "name": "John Doe",
    "phone": "999999999",
    "return_url": "https://www.google.com/",
    "authentication_type": "no_three_ds",
    "statement_descriptor_name": "joseph",
    "statement_descriptor_suffix": "JS",
    "next_action": null,
    "cancellation_reason": null,
    "error_code": null,
    "error_message": null,
    "unified_code": null,
    "unified_message": null,
    "payment_experience": null,
    "payment_method_type": "open_banking_uk",
    "connector_label": null,
    "business_country": null,
    "business_label": "default",
    "business_sub_label": null,
    "allowed_payment_method_types": null,
    "ephemeral_key": null,
    "manual_retry_allowed": false,
    "connector_transaction_id": "87a41138-a92e-47b4-916b-586fa9343ded",
    "frm_message": null,
    "metadata": {
        "udf1": "value1",
        "login_date": "2019-09-10T10:11:12Z",
        "new_customer": "true"
    },
    "connector_metadata": null,
    "feature_metadata": null,
    "reference_id": "pay_aWNvDHbGqOHdT0ZPe0vA_1",
    "payment_link": null,
    "profile_id": "pro_BAjOZ9EktLxLMBgVACoU",
    "surcharge_details": null,
    "attempt_count": 1,
    "merchant_decision": null,
    "merchant_connector_id": "mca_Oi38wo3zd8gwyQQRU2bd",
    "incremental_authorization_allowed": null,
    "authorization_count": null,
    "incremental_authorizations": null,
    "external_authentication_details": null,
    "external_3ds_authentication_attempted": false,
    "expires_on": "2024-12-16T09:29:56.795Z",
    "fingerprint": null,
    "browser_info": null,
    "payment_method_id": null,
    "payment_method_status": null,
    "updated": "2024-12-16T09:15:25.277Z",
    "split_payments": null,
    "frm_metadata": null,
    "merchant_order_reference_id": null,
    "order_tax_amount": null,
    "connector_mandate_id": null
}
```
We can not test Unknown Status as it some unexpected status in PROD. We can not re generate this Status. But if we get `UNKNOWN` in PROD it is handled in this PR


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
