### PR TITLE
fix(user_roles): migrations for backfilling user_roles entity_id

### DIFF
--- a/migrations/2024-12-02-110129_update-user-role-entity-type/down.sql
+++ b/migrations/2024-12-02-110129_update-user-role-entity-type/down.sql
@@ -1,2 +1,2 @@
 -- This file should undo anything in `up.sql`
-UPDATE user_roles SET entity_type = NULL WHERE version = 'v1'
+UPDATE user_roles SET entity_type = NULL WHERE version = 'v1';

--- a/migrations/2024-12-02-110129_update-user-role-entity-type/down.sql
+++ b/migrations/2024-12-02-110129_update-user-role-entity-type/down.sql
@@ -1,2 +1,2 @@
 -- This file should undo anything in `up.sql`
-SELECT 1;
+UPDATE user_roles SET entity_type = NULL WHERE version = 'v1'

--- a/migrations/2024-12-02-110129_update-user-role-entity-type/up.sql
+++ b/migrations/2024-12-02-110129_update-user-role-entity-type/up.sql
@@ -1,4 +1,5 @@
 -- Your SQL goes here
+-- Incomplete migration, also run migrations/2024-12-13-080558_entity-id-backfill-for-user-roles
 UPDATE user_roles
 SET
     entity_type = CASE

--- a/migrations/2024-12-13-080558_entity-id-backfill-for-user-roles/down.sql
+++ b/migrations/2024-12-13-080558_entity-id-backfill-for-user-roles/down.sql
@@ -1,2 +1,2 @@
 -- This file should undo anything in `up.sql`
-UPDATE user_roles SET entity_id = NULL WHERE version = 'v1'
+UPDATE user_roles SET entity_id = NULL WHERE version = 'v1';

--- a/migrations/2024-12-13-080558_entity-id-backfill-for-user-roles/down.sql
+++ b/migrations/2024-12-13-080558_entity-id-backfill-for-user-roles/down.sql
@@ -1,0 +1,2 @@
+-- This file should undo anything in `up.sql`
+UPDATE user_roles SET entity_id = NULL WHERE version = 'v1'

--- a/migrations/2024-12-13-080558_entity-id-backfill-for-user-roles/up.sql
+++ b/migrations/2024-12-13-080558_entity-id-backfill-for-user-roles/up.sql
@@ -1,0 +1,10 @@
+-- Your SQL goes here
+UPDATE user_roles
+SET
+    entity_id = CASE
+        WHEN role_id = 'org_admin' THEN org_id
+        ELSE merchant_id
+    END
+WHERE
+    version = 'v1'
+    AND entity_id IS NULL;


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
This PR ensures that the entity_id is backfilled in the user_roles table, preventing issues for V1 users when switching organizations and logging in.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
Main pr #6837 
Closes #6843
## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Using local dashboard
- Login to V1 account 
- invite the user to that same account 
- Try to switch organizations and merchant 


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [X] I formatted the code `cargo +nightly fmt --all`
- [X] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
