### PR TITLE
refactor(payment_methods): update `connector_mandate_details` for card metadata changes

### DIFF
--- a/crates/router/src/core/payments/operations/payment_response.rs
+++ b/crates/router/src/core/payments/operations/payment_response.rs
@@ -200,6 +200,7 @@ impl<F: Send + Clone> PostUpdateTracker<F, PaymentData<F>, types::PaymentsAuthor
             payment_method_billing_address,
             business_profile,
             connector_mandate_reference_id.clone(),
+            merchant_connector_id.clone(),
         ));
 
         let is_connector_mandate = resp.request.customer_acceptance.is_some()
@@ -315,6 +316,7 @@ impl<F: Send + Clone> PostUpdateTracker<F, PaymentData<F>, types::PaymentsAuthor
                         payment_method_billing_address.as_ref(),
                         &business_profile,
                         connector_mandate_reference_id,
+                        merchant_connector_id.clone(),
                     ))
                     .await;
 
@@ -1099,6 +1101,7 @@ impl<F: Clone> PostUpdateTracker<F, PaymentData<F>, types::SetupMandateRequestDa
             payment_method_billing_address,
             business_profile,
             connector_mandate_reference_id,
+            merchant_connector_id.clone(),
         ))
         .await?;
 

--- a/crates/router/src/core/payments/tokenization.rs
+++ b/crates/router/src/core/payments/tokenization.rs
@@ -1292,11 +1292,10 @@ pub fn update_connector_mandate_details_status(
                 payment_mandate_reference.entry(mca_id).and_modify(|pm| {
                     let update_rec = diesel_models::PaymentsMandateReferenceRecord {
                         connector_mandate_id: pm.connector_mandate_id.clone(),
-                        payment_method_type: pm.payment_method_type.clone(),
+                        payment_method_type: pm.payment_method_type,
                         original_payment_authorized_amount: pm.original_payment_authorized_amount,
                         original_payment_authorized_currency: pm
-                            .original_payment_authorized_currency
-                            .clone(),
+                            .original_payment_authorized_currency,
                         mandate_metadata: pm.mandate_metadata.clone(),
                         connector_mandate_status: Some(ConnectorMandateStatus::Inactive),
                         connector_mandate_request_reference_id: pm


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
Allow update of `connector_mandate_details` for card in case of metadata changes(in case of expiry changes). First the  value is set as inactive and if a successful payment has been made then set it back to active

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
 
- Nothreeds

> - Create a MA and a MCA
> - Make a off_Session save card payment
> - Make a off_Session payment again with the same card just and changes expiry 
> - After a successful payment the Connector Mandate Details would be overriden
<img width="1725" alt="Screenshot 2024-12-16 at 4 21 51 PM" src="https://github.com/user-attachments/assets/2c68dc5e-f27c-400d-9b16-3080029ccfb3" />

- Follow the same step for 3threeds
> - Create a MA and a MCA
> - Make a off_Session save card payment
> - Make a off_Session payment again with the same card just and changed expiry 
> -Before a successful redirection ( the connector mandate is inactive)
<img width="1725" alt="Screenshot 2024-12-16 at 4 23 50 PM" src="https://github.com/user-attachments/assets/69c74c67-f596-447e-baac-ea5191b3a7f0" />

> - After a successful redirection ( the connector mandate is active)
<img width="1725" alt="Screenshot 2024-12-16 at 4 24 24 PM" src="https://github.com/user-attachments/assets/b141a8b1-2d91-4f68-b478-928d4f6149f2" />

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
