### PR TITLE
refactor(users): move roles schema to global interface

### DIFF
--- a/crates/router/src/core/user/theme.rs
+++ b/crates/router/src/core/user/theme.rs
@@ -21,7 +21,7 @@ pub async fn get_theme_using_lineage(
     lineage: ThemeLineage,
 ) -> UserResponse<theme_api::GetThemeResponse> {
     let theme = state
-        .global_store
+        .store
         .find_theme_by_lineage(lineage)
         .await
         .to_not_found_response(UserErrors::ThemeNotFound)?;
@@ -55,7 +55,7 @@ pub async fn get_theme_using_theme_id(
     theme_id: String,
 ) -> UserResponse<theme_api::GetThemeResponse> {
     let theme = state
-        .global_store
+        .store
         .find_theme_by_theme_id(theme_id.clone())
         .await
         .to_not_found_response(UserErrors::ThemeNotFound)?;
@@ -90,7 +90,7 @@ pub async fn upload_file_to_theme_storage(
     request: theme_api::UploadFileRequest,
 ) -> UserResponse<()> {
     let db_theme = state
-        .global_store
+        .store
         .find_theme_by_lineage(request.lineage)
         .await
         .to_not_found_response(UserErrors::ThemeNotFound)?;
@@ -131,7 +131,7 @@ pub async fn create_theme(
     );
 
     let db_theme = state
-        .global_store
+        .store
         .insert_theme(new_theme)
         .await
         .to_duplicate_response(UserErrors::ThemeAlreadyExists)?;
@@ -176,7 +176,7 @@ pub async fn update_theme(
     request: theme_api::UpdateThemeRequest,
 ) -> UserResponse<theme_api::GetThemeResponse> {
     let db_theme = state
-        .global_store
+        .store
         .find_theme_by_lineage(request.lineage)
         .await
         .to_not_found_response(UserErrors::ThemeNotFound)?;
@@ -225,7 +225,7 @@ pub async fn delete_theme(
     lineage: ThemeLineage,
 ) -> UserResponse<()> {
     state
-        .global_store
+        .store
         .delete_theme_by_lineage_and_theme_id(theme_id.clone(), lineage)
         .await
         .to_not_found_response(UserErrors::ThemeNotFound)?;

--- a/crates/router/src/core/user_role/role.rs
+++ b/crates/router/src/core/user_role/role.rs
@@ -86,7 +86,7 @@ pub async fn create_role(
     }
 
     let role = state
-        .store
+        .global_store
         .insert_role(RoleNew {
             role_id: generate_id_with_default_len("role"),
             role_name: role_name.get_role_name(),
@@ -220,7 +220,7 @@ pub async fn update_role(
     }
 
     let updated_role = state
-        .store
+        .global_store
         .update_role_by_role_id(
             role_id,
             RoleUpdate::UpdateDetails {
@@ -271,7 +271,7 @@ pub async fn list_roles_with_info(
     let custom_roles =
         match utils::user_role::get_min_entity(user_role_entity, request.entity_type)? {
             EntityType::Tenant | EntityType::Organization => state
-                .store
+                .global_store
                 .list_roles_for_org_by_parameters(
                     &user_from_token.org_id,
                     None,
@@ -282,7 +282,7 @@ pub async fn list_roles_with_info(
                 .change_context(UserErrors::InternalServerError)
                 .attach_printable("Failed to get roles")?,
             EntityType::Merchant => state
-                .store
+                .global_store
                 .list_roles_for_org_by_parameters(
                     &user_from_token.org_id,
                     Some(&user_from_token.merchant_id),
@@ -344,7 +344,7 @@ pub async fn list_roles_at_entity_level(
 
     let custom_roles = match req.entity_type {
         EntityType::Tenant | EntityType::Organization => state
-            .store
+            .global_store
             .list_roles_for_org_by_parameters(
                 &user_from_token.org_id,
                 None,
@@ -356,7 +356,7 @@ pub async fn list_roles_at_entity_level(
             .attach_printable("Failed to get roles")?,
 
         EntityType::Merchant => state
-            .store
+            .global_store
             .list_roles_for_org_by_parameters(
                 &user_from_token.org_id,
                 Some(&user_from_token.merchant_id),

--- a/crates/router/src/db.rs
+++ b/crates/router/src/db.rs
@@ -131,6 +131,7 @@ pub trait StorageInterface:
     + user_authentication_method::UserAuthenticationMethodInterface
     + authentication::AuthenticationInterface
     + generic_link::GenericLinkInterface
+    + user::theme::ThemeInterface
     + 'static
 {
     fn get_scheduler_db(&self) -> Box<dyn scheduler::SchedulerInterface>;
@@ -146,7 +147,6 @@ pub trait GlobalStorageInterface:
     + user::UserInterface
     + user_role::UserRoleInterface
     + user_key_store::UserKeyStoreInterface
-    + user::theme::ThemeInterface
     + role::RoleInterface
     + 'static
 {

--- a/crates/router/src/db.rs
+++ b/crates/router/src/db.rs
@@ -128,7 +128,6 @@ pub trait StorageInterface:
     + authorization::AuthorizationInterface
     + user::sample_data::BatchSampleDataInterface
     + health_check::HealthCheckDbInterface
-    + role::RoleInterface
     + user_authentication_method::UserAuthenticationMethodInterface
     + authentication::AuthenticationInterface
     + generic_link::GenericLinkInterface
@@ -148,6 +147,7 @@ pub trait GlobalStorageInterface:
     + user_role::UserRoleInterface
     + user_key_store::UserKeyStoreInterface
     + user::theme::ThemeInterface
+    + role::RoleInterface
     + 'static
 {
 }

--- a/crates/router/src/services/authorization.rs
+++ b/crates/router/src/services/authorization.rs
@@ -73,7 +73,8 @@ where
     A: SessionStateInfo + Sync,
 {
     state
-        .store()
+        .session_state()
+        .global_store
         .find_by_role_id_and_org_id(role_id, org_id)
         .await
         .map(roles::RoleInfo::from)

--- a/crates/router/src/services/authorization/roles.rs
+++ b/crates/router/src/services/authorization/roles.rs
@@ -126,7 +126,7 @@ impl RoleInfo {
             Ok(role.clone())
         } else {
             state
-                .store
+                .global_store
                 .find_role_by_role_id_in_lineage(role_id, merchant_id, org_id)
                 .await
                 .map(Self::from)
@@ -142,7 +142,7 @@ impl RoleInfo {
             Ok(role.clone())
         } else {
             state
-                .store
+                .global_store
                 .find_by_role_id_and_org_id(role_id, org_id)
                 .await
                 .map(Self::from)

--- a/crates/router/src/utils/user/theme.rs
+++ b/crates/router/src/utils/user/theme.rs
@@ -190,7 +190,7 @@ pub async fn get_most_specific_theme_using_lineage(
     lineage: ThemeLineage,
 ) -> UserResult<Option<Theme>> {
     match state
-        .global_store
+        .store
         .find_most_specific_theme_in_lineage(lineage)
         .await
     {
@@ -210,7 +210,7 @@ pub async fn get_theme_using_optional_theme_id(
     theme_id: Option<String>,
 ) -> UserResult<Option<Theme>> {
     match theme_id
-        .async_map(|theme_id| state.global_store.find_theme_by_theme_id(theme_id))
+        .async_map(|theme_id| state.store.find_theme_by_theme_id(theme_id))
         .await
         .transpose()
     {

--- a/crates/router/src/utils/user_role.rs
+++ b/crates/router/src/utils/user_role.rs
@@ -57,7 +57,7 @@ pub async fn validate_role_name(
 
     // TODO: Create and use find_by_role_name to make this efficient
     let is_present_in_custom_roles = state
-        .store
+        .global_store
         .list_all_roles(merchant_id, org_id)
         .await
         .change_context(UserErrors::InternalServerError)?


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
Refactor:
- move roles to global schema
- remove themes from global schema

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
Closes [#6861](https://github.com/juspay/hyperswitch/issues/6861)


## How did you test it?
Refactoring changes, currently in config global schema points to public, so no change in behaviour.
Changes will be reflected after we turn on feature flag for multi-tenancy and update the configs. Global interface will point to global (shared resources) schema.

When interacting with roles and themes storeage fucntions/queries we are getting expected response as we were getting before.
```
curl --location 'http://localhost:8080/user/role' \
--header 'Content-Type: application/json' \
--header 'Authorization: Bearer JWT' \
--header 'Cookie: Cookier' \
--data '{
  "role_name": "custom_role_1",
  "groups": ["users_view"],
  "role_scope": "merchant"
}'
```
Response
```
{
    "role_id": "role_Ve3BT4c2knBPYnI0EIbq",
    "groups": [
        "users_view"
    ],
    "role_name": "custom_role_1",
    "role_scope": "merchant"
}
```
## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
