### PR TITLE
refactor(customers_v2): include minor fixes for customer v2 flows

### DIFF
--- a/api-reference-v2/openapi_spec.json
+++ b/api-reference-v2/openapi_spec.json
@@ -14426,6 +14426,7 @@
           "id",
           "status",
           "amount",
+          "customer_id",
           "connector",
           "client_secret",
           "created",
@@ -14446,6 +14447,13 @@
           },
           "amount": {
             "$ref": "#/components/schemas/ConfirmIntentAmountDetailsResponse"
+          },
+          "customer_id": {
+            "type": "string",
+            "description": "The identifier for the customer",
+            "example": "12345_cus_01926c58bc6e77c09e809964e72af8c8",
+            "maxLength": 64,
+            "minLength": 32
           },
           "connector": {
             "type": "string",
@@ -16171,6 +16179,7 @@
           "id",
           "status",
           "amount",
+          "customer_id",
           "client_secret",
           "created"
         ],
@@ -16187,6 +16196,13 @@
           },
           "amount": {
             "$ref": "#/components/schemas/ConfirmIntentAmountDetailsResponse"
+          },
+          "customer_id": {
+            "type": "string",
+            "description": "The identifier for the customer",
+            "example": "12345_cus_01926c58bc6e77c09e809964e72af8c8",
+            "maxLength": 64,
+            "minLength": 32
           },
           "connector": {
             "type": "string",

--- a/crates/api_models/src/events/customer.rs
+++ b/crates/api_models/src/events/customer.rs
@@ -1,6 +1,8 @@
 use common_utils::events::{ApiEventMetric, ApiEventsType};
 
-use crate::customers::{CustomerDeleteResponse, CustomerRequest, CustomerResponse};
+use crate::customers::{
+    CustomerDeleteResponse, CustomerRequest, CustomerResponse, CustomerUpdateRequestInternal,
+};
 
 #[cfg(all(any(feature = "v1", feature = "v2"), not(feature = "customer_v2")))]
 impl ApiEventMetric for CustomerDeleteResponse {
@@ -55,7 +57,7 @@ impl ApiEventMetric for CustomerResponse {
 }
 
 #[cfg(all(any(feature = "v1", feature = "v2"), not(feature = "customer_v2")))]
-impl ApiEventMetric for crate::customers::CustomerUpdateRequestInternal {
+impl ApiEventMetric for CustomerUpdateRequestInternal {
     fn get_api_event_type(&self) -> Option<ApiEventsType> {
         Some(ApiEventsType::Customer {
             customer_id: self.customer_id.clone(),
@@ -64,7 +66,7 @@ impl ApiEventMetric for crate::customers::CustomerUpdateRequestInternal {
 }
 
 #[cfg(all(feature = "v2", feature = "customer_v2"))]
-impl ApiEventMetric for crate::customers::CustomerUpdateRequestInternal {
+impl ApiEventMetric for CustomerUpdateRequestInternal {
     fn get_api_event_type(&self) -> Option<ApiEventsType> {
         Some(ApiEventsType::Customer {
             customer_id: Some(self.id.clone()),

--- a/crates/api_models/src/payments.rs
+++ b/crates/api_models/src/payments.rs
@@ -4793,6 +4793,15 @@ pub struct PaymentsConfirmIntentResponse {
     /// Amount related information for this payment and attempt
     pub amount: ConfirmIntentAmountDetailsResponse,
 
+    /// The identifier for the customer
+    #[schema(
+        min_length = 32,
+        max_length = 64,
+        example = "12345_cus_01926c58bc6e77c09e809964e72af8c8",
+        value_type = String
+    )]
+    pub customer_id: Option<id_type::GlobalCustomerId>,
+
     /// The connector used for the payment
     #[schema(example = "stripe")]
     pub connector: String,
@@ -4861,6 +4870,15 @@ pub struct PaymentsRetrieveResponse {
 
     /// Amount related information for this payment and attempt
     pub amount: ConfirmIntentAmountDetailsResponse,
+
+    /// The identifier for the customer
+    #[schema(
+        min_length = 32,
+        max_length = 64,
+        example = "12345_cus_01926c58bc6e77c09e809964e72af8c8",
+        value_type = String
+    )]
+    pub customer_id: Option<id_type::GlobalCustomerId>,
 
     /// The connector used for the payment
     #[schema(example = "stripe")]

--- a/crates/router/src/core/customers.rs
+++ b/crates/router/src/core/customers.rs
@@ -568,7 +568,7 @@ pub async fn delete_customer(
 ) -> errors::CustomerResponse<customers::CustomerDeleteResponse> {
     let db = &*state.store;
     let key_manager_state = &(&state).into();
-    id.fetch_domain_model_and_update_and_generate_delete_customer_response(
+    id.redact_customer_details_and_generate_response(
         db,
         &key_store,
         &merchant_account,
@@ -585,7 +585,7 @@ pub async fn delete_customer(
 ))]
 #[async_trait::async_trait]
 impl CustomerDeleteBridge for id_type::GlobalCustomerId {
-    async fn fetch_domain_model_and_update_and_generate_delete_customer_response<'a>(
+    async fn redact_customer_details_and_generate_response<'a>(
         &'a self,
         db: &'a dyn StorageInterface,
         key_store: &'a domain::MerchantKeyStore,
@@ -717,7 +717,7 @@ impl CustomerDeleteBridge for id_type::GlobalCustomerId {
 
 #[async_trait::async_trait]
 trait CustomerDeleteBridge {
-    async fn fetch_domain_model_and_update_and_generate_delete_customer_response<'a>(
+    async fn redact_customer_details_and_generate_response<'a>(
         &'a self,
         db: &'a dyn StorageInterface,
         key_store: &'a domain::MerchantKeyStore,
@@ -742,7 +742,7 @@ pub async fn delete_customer(
     let db = &*state.store;
     let key_manager_state = &(&state).into();
     customer_id
-        .fetch_domain_model_and_update_and_generate_delete_customer_response(
+        .redact_customer_details_and_generate_response(
             db,
             &key_store,
             &merchant_account,
@@ -759,7 +759,7 @@ pub async fn delete_customer(
 ))]
 #[async_trait::async_trait]
 impl CustomerDeleteBridge for id_type::CustomerId {
-    async fn fetch_domain_model_and_update_and_generate_delete_customer_response<'a>(
+    async fn redact_customer_details_and_generate_response<'a>(
         &'a self,
         db: &'a dyn StorageInterface,
         key_store: &'a domain::MerchantKeyStore,

--- a/crates/router/src/core/payments/transformers.rs
+++ b/crates/router/src/core/payments/transformers.rs
@@ -1214,6 +1214,7 @@ where
             id: payment_intent.id.clone(),
             status: payment_intent.status,
             amount,
+            customer_id: payment_intent.customer_id.clone(),
             connector,
             client_secret: payment_intent.client_secret.clone(),
             created: payment_intent.created_at,
@@ -1287,6 +1288,7 @@ where
             id: payment_intent.id.clone(),
             status: payment_intent.status,
             amount,
+            customer_id: payment_intent.customer_id.clone(),
             connector,
             billing: payment_address
                 .get_payment_billing()


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->

This PR includes minor fixes suggested in my previous PR #6836. This PR includes the following changes:

- Import `CustomerUpdateRequestInternal` instead of fully qualifying it.
- Renames the `fetch_domain_model_and_update_and_generate_delete_customer_response()` method to `redact_customer_details_and_generate_response()`.
- Includes the `customer_id` field in `PaymentsConfirmIntentResponse` and `PaymentsRetrieveResponse` API models.

### Additional Changes

- [x] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->

This PR adds the `customer_id` field in the `PaymentsConfirmIntentResponse` and `PaymentsRetrieveResponse` API models. This does not affect any API contract for v1 APIs.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->

Addresses minor fixes in customers v2 APIs.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

For the `customer_id` field in being included in `PaymentsConfirmIntentResponse` and `PaymentsRetrieveResponse` API models, I tried out the payment confirm intent v2 and payment intent retrieve v2 endpoint and confirmed that the `customer_id` field is being included and populated correctly.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
