### PR TITLE
fix(cors): expose all headers set by application in `access-control-expose-headers` header value

### DIFF
--- a/crates/router/src/cors.rs
+++ b/crates/router/src/cors.rs
@@ -8,6 +8,7 @@ pub fn cors(config: settings::CorsSettings) -> actix_cors::Cors {
     let mut cors = actix_cors::Cors::default()
         .allowed_methods(allowed_methods)
         .allow_any_header()
+        .expose_any_header()
         .max_age(config.max_age);
 
     if config.wildcard_origin {


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->

This PR exposes all headers set by the application in the `access-control-expose-headers` header value. This should thus allow our headers like `x-request-id` to be accessed by the browser.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->

This should allow headers set by our application like the `x-request-id` header to be accessed by the browser.

This was fixed once before in #1673, but I suspect the behavior changed again when #3646 was merged.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

Locally.

```shell
$ curl -i http://localhost:8080/health
[...]
access-control-expose-headers: x-request-id, via, strict-transport-security
[...]
```

The `access-control-expose-headers` header is included in the response headers, and `x-request-id` is included in the header value.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
