### PR TITLE
refactor(dynamic_routing): add non_deterministic value in SuccessBasedRoutingConclusiveState type

### DIFF
--- a/migrations/2024-12-18-124527_add_new_value_in_success_based_routing_conclusive_state/down.sql
+++ b/migrations/2024-12-18-124527_add_new_value_in_success_based_routing_conclusive_state/down.sql
@@ -1,0 +1,6 @@
+-- This file should undo anything in `up.sql`
+DELETE FROM pg_enum
+WHERE enumlabel = 'non_deterministic'
+AND enumtypid = (
+  SELECT oid FROM pg_type WHERE typname = 'SuccessBasedRoutingConclusiveState'
+)

--- a/migrations/2024-12-18-124527_add_new_value_in_success_based_routing_conclusive_state/down.sql
+++ b/migrations/2024-12-18-124527_add_new_value_in_success_based_routing_conclusive_state/down.sql
@@ -1,6 +1,2 @@
 -- This file should undo anything in `up.sql`
-DELETE FROM pg_enum
-WHERE enumlabel = 'non_deterministic'
-AND enumtypid = (
-  SELECT oid FROM pg_type WHERE typname = 'SuccessBasedRoutingConclusiveState'
-)
+SELECT 1;

--- a/migrations/2024-12-18-124527_add_new_value_in_success_based_routing_conclusive_state/up.sql
+++ b/migrations/2024-12-18-124527_add_new_value_in_success_based_routing_conclusive_state/up.sql
@@ -1,0 +1,2 @@
+-- Your SQL goes here
+ALTER TYPE "SuccessBasedRoutingConclusiveState" ADD VALUE 'non_deterministic';

--- a/migrations/2024-12-18-124527_add_new_value_in_success_based_routing_conclusive_state/up.sql
+++ b/migrations/2024-12-18-124527_add_new_value_in_success_based_routing_conclusive_state/up.sql
@@ -1,2 +1,12 @@
 -- Your SQL goes here
-ALTER TYPE "SuccessBasedRoutingConclusiveState" ADD VALUE 'non_deterministic';
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_enum 
+        WHERE enumlabel = 'non_deterministic'
+          AND enumtypid = (SELECT oid FROM pg_type WHERE typname = 'SuccessBasedRoutingConclusiveState')
+    ) THEN
+        ALTER TYPE "SuccessBasedRoutingConclusiveState" ADD VALUE 'non_deterministic';
+    END IF;
+END $$;


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
This will add a value `non_deterministic` in `SuccessBasedRoutingConclusiveState` type.

### Additional Changes

- [ ] This PR modifies the API contract
- [x] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
1. Toggle Success Based routing for the merchant.
```
curl --location --request POST 'http://localhost:8080/account/xxxxxx/business_profile/xxxxxxx/dynamic_routing/success_based/toggle?enable=metrics' \
--header 'api-key: xxxxxxx'
```

2. Create a payment that goes in processing state or any non terminal state.
3. Check the `dynamic_routing_stats` table for the `payment_id` for the `non_determinisctic`.


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
