### PR TITLE
fix(ci): abrupt exist upon ci failure

### DIFF
--- a/scripts/execute_cypress.sh
+++ b/scripts/execute_cypress.sh
@@ -51,6 +51,8 @@ function read_service_arrays() {
   # Loop through the associative array and check if each service is exported
   for var in "${!services[@]}"; do
     if [[ -n "${!var+x}" ]]; then
+      # Ensure the variable is split correctly into an array
+      eval "${services[$var]}=($(echo "${!var}" | tr ' ' '\n'))"
       connector_map+=("${services[$var]}")
     else
       print_color "yellow" "Environment variable ${var} is not set. Skipping..."
@@ -114,7 +116,6 @@ function run_tests() {
     failed_connectors=($(< "${tmp_file}"))
     print_color "red" "One or more connectors failed to run:"
     printf '%s\n' "${failed_connectors[@]}"
-    exit 1
   else
     print_color "green" "Cypress tests execution successful!"
   fi


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->

When CI checks are run in parallel, it would result in abrupt exit when one of the connector failed. This PR aims to fix that.

closes #6890 

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->

Parallel CI needed this fix for so long.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

This cannot be tested without running CI checks in parallel which is bound to fail due to resource constraints.  

The issue cannot be reproduced in local at all.

This change shouldn't cause any abrupt exits going forward.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
