### PR TITLE
refactor(grpc): send `x-tenant-id` and `x-request-id` in grpc headers

### DIFF
--- a/crates/common_utils/src/consts.rs
+++ b/crates/common_utils/src/consts.rs
@@ -146,3 +146,6 @@ pub const CONNECTOR_TRANSACTION_ID_HASH_BYTES: usize = 25;
 /// Apple Pay validation url
 pub const APPLEPAY_VALIDATION_URL: &str =
     "https://apple-pay-gateway-cert.apple.com/paymentservices/startSession";
+
+/// Request ID
+pub const X_REQUEST_ID: &str = "x-request-id";

--- a/crates/external_services/src/grpc_client.rs
+++ b/crates/external_services/src/grpc_client.rs
@@ -76,3 +76,12 @@ impl GrpcClientSettings {
         })
     }
 }
+
+/// Contains grpc headers
+#[derive(Debug)]
+pub struct GrpcHeaders {
+    /// Tenant id
+    pub tenant_id: String,
+    /// Request id
+    pub request_id: Option<String>,
+}

--- a/crates/external_services/src/grpc_client/dynamic_routing/elimination_rate_client.rs
+++ b/crates/external_services/src/grpc_client/dynamic_routing/elimination_rate_client.rs
@@ -21,9 +21,8 @@ pub mod elimination_rate {
     tonic::include_proto!("elimination");
 }
 
-use crate::grpc_client::GrpcHeaders;
-
 use super::{Client, DynamicRoutingError, DynamicRoutingResult};
+use crate::grpc_client::GrpcHeaders;
 
 /// The trait Elimination Based Routing would have the functions required to support performance, calculation and invalidation bucket
 #[async_trait::async_trait]

--- a/crates/external_services/src/grpc_client/dynamic_routing/elimination_rate_client.rs
+++ b/crates/external_services/src/grpc_client/dynamic_routing/elimination_rate_client.rs
@@ -21,7 +21,7 @@ pub mod elimination_rate {
 }
 
 use super::{Client, DynamicRoutingError, DynamicRoutingResult};
-use crate::grpc_client::GrpcHeaders;
+use crate::grpc_client::{AddHeaders, GrpcHeaders};
 
 /// The trait Elimination Based Routing would have the functions required to support performance, calculation and invalidation bucket
 #[async_trait::async_trait]
@@ -76,7 +76,7 @@ impl EliminationBasedRouting for EliminationAnalyserClient<Client> {
             config,
         });
 
-        headers.add_headers_to_grpc_request(&mut request);
+        request.add_headers_to_grpc_request(headers);
 
         let response = self
             .clone()
@@ -117,7 +117,7 @@ impl EliminationBasedRouting for EliminationAnalyserClient<Client> {
             config,
         });
 
-        headers.add_headers_to_grpc_request(&mut request);
+        request.add_headers_to_grpc_request(headers);
 
         let response = self
             .clone()
@@ -136,7 +136,7 @@ impl EliminationBasedRouting for EliminationAnalyserClient<Client> {
     ) -> DynamicRoutingResult<InvalidateBucketResponse> {
         let mut request = tonic::Request::new(InvalidateBucketRequest { id });
 
-        headers.add_headers_to_grpc_request(&mut request);
+        request.add_headers_to_grpc_request(headers);
 
         let response = self
             .clone()

--- a/crates/external_services/src/grpc_client/dynamic_routing/elimination_rate_client.rs
+++ b/crates/external_services/src/grpc_client/dynamic_routing/elimination_rate_client.rs
@@ -9,7 +9,6 @@ pub use elimination_rate::{
     LabelWithBucketName, UpdateEliminationBucketRequest, UpdateEliminationBucketResponse,
 };
 use error_stack::ResultExt;
-use router_env::logger;
 #[allow(
     missing_docs,
     unused_qualifications,
@@ -77,22 +76,7 @@ impl EliminationBasedRouting for EliminationAnalyserClient<Client> {
             config,
         });
 
-        headers
-            .tenant_id
-            .parse()
-            .map(|tenant_id| request.metadata_mut().append("x-tenant-id", tenant_id))
-            .inspect_err(|err| logger::warn!(header_parse_error=?err,"invalid x-tenant-id received in perform_elimination_routing"))
-            .ok();
-
-        headers.request_id.map(|request_id| {
-            request_id
-                .parse()
-                .map(|request_id| request.metadata_mut().append("x-request-id", request_id))
-                .inspect_err(|err| {
-                    logger::warn!(header_parse_error=?err,"invalid x-request-id received in perform_elimination_routing")
-                })
-                .ok();
-        });
+        headers.add_headers_to_grpc_request(&mut request);
 
         let response = self
             .clone()
@@ -133,22 +117,7 @@ impl EliminationBasedRouting for EliminationAnalyserClient<Client> {
             config,
         });
 
-        headers
-            .tenant_id
-            .parse()
-            .map(|tenant_id| request.metadata_mut().append("x-tenant-id", tenant_id))
-            .inspect_err(|err| logger::warn!(header_parse_error=?err,"invalid x-tenant-id received in update_elimination_bucket_config"))
-            .ok();
-
-        headers.request_id.map(|request_id| {
-            request_id
-                .parse()
-                .map(|request_id| request.metadata_mut().append("x-request-id", request_id))
-                .inspect_err(|err| {
-                    logger::warn!(header_parse_error=?err,"invalid x-request-id received in update_elimination_bucket_config")
-                })
-                .ok();
-        });
+        headers.add_headers_to_grpc_request(&mut request);
 
         let response = self
             .clone()
@@ -167,22 +136,7 @@ impl EliminationBasedRouting for EliminationAnalyserClient<Client> {
     ) -> DynamicRoutingResult<InvalidateBucketResponse> {
         let mut request = tonic::Request::new(InvalidateBucketRequest { id });
 
-        headers
-            .tenant_id
-            .parse()
-            .map(|tenant_id| request.metadata_mut().append("x-tenant-id", tenant_id))
-            .inspect_err(|err| logger::warn!(header_parse_error=?err,"invalid x-tenant-id received in invalidate_elimination_bucket"))
-            .ok();
-
-        headers.request_id.map(|request_id| {
-            request_id
-                .parse()
-                .map(|request_id| request.metadata_mut().append("x-request-id", request_id))
-                .inspect_err(|err| {
-                    logger::warn!(header_parse_error=?err,"invalid x-request-id received in invalidate_elimination_bucket")
-                })
-                .ok();
-        });
+        headers.add_headers_to_grpc_request(&mut request);
 
         let response = self
             .clone()

--- a/crates/external_services/src/grpc_client/dynamic_routing/success_rate_client.rs
+++ b/crates/external_services/src/grpc_client/dynamic_routing/success_rate_client.rs
@@ -4,7 +4,6 @@ use api_models::routing::{
 };
 use common_utils::{ext_traits::OptionExt, transformers::ForeignTryFrom};
 use error_stack::ResultExt;
-use router_env::logger;
 pub use success_rate::{
     success_rate_calculator_client::SuccessRateCalculatorClient, CalSuccessRateConfig,
     CalSuccessRateRequest, CalSuccessRateResponse,
@@ -79,22 +78,7 @@ impl SuccessBasedDynamicRouting for SuccessRateCalculatorClient<Client> {
             config,
         });
 
-        headers
-            .tenant_id
-            .parse()
-            .map(|tenant_id| request.metadata_mut().append("x-tenant-id", tenant_id))
-            .inspect_err(|err| logger::warn!(header_parse_error=?err,"invalid x-tenant-id received in calculate_success_rate"))
-            .ok();
-
-        headers.request_id.map(|request_id| {
-            request_id
-                .parse()
-                .map(|request_id| request.metadata_mut().append("x-request-id", request_id))
-                .inspect_err(|err| {
-                    logger::warn!(header_parse_error=?err,"invalid x-request-id received in calculate_success_rate")
-                })
-                .ok();
-        });
+        headers.add_headers_to_grpc_request(&mut request);
 
         let response = self
             .clone()
@@ -136,22 +120,7 @@ impl SuccessBasedDynamicRouting for SuccessRateCalculatorClient<Client> {
             config,
         });
 
-        headers
-            .tenant_id
-            .parse()
-            .map(|tenant_id| request.metadata_mut().append("x-tenant-id", tenant_id))
-            .inspect_err(|err| logger::warn!(header_parse_error=?err,"invalid x-tenant-id received in update_success_rate"))
-            .ok();
-
-        headers.request_id.map(|request_id| {
-            request_id
-                .parse()
-                .map(|request_id| request.metadata_mut().append("x-request-id", request_id))
-                .inspect_err(|err| {
-                    logger::warn!(header_parse_error=?err,"invalid x-request-id received in update_success_rate")
-                })
-                .ok();
-        });
+        headers.add_headers_to_grpc_request(&mut request);
 
         let response = self
             .clone()
@@ -171,22 +140,7 @@ impl SuccessBasedDynamicRouting for SuccessRateCalculatorClient<Client> {
     ) -> DynamicRoutingResult<InvalidateWindowsResponse> {
         let mut request = tonic::Request::new(InvalidateWindowsRequest { id });
 
-        headers
-            .tenant_id
-            .parse()
-            .map(|tenant_id| request.metadata_mut().append("x-tenant-id", tenant_id))
-            .inspect_err(|err| logger::warn!(header_parse_error=?err,"invalid x-tenant-id received in invalidate_success_rate_routing_keys"))
-            .ok();
-
-        headers.request_id.map(|request_id| {
-            request_id
-                .parse()
-                .map(|request_id| request.metadata_mut().append("x-request-id", request_id))
-                .inspect_err(|err| {
-                    logger::warn!(header_parse_error=?err,"invalid x-request-id received in invalidate_success_rate_routing_keys")
-                })
-                .ok();
-        });
+        headers.add_headers_to_grpc_request(&mut request);
 
         let response = self
             .clone()

--- a/crates/external_services/src/grpc_client/dynamic_routing/success_rate_client.rs
+++ b/crates/external_services/src/grpc_client/dynamic_routing/success_rate_client.rs
@@ -21,9 +21,8 @@ pub use success_rate::{
 pub mod success_rate {
     tonic::include_proto!("success_rate");
 }
-use crate::grpc_client::GrpcHeaders;
-
 use super::{Client, DynamicRoutingError, DynamicRoutingResult};
+use crate::grpc_client::GrpcHeaders;
 /// The trait Success Based Dynamic Routing would have the functions required to support the calculation and updation window
 #[async_trait::async_trait]
 pub trait SuccessBasedDynamicRouting: dyn_clone::DynClone + Send + Sync {

--- a/crates/external_services/src/grpc_client/dynamic_routing/success_rate_client.rs
+++ b/crates/external_services/src/grpc_client/dynamic_routing/success_rate_client.rs
@@ -21,7 +21,7 @@ pub mod success_rate {
     tonic::include_proto!("success_rate");
 }
 use super::{Client, DynamicRoutingError, DynamicRoutingResult};
-use crate::grpc_client::GrpcHeaders;
+use crate::grpc_client::{AddHeaders, GrpcHeaders};
 /// The trait Success Based Dynamic Routing would have the functions required to support the calculation and updation window
 #[async_trait::async_trait]
 pub trait SuccessBasedDynamicRouting: dyn_clone::DynClone + Send + Sync {
@@ -78,7 +78,7 @@ impl SuccessBasedDynamicRouting for SuccessRateCalculatorClient<Client> {
             config,
         });
 
-        headers.add_headers_to_grpc_request(&mut request);
+        request.add_headers_to_grpc_request(headers);
 
         let response = self
             .clone()
@@ -120,7 +120,7 @@ impl SuccessBasedDynamicRouting for SuccessRateCalculatorClient<Client> {
             config,
         });
 
-        headers.add_headers_to_grpc_request(&mut request);
+        request.add_headers_to_grpc_request(headers);
 
         let response = self
             .clone()
@@ -140,7 +140,7 @@ impl SuccessBasedDynamicRouting for SuccessRateCalculatorClient<Client> {
     ) -> DynamicRoutingResult<InvalidateWindowsResponse> {
         let mut request = tonic::Request::new(InvalidateWindowsRequest { id });
 
-        headers.add_headers_to_grpc_request(&mut request);
+        request.add_headers_to_grpc_request(headers);
 
         let response = self
             .clone()

--- a/crates/router/src/core/payments/routing.rs
+++ b/crates/router/src/core/payments/routing.rs
@@ -1343,6 +1343,7 @@ pub async fn perform_success_based_routing(
                 success_based_routing_configs,
                 success_based_routing_config_params,
                 routable_connectors,
+                state.get_grpc_headers(),
             )
             .await
             .change_context(errors::RoutingError::SuccessRateCalculationError)

--- a/crates/router/src/core/routing.rs
+++ b/crates/router/src/core/routing.rs
@@ -1408,7 +1408,10 @@ pub async fn success_based_routing_update_configs(
         .as_ref()
         .async_map(|sr_client| async {
             sr_client
-                .invalidate_success_rate_routing_keys(prefix_of_dynamic_routing_keys)
+                .invalidate_success_rate_routing_keys(
+                    prefix_of_dynamic_routing_keys,
+                    state.get_grpc_headers(),
+                )
                 .await
                 .change_context(errors::ApiErrorResponse::GenericNotFoundError {
                     message: "Failed to invalidate the routing keys".to_string(),

--- a/crates/router/src/core/routing/helpers.rs
+++ b/crates/router/src/core/routing/helpers.rs
@@ -719,6 +719,7 @@ pub async fn push_metrics_with_update_window_for_success_based_routing(
                 success_based_routing_configs.clone(),
                 success_based_routing_config_params.clone(),
                 routable_connectors.clone(),
+                state.get_grpc_headers(),
             )
             .await
             .change_context(errors::ApiErrorResponse::InternalServerError)
@@ -854,6 +855,7 @@ pub async fn push_metrics_with_update_window_for_success_based_routing(
                     },
                     payment_status_attribute == common_enums::AttemptStatus::Charged,
                 )],
+                state.get_grpc_headers(),
             )
             .await
             .change_context(errors::ApiErrorResponse::InternalServerError)

--- a/crates/router/src/routes/app.rs
+++ b/crates/router/src/routes/app.rs
@@ -12,7 +12,10 @@ use common_utils::id_type;
 use external_services::email::{
     no_email::NoEmailClient, ses::AwsSes, smtp::SmtpServer, EmailClientConfigs, EmailService,
 };
-use external_services::{file_storage::FileStorageInterface, grpc_client::GrpcClients};
+use external_services::{
+    file_storage::FileStorageInterface,
+    grpc_client::{GrpcClients, GrpcHeaders},
+};
 use hyperswitch_interfaces::{
     encryption_interface::EncryptionManagementInterface,
     secrets_interface::secret_state::{RawSecret, SecuredSecret},
@@ -121,6 +124,12 @@ impl SessionState {
     pub fn get_req_state(&self) -> ReqState {
         ReqState {
             event_context: events::EventContext::new(self.event_handler.clone()),
+        }
+    }
+    pub fn get_grpc_headers(&self) -> GrpcHeaders {
+        GrpcHeaders {
+            tenant_id: self.tenant.tenant_id.get_string_repr().to_string(),
+            request_id: self.request_id.map(|req_id| (*req_id).to_string()),
         }
     }
 }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
This PR adds support for sending the `x-tenant-id` and `x-request-id` in the grpc headers

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
1. Create merchant_account, api_key and mca (any connector)
2. Toggle dynamic routing

```
curl --location --request POST 'http://localhost:8080/account/merchant_1734609410/business_profile/pro_gPTjn9jLm0CxI8ZD1omL/dynamic_routing/success_based/toggle?enable=metrics' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: dev_K70Wr6zqJLbPECg8eEXrnZ43TW41JNUuXYHzRB50geiG0lViLExjxNUld6sgdNd0' \
--data ''
```

3. Create a payment

```
curl --location 'http://localhost:8080/payments' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: dev_K70Wr6zqJLbPECg8eEXrnZ43TW41JNUuXYHzRB50geiG0lViLExjxNUld6sgdNd0' \
--data '{
    "amount": 6540,
    "authentication_type": "no_three_ds",
    "confirm": true,
    "currency": "USD",
    "customer_acceptance": {
        "acceptance_type": "online"
    },
    "customer_id": "cus_uYakn3OQTUtAgetLDOE1",
    "payment_method": "card",
    "payment_method_data": {
        "card": {
            "card_cvc": "123",
            "card_exp_month": "10",
            "card_exp_year": "25",
            "card_holder_name": "joseph Doe",
            "card_number": "4242424242424242"
        }
    }
}'
```

Check the grafana dashboard with `app = dynamo` label in loki. Logs should have `x-tenant-id` and `x-request-id` in the headers.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
