### PR TITLE
fix(wasm): remove extra space from wasm for payment_method_type of JPMorgan

### DIFF
--- a/crates/connector_configs/toml/development.toml
+++ b/crates/connector_configs/toml/development.toml
@@ -1733,11 +1733,11 @@ key2="Certificate Key"
 
 [jpmorgan]
 [[jpmorgan.credit]]
-  payment_method_type = "American Express"
+  payment_method_type = "AmericanExpress"
 [[jpmorgan.credit]]
   payment_method_type = "ChaseNet"
 [[jpmorgan.credit]]
-  payment_method_type = "Diners Club"
+  payment_method_type = "DinersClub"
 [[jpmorgan.credit]]
   payment_method_type = "Discover"
 [[jpmorgan.credit]]
@@ -1751,11 +1751,11 @@ key2="Certificate Key"
 [[jpmorgan.credit]]
   payment_method_type = "Visa"
   [[jpmorgan.debit]]
-  payment_method_type = "American Express"
+  payment_method_type = "AmericanExpress"
 [[jpmorgan.debit]]
   payment_method_type = "ChaseNet"
 [[jpmorgan.debit]]
-  payment_method_type = "Diners Club"
+  payment_method_type = "DinersClub"
 [[jpmorgan.debit]]
   payment_method_type = "Discover"
 [[jpmorgan.debit]]

--- a/crates/connector_configs/toml/production.toml
+++ b/crates/connector_configs/toml/production.toml
@@ -1481,8 +1481,7 @@ key2="Certificate Key"
 [[jpmorgan.debit]]
   payment_method_type = "Visa"
 [jpmorgan.connector_auth.BodyKey]
-api_key="Client ID"
-key1="Client Secret"
+api_key="Access Token"
 
 [klarna]
 [[klarna.pay_later]]

--- a/crates/connector_configs/toml/production.toml
+++ b/crates/connector_configs/toml/production.toml
@@ -1445,11 +1445,11 @@ key2="Certificate Key"
 
 [jpmorgan]
 [[jpmorgan.credit]]
-  payment_method_type = "American Express"
+  payment_method_type = "AmericanExpress"
 [[jpmorgan.credit]]
   payment_method_type = "ChaseNet"
 [[jpmorgan.credit]]
-  payment_method_type = "Diners Club"
+  payment_method_type = "DinersClub"
 [[jpmorgan.credit]]
   payment_method_type = "Discover"
 [[jpmorgan.credit]]
@@ -1463,11 +1463,11 @@ key2="Certificate Key"
 [[jpmorgan.credit]]
   payment_method_type = "Visa"
   [[jpmorgan.debit]]
-  payment_method_type = "American Express"
+  payment_method_type = "AmericanExpress"
 [[jpmorgan.debit]]
   payment_method_type = "ChaseNet"
 [[jpmorgan.debit]]
-  payment_method_type = "Diners Club"
+  payment_method_type = "DinersClub"
 [[jpmorgan.debit]]
   payment_method_type = "Discover"
 [[jpmorgan.debit]]
@@ -1481,7 +1481,8 @@ key2="Certificate Key"
 [[jpmorgan.debit]]
   payment_method_type = "Visa"
 [jpmorgan.connector_auth.BodyKey]
-api_key="Access Token"
+api_key="Client ID"
+key1="Client Secret"
 
 [klarna]
 [[klarna.pay_later]]

--- a/crates/connector_configs/toml/sandbox.toml
+++ b/crates/connector_configs/toml/sandbox.toml
@@ -1683,11 +1683,11 @@ key2="Certificate Key"
 
 [jpmorgan]
 [[jpmorgan.credit]]
-  payment_method_type = "American Express"
+  payment_method_type = "AmericanExpress"
 [[jpmorgan.credit]]
   payment_method_type = "ChaseNet"
 [[jpmorgan.credit]]
-  payment_method_type = "Diners Club"
+  payment_method_type = "DinersClub"
 [[jpmorgan.credit]]
   payment_method_type = "Discover"
 [[jpmorgan.credit]]
@@ -1701,11 +1701,11 @@ key2="Certificate Key"
 [[jpmorgan.credit]]
   payment_method_type = "Visa"
   [[jpmorgan.debit]]
-  payment_method_type = "American Express"
+  payment_method_type = "AmericanExpress"
 [[jpmorgan.debit]]
   payment_method_type = "ChaseNet"
 [[jpmorgan.debit]]
-  payment_method_type = "Diners Club"
+  payment_method_type = "DinersClub"
 [[jpmorgan.debit]]
   payment_method_type = "Discover"
 [[jpmorgan.debit]]
@@ -1719,7 +1719,8 @@ key2="Certificate Key"
 [[jpmorgan.debit]]
   payment_method_type = "Visa"
 [jpmorgan.connector_auth.BodyKey]
-api_key="Access Token"
+api_key="Client ID"
+key1="Client Secret"
 
 [klarna]
 [[klarna.pay_later]]

--- a/crates/connector_configs/toml/sandbox.toml
+++ b/crates/connector_configs/toml/sandbox.toml
@@ -1719,8 +1719,7 @@ key2="Certificate Key"
 [[jpmorgan.debit]]
   payment_method_type = "Visa"
 [jpmorgan.connector_auth.BodyKey]
-api_key="Client ID"
-key1="Client Secret"
+api_key="Access Token"
 
 [klarna]
 [[klarna.pay_later]]


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
remove extra space from wasm for payment_method_type of JPMorgan

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
No test required as only wasm changes are done in this PR
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
