### PR TITLE
fix(wasm): remove chasenet from jpmorgan wasm as ChaseNet doesn’t exist in PMT

### DIFF
--- a/crates/connector_configs/src/connector.rs
+++ b/crates/connector_configs/src/connector.rs
@@ -113,11 +113,11 @@ pub struct ConfigMetadata {
     pub source_balance_account: Option<InputData>,
     pub brand_id: Option<InputData>,
     pub destination_account_number: Option<InputData>,
-    pub dpa_id: Option<String>,
-    pub dpa_name: Option<String>,
-    pub locale: Option<String>,
-    pub card_brands: Option<Vec<String>>,
-    pub merchant_category_code: Option<String>,
+    pub dpa_id: Option<InputData>,
+    pub dpa_name: Option<InputData>,
+    pub locale: Option<InputData>,
+    pub card_brands: Option<InputData>,
+    pub merchant_category_code: Option<InputData>,
 }
 
 #[serde_with::skip_serializing_none]

--- a/crates/connector_configs/toml/development.toml
+++ b/crates/connector_configs/toml/development.toml
@@ -1735,8 +1735,6 @@ key2="Certificate Key"
 [[jpmorgan.credit]]
   payment_method_type = "AmericanExpress"
 [[jpmorgan.credit]]
-  payment_method_type = "ChaseNet"
-[[jpmorgan.credit]]
   payment_method_type = "DinersClub"
 [[jpmorgan.credit]]
   payment_method_type = "Discover"
@@ -1752,8 +1750,6 @@ key2="Certificate Key"
   payment_method_type = "Visa"
   [[jpmorgan.debit]]
   payment_method_type = "AmericanExpress"
-[[jpmorgan.debit]]
-  payment_method_type = "ChaseNet"
 [[jpmorgan.debit]]
   payment_method_type = "DinersClub"
 [[jpmorgan.debit]]

--- a/crates/connector_configs/toml/development.toml
+++ b/crates/connector_configs/toml/development.toml
@@ -4437,7 +4437,7 @@ placeholder="Enter locale"
 required=true
 type="Text"
 
-[[ctp_mastercard.metadata.card_brands]]
+[ctp_mastercard.metadata.card_brands]
 name="card_brands"
 label="Card Brands"
 placeholder="Enter Card Brands"
@@ -4445,28 +4445,28 @@ required=true
 type="MultiSelect"
 options=["visa","mastercard"]
 
-[[ctp_mastercard.metadata.acquirer_bin]]
+[ctp_mastercard.metadata.acquirer_bin]
 name="acquirer_bin"
 label="Acquire Bin"
 placeholder="Enter Acquirer Bin"
 required=true
 type="Text"
 
-[[ctp_mastercard.metadata.acquirer_merchant_id]]
+[ctp_mastercard.metadata.acquirer_merchant_id]
 name="acquirer_merchant_id"
 label="Acquire Merchant Id"
 placeholder="Enter Acquirer Merchant Id"
 required=true
 type="Text"
 
-[[ctp_mastercard.metadata.merchant_category_code]]
+[ctp_mastercard.metadata.merchant_category_code]
 name="merchant_category_code"
 label="Merchant Category Code"
 placeholder="Enter Merchant Category Code"
 required=true
 type="Text"
 
-[[ctp_mastercard.metadata.merchant_country_code]]
+[ctp_mastercard.metadata.merchant_country_code]
 name="merchant_country_code"
 label="Merchant Country Code"
 placeholder="Enter Merchant Country Code"

--- a/crates/connector_configs/toml/production.toml
+++ b/crates/connector_configs/toml/production.toml
@@ -1447,8 +1447,6 @@ key2="Certificate Key"
 [[jpmorgan.credit]]
   payment_method_type = "AmericanExpress"
 [[jpmorgan.credit]]
-  payment_method_type = "ChaseNet"
-[[jpmorgan.credit]]
   payment_method_type = "DinersClub"
 [[jpmorgan.credit]]
   payment_method_type = "Discover"
@@ -1464,8 +1462,6 @@ key2="Certificate Key"
   payment_method_type = "Visa"
   [[jpmorgan.debit]]
   payment_method_type = "AmericanExpress"
-[[jpmorgan.debit]]
-  payment_method_type = "ChaseNet"
 [[jpmorgan.debit]]
   payment_method_type = "DinersClub"
 [[jpmorgan.debit]]

--- a/crates/connector_configs/toml/sandbox.toml
+++ b/crates/connector_configs/toml/sandbox.toml
@@ -1683,8 +1683,6 @@ key2="Certificate Key"
 [[jpmorgan.credit]]
   payment_method_type = "AmericanExpress"
 [[jpmorgan.credit]]
-  payment_method_type = "ChaseNet"
-[[jpmorgan.credit]]
   payment_method_type = "DinersClub"
 [[jpmorgan.credit]]
   payment_method_type = "Discover"
@@ -1700,8 +1698,6 @@ key2="Certificate Key"
   payment_method_type = "Visa"
   [[jpmorgan.debit]]
   payment_method_type = "AmericanExpress"
-[[jpmorgan.debit]]
-  payment_method_type = "ChaseNet"
 [[jpmorgan.debit]]
   payment_method_type = "DinersClub"
 [[jpmorgan.debit]]


### PR DESCRIPTION

## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
remove chasenet from jpmorgan wasm as ChaseNet doesn’t exist in PMT

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
No test required as only wasm changes are done in this PR



## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
