### PR TITLE
fix(users): remove force cookie for docker setup

### DIFF
--- a/config/docker_compose.toml
+++ b/config/docker_compose.toml
@@ -57,7 +57,7 @@ two_factor_auth_expiry_in_secs = 300
 totp_issuer_name = "Hyperswitch"
 base_url = "http://localhost:8080"
 force_two_factor_auth = false
-force_cookies = true
+force_cookies = false
 
 [locker]
 host = ""


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
Users not able to login using local setup. 
This PR removes force cookie option for docker setup.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
Closes [#6931](https://github.com/juspay/hyperswitch/issues/6931)

## How did you test it?
Tested locally with updated docker configs, and re run the container.
<img width="1728" alt="Screenshot 2024-12-23 at 12 40 17 AM" src="https://github.com/user-attachments/assets/54a4b06a-d4c1-4e64-b5f7-33f55de5edc9" />



## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
