### PR TITLE
fix(cache): address in-memory cache invalidation using global tenant as `key_prefix`

### DIFF
--- a/crates/router/src/core/admin.rs
+++ b/crates/router/src/core/admin.rs
@@ -4288,7 +4288,7 @@ impl ProfileWrapper {
         .change_context(errors::ApiErrorResponse::InternalServerError)
         .attach_printable("Failed to update routing algorithm ref in business profile")?;
 
-        storage_impl::redis::cache::publish_into_redact_channel(
+        storage_impl::redis::cache::redact_from_redis_and_publish(
             db.get_cache_store().as_ref(),
             [routing_cache_key],
         )

--- a/crates/router/src/core/cache.rs
+++ b/crates/router/src/core/cache.rs
@@ -1,6 +1,6 @@
 use common_utils::errors::CustomResult;
 use error_stack::{report, ResultExt};
-use storage_impl::redis::cache::{publish_into_redact_channel, CacheKind};
+use storage_impl::redis::cache::{redact_from_redis_and_publish, CacheKind};
 
 use super::errors;
 use crate::{routes::SessionState, services};
@@ -10,7 +10,7 @@ pub async fn invalidate(
     key: &str,
 ) -> CustomResult<services::api::ApplicationResponse<serde_json::Value>, errors::ApiErrorResponse> {
     let store = state.store.as_ref();
-    let result = publish_into_redact_channel(
+    let result = redact_from_redis_and_publish(
         store.get_cache_store().as_ref(),
         [CacheKind::All(key.into())],
     )

--- a/crates/router/src/core/routing.rs
+++ b/crates/router/src/core/routing.rs
@@ -1383,7 +1383,7 @@ pub async fn success_based_routing_update_configs(
     let cache_entries_to_redact = vec![cache::CacheKind::SuccessBasedDynamicRoutingCache(
         cache_key.into(),
     )];
-    let _ = cache::publish_into_redact_channel(
+    let _ = cache::redact_from_redis_and_publish(
         state.store.get_cache_store().as_ref(),
         cache_entries_to_redact,
     )

--- a/crates/router/src/core/routing/helpers.rs
+++ b/crates/router/src/core/routing/helpers.rs
@@ -189,7 +189,7 @@ pub async fn update_merchant_active_algorithm_ref(
     .change_context(errors::ApiErrorResponse::InternalServerError)
     .attach_printable("Failed to update routing algorithm ref in merchant account")?;
 
-    cache::publish_into_redact_channel(db.get_cache_store().as_ref(), [config_key])
+    cache::redact_from_redis_and_publish(db.get_cache_store().as_ref(), [config_key])
         .await
         .change_context(errors::ApiErrorResponse::InternalServerError)
         .attach_printable("Failed to invalidate the config cache")?;
@@ -256,7 +256,7 @@ pub async fn update_profile_active_algorithm_ref(
     .change_context(errors::ApiErrorResponse::InternalServerError)
     .attach_printable("Failed to update routing algorithm ref in business profile")?;
 
-    cache::publish_into_redact_channel(db.get_cache_store().as_ref(), [routing_cache_key])
+    cache::redact_from_redis_and_publish(db.get_cache_store().as_ref(), [routing_cache_key])
         .await
         .change_context(errors::ApiErrorResponse::InternalServerError)
         .attach_printable("Failed to invalidate routing cache")?;
@@ -1031,7 +1031,7 @@ pub async fn disable_dynamic_routing_algorithm(
         };
 
     // redact cache for dynamic routing config
-    let _ = cache::publish_into_redact_channel(
+    let _ = cache::redact_from_redis_and_publish(
         state.store.get_cache_store().as_ref(),
         cache_entries_to_redact,
     )

--- a/crates/router/src/db/configs.rs
+++ b/crates/router/src/db/configs.rs
@@ -66,7 +66,7 @@ impl ConfigInterface for Store {
             .await
             .map_err(|error| report!(errors::StorageError::from(error)))?;
 
-        cache::publish_into_redact_channel(
+        cache::redact_from_redis_and_publish(
             self.get_cache_store().as_ref(),
             [CacheKind::Config((&inserted.key).into())],
         )
@@ -171,7 +171,7 @@ impl ConfigInterface for Store {
             .await
             .map_err(|error| report!(errors::StorageError::from(error)))?;
 
-        cache::publish_into_redact_channel(
+        cache::redact_from_redis_and_publish(
             self.get_cache_store().as_ref(),
             [CacheKind::Config((&deleted.key).into())],
         )

--- a/crates/router/src/db/configs.rs
+++ b/crates/router/src/db/configs.rs
@@ -1,16 +1,13 @@
 use diesel_models::configs::ConfigUpdateInternal;
 use error_stack::{report, ResultExt};
 use router_env::{instrument, tracing};
-use storage_impl::redis::{
-    cache::{self, CacheKind, CONFIG_CACHE},
-    kv_store::RedisConnInterface,
-    pub_sub::PubSubInterface,
-};
+use storage_impl::redis::cache::{self, CacheKind, CONFIG_CACHE};
 
 use super::{MockDb, Store};
 use crate::{
     connection,
     core::errors::{self, CustomResult},
+    db::StorageInterface,
     types::storage,
 };
 
@@ -69,14 +66,11 @@ impl ConfigInterface for Store {
             .await
             .map_err(|error| report!(errors::StorageError::from(error)))?;
 
-        self.get_redis_conn()
-            .map_err(Into::<errors::StorageError>::into)?
-            .publish(
-                cache::IMC_INVALIDATION_CHANNEL,
-                CacheKind::Config((&inserted.key).into()),
-            )
-            .await
-            .map_err(Into::<errors::StorageError>::into)?;
+        cache::publish_into_redact_channel(
+            self.get_cache_store().as_ref(),
+            [CacheKind::Config((&inserted.key).into())],
+        )
+        .await?;
 
         Ok(inserted)
     }
@@ -177,14 +171,11 @@ impl ConfigInterface for Store {
             .await
             .map_err(|error| report!(errors::StorageError::from(error)))?;
 
-        self.get_redis_conn()
-            .map_err(Into::<errors::StorageError>::into)?
-            .publish(
-                cache::IMC_INVALIDATION_CHANNEL,
-                CacheKind::Config(key.into()),
-            )
-            .await
-            .map_err(Into::<errors::StorageError>::into)?;
+        cache::publish_into_redact_channel(
+            self.get_cache_store().as_ref(),
+            [CacheKind::Config((&deleted.key).into())],
+        )
+        .await?;
 
         Ok(deleted)
     }

--- a/crates/router/src/db/merchant_account.rs
+++ b/crates/router/src/db/merchant_account.rs
@@ -801,7 +801,7 @@ async fn publish_and_redact_merchant_account_cache(
     cache_keys.extend(publishable_key.into_iter());
     cache_keys.extend(cgraph_key.into_iter());
 
-    cache::publish_into_redact_channel(store.get_cache_store().as_ref(), cache_keys).await?;
+    cache::redact_from_redis_and_publish(store.get_cache_store().as_ref(), cache_keys).await?;
     Ok(())
 }
 
@@ -822,6 +822,6 @@ async fn publish_and_redact_all_merchant_account_cache(
         .map(|s| CacheKind::Accounts(s.into()))
         .collect();
 
-    cache::publish_into_redact_channel(store.get_cache_store().as_ref(), cache_keys).await?;
+    cache::redact_from_redis_and_publish(store.get_cache_store().as_ref(), cache_keys).await?;
     Ok(())
 }

--- a/crates/storage_impl/src/redis/cache.rs
+++ b/crates/storage_impl/src/redis/cache.rs
@@ -363,7 +363,7 @@ where
 }
 
 #[instrument(skip_all)]
-pub async fn publish_into_redact_channel<
+pub async fn redact_from_redis_and_publish<
     'a,
     K: IntoIterator<Item = CacheKind<'a>> + Send + Clone,
 >(
@@ -420,7 +420,7 @@ where
     Fut: futures::Future<Output = CustomResult<T, StorageError>> + Send,
 {
     let data = fun().await?;
-    publish_into_redact_channel(store, [key]).await?;
+    redact_from_redis_and_publish(store, [key]).await?;
     Ok(data)
 }
 
@@ -436,7 +436,7 @@ where
     K: IntoIterator<Item = CacheKind<'a>> + Send + Clone,
 {
     let data = fun().await?;
-    publish_into_redact_channel(store, keys).await?;
+    redact_from_redis_and_publish(store, keys).await?;
     Ok(data)
 }
 

--- a/crates/storage_impl/src/redis/pub_sub.rs
+++ b/crates/storage_impl/src/redis/pub_sub.rs
@@ -243,11 +243,6 @@ impl PubSubInterface for std::sync::Arc<redis_interface::RedisConnectionPool> {
                         }
                     };
 
-                    self.delete_key(key.as_ref())
-                        .await
-                        .map_err(|err| logger::error!("Error while deleting redis key: {err:?}"))
-                        .ok();
-
                     logger::debug!(
                         key_prefix=?message.tenant.clone(),
                         channel_name=?channel_name,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
This PR fixes an inconsistency in the redis `key_prefix` that was used when invalidating the cache entries which affected all the cache types (configs, accounts, routing, etc).
The `delete_key` redis call during cache invalidation was using `global` as the `key_prefix` (key like `global:test_key` was being deleted in redis) while each of the tenants were reading using their corresponding `key_prefix` (key like `public:test_key` was being set/read in redis).

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
PUT/GET/UPDATE/DELETE on configs table as configs has cache usage

1. PUT

```
curl --location 'http://localhost:8080/configs/' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'x-tenant-id: public' \
--header 'api-key: test_admin' \
--data '{
    "key": "test_key_1",
    "value": "test_val_1"
}'
```

2. GET

```
curl --location 'http://localhost:8080/configs/test_key_1' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'x-tenant-id: public' \
--header 'api-key: test_admin' \
--data ''
```

![image](https://github.com/user-attachments/assets/c54c200a-925c-4618-8ef5-79b48eb89500)

3. UPDATE

```
curl --location 'http://localhost:8080/configs/test_key_1' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'x-tenant-id: public' \
--header 'api-key: test_admin' \
--data '{
    "value": "test_val_2"
}'
```

4. GET
```
curl --location 'http://localhost:8080/configs/test_key_1' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'x-tenant-id: public' \
--header 'api-key: test_admin' \
--data ''
```

![image](https://github.com/user-attachments/assets/e03d969c-af1e-4b04-91a6-b0a98c1fc64c)

5. DELETE

```
curl --location --request DELETE 'http://localhost:8080/configs/test_key_1' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'x-tenant-id: public' \
--header 'api-key: test_admin' \
--data ''
```

6. GET

```
curl --location 'http://localhost:8080/configs/test_key_1' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'x-tenant-id: public' \
--header 'api-key: test_admin' \
--data ''
```

![image](https://github.com/user-attachments/assets/501d852c-fa2c-48a6-b07e-9ff1573c93de)



## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
