### PR TITLE
ci(cypress): fix adyen sofort in cypress

### DIFF
--- a/cypress-tests/cypress/e2e/PaymentUtils/Adyen.js
+++ b/cypress-tests/cypress/e2e/PaymentUtils/Adyen.js
@@ -909,7 +909,9 @@ export const connectorDetails = {
       Response: {
         status: 200,
         body: {
-          status: "requires_customer_action",
+          status: "failed",
+          error_code: "14_006",
+          error_message: "Required object 'paymentMethod' is not provided.",
         },
       },
     },

--- a/cypress-tests/cypress/e2e/PaymentUtils/Commons.js
+++ b/cypress-tests/cypress/e2e/PaymentUtils/Commons.js
@@ -715,10 +715,6 @@ export const connectorDetails = {
         customer_acceptance: null,
         setup_future_usage: "on_session",
       },
-      Response: {
-        status: 200,
-        body: {},
-      },
     }),
     Capture: getCustomExchange({
       Request: {

--- a/cypress-tests/cypress/e2e/PaymentUtils/Commons.js
+++ b/cypress-tests/cypress/e2e/PaymentUtils/Commons.js
@@ -715,6 +715,10 @@ export const connectorDetails = {
         customer_acceptance: null,
         setup_future_usage: "on_session",
       },
+      Response: {
+        status: 200,
+        body: {},
+      },
     }),
     Capture: getCustomExchange({
       Request: {

--- a/cypress-tests/cypress/e2e/PaymentUtils/Iatapay.js
+++ b/cypress-tests/cypress/e2e/PaymentUtils/Iatapay.js
@@ -88,6 +88,27 @@ export const connectorDetails = {
         },
       },
     },
+    No3DSFailPayment: {
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulNo3DSCardDetails,
+        },
+        customer_acceptance: null,
+        setup_future_usage: "on_session",
+      },
+      Response: {
+        status: 400,
+        body: {
+          error: {
+            type: "invalid_request",
+            message:
+              "Selected payment method through iatapay is not implemented",
+            code: "IR_00",
+          },
+        },
+      },
+    },
   },
   upi_pm: {
     PaymentIntent: {


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [x] CI/CD

## Description

- Adyen sofort was failing in cypress automation as sofort payment method is deprecated from adyen, hence handled the error message 
- Fixed Variation case for iatapay

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
Adyen cypress tests were failing

## How did you test it?

- Adyen
<img width="731" alt="image" src="https://github.com/user-attachments/assets/96ab0176-e616-4ed6-a9bf-e244f737ac9a" />

- Iatapay
<img width="731" alt="image" src="https://github.com/user-attachments/assets/6ae82421-1ef6-4a71-8af1-45ce3150b526" />

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
