### PR TITLE
feat(connector): [Fiuu] Consume transaction id for error cases for Fiuu

### DIFF
--- a/crates/hyperswitch_connectors/src/connectors/fiuu/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/fiuu/transformers.rs
@@ -838,11 +838,11 @@ impl<F>
                             reason: non_threeds_data.error_desc.clone(),
                             status_code: item.http_code,
                             attempt_status: None,
-                            connector_transaction_id: None,
+                            connector_transaction_id: Some(data.txn_id), 
                         })
                     } else {
                         Ok(PaymentsResponseData::TransactionResponse {
-                            resource_id: ResponseId::ConnectorTransactionId(data.txn_id),
+                            resource_id: ResponseId::ConnectorTransactionId(data.txn_id.clone()),
                             redirection_data: Box::new(None),
                             mandate_reference: Box::new(mandate_reference),
                             connector_metadata: None,
@@ -884,7 +884,7 @@ impl<F>
                                 reason: recurring_response.reason.clone(),
                                 status_code: item.http_code,
                                 attempt_status: None,
-                                connector_transaction_id: recurring_response.tran_id.clone(),
+                                connector_transaction_id: recurring_response.tran_id.clone(), 
                             })
                         } else {
                             Ok(PaymentsResponseData::TransactionResponse {
@@ -1041,14 +1041,14 @@ impl TryFrom<RefundsResponseRouterData<Execute, FiuuRefundResponse>>
                             reason: refund_data.reason.clone(),
                             status_code: item.http_code,
                             attempt_status: None,
-                            connector_transaction_id: None,
+                            connector_transaction_id: Some(refund_data.refund_id.to_string()), 
                         }),
                         ..item.data
                     })
                 } else {
                     Ok(Self {
                         response: Ok(RefundsResponseData {
-                            connector_refund_id: refund_data.refund_id.to_string(),
+                            connector_refund_id: refund_data.refund_id.clone().to_string(),
                             refund_status,
                         }),
                         ..item.data
@@ -1161,6 +1161,7 @@ impl TryFrom<PaymentsSyncResponseRouterData<FiuuPaymentResponse>> for PaymentsSy
             FiuuPaymentResponse::FiuuPaymentSyncResponse(response) => {
                 let stat_name = response.stat_name;
                 let stat_code = response.stat_code.clone();
+                let txn_id = response.tran_id;
                 let status = enums::AttemptStatus::try_from(FiuuSyncStatus {
                     stat_name,
                     stat_code,
@@ -1172,13 +1173,13 @@ impl TryFrom<PaymentsSyncResponseRouterData<FiuuPaymentResponse>> for PaymentsSy
                         message: response.error_desc.clone(),
                         reason: Some(response.error_desc),
                         attempt_status: Some(enums::AttemptStatus::Failure),
-                        connector_transaction_id: None,
+                        connector_transaction_id: Some(txn_id.clone()), 
                     })
                 } else {
                     None
                 };
                 let payments_response_data = PaymentsResponseData::TransactionResponse {
-                    resource_id: item.data.request.connector_transaction_id.clone(),
+                    resource_id: ResponseId::ConnectorTransactionId(txn_id.clone().to_string()), 
                     redirection_data: Box::new(None),
                     mandate_reference: Box::new(None),
                     connector_metadata: None,
@@ -1198,6 +1199,7 @@ impl TryFrom<PaymentsSyncResponseRouterData<FiuuPaymentResponse>> for PaymentsSy
                     capture_method: item.data.request.capture_method,
                     status: response.status,
                 })?;
+                let txn_id = response.tran_id;
                 let mandate_reference = response.extra_parameters.as_ref().and_then(|extra_p| {
                     let mandate_token: Result<ExtraParameters, _> = serde_json::from_str(&extra_p.clone().expose());
                     match mandate_token {
@@ -1233,13 +1235,13 @@ impl TryFrom<PaymentsSyncResponseRouterData<FiuuPaymentResponse>> for PaymentsSy
                             .unwrap_or(consts::NO_ERROR_MESSAGE.to_owned()),
                         reason: response.error_desc.clone(),
                         attempt_status: Some(enums::AttemptStatus::Failure),
-                        connector_transaction_id: None,
+                        connector_transaction_id: Some(txn_id.clone()),
                     })
                 } else {
                     None
                 };
                 let payments_response_data = PaymentsResponseData::TransactionResponse {
-                    resource_id: item.data.request.connector_transaction_id.clone(),
+                    resource_id: ResponseId::ConnectorTransactionId(txn_id.clone().to_string()),
                     redirection_data: Box::new(None),
                     mandate_reference: Box::new(mandate_reference),
                     connector_metadata: None,
@@ -1402,13 +1404,13 @@ impl TryFrom<PaymentsCaptureResponseRouterData<PaymentCaptureResponse>>
                         .to_string(),
                 ),
                 attempt_status: None,
-                connector_transaction_id: None,
+                connector_transaction_id: Some(item.response.tran_id.clone()),
             })
         } else {
             None
         };
         let payments_response_data = PaymentsResponseData::TransactionResponse {
-            resource_id: ResponseId::ConnectorTransactionId(item.response.tran_id.to_string()),
+            resource_id: ResponseId::ConnectorTransactionId(item.response.tran_id.clone().to_string()),
             redirection_data: Box::new(None),
             mandate_reference: Box::new(None),
             connector_metadata: None,
@@ -1513,13 +1515,13 @@ impl TryFrom<PaymentsCancelResponseRouterData<FiuuPaymentCancelResponse>>
                         .to_string(),
                 ),
                 attempt_status: None,
-                connector_transaction_id: None,
+                connector_transaction_id: Some(item.response.tran_id.clone()), 
             })
         } else {
             None
         };
         let payments_response_data = PaymentsResponseData::TransactionResponse {
-            resource_id: ResponseId::ConnectorTransactionId(item.response.tran_id.to_string()),
+            resource_id: ResponseId::ConnectorTransactionId(item.response.tran_id.clone().to_string()),
             redirection_data: Box::new(None),
             mandate_reference: Box::new(None),
             connector_metadata: None,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [X] Bugfix
- [ ] New feature
- [X] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
To consume transaction id for some error cases , where currently its not consumed. This PR addresses this issue.


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Tested manually by hitting payments retrieve
### 

> After

### cURL
```
curl --location --request GET 'http://localhost:8080/payments/pay_9EIH03YnsLSJAqfoYkxU' \
--header 'Accept: application/json' \
--header 'api-key: dev_laI3IG0iKD2bmhZIwT5b0kq1VrWDKoCZ3eJqkWbWeHGEEUpzSy7rg2ZjjlV7JRhy'
```
### Response
`{
    "payment_id": "pay_9EIH03YnsLSJAqfoYkxU",
    "merchant_id": "merchant_1736151941",
    "status": "failed",
    "amount": 1000,
    "net_amount": 1000,
    "shipping_cost": null,
    "amount_capturable": 0,
    "amount_received": null,
    "connector": "fiuu",
    "client_secret": "pay_9EIH03YnsLSJAqfoYkxU_secret_CXYmUD5F0wg8tQbExwjE",
    "created": "2025-01-06T10:45:23.087Z",
    "currency": "MYR",
    "customer_id": "exampel3rewfdsvc2",
    "customer": {
        "id": "exampel3rewfdsvc2",
        "name": null,
        "email": null,
        "phone": "999999999",
        "phone_country_code": "+1"
    },
    "description": "Its my first payment request",
    "refunds": null,
    "disputes": null,
    "mandate_id": null,
    "mandate_data": null,
    "setup_future_usage": null,
    "off_session": null,
    "capture_on": null,
    "capture_method": "automatic",
    "payment_method": "card",
    "payment_method_data": {
        "card": {
            "last4": "5100",
            "card_type": null,
            "card_network": null,
            "card_issuer": null,
            "card_issuing_country": null,
            "card_isin": "510510",
            "card_extended_bin": null,
            "card_exp_month": "12",
            "card_exp_year": "2030",
            "card_holder_name": "Max Mustermann",
            "payment_checks": null,
            "authentication_data": null
        },
        "billing": null
    },
    "payment_token": null,
    "shipping": null,
    "billing": null,
    "order_details": null,
    "email": null,
    "name": null,
    "phone": "999999999",
    "return_url": "https://google.com/",
    "authentication_type": "three_ds",
    "statement_descriptor_name": "joseph",
    "statement_descriptor_suffix": "JS",
    "next_action": null,
    "cancellation_reason": null,
    "error_code": "",
    "error_message": "",
    "unified_code": "UE_9000",
    "unified_message": "Something went wrong",
    "payment_experience": null,
    "payment_method_type": "credit",
    "connector_label": null,
    "business_country": null,
    "business_label": "default",
    "business_sub_label": null,
    "allowed_payment_method_types": null,
    "ephemeral_key": null,
    "manual_retry_allowed": true,
    "connector_transaction_id": "30926945",
    "frm_message": null,
    "metadata": {
        "udf1": "value1",
        "login_date": "2019-09-10T10:11:12Z",
        "new_customer": "true"
    },
    "connector_metadata": null,
    "feature_metadata": null,
    "reference_id": null,
    "payment_link": null,
    "profile_id": "pro_ne27DW6cFOwPOUdMLTLY",
    "surcharge_details": null,
    "attempt_count": 1,
    "merchant_decision": null,
    "merchant_connector_id": "mca_tfcWJii5BjqSKlxoqbdJ",
    "incremental_authorization_allowed": false,
    "authorization_count": null,
    "incremental_authorizations": null,
    "external_authentication_details": null,
    "external_3ds_authentication_attempted": false,
    "expires_on": "2025-01-06T11:00:23.086Z",
    "fingerprint": null,
    "browser_info": {
        "language": "nl-NL",
        "time_zone": 0,
        "ip_address": "103.77.139.95",
        "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Safari/537.36",
        "color_depth": 24,
        "java_enabled": true,
        "screen_width": 1536,
        "accept_header": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,/;q=0.8",
        "screen_height": 723,
        "java_script_enabled": true
    },
    "payment_method_id": null,
    "payment_method_status": null,
    "updated": "2025-01-06T10:45:29.931Z",
    "split_payments": null,
    "frm_metadata": null,
    "merchant_order_reference_id": null,
    "order_tax_amount": null,
    "connector_mandate_id": null
}`
<img width="903" alt="Screenshot 2025-01-06 at 16 34 39" src="https://github.com/user-attachments/assets/0f4f5f37-9d7c-498c-aee0-e5af365d9482" />
(connector_transaction_id present in response)

### 

> Before
<img width="1153" alt="Screenshot 2025-01-06 at 16 27 42" src="https://github.com/user-attachments/assets/064e30dd-13f0-4877-b946-7a77de08f633" />
<img width="903" alt="Screenshot 2025-01-06 at 16 47 22" src="https://github.com/user-attachments/assets/fb423029-024f-4867-9ea2-38f08cbb3c73" />


(connector_transaction_id not present in response)

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [X] I formatted the code `cargo +nightly fmt --all`
- [X] I addressed lints thrown by `cargo clippy`
- [X] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
