### PR TITLE
chore(dynamic-fields): [Worldpay] update dynamic fields for payments

### DIFF
--- a/crates/router/src/configs/defaults/payment_connector_required_fields.rs
+++ b/crates/router/src/configs/defaults/payment_connector_required_fields.rs
@@ -3224,7 +3224,8 @@ impl Default for settings::RequiredFields {
                                 enums::Connector::Worldpay,
                                 RequiredFieldFinal {
                                     mandate: HashMap::new(),
-                                    non_mandate: {
+                                    non_mandate: HashMap::new(),
+                                    common: {
                                         let mut pmd_fields = HashMap::from([
                                             (
                                                 "payment_method_data.card.card_number".to_string(),
@@ -3257,7 +3258,6 @@ impl Default for settings::RequiredFields {
                                         pmd_fields.extend(get_worldpay_billing_required_fields());
                                         pmd_fields
                                     },
-                                    common: HashMap::new(),
                                 }
                             ),
                             (
@@ -6420,7 +6420,8 @@ impl Default for settings::RequiredFields {
                                 enums::Connector::Worldpay,
                                 RequiredFieldFinal {
                                     mandate: HashMap::new(),
-                                    non_mandate: {
+                                    non_mandate: HashMap::new(),
+                                    common: {
                                         let mut pmd_fields = HashMap::from([
                                             (
                                                 "payment_method_data.card.card_number".to_string(),
@@ -6453,7 +6454,6 @@ impl Default for settings::RequiredFields {
                                         pmd_fields.extend(get_worldpay_billing_required_fields());
                                         pmd_fields
                                     },
-                                    common: HashMap::new(),
                                 }
                             ),
                             (
@@ -12840,18 +12840,18 @@ impl Default for settings::RequiredFields {
 pub fn get_worldpay_billing_required_fields() -> HashMap<String, RequiredFieldInfo> {
     HashMap::from([
         (
-            "billing.address.zip".to_string(),
+            "billing.address.line1".to_string(),
             RequiredFieldInfo {
-                required_field: "billing.address.zip".to_string(),
-                display_name: "zip".to_string(),
-                field_type: enums::FieldType::UserAddressPincode,
+                required_field: "payment_method_data.billing.address.line1".to_string(),
+                display_name: "line1".to_string(),
+                field_type: enums::FieldType::UserAddressLine1,
                 value: None,
             },
         ),
         (
             "billing.address.country".to_string(),
             RequiredFieldInfo {
-                required_field: "billing.address.country".to_string(),
+                required_field: "payment_method_data.billing.address.country".to_string(),
                 display_name: "country".to_string(),
                 field_type: enums::FieldType::UserAddressCountry {
                     options: vec![
@@ -12994,5 +12994,14 @@ pub fn get_worldpay_billing_required_fields() -> HashMap<String, RequiredFieldIn
                 value: None,
             },
         ),
+        (
+            "billing.address.city".to_string(),
+            RequiredFieldInfo {
+                required_field: "payment_method_data.billing.address.city".to_string(),
+                display_name: "city".to_string(),
+                field_type: enums::FieldType::UserAddressCity,
+                value: None,
+            },
+        )
     ])
 }

--- a/crates/router/src/configs/defaults/payment_connector_required_fields.rs
+++ b/crates/router/src/configs/defaults/payment_connector_required_fields.rs
@@ -13002,6 +13002,6 @@ pub fn get_worldpay_billing_required_fields() -> HashMap<String, RequiredFieldIn
                 field_type: enums::FieldType::UserAddressCity,
                 value: None,
             },
-        )
+        ),
     ])
 }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
This PR adds below dynamic required fields for processing Worldpay payments -
- address.line1
- address.city
- address.country


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
The txn will fail in case a few details are missing from address while processing a payment. To fix this, required fields are updated in `RequiredFields` struct which is requested by SDK at runtime for dynamically rendering the inputs for the required fields.

## How did you test it?
Tested by rendering a payment link locally.

<img width="612" alt="Screenshot 2025-01-07 at 4 22 32 PM" src="https://github.com/user-attachments/assets/8672d393-2774-40d1-b139-c86740f24cba" />

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
