### PR TITLE
fix(users): restrict user sign-in for no user role in given tenancy

### DIFF
--- a/crates/router/src/core/errors/user.rs
+++ b/crates/router/src/core/errors/user.rs
@@ -110,6 +110,8 @@ pub enum UserErrors {
     MissingEmailConfig,
     #[error("Invalid Auth Method Operation: {0}")]
     InvalidAuthMethodOperationWithMessage(String),
+    #[error("User Role not found")]
+    UserRoleNotFound,
 }
 
 impl common_utils::errors::ErrorSwitch<api_models::errors::types::ApiErrorResponse> for UserErrors {
@@ -285,6 +287,9 @@ impl common_utils::errors::ErrorSwitch<api_models::errors::types::ApiErrorRespon
             Self::InvalidAuthMethodOperationWithMessage(_) => {
                 AER::BadRequest(ApiError::new(sub_code, 57, self.get_error_message(), None))
             }
+            Self::UserRoleNotFound => {
+                AER::BadRequest(ApiError::new(sub_code, 58, self.get_error_message(), None))
+            }
         }
     }
 }
@@ -355,6 +360,7 @@ impl UserErrors {
             Self::InvalidAuthMethodOperationWithMessage(operation) => {
                 format!("Invalid Auth Method Operation: {}", operation)
             }
+            Self::UserRoleNotFound => "User Role Not Found".to_string(),
         }
     }
 }

--- a/crates/router/src/core/user_role.rs
+++ b/crates/router/src/core/user_role.rs
@@ -675,21 +675,7 @@ pub async fn delete_user_role(
     // Check if user has any more role associations
     let remaining_roles = state
         .global_store
-        .list_user_roles_by_user_id(ListUserRolesByUserIdPayload {
-            user_id: user_from_db.get_user_id(),
-            tenant_id: user_from_token
-                .tenant_id
-                .as_ref()
-                .unwrap_or(&state.tenant.tenant_id),
-
-            org_id: None,
-            merchant_id: None,
-            profile_id: None,
-            entity_id: None,
-            version: None,
-            status: None,
-            limit: None,
-        })
+        .list_user_roles_by_user_id_across_tenants(user_from_db.get_user_id(), Some(1))
         .await
         .change_context(UserErrors::InternalServerError)?;
 


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
- Currently user can enter the id password in the given tenancy and can reach to intermediate state even if it has no user role in the current tenancy. Though he won't be able to signin, still its better to have a check when entering credentials only.
- Also when deleting user after user role deletion, we need to search for its user role across tenancies.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
Closes [#7026](https://github.com/juspay/hyperswitch/issues/7026)

## How did you test it?
Tried with signin where user exists but doesn't have any role in the given tenancy
<img width="1728" alt="Screenshot 2025-01-12 at 6 50 21 PM" src="https://github.com/user-attachments/assets/35dd0ef3-3099-4a8e-ba7c-a7dd3e02bb37" />

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
