### PR TITLE
Refactor: Customer email and browser Information

### DIFF
--- a/crates/hyperswitch_domain_models/src/router_request_types.rs
+++ b/crates/hyperswitch_domain_models/src/router_request_types.rs
@@ -491,6 +491,27 @@ pub struct BrowserInformation {
     pub device_model: Option<String>,
 }
 
+#[cfg(feature = "v2")]
+impl From<common_utils::types::BrowserInformation> for BrowserInformation {
+    fn from(value: common_utils::types::BrowserInformation) -> Self {
+        Self {
+            color_depth: value.color_depth,
+            java_enabled: value.java_enabled,
+            java_script_enabled: value.java_script_enabled,
+            language: value.language,
+            screen_height: value.screen_height,
+            screen_width: value.screen_width,
+            time_zone: value.time_zone,
+            ip_address: value.ip_address,
+            accept_header: value.accept_header,
+            user_agent: value.user_agent,
+            os_type: value.os_type,
+            os_version: value.os_version,
+            device_model: value.device_model,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Default, Serialize)]
 pub enum ResponseId {
     ConnectorTransactionId(String),

--- a/crates/router/src/core/payments/transformers.rs
+++ b/crates/router/src/core/payments/transformers.rs
@@ -241,6 +241,17 @@ pub async fn construct_payment_router_data_for_authorize<'a>(
         .map(|id| id.get_string_repr().to_owned())
         .unwrap_or(payment_data.payment_attempt.id.get_string_repr().to_owned());
 
+    let email = customer
+        .as_ref()
+        .and_then(|customer| customer.email.clone())
+        .map(pii::Email::from);
+
+    let browser_info = payment_data
+        .payment_attempt
+        .browser_info
+        .clone()
+        .map(types::BrowserInformation::from);
+
     // TODO: few fields are repeated in both routerdata and request
     let request = types::PaymentsAuthorizeData {
         payment_method_data: payment_data
@@ -262,8 +273,8 @@ pub async fn construct_payment_router_data_for_authorize<'a>(
         minor_amount: payment_data.payment_attempt.amount_details.get_net_amount(),
         order_tax_amount: None,
         currency: payment_data.payment_intent.amount_details.currency,
-        browser_info: None,
-        email: None,
+        browser_info,
+        email,
         customer_name: None,
         payment_experience: None,
         order_details: None,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
Refactored customer email and browser information in router data

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
This refactoring provides data to the connector integrations, so that it can be used in connector calls. 

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
- Confirm Intent API Call for trustpay connector.
```
curl --location 'http://localhost:8080/v2/payments/12345_pay_01945e865f697553bbf0eb847611cfcd/confirm-intent' \
--header 'x-client-secret: 1secret-client-secret' \
--header 'x-profile-id: pro_id' \
--header 'Content-Type: application/json' \
--header 'api-key: api-key' \
--data '{
    "payment_method_data": {
        "card": {
            "card_number": "4242424242424242",
            "card_exp_month": "01",
            "card_exp_year": "25",
            "card_holder_name": "John Doe",
            "card_cvc": "100"
        }
    },
    "payment_method_type": "card",
    "payment_method_subtype": "credit",
    "browser_info": {
        "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Safari/537.36",
        "accept_header": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8",
        "language": "nl-NL",
        "color_depth": 24,
        "screen_height": 723,
        "screen_width": 1536,
        "time_zone": 0,
        "java_enabled": true,
        "java_script_enabled": true,
        "ip_address": "127.0.0.1"
    }
}'
```
- Response from above call
```
{
    "id": "12345_pay_01945f254dc27802a54be556c0acab7a",
    "status": "failed",
    "amount": {
        "order_amount": 100,
        "currency": "USD",
        "shipping_cost": null,
        "order_tax_amount": null,
        "external_tax_calculation": "skip",
        "surcharge_calculation": "skip",
        "surcharge_amount": null,
        "tax_on_surcharge": null,
        "net_amount": 100,
        "amount_to_capture": null,
        "amount_capturable": 0,
        "amount_captured": null
    },
    "customer_id": "12345_cus_01945f252cb37e20a6fb6105be0c976f",
    "connector": "trustpay",
    "client_secret": "12345_pay_01945f254dc27802a54be556c0acab7a_secret_01945f254ddd7cb385275b8d620bbb24",
    "created": "2025-01-13T10:11:07.869Z",
    "payment_method_data": {
        "billing": null
    },
    "payment_method_type": "card",
    "payment_method_subtype": "credit",
    "next_action": null,
    "connector_transaction_id": null,
    "connector_reference_id": null,
    "merchant_connector_id": "mca_lZ6moeYo6Ce2vdD01f7s",
    "browser_info": null,
    "error": {
        "code": "4",
        "message": "The field Reference must be a string with a maximum length of 35.",
        "unified_code": null,
        "unified_message": null
    }
}
```

- This refactoring fixes availability of email and browser information fields for trustpay.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
