### PR TITLE
refactor(payment-link): use shouldRemoveBeforeUnloadEvents flag for handling removal of beforeunload events through SDK

### DIFF
--- a/crates/router/src/core/payment_link/payment_link_initiate/payment_link_initiator.js
+++ b/crates/router/src/core/payment_link/payment_link_initiate/payment_link_initiator.js
@@ -27,7 +27,12 @@ function initializeSDK() {
   // @ts-ignore
   hyper = window.Hyper(pub_key, {
     isPreloadEnabled: false,
+    // TODO: Remove in next deployment
     shouldUseTopRedirection: true,
+    redirectionFlags: {
+      shouldRemoveBeforeUnloadEvents: true,
+      shouldUseTopRedirection: true,
+    }
   });
   // @ts-ignore
   widgets = hyper.widgets({

--- a/crates/router/src/core/payment_link/payment_link_initiate/secure_payment_link_initiator.js
+++ b/crates/router/src/core/payment_link/payment_link_initiate/secure_payment_link_initiator.js
@@ -48,7 +48,12 @@ if (!isFramed) {
     // @ts-ignore
     hyper = window.Hyper(pub_key, {
       isPreloadEnabled: false,
+      // TODO: Remove in next deployment
       shouldUseTopRedirection: true,
+      redirectionFlags: {
+        shouldRemoveBeforeUnloadEvents: true,
+        shouldUseTopRedirection: true,
+      }
     });
     // @ts-ignore
     widgets = hyper.widgets({


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
This PR enables a flag which enables HyperSwitch SDK to handle removal of `beforeunload` events based on it's consumption by the integrating merchants.


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
This PR enables handling of removal of `beforeunload` events once checkout form is submitted by the user. Helps keep a clean user experience.


## How did you test it?
Tested locally using payment links.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
