### PR TITLE
chore: run clippy with default number of jobs in github workflows

### DIFF
--- a/.github/workflows/CI-pr.yml
+++ b/.github/workflows/CI-pr.yml
@@ -259,7 +259,7 @@ jobs:
 
       - name: Run clippy
         shell: bash
-        run: just clippy --jobs 2
+        run: just clippy
 
       - name: Check Cargo.lock changed
         if: ${{ (github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name) }}

--- a/.github/workflows/CI-pr.yml
+++ b/.github/workflows/CI-pr.yml
@@ -131,6 +131,9 @@ jobs:
         with:
           tool: sccache
           checksum: true
+      
+      - name: Install rust cache
+        uses: Swatinem/rust-cache@v2.7.0
 
       - name: Install cargo-hack
         uses: taiki-e/install-action@v2.33.28
@@ -234,6 +237,9 @@ jobs:
         with:
           tool: sccache
           checksum: true
+
+      - name: Install rust cache
+        uses: Swatinem/rust-cache@v2.7.0
 
       - name: Install cargo-hack
         uses: taiki-e/install-action@v2.33.28

--- a/.github/workflows/CI-pr.yml
+++ b/.github/workflows/CI-pr.yml
@@ -90,7 +90,7 @@ jobs:
 
     env:
       # Use `sccache` for caching compilation artifacts
-      RUSTC_WRAPPER: sccache
+      # RUSTC_WRAPPER: sccache
       RUSTFLAGS: "-D warnings"
 
     strategy:
@@ -126,11 +126,11 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install sccache
-        uses: taiki-e/install-action@v2.33.28
-        with:
-          tool: sccache
-          checksum: true
+      # - name: Install sccache
+      #   uses: taiki-e/install-action@v2.33.28
+      #   with:
+      #     tool: sccache
+      #     checksum: true
       
       - name: Install rust cache
         uses: Swatinem/rust-cache@v2.7.0
@@ -184,7 +184,7 @@ jobs:
 
     env:
       # Use `sccache` for caching compilation artifacts
-      RUSTC_WRAPPER: sccache
+      # RUSTC_WRAPPER: sccache
       RUSTFLAGS: "-D warnings"
 
     strategy:
@@ -232,11 +232,11 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install sccache
-        uses: taiki-e/install-action@v2.33.28
-        with:
-          tool: sccache
-          checksum: true
+      # - name: Install sccache
+      #   uses: taiki-e/install-action@v2.33.28
+      #   with:
+      #     tool: sccache
+      #     checksum: true
 
       - name: Install rust cache
         uses: Swatinem/rust-cache@v2.7.0

--- a/.github/workflows/CI-pr.yml
+++ b/.github/workflows/CI-pr.yml
@@ -133,7 +133,9 @@ jobs:
       #     checksum: true
       
       - name: Install rust cache
-        uses: Swatinem/rust-cache@v2.7.0
+        uses: Swatinem/rust-cache@v2.7.7
+        with: 
+            save-if: false
 
       - name: Install cargo-hack
         uses: taiki-e/install-action@v2.33.28
@@ -239,7 +241,9 @@ jobs:
       #     checksum: true
 
       - name: Install rust cache
-        uses: Swatinem/rust-cache@v2.7.0
+        uses: Swatinem/rust-cache@v2.7.7
+        with: 
+            save-if: false
 
       - name: Install cargo-hack
         uses: taiki-e/install-action@v2.33.28
@@ -321,7 +325,9 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install rust cache
-        uses: Swatinem/rust-cache@v2.7.0
+        uses: Swatinem/rust-cache@v2.7.7
+        with: 
+            save-if: false
 
       - name: Install just
         uses: taiki-e/install-action@v2.41.10

--- a/.github/workflows/CI-push.yml
+++ b/.github/workflows/CI-push.yml
@@ -84,7 +84,7 @@ jobs:
       #     tool: sccache
       #     checksum: true
 
-      - uses: Swatinem/rust-cache@v2.7.0
+      - uses: Swatinem/rust-cache@v2.7.7
         with:
           save-if: ${{ github.event_name == 'push' }}
 
@@ -196,7 +196,7 @@ jobs:
       #   with:
       #     crate: cargo-nextest
 
-      - uses: Swatinem/rust-cache@v2.7.0
+      - uses: Swatinem/rust-cache@v2.7.7
         with:
           save-if: ${{ github.event_name == 'push' }}
 
@@ -249,7 +249,7 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install rust cache
-        uses: Swatinem/rust-cache@v2.7.0
+        uses: Swatinem/rust-cache@v2.7.7
 
       - name: Run cargo check enabling only the release and v2 features
         shell: bash

--- a/.github/workflows/CI-push.yml
+++ b/.github/workflows/CI-push.yml
@@ -84,9 +84,9 @@ jobs:
           tool: sccache
           checksum: true
 
-      # - uses: Swatinem/rust-cache@v2.7.0
-      #   with:
-      #     save-if: ${{ github.event_name == 'push' }}
+      - uses: Swatinem/rust-cache@v2.7.0
+        with:
+          save-if: ${{ github.event_name == 'push' }}
 
       - name: Install cargo-hack
         uses: baptiste0928/cargo-install@v2.2.0
@@ -196,9 +196,9 @@ jobs:
       #   with:
       #     crate: cargo-nextest
 
-      # - uses: Swatinem/rust-cache@v2.7.0
-      #   with:
-      #     save-if: ${{ github.event_name == 'push' }}
+      - uses: Swatinem/rust-cache@v2.7.0
+        with:
+          save-if: ${{ github.event_name == 'push' }}
 
       - name: Run clippy
         shell: bash

--- a/.github/workflows/CI-push.yml
+++ b/.github/workflows/CI-push.yml
@@ -202,7 +202,7 @@ jobs:
 
       - name: Run clippy
         shell: bash
-        run: just clippy --jobs 2
+        run: just clippy
 
       - name: Cargo hack
         if: ${{ github.event_name == 'push' }}

--- a/.github/workflows/CI-push.yml
+++ b/.github/workflows/CI-push.yml
@@ -43,7 +43,7 @@ jobs:
 
     env:
       # Use `sccache` for caching compilation artifacts
-      RUSTC_WRAPPER: sccache
+      # RUSTC_WRAPPER: sccache
       RUSTFLAGS: "-D warnings"
 
     strategy:
@@ -78,11 +78,11 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           
-      - name: Install sccache
-        uses: taiki-e/install-action@v2.33.28
-        with:
-          tool: sccache
-          checksum: true
+      # - name: Install sccache
+      #   uses: taiki-e/install-action@v2.33.28
+      #   with:
+      #     tool: sccache
+      #     checksum: true
 
       - uses: Swatinem/rust-cache@v2.7.0
         with:
@@ -140,7 +140,7 @@ jobs:
 
     env:
       # Use `sccache` for caching compilation artifacts
-      RUSTC_WRAPPER: sccache
+      # RUSTC_WRAPPER: sccache
       RUSTFLAGS: "-D warnings"
 
     strategy:
@@ -170,11 +170,11 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install sccache
-        uses: taiki-e/install-action@v2.33.28
-        with:
-          tool: sccache
-          checksum: true
+      # - name: Install sccache
+      #   uses: taiki-e/install-action@v2.33.28
+      #   with:
+      #     tool: sccache
+      #     checksum: true
 
       - name: Install cargo-hack
         uses: baptiste0928/cargo-install@v2.2.0

--- a/.github/workflows/connector-sanity-tests.yml
+++ b/.github/workflows/connector-sanity-tests.yml
@@ -86,7 +86,9 @@ jobs:
         with:
           toolchain: stable 2 weeks ago
 
-      - uses: Swatinem/rust-cache@v2.7.0
+      - uses: Swatinem/rust-cache@v2.7.7
+        with: 
+          save-if: false
 
       - name: Decrypt connector auth file
         env:

--- a/.github/workflows/connector-ui-sanity-tests.yml
+++ b/.github/workflows/connector-ui-sanity-tests.yml
@@ -122,7 +122,9 @@ jobs:
           toolchain: stable
 
       - name: Build and Cache Rust Dependencies
-        uses: Swatinem/rust-cache@v2.7.0
+        uses: Swatinem/rust-cache@v2.7.7
+        with: 
+            save-if: false
 
       - name: Install Diesel CLI with Postgres Support
         uses: baptiste0928/cargo-install@v2.2.0

--- a/.github/workflows/postman-collection-runner.yml
+++ b/.github/workflows/postman-collection-runner.yml
@@ -92,7 +92,9 @@ jobs:
 
       - name: Build and Cache Rust Dependencies
         if: ${{ ((github.event_name == 'pull_request') && (github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name)) || (github.event_name == 'merge_group')}}
-        uses: Swatinem/rust-cache@v2.7.0
+        uses: Swatinem/rust-cache@v2.7.7
+        with: 
+            save-if: false
 
       - name: Install Protoc
         if: ${{ ((github.event_name == 'pull_request') && (github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name)) || (github.event_name == 'merge_group')}}


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
changed cargo clippy command in workflow files to use default number of jobs instead of 2.


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Github CI checks has passed.


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
