### PR TITLE
fix(samsung_pay): populate `payment_method_data` in the payment response

### DIFF
--- a/api-reference-v2/openapi_spec.json
+++ b/api-reference-v2/openapi_spec.json
@@ -21469,8 +21469,7 @@
         "type": "object",
         "required": [
           "last4",
-          "card_network",
-          "type"
+          "card_network"
         ],
         "properties": {
           "last4": {
@@ -21483,7 +21482,8 @@
           },
           "type": {
             "type": "string",
-            "description": "The type of payment method"
+            "description": "The type of payment method",
+            "nullable": true
           }
         }
       },
@@ -21837,6 +21837,17 @@
             ],
             "properties": {
               "google_pay": {
+                "$ref": "#/components/schemas/WalletAdditionalDataForCard"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "samsung_pay"
+            ],
+            "properties": {
+              "samsung_pay": {
                 "$ref": "#/components/schemas/WalletAdditionalDataForCard"
               }
             }

--- a/api-reference/openapi_spec.json
+++ b/api-reference/openapi_spec.json
@@ -26083,8 +26083,7 @@
         "type": "object",
         "required": [
           "last4",
-          "card_network",
-          "type"
+          "card_network"
         ],
         "properties": {
           "last4": {
@@ -26097,7 +26096,8 @@
           },
           "type": {
             "type": "string",
-            "description": "The type of payment method"
+            "description": "The type of payment method",
+            "nullable": true
           }
         }
       },
@@ -26451,6 +26451,17 @@
             ],
             "properties": {
               "google_pay": {
+                "$ref": "#/components/schemas/WalletAdditionalDataForCard"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "samsung_pay"
+            ],
+            "properties": {
+              "samsung_pay": {
                 "$ref": "#/components/schemas/WalletAdditionalDataForCard"
               }
             }

--- a/crates/api_models/src/payment_methods.rs
+++ b/crates/api_models/src/payment_methods.rs
@@ -829,7 +829,7 @@ pub struct PaymentMethodDataWalletInfo {
     pub card_network: String,
     /// The type of payment method
     #[serde(rename = "type")]
-    pub card_type: String,
+    pub card_type: Option<String>,
 }
 
 impl From<payments::additional_info::WalletAdditionalDataForCard> for PaymentMethodDataWalletInfo {

--- a/crates/api_models/src/payments.rs
+++ b/crates/api_models/src/payments.rs
@@ -2601,6 +2601,7 @@ pub enum AdditionalPaymentData {
     Wallet {
         apple_pay: Option<ApplepayPaymentMethod>,
         google_pay: Option<additional_info::WalletAdditionalDataForCard>,
+        samsung_pay: Option<additional_info::WalletAdditionalDataForCard>,
     },
     PayLater {
         klarna_sdk: Option<KlarnaSdkPaymentMethod>,
@@ -3874,6 +3875,8 @@ pub enum WalletResponseData {
     ApplePay(Box<additional_info::WalletAdditionalDataForCard>),
     #[schema(value_type = WalletAdditionalDataForCard)]
     GooglePay(Box<additional_info::WalletAdditionalDataForCard>),
+    #[schema(value_type = WalletAdditionalDataForCard)]
+    SamsungPay(Box<additional_info::WalletAdditionalDataForCard>),
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, serde::Deserialize, serde::Serialize, ToSchema)]
@@ -5410,8 +5413,9 @@ impl From<AdditionalPaymentData> for PaymentMethodDataResponse {
             AdditionalPaymentData::Wallet {
                 apple_pay,
                 google_pay,
-            } => match (apple_pay, google_pay) {
-                (Some(apple_pay_pm), _) => Self::Wallet(Box::new(WalletResponse {
+                samsung_pay,
+            } => match (apple_pay, google_pay, samsung_pay) {
+                (Some(apple_pay_pm), _, _) => Self::Wallet(Box::new(WalletResponse {
                     details: Some(WalletResponseData::ApplePay(Box::new(
                         additional_info::WalletAdditionalDataForCard {
                             last4: apple_pay_pm
@@ -5425,12 +5429,15 @@ impl From<AdditionalPaymentData> for PaymentMethodDataResponse {
                                 .rev()
                                 .collect::<String>(),
                             card_network: apple_pay_pm.network.clone(),
-                            card_type: apple_pay_pm.pm_type.clone(),
+                            card_type: Some(apple_pay_pm.pm_type.clone()),
                         },
                     ))),
                 })),
-                (_, Some(google_pay_pm)) => Self::Wallet(Box::new(WalletResponse {
+                (_, Some(google_pay_pm), _) => Self::Wallet(Box::new(WalletResponse {
                     details: Some(WalletResponseData::GooglePay(Box::new(google_pay_pm))),
+                })),
+                (_, _,Some(samsung_pay_pm)) => Self::Wallet(Box::new(WalletResponse {
+                    details: Some(WalletResponseData::SamsungPay(Box::new(samsung_pay_pm))),
                 })),
                 _ => Self::Wallet(Box::new(WalletResponse { details: None })),
             },

--- a/crates/api_models/src/payments.rs
+++ b/crates/api_models/src/payments.rs
@@ -5436,7 +5436,7 @@ impl From<AdditionalPaymentData> for PaymentMethodDataResponse {
                 (_, Some(google_pay_pm), _) => Self::Wallet(Box::new(WalletResponse {
                     details: Some(WalletResponseData::GooglePay(Box::new(google_pay_pm))),
                 })),
-                (_, _,Some(samsung_pay_pm)) => Self::Wallet(Box::new(WalletResponse {
+                (_, _, Some(samsung_pay_pm)) => Self::Wallet(Box::new(WalletResponse {
                     details: Some(WalletResponseData::SamsungPay(Box::new(samsung_pay_pm))),
                 })),
                 _ => Self::Wallet(Box::new(WalletResponse { details: None })),

--- a/crates/api_models/src/payments/additional_info.rs
+++ b/crates/api_models/src/payments/additional_info.rs
@@ -219,5 +219,5 @@ pub struct WalletAdditionalDataForCard {
     pub card_network: String,
     /// The type of payment method
     #[serde(rename = "type")]
-    pub card_type: String,
+    pub card_type: Option<String>,
 }

--- a/crates/hyperswitch_domain_models/src/payment_method_data.rs
+++ b/crates/hyperswitch_domain_models/src/payment_method_data.rs
@@ -1718,7 +1718,7 @@ impl From<GooglePayWalletData> for payment_methods::PaymentMethodDataWalletInfo 
         Self {
             last4: item.info.card_details,
             card_network: item.info.card_network,
-            card_type: item.pm_type,
+            card_type: Some(item.pm_type),
         }
     }
 }

--- a/crates/router/src/core/fraud_check/operation/fraud_check_pre.rs
+++ b/crates/router/src/core/fraud_check/operation/fraud_check_pre.rs
@@ -239,7 +239,7 @@ where
             connector: router_data.connector,
             payment_id: router_data.payment_id.clone(),
             attempt_id: router_data.attempt_id,
-            request: FrmRequest::Checkout(FraudCheckCheckoutData {
+            request: FrmRequest::Checkout(Box::new(FraudCheckCheckoutData {
                 amount: router_data.request.amount,
                 order_details: router_data.request.order_details,
                 currency: router_data.request.currency,
@@ -247,7 +247,7 @@ where
                 payment_method_data: router_data.request.payment_method_data,
                 email: router_data.request.email,
                 gateway: router_data.request.gateway,
-            }),
+            })),
             response: FrmResponse::Checkout(router_data.response),
         })
     }

--- a/crates/router/src/core/payments/helpers.rs
+++ b/crates/router/src/core/payments/helpers.rs
@@ -4671,6 +4671,7 @@ pub async fn get_additional_payment_data(
                         pm_type: apple_pay_wallet_data.payment_method.pm_type.clone(),
                     }),
                     google_pay: None,
+                    samsung_pay: None,
                 }))
             }
             domain::WalletData::GooglePay(google_pay_pm_data) => {
@@ -4679,13 +4680,32 @@ pub async fn get_additional_payment_data(
                     google_pay: Some(payment_additional_types::WalletAdditionalDataForCard {
                         last4: google_pay_pm_data.info.card_details.clone(),
                         card_network: google_pay_pm_data.info.card_network.clone(),
-                        card_type: google_pay_pm_data.pm_type.clone(),
+                        card_type: Some(google_pay_pm_data.pm_type.clone()),
+                    }),
+                    samsung_pay: None,
+                }))
+            }
+            domain::WalletData::SamsungPay(samsung_pay_pm_data) => {
+                Ok(Some(api_models::payments::AdditionalPaymentData::Wallet {
+                    apple_pay: None,
+                    google_pay: None,
+                    samsung_pay: Some(payment_additional_types::WalletAdditionalDataForCard {
+                        last4: samsung_pay_pm_data
+                            .payment_credential
+                            .card_last_four_digits
+                            .clone(),
+                        card_network: samsung_pay_pm_data
+                            .payment_credential
+                            .card_brand
+                            .to_string(),
+                        card_type: None,
                     }),
                 }))
             }
             _ => Ok(Some(api_models::payments::AdditionalPaymentData::Wallet {
                 apple_pay: None,
                 google_pay: None,
+                samsung_pay: None,
             })),
         },
         domain::PaymentMethodData::PayLater(_) => Ok(Some(

--- a/crates/router/src/core/payments/operations/payment_create.rs
+++ b/crates/router/src/core/payments/operations/payment_create.rs
@@ -1178,6 +1178,14 @@ impl PaymentCreate {
                                 Some(api_models::payments::AdditionalPaymentData::Wallet {
                                     apple_pay: None,
                                     google_pay: Some(wallet.into()),
+                                    samsung_pay: None,
+                                })
+                            }
+                            Some(enums::PaymentMethodType::SamsungPay) => {
+                                Some(api_models::payments::AdditionalPaymentData::Wallet {
+                                    apple_pay: None,
+                                    google_pay: None,
+                                    samsung_pay: Some(wallet.into()),
                                 })
                             }
                             _ => None,

--- a/crates/router/src/types/fraud_check.rs
+++ b/crates/router/src/types/fraud_check.rs
@@ -29,7 +29,7 @@ pub struct FrmRouterData {
 #[derive(Debug, Clone)]
 pub enum FrmRequest {
     Sale(FraudCheckSaleData),
-    Checkout(FraudCheckCheckoutData),
+    Checkout(Box<FraudCheckCheckoutData>),
     Transaction(FraudCheckTransactionData),
     Fulfillment(FraudCheckFulfillmentData),
     RecordReturn(FraudCheckRecordReturnData),


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
This pr contains the changes to populate `payment_method_data` in the samsung pay payment response. As part of this card_type is made a optional for wallet  payment_method_data as samsung pay does not send credit or debit in the samsung pay token.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
Having `payment_method_data` for Samsung Pay would be helpful in identifying the customer's card, as it contains the last four digits during a wallet payment.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
-> Create a connector with samsung pay enabled
-> Make a samsung pay payment, payment_method_data would be populated in the resposne.
```
curl --location 'http://localhost:8080/payments' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: <api-key>' \
--data-raw '{
    "amount": 1,
    "currency": "USD",
    "confirm": true,
    "business_country": "US",
    "business_label": "default",
    "amount_to_capture": 1,
    "customer_id": "cu_1737628105",
    "setup_future_usage": "off_session",
    "capture_method": "automatic",
    "capture_on": "2022-09-10T10:11:12Z",
    "return_url": "https://google.com",
    "email": "samsungpay@gmail.com",
    "name": "Joseph Doe",
    "phone": "999999999",
    "phone_country_code": "+65",
    "description": "Its my first payment request",
    "statement_descriptor_name": "Juspay",
    "statement_descriptor_suffix": "Router",
    "payment_method": "wallet",
    "payment_method_type": "samsung_pay",
    "billing": {
        "address": {
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "city": "San Fransico",
            "state": "California",
            "zip": "94122",
            "country": "US",
            "first_name": "joseph",
            "last_name": "Doe"
        },
        "phone": {
            "number": "8056594427",
            "country_code": "+91"
        }
    },
    "payment_method_data": {
        "wallet": {
            "samsung_pay": {
                "payment_credential": {
                    "3_d_s": {
                        "type": "S",
                        "version": "100",
                        "data": ""
                    },
                    "payment_card_brand": "VI",
                    "payment_currency_type": "USD",
                    "payment_last4_fpan": "1661",
                    "method": "3DS",
                    "recurring_payment": false
                }
            }
        }
    }
}
'
```
```
{
    "payment_id": "pay_JfvIOAfcN2hhbntSD4Wl",
    "merchant_id": "merchant_1737542123",
    "status": "processing",
    "amount": 1,
    "net_amount": 1,
    "shipping_cost": null,
    "amount_capturable": 0,
    "amount_received": null,
    "connector": "cybersource",
    "client_secret": "pay_JfvIOAfcN2hhbntSD4Wl_secret_XQLmNkq4plkpVOnRJ4Tj",
    "created": "2025-01-23T08:14:47.701Z",
    "currency": "USD",
    "customer_id": "cu_1737620088",
    "customer": {
        "id": "cu_1737620088",
        "name": "Joseph Doe",
        "email": "samsungpay@gmail.com",
        "phone": "999999999",
        "phone_country_code": "+65"
    },
    "description": "Its my first payment request",
    "refunds": null,
    "disputes": null,
    "mandate_id": null,
    "mandate_data": null,
    "setup_future_usage": "off_session",
    "off_session": null,
    "capture_on": null,
    "capture_method": "automatic",
    "payment_method": "wallet",
    "payment_method_data": {
        "wallet": {
            "samsung_pay": {
                "last4": "1661",
                "card_network": "Visa",
                "type": null
            }
        },
        "billing": null
    },
    "payment_token": null,
    "shipping": null,
    "billing": {
        "address": {
            "city": "San Fransico",
            "country": "US",
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "zip": "94122",
            "state": "California",
            "first_name": "joseph",
            "last_name": "Doe"
        },
        "phone": {
            "number": "8056594427",
            "country_code": "+91"
        },
        "email": null
    },
    "order_details": null,
    "email": "samsungpay@gmail.com",
    "name": "Joseph Doe",
    "phone": "999999999",
    "return_url": "https://google.com/",
    "authentication_type": "no_three_ds",
    "statement_descriptor_name": "Juspay",
    "statement_descriptor_suffix": "Router",
    "next_action": null,
    "cancellation_reason": null,
    "error_code": null,
    "error_message": null,
    "unified_code": null,
    "unified_message": null,
    "payment_experience": null,
    "payment_method_type": "samsung_pay",
    "connector_label": "cybersource_US_default_default",
    "business_country": "US",
    "business_label": "default",
    "business_sub_label": null,
    "allowed_payment_method_types": null,
    "ephemeral_key": {
        "customer_id": "cu_1737620088",
        "created_at": 1737620087,
        "expires": 1737623687,
        "secret": "epk_7b4a3abd8dd549c9a62694843d1f34b4"
    },
    "manual_retry_allowed": false,
    "connector_transaction_id": "7376200888906816004807",
    "frm_message": null,
    "metadata": null,
    "connector_metadata": null,
    "feature_metadata": null,
    "reference_id": "7376200888906816004807",
    "payment_link": null,
    "profile_id": "pro_ufywYBbtUhSFzOf1cGEM",
    "surcharge_details": null,
    "attempt_count": 1,
    "merchant_decision": null,
    "merchant_connector_id": "mca_27p7IwQqrL6FogXi41pr",
    "incremental_authorization_allowed": false,
    "authorization_count": null,
    "incremental_authorizations": null,
    "external_authentication_details": null,
    "external_3ds_authentication_attempted": false,
    "expires_on": "2025-01-23T08:29:47.701Z",
    "fingerprint": null,
    "browser_info": null,
    "payment_method_id": null,
    "payment_method_status": null,
    "updated": "2025-01-23T08:14:49.229Z",
    "split_payments": null,
    "frm_metadata": null,
    "merchant_order_reference_id": null,
    "order_tax_amount": null,
    "connector_mandate_id": null
}
```


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
