### PR TITLE
feat(core): Add Authorize flow as fallback flow while fetching GSM for refund errors

### DIFF
--- a/crates/router/src/consts.rs
+++ b/crates/router/src/consts.rs
@@ -216,3 +216,6 @@ pub const AUTHENTICATION_SERVICE_ELIGIBLE_CONFIG: &str =
 
 /// Refund flow identifier used for performing GSM operations
 pub const REFUND_FLOW_STR: &str = "refund_flow";
+
+/// Authorize flow identifier used for performing GSM operations
+pub const AUTHORIZE_FLOW_STR: &str = "Authorize";


### PR DESCRIPTION
…ated errors

## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [X] New feature
- [X] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
Some connectors  like Novalnet do not have a separate list of refund errors, they only have a single list for all the possible connector error codes.
In such cases, the error codes and messages are stored under "Authorize" flow in GSM table.

During refund related error when we fetch GSM in code, we will have to fetch the GSM using Authorize flow in case GSM is not found using "refund_flow".
[ Enhancement for [this](https://github.com/juspay/hyperswitch/pull/6933 ) PR ]

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
### Steps:
1) Make a  card payment for 1000 MYR, and capture.
2) Update DB to alter the captured amount to a greater amount say 3000 MYR.
3) Make refunds call with 3000 MYR, connector will throw error since the real captured amount is lesser than this new amount.

### 1) Make card payment via Fiuu
**cURL**

`curl --location --request POST 'http://localhost:8080/payments' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: dev_k6hN6WS14LcwHh4Q7bKCcTDRBwPRUnfQpraO5c7dW6oWiAFOmK8pdWfHlmg6adrt' \
--data-raw '{
    "amount":1000,
    "currency": "MYR",
    "confirm": true,
    "payment_link" : false,
    "capture_method": "automatic",
    "capture_on": "2022-09-10T10:11:12Z",
    "amount_to_capture": 1000,
    "customer_id": "exampel3rewfdsvc2",
    "phone": "999999999",
    "phone_country_code": "+1",
    "description": "Its my first payment request",
    "authentication_type": "three_ds",
    "return_url": "https://google.com",
    "payment_method": "card",
    "payment_method_type": "credit",
    "payment_method_data": {
        "card": {
            "card_number": "5105105105105100",
            "card_exp_month": "12",
            "card_exp_year": "2030",
            "card_holder_name": "Max Mustermann",
            "card_cvc": "444"
        }
    },
    "browser_info": {
        "user_agent": "Mozilla\/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/70.0.3538.110 Safari\/537.36",
        "accept_header": "text\/html,application\/xhtml+xml,application\/xml;q=0.9,image\/webp,image\/apng,\/;q=0.8",
        "language": "nl-NL",
        "color_depth": 24,
        "ip_address": "103.77.139.95",
        "screen_height": 723,
        "screen_width": 1536,
        "time_zone": 0,
        "java_enabled": true,
        "java_script_enabled": true
    },
    "statement_descriptor_name": "joseph",
    "statement_descriptor_suffix": "JS",
    "metadata": {
        "udf1": "value1",
        "new_customer": "true",
        "login_date": "2019-09-10T10:11:12Z"
    }
}'`

**Response**
<img width="1308" alt="Screenshot 2024-12-24 at 16 54 21" src="https://github.com/user-attachments/assets/5c1577ea-a797-4013-aa57-59206683c80d" />


### 2)Update DB with following commands to make captured amount greater than the real captured amount


```
UPDATE payment_intent
SET amount = 3000
WHERE payment_id='pay_FBXuXJ8A2WdhcwYueQCY';
UPDATE payment_intent
SET amount_captured = 3000
WHERE payment_id='pay_FBXuXJ8A2WdhcwYueQCY';

UPDATE payment_attempt
SET amount = 3000
WHERE payment_id='pay_FBXuXJ8A2WdhcwYueQCY';
UPDATE payment_attempt
SET amount_to_capture = 3000
WHERE payment_id='pay_FBXuXJ8A2WdhcwYueQCY';
```

### 3)Update  ***gateway_status_map*** (with "Authorize flow") and ***unified_translations*** table 

```
INSERT INTO unified_translations (unified_code, unified_message, locale, translation)
VALUES ('UE_1000', 'Issue with payment method details', 'zh-Hant', '支付方式資訊有問題');

INSERT INTO unified_translations (unified_code, unified_message, locale, translation)
VALUES ('UE_2000', 'Issue with Configurations', 'zh-Hant', '配置有問題');

INSERT INTO unified_translations (unified_code, unified_message, locale, translation)
VALUES ('UE_3000', 'Technical issue with PSP', 'zh-Hant', '支付服務提供商 (PSP) 出現技術問題');

INSERT INTO unified_translations (unified_code, unified_message, locale, translation)
VALUES ('UE_4000', 'Issue in the integration', 'zh-Hant', '整合過程中出現問題');

INSERT INTO unified_translations (unified_code, unified_message, locale, translation)
VALUES ('UE_9000', 'Something went wrong', 'zh-Hant', '授權被拒絕');

INSERT INTO
    gateway_status_map (
        connector,
        flow,
        sub_flow,
        code,
        message,
        status,
        decision,
        step_up_possible,
        unified_code,
        unified_message
    )
VALUES (
        'fiuu',
        'Authorize',
        'sub_flow',
        'PR011',
        'Exceed refund amount for this transaction.',
        'Failure',
        'do_default',
        false,
        'UE_1000',
        'Issue with payment method details'
    );

```

### 4)a) Make refunds call with locale "zh-Hant"

**cURL**


```
curl --location --request POST 'http://localhost:8080/refunds' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: dev_k6hN6WS14LcwHh4Q7bKCcTDRBwPRUnfQpraO5c7dW6oWiAFOmK8pdWfHlmg6adrt' \
--data-raw '{
    "payment_id": "pay_FBXuXJ8A2WdhcwYueQCY",
    "amount": 3000,
    "reason": "Customer returned product",
    "refund_type": "instant",
    "metadata": {
        "udf1": "value1",
        "new_customer": "true",
        "login_date": "2019-09-10T10:11:12Z"
    }
}'

```


**Response**
<img width="924" alt="Screenshot 2024-12-24 at 16 55 49" src="https://github.com/user-attachments/assets/91ca038a-b950-450e-a734-87816ca9df5b" />



## Checklist
<!-- Put an `x` in the boxes that apply -->

- [X] I formatted the code `cargo +nightly fmt --all`
- [X] I addressed lints thrown by `cargo clippy`
- [X] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
