### PR TITLE
fix(connector): [NETCETERA] add `sdk-type` and `default-sdk-type` in netcetera authentication request

### DIFF
--- a/api-reference-v2/openapi_spec.json
+++ b/api-reference-v2/openapi_spec.json
@@ -19982,6 +19982,14 @@
             "format": "int32",
             "description": "Indicates maximum amount of time in minutes",
             "minimum": 0
+          },
+          "sdk_type": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SdkType"
+              }
+            ],
+            "nullable": true
           }
         }
       },
@@ -20010,6 +20018,17 @@
             "nullable": true
           }
         }
+      },
+      "SdkType": {
+        "type": "string",
+        "description": "Enum representing the type of 3DS SDK.",
+        "enum": [
+          "01",
+          "02",
+          "03",
+          "04",
+          "05"
+        ]
       },
       "SecretInfoToInitiateSdk": {
         "type": "object",

--- a/api-reference/openapi_spec.json
+++ b/api-reference/openapi_spec.json
@@ -24523,6 +24523,14 @@
             "format": "int32",
             "description": "Indicates maximum amount of time in minutes",
             "minimum": 0
+          },
+          "sdk_type": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SdkType"
+              }
+            ],
+            "nullable": true
           }
         }
       },
@@ -24551,6 +24559,17 @@
             "nullable": true
           }
         }
+      },
+      "SdkType": {
+        "type": "string",
+        "description": "Enum representing the type of 3DS SDK.",
+        "enum": [
+          "01",
+          "02",
+          "03",
+          "04",
+          "05"
+        ]
       },
       "SecretInfoToInitiateSdk": {
         "type": "object",

--- a/crates/api_models/src/payments.rs
+++ b/crates/api_models/src/payments.rs
@@ -6548,6 +6548,23 @@ pub struct SdkInformation {
     pub sdk_reference_number: String,
     /// Indicates maximum amount of time in minutes
     pub sdk_max_timeout: u8,
+    /// Indicates the type of 3DS SDK
+    pub sdk_type: Option<SdkTypeEnum>,
+}
+
+/// Enum representing the type of 3DS SDK.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub enum SdkTypeEnum {
+    #[serde(rename = "01")]
+    DefaultSdk,
+    #[serde(rename = "02")]
+    SplitSdk,
+    #[serde(rename = "03")]
+    LimitedSdk,
+    #[serde(rename = "04")]
+    BrowserSdk,
+    #[serde(rename = "05")]
+    ShellSdk,
 }
 
 #[cfg(feature = "v2")]

--- a/crates/api_models/src/payments.rs
+++ b/crates/api_models/src/payments.rs
@@ -6549,12 +6549,12 @@ pub struct SdkInformation {
     /// Indicates maximum amount of time in minutes
     pub sdk_max_timeout: u8,
     /// Indicates the type of 3DS SDK
-    pub sdk_type: Option<SdkTypeEnum>,
+    pub sdk_type: Option<SdkType>,
 }
 
 /// Enum representing the type of 3DS SDK.
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub enum SdkTypeEnum {
+#[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
+pub enum SdkType {
     #[serde(rename = "01")]
     DefaultSdk,
     #[serde(rename = "02")]

--- a/crates/openapi/src/openapi.rs
+++ b/crates/openapi/src/openapi.rs
@@ -653,6 +653,7 @@ Never share your secret api keys. Keep them guarded and secure.
         api_models::enums::PaymentChargeType,
         api_models::enums::StripeChargeType,
         api_models::payments::CustomerDetailsResponse,
+        api_models::payments::SdkType,
         api_models::payments::OpenBankingData,
         api_models::payments::OpenBankingSessionToken,
         api_models::payments::BankDebitResponse,

--- a/crates/openapi/src/openapi_v2.rs
+++ b/crates/openapi/src/openapi_v2.rs
@@ -328,6 +328,7 @@ Never share your secret api keys. Keep them guarded and secure.
         api_models::payments::BankRedirectBilling,
         api_models::payments::ConnectorMetadata,
         api_models::payments::FeatureMetadata,
+        api_models::payments::SdkType,
         api_models::payments::ApplepayConnectorMetadataRequest,
         api_models::payments::SessionTokenInfo,
         api_models::payments::PaymentProcessingDetailsAt,

--- a/crates/router/src/connector/netcetera/netcetera_types.rs
+++ b/crates/router/src/connector/netcetera/netcetera_types.rs
@@ -1538,7 +1538,7 @@ pub struct Sdk {
     ///
     /// This field is required for requests where deviceChannel = 01 (APP).
     /// Available for supporting EMV 3DS 2.3.1 and later versions.
-    sdk_type: Option<SdkTypeEnum>,
+    sdk_type: Option<SdkType>,
 
     /// Indicates the characteristics of a Default-SDK.
     ///
@@ -1565,8 +1565,8 @@ impl From<api_models::payments::SdkInformation> for Sdk {
             sdk_server_signed_content: None,
             sdk_type: sdk_info
                 .sdk_type
-                .map(SdkTypeEnum::from)
-                .or(Some(SdkTypeEnum::DefaultSdk)),
+                .map(SdkType::from)
+                .or(Some(SdkType::DefaultSdk)),
             default_sdk_type: Some(DefaultSdkType {
                 // hardcoding this value because, it's the only value that is accepted
                 sdk_variant: "01".to_string(),
@@ -1577,21 +1577,21 @@ impl From<api_models::payments::SdkInformation> for Sdk {
     }
 }
 
-impl From<api_models::payments::SdkTypeEnum> for SdkTypeEnum {
-    fn from(sdk_type: api_models::payments::SdkTypeEnum) -> Self {
+impl From<api_models::payments::SdkType> for SdkType {
+    fn from(sdk_type: api_models::payments::SdkType) -> Self {
         match sdk_type {
-            api_models::payments::SdkTypeEnum::DefaultSdk => Self::DefaultSdk,
-            api_models::payments::SdkTypeEnum::SplitSdk => Self::SplitSdk,
-            api_models::payments::SdkTypeEnum::LimitedSdk => Self::LimitedSdk,
-            api_models::payments::SdkTypeEnum::BrowserSdk => Self::BrowserSdk,
-            api_models::payments::SdkTypeEnum::ShellSdk => Self::ShellSdk,
+            api_models::payments::SdkType::DefaultSdk => Self::DefaultSdk,
+            api_models::payments::SdkType::SplitSdk => Self::SplitSdk,
+            api_models::payments::SdkType::LimitedSdk => Self::LimitedSdk,
+            api_models::payments::SdkType::BrowserSdk => Self::BrowserSdk,
+            api_models::payments::SdkType::ShellSdk => Self::ShellSdk,
         }
     }
 }
 
 /// Enum representing the type of 3DS SDK.
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub enum SdkTypeEnum {
+pub enum SdkType {
     #[serde(rename = "01")]
     DefaultSdk,
     #[serde(rename = "02")]

--- a/crates/router/src/connector/netcetera/netcetera_types.rs
+++ b/crates/router/src/connector/netcetera/netcetera_types.rs
@@ -1563,9 +1563,28 @@ impl From<api_models::payments::SdkInformation> for Sdk {
             sdk_reference_number: Some(sdk_info.sdk_reference_number),
             sdk_trans_id: Some(sdk_info.sdk_trans_id),
             sdk_server_signed_content: None,
-            sdk_type: None,
-            default_sdk_type: None,
+            sdk_type: sdk_info
+                .sdk_type
+                .map(SdkTypeEnum::from)
+                .or(Some(SdkTypeEnum::DefaultSdk)),
+            default_sdk_type: Some(DefaultSdkType {
+                // hardcoding this value because, it's the only value that is accepted
+                sdk_variant: "01".to_string(),
+                wrapped_ind: None,
+            }),
             split_sdk_type: None,
+        }
+    }
+}
+
+impl From<api_models::payments::SdkTypeEnum> for SdkTypeEnum {
+    fn from(sdk_type: api_models::payments::SdkTypeEnum) -> Self {
+        match sdk_type {
+            api_models::payments::SdkTypeEnum::DefaultSdk => Self::DefaultSdk,
+            api_models::payments::SdkTypeEnum::SplitSdk => Self::SplitSdk,
+            api_models::payments::SdkTypeEnum::LimitedSdk => Self::LimitedSdk,
+            api_models::payments::SdkTypeEnum::BrowserSdk => Self::BrowserSdk,
+            api_models::payments::SdkTypeEnum::ShellSdk => Self::ShellSdk,
         }
     }
 }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
add `sdk-type` and `default-sdk-type` in netcetera authentication request
add `sdk-type` in SDK Information of PaymentsExternalAuthenticationRequest

### Additional Changes

- [x] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Tested Manually
1. Sanity External Authentication Request through Mobile SDK
CURL
```
curl --location 'localhost:8080/payments/pay_OxGBWwRs9qH0nJP1CI99/3ds/authentication' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: pk_dev_74ab7c8aac7c49d793f9c980c544a09f' \
--data '{
    "client_secret": "pay_OxGBWwRs9qH0nJP1CI99_secret_Vw1ItPPePtpz32zI2V9d",
    "device_channel": "APP",
    "threeds_method_comp_ind": "Y",
    "sdk_information": {
        "sdk_app_id": "92deb809-a452-47af-ac3b-301978a9e9e0",
        "sdk_enc_data": "eyJraWQiOiIzYzVlZDMxOTBhOWFlNGI2OTI1NjZiYmZkZTc0ODNiZTI4MDAyMzg4IiwiZW5jIjoiQTEyOEdDTSIsImFsZyI6IlJTQS1PQUVQLTI1NiJ9.at-tUcn4zXOCzxRdP7FB6cpSLsC9M5fKRCLZrup6nIkwfV80aa0.rQ2YtC2RZvW-LeznAErdMg",
        "sdk_ephem_pub_key": {
            "kty": "EC",
            "x": "P5zWKpoAZoUlrtUoe6Xzvia3zgCX1mSmpGj5XlV9R0w",
            "y": "ov2s2HF_HVwf2vzZMPOLjGwFASSmEGxeSUEuyMcrhLI",
            "crv": "P-256"
        },
        "sdk_trans_id": "4fa7696e-ca08-42cc-806f-1081287a1b9b",
        "sdk_reference_number": "3DS_LOA_SDK_JTPL_020200_00788",
        "sdk_max_timeout": 5
    }
}'
```
Response
```
{
    "trans_status": "C",
    "acs_url": null,
    "challenge_request": null,
    "acs_reference_number": "3DS_LOA_ACS_201_13579",
    "acs_trans_id": "c532ad1e-0fb7-438e-a0db-be68405c6bdc",
    "three_dsserver_trans_id": "305f8eaa-43c1-49f0-a5f4-0789b8eae7d1",
    "acs_signed_content": "eyJhbGciOiJQUzI1NiIsIng1YyI6WyJNSUlFRURDQ0F2aWdBd0lCQWdJSWFYL2RWZE9CM0hnd0RRWUpLb1pJaHZjTkFRRUxCUUKQ",
    "three_ds_requestor_url": "https://google.com/"
}

```
## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
