### PR TITLE
feat(payments): propagate additional payment method data for apple pay during MIT

### DIFF
--- a/crates/api_models/src/payment_methods.rs
+++ b/crates/api_models/src/payment_methods.rs
@@ -852,6 +852,35 @@ impl From<PaymentMethodDataWalletInfo> for payments::additional_info::WalletAddi
     }
 }
 
+impl From<payments::ApplepayPaymentMethod> for PaymentMethodDataWalletInfo {
+    fn from(item: payments::ApplepayPaymentMethod) -> Self {
+        Self {
+            last4: item
+                .display_name
+                .clone()
+                .chars()
+                .rev()
+                .take(4)
+                .collect::<String>()
+                .chars()
+                .rev()
+                .collect::<String>(),
+            card_network: item.network,
+            card_type: item.pm_type,
+        }
+    }
+}
+
+impl From<PaymentMethodDataWalletInfo> for payments::ApplepayPaymentMethod {
+    fn from(item: PaymentMethodDataWalletInfo) -> Self {
+        Self {
+            display_name: item.last4,
+            network: item.card_network,
+            pm_type: item.card_type,
+        }
+    }
+}
+
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct BankAccountTokenData {
     pub payment_method_type: api_enums::PaymentMethodType,

--- a/crates/hyperswitch_domain_models/src/payment_method_data.rs
+++ b/crates/hyperswitch_domain_models/src/payment_method_data.rs
@@ -1713,6 +1713,26 @@ impl From<Card> for ExtendedCardInfo {
     }
 }
 
+impl From<ApplePayWalletData> for payment_methods::PaymentMethodDataWalletInfo {
+    fn from(item: ApplePayWalletData) -> Self {
+        Self {
+            last4: item
+                .payment_method
+                .display_name
+                .clone()
+                .chars()
+                .rev()
+                .take(4)
+                .collect::<String>()
+                .chars()
+                .rev()
+                .collect::<String>(),
+            card_network: item.payment_method.network,
+            card_type: item.payment_method.pm_type,
+        }
+    }
+}
+
 impl From<GooglePayWalletData> for payment_methods::PaymentMethodDataWalletInfo {
     fn from(item: GooglePayWalletData) -> Self {
         Self {

--- a/crates/router/src/core/payments/operations/payment_create.rs
+++ b/crates/router/src/core/payments/operations/payment_create.rs
@@ -1174,6 +1174,12 @@ impl PaymentCreate {
                             )))
                         }
                         PaymentMethodsData::WalletDetails(wallet) => match payment_method_type {
+                            Some(enums::PaymentMethodType::ApplePay) => {
+                                Some(api_models::payments::AdditionalPaymentData::Wallet {
+                                    apple_pay: Some(wallet.into()),
+                                    google_pay: None,
+                                })
+                            }
                             Some(enums::PaymentMethodType::GooglePay) => {
                                 Some(api_models::payments::AdditionalPaymentData::Wallet {
                                     apple_pay: None,

--- a/crates/router/src/core/payments/tokenization.rs
+++ b/crates/router/src/core/payments/tokenization.rs
@@ -260,6 +260,12 @@ where
                     )),
                     (
                         _,
+                        domain::PaymentMethodData::Wallet(domain::WalletData::ApplePay(applepay)),
+                    ) => Some(PaymentMethodsData::WalletDetails(
+                        PaymentMethodDataWalletInfo::from(applepay),
+                    )),
+                    (
+                        _,
                         domain::PaymentMethodData::Wallet(domain::WalletData::GooglePay(googlepay)),
                     ) => Some(PaymentMethodsData::WalletDetails(
                         PaymentMethodDataWalletInfo::from(googlepay),


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description


Described in detail in #5868 point # 3


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
Helps the requestor identify the cards used for ApplePay MIT


## How did you test it?
To be added.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
