### PR TITLE
fix(connector): [BOA] throw unsupported error incase of 3DS cards

### DIFF
--- a/crates/hyperswitch_connectors/src/connectors/bankofamerica/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/bankofamerica/transformers.rs
@@ -510,18 +510,25 @@ fn build_bill_to(
         country: None,
         email: email.clone(),
     };
+
+
     Ok(address_details
         .and_then(|addr| {
-            addr.address.as_ref().map(|addr| BillTo {
+            addr.address.as_ref().map(|addr| {
+                let administrative_area = addr.to_state_code_as_optional().unwrap_or_else(|_| {
+                    addr.state.clone().map(|state| Secret::new(format!("{:.20}", state.expose())))
+                });
+
+                BillTo {
                 first_name: addr.first_name.clone(),
                 last_name: addr.last_name.clone(),
                 address1: addr.line1.clone(),
                 locality: addr.city.clone(),
-                administrative_area: addr.to_state_code_as_optional().ok().flatten(),
+                administrative_area,
                 postal_code: addr.zip.clone(),
                 country: addr.country,
                 email,
-            })
+        }})
         })
         .unwrap_or(default_address))
 }
@@ -813,6 +820,14 @@ impl
             hyperswitch_domain_models::payment_method_data::Card,
         ),
     ) -> Result<Self, Self::Error> {
+        if item.router_data.is_three_ds() {
+            Err(errors::ConnectorError::NotSupported {
+                message: "Card 3DS".to_string(),
+                connector: "BankOfAmerica",
+            }
+            )?
+        };
+
         let email = item.router_data.request.get_email()?;
         let bill_to = build_bill_to(item.router_data.get_optional_billing(), email)?;
         let order_information = OrderInformationWithBill::from((item, Some(bill_to)));
@@ -2236,6 +2251,14 @@ impl
             hyperswitch_domain_models::payment_method_data::Card,
         ),
     ) -> Result<Self, Self::Error> {
+        if item.is_three_ds() {
+            Err(errors::ConnectorError::NotSupported {
+                message: "Card 3DS".to_string(),
+                connector: "BankOfAmerica",
+            }
+            )?
+        };
+
         let order_information = OrderInformationWithBill::try_from(item)?;
         let client_reference_information = ClientReferenceInformation::from(item);
         let merchant_defined_information =


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Throw unsupported error incase of 3DS cards. As BOA doesn't support card 3ds payments

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
