### PR TITLE
refactor(connector): Added amount conversion framework to Threedsecureio

### DIFF
--- a/crates/router/src/connector/threedsecureio.rs
+++ b/crates/router/src/connector/threedsecureio.rs
@@ -23,11 +23,8 @@ use crate::{
     utils::{self, BytesExt},
 };
 
-use common_utils::types::{AmountConvertor , StringMajorUnit,StringMajorUnitForConnector};
-
-#[derive(Debug, Clone)]
-pub struct Threedsecureio;
-
+use super::utils::convert_amount;
+use common_utils::types::{AmountConvertor, StringMajorUnit, StringMajorUnitForConnector};
 #[derive(Clone)]
 pub struct Threedsecureio {
     amount_converter: &'static (dyn AmountConvertor<Output = StringMajorUnit> + Sync),
@@ -257,13 +254,13 @@ impl
         req: &types::authentication::ConnectorAuthenticationRouterData,
         _connectors: &settings::Connectors,
     ) -> CustomResult<RequestContent, errors::ConnectorError> {
-        let amount_to_capture = connector_utils::convert_amount(
+        let amount = convert_amount(
             self.amount_converter,
             req.request.minor_amount_to_capture,
             req.request.currency,
         )?;
         let connector_router_data =
-           threedsecureio::ThreedsecureioRouterData::try_from((amount_to_capture, req))?;
+            threedsecureio::ThreedsecureioRouterData::try_from((amount, req))?;
         let req_obj =
             threedsecureio::ThreedsecureioAuthenticationRequest::try_from(&connector_router_data);
         Ok(RequestContent::Json(Box::new(req_obj?)))
@@ -360,8 +357,8 @@ impl
         req: &types::authentication::PreAuthNRouterData,
         _connectors: &settings::Connectors,
     ) -> CustomResult<RequestContent, errors::ConnectorError> {
-        
-        let connector_router_data = threedsecureio::ThreedsecureioRouterData::try_from((0, req))?;
+        let connector_router_data =
+            threedsecureio::ThreedsecureioRouterData::try_from((StringMajorUnit::zero, req))?;
         let req_obj = threedsecureio::ThreedsecureioPreAuthenticationRequest::try_from(
             &connector_router_data,
         )?;

--- a/crates/router/src/connector/threedsecureio.rs
+++ b/crates/router/src/connector/threedsecureio.rs
@@ -1,7 +1,5 @@
 pub mod transformers;
 
-use std::fmt::Debug;
-
 use error_stack::{report, ResultExt};
 use masking::ExposeInterface;
 use pm_auth::consts;
@@ -25,9 +23,23 @@ use crate::{
     utils::{self, BytesExt},
 };
 
+use common_utils::types::{AmountConvertor , StringMajorUnit,StringMajorUnitForConnector};
+
 #[derive(Debug, Clone)]
 pub struct Threedsecureio;
 
+#[derive(Clone)]
+pub struct Threedsecureio {
+    amount_converter: &'static (dyn AmountConvertor<Output = StringMajorUnit> + Sync),
+}
+
+impl Threedsecureio {
+    pub fn new() -> &'static Self {
+        &Self {
+            amount_converter: &StringMajorUnitForConnector,
+        }
+    }
+}
 impl api::Payment for Threedsecureio {}
 impl api::PaymentSession for Threedsecureio {}
 impl api::ConnectorAccessToken for Threedsecureio {}
@@ -245,20 +257,13 @@ impl
         req: &types::authentication::ConnectorAuthenticationRouterData,
         _connectors: &settings::Connectors,
     ) -> CustomResult<RequestContent, errors::ConnectorError> {
-        let connector_router_data = threedsecureio::ThreedsecureioRouterData::try_from((
-            &self.get_currency_unit(),
-            req.request
-                .currency
-                .ok_or(errors::ConnectorError::MissingRequiredField {
-                    field_name: "currency",
-                })?,
-            req.request
-                .amount
-                .ok_or(errors::ConnectorError::MissingRequiredField {
-                    field_name: "amount",
-                })?,
-            req,
-        ))?;
+        let amount_to_capture = connector_utils::convert_amount(
+            self.amount_converter,
+            req.request.minor_amount_to_capture,
+            req.request.currency,
+        )?;
+        let connector_router_data =
+           threedsecureio::ThreedsecureioRouterData::try_from((amount_to_capture, req))?;
         let req_obj =
             threedsecureio::ThreedsecureioAuthenticationRequest::try_from(&connector_router_data);
         Ok(RequestContent::Json(Box::new(req_obj?)))
@@ -355,6 +360,7 @@ impl
         req: &types::authentication::PreAuthNRouterData,
         _connectors: &settings::Connectors,
     ) -> CustomResult<RequestContent, errors::ConnectorError> {
+        
         let connector_router_data = threedsecureio::ThreedsecureioRouterData::try_from((0, req))?;
         let req_obj = threedsecureio::ThreedsecureioPreAuthenticationRequest::try_from(
             &connector_router_data,

--- a/crates/router/src/connector/threedsecureio/transformers.rs
+++ b/crates/router/src/connector/threedsecureio/transformers.rs
@@ -2,7 +2,7 @@ use std::str::FromStr;
 
 use api_models::payments::{DeviceChannel, ThreeDsCompletionIndicator};
 use base64::Engine;
-use common_utils::{date_time,types::StringMajorUnit};
+use common_utils::{date_time, types::StringMajorUnit};
 use error_stack::ResultExt;
 use iso_currency::Currency;
 use isocountry;
@@ -27,16 +27,9 @@ pub struct ThreedsecureioRouterData<T> {
     pub router_data: T,
 }
 
-impl<T> TryFrom<(StringMajorUnit, T)>
-    for ThreedsecureioRouterData<T>
-{
+impl<T> TryFrom<(StringMajorUnit, T)> for ThreedsecureioRouterData<T> {
     type Error = error_stack::Report<errors::ConnectorError>;
-    fn try_from(
-        (amount, item): (
-            StringMajorUnit,
-            T,
-        ),
-    ) -> Result<Self, Self::Error> {
+    fn try_from((amount, item): (StringMajorUnit, T)) -> Result<Self, Self::Error> {
         Ok(Self {
             amount,
             router_data: item,

--- a/crates/router/src/connector/threedsecureio/transformers.rs
+++ b/crates/router/src/connector/threedsecureio/transformers.rs
@@ -37,7 +37,7 @@ impl<T> TryFrom<(StringMajorUnit, T)> for ThreedsecureioRouterData<T> {
     }
 }
 
-impl<T> TryFrom<(i64, T)> for ThreedsecureioRouterData<T> {
+impl<T> TryFrom<(StringMajorUnit, T)> for ThreedsecureioRouterData<T> {
     type Error = error_stack::Report<errors::ConnectorError>;
     fn try_from((amount, router_data): (StringMajorUnit, T)) -> Result<Self, Self::Error> {
         Ok(Self {

--- a/crates/router/src/connector/threedsecureio/transformers.rs
+++ b/crates/router/src/connector/threedsecureio/transformers.rs
@@ -2,7 +2,7 @@ use std::str::FromStr;
 
 use api_models::payments::{DeviceChannel, ThreeDsCompletionIndicator};
 use base64::Engine;
-use common_utils::date_time;
+use common_utils::{date_time,types::StringMajorUnit};
 use error_stack::ResultExt;
 use iso_currency::Currency;
 use isocountry;
@@ -23,24 +23,22 @@ use crate::{
 };
 
 pub struct ThreedsecureioRouterData<T> {
-    pub amount: String,
+    pub amount: StringMajorUnit,
     pub router_data: T,
 }
 
-impl<T> TryFrom<(&api::CurrencyUnit, types::storage::enums::Currency, i64, T)>
+impl<T> TryFrom<(StringMajorUnit, T)>
     for ThreedsecureioRouterData<T>
 {
     type Error = error_stack::Report<errors::ConnectorError>;
     fn try_from(
-        (_currency_unit, _currency, amount, item): (
-            &api::CurrencyUnit,
-            types::storage::enums::Currency,
-            i64,
+        (amount, item): (
+            StringMajorUnit,
             T,
         ),
     ) -> Result<Self, Self::Error> {
         Ok(Self {
-            amount: amount.to_string(),
+            amount,
             router_data: item,
         })
     }
@@ -48,9 +46,9 @@ impl<T> TryFrom<(&api::CurrencyUnit, types::storage::enums::Currency, i64, T)>
 
 impl<T> TryFrom<(i64, T)> for ThreedsecureioRouterData<T> {
     type Error = error_stack::Report<errors::ConnectorError>;
-    fn try_from((amount, router_data): (i64, T)) -> Result<Self, Self::Error> {
+    fn try_from((amount, router_data): (StringMajorUnit, T)) -> Result<Self, Self::Error> {
         Ok(Self {
-            amount: amount.to_string(),
+            amount,
             router_data,
         })
     }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
This pull request introduces significant changes to the `Threedsecureio` connector in the crates/router module, focusing on the integration of a new amount conversion utility and refactoring to utilize a new `ThreedsecureioRouterData` struct. The changes enhance how amounts are handled and improve the overall structure and clarity of the code.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
- Fixes https://github.com/juspay/hyperswitch/issues/6022

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
