### PR TITLE
feat(core): add card_discovery filter to payment list and payments Response

### DIFF
--- a/api-reference/openapi_spec.json
+++ b/api-reference/openapi_spec.json
@@ -9098,6 +9098,15 @@
         },
         "additionalProperties": false
       },
+      "CardDiscovery": {
+        "type": "string",
+        "description": "Indicates the method by which a card is discovered during a payment",
+        "enum": [
+          "manual",
+          "saved_card",
+          "click_to_pay"
+        ]
+      },
       "CardNetwork": {
         "type": "string",
         "description": "Indicates the card network.",

--- a/api-reference/openapi_spec.json
+++ b/api-reference/openapi_spec.json
@@ -19212,6 +19212,14 @@
             "type": "string",
             "description": "Connector Identifier for the payment method",
             "nullable": true
+          },
+          "card_discovery": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/CardDiscovery"
+              }
+            ],
+            "nullable": true
           }
         }
       },
@@ -20454,6 +20462,14 @@
           "connector_mandate_id": {
             "type": "string",
             "description": "Connector Identifier for the payment method",
+            "nullable": true
+          },
+          "card_discovery": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/CardDiscovery"
+              }
+            ],
             "nullable": true
           }
         }

--- a/crates/api_models/src/payments.rs
+++ b/crates/api_models/src/payments.rs
@@ -5439,6 +5439,8 @@ pub struct PaymentListFilterConstraints {
     pub card_network: Option<Vec<enums::CardNetwork>>,
     /// The identifier for merchant order reference id
     pub merchant_order_reference_id: Option<String>,
+    /// Indicates the method by which a card is discovered during a payment
+    pub card_discovery: Option<Vec<enums::CardDiscovery>>,
 }
 
 impl PaymentListFilterConstraints {
@@ -5449,6 +5451,7 @@ impl PaymentListFilterConstraints {
             && self.authentication_type.is_none()
             && self.merchant_connector_id.is_none()
             && self.card_network.is_none()
+            && self.card_discovery.is_none()
     }
 }
 

--- a/crates/api_models/src/payments.rs
+++ b/crates/api_models/src/payments.rs
@@ -4757,7 +4757,7 @@ pub struct PaymentsResponse {
     pub connector_mandate_id: Option<String>,
 
     /// Method through which card was discovered
-    #[schema(value_type = Option<CardDiscovery>)]
+    #[schema(value_type = Option<CardDiscovery>, example = "manual")]
     pub card_discovery: Option<enums::CardDiscovery>,
 }
 

--- a/crates/api_models/src/payments.rs
+++ b/crates/api_models/src/payments.rs
@@ -4755,6 +4755,9 @@ pub struct PaymentsResponse {
 
     /// Connector Identifier for the payment method
     pub connector_mandate_id: Option<String>,
+
+    /// Method through which card was discovered
+    pub card_discovery: Option<enums::CardDiscovery>,
 }
 
 // Serialize is implemented because, this will be serialized in the api events.
@@ -5485,6 +5488,8 @@ pub struct PaymentListFiltersV2 {
     pub authentication_type: Vec<enums::AuthenticationType>,
     /// The list of available card networks
     pub card_network: Vec<enums::CardNetwork>,
+    /// The list of available Card discovery methods
+    pub card_discovery: Vec<enums::CardDiscovery>,
 }
 
 #[derive(Clone, Debug, serde::Serialize)]

--- a/crates/api_models/src/payments.rs
+++ b/crates/api_models/src/payments.rs
@@ -4757,6 +4757,7 @@ pub struct PaymentsResponse {
     pub connector_mandate_id: Option<String>,
 
     /// Method through which card was discovered
+    #[schema(value_type = Option<CardDiscovery>)]
     pub card_discovery: Option<enums::CardDiscovery>,
 }
 

--- a/crates/common_enums/src/enums.rs
+++ b/crates/common_enums/src/enums.rs
@@ -194,6 +194,7 @@ impl AttemptStatus {
     serde::Serialize,
     strum::Display,
     strum::EnumString,
+    strum::EnumIter,
     ToSchema,
 )]
 #[router_derive::diesel_enum(storage_type = "db_enum")]

--- a/crates/diesel_models/src/query/payment_attempt.rs
+++ b/crates/diesel_models/src/query/payment_attempt.rs
@@ -409,6 +409,7 @@ impl PaymentAttempt {
         authentication_type: Option<Vec<enums::AuthenticationType>>,
         merchant_connector_id: Option<Vec<common_utils::id_type::MerchantConnectorAccountId>>,
         card_network: Option<Vec<enums::CardNetwork>>,
+        card_discovery: Option<Vec<enums::CardDiscovery>>,
     ) -> StorageResult<i64> {
         let mut filter = <Self as HasTable>::table()
             .count()
@@ -434,6 +435,9 @@ impl PaymentAttempt {
         }
         if let Some(card_network) = card_network {
             filter = filter.filter(dsl::card_network.eq_any(card_network))
+        }
+        if let Some(card_discovery) = card_discovery {
+            filter = filter.filter(dsl::card_discovery.eq_any(card_discovery))
         }
 
         router_env::logger::debug!(query = %debug_query::<Pg, _>(&filter).to_string());

--- a/crates/hyperswitch_domain_models/src/payments/payment_attempt.rs
+++ b/crates/hyperswitch_domain_models/src/payments/payment_attempt.rs
@@ -187,6 +187,7 @@ pub trait PaymentAttemptInterface {
         authentication_type: Option<Vec<storage_enums::AuthenticationType>>,
         merchant_connector_id: Option<Vec<id_type::MerchantConnectorAccountId>>,
         card_network: Option<Vec<storage_enums::CardNetwork>>,
+        card_discovery: Option<Vec<storage_enums::CardDiscovery>>,
         storage_scheme: storage_enums::MerchantStorageScheme,
     ) -> error_stack::Result<i64, errors::StorageError>;
 }

--- a/crates/hyperswitch_domain_models/src/payments/payment_intent.rs
+++ b/crates/hyperswitch_domain_models/src/payments/payment_intent.rs
@@ -1113,6 +1113,7 @@ pub struct PaymentIntentListParams {
     pub limit: Option<u32>,
     pub order: api_models::payments::Order,
     pub card_network: Option<Vec<common_enums::CardNetwork>>,
+    pub card_discovery: Option<Vec<common_enums::CardDiscovery>>,
     pub merchant_order_reference_id: Option<String>,
 }
 
@@ -1148,6 +1149,7 @@ impl From<api_models::payments::PaymentListConstraints> for PaymentIntentFetchCo
             limit: Some(std::cmp::min(limit, PAYMENTS_LIST_MAX_LIMIT_V1)),
             order: Default::default(),
             card_network: None,
+            card_discovery: None,
             merchant_order_reference_id: None,
         }))
     }
@@ -1174,6 +1176,7 @@ impl From<common_utils::types::TimeRange> for PaymentIntentFetchConstraints {
             limit: None,
             order: Default::default(),
             card_network: None,
+            card_discovery: None,
             merchant_order_reference_id: None,
         }))
     }
@@ -1198,6 +1201,7 @@ impl From<api_models::payments::PaymentListFilterConstraints> for PaymentIntentF
             merchant_connector_id,
             order,
             card_network,
+            card_discovery,
             merchant_order_reference_id,
         } = value;
         if let Some(payment_intent_id) = payment_id {
@@ -1222,6 +1226,7 @@ impl From<api_models::payments::PaymentListFilterConstraints> for PaymentIntentF
                 limit: Some(std::cmp::min(limit, PAYMENTS_LIST_MAX_LIMIT_V2)),
                 order,
                 card_network,
+                card_discovery,
                 merchant_order_reference_id,
             }))
         }

--- a/crates/openapi/src/openapi.rs
+++ b/crates/openapi/src/openapi.rs
@@ -312,6 +312,7 @@ Never share your secret api keys. Keep them guarded and secure.
         api_models::enums::PaymentMethodStatus,
         api_models::enums::UIWidgetFormLayout,
         api_models::enums::PaymentConnectorCategory,
+        api_models::enums::CardDiscovery,
         api_models::enums::FeatureStatus,
         api_models::admin::MerchantConnectorCreate,
         api_models::admin::AdditionalMerchantData,

--- a/crates/router/src/core/payments.rs
+++ b/crates/router/src/core/payments.rs
@@ -5158,6 +5158,7 @@ pub async fn apply_filters_on_payments(
                     constraints.authentication_type,
                     constraints.merchant_connector_id,
                     constraints.card_network,
+                    constraints.card_discovery,
                     merchant.storage_scheme,
                 )
                 .await

--- a/crates/router/src/core/payments.rs
+++ b/crates/router/src/core/payments.rs
@@ -5297,6 +5297,7 @@ pub async fn get_payment_filters(
             payment_method: payment_method_types_map,
             authentication_type: enums::AuthenticationType::iter().collect(),
             card_network: enums::CardNetwork::iter().collect(),
+            card_discovery: enums::CardDiscovery::iter().collect(),
         },
     ))
 }

--- a/crates/router/src/core/payments/transformers.rs
+++ b/crates/router/src/core/payments/transformers.rs
@@ -2484,6 +2484,7 @@ where
             order_tax_amount,
             connector_mandate_id,
             shipping_cost: payment_intent.shipping_cost,
+            card_discovery: payment_attempt.card_discovery,
         };
 
         services::ApplicationResponse::JsonWithHeaders((payments_response, headers))
@@ -2740,6 +2741,7 @@ impl ForeignFrom<(storage::PaymentIntent, storage::PaymentAttempt)> for api::Pay
             order_tax_amount: None,
             connector_mandate_id:None,
             shipping_cost: None,
+            card_discovery: pa.card_discovery
         }
     }
 }

--- a/crates/router/src/db/kafka_store.rs
+++ b/crates/router/src/db/kafka_store.rs
@@ -1692,6 +1692,7 @@ impl PaymentAttemptInterface for KafkaStore {
         authentication_type: Option<Vec<common_enums::AuthenticationType>>,
         merchant_connector_id: Option<Vec<id_type::MerchantConnectorAccountId>>,
         card_network: Option<Vec<common_enums::CardNetwork>>,
+        card_discovery: Option<Vec<common_enums::CardDiscovery>>,
         storage_scheme: MerchantStorageScheme,
     ) -> CustomResult<i64, errors::DataStorageError> {
         self.diesel_store
@@ -1704,6 +1705,7 @@ impl PaymentAttemptInterface for KafkaStore {
                 authentication_type,
                 merchant_connector_id,
                 card_network,
+                card_discovery,
                 storage_scheme,
             )
             .await

--- a/crates/router/src/services/kafka/payment_attempt.rs
+++ b/crates/router/src/services/kafka/payment_attempt.rs
@@ -57,6 +57,7 @@ pub struct KafkaPaymentAttempt<'a> {
     pub profile_id: &'a id_type::ProfileId,
     pub organization_id: &'a id_type::OrganizationId,
     pub card_network: Option<String>,
+    pub card_discovery: Option<String>,
 }
 
 #[cfg(feature = "v1")]
@@ -115,6 +116,9 @@ impl<'a> KafkaPaymentAttempt<'a> {
                 .and_then(|card| card.get("card_network"))
                 .and_then(|network| network.as_str())
                 .map(|network| network.to_string()),
+            card_discovery: attempt
+                .card_discovery
+                .map(|discovery| discovery.to_string()),
         }
     }
 }

--- a/crates/router/src/services/kafka/payment_attempt_event.rs
+++ b/crates/router/src/services/kafka/payment_attempt_event.rs
@@ -58,6 +58,7 @@ pub struct KafkaPaymentAttemptEvent<'a> {
     pub profile_id: &'a id_type::ProfileId,
     pub organization_id: &'a id_type::OrganizationId,
     pub card_network: Option<String>,
+    pub card_discovery: Option<String>,
 }
 
 #[cfg(feature = "v1")]
@@ -116,6 +117,9 @@ impl<'a> KafkaPaymentAttemptEvent<'a> {
                 .and_then(|card| card.get("card_network"))
                 .and_then(|network| network.as_str())
                 .map(|network| network.to_string()),
+            card_discovery: attempt
+                .card_discovery
+                .map(|discovery| discovery.to_string()),
         }
     }
 }

--- a/crates/router/tests/payments.rs
+++ b/crates/router/tests/payments.rs
@@ -451,6 +451,7 @@ async fn payments_create_core() {
         order_tax_amount: None,
         connector_mandate_id: None,
         shipping_cost: None,
+        card_discovery: None,
     };
     let expected_response =
         services::ApplicationResponse::JsonWithHeaders((expected_response, vec![]));
@@ -715,6 +716,7 @@ async fn payments_create_core_adyen_no_redirect() {
             order_tax_amount: None,
             connector_mandate_id: None,
             shipping_cost: None,
+            card_discovery: None,
         },
         vec![],
     ));

--- a/crates/router/tests/payments2.rs
+++ b/crates/router/tests/payments2.rs
@@ -212,6 +212,7 @@ async fn payments_create_core() {
         order_tax_amount: None,
         connector_mandate_id: None,
         shipping_cost: None,
+        card_discovery: None,
     };
 
     let expected_response =
@@ -485,6 +486,7 @@ async fn payments_create_core_adyen_no_redirect() {
             order_tax_amount: None,
             connector_mandate_id: None,
             shipping_cost: None,
+            card_discovery: None,
         },
         vec![],
     ));

--- a/crates/storage_impl/src/mock_db/payment_attempt.rs
+++ b/crates/storage_impl/src/mock_db/payment_attempt.rs
@@ -53,6 +53,7 @@ impl PaymentAttemptInterface for MockDb {
         _authentication_type: Option<Vec<common_enums::AuthenticationType>>,
         _merchanat_connector_id: Option<Vec<common_utils::id_type::MerchantConnectorAccountId>>,
         _card_network: Option<Vec<storage_enums::CardNetwork>>,
+        _card_discovery: Option<Vec<storage_enums::CardDiscovery>>,
         _storage_scheme: storage_enums::MerchantStorageScheme,
     ) -> CustomResult<i64, StorageError> {
         Err(StorageError::MockDbError)?

--- a/crates/storage_impl/src/payments/payment_attempt.rs
+++ b/crates/storage_impl/src/payments/payment_attempt.rs
@@ -437,6 +437,7 @@ impl<T: DatabaseStore> PaymentAttemptInterface for RouterStore<T> {
         authentication_type: Option<Vec<common_enums::AuthenticationType>>,
         merchant_connector_id: Option<Vec<common_utils::id_type::MerchantConnectorAccountId>>,
         card_network: Option<Vec<common_enums::CardNetwork>>,
+        card_discovery: Option<Vec<common_enums::CardDiscovery>>,
         _storage_scheme: MerchantStorageScheme,
     ) -> CustomResult<i64, errors::StorageError> {
         let conn = self
@@ -461,6 +462,7 @@ impl<T: DatabaseStore> PaymentAttemptInterface for RouterStore<T> {
             authentication_type,
             merchant_connector_id,
             card_network,
+            card_discovery,
         )
         .await
         .map_err(|er| {
@@ -1348,6 +1350,7 @@ impl<T: DatabaseStore> PaymentAttemptInterface for KVRouterStore<T> {
         authentication_type: Option<Vec<common_enums::AuthenticationType>>,
         merchant_connector_id: Option<Vec<common_utils::id_type::MerchantConnectorAccountId>>,
         card_network: Option<Vec<common_enums::CardNetwork>>,
+        card_discovery: Option<Vec<common_enums::CardDiscovery>>,
         storage_scheme: MerchantStorageScheme,
     ) -> CustomResult<i64, errors::StorageError> {
         self.router_store
@@ -1360,6 +1363,7 @@ impl<T: DatabaseStore> PaymentAttemptInterface for KVRouterStore<T> {
                 authentication_type,
                 merchant_connector_id,
                 card_network,
+                card_discovery,
                 storage_scheme,
             )
             .await

--- a/crates/storage_impl/src/payments/payment_intent.rs
+++ b/crates/storage_impl/src/payments/payment_intent.rs
@@ -1044,6 +1044,11 @@ impl<T: DatabaseStore> PaymentIntentInterface for crate::RouterStore<T> {
                 if let Some(card_network) = &params.card_network {
                     query = query.filter(pa_dsl::card_network.eq_any(card_network.clone()));
                 }
+
+                if let Some(card_discovery) = &params.card_discovery {
+                    query = query.filter(pa_dsl::card_discovery.eq_any(card_discovery.clone()));
+                }
+
                 query
             }
         };


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->
- [x] Enhancement

## Description
<!-- Describe your changes in detail -->
add card_discovery filter to payment list and payments Response

### Additional Changes

- [x] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Enable `Click To Pay` and try to do a payment, after that do list payment list with constraint `card_discovery`

to enable `Click To Pay` you can refer this PR (https://github.com/juspay/hyperswitch/pull/6982)

```shell
curl --location 'http://localhost:8080/payments/list' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'x-api-key: dev_lqs6topblZKyE7pXWRRtzmWkZcAZNxSzkXDCsNTfsgsaJXoGPN6JmR0Pwey4Aknz' \
--header 'api-key: dev_lqs6topblZKyE7pXWRRtzmWkZcAZNxSzkXDCsNTfsgsaJXoGPN6JmR0Pwey4Aknz' \
--data '{
    
    "card_discovery": ["click_to_pay"]
    
}'
```
Response :

```shell
{
    "count": 2,
    "total_count": 1,
    "data": [
        {
            "payment_id": "pay_JI24u3IxBDkutHtxqxVK",
            "merchant_id": "sahkal",
            "status": "failed",
            "amount": 1130,
            "net_amount": 1130,
            "shipping_cost": null,
            "amount_capturable": 0,
            "amount_received": null,
            "connector": "adyen",
            "client_secret": "pay_JI24u3IxBDkutHtxqxVK_secret_FzRctDiX9eBQLreSa1mo",
            "created": "2025-02-11T09:20:28.155Z",
            "currency": "USD",
            "customer_id": null,
            "customer": null,
            "description": null,
            "refunds": null,
            "disputes": null,
            "mandate_id": null,
            "mandate_data": null,
            "setup_future_usage": null,
            "off_session": null,
            "capture_on": null,
            "capture_method": null,
            "payment_method": "card",
            "payment_method_data": null,
            "payment_token": null,
            "shipping": null,
            "billing": null,
            "order_details": null,
            "email": null,
            "name": null,
            "phone": null,
            "return_url": null,
            "authentication_type": "no_three_ds",
            "statement_descriptor_name": null,
            "statement_descriptor_suffix": null,
            "next_action": null,
            "cancellation_reason": null,
            "error_code": null,
            "error_message": null,
            "unified_code": null,
            "unified_message": null,
            "payment_experience": null,
            "payment_method_type": "debit",
            "connector_label": null,
            "business_country": null,
            "business_label": "default",
            "business_sub_label": null,
            "allowed_payment_method_types": null,
            "ephemeral_key": null,
            "manual_retry_allowed": null,
            "connector_transaction_id": "FGBRQ528VFKLJJV5",
            "frm_message": null,
            "metadata": null,
            "connector_metadata": null,
            "feature_metadata": null,
            "reference_id": null,
            "payment_link": null,
            "profile_id": "pro_crxsi6miDgts1Y0j0qp8",
            "surcharge_details": null,
            "attempt_count": 1,
            "merchant_decision": null,
            "merchant_connector_id": "mca_sN3IpyjFt7nLkExHaZeu",
            "incremental_authorization_allowed": null,
            "authorization_count": null,
            "incremental_authorizations": null,
            "external_authentication_details": null,
            "external_3ds_authentication_attempted": null,
            "expires_on": null,
            "fingerprint": null,
            "browser_info": null,
            "payment_method_id": null,
            "payment_method_status": null,
            "updated": null,
            "split_payments": null,
            "frm_metadata": null,
            "merchant_order_reference_id": null,
            "order_tax_amount": null,
            "connector_mandate_id": null
        },
        {
            "payment_id": "pay_8g0o7JhNX9sSYFj6uyMS",
            "merchant_id": "sahkal",
            "status": "requires_payment_method",
            "amount": 1130,
            "net_amount": 1130,
            "shipping_cost": null,
            "amount_capturable": 0,
            "amount_received": null,
            "connector": null,
            "client_secret": "pay_8g0o7JhNX9sSYFj6uyMS_secret_vS15DUDv71Zy14hrvUxU",
            "created": "2025-02-11T09:17:13.041Z",
            "currency": "USD",
            "customer_id": null,
            "customer": null,
            "description": null,
            "refunds": null,
            "disputes": null,
            "mandate_id": null,
            "mandate_data": null,
            "setup_future_usage": null,
            "off_session": null,
            "capture_on": null,
            "capture_method": null,
            "payment_method": null,
            "payment_method_data": null,
            "payment_token": null,
            "shipping": null,
            "billing": null,
            "order_details": null,
            "email": null,
            "name": null,
            "phone": null,
            "return_url": null,
            "authentication_type": null,
            "statement_descriptor_name": null,
            "statement_descriptor_suffix": null,
            "next_action": null,
            "cancellation_reason": null,
            "error_code": null,
            "error_message": null,
            "unified_code": null,
            "unified_message": null,
            "payment_experience": null,
            "payment_method_type": null,
            "connector_label": null,
            "business_country": null,
            "business_label": "default",
            "business_sub_label": null,
            "allowed_payment_method_types": null,
            "ephemeral_key": null,
            "manual_retry_allowed": null,
            "connector_transaction_id": null,
            "frm_message": null,
            "metadata": null,
            "connector_metadata": null,
            "feature_metadata": null,
            "reference_id": null,
            "payment_link": null,
            "profile_id": "pro_crxsi6miDgts1Y0j0qp8",
            "surcharge_details": null,
            "attempt_count": 1,
            "merchant_decision": null,
            "merchant_connector_id": null,
            "incremental_authorization_allowed": null,
            "authorization_count": null,
            "incremental_authorizations": null,
            "external_authentication_details": null,
            "external_3ds_authentication_attempted": null,
            "expires_on": null,
            "fingerprint": null,
            "browser_info": null,
            "payment_method_id": null,
            "payment_method_status": null,
            "updated": null,
            "split_payments": null,
            "frm_metadata": null,
            "merchant_order_reference_id": null,
            "order_tax_amount": null,
            "connector_mandate_id": null
        }
    ]
}
```

Payment Response
```shell
{
    "payment_id": "pay_d73IKuzppDYMaLCy7Jup",
    "merchant_id": "sahkal",
    "status": "failed",
    "amount": 1130,
    "net_amount": 1130,
    "shipping_cost": null,
    "amount_capturable": 0,
    "amount_received": null,
    "connector": "adyen",
    "client_secret": "pay_d73IKuzppDYMaLCy7Jup_secret_zImkzJOHimtj9mKLam7h",
    "created": "2025-02-11T14:06:57.252Z",
    "currency": "USD",
    "customer_id": null,
    "customer": null,
    "description": null,
    "refunds": null,
    "disputes": null,
    "mandate_id": null,
    "mandate_data": null,
    "setup_future_usage": null,
    "off_session": null,
    "capture_on": null,
    "capture_method": null,
    "payment_method": "card",
    "payment_method_data": null,
    "payment_token": null,
    "shipping": null,
    "billing": null,
    "order_details": null,
    "email": null,
    "name": null,
    "phone": null,
    "return_url": "https://hyperswitch.io/",
    "authentication_type": "no_three_ds",
    "statement_descriptor_name": null,
    "statement_descriptor_suffix": null,
    "next_action": null,
    "cancellation_reason": null,
    "error_code": "2",
    "error_message": "Refused",
    "unified_code": "UE_9000",
    "unified_message": "Something went wrong",
    "payment_experience": null,
    "payment_method_type": "debit",
    "connector_label": null,
    "business_country": null,
    "business_label": "default",
    "business_sub_label": null,
    "allowed_payment_method_types": null,
    "ephemeral_key": null,
    "manual_retry_allowed": true,
    "connector_transaction_id": "MPDCQ27C4ZQJH275",
    "frm_message": null,
    "metadata": null,
    "connector_metadata": null,
    "feature_metadata": null,
    "reference_id": null,
    "payment_link": null,
    "profile_id": "pro_crxsi6miDgts1Y0j0qp8",
    "surcharge_details": null,
    "attempt_count": 1,
    "merchant_decision": null,
    "merchant_connector_id": "mca_sN3IpyjFt7nLkExHaZeu",
    "incremental_authorization_allowed": false,
    "authorization_count": null,
    "incremental_authorizations": null,
    "external_authentication_details": null,
    "external_3ds_authentication_attempted": false,
    "expires_on": "2025-02-11T14:21:57.251Z",
    "fingerprint": null,
    "browser_info": {
        "os_type": null,
        "language": "en-GB",
        "time_zone": -330,
        "ip_address": "::1",
        "os_version": null,
        "user_agent": "Mozilla/5.0 (Linux; Android 6.0; Nexus 5 Build/MRA58N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Mobile Safari/537.36",
        "color_depth": 24,
        "device_model": null,
        "java_enabled": true,
        "screen_width": 2560,
        "accept_header": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8",
        "screen_height": 1440,
        "accept_language": "en",
        "java_script_enabled": true
    },
    "payment_method_id": null,
    "payment_method_status": null,
    "updated": "2025-02-11T14:08:40.820Z",
    "split_payments": null,
    "frm_metadata": null,
    "merchant_order_reference_id": null,
    "order_tax_amount": null,
    "connector_mandate_id": null,
    "card_discovery": "click_to_pay"
}
```

Screenshot for kafka logs

<img width="667" alt="Screenshot 2025-02-12 at 2 51 03 PM" src="https://github.com/user-attachments/assets/ee7a5046-9004-4d6d-adce-8519124ef161" />

<img width="664" alt="Screenshot 2025-02-12 at 2 51 40 PM" src="https://github.com/user-attachments/assets/617f40a2-f25d-424b-9bf4-38ebbc2b2841" />


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
