### PR TITLE
feat(refunds): add support for platform merchant account in refunds

### DIFF
--- a/crates/diesel_models/src/refund.rs
+++ b/crates/diesel_models/src/refund.rs
@@ -56,6 +56,7 @@ pub struct Refund {
     pub split_refunds: Option<common_types::refunds::SplitRefund>,
     pub unified_code: Option<String>,
     pub unified_message: Option<String>,
+    pub platform_merchant_id: Option<common_utils::id_type::MerchantId>,
 }
 
 #[derive(
@@ -102,6 +103,7 @@ pub struct RefundNew {
     pub connector_refund_data: Option<String>,
     pub connector_transaction_data: Option<String>,
     pub split_refunds: Option<common_types::refunds::SplitRefund>,
+    pub platform_merchant_id: Option<common_utils::id_type::MerchantId>,
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]

--- a/crates/diesel_models/src/schema.rs
+++ b/crates/diesel_models/src/schema.rs
@@ -1260,6 +1260,8 @@ diesel::table! {
         unified_code -> Nullable<Varchar>,
         #[max_length = 1024]
         unified_message -> Nullable<Varchar>,
+        #[max_length = 64]
+        platform_merchant_id -> Nullable<Varchar>,
     }
 }
 

--- a/crates/router/src/compatibility/stripe/refunds.rs
+++ b/crates/router/src/compatibility/stripe/refunds.rs
@@ -50,7 +50,14 @@ pub async fn refund_create(
         &req,
         create_refund_req,
         |state, auth: auth::AuthenticationData, req, _| {
-            refunds::refund_create_core(state, auth.merchant_account, None, auth.key_store, req)
+            refunds::refund_create_core(
+                state,
+                auth.merchant_account,
+                None,
+                auth.key_store,
+                req,
+                auth.platform_merchant_account,
+            )
         },
         &auth::HeaderAuth(auth::ApiKeyAuth),
         api_locking::LockAction::NotApplicable,

--- a/crates/router/src/db/refund.rs
+++ b/crates/router/src/db/refund.rs
@@ -439,6 +439,7 @@ mod storage {
                         connector_transaction_data: new.connector_transaction_data.clone(),
                         unified_code: None,
                         unified_message: None,
+                        platform_merchant_id: new.platform_merchant_id.clone(),
                     };
 
                     let field = format!(
@@ -936,6 +937,7 @@ impl RefundInterface for MockDb {
             connector_transaction_data: new.connector_transaction_data,
             unified_code: None,
             unified_message: None,
+            platform_merchant_id: new.platform_merchant_id,
         };
         refunds.push(refund.clone());
         Ok(refund)

--- a/crates/router/src/routes/refunds.rs
+++ b/crates/router/src/routes/refunds.rs
@@ -43,6 +43,7 @@ pub async fn refunds_create(
                 auth.profile_id,
                 auth.key_store,
                 req,
+                auth.platform_merchant_account,
             )
         },
         auth::auth_type(

--- a/crates/router/src/utils/user/sample_data.rs
+++ b/crates/router/src/utils/user/sample_data.rs
@@ -403,6 +403,7 @@ pub async fn generate_sample_data(
                 organization_id: org_id.clone(),
                 connector_refund_data: None,
                 connector_transaction_data,
+                platform_merchant_id: None,
             })
         } else {
             None

--- a/migrations/2025-02-07-122429_add_column_platform_merchant_id_in_refund/down.sql
+++ b/migrations/2025-02-07-122429_add_column_platform_merchant_id_in_refund/down.sql
@@ -1,0 +1,2 @@
+-- This file should undo anything in `up.sql`
+ALTER TABLE refund DROP COLUMN IF EXISTS platform_merchant_id;

--- a/migrations/2025-02-07-122429_add_column_platform_merchant_id_in_refund/up.sql
+++ b/migrations/2025-02-07-122429_add_column_platform_merchant_id_in_refund/up.sql
@@ -1,0 +1,2 @@
+-- Your SQL goes here
+ALTER TABLE refund ADD COLUMN IF NOT EXISTS platform_merchant_id VARCHAR(64) NULL;


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
Add support for platform merchant id in refunds.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
