### PR TITLE
chore(connector): [Fiuu] log keys in the PSync response

### DIFF
--- a/crates/hyperswitch_connectors/src/connectors/fiuu.rs
+++ b/crates/hyperswitch_connectors/src/connectors/fiuu.rs
@@ -1,6 +1,10 @@
 pub mod transformers;
 
-use std::collections::{HashMap, HashSet};
+use std::{
+    any::type_name,
+    borrow::Cow,
+    collections::{HashMap, HashSet},
+};
 
 use common_enums::{CaptureMethod, PaymentMethod, PaymentMethodType};
 use common_utils::{
@@ -53,6 +57,40 @@ use crate::{
     utils::{self, PaymentMethodDataType},
 };
 
+pub fn parse_and_log_keys_in_url_encoded_response<T>(data: &[u8]) {
+    match std::str::from_utf8(data) {
+        Ok(query_str) => {
+            let loggable_keys = [
+                "status",
+                "orderid",
+                "tranID",
+                "nbcb",
+                "amount",
+                "currency",
+                "paydate",
+                "channel",
+                "error_desc",
+                "error_code",
+                "extraP",
+            ];
+            let keys: Vec<(Cow<'_, str>, String)> =
+                url::form_urlencoded::parse(query_str.as_bytes())
+                    .map(|(key, value)| {
+                        if loggable_keys.contains(&key.to_string().as_str()) {
+                            (key, value.to_string())
+                        } else {
+                            (key, "SECRET".to_string())
+                        }
+                    })
+                    .collect();
+            router_env::logger::info!("Keys in {} response\n{:?}", type_name::<T>(), keys);
+        }
+        Err(err) => {
+            router_env::logger::error!("Failed to convert bytes to string: {:?}", err);
+        }
+    }
+}
+
 fn parse_response<T>(data: &[u8]) -> Result<T, errors::ConnectorError>
 where
     T: for<'de> Deserialize<'de>,
@@ -86,6 +124,27 @@ where
         })?;
         json.insert("miscellaneous".to_string(), misc_value);
     }
+
+    // TODO: Remove this after debugging
+    let loggable_keys = [
+        "StatCode",
+        "StatName",
+        "TranID",
+        "ErrorCode",
+        "ErrorDesc",
+        "miscellaneous",
+    ];
+    let keys: Vec<(&str, Value)> = json
+        .iter()
+        .map(|(key, value)| {
+            if loggable_keys.contains(&key.as_str()) {
+                (key.as_str(), value.to_owned())
+            } else {
+                (key.as_str(), Value::String("SECRET".to_string()))
+            }
+        })
+        .collect();
+    router_env::logger::info!("Keys in response for type {}\n{:?}", type_name::<T>(), keys);
 
     let response: T = serde_json::from_value(Value::Object(json)).map_err(|e| {
         router_env::logger::error!("Error in Deserializing Response Data: {:?}", e);
@@ -747,6 +806,7 @@ impl webhooks::IncomingWebhook for Fiuu {
     ) -> CustomResult<Vec<u8>, errors::ConnectorError> {
         let header = utils::get_header_key_value("content-type", request.headers)?;
         let resource: FiuuWebhooksResponse = if header == "application/x-www-form-urlencoded" {
+            parse_and_log_keys_in_url_encoded_response::<FiuuWebhooksResponse>(request.body);
             serde_urlencoded::from_bytes::<FiuuWebhooksResponse>(request.body)
                 .change_context(errors::ConnectorError::WebhookSourceVerificationFailed)?
         } else {
@@ -776,6 +836,7 @@ impl webhooks::IncomingWebhook for Fiuu {
     ) -> CustomResult<Vec<u8>, errors::ConnectorError> {
         let header = utils::get_header_key_value("content-type", request.headers)?;
         let resource: FiuuWebhooksResponse = if header == "application/x-www-form-urlencoded" {
+            parse_and_log_keys_in_url_encoded_response::<FiuuWebhooksResponse>(request.body);
             serde_urlencoded::from_bytes::<FiuuWebhooksResponse>(request.body)
                 .change_context(errors::ConnectorError::WebhookSourceVerificationFailed)?
         } else {
@@ -833,6 +894,7 @@ impl webhooks::IncomingWebhook for Fiuu {
     ) -> CustomResult<api_models::webhooks::ObjectReferenceId, errors::ConnectorError> {
         let header = utils::get_header_key_value("content-type", request.headers)?;
         let resource: FiuuWebhooksResponse = if header == "application/x-www-form-urlencoded" {
+            parse_and_log_keys_in_url_encoded_response::<FiuuWebhooksResponse>(request.body);
             serde_urlencoded::from_bytes::<FiuuWebhooksResponse>(request.body)
                 .change_context(errors::ConnectorError::WebhookReferenceIdNotFound)?
         } else {
@@ -866,6 +928,7 @@ impl webhooks::IncomingWebhook for Fiuu {
     ) -> CustomResult<api_models::webhooks::IncomingWebhookEvent, errors::ConnectorError> {
         let header = utils::get_header_key_value("content-type", request.headers)?;
         let resource: FiuuWebhooksResponse = if header == "application/x-www-form-urlencoded" {
+            parse_and_log_keys_in_url_encoded_response::<FiuuWebhooksResponse>(request.body);
             serde_urlencoded::from_bytes::<FiuuWebhooksResponse>(request.body)
                 .change_context(errors::ConnectorError::WebhookEventTypeNotFound)?
         } else {
@@ -891,6 +954,7 @@ impl webhooks::IncomingWebhook for Fiuu {
     ) -> CustomResult<Box<dyn masking::ErasedMaskSerialize>, errors::ConnectorError> {
         let header = utils::get_header_key_value("content-type", request.headers)?;
         let payload: FiuuWebhooksResponse = if header == "application/x-www-form-urlencoded" {
+            parse_and_log_keys_in_url_encoded_response::<FiuuWebhooksResponse>(request.body);
             serde_urlencoded::from_bytes::<FiuuWebhooksResponse>(request.body)
                 .change_context(errors::ConnectorError::WebhookResourceObjectNotFound)?
         } else {
@@ -921,6 +985,9 @@ impl webhooks::IncomingWebhook for Fiuu {
         Option<hyperswitch_domain_models::router_flow_types::ConnectorMandateDetails>,
         errors::ConnectorError,
     > {
+        parse_and_log_keys_in_url_encoded_response::<transformers::FiuuWebhooksPaymentResponse>(
+            request.body,
+        );
         let webhook_payment_response: transformers::FiuuWebhooksPaymentResponse =
             serde_urlencoded::from_bytes::<transformers::FiuuWebhooksPaymentResponse>(request.body)
                 .change_context(errors::ConnectorError::WebhookResourceObjectNotFound)?;


### PR DESCRIPTION
(cherry picked from commit c044ffff0c47ee5d3ef5f905c3f590fae4ac9a24)

## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
Hotfix for https://github.com/juspay/hyperswitch/pull/7189


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
This helps in debugging PSync deserialization errors for Fiuu for DuitNow payment method.

## How did you test it?
As mentioned in https://github.com/juspay/hyperswitch/pull/7189


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
