### PR TITLE
fix(connector): [fiuu] update PSync and webhooks response

### DIFF
--- a/crates/hyperswitch_connectors/src/connectors/fiuu.rs
+++ b/crates/hyperswitch_connectors/src/connectors/fiuu.rs
@@ -805,7 +805,9 @@ impl webhooks::IncomingWebhook for Fiuu {
                     webhooks_payment_response.paydate,
                     webhooks_payment_response.domain.peek(),
                     md5_key0,
-                    webhooks_payment_response.appcode.peek(),
+                    webhooks_payment_response
+                        .appcode
+                        .map_or("".to_string(), |appcode| appcode.expose()),
                     String::from_utf8_lossy(&connector_webhook_secrets.secret)
                 );
                 key1

--- a/crates/hyperswitch_connectors/src/connectors/fiuu/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/fiuu/transformers.rs
@@ -1141,8 +1141,8 @@ pub struct FiuuPaymentSyncResponse {
     stat_name: StatName,
     #[serde(rename = "TranID")]
     tran_id: String,
-    error_code: String,
-    error_desc: String,
+    error_code: Option<String>,
+    error_desc: Option<String>,
     #[serde(rename = "miscellaneous")]
     miscellaneous: Option<HashMap<String, Secret<String>>>,
     #[serde(rename = "SchemeTransactionID")]
@@ -1224,9 +1224,14 @@ impl TryFrom<PaymentsSyncResponseRouterData<FiuuPaymentResponse>> for PaymentsSy
                 let error_response = if status == enums::AttemptStatus::Failure {
                     Some(ErrorResponse {
                         status_code: item.http_code,
-                        code: response.error_code.clone(),
-                        message: response.error_desc.clone(),
-                        reason: Some(response.error_desc),
+                        code: response
+                            .error_code
+                            .unwrap_or(consts::NO_ERROR_CODE.to_owned()),
+                        message: response
+                            .error_desc
+                            .clone()
+                            .unwrap_or(consts::NO_ERROR_MESSAGE.to_owned()),
+                        reason: response.error_desc,
                         attempt_status: Some(enums::AttemptStatus::Failure),
                         connector_transaction_id: Some(txn_id.clone()),
                     })
@@ -1755,7 +1760,7 @@ pub struct FiuuWebhooksPaymentResponse {
     pub amount: StringMajorUnit,
     pub currency: String,
     pub domain: Secret<String>,
-    pub appcode: Secret<String>,
+    pub appcode: Option<Secret<String>>,
     pub paydate: String,
     pub channel: String,
     pub error_desc: Option<String>,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
Hotfix for https://github.com/juspay/hyperswitch/pull/7211


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
Helps fix Fiuu connector specifically for DuitNow.

## How did you test it?
DuitNow cannot be tested. Updated based on API documentation.


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
