### PR TITLE
refactor(payments_v2): create customer at connector end and populate connector customer ID

### DIFF
--- a/crates/diesel_models/src/customers.rs
+++ b/crates/diesel_models/src/customers.rs
@@ -64,13 +64,7 @@ impl From<CustomerNew> for Customer {
 
 #[cfg(all(feature = "v2", feature = "customer_v2"))]
 #[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Insertable,
-    router_derive::DebugAsDisplay,
-    serde::Deserialize,
-    serde::Serialize,
+    Clone, Debug, Insertable, router_derive::DebugAsDisplay, serde::Deserialize, serde::Serialize,
 )]
 #[diesel(table_name = customers, primary_key(id))]
 pub struct CustomerNew {
@@ -82,7 +76,7 @@ pub struct CustomerNew {
     pub description: Option<Description>,
     pub created_at: PrimitiveDateTime,
     pub metadata: Option<pii::SecretSerdeValue>,
-    pub connector_customer: Option<pii::SecretSerdeValue>,
+    pub connector_customer: Option<ConnectorCustomerMap>,
     pub modified_at: PrimitiveDateTime,
     pub default_payment_method_id: Option<common_utils::id_type::GlobalPaymentMethodId>,
     pub updated_by: Option<String>,
@@ -164,7 +158,7 @@ pub struct Customer {
     pub description: Option<Description>,
     pub created_at: PrimitiveDateTime,
     pub metadata: Option<pii::SecretSerdeValue>,
-    pub connector_customer: Option<pii::SecretSerdeValue>,
+    pub connector_customer: Option<ConnectorCustomerMap>,
     pub modified_at: PrimitiveDateTime,
     pub default_payment_method_id: Option<common_utils::id_type::GlobalPaymentMethodId>,
     pub updated_by: Option<String>,
@@ -242,7 +236,7 @@ pub struct CustomerUpdateInternal {
     pub phone_country_code: Option<String>,
     pub metadata: Option<pii::SecretSerdeValue>,
     pub modified_at: PrimitiveDateTime,
-    pub connector_customer: Option<pii::SecretSerdeValue>,
+    pub connector_customer: Option<ConnectorCustomerMap>,
     pub default_payment_method_id: Option<Option<common_utils::id_type::GlobalPaymentMethodId>>,
     pub updated_by: Option<String>,
     pub default_billing_address: Option<Encryption>,
@@ -287,5 +281,33 @@ impl CustomerUpdateInternal {
             status: status.unwrap_or(source.status),
             ..source
         }
+    }
+}
+
+#[cfg(all(feature = "v2", feature = "customer_v2"))]
+#[derive(Clone, Debug, Default, serde::Deserialize, serde::Serialize, diesel::AsExpression)]
+#[diesel(sql_type = diesel::sql_types::Jsonb)]
+#[serde(transparent)]
+pub struct ConnectorCustomerMap(
+    std::collections::HashMap<common_utils::id_type::MerchantConnectorAccountId, String>,
+);
+
+#[cfg(all(feature = "v2", feature = "customer_v2"))]
+common_utils::impl_to_sql_from_sql_json!(ConnectorCustomerMap);
+
+#[cfg(all(feature = "v2", feature = "customer_v2"))]
+impl std::ops::Deref for ConnectorCustomerMap {
+    type Target =
+        std::collections::HashMap<common_utils::id_type::MerchantConnectorAccountId, String>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+#[cfg(all(feature = "v2", feature = "customer_v2"))]
+impl std::ops::DerefMut for ConnectorCustomerMap {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
     }
 }

--- a/crates/hyperswitch_domain_models/src/business_profile.rs
+++ b/crates/hyperswitch_domain_models/src/business_profile.rs
@@ -985,7 +985,7 @@ impl From<ProfileUpdate> for ProfileUpdateInternal {
                     is_network_tokenization_enabled,
                     is_auto_retries_enabled: None,
                     max_auto_retries_enabled: None,
-                    is_click_to_pay_enabled: None,
+                    is_click_to_pay_enabled,
                     authentication_product_ids,
                     three_ds_decision_manager_config,
                 }

--- a/crates/hyperswitch_domain_models/src/customer.rs
+++ b/crates/hyperswitch_domain_models/src/customer.rs
@@ -56,7 +56,7 @@ pub struct Customer {
     pub description: Option<Description>,
     pub created_at: PrimitiveDateTime,
     pub metadata: Option<pii::SecretSerdeValue>,
-    pub connector_customer: Option<pii::SecretSerdeValue>,
+    pub connector_customer: Option<diesel_models::ConnectorCustomerMap>,
     pub modified_at: PrimitiveDateTime,
     pub default_payment_method_id: Option<id_type::GlobalPaymentMethodId>,
     pub updated_by: Option<String>,
@@ -79,6 +79,31 @@ impl Customer {
     #[cfg(all(feature = "v2", feature = "customer_v2"))]
     pub fn get_id(&self) -> &id_type::GlobalCustomerId {
         &self.id
+    }
+
+    /// Get the connector customer ID for the specified connector label, if present
+    #[cfg(all(any(feature = "v1", feature = "v2"), not(feature = "customer_v2")))]
+    pub fn get_connector_customer_id(&self, connector_label: &str) -> Option<&str> {
+        use masking::PeekInterface;
+
+        self.connector_customer
+            .as_ref()
+            .and_then(|connector_customer_value| {
+                connector_customer_value.peek().get(connector_label)
+            })
+            .and_then(|connector_customer| connector_customer.as_str())
+    }
+
+    /// Get the connector customer ID for the specified merchant connector account ID, if present
+    #[cfg(all(feature = "v2", feature = "customer_v2"))]
+    pub fn get_connector_customer_id(
+        &self,
+        merchant_connector_id: &id_type::MerchantConnectorAccountId,
+    ) -> Option<&str> {
+        self.connector_customer
+            .as_ref()
+            .and_then(|connector_customer_map| connector_customer_map.get(merchant_connector_id))
+            .map(|connector_customer_id| connector_customer_id.as_str())
     }
 }
 
@@ -310,14 +335,14 @@ pub enum CustomerUpdate {
         description: Option<Description>,
         phone_country_code: Option<String>,
         metadata: Option<pii::SecretSerdeValue>,
-        connector_customer: Box<Option<pii::SecretSerdeValue>>,
+        connector_customer: Box<Option<diesel_models::ConnectorCustomerMap>>,
         default_billing_address: Option<Encryption>,
         default_shipping_address: Option<Encryption>,
         default_payment_method_id: Option<Option<id_type::GlobalPaymentMethodId>>,
         status: Option<DeleteStatus>,
     },
     ConnectorCustomer {
-        connector_customer: Option<pii::SecretSerdeValue>,
+        connector_customer: Option<diesel_models::ConnectorCustomerMap>,
     },
     UpdateDefaultPaymentMethod {
         default_payment_method_id: Option<Option<id_type::GlobalPaymentMethodId>>,

--- a/crates/router/src/core/customers.rs
+++ b/crates/router/src/core/customers.rs
@@ -679,19 +679,20 @@ impl CustomerDeleteBridge for id_type::GlobalCustomerId {
             redacted_encrypted_value.clone().into_encrypted(),
         );
 
-        let updated_customer = storage::CustomerUpdate::Update {
-            name: Some(redacted_encrypted_value.clone()),
-            email: Box::new(Some(redacted_encrypted_email)),
-            phone: Box::new(Some(redacted_encrypted_value.clone())),
-            description: Some(Description::from_str_unchecked(REDACTED)),
-            phone_country_code: Some(REDACTED.to_string()),
-            metadata: None,
-            connector_customer: Box::new(None),
-            default_billing_address: None,
-            default_shipping_address: None,
-            default_payment_method_id: None,
-            status: Some(common_enums::DeleteStatus::Redacted),
-        };
+        let updated_customer =
+            storage::CustomerUpdate::Update(Box::new(storage::CustomerGeneralUpdate {
+                name: Some(redacted_encrypted_value.clone()),
+                email: Box::new(Some(redacted_encrypted_email)),
+                phone: Box::new(Some(redacted_encrypted_value.clone())),
+                description: Some(Description::from_str_unchecked(REDACTED)),
+                phone_country_code: Some(REDACTED.to_string()),
+                metadata: None,
+                connector_customer: Box::new(None),
+                default_billing_address: None,
+                default_shipping_address: None,
+                default_payment_method_id: None,
+                status: Some(common_enums::DeleteStatus::Redacted),
+            }));
 
         db.update_customer_by_global_id(
             key_manager_state,
@@ -1338,7 +1339,7 @@ impl CustomerUpdateBridge for customers::CustomerUpdateRequest {
                 &domain_customer.id,
                 domain_customer.to_owned(),
                 merchant_account.get_id(),
-                storage::CustomerUpdate::Update {
+                storage::CustomerUpdate::Update(Box::new(storage::CustomerGeneralUpdate {
                     name: encryptable_customer.name,
                     email: Box::new(encryptable_customer.email.map(|email| {
                         let encryptable: Encryptable<Secret<String, pii::EmailStrategy>> =
@@ -1357,7 +1358,7 @@ impl CustomerUpdateBridge for customers::CustomerUpdateRequest {
                     default_shipping_address: encrypted_customer_shipping_address.map(Into::into),
                     default_payment_method_id: Some(self.default_payment_method_id.clone()),
                     status: None,
-                },
+                })),
                 key_store,
                 merchant_account.storage_scheme,
             )

--- a/crates/router/src/core/payments.rs
+++ b/crates/router/src/core/payments.rs
@@ -3940,7 +3940,7 @@ where
                 let customer_update = customers::update_connector_customer_in_customers(
                     &label,
                     customer.as_ref(),
-                    &connector_customer_id,
+                    connector_customer_id.clone(),
                 )
                 .await;
 
@@ -3991,14 +3991,14 @@ where
                 Some(merchant_connector_account.get_id()),
             )?;
 
-            let label = merchant_connector_account
-                .get_id()
-                .get_string_repr()
-                .to_owned();
+            let merchant_connector_id = merchant_connector_account.get_id();
 
             let (should_call_connector, existing_connector_customer_id) =
                 customers::should_call_connector_create_customer(
-                    state, &connector, customer, &label,
+                    state,
+                    &connector,
+                    customer,
+                    &merchant_connector_id,
                 );
 
             if should_call_connector {
@@ -4021,9 +4021,9 @@ where
                     .await?;
 
                 let customer_update = customers::update_connector_customer_in_customers(
-                    &label,
+                    merchant_connector_id,
                     customer.as_ref(),
-                    &connector_customer_id,
+                    connector_customer_id.clone(),
                 )
                 .await;
 

--- a/crates/router/src/core/payments.rs
+++ b/crates/router/src/core/payments.rs
@@ -2996,6 +2996,16 @@ where
             id: merchant_connector_id.get_string_repr().to_owned(),
         })?;
 
+    let updated_customer = call_create_connector_customer_if_required(
+        state,
+        customer,
+        merchant_account,
+        key_store,
+        &merchant_connector_account,
+        payment_data,
+    )
+    .await?;
+
     let mut router_data = payment_data
         .construct_router_data(
             state,
@@ -3048,8 +3058,7 @@ where
             payment_data.clone(),
             customer.clone(),
             merchant_account.storage_scheme,
-            // TODO: update the customer with connector customer id
-            None,
+            updated_customer,
             key_store,
             frm_suggestion,
             header_payload.clone(),
@@ -3874,7 +3883,6 @@ where
                 merchant_connector_account.get_mca_id(),
             )?;
 
-            #[cfg(feature = "v1")]
             let label = {
                 let connector_label = core_utils::get_connector_label(
                     payment_data.get_payment_intent().business_country,
@@ -3905,14 +3913,88 @@ where
                 }
             };
 
-            #[cfg(feature = "v2")]
-            let label = {
-                merchant_connector_account
-                    .get_mca_id()
-                    .get_required_value("merchant_connector_account_id")?
-                    .get_string_repr()
-                    .to_owned()
-            };
+            let (should_call_connector, existing_connector_customer_id) =
+                customers::should_call_connector_create_customer(
+                    state, &connector, customer, &label,
+                );
+
+            if should_call_connector {
+                // Create customer at connector and update the customer table to store this data
+                let router_data = payment_data
+                    .construct_router_data(
+                        state,
+                        connector.connector.id(),
+                        merchant_account,
+                        key_store,
+                        customer,
+                        merchant_connector_account,
+                        None,
+                        None,
+                    )
+                    .await?;
+
+                let connector_customer_id = router_data
+                    .create_connector_customer(state, &connector)
+                    .await?;
+
+                let customer_update = customers::update_connector_customer_in_customers(
+                    &label,
+                    customer.as_ref(),
+                    &connector_customer_id,
+                )
+                .await;
+
+                payment_data.set_connector_customer_id(connector_customer_id);
+                Ok(customer_update)
+            } else {
+                // Customer already created in previous calls use the same value, no need to update
+                payment_data.set_connector_customer_id(
+                    existing_connector_customer_id.map(ToOwned::to_owned),
+                );
+                Ok(None)
+            }
+        }
+        None => Ok(None),
+    }
+}
+
+#[cfg(feature = "v2")]
+pub async fn call_create_connector_customer_if_required<F, Req, D>(
+    state: &SessionState,
+    customer: &Option<domain::Customer>,
+    merchant_account: &domain::MerchantAccount,
+    key_store: &domain::MerchantKeyStore,
+    merchant_connector_account: &domain::MerchantConnectorAccount,
+    payment_data: &mut D,
+) -> RouterResult<Option<storage::CustomerUpdate>>
+where
+    F: Send + Clone + Sync,
+    Req: Send + Sync,
+
+    // To create connector flow specific interface data
+    D: OperationSessionGetters<F> + OperationSessionSetters<F> + Send + Sync + Clone,
+    D: ConstructFlowSpecificData<F, Req, router_types::PaymentsResponseData>,
+    RouterData<F, Req, router_types::PaymentsResponseData>: Feature<F, Req> + Send,
+
+    // To construct connector flow specific api
+    dyn api::Connector:
+        services::api::ConnectorIntegration<F, Req, router_types::PaymentsResponseData>,
+{
+    let connector_name = payment_data.get_payment_attempt().connector.clone();
+
+    match connector_name {
+        Some(connector_name) => {
+            let connector = api::ConnectorData::get_connector_by_name(
+                &state.conf.connectors,
+                &connector_name,
+                api::GetToken::Connector,
+                Some(merchant_connector_account.get_id()),
+            )?;
+
+            let label = merchant_connector_account
+                .get_id()
+                .get_string_repr()
+                .to_owned();
 
             let (should_call_connector, existing_connector_customer_id) =
                 customers::should_call_connector_create_customer(

--- a/crates/router/src/core/payments/customers.rs
+++ b/crates/router/src/core/payments/customers.rs
@@ -1,5 +1,5 @@
 use common_utils::pii;
-use masking::{ExposeOptionInterface, PeekInterface};
+use masking::ExposeOptionInterface;
 use router_env::{instrument, tracing};
 
 use crate::{
@@ -73,17 +73,7 @@ pub async fn create_connector_customer<F: Clone, T: Clone>(
     Ok(connector_customer_id)
 }
 
-pub fn get_connector_customer_details_if_present<'a>(
-    customer: &'a domain::Customer,
-    connector_name: &str,
-) -> Option<&'a str> {
-    customer
-        .connector_customer
-        .as_ref()
-        .and_then(|connector_customer_value| connector_customer_value.peek().get(connector_name))
-        .and_then(|connector_customer| connector_customer.as_str())
-}
-
+#[cfg(all(any(feature = "v1", feature = "v2"), not(feature = "customer_v2")))]
 pub fn should_call_connector_create_customer<'a>(
     state: &SessionState,
     connector: &api::ConnectorData,
@@ -98,9 +88,9 @@ pub fn should_call_connector_create_customer<'a>(
         .contains(&connector.connector_name);
 
     if connector_needs_customer {
-        let connector_customer_details = customer.as_ref().and_then(|customer| {
-            get_connector_customer_details_if_present(customer, connector_label)
-        });
+        let connector_customer_details = customer
+            .as_ref()
+            .and_then(|customer| customer.get_connector_customer_id(connector_label));
         let should_call_connector = connector_customer_details.is_none();
         (should_call_connector, connector_customer_details)
     } else {
@@ -108,25 +98,48 @@ pub fn should_call_connector_create_customer<'a>(
     }
 }
 
+#[cfg(all(feature = "v2", feature = "customer_v2"))]
+pub fn should_call_connector_create_customer<'a>(
+    state: &SessionState,
+    connector: &api::ConnectorData,
+    customer: &'a Option<domain::Customer>,
+    merchant_connector_id: &common_utils::id_type::MerchantConnectorAccountId,
+) -> (bool, Option<&'a str>) {
+    // Check if create customer is required for the connector
+    let connector_needs_customer = state
+        .conf
+        .connector_customer
+        .connector_list
+        .contains(&connector.connector_name);
+
+    if connector_needs_customer {
+        let connector_customer_details = customer
+            .as_ref()
+            .and_then(|customer| customer.get_connector_customer_id(merchant_connector_id));
+        let should_call_connector = connector_customer_details.is_none();
+        (should_call_connector, connector_customer_details)
+    } else {
+        (false, None)
+    }
+}
+
+#[cfg(all(any(feature = "v1", feature = "v2"), not(feature = "customer_v2")))]
 #[instrument]
 pub async fn update_connector_customer_in_customers(
     connector_label: &str,
     customer: Option<&domain::Customer>,
-    connector_customer_id: &Option<String>,
+    connector_customer_id: Option<String>,
 ) -> Option<storage::CustomerUpdate> {
-    let connector_customer_map = customer
+    let mut connector_customer_map = customer
         .and_then(|customer| customer.connector_customer.clone().expose_option())
         .and_then(|connector_customer| connector_customer.as_object().cloned())
         .unwrap_or_default();
 
-    let updated_connector_customer_map =
-        connector_customer_id.as_ref().map(|connector_customer_id| {
-            let mut connector_customer_map = connector_customer_map;
-            let connector_customer_value =
-                serde_json::Value::String(connector_customer_id.to_string());
-            connector_customer_map.insert(connector_label.to_string(), connector_customer_value);
-            connector_customer_map
-        });
+    let updated_connector_customer_map = connector_customer_id.map(|connector_customer_id| {
+        let connector_customer_value = serde_json::Value::String(connector_customer_id);
+        connector_customer_map.insert(connector_label.to_string(), connector_customer_value);
+        connector_customer_map
+    });
 
     updated_connector_customer_map
         .map(serde_json::Value::Object)
@@ -135,4 +148,23 @@ pub async fn update_connector_customer_in_customers(
                 connector_customer: Some(pii::SecretSerdeValue::new(connector_customer_value)),
             },
         )
+}
+
+#[cfg(all(feature = "v2", feature = "customer_v2"))]
+#[instrument]
+pub async fn update_connector_customer_in_customers(
+    merchant_connector_id: common_utils::id_type::MerchantConnectorAccountId,
+    customer: Option<&domain::Customer>,
+    connector_customer_id: Option<String>,
+) -> Option<storage::CustomerUpdate> {
+    connector_customer_id.map(|connector_customer_id| {
+        let mut connector_customer_map = customer
+            .and_then(|customer| customer.connector_customer.clone())
+            .unwrap_or_default();
+        connector_customer_map.insert(merchant_connector_id, connector_customer_id);
+
+        storage::CustomerUpdate::ConnectorCustomer {
+            connector_customer: Some(connector_customer_map),
+        }
+    })
 }

--- a/crates/router/src/core/payments/operations/payment_confirm_intent.rs
+++ b/crates/router/src/core/payments/operations/payment_confirm_intent.rs
@@ -432,6 +432,25 @@ impl<F: Clone + Sync> UpdateTracker<F, PaymentConfirmData<F>, PaymentsConfirmInt
 
         payment_data.payment_attempt = updated_payment_attempt;
 
+        if let Some((customer, updated_customer)) = customer.zip(updated_customer) {
+            let customer_id = customer.get_id().clone();
+            let customer_merchant_id = customer.merchant_id.clone();
+
+            let _updated_customer = db
+                .update_customer_by_global_id(
+                    key_manager_state,
+                    &customer_id,
+                    customer,
+                    &customer_merchant_id,
+                    updated_customer,
+                    key_store,
+                    storage_scheme,
+                )
+                .await
+                .change_context(errors::ApiErrorResponse::InternalServerError)
+                .attach_printable("Failed to update customer during `update_trackers`")?;
+        }
+
         Ok((Box::new(self), payment_data))
     }
 }

--- a/crates/router/src/core/payments/transformers.rs
+++ b/crates/router/src/core/payments/transformers.rs
@@ -211,6 +211,12 @@ pub async fn construct_payment_router_data_for_authorize<'a>(
             "Invalid global customer generated, not able to convert to reference id",
         )?;
 
+    let connector_customer_id = customer.as_ref().and_then(|customer| {
+        customer
+            .get_connector_customer_id(&merchant_connector_account.get_id())
+            .map(String::from)
+    });
+
     let payment_method = payment_data.payment_attempt.payment_method_type;
 
     let router_base_url = &state.base_url;
@@ -352,7 +358,7 @@ pub async fn construct_payment_router_data_for_authorize<'a>(
         reference_id: None,
         payment_method_status: None,
         payment_method_token: None,
-        connector_customer: None,
+        connector_customer: connector_customer_id,
         recurring_mandate_payment_data: None,
         // TODO: This has to be generated as the reference id based on the connector configuration
         // Some connectros might not accept accept the global id. This has to be done when generating the reference id
@@ -864,6 +870,12 @@ pub async fn construct_payment_router_data_for_setup_mandate<'a>(
             "Invalid global customer generated, not able to convert to reference id",
         )?;
 
+    let connector_customer_id = customer.as_ref().and_then(|customer| {
+        customer
+            .get_connector_customer_id(&merchant_connector_account.get_id())
+            .map(String::from)
+    });
+
     let payment_method = payment_data.payment_attempt.payment_method_type;
 
     let router_base_url = &state.base_url;
@@ -991,7 +1003,7 @@ pub async fn construct_payment_router_data_for_setup_mandate<'a>(
         reference_id: None,
         payment_method_status: None,
         payment_method_token: None,
-        connector_customer: None,
+        connector_customer: connector_customer_id,
         recurring_mandate_payment_data: None,
         // TODO: This has to be generated as the reference id based on the connector configuration
         // Some connectros might not accept accept the global id. This has to be done when generating the reference id

--- a/crates/router/src/core/payouts.rs
+++ b/crates/router/src/core/payouts.rs
@@ -1203,6 +1203,7 @@ pub async fn complete_create_recipient(
     Ok(())
 }
 
+#[cfg(all(any(feature = "v1", feature = "v2"), not(feature = "customer_v2")))]
 pub async fn create_recipient(
     state: &SessionState,
     merchant_account: &domain::MerchantAccount,
@@ -1262,7 +1263,7 @@ pub async fn create_recipient(
                         customers::update_connector_customer_in_customers(
                             &connector_label,
                             Some(&customer),
-                            &recipient_create_data.connector_payout_id.clone(),
+                            recipient_create_data.connector_payout_id.clone(),
                         )
                         .await
                     {
@@ -1400,6 +1401,17 @@ pub async fn create_recipient(
         }
     }
     Ok(())
+}
+
+#[cfg(all(feature = "v2", feature = "customer_v2"))]
+pub async fn create_recipient(
+    state: &SessionState,
+    merchant_account: &domain::MerchantAccount,
+    key_store: &domain::MerchantKeyStore,
+    connector_data: &api::ConnectorData,
+    payout_data: &mut PayoutData,
+) -> RouterResult<()> {
+    todo!()
 }
 
 pub async fn complete_payout_eligibility(

--- a/crates/router/src/types/storage/customers.rs
+++ b/crates/router/src/types/storage/customers.rs
@@ -1,3 +1,5 @@
 pub use diesel_models::customers::{Customer, CustomerNew, CustomerUpdateInternal};
 
+#[cfg(all(feature = "v2", feature = "customer_v2"))]
+pub use crate::types::domain::CustomerGeneralUpdate;
 pub use crate::types::domain::CustomerUpdate;


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->

This PR updates the payments v2 flows to create a customer at connector's end, where applicable, and populate the connector's customer ID in `RouterData`, so that the connector integrations which need the connector customer ID can access the field and pass it along.

Additionally, this PR includes some refactors done around relevant code:

- Introduces a newtype instead of `serde_json::Value` for the `connector_customer` field in the customer v2 diesel and domain models.
- Addresses a `clippy::large_enum_variant` warning arising with the `CustomerUpdate` v2 enum.
- Addresses an unused variable warning for `is_click_to_pay_enabled` field in the business profile v2 code. (I just opened the file and my IDE displayed only this warning in the entire file, so I ended up fixing it.)

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->

As of opening this PR, a customer is not created on the connector's end for those connectors that support / require such an operation. And with respect to the multi-use tokens that were created with Stripe (support added in #7106), the payment methods were created on Stripe's end, but were not associated with a customer, due to which they could not be used to make transactions again, we used to receive such an error:

```text
The provided PaymentMethod cannot be attached. To reuse a PaymentMethod, you must attach it to a Customer first.
```

To address this, we have to create a customer on Stripe's end first, and then pass Stripe's customer ID when saving the payment method with Stripe.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

Locally, via Postman.

- Create an organization, merchant account, API key, (business) profile, merchant connector account using the respective v2 APIs.
- Create a customer using the customer create v2 API.
- Create and confirm a payment intent, either using the separate APIs, or using the API introduced in #7106, while ensuring to pass `customer_id` field with the customer ID obtained in the previous step.
  - If a merchant connector account was set up with Stripe and the payment is also routed through Stripe, then a connector customer ID must be populated in the database for the customer entry:
    ![Screenshot of connector_customer field being populated in the database](https://github.com/user-attachments/assets/6f40d964-6b7f-46c3-aaab-b0fae72cff88)
- Additionally, if trying a zero amount transaction using the API introduced in #7106, we should be able to use the Stripe's payment method ID returned in our payments response (within the `connector_token_details` field) to create payments with Stripe directly (provided we pass the same connector customer ID as well).

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
