### PR TITLE
feat(utils): add iso representation for each state for european countries

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -43,7 +43,8 @@ ws2tcpip = "ws2tcpip" # WinSock Extension
 ZAR = "ZAR"  # South African Rand currency code
 JOD = "JOD" # Jordan currency code
 Payed = "Payed" # Paid status for digital virgo
-Alo = "Alo" # Is a state in France
+Alo = "Alo" # Is iso representation of a state in France
+alo = "alo" # Is iso representation of a state in France
 BRE = "BRE" # Is iso representation of Brittany
 VasCounty = "VasCounty" # Is a state in Hungary
 StipMunicipality = "StipMunicipality" # Is a municipality in North Macedonia
@@ -54,8 +55,10 @@ WLL = "WLL" # Is iso representation of a state in UK
 WIL = "WIL" # Is iso representation of a state in UK
 YOR = "YOR" # Is iso representation of a state in UK
 OT = "OT" # Is iso representation of a state in Romania
+OltCounty = "OltCounty" # Is a state in Romania
 olt = "olt" # Is iso representation of a state in Romania
 Vas = "Vas" # Is iso representation of a state in Hungary
+vas = "vas" # Is iso representation of a state in Hungary
 
 [default.extend-words]
 aci = "aci" # Name of a connector

--- a/.typos.toml
+++ b/.typos.toml
@@ -43,6 +43,19 @@ ws2tcpip = "ws2tcpip" # WinSock Extension
 ZAR = "ZAR"  # South African Rand currency code
 JOD = "JOD" # Jordan currency code
 Payed = "Payed" # Paid status for digital virgo
+Alo = "Alo" # Is a state in France
+BRE = "BRE" # Is iso representation of Brittany
+VasCounty = "VasCounty" # Is a state in Hungary
+StipMunicipality = "StipMunicipality" # Is a municipality in North Macedonia
+HAV = "HAV" # Is iso representation of a state in UK
+LEW = "LEW" # Is iso representation of a state in UK
+THR = "THR" # Is iso representation of a state in UK
+WLL = "WLL" # Is iso representation of a state in UK
+WIL = "WIL" # Is iso representation of a state in UK
+YOR = "YOR" # Is iso representation of a state in UK
+OT = "OT" # Is iso representation of a state in Romania
+olt = "olt" # Is iso representation of a state in Romania
+Vas = "Vas" # Is iso representation of a state in Hungary
 
 [default.extend-words]
 aci = "aci" # Name of a connector

--- a/crates/api_models/src/payments.rs
+++ b/crates/api_models/src/payments.rs
@@ -1682,7 +1682,7 @@ impl MandateIds {
 pub struct MandateData {
     /// A way to update the mandate's payment method details
     pub update_mandate_id: Option<String>,
-    /// A concent from the customer to store the payment method
+    /// A consent from the customer to store the payment method
     pub customer_acceptance: Option<CustomerAcceptance>,
     /// A way to select the type of mandate used
     pub mandate_type: Option<MandateType>,

--- a/crates/common_enums/src/enums.rs
+++ b/crates/common_enums/src/enums.rs
@@ -2424,29 +2424,29 @@ pub enum CanadaStatesAbbreviation {
     Debug, Clone, PartialEq, Eq, Serialize, Deserialize, strum::Display, strum::EnumString,
 )]
 pub enum AlbaniaStatesAbbreviation {
-    #[serde(rename = "01")]
+    #[strum(serialize = "01")]
     Berat,
-    #[serde(rename = "09")]
+    #[strum(serialize = "09")]
     Diber,
-    #[serde(rename = "02")]
+    #[strum(serialize = "02")]
     Durres,
-    #[serde(rename = "03")]
+    #[strum(serialize = "03")]
     Elbasan,
-    #[serde(rename = "04")]
+    #[strum(serialize = "04")]
     Fier,
-    #[serde(rename = "05")]
+    #[strum(serialize = "05")]
     Gjirokaster,
-    #[serde(rename = "06")]
+    #[strum(serialize = "06")]
     Korce,
-    #[serde(rename = "07")]
+    #[strum(serialize = "07")]
     Kukes,
-    #[serde(rename = "08")]
+    #[strum(serialize = "08")]
     Lezhe,
-    #[serde(rename = "10")]
+    #[strum(serialize = "10")]
     Shkoder,
-    #[serde(rename = "11")]
+    #[strum(serialize = "11")]
     Tirane,
-    #[serde(rename = "12")]
+    #[strum(serialize = "12")]
     Vlore,
 }
 
@@ -2454,19 +2454,19 @@ pub enum AlbaniaStatesAbbreviation {
     Debug, Clone, PartialEq, Eq, Serialize, Deserialize, strum::Display, strum::EnumString,
 )]
 pub enum AndorraStatesAbbreviation {
-    #[serde(rename = "07")]
+    #[strum(serialize = "07")]
     AndorraLaVella,
-    #[serde(rename = "02")]
+    #[strum(serialize = "02")]
     Canillo,
-    #[serde(rename = "03")]
+    #[strum(serialize = "03")]
     Encamp,
-    #[serde(rename = "08")]
+    #[strum(serialize = "08")]
     EscaldesEngordany,
-    #[serde(rename = "04")]
+    #[strum(serialize = "04")]
     LaMassana,
-    #[serde(rename = "05")]
+    #[strum(serialize = "05")]
     Ordino,
-    #[serde(rename = "06")]
+    #[strum(serialize = "06")]
     SantJuliaDeLoria,
 }
 
@@ -2474,23 +2474,23 @@ pub enum AndorraStatesAbbreviation {
     Debug, Clone, PartialEq, Eq, Serialize, Deserialize, strum::Display, strum::EnumString,
 )]
 pub enum AustriaStatesAbbreviation {
-    #[serde(rename = "1")]
+    #[strum(serialize = "1")]
     Burgenland,
-    #[serde(rename = "2")]
+    #[strum(serialize = "2")]
     Carinthia,
-    #[serde(rename = "3")]
+    #[strum(serialize = "3")]
     LowerAustria,
-    #[serde(rename = "5")]
+    #[strum(serialize = "5")]
     Salzburg,
-    #[serde(rename = "6")]
+    #[strum(serialize = "6")]
     Styria,
-    #[serde(rename = "7")]
+    #[strum(serialize = "7")]
     Tyrol,
-    #[serde(rename = "4")]
+    #[strum(serialize = "4")]
     UpperAustria,
-    #[serde(rename = "9")]
+    #[strum(serialize = "9")]
     Vienna,
-    #[serde(rename = "8")]
+    #[strum(serialize = "8")]
     Vorarlberg,
 }
 
@@ -2498,19 +2498,19 @@ pub enum AustriaStatesAbbreviation {
     Debug, Clone, PartialEq, Eq, Serialize, Deserialize, strum::Display, strum::EnumString,
 )]
 pub enum BelarusStatesAbbreviation {
-    #[serde(rename = "BR")]
+    #[strum(serialize = "BR")]
     BrestRegion,
-    #[serde(rename = "HO")]
+    #[strum(serialize = "HO")]
     GomelRegion,
-    #[serde(rename = "HR")]
+    #[strum(serialize = "HR")]
     GrodnoRegion,
-    #[serde(rename = "HM")]
+    #[strum(serialize = "HM")]
     Minsk,
-    #[serde(rename = "MI")]
+    #[strum(serialize = "MI")]
     MinskRegion,
-    #[serde(rename = "MA")]
+    #[strum(serialize = "MA")]
     MogilevRegion,
-    #[serde(rename = "VI")]
+    #[strum(serialize = "VI")]
     VitebskRegion,
 }
 
@@ -2518,31 +2518,31 @@ pub enum BelarusStatesAbbreviation {
     Debug, Clone, PartialEq, Eq, Serialize, Deserialize, strum::Display, strum::EnumString,
 )]
 pub enum BosniaAndHerzegovinaStatesAbbreviation {
-    #[serde(rename = "05")]
+    #[strum(serialize = "05")]
     BosnianPodrinjeCanton,
-    #[serde(rename = "BRC")]
+    #[strum(serialize = "BRC")]
     BrckoDistrict,
-    #[serde(rename = "10")]
+    #[strum(serialize = "10")]
     Canton10,
-    #[serde(rename = "06")]
+    #[strum(serialize = "06")]
     CentralBosniaCanton,
-    #[serde(rename = "BIH")]
+    #[strum(serialize = "BIH")]
     FederationOfBosniaAndHerzegovina,
-    #[serde(rename = "07")]
+    #[strum(serialize = "07")]
     HerzegovinaNeretvaCanton,
-    #[serde(rename = "02")]
+    #[strum(serialize = "02")]
     PosavinaCanton,
-    #[serde(rename = "SRP")]
+    #[strum(serialize = "SRP")]
     RepublikaSrpska,
-    #[serde(rename = "09")]
+    #[strum(serialize = "09")]
     SarajevoCanton,
-    #[serde(rename = "03")]
+    #[strum(serialize = "03")]
     TuzlaCanton,
-    #[serde(rename = "01")]
+    #[strum(serialize = "01")]
     UnaSanaCanton,
-    #[serde(rename = "08")]
+    #[strum(serialize = "08")]
     WestHerzegovinaCanton,
-    #[serde(rename = "04")]
+    #[strum(serialize = "04")]
     ZenicaDobojCanton,
 }
 
@@ -2550,61 +2550,61 @@ pub enum BosniaAndHerzegovinaStatesAbbreviation {
     Debug, Clone, PartialEq, Eq, Serialize, Deserialize, strum::Display, strum::EnumString,
 )]
 pub enum BulgariaStatesAbbreviation {
-    #[serde(rename = "01")]
+    #[strum(serialize = "01")]
     BlagoevgradProvince,
-    #[serde(rename = "02")]
+    #[strum(serialize = "02")]
     BurgasProvince,
-    #[serde(rename = "08")]
+    #[strum(serialize = "08")]
     DobrichProvince,
-    #[serde(rename = "07")]
+    #[strum(serialize = "07")]
     GabrovoProvince,
-    #[serde(rename = "26")]
+    #[strum(serialize = "26")]
     HaskovoProvince,
-    #[serde(rename = "09")]
+    #[strum(serialize = "09")]
     KardzhaliProvince,
-    #[serde(rename = "10")]
+    #[strum(serialize = "10")]
     KyustendilProvince,
-    #[serde(rename = "11")]
+    #[strum(serialize = "11")]
     LovechProvince,
-    #[serde(rename = "12")]
+    #[strum(serialize = "12")]
     MontanaProvince,
-    #[serde(rename = "13")]
+    #[strum(serialize = "13")]
     PazardzhikProvince,
-    #[serde(rename = "14")]
+    #[strum(serialize = "14")]
     PernikProvince,
-    #[serde(rename = "15")]
+    #[strum(serialize = "15")]
     PlevenProvince,
-    #[serde(rename = "16")]
+    #[strum(serialize = "16")]
     PlovdivProvince,
-    #[serde(rename = "17")]
+    #[strum(serialize = "17")]
     RazgradProvince,
-    #[serde(rename = "18")]
+    #[strum(serialize = "18")]
     RuseProvince,
-    #[serde(rename = "27")]
+    #[strum(serialize = "27")]
     Shumen,
-    #[serde(rename = "19")]
+    #[strum(serialize = "19")]
     SilistraProvince,
-    #[serde(rename = "20")]
+    #[strum(serialize = "20")]
     SlivenProvince,
-    #[serde(rename = "21")]
+    #[strum(serialize = "21")]
     SmolyanProvince,
-    #[serde(rename = "22")]
+    #[strum(serialize = "22")]
     SofiaCityProvince,
-    #[serde(rename = "23")]
+    #[strum(serialize = "23")]
     SofiaProvince,
-    #[serde(rename = "24")]
+    #[strum(serialize = "24")]
     StaraZagoraProvince,
-    #[serde(rename = "25")]
+    #[strum(serialize = "25")]
     TargovishteProvince,
-    #[serde(rename = "03")]
+    #[strum(serialize = "03")]
     VarnaProvince,
-    #[serde(rename = "04")]
+    #[strum(serialize = "04")]
     VelikoTarnovoProvince,
-    #[serde(rename = "05")]
+    #[strum(serialize = "05")]
     VidinProvince,
-    #[serde(rename = "06")]
+    #[strum(serialize = "06")]
     VratsaProvince,
-    #[serde(rename = "28")]
+    #[strum(serialize = "28")]
     YambolProvince,
 }
 
@@ -2612,45 +2612,45 @@ pub enum BulgariaStatesAbbreviation {
     Debug, Clone, PartialEq, Eq, Serialize, Deserialize, strum::Display, strum::EnumString,
 )]
 pub enum CroatiaStatesAbbreviation {
-    #[serde(rename = "07")]
+    #[strum(serialize = "07")]
     BjelovarBilogoraCounty,
-    #[serde(rename = "12")]
+    #[strum(serialize = "12")]
     BrodPosavinaCounty,
-    #[serde(rename = "19")]
+    #[strum(serialize = "19")]
     DubrovnikNeretvaCounty,
-    #[serde(rename = "18")]
+    #[strum(serialize = "18")]
     IstriaCounty,
-    #[serde(rename = "06")]
+    #[strum(serialize = "06")]
     KoprivnicaKrizevciCounty,
-    #[serde(rename = "02")]
+    #[strum(serialize = "02")]
     KrapinaZagorjeCounty,
-    #[serde(rename = "09")]
+    #[strum(serialize = "09")]
     LikaSenjCounty,
-    #[serde(rename = "20")]
+    #[strum(serialize = "20")]
     MedimurjeCounty,
-    #[serde(rename = "14")]
+    #[strum(serialize = "14")]
     OsijekBaranjaCounty,
-    #[serde(rename = "11")]
+    #[strum(serialize = "11")]
     PozegaSlavoniaCounty,
-    #[serde(rename = "08")]
+    #[strum(serialize = "08")]
     PrimorjeGorskiKotarCounty,
-    #[serde(rename = "03")]
+    #[strum(serialize = "03")]
     SisakMoslavinaCounty,
-    #[serde(rename = "17")]
+    #[strum(serialize = "17")]
     SplitDalmatiaCounty,
-    #[serde(rename = "05")]
+    #[strum(serialize = "05")]
     VarazdinCounty,
-    #[serde(rename = "10")]
+    #[strum(serialize = "10")]
     ViroviticaPodravinaCounty,
-    #[serde(rename = "16")]
+    #[strum(serialize = "16")]
     VukovarSyrmiaCounty,
-    #[serde(rename = "13")]
+    #[strum(serialize = "13")]
     ZadarCounty,
-    #[serde(rename = "21")]
+    #[strum(serialize = "21")]
     Zagreb,
-    #[serde(rename = "01")]
+    #[strum(serialize = "01")]
     ZagrebCounty,
-    #[serde(rename = "15")]
+    #[strum(serialize = "15")]
     SibenikKninCounty,
 }
 
@@ -2658,219 +2658,219 @@ pub enum CroatiaStatesAbbreviation {
     Debug, Clone, PartialEq, Eq, Serialize, Deserialize, strum::Display, strum::EnumString,
 )]
 pub enum CzechRepublicStatesAbbreviation {
-    #[serde(rename = "201")]
+    #[strum(serialize = "201")]
     BenesovDistrict,
-    #[serde(rename = "202")]
+    #[strum(serialize = "202")]
     BerounDistrict,
-    #[serde(rename = "641")]
+    #[strum(serialize = "641")]
     BlanskoDistrict,
-    #[serde(rename = "642")]
+    #[strum(serialize = "642")]
     BrnoCityDistrict,
-    #[serde(rename = "643")]
+    #[strum(serialize = "643")]
     BrnoCountryDistrict,
-    #[serde(rename = "801")]
+    #[strum(serialize = "801")]
     BruntalDistrict,
-    #[serde(rename = "644")]
+    #[strum(serialize = "644")]
     BreclavDistrict,
-    #[serde(rename = "20")]
+    #[strum(serialize = "20")]
     CentralBohemianRegion,
-    #[serde(rename = "411")]
+    #[strum(serialize = "411")]
     ChebDistrict,
-    #[serde(rename = "422")]
+    #[strum(serialize = "422")]
     ChomutovDistrict,
-    #[serde(rename = "531")]
+    #[strum(serialize = "531")]
     ChrudimDistrict,
-    #[serde(rename = "321")]
+    #[strum(serialize = "321")]
     DomazliceDistrict,
-    #[serde(rename = "421")]
+    #[strum(serialize = "421")]
     DecinDistrict,
-    #[serde(rename = "802")]
+    #[strum(serialize = "802")]
     FrydekMistekDistrict,
-    #[serde(rename = "631")]
+    #[strum(serialize = "631")]
     HavlickuvBrodDistrict,
-    #[serde(rename = "645")]
+    #[strum(serialize = "645")]
     HodoninDistrict,
-    #[serde(rename = "120")]
+    #[strum(serialize = "120")]
     HorniPocernice,
-    #[serde(rename = "521")]
+    #[strum(serialize = "521")]
     HradecKraloveDistrict,
-    #[serde(rename = "52")]
+    #[strum(serialize = "52")]
     HradecKraloveRegion,
-    #[serde(rename = "512")]
+    #[strum(serialize = "512")]
     JablonecNadNisouDistrict,
-    #[serde(rename = "711")]
+    #[strum(serialize = "711")]
     JesenikDistrict,
-    #[serde(rename = "632")]
+    #[strum(serialize = "632")]
     JihlavaDistrict,
-    #[serde(rename = "313")]
+    #[strum(serialize = "313")]
     JindrichuvHradecDistrict,
-    #[serde(rename = "522")]
+    #[strum(serialize = "522")]
     JicinDistrict,
-    #[serde(rename = "412")]
+    #[strum(serialize = "412")]
     KarlovyVaryDistrict,
-    #[serde(rename = "41")]
+    #[strum(serialize = "41")]
     KarlovyVaryRegion,
-    #[serde(rename = "803")]
+    #[strum(serialize = "803")]
     KarvinaDistrict,
-    #[serde(rename = "203")]
+    #[strum(serialize = "203")]
     KladnoDistrict,
-    #[serde(rename = "322")]
+    #[strum(serialize = "322")]
     KlatovyDistrict,
-    #[serde(rename = "204")]
+    #[strum(serialize = "204")]
     KolinDistrict,
-    #[serde(rename = "721")]
+    #[strum(serialize = "721")]
     KromerizDistrict,
-    #[serde(rename = "513")]
+    #[strum(serialize = "513")]
     LiberecDistrict,
-    #[serde(rename = "51")]
+    #[strum(serialize = "51")]
     LiberecRegion,
-    #[serde(rename = "423")]
+    #[strum(serialize = "423")]
     LitomericeDistrict,
-    #[serde(rename = "424")]
+    #[strum(serialize = "424")]
     LounyDistrict,
-    #[serde(rename = "207")]
+    #[strum(serialize = "207")]
     MladaBoleslavDistrict,
-    #[serde(rename = "80")]
+    #[strum(serialize = "80")]
     MoravianSilesianRegion,
-    #[serde(rename = "425")]
+    #[strum(serialize = "425")]
     MostDistrict,
-    #[serde(rename = "206")]
+    #[strum(serialize = "206")]
     MelnikDistrict,
-    #[serde(rename = "804")]
+    #[strum(serialize = "804")]
     NovyJicinDistrict,
-    #[serde(rename = "208")]
+    #[strum(serialize = "208")]
     NymburkDistrict,
-    #[serde(rename = "523")]
+    #[strum(serialize = "523")]
     NachodDistrict,
-    #[serde(rename = "712")]
+    #[strum(serialize = "712")]
     OlomoucDistrict,
-    #[serde(rename = "71")]
+    #[strum(serialize = "71")]
     OlomoucRegion,
-    #[serde(rename = "805")]
+    #[strum(serialize = "805")]
     OpavaDistrict,
-    #[serde(rename = "806")]
+    #[strum(serialize = "806")]
     OstravaCityDistrict,
-    #[serde(rename = "532")]
+    #[strum(serialize = "532")]
     PardubiceDistrict,
-    #[serde(rename = "53")]
+    #[strum(serialize = "53")]
     PardubiceRegion,
-    #[serde(rename = "633")]
+    #[strum(serialize = "633")]
     PelhrimovDistrict,
-    #[serde(rename = "32")]
+    #[strum(serialize = "32")]
     PlzenRegion,
-    #[serde(rename = "323")]
+    #[strum(serialize = "323")]
     PlzenCityDistrict,
-    #[serde(rename = "325")]
+    #[strum(serialize = "325")]
     PlzenNorthDistrict,
-    #[serde(rename = "324")]
+    #[strum(serialize = "324")]
     PlzenSouthDistrict,
-    #[serde(rename = "315")]
+    #[strum(serialize = "315")]
     PrachaticeDistrict,
-    #[serde(rename = "10")]
+    #[strum(serialize = "10")]
     Prague,
-    #[serde(rename = "101")]
+    #[strum(serialize = "101")]
     Prague1,
-    #[serde(rename = "110")]
+    #[strum(serialize = "110")]
     Prague10,
-    #[serde(rename = "111")]
+    #[strum(serialize = "111")]
     Prague11,
-    #[serde(rename = "112")]
+    #[strum(serialize = "112")]
     Prague12,
-    #[serde(rename = "113")]
+    #[strum(serialize = "113")]
     Prague13,
-    #[serde(rename = "114")]
+    #[strum(serialize = "114")]
     Prague14,
-    #[serde(rename = "115")]
+    #[strum(serialize = "115")]
     Prague15,
-    #[serde(rename = "116")]
+    #[strum(serialize = "116")]
     Prague16,
-    #[serde(rename = "102")]
+    #[strum(serialize = "102")]
     Prague2,
-    #[serde(rename = "121")]
+    #[strum(serialize = "121")]
     Prague21,
-    #[serde(rename = "103")]
+    #[strum(serialize = "103")]
     Prague3,
-    #[serde(rename = "104")]
+    #[strum(serialize = "104")]
     Prague4,
-    #[serde(rename = "105")]
+    #[strum(serialize = "105")]
     Prague5,
-    #[serde(rename = "106")]
+    #[strum(serialize = "106")]
     Prague6,
-    #[serde(rename = "107")]
+    #[strum(serialize = "107")]
     Prague7,
-    #[serde(rename = "108")]
+    #[strum(serialize = "108")]
     Prague8,
-    #[serde(rename = "109")]
+    #[strum(serialize = "109")]
     Prague9,
-    #[serde(rename = "209")]
+    #[strum(serialize = "209")]
     PragueEastDistrict,
-    #[serde(rename = "20A")]
+    #[strum(serialize = "20A")]
     PragueWestDistrict,
-    #[serde(rename = "713")]
+    #[strum(serialize = "713")]
     ProstejovDistrict,
-    #[serde(rename = "314")]
+    #[strum(serialize = "314")]
     PisekDistrict,
-    #[serde(rename = "714")]
+    #[strum(serialize = "714")]
     PrerovDistrict,
-    #[serde(rename = "20B")]
+    #[strum(serialize = "20B")]
     PribramDistrict,
-    #[serde(rename = "20C")]
+    #[strum(serialize = "20C")]
     RakovnikDistrict,
-    #[serde(rename = "326")]
+    #[strum(serialize = "326")]
     RokycanyDistrict,
-    #[serde(rename = "524")]
+    #[strum(serialize = "524")]
     RychnovNadKneznouDistrict,
-    #[serde(rename = "514")]
+    #[strum(serialize = "514")]
     SemilyDistrict,
-    #[serde(rename = "413")]
+    #[strum(serialize = "413")]
     SokolovDistrict,
-    #[serde(rename = "31")]
+    #[strum(serialize = "31")]
     SouthBohemianRegion,
-    #[serde(rename = "64")]
+    #[strum(serialize = "64")]
     SouthMoravianRegion,
-    #[serde(rename = "316")]
+    #[strum(serialize = "316")]
     StrakoniceDistrict,
-    #[serde(rename = "533")]
+    #[strum(serialize = "533")]
     SvitavyDistrict,
-    #[serde(rename = "327")]
+    #[strum(serialize = "327")]
     TachovDistrict,
-    #[serde(rename = "426")]
+    #[strum(serialize = "426")]
     TepliceDistrict,
-    #[serde(rename = "525")]
+    #[strum(serialize = "525")]
     TrutnovDistrict,
-    #[serde(rename = "317")]
+    #[strum(serialize = "317")]
     TaborDistrict,
-    #[serde(rename = "634")]
+    #[strum(serialize = "634")]
     TrebicDistrict,
-    #[serde(rename = "722")]
+    #[strum(serialize = "722")]
     UherskeHradisteDistrict,
-    #[serde(rename = "723")]
+    #[strum(serialize = "723")]
     VsetinDistrict,
-    #[serde(rename = "63")]
+    #[strum(serialize = "63")]
     VysocinaRegion,
-    #[serde(rename = "646")]
+    #[strum(serialize = "646")]
     VyskovDistrict,
-    #[serde(rename = "724")]
+    #[strum(serialize = "724")]
     ZlinDistrict,
-    #[serde(rename = "72")]
+    #[strum(serialize = "72")]
     ZlinRegion,
-    #[serde(rename = "647")]
+    #[strum(serialize = "647")]
     ZnojmoDistrict,
-    #[serde(rename = "427")]
+    #[strum(serialize = "427")]
     UstiNadLabemDistrict,
-    #[serde(rename = "42")]
+    #[strum(serialize = "42")]
     UstiNadLabemRegion,
-    #[serde(rename = "534")]
+    #[strum(serialize = "534")]
     UstiNadOrliciDistrict,
-    #[serde(rename = "511")]
+    #[strum(serialize = "511")]
     CeskaLipaDistrict,
-    #[serde(rename = "311")]
+    #[strum(serialize = "311")]
     CeskeBudejoviceDistrict,
-    #[serde(rename = "312")]
+    #[strum(serialize = "312")]
     CeskyKrumlovDistrict,
-    #[serde(rename = "715")]
+    #[strum(serialize = "715")]
     SumperkDistrict,
-    #[serde(rename = "635")]
+    #[strum(serialize = "635")]
     ZdarNadSazavouDistrict,
 }
 
@@ -2878,15 +2878,15 @@ pub enum CzechRepublicStatesAbbreviation {
     Debug, Clone, PartialEq, Eq, Serialize, Deserialize, strum::Display, strum::EnumString,
 )]
 pub enum DenmarkStatesAbbreviation {
-    #[serde(rename = "84")]
+    #[strum(serialize = "84")]
     CapitalRegionOfDenmark,
-    #[serde(rename = "82")]
+    #[strum(serialize = "82")]
     CentralDenmarkRegion,
-    #[serde(rename = "81")]
+    #[strum(serialize = "81")]
     NorthDenmarkRegion,
-    #[serde(rename = "85")]
+    #[strum(serialize = "85")]
     RegionZealand,
-    #[serde(rename = "83")]
+    #[strum(serialize = "83")]
     RegionOfSouthernDenmark,
 }
 
@@ -2894,47 +2894,47 @@ pub enum DenmarkStatesAbbreviation {
     Debug, Clone, PartialEq, Eq, Serialize, Deserialize, strum::Display, strum::EnumString,
 )]
 pub enum FinlandStatesAbbreviation {
-    #[serde(rename = "08")]
+    #[strum(serialize = "08")]
     CentralFinland,
-    #[serde(rename = "07")]
+    #[strum(serialize = "07")]
     CentralOstrobothnia,
-    #[serde(rename = "IS")]
+    #[strum(serialize = "IS")]
     EasternFinlandProvince,
-    #[serde(rename = "19")]
+    #[strum(serialize = "19")]
     FinlandProper,
-    #[serde(rename = "05")]
+    #[strum(serialize = "05")]
     Kainuu,
-    #[serde(rename = "09")]
+    #[strum(serialize = "09")]
     Kymenlaakso,
-    #[serde(rename = "LL")]
+    #[strum(serialize = "LL")]
     Lapland,
-    #[serde(rename = "13")]
+    #[strum(serialize = "13")]
     NorthKarelia,
-    #[serde(rename = "14")]
+    #[strum(serialize = "14")]
     NorthernOstrobothnia,
-    #[serde(rename = "15")]
+    #[strum(serialize = "15")]
     NorthernSavonia,
-    #[serde(rename = "12")]
+    #[strum(serialize = "12")]
     Ostrobothnia,
-    #[serde(rename = "OL")]
+    #[strum(serialize = "OL")]
     OuluProvince,
-    #[serde(rename = "11")]
+    #[strum(serialize = "11")]
     Pirkanmaa,
-    #[serde(rename = "16")]
+    #[strum(serialize = "16")]
     PaijanneTavastia,
-    #[serde(rename = "17")]
+    #[strum(serialize = "17")]
     Satakunta,
-    #[serde(rename = "02")]
+    #[strum(serialize = "02")]
     SouthKarelia,
-    #[serde(rename = "03")]
+    #[strum(serialize = "03")]
     SouthernOstrobothnia,
-    #[serde(rename = "04")]
+    #[strum(serialize = "04")]
     SouthernSavonia,
-    #[serde(rename = "06")]
+    #[strum(serialize = "06")]
     TavastiaProper,
-    #[serde(rename = "18")]
+    #[strum(serialize = "18")]
     Uusimaa,
-    #[serde(rename = "01")]
+    #[strum(serialize = "01")]
     AlandIslands,
 }
 
@@ -2942,89 +2942,89 @@ pub enum FinlandStatesAbbreviation {
     Debug, Clone, PartialEq, Eq, Serialize, Deserialize, strum::Display, strum::EnumString,
 )]
 pub enum FranceStatesAbbreviation {
-    #[serde(rename = "WF-AL")]
+    #[strum(serialize = "WF-AL")]
     Alo,
-    #[serde(rename = "A")]
+    #[strum(serialize = "A")]
     Alsace,
-    #[serde(rename = "B")]
+    #[strum(serialize = "B")]
     Aquitaine,
-    #[serde(rename = "C")]
+    #[strum(serialize = "C")]
     Auvergne,
-    #[serde(rename = "ARA")]
+    #[strum(serialize = "ARA")]
     AuvergneRhoneAlpes,
-    #[serde(rename = "BFC")]
+    #[strum(serialize = "BFC")]
     BourgogneFrancheComte,
-    #[serde(rename = "BRE")]
+    #[strum(serialize = "BRE")]
     Brittany,
-    #[serde(rename = "D")]
+    #[strum(serialize = "D")]
     Burgundy,
-    #[serde(rename = "CVL")]
+    #[strum(serialize = "CVL")]
     CentreValDeLoire,
-    #[serde(rename = "G")]
+    #[strum(serialize = "G")]
     ChampagneArdenne,
-    #[serde(rename = "COR")]
+    #[strum(serialize = "COR")]
     Corsica,
-    #[serde(rename = "I")]
+    #[strum(serialize = "I")]
     FrancheComte,
-    #[serde(rename = "GF")]
+    #[strum(serialize = "GF")]
     FrenchGuiana,
-    #[serde(rename = "PF")]
+    #[strum(serialize = "PF")]
     FrenchPolynesia,
-    #[serde(rename = "GES")]
+    #[strum(serialize = "GES")]
     GrandEst,
-    #[serde(rename = "GP")]
+    #[strum(serialize = "GP")]
     Guadeloupe,
-    #[serde(rename = "HDF")]
+    #[strum(serialize = "HDF")]
     HautsDeFrance,
-    #[serde(rename = "K")]
+    #[strum(serialize = "K")]
     LanguedocRoussillon,
-    #[serde(rename = "L")]
+    #[strum(serialize = "L")]
     Limousin,
-    #[serde(rename = "M")]
+    #[strum(serialize = "M")]
     Lorraine,
-    #[serde(rename = "P")]
+    #[strum(serialize = "P")]
     LowerNormandy,
-    #[serde(rename = "MQ")]
+    #[strum(serialize = "MQ")]
     Martinique,
-    #[serde(rename = "YT")]
+    #[strum(serialize = "YT")]
     Mayotte,
-    #[serde(rename = "O")]
+    #[strum(serialize = "O")]
     NordPasDeCalais,
-    #[serde(rename = "NOR")]
+    #[strum(serialize = "NOR")]
     Normandy,
-    #[serde(rename = "NAQ")]
+    #[strum(serialize = "NAQ")]
     NouvelleAquitaine,
-    #[serde(rename = "OCC")]
+    #[strum(serialize = "OCC")]
     Occitania,
-    #[serde(rename = "75")]
+    #[strum(serialize = "75")]
     Paris,
-    #[serde(rename = "PDL")]
+    #[strum(serialize = "PDL")]
     PaysDeLaLoire,
-    #[serde(rename = "S")]
+    #[strum(serialize = "S")]
     Picardy,
-    #[serde(rename = "T")]
+    #[strum(serialize = "T")]
     PoitouCharentes,
-    #[serde(rename = "PAC")]
+    #[strum(serialize = "PAC")]
     ProvenceAlpesCoteDAzur,
-    #[serde(rename = "V")]
+    #[strum(serialize = "V")]
     RhoneAlpes,
-    #[serde(rename = "RE")]
+    #[strum(serialize = "RE")]
     Reunion,
-    #[serde(rename = "BL")]
+    #[strum(serialize = "BL")]
     SaintBarthelemy,
-    #[serde(rename = "MF")]
+    #[strum(serialize = "MF")]
     SaintMartin,
-    #[serde(rename = "PM")]
+    #[strum(serialize = "PM")]
     SaintPierreAndMiquelon,
-    #[serde(rename = "WF-SG")]
+    #[strum(serialize = "WF-SG")]
     Sigave,
-    #[serde(rename = "Q")]
+    #[strum(serialize = "Q")]
     UpperNormandy,
-    #[serde(rename = "WF-UV")]
+    #[strum(serialize = "WF-UV")]
     Uvea,
-    #[serde(rename = "WF")]
+    #[strum(serialize = "WF")]
     WallisAndFutuna,
-    #[serde(rename = "IDF")]
+    #[strum(serialize = "IDF")]
     IleDeFrance,
 }
 
@@ -3032,37 +3032,37 @@ pub enum FranceStatesAbbreviation {
     Debug, Clone, PartialEq, Eq, Serialize, Deserialize, strum::Display, strum::EnumString,
 )]
 pub enum GermanyStatesAbbreviation {
-    #[serde(rename = "BW")]
+    #[strum(serialize = "BW")]
     BadenWurttemberg,
-    #[serde(rename = "BY")]
+    #[strum(serialize = "BY")]
     Bavaria,
-    #[serde(rename = "BE")]
+    #[strum(serialize = "BE")]
     Berlin,
-    #[serde(rename = "BB")]
+    #[strum(serialize = "BB")]
     Brandenburg,
-    #[serde(rename = "HB")]
+    #[strum(serialize = "HB")]
     Bremen,
-    #[serde(rename = "HH")]
+    #[strum(serialize = "HH")]
     Hamburg,
-    #[serde(rename = "HE")]
+    #[strum(serialize = "HE")]
     Hesse,
-    #[serde(rename = "NI")]
+    #[strum(serialize = "NI")]
     LowerSaxony,
-    #[serde(rename = "MV")]
+    #[strum(serialize = "MV")]
     MecklenburgVorpommern,
-    #[serde(rename = "NW")]
+    #[strum(serialize = "NW")]
     NorthRhineWestphalia,
-    #[serde(rename = "RP")]
+    #[strum(serialize = "RP")]
     RhinelandPalatinate,
-    #[serde(rename = "SL")]
+    #[strum(serialize = "SL")]
     Saarland,
-    #[serde(rename = "SN")]
+    #[strum(serialize = "SN")]
     Saxony,
-    #[serde(rename = "ST")]
+    #[strum(serialize = "ST")]
     SaxonyAnhalt,
-    #[serde(rename = "SH")]
+    #[strum(serialize = "SH")]
     SchleswigHolstein,
-    #[serde(rename = "TH")]
+    #[strum(serialize = "TH")]
     Thuringia,
 }
 
@@ -3070,81 +3070,81 @@ pub enum GermanyStatesAbbreviation {
     Debug, Clone, PartialEq, Eq, Serialize, Deserialize, strum::Display, strum::EnumString,
 )]
 pub enum GreeceStatesAbbreviation {
-    #[serde(rename = "13")]
+    #[strum(serialize = "13")]
     AchaeaRegionalUnit,
-    #[serde(rename = "01")]
+    #[strum(serialize = "01")]
     AetoliaAcarnaniaRegionalUnit,
-    #[serde(rename = "12")]
+    #[strum(serialize = "12")]
     ArcadiaPrefecture,
-    #[serde(rename = "11")]
+    #[strum(serialize = "11")]
     ArgolisRegionalUnit,
-    #[serde(rename = "I")]
+    #[strum(serialize = "I")]
     AtticaRegion,
-    #[serde(rename = "03")]
+    #[strum(serialize = "03")]
     BoeotiaRegionalUnit,
-    #[serde(rename = "H")]
+    #[strum(serialize = "H")]
     CentralGreeceRegion,
-    #[serde(rename = "B")]
+    #[strum(serialize = "B")]
     CentralMacedonia,
-    #[serde(rename = "94")]
+    #[strum(serialize = "94")]
     ChaniaRegionalUnit,
-    #[serde(rename = "22")]
+    #[strum(serialize = "22")]
     CorfuPrefecture,
-    #[serde(rename = "15")]
+    #[strum(serialize = "15")]
     CorinthiaRegionalUnit,
-    #[serde(rename = "M")]
+    #[strum(serialize = "M")]
     CreteRegion,
-    #[serde(rename = "52")]
+    #[strum(serialize = "52")]
     DramaRegionalUnit,
-    #[serde(rename = "A2")]
+    #[strum(serialize = "A2")]
     EastAtticaRegionalUnit,
-    #[serde(rename = "A")]
+    #[strum(serialize = "A")]
     EastMacedoniaAndThrace,
-    #[serde(rename = "D")]
+    #[strum(serialize = "D")]
     EpirusRegion,
-    #[serde(rename = "04")]
+    #[strum(serialize = "04")]
     Euboea,
-    #[serde(rename = "51")]
+    #[strum(serialize = "51")]
     GrevenaPrefecture,
-    #[serde(rename = "53")]
+    #[strum(serialize = "53")]
     ImathiaRegionalUnit,
-    #[serde(rename = "33")]
+    #[strum(serialize = "33")]
     IoanninaRegionalUnit,
-    #[serde(rename = "F")]
+    #[strum(serialize = "F")]
     IonianIslandsRegion,
-    #[serde(rename = "41")]
+    #[strum(serialize = "41")]
     KarditsaRegionalUnit,
-    #[serde(rename = "56")]
+    #[strum(serialize = "56")]
     KastoriaRegionalUnit,
-    #[serde(rename = "23")]
+    #[strum(serialize = "23")]
     KefaloniaPrefecture,
-    #[serde(rename = "57")]
+    #[strum(serialize = "57")]
     KilkisRegionalUnit,
-    #[serde(rename = "58")]
+    #[strum(serialize = "58")]
     KozaniPrefecture,
-    #[serde(rename = "16")]
+    #[strum(serialize = "16")]
     Laconia,
-    #[serde(rename = "42")]
+    #[strum(serialize = "42")]
     LarissaPrefecture,
-    #[serde(rename = "24")]
+    #[strum(serialize = "24")]
     LefkadaRegionalUnit,
-    #[serde(rename = "59")]
+    #[strum(serialize = "59")]
     PellaRegionalUnit,
-    #[serde(rename = "J")]
+    #[strum(serialize = "J")]
     PeloponneseRegion,
-    #[serde(rename = "06")]
+    #[strum(serialize = "06")]
     PhthiotisPrefecture,
-    #[serde(rename = "34")]
+    #[strum(serialize = "34")]
     PrevezaPrefecture,
-    #[serde(rename = "62")]
+    #[strum(serialize = "62")]
     SerresPrefecture,
-    #[serde(rename = "L")]
+    #[strum(serialize = "L")]
     SouthAegean,
-    #[serde(rename = "54")]
+    #[strum(serialize = "54")]
     ThessalonikiRegionalUnit,
-    #[serde(rename = "G")]
+    #[strum(serialize = "G")]
     WestGreeceRegion,
-    #[serde(rename = "C")]
+    #[strum(serialize = "C")]
     WestMacedoniaRegion,
 }
 
@@ -3152,89 +3152,89 @@ pub enum GreeceStatesAbbreviation {
     Debug, Clone, PartialEq, Eq, Serialize, Deserialize, strum::Display, strum::EnumString,
 )]
 pub enum HungaryStatesAbbreviation {
-    #[serde(rename = "BA")]
+    #[strum(serialize = "BA")]
     BaranyaCounty,
-    #[serde(rename = "BZ")]
+    #[strum(serialize = "BZ")]
     BorsodAbaujZemplenCounty,
-    #[serde(rename = "BU")]
+    #[strum(serialize = "BU")]
     Budapest,
-    #[serde(rename = "BK")]
+    #[strum(serialize = "BK")]
     BacsKiskunCounty,
-    #[serde(rename = "BE")]
+    #[strum(serialize = "BE")]
     BekesCounty,
-    #[serde(rename = "BC")]
+    #[strum(serialize = "BC")]
     Bekescsaba,
-    #[serde(rename = "CS")]
+    #[strum(serialize = "CS")]
     CsongradCounty,
-    #[serde(rename = "DE")]
+    #[strum(serialize = "DE")]
     Debrecen,
-    #[serde(rename = "DU")]
+    #[strum(serialize = "DU")]
     Dunaujvaros,
-    #[serde(rename = "EG")]
+    #[strum(serialize = "EG")]
     Eger,
-    #[serde(rename = "FE")]
+    #[strum(serialize = "FE")]
     FejerCounty,
-    #[serde(rename = "GY")]
+    #[strum(serialize = "GY")]
     Gyor,
-    #[serde(rename = "GS")]
+    #[strum(serialize = "GS")]
     GyorMosonSopronCounty,
-    #[serde(rename = "HB")]
+    #[strum(serialize = "HB")]
     HajduBiharCounty,
-    #[serde(rename = "HE")]
+    #[strum(serialize = "HE")]
     HevesCounty,
-    #[serde(rename = "HV")]
+    #[strum(serialize = "HV")]
     Hodmezovasarhely,
-    #[serde(rename = "JN")]
+    #[strum(serialize = "JN")]
     JaszNagykunSzolnokCounty,
-    #[serde(rename = "KV")]
+    #[strum(serialize = "KV")]
     Kaposvar,
-    #[serde(rename = "KM")]
+    #[strum(serialize = "KM")]
     Kecskemet,
-    #[serde(rename = "MI")]
+    #[strum(serialize = "MI")]
     Miskolc,
-    #[serde(rename = "NK")]
+    #[strum(serialize = "NK")]
     Nagykanizsa,
-    #[serde(rename = "NY")]
+    #[strum(serialize = "NY")]
     Nyiregyhaza,
-    #[serde(rename = "NO")]
+    #[strum(serialize = "NO")]
     NogradCounty,
-    #[serde(rename = "PE")]
+    #[strum(serialize = "PE")]
     PestCounty,
-    #[serde(rename = "PS")]
+    #[strum(serialize = "PS")]
     Pecs,
-    #[serde(rename = "ST")]
+    #[strum(serialize = "ST")]
     Salgotarjan,
-    #[serde(rename = "SO")]
+    #[strum(serialize = "SO")]
     SomogyCounty,
-    #[serde(rename = "SN")]
+    #[strum(serialize = "SN")]
     Sopron,
-    #[serde(rename = "SZ")]
+    #[strum(serialize = "SZ")]
     SzabolcsSzatmarBeregCounty,
-    #[serde(rename = "SD")]
+    #[strum(serialize = "SD")]
     Szeged,
-    #[serde(rename = "SS")]
+    #[strum(serialize = "SS")]
     Szekszard,
-    #[serde(rename = "SK")]
+    #[strum(serialize = "SK")]
     Szolnok,
-    #[serde(rename = "SH")]
+    #[strum(serialize = "SH")]
     Szombathely,
-    #[serde(rename = "SF")]
+    #[strum(serialize = "SF")]
     Szekesfehervar,
-    #[serde(rename = "TB")]
+    #[strum(serialize = "TB")]
     Tatabanya,
-    #[serde(rename = "TO")]
+    #[strum(serialize = "TO")]
     TolnaCounty,
-    #[serde(rename = "VA")]
+    #[strum(serialize = "VA")]
     VasCounty,
-    #[serde(rename = "VM")]
+    #[strum(serialize = "VM")]
     Veszprem,
-    #[serde(rename = "VE")]
+    #[strum(serialize = "VE")]
     VeszpremCounty,
-    #[serde(rename = "ZA")]
+    #[strum(serialize = "ZA")]
     ZalaCounty,
-    #[serde(rename = "ZE")]
+    #[strum(serialize = "ZE")]
     Zalaegerszeg,
-    #[serde(rename = "ER")]
+    #[strum(serialize = "ER")]
     Erd,
 }
 
@@ -3242,21 +3242,21 @@ pub enum HungaryStatesAbbreviation {
     Debug, Clone, PartialEq, Eq, Serialize, Deserialize, strum::Display, strum::EnumString,
 )]
 pub enum IcelandStatesAbbreviation {
-    #[serde(rename = "1")]
+    #[strum(serialize = "1")]
     CapitalRegion,
-    #[serde(rename = "7")]
+    #[strum(serialize = "7")]
     EasternRegion,
-    #[serde(rename = "6")]
+    #[strum(serialize = "6")]
     NortheasternRegion,
-    #[serde(rename = "5")]
+    #[strum(serialize = "5")]
     NorthwesternRegion,
-    #[serde(rename = "2")]
+    #[strum(serialize = "2")]
     SouthernPeninsulaRegion,
-    #[serde(rename = "8")]
+    #[strum(serialize = "8")]
     SouthernRegion,
-    #[serde(rename = "3")]
+    #[strum(serialize = "3")]
     WesternRegion,
-    #[serde(rename = "4")]
+    #[strum(serialize = "4")]
     Westfjords,
 }
 
@@ -3264,63 +3264,63 @@ pub enum IcelandStatesAbbreviation {
     Debug, Clone, PartialEq, Eq, Serialize, Deserialize, strum::Display, strum::EnumString,
 )]
 pub enum IrelandStatesAbbreviation {
-    #[serde(rename = "C")]
+    #[strum(serialize = "C")]
     Connacht,
-    #[serde(rename = "CW")]
+    #[strum(serialize = "CW")]
     CountyCarlow,
-    #[serde(rename = "CN")]
+    #[strum(serialize = "CN")]
     CountyCavan,
-    #[serde(rename = "CE")]
+    #[strum(serialize = "CE")]
     CountyClare,
-    #[serde(rename = "CO")]
+    #[strum(serialize = "CO")]
     CountyCork,
-    #[serde(rename = "DL")]
+    #[strum(serialize = "DL")]
     CountyDonegal,
-    #[serde(rename = "D")]
+    #[strum(serialize = "D")]
     CountyDublin,
-    #[serde(rename = "G")]
+    #[strum(serialize = "G")]
     CountyGalway,
-    #[serde(rename = "KY")]
+    #[strum(serialize = "KY")]
     CountyKerry,
-    #[serde(rename = "KE")]
+    #[strum(serialize = "KE")]
     CountyKildare,
-    #[serde(rename = "KK")]
+    #[strum(serialize = "KK")]
     CountyKilkenny,
-    #[serde(rename = "LS")]
+    #[strum(serialize = "LS")]
     CountyLaois,
-    #[serde(rename = "LK")]
+    #[strum(serialize = "LK")]
     CountyLimerick,
-    #[serde(rename = "LD")]
+    #[strum(serialize = "LD")]
     CountyLongford,
-    #[serde(rename = "LH")]
+    #[strum(serialize = "LH")]
     CountyLouth,
-    #[serde(rename = "MO")]
+    #[strum(serialize = "MO")]
     CountyMayo,
-    #[serde(rename = "MH")]
+    #[strum(serialize = "MH")]
     CountyMeath,
-    #[serde(rename = "MN")]
+    #[strum(serialize = "MN")]
     CountyMonaghan,
-    #[serde(rename = "OY")]
+    #[strum(serialize = "OY")]
     CountyOffaly,
-    #[serde(rename = "RN")]
+    #[strum(serialize = "RN")]
     CountyRoscommon,
-    #[serde(rename = "SO")]
+    #[strum(serialize = "SO")]
     CountySligo,
-    #[serde(rename = "TA")]
+    #[strum(serialize = "TA")]
     CountyTipperary,
-    #[serde(rename = "WD")]
+    #[strum(serialize = "WD")]
     CountyWaterford,
-    #[serde(rename = "WH")]
+    #[strum(serialize = "WH")]
     CountyWestmeath,
-    #[serde(rename = "WX")]
+    #[strum(serialize = "WX")]
     CountyWexford,
-    #[serde(rename = "WW")]
+    #[strum(serialize = "WW")]
     CountyWicklow,
-    #[serde(rename = "L")]
+    #[strum(serialize = "L")]
     Leinster,
-    #[serde(rename = "M")]
+    #[strum(serialize = "M")]
     Munster,
-    #[serde(rename = "U")]
+    #[strum(serialize = "U")]
     Ulster,
 }
 
@@ -3328,203 +3328,203 @@ pub enum IrelandStatesAbbreviation {
     Debug, Clone, PartialEq, Eq, Serialize, Deserialize, strum::Display, strum::EnumString,
 )]
 pub enum LatviaStatesAbbreviation {
-    #[serde(rename = "001")]
+    #[strum(serialize = "001")]
     AglonaMunicipality,
-    #[serde(rename = "002")]
+    #[strum(serialize = "002")]
     AizkraukleMunicipality,
-    #[serde(rename = "003")]
+    #[strum(serialize = "003")]
     AizputeMunicipality,
-    #[serde(rename = "004")]
+    #[strum(serialize = "004")]
     AknīsteMunicipality,
-    #[serde(rename = "005")]
+    #[strum(serialize = "005")]
     AlojaMunicipality,
-    #[serde(rename = "006")]
+    #[strum(serialize = "006")]
     AlsungaMunicipality,
-    #[serde(rename = "007")]
+    #[strum(serialize = "007")]
     AlūksneMunicipality,
-    #[serde(rename = "008")]
+    #[strum(serialize = "008")]
     AmataMunicipality,
-    #[serde(rename = "009")]
+    #[strum(serialize = "009")]
     ApeMunicipality,
-    #[serde(rename = "010")]
+    #[strum(serialize = "010")]
     AuceMunicipality,
-    #[serde(rename = "012")]
+    #[strum(serialize = "012")]
     BabīteMunicipality,
-    #[serde(rename = "013")]
+    #[strum(serialize = "013")]
     BaldoneMunicipality,
-    #[serde(rename = "014")]
+    #[strum(serialize = "014")]
     BaltinavaMunicipality,
-    #[serde(rename = "015")]
+    #[strum(serialize = "015")]
     BalviMunicipality,
-    #[serde(rename = "016")]
+    #[strum(serialize = "016")]
     BauskaMunicipality,
-    #[serde(rename = "017")]
+    #[strum(serialize = "017")]
     BeverīnaMunicipality,
-    #[serde(rename = "018")]
+    #[strum(serialize = "018")]
     BrocēniMunicipality,
-    #[serde(rename = "019")]
+    #[strum(serialize = "019")]
     BurtniekiMunicipality,
-    #[serde(rename = "020")]
+    #[strum(serialize = "020")]
     CarnikavaMunicipality,
-    #[serde(rename = "021")]
+    #[strum(serialize = "021")]
     CesvaineMunicipality,
-    #[serde(rename = "023")]
+    #[strum(serialize = "023")]
     CiblaMunicipality,
-    #[serde(rename = "022")]
+    #[strum(serialize = "022")]
     CēsisMunicipality,
-    #[serde(rename = "024")]
+    #[strum(serialize = "024")]
     DagdaMunicipality,
-    #[serde(rename = "DGV")]
+    #[strum(serialize = "DGV")]
     Daugavpils,
-    #[serde(rename = "025")]
+    #[strum(serialize = "025")]
     DaugavpilsMunicipality,
-    #[serde(rename = "026")]
+    #[strum(serialize = "026")]
     DobeleMunicipality,
-    #[serde(rename = "027")]
+    #[strum(serialize = "027")]
     DundagaMunicipality,
-    #[serde(rename = "028")]
+    #[strum(serialize = "028")]
     DurbeMunicipality,
-    #[serde(rename = "029")]
+    #[strum(serialize = "029")]
     EngureMunicipality,
-    #[serde(rename = "031")]
+    #[strum(serialize = "031")]
     GarkalneMunicipality,
-    #[serde(rename = "032")]
+    #[strum(serialize = "032")]
     GrobiņaMunicipality,
-    #[serde(rename = "033")]
+    #[strum(serialize = "033")]
     GulbeneMunicipality,
-    #[serde(rename = "034")]
+    #[strum(serialize = "034")]
     IecavaMunicipality,
-    #[serde(rename = "035")]
+    #[strum(serialize = "035")]
     IkšķileMunicipality,
-    #[serde(rename = "036")]
+    #[strum(serialize = "036")]
     IlūksteMunicipality,
-    #[serde(rename = "037")]
+    #[strum(serialize = "037")]
     InčukalnsMunicipality,
-    #[serde(rename = "038")]
+    #[strum(serialize = "038")]
     JaunjelgavaMunicipality,
-    #[serde(rename = "039")]
+    #[strum(serialize = "039")]
     JaunpiebalgaMunicipality,
-    #[serde(rename = "040")]
+    #[strum(serialize = "040")]
     JaunpilsMunicipality,
-    #[serde(rename = "JEL")]
+    #[strum(serialize = "JEL")]
     Jelgava,
-    #[serde(rename = "041")]
+    #[strum(serialize = "041")]
     JelgavaMunicipality,
-    #[serde(rename = "JKB")]
+    #[strum(serialize = "JKB")]
     Jēkabpils,
-    #[serde(rename = "042")]
+    #[strum(serialize = "042")]
     JēkabpilsMunicipality,
-    #[serde(rename = "JUR")]
+    #[strum(serialize = "JUR")]
     Jūrmala,
-    #[serde(rename = "043")]
+    #[strum(serialize = "043")]
     KandavaMunicipality,
-    #[serde(rename = "045")]
+    #[strum(serialize = "045")]
     KocēniMunicipality,
-    #[serde(rename = "046")]
+    #[strum(serialize = "046")]
     KokneseMunicipality,
-    #[serde(rename = "048")]
+    #[strum(serialize = "048")]
     KrimuldaMunicipality,
-    #[serde(rename = "049")]
+    #[strum(serialize = "049")]
     KrustpilsMunicipality,
-    #[serde(rename = "047")]
+    #[strum(serialize = "047")]
     KrāslavaMunicipality,
-    #[serde(rename = "050")]
+    #[strum(serialize = "050")]
     KuldīgaMunicipality,
-    #[serde(rename = "044")]
+    #[strum(serialize = "044")]
     KārsavaMunicipality,
-    #[serde(rename = "053")]
+    #[strum(serialize = "053")]
     LielvārdeMunicipality,
-    #[serde(rename = "LPX")]
+    #[strum(serialize = "LPX")]
     Liepāja,
-    #[serde(rename = "054")]
+    #[strum(serialize = "054")]
     LimbažiMunicipality,
-    #[serde(rename = "057")]
+    #[strum(serialize = "057")]
     LubānaMunicipality,
-    #[serde(rename = "058")]
+    #[strum(serialize = "058")]
     LudzaMunicipality,
-    #[serde(rename = "055")]
+    #[strum(serialize = "055")]
     LīgatneMunicipality,
-    #[serde(rename = "056")]
+    #[strum(serialize = "056")]
     LīvāniMunicipality,
-    #[serde(rename = "059")]
+    #[strum(serialize = "059")]
     MadonaMunicipality,
-    #[serde(rename = "060")]
+    #[strum(serialize = "060")]
     MazsalacaMunicipality,
-    #[serde(rename = "061")]
+    #[strum(serialize = "061")]
     MālpilsMunicipality,
-    #[serde(rename = "062")]
+    #[strum(serialize = "062")]
     MārupeMunicipality,
-    #[serde(rename = "063")]
+    #[strum(serialize = "063")]
     MērsragsMunicipality,
-    #[serde(rename = "064")]
+    #[strum(serialize = "064")]
     NaukšēniMunicipality,
-    #[serde(rename = "065")]
+    #[strum(serialize = "065")]
     NeretaMunicipality,
-    #[serde(rename = "066")]
+    #[strum(serialize = "066")]
     NīcaMunicipality,
-    #[serde(rename = "067")]
+    #[strum(serialize = "067")]
     OgreMunicipality,
-    #[serde(rename = "068")]
+    #[strum(serialize = "068")]
     OlaineMunicipality,
-    #[serde(rename = "069")]
+    #[strum(serialize = "069")]
     OzolniekiMunicipality,
-    #[serde(rename = "073")]
+    #[strum(serialize = "073")]
     PreiļiMunicipality,
-    #[serde(rename = "074")]
+    #[strum(serialize = "074")]
     PriekuleMunicipality,
-    #[serde(rename = "075")]
+    #[strum(serialize = "075")]
     PriekuļiMunicipality,
-    #[serde(rename = "070")]
+    #[strum(serialize = "070")]
     PārgaujaMunicipality,
-    #[serde(rename = "071")]
+    #[strum(serialize = "071")]
     PāvilostaMunicipality,
-    #[serde(rename = "072")]
+    #[strum(serialize = "072")]
     PļaviņasMunicipality,
-    #[serde(rename = "076")]
+    #[strum(serialize = "076")]
     RaunaMunicipality,
-    #[serde(rename = "078")]
+    #[strum(serialize = "078")]
     RiebiņiMunicipality,
-    #[serde(rename = "RIX")]
+    #[strum(serialize = "RIX")]
     Riga,
-    #[serde(rename = "079")]
+    #[strum(serialize = "079")]
     RojaMunicipality,
-    #[serde(rename = "080")]
+    #[strum(serialize = "080")]
     RopažiMunicipality,
-    #[serde(rename = "081")]
+    #[strum(serialize = "081")]
     RucavaMunicipality,
-    #[serde(rename = "082")]
+    #[strum(serialize = "082")]
     RugājiMunicipality,
-    #[serde(rename = "083")]
+    #[strum(serialize = "083")]
     RundāleMunicipality,
-    #[serde(rename = "REZ")]
+    #[strum(serialize = "REZ")]
     Rēzekne,
-    #[serde(rename = "077")]
+    #[strum(serialize = "077")]
     RēzekneMunicipality,
-    #[serde(rename = "084")]
+    #[strum(serialize = "084")]
     RūjienaMunicipality,
-    #[serde(rename = "085")]
+    #[strum(serialize = "085")]
     SalaMunicipality,
-    #[serde(rename = "086")]
+    #[strum(serialize = "086")]
     SalacgrīvaMunicipality,
-    #[serde(rename = "087")]
+    #[strum(serialize = "087")]
     SalaspilsMunicipality,
-    #[serde(rename = "088")]
+    #[strum(serialize = "088")]
     SaldusMunicipality,
-    #[serde(rename = "089")]
+    #[strum(serialize = "089")]
     SaulkrastiMunicipality,
-    #[serde(rename = "091")]
+    #[strum(serialize = "091")]
     SiguldaMunicipality,
-    #[serde(rename = "093")]
+    #[strum(serialize = "093")]
     SkrundaMunicipality,
-    #[serde(rename = "092")]
+    #[strum(serialize = "092")]
     SkrīveriMunicipality,
-    #[serde(rename = "094")]
+    #[strum(serialize = "094")]
     SmilteneMunicipality,
-    #[serde(rename = "095")]
+    #[strum(serialize = "095")]
     StopiņiMunicipality,
-    #[serde(rename = "096")]
+    #[strum(serialize = "096")]
     StrenčiMunicipality,
-    #[serde(rename = "090")]
+    #[strum(serialize = "090")]
     SējaMunicipality,
 }
 
@@ -3532,87 +3532,87 @@ pub enum LatviaStatesAbbreviation {
     Debug, Clone, PartialEq, Eq, Serialize, Deserialize, strum::Display, strum::EnumString,
 )]
 pub enum ItalyStatesAbbreviation {
-    #[serde(rename = "65")]
+    #[strum(serialize = "65")]
     Abruzzo,
-    #[serde(rename = "23")]
+    #[strum(serialize = "23")]
     AostaValley,
-    #[serde(rename = "75")]
+    #[strum(serialize = "75")]
     Apulia,
-    #[serde(rename = "77")]
+    #[strum(serialize = "77")]
     Basilicata,
-    #[serde(rename = "BN")]
+    #[strum(serialize = "BN")]
     BeneventoProvince,
-    #[serde(rename = "78")]
+    #[strum(serialize = "78")]
     Calabria,
-    #[serde(rename = "72")]
+    #[strum(serialize = "72")]
     Campania,
-    #[serde(rename = "45")]
+    #[strum(serialize = "45")]
     EmiliaRomagna,
-    #[serde(rename = "36")]
+    #[strum(serialize = "36")]
     FriuliVeneziaGiulia,
-    #[serde(rename = "62")]
+    #[strum(serialize = "62")]
     Lazio,
-    #[serde(rename = "42")]
+    #[strum(serialize = "42")]
     Liguria,
-    #[serde(rename = "25")]
+    #[strum(serialize = "25")]
     Lombardy,
-    #[serde(rename = "57")]
+    #[strum(serialize = "57")]
     Marche,
-    #[serde(rename = "67")]
+    #[strum(serialize = "67")]
     Molise,
-    #[serde(rename = "21")]
+    #[strum(serialize = "21")]
     Piedmont,
-    #[serde(rename = "88")]
+    #[strum(serialize = "88")]
     Sardinia,
-    #[serde(rename = "82")]
+    #[strum(serialize = "82")]
     Sicily,
-    #[serde(rename = "32")]
+    #[strum(serialize = "32")]
     TrentinoSouthTyrol,
-    #[serde(rename = "52")]
+    #[strum(serialize = "52")]
     Tuscany,
-    #[serde(rename = "55")]
+    #[strum(serialize = "55")]
     Umbria,
-    #[serde(rename = "34")]
+    #[strum(serialize = "34")]
     Veneto,
-    #[serde(rename = "AG")]
+    #[strum(serialize = "AG")]
     Agrigento,
-    #[serde(rename = "CL")]
+    #[strum(serialize = "CL")]
     Caltanissetta,
-    #[serde(rename = "EN")]
+    #[strum(serialize = "EN")]
     Enna,
-    #[serde(rename = "RG")]
+    #[strum(serialize = "RG")]
     Ragusa,
-    #[serde(rename = "SR")]
+    #[strum(serialize = "SR")]
     Siracusa,
-    #[serde(rename = "TP")]
+    #[strum(serialize = "TP")]
     Trapani,
-    #[serde(rename = "BA")]
+    #[strum(serialize = "BA")]
     Bari,
-    #[serde(rename = "BO")]
+    #[strum(serialize = "BO")]
     Bologna,
-    #[serde(rename = "CA")]
+    #[strum(serialize = "CA")]
     Cagliari,
-    #[serde(rename = "CT")]
+    #[strum(serialize = "CT")]
     Catania,
-    #[serde(rename = "FI")]
+    #[strum(serialize = "FI")]
     Florence,
-    #[serde(rename = "GE")]
+    #[strum(serialize = "GE")]
     Genoa,
-    #[serde(rename = "ME")]
+    #[strum(serialize = "ME")]
     Messina,
-    #[serde(rename = "MI")]
+    #[strum(serialize = "MI")]
     Milan,
-    #[serde(rename = "NA")]
+    #[strum(serialize = "NA")]
     Naples,
-    #[serde(rename = "PA")]
+    #[strum(serialize = "PA")]
     Palermo,
-    #[serde(rename = "RC")]
+    #[strum(serialize = "RC")]
     ReggioCalabria,
-    #[serde(rename = "RM")]
+    #[strum(serialize = "RM")]
     Rome,
-    #[serde(rename = "TO")]
+    #[strum(serialize = "TO")]
     Turin,
-    #[serde(rename = "VE")]
+    #[strum(serialize = "VE")]
     Venice,
 }
 
@@ -3620,27 +3620,27 @@ pub enum ItalyStatesAbbreviation {
     Debug, Clone, PartialEq, Eq, Serialize, Deserialize, strum::Display, strum::EnumString,
 )]
 pub enum LiechtensteinStatesAbbreviation {
-    #[serde(rename = "01")]
+    #[strum(serialize = "01")]
     Balzers,
-    #[serde(rename = "02")]
+    #[strum(serialize = "02")]
     Eschen,
-    #[serde(rename = "03")]
+    #[strum(serialize = "03")]
     Gamprin,
-    #[serde(rename = "04")]
+    #[strum(serialize = "04")]
     Mauren,
-    #[serde(rename = "05")]
+    #[strum(serialize = "05")]
     Planken,
-    #[serde(rename = "06")]
+    #[strum(serialize = "06")]
     Ruggell,
-    #[serde(rename = "07")]
+    #[strum(serialize = "07")]
     Schaan,
-    #[serde(rename = "08")]
+    #[strum(serialize = "08")]
     Schellenberg,
-    #[serde(rename = "09")]
+    #[strum(serialize = "09")]
     Triesen,
-    #[serde(rename = "10")]
+    #[strum(serialize = "10")]
     Triesenberg,
-    #[serde(rename = "11")]
+    #[strum(serialize = "11")]
     Vaduz,
 }
 
@@ -3648,143 +3648,143 @@ pub enum LiechtensteinStatesAbbreviation {
     Debug, Clone, PartialEq, Eq, Serialize, Deserialize, strum::Display, strum::EnumString,
 )]
 pub enum LithuaniaStatesAbbreviation {
-    #[serde(rename = "01")]
+    #[strum(serialize = "01")]
     AkmeneDistrictMunicipality,
-    #[serde(rename = "02")]
+    #[strum(serialize = "02")]
     AlytusCityMunicipality,
-    #[serde(rename = "AL")]
+    #[strum(serialize = "AL")]
     AlytusCounty,
-    #[serde(rename = "03")]
+    #[strum(serialize = "03")]
     AlytusDistrictMunicipality,
-    #[serde(rename = "05")]
+    #[strum(serialize = "05")]
     BirstonasMunicipality,
-    #[serde(rename = "06")]
+    #[strum(serialize = "06")]
     BirzaiDistrictMunicipality,
-    #[serde(rename = "07")]
+    #[strum(serialize = "07")]
     DruskininkaiMunicipality,
-    #[serde(rename = "08")]
+    #[strum(serialize = "08")]
     ElektrenaiMunicipality,
-    #[serde(rename = "09")]
+    #[strum(serialize = "09")]
     IgnalinaDistrictMunicipality,
-    #[serde(rename = "10")]
+    #[strum(serialize = "10")]
     JonavaDistrictMunicipality,
-    #[serde(rename = "11")]
+    #[strum(serialize = "11")]
     JoniskisDistrictMunicipality,
-    #[serde(rename = "12")]
+    #[strum(serialize = "12")]
     JurbarkasDistrictMunicipality,
-    #[serde(rename = "13")]
+    #[strum(serialize = "13")]
     KaisiadorysDistrictMunicipality,
-    #[serde(rename = "14")]
+    #[strum(serialize = "14")]
     KalvarijaMunicipality,
-    #[serde(rename = "15")]
+    #[strum(serialize = "15")]
     KaunasCityMunicipality,
-    #[serde(rename = "KU")]
+    #[strum(serialize = "KU")]
     KaunasCounty,
-    #[serde(rename = "16")]
+    #[strum(serialize = "16")]
     KaunasDistrictMunicipality,
-    #[serde(rename = "17")]
+    #[strum(serialize = "17")]
     KazluRudaMunicipality,
-    #[serde(rename = "19")]
+    #[strum(serialize = "19")]
     KelmeDistrictMunicipality,
-    #[serde(rename = "20")]
+    #[strum(serialize = "20")]
     KlaipedaCityMunicipality,
-    #[serde(rename = "KL")]
+    #[strum(serialize = "KL")]
     KlaipedaCounty,
-    #[serde(rename = "21")]
+    #[strum(serialize = "21")]
     KlaipedaDistrictMunicipality,
-    #[serde(rename = "22")]
+    #[strum(serialize = "22")]
     KretingaDistrictMunicipality,
-    #[serde(rename = "23")]
+    #[strum(serialize = "23")]
     KupiskisDistrictMunicipality,
-    #[serde(rename = "18")]
+    #[strum(serialize = "18")]
     KedainiaiDistrictMunicipality,
-    #[serde(rename = "24")]
+    #[strum(serialize = "24")]
     LazdijaiDistrictMunicipality,
-    #[serde(rename = "MR")]
+    #[strum(serialize = "MR")]
     MarijampoleCounty,
-    #[serde(rename = "25")]
+    #[strum(serialize = "25")]
     MarijampoleMunicipality,
-    #[serde(rename = "26")]
+    #[strum(serialize = "26")]
     MazeikiaiDistrictMunicipality,
-    #[serde(rename = "27")]
+    #[strum(serialize = "27")]
     MoletaiDistrictMunicipality,
-    #[serde(rename = "28")]
+    #[strum(serialize = "28")]
     NeringaMunicipality,
-    #[serde(rename = "29")]
+    #[strum(serialize = "29")]
     PagegiaiMunicipality,
-    #[serde(rename = "30")]
+    #[strum(serialize = "30")]
     PakruojisDistrictMunicipality,
-    #[serde(rename = "31")]
+    #[strum(serialize = "31")]
     PalangaCityMunicipality,
-    #[serde(rename = "32")]
+    #[strum(serialize = "32")]
     PanevezysCityMunicipality,
-    #[serde(rename = "PN")]
+    #[strum(serialize = "PN")]
     PanevezysCounty,
-    #[serde(rename = "33")]
+    #[strum(serialize = "33")]
     PanevezysDistrictMunicipality,
-    #[serde(rename = "34")]
+    #[strum(serialize = "34")]
     PasvalysDistrictMunicipality,
-    #[serde(rename = "35")]
+    #[strum(serialize = "35")]
     PlungeDistrictMunicipality,
-    #[serde(rename = "36")]
+    #[strum(serialize = "36")]
     PrienaiDistrictMunicipality,
-    #[serde(rename = "37")]
+    #[strum(serialize = "37")]
     RadviliskisDistrictMunicipality,
-    #[serde(rename = "38")]
+    #[strum(serialize = "38")]
     RaseiniaiDistrictMunicipality,
-    #[serde(rename = "39")]
+    #[strum(serialize = "39")]
     RietavasMunicipality,
-    #[serde(rename = "40")]
+    #[strum(serialize = "40")]
     RokiskisDistrictMunicipality,
-    #[serde(rename = "48")]
+    #[strum(serialize = "48")]
     SkuodasDistrictMunicipality,
-    #[serde(rename = "TA")]
+    #[strum(serialize = "TA")]
     TaurageCounty,
-    #[serde(rename = "50")]
+    #[strum(serialize = "50")]
     TaurageDistrictMunicipality,
-    #[serde(rename = "TE")]
+    #[strum(serialize = "TE")]
     TelsiaiCounty,
-    #[serde(rename = "51")]
+    #[strum(serialize = "51")]
     TelsiaiDistrictMunicipality,
-    #[serde(rename = "52")]
+    #[strum(serialize = "52")]
     TrakaiDistrictMunicipality,
-    #[serde(rename = "53")]
+    #[strum(serialize = "53")]
     UkmergeDistrictMunicipality,
-    #[serde(rename = "UT")]
+    #[strum(serialize = "UT")]
     UtenaCounty,
-    #[serde(rename = "54")]
+    #[strum(serialize = "54")]
     UtenaDistrictMunicipality,
-    #[serde(rename = "55")]
+    #[strum(serialize = "55")]
     VarenaDistrictMunicipality,
-    #[serde(rename = "56")]
+    #[strum(serialize = "56")]
     VilkaviskisDistrictMunicipality,
-    #[serde(rename = "57")]
+    #[strum(serialize = "57")]
     VilniusCityMunicipality,
-    #[serde(rename = "VL")]
+    #[strum(serialize = "VL")]
     VilniusCounty,
-    #[serde(rename = "58")]
+    #[strum(serialize = "58")]
     VilniusDistrictMunicipality,
-    #[serde(rename = "59")]
+    #[strum(serialize = "59")]
     VisaginasMunicipality,
-    #[serde(rename = "60")]
+    #[strum(serialize = "60")]
     ZarasaiDistrictMunicipality,
-    #[serde(rename = "41")]
+    #[strum(serialize = "41")]
     SakiaiDistrictMunicipality,
-    #[serde(rename = "42")]
+    #[strum(serialize = "42")]
     SalcininkaiDistrictMunicipality,
-    #[serde(rename = "43")]
+    #[strum(serialize = "43")]
     SiauliaiCityMunicipality,
-    #[serde(rename = "SA")]
+    #[strum(serialize = "SA")]
     SiauliaiCounty,
-    #[serde(rename = "44")]
+    #[strum(serialize = "44")]
     SiauliaiDistrictMunicipality,
-    #[serde(rename = "45")]
+    #[strum(serialize = "45")]
     SilaleDistrictMunicipality,
-    #[serde(rename = "46")]
+    #[strum(serialize = "46")]
     SiluteDistrictMunicipality,
-    #[serde(rename = "47")]
+    #[strum(serialize = "47")]
     SirvintosDistrictMunicipality,
-    #[serde(rename = "49")]
+    #[strum(serialize = "49")]
     SvencionysDistrictMunicipality,
 }
 
@@ -3792,139 +3792,139 @@ pub enum LithuaniaStatesAbbreviation {
     Debug, Clone, PartialEq, Eq, Serialize, Deserialize, strum::Display, strum::EnumString,
 )]
 pub enum MaltaStatesAbbreviation {
-    #[serde(rename = "01")]
+    #[strum(serialize = "01")]
     Attard,
-    #[serde(rename = "02")]
+    #[strum(serialize = "02")]
     Balzan,
-    #[serde(rename = "03")]
+    #[strum(serialize = "03")]
     Birgu,
-    #[serde(rename = "04")]
+    #[strum(serialize = "04")]
     Birkirkara,
-    #[serde(rename = "05")]
+    #[strum(serialize = "05")]
     Birzebbuga,
-    #[serde(rename = "06")]
+    #[strum(serialize = "06")]
     Cospicua,
-    #[serde(rename = "07")]
+    #[strum(serialize = "07")]
     Dingli,
-    #[serde(rename = "08")]
+    #[strum(serialize = "08")]
     Fgura,
-    #[serde(rename = "09")]
+    #[strum(serialize = "09")]
     Floriana,
-    #[serde(rename = "10")]
+    #[strum(serialize = "10")]
     Fontana,
-    #[serde(rename = "11")]
+    #[strum(serialize = "11")]
     Gudja,
-    #[serde(rename = "12")]
+    #[strum(serialize = "12")]
     Gzira,
-    #[serde(rename = "13")]
+    #[strum(serialize = "13")]
     Ghajnsielem,
-    #[serde(rename = "14")]
+    #[strum(serialize = "14")]
     Gharb,
-    #[serde(rename = "15")]
+    #[strum(serialize = "15")]
     Gharghur,
-    #[serde(rename = "16")]
+    #[strum(serialize = "16")]
     Ghasri,
-    #[serde(rename = "17")]
+    #[strum(serialize = "17")]
     Ghaxaq,
-    #[serde(rename = "18")]
+    #[strum(serialize = "18")]
     Hamrun,
-    #[serde(rename = "19")]
+    #[strum(serialize = "19")]
     Iklin,
-    #[serde(rename = "20")]
+    #[strum(serialize = "20")]
     Senglea,
-    #[serde(rename = "21")]
+    #[strum(serialize = "21")]
     Kalkara,
-    #[serde(rename = "22")]
+    #[strum(serialize = "22")]
     Kercem,
-    #[serde(rename = "23")]
+    #[strum(serialize = "23")]
     Kirkop,
-    #[serde(rename = "24")]
+    #[strum(serialize = "24")]
     Lija,
-    #[serde(rename = "25")]
+    #[strum(serialize = "25")]
     Luqa,
-    #[serde(rename = "26")]
+    #[strum(serialize = "26")]
     Marsa,
-    #[serde(rename = "27")]
+    #[strum(serialize = "27")]
     Marsaskala,
-    #[serde(rename = "28")]
+    #[strum(serialize = "28")]
     Marsaxlokk,
-    #[serde(rename = "29")]
+    #[strum(serialize = "29")]
     Mdina,
-    #[serde(rename = "30")]
+    #[strum(serialize = "30")]
     Mellieha,
-    #[serde(rename = "31")]
+    #[strum(serialize = "31")]
     Mgarr,
-    #[serde(rename = "32")]
+    #[strum(serialize = "32")]
     Mosta,
-    #[serde(rename = "33")]
+    #[strum(serialize = "33")]
     Mqabba,
-    #[serde(rename = "34")]
+    #[strum(serialize = "34")]
     Msida,
-    #[serde(rename = "35")]
+    #[strum(serialize = "35")]
     Mtarfa,
-    #[serde(rename = "36")]
+    #[strum(serialize = "36")]
     Munxar,
-    #[serde(rename = "37")]
+    #[strum(serialize = "37")]
     Nadur,
-    #[serde(rename = "38")]
+    #[strum(serialize = "38")]
     Naxxar,
-    #[serde(rename = "39")]
+    #[strum(serialize = "39")]
     Paola,
-    #[serde(rename = "40")]
+    #[strum(serialize = "40")]
     Pembroke,
-    #[serde(rename = "41")]
+    #[strum(serialize = "41")]
     Pieta,
-    #[serde(rename = "42")]
+    #[strum(serialize = "42")]
     Qala,
-    #[serde(rename = "43")]
+    #[strum(serialize = "43")]
     Qormi,
-    #[serde(rename = "44")]
+    #[strum(serialize = "44")]
     Qrendi,
-    #[serde(rename = "45")]
+    #[strum(serialize = "45")]
     Victoria,
-    #[serde(rename = "46")]
+    #[strum(serialize = "46")]
     Rabat,
-    #[serde(rename = "48")]
+    #[strum(serialize = "48")]
     StJulians,
-    #[serde(rename = "49")]
+    #[strum(serialize = "49")]
     SanGwann,
-    #[serde(rename = "50")]
+    #[strum(serialize = "50")]
     SaintLawrence,
-    #[serde(rename = "51")]
+    #[strum(serialize = "51")]
     StPaulsBay,
-    #[serde(rename = "52")]
+    #[strum(serialize = "52")]
     Sannat,
-    #[serde(rename = "53")]
+    #[strum(serialize = "53")]
     SantaLucija,
-    #[serde(rename = "54")]
+    #[strum(serialize = "54")]
     SantaVenera,
-    #[serde(rename = "55")]
+    #[strum(serialize = "55")]
     Siggiewi,
-    #[serde(rename = "56")]
+    #[strum(serialize = "56")]
     Sliema,
-    #[serde(rename = "57")]
+    #[strum(serialize = "57")]
     Swieqi,
-    #[serde(rename = "58")]
+    #[strum(serialize = "58")]
     TaXbiex,
-    #[serde(rename = "59")]
+    #[strum(serialize = "59")]
     Tarxien,
-    #[serde(rename = "60")]
+    #[strum(serialize = "60")]
     Valletta,
-    #[serde(rename = "61")]
+    #[strum(serialize = "61")]
     Xaghra,
-    #[serde(rename = "62")]
+    #[strum(serialize = "62")]
     Xewkija,
-    #[serde(rename = "63")]
+    #[strum(serialize = "63")]
     Xghajra,
-    #[serde(rename = "64")]
+    #[strum(serialize = "64")]
     Zabbar,
-    #[serde(rename = "65")]
+    #[strum(serialize = "65")]
     ZebbugGozo,
-    #[serde(rename = "66")]
+    #[strum(serialize = "66")]
     ZebbugMalta,
-    #[serde(rename = "67")]
+    #[strum(serialize = "67")]
     Zejtun,
-    #[serde(rename = "68")]
+    #[strum(serialize = "68")]
     Zurrieq,
 }
 
@@ -3932,77 +3932,77 @@ pub enum MaltaStatesAbbreviation {
     Debug, Clone, PartialEq, Eq, Serialize, Deserialize, strum::Display, strum::EnumString,
 )]
 pub enum MoldovaStatesAbbreviation {
-    #[serde(rename = "AN")]
+    #[strum(serialize = "AN")]
     AneniiNoiDistrict,
-    #[serde(rename = "BS")]
+    #[strum(serialize = "BS")]
     BasarabeascaDistrict,
-    #[serde(rename = "BD")]
+    #[strum(serialize = "BD")]
     BenderMunicipality,
-    #[serde(rename = "BR")]
+    #[strum(serialize = "BR")]
     BriceniDistrict,
-    #[serde(rename = "BA")]
+    #[strum(serialize = "BA")]
     BaltiMunicipality,
-    #[serde(rename = "CA")]
+    #[strum(serialize = "CA")]
     CahulDistrict,
-    #[serde(rename = "CT")]
+    #[strum(serialize = "CT")]
     CantemirDistrict,
-    #[serde(rename = "CU")]
+    #[strum(serialize = "CU")]
     ChisinauMunicipality,
-    #[serde(rename = "CM")]
+    #[strum(serialize = "CM")]
     CimisliaDistrict,
-    #[serde(rename = "CR")]
+    #[strum(serialize = "CR")]
     CriuleniDistrict,
-    #[serde(rename = "CL")]
+    #[strum(serialize = "CL")]
     CalarasiDistrict,
-    #[serde(rename = "CS")]
+    #[strum(serialize = "CS")]
     CauseniDistrict,
-    #[serde(rename = "DO")]
+    #[strum(serialize = "DO")]
     DonduseniDistrict,
-    #[serde(rename = "DR")]
+    #[strum(serialize = "DR")]
     DrochiaDistrict,
-    #[serde(rename = "DU")]
+    #[strum(serialize = "DU")]
     DubasariDistrict,
-    #[serde(rename = "ED")]
+    #[strum(serialize = "ED")]
     EdinetDistrict,
-    #[serde(rename = "FL")]
+    #[strum(serialize = "FL")]
     FlorestiDistrict,
-    #[serde(rename = "FA")]
+    #[strum(serialize = "FA")]
     FalestiDistrict,
-    #[serde(rename = "GA")]
+    #[strum(serialize = "GA")]
     Gagauzia,
-    #[serde(rename = "GL")]
+    #[strum(serialize = "GL")]
     GlodeniDistrict,
-    #[serde(rename = "HI")]
+    #[strum(serialize = "HI")]
     HincestiDistrict,
-    #[serde(rename = "IA")]
+    #[strum(serialize = "IA")]
     IaloveniDistrict,
-    #[serde(rename = "NI")]
+    #[strum(serialize = "NI")]
     NisporeniDistrict,
-    #[serde(rename = "OC")]
+    #[strum(serialize = "OC")]
     OcnitaDistrict,
-    #[serde(rename = "OR")]
+    #[strum(serialize = "OR")]
     OrheiDistrict,
-    #[serde(rename = "RE")]
+    #[strum(serialize = "RE")]
     RezinaDistrict,
-    #[serde(rename = "RI")]
+    #[strum(serialize = "RI")]
     RiscaniDistrict,
-    #[serde(rename = "SO")]
+    #[strum(serialize = "SO")]
     SorocaDistrict,
-    #[serde(rename = "ST")]
+    #[strum(serialize = "ST")]
     StraseniDistrict,
-    #[serde(rename = "SI")]
+    #[strum(serialize = "SI")]
     SingereiDistrict,
-    #[serde(rename = "TA")]
+    #[strum(serialize = "TA")]
     TaracliaDistrict,
-    #[serde(rename = "TE")]
+    #[strum(serialize = "TE")]
     TelenestiDistrict,
-    #[serde(rename = "SN")]
+    #[strum(serialize = "SN")]
     TransnistriaAutonomousTerritorialUnit,
-    #[serde(rename = "UN")]
+    #[strum(serialize = "UN")]
     UngheniDistrict,
-    #[serde(rename = "SD")]
+    #[strum(serialize = "SD")]
     SoldanestiDistrict,
-    #[serde(rename = "SV")]
+    #[strum(serialize = "SV")]
     StefanVodaDistrict,
 }
 
@@ -4017,49 +4017,49 @@ pub enum MonacoStatesAbbreviation {
     Debug, Clone, PartialEq, Eq, Serialize, Deserialize, strum::Display, strum::EnumString,
 )]
 pub enum MontenegroStatesAbbreviation {
-    #[serde(rename = "01")]
+    #[strum(serialize = "01")]
     AndrijevicaMunicipality,
-    #[serde(rename = "02")]
+    #[strum(serialize = "02")]
     BarMunicipality,
-    #[serde(rename = "03")]
+    #[strum(serialize = "03")]
     BeraneMunicipality,
-    #[serde(rename = "04")]
+    #[strum(serialize = "04")]
     BijeloPoljeMunicipality,
-    #[serde(rename = "05")]
+    #[strum(serialize = "05")]
     BudvaMunicipality,
-    #[serde(rename = "07")]
+    #[strum(serialize = "07")]
     DanilovgradMunicipality,
-    #[serde(rename = "22")]
+    #[strum(serialize = "22")]
     GusinjeMunicipality,
-    #[serde(rename = "09")]
+    #[strum(serialize = "09")]
     KolasinMunicipality,
-    #[serde(rename = "10")]
+    #[strum(serialize = "10")]
     KotorMunicipality,
-    #[serde(rename = "11")]
+    #[strum(serialize = "11")]
     MojkovacMunicipality,
-    #[serde(rename = "12")]
+    #[strum(serialize = "12")]
     NiksicMunicipality,
-    #[serde(rename = "06")]
+    #[strum(serialize = "06")]
     OldRoyalCapitalCetinje,
-    #[serde(rename = "23")]
+    #[strum(serialize = "23")]
     PetnjicaMunicipality,
-    #[serde(rename = "13")]
+    #[strum(serialize = "13")]
     PlavMunicipality,
-    #[serde(rename = "14")]
+    #[strum(serialize = "14")]
     PljevljaMunicipality,
-    #[serde(rename = "15")]
+    #[strum(serialize = "15")]
     PluzineMunicipality,
-    #[serde(rename = "16")]
+    #[strum(serialize = "16")]
     PodgoricaMunicipality,
-    #[serde(rename = "17")]
+    #[strum(serialize = "17")]
     RozajeMunicipality,
-    #[serde(rename = "19")]
+    #[strum(serialize = "19")]
     TivatMunicipality,
-    #[serde(rename = "20")]
+    #[strum(serialize = "20")]
     UlcinjMunicipality,
-    #[serde(rename = "18")]
+    #[strum(serialize = "18")]
     SavnikMunicipality,
-    #[serde(rename = "21")]
+    #[strum(serialize = "21")]
     ZabljakMunicipality,
 }
 
@@ -4067,35 +4067,35 @@ pub enum MontenegroStatesAbbreviation {
     Debug, Clone, PartialEq, Eq, Serialize, Deserialize, strum::Display, strum::EnumString,
 )]
 pub enum NetherlandsStatesAbbreviation {
-    #[serde(rename = "BQ1")]
+    #[strum(serialize = "BQ1")]
     Bonaire,
-    #[serde(rename = "DR")]
+    #[strum(serialize = "DR")]
     Drenthe,
-    #[serde(rename = "FL")]
+    #[strum(serialize = "FL")]
     Flevoland,
-    #[serde(rename = "FR")]
+    #[strum(serialize = "FR")]
     Friesland,
-    #[serde(rename = "GE")]
+    #[strum(serialize = "GE")]
     Gelderland,
-    #[serde(rename = "GR")]
+    #[strum(serialize = "GR")]
     Groningen,
-    #[serde(rename = "LI")]
+    #[strum(serialize = "LI")]
     Limburg,
-    #[serde(rename = "NB")]
+    #[strum(serialize = "NB")]
     NorthBrabant,
-    #[serde(rename = "NH")]
+    #[strum(serialize = "NH")]
     NorthHolland,
-    #[serde(rename = "OV")]
+    #[strum(serialize = "OV")]
     Overijssel,
-    #[serde(rename = "BQ2")]
+    #[strum(serialize = "BQ2")]
     Saba,
-    #[serde(rename = "BQ3")]
+    #[strum(serialize = "BQ3")]
     SintEustatius,
-    #[serde(rename = "ZH")]
+    #[strum(serialize = "ZH")]
     SouthHolland,
-    #[serde(rename = "UT")]
+    #[strum(serialize = "UT")]
     Utrecht,
-    #[serde(rename = "ZE")]
+    #[strum(serialize = "ZE")]
     Zeeland,
 }
 
@@ -4103,173 +4103,173 @@ pub enum NetherlandsStatesAbbreviation {
     Debug, Clone, PartialEq, Eq, Serialize, Deserialize, strum::Display, strum::EnumString,
 )]
 pub enum NorthMacedoniaStatesAbbreviation {
-    #[serde(rename = "01")]
+    #[strum(serialize = "01")]
     AerodromMunicipality,
-    #[serde(rename = "02")]
+    #[strum(serialize = "02")]
     AracinovoMunicipality,
-    #[serde(rename = "03")]
+    #[strum(serialize = "03")]
     BerovoMunicipality,
-    #[serde(rename = "04")]
+    #[strum(serialize = "04")]
     BitolaMunicipality,
-    #[serde(rename = "05")]
+    #[strum(serialize = "05")]
     BogdanciMunicipality,
-    #[serde(rename = "06")]
+    #[strum(serialize = "06")]
     BogovinjeMunicipality,
-    #[serde(rename = "07")]
+    #[strum(serialize = "07")]
     BosilovoMunicipality,
-    #[serde(rename = "08")]
+    #[strum(serialize = "08")]
     BrvenicaMunicipality,
-    #[serde(rename = "09")]
+    #[strum(serialize = "09")]
     ButelMunicipality,
-    #[serde(rename = "77")]
+    #[strum(serialize = "77")]
     CentarMunicipality,
-    #[serde(rename = "78")]
+    #[strum(serialize = "78")]
     CentarZupaMunicipality,
-    #[serde(rename = "22")]
+    #[strum(serialize = "22")]
     DebarcaMunicipality,
-    #[serde(rename = "23")]
+    #[strum(serialize = "23")]
     DelcevoMunicipality,
-    #[serde(rename = "25")]
+    #[strum(serialize = "25")]
     DemirHisarMunicipality,
-    #[serde(rename = "24")]
+    #[strum(serialize = "24")]
     DemirKapijaMunicipality,
-    #[serde(rename = "26")]
+    #[strum(serialize = "26")]
     DojranMunicipality,
-    #[serde(rename = "27")]
+    #[strum(serialize = "27")]
     DolneniMunicipality,
-    #[serde(rename = "28")]
+    #[strum(serialize = "28")]
     DrugovoMunicipality,
-    #[serde(rename = "17")]
+    #[strum(serialize = "17")]
     GaziBabaMunicipality,
-    #[serde(rename = "18")]
+    #[strum(serialize = "18")]
     GevgelijaMunicipality,
-    #[serde(rename = "29")]
+    #[strum(serialize = "29")]
     GjorcePetrovMunicipality,
-    #[serde(rename = "19")]
+    #[strum(serialize = "19")]
     GostivarMunicipality,
-    #[serde(rename = "20")]
+    #[strum(serialize = "20")]
     GradskoMunicipality,
-    #[serde(rename = "85")]
+    #[strum(serialize = "85")]
     GreaterSkopje,
-    #[serde(rename = "34")]
+    #[strum(serialize = "34")]
     IlindenMunicipality,
-    #[serde(rename = "35")]
+    #[strum(serialize = "35")]
     JegunovceMunicipality,
-    #[serde(rename = "37")]
+    #[strum(serialize = "37")]
     Karbinci,
-    #[serde(rename = "38")]
+    #[strum(serialize = "38")]
     KarposMunicipality,
-    #[serde(rename = "36")]
+    #[strum(serialize = "36")]
     KavadarciMunicipality,
-    #[serde(rename = "39")]
+    #[strum(serialize = "39")]
     KiselaVodaMunicipality,
-    #[serde(rename = "40")]
+    #[strum(serialize = "40")]
     KicevoMunicipality,
-    #[serde(rename = "41")]
+    #[strum(serialize = "41")]
     KonceMunicipality,
-    #[serde(rename = "42")]
+    #[strum(serialize = "42")]
     KocaniMunicipality,
-    #[serde(rename = "43")]
+    #[strum(serialize = "43")]
     KratovoMunicipality,
-    #[serde(rename = "44")]
+    #[strum(serialize = "44")]
     KrivaPalankaMunicipality,
-    #[serde(rename = "45")]
+    #[strum(serialize = "45")]
     KrivogastaniMunicipality,
-    #[serde(rename = "46")]
+    #[strum(serialize = "46")]
     KrusevoMunicipality,
-    #[serde(rename = "47")]
+    #[strum(serialize = "47")]
     KumanovoMunicipality,
-    #[serde(rename = "48")]
+    #[strum(serialize = "48")]
     LipkovoMunicipality,
-    #[serde(rename = "49")]
+    #[strum(serialize = "49")]
     LozovoMunicipality,
-    #[serde(rename = "51")]
+    #[strum(serialize = "51")]
     MakedonskaKamenicaMunicipality,
-    #[serde(rename = "52")]
+    #[strum(serialize = "52")]
     MakedonskiBrodMunicipality,
-    #[serde(rename = "50")]
+    #[strum(serialize = "50")]
     MavrovoAndRostusaMunicipality,
-    #[serde(rename = "53")]
+    #[strum(serialize = "53")]
     MogilaMunicipality,
-    #[serde(rename = "54")]
+    #[strum(serialize = "54")]
     NegotinoMunicipality,
-    #[serde(rename = "55")]
+    #[strum(serialize = "55")]
     NovaciMunicipality,
-    #[serde(rename = "56")]
+    #[strum(serialize = "56")]
     NovoSeloMunicipality,
-    #[serde(rename = "58")]
+    #[strum(serialize = "58")]
     OhridMunicipality,
-    #[serde(rename = "57")]
+    #[strum(serialize = "57")]
     OslomejMunicipality,
-    #[serde(rename = "60")]
+    #[strum(serialize = "60")]
     PehcevoMunicipality,
-    #[serde(rename = "59")]
+    #[strum(serialize = "59")]
     PetrovecMunicipality,
-    #[serde(rename = "61")]
+    #[strum(serialize = "61")]
     PlasnicaMunicipality,
-    #[serde(rename = "62")]
+    #[strum(serialize = "62")]
     PrilepMunicipality,
-    #[serde(rename = "63")]
+    #[strum(serialize = "63")]
     ProbistipMunicipality,
-    #[serde(rename = "64")]
+    #[strum(serialize = "64")]
     RadovisMunicipality,
-    #[serde(rename = "65")]
+    #[strum(serialize = "65")]
     RankovceMunicipality,
-    #[serde(rename = "66")]
+    #[strum(serialize = "66")]
     ResenMunicipality,
-    #[serde(rename = "67")]
+    #[strum(serialize = "67")]
     RosomanMunicipality,
-    #[serde(rename = "68")]
+    #[strum(serialize = "68")]
     SarajMunicipality,
-    #[serde(rename = "70")]
+    #[strum(serialize = "70")]
     SopisteMunicipality,
-    #[serde(rename = "71")]
+    #[strum(serialize = "71")]
     StaroNagoricaneMunicipality,
-    #[serde(rename = "72")]
+    #[strum(serialize = "72")]
     StrugaMunicipality,
-    #[serde(rename = "73")]
+    #[strum(serialize = "73")]
     StrumicaMunicipality,
-    #[serde(rename = "74")]
+    #[strum(serialize = "74")]
     StudenicaniMunicipality,
-    #[serde(rename = "69")]
+    #[strum(serialize = "69")]
     SvetiNikoleMunicipality,
-    #[serde(rename = "75")]
+    #[strum(serialize = "75")]
     TearceMunicipality,
-    #[serde(rename = "76")]
+    #[strum(serialize = "76")]
     TetovoMunicipality,
-    #[serde(rename = "10")]
+    #[strum(serialize = "10")]
     ValandovoMunicipality,
-    #[serde(rename = "11")]
+    #[strum(serialize = "11")]
     VasilevoMunicipality,
-    #[serde(rename = "13")]
+    #[strum(serialize = "13")]
     VelesMunicipality,
-    #[serde(rename = "12")]
+    #[strum(serialize = "12")]
     VevcaniMunicipality,
-    #[serde(rename = "14")]
+    #[strum(serialize = "14")]
     VinicaMunicipality,
-    #[serde(rename = "15")]
+    #[strum(serialize = "15")]
     VranesticaMunicipality,
-    #[serde(rename = "16")]
+    #[strum(serialize = "16")]
     VrapcisteMunicipality,
-    #[serde(rename = "31")]
+    #[strum(serialize = "31")]
     ZajasMunicipality,
-    #[serde(rename = "32")]
+    #[strum(serialize = "32")]
     ZelenikovoMunicipality,
-    #[serde(rename = "33")]
+    #[strum(serialize = "33")]
     ZrnovciMunicipality,
-    #[serde(rename = "79")]
+    #[strum(serialize = "79")]
     CairMunicipality,
-    #[serde(rename = "80")]
+    #[strum(serialize = "80")]
     CaskaMunicipality,
-    #[serde(rename = "81")]
+    #[strum(serialize = "81")]
     CesinovoOblesevoMunicipality,
-    #[serde(rename = "82")]
+    #[strum(serialize = "82")]
     CucerSandevoMunicipality,
-    #[serde(rename = "83")]
+    #[strum(serialize = "83")]
     StipMunicipality,
-    #[serde(rename = "84")]
+    #[strum(serialize = "84")]
     SutoOrizariMunicipality,
-    #[serde(rename = "30")]
+    #[strum(serialize = "30")]
     ZelinoMunicipality,
 }
 
@@ -4277,47 +4277,47 @@ pub enum NorthMacedoniaStatesAbbreviation {
     Debug, Clone, PartialEq, Eq, Serialize, Deserialize, strum::Display, strum::EnumString,
 )]
 pub enum NorwayStatesAbbreviation {
-    #[serde(rename = "02")]
+    #[strum(serialize = "02")]
     Akershus,
-    #[serde(rename = "06")]
+    #[strum(serialize = "06")]
     Buskerud,
-    #[serde(rename = "20")]
+    #[strum(serialize = "20")]
     Finnmark,
-    #[serde(rename = "04")]
+    #[strum(serialize = "04")]
     Hedmark,
-    #[serde(rename = "12")]
+    #[strum(serialize = "12")]
     Hordaland,
-    #[serde(rename = "22")]
+    #[strum(serialize = "22")]
     JanMayen,
-    #[serde(rename = "15")]
+    #[strum(serialize = "15")]
     MoreOgRomsdal,
-    #[serde(rename = "17")]
+    #[strum(serialize = "17")]
     NordTrondelag,
-    #[serde(rename = "18")]
+    #[strum(serialize = "18")]
     Nordland,
-    #[serde(rename = "05")]
+    #[strum(serialize = "05")]
     Oppland,
-    #[serde(rename = "03")]
+    #[strum(serialize = "03")]
     Oslo,
-    #[serde(rename = "11")]
+    #[strum(serialize = "11")]
     Rogaland,
-    #[serde(rename = "14")]
+    #[strum(serialize = "14")]
     SognOgFjordane,
-    #[serde(rename = "21")]
+    #[strum(serialize = "21")]
     Svalbard,
-    #[serde(rename = "16")]
+    #[strum(serialize = "16")]
     SorTrondelag,
-    #[serde(rename = "08")]
+    #[strum(serialize = "08")]
     Telemark,
-    #[serde(rename = "19")]
+    #[strum(serialize = "19")]
     Troms,
-    #[serde(rename = "50")]
+    #[strum(serialize = "50")]
     Trondelag,
-    #[serde(rename = "10")]
+    #[strum(serialize = "10")]
     VestAgder,
-    #[serde(rename = "07")]
+    #[strum(serialize = "07")]
     Vestfold,
-    #[serde(rename = "01")]
+    #[strum(serialize = "01")]
     Ostfold,
 }
 
@@ -4325,39 +4325,39 @@ pub enum NorwayStatesAbbreviation {
     Debug, Clone, PartialEq, Eq, Serialize, Deserialize, strum::Display, strum::EnumString,
 )]
 pub enum PolandStatesAbbreviation {
-    #[serde(rename = "WP")]
+    #[strum(serialize = "WP")]
     GreaterPolandVoivodeship,
-    #[serde(rename = "KI")]
+    #[strum(serialize = "KI")]
     Kielce,
-    #[serde(rename = "KP")]
+    #[strum(serialize = "KP")]
     KuyavianPomeranianVoivodeship,
-    #[serde(rename = "MA")]
+    #[strum(serialize = "MA")]
     LesserPolandVoivodeship,
-    #[serde(rename = "DS")]
+    #[strum(serialize = "DS")]
     LowerSilesianVoivodeship,
-    #[serde(rename = "LU")]
+    #[strum(serialize = "LU")]
     LublinVoivodeship,
-    #[serde(rename = "LB")]
+    #[strum(serialize = "LB")]
     LubuszVoivodeship,
-    #[serde(rename = "MZ")]
+    #[strum(serialize = "MZ")]
     MasovianVoivodeship,
-    #[serde(rename = "OP")]
+    #[strum(serialize = "OP")]
     OpoleVoivodeship,
-    #[serde(rename = "PK")]
+    #[strum(serialize = "PK")]
     PodkarpackieVoivodeship,
-    #[serde(rename = "PD")]
+    #[strum(serialize = "PD")]
     PodlaskieVoivodeship,
-    #[serde(rename = "PM")]
+    #[strum(serialize = "PM")]
     PomeranianVoivodeship,
-    #[serde(rename = "SL")]
+    #[strum(serialize = "SL")]
     SilesianVoivodeship,
-    #[serde(rename = "WN")]
+    #[strum(serialize = "WN")]
     WarmianMasurianVoivodeship,
-    #[serde(rename = "ZP")]
+    #[strum(serialize = "ZP")]
     WestPomeranianVoivodeship,
-    #[serde(rename = "LD")]
+    #[strum(serialize = "LD")]
     LodzVoivodeship,
-    #[serde(rename = "SK")]
+    #[strum(serialize = "SK")]
     SwietokrzyskieVoivodeship,
 }
 
@@ -4365,45 +4365,45 @@ pub enum PolandStatesAbbreviation {
     Debug, Clone, PartialEq, Eq, Serialize, Deserialize, strum::Display, strum::EnumString,
 )]
 pub enum PortugalStatesAbbreviation {
-    #[serde(rename = "01")]
+    #[strum(serialize = "01")]
     AveiroDistrict,
-    #[serde(rename = "20")]
+    #[strum(serialize = "20")]
     Azores,
-    #[serde(rename = "02")]
+    #[strum(serialize = "02")]
     BejaDistrict,
-    #[serde(rename = "03")]
+    #[strum(serialize = "03")]
     BragaDistrict,
-    #[serde(rename = "04")]
+    #[strum(serialize = "04")]
     BragancaDistrict,
-    #[serde(rename = "05")]
+    #[strum(serialize = "05")]
     CasteloBrancoDistrict,
-    #[serde(rename = "06")]
+    #[strum(serialize = "06")]
     CoimbraDistrict,
-    #[serde(rename = "08")]
+    #[strum(serialize = "08")]
     FaroDistrict,
-    #[serde(rename = "09")]
+    #[strum(serialize = "09")]
     GuardaDistrict,
-    #[serde(rename = "10")]
+    #[strum(serialize = "10")]
     LeiriaDistrict,
-    #[serde(rename = "11")]
+    #[strum(serialize = "11")]
     LisbonDistrict,
-    #[serde(rename = "30")]
+    #[strum(serialize = "30")]
     Madeira,
-    #[serde(rename = "12")]
+    #[strum(serialize = "12")]
     PortalegreDistrict,
-    #[serde(rename = "13")]
+    #[strum(serialize = "13")]
     PortoDistrict,
-    #[serde(rename = "14")]
+    #[strum(serialize = "14")]
     SantaremDistrict,
-    #[serde(rename = "15")]
+    #[strum(serialize = "15")]
     SetubalDistrict,
-    #[serde(rename = "16")]
+    #[strum(serialize = "16")]
     VianaDoCasteloDistrict,
-    #[serde(rename = "17")]
+    #[strum(serialize = "17")]
     VilaRealDistrict,
-    #[serde(rename = "18")]
+    #[strum(serialize = "18")]
     ViseuDistrict,
-    #[serde(rename = "07")]
+    #[strum(serialize = "07")]
     EvoraDistrict,
 }
 
@@ -4411,133 +4411,133 @@ pub enum PortugalStatesAbbreviation {
     Debug, Clone, PartialEq, Eq, Serialize, Deserialize, strum::Display, strum::EnumString,
 )]
 pub enum SpainStatesAbbreviation {
-    #[serde(rename = "C")]
+    #[strum(serialize = "C")]
     ACorunaProvince,
-    #[serde(rename = "AB")]
+    #[strum(serialize = "AB")]
     AlbaceteProvince,
-    #[serde(rename = "A")]
+    #[strum(serialize = "A")]
     AlicanteProvince,
-    #[serde(rename = "AL")]
+    #[strum(serialize = "AL")]
     AlmeriaProvince,
-    #[serde(rename = "AN")]
+    #[strum(serialize = "AN")]
     Andalusia,
-    #[serde(rename = "VI")]
+    #[strum(serialize = "VI")]
     ArabaAlava,
-    #[serde(rename = "AR")]
+    #[strum(serialize = "AR")]
     Aragon,
-    #[serde(rename = "BA")]
+    #[strum(serialize = "BA")]
     BadajozProvince,
-    #[serde(rename = "PM")]
+    #[strum(serialize = "PM")]
     BalearicIslands,
-    #[serde(rename = "B")]
+    #[strum(serialize = "B")]
     BarcelonaProvince,
-    #[serde(rename = "PV")]
+    #[strum(serialize = "PV")]
     BasqueCountry,
-    #[serde(rename = "BI")]
+    #[strum(serialize = "BI")]
     Biscay,
-    #[serde(rename = "BU")]
+    #[strum(serialize = "BU")]
     BurgosProvince,
-    #[serde(rename = "CN")]
+    #[strum(serialize = "CN")]
     CanaryIslands,
-    #[serde(rename = "S")]
+    #[strum(serialize = "S")]
     Cantabria,
-    #[serde(rename = "CS")]
+    #[strum(serialize = "CS")]
     CastellonProvince,
-    #[serde(rename = "CL")]
+    #[strum(serialize = "CL")]
     CastileAndLeon,
-    #[serde(rename = "CM")]
+    #[strum(serialize = "CM")]
     CastileLaMancha,
-    #[serde(rename = "CT")]
+    #[strum(serialize = "CT")]
     Catalonia,
-    #[serde(rename = "CE")]
+    #[strum(serialize = "CE")]
     Ceuta,
-    #[serde(rename = "CR")]
+    #[strum(serialize = "CR")]
     CiudadRealProvince,
-    #[serde(rename = "MD")]
+    #[strum(serialize = "MD")]
     CommunityOfMadrid,
-    #[serde(rename = "CU")]
+    #[strum(serialize = "CU")]
     CuencaProvince,
-    #[serde(rename = "CC")]
+    #[strum(serialize = "CC")]
     CaceresProvince,
-    #[serde(rename = "CA")]
+    #[strum(serialize = "CA")]
     CadizProvince,
-    #[serde(rename = "CO")]
+    #[strum(serialize = "CO")]
     CordobaProvince,
-    #[serde(rename = "EX")]
+    #[strum(serialize = "EX")]
     Extremadura,
-    #[serde(rename = "GA")]
+    #[strum(serialize = "GA")]
     Galicia,
-    #[serde(rename = "SS")]
+    #[strum(serialize = "SS")]
     Gipuzkoa,
-    #[serde(rename = "GI")]
+    #[strum(serialize = "GI")]
     GironaProvince,
-    #[serde(rename = "GR")]
+    #[strum(serialize = "GR")]
     GranadaProvince,
-    #[serde(rename = "GU")]
+    #[strum(serialize = "GU")]
     GuadalajaraProvince,
-    #[serde(rename = "H")]
+    #[strum(serialize = "H")]
     HuelvaProvince,
-    #[serde(rename = "HU")]
+    #[strum(serialize = "HU")]
     HuescaProvince,
-    #[serde(rename = "J")]
+    #[strum(serialize = "J")]
     JaenProvince,
-    #[serde(rename = "RI")]
+    #[strum(serialize = "RI")]
     LaRioja,
-    #[serde(rename = "GC")]
+    #[strum(serialize = "GC")]
     LasPalmasProvince,
-    #[serde(rename = "LE")]
+    #[strum(serialize = "LE")]
     LeonProvince,
-    #[serde(rename = "L")]
+    #[strum(serialize = "L")]
     LleidaProvince,
-    #[serde(rename = "LU")]
+    #[strum(serialize = "LU")]
     LugoProvince,
-    #[serde(rename = "M")]
+    #[strum(serialize = "M")]
     MadridProvince,
-    #[serde(rename = "ML")]
+    #[strum(serialize = "ML")]
     Melilla,
-    #[serde(rename = "MU")]
+    #[strum(serialize = "MU")]
     MurciaProvince,
-    #[serde(rename = "MA")]
+    #[strum(serialize = "MA")]
     MalagaProvince,
-    #[serde(rename = "NC")]
+    #[strum(serialize = "NC")]
     Navarre,
-    #[serde(rename = "OR")]
+    #[strum(serialize = "OR")]
     OurenseProvince,
-    #[serde(rename = "P")]
+    #[strum(serialize = "P")]
     PalenciaProvince,
-    #[serde(rename = "PO")]
+    #[strum(serialize = "PO")]
     PontevedraProvince,
-    #[serde(rename = "O")]
+    #[strum(serialize = "O")]
     ProvinceOfAsturias,
-    #[serde(rename = "AV")]
+    #[strum(serialize = "AV")]
     ProvinceOfAvila,
-    #[serde(rename = "MC")]
+    #[strum(serialize = "MC")]
     RegionOfMurcia,
-    #[serde(rename = "SA")]
+    #[strum(serialize = "SA")]
     SalamancaProvince,
-    #[serde(rename = "TF")]
+    #[strum(serialize = "TF")]
     SantaCruzDeTenerifeProvince,
-    #[serde(rename = "SG")]
+    #[strum(serialize = "SG")]
     SegoviaProvince,
-    #[serde(rename = "SE")]
+    #[strum(serialize = "SE")]
     SevilleProvince,
-    #[serde(rename = "SO")]
+    #[strum(serialize = "SO")]
     SoriaProvince,
-    #[serde(rename = "T")]
+    #[strum(serialize = "T")]
     TarragonaProvince,
-    #[serde(rename = "TE")]
+    #[strum(serialize = "TE")]
     TeruelProvince,
-    #[serde(rename = "TO")]
+    #[strum(serialize = "TO")]
     ToledoProvince,
-    #[serde(rename = "V")]
+    #[strum(serialize = "V")]
     ValenciaProvince,
-    #[serde(rename = "VC")]
+    #[strum(serialize = "VC")]
     ValencianCommunity,
-    #[serde(rename = "VA")]
+    #[strum(serialize = "VA")]
     ValladolidProvince,
-    #[serde(rename = "ZA")]
+    #[strum(serialize = "ZA")]
     ZamoraProvince,
-    #[serde(rename = "Z")]
+    #[strum(serialize = "Z")]
     ZaragozaProvince,
 }
 
@@ -4545,55 +4545,55 @@ pub enum SpainStatesAbbreviation {
     Debug, Clone, PartialEq, Eq, Serialize, Deserialize, strum::Display, strum::EnumString,
 )]
 pub enum SwitzerlandStatesAbbreviation {
-    #[serde(rename = "AG")]
+    #[strum(serialize = "AG")]
     Aargau,
-    #[serde(rename = "AR")]
+    #[strum(serialize = "AR")]
     AppenzellAusserrhoden,
-    #[serde(rename = "AI")]
+    #[strum(serialize = "AI")]
     AppenzellInnerrhoden,
-    #[serde(rename = "BL")]
+    #[strum(serialize = "BL")]
     BaselLandschaft,
-    #[serde(rename = "FR")]
+    #[strum(serialize = "FR")]
     CantonOfFribourg,
-    #[serde(rename = "GE")]
+    #[strum(serialize = "GE")]
     CantonOfGeneva,
-    #[serde(rename = "JU")]
+    #[strum(serialize = "JU")]
     CantonOfJura,
-    #[serde(rename = "LU")]
+    #[strum(serialize = "LU")]
     CantonOfLucerne,
-    #[serde(rename = "NE")]
+    #[strum(serialize = "NE")]
     CantonOfNeuchatel,
-    #[serde(rename = "SH")]
+    #[strum(serialize = "SH")]
     CantonOfSchaffhausen,
-    #[serde(rename = "SO")]
+    #[strum(serialize = "SO")]
     CantonOfSolothurn,
-    #[serde(rename = "SG")]
+    #[strum(serialize = "SG")]
     CantonOfStGallen,
-    #[serde(rename = "VS")]
+    #[strum(serialize = "VS")]
     CantonOfValais,
-    #[serde(rename = "VD")]
+    #[strum(serialize = "VD")]
     CantonOfVaud,
-    #[serde(rename = "ZG")]
+    #[strum(serialize = "ZG")]
     CantonOfZug,
-    #[serde(rename = "GL")]
+    #[strum(serialize = "GL")]
     Glarus,
-    #[serde(rename = "GR")]
+    #[strum(serialize = "GR")]
     Graubunden,
-    #[serde(rename = "NW")]
+    #[strum(serialize = "NW")]
     Nidwalden,
-    #[serde(rename = "OW")]
+    #[strum(serialize = "OW")]
     Obwalden,
-    #[serde(rename = "SZ")]
+    #[strum(serialize = "SZ")]
     Schwyz,
-    #[serde(rename = "TG")]
+    #[strum(serialize = "TG")]
     Thurgau,
-    #[serde(rename = "TI")]
+    #[strum(serialize = "TI")]
     Ticino,
-    #[serde(rename = "UR")]
+    #[strum(serialize = "UR")]
     Uri,
-    #[serde(rename = "BE")]
+    #[strum(serialize = "BE")]
     CantonOfBern,
-    #[serde(rename = "ZH")]
+    #[strum(serialize = "ZH")]
     CantonOfZurich,
 }
 
@@ -4601,437 +4601,437 @@ pub enum SwitzerlandStatesAbbreviation {
     Debug, Clone, PartialEq, Eq, Serialize, Deserialize, strum::Display, strum::EnumString,
 )]
 pub enum UnitedKingdomStatesAbbreviation {
-    #[serde(rename = "ABE")]
+    #[strum(serialize = "ABE")]
     AberdeenCity,
-    #[serde(rename = "ABD")]
+    #[strum(serialize = "ABD")]
     Aberdeenshire,
-    #[serde(rename = "ANS")]
+    #[strum(serialize = "ANS")]
     Angus,
-    #[serde(rename = "ANN")]
+    #[strum(serialize = "ANN")]
     AntrimAndNewtownabbey,
-    #[serde(rename = "AND")]
+    #[strum(serialize = "AND")]
     ArdsAndNorthDown,
-    #[serde(rename = "AGB")]
+    #[strum(serialize = "AGB")]
     ArgyllAndBute,
-    #[serde(rename = "ABC")]
+    #[strum(serialize = "ABC")]
     ArmaghCityBanbridgeAndCraigavon,
-    #[serde(rename = "BDG")]
+    #[strum(serialize = "BDG")]
     BarkingAndDagenham,
-    #[serde(rename = "BNE")]
+    #[strum(serialize = "BNE")]
     Barnet,
-    #[serde(rename = "BNS")]
+    #[strum(serialize = "BNS")]
     Barnsley,
-    #[serde(rename = "BAS")]
+    #[strum(serialize = "BAS")]
     BathAndNorthEastSomerset,
-    #[serde(rename = "BDF")]
+    #[strum(serialize = "BDF")]
     Bedford,
-    #[serde(rename = "BFS")]
+    #[strum(serialize = "BFS")]
     BelfastCity,
-    #[serde(rename = "BEX")]
+    #[strum(serialize = "BEX")]
     Bexley,
-    #[serde(rename = "BIR")]
+    #[strum(serialize = "BIR")]
     Birmingham,
-    #[serde(rename = "BBD")]
+    #[strum(serialize = "BBD")]
     BlackburnWithDarwen,
-    #[serde(rename = "BPL")]
+    #[strum(serialize = "BPL")]
     Blackpool,
-    #[serde(rename = "BGW")]
+    #[strum(serialize = "BGW")]
     BlaenauGwent,
-    #[serde(rename = "BOL")]
+    #[strum(serialize = "BOL")]
     Bolton,
-    #[serde(rename = "BCP")]
+    #[strum(serialize = "BCP")]
     BournemouthChristchurchAndPoole,
-    #[serde(rename = "BRC")]
+    #[strum(serialize = "BRC")]
     BracknellForest,
-    #[serde(rename = "BRD")]
+    #[strum(serialize = "BRD")]
     Bradford,
-    #[serde(rename = "BEN")]
+    #[strum(serialize = "BEN")]
     Brent,
-    #[serde(rename = "BGE")]
+    #[strum(serialize = "BGE")]
     Bridgend,
-    #[serde(rename = "BNH")]
+    #[strum(serialize = "BNH")]
     BrightonAndHove,
-    #[serde(rename = "BST")]
+    #[strum(serialize = "BST")]
     BristolCityOf,
-    #[serde(rename = "BRY")]
+    #[strum(serialize = "BRY")]
     Bromley,
-    #[serde(rename = "BKM")]
+    #[strum(serialize = "BKM")]
     Buckinghamshire,
-    #[serde(rename = "BUR")]
+    #[strum(serialize = "BUR")]
     Bury,
-    #[serde(rename = "CAY")]
+    #[strum(serialize = "CAY")]
     Caerphilly,
-    #[serde(rename = "CLD")]
+    #[strum(serialize = "CLD")]
     Calderdale,
-    #[serde(rename = "CAM")]
+    #[strum(serialize = "CAM")]
     Cambridgeshire,
-    #[serde(rename = "CMD")]
+    #[strum(serialize = "CMD")]
     Camden,
-    #[serde(rename = "CRF")]
+    #[strum(serialize = "CRF")]
     Cardiff,
-    #[serde(rename = "CMN")]
+    #[strum(serialize = "CMN")]
     Carmarthenshire,
-    #[serde(rename = "CCG")]
+    #[strum(serialize = "CCG")]
     CausewayCoastAndGlens,
-    #[serde(rename = "CBF")]
+    #[strum(serialize = "CBF")]
     CentralBedfordshire,
-    #[serde(rename = "CGN")]
+    #[strum(serialize = "CGN")]
     Ceredigion,
-    #[serde(rename = "CHE")]
+    #[strum(serialize = "CHE")]
     CheshireEast,
-    #[serde(rename = "CHW")]
+    #[strum(serialize = "CHW")]
     CheshireWestAndChester,
-    #[serde(rename = "CLK")]
+    #[strum(serialize = "CLK")]
     Clackmannanshire,
-    #[serde(rename = "CWY")]
+    #[strum(serialize = "CWY")]
     Conwy,
-    #[serde(rename = "CON")]
+    #[strum(serialize = "CON")]
     Cornwall,
-    #[serde(rename = "COV")]
+    #[strum(serialize = "COV")]
     Coventry,
-    #[serde(rename = "CRY")]
+    #[strum(serialize = "CRY")]
     Croydon,
-    #[serde(rename = "CMA")]
+    #[strum(serialize = "CMA")]
     Cumbria,
-    #[serde(rename = "DAL")]
+    #[strum(serialize = "DAL")]
     Darlington,
-    #[serde(rename = "DEN")]
+    #[strum(serialize = "DEN")]
     Denbighshire,
-    #[serde(rename = "DER")]
+    #[strum(serialize = "DER")]
     Derby,
-    #[serde(rename = "DBY")]
+    #[strum(serialize = "DBY")]
     Derbyshire,
-    #[serde(rename = "DRS")]
+    #[strum(serialize = "DRS")]
     DerryAndStrabane,
-    #[serde(rename = "DEV")]
+    #[strum(serialize = "DEV")]
     Devon,
-    #[serde(rename = "DNC")]
+    #[strum(serialize = "DNC")]
     Doncaster,
-    #[serde(rename = "DOR")]
+    #[strum(serialize = "DOR")]
     Dorset,
-    #[serde(rename = "DUD")]
+    #[strum(serialize = "DUD")]
     Dudley,
-    #[serde(rename = "DGY")]
+    #[strum(serialize = "DGY")]
     DumfriesAndGalloway,
-    #[serde(rename = "DND")]
+    #[strum(serialize = "DND")]
     DundeeCity,
-    #[serde(rename = "DUR")]
+    #[strum(serialize = "DUR")]
     DurhamCounty,
-    #[serde(rename = "EAL")]
+    #[strum(serialize = "EAL")]
     Ealing,
-    #[serde(rename = "EAY")]
+    #[strum(serialize = "EAY")]
     EastAyrshire,
-    #[serde(rename = "EDU")]
+    #[strum(serialize = "EDU")]
     EastDunbartonshire,
-    #[serde(rename = "ELN")]
+    #[strum(serialize = "ELN")]
     EastLothian,
-    #[serde(rename = "ERW")]
+    #[strum(serialize = "ERW")]
     EastRenfrewshire,
-    #[serde(rename = "ERY")]
+    #[strum(serialize = "ERY")]
     EastRidingOfYorkshire,
-    #[serde(rename = "ESX")]
+    #[strum(serialize = "ESX")]
     EastSussex,
-    #[serde(rename = "EDH")]
+    #[strum(serialize = "EDH")]
     EdinburghCityOf,
-    #[serde(rename = "ELS")]
+    #[strum(serialize = "ELS")]
     EileanSiar,
-    #[serde(rename = "ENF")]
+    #[strum(serialize = "ENF")]
     Enfield,
-    #[serde(rename = "ESS")]
+    #[strum(serialize = "ESS")]
     Essex,
-    #[serde(rename = "FAL")]
+    #[strum(serialize = "FAL")]
     Falkirk,
-    #[serde(rename = "FMO")]
+    #[strum(serialize = "FMO")]
     FermanaghAndOmagh,
-    #[serde(rename = "FIF")]
+    #[strum(serialize = "FIF")]
     Fife,
-    #[serde(rename = "FLN")]
+    #[strum(serialize = "FLN")]
     Flintshire,
-    #[serde(rename = "GAT")]
+    #[strum(serialize = "GAT")]
     Gateshead,
-    #[serde(rename = "GLG")]
+    #[strum(serialize = "GLG")]
     GlasgowCity,
-    #[serde(rename = "GLS")]
+    #[strum(serialize = "GLS")]
     Gloucestershire,
-    #[serde(rename = "GRE")]
+    #[strum(serialize = "GRE")]
     Greenwich,
-    #[serde(rename = "GWN")]
+    #[strum(serialize = "GWN")]
     Gwynedd,
-    #[serde(rename = "HCK")]
+    #[strum(serialize = "HCK")]
     Hackney,
-    #[serde(rename = "HAL")]
+    #[strum(serialize = "HAL")]
     Halton,
-    #[serde(rename = "HMF")]
+    #[strum(serialize = "HMF")]
     HammersmithAndFulham,
-    #[serde(rename = "HAM")]
+    #[strum(serialize = "HAM")]
     Hampshire,
-    #[serde(rename = "HRY")]
+    #[strum(serialize = "HRY")]
     Haringey,
-    #[serde(rename = "HRW")]
+    #[strum(serialize = "HRW")]
     Harrow,
-    #[serde(rename = "HPL")]
+    #[strum(serialize = "HPL")]
     Hartlepool,
-    #[serde(rename = "HAV")]
+    #[strum(serialize = "HAV")]
     Havering,
-    #[serde(rename = "HEF")]
+    #[strum(serialize = "HEF")]
     Herefordshire,
-    #[serde(rename = "HRT")]
+    #[strum(serialize = "HRT")]
     Hertfordshire,
-    #[serde(rename = "HLD")]
+    #[strum(serialize = "HLD")]
     Highland,
-    #[serde(rename = "HIL")]
+    #[strum(serialize = "HIL")]
     Hillingdon,
-    #[serde(rename = "HNS")]
+    #[strum(serialize = "HNS")]
     Hounslow,
-    #[serde(rename = "IVC")]
+    #[strum(serialize = "IVC")]
     Inverclyde,
-    #[serde(rename = "AGY")]
+    #[strum(serialize = "AGY")]
     IsleOfAnglesey,
-    #[serde(rename = "IOW")]
+    #[strum(serialize = "IOW")]
     IsleOfWight,
-    #[serde(rename = "IOS")]
+    #[strum(serialize = "IOS")]
     IslesOfScilly,
-    #[serde(rename = "ISL")]
+    #[strum(serialize = "ISL")]
     Islington,
-    #[serde(rename = "KEC")]
+    #[strum(serialize = "KEC")]
     KensingtonAndChelsea,
-    #[serde(rename = "KEN")]
+    #[strum(serialize = "KEN")]
     Kent,
-    #[serde(rename = "KHL")]
+    #[strum(serialize = "KHL")]
     KingstonUponHull,
-    #[serde(rename = "KTT")]
+    #[strum(serialize = "KTT")]
     KingstonUponThames,
-    #[serde(rename = "KIR")]
+    #[strum(serialize = "KIR")]
     Kirklees,
-    #[serde(rename = "KWL")]
+    #[strum(serialize = "KWL")]
     Knowsley,
-    #[serde(rename = "LBH")]
+    #[strum(serialize = "LBH")]
     Lambeth,
-    #[serde(rename = "LAN")]
+    #[strum(serialize = "LAN")]
     Lancashire,
-    #[serde(rename = "LDS")]
+    #[strum(serialize = "LDS")]
     Leeds,
-    #[serde(rename = "LCE")]
+    #[strum(serialize = "LCE")]
     Leicester,
-    #[serde(rename = "LEC")]
+    #[strum(serialize = "LEC")]
     Leicestershire,
-    #[serde(rename = "LEW")]
+    #[strum(serialize = "LEW")]
     Lewisham,
-    #[serde(rename = "LIN")]
+    #[strum(serialize = "LIN")]
     Lincolnshire,
-    #[serde(rename = "LBC")]
+    #[strum(serialize = "LBC")]
     LisburnAndCastlereagh,
-    #[serde(rename = "LIV")]
+    #[strum(serialize = "LIV")]
     Liverpool,
-    #[serde(rename = "LND")]
+    #[strum(serialize = "LND")]
     LondonCityOf,
-    #[serde(rename = "LUT")]
+    #[strum(serialize = "LUT")]
     Luton,
-    #[serde(rename = "MAN")]
+    #[strum(serialize = "MAN")]
     Manchester,
-    #[serde(rename = "MDW")]
+    #[strum(serialize = "MDW")]
     Medway,
-    #[serde(rename = "MTY")]
+    #[strum(serialize = "MTY")]
     MerthyrTydfil,
-    #[serde(rename = "MRT")]
+    #[strum(serialize = "MRT")]
     Merton,
-    #[serde(rename = "MEA")]
+    #[strum(serialize = "MEA")]
     MidAndEastAntrim,
-    #[serde(rename = "MUL")]
+    #[strum(serialize = "MUL")]
     MidUlster,
-    #[serde(rename = "MDB")]
+    #[strum(serialize = "MDB")]
     Middlesbrough,
-    #[serde(rename = "MLN")]
+    #[strum(serialize = "MLN")]
     Midlothian,
-    #[serde(rename = "MIK")]
+    #[strum(serialize = "MIK")]
     MiltonKeynes,
-    #[serde(rename = "MON")]
+    #[strum(serialize = "MON")]
     Monmouthshire,
-    #[serde(rename = "MRY")]
+    #[strum(serialize = "MRY")]
     Moray,
-    #[serde(rename = "NTL")]
+    #[strum(serialize = "NTL")]
     NeathPortTalbot,
-    #[serde(rename = "NET")]
+    #[strum(serialize = "NET")]
     NewcastleUponTyne,
-    #[serde(rename = "NWM")]
+    #[strum(serialize = "NWM")]
     Newham,
-    #[serde(rename = "NWP")]
+    #[strum(serialize = "NWP")]
     Newport,
-    #[serde(rename = "NMD")]
+    #[strum(serialize = "NMD")]
     NewryMourneAndDown,
-    #[serde(rename = "NFK")]
+    #[strum(serialize = "NFK")]
     Norfolk,
-    #[serde(rename = "NAY")]
+    #[strum(serialize = "NAY")]
     NorthAyrshire,
-    #[serde(rename = "NEL")]
+    #[strum(serialize = "NEL")]
     NorthEastLincolnshire,
-    #[serde(rename = "NLK")]
+    #[strum(serialize = "NLK")]
     NorthLanarkshire,
-    #[serde(rename = "NLN")]
+    #[strum(serialize = "NLN")]
     NorthLincolnshire,
-    #[serde(rename = "NSM")]
+    #[strum(serialize = "NSM")]
     NorthSomerset,
-    #[serde(rename = "NTY")]
+    #[strum(serialize = "NTY")]
     NorthTyneside,
-    #[serde(rename = "NYK")]
+    #[strum(serialize = "NYK")]
     NorthYorkshire,
-    #[serde(rename = "NTH")]
+    #[strum(serialize = "NTH")]
     Northamptonshire,
-    #[serde(rename = "NBL")]
+    #[strum(serialize = "NBL")]
     Northumberland,
-    #[serde(rename = "NGM")]
+    #[strum(serialize = "NGM")]
     Nottingham,
-    #[serde(rename = "NTT")]
+    #[strum(serialize = "NTT")]
     Nottinghamshire,
-    #[serde(rename = "OLD")]
+    #[strum(serialize = "OLD")]
     Oldham,
-    #[serde(rename = "ORK")]
+    #[strum(serialize = "ORK")]
     OrkneyIslands,
-    #[serde(rename = "OXF")]
+    #[strum(serialize = "OXF")]
     Oxfordshire,
-    #[serde(rename = "PEM")]
+    #[strum(serialize = "PEM")]
     Pembrokeshire,
-    #[serde(rename = "PKN")]
+    #[strum(serialize = "PKN")]
     PerthAndKinross,
-    #[serde(rename = "PTE")]
+    #[strum(serialize = "PTE")]
     Peterborough,
-    #[serde(rename = "PLY")]
+    #[strum(serialize = "PLY")]
     Plymouth,
-    #[serde(rename = "POR")]
+    #[strum(serialize = "POR")]
     Portsmouth,
-    #[serde(rename = "POW")]
+    #[strum(serialize = "POW")]
     Powys,
-    #[serde(rename = "RDG")]
+    #[strum(serialize = "RDG")]
     Reading,
-    #[serde(rename = "RDB")]
+    #[strum(serialize = "RDB")]
     Redbridge,
-    #[serde(rename = "RCC")]
+    #[strum(serialize = "RCC")]
     RedcarAndCleveland,
-    #[serde(rename = "RFW")]
+    #[strum(serialize = "RFW")]
     Renfrewshire,
-    #[serde(rename = "RCT")]
+    #[strum(serialize = "RCT")]
     RhonddaCynonTaff,
-    #[serde(rename = "RIC")]
+    #[strum(serialize = "RIC")]
     RichmondUponThames,
-    #[serde(rename = "RCH")]
+    #[strum(serialize = "RCH")]
     Rochdale,
-    #[serde(rename = "ROT")]
+    #[strum(serialize = "ROT")]
     Rotherham,
-    #[serde(rename = "RUT")]
+    #[strum(serialize = "RUT")]
     Rutland,
-    #[serde(rename = "SLF")]
+    #[strum(serialize = "SLF")]
     Salford,
-    #[serde(rename = "SAW")]
+    #[strum(serialize = "SAW")]
     Sandwell,
-    #[serde(rename = "SCB")]
+    #[strum(serialize = "SCB")]
     ScottishBorders,
-    #[serde(rename = "SFT")]
+    #[strum(serialize = "SFT")]
     Sefton,
-    #[serde(rename = "SHF")]
+    #[strum(serialize = "SHF")]
     Sheffield,
-    #[serde(rename = "ZET")]
+    #[strum(serialize = "ZET")]
     ShetlandIslands,
-    #[serde(rename = "SHR")]
+    #[strum(serialize = "SHR")]
     Shropshire,
-    #[serde(rename = "SLG")]
+    #[strum(serialize = "SLG")]
     Slough,
-    #[serde(rename = "SOL")]
+    #[strum(serialize = "SOL")]
     Solihull,
-    #[serde(rename = "SOM")]
+    #[strum(serialize = "SOM")]
     Somerset,
-    #[serde(rename = "SAY")]
+    #[strum(serialize = "SAY")]
     SouthAyrshire,
-    #[serde(rename = "SGC")]
+    #[strum(serialize = "SGC")]
     SouthGloucestershire,
-    #[serde(rename = "SLK")]
+    #[strum(serialize = "SLK")]
     SouthLanarkshire,
-    #[serde(rename = "STY")]
+    #[strum(serialize = "STY")]
     SouthTyneside,
-    #[serde(rename = "STH")]
+    #[strum(serialize = "STH")]
     Southampton,
-    #[serde(rename = "SOS")]
+    #[strum(serialize = "SOS")]
     SouthendOnSea,
-    #[serde(rename = "SWK")]
+    #[strum(serialize = "SWK")]
     Southwark,
-    #[serde(rename = "SHN")]
+    #[strum(serialize = "SHN")]
     StHelens,
-    #[serde(rename = "STS")]
+    #[strum(serialize = "STS")]
     Staffordshire,
-    #[serde(rename = "STG")]
+    #[strum(serialize = "STG")]
     Stirling,
-    #[serde(rename = "SKP")]
+    #[strum(serialize = "SKP")]
     Stockport,
-    #[serde(rename = "STT")]
+    #[strum(serialize = "STT")]
     StocktonOnTees,
-    #[serde(rename = "STE")]
+    #[strum(serialize = "STE")]
     StokeOnTrent,
-    #[serde(rename = "SFK")]
+    #[strum(serialize = "SFK")]
     Suffolk,
-    #[serde(rename = "SND")]
+    #[strum(serialize = "SND")]
     Sunderland,
-    #[serde(rename = "SRY")]
+    #[strum(serialize = "SRY")]
     Surrey,
-    #[serde(rename = "STN")]
+    #[strum(serialize = "STN")]
     Sutton,
-    #[serde(rename = "SWA")]
+    #[strum(serialize = "SWA")]
     Swansea,
-    #[serde(rename = "SWD")]
+    #[strum(serialize = "SWD")]
     Swindon,
-    #[serde(rename = "TAM")]
+    #[strum(serialize = "TAM")]
     Tameside,
-    #[serde(rename = "TFW")]
+    #[strum(serialize = "TFW")]
     TelfordAndWrekin,
-    #[serde(rename = "THR")]
+    #[strum(serialize = "THR")]
     Thurrock,
-    #[serde(rename = "TOB")]
+    #[strum(serialize = "TOB")]
     Torbay,
-    #[serde(rename = "TOF")]
+    #[strum(serialize = "TOF")]
     Torfaen,
-    #[serde(rename = "TWH")]
+    #[strum(serialize = "TWH")]
     TowerHamlets,
-    #[serde(rename = "TRF")]
+    #[strum(serialize = "TRF")]
     Trafford,
-    #[serde(rename = "VGL")]
+    #[strum(serialize = "VGL")]
     ValeOfGlamorgan,
-    #[serde(rename = "WKF")]
+    #[strum(serialize = "WKF")]
     Wakefield,
-    #[serde(rename = "WLL")]
+    #[strum(serialize = "WLL")]
     Walsall,
-    #[serde(rename = "WFT")]
+    #[strum(serialize = "WFT")]
     WalthamForest,
-    #[serde(rename = "WND")]
+    #[strum(serialize = "WND")]
     Wandsworth,
-    #[serde(rename = "WRT")]
+    #[strum(serialize = "WRT")]
     Warrington,
-    #[serde(rename = "WAR")]
+    #[strum(serialize = "WAR")]
     Warwickshire,
-    #[serde(rename = "WBK")]
+    #[strum(serialize = "WBK")]
     WestBerkshire,
-    #[serde(rename = "WDU")]
+    #[strum(serialize = "WDU")]
     WestDunbartonshire,
-    #[serde(rename = "WLN")]
+    #[strum(serialize = "WLN")]
     WestLothian,
-    #[serde(rename = "WSX")]
+    #[strum(serialize = "WSX")]
     WestSussex,
-    #[serde(rename = "WSM")]
+    #[strum(serialize = "WSM")]
     Westminster,
-    #[serde(rename = "WGN")]
+    #[strum(serialize = "WGN")]
     Wigan,
-    #[serde(rename = "WIL")]
+    #[strum(serialize = "WIL")]
     Wiltshire,
-    #[serde(rename = "WNM")]
+    #[strum(serialize = "WNM")]
     WindsorAndMaidenhead,
-    #[serde(rename = "WRL")]
+    #[strum(serialize = "WRL")]
     Wirral,
-    #[serde(rename = "WOK")]
+    #[strum(serialize = "WOK")]
     Wokingham,
-    #[serde(rename = "WLV")]
+    #[strum(serialize = "WLV")]
     Wolverhampton,
-    #[serde(rename = "WOR")]
+    #[strum(serialize = "WOR")]
     Worcestershire,
-    #[serde(rename = "WRX")]
+    #[strum(serialize = "WRX")]
     Wrexham,
-    #[serde(rename = "YOR")]
+    #[strum(serialize = "YOR")]
     York,
 }
 
@@ -5039,87 +5039,87 @@ pub enum UnitedKingdomStatesAbbreviation {
     Debug, Clone, PartialEq, Eq, Serialize, Deserialize, strum::Display, strum::EnumString,
 )]
 pub enum RomaniaStatesAbbreviation {
-    #[serde(rename = "AB")]
+    #[strum(serialize = "AB")]
     Alba,
-    #[serde(rename = "AR")]
+    #[strum(serialize = "AR")]
     AradCounty,
-    #[serde(rename = "AG")]
+    #[strum(serialize = "AG")]
     Arges,
-    #[serde(rename = "BC")]
+    #[strum(serialize = "BC")]
     BacauCounty,
-    #[serde(rename = "BH")]
+    #[strum(serialize = "BH")]
     BihorCounty,
-    #[serde(rename = "BN")]
+    #[strum(serialize = "BN")]
     BistritaNasaudCounty,
-    #[serde(rename = "BT")]
+    #[strum(serialize = "BT")]
     BotosaniCounty,
-    #[serde(rename = "BR")]
+    #[strum(serialize = "BR")]
     Braila,
-    #[serde(rename = "BV")]
+    #[strum(serialize = "BV")]
     BrasovCounty,
-    #[serde(rename = "B")]
+    #[strum(serialize = "B")]
     Bucharest,
-    #[serde(rename = "BZ")]
+    #[strum(serialize = "BZ")]
     BuzauCounty,
-    #[serde(rename = "CS")]
+    #[strum(serialize = "CS")]
     CarasSeverinCounty,
-    #[serde(rename = "CJ")]
+    #[strum(serialize = "CJ")]
     ClujCounty,
-    #[serde(rename = "CT")]
+    #[strum(serialize = "CT")]
     ConstantaCounty,
-    #[serde(rename = "CV")]
+    #[strum(serialize = "CV")]
     CovasnaCounty,
-    #[serde(rename = "CL")]
+    #[strum(serialize = "CL")]
     CalarasiCounty,
-    #[serde(rename = "DJ")]
+    #[strum(serialize = "DJ")]
     DoljCounty,
-    #[serde(rename = "DB")]
+    #[strum(serialize = "DB")]
     DambovitaCounty,
-    #[serde(rename = "GL")]
+    #[strum(serialize = "GL")]
     GalatiCounty,
-    #[serde(rename = "GR")]
+    #[strum(serialize = "GR")]
     GiurgiuCounty,
-    #[serde(rename = "GJ")]
+    #[strum(serialize = "GJ")]
     GorjCounty,
-    #[serde(rename = "HR")]
+    #[strum(serialize = "HR")]
     HarghitaCounty,
-    #[serde(rename = "HD")]
+    #[strum(serialize = "HD")]
     HunedoaraCounty,
-    #[serde(rename = "IL")]
+    #[strum(serialize = "IL")]
     IalomitaCounty,
-    #[serde(rename = "IS")]
+    #[strum(serialize = "IS")]
     IasiCounty,
-    #[serde(rename = "IF")]
+    #[strum(serialize = "IF")]
     IlfovCounty,
-    #[serde(rename = "MH")]
+    #[strum(serialize = "MH")]
     MehedintiCounty,
-    #[serde(rename = "MM")]
+    #[strum(serialize = "MM")]
     MuresCounty,
-    #[serde(rename = "NT")]
+    #[strum(serialize = "NT")]
     NeamtCounty,
-    #[serde(rename = "OT")]
+    #[strum(serialize = "OT")]
     OltCounty,
-    #[serde(rename = "PH")]
+    #[strum(serialize = "PH")]
     PrahovaCounty,
-    #[serde(rename = "SM")]
+    #[strum(serialize = "SM")]
     SatuMareCounty,
-    #[serde(rename = "SB")]
+    #[strum(serialize = "SB")]
     SibiuCounty,
-    #[serde(rename = "SV")]
+    #[strum(serialize = "SV")]
     SuceavaCounty,
-    #[serde(rename = "SJ")]
+    #[strum(serialize = "SJ")]
     SalajCounty,
-    #[serde(rename = "TR")]
+    #[strum(serialize = "TR")]
     TeleormanCounty,
-    #[serde(rename = "TM")]
+    #[strum(serialize = "TM")]
     TimisCounty,
-    #[serde(rename = "TL")]
+    #[strum(serialize = "TL")]
     TulceaCounty,
-    #[serde(rename = "VS")]
+    #[strum(serialize = "VS")]
     VasluiCounty,
-    #[serde(rename = "VN")]
+    #[strum(serialize = "VN")]
     VranceaCounty,
-    #[serde(rename = "VL")]
+    #[strum(serialize = "VL")]
     ValceaCounty,
 }
 

--- a/crates/common_enums/src/enums.rs
+++ b/crates/common_enums/src/enums.rs
@@ -2421,6 +2421,2709 @@ pub enum CanadaStatesAbbreviation {
 }
 
 #[derive(
+    Debug, Clone, PartialEq, Eq, Serialize, Deserialize, strum::Display, strum::EnumString,
+)]
+pub enum AlbaniaStatesAbbreviation {
+    #[serde(rename = "01")]
+    Berat,
+    #[serde(rename = "09")]
+    Diber,
+    #[serde(rename = "02")]
+    Durres,
+    #[serde(rename = "03")]
+    Elbasan,
+    #[serde(rename = "04")]
+    Fier,
+    #[serde(rename = "05")]
+    Gjirokaster,
+    #[serde(rename = "06")]
+    Korce,
+    #[serde(rename = "07")]
+    Kukes,
+    #[serde(rename = "08")]
+    Lezhe,
+    #[serde(rename = "10")]
+    Shkoder,
+    #[serde(rename = "11")]
+    Tirane,
+    #[serde(rename = "12")]
+    Vlore,
+}
+
+#[derive(
+    Debug, Clone, PartialEq, Eq, Serialize, Deserialize, strum::Display, strum::EnumString,
+)]
+pub enum AndorraStatesAbbreviation {
+    #[serde(rename = "07")]
+    AndorraLaVella,
+    #[serde(rename = "02")]
+    Canillo,
+    #[serde(rename = "03")]
+    Encamp,
+    #[serde(rename = "08")]
+    EscaldesEngordany,
+    #[serde(rename = "04")]
+    LaMassana,
+    #[serde(rename = "05")]
+    Ordino,
+    #[serde(rename = "06")]
+    SantJuliaDeLoria,
+}
+
+#[derive(
+    Debug, Clone, PartialEq, Eq, Serialize, Deserialize, strum::Display, strum::EnumString,
+)]
+pub enum AustriaStatesAbbreviation {
+    #[serde(rename = "1")]
+    Burgenland,
+    #[serde(rename = "2")]
+    Carinthia,
+    #[serde(rename = "3")]
+    LowerAustria,
+    #[serde(rename = "5")]
+    Salzburg,
+    #[serde(rename = "6")]
+    Styria,
+    #[serde(rename = "7")]
+    Tyrol,
+    #[serde(rename = "4")]
+    UpperAustria,
+    #[serde(rename = "9")]
+    Vienna,
+    #[serde(rename = "8")]
+    Vorarlberg,
+}
+
+#[derive(
+    Debug, Clone, PartialEq, Eq, Serialize, Deserialize, strum::Display, strum::EnumString,
+)]
+pub enum BelarusStatesAbbreviation {
+    #[serde(rename = "BR")]
+    BrestRegion,
+    #[serde(rename = "HO")]
+    GomelRegion,
+    #[serde(rename = "HR")]
+    GrodnoRegion,
+    #[serde(rename = "HM")]
+    Minsk,
+    #[serde(rename = "MI")]
+    MinskRegion,
+    #[serde(rename = "MA")]
+    MogilevRegion,
+    #[serde(rename = "VI")]
+    VitebskRegion,
+}
+
+#[derive(
+    Debug, Clone, PartialEq, Eq, Serialize, Deserialize, strum::Display, strum::EnumString,
+)]
+pub enum BosniaAndHerzegovinaStatesAbbreviation {
+    #[serde(rename = "05")]
+    BosnianPodrinjeCanton,
+    #[serde(rename = "BRC")]
+    BrckoDistrict,
+    #[serde(rename = "10")]
+    Canton10,
+    #[serde(rename = "06")]
+    CentralBosniaCanton,
+    #[serde(rename = "BIH")]
+    FederationOfBosniaAndHerzegovina,
+    #[serde(rename = "07")]
+    HerzegovinaNeretvaCanton,
+    #[serde(rename = "02")]
+    PosavinaCanton,
+    #[serde(rename = "SRP")]
+    RepublikaSrpska,
+    #[serde(rename = "09")]
+    SarajevoCanton,
+    #[serde(rename = "03")]
+    TuzlaCanton,
+    #[serde(rename = "01")]
+    UnaSanaCanton,
+    #[serde(rename = "08")]
+    WestHerzegovinaCanton,
+    #[serde(rename = "04")]
+    ZenicaDobojCanton,
+}
+
+#[derive(
+    Debug, Clone, PartialEq, Eq, Serialize, Deserialize, strum::Display, strum::EnumString,
+)]
+pub enum BulgariaStatesAbbreviation {
+    #[serde(rename = "01")]
+    BlagoevgradProvince,
+    #[serde(rename = "02")]
+    BurgasProvince,
+    #[serde(rename = "08")]
+    DobrichProvince,
+    #[serde(rename = "07")]
+    GabrovoProvince,
+    #[serde(rename = "26")]
+    HaskovoProvince,
+    #[serde(rename = "09")]
+    KardzhaliProvince,
+    #[serde(rename = "10")]
+    KyustendilProvince,
+    #[serde(rename = "11")]
+    LovechProvince,
+    #[serde(rename = "12")]
+    MontanaProvince,
+    #[serde(rename = "13")]
+    PazardzhikProvince,
+    #[serde(rename = "14")]
+    PernikProvince,
+    #[serde(rename = "15")]
+    PlevenProvince,
+    #[serde(rename = "16")]
+    PlovdivProvince,
+    #[serde(rename = "17")]
+    RazgradProvince,
+    #[serde(rename = "18")]
+    RuseProvince,
+    #[serde(rename = "27")]
+    Shumen,
+    #[serde(rename = "19")]
+    SilistraProvince,
+    #[serde(rename = "20")]
+    SlivenProvince,
+    #[serde(rename = "21")]
+    SmolyanProvince,
+    #[serde(rename = "22")]
+    SofiaCityProvince,
+    #[serde(rename = "23")]
+    SofiaProvince,
+    #[serde(rename = "24")]
+    StaraZagoraProvince,
+    #[serde(rename = "25")]
+    TargovishteProvince,
+    #[serde(rename = "03")]
+    VarnaProvince,
+    #[serde(rename = "04")]
+    VelikoTarnovoProvince,
+    #[serde(rename = "05")]
+    VidinProvince,
+    #[serde(rename = "06")]
+    VratsaProvince,
+    #[serde(rename = "28")]
+    YambolProvince,
+}
+
+#[derive(
+    Debug, Clone, PartialEq, Eq, Serialize, Deserialize, strum::Display, strum::EnumString,
+)]
+pub enum CroatiaStatesAbbreviation {
+    #[serde(rename = "07")]
+    BjelovarBilogoraCounty,
+    #[serde(rename = "12")]
+    BrodPosavinaCounty,
+    #[serde(rename = "19")]
+    DubrovnikNeretvaCounty,
+    #[serde(rename = "18")]
+    IstriaCounty,
+    #[serde(rename = "06")]
+    KoprivnicaKrizevciCounty,
+    #[serde(rename = "02")]
+    KrapinaZagorjeCounty,
+    #[serde(rename = "09")]
+    LikaSenjCounty,
+    #[serde(rename = "20")]
+    MedimurjeCounty,
+    #[serde(rename = "14")]
+    OsijekBaranjaCounty,
+    #[serde(rename = "11")]
+    PozegaSlavoniaCounty,
+    #[serde(rename = "08")]
+    PrimorjeGorskiKotarCounty,
+    #[serde(rename = "03")]
+    SisakMoslavinaCounty,
+    #[serde(rename = "17")]
+    SplitDalmatiaCounty,
+    #[serde(rename = "05")]
+    VarazdinCounty,
+    #[serde(rename = "10")]
+    ViroviticaPodravinaCounty,
+    #[serde(rename = "16")]
+    VukovarSyrmiaCounty,
+    #[serde(rename = "13")]
+    ZadarCounty,
+    #[serde(rename = "21")]
+    Zagreb,
+    #[serde(rename = "01")]
+    ZagrebCounty,
+    #[serde(rename = "15")]
+    SibenikKninCounty,
+}
+
+#[derive(
+    Debug, Clone, PartialEq, Eq, Serialize, Deserialize, strum::Display, strum::EnumString,
+)]
+pub enum CzechRepublicStatesAbbreviation {
+    #[serde(rename = "201")]
+    BenesovDistrict,
+    #[serde(rename = "202")]
+    BerounDistrict,
+    #[serde(rename = "641")]
+    BlanskoDistrict,
+    #[serde(rename = "642")]
+    BrnoCityDistrict,
+    #[serde(rename = "643")]
+    BrnoCountryDistrict,
+    #[serde(rename = "801")]
+    BruntalDistrict,
+    #[serde(rename = "644")]
+    BreclavDistrict,
+    #[serde(rename = "20")]
+    CentralBohemianRegion,
+    #[serde(rename = "411")]
+    ChebDistrict,
+    #[serde(rename = "422")]
+    ChomutovDistrict,
+    #[serde(rename = "531")]
+    ChrudimDistrict,
+    #[serde(rename = "321")]
+    DomazliceDistrict,
+    #[serde(rename = "421")]
+    DecinDistrict,
+    #[serde(rename = "802")]
+    FrydekMistekDistrict,
+    #[serde(rename = "631")]
+    HavlickuvBrodDistrict,
+    #[serde(rename = "645")]
+    HodoninDistrict,
+    #[serde(rename = "120")]
+    HorniPocernice,
+    #[serde(rename = "521")]
+    HradecKraloveDistrict,
+    #[serde(rename = "52")]
+    HradecKraloveRegion,
+    #[serde(rename = "512")]
+    JablonecNadNisouDistrict,
+    #[serde(rename = "711")]
+    JesenikDistrict,
+    #[serde(rename = "632")]
+    JihlavaDistrict,
+    #[serde(rename = "313")]
+    JindrichuvHradecDistrict,
+    #[serde(rename = "522")]
+    JicinDistrict,
+    #[serde(rename = "412")]
+    KarlovyVaryDistrict,
+    #[serde(rename = "41")]
+    KarlovyVaryRegion,
+    #[serde(rename = "803")]
+    KarvinaDistrict,
+    #[serde(rename = "203")]
+    KladnoDistrict,
+    #[serde(rename = "322")]
+    KlatovyDistrict,
+    #[serde(rename = "204")]
+    KolinDistrict,
+    #[serde(rename = "721")]
+    KromerizDistrict,
+    #[serde(rename = "513")]
+    LiberecDistrict,
+    #[serde(rename = "51")]
+    LiberecRegion,
+    #[serde(rename = "423")]
+    LitomericeDistrict,
+    #[serde(rename = "424")]
+    LounyDistrict,
+    #[serde(rename = "207")]
+    MladaBoleslavDistrict,
+    #[serde(rename = "80")]
+    MoravianSilesianRegion,
+    #[serde(rename = "425")]
+    MostDistrict,
+    #[serde(rename = "206")]
+    MelnikDistrict,
+    #[serde(rename = "804")]
+    NovyJicinDistrict,
+    #[serde(rename = "208")]
+    NymburkDistrict,
+    #[serde(rename = "523")]
+    NachodDistrict,
+    #[serde(rename = "712")]
+    OlomoucDistrict,
+    #[serde(rename = "71")]
+    OlomoucRegion,
+    #[serde(rename = "805")]
+    OpavaDistrict,
+    #[serde(rename = "806")]
+    OstravaCityDistrict,
+    #[serde(rename = "532")]
+    PardubiceDistrict,
+    #[serde(rename = "53")]
+    PardubiceRegion,
+    #[serde(rename = "633")]
+    PelhrimovDistrict,
+    #[serde(rename = "32")]
+    PlzenRegion,
+    #[serde(rename = "323")]
+    PlzenCityDistrict,
+    #[serde(rename = "325")]
+    PlzenNorthDistrict,
+    #[serde(rename = "324")]
+    PlzenSouthDistrict,
+    #[serde(rename = "315")]
+    PrachaticeDistrict,
+    #[serde(rename = "10")]
+    Prague,
+    #[serde(rename = "101")]
+    Prague1,
+    #[serde(rename = "110")]
+    Prague10,
+    #[serde(rename = "111")]
+    Prague11,
+    #[serde(rename = "112")]
+    Prague12,
+    #[serde(rename = "113")]
+    Prague13,
+    #[serde(rename = "114")]
+    Prague14,
+    #[serde(rename = "115")]
+    Prague15,
+    #[serde(rename = "116")]
+    Prague16,
+    #[serde(rename = "102")]
+    Prague2,
+    #[serde(rename = "121")]
+    Prague21,
+    #[serde(rename = "103")]
+    Prague3,
+    #[serde(rename = "104")]
+    Prague4,
+    #[serde(rename = "105")]
+    Prague5,
+    #[serde(rename = "106")]
+    Prague6,
+    #[serde(rename = "107")]
+    Prague7,
+    #[serde(rename = "108")]
+    Prague8,
+    #[serde(rename = "109")]
+    Prague9,
+    #[serde(rename = "209")]
+    PragueEastDistrict,
+    #[serde(rename = "20A")]
+    PragueWestDistrict,
+    #[serde(rename = "713")]
+    ProstejovDistrict,
+    #[serde(rename = "314")]
+    PisekDistrict,
+    #[serde(rename = "714")]
+    PrerovDistrict,
+    #[serde(rename = "20B")]
+    PribramDistrict,
+    #[serde(rename = "20C")]
+    RakovnikDistrict,
+    #[serde(rename = "326")]
+    RokycanyDistrict,
+    #[serde(rename = "524")]
+    RychnovNadKneznouDistrict,
+    #[serde(rename = "514")]
+    SemilyDistrict,
+    #[serde(rename = "413")]
+    SokolovDistrict,
+    #[serde(rename = "31")]
+    SouthBohemianRegion,
+    #[serde(rename = "64")]
+    SouthMoravianRegion,
+    #[serde(rename = "316")]
+    StrakoniceDistrict,
+    #[serde(rename = "533")]
+    SvitavyDistrict,
+    #[serde(rename = "327")]
+    TachovDistrict,
+    #[serde(rename = "426")]
+    TepliceDistrict,
+    #[serde(rename = "525")]
+    TrutnovDistrict,
+    #[serde(rename = "317")]
+    TaborDistrict,
+    #[serde(rename = "634")]
+    TrebicDistrict,
+    #[serde(rename = "722")]
+    UherskeHradisteDistrict,
+    #[serde(rename = "723")]
+    VsetinDistrict,
+    #[serde(rename = "63")]
+    VysocinaRegion,
+    #[serde(rename = "646")]
+    VyskovDistrict,
+    #[serde(rename = "724")]
+    ZlinDistrict,
+    #[serde(rename = "72")]
+    ZlinRegion,
+    #[serde(rename = "647")]
+    ZnojmoDistrict,
+    #[serde(rename = "427")]
+    UstiNadLabemDistrict,
+    #[serde(rename = "42")]
+    UstiNadLabemRegion,
+    #[serde(rename = "534")]
+    UstiNadOrliciDistrict,
+    #[serde(rename = "511")]
+    CeskaLipaDistrict,
+    #[serde(rename = "311")]
+    CeskeBudejoviceDistrict,
+    #[serde(rename = "312")]
+    CeskyKrumlovDistrict,
+    #[serde(rename = "715")]
+    SumperkDistrict,
+    #[serde(rename = "635")]
+    ZdarNadSazavouDistrict,
+}
+
+#[derive(
+    Debug, Clone, PartialEq, Eq, Serialize, Deserialize, strum::Display, strum::EnumString,
+)]
+pub enum DenmarkStatesAbbreviation {
+    #[serde(rename = "84")]
+    CapitalRegionOfDenmark,
+    #[serde(rename = "82")]
+    CentralDenmarkRegion,
+    #[serde(rename = "81")]
+    NorthDenmarkRegion,
+    #[serde(rename = "85")]
+    RegionZealand,
+    #[serde(rename = "83")]
+    RegionOfSouthernDenmark,
+}
+
+#[derive(
+    Debug, Clone, PartialEq, Eq, Serialize, Deserialize, strum::Display, strum::EnumString,
+)]
+pub enum FinlandStatesAbbreviation {
+    #[serde(rename = "08")]
+    CentralFinland,
+    #[serde(rename = "07")]
+    CentralOstrobothnia,
+    #[serde(rename = "IS")]
+    EasternFinlandProvince,
+    #[serde(rename = "19")]
+    FinlandProper,
+    #[serde(rename = "05")]
+    Kainuu,
+    #[serde(rename = "09")]
+    Kymenlaakso,
+    #[serde(rename = "LL")]
+    Lapland,
+    #[serde(rename = "13")]
+    NorthKarelia,
+    #[serde(rename = "14")]
+    NorthernOstrobothnia,
+    #[serde(rename = "15")]
+    NorthernSavonia,
+    #[serde(rename = "12")]
+    Ostrobothnia,
+    #[serde(rename = "OL")]
+    OuluProvince,
+    #[serde(rename = "11")]
+    Pirkanmaa,
+    #[serde(rename = "16")]
+    PaijanneTavastia,
+    #[serde(rename = "17")]
+    Satakunta,
+    #[serde(rename = "02")]
+    SouthKarelia,
+    #[serde(rename = "03")]
+    SouthernOstrobothnia,
+    #[serde(rename = "04")]
+    SouthernSavonia,
+    #[serde(rename = "06")]
+    TavastiaProper,
+    #[serde(rename = "18")]
+    Uusimaa,
+    #[serde(rename = "01")]
+    AlandIslands,
+}
+
+#[derive(
+    Debug, Clone, PartialEq, Eq, Serialize, Deserialize, strum::Display, strum::EnumString,
+)]
+pub enum FranceStatesAbbreviation {
+    #[serde(rename = "WF-AL")]
+    Alo,
+    #[serde(rename = "A")]
+    Alsace,
+    #[serde(rename = "B")]
+    Aquitaine,
+    #[serde(rename = "C")]
+    Auvergne,
+    #[serde(rename = "ARA")]
+    AuvergneRhoneAlpes,
+    #[serde(rename = "BFC")]
+    BourgogneFrancheComte,
+    #[serde(rename = "BRE")]
+    Brittany,
+    #[serde(rename = "D")]
+    Burgundy,
+    #[serde(rename = "CVL")]
+    CentreValDeLoire,
+    #[serde(rename = "G")]
+    ChampagneArdenne,
+    #[serde(rename = "COR")]
+    Corsica,
+    #[serde(rename = "I")]
+    FrancheComte,
+    #[serde(rename = "GF")]
+    FrenchGuiana,
+    #[serde(rename = "PF")]
+    FrenchPolynesia,
+    #[serde(rename = "GES")]
+    GrandEst,
+    #[serde(rename = "GP")]
+    Guadeloupe,
+    #[serde(rename = "HDF")]
+    HautsDeFrance,
+    #[serde(rename = "K")]
+    LanguedocRoussillon,
+    #[serde(rename = "L")]
+    Limousin,
+    #[serde(rename = "M")]
+    Lorraine,
+    #[serde(rename = "P")]
+    LowerNormandy,
+    #[serde(rename = "MQ")]
+    Martinique,
+    #[serde(rename = "YT")]
+    Mayotte,
+    #[serde(rename = "O")]
+    NordPasDeCalais,
+    #[serde(rename = "NOR")]
+    Normandy,
+    #[serde(rename = "NAQ")]
+    NouvelleAquitaine,
+    #[serde(rename = "OCC")]
+    Occitania,
+    #[serde(rename = "75")]
+    Paris,
+    #[serde(rename = "PDL")]
+    PaysDeLaLoire,
+    #[serde(rename = "S")]
+    Picardy,
+    #[serde(rename = "T")]
+    PoitouCharentes,
+    #[serde(rename = "PAC")]
+    ProvenceAlpesCoteDAzur,
+    #[serde(rename = "V")]
+    RhoneAlpes,
+    #[serde(rename = "RE")]
+    Reunion,
+    #[serde(rename = "BL")]
+    SaintBarthelemy,
+    #[serde(rename = "MF")]
+    SaintMartin,
+    #[serde(rename = "PM")]
+    SaintPierreAndMiquelon,
+    #[serde(rename = "WF-SG")]
+    Sigave,
+    #[serde(rename = "Q")]
+    UpperNormandy,
+    #[serde(rename = "WF-UV")]
+    Uvea,
+    #[serde(rename = "WF")]
+    WallisAndFutuna,
+    #[serde(rename = "IDF")]
+    IleDeFrance,
+}
+
+#[derive(
+    Debug, Clone, PartialEq, Eq, Serialize, Deserialize, strum::Display, strum::EnumString,
+)]
+pub enum GermanyStatesAbbreviation {
+    #[serde(rename = "BW")]
+    BadenWurttemberg,
+    #[serde(rename = "BY")]
+    Bavaria,
+    #[serde(rename = "BE")]
+    Berlin,
+    #[serde(rename = "BB")]
+    Brandenburg,
+    #[serde(rename = "HB")]
+    Bremen,
+    #[serde(rename = "HH")]
+    Hamburg,
+    #[serde(rename = "HE")]
+    Hesse,
+    #[serde(rename = "NI")]
+    LowerSaxony,
+    #[serde(rename = "MV")]
+    MecklenburgVorpommern,
+    #[serde(rename = "NW")]
+    NorthRhineWestphalia,
+    #[serde(rename = "RP")]
+    RhinelandPalatinate,
+    #[serde(rename = "SL")]
+    Saarland,
+    #[serde(rename = "SN")]
+    Saxony,
+    #[serde(rename = "ST")]
+    SaxonyAnhalt,
+    #[serde(rename = "SH")]
+    SchleswigHolstein,
+    #[serde(rename = "TH")]
+    Thuringia,
+}
+
+#[derive(
+    Debug, Clone, PartialEq, Eq, Serialize, Deserialize, strum::Display, strum::EnumString,
+)]
+pub enum GreeceStatesAbbreviation {
+    #[serde(rename = "13")]
+    AchaeaRegionalUnit,
+    #[serde(rename = "01")]
+    AetoliaAcarnaniaRegionalUnit,
+    #[serde(rename = "12")]
+    ArcadiaPrefecture,
+    #[serde(rename = "11")]
+    ArgolisRegionalUnit,
+    #[serde(rename = "I")]
+    AtticaRegion,
+    #[serde(rename = "03")]
+    BoeotiaRegionalUnit,
+    #[serde(rename = "H")]
+    CentralGreeceRegion,
+    #[serde(rename = "B")]
+    CentralMacedonia,
+    #[serde(rename = "94")]
+    ChaniaRegionalUnit,
+    #[serde(rename = "22")]
+    CorfuPrefecture,
+    #[serde(rename = "15")]
+    CorinthiaRegionalUnit,
+    #[serde(rename = "M")]
+    CreteRegion,
+    #[serde(rename = "52")]
+    DramaRegionalUnit,
+    #[serde(rename = "A2")]
+    EastAtticaRegionalUnit,
+    #[serde(rename = "A")]
+    EastMacedoniaAndThrace,
+    #[serde(rename = "D")]
+    EpirusRegion,
+    #[serde(rename = "04")]
+    Euboea,
+    #[serde(rename = "51")]
+    GrevenaPrefecture,
+    #[serde(rename = "53")]
+    ImathiaRegionalUnit,
+    #[serde(rename = "33")]
+    IoanninaRegionalUnit,
+    #[serde(rename = "F")]
+    IonianIslandsRegion,
+    #[serde(rename = "41")]
+    KarditsaRegionalUnit,
+    #[serde(rename = "56")]
+    KastoriaRegionalUnit,
+    #[serde(rename = "23")]
+    KefaloniaPrefecture,
+    #[serde(rename = "57")]
+    KilkisRegionalUnit,
+    #[serde(rename = "58")]
+    KozaniPrefecture,
+    #[serde(rename = "16")]
+    Laconia,
+    #[serde(rename = "42")]
+    LarissaPrefecture,
+    #[serde(rename = "24")]
+    LefkadaRegionalUnit,
+    #[serde(rename = "59")]
+    PellaRegionalUnit,
+    #[serde(rename = "J")]
+    PeloponneseRegion,
+    #[serde(rename = "06")]
+    PhthiotisPrefecture,
+    #[serde(rename = "34")]
+    PrevezaPrefecture,
+    #[serde(rename = "62")]
+    SerresPrefecture,
+    #[serde(rename = "L")]
+    SouthAegean,
+    #[serde(rename = "54")]
+    ThessalonikiRegionalUnit,
+    #[serde(rename = "G")]
+    WestGreeceRegion,
+    #[serde(rename = "C")]
+    WestMacedoniaRegion,
+}
+
+#[derive(
+    Debug, Clone, PartialEq, Eq, Serialize, Deserialize, strum::Display, strum::EnumString,
+)]
+pub enum HungaryStatesAbbreviation {
+    #[serde(rename = "BA")]
+    BaranyaCounty,
+    #[serde(rename = "BZ")]
+    BorsodAbaujZemplenCounty,
+    #[serde(rename = "BU")]
+    Budapest,
+    #[serde(rename = "BK")]
+    BacsKiskunCounty,
+    #[serde(rename = "BE")]
+    BekesCounty,
+    #[serde(rename = "BC")]
+    Bekescsaba,
+    #[serde(rename = "CS")]
+    CsongradCounty,
+    #[serde(rename = "DE")]
+    Debrecen,
+    #[serde(rename = "DU")]
+    Dunaujvaros,
+    #[serde(rename = "EG")]
+    Eger,
+    #[serde(rename = "FE")]
+    FejerCounty,
+    #[serde(rename = "GY")]
+    Gyor,
+    #[serde(rename = "GS")]
+    GyorMosonSopronCounty,
+    #[serde(rename = "HB")]
+    HajduBiharCounty,
+    #[serde(rename = "HE")]
+    HevesCounty,
+    #[serde(rename = "HV")]
+    Hodmezovasarhely,
+    #[serde(rename = "JN")]
+    JaszNagykunSzolnokCounty,
+    #[serde(rename = "KV")]
+    Kaposvar,
+    #[serde(rename = "KM")]
+    Kecskemet,
+    #[serde(rename = "MI")]
+    Miskolc,
+    #[serde(rename = "NK")]
+    Nagykanizsa,
+    #[serde(rename = "NY")]
+    Nyiregyhaza,
+    #[serde(rename = "NO")]
+    NogradCounty,
+    #[serde(rename = "PE")]
+    PestCounty,
+    #[serde(rename = "PS")]
+    Pecs,
+    #[serde(rename = "ST")]
+    Salgotarjan,
+    #[serde(rename = "SO")]
+    SomogyCounty,
+    #[serde(rename = "SN")]
+    Sopron,
+    #[serde(rename = "SZ")]
+    SzabolcsSzatmarBeregCounty,
+    #[serde(rename = "SD")]
+    Szeged,
+    #[serde(rename = "SS")]
+    Szekszard,
+    #[serde(rename = "SK")]
+    Szolnok,
+    #[serde(rename = "SH")]
+    Szombathely,
+    #[serde(rename = "SF")]
+    Szekesfehervar,
+    #[serde(rename = "TB")]
+    Tatabanya,
+    #[serde(rename = "TO")]
+    TolnaCounty,
+    #[serde(rename = "VA")]
+    VasCounty,
+    #[serde(rename = "VM")]
+    Veszprem,
+    #[serde(rename = "VE")]
+    VeszpremCounty,
+    #[serde(rename = "ZA")]
+    ZalaCounty,
+    #[serde(rename = "ZE")]
+    Zalaegerszeg,
+    #[serde(rename = "ER")]
+    Erd,
+}
+
+#[derive(
+    Debug, Clone, PartialEq, Eq, Serialize, Deserialize, strum::Display, strum::EnumString,
+)]
+pub enum IcelandStatesAbbreviation {
+    #[serde(rename = "1")]
+    CapitalRegion,
+    #[serde(rename = "7")]
+    EasternRegion,
+    #[serde(rename = "6")]
+    NortheasternRegion,
+    #[serde(rename = "5")]
+    NorthwesternRegion,
+    #[serde(rename = "2")]
+    SouthernPeninsulaRegion,
+    #[serde(rename = "8")]
+    SouthernRegion,
+    #[serde(rename = "3")]
+    WesternRegion,
+    #[serde(rename = "4")]
+    Westfjords,
+}
+
+#[derive(
+    Debug, Clone, PartialEq, Eq, Serialize, Deserialize, strum::Display, strum::EnumString,
+)]
+pub enum IrelandStatesAbbreviation {
+    #[serde(rename = "C")]
+    Connacht,
+    #[serde(rename = "CW")]
+    CountyCarlow,
+    #[serde(rename = "CN")]
+    CountyCavan,
+    #[serde(rename = "CE")]
+    CountyClare,
+    #[serde(rename = "CO")]
+    CountyCork,
+    #[serde(rename = "DL")]
+    CountyDonegal,
+    #[serde(rename = "D")]
+    CountyDublin,
+    #[serde(rename = "G")]
+    CountyGalway,
+    #[serde(rename = "KY")]
+    CountyKerry,
+    #[serde(rename = "KE")]
+    CountyKildare,
+    #[serde(rename = "KK")]
+    CountyKilkenny,
+    #[serde(rename = "LS")]
+    CountyLaois,
+    #[serde(rename = "LK")]
+    CountyLimerick,
+    #[serde(rename = "LD")]
+    CountyLongford,
+    #[serde(rename = "LH")]
+    CountyLouth,
+    #[serde(rename = "MO")]
+    CountyMayo,
+    #[serde(rename = "MH")]
+    CountyMeath,
+    #[serde(rename = "MN")]
+    CountyMonaghan,
+    #[serde(rename = "OY")]
+    CountyOffaly,
+    #[serde(rename = "RN")]
+    CountyRoscommon,
+    #[serde(rename = "SO")]
+    CountySligo,
+    #[serde(rename = "TA")]
+    CountyTipperary,
+    #[serde(rename = "WD")]
+    CountyWaterford,
+    #[serde(rename = "WH")]
+    CountyWestmeath,
+    #[serde(rename = "WX")]
+    CountyWexford,
+    #[serde(rename = "WW")]
+    CountyWicklow,
+    #[serde(rename = "L")]
+    Leinster,
+    #[serde(rename = "M")]
+    Munster,
+    #[serde(rename = "U")]
+    Ulster,
+}
+
+#[derive(
+    Debug, Clone, PartialEq, Eq, Serialize, Deserialize, strum::Display, strum::EnumString,
+)]
+pub enum LatviaStatesAbbreviation {
+    #[serde(rename = "001")]
+    AglonaMunicipality,
+    #[serde(rename = "002")]
+    AizkraukleMunicipality,
+    #[serde(rename = "003")]
+    AizputeMunicipality,
+    #[serde(rename = "004")]
+    AknīsteMunicipality,
+    #[serde(rename = "005")]
+    AlojaMunicipality,
+    #[serde(rename = "006")]
+    AlsungaMunicipality,
+    #[serde(rename = "007")]
+    AlūksneMunicipality,
+    #[serde(rename = "008")]
+    AmataMunicipality,
+    #[serde(rename = "009")]
+    ApeMunicipality,
+    #[serde(rename = "010")]
+    AuceMunicipality,
+    #[serde(rename = "012")]
+    BabīteMunicipality,
+    #[serde(rename = "013")]
+    BaldoneMunicipality,
+    #[serde(rename = "014")]
+    BaltinavaMunicipality,
+    #[serde(rename = "015")]
+    BalviMunicipality,
+    #[serde(rename = "016")]
+    BauskaMunicipality,
+    #[serde(rename = "017")]
+    BeverīnaMunicipality,
+    #[serde(rename = "018")]
+    BrocēniMunicipality,
+    #[serde(rename = "019")]
+    BurtniekiMunicipality,
+    #[serde(rename = "020")]
+    CarnikavaMunicipality,
+    #[serde(rename = "021")]
+    CesvaineMunicipality,
+    #[serde(rename = "023")]
+    CiblaMunicipality,
+    #[serde(rename = "022")]
+    CēsisMunicipality,
+    #[serde(rename = "024")]
+    DagdaMunicipality,
+    #[serde(rename = "DGV")]
+    Daugavpils,
+    #[serde(rename = "025")]
+    DaugavpilsMunicipality,
+    #[serde(rename = "026")]
+    DobeleMunicipality,
+    #[serde(rename = "027")]
+    DundagaMunicipality,
+    #[serde(rename = "028")]
+    DurbeMunicipality,
+    #[serde(rename = "029")]
+    EngureMunicipality,
+    #[serde(rename = "031")]
+    GarkalneMunicipality,
+    #[serde(rename = "032")]
+    GrobiņaMunicipality,
+    #[serde(rename = "033")]
+    GulbeneMunicipality,
+    #[serde(rename = "034")]
+    IecavaMunicipality,
+    #[serde(rename = "035")]
+    IkšķileMunicipality,
+    #[serde(rename = "036")]
+    IlūksteMunicipality,
+    #[serde(rename = "037")]
+    InčukalnsMunicipality,
+    #[serde(rename = "038")]
+    JaunjelgavaMunicipality,
+    #[serde(rename = "039")]
+    JaunpiebalgaMunicipality,
+    #[serde(rename = "040")]
+    JaunpilsMunicipality,
+    #[serde(rename = "JEL")]
+    Jelgava,
+    #[serde(rename = "041")]
+    JelgavaMunicipality,
+    #[serde(rename = "JKB")]
+    Jēkabpils,
+    #[serde(rename = "042")]
+    JēkabpilsMunicipality,
+    #[serde(rename = "JUR")]
+    Jūrmala,
+    #[serde(rename = "043")]
+    KandavaMunicipality,
+    #[serde(rename = "045")]
+    KocēniMunicipality,
+    #[serde(rename = "046")]
+    KokneseMunicipality,
+    #[serde(rename = "048")]
+    KrimuldaMunicipality,
+    #[serde(rename = "049")]
+    KrustpilsMunicipality,
+    #[serde(rename = "047")]
+    KrāslavaMunicipality,
+    #[serde(rename = "050")]
+    KuldīgaMunicipality,
+    #[serde(rename = "044")]
+    KārsavaMunicipality,
+    #[serde(rename = "053")]
+    LielvārdeMunicipality,
+    #[serde(rename = "LPX")]
+    Liepāja,
+    #[serde(rename = "054")]
+    LimbažiMunicipality,
+    #[serde(rename = "057")]
+    LubānaMunicipality,
+    #[serde(rename = "058")]
+    LudzaMunicipality,
+    #[serde(rename = "055")]
+    LīgatneMunicipality,
+    #[serde(rename = "056")]
+    LīvāniMunicipality,
+    #[serde(rename = "059")]
+    MadonaMunicipality,
+    #[serde(rename = "060")]
+    MazsalacaMunicipality,
+    #[serde(rename = "061")]
+    MālpilsMunicipality,
+    #[serde(rename = "062")]
+    MārupeMunicipality,
+    #[serde(rename = "063")]
+    MērsragsMunicipality,
+    #[serde(rename = "064")]
+    NaukšēniMunicipality,
+    #[serde(rename = "065")]
+    NeretaMunicipality,
+    #[serde(rename = "066")]
+    NīcaMunicipality,
+    #[serde(rename = "067")]
+    OgreMunicipality,
+    #[serde(rename = "068")]
+    OlaineMunicipality,
+    #[serde(rename = "069")]
+    OzolniekiMunicipality,
+    #[serde(rename = "073")]
+    PreiļiMunicipality,
+    #[serde(rename = "074")]
+    PriekuleMunicipality,
+    #[serde(rename = "075")]
+    PriekuļiMunicipality,
+    #[serde(rename = "070")]
+    PārgaujaMunicipality,
+    #[serde(rename = "071")]
+    PāvilostaMunicipality,
+    #[serde(rename = "072")]
+    PļaviņasMunicipality,
+    #[serde(rename = "076")]
+    RaunaMunicipality,
+    #[serde(rename = "078")]
+    RiebiņiMunicipality,
+    #[serde(rename = "RIX")]
+    Riga,
+    #[serde(rename = "079")]
+    RojaMunicipality,
+    #[serde(rename = "080")]
+    RopažiMunicipality,
+    #[serde(rename = "081")]
+    RucavaMunicipality,
+    #[serde(rename = "082")]
+    RugājiMunicipality,
+    #[serde(rename = "083")]
+    RundāleMunicipality,
+    #[serde(rename = "REZ")]
+    Rēzekne,
+    #[serde(rename = "077")]
+    RēzekneMunicipality,
+    #[serde(rename = "084")]
+    RūjienaMunicipality,
+    #[serde(rename = "085")]
+    SalaMunicipality,
+    #[serde(rename = "086")]
+    SalacgrīvaMunicipality,
+    #[serde(rename = "087")]
+    SalaspilsMunicipality,
+    #[serde(rename = "088")]
+    SaldusMunicipality,
+    #[serde(rename = "089")]
+    SaulkrastiMunicipality,
+    #[serde(rename = "091")]
+    SiguldaMunicipality,
+    #[serde(rename = "093")]
+    SkrundaMunicipality,
+    #[serde(rename = "092")]
+    SkrīveriMunicipality,
+    #[serde(rename = "094")]
+    SmilteneMunicipality,
+    #[serde(rename = "095")]
+    StopiņiMunicipality,
+    #[serde(rename = "096")]
+    StrenčiMunicipality,
+    #[serde(rename = "090")]
+    SējaMunicipality,
+}
+
+#[derive(
+    Debug, Clone, PartialEq, Eq, Serialize, Deserialize, strum::Display, strum::EnumString,
+)]
+pub enum ItalyStatesAbbreviation {
+    #[serde(rename = "65")]
+    Abruzzo,
+    #[serde(rename = "23")]
+    AostaValley,
+    #[serde(rename = "75")]
+    Apulia,
+    #[serde(rename = "77")]
+    Basilicata,
+    #[serde(rename = "BN")]
+    BeneventoProvince,
+    #[serde(rename = "78")]
+    Calabria,
+    #[serde(rename = "72")]
+    Campania,
+    #[serde(rename = "45")]
+    EmiliaRomagna,
+    #[serde(rename = "36")]
+    FriuliVeneziaGiulia,
+    #[serde(rename = "62")]
+    Lazio,
+    #[serde(rename = "42")]
+    Liguria,
+    #[serde(rename = "25")]
+    Lombardy,
+    #[serde(rename = "57")]
+    Marche,
+    #[serde(rename = "67")]
+    Molise,
+    #[serde(rename = "21")]
+    Piedmont,
+    #[serde(rename = "88")]
+    Sardinia,
+    #[serde(rename = "82")]
+    Sicily,
+    #[serde(rename = "32")]
+    TrentinoSouthTyrol,
+    #[serde(rename = "52")]
+    Tuscany,
+    #[serde(rename = "55")]
+    Umbria,
+    #[serde(rename = "34")]
+    Veneto,
+    #[serde(rename = "AG")]
+    Agrigento,
+    #[serde(rename = "CL")]
+    Caltanissetta,
+    #[serde(rename = "EN")]
+    Enna,
+    #[serde(rename = "RG")]
+    Ragusa,
+    #[serde(rename = "SR")]
+    Siracusa,
+    #[serde(rename = "TP")]
+    Trapani,
+    #[serde(rename = "BA")]
+    Bari,
+    #[serde(rename = "BO")]
+    Bologna,
+    #[serde(rename = "CA")]
+    Cagliari,
+    #[serde(rename = "CT")]
+    Catania,
+    #[serde(rename = "FI")]
+    Florence,
+    #[serde(rename = "GE")]
+    Genoa,
+    #[serde(rename = "ME")]
+    Messina,
+    #[serde(rename = "MI")]
+    Milan,
+    #[serde(rename = "NA")]
+    Naples,
+    #[serde(rename = "PA")]
+    Palermo,
+    #[serde(rename = "RC")]
+    ReggioCalabria,
+    #[serde(rename = "RM")]
+    Rome,
+    #[serde(rename = "TO")]
+    Turin,
+    #[serde(rename = "VE")]
+    Venice,
+}
+
+#[derive(
+    Debug, Clone, PartialEq, Eq, Serialize, Deserialize, strum::Display, strum::EnumString,
+)]
+pub enum LiechtensteinStatesAbbreviation {
+    #[serde(rename = "01")]
+    Balzers,
+    #[serde(rename = "02")]
+    Eschen,
+    #[serde(rename = "03")]
+    Gamprin,
+    #[serde(rename = "04")]
+    Mauren,
+    #[serde(rename = "05")]
+    Planken,
+    #[serde(rename = "06")]
+    Ruggell,
+    #[serde(rename = "07")]
+    Schaan,
+    #[serde(rename = "08")]
+    Schellenberg,
+    #[serde(rename = "09")]
+    Triesen,
+    #[serde(rename = "10")]
+    Triesenberg,
+    #[serde(rename = "11")]
+    Vaduz,
+}
+
+#[derive(
+    Debug, Clone, PartialEq, Eq, Serialize, Deserialize, strum::Display, strum::EnumString,
+)]
+pub enum LithuaniaStatesAbbreviation {
+    #[serde(rename = "01")]
+    AkmeneDistrictMunicipality,
+    #[serde(rename = "02")]
+    AlytusCityMunicipality,
+    #[serde(rename = "AL")]
+    AlytusCounty,
+    #[serde(rename = "03")]
+    AlytusDistrictMunicipality,
+    #[serde(rename = "05")]
+    BirstonasMunicipality,
+    #[serde(rename = "06")]
+    BirzaiDistrictMunicipality,
+    #[serde(rename = "07")]
+    DruskininkaiMunicipality,
+    #[serde(rename = "08")]
+    ElektrenaiMunicipality,
+    #[serde(rename = "09")]
+    IgnalinaDistrictMunicipality,
+    #[serde(rename = "10")]
+    JonavaDistrictMunicipality,
+    #[serde(rename = "11")]
+    JoniskisDistrictMunicipality,
+    #[serde(rename = "12")]
+    JurbarkasDistrictMunicipality,
+    #[serde(rename = "13")]
+    KaisiadorysDistrictMunicipality,
+    #[serde(rename = "14")]
+    KalvarijaMunicipality,
+    #[serde(rename = "15")]
+    KaunasCityMunicipality,
+    #[serde(rename = "KU")]
+    KaunasCounty,
+    #[serde(rename = "16")]
+    KaunasDistrictMunicipality,
+    #[serde(rename = "17")]
+    KazluRudaMunicipality,
+    #[serde(rename = "19")]
+    KelmeDistrictMunicipality,
+    #[serde(rename = "20")]
+    KlaipedaCityMunicipality,
+    #[serde(rename = "KL")]
+    KlaipedaCounty,
+    #[serde(rename = "21")]
+    KlaipedaDistrictMunicipality,
+    #[serde(rename = "22")]
+    KretingaDistrictMunicipality,
+    #[serde(rename = "23")]
+    KupiskisDistrictMunicipality,
+    #[serde(rename = "18")]
+    KedainiaiDistrictMunicipality,
+    #[serde(rename = "24")]
+    LazdijaiDistrictMunicipality,
+    #[serde(rename = "MR")]
+    MarijampoleCounty,
+    #[serde(rename = "25")]
+    MarijampoleMunicipality,
+    #[serde(rename = "26")]
+    MazeikiaiDistrictMunicipality,
+    #[serde(rename = "27")]
+    MoletaiDistrictMunicipality,
+    #[serde(rename = "28")]
+    NeringaMunicipality,
+    #[serde(rename = "29")]
+    PagegiaiMunicipality,
+    #[serde(rename = "30")]
+    PakruojisDistrictMunicipality,
+    #[serde(rename = "31")]
+    PalangaCityMunicipality,
+    #[serde(rename = "32")]
+    PanevezysCityMunicipality,
+    #[serde(rename = "PN")]
+    PanevezysCounty,
+    #[serde(rename = "33")]
+    PanevezysDistrictMunicipality,
+    #[serde(rename = "34")]
+    PasvalysDistrictMunicipality,
+    #[serde(rename = "35")]
+    PlungeDistrictMunicipality,
+    #[serde(rename = "36")]
+    PrienaiDistrictMunicipality,
+    #[serde(rename = "37")]
+    RadviliskisDistrictMunicipality,
+    #[serde(rename = "38")]
+    RaseiniaiDistrictMunicipality,
+    #[serde(rename = "39")]
+    RietavasMunicipality,
+    #[serde(rename = "40")]
+    RokiskisDistrictMunicipality,
+    #[serde(rename = "48")]
+    SkuodasDistrictMunicipality,
+    #[serde(rename = "TA")]
+    TaurageCounty,
+    #[serde(rename = "50")]
+    TaurageDistrictMunicipality,
+    #[serde(rename = "TE")]
+    TelsiaiCounty,
+    #[serde(rename = "51")]
+    TelsiaiDistrictMunicipality,
+    #[serde(rename = "52")]
+    TrakaiDistrictMunicipality,
+    #[serde(rename = "53")]
+    UkmergeDistrictMunicipality,
+    #[serde(rename = "UT")]
+    UtenaCounty,
+    #[serde(rename = "54")]
+    UtenaDistrictMunicipality,
+    #[serde(rename = "55")]
+    VarenaDistrictMunicipality,
+    #[serde(rename = "56")]
+    VilkaviskisDistrictMunicipality,
+    #[serde(rename = "57")]
+    VilniusCityMunicipality,
+    #[serde(rename = "VL")]
+    VilniusCounty,
+    #[serde(rename = "58")]
+    VilniusDistrictMunicipality,
+    #[serde(rename = "59")]
+    VisaginasMunicipality,
+    #[serde(rename = "60")]
+    ZarasaiDistrictMunicipality,
+    #[serde(rename = "41")]
+    SakiaiDistrictMunicipality,
+    #[serde(rename = "42")]
+    SalcininkaiDistrictMunicipality,
+    #[serde(rename = "43")]
+    SiauliaiCityMunicipality,
+    #[serde(rename = "SA")]
+    SiauliaiCounty,
+    #[serde(rename = "44")]
+    SiauliaiDistrictMunicipality,
+    #[serde(rename = "45")]
+    SilaleDistrictMunicipality,
+    #[serde(rename = "46")]
+    SiluteDistrictMunicipality,
+    #[serde(rename = "47")]
+    SirvintosDistrictMunicipality,
+    #[serde(rename = "49")]
+    SvencionysDistrictMunicipality,
+}
+
+#[derive(
+    Debug, Clone, PartialEq, Eq, Serialize, Deserialize, strum::Display, strum::EnumString,
+)]
+pub enum MaltaStatesAbbreviation {
+    #[serde(rename = "01")]
+    Attard,
+    #[serde(rename = "02")]
+    Balzan,
+    #[serde(rename = "03")]
+    Birgu,
+    #[serde(rename = "04")]
+    Birkirkara,
+    #[serde(rename = "05")]
+    Birzebbuga,
+    #[serde(rename = "06")]
+    Cospicua,
+    #[serde(rename = "07")]
+    Dingli,
+    #[serde(rename = "08")]
+    Fgura,
+    #[serde(rename = "09")]
+    Floriana,
+    #[serde(rename = "10")]
+    Fontana,
+    #[serde(rename = "11")]
+    Gudja,
+    #[serde(rename = "12")]
+    Gzira,
+    #[serde(rename = "13")]
+    Ghajnsielem,
+    #[serde(rename = "14")]
+    Gharb,
+    #[serde(rename = "15")]
+    Gharghur,
+    #[serde(rename = "16")]
+    Ghasri,
+    #[serde(rename = "17")]
+    Ghaxaq,
+    #[serde(rename = "18")]
+    Hamrun,
+    #[serde(rename = "19")]
+    Iklin,
+    #[serde(rename = "20")]
+    Senglea,
+    #[serde(rename = "21")]
+    Kalkara,
+    #[serde(rename = "22")]
+    Kercem,
+    #[serde(rename = "23")]
+    Kirkop,
+    #[serde(rename = "24")]
+    Lija,
+    #[serde(rename = "25")]
+    Luqa,
+    #[serde(rename = "26")]
+    Marsa,
+    #[serde(rename = "27")]
+    Marsaskala,
+    #[serde(rename = "28")]
+    Marsaxlokk,
+    #[serde(rename = "29")]
+    Mdina,
+    #[serde(rename = "30")]
+    Mellieha,
+    #[serde(rename = "31")]
+    Mgarr,
+    #[serde(rename = "32")]
+    Mosta,
+    #[serde(rename = "33")]
+    Mqabba,
+    #[serde(rename = "34")]
+    Msida,
+    #[serde(rename = "35")]
+    Mtarfa,
+    #[serde(rename = "36")]
+    Munxar,
+    #[serde(rename = "37")]
+    Nadur,
+    #[serde(rename = "38")]
+    Naxxar,
+    #[serde(rename = "39")]
+    Paola,
+    #[serde(rename = "40")]
+    Pembroke,
+    #[serde(rename = "41")]
+    Pieta,
+    #[serde(rename = "42")]
+    Qala,
+    #[serde(rename = "43")]
+    Qormi,
+    #[serde(rename = "44")]
+    Qrendi,
+    #[serde(rename = "45")]
+    Victoria,
+    #[serde(rename = "46")]
+    Rabat,
+    #[serde(rename = "48")]
+    StJulians,
+    #[serde(rename = "49")]
+    SanGwann,
+    #[serde(rename = "50")]
+    SaintLawrence,
+    #[serde(rename = "51")]
+    StPaulsBay,
+    #[serde(rename = "52")]
+    Sannat,
+    #[serde(rename = "53")]
+    SantaLucija,
+    #[serde(rename = "54")]
+    SantaVenera,
+    #[serde(rename = "55")]
+    Siggiewi,
+    #[serde(rename = "56")]
+    Sliema,
+    #[serde(rename = "57")]
+    Swieqi,
+    #[serde(rename = "58")]
+    TaXbiex,
+    #[serde(rename = "59")]
+    Tarxien,
+    #[serde(rename = "60")]
+    Valletta,
+    #[serde(rename = "61")]
+    Xaghra,
+    #[serde(rename = "62")]
+    Xewkija,
+    #[serde(rename = "63")]
+    Xghajra,
+    #[serde(rename = "64")]
+    Zabbar,
+    #[serde(rename = "65")]
+    ZebbugGozo,
+    #[serde(rename = "66")]
+    ZebbugMalta,
+    #[serde(rename = "67")]
+    Zejtun,
+    #[serde(rename = "68")]
+    Zurrieq,
+}
+
+#[derive(
+    Debug, Clone, PartialEq, Eq, Serialize, Deserialize, strum::Display, strum::EnumString,
+)]
+pub enum MoldovaStatesAbbreviation {
+    #[serde(rename = "AN")]
+    AneniiNoiDistrict,
+    #[serde(rename = "BS")]
+    BasarabeascaDistrict,
+    #[serde(rename = "BD")]
+    BenderMunicipality,
+    #[serde(rename = "BR")]
+    BriceniDistrict,
+    #[serde(rename = "BA")]
+    BaltiMunicipality,
+    #[serde(rename = "CA")]
+    CahulDistrict,
+    #[serde(rename = "CT")]
+    CantemirDistrict,
+    #[serde(rename = "CU")]
+    ChisinauMunicipality,
+    #[serde(rename = "CM")]
+    CimisliaDistrict,
+    #[serde(rename = "CR")]
+    CriuleniDistrict,
+    #[serde(rename = "CL")]
+    CalarasiDistrict,
+    #[serde(rename = "CS")]
+    CauseniDistrict,
+    #[serde(rename = "DO")]
+    DonduseniDistrict,
+    #[serde(rename = "DR")]
+    DrochiaDistrict,
+    #[serde(rename = "DU")]
+    DubasariDistrict,
+    #[serde(rename = "ED")]
+    EdinetDistrict,
+    #[serde(rename = "FL")]
+    FlorestiDistrict,
+    #[serde(rename = "FA")]
+    FalestiDistrict,
+    #[serde(rename = "GA")]
+    Gagauzia,
+    #[serde(rename = "GL")]
+    GlodeniDistrict,
+    #[serde(rename = "HI")]
+    HincestiDistrict,
+    #[serde(rename = "IA")]
+    IaloveniDistrict,
+    #[serde(rename = "NI")]
+    NisporeniDistrict,
+    #[serde(rename = "OC")]
+    OcnitaDistrict,
+    #[serde(rename = "OR")]
+    OrheiDistrict,
+    #[serde(rename = "RE")]
+    RezinaDistrict,
+    #[serde(rename = "RI")]
+    RiscaniDistrict,
+    #[serde(rename = "SO")]
+    SorocaDistrict,
+    #[serde(rename = "ST")]
+    StraseniDistrict,
+    #[serde(rename = "SI")]
+    SingereiDistrict,
+    #[serde(rename = "TA")]
+    TaracliaDistrict,
+    #[serde(rename = "TE")]
+    TelenestiDistrict,
+    #[serde(rename = "SN")]
+    TransnistriaAutonomousTerritorialUnit,
+    #[serde(rename = "UN")]
+    UngheniDistrict,
+    #[serde(rename = "SD")]
+    SoldanestiDistrict,
+    #[serde(rename = "SV")]
+    StefanVodaDistrict,
+}
+
+#[derive(
+    Debug, Clone, PartialEq, Eq, Serialize, Deserialize, strum::Display, strum::EnumString,
+)]
+pub enum MonacoStatesAbbreviation {
+    Monaco,
+}
+
+#[derive(
+    Debug, Clone, PartialEq, Eq, Serialize, Deserialize, strum::Display, strum::EnumString,
+)]
+pub enum MontenegroStatesAbbreviation {
+    #[serde(rename = "01")]
+    AndrijevicaMunicipality,
+    #[serde(rename = "02")]
+    BarMunicipality,
+    #[serde(rename = "03")]
+    BeraneMunicipality,
+    #[serde(rename = "04")]
+    BijeloPoljeMunicipality,
+    #[serde(rename = "05")]
+    BudvaMunicipality,
+    #[serde(rename = "07")]
+    DanilovgradMunicipality,
+    #[serde(rename = "22")]
+    GusinjeMunicipality,
+    #[serde(rename = "09")]
+    KolasinMunicipality,
+    #[serde(rename = "10")]
+    KotorMunicipality,
+    #[serde(rename = "11")]
+    MojkovacMunicipality,
+    #[serde(rename = "12")]
+    NiksicMunicipality,
+    #[serde(rename = "06")]
+    OldRoyalCapitalCetinje,
+    #[serde(rename = "23")]
+    PetnjicaMunicipality,
+    #[serde(rename = "13")]
+    PlavMunicipality,
+    #[serde(rename = "14")]
+    PljevljaMunicipality,
+    #[serde(rename = "15")]
+    PluzineMunicipality,
+    #[serde(rename = "16")]
+    PodgoricaMunicipality,
+    #[serde(rename = "17")]
+    RozajeMunicipality,
+    #[serde(rename = "19")]
+    TivatMunicipality,
+    #[serde(rename = "20")]
+    UlcinjMunicipality,
+    #[serde(rename = "18")]
+    SavnikMunicipality,
+    #[serde(rename = "21")]
+    ZabljakMunicipality,
+}
+
+#[derive(
+    Debug, Clone, PartialEq, Eq, Serialize, Deserialize, strum::Display, strum::EnumString,
+)]
+pub enum NetherlandsStatesAbbreviation {
+    #[serde(rename = "BQ1")]
+    Bonaire,
+    #[serde(rename = "DR")]
+    Drenthe,
+    #[serde(rename = "FL")]
+    Flevoland,
+    #[serde(rename = "FR")]
+    Friesland,
+    #[serde(rename = "GE")]
+    Gelderland,
+    #[serde(rename = "GR")]
+    Groningen,
+    #[serde(rename = "LI")]
+    Limburg,
+    #[serde(rename = "NB")]
+    NorthBrabant,
+    #[serde(rename = "NH")]
+    NorthHolland,
+    #[serde(rename = "OV")]
+    Overijssel,
+    #[serde(rename = "BQ2")]
+    Saba,
+    #[serde(rename = "BQ3")]
+    SintEustatius,
+    #[serde(rename = "ZH")]
+    SouthHolland,
+    #[serde(rename = "UT")]
+    Utrecht,
+    #[serde(rename = "ZE")]
+    Zeeland,
+}
+
+#[derive(
+    Debug, Clone, PartialEq, Eq, Serialize, Deserialize, strum::Display, strum::EnumString,
+)]
+pub enum NorthMacedoniaStatesAbbreviation {
+    #[serde(rename = "01")]
+    AerodromMunicipality,
+    #[serde(rename = "02")]
+    AracinovoMunicipality,
+    #[serde(rename = "03")]
+    BerovoMunicipality,
+    #[serde(rename = "04")]
+    BitolaMunicipality,
+    #[serde(rename = "05")]
+    BogdanciMunicipality,
+    #[serde(rename = "06")]
+    BogovinjeMunicipality,
+    #[serde(rename = "07")]
+    BosilovoMunicipality,
+    #[serde(rename = "08")]
+    BrvenicaMunicipality,
+    #[serde(rename = "09")]
+    ButelMunicipality,
+    #[serde(rename = "77")]
+    CentarMunicipality,
+    #[serde(rename = "78")]
+    CentarZupaMunicipality,
+    #[serde(rename = "22")]
+    DebarcaMunicipality,
+    #[serde(rename = "23")]
+    DelcevoMunicipality,
+    #[serde(rename = "25")]
+    DemirHisarMunicipality,
+    #[serde(rename = "24")]
+    DemirKapijaMunicipality,
+    #[serde(rename = "26")]
+    DojranMunicipality,
+    #[serde(rename = "27")]
+    DolneniMunicipality,
+    #[serde(rename = "28")]
+    DrugovoMunicipality,
+    #[serde(rename = "17")]
+    GaziBabaMunicipality,
+    #[serde(rename = "18")]
+    GevgelijaMunicipality,
+    #[serde(rename = "29")]
+    GjorcePetrovMunicipality,
+    #[serde(rename = "19")]
+    GostivarMunicipality,
+    #[serde(rename = "20")]
+    GradskoMunicipality,
+    #[serde(rename = "85")]
+    GreaterSkopje,
+    #[serde(rename = "34")]
+    IlindenMunicipality,
+    #[serde(rename = "35")]
+    JegunovceMunicipality,
+    #[serde(rename = "37")]
+    Karbinci,
+    #[serde(rename = "38")]
+    KarposMunicipality,
+    #[serde(rename = "36")]
+    KavadarciMunicipality,
+    #[serde(rename = "39")]
+    KiselaVodaMunicipality,
+    #[serde(rename = "40")]
+    KicevoMunicipality,
+    #[serde(rename = "41")]
+    KonceMunicipality,
+    #[serde(rename = "42")]
+    KocaniMunicipality,
+    #[serde(rename = "43")]
+    KratovoMunicipality,
+    #[serde(rename = "44")]
+    KrivaPalankaMunicipality,
+    #[serde(rename = "45")]
+    KrivogastaniMunicipality,
+    #[serde(rename = "46")]
+    KrusevoMunicipality,
+    #[serde(rename = "47")]
+    KumanovoMunicipality,
+    #[serde(rename = "48")]
+    LipkovoMunicipality,
+    #[serde(rename = "49")]
+    LozovoMunicipality,
+    #[serde(rename = "51")]
+    MakedonskaKamenicaMunicipality,
+    #[serde(rename = "52")]
+    MakedonskiBrodMunicipality,
+    #[serde(rename = "50")]
+    MavrovoAndRostusaMunicipality,
+    #[serde(rename = "53")]
+    MogilaMunicipality,
+    #[serde(rename = "54")]
+    NegotinoMunicipality,
+    #[serde(rename = "55")]
+    NovaciMunicipality,
+    #[serde(rename = "56")]
+    NovoSeloMunicipality,
+    #[serde(rename = "58")]
+    OhridMunicipality,
+    #[serde(rename = "57")]
+    OslomejMunicipality,
+    #[serde(rename = "60")]
+    PehcevoMunicipality,
+    #[serde(rename = "59")]
+    PetrovecMunicipality,
+    #[serde(rename = "61")]
+    PlasnicaMunicipality,
+    #[serde(rename = "62")]
+    PrilepMunicipality,
+    #[serde(rename = "63")]
+    ProbistipMunicipality,
+    #[serde(rename = "64")]
+    RadovisMunicipality,
+    #[serde(rename = "65")]
+    RankovceMunicipality,
+    #[serde(rename = "66")]
+    ResenMunicipality,
+    #[serde(rename = "67")]
+    RosomanMunicipality,
+    #[serde(rename = "68")]
+    SarajMunicipality,
+    #[serde(rename = "70")]
+    SopisteMunicipality,
+    #[serde(rename = "71")]
+    StaroNagoricaneMunicipality,
+    #[serde(rename = "72")]
+    StrugaMunicipality,
+    #[serde(rename = "73")]
+    StrumicaMunicipality,
+    #[serde(rename = "74")]
+    StudenicaniMunicipality,
+    #[serde(rename = "69")]
+    SvetiNikoleMunicipality,
+    #[serde(rename = "75")]
+    TearceMunicipality,
+    #[serde(rename = "76")]
+    TetovoMunicipality,
+    #[serde(rename = "10")]
+    ValandovoMunicipality,
+    #[serde(rename = "11")]
+    VasilevoMunicipality,
+    #[serde(rename = "13")]
+    VelesMunicipality,
+    #[serde(rename = "12")]
+    VevcaniMunicipality,
+    #[serde(rename = "14")]
+    VinicaMunicipality,
+    #[serde(rename = "15")]
+    VranesticaMunicipality,
+    #[serde(rename = "16")]
+    VrapcisteMunicipality,
+    #[serde(rename = "31")]
+    ZajasMunicipality,
+    #[serde(rename = "32")]
+    ZelenikovoMunicipality,
+    #[serde(rename = "33")]
+    ZrnovciMunicipality,
+    #[serde(rename = "79")]
+    CairMunicipality,
+    #[serde(rename = "80")]
+    CaskaMunicipality,
+    #[serde(rename = "81")]
+    CesinovoOblesevoMunicipality,
+    #[serde(rename = "82")]
+    CucerSandevoMunicipality,
+    #[serde(rename = "83")]
+    StipMunicipality,
+    #[serde(rename = "84")]
+    SutoOrizariMunicipality,
+    #[serde(rename = "30")]
+    ZelinoMunicipality,
+}
+
+#[derive(
+    Debug, Clone, PartialEq, Eq, Serialize, Deserialize, strum::Display, strum::EnumString,
+)]
+pub enum NorwayStatesAbbreviation {
+    #[serde(rename = "02")]
+    Akershus,
+    #[serde(rename = "06")]
+    Buskerud,
+    #[serde(rename = "20")]
+    Finnmark,
+    #[serde(rename = "04")]
+    Hedmark,
+    #[serde(rename = "12")]
+    Hordaland,
+    #[serde(rename = "22")]
+    JanMayen,
+    #[serde(rename = "15")]
+    MoreOgRomsdal,
+    #[serde(rename = "17")]
+    NordTrondelag,
+    #[serde(rename = "18")]
+    Nordland,
+    #[serde(rename = "05")]
+    Oppland,
+    #[serde(rename = "03")]
+    Oslo,
+    #[serde(rename = "11")]
+    Rogaland,
+    #[serde(rename = "14")]
+    SognOgFjordane,
+    #[serde(rename = "21")]
+    Svalbard,
+    #[serde(rename = "16")]
+    SorTrondelag,
+    #[serde(rename = "08")]
+    Telemark,
+    #[serde(rename = "19")]
+    Troms,
+    #[serde(rename = "50")]
+    Trondelag,
+    #[serde(rename = "10")]
+    VestAgder,
+    #[serde(rename = "07")]
+    Vestfold,
+    #[serde(rename = "01")]
+    Ostfold,
+}
+
+#[derive(
+    Debug, Clone, PartialEq, Eq, Serialize, Deserialize, strum::Display, strum::EnumString,
+)]
+pub enum PolandStatesAbbreviation {
+    #[serde(rename = "WP")]
+    GreaterPolandVoivodeship,
+    #[serde(rename = "KI")]
+    Kielce,
+    #[serde(rename = "KP")]
+    KuyavianPomeranianVoivodeship,
+    #[serde(rename = "MA")]
+    LesserPolandVoivodeship,
+    #[serde(rename = "DS")]
+    LowerSilesianVoivodeship,
+    #[serde(rename = "LU")]
+    LublinVoivodeship,
+    #[serde(rename = "LB")]
+    LubuszVoivodeship,
+    #[serde(rename = "MZ")]
+    MasovianVoivodeship,
+    #[serde(rename = "OP")]
+    OpoleVoivodeship,
+    #[serde(rename = "PK")]
+    PodkarpackieVoivodeship,
+    #[serde(rename = "PD")]
+    PodlaskieVoivodeship,
+    #[serde(rename = "PM")]
+    PomeranianVoivodeship,
+    #[serde(rename = "SL")]
+    SilesianVoivodeship,
+    #[serde(rename = "WN")]
+    WarmianMasurianVoivodeship,
+    #[serde(rename = "ZP")]
+    WestPomeranianVoivodeship,
+    #[serde(rename = "LD")]
+    LodzVoivodeship,
+    #[serde(rename = "SK")]
+    SwietokrzyskieVoivodeship,
+}
+
+#[derive(
+    Debug, Clone, PartialEq, Eq, Serialize, Deserialize, strum::Display, strum::EnumString,
+)]
+pub enum PortugalStatesAbbreviation {
+    #[serde(rename = "01")]
+    AveiroDistrict,
+    #[serde(rename = "20")]
+    Azores,
+    #[serde(rename = "02")]
+    BejaDistrict,
+    #[serde(rename = "03")]
+    BragaDistrict,
+    #[serde(rename = "04")]
+    BragancaDistrict,
+    #[serde(rename = "05")]
+    CasteloBrancoDistrict,
+    #[serde(rename = "06")]
+    CoimbraDistrict,
+    #[serde(rename = "08")]
+    FaroDistrict,
+    #[serde(rename = "09")]
+    GuardaDistrict,
+    #[serde(rename = "10")]
+    LeiriaDistrict,
+    #[serde(rename = "11")]
+    LisbonDistrict,
+    #[serde(rename = "30")]
+    Madeira,
+    #[serde(rename = "12")]
+    PortalegreDistrict,
+    #[serde(rename = "13")]
+    PortoDistrict,
+    #[serde(rename = "14")]
+    SantaremDistrict,
+    #[serde(rename = "15")]
+    SetubalDistrict,
+    #[serde(rename = "16")]
+    VianaDoCasteloDistrict,
+    #[serde(rename = "17")]
+    VilaRealDistrict,
+    #[serde(rename = "18")]
+    ViseuDistrict,
+    #[serde(rename = "07")]
+    EvoraDistrict,
+}
+
+#[derive(
+    Debug, Clone, PartialEq, Eq, Serialize, Deserialize, strum::Display, strum::EnumString,
+)]
+pub enum SpainStatesAbbreviation {
+    #[serde(rename = "C")]
+    ACorunaProvince,
+    #[serde(rename = "AB")]
+    AlbaceteProvince,
+    #[serde(rename = "A")]
+    AlicanteProvince,
+    #[serde(rename = "AL")]
+    AlmeriaProvince,
+    #[serde(rename = "AN")]
+    Andalusia,
+    #[serde(rename = "VI")]
+    ArabaAlava,
+    #[serde(rename = "AR")]
+    Aragon,
+    #[serde(rename = "BA")]
+    BadajozProvince,
+    #[serde(rename = "PM")]
+    BalearicIslands,
+    #[serde(rename = "B")]
+    BarcelonaProvince,
+    #[serde(rename = "PV")]
+    BasqueCountry,
+    #[serde(rename = "BI")]
+    Biscay,
+    #[serde(rename = "BU")]
+    BurgosProvince,
+    #[serde(rename = "CN")]
+    CanaryIslands,
+    #[serde(rename = "S")]
+    Cantabria,
+    #[serde(rename = "CS")]
+    CastellonProvince,
+    #[serde(rename = "CL")]
+    CastileAndLeon,
+    #[serde(rename = "CM")]
+    CastileLaMancha,
+    #[serde(rename = "CT")]
+    Catalonia,
+    #[serde(rename = "CE")]
+    Ceuta,
+    #[serde(rename = "CR")]
+    CiudadRealProvince,
+    #[serde(rename = "MD")]
+    CommunityOfMadrid,
+    #[serde(rename = "CU")]
+    CuencaProvince,
+    #[serde(rename = "CC")]
+    CaceresProvince,
+    #[serde(rename = "CA")]
+    CadizProvince,
+    #[serde(rename = "CO")]
+    CordobaProvince,
+    #[serde(rename = "EX")]
+    Extremadura,
+    #[serde(rename = "GA")]
+    Galicia,
+    #[serde(rename = "SS")]
+    Gipuzkoa,
+    #[serde(rename = "GI")]
+    GironaProvince,
+    #[serde(rename = "GR")]
+    GranadaProvince,
+    #[serde(rename = "GU")]
+    GuadalajaraProvince,
+    #[serde(rename = "H")]
+    HuelvaProvince,
+    #[serde(rename = "HU")]
+    HuescaProvince,
+    #[serde(rename = "J")]
+    JaenProvince,
+    #[serde(rename = "RI")]
+    LaRioja,
+    #[serde(rename = "GC")]
+    LasPalmasProvince,
+    #[serde(rename = "LE")]
+    LeonProvince,
+    #[serde(rename = "L")]
+    LleidaProvince,
+    #[serde(rename = "LU")]
+    LugoProvince,
+    #[serde(rename = "M")]
+    MadridProvince,
+    #[serde(rename = "ML")]
+    Melilla,
+    #[serde(rename = "MU")]
+    MurciaProvince,
+    #[serde(rename = "MA")]
+    MalagaProvince,
+    #[serde(rename = "NC")]
+    Navarre,
+    #[serde(rename = "OR")]
+    OurenseProvince,
+    #[serde(rename = "P")]
+    PalenciaProvince,
+    #[serde(rename = "PO")]
+    PontevedraProvince,
+    #[serde(rename = "O")]
+    ProvinceOfAsturias,
+    #[serde(rename = "AV")]
+    ProvinceOfAvila,
+    #[serde(rename = "MC")]
+    RegionOfMurcia,
+    #[serde(rename = "SA")]
+    SalamancaProvince,
+    #[serde(rename = "TF")]
+    SantaCruzDeTenerifeProvince,
+    #[serde(rename = "SG")]
+    SegoviaProvince,
+    #[serde(rename = "SE")]
+    SevilleProvince,
+    #[serde(rename = "SO")]
+    SoriaProvince,
+    #[serde(rename = "T")]
+    TarragonaProvince,
+    #[serde(rename = "TE")]
+    TeruelProvince,
+    #[serde(rename = "TO")]
+    ToledoProvince,
+    #[serde(rename = "V")]
+    ValenciaProvince,
+    #[serde(rename = "VC")]
+    ValencianCommunity,
+    #[serde(rename = "VA")]
+    ValladolidProvince,
+    #[serde(rename = "ZA")]
+    ZamoraProvince,
+    #[serde(rename = "Z")]
+    ZaragozaProvince,
+}
+
+#[derive(
+    Debug, Clone, PartialEq, Eq, Serialize, Deserialize, strum::Display, strum::EnumString,
+)]
+pub enum SwitzerlandStatesAbbreviation {
+    #[serde(rename = "AG")]
+    Aargau,
+    #[serde(rename = "AR")]
+    AppenzellAusserrhoden,
+    #[serde(rename = "AI")]
+    AppenzellInnerrhoden,
+    #[serde(rename = "BL")]
+    BaselLandschaft,
+    #[serde(rename = "FR")]
+    CantonOfFribourg,
+    #[serde(rename = "GE")]
+    CantonOfGeneva,
+    #[serde(rename = "JU")]
+    CantonOfJura,
+    #[serde(rename = "LU")]
+    CantonOfLucerne,
+    #[serde(rename = "NE")]
+    CantonOfNeuchatel,
+    #[serde(rename = "SH")]
+    CantonOfSchaffhausen,
+    #[serde(rename = "SO")]
+    CantonOfSolothurn,
+    #[serde(rename = "SG")]
+    CantonOfStGallen,
+    #[serde(rename = "VS")]
+    CantonOfValais,
+    #[serde(rename = "VD")]
+    CantonOfVaud,
+    #[serde(rename = "ZG")]
+    CantonOfZug,
+    #[serde(rename = "GL")]
+    Glarus,
+    #[serde(rename = "GR")]
+    Graubunden,
+    #[serde(rename = "NW")]
+    Nidwalden,
+    #[serde(rename = "OW")]
+    Obwalden,
+    #[serde(rename = "SZ")]
+    Schwyz,
+    #[serde(rename = "TG")]
+    Thurgau,
+    #[serde(rename = "TI")]
+    Ticino,
+    #[serde(rename = "UR")]
+    Uri,
+    #[serde(rename = "BE")]
+    CantonOfBern,
+    #[serde(rename = "ZH")]
+    CantonOfZurich,
+}
+
+#[derive(
+    Debug, Clone, PartialEq, Eq, Serialize, Deserialize, strum::Display, strum::EnumString,
+)]
+pub enum UnitedKingdomStatesAbbreviation {
+    #[serde(rename = "ABE")]
+    AberdeenCity,
+    #[serde(rename = "ABD")]
+    Aberdeenshire,
+    #[serde(rename = "ANS")]
+    Angus,
+    #[serde(rename = "ANN")]
+    AntrimAndNewtownabbey,
+    #[serde(rename = "AND")]
+    ArdsAndNorthDown,
+    #[serde(rename = "AGB")]
+    ArgyllAndBute,
+    #[serde(rename = "ABC")]
+    ArmaghCityBanbridgeAndCraigavon,
+    #[serde(rename = "BDG")]
+    BarkingAndDagenham,
+    #[serde(rename = "BNE")]
+    Barnet,
+    #[serde(rename = "BNS")]
+    Barnsley,
+    #[serde(rename = "BAS")]
+    BathAndNorthEastSomerset,
+    #[serde(rename = "BDF")]
+    Bedford,
+    #[serde(rename = "BFS")]
+    BelfastCity,
+    #[serde(rename = "BEX")]
+    Bexley,
+    #[serde(rename = "BIR")]
+    Birmingham,
+    #[serde(rename = "BBD")]
+    BlackburnWithDarwen,
+    #[serde(rename = "BPL")]
+    Blackpool,
+    #[serde(rename = "BGW")]
+    BlaenauGwent,
+    #[serde(rename = "BOL")]
+    Bolton,
+    #[serde(rename = "BCP")]
+    BournemouthChristchurchAndPoole,
+    #[serde(rename = "BRC")]
+    BracknellForest,
+    #[serde(rename = "BRD")]
+    Bradford,
+    #[serde(rename = "BEN")]
+    Brent,
+    #[serde(rename = "BGE")]
+    Bridgend,
+    #[serde(rename = "BNH")]
+    BrightonAndHove,
+    #[serde(rename = "BST")]
+    BristolCityOf,
+    #[serde(rename = "BRY")]
+    Bromley,
+    #[serde(rename = "BKM")]
+    Buckinghamshire,
+    #[serde(rename = "BUR")]
+    Bury,
+    #[serde(rename = "CAY")]
+    Caerphilly,
+    #[serde(rename = "CLD")]
+    Calderdale,
+    #[serde(rename = "CAM")]
+    Cambridgeshire,
+    #[serde(rename = "CMD")]
+    Camden,
+    #[serde(rename = "CRF")]
+    Cardiff,
+    #[serde(rename = "CMN")]
+    Carmarthenshire,
+    #[serde(rename = "CCG")]
+    CausewayCoastAndGlens,
+    #[serde(rename = "CBF")]
+    CentralBedfordshire,
+    #[serde(rename = "CGN")]
+    Ceredigion,
+    #[serde(rename = "CHE")]
+    CheshireEast,
+    #[serde(rename = "CHW")]
+    CheshireWestAndChester,
+    #[serde(rename = "CLK")]
+    Clackmannanshire,
+    #[serde(rename = "CWY")]
+    Conwy,
+    #[serde(rename = "CON")]
+    Cornwall,
+    #[serde(rename = "COV")]
+    Coventry,
+    #[serde(rename = "CRY")]
+    Croydon,
+    #[serde(rename = "CMA")]
+    Cumbria,
+    #[serde(rename = "DAL")]
+    Darlington,
+    #[serde(rename = "DEN")]
+    Denbighshire,
+    #[serde(rename = "DER")]
+    Derby,
+    #[serde(rename = "DBY")]
+    Derbyshire,
+    #[serde(rename = "DRS")]
+    DerryAndStrabane,
+    #[serde(rename = "DEV")]
+    Devon,
+    #[serde(rename = "DNC")]
+    Doncaster,
+    #[serde(rename = "DOR")]
+    Dorset,
+    #[serde(rename = "DUD")]
+    Dudley,
+    #[serde(rename = "DGY")]
+    DumfriesAndGalloway,
+    #[serde(rename = "DND")]
+    DundeeCity,
+    #[serde(rename = "DUR")]
+    DurhamCounty,
+    #[serde(rename = "EAL")]
+    Ealing,
+    #[serde(rename = "EAY")]
+    EastAyrshire,
+    #[serde(rename = "EDU")]
+    EastDunbartonshire,
+    #[serde(rename = "ELN")]
+    EastLothian,
+    #[serde(rename = "ERW")]
+    EastRenfrewshire,
+    #[serde(rename = "ERY")]
+    EastRidingOfYorkshire,
+    #[serde(rename = "ESX")]
+    EastSussex,
+    #[serde(rename = "EDH")]
+    EdinburghCityOf,
+    #[serde(rename = "ELS")]
+    EileanSiar,
+    #[serde(rename = "ENF")]
+    Enfield,
+    #[serde(rename = "ESS")]
+    Essex,
+    #[serde(rename = "FAL")]
+    Falkirk,
+    #[serde(rename = "FMO")]
+    FermanaghAndOmagh,
+    #[serde(rename = "FIF")]
+    Fife,
+    #[serde(rename = "FLN")]
+    Flintshire,
+    #[serde(rename = "GAT")]
+    Gateshead,
+    #[serde(rename = "GLG")]
+    GlasgowCity,
+    #[serde(rename = "GLS")]
+    Gloucestershire,
+    #[serde(rename = "GRE")]
+    Greenwich,
+    #[serde(rename = "GWN")]
+    Gwynedd,
+    #[serde(rename = "HCK")]
+    Hackney,
+    #[serde(rename = "HAL")]
+    Halton,
+    #[serde(rename = "HMF")]
+    HammersmithAndFulham,
+    #[serde(rename = "HAM")]
+    Hampshire,
+    #[serde(rename = "HRY")]
+    Haringey,
+    #[serde(rename = "HRW")]
+    Harrow,
+    #[serde(rename = "HPL")]
+    Hartlepool,
+    #[serde(rename = "HAV")]
+    Havering,
+    #[serde(rename = "HEF")]
+    Herefordshire,
+    #[serde(rename = "HRT")]
+    Hertfordshire,
+    #[serde(rename = "HLD")]
+    Highland,
+    #[serde(rename = "HIL")]
+    Hillingdon,
+    #[serde(rename = "HNS")]
+    Hounslow,
+    #[serde(rename = "IVC")]
+    Inverclyde,
+    #[serde(rename = "AGY")]
+    IsleOfAnglesey,
+    #[serde(rename = "IOW")]
+    IsleOfWight,
+    #[serde(rename = "IOS")]
+    IslesOfScilly,
+    #[serde(rename = "ISL")]
+    Islington,
+    #[serde(rename = "KEC")]
+    KensingtonAndChelsea,
+    #[serde(rename = "KEN")]
+    Kent,
+    #[serde(rename = "KHL")]
+    KingstonUponHull,
+    #[serde(rename = "KTT")]
+    KingstonUponThames,
+    #[serde(rename = "KIR")]
+    Kirklees,
+    #[serde(rename = "KWL")]
+    Knowsley,
+    #[serde(rename = "LBH")]
+    Lambeth,
+    #[serde(rename = "LAN")]
+    Lancashire,
+    #[serde(rename = "LDS")]
+    Leeds,
+    #[serde(rename = "LCE")]
+    Leicester,
+    #[serde(rename = "LEC")]
+    Leicestershire,
+    #[serde(rename = "LEW")]
+    Lewisham,
+    #[serde(rename = "LIN")]
+    Lincolnshire,
+    #[serde(rename = "LBC")]
+    LisburnAndCastlereagh,
+    #[serde(rename = "LIV")]
+    Liverpool,
+    #[serde(rename = "LND")]
+    LondonCityOf,
+    #[serde(rename = "LUT")]
+    Luton,
+    #[serde(rename = "MAN")]
+    Manchester,
+    #[serde(rename = "MDW")]
+    Medway,
+    #[serde(rename = "MTY")]
+    MerthyrTydfil,
+    #[serde(rename = "MRT")]
+    Merton,
+    #[serde(rename = "MEA")]
+    MidAndEastAntrim,
+    #[serde(rename = "MUL")]
+    MidUlster,
+    #[serde(rename = "MDB")]
+    Middlesbrough,
+    #[serde(rename = "MLN")]
+    Midlothian,
+    #[serde(rename = "MIK")]
+    MiltonKeynes,
+    #[serde(rename = "MON")]
+    Monmouthshire,
+    #[serde(rename = "MRY")]
+    Moray,
+    #[serde(rename = "NTL")]
+    NeathPortTalbot,
+    #[serde(rename = "NET")]
+    NewcastleUponTyne,
+    #[serde(rename = "NWM")]
+    Newham,
+    #[serde(rename = "NWP")]
+    Newport,
+    #[serde(rename = "NMD")]
+    NewryMourneAndDown,
+    #[serde(rename = "NFK")]
+    Norfolk,
+    #[serde(rename = "NAY")]
+    NorthAyrshire,
+    #[serde(rename = "NEL")]
+    NorthEastLincolnshire,
+    #[serde(rename = "NLK")]
+    NorthLanarkshire,
+    #[serde(rename = "NLN")]
+    NorthLincolnshire,
+    #[serde(rename = "NSM")]
+    NorthSomerset,
+    #[serde(rename = "NTY")]
+    NorthTyneside,
+    #[serde(rename = "NYK")]
+    NorthYorkshire,
+    #[serde(rename = "NTH")]
+    Northamptonshire,
+    #[serde(rename = "NBL")]
+    Northumberland,
+    #[serde(rename = "NGM")]
+    Nottingham,
+    #[serde(rename = "NTT")]
+    Nottinghamshire,
+    #[serde(rename = "OLD")]
+    Oldham,
+    #[serde(rename = "ORK")]
+    OrkneyIslands,
+    #[serde(rename = "OXF")]
+    Oxfordshire,
+    #[serde(rename = "PEM")]
+    Pembrokeshire,
+    #[serde(rename = "PKN")]
+    PerthAndKinross,
+    #[serde(rename = "PTE")]
+    Peterborough,
+    #[serde(rename = "PLY")]
+    Plymouth,
+    #[serde(rename = "POR")]
+    Portsmouth,
+    #[serde(rename = "POW")]
+    Powys,
+    #[serde(rename = "RDG")]
+    Reading,
+    #[serde(rename = "RDB")]
+    Redbridge,
+    #[serde(rename = "RCC")]
+    RedcarAndCleveland,
+    #[serde(rename = "RFW")]
+    Renfrewshire,
+    #[serde(rename = "RCT")]
+    RhonddaCynonTaff,
+    #[serde(rename = "RIC")]
+    RichmondUponThames,
+    #[serde(rename = "RCH")]
+    Rochdale,
+    #[serde(rename = "ROT")]
+    Rotherham,
+    #[serde(rename = "RUT")]
+    Rutland,
+    #[serde(rename = "SLF")]
+    Salford,
+    #[serde(rename = "SAW")]
+    Sandwell,
+    #[serde(rename = "SCB")]
+    ScottishBorders,
+    #[serde(rename = "SFT")]
+    Sefton,
+    #[serde(rename = "SHF")]
+    Sheffield,
+    #[serde(rename = "ZET")]
+    ShetlandIslands,
+    #[serde(rename = "SHR")]
+    Shropshire,
+    #[serde(rename = "SLG")]
+    Slough,
+    #[serde(rename = "SOL")]
+    Solihull,
+    #[serde(rename = "SOM")]
+    Somerset,
+    #[serde(rename = "SAY")]
+    SouthAyrshire,
+    #[serde(rename = "SGC")]
+    SouthGloucestershire,
+    #[serde(rename = "SLK")]
+    SouthLanarkshire,
+    #[serde(rename = "STY")]
+    SouthTyneside,
+    #[serde(rename = "STH")]
+    Southampton,
+    #[serde(rename = "SOS")]
+    SouthendOnSea,
+    #[serde(rename = "SWK")]
+    Southwark,
+    #[serde(rename = "SHN")]
+    StHelens,
+    #[serde(rename = "STS")]
+    Staffordshire,
+    #[serde(rename = "STG")]
+    Stirling,
+    #[serde(rename = "SKP")]
+    Stockport,
+    #[serde(rename = "STT")]
+    StocktonOnTees,
+    #[serde(rename = "STE")]
+    StokeOnTrent,
+    #[serde(rename = "SFK")]
+    Suffolk,
+    #[serde(rename = "SND")]
+    Sunderland,
+    #[serde(rename = "SRY")]
+    Surrey,
+    #[serde(rename = "STN")]
+    Sutton,
+    #[serde(rename = "SWA")]
+    Swansea,
+    #[serde(rename = "SWD")]
+    Swindon,
+    #[serde(rename = "TAM")]
+    Tameside,
+    #[serde(rename = "TFW")]
+    TelfordAndWrekin,
+    #[serde(rename = "THR")]
+    Thurrock,
+    #[serde(rename = "TOB")]
+    Torbay,
+    #[serde(rename = "TOF")]
+    Torfaen,
+    #[serde(rename = "TWH")]
+    TowerHamlets,
+    #[serde(rename = "TRF")]
+    Trafford,
+    #[serde(rename = "VGL")]
+    ValeOfGlamorgan,
+    #[serde(rename = "WKF")]
+    Wakefield,
+    #[serde(rename = "WLL")]
+    Walsall,
+    #[serde(rename = "WFT")]
+    WalthamForest,
+    #[serde(rename = "WND")]
+    Wandsworth,
+    #[serde(rename = "WRT")]
+    Warrington,
+    #[serde(rename = "WAR")]
+    Warwickshire,
+    #[serde(rename = "WBK")]
+    WestBerkshire,
+    #[serde(rename = "WDU")]
+    WestDunbartonshire,
+    #[serde(rename = "WLN")]
+    WestLothian,
+    #[serde(rename = "WSX")]
+    WestSussex,
+    #[serde(rename = "WSM")]
+    Westminster,
+    #[serde(rename = "WGN")]
+    Wigan,
+    #[serde(rename = "WIL")]
+    Wiltshire,
+    #[serde(rename = "WNM")]
+    WindsorAndMaidenhead,
+    #[serde(rename = "WRL")]
+    Wirral,
+    #[serde(rename = "WOK")]
+    Wokingham,
+    #[serde(rename = "WLV")]
+    Wolverhampton,
+    #[serde(rename = "WOR")]
+    Worcestershire,
+    #[serde(rename = "WRX")]
+    Wrexham,
+    #[serde(rename = "YOR")]
+    York,
+}
+
+#[derive(
+    Debug, Clone, PartialEq, Eq, Serialize, Deserialize, strum::Display, strum::EnumString,
+)]
+pub enum RomaniaStatesAbbreviation {
+    #[serde(rename = "AB")]
+    Alba,
+    #[serde(rename = "AR")]
+    AradCounty,
+    #[serde(rename = "AG")]
+    Arges,
+    #[serde(rename = "BC")]
+    BacauCounty,
+    #[serde(rename = "BH")]
+    BihorCounty,
+    #[serde(rename = "BN")]
+    BistritaNasaudCounty,
+    #[serde(rename = "BT")]
+    BotosaniCounty,
+    #[serde(rename = "BR")]
+    Braila,
+    #[serde(rename = "BV")]
+    BrasovCounty,
+    #[serde(rename = "B")]
+    Bucharest,
+    #[serde(rename = "BZ")]
+    BuzauCounty,
+    #[serde(rename = "CS")]
+    CarasSeverinCounty,
+    #[serde(rename = "CJ")]
+    ClujCounty,
+    #[serde(rename = "CT")]
+    ConstantaCounty,
+    #[serde(rename = "CV")]
+    CovasnaCounty,
+    #[serde(rename = "CL")]
+    CalarasiCounty,
+    #[serde(rename = "DJ")]
+    DoljCounty,
+    #[serde(rename = "DB")]
+    DambovitaCounty,
+    #[serde(rename = "GL")]
+    GalatiCounty,
+    #[serde(rename = "GR")]
+    GiurgiuCounty,
+    #[serde(rename = "GJ")]
+    GorjCounty,
+    #[serde(rename = "HR")]
+    HarghitaCounty,
+    #[serde(rename = "HD")]
+    HunedoaraCounty,
+    #[serde(rename = "IL")]
+    IalomitaCounty,
+    #[serde(rename = "IS")]
+    IasiCounty,
+    #[serde(rename = "IF")]
+    IlfovCounty,
+    #[serde(rename = "MH")]
+    MehedintiCounty,
+    #[serde(rename = "MM")]
+    MuresCounty,
+    #[serde(rename = "NT")]
+    NeamtCounty,
+    #[serde(rename = "OT")]
+    OltCounty,
+    #[serde(rename = "PH")]
+    PrahovaCounty,
+    #[serde(rename = "SM")]
+    SatuMareCounty,
+    #[serde(rename = "SB")]
+    SibiuCounty,
+    #[serde(rename = "SV")]
+    SuceavaCounty,
+    #[serde(rename = "SJ")]
+    SalajCounty,
+    #[serde(rename = "TR")]
+    TeleormanCounty,
+    #[serde(rename = "TM")]
+    TimisCounty,
+    #[serde(rename = "TL")]
+    TulceaCounty,
+    #[serde(rename = "VS")]
+    VasluiCounty,
+    #[serde(rename = "VN")]
+    VranceaCounty,
+    #[serde(rename = "VL")]
+    ValceaCounty,
+}
+
+#[derive(
     Clone,
     Copy,
     Debug,

--- a/crates/hyperswitch_connectors/src/utils.rs
+++ b/crates/hyperswitch_connectors/src/utils.rs
@@ -6,7 +6,21 @@ use api_models::payouts::PayoutVendorAccountDetails;
 use base64::Engine;
 use common_enums::{
     enums,
-    enums::{AttemptStatus, CanadaStatesAbbreviation, FutureUsage, UsStatesAbbreviation},
+    enums::{
+        AlbaniaStatesAbbreviation, AndorraStatesAbbreviation, AttemptStatus,
+        AustriaStatesAbbreviation, BelarusStatesAbbreviation,
+        BosniaAndHerzegovinaStatesAbbreviation, BulgariaStatesAbbreviation,
+        CanadaStatesAbbreviation, CroatiaStatesAbbreviation, CzechRepublicStatesAbbreviation,
+        DenmarkStatesAbbreviation, FinlandStatesAbbreviation, FranceStatesAbbreviation,
+        FutureUsage, GermanyStatesAbbreviation, GreeceStatesAbbreviation,
+        HungaryStatesAbbreviation, IcelandStatesAbbreviation, IrelandStatesAbbreviation,
+        ItalyStatesAbbreviation, LatviaStatesAbbreviation, LiechtensteinStatesAbbreviation,
+        LithuaniaStatesAbbreviation, MaltaStatesAbbreviation, MoldovaStatesAbbreviation,
+        MonacoStatesAbbreviation, MontenegroStatesAbbreviation, NetherlandsStatesAbbreviation,
+        NorthMacedoniaStatesAbbreviation, NorwayStatesAbbreviation, PolandStatesAbbreviation,
+        PortugalStatesAbbreviation, RomaniaStatesAbbreviation, SpainStatesAbbreviation,
+        SwitzerlandStatesAbbreviation, UnitedKingdomStatesAbbreviation, UsStatesAbbreviation,
+    },
 };
 use common_utils::{
     consts::BASE64_ENGINE,
@@ -1343,6 +1357,111 @@ impl AddressDetailsData for AddressDetails {
             api_models::enums::CountryAlpha2::CA => Ok(Secret::new(
                 CanadaStatesAbbreviation::foreign_try_from(state.peek().to_string())?.to_string(),
             )),
+            api_models::enums::CountryAlpha2::AL => Ok(Secret::new(
+                AlbaniaStatesAbbreviation::foreign_try_from(state.peek().to_string())?.to_string(),
+            )),
+            api_models::enums::CountryAlpha2::AD => Ok(Secret::new(
+                AndorraStatesAbbreviation::foreign_try_from(state.peek().to_string())?.to_string(),
+            )),
+            api_models::enums::CountryAlpha2::AT => Ok(Secret::new(
+                AustriaStatesAbbreviation::foreign_try_from(state.peek().to_string())?.to_string(),
+            )),
+            api_models::enums::CountryAlpha2::BY => Ok(Secret::new(
+                BelarusStatesAbbreviation::foreign_try_from(state.peek().to_string())?.to_string(),
+            )),
+            api_models::enums::CountryAlpha2::BA => Ok(Secret::new(
+                BosniaAndHerzegovinaStatesAbbreviation::foreign_try_from(state.peek().to_string())?
+                    .to_string(),
+            )),
+            api_models::enums::CountryAlpha2::BG => Ok(Secret::new(
+                BulgariaStatesAbbreviation::foreign_try_from(state.peek().to_string())?.to_string(),
+            )),
+            api_models::enums::CountryAlpha2::HR => Ok(Secret::new(
+                CroatiaStatesAbbreviation::foreign_try_from(state.peek().to_string())?.to_string(),
+            )),
+            api_models::enums::CountryAlpha2::CZ => Ok(Secret::new(
+                CzechRepublicStatesAbbreviation::foreign_try_from(state.peek().to_string())?
+                    .to_string(),
+            )),
+            api_models::enums::CountryAlpha2::DK => Ok(Secret::new(
+                DenmarkStatesAbbreviation::foreign_try_from(state.peek().to_string())?.to_string(),
+            )),
+            api_models::enums::CountryAlpha2::FI => Ok(Secret::new(
+                FinlandStatesAbbreviation::foreign_try_from(state.peek().to_string())?.to_string(),
+            )),
+            api_models::enums::CountryAlpha2::FR => Ok(Secret::new(
+                FranceStatesAbbreviation::foreign_try_from(state.peek().to_string())?.to_string(),
+            )),
+            api_models::enums::CountryAlpha2::DE => Ok(Secret::new(
+                GermanyStatesAbbreviation::foreign_try_from(state.peek().to_string())?.to_string(),
+            )),
+            api_models::enums::CountryAlpha2::GR => Ok(Secret::new(
+                GreeceStatesAbbreviation::foreign_try_from(state.peek().to_string())?.to_string(),
+            )),
+            api_models::enums::CountryAlpha2::HU => Ok(Secret::new(
+                HungaryStatesAbbreviation::foreign_try_from(state.peek().to_string())?.to_string(),
+            )),
+            api_models::enums::CountryAlpha2::IS => Ok(Secret::new(
+                IcelandStatesAbbreviation::foreign_try_from(state.peek().to_string())?.to_string(),
+            )),
+            api_models::enums::CountryAlpha2::IE => Ok(Secret::new(
+                IrelandStatesAbbreviation::foreign_try_from(state.peek().to_string())?.to_string(),
+            )),
+            api_models::enums::CountryAlpha2::LV => Ok(Secret::new(
+                LatviaStatesAbbreviation::foreign_try_from(state.peek().to_string())?.to_string(),
+            )),
+            api_models::enums::CountryAlpha2::IT => Ok(Secret::new(
+                ItalyStatesAbbreviation::foreign_try_from(state.peek().to_string())?.to_string(),
+            )),
+            api_models::enums::CountryAlpha2::LI => Ok(Secret::new(
+                LiechtensteinStatesAbbreviation::foreign_try_from(state.peek().to_string())?
+                    .to_string(),
+            )),
+            api_models::enums::CountryAlpha2::LT => Ok(Secret::new(
+                LithuaniaStatesAbbreviation::foreign_try_from(state.peek().to_string())?
+                    .to_string(),
+            )),
+            api_models::enums::CountryAlpha2::MT => Ok(Secret::new(
+                MaltaStatesAbbreviation::foreign_try_from(state.peek().to_string())?.to_string(),
+            )),
+            api_models::enums::CountryAlpha2::MD => Ok(Secret::new(
+                MoldovaStatesAbbreviation::foreign_try_from(state.peek().to_string())?.to_string(),
+            )),
+            api_models::enums::CountryAlpha2::MC => Ok(Secret::new(
+                MonacoStatesAbbreviation::foreign_try_from(state.peek().to_string())?.to_string(),
+            )),
+            api_models::enums::CountryAlpha2::ME => Ok(Secret::new(
+                MontenegroStatesAbbreviation::foreign_try_from(state.peek().to_string())?
+                    .to_string(),
+            )),
+            api_models::enums::CountryAlpha2::NL => Ok(Secret::new(
+                NetherlandsStatesAbbreviation::foreign_try_from(state.peek().to_string())?
+                    .to_string(),
+            )),
+            api_models::enums::CountryAlpha2::MK => Ok(Secret::new(
+                NorthMacedoniaStatesAbbreviation::foreign_try_from(state.peek().to_string())?
+                    .to_string(),
+            )),
+            api_models::enums::CountryAlpha2::NO => Ok(Secret::new(
+                NorwayStatesAbbreviation::foreign_try_from(state.peek().to_string())?.to_string(),
+            )),
+            api_models::enums::CountryAlpha2::PL => Ok(Secret::new(
+                PolandStatesAbbreviation::foreign_try_from(state.peek().to_string())?.to_string(),
+            )),
+            api_models::enums::CountryAlpha2::PT => Ok(Secret::new(
+                PortugalStatesAbbreviation::foreign_try_from(state.peek().to_string())?.to_string(),
+            )),
+            api_models::enums::CountryAlpha2::ES => Ok(Secret::new(
+                SpainStatesAbbreviation::foreign_try_from(state.peek().to_string())?.to_string(),
+            )),
+            api_models::enums::CountryAlpha2::CH => Ok(Secret::new(
+                SwitzerlandStatesAbbreviation::foreign_try_from(state.peek().to_string())?
+                    .to_string(),
+            )),
+            api_models::enums::CountryAlpha2::GB => Ok(Secret::new(
+                UnitedKingdomStatesAbbreviation::foreign_try_from(state.peek().to_string())?
+                    .to_string(),
+            )),
             _ => Ok(state.clone()),
         }
     }
@@ -2307,6 +2426,1952 @@ impl ForeignTryFrom<String> for CanadaStatesAbbreviation {
                     "quebec" => Ok(Self::QC),
                     "saskatchewan" => Ok(Self::SK),
                     "yukon" => Ok(Self::YT),
+                    _ => Err(errors::ConnectorError::InvalidDataFormat {
+                        field_name: "address.state",
+                    }
+                    .into()),
+                }
+            }
+        }
+    }
+}
+
+impl ForeignTryFrom<String> for PolandStatesAbbreviation {
+    type Error = error_stack::Report<errors::ConnectorError>;
+    fn foreign_try_from(value: String) -> Result<Self, Self::Error> {
+        let state_abbreviation_check =
+            StringExt::<Self>::parse_enum(value.to_uppercase().clone(), "PolandStatesAbbreviation");
+        match state_abbreviation_check {
+            Ok(state_abbreviation) => Ok(state_abbreviation),
+            Err(_) => {
+                let binding = value.as_str().to_lowercase();
+                let state = binding.as_str();
+                match state {
+                    "greater poland voivodeship" => Ok(Self::GreaterPolandVoivodeship),
+                    "kielce" => Ok(Self::Kielce),
+                    "kuyavian pomeranian voivodeship" => Ok(Self::KuyavianPomeranianVoivodeship),
+                    "lesser poland voivodeship" => Ok(Self::LesserPolandVoivodeship),
+                    "lower silesian voivodeship" => Ok(Self::LowerSilesianVoivodeship),
+                    "lublin voivodeship" => Ok(Self::LublinVoivodeship),
+                    "lubusz voivodeship" => Ok(Self::LubuszVoivodeship),
+                    "masovian voivodeship" => Ok(Self::MasovianVoivodeship),
+                    "opole voivodeship" => Ok(Self::OpoleVoivodeship),
+                    "podkarpackie voivodeship" => Ok(Self::PodkarpackieVoivodeship),
+                    "podlaskie voivodeship" => Ok(Self::PodlaskieVoivodeship),
+                    "pomeranian voivodeship" => Ok(Self::PomeranianVoivodeship),
+                    "silesian voivodeship" => Ok(Self::SilesianVoivodeship),
+                    "warmian masurian voivodeship" => Ok(Self::WarmianMasurianVoivodeship),
+                    "west pomeranian voivodeship" => Ok(Self::WestPomeranianVoivodeship),
+                    "lodz voivodeship" => Ok(Self::LodzVoivodeship),
+                    "swietokrzyskie voivodeship" => Ok(Self::SwietokrzyskieVoivodeship),
+                    _ => Err(errors::ConnectorError::InvalidDataFormat {
+                        field_name: "address.state",
+                    }
+                    .into()),
+                }
+            }
+        }
+    }
+}
+
+impl ForeignTryFrom<String> for FranceStatesAbbreviation {
+    type Error = error_stack::Report<errors::ConnectorError>;
+    fn foreign_try_from(value: String) -> Result<Self, Self::Error> {
+        let state_abbreviation_check =
+            StringExt::<Self>::parse_enum(value.to_uppercase().clone(), "FranceStatesAbbreviation");
+        match state_abbreviation_check {
+            Ok(state_abbreviation) => Ok(state_abbreviation),
+            Err(_) => {
+                let binding = value.as_str().to_lowercase();
+                let state = binding.as_str();
+                match state {
+                    "alo" => Ok(Self::Alo),
+                    "alsace" => Ok(Self::Alsace),
+                    "aquitaine" => Ok(Self::Aquitaine),
+                    "auvergne" => Ok(Self::Auvergne),
+                    "auvergne rhone alpes" => Ok(Self::AuvergneRhoneAlpes),
+                    "bourgogne franche comte" => Ok(Self::BourgogneFrancheComte),
+                    "brittany" => Ok(Self::Brittany),
+                    "burgundy" => Ok(Self::Burgundy),
+                    "centre val de loire" => Ok(Self::CentreValDeLoire),
+                    "champagne ardenne" => Ok(Self::ChampagneArdenne),
+                    "corsica" => Ok(Self::Corsica),
+                    "franche comte" => Ok(Self::FrancheComte),
+                    "french guiana" => Ok(Self::FrenchGuiana),
+                    "french polynesia" => Ok(Self::FrenchPolynesia),
+                    "grand est" => Ok(Self::GrandEst),
+                    "guadeloupe" => Ok(Self::Guadeloupe),
+                    "hauts de france" => Ok(Self::HautsDeFrance),
+                    "ile de france" => Ok(Self::IleDeFrance),
+                    "normandy" => Ok(Self::Normandy),
+                    "nouvelle aquitaine" => Ok(Self::NouvelleAquitaine),
+                    "occitania" => Ok(Self::Occitania),
+                    "paris" => Ok(Self::Paris),
+                    "pays de la loire" => Ok(Self::PaysDeLaLoire),
+                    "provence alpes cote d azur" => Ok(Self::ProvenceAlpesCoteDAzur),
+                    "reunion" => Ok(Self::Reunion),
+                    "saint barthelemy" => Ok(Self::SaintBarthelemy),
+                    "saint martin" => Ok(Self::SaintMartin),
+                    "saint pierre and miquelon" => Ok(Self::SaintPierreAndMiquelon),
+                    "upper normandy" => Ok(Self::UpperNormandy),
+                    "wallis and futuna" => Ok(Self::WallisAndFutuna),
+                    _ => Err(errors::ConnectorError::InvalidDataFormat {
+                        field_name: "address.state",
+                    }
+                    .into()),
+                }
+            }
+        }
+    }
+}
+
+impl ForeignTryFrom<String> for GermanyStatesAbbreviation {
+    type Error = error_stack::Report<errors::ConnectorError>;
+    fn foreign_try_from(value: String) -> Result<Self, Self::Error> {
+        let state_abbreviation_check = StringExt::<Self>::parse_enum(
+            value.to_uppercase().clone(),
+            "GermanyStatesAbbreviation",
+        );
+        match state_abbreviation_check {
+            Ok(state_abbreviation) => Ok(state_abbreviation),
+            Err(_) => {
+                let binding = value.as_str().to_lowercase();
+                let state = binding.as_str();
+                match state {
+                    "baden wurttemberg" => Ok(Self::BadenWurttemberg),
+                    "bavaria" => Ok(Self::Bavaria),
+                    "berlin" => Ok(Self::Berlin),
+                    "brandenburg" => Ok(Self::Brandenburg),
+                    "bremen" => Ok(Self::Bremen),
+                    "hamburg" => Ok(Self::Hamburg),
+                    "hesse" => Ok(Self::Hesse),
+                    "lower saxony" => Ok(Self::LowerSaxony),
+                    "mecklenburg vorpommern" => Ok(Self::MecklenburgVorpommern),
+                    "north rhine westphalia" => Ok(Self::NorthRhineWestphalia),
+                    "rhineland palatinate" => Ok(Self::RhinelandPalatinate),
+                    "saarland" => Ok(Self::Saarland),
+                    "saxony" => Ok(Self::Saxony),
+                    "saxony anhalt" => Ok(Self::SaxonyAnhalt),
+                    "schleswig holstein" => Ok(Self::SchleswigHolstein),
+                    "thuringia" => Ok(Self::Thuringia),
+                    _ => Err(errors::ConnectorError::InvalidDataFormat {
+                        field_name: "address.state",
+                    }
+                    .into()),
+                }
+            }
+        }
+    }
+}
+
+impl ForeignTryFrom<String> for SpainStatesAbbreviation {
+    type Error = error_stack::Report<errors::ConnectorError>;
+    fn foreign_try_from(value: String) -> Result<Self, Self::Error> {
+        let state_abbreviation_check =
+            StringExt::<Self>::parse_enum(value.to_uppercase().clone(), "SpainStatesAbbreviation");
+        match state_abbreviation_check {
+            Ok(state_abbreviation) => Ok(state_abbreviation),
+            Err(_) => {
+                let binding = value.as_str().to_lowercase();
+                let state = binding.as_str();
+                match state {
+                    "a coruna province" => Ok(Self::ACorunaProvince),
+                    "albacete province" => Ok(Self::AlbaceteProvince),
+                    "alicante province" => Ok(Self::AlicanteProvince),
+                    "almeria province" => Ok(Self::AlmeriaProvince),
+                    "andalusia" => Ok(Self::Andalusia),
+                    "araba alava" => Ok(Self::ArabaAlava),
+                    "aragon" => Ok(Self::Aragon),
+                    "badajoz province" => Ok(Self::BadajozProvince),
+                    "balearic islands" => Ok(Self::BalearicIslands),
+                    "barcelona province" => Ok(Self::BarcelonaProvince),
+                    "basque country" => Ok(Self::BasqueCountry),
+                    "biscay" => Ok(Self::Biscay),
+                    "burgos province" => Ok(Self::BurgosProvince),
+                    "canary islands" => Ok(Self::CanaryIslands),
+                    "cantabria" => Ok(Self::Cantabria),
+                    "castellon province" => Ok(Self::CastellonProvince),
+                    "castile and leon" => Ok(Self::CastileAndLeon),
+                    "castile la mancha" => Ok(Self::CastileLaMancha),
+                    "catalonia" => Ok(Self::Catalonia),
+                    "ceuta" => Ok(Self::Ceuta),
+                    "ciudad real province" => Ok(Self::CiudadRealProvince),
+                    "community of madrid" => Ok(Self::CommunityOfMadrid),
+                    "cuenca province" => Ok(Self::CuencaProvince),
+                    "caceres province" => Ok(Self::CaceresProvince),
+                    "cadiz province" => Ok(Self::CadizProvince),
+                    "cordoba province" => Ok(Self::CordobaProvince),
+                    "extremadura" => Ok(Self::Extremadura),
+                    "galicia" => Ok(Self::Galicia),
+                    "gipuzkoa" => Ok(Self::Gipuzkoa),
+                    "girona province" => Ok(Self::GironaProvince),
+                    "granada province" => Ok(Self::GranadaProvince),
+                    "guadalajara province" => Ok(Self::GuadalajaraProvince),
+                    "huelva province" => Ok(Self::HuelvaProvince),
+                    "huesca province" => Ok(Self::HuescaProvince),
+                    "jaen province" => Ok(Self::JaenProvince),
+                    "la rioja" => Ok(Self::LaRioja),
+                    "las palmas province" => Ok(Self::LasPalmasProvince),
+                    "leon province" => Ok(Self::LeonProvince),
+                    "lleida province" => Ok(Self::LleidaProvince),
+                    "lugo province" => Ok(Self::LugoProvince),
+                    "madrid province" => Ok(Self::MadridProvince),
+                    "melilla" => Ok(Self::Melilla),
+                    "murcia province" => Ok(Self::MurciaProvince),
+                    "malaga province" => Ok(Self::MalagaProvince),
+                    "navarre" => Ok(Self::Navarre),
+                    "ourense province" => Ok(Self::OurenseProvince),
+                    "palencia province" => Ok(Self::PalenciaProvince),
+                    "pontevedra province" => Ok(Self::PontevedraProvince),
+                    "province of asturias" => Ok(Self::ProvinceOfAsturias),
+                    "province of avila" => Ok(Self::ProvinceOfAvila),
+                    "region of murcia" => Ok(Self::RegionOfMurcia),
+                    "salamanca province" => Ok(Self::SalamancaProvince),
+                    "santa cruz de tenerife province" => Ok(Self::SantaCruzDeTenerifeProvince),
+                    "segovia province" => Ok(Self::SegoviaProvince),
+                    "seville province" => Ok(Self::SevilleProvince),
+                    "soria province" => Ok(Self::SoriaProvince),
+                    "tarragona province" => Ok(Self::TarragonaProvince),
+                    "teruel province" => Ok(Self::TeruelProvince),
+                    "toledo province" => Ok(Self::ToledoProvince),
+                    "valencia province" => Ok(Self::ValenciaProvince),
+                    "valencian community" => Ok(Self::ValencianCommunity),
+                    "valladolid province" => Ok(Self::ValladolidProvince),
+                    "zamora province" => Ok(Self::ZamoraProvince),
+                    "zaragoza province" => Ok(Self::ZaragozaProvince),
+                    _ => Err(errors::ConnectorError::InvalidDataFormat {
+                        field_name: "address.state",
+                    }
+                    .into()),
+                }
+            }
+        }
+    }
+}
+
+impl ForeignTryFrom<String> for ItalyStatesAbbreviation {
+    type Error = error_stack::Report<errors::ConnectorError>;
+    fn foreign_try_from(value: String) -> Result<Self, Self::Error> {
+        let state_abbreviation_check =
+            StringExt::<Self>::parse_enum(value.to_uppercase().clone(), "ItalyStatesAbbreviation");
+        match state_abbreviation_check {
+            Ok(state_abbreviation) => Ok(state_abbreviation),
+            Err(_) => {
+                let binding = value.as_str().to_lowercase();
+                let state = binding.as_str();
+                match state {
+                    "abruzzo" => Ok(Self::Abruzzo),
+                    "aosta valley" => Ok(Self::AostaValley),
+                    "apulia" => Ok(Self::Apulia),
+                    "basilicata" => Ok(Self::Basilicata),
+                    "benevento province" => Ok(Self::BeneventoProvince),
+                    "calabria" => Ok(Self::Calabria),
+                    "campania" => Ok(Self::Campania),
+                    "emilia romagna" => Ok(Self::EmiliaRomagna),
+                    "friuli venezia giulia" => Ok(Self::FriuliVeneziaGiulia),
+                    "lazio" => Ok(Self::Lazio),
+                    "liguria" => Ok(Self::Liguria),
+                    "lombardy" => Ok(Self::Lombardy),
+                    "marche" => Ok(Self::Marche),
+                    "molise" => Ok(Self::Molise),
+                    "piedmont" => Ok(Self::Piedmont),
+                    "sardinia" => Ok(Self::Sardinia),
+                    "sicily" => Ok(Self::Sicily),
+                    "trentino south tyrol" => Ok(Self::TrentinoSouthTyrol),
+                    "tuscany" => Ok(Self::Tuscany),
+                    "umbria" => Ok(Self::Umbria),
+                    "veneto" => Ok(Self::Veneto),
+                    "agrigento" => Ok(Self::Agrigento),
+                    "caltanissetta" => Ok(Self::Caltanissetta),
+                    "enna" => Ok(Self::Enna),
+                    "ragusa" => Ok(Self::Ragusa),
+                    "siracusa" => Ok(Self::Siracusa),
+                    "trapani" => Ok(Self::Trapani),
+                    "bari" => Ok(Self::Bari),
+                    "bologna" => Ok(Self::Bologna),
+                    "cagliari" => Ok(Self::Cagliari),
+                    "catania" => Ok(Self::Catania),
+                    "florence" => Ok(Self::Florence),
+                    "genoa" => Ok(Self::Genoa),
+                    "messina" => Ok(Self::Messina),
+                    "milan" => Ok(Self::Milan),
+                    "naples" => Ok(Self::Naples),
+                    "palermo" => Ok(Self::Palermo),
+                    "reggio calabria" => Ok(Self::ReggioCalabria),
+                    "rome" => Ok(Self::Rome),
+                    "turin" => Ok(Self::Turin),
+                    "venice" => Ok(Self::Venice),
+                    _ => Err(errors::ConnectorError::InvalidDataFormat {
+                        field_name: "address.state",
+                    }
+                    .into()),
+                }
+            }
+        }
+    }
+}
+
+impl ForeignTryFrom<String> for NorwayStatesAbbreviation {
+    type Error = error_stack::Report<errors::ConnectorError>;
+    fn foreign_try_from(value: String) -> Result<Self, Self::Error> {
+        let state_abbreviation_check =
+            StringExt::<Self>::parse_enum(value.to_uppercase().clone(), "NorwayStatesAbbreviation");
+        match state_abbreviation_check {
+            Ok(state_abbreviation) => Ok(state_abbreviation),
+            Err(_) => {
+                let binding = value.as_str().to_lowercase();
+                let state = binding.as_str();
+                match state {
+                    "akershus" => Ok(Self::Akershus),
+                    "buskerud" => Ok(Self::Buskerud),
+                    "finnmark" => Ok(Self::Finnmark),
+                    "hedmark" => Ok(Self::Hedmark),
+                    "hordaland" => Ok(Self::Hordaland),
+                    "janmayen" => Ok(Self::JanMayen),
+                    "nordtrondelag" => Ok(Self::NordTrondelag),
+                    "nordland" => Ok(Self::Nordland),
+                    "oppland" => Ok(Self::Oppland),
+                    "oslo" => Ok(Self::Oslo),
+                    "rogaland" => Ok(Self::Rogaland),
+                    "sognogfjordane" => Ok(Self::SognOgFjordane),
+                    "svalbard" => Ok(Self::Svalbard),
+                    "sortrondelag" => Ok(Self::SorTrondelag),
+                    "telemark" => Ok(Self::Telemark),
+                    "troms" => Ok(Self::Troms),
+                    "trondelag" => Ok(Self::Trondelag),
+                    "vestagder" => Ok(Self::VestAgder),
+                    "vestfold" => Ok(Self::Vestfold),
+                    "ostfold" => Ok(Self::Ostfold),
+                    _ => Err(errors::ConnectorError::InvalidDataFormat {
+                        field_name: "address.state",
+                    }
+                    .into()),
+                }
+            }
+        }
+    }
+}
+
+impl ForeignTryFrom<String> for AlbaniaStatesAbbreviation {
+    type Error = error_stack::Report<errors::ConnectorError>;
+    fn foreign_try_from(value: String) -> Result<Self, Self::Error> {
+        let state_abbreviation_check = StringExt::<Self>::parse_enum(
+            value.to_uppercase().clone(),
+            "AlbaniaStatesAbbreviation",
+        );
+        match state_abbreviation_check {
+            Ok(state_abbreviation) => Ok(state_abbreviation),
+            Err(_) => {
+                let binding = value.as_str().to_lowercase();
+                let state = binding.as_str();
+                match state {
+                    "berat" => Ok(Self::Berat),
+                    "diber" => Ok(Self::Diber),
+                    "durres" => Ok(Self::Durres),
+                    "elbasan" => Ok(Self::Elbasan),
+                    "fier" => Ok(Self::Fier),
+                    "gjirokaster" => Ok(Self::Gjirokaster),
+                    "korce" => Ok(Self::Korce),
+                    "kukes" => Ok(Self::Kukes),
+                    "lezhe" => Ok(Self::Lezhe),
+                    "shkoder" => Ok(Self::Shkoder),
+                    "tirane" => Ok(Self::Tirane),
+                    "vlore" => Ok(Self::Vlore),
+                    _ => Err(errors::ConnectorError::InvalidDataFormat {
+                        field_name: "address.state",
+                    }
+                    .into()),
+                }
+            }
+        }
+    }
+}
+
+impl ForeignTryFrom<String> for AndorraStatesAbbreviation {
+    type Error = error_stack::Report<errors::ConnectorError>;
+    fn foreign_try_from(value: String) -> Result<Self, Self::Error> {
+        let state_abbreviation_check = StringExt::<Self>::parse_enum(
+            value.to_uppercase().clone(),
+            "AndorraStatesAbbreviation",
+        );
+        match state_abbreviation_check {
+            Ok(state_abbreviation) => Ok(state_abbreviation),
+            Err(_) => {
+                let binding = value.as_str().to_lowercase();
+                let state = binding.as_str();
+                match state {
+                    "andorra la vella" => Ok(Self::AndorraLaVella),
+                    "canillo" => Ok(Self::Canillo),
+                    "encamp" => Ok(Self::Encamp),
+                    "escaldes engordany" => Ok(Self::EscaldesEngordany),
+                    "la massana" => Ok(Self::LaMassana),
+                    "ordino" => Ok(Self::Ordino),
+                    "sant julia de loria" => Ok(Self::SantJuliaDeLoria),
+                    _ => Err(errors::ConnectorError::InvalidDataFormat {
+                        field_name: "address.state",
+                    }
+                    .into()),
+                }
+            }
+        }
+    }
+}
+
+impl ForeignTryFrom<String> for AustriaStatesAbbreviation {
+    type Error = error_stack::Report<errors::ConnectorError>;
+    fn foreign_try_from(value: String) -> Result<Self, Self::Error> {
+        let state_abbreviation_check = StringExt::<Self>::parse_enum(
+            value.to_uppercase().clone(),
+            "AustriaStatesAbbreviation",
+        );
+        match state_abbreviation_check {
+            Ok(state_abbreviation) => Ok(state_abbreviation),
+            Err(_) => {
+                let binding = value.as_str().to_lowercase();
+                let state = binding.as_str();
+                match state {
+                    "burgenland" => Ok(Self::Burgenland),
+                    "carinthia" => Ok(Self::Carinthia),
+                    "lower austria" => Ok(Self::LowerAustria),
+                    "salzburg" => Ok(Self::Salzburg),
+                    "styria" => Ok(Self::Styria),
+                    "tyrol" => Ok(Self::Tyrol),
+                    "upper austria" => Ok(Self::UpperAustria),
+                    "vienna" => Ok(Self::Vienna),
+                    "vorarlberg" => Ok(Self::Vorarlberg),
+                    _ => Err(errors::ConnectorError::InvalidDataFormat {
+                        field_name: "address.state",
+                    }
+                    .into()),
+                }
+            }
+        }
+    }
+}
+
+impl ForeignTryFrom<String> for RomaniaStatesAbbreviation {
+    type Error = error_stack::Report<errors::ConnectorError>;
+    fn foreign_try_from(value: String) -> Result<Self, Self::Error> {
+        let state_abbreviation_check = StringExt::<Self>::parse_enum(
+            value.to_uppercase().clone(),
+            "RomaniaStatesAbbreviation",
+        );
+        match state_abbreviation_check {
+            Ok(state_abbreviation) => Ok(state_abbreviation),
+            Err(_) => {
+                let binding = value.as_str().to_lowercase();
+                let state = binding.as_str();
+                match state {
+                    "alba" => Ok(Self::Alba),
+                    "arad county" => Ok(Self::AradCounty),
+                    "arges" => Ok(Self::Arges),
+                    "bacau county" => Ok(Self::BacauCounty),
+                    "bihor county" => Ok(Self::BihorCounty),
+                    "bistrita nasaud county" => Ok(Self::BistritaNasaudCounty),
+                    "botosani county" => Ok(Self::BotosaniCounty),
+                    "braila" => Ok(Self::Braila),
+                    "brasov county" => Ok(Self::BrasovCounty),
+                    "bucharest" => Ok(Self::Bucharest),
+                    "buzau county" => Ok(Self::BuzauCounty),
+                    "caras severin county" => Ok(Self::CarasSeverinCounty),
+                    "cluj county" => Ok(Self::ClujCounty),
+                    "constanta county" => Ok(Self::ConstantaCounty),
+                    "covasna county" => Ok(Self::CovasnaCounty),
+                    "calarasi county" => Ok(Self::CalarasiCounty),
+                    "dolj county" => Ok(Self::DoljCounty),
+                    "dambovita county" => Ok(Self::DambovitaCounty),
+                    "galati county" => Ok(Self::GalatiCounty),
+                    "giurgiu county" => Ok(Self::GiurgiuCounty),
+                    "gorj county" => Ok(Self::GorjCounty),
+                    "harghita county" => Ok(Self::HarghitaCounty),
+                    "hunedoara county" => Ok(Self::HunedoaraCounty),
+                    "ialomita county" => Ok(Self::IalomitaCounty),
+                    "iasi county" => Ok(Self::IasiCounty),
+                    "ilfov county" => Ok(Self::IlfovCounty),
+                    "mehedinti county" => Ok(Self::MehedintiCounty),
+                    "mures county" => Ok(Self::MuresCounty),
+                    "neamt county" => Ok(Self::NeamtCounty),
+                    "olt county" => Ok(Self::OltCounty),
+                    "prahova county" => Ok(Self::PrahovaCounty),
+                    "satu mare county" => Ok(Self::SatuMareCounty),
+                    "sibiu county" => Ok(Self::SibiuCounty),
+                    "suceava county" => Ok(Self::SuceavaCounty),
+                    "salaj county" => Ok(Self::SalajCounty),
+                    "teleorman county" => Ok(Self::TeleormanCounty),
+                    "timis county" => Ok(Self::TimisCounty),
+                    "tulcea county" => Ok(Self::TulceaCounty),
+                    "vaslui county" => Ok(Self::VasluiCounty),
+                    "vrancea county" => Ok(Self::VranceaCounty),
+                    "valcea county" => Ok(Self::ValceaCounty),
+                    _ => Err(errors::ConnectorError::InvalidDataFormat {
+                        field_name: "address.state",
+                    }
+                    .into()),
+                }
+            }
+        }
+    }
+}
+
+impl ForeignTryFrom<String> for PortugalStatesAbbreviation {
+    type Error = error_stack::Report<errors::ConnectorError>;
+    fn foreign_try_from(value: String) -> Result<Self, Self::Error> {
+        let state_abbreviation_check = StringExt::<Self>::parse_enum(
+            value.to_uppercase().clone(),
+            "PortugalStatesAbbreviation",
+        );
+        match state_abbreviation_check {
+            Ok(state_abbreviation) => Ok(state_abbreviation),
+            Err(_) => {
+                let binding = value.as_str().to_lowercase();
+                let state = binding.as_str();
+                match state {
+                    "aveiro district" => Ok(Self::AveiroDistrict),
+                    "azores" => Ok(Self::Azores),
+                    "beja district" => Ok(Self::BejaDistrict),
+                    "braga district" => Ok(Self::BragaDistrict),
+                    "braganca district" => Ok(Self::BragancaDistrict),
+                    "castelo branco district" => Ok(Self::CasteloBrancoDistrict),
+                    "coimbra district" => Ok(Self::CoimbraDistrict),
+                    "faro district" => Ok(Self::FaroDistrict),
+                    "guarda district" => Ok(Self::GuardaDistrict),
+                    "leiria district" => Ok(Self::LeiriaDistrict),
+                    "lisbon district" => Ok(Self::LisbonDistrict),
+                    "madeira" => Ok(Self::Madeira),
+                    "portalegre district" => Ok(Self::PortalegreDistrict),
+                    "porto district" => Ok(Self::PortoDistrict),
+                    "santarem district" => Ok(Self::SantaremDistrict),
+                    "setubal district" => Ok(Self::SetubalDistrict),
+                    "viana do castelo district" => Ok(Self::VianaDoCasteloDistrict),
+                    "vila real district" => Ok(Self::VilaRealDistrict),
+                    "viseu district" => Ok(Self::ViseuDistrict),
+                    "evora district" => Ok(Self::EvoraDistrict),
+                    _ => Err(errors::ConnectorError::InvalidDataFormat {
+                        field_name: "address.state",
+                    }
+                    .into()),
+                }
+            }
+        }
+    }
+}
+
+impl ForeignTryFrom<String> for SwitzerlandStatesAbbreviation {
+    type Error = error_stack::Report<errors::ConnectorError>;
+    fn foreign_try_from(value: String) -> Result<Self, Self::Error> {
+        let state_abbreviation_check = StringExt::<Self>::parse_enum(
+            value.to_uppercase().clone(),
+            "SwitzerlandStatesAbbreviation",
+        );
+        match state_abbreviation_check {
+            Ok(state_abbreviation) => Ok(state_abbreviation),
+            Err(_) => {
+                let binding = value.as_str().to_lowercase();
+                let state = binding.as_str();
+                match state {
+                    "aargau" => Ok(Self::Aargau),
+                    "appenzell ausserrhoden" => Ok(Self::AppenzellAusserrhoden),
+                    "appenzell innerrhoden" => Ok(Self::AppenzellInnerrhoden),
+                    "basel landschaft" => Ok(Self::BaselLandschaft),
+                    "canton of fribourg" => Ok(Self::CantonOfFribourg),
+                    "canton of geneva" => Ok(Self::CantonOfGeneva),
+                    "canton of jura" => Ok(Self::CantonOfJura),
+                    "canton of lucerne" => Ok(Self::CantonOfLucerne),
+                    "canton of neuchatel" => Ok(Self::CantonOfNeuchatel),
+                    "canton of schaffhausen" => Ok(Self::CantonOfSchaffhausen),
+                    "canton of solothurn" => Ok(Self::CantonOfSolothurn),
+                    "canton of st gallen" => Ok(Self::CantonOfStGallen),
+                    "canton of valais" => Ok(Self::CantonOfValais),
+                    "canton of vaud" => Ok(Self::CantonOfVaud),
+                    "canton of zug" => Ok(Self::CantonOfZug),
+                    "glarus" => Ok(Self::Glarus),
+                    "graubunden" => Ok(Self::Graubunden),
+                    "nidwalden" => Ok(Self::Nidwalden),
+                    "obwalden" => Ok(Self::Obwalden),
+                    "schwyz" => Ok(Self::Schwyz),
+                    "thurgau" => Ok(Self::Thurgau),
+                    "ticino" => Ok(Self::Ticino),
+                    "uri" => Ok(Self::Uri),
+                    "canton of bern" => Ok(Self::CantonOfBern),
+                    "canton of zurich" => Ok(Self::CantonOfZurich),
+                    _ => Err(errors::ConnectorError::InvalidDataFormat {
+                        field_name: "address.state",
+                    }
+                    .into()),
+                }
+            }
+        }
+    }
+}
+
+impl ForeignTryFrom<String> for NorthMacedoniaStatesAbbreviation {
+    type Error = error_stack::Report<errors::ConnectorError>;
+    fn foreign_try_from(value: String) -> Result<Self, Self::Error> {
+        let state_abbreviation_check = StringExt::<Self>::parse_enum(
+            value.to_uppercase().clone(),
+            "NorthMacedoniaStatesAbbreviation",
+        );
+        match state_abbreviation_check {
+            Ok(state_abbreviation) => Ok(state_abbreviation),
+            Err(_) => {
+                let binding = value.as_str().to_lowercase();
+                let state = binding.as_str();
+                match state {
+                    "aerodrom municipality" => Ok(Self::AerodromMunicipality),
+                    "aracinovo municipality" => Ok(Self::AracinovoMunicipality),
+                    "berovo municipality" => Ok(Self::BerovoMunicipality),
+                    "bitola municipality" => Ok(Self::BitolaMunicipality),
+                    "bogdanci municipality" => Ok(Self::BogdanciMunicipality),
+                    "bogovinje municipality" => Ok(Self::BogovinjeMunicipality),
+                    "bosilovo municipality" => Ok(Self::BosilovoMunicipality),
+                    "brvenica municipality" => Ok(Self::BrvenicaMunicipality),
+                    "butel municipality" => Ok(Self::ButelMunicipality),
+                    "centar municipality" => Ok(Self::CentarMunicipality),
+                    "centar zupa municipality" => Ok(Self::CentarZupaMunicipality),
+                    "debarca municipality" => Ok(Self::DebarcaMunicipality),
+                    "delcevo municipality" => Ok(Self::DelcevoMunicipality),
+                    "demir hisar municipality" => Ok(Self::DemirHisarMunicipality),
+                    "demir kapija municipality" => Ok(Self::DemirKapijaMunicipality),
+                    "dojran municipality" => Ok(Self::DojranMunicipality),
+                    "dolneni municipality" => Ok(Self::DolneniMunicipality),
+                    "drugovo municipality" => Ok(Self::DrugovoMunicipality),
+                    "gazi baba municipality" => Ok(Self::GaziBabaMunicipality),
+                    "gevgelija municipality" => Ok(Self::GevgelijaMunicipality),
+                    "gjorce petrov municipality" => Ok(Self::GjorcePetrovMunicipality),
+                    "gostivar municipality" => Ok(Self::GostivarMunicipality),
+                    "gradsko municipality" => Ok(Self::GradskoMunicipality),
+                    "greater skopje" => Ok(Self::GreaterSkopje),
+                    "ilinden municipality" => Ok(Self::IlindenMunicipality),
+                    "jegunovce municipality" => Ok(Self::JegunovceMunicipality),
+                    "karbinci" => Ok(Self::Karbinci),
+                    "karpos municipality" => Ok(Self::KarposMunicipality),
+                    "kavadarci municipality" => Ok(Self::KavadarciMunicipality),
+                    "kisela voda municipality" => Ok(Self::KiselaVodaMunicipality),
+                    "kicevo municipality" => Ok(Self::KicevoMunicipality),
+                    "konce municipality" => Ok(Self::KonceMunicipality),
+                    _ => Err(errors::ConnectorError::InvalidDataFormat {
+                        field_name: "address.state",
+                    }
+                    .into()),
+                }
+            }
+        }
+    }
+}
+
+impl ForeignTryFrom<String> for MontenegroStatesAbbreviation {
+    type Error = error_stack::Report<errors::ConnectorError>;
+    fn foreign_try_from(value: String) -> Result<Self, Self::Error> {
+        let state_abbreviation_check = StringExt::<Self>::parse_enum(
+            value.to_uppercase().clone(),
+            "MontenegroStatesAbbreviation",
+        );
+        match state_abbreviation_check {
+            Ok(state_abbreviation) => Ok(state_abbreviation),
+            Err(_) => {
+                let binding = value.as_str().to_lowercase();
+                let state = binding.as_str();
+                match state {
+                    "andrijevica municipality" => Ok(Self::AndrijevicaMunicipality),
+                    "bar municipality" => Ok(Self::BarMunicipality),
+                    "berane municipality" => Ok(Self::BeraneMunicipality),
+                    "bijelo polje municipality" => Ok(Self::BijeloPoljeMunicipality),
+                    "budva municipality" => Ok(Self::BudvaMunicipality),
+                    "danilovgrad municipality" => Ok(Self::DanilovgradMunicipality),
+                    "gusinje municipality" => Ok(Self::GusinjeMunicipality),
+                    "kolasin municipality" => Ok(Self::KolasinMunicipality),
+                    "kotor municipality" => Ok(Self::KotorMunicipality),
+                    "mojkovac municipality" => Ok(Self::MojkovacMunicipality),
+                    "niksic municipality" => Ok(Self::NiksicMunicipality),
+                    "old royal capital cetinje" => Ok(Self::OldRoyalCapitalCetinje),
+                    "petnjica municipality" => Ok(Self::PetnjicaMunicipality),
+                    "plav municipality" => Ok(Self::PlavMunicipality),
+                    "pljevlja municipality" => Ok(Self::PljevljaMunicipality),
+                    "pluzine municipality" => Ok(Self::PluzineMunicipality),
+                    "podgorica municipality" => Ok(Self::PodgoricaMunicipality),
+                    "rozaje municipality" => Ok(Self::RozajeMunicipality),
+                    "tivat municipality" => Ok(Self::TivatMunicipality),
+                    "ulcinj municipality" => Ok(Self::UlcinjMunicipality),
+                    "savnik municipality" => Ok(Self::SavnikMunicipality),
+                    "zabljak municipality" => Ok(Self::ZabljakMunicipality),
+                    _ => Err(errors::ConnectorError::InvalidDataFormat {
+                        field_name: "address.state",
+                    }
+                    .into()),
+                }
+            }
+        }
+    }
+}
+
+impl ForeignTryFrom<String> for MonacoStatesAbbreviation {
+    type Error = error_stack::Report<errors::ConnectorError>;
+    fn foreign_try_from(value: String) -> Result<Self, Self::Error> {
+        let state_abbreviation_check =
+            StringExt::<Self>::parse_enum(value.to_uppercase().clone(), "MonacoStatesAbbreviation");
+        match state_abbreviation_check {
+            Ok(state_abbreviation) => Ok(state_abbreviation),
+            Err(_) => {
+                let binding = value.as_str().to_lowercase();
+                let state = binding.as_str();
+                match state {
+                    "monaco" => Ok(Self::Monaco),
+                    _ => Err(errors::ConnectorError::InvalidDataFormat {
+                        field_name: "address.state",
+                    }
+                    .into()),
+                }
+            }
+        }
+    }
+}
+
+impl ForeignTryFrom<String> for NetherlandsStatesAbbreviation {
+    type Error = error_stack::Report<errors::ConnectorError>;
+    fn foreign_try_from(value: String) -> Result<Self, Self::Error> {
+        let state_abbreviation_check = StringExt::<Self>::parse_enum(
+            value.to_uppercase().clone(),
+            "NetherlandsStatesAbbreviation",
+        );
+        match state_abbreviation_check {
+            Ok(state_abbreviation) => Ok(state_abbreviation),
+            Err(_) => {
+                let binding = value.as_str().to_lowercase();
+                let state = binding.as_str();
+                match state {
+                    "bonaire" => Ok(Self::Bonaire),
+                    "drenthe" => Ok(Self::Drenthe),
+                    "flevoland" => Ok(Self::Flevoland),
+                    "friesland" => Ok(Self::Friesland),
+                    "gelderland" => Ok(Self::Gelderland),
+                    "groningen" => Ok(Self::Groningen),
+                    "limburg" => Ok(Self::Limburg),
+                    "north brabant" => Ok(Self::NorthBrabant),
+                    "north holland" => Ok(Self::NorthHolland),
+                    "overijssel" => Ok(Self::Overijssel),
+                    "saba" => Ok(Self::Saba),
+                    "sint eustatius" => Ok(Self::SintEustatius),
+                    "south holland" => Ok(Self::SouthHolland),
+                    "utrecht" => Ok(Self::Utrecht),
+                    "zeeland" => Ok(Self::Zeeland),
+                    _ => Err(errors::ConnectorError::InvalidDataFormat {
+                        field_name: "address.state",
+                    }
+                    .into()),
+                }
+            }
+        }
+    }
+}
+
+impl ForeignTryFrom<String> for MoldovaStatesAbbreviation {
+    type Error = error_stack::Report<errors::ConnectorError>;
+    fn foreign_try_from(value: String) -> Result<Self, Self::Error> {
+        let state_abbreviation_check = StringExt::<Self>::parse_enum(
+            value.to_uppercase().clone(),
+            "MoldovaStatesAbbreviation",
+        );
+        match state_abbreviation_check {
+            Ok(state_abbreviation) => Ok(state_abbreviation),
+            Err(_) => {
+                let binding = value.as_str().to_lowercase();
+                let state = binding.as_str();
+                match state {
+                    "anenii noi district" => Ok(Self::AneniiNoiDistrict),
+                    "basarabeasca district" => Ok(Self::BasarabeascaDistrict),
+                    "bender municipality" => Ok(Self::BenderMunicipality),
+                    "briceni district" => Ok(Self::BriceniDistrict),
+                    "balti municipality" => Ok(Self::BaltiMunicipality),
+                    "cahul district" => Ok(Self::CahulDistrict),
+                    "cantemir district" => Ok(Self::CantemirDistrict),
+                    "chisinau municipality" => Ok(Self::ChisinauMunicipality),
+                    "cimislia district" => Ok(Self::CimisliaDistrict),
+                    "criuleni district" => Ok(Self::CriuleniDistrict),
+                    "calarasi district" => Ok(Self::CalarasiDistrict),
+                    "causeni district" => Ok(Self::CauseniDistrict),
+                    "donduseni district" => Ok(Self::DonduseniDistrict),
+                    "drochia district" => Ok(Self::DrochiaDistrict),
+                    "dubasari district" => Ok(Self::DubasariDistrict),
+                    "edinet district" => Ok(Self::EdinetDistrict),
+                    "floresti district" => Ok(Self::FlorestiDistrict),
+                    "falesti district" => Ok(Self::FalestiDistrict),
+                    "gagauzia" => Ok(Self::Gagauzia),
+                    "glodeni district" => Ok(Self::GlodeniDistrict),
+                    "hincesti district" => Ok(Self::HincestiDistrict),
+                    "ialoveni district" => Ok(Self::IaloveniDistrict),
+                    "nisporeni district" => Ok(Self::NisporeniDistrict),
+                    "ocnita district" => Ok(Self::OcnitaDistrict),
+                    "orhei district" => Ok(Self::OrheiDistrict),
+                    "rezina district" => Ok(Self::RezinaDistrict),
+                    "riscani district" => Ok(Self::RiscaniDistrict),
+                    "soroca district" => Ok(Self::SorocaDistrict),
+                    "straseni district" => Ok(Self::StraseniDistrict),
+                    "singerei district" => Ok(Self::SingereiDistrict),
+                    "taraclia district" => Ok(Self::TaracliaDistrict),
+                    "telenesti district" => Ok(Self::TelenestiDistrict),
+                    "transnistria autonomous territorial unit" => {
+                        Ok(Self::TransnistriaAutonomousTerritorialUnit)
+                    }
+                    "ungheni district" => Ok(Self::UngheniDistrict),
+                    "soldanesti district" => Ok(Self::SoldanestiDistrict),
+                    "stefan voda district" => Ok(Self::StefanVodaDistrict),
+                    _ => Err(errors::ConnectorError::InvalidDataFormat {
+                        field_name: "address.state",
+                    }
+                    .into()),
+                }
+            }
+        }
+    }
+}
+
+impl ForeignTryFrom<String> for LithuaniaStatesAbbreviation {
+    type Error = error_stack::Report<errors::ConnectorError>;
+    fn foreign_try_from(value: String) -> Result<Self, Self::Error> {
+        let state_abbreviation_check = StringExt::<Self>::parse_enum(
+            value.to_uppercase().clone(),
+            "LithuaniaStatesAbbreviation",
+        );
+        match state_abbreviation_check {
+            Ok(state_abbreviation) => Ok(state_abbreviation),
+            Err(_) => {
+                let binding = value.as_str().to_lowercase();
+                let state = binding.as_str();
+                match state {
+                    "akmene district municipality" => Ok(Self::AkmeneDistrictMunicipality),
+                    "alytus city municipality" => Ok(Self::AlytusCityMunicipality),
+                    "alytus county" => Ok(Self::AlytusCounty),
+                    "alytus district municipality" => Ok(Self::AlytusDistrictMunicipality),
+                    "birstonas municipality" => Ok(Self::BirstonasMunicipality),
+                    "birzai district municipality" => Ok(Self::BirzaiDistrictMunicipality),
+                    "druskininkai municipality" => Ok(Self::DruskininkaiMunicipality),
+                    "elektrenai municipality" => Ok(Self::ElektrenaiMunicipality),
+                    "ignalina district municipality" => Ok(Self::IgnalinaDistrictMunicipality),
+                    "jonava district municipality" => Ok(Self::JonavaDistrictMunicipality),
+                    "joniskis district municipality" => Ok(Self::JoniskisDistrictMunicipality),
+                    "jurbarkas district municipality" => Ok(Self::JurbarkasDistrictMunicipality),
+                    "kaisiadorys district municipality" => {
+                        Ok(Self::KaisiadorysDistrictMunicipality)
+                    }
+                    "kalvarija municipality" => Ok(Self::KalvarijaMunicipality),
+                    "kaunas city municipality" => Ok(Self::KaunasCityMunicipality),
+                    "kaunas county" => Ok(Self::KaunasCounty),
+                    "kaunas district municipality" => Ok(Self::KaunasDistrictMunicipality),
+                    "kazlu ruda municipality" => Ok(Self::KazluRudaMunicipality),
+                    "kelme district municipality" => Ok(Self::KelmeDistrictMunicipality),
+                    "klaipeda city municipality" => Ok(Self::KlaipedaCityMunicipality),
+                    "klaipeda county" => Ok(Self::KlaipedaCounty),
+                    "klaipeda district municipality" => Ok(Self::KlaipedaDistrictMunicipality),
+                    "kretinga district municipality" => Ok(Self::KretingaDistrictMunicipality),
+                    "kupiskis district municipality" => Ok(Self::KupiskisDistrictMunicipality),
+                    "kedainiai district municipality" => Ok(Self::KedainiaiDistrictMunicipality),
+                    "lazdijai district municipality" => Ok(Self::LazdijaiDistrictMunicipality),
+                    "marijampole county" => Ok(Self::MarijampoleCounty),
+                    "marijampole municipality" => Ok(Self::MarijampoleMunicipality),
+                    "mazeikiai district municipality" => Ok(Self::MazeikiaiDistrictMunicipality),
+                    "moletai district municipality" => Ok(Self::MoletaiDistrictMunicipality),
+                    "neringa municipality" => Ok(Self::NeringaMunicipality),
+                    "pagegiai municipality" => Ok(Self::PagegiaiMunicipality),
+                    "pakruojis district municipality" => Ok(Self::PakruojisDistrictMunicipality),
+                    "palanga city municipality" => Ok(Self::PalangaCityMunicipality),
+                    "panevezys city municipality" => Ok(Self::PanevezysCityMunicipality),
+                    "panevezys county" => Ok(Self::PanevezysCounty),
+                    "panevezys district municipality" => Ok(Self::PanevezysDistrictMunicipality),
+                    "pasvalys district municipality" => Ok(Self::PasvalysDistrictMunicipality),
+                    "plunge district municipality" => Ok(Self::PlungeDistrictMunicipality),
+                    "prienai district municipality" => Ok(Self::PrienaiDistrictMunicipality),
+                    "radviliskis district municipality" => {
+                        Ok(Self::RadviliskisDistrictMunicipality)
+                    }
+                    "raseiniai district municipality" => Ok(Self::RaseiniaiDistrictMunicipality),
+                    "rietavas municipality" => Ok(Self::RietavasMunicipality),
+                    "rokiskis district municipality" => Ok(Self::RokiskisDistrictMunicipality),
+                    "skuodas district municipality" => Ok(Self::SkuodasDistrictMunicipality),
+                    "taurage county" => Ok(Self::TaurageCounty),
+                    "taurage district municipality" => Ok(Self::TaurageDistrictMunicipality),
+                    "telsiai county" => Ok(Self::TelsiaiCounty),
+                    "telsiai district municipality" => Ok(Self::TelsiaiDistrictMunicipality),
+                    "trakai district municipality" => Ok(Self::TrakaiDistrictMunicipality),
+                    "ukmerge district municipality" => Ok(Self::UkmergeDistrictMunicipality),
+                    "utena county" => Ok(Self::UtenaCounty),
+                    "utena district municipality" => Ok(Self::UtenaDistrictMunicipality),
+                    "varena district municipality" => Ok(Self::VarenaDistrictMunicipality),
+                    "vilkaviskis district municipality" => {
+                        Ok(Self::VilkaviskisDistrictMunicipality)
+                    }
+                    "vilnius city municipality" => Ok(Self::VilniusCityMunicipality),
+                    "vilnius county" => Ok(Self::VilniusCounty),
+                    "vilnius district municipality" => Ok(Self::VilniusDistrictMunicipality),
+                    "visaginas municipality" => Ok(Self::VisaginasMunicipality),
+                    "zarasai district municipality" => Ok(Self::ZarasaiDistrictMunicipality),
+                    "sakiai district municipality" => Ok(Self::SakiaiDistrictMunicipality),
+                    "salcininkai district municipality" => {
+                        Ok(Self::SalcininkaiDistrictMunicipality)
+                    }
+                    "siauliai city municipality" => Ok(Self::SiauliaiCityMunicipality),
+                    "siauliai county" => Ok(Self::SiauliaiCounty),
+                    "siauliai district municipality" => Ok(Self::SiauliaiDistrictMunicipality),
+                    "silale district municipality" => Ok(Self::SilaleDistrictMunicipality),
+                    "silute district municipality" => Ok(Self::SiluteDistrictMunicipality),
+                    "sirvintos district municipality" => Ok(Self::SirvintosDistrictMunicipality),
+                    "svencionys district municipality" => Ok(Self::SvencionysDistrictMunicipality),
+                    _ => Err(errors::ConnectorError::InvalidDataFormat {
+                        field_name: "address.state",
+                    }
+                    .into()),
+                }
+            }
+        }
+    }
+}
+
+impl ForeignTryFrom<String> for LiechtensteinStatesAbbreviation {
+    type Error = error_stack::Report<errors::ConnectorError>;
+    fn foreign_try_from(value: String) -> Result<Self, Self::Error> {
+        let state_abbreviation_check = StringExt::<Self>::parse_enum(
+            value.to_uppercase().clone(),
+            "LiechtensteinStatesAbbreviation",
+        );
+        match state_abbreviation_check {
+            Ok(state_abbreviation) => Ok(state_abbreviation),
+            Err(_) => {
+                let binding = value.as_str().to_lowercase();
+                let state = binding.as_str();
+                match state {
+                    "balzers" => Ok(Self::Balzers),
+                    "eschen" => Ok(Self::Eschen),
+                    "gamprin" => Ok(Self::Gamprin),
+                    "mauren" => Ok(Self::Mauren),
+                    "planken" => Ok(Self::Planken),
+                    "ruggell" => Ok(Self::Ruggell),
+                    "schaan" => Ok(Self::Schaan),
+                    "schellenberg" => Ok(Self::Schellenberg),
+                    "triesen" => Ok(Self::Triesen),
+                    "triesenberg" => Ok(Self::Triesenberg),
+                    "vaduz" => Ok(Self::Vaduz),
+                    _ => Err(errors::ConnectorError::InvalidDataFormat {
+                        field_name: "address.state",
+                    }
+                    .into()),
+                }
+            }
+        }
+    }
+}
+
+impl ForeignTryFrom<String> for LatviaStatesAbbreviation {
+    type Error = error_stack::Report<errors::ConnectorError>;
+    fn foreign_try_from(value: String) -> Result<Self, Self::Error> {
+        let state_abbreviation_check =
+            StringExt::<Self>::parse_enum(value.to_uppercase().clone(), "LatviaStatesAbbreviation");
+        match state_abbreviation_check {
+            Ok(state_abbreviation) => Ok(state_abbreviation),
+            Err(_) => {
+                let binding = value.as_str().to_lowercase();
+                let state = binding.as_str();
+                match state {
+                    "aglona municipality" => Ok(Self::AglonaMunicipality),
+                    "aizkraukle municipality" => Ok(Self::AizkraukleMunicipality),
+                    "aizpute municipality" => Ok(Self::AizputeMunicipality),
+                    "akniiste municipality" => Ok(Self::AknīsteMunicipality),
+                    "aloja municipality" => Ok(Self::AlojaMunicipality),
+                    "alsunga municipality" => Ok(Self::AlsungaMunicipality),
+                    "aluksne municipality" => Ok(Self::AlūksneMunicipality),
+                    "amata municipality" => Ok(Self::AmataMunicipality),
+                    "ape municipality" => Ok(Self::ApeMunicipality),
+                    "auce municipality" => Ok(Self::AuceMunicipality),
+                    "babite municipality" => Ok(Self::BabīteMunicipality),
+                    "baldone municipality" => Ok(Self::BaldoneMunicipality),
+                    "baltinava municipality" => Ok(Self::BaltinavaMunicipality),
+                    "balvi municipality" => Ok(Self::BalviMunicipality),
+                    "bauska municipality" => Ok(Self::BauskaMunicipality),
+                    "beverina municipality" => Ok(Self::BeverīnaMunicipality),
+                    "broceni municipality" => Ok(Self::BrocēniMunicipality),
+                    "burtnieki municipality" => Ok(Self::BurtniekiMunicipality),
+                    "carnikava municipality" => Ok(Self::CarnikavaMunicipality),
+                    "cesvaine municipality" => Ok(Self::CesvaineMunicipality),
+                    "cibla municipality" => Ok(Self::CiblaMunicipality),
+                    "cesis municipality" => Ok(Self::CēsisMunicipality),
+                    "dagda municipality" => Ok(Self::DagdaMunicipality),
+                    "daugavpils" => Ok(Self::Daugavpils),
+                    "daugavpils municipality" => Ok(Self::DaugavpilsMunicipality),
+                    "dobele municipality" => Ok(Self::DobeleMunicipality),
+                    "dundaga municipality" => Ok(Self::DundagaMunicipality),
+                    "durbe municipality" => Ok(Self::DurbeMunicipality),
+                    "engure municipality" => Ok(Self::EngureMunicipality),
+                    "garkalne municipality" => Ok(Self::GarkalneMunicipality),
+                    "grobina municipality" => Ok(Self::GrobiņaMunicipality),
+                    "gulbene municipality" => Ok(Self::GulbeneMunicipality),
+                    "iecava municipality" => Ok(Self::IecavaMunicipality),
+                    "ikskile municipality" => Ok(Self::IkšķileMunicipality),
+                    "ilukste municipality" => Ok(Self::IlūksteMunicipality),
+                    "incukalns municipality" => Ok(Self::InčukalnsMunicipality),
+                    "jaunjelgava municipality" => Ok(Self::JaunjelgavaMunicipality),
+                    "jaunpiebalga municipality" => Ok(Self::JaunpiebalgaMunicipality),
+                    "jaunpils municipality" => Ok(Self::JaunpilsMunicipality),
+                    "jelgava" => Ok(Self::Jelgava),
+                    "jelgava municipality" => Ok(Self::JelgavaMunicipality),
+                    "jekabpils" => Ok(Self::Jēkabpils),
+                    "jekabpils municipality" => Ok(Self::JēkabpilsMunicipality),
+                    "jurmala" => Ok(Self::Jūrmala),
+                    "kandava municipality" => Ok(Self::KandavaMunicipality),
+                    "koceni municipality" => Ok(Self::KocēniMunicipality),
+                    "koknese municipality" => Ok(Self::KokneseMunicipality),
+                    "krimulda municipality" => Ok(Self::KrimuldaMunicipality),
+                    "kustpils municipality" => Ok(Self::KrustpilsMunicipality),
+                    "kraslava municipality" => Ok(Self::KrāslavaMunicipality),
+                    "kuldiga municipality" => Ok(Self::KuldīgaMunicipality),
+                    "karsava municipality" => Ok(Self::KārsavaMunicipality),
+                    "lielvarde municipality" => Ok(Self::LielvārdeMunicipality),
+                    "liepaja" => Ok(Self::Liepāja),
+                    "limbazi municipality" => Ok(Self::LimbažiMunicipality),
+                    "lubana municipality" => Ok(Self::LubānaMunicipality),
+                    "ludza municipality" => Ok(Self::LudzaMunicipality),
+                    "ligatne municipality" => Ok(Self::LīgatneMunicipality),
+                    "livani municipality" => Ok(Self::LīvāniMunicipality),
+                    "madona municipality" => Ok(Self::MadonaMunicipality),
+                    "mazsalaca municipality" => Ok(Self::MazsalacaMunicipality),
+                    "malpils municipality" => Ok(Self::MālpilsMunicipality),
+                    "marupe municipality" => Ok(Self::MārupeMunicipality),
+                    "mersrags municipality" => Ok(Self::MērsragsMunicipality),
+                    "naukseni municipality" => Ok(Self::NaukšēniMunicipality),
+                    "nereta municipality" => Ok(Self::NeretaMunicipality),
+                    "nica municipality" => Ok(Self::NīcaMunicipality),
+                    "ogre municipality" => Ok(Self::OgreMunicipality),
+                    "olaine municipality" => Ok(Self::OlaineMunicipality),
+                    "ozolnieki municipality" => Ok(Self::OzolniekiMunicipality),
+                    "preili municipality" => Ok(Self::PreiļiMunicipality),
+                    "priekule municipality" => Ok(Self::PriekuleMunicipality),
+                    "priekuli municipality" => Ok(Self::PriekuļiMunicipality),
+                    "pargauja municipality" => Ok(Self::PārgaujaMunicipality),
+                    "pavilosta municipality" => Ok(Self::PāvilostaMunicipality),
+                    "plavinas municipality" => Ok(Self::PļaviņasMunicipality),
+                    "rauna municipality" => Ok(Self::RaunaMunicipality),
+                    "riebini municipality" => Ok(Self::RiebiņiMunicipality),
+                    "riga" => Ok(Self::Riga),
+                    "roja municipality" => Ok(Self::RojaMunicipality),
+                    "ropazi municipality" => Ok(Self::RopažiMunicipality),
+                    "rucava municipality" => Ok(Self::RucavaMunicipality),
+                    "rugaji municipality" => Ok(Self::RugājiMunicipality),
+                    "rundale municipality" => Ok(Self::RundāleMunicipality),
+                    "rezekne" => Ok(Self::Rēzekne),
+                    "rezekne municipality" => Ok(Self::RēzekneMunicipality),
+                    "rujiena municipality" => Ok(Self::RūjienaMunicipality),
+                    "sala municipality" => Ok(Self::SalaMunicipality),
+                    "salacgriva municipality" => Ok(Self::SalacgrīvaMunicipality),
+                    "salaspils municipality" => Ok(Self::SalaspilsMunicipality),
+                    "saldus municipality" => Ok(Self::SaldusMunicipality),
+                    "saulkrasti municipality" => Ok(Self::SaulkrastiMunicipality),
+                    "sigulda municipality" => Ok(Self::SiguldaMunicipality),
+                    "skrunda municipality" => Ok(Self::SkrundaMunicipality),
+                    "skriveri municipality" => Ok(Self::SkrīveriMunicipality),
+                    "smiltene municipality" => Ok(Self::SmilteneMunicipality),
+                    "stopini municipality" => Ok(Self::StopiņiMunicipality),
+                    "strenci municipality" => Ok(Self::StrenčiMunicipality),
+                    "seja municipality" => Ok(Self::SējaMunicipality),
+                    _ => Err(errors::ConnectorError::InvalidDataFormat {
+                        field_name: "address.state",
+                    }
+                    .into()),
+                }
+            }
+        }
+    }
+}
+
+impl ForeignTryFrom<String> for MaltaStatesAbbreviation {
+    type Error = error_stack::Report<errors::ConnectorError>;
+    fn foreign_try_from(value: String) -> Result<Self, Self::Error> {
+        let state_abbreviation_check =
+            StringExt::<Self>::parse_enum(value.to_uppercase().clone(), "MaltaStatesAbbreviation");
+
+        match state_abbreviation_check {
+            Ok(municipality) => Ok(municipality),
+            Err(_) => {
+                let binding = value.as_str().to_lowercase();
+                let municipality = binding.as_str();
+                match municipality {
+                    "attard" => Ok(Self::Attard),
+                    "balzan" => Ok(Self::Balzan),
+                    "birgu" => Ok(Self::Birgu),
+                    "birkirkara" => Ok(Self::Birkirkara),
+                    "birzebbuga" => Ok(Self::Birzebbuga),
+                    "cospicua" => Ok(Self::Cospicua),
+                    "dingli" => Ok(Self::Dingli),
+                    "fgura" => Ok(Self::Fgura),
+                    "floriana" => Ok(Self::Floriana),
+                    "fontana" => Ok(Self::Fontana),
+                    "gudja" => Ok(Self::Gudja),
+                    "gzira" => Ok(Self::Gzira),
+                    "ghajnsielem" => Ok(Self::Ghajnsielem),
+                    "gharb" => Ok(Self::Gharb),
+                    "gharghur" => Ok(Self::Gharghur),
+                    "ghasri" => Ok(Self::Ghasri),
+                    "ghaxaq" => Ok(Self::Ghaxaq),
+                    "hamrun" => Ok(Self::Hamrun),
+                    "iklin" => Ok(Self::Iklin),
+                    "senglea" => Ok(Self::Senglea),
+                    "kalkara" => Ok(Self::Kalkara),
+                    "kercem" => Ok(Self::Kercem),
+                    "kirkop" => Ok(Self::Kirkop),
+                    "lija" => Ok(Self::Lija),
+                    "luqa" => Ok(Self::Luqa),
+                    "marsa" => Ok(Self::Marsa),
+                    "marsaskala" => Ok(Self::Marsaskala),
+                    "marsaxlokk" => Ok(Self::Marsaxlokk),
+                    "mdina" => Ok(Self::Mdina),
+                    "mellieha" => Ok(Self::Mellieha),
+                    "mgarr" => Ok(Self::Mgarr),
+                    "mosta" => Ok(Self::Mosta),
+                    "mqabba" => Ok(Self::Mqabba),
+                    "msida" => Ok(Self::Msida),
+                    "mtarfa" => Ok(Self::Mtarfa),
+                    "munxar" => Ok(Self::Munxar),
+                    "nadur" => Ok(Self::Nadur),
+                    "naxxar" => Ok(Self::Naxxar),
+                    "paola" => Ok(Self::Paola),
+                    "pembroke" => Ok(Self::Pembroke),
+                    "pieta" => Ok(Self::Pieta),
+                    "qala" => Ok(Self::Qala),
+                    "qormi" => Ok(Self::Qormi),
+                    "qrendi" => Ok(Self::Qrendi),
+                    "victoria" => Ok(Self::Victoria),
+                    "rabat" => Ok(Self::Rabat),
+                    "st julians" => Ok(Self::StJulians),
+                    "san gwann" => Ok(Self::SanGwann),
+                    "saint lawrence" => Ok(Self::SaintLawrence),
+                    "st pauls bay" => Ok(Self::StPaulsBay),
+                    "sannat" => Ok(Self::Sannat),
+                    "santa lucija" => Ok(Self::SantaLucija),
+                    "santa venera" => Ok(Self::SantaVenera),
+                    "siggiewi" => Ok(Self::Siggiewi),
+                    "sliema" => Ok(Self::Sliema),
+                    "swieqi" => Ok(Self::Swieqi),
+                    "ta xbiex" => Ok(Self::TaXbiex),
+                    "tarxien" => Ok(Self::Tarxien),
+                    "valletta" => Ok(Self::Valletta),
+                    "xaghra" => Ok(Self::Xaghra),
+                    "xewkija" => Ok(Self::Xewkija),
+                    "xghajra" => Ok(Self::Xghajra),
+                    "zabbar" => Ok(Self::Zabbar),
+                    "zebbug gozo" => Ok(Self::ZebbugGozo),
+                    "zebbug malta" => Ok(Self::ZebbugMalta),
+                    "zejtun" => Ok(Self::Zejtun),
+                    "zurrieq" => Ok(Self::Zurrieq),
+                    _ => Err(errors::ConnectorError::InvalidDataFormat {
+                        field_name: "address.state",
+                    }
+                    .into()),
+                }
+            }
+        }
+    }
+}
+
+impl ForeignTryFrom<String> for BelarusStatesAbbreviation {
+    type Error = error_stack::Report<errors::ConnectorError>;
+    fn foreign_try_from(value: String) -> Result<Self, Self::Error> {
+        let state_abbreviation_check = StringExt::<Self>::parse_enum(
+            value.to_uppercase().clone(),
+            "BelarusStatesAbbreviation",
+        );
+        match state_abbreviation_check {
+            Ok(state_abbreviation) => Ok(state_abbreviation),
+            Err(_) => {
+                let binding = value.as_str().to_lowercase();
+                let state = binding.as_str();
+                match state {
+                    "brest region" => Ok(Self::BrestRegion),
+                    "gomel region" => Ok(Self::GomelRegion),
+                    "grodno region" => Ok(Self::GrodnoRegion),
+                    "minsk" => Ok(Self::Minsk),
+                    "minsk region" => Ok(Self::MinskRegion),
+                    "mogilev region" => Ok(Self::MogilevRegion),
+                    "vitebsk region" => Ok(Self::VitebskRegion),
+                    _ => Err(errors::ConnectorError::InvalidDataFormat {
+                        field_name: "address.state",
+                    }
+                    .into()),
+                }
+            }
+        }
+    }
+}
+
+impl ForeignTryFrom<String> for IrelandStatesAbbreviation {
+    type Error = error_stack::Report<errors::ConnectorError>;
+    fn foreign_try_from(value: String) -> Result<Self, Self::Error> {
+        let state_abbreviation_check = StringExt::<Self>::parse_enum(
+            value.to_uppercase().clone(),
+            "IrelandStatesAbbreviation",
+        );
+        match state_abbreviation_check {
+            Ok(state_abbreviation) => Ok(state_abbreviation),
+            Err(_) => {
+                let binding = value.as_str().to_lowercase();
+                let state = binding.as_str();
+                match state {
+                    "connacht" => Ok(Self::Connacht),
+                    "county carlow" => Ok(Self::CountyCarlow),
+                    "county cavan" => Ok(Self::CountyCavan),
+                    "county clare" => Ok(Self::CountyClare),
+                    "county cork" => Ok(Self::CountyCork),
+                    "county donegal" => Ok(Self::CountyDonegal),
+                    "county dublin" => Ok(Self::CountyDublin),
+                    "county galway" => Ok(Self::CountyGalway),
+                    "county kerry" => Ok(Self::CountyKerry),
+                    "county kildare" => Ok(Self::CountyKildare),
+                    "county kilkenny" => Ok(Self::CountyKilkenny),
+                    "county laois" => Ok(Self::CountyLaois),
+                    "county limerick" => Ok(Self::CountyLimerick),
+                    "county longford" => Ok(Self::CountyLongford),
+                    "county louth" => Ok(Self::CountyLouth),
+                    "county mayo" => Ok(Self::CountyMayo),
+                    "county meath" => Ok(Self::CountyMeath),
+                    "county monaghan" => Ok(Self::CountyMonaghan),
+                    "county offaly" => Ok(Self::CountyOffaly),
+                    "county roscommon" => Ok(Self::CountyRoscommon),
+                    "county sligo" => Ok(Self::CountySligo),
+                    "county tipperary" => Ok(Self::CountyTipperary),
+                    "county waterford" => Ok(Self::CountyWaterford),
+                    "county westmeath" => Ok(Self::CountyWestmeath),
+                    "county wexford" => Ok(Self::CountyWexford),
+                    "county wicklow" => Ok(Self::CountyWicklow),
+                    "leinster" => Ok(Self::Leinster),
+                    "munster" => Ok(Self::Munster),
+                    "ulster" => Ok(Self::Ulster),
+                    _ => Err(errors::ConnectorError::InvalidDataFormat {
+                        field_name: "address.state",
+                    }
+                    .into()),
+                }
+            }
+        }
+    }
+}
+
+impl ForeignTryFrom<String> for IcelandStatesAbbreviation {
+    type Error = error_stack::Report<errors::ConnectorError>;
+    fn foreign_try_from(value: String) -> Result<Self, Self::Error> {
+        let state_abbreviation_check = StringExt::<Self>::parse_enum(
+            value.to_uppercase().clone(),
+            "IcelandStatesAbbreviation",
+        );
+        match state_abbreviation_check {
+            Ok(state_abbreviation) => Ok(state_abbreviation),
+            Err(_) => {
+                let binding = value.as_str().to_lowercase();
+                let state = binding.as_str();
+                match state {
+                    "capital region" => Ok(Self::CapitalRegion),
+                    "eastern region" => Ok(Self::EasternRegion),
+                    "northeastern region" => Ok(Self::NortheasternRegion),
+                    "northwestern region" => Ok(Self::NorthwesternRegion),
+                    "southern peninsula region" => Ok(Self::SouthernPeninsulaRegion),
+                    "southern region" => Ok(Self::SouthernRegion),
+                    "western region" => Ok(Self::WesternRegion),
+                    "westfjords" => Ok(Self::Westfjords),
+                    _ => Err(errors::ConnectorError::InvalidDataFormat {
+                        field_name: "address.state",
+                    }
+                    .into()),
+                }
+            }
+        }
+    }
+}
+
+impl ForeignTryFrom<String> for HungaryStatesAbbreviation {
+    type Error = error_stack::Report<errors::ConnectorError>;
+    fn foreign_try_from(value: String) -> Result<Self, Self::Error> {
+        let state_abbreviation_check = StringExt::<Self>::parse_enum(
+            value.to_uppercase().clone(),
+            "HungaryStatesAbbreviation",
+        );
+        match state_abbreviation_check {
+            Ok(state_abbreviation) => Ok(state_abbreviation),
+            Err(_) => {
+                let binding = value.as_str().to_lowercase();
+                let state = binding.as_str();
+                match state {
+                    "baranya county" => Ok(Self::BaranyaCounty),
+                    "borsod abauj zemplen county" => Ok(Self::BorsodAbaujZemplenCounty),
+                    "budapest" => Ok(Self::Budapest),
+                    "bacs kiskun county" => Ok(Self::BacsKiskunCounty),
+                    "bekes county" => Ok(Self::BekesCounty),
+                    "bekescsaba" => Ok(Self::Bekescsaba),
+                    "csongrad county" => Ok(Self::CsongradCounty),
+                    "debrecen" => Ok(Self::Debrecen),
+                    "dunaujvaros" => Ok(Self::Dunaujvaros),
+                    "eger" => Ok(Self::Eger),
+                    "fejer county" => Ok(Self::FejerCounty),
+                    "gyor" => Ok(Self::Gyor),
+                    "gyor moson sopron county" => Ok(Self::GyorMosonSopronCounty),
+                    "hajdu bihar county" => Ok(Self::HajduBiharCounty),
+                    "heves county" => Ok(Self::HevesCounty),
+                    "hodmezovasarhely" => Ok(Self::Hodmezovasarhely),
+                    "jasz nagykun szolnok county" => Ok(Self::JaszNagykunSzolnokCounty),
+                    "kaposvar" => Ok(Self::Kaposvar),
+                    "kecskemet" => Ok(Self::Kecskemet),
+                    "miskolc" => Ok(Self::Miskolc),
+                    "nagykanizsa" => Ok(Self::Nagykanizsa),
+                    "nyiregyhaza" => Ok(Self::Nyiregyhaza),
+                    "nograd county" => Ok(Self::NogradCounty),
+                    "pest county" => Ok(Self::PestCounty),
+                    "pecs" => Ok(Self::Pecs),
+                    "salgotarjan" => Ok(Self::Salgotarjan),
+                    "somogy county" => Ok(Self::SomogyCounty),
+                    "sopron" => Ok(Self::Sopron),
+                    "szabolcs szatmar bereg county" => Ok(Self::SzabolcsSzatmarBeregCounty),
+                    "szeged" => Ok(Self::Szeged),
+                    "szekszard" => Ok(Self::Szekszard),
+                    "szolnok" => Ok(Self::Szolnok),
+                    "szombathely" => Ok(Self::Szombathely),
+                    "szekesfehervar" => Ok(Self::Szekesfehervar),
+                    "tatabanya" => Ok(Self::Tatabanya),
+                    "tolna county" => Ok(Self::TolnaCounty),
+                    "vas county" => Ok(Self::VasCounty),
+                    "veszprem" => Ok(Self::Veszprem),
+                    "veszprem county" => Ok(Self::VeszpremCounty),
+                    "zala county" => Ok(Self::ZalaCounty),
+                    "zalaegerszeg" => Ok(Self::Zalaegerszeg),
+                    "erd" => Ok(Self::Erd),
+                    _ => Err(errors::ConnectorError::InvalidDataFormat {
+                        field_name: "address.state",
+                    }
+                    .into()),
+                }
+            }
+        }
+    }
+}
+
+impl ForeignTryFrom<String> for GreeceStatesAbbreviation {
+    type Error = error_stack::Report<errors::ConnectorError>;
+    fn foreign_try_from(value: String) -> Result<Self, Self::Error> {
+        let state_abbreviation_check =
+            StringExt::<Self>::parse_enum(value.to_uppercase().clone(), "GreeceStatesAbbreviation");
+        match state_abbreviation_check {
+            Ok(state_abbreviation) => Ok(state_abbreviation),
+            Err(_) => {
+                let binding = value.as_str().to_lowercase();
+                let state = binding.as_str();
+                match state {
+                    "achaea regional unit" => Ok(Self::AchaeaRegionalUnit),
+                    "aetolia acarnania regional unit" => Ok(Self::AetoliaAcarnaniaRegionalUnit),
+                    "arcadia prefecture" => Ok(Self::ArcadiaPrefecture),
+                    "argolis regional unit" => Ok(Self::ArgolisRegionalUnit),
+                    "attica region" => Ok(Self::AtticaRegion),
+                    "boeotia regional unit" => Ok(Self::BoeotiaRegionalUnit),
+                    "central greece region" => Ok(Self::CentralGreeceRegion),
+                    "central macedonia" => Ok(Self::CentralMacedonia),
+                    "chania regional unit" => Ok(Self::ChaniaRegionalUnit),
+                    "corfu prefecture" => Ok(Self::CorfuPrefecture),
+                    "corinthia regional unit" => Ok(Self::CorinthiaRegionalUnit),
+                    "crete region" => Ok(Self::CreteRegion),
+                    "drama regional unit" => Ok(Self::DramaRegionalUnit),
+                    "east attica regional unit" => Ok(Self::EastAtticaRegionalUnit),
+                    "east macedonia and thrace" => Ok(Self::EastMacedoniaAndThrace),
+                    "epirus region" => Ok(Self::EpirusRegion),
+                    "euboea" => Ok(Self::Euboea),
+                    "grevena prefecture" => Ok(Self::GrevenaPrefecture),
+                    "imathia regional unit" => Ok(Self::ImathiaRegionalUnit),
+                    "ioannina regional unit" => Ok(Self::IoanninaRegionalUnit),
+                    "ionian islands region" => Ok(Self::IonianIslandsRegion),
+                    "karditsa regional unit" => Ok(Self::KarditsaRegionalUnit),
+                    "kastoria regional unit" => Ok(Self::KastoriaRegionalUnit),
+                    "kefalonia prefecture" => Ok(Self::KefaloniaPrefecture),
+                    "kilkis regional unit" => Ok(Self::KilkisRegionalUnit),
+                    "kozani prefecture" => Ok(Self::KozaniPrefecture),
+                    "laconia" => Ok(Self::Laconia),
+                    "larissa prefecture" => Ok(Self::LarissaPrefecture),
+                    "lefkada regional unit" => Ok(Self::LefkadaRegionalUnit),
+                    "pella regional unit" => Ok(Self::PellaRegionalUnit),
+                    "peloponnese region" => Ok(Self::PeloponneseRegion),
+                    "phthiotis prefecture" => Ok(Self::PhthiotisPrefecture),
+                    "preveza prefecture" => Ok(Self::PrevezaPrefecture),
+                    "serres prefecture" => Ok(Self::SerresPrefecture),
+                    "south aegean" => Ok(Self::SouthAegean),
+                    "thessaloniki regional unit" => Ok(Self::ThessalonikiRegionalUnit),
+                    "west greece region" => Ok(Self::WestGreeceRegion),
+                    "west macedonia region" => Ok(Self::WestMacedoniaRegion),
+                    _ => Err(errors::ConnectorError::InvalidDataFormat {
+                        field_name: "address.state",
+                    }
+                    .into()),
+                }
+            }
+        }
+    }
+}
+
+impl ForeignTryFrom<String> for FinlandStatesAbbreviation {
+    type Error = error_stack::Report<errors::ConnectorError>;
+    fn foreign_try_from(value: String) -> Result<Self, Self::Error> {
+        let state_abbreviation_check = StringExt::<Self>::parse_enum(
+            value.to_uppercase().clone(),
+            "FinlandStatesAbbreviation",
+        );
+        match state_abbreviation_check {
+            Ok(state_abbreviation) => Ok(state_abbreviation),
+            Err(_) => {
+                let binding = value.as_str().to_lowercase();
+                let state = binding.as_str();
+                match state {
+                    "central finland" => Ok(Self::CentralFinland),
+                    "central ostrobothnia" => Ok(Self::CentralOstrobothnia),
+                    "eastern finland province" => Ok(Self::EasternFinlandProvince),
+                    "finland proper" => Ok(Self::FinlandProper),
+                    "kainuu" => Ok(Self::Kainuu),
+                    "kymenlaakso" => Ok(Self::Kymenlaakso),
+                    "lapland" => Ok(Self::Lapland),
+                    "north karelia" => Ok(Self::NorthKarelia),
+                    "northern ostrobothnia" => Ok(Self::NorthernOstrobothnia),
+                    "northern savonia" => Ok(Self::NorthernSavonia),
+                    "ostrobothnia" => Ok(Self::Ostrobothnia),
+                    "oulu province" => Ok(Self::OuluProvince),
+                    "pirkanmaa" => Ok(Self::Pirkanmaa),
+                    "paijanne tavastia" => Ok(Self::PaijanneTavastia),
+                    "satakunta" => Ok(Self::Satakunta),
+                    "south karelia" => Ok(Self::SouthKarelia),
+                    "southern ostrobothnia" => Ok(Self::SouthernOstrobothnia),
+                    "southern savonia" => Ok(Self::SouthernSavonia),
+                    "tavastia proper" => Ok(Self::TavastiaProper),
+                    "uusimaa" => Ok(Self::Uusimaa),
+                    "aland islands" => Ok(Self::AlandIslands),
+                    _ => Err(errors::ConnectorError::InvalidDataFormat {
+                        field_name: "address.state",
+                    }
+                    .into()),
+                }
+            }
+        }
+    }
+}
+
+impl ForeignTryFrom<String> for DenmarkStatesAbbreviation {
+    type Error = error_stack::Report<errors::ConnectorError>;
+    fn foreign_try_from(value: String) -> Result<Self, Self::Error> {
+        let state_abbreviation_check = StringExt::<Self>::parse_enum(
+            value.to_uppercase().clone(),
+            "DenmarkStatesAbbreviation",
+        );
+        match state_abbreviation_check {
+            Ok(state_abbreviation) => Ok(state_abbreviation),
+            Err(_) => {
+                let binding = value.as_str().to_lowercase();
+                let state = binding.as_str();
+                match state {
+                    "capital region of denmark" => Ok(Self::CapitalRegionOfDenmark),
+                    "central denmark region" => Ok(Self::CentralDenmarkRegion),
+                    "north denmark region" => Ok(Self::NorthDenmarkRegion),
+                    "region zealand" => Ok(Self::RegionZealand),
+                    "region of southern denmark" => Ok(Self::RegionOfSouthernDenmark),
+                    _ => Err(errors::ConnectorError::InvalidDataFormat {
+                        field_name: "address.state",
+                    }
+                    .into()),
+                }
+            }
+        }
+    }
+}
+
+impl ForeignTryFrom<String> for CzechRepublicStatesAbbreviation {
+    type Error = error_stack::Report<errors::ConnectorError>;
+    fn foreign_try_from(value: String) -> Result<Self, Self::Error> {
+        let state_abbreviation_check = StringExt::<Self>::parse_enum(
+            value.to_uppercase().clone(),
+            "CzechRepublicStatesAbbreviation",
+        );
+        match state_abbreviation_check {
+            Ok(state_abbreviation) => Ok(state_abbreviation),
+            Err(_) => {
+                let binding = value.as_str().to_lowercase();
+                let state = binding.as_str();
+                match state {
+                    "benesov district" => Ok(Self::BenesovDistrict),
+                    "beroun district" => Ok(Self::BerounDistrict),
+                    "blansko district" => Ok(Self::BlanskoDistrict),
+                    "brno city district" => Ok(Self::BrnoCityDistrict),
+                    "brno country district" => Ok(Self::BrnoCountryDistrict),
+                    "bruntal district" => Ok(Self::BruntalDistrict),
+                    "breclav district" => Ok(Self::BreclavDistrict),
+                    "central bohemian region" => Ok(Self::CentralBohemianRegion),
+                    "cheb district" => Ok(Self::ChebDistrict),
+                    "chomutov district" => Ok(Self::ChomutovDistrict),
+                    "chrudim district" => Ok(Self::ChrudimDistrict),
+                    "domazlice district" => Ok(Self::DomazliceDistrict),
+                    "decin district" => Ok(Self::DecinDistrict),
+                    "frydek mistek district" => Ok(Self::FrydekMistekDistrict),
+                    "havlickuv brod district" => Ok(Self::HavlickuvBrodDistrict),
+                    "hodonin district" => Ok(Self::HodoninDistrict),
+                    "horni pocernice" => Ok(Self::HorniPocernice),
+                    "hradec kralove district" => Ok(Self::HradecKraloveDistrict),
+                    "hradec kralove region" => Ok(Self::HradecKraloveRegion),
+                    "jablonec nad nisou district" => Ok(Self::JablonecNadNisouDistrict),
+                    "jesenik district" => Ok(Self::JesenikDistrict),
+                    "jihlava district" => Ok(Self::JihlavaDistrict),
+                    "jindrichuv hradec district" => Ok(Self::JindrichuvHradecDistrict),
+                    "jicin district" => Ok(Self::JicinDistrict),
+                    "karlovy vary district" => Ok(Self::KarlovyVaryDistrict),
+                    "karlovy vary region" => Ok(Self::KarlovyVaryRegion),
+                    "karvina district" => Ok(Self::KarvinaDistrict),
+                    "kladno district" => Ok(Self::KladnoDistrict),
+                    "klatovy district" => Ok(Self::KlatovyDistrict),
+                    "kolin district" => Ok(Self::KolinDistrict),
+                    "kromeriz district" => Ok(Self::KromerizDistrict),
+                    "liberec district" => Ok(Self::LiberecDistrict),
+                    "liberec region" => Ok(Self::LiberecRegion),
+                    "litomerice district" => Ok(Self::LitomericeDistrict),
+                    "louny district" => Ok(Self::LounyDistrict),
+                    "mlada boleslav district" => Ok(Self::MladaBoleslavDistrict),
+                    "moravian silesian region" => Ok(Self::MoravianSilesianRegion),
+                    "most district" => Ok(Self::MostDistrict),
+                    "melnik district" => Ok(Self::MelnikDistrict),
+                    "novy jicin district" => Ok(Self::NovyJicinDistrict),
+                    "nymburk district" => Ok(Self::NymburkDistrict),
+                    "nachod district" => Ok(Self::NachodDistrict),
+                    "olomouc district" => Ok(Self::OlomoucDistrict),
+                    "olomouc region" => Ok(Self::OlomoucRegion),
+                    "opava district" => Ok(Self::OpavaDistrict),
+                    "ostrava city district" => Ok(Self::OstravaCityDistrict),
+                    "pardubice district" => Ok(Self::PardubiceDistrict),
+                    "pardubice region" => Ok(Self::PardubiceRegion),
+                    "pelhrimov district" => Ok(Self::PelhrimovDistrict),
+                    "plzen region" => Ok(Self::PlzenRegion),
+                    "plzen city district" => Ok(Self::PlzenCityDistrict),
+                    "plzen north district" => Ok(Self::PlzenNorthDistrict),
+                    "plzen south district" => Ok(Self::PlzenSouthDistrict),
+                    "prachatice district" => Ok(Self::PrachaticeDistrict),
+                    "prague" => Ok(Self::Prague),
+                    "prague1" => Ok(Self::Prague1),
+                    "prague10" => Ok(Self::Prague10),
+                    "prague11" => Ok(Self::Prague11),
+                    "prague12" => Ok(Self::Prague12),
+                    "prague13" => Ok(Self::Prague13),
+                    "prague14" => Ok(Self::Prague14),
+                    "prague15" => Ok(Self::Prague15),
+                    "prague16" => Ok(Self::Prague16),
+                    "prague2" => Ok(Self::Prague2),
+                    "prague21" => Ok(Self::Prague21),
+                    "prague3" => Ok(Self::Prague3),
+                    "prague4" => Ok(Self::Prague4),
+                    "prague5" => Ok(Self::Prague5),
+                    "prague6" => Ok(Self::Prague6),
+                    "prague7" => Ok(Self::Prague7),
+                    "prague8" => Ok(Self::Prague8),
+                    "prague9" => Ok(Self::Prague9),
+                    "prague east district" => Ok(Self::PragueEastDistrict),
+                    "prague west district" => Ok(Self::PragueWestDistrict),
+                    "prostejov district" => Ok(Self::ProstejovDistrict),
+                    "pisek district" => Ok(Self::PisekDistrict),
+                    "prerov district" => Ok(Self::PrerovDistrict),
+                    "pribram district" => Ok(Self::PribramDistrict),
+                    "rakovnik district" => Ok(Self::RakovnikDistrict),
+                    "rokycany district" => Ok(Self::RokycanyDistrict),
+                    "rychnov nad kneznou district" => Ok(Self::RychnovNadKneznouDistrict),
+                    "semily district" => Ok(Self::SemilyDistrict),
+                    "sokolov district" => Ok(Self::SokolovDistrict),
+                    "south bohemian region" => Ok(Self::SouthBohemianRegion),
+                    "south moravian region" => Ok(Self::SouthMoravianRegion),
+                    "strakonice district" => Ok(Self::StrakoniceDistrict),
+                    "svitavy district" => Ok(Self::SvitavyDistrict),
+                    "tachov district" => Ok(Self::TachovDistrict),
+                    "teplice district" => Ok(Self::TepliceDistrict),
+                    "trutnov district" => Ok(Self::TrutnovDistrict),
+                    "tabor district" => Ok(Self::TaborDistrict),
+                    "trebic district" => Ok(Self::TrebicDistrict),
+                    "uherske hradiste district" => Ok(Self::UherskeHradisteDistrict),
+                    "vsetin district" => Ok(Self::VsetinDistrict),
+                    "vysocina region" => Ok(Self::VysocinaRegion),
+                    "vyskov district" => Ok(Self::VyskovDistrict),
+                    "zlin district" => Ok(Self::ZlinDistrict),
+                    "zlin region" => Ok(Self::ZlinRegion),
+                    "znojmo district" => Ok(Self::ZnojmoDistrict),
+                    "usti nad labem district" => Ok(Self::UstiNadLabemDistrict),
+                    "usti nad labem region" => Ok(Self::UstiNadLabemRegion),
+                    "usti nad orlici district" => Ok(Self::UstiNadOrliciDistrict),
+                    "ceska lipa district" => Ok(Self::CeskaLipaDistrict),
+                    "ceske budejovice district" => Ok(Self::CeskeBudejoviceDistrict),
+                    "cesky krumlov district" => Ok(Self::CeskyKrumlovDistrict),
+                    "sumperk district" => Ok(Self::SumperkDistrict),
+                    "zdar nad sazavou district" => Ok(Self::ZdarNadSazavouDistrict),
+                    _ => Err(errors::ConnectorError::InvalidDataFormat {
+                        field_name: "address.state",
+                    }
+                    .into()),
+                }
+            }
+        }
+    }
+}
+
+impl ForeignTryFrom<String> for CroatiaStatesAbbreviation {
+    type Error = error_stack::Report<errors::ConnectorError>;
+    fn foreign_try_from(value: String) -> Result<Self, Self::Error> {
+        let state_abbreviation_check = StringExt::<Self>::parse_enum(
+            value.to_uppercase().clone(),
+            "CroatiaStatesAbbreviation",
+        );
+        match state_abbreviation_check {
+            Ok(state_abbreviation) => Ok(state_abbreviation),
+            Err(_) => {
+                let binding = value.as_str().to_lowercase();
+                let state = binding.as_str();
+                match state {
+                    "bjelovar bilogora county" => Ok(Self::BjelovarBilogoraCounty),
+                    "brod posavina county" => Ok(Self::BrodPosavinaCounty),
+                    "dubrovnik neretva county" => Ok(Self::DubrovnikNeretvaCounty),
+                    "istria county" => Ok(Self::IstriaCounty),
+                    "koprivnica krizevci county" => Ok(Self::KoprivnicaKrizevciCounty),
+                    "krapina zagorje county" => Ok(Self::KrapinaZagorjeCounty),
+                    "lika senj county" => Ok(Self::LikaSenjCounty),
+                    "medimurje county" => Ok(Self::MedimurjeCounty),
+                    "osijek baranja county" => Ok(Self::OsijekBaranjaCounty),
+                    "pozega slavonian county" => Ok(Self::PozegaSlavoniaCounty),
+                    "primorje gorski kotar county" => Ok(Self::PrimorjeGorskiKotarCounty),
+                    "sisak moslavina county" => Ok(Self::SisakMoslavinaCounty),
+                    "split dalmatia county" => Ok(Self::SplitDalmatiaCounty),
+                    "varazdin county" => Ok(Self::VarazdinCounty),
+                    "virovitica podravina county" => Ok(Self::ViroviticaPodravinaCounty),
+                    "vukovar syrmia county" => Ok(Self::VukovarSyrmiaCounty),
+                    "zadar county" => Ok(Self::ZadarCounty),
+                    "zagreb" => Ok(Self::Zagreb),
+                    "zagreb county" => Ok(Self::ZagrebCounty),
+                    "sibenik knin county" => Ok(Self::SibenikKninCounty),
+                    _ => Err(errors::ConnectorError::InvalidDataFormat {
+                        field_name: "address.state",
+                    }
+                    .into()),
+                }
+            }
+        }
+    }
+}
+
+impl ForeignTryFrom<String> for BulgariaStatesAbbreviation {
+    type Error = error_stack::Report<errors::ConnectorError>;
+    fn foreign_try_from(value: String) -> Result<Self, Self::Error> {
+        let state_abbreviation_check = StringExt::<Self>::parse_enum(
+            value.to_uppercase().clone(),
+            "BulgariaStatesAbbreviation",
+        );
+        match state_abbreviation_check {
+            Ok(state_abbreviation) => Ok(state_abbreviation),
+            Err(_) => {
+                let binding = value.as_str().to_lowercase();
+                let state = binding.as_str();
+                match state {
+                    "blagoevgrad province" => Ok(Self::BlagoevgradProvince),
+                    "burgas province" => Ok(Self::BurgasProvince),
+                    "dobrich province" => Ok(Self::DobrichProvince),
+                    "gabrovo province" => Ok(Self::GabrovoProvince),
+                    "haskovo province" => Ok(Self::HaskovoProvince),
+                    "kardzhali province" => Ok(Self::KardzhaliProvince),
+                    "kyustendil province" => Ok(Self::KyustendilProvince),
+                    "lovech province" => Ok(Self::LovechProvince),
+                    "montana province" => Ok(Self::MontanaProvince),
+                    "pazardzhik province" => Ok(Self::PazardzhikProvince),
+                    "pernik province" => Ok(Self::PernikProvince),
+                    "pleven province" => Ok(Self::PlevenProvince),
+                    "plovdiv province" => Ok(Self::PlovdivProvince),
+                    "razgrad province" => Ok(Self::RazgradProvince),
+                    "ruse province" => Ok(Self::RuseProvince),
+                    "shumen" => Ok(Self::Shumen),
+                    "silistra province" => Ok(Self::SilistraProvince),
+                    "sliven province" => Ok(Self::SlivenProvince),
+                    "smolyan province" => Ok(Self::SmolyanProvince),
+                    "sofia city province" => Ok(Self::SofiaCityProvince),
+                    "sofia province" => Ok(Self::SofiaProvince),
+                    "stara zagora province" => Ok(Self::StaraZagoraProvince),
+                    "targovishte province" => Ok(Self::TargovishteProvince),
+                    "varna province" => Ok(Self::VarnaProvince),
+                    "veliko tarnovo province" => Ok(Self::VelikoTarnovoProvince),
+                    "vidin province" => Ok(Self::VidinProvince),
+                    "vratsa province" => Ok(Self::VratsaProvince),
+                    "yambol province" => Ok(Self::YambolProvince),
+                    _ => Err(errors::ConnectorError::InvalidDataFormat {
+                        field_name: "address.state",
+                    }
+                    .into()),
+                }
+            }
+        }
+    }
+}
+
+impl ForeignTryFrom<String> for BosniaAndHerzegovinaStatesAbbreviation {
+    type Error = error_stack::Report<errors::ConnectorError>;
+    fn foreign_try_from(value: String) -> Result<Self, Self::Error> {
+        let state_abbreviation_check = StringExt::<Self>::parse_enum(
+            value.to_uppercase().clone(),
+            "BosniaAndHerzegovinaStatesAbbreviation",
+        );
+        match state_abbreviation_check {
+            Ok(state_abbreviation) => Ok(state_abbreviation),
+            Err(_) => {
+                let binding = value.as_str().to_lowercase();
+                let state = binding.as_str();
+                match state {
+                    "bosnian podrinje canton" => Ok(Self::BosnianPodrinjeCanton),
+                    "brcko district" => Ok(Self::BrckoDistrict),
+                    "canton 10" => Ok(Self::Canton10),
+                    "central bosnia canton" => Ok(Self::CentralBosniaCanton),
+                    "federation of bosnia and herzegovina" => {
+                        Ok(Self::FederationOfBosniaAndHerzegovina)
+                    }
+                    "herzegovina neretva canton" => Ok(Self::HerzegovinaNeretvaCanton),
+                    "posavina canton" => Ok(Self::PosavinaCanton),
+                    "republika srpska" => Ok(Self::RepublikaSrpska),
+                    "sarajevo canton" => Ok(Self::SarajevoCanton),
+                    "tuzla canton" => Ok(Self::TuzlaCanton),
+                    "una sana canton" => Ok(Self::UnaSanaCanton),
+                    "west herzegovina canton" => Ok(Self::WestHerzegovinaCanton),
+                    "zenica doboj canton" => Ok(Self::ZenicaDobojCanton),
+                    _ => Err(errors::ConnectorError::InvalidDataFormat {
+                        field_name: "address.state",
+                    }
+                    .into()),
+                }
+            }
+        }
+    }
+}
+
+impl ForeignTryFrom<String> for UnitedKingdomStatesAbbreviation {
+    type Error = error_stack::Report<errors::ConnectorError>;
+    fn foreign_try_from(value: String) -> Result<Self, Self::Error> {
+        let state_abbreviation_check = StringExt::<Self>::parse_enum(
+            value.to_uppercase().clone(),
+            "UnitedKingdomStatesAbbreviation",
+        );
+        match state_abbreviation_check {
+            Ok(state_abbreviation) => Ok(state_abbreviation),
+            Err(_) => {
+                let binding = value.as_str().to_lowercase();
+                let state = binding.as_str();
+                match state {
+                    "aberdeen city" => Ok(Self::AberdeenCity),
+                    "aberdeenshire" => Ok(Self::Aberdeenshire),
+                    "angus" => Ok(Self::Angus),
+                    "antrim and newtownabbey" => Ok(Self::AntrimAndNewtownabbey),
+                    "ards and north down" => Ok(Self::ArdsAndNorthDown),
+                    "argyll and bute" => Ok(Self::ArgyllAndBute),
+                    "armagh city banbridge and craigavon" => {
+                        Ok(Self::ArmaghCityBanbridgeAndCraigavon)
+                    }
+                    "barking and dagenham" => Ok(Self::BarkingAndDagenham),
+                    "barnet" => Ok(Self::Barnet),
+                    "barnsley" => Ok(Self::Barnsley),
+                    "bath and north east somerset" => Ok(Self::BathAndNorthEastSomerset),
+                    "bedford" => Ok(Self::Bedford),
+                    "belfast city" => Ok(Self::BelfastCity),
+                    "bexley" => Ok(Self::Bexley),
+                    "birmingham" => Ok(Self::Birmingham),
+                    "blackburn with darwen" => Ok(Self::BlackburnWithDarwen),
+                    "blackpool" => Ok(Self::Blackpool),
+                    "blaenau gwent" => Ok(Self::BlaenauGwent),
+                    "bolton" => Ok(Self::Bolton),
+                    "bournemouth christchurch and poole" => {
+                        Ok(Self::BournemouthChristchurchAndPoole)
+                    }
+                    "bracknell forest" => Ok(Self::BracknellForest),
+                    "bradford" => Ok(Self::Bradford),
+                    "brent" => Ok(Self::Brent),
+                    "bridgend" => Ok(Self::Bridgend),
+                    "brighton and hove" => Ok(Self::BrightonAndHove),
+                    "bristol city of" => Ok(Self::BristolCityOf),
+                    "bromley" => Ok(Self::Bromley),
+                    "buckinghamshire" => Ok(Self::Buckinghamshire),
+                    "bury" => Ok(Self::Bury),
+                    "caerphilly" => Ok(Self::Caerphilly),
+                    "calderdale" => Ok(Self::Calderdale),
+                    "cambridgeshire" => Ok(Self::Cambridgeshire),
+                    "camden" => Ok(Self::Camden),
+                    "cardiff" => Ok(Self::Cardiff),
+                    "carmarthenshire" => Ok(Self::Carmarthenshire),
+                    "causeway coast and glens" => Ok(Self::CausewayCoastAndGlens),
+                    "central bedfordshire" => Ok(Self::CentralBedfordshire),
+                    "ceredigion" => Ok(Self::Ceredigion),
+                    "cheshire east" => Ok(Self::CheshireEast),
+                    "cheshire west and chester" => Ok(Self::CheshireWestAndChester),
+                    "clackmannanshire" => Ok(Self::Clackmannanshire),
+                    "conwy" => Ok(Self::Conwy),
+                    "cornwall" => Ok(Self::Cornwall),
+                    "coventry" => Ok(Self::Coventry),
+                    "croydon" => Ok(Self::Croydon),
+                    "cumbria" => Ok(Self::Cumbria),
+                    "darlington" => Ok(Self::Darlington),
+                    "denbighshire" => Ok(Self::Denbighshire),
+                    "derby" => Ok(Self::Derby),
+                    "derbyshire" => Ok(Self::Derbyshire),
+                    "derry and strabane" => Ok(Self::DerryAndStrabane),
+                    "devon" => Ok(Self::Devon),
+                    "doncaster" => Ok(Self::Doncaster),
+                    "dorset" => Ok(Self::Dorset),
+                    "dudley" => Ok(Self::Dudley),
+                    "dumfries and galloway" => Ok(Self::DumfriesAndGalloway),
+                    "dundee city" => Ok(Self::DundeeCity),
+                    "durham county" => Ok(Self::DurhamCounty),
+                    "ealing" => Ok(Self::Ealing),
+                    "east ayrshire" => Ok(Self::EastAyrshire),
+                    "east dunbartonshire" => Ok(Self::EastDunbartonshire),
+                    "east lothian" => Ok(Self::EastLothian),
+                    "east renfrewshire" => Ok(Self::EastRenfrewshire),
+                    "east riding of yorkshire" => Ok(Self::EastRidingOfYorkshire),
+                    "east sussex" => Ok(Self::EastSussex),
+                    "edinburgh city of" => Ok(Self::EdinburghCityOf),
+                    "eilean siar" => Ok(Self::EileanSiar),
+                    "enfield" => Ok(Self::Enfield),
+                    "essex" => Ok(Self::Essex),
+                    "falkirk" => Ok(Self::Falkirk),
+                    "fermanagh and omagh" => Ok(Self::FermanaghAndOmagh),
+                    "fife" => Ok(Self::Fife),
+                    "flintshire" => Ok(Self::Flintshire),
+                    "gateshead" => Ok(Self::Gateshead),
+                    "glasgow city" => Ok(Self::GlasgowCity),
+                    "gloucestershire" => Ok(Self::Gloucestershire),
+                    "greenwich" => Ok(Self::Greenwich),
+                    "gwynedd" => Ok(Self::Gwynedd),
+                    "hackney" => Ok(Self::Hackney),
+                    "halton" => Ok(Self::Halton),
+                    "hammersmith and fulham" => Ok(Self::HammersmithAndFulham),
+                    "hampshire" => Ok(Self::Hampshire),
+                    "haringey" => Ok(Self::Haringey),
+                    "harrow" => Ok(Self::Harrow),
+                    "hartlepool" => Ok(Self::Hartlepool),
+                    "havering" => Ok(Self::Havering),
+                    "herefordshire" => Ok(Self::Herefordshire),
+                    "hertfordshire" => Ok(Self::Hertfordshire),
+                    "highland" => Ok(Self::Highland),
+                    "hillingdon" => Ok(Self::Hillingdon),
+                    "hounslow" => Ok(Self::Hounslow),
+                    "inverclyde" => Ok(Self::Inverclyde),
+                    "isle of anglesey" => Ok(Self::IsleOfAnglesey),
+                    "isle of wight" => Ok(Self::IsleOfWight),
+                    "isles of scilly" => Ok(Self::IslesOfScilly),
+                    "islington" => Ok(Self::Islington),
+                    "kensington and chelsea" => Ok(Self::KensingtonAndChelsea),
+                    "kent" => Ok(Self::Kent),
+                    "kingston upon hull" => Ok(Self::KingstonUponHull),
+                    "kingston upon thames" => Ok(Self::KingstonUponThames),
+                    "kirklees" => Ok(Self::Kirklees),
+                    "knowsley" => Ok(Self::Knowsley),
+                    "lambeth" => Ok(Self::Lambeth),
+                    "lancashire" => Ok(Self::Lancashire),
+                    "leeds" => Ok(Self::Leeds),
+                    "leicester" => Ok(Self::Leicester),
+                    "leicestershire" => Ok(Self::Leicestershire),
+                    "lewisham" => Ok(Self::Lewisham),
+                    "lincolnshire" => Ok(Self::Lincolnshire),
+                    "lisburn and castlereagh" => Ok(Self::LisburnAndCastlereagh),
+                    "liverpool" => Ok(Self::Liverpool),
+                    "london city of" => Ok(Self::LondonCityOf),
+                    "luton" => Ok(Self::Luton),
+                    "manchester" => Ok(Self::Manchester),
+                    "medway" => Ok(Self::Medway),
+                    "merthyr tydfil" => Ok(Self::MerthyrTydfil),
+                    "merton" => Ok(Self::Merton),
+                    "mid and east antrim" => Ok(Self::MidAndEastAntrim),
+                    "mid ulster" => Ok(Self::MidUlster),
+                    "middlesbrough" => Ok(Self::Middlesbrough),
+                    "midlothian" => Ok(Self::Midlothian),
+                    "milton keynes" => Ok(Self::MiltonKeynes),
+                    "monmouthshire" => Ok(Self::Monmouthshire),
+                    "moray" => Ok(Self::Moray),
+                    "neath port talbot" => Ok(Self::NeathPortTalbot),
+                    "newcastle upon tyne" => Ok(Self::NewcastleUponTyne),
+                    "newham" => Ok(Self::Newham),
+                    "newport" => Ok(Self::Newport),
+                    "newry mourne and down" => Ok(Self::NewryMourneAndDown),
+                    "norfolk" => Ok(Self::Norfolk),
+                    "north ayrshire" => Ok(Self::NorthAyrshire),
+                    "north east lincolnshire" => Ok(Self::NorthEastLincolnshire),
+                    "north lanarkshire" => Ok(Self::NorthLanarkshire),
+                    "north lincolnshire" => Ok(Self::NorthLincolnshire),
+                    "north somerset" => Ok(Self::NorthSomerset),
+                    "north tyneside" => Ok(Self::NorthTyneside),
+                    "north yorkshire" => Ok(Self::NorthYorkshire),
+                    "northamptonshire" => Ok(Self::Northamptonshire),
+                    "northumberland" => Ok(Self::Northumberland),
+                    "nottingham" => Ok(Self::Nottingham),
+                    "nottinghamshire" => Ok(Self::Nottinghamshire),
+                    "oldham" => Ok(Self::Oldham),
+                    "orkney islands" => Ok(Self::OrkneyIslands),
+                    "oxfordshire" => Ok(Self::Oxfordshire),
+                    "pembrokeshire" => Ok(Self::Pembrokeshire),
+                    "perth and kinross" => Ok(Self::PerthAndKinross),
+                    "peterborough" => Ok(Self::Peterborough),
+                    "plymouth" => Ok(Self::Plymouth),
+                    "portsmouth" => Ok(Self::Portsmouth),
+                    "powys" => Ok(Self::Powys),
+                    "reading" => Ok(Self::Reading),
+                    "redbridge" => Ok(Self::Redbridge),
+                    "redcar and cleveland" => Ok(Self::RedcarAndCleveland),
+                    "renfrewshire" => Ok(Self::Renfrewshire),
+                    "rhondda cynon taff" => Ok(Self::RhonddaCynonTaff),
+                    "richmond upon thames" => Ok(Self::RichmondUponThames),
+                    "rochdale" => Ok(Self::Rochdale),
+                    "rotherham" => Ok(Self::Rotherham),
+                    "rutland" => Ok(Self::Rutland),
+                    "salford" => Ok(Self::Salford),
+                    "sandwell" => Ok(Self::Sandwell),
+                    "scottish borders" => Ok(Self::ScottishBorders),
+                    "sefton" => Ok(Self::Sefton),
+                    "sheffield" => Ok(Self::Sheffield),
+                    "shetland islands" => Ok(Self::ShetlandIslands),
+                    "shropshire" => Ok(Self::Shropshire),
+                    "slough" => Ok(Self::Slough),
+                    "solihull" => Ok(Self::Solihull),
+                    "somerset" => Ok(Self::Somerset),
+                    "south ayrshire" => Ok(Self::SouthAyrshire),
+                    "south gloucestershire" => Ok(Self::SouthGloucestershire),
+                    "south lanarkshire" => Ok(Self::SouthLanarkshire),
+                    "south tyneside" => Ok(Self::SouthTyneside),
+                    "southampton" => Ok(Self::Southampton),
+                    "southend on sea" => Ok(Self::SouthendOnSea),
+                    "southwark" => Ok(Self::Southwark),
+                    "st helens" => Ok(Self::StHelens),
+                    "staffordshire" => Ok(Self::Staffordshire),
+                    "stirling" => Ok(Self::Stirling),
+                    "stockport" => Ok(Self::Stockport),
+                    "stockton on tees" => Ok(Self::StocktonOnTees),
+                    "stoke on trent" => Ok(Self::StokeOnTrent),
+                    "suffolk" => Ok(Self::Suffolk),
+                    "sunderland" => Ok(Self::Sunderland),
+                    "surrey" => Ok(Self::Surrey),
+                    "sutton" => Ok(Self::Sutton),
+                    "swansea" => Ok(Self::Swansea),
+                    "swindon" => Ok(Self::Swindon),
+                    "tameside" => Ok(Self::Tameside),
+                    "telford and wrekin" => Ok(Self::TelfordAndWrekin),
+                    "thurrock" => Ok(Self::Thurrock),
+                    "torbay" => Ok(Self::Torbay),
+                    "torfaen" => Ok(Self::Torfaen),
+                    "tower hamlets" => Ok(Self::TowerHamlets),
+                    "trafford" => Ok(Self::Trafford),
+                    "vale of glamorgan" => Ok(Self::ValeOfGlamorgan),
+                    "wakefield" => Ok(Self::Wakefield),
+                    "walsall" => Ok(Self::Walsall),
+                    "waltham forest" => Ok(Self::WalthamForest),
+                    "wandsworth" => Ok(Self::Wandsworth),
+                    "warrington" => Ok(Self::Warrington),
+                    "warwickshire" => Ok(Self::Warwickshire),
+                    "west berkshire" => Ok(Self::WestBerkshire),
+                    "west dunbartonshire" => Ok(Self::WestDunbartonshire),
+                    "west lothian" => Ok(Self::WestLothian),
+                    "west sussex" => Ok(Self::WestSussex),
+                    "westminster" => Ok(Self::Westminster),
+                    "wigan" => Ok(Self::Wigan),
+                    "wiltshire" => Ok(Self::Wiltshire),
+                    "windsor and maidenhead" => Ok(Self::WindsorAndMaidenhead),
+                    "wirral" => Ok(Self::Wirral),
+                    "wokingham" => Ok(Self::Wokingham),
+                    "wolverhampton" => Ok(Self::Wolverhampton),
+                    "worcestershire" => Ok(Self::Worcestershire),
+                    "wrexham" => Ok(Self::Wrexham),
+                    "york" => Ok(Self::York),
                     _ => Err(errors::ConnectorError::InvalidDataFormat {
                         field_name: "address.state",
                     }

--- a/crates/hyperswitch_domain_models/src/mandates.rs
+++ b/crates/hyperswitch_domain_models/src/mandates.rs
@@ -60,7 +60,7 @@ pub struct MandateAmountData {
 pub struct MandateData {
     /// A way to update the mandate's payment method details
     pub update_mandate_id: Option<String>,
-    /// A concent from the customer to store the payment method
+    /// A consent from the customer to store the payment method
     pub customer_acceptance: Option<CustomerAcceptance>,
     /// A way to select the type of mandate used
     pub mandate_type: Option<MandateDataType>,

--- a/crates/router/src/core/payments.rs
+++ b/crates/router/src/core/payments.rs
@@ -6952,7 +6952,10 @@ pub async fn payment_external_authentication<F: Clone + Sync>(
     let billing_address = helpers::create_or_find_address_for_payment_by_request(
         &state,
         None,
-        payment_intent.billing_address_id.as_deref(),
+        payment_attempt
+            .payment_method_billing_address_id
+            .as_deref()
+            .or(payment_intent.billing_address_id.as_deref()),
         merchant_id,
         payment_intent.customer_id.as_ref(),
         &key_store,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
For each countries present in Europe, their states are converted to ISO Standard 
[Source for standard](https://github.com/juspay/hyperswitch-web/blob/main/src/States.json)

Note: A bugfix is present as well for address_id used to fetch billing_address for external authentication

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Sanity External 3DS payment, by sending billing_address in payment_method_data for Poland country address
CURL
```
curl --location 'localhost:8080/payments/pay_MRVy1jlxGGGZafdE7xsJ/3ds/authentication' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: pk_dev_d3a60dc7950549aa954219ca29746442' \
--data '{
    "client_secret": "pay_MRVy1jlxGGGZafdE7xsJ_secret_at05FqOzGfMCtJ3bRw4Y",
    "device_channel": "BRW",
    "threeds_method_comp_ind": "Y"
}'
```

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
