### PR TITLE
refactor(utils): use to_state_code of hyperswitch_connectors in router

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -59,6 +59,10 @@ OltCounty = "OltCounty" # Is a state in Romania
 olt = "olt" # Is iso representation of a state in Romania
 Vas = "Vas" # Is iso representation of a state in Hungary
 vas = "vas" # Is iso representation of a state in Hungary
+WHT = "WHT" # Is iso representation of a state in Belgium
+CantonOfEschSurAlzette = "CantonOfEschSurAlzette" # Is a state in Luxembourg
+GorenjaVasPoljane = "GorenjaVasPoljane" # Is a state in Slovenia
+sur = "sur" # Is iso representation of a state in Luxembourg
 
 [default.extend-words]
 aci = "aci" # Name of a connector

--- a/crates/common_enums/src/enums.rs
+++ b/crates/common_enums/src/enums.rs
@@ -5039,6 +5039,591 @@ pub enum UnitedKingdomStatesAbbreviation {
 #[derive(
     Debug, Clone, PartialEq, Eq, Serialize, Deserialize, strum::Display, strum::EnumString,
 )]
+pub enum BelgiumStatesAbbreviation {
+    #[strum(serialize = "VAN")]
+    Antwerp,
+    #[strum(serialize = "BRU")]
+    BrusselsCapitalRegion,
+    #[strum(serialize = "VOV")]
+    EastFlanders,
+    #[strum(serialize = "VLG")]
+    Flanders,
+    #[strum(serialize = "VBR")]
+    FlemishBrabant,
+    #[strum(serialize = "WHT")]
+    Hainaut,
+    #[strum(serialize = "VLI")]
+    Limburg,
+    #[strum(serialize = "WLG")]
+    Liege,
+    #[strum(serialize = "WLX")]
+    Luxembourg,
+    #[strum(serialize = "WNA")]
+    Namur,
+    #[strum(serialize = "WAL")]
+    Wallonia,
+    #[strum(serialize = "WBR")]
+    WalloonBrabant,
+    #[strum(serialize = "VWV")]
+    WestFlanders,
+}
+
+#[derive(
+    Debug, Clone, PartialEq, Eq, Serialize, Deserialize, strum::Display, strum::EnumString,
+)]
+pub enum LuxembourgStatesAbbreviation {
+    #[strum(serialize = "CA")]
+    CantonOfCapellen,
+    #[strum(serialize = "CL")]
+    CantonOfClervaux,
+    #[strum(serialize = "DI")]
+    CantonOfDiekirch,
+    #[strum(serialize = "EC")]
+    CantonOfEchternach,
+    #[strum(serialize = "ES")]
+    CantonOfEschSurAlzette,
+    #[strum(serialize = "GR")]
+    CantonOfGrevenmacher,
+    #[strum(serialize = "LU")]
+    CantonOfLuxembourg,
+    #[strum(serialize = "ME")]
+    CantonOfMersch,
+    #[strum(serialize = "RD")]
+    CantonOfRedange,
+    #[strum(serialize = "RM")]
+    CantonOfRemich,
+    #[strum(serialize = "VD")]
+    CantonOfVianden,
+    #[strum(serialize = "WI")]
+    CantonOfWiltz,
+    #[strum(serialize = "D")]
+    DiekirchDistrict,
+    #[strum(serialize = "G")]
+    GrevenmacherDistrict,
+    #[strum(serialize = "L")]
+    LuxembourgDistrict,
+}
+
+#[derive(
+    Debug, Clone, PartialEq, Eq, Serialize, Deserialize, strum::Display, strum::EnumString,
+)]
+pub enum RussiaStatesAbbreviation {
+    #[strum(serialize = "ALT")]
+    AltaiKrai,
+    #[strum(serialize = "AL")]
+    AltaiRepublic,
+    #[strum(serialize = "AMU")]
+    AmurOblast,
+    #[strum(serialize = "ARK")]
+    Arkhangelsk,
+    #[strum(serialize = "AST")]
+    AstrakhanOblast,
+    #[strum(serialize = "BEL")]
+    BelgorodOblast,
+    #[strum(serialize = "BRY")]
+    BryanskOblast,
+    #[strum(serialize = "CE")]
+    ChechenRepublic,
+    #[strum(serialize = "CHE")]
+    ChelyabinskOblast,
+    #[strum(serialize = "CHU")]
+    ChukotkaAutonomousOkrug,
+    #[strum(serialize = "CU")]
+    ChuvashRepublic,
+    #[strum(serialize = "IRK")]
+    Irkutsk,
+    #[strum(serialize = "IVA")]
+    IvanovoOblast,
+    #[strum(serialize = "YEV")]
+    JewishAutonomousOblast,
+    #[strum(serialize = "KB")]
+    KabardinoBalkarRepublic,
+    #[strum(serialize = "KGD")]
+    Kaliningrad,
+    #[strum(serialize = "KLU")]
+    KalugaOblast,
+    #[strum(serialize = "KAM")]
+    KamchatkaKrai,
+    #[strum(serialize = "KC")]
+    KarachayCherkessRepublic,
+    #[strum(serialize = "KEM")]
+    KemerovoOblast,
+    #[strum(serialize = "KHA")]
+    KhabarovskKrai,
+    #[strum(serialize = "KHM")]
+    KhantyMansiAutonomousOkrug,
+    #[strum(serialize = "KIR")]
+    KirovOblast,
+    #[strum(serialize = "KO")]
+    KomiRepublic,
+    #[strum(serialize = "KOS")]
+    KostromaOblast,
+    #[strum(serialize = "KDA")]
+    KrasnodarKrai,
+    #[strum(serialize = "KYA")]
+    KrasnoyarskKrai,
+    #[strum(serialize = "KGN")]
+    KurganOblast,
+    #[strum(serialize = "KRS")]
+    KurskOblast,
+    #[strum(serialize = "LEN")]
+    LeningradOblast,
+    #[strum(serialize = "LIP")]
+    LipetskOblast,
+    #[strum(serialize = "MAG")]
+    MagadanOblast,
+    #[strum(serialize = "ME")]
+    MariElRepublic,
+    #[strum(serialize = "MOW")]
+    Moscow,
+    #[strum(serialize = "MOS")]
+    MoscowOblast,
+    #[strum(serialize = "MUR")]
+    MurmanskOblast,
+    #[strum(serialize = "NEN")]
+    NenetsAutonomousOkrug,
+    #[strum(serialize = "NIZ")]
+    NizhnyNovgorodOblast,
+    #[strum(serialize = "NGR")]
+    NovgorodOblast,
+    #[strum(serialize = "NVS")]
+    Novosibirsk,
+    #[strum(serialize = "OMS")]
+    OmskOblast,
+    #[strum(serialize = "ORE")]
+    OrenburgOblast,
+    #[strum(serialize = "ORL")]
+    OryolOblast,
+    #[strum(serialize = "PNZ")]
+    PenzaOblast,
+    #[strum(serialize = "PER")]
+    PermKrai,
+    #[strum(serialize = "PRI")]
+    PrimorskyKrai,
+    #[strum(serialize = "PSK")]
+    PskovOblast,
+    #[strum(serialize = "AD")]
+    RepublicOfAdygea,
+    #[strum(serialize = "BA")]
+    RepublicOfBashkortostan,
+    #[strum(serialize = "BU")]
+    RepublicOfBuryatia,
+    #[strum(serialize = "DA")]
+    RepublicOfDagestan,
+    #[strum(serialize = "IN")]
+    RepublicOfIngushetia,
+    #[strum(serialize = "KL")]
+    RepublicOfKalmykia,
+    #[strum(serialize = "KR")]
+    RepublicOfKarelia,
+    #[strum(serialize = "KK")]
+    RepublicOfKhakassia,
+    #[strum(serialize = "MO")]
+    RepublicOfMordovia,
+    #[strum(serialize = "SE")]
+    RepublicOfNorthOssetiaAlania,
+    #[strum(serialize = "TA")]
+    RepublicOfTatarstan,
+    #[strum(serialize = "ROS")]
+    RostovOblast,
+    #[strum(serialize = "RYA")]
+    RyazanOblast,
+    #[strum(serialize = "SPE")]
+    SaintPetersburg,
+    #[strum(serialize = "SA")]
+    SakhaRepublic,
+    #[strum(serialize = "SAK")]
+    Sakhalin,
+    #[strum(serialize = "SAM")]
+    SamaraOblast,
+    #[strum(serialize = "SAR")]
+    SaratovOblast,
+    #[strum(serialize = "UA-40")]
+    Sevastopol,
+    #[strum(serialize = "SMO")]
+    SmolenskOblast,
+    #[strum(serialize = "STA")]
+    StavropolKrai,
+    #[strum(serialize = "SVE")]
+    Sverdlovsk,
+    #[strum(serialize = "TAM")]
+    TambovOblast,
+    #[strum(serialize = "TOM")]
+    TomskOblast,
+    #[strum(serialize = "TUL")]
+    TulaOblast,
+    #[strum(serialize = "TY")]
+    TuvaRepublic,
+    #[strum(serialize = "TVE")]
+    TverOblast,
+    #[strum(serialize = "TYU")]
+    TyumenOblast,
+    #[strum(serialize = "UD")]
+    UdmurtRepublic,
+    #[strum(serialize = "ULY")]
+    UlyanovskOblast,
+    #[strum(serialize = "VLA")]
+    VladimirOblast,
+    #[strum(serialize = "VLG")]
+    VologdaOblast,
+    #[strum(serialize = "VOR")]
+    VoronezhOblast,
+    #[strum(serialize = "YAN")]
+    YamaloNenetsAutonomousOkrug,
+    #[strum(serialize = "YAR")]
+    YaroslavlOblast,
+    #[strum(serialize = "ZAB")]
+    ZabaykalskyKrai,
+}
+
+#[derive(
+    Debug, Clone, PartialEq, Eq, Serialize, Deserialize, strum::Display, strum::EnumString,
+)]
+pub enum SanMarinoStatesAbbreviation {
+    #[strum(serialize = "01")]
+    Acquaviva,
+    #[strum(serialize = "06")]
+    BorgoMaggiore,
+    #[strum(serialize = "02")]
+    Chiesanuova,
+    #[strum(serialize = "03")]
+    Domagnano,
+    #[strum(serialize = "04")]
+    Faetano,
+    #[strum(serialize = "05")]
+    Fiorentino,
+    #[strum(serialize = "08")]
+    Montegiardino,
+    #[strum(serialize = "07")]
+    SanMarino,
+    #[strum(serialize = "09")]
+    Serravalle,
+}
+
+#[derive(
+    Debug, Clone, PartialEq, Eq, Serialize, Deserialize, strum::Display, strum::EnumString,
+)]
+pub enum SerbiaStatesAbbreviation {
+    #[strum(serialize = "00")]
+    Belgrade,
+
+    #[strum(serialize = "01")]
+    BorDistrict,
+
+    #[strum(serialize = "02")]
+    BraničevoDistrict,
+
+    #[strum(serialize = "03")]
+    CentralBanatDistrict,
+
+    #[strum(serialize = "04")]
+    JablanicaDistrict,
+
+    #[strum(serialize = "05")]
+    KolubaraDistrict,
+
+    #[strum(serialize = "06")]
+    MačvaDistrict,
+
+    #[strum(serialize = "07")]
+    MoravicaDistrict,
+
+    #[strum(serialize = "08")]
+    NišavaDistrict,
+
+    #[strum(serialize = "09")]
+    NorthBanatDistrict,
+
+    #[strum(serialize = "10")]
+    NorthBačkaDistrict,
+
+    #[strum(serialize = "11")]
+    PirotDistrict,
+
+    #[strum(serialize = "12")]
+    PodunavljeDistrict,
+
+    #[strum(serialize = "13")]
+    PomoravljeDistrict,
+
+    #[strum(serialize = "14")]
+    PčinjaDistrict,
+
+    #[strum(serialize = "15")]
+    RasinaDistrict,
+
+    #[strum(serialize = "16")]
+    RaškaDistrict,
+
+    #[strum(serialize = "17")]
+    SouthBanatDistrict,
+
+    #[strum(serialize = "18")]
+    SouthBačkaDistrict,
+
+    #[strum(serialize = "19")]
+    SremDistrict,
+
+    #[strum(serialize = "20")]
+    ToplicaDistrict,
+
+    #[strum(serialize = "21")]
+    Vojvodina,
+
+    #[strum(serialize = "22")]
+    WestBačkaDistrict,
+
+    #[strum(serialize = "23")]
+    ZaječarDistrict,
+
+    #[strum(serialize = "24")]
+    ZlatiborDistrict,
+
+    #[strum(serialize = "25")]
+    ŠumadijaDistrict,
+}
+
+#[derive(
+    Debug, Clone, PartialEq, Eq, Serialize, Deserialize, strum::Display, strum::EnumString,
+)]
+pub enum SlovakiaStatesAbbreviation {
+    #[strum(serialize = "BC")]
+    BanskaBystricaRegion,
+    #[strum(serialize = "BL")]
+    BratislavaRegion,
+    #[strum(serialize = "KI")]
+    KosiceRegion,
+    #[strum(serialize = "NI")]
+    NitraRegion,
+    #[strum(serialize = "PV")]
+    PresovRegion,
+    #[strum(serialize = "TC")]
+    TrencinRegion,
+    #[strum(serialize = "TA")]
+    TrnavaRegion,
+    #[strum(serialize = "ZI")]
+    ZilinaRegion,
+}
+
+#[derive(
+    Debug, Clone, PartialEq, Eq, Serialize, Deserialize, strum::Display, strum::EnumString,
+)]
+pub enum SloveniaStatesAbbreviation {
+    #[strum(serialize = "001")]
+    Ajdovščina,
+    #[strum(serialize = "213")]
+    Ankaran,
+    #[strum(serialize = "002")]
+    Beltinci,
+    #[strum(serialize = "148")]
+    Benedikt,
+    #[strum(serialize = "149")]
+    BistricaObSotli,
+    #[strum(serialize = "003")]
+    Bled,
+    #[strum(serialize = "150")]
+    Bloke,
+    #[strum(serialize = "004")]
+    Bohinj,
+    #[strum(serialize = "005")]
+    Borovnica,
+    #[strum(serialize = "006")]
+    Bovec,
+    #[strum(serialize = "151")]
+    Braslovče,
+    #[strum(serialize = "007")]
+    Brda,
+    #[strum(serialize = "008")]
+    Brezovica,
+    #[strum(serialize = "009")]
+    Brežice,
+    #[strum(serialize = "152")]
+    Cankova,
+    #[strum(serialize = "012")]
+    CerkljeNaGorenjskem,
+    #[strum(serialize = "013")]
+    Cerknica,
+    #[strum(serialize = "014")]
+    Cerkno,
+    #[strum(serialize = "153")]
+    Cerkvenjak,
+    #[strum(serialize = "011")]
+    CityMunicipalityOfCelje,
+    #[strum(serialize = "085")]
+    CityMunicipalityOfNovoMesto,
+    #[strum(serialize = "018")]
+    Destrnik,
+    #[strum(serialize = "019")]
+    Divača,
+    #[strum(serialize = "154")]
+    Dobje,
+    #[strum(serialize = "020")]
+    Dobrepolje,
+    #[strum(serialize = "155")]
+    Dobrna,
+    #[strum(serialize = "021")]
+    DobrovaPolhovGradec,
+    #[strum(serialize = "156")]
+    Dobrovnik,
+    #[strum(serialize = "022")]
+    DolPriLjubljani,
+    #[strum(serialize = "157")]
+    DolenjskeToplice,
+    #[strum(serialize = "023")]
+    Domžale,
+    #[strum(serialize = "024")]
+    Dornava,
+    #[strum(serialize = "025")]
+    Dravograd,
+    #[strum(serialize = "026")]
+    Duplek,
+    #[strum(serialize = "027")]
+    GorenjaVasPoljane,
+    #[strum(serialize = "028")]
+    Gorišnica,
+    #[strum(serialize = "207")]
+    Gorje,
+    #[strum(serialize = "029")]
+    GornjaRadgona,
+    #[strum(serialize = "030")]
+    GornjiGrad,
+    #[strum(serialize = "031")]
+    GornjiPetrovci,
+    #[strum(serialize = "158")]
+    Grad,
+    #[strum(serialize = "032")]
+    Grosuplje,
+    #[strum(serialize = "159")]
+    Hajdina,
+    #[strum(serialize = "161")]
+    Hodoš,
+    #[strum(serialize = "162")]
+    Horjul,
+    #[strum(serialize = "160")]
+    HočeSlivnica,
+    #[strum(serialize = "034")]
+    Hrastnik,
+    #[strum(serialize = "035")]
+    HrpeljeKozina,
+    #[strum(serialize = "036")]
+    Idrija,
+    #[strum(serialize = "037")]
+    Ig,
+    #[strum(serialize = "039")]
+    IvančnaGorica,
+    #[strum(serialize = "040")]
+    Izola,
+    #[strum(serialize = "041")]
+    Jesenice,
+    #[strum(serialize = "163")]
+    Jezersko,
+}
+
+#[derive(
+    Debug, Clone, PartialEq, Eq, Serialize, Deserialize, strum::Display, strum::EnumString,
+)]
+pub enum SwedenStatesAbbreviation {
+    #[strum(serialize = "K")]
+    Blekinge,
+    #[strum(serialize = "W")]
+    DalarnaCounty,
+    #[strum(serialize = "I")]
+    GotlandCounty,
+    #[strum(serialize = "X")]
+    GävleborgCounty,
+    #[strum(serialize = "N")]
+    HallandCounty,
+    #[strum(serialize = "F")]
+    JönköpingCounty,
+    #[strum(serialize = "H")]
+    KalmarCounty,
+    #[strum(serialize = "G")]
+    KronobergCounty,
+    #[strum(serialize = "BD")]
+    NorrbottenCounty,
+    #[strum(serialize = "M")]
+    SkåneCounty,
+    #[strum(serialize = "AB")]
+    StockholmCounty,
+    #[strum(serialize = "D")]
+    SödermanlandCounty,
+    #[strum(serialize = "C")]
+    UppsalaCounty,
+    #[strum(serialize = "S")]
+    VärmlandCounty,
+    #[strum(serialize = "AC")]
+    VästerbottenCounty,
+    #[strum(serialize = "Y")]
+    VästernorrlandCounty,
+    #[strum(serialize = "U")]
+    VästmanlandCounty,
+    #[strum(serialize = "O")]
+    VästraGötalandCounty,
+    #[strum(serialize = "T")]
+    ÖrebroCounty,
+    #[strum(serialize = "E")]
+    ÖstergötlandCounty,
+}
+
+#[derive(
+    Debug, Clone, PartialEq, Eq, Serialize, Deserialize, strum::Display, strum::EnumString,
+)]
+pub enum UkraineStatesAbbreviation {
+    #[strum(serialize = "43")]
+    AutonomousRepublicOfCrimea,
+    #[strum(serialize = "71")]
+    CherkasyOblast,
+    #[strum(serialize = "74")]
+    ChernihivOblast,
+    #[strum(serialize = "77")]
+    ChernivtsiOblast,
+    #[strum(serialize = "12")]
+    DnipropetrovskOblast,
+    #[strum(serialize = "14")]
+    DonetskOblast,
+    #[strum(serialize = "26")]
+    IvanoFrankivskOblast,
+    #[strum(serialize = "63")]
+    KharkivOblast,
+    #[strum(serialize = "65")]
+    KhersonOblast,
+    #[strum(serialize = "68")]
+    KhmelnytskyOblast,
+    #[strum(serialize = "30")]
+    Kiev,
+    #[strum(serialize = "35")]
+    KirovohradOblast,
+    #[strum(serialize = "32")]
+    KyivOblast,
+    #[strum(serialize = "09")]
+    LuhanskOblast,
+    #[strum(serialize = "46")]
+    LvivOblast,
+    #[strum(serialize = "48")]
+    MykolaivOblast,
+    #[strum(serialize = "51")]
+    OdessaOblast,
+    #[strum(serialize = "56")]
+    RivneOblast,
+    #[strum(serialize = "59")]
+    SumyOblast,
+    #[strum(serialize = "61")]
+    TernopilOblast,
+    #[strum(serialize = "05")]
+    VinnytsiaOblast,
+    #[strum(serialize = "07")]
+    VolynOblast,
+    #[strum(serialize = "21")]
+    ZakarpattiaOblast,
+    #[strum(serialize = "23")]
+    ZaporizhzhyaOblast,
+    #[strum(serialize = "18")]
+    ZhytomyrOblast,
+}
+
+#[derive(
+    Debug, Clone, PartialEq, Eq, Serialize, Deserialize, strum::Display, strum::EnumString,
+)]
 pub enum RomaniaStatesAbbreviation {
     #[strum(serialize = "AB")]
     Alba,

--- a/crates/hyperswitch_connectors/src/utils.rs
+++ b/crates/hyperswitch_connectors/src/utils.rs
@@ -8,18 +8,21 @@ use common_enums::{
     enums,
     enums::{
         AlbaniaStatesAbbreviation, AndorraStatesAbbreviation, AttemptStatus,
-        AustriaStatesAbbreviation, BelarusStatesAbbreviation,
+        AustriaStatesAbbreviation, BelarusStatesAbbreviation, BelgiumStatesAbbreviation,
         BosniaAndHerzegovinaStatesAbbreviation, BulgariaStatesAbbreviation,
         CanadaStatesAbbreviation, CroatiaStatesAbbreviation, CzechRepublicStatesAbbreviation,
         DenmarkStatesAbbreviation, FinlandStatesAbbreviation, FranceStatesAbbreviation,
         FutureUsage, GermanyStatesAbbreviation, GreeceStatesAbbreviation,
         HungaryStatesAbbreviation, IcelandStatesAbbreviation, IrelandStatesAbbreviation,
         ItalyStatesAbbreviation, LatviaStatesAbbreviation, LiechtensteinStatesAbbreviation,
-        LithuaniaStatesAbbreviation, MaltaStatesAbbreviation, MoldovaStatesAbbreviation,
-        MonacoStatesAbbreviation, MontenegroStatesAbbreviation, NetherlandsStatesAbbreviation,
-        NorthMacedoniaStatesAbbreviation, NorwayStatesAbbreviation, PolandStatesAbbreviation,
-        PortugalStatesAbbreviation, RomaniaStatesAbbreviation, SpainStatesAbbreviation,
-        SwitzerlandStatesAbbreviation, UnitedKingdomStatesAbbreviation, UsStatesAbbreviation,
+        LithuaniaStatesAbbreviation, LuxembourgStatesAbbreviation, MaltaStatesAbbreviation,
+        MoldovaStatesAbbreviation, MonacoStatesAbbreviation, MontenegroStatesAbbreviation,
+        NetherlandsStatesAbbreviation, NorthMacedoniaStatesAbbreviation, NorwayStatesAbbreviation,
+        PolandStatesAbbreviation, PortugalStatesAbbreviation, RomaniaStatesAbbreviation,
+        RussiaStatesAbbreviation, SanMarinoStatesAbbreviation, SerbiaStatesAbbreviation,
+        SlovakiaStatesAbbreviation, SloveniaStatesAbbreviation, SpainStatesAbbreviation,
+        SwedenStatesAbbreviation, SwitzerlandStatesAbbreviation, UkraineStatesAbbreviation,
+        UnitedKingdomStatesAbbreviation, UsStatesAbbreviation,
     },
 };
 use common_utils::{
@@ -3508,11 +3511,11 @@ impl ForeignTryFrom<String> for MaltaStatesAbbreviation {
             StringExt::<Self>::parse_enum(value.to_uppercase().clone(), "MaltaStatesAbbreviation");
 
         match state_abbreviation_check {
-            Ok(municipality) => Ok(municipality),
+            Ok(state_abbreviation) => Ok(state_abbreviation),
             Err(_) => {
                 let binding = value.as_str().to_lowercase();
-                let municipality = binding.as_str();
-                match municipality {
+                let state = binding.as_str();
+                match state {
                     "attard" => Ok(Self::Attard),
                     "balzan" => Ok(Self::Balzan),
                     "birgu" => Ok(Self::Birgu),
@@ -4394,6 +4397,463 @@ impl ForeignTryFrom<String> for UnitedKingdomStatesAbbreviation {
                     "worcestershire" => Ok(Self::Worcestershire),
                     "wrexham" => Ok(Self::Wrexham),
                     "york" => Ok(Self::York),
+                    _ => Err(errors::ConnectorError::InvalidDataFormat {
+                        field_name: "address.state",
+                    }
+                    .into()),
+                }
+            }
+        }
+    }
+}
+
+impl ForeignTryFrom<String> for BelgiumStatesAbbreviation {
+    type Error = error_stack::Report<errors::ConnectorError>;
+    fn foreign_try_from(value: String) -> Result<Self, Self::Error> {
+        let state_abbreviation_check = StringExt::<Self>::parse_enum(
+            value.to_uppercase().clone(),
+            "BelgiumStatesAbbreviation",
+        );
+        match state_abbreviation_check {
+            Ok(state_abbreviation) => Ok(state_abbreviation),
+            Err(_) => {
+                let binding = value.as_str().to_lowercase();
+                let state = binding.as_str();
+                match state {
+                    "antwerp" => Ok(Self::Antwerp),
+                    "brussels capital region" => Ok(Self::BrusselsCapitalRegion),
+                    "east flanders" => Ok(Self::EastFlanders),
+                    "flanders" => Ok(Self::Flanders),
+                    "flemish brabant" => Ok(Self::FlemishBrabant),
+                    "hainaut" => Ok(Self::Hainaut),
+                    "limburg" => Ok(Self::Limburg),
+                    "liege" => Ok(Self::Liege),
+                    "luxembourg" => Ok(Self::Luxembourg),
+                    "namur" => Ok(Self::Namur),
+                    "wallonia" => Ok(Self::Wallonia),
+                    "walloon brabant" => Ok(Self::WalloonBrabant),
+                    "west flanders" => Ok(Self::WestFlanders),
+                    _ => Err(errors::ConnectorError::InvalidDataFormat {
+                        field_name: "address.state",
+                    }
+                    .into()),
+                }
+            }
+        }
+    }
+}
+
+impl ForeignTryFrom<String> for LuxembourgStatesAbbreviation {
+    type Error = error_stack::Report<errors::ConnectorError>;
+    fn foreign_try_from(value: String) -> Result<Self, Self::Error> {
+        let state_abbreviation_check = StringExt::<Self>::parse_enum(
+            value.to_uppercase().clone(),
+            "LuxembourgStatesAbbreviation",
+        );
+        match state_abbreviation_check {
+            Ok(state_abbreviation) => Ok(state_abbreviation),
+            Err(_) => {
+                let binding = value.as_str().to_lowercase();
+                let state = binding.as_str();
+                match state {
+                    "canton of capellen" => Ok(Self::CantonOfCapellen),
+                    "canton of clervaux" => Ok(Self::CantonOfClervaux),
+                    "canton of diekirch" => Ok(Self::CantonOfDiekirch),
+                    "canton of echternach" => Ok(Self::CantonOfEchternach),
+                    "canton of esch sur alzette" => Ok(Self::CantonOfEschSurAlzette),
+                    "canton of grevenmacher" => Ok(Self::CantonOfGrevenmacher),
+                    "canton of luxembourg" => Ok(Self::CantonOfLuxembourg),
+                    "canton of mersch" => Ok(Self::CantonOfMersch),
+                    "canton of redange" => Ok(Self::CantonOfRedange),
+                    "canton of remich" => Ok(Self::CantonOfRemich),
+                    "canton of vianden" => Ok(Self::CantonOfVianden),
+                    "canton of wiltz" => Ok(Self::CantonOfWiltz),
+                    "diekirch district" => Ok(Self::DiekirchDistrict),
+                    "grevenmacher district" => Ok(Self::GrevenmacherDistrict),
+                    "luxembourg district" => Ok(Self::LuxembourgDistrict),
+                    _ => Err(errors::ConnectorError::InvalidDataFormat {
+                        field_name: "address.state",
+                    }
+                    .into()),
+                }
+            }
+        }
+    }
+}
+
+impl ForeignTryFrom<String> for RussiaStatesAbbreviation {
+    type Error = error_stack::Report<errors::ConnectorError>;
+    fn foreign_try_from(value: String) -> Result<Self, Self::Error> {
+        let state_abbreviation_check =
+            StringExt::<Self>::parse_enum(value.to_uppercase().clone(), "RussiaStatesAbbreviation");
+        match state_abbreviation_check {
+            Ok(state_abbreviation) => Ok(state_abbreviation),
+            Err(_) => {
+                let binding = value.as_str().to_lowercase();
+                let state = binding.as_str();
+                match state {
+                    "altai krai" => Ok(Self::AltaiKrai),
+                    "altai republic" => Ok(Self::AltaiRepublic),
+                    "amur oblast" => Ok(Self::AmurOblast),
+                    "arkhangelsk" => Ok(Self::Arkhangelsk),
+                    "astrakhan oblast" => Ok(Self::AstrakhanOblast),
+                    "belgorod oblast" => Ok(Self::BelgorodOblast),
+                    "bryansk oblast" => Ok(Self::BryanskOblast),
+                    "chechen republic" => Ok(Self::ChechenRepublic),
+                    "chelyabinsk oblast" => Ok(Self::ChelyabinskOblast),
+                    "chukotka autonomous okrug" => Ok(Self::ChukotkaAutonomousOkrug),
+                    "chuvash republic" => Ok(Self::ChuvashRepublic),
+                    "irkutsk" => Ok(Self::Irkutsk),
+                    "ivanovo oblast" => Ok(Self::IvanovoOblast),
+                    "jewish autonomous oblast" => Ok(Self::JewishAutonomousOblast),
+                    "kabardino-balkar republic" => Ok(Self::KabardinoBalkarRepublic),
+                    "kaliningrad" => Ok(Self::Kaliningrad),
+                    "kaluga oblast" => Ok(Self::KalugaOblast),
+                    "kamchatka krai" => Ok(Self::KamchatkaKrai),
+                    "karachay-cherkess republic" => Ok(Self::KarachayCherkessRepublic),
+                    "kemerovo oblast" => Ok(Self::KemerovoOblast),
+                    "khabarovsk krai" => Ok(Self::KhabarovskKrai),
+                    "khanty-mansi autonomous okrug" => Ok(Self::KhantyMansiAutonomousOkrug),
+                    "kirov oblast" => Ok(Self::KirovOblast),
+                    "komi republic" => Ok(Self::KomiRepublic),
+                    "kostroma oblast" => Ok(Self::KostromaOblast),
+                    "krasnodar krai" => Ok(Self::KrasnodarKrai),
+                    "krasnoyarsk krai" => Ok(Self::KrasnoyarskKrai),
+                    "kurgan oblast" => Ok(Self::KurganOblast),
+                    "kursk oblast" => Ok(Self::KurskOblast),
+                    "leningrad oblast" => Ok(Self::LeningradOblast),
+                    "lipetsk oblast" => Ok(Self::LipetskOblast),
+                    "magadan oblast" => Ok(Self::MagadanOblast),
+                    "mari el republic" => Ok(Self::MariElRepublic),
+                    "moscow" => Ok(Self::Moscow),
+                    "moscow oblast" => Ok(Self::MoscowOblast),
+                    "murmansk oblast" => Ok(Self::MurmanskOblast),
+                    "nenets autonomous okrug" => Ok(Self::NenetsAutonomousOkrug),
+                    "nizhny novgorod oblast" => Ok(Self::NizhnyNovgorodOblast),
+                    "novgorod oblast" => Ok(Self::NovgorodOblast),
+                    "novosibirsk" => Ok(Self::Novosibirsk),
+                    "omsk oblast" => Ok(Self::OmskOblast),
+                    "orenburg oblast" => Ok(Self::OrenburgOblast),
+                    "oryol oblast" => Ok(Self::OryolOblast),
+                    "penza oblast" => Ok(Self::PenzaOblast),
+                    "perm krai" => Ok(Self::PermKrai),
+                    "primorsky krai" => Ok(Self::PrimorskyKrai),
+                    "pskov oblast" => Ok(Self::PskovOblast),
+                    "republic of adygea" => Ok(Self::RepublicOfAdygea),
+                    "republic of bashkortostan" => Ok(Self::RepublicOfBashkortostan),
+                    "republic of buryatia" => Ok(Self::RepublicOfBuryatia),
+                    "republic of dagestan" => Ok(Self::RepublicOfDagestan),
+                    "republic of ingushetia" => Ok(Self::RepublicOfIngushetia),
+                    "republic of kalmykia" => Ok(Self::RepublicOfKalmykia),
+                    "republic of karelia" => Ok(Self::RepublicOfKarelia),
+                    "republic of khakassia" => Ok(Self::RepublicOfKhakassia),
+                    "republic of mordovia" => Ok(Self::RepublicOfMordovia),
+                    "republic of north ossetia-alania" => Ok(Self::RepublicOfNorthOssetiaAlania),
+                    "republic of tatarstan" => Ok(Self::RepublicOfTatarstan),
+                    "rostov oblast" => Ok(Self::RostovOblast),
+                    "ryazan oblast" => Ok(Self::RyazanOblast),
+                    "saint petersburg" => Ok(Self::SaintPetersburg),
+                    "sakha republic" => Ok(Self::SakhaRepublic),
+                    "sakhalin" => Ok(Self::Sakhalin),
+                    "samara oblast" => Ok(Self::SamaraOblast),
+                    "saratov oblast" => Ok(Self::SaratovOblast),
+                    "sevastopol" => Ok(Self::Sevastopol),
+                    "smolensk oblast" => Ok(Self::SmolenskOblast),
+                    "stavropol krai" => Ok(Self::StavropolKrai),
+                    "sverdlovsk" => Ok(Self::Sverdlovsk),
+                    "tambov oblast" => Ok(Self::TambovOblast),
+                    "tomsk oblast" => Ok(Self::TomskOblast),
+                    "tula oblast" => Ok(Self::TulaOblast),
+                    "tuva republic" => Ok(Self::TuvaRepublic),
+                    "tver oblast" => Ok(Self::TverOblast),
+                    "tyumen oblast" => Ok(Self::TyumenOblast),
+                    "udmurt republic" => Ok(Self::UdmurtRepublic),
+                    "ulyanovsk oblast" => Ok(Self::UlyanovskOblast),
+                    "vladimir oblast" => Ok(Self::VladimirOblast),
+                    "vologda oblast" => Ok(Self::VologdaOblast),
+                    "voronezh oblast" => Ok(Self::VoronezhOblast),
+                    "yamalo-nenets autonomous okrug" => Ok(Self::YamaloNenetsAutonomousOkrug),
+                    "yaroslavl oblast" => Ok(Self::YaroslavlOblast),
+                    "zabaykalsky krai" => Ok(Self::ZabaykalskyKrai),
+                    _ => Err(errors::ConnectorError::InvalidDataFormat {
+                        field_name: "address.state",
+                    }
+                    .into()),
+                }
+            }
+        }
+    }
+}
+
+impl ForeignTryFrom<String> for SanMarinoStatesAbbreviation {
+    type Error = error_stack::Report<errors::ConnectorError>;
+    fn foreign_try_from(value: String) -> Result<Self, Self::Error> {
+        let state_abbreviation_check = StringExt::<Self>::parse_enum(
+            value.to_uppercase().clone(),
+            "SanMarinoStatesAbbreviation",
+        );
+        match state_abbreviation_check {
+            Ok(state_abbreviation) => Ok(state_abbreviation),
+            Err(_) => {
+                let binding = value.as_str().to_lowercase();
+                let state = binding.as_str();
+                match state {
+                    "acquaviva" => Ok(Self::Acquaviva),
+                    "borgo maggiore" => Ok(Self::BorgoMaggiore),
+                    "chiesanuova" => Ok(Self::Chiesanuova),
+                    "domagnano" => Ok(Self::Domagnano),
+                    "faetano" => Ok(Self::Faetano),
+                    "fiorentino" => Ok(Self::Fiorentino),
+                    "montegiardino" => Ok(Self::Montegiardino),
+                    "san marino" => Ok(Self::SanMarino),
+                    "serravalle" => Ok(Self::Serravalle),
+                    _ => Err(errors::ConnectorError::InvalidDataFormat {
+                        field_name: "address.state",
+                    }
+                    .into()),
+                }
+            }
+        }
+    }
+}
+
+impl ForeignTryFrom<String> for SerbiaStatesAbbreviation {
+    type Error = error_stack::Report<errors::ConnectorError>;
+    fn foreign_try_from(value: String) -> Result<Self, Self::Error> {
+        let state_abbreviation_check =
+            StringExt::<Self>::parse_enum(value.to_uppercase().clone(), "SerbiaStatesAbbreviation");
+        match state_abbreviation_check {
+            Ok(state_abbreviation) => Ok(state_abbreviation),
+            Err(_) => {
+                let binding = value.as_str().to_lowercase();
+                let state = binding.as_str();
+                match state {
+                    "belgrade" => Ok(Self::Belgrade),
+                    "bor district" => Ok(Self::BorDistrict),
+                    "braničevo district" => Ok(Self::BraničevoDistrict),
+                    "central banat district" => Ok(Self::CentralBanatDistrict),
+                    "jablanica district" => Ok(Self::JablanicaDistrict),
+                    "kolubara district" => Ok(Self::KolubaraDistrict),
+                    "mačva district" => Ok(Self::MačvaDistrict),
+                    "moravica district" => Ok(Self::MoravicaDistrict),
+                    "nišava district" => Ok(Self::NišavaDistrict),
+                    "north banat district" => Ok(Self::NorthBanatDistrict),
+                    "north bačka district" => Ok(Self::NorthBačkaDistrict),
+                    "pirot district" => Ok(Self::PirotDistrict),
+                    "podunavlje district" => Ok(Self::PodunavljeDistrict),
+                    "pomoravlje district" => Ok(Self::PomoravljeDistrict),
+                    "pčinja district" => Ok(Self::PčinjaDistrict),
+                    "rasina district" => Ok(Self::RasinaDistrict),
+                    "raška district" => Ok(Self::RaškaDistrict),
+                    "south banat district" => Ok(Self::SouthBanatDistrict),
+                    "south bačka district" => Ok(Self::SouthBačkaDistrict),
+                    "srem district" => Ok(Self::SremDistrict),
+                    "toplica district" => Ok(Self::ToplicaDistrict),
+                    "vojvodina" => Ok(Self::Vojvodina),
+                    "west bačka district" => Ok(Self::WestBačkaDistrict),
+                    "zaječar district" => Ok(Self::ZaječarDistrict),
+                    "zlatibor district" => Ok(Self::ZlatiborDistrict),
+                    "šumadija district" => Ok(Self::ŠumadijaDistrict),
+                    _ => Err(errors::ConnectorError::InvalidDataFormat {
+                        field_name: "address.state",
+                    }
+                    .into()),
+                }
+            }
+        }
+    }
+}
+
+impl ForeignTryFrom<String> for SlovakiaStatesAbbreviation {
+    type Error = error_stack::Report<errors::ConnectorError>;
+    fn foreign_try_from(value: String) -> Result<Self, Self::Error> {
+        let state_abbreviation_check = StringExt::<Self>::parse_enum(
+            value.to_uppercase().clone(),
+            "SlovakiaStatesAbbreviation",
+        );
+        match state_abbreviation_check {
+            Ok(state_abbreviation) => Ok(state_abbreviation),
+            Err(_) => {
+                let binding = value.as_str().to_lowercase();
+                let state = binding.as_str();
+                match state {
+                    "banska bystrica region" => Ok(Self::BanskaBystricaRegion),
+                    "bratislava region" => Ok(Self::BratislavaRegion),
+                    "kosice region" => Ok(Self::KosiceRegion),
+                    "nitra region" => Ok(Self::NitraRegion),
+                    "presov region" => Ok(Self::PresovRegion),
+                    "trencin region" => Ok(Self::TrencinRegion),
+                    "trnava region" => Ok(Self::TrnavaRegion),
+                    "zilina region" => Ok(Self::ZilinaRegion),
+                    _ => Err(errors::ConnectorError::InvalidDataFormat {
+                        field_name: "address.state",
+                    }
+                    .into()),
+                }
+            }
+        }
+    }
+}
+
+impl ForeignTryFrom<String> for SwedenStatesAbbreviation {
+    type Error = error_stack::Report<errors::ConnectorError>;
+    fn foreign_try_from(value: String) -> Result<Self, Self::Error> {
+        let state_abbreviation_check =
+            StringExt::<Self>::parse_enum(value.to_uppercase().clone(), "SwedenStatesAbbreviation");
+        match state_abbreviation_check {
+            Ok(state_abbreviation) => Ok(state_abbreviation),
+            Err(_) => {
+                let binding = value.as_str().to_lowercase();
+                let state = binding.as_str();
+                match state {
+                    "blekinge" => Ok(Self::Blekinge),
+                    "dalarna county" => Ok(Self::DalarnaCounty),
+                    "gotland county" => Ok(Self::GotlandCounty),
+                    "gävleborg county" => Ok(Self::GävleborgCounty),
+                    "halland county" => Ok(Self::HallandCounty),
+                    "jönköping county" => Ok(Self::JönköpingCounty),
+                    "kalmar county" => Ok(Self::KalmarCounty),
+                    "kronoberg county" => Ok(Self::KronobergCounty),
+                    "norrbotten county" => Ok(Self::NorrbottenCounty),
+                    "skåne county" => Ok(Self::SkåneCounty),
+                    "stockholm county" => Ok(Self::StockholmCounty),
+                    "södermanland county" => Ok(Self::SödermanlandCounty),
+                    "uppsala county" => Ok(Self::UppsalaCounty),
+                    "värmland county" => Ok(Self::VärmlandCounty),
+                    "västerbotten county" => Ok(Self::VästerbottenCounty),
+                    "västernorrland county" => Ok(Self::VästernorrlandCounty),
+                    "västmanland county" => Ok(Self::VästmanlandCounty),
+                    "västra götaland county" => Ok(Self::VästraGötalandCounty),
+                    "örebro county" => Ok(Self::ÖrebroCounty),
+                    "östergötland county" => Ok(Self::ÖstergötlandCounty),
+                    _ => Err(errors::ConnectorError::InvalidDataFormat {
+                        field_name: "address.state",
+                    }
+                    .into()),
+                }
+            }
+        }
+    }
+}
+
+impl ForeignTryFrom<String> for SloveniaStatesAbbreviation {
+    type Error = error_stack::Report<errors::ConnectorError>;
+    fn foreign_try_from(value: String) -> Result<Self, Self::Error> {
+        let state_abbreviation_check = StringExt::<Self>::parse_enum(
+            value.to_uppercase().clone(),
+            "SloveniaStatesAbbreviation",
+        );
+        match state_abbreviation_check {
+            Ok(state_abbreviation) => Ok(state_abbreviation),
+            Err(_) => {
+                let binding = value.as_str().to_lowercase();
+                let state = binding.as_str();
+                match state {
+                    "ajdovščina" => Ok(Self::Ajdovščina),
+                    "ankaran" => Ok(Self::Ankaran),
+                    "beltinci" => Ok(Self::Beltinci),
+                    "benedikt" => Ok(Self::Benedikt),
+                    "bistrica ob sotli" => Ok(Self::BistricaObSotli),
+                    "bled" => Ok(Self::Bled),
+                    "bloke" => Ok(Self::Bloke),
+                    "bohinj" => Ok(Self::Bohinj),
+                    "borovnica" => Ok(Self::Borovnica),
+                    "bovec" => Ok(Self::Bovec),
+                    "braslovče" => Ok(Self::Braslovče),
+                    "brda" => Ok(Self::Brda),
+                    "brezovica" => Ok(Self::Brezovica),
+                    "brežice" => Ok(Self::Brežice),
+                    "cankova" => Ok(Self::Cankova),
+                    "cerklje na gorenjskem" => Ok(Self::CerkljeNaGorenjskem),
+                    "cerknica" => Ok(Self::Cerknica),
+                    "cerkno" => Ok(Self::Cerkno),
+                    "cerkvenjak" => Ok(Self::Cerkvenjak),
+                    "city municipality of celje" => Ok(Self::CityMunicipalityOfCelje),
+                    "city municipality of novo mesto" => Ok(Self::CityMunicipalityOfNovoMesto),
+                    "destrnik" => Ok(Self::Destrnik),
+                    "divača" => Ok(Self::Divača),
+                    "dobje" => Ok(Self::Dobje),
+                    "dobrepolje" => Ok(Self::Dobrepolje),
+                    "dobrna" => Ok(Self::Dobrna),
+                    "dobrova-polhov gradec" => Ok(Self::DobrovaPolhovGradec),
+                    "dobrovnik" => Ok(Self::Dobrovnik),
+                    "dol pri ljubljani" => Ok(Self::DolPriLjubljani),
+                    "dolenjske toplice" => Ok(Self::DolenjskeToplice),
+                    "domžale" => Ok(Self::Domžale),
+                    "dornava" => Ok(Self::Dornava),
+                    "dravograd" => Ok(Self::Dravograd),
+                    "duplek" => Ok(Self::Duplek),
+                    "gorenja vas-poljane" => Ok(Self::GorenjaVasPoljane),
+                    "gorišnica" => Ok(Self::Gorišnica),
+                    "gorje" => Ok(Self::Gorje),
+                    "gornja radgona" => Ok(Self::GornjaRadgona),
+                    "gornji grad" => Ok(Self::GornjiGrad),
+                    "gornji petrovci" => Ok(Self::GornjiPetrovci),
+                    "grad" => Ok(Self::Grad),
+                    "grosuplje" => Ok(Self::Grosuplje),
+                    "hajdina" => Ok(Self::Hajdina),
+                    "hodoš" => Ok(Self::Hodoš),
+                    "horjul" => Ok(Self::Horjul),
+                    "hoče-slivnica" => Ok(Self::HočeSlivnica),
+                    "hrastnik" => Ok(Self::Hrastnik),
+                    "hrpelje-kozina" => Ok(Self::HrpeljeKozina),
+                    "idrija" => Ok(Self::Idrija),
+                    "ig" => Ok(Self::Ig),
+                    "ivančna gorica" => Ok(Self::IvančnaGorica),
+                    "izola" => Ok(Self::Izola),
+                    "jesenice" => Ok(Self::Jesenice),
+                    "jezersko" => Ok(Self::Jezersko),
+                    _ => Err(errors::ConnectorError::InvalidDataFormat {
+                        field_name: "address.state",
+                    }
+                    .into()),
+                }
+            }
+        }
+    }
+}
+
+impl ForeignTryFrom<String> for UkraineStatesAbbreviation {
+    type Error = error_stack::Report<errors::ConnectorError>;
+
+    fn foreign_try_from(value: String) -> Result<Self, Self::Error> {
+        let state_abbreviation_check = StringExt::<Self>::parse_enum(
+            value.to_uppercase().clone(),
+            "UkraineStatesAbbreviation",
+        );
+
+        match state_abbreviation_check {
+            Ok(state_abbreviation) => Ok(state_abbreviation),
+            Err(_) => {
+                let binding = value.as_str().to_lowercase();
+                let state = binding.as_str();
+
+                match state {
+                    "autonomous republic of crimea" => Ok(Self::AutonomousRepublicOfCrimea),
+                    "cherkasy oblast" => Ok(Self::CherkasyOblast),
+                    "chernihiv oblast" => Ok(Self::ChernihivOblast),
+                    "chernivtsi oblast" => Ok(Self::ChernivtsiOblast),
+                    "dnipropetrovsk oblast" => Ok(Self::DnipropetrovskOblast),
+                    "donetsk oblast" => Ok(Self::DonetskOblast),
+                    "ivano-frankivsk oblast" => Ok(Self::IvanoFrankivskOblast),
+                    "kharkiv oblast" => Ok(Self::KharkivOblast),
+                    "kherson oblast" => Ok(Self::KhersonOblast),
+                    "khmelnytsky oblast" => Ok(Self::KhmelnytskyOblast),
+                    "kiev" => Ok(Self::Kiev),
+                    "kirovohrad oblast" => Ok(Self::KirovohradOblast),
+                    "kyiv oblast" => Ok(Self::KyivOblast),
+                    "luhansk oblast" => Ok(Self::LuhanskOblast),
+                    "lviv oblast" => Ok(Self::LvivOblast),
+                    "mykolaiv oblast" => Ok(Self::MykolaivOblast),
+                    "odessa oblast" => Ok(Self::OdessaOblast),
+                    "rivne oblast" => Ok(Self::RivneOblast),
+                    "sumy oblast" => Ok(Self::SumyOblast),
+                    "ternopil oblast" => Ok(Self::TernopilOblast),
+                    "vinnytsia oblast" => Ok(Self::VinnytsiaOblast),
+                    "volyn oblast" => Ok(Self::VolynOblast),
+                    "zakarpattia oblast" => Ok(Self::ZakarpattiaOblast),
+                    "zaporizhzhya oblast" => Ok(Self::ZaporizhzhyaOblast),
+                    "zhytomyr oblast" => Ok(Self::ZhytomyrOblast),
                     _ => Err(errors::ConnectorError::InvalidDataFormat {
                         field_name: "address.state",
                     }

--- a/crates/router/src/connector/netcetera/netcetera_types.rs
+++ b/crates/router/src/connector/netcetera/netcetera_types.rs
@@ -1,15 +1,12 @@
 use std::collections::HashMap;
 
 use common_utils::pii::Email;
+use hyperswitch_connectors::utils::AddressDetailsData;
 use masking::ExposeInterface;
 use serde::{Deserialize, Serialize};
 use unidecode::unidecode;
 
-use crate::{
-    connector::utils::{AddressDetailsData, PhoneDetailsData},
-    errors,
-    types::api::MessageCategory,
-};
+use crate::{connector::utils::PhoneDetailsData, errors, types::api::MessageCategory};
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
 #[serde(untagged)]

--- a/crates/router/src/connector/threedsecureio/transformers.rs
+++ b/crates/router/src/connector/threedsecureio/transformers.rs
@@ -4,6 +4,7 @@ use api_models::payments::{DeviceChannel, ThreeDsCompletionIndicator};
 use base64::Engine;
 use common_utils::date_time;
 use error_stack::ResultExt;
+use hyperswitch_connectors::utils::AddressDetailsData;
 use iso_currency::Currency;
 use isocountry;
 use masking::{ExposeInterface, Secret};
@@ -11,7 +12,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{json, to_string};
 
 use crate::{
-    connector::utils::{get_card_details, to_connector_meta, AddressDetailsData, CardData},
+    connector::utils::{get_card_details, to_connector_meta, CardData},
     consts::{BASE64_ENGINE, NO_ERROR_MESSAGE},
     core::errors,
     types::{

--- a/crates/router/src/connector/utils.rs
+++ b/crates/router/src/connector/utils.rs
@@ -1857,8 +1857,6 @@ pub trait AddressDetailsData {
     fn get_zip(&self) -> Result<&Secret<String>, Error>;
     fn get_country(&self) -> Result<&api_models::enums::CountryAlpha2, Error>;
     fn get_combined_address_line(&self) -> Result<Secret<String>, Error>;
-    fn to_state_code(&self) -> Result<Secret<String>, Error>;
-    fn to_state_code_as_optional(&self) -> Result<Option<Secret<String>>, Error>;
     fn get_optional_line2(&self) -> Option<Secret<String>>;
     fn get_optional_country(&self) -> Option<api_models::enums::CountryAlpha2>;
 }
@@ -1930,31 +1928,6 @@ impl AddressDetailsData for hyperswitch_domain_models::address::AddressDetails {
             self.get_line1()?.peek(),
             self.get_line2()?.peek()
         )))
-    }
-    fn to_state_code(&self) -> Result<Secret<String>, Error> {
-        let country = self.get_country()?;
-        let state = self.get_state()?;
-        match country {
-            api_models::enums::CountryAlpha2::US => Ok(Secret::new(
-                UsStatesAbbreviation::foreign_try_from(state.peek().to_string())?.to_string(),
-            )),
-            api_models::enums::CountryAlpha2::CA => Ok(Secret::new(
-                CanadaStatesAbbreviation::foreign_try_from(state.peek().to_string())?.to_string(),
-            )),
-            _ => Ok(state.clone()),
-        }
-    }
-    fn to_state_code_as_optional(&self) -> Result<Option<Secret<String>>, Error> {
-        self.state
-            .as_ref()
-            .map(|state| {
-                if state.peek().len() == 2 {
-                    Ok(state.to_owned())
-                } else {
-                    self.to_state_code()
-                }
-            })
-            .transpose()
     }
 
     fn get_optional_line2(&self) -> Option<Secret<String>> {


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
to_state_code method of router is not updated so the implementation from hyperswitch_connectors needs to be used and the one from router is depreciated.

Note: Contains remaning European countries for ISO conversion

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Sanity External 3DS payment, by sending billing_address in payment_method_data for Poland country address
CURL
```
curl --location 'localhost:8080/payments/pay_MRVy1jlxGGGZafdE7xsJ/3ds/authentication' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: pk_dev_d3a60dc7950549aa954219ca29746442' \
--data '{
    "client_secret": "pay_MRVy1jlxGGGZafdE7xsJ_secret_at05FqOzGfMCtJ3bRw4Y",
    "device_channel": "BRW",
    "threeds_method_comp_ind": "Y"
}'
```

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
