### PR TITLE
chore(masking): add peek_mut to PeekInterface

### DIFF
--- a/crates/masking/src/abs.rs
+++ b/crates/masking/src/abs.rs
@@ -6,6 +6,9 @@ use crate::Secret;
 pub trait PeekInterface<S> {
     /// Only method providing access to the secret value.
     fn peek(&self) -> &S;
+
+    /// Provide a mutable reference to the inner value.
+    fn peek_mut(&mut self) -> &mut S;
 }
 
 /// Interface that consumes a option secret and returns the value.

--- a/crates/masking/src/bytes.rs
+++ b/crates/masking/src/bytes.rs
@@ -28,6 +28,10 @@ impl PeekInterface<BytesMut> for SecretBytesMut {
     fn peek(&self) -> &BytesMut {
         &self.0
     }
+
+    fn peek_mut(&mut self) -> &mut BytesMut {
+        &mut self.0
+    }
 }
 
 impl fmt::Debug for SecretBytesMut {

--- a/crates/masking/src/secret.rs
+++ b/crates/masking/src/secret.rs
@@ -95,6 +95,10 @@ where
     fn peek(&self) -> &SecretValue {
         &self.inner_secret
     }
+
+    fn peek_mut(&mut self) -> &mut SecretValue {
+        &mut self.inner_secret
+    }
 }
 
 impl<SecretValue, MaskingStrategy> From<SecretValue> for Secret<SecretValue, MaskingStrategy>

--- a/crates/masking/src/strong_secret.rs
+++ b/crates/masking/src/strong_secret.rs
@@ -32,6 +32,10 @@ impl<Secret: ZeroizableSecret, MaskingStrategy> PeekInterface<Secret>
     fn peek(&self) -> &Secret {
         &self.inner_secret
     }
+
+    fn peek_mut(&mut self) -> &mut Secret {
+        &mut self.inner_secret
+    }
 }
 
 impl<Secret: ZeroizableSecret, MaskingStrategy> From<Secret>


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->
- [x] Enhancement

## Description
<!-- Describe your changes in detail -->
Add `peek_mut` function to PeekInterface to get mutable reference for the inner data.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
To get the mutable reference for inner data in StrongSecret.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
** THIS CANNOT BE TESTED IN ENVIRONMENTS **

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code