### PR TITLE
feat(utils): add iso representation for each state for european countries

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -43,6 +43,22 @@ ws2tcpip = "ws2tcpip" # WinSock Extension
 ZAR = "ZAR"  # South African Rand currency code
 JOD = "JOD" # Jordan currency code
 Payed = "Payed" # Paid status for digital virgo
+Alo = "Alo" # Is iso representation of a state in France
+alo = "alo" # Is iso representation of a state in France
+BRE = "BRE" # Is iso representation of Brittany
+VasCounty = "VasCounty" # Is a state in Hungary
+StipMunicipality = "StipMunicipality" # Is a municipality in North Macedonia
+HAV = "HAV" # Is iso representation of a state in UK
+LEW = "LEW" # Is iso representation of a state in UK
+THR = "THR" # Is iso representation of a state in UK
+WLL = "WLL" # Is iso representation of a state in UK
+WIL = "WIL" # Is iso representation of a state in UK
+YOR = "YOR" # Is iso representation of a state in UK
+OT = "OT" # Is iso representation of a state in Romania
+OltCounty = "OltCounty" # Is a state in Romania
+olt = "olt" # Is iso representation of a state in Romania
+Vas = "Vas" # Is iso representation of a state in Hungary
+vas = "vas" # Is iso representation of a state in Hungary
 
 [default.extend-words]
 aci = "aci" # Name of a connector

--- a/crates/api_models/src/payments.rs
+++ b/crates/api_models/src/payments.rs
@@ -1583,7 +1583,7 @@ impl MandateIds {
 pub struct MandateData {
     /// A way to update the mandate's payment method details
     pub update_mandate_id: Option<String>,
-    /// A concent from the customer to store the payment method
+    /// A consent from the customer to store the payment method
     pub customer_acceptance: Option<CustomerAcceptance>,
     /// A way to select the type of mandate used
     pub mandate_type: Option<MandateType>,

--- a/crates/common_enums/src/enums.rs
+++ b/crates/common_enums/src/enums.rs
@@ -2421,6 +2421,2709 @@ pub enum CanadaStatesAbbreviation {
 }
 
 #[derive(
+    Debug, Clone, PartialEq, Eq, Serialize, Deserialize, strum::Display, strum::EnumString,
+)]
+pub enum AlbaniaStatesAbbreviation {
+    #[strum(serialize = "01")]
+    Berat,
+    #[strum(serialize = "09")]
+    Diber,
+    #[strum(serialize = "02")]
+    Durres,
+    #[strum(serialize = "03")]
+    Elbasan,
+    #[strum(serialize = "04")]
+    Fier,
+    #[strum(serialize = "05")]
+    Gjirokaster,
+    #[strum(serialize = "06")]
+    Korce,
+    #[strum(serialize = "07")]
+    Kukes,
+    #[strum(serialize = "08")]
+    Lezhe,
+    #[strum(serialize = "10")]
+    Shkoder,
+    #[strum(serialize = "11")]
+    Tirane,
+    #[strum(serialize = "12")]
+    Vlore,
+}
+
+#[derive(
+    Debug, Clone, PartialEq, Eq, Serialize, Deserialize, strum::Display, strum::EnumString,
+)]
+pub enum AndorraStatesAbbreviation {
+    #[strum(serialize = "07")]
+    AndorraLaVella,
+    #[strum(serialize = "02")]
+    Canillo,
+    #[strum(serialize = "03")]
+    Encamp,
+    #[strum(serialize = "08")]
+    EscaldesEngordany,
+    #[strum(serialize = "04")]
+    LaMassana,
+    #[strum(serialize = "05")]
+    Ordino,
+    #[strum(serialize = "06")]
+    SantJuliaDeLoria,
+}
+
+#[derive(
+    Debug, Clone, PartialEq, Eq, Serialize, Deserialize, strum::Display, strum::EnumString,
+)]
+pub enum AustriaStatesAbbreviation {
+    #[strum(serialize = "1")]
+    Burgenland,
+    #[strum(serialize = "2")]
+    Carinthia,
+    #[strum(serialize = "3")]
+    LowerAustria,
+    #[strum(serialize = "5")]
+    Salzburg,
+    #[strum(serialize = "6")]
+    Styria,
+    #[strum(serialize = "7")]
+    Tyrol,
+    #[strum(serialize = "4")]
+    UpperAustria,
+    #[strum(serialize = "9")]
+    Vienna,
+    #[strum(serialize = "8")]
+    Vorarlberg,
+}
+
+#[derive(
+    Debug, Clone, PartialEq, Eq, Serialize, Deserialize, strum::Display, strum::EnumString,
+)]
+pub enum BelarusStatesAbbreviation {
+    #[strum(serialize = "BR")]
+    BrestRegion,
+    #[strum(serialize = "HO")]
+    GomelRegion,
+    #[strum(serialize = "HR")]
+    GrodnoRegion,
+    #[strum(serialize = "HM")]
+    Minsk,
+    #[strum(serialize = "MI")]
+    MinskRegion,
+    #[strum(serialize = "MA")]
+    MogilevRegion,
+    #[strum(serialize = "VI")]
+    VitebskRegion,
+}
+
+#[derive(
+    Debug, Clone, PartialEq, Eq, Serialize, Deserialize, strum::Display, strum::EnumString,
+)]
+pub enum BosniaAndHerzegovinaStatesAbbreviation {
+    #[strum(serialize = "05")]
+    BosnianPodrinjeCanton,
+    #[strum(serialize = "BRC")]
+    BrckoDistrict,
+    #[strum(serialize = "10")]
+    Canton10,
+    #[strum(serialize = "06")]
+    CentralBosniaCanton,
+    #[strum(serialize = "BIH")]
+    FederationOfBosniaAndHerzegovina,
+    #[strum(serialize = "07")]
+    HerzegovinaNeretvaCanton,
+    #[strum(serialize = "02")]
+    PosavinaCanton,
+    #[strum(serialize = "SRP")]
+    RepublikaSrpska,
+    #[strum(serialize = "09")]
+    SarajevoCanton,
+    #[strum(serialize = "03")]
+    TuzlaCanton,
+    #[strum(serialize = "01")]
+    UnaSanaCanton,
+    #[strum(serialize = "08")]
+    WestHerzegovinaCanton,
+    #[strum(serialize = "04")]
+    ZenicaDobojCanton,
+}
+
+#[derive(
+    Debug, Clone, PartialEq, Eq, Serialize, Deserialize, strum::Display, strum::EnumString,
+)]
+pub enum BulgariaStatesAbbreviation {
+    #[strum(serialize = "01")]
+    BlagoevgradProvince,
+    #[strum(serialize = "02")]
+    BurgasProvince,
+    #[strum(serialize = "08")]
+    DobrichProvince,
+    #[strum(serialize = "07")]
+    GabrovoProvince,
+    #[strum(serialize = "26")]
+    HaskovoProvince,
+    #[strum(serialize = "09")]
+    KardzhaliProvince,
+    #[strum(serialize = "10")]
+    KyustendilProvince,
+    #[strum(serialize = "11")]
+    LovechProvince,
+    #[strum(serialize = "12")]
+    MontanaProvince,
+    #[strum(serialize = "13")]
+    PazardzhikProvince,
+    #[strum(serialize = "14")]
+    PernikProvince,
+    #[strum(serialize = "15")]
+    PlevenProvince,
+    #[strum(serialize = "16")]
+    PlovdivProvince,
+    #[strum(serialize = "17")]
+    RazgradProvince,
+    #[strum(serialize = "18")]
+    RuseProvince,
+    #[strum(serialize = "27")]
+    Shumen,
+    #[strum(serialize = "19")]
+    SilistraProvince,
+    #[strum(serialize = "20")]
+    SlivenProvince,
+    #[strum(serialize = "21")]
+    SmolyanProvince,
+    #[strum(serialize = "22")]
+    SofiaCityProvince,
+    #[strum(serialize = "23")]
+    SofiaProvince,
+    #[strum(serialize = "24")]
+    StaraZagoraProvince,
+    #[strum(serialize = "25")]
+    TargovishteProvince,
+    #[strum(serialize = "03")]
+    VarnaProvince,
+    #[strum(serialize = "04")]
+    VelikoTarnovoProvince,
+    #[strum(serialize = "05")]
+    VidinProvince,
+    #[strum(serialize = "06")]
+    VratsaProvince,
+    #[strum(serialize = "28")]
+    YambolProvince,
+}
+
+#[derive(
+    Debug, Clone, PartialEq, Eq, Serialize, Deserialize, strum::Display, strum::EnumString,
+)]
+pub enum CroatiaStatesAbbreviation {
+    #[strum(serialize = "07")]
+    BjelovarBilogoraCounty,
+    #[strum(serialize = "12")]
+    BrodPosavinaCounty,
+    #[strum(serialize = "19")]
+    DubrovnikNeretvaCounty,
+    #[strum(serialize = "18")]
+    IstriaCounty,
+    #[strum(serialize = "06")]
+    KoprivnicaKrizevciCounty,
+    #[strum(serialize = "02")]
+    KrapinaZagorjeCounty,
+    #[strum(serialize = "09")]
+    LikaSenjCounty,
+    #[strum(serialize = "20")]
+    MedimurjeCounty,
+    #[strum(serialize = "14")]
+    OsijekBaranjaCounty,
+    #[strum(serialize = "11")]
+    PozegaSlavoniaCounty,
+    #[strum(serialize = "08")]
+    PrimorjeGorskiKotarCounty,
+    #[strum(serialize = "03")]
+    SisakMoslavinaCounty,
+    #[strum(serialize = "17")]
+    SplitDalmatiaCounty,
+    #[strum(serialize = "05")]
+    VarazdinCounty,
+    #[strum(serialize = "10")]
+    ViroviticaPodravinaCounty,
+    #[strum(serialize = "16")]
+    VukovarSyrmiaCounty,
+    #[strum(serialize = "13")]
+    ZadarCounty,
+    #[strum(serialize = "21")]
+    Zagreb,
+    #[strum(serialize = "01")]
+    ZagrebCounty,
+    #[strum(serialize = "15")]
+    SibenikKninCounty,
+}
+
+#[derive(
+    Debug, Clone, PartialEq, Eq, Serialize, Deserialize, strum::Display, strum::EnumString,
+)]
+pub enum CzechRepublicStatesAbbreviation {
+    #[strum(serialize = "201")]
+    BenesovDistrict,
+    #[strum(serialize = "202")]
+    BerounDistrict,
+    #[strum(serialize = "641")]
+    BlanskoDistrict,
+    #[strum(serialize = "642")]
+    BrnoCityDistrict,
+    #[strum(serialize = "643")]
+    BrnoCountryDistrict,
+    #[strum(serialize = "801")]
+    BruntalDistrict,
+    #[strum(serialize = "644")]
+    BreclavDistrict,
+    #[strum(serialize = "20")]
+    CentralBohemianRegion,
+    #[strum(serialize = "411")]
+    ChebDistrict,
+    #[strum(serialize = "422")]
+    ChomutovDistrict,
+    #[strum(serialize = "531")]
+    ChrudimDistrict,
+    #[strum(serialize = "321")]
+    DomazliceDistrict,
+    #[strum(serialize = "421")]
+    DecinDistrict,
+    #[strum(serialize = "802")]
+    FrydekMistekDistrict,
+    #[strum(serialize = "631")]
+    HavlickuvBrodDistrict,
+    #[strum(serialize = "645")]
+    HodoninDistrict,
+    #[strum(serialize = "120")]
+    HorniPocernice,
+    #[strum(serialize = "521")]
+    HradecKraloveDistrict,
+    #[strum(serialize = "52")]
+    HradecKraloveRegion,
+    #[strum(serialize = "512")]
+    JablonecNadNisouDistrict,
+    #[strum(serialize = "711")]
+    JesenikDistrict,
+    #[strum(serialize = "632")]
+    JihlavaDistrict,
+    #[strum(serialize = "313")]
+    JindrichuvHradecDistrict,
+    #[strum(serialize = "522")]
+    JicinDistrict,
+    #[strum(serialize = "412")]
+    KarlovyVaryDistrict,
+    #[strum(serialize = "41")]
+    KarlovyVaryRegion,
+    #[strum(serialize = "803")]
+    KarvinaDistrict,
+    #[strum(serialize = "203")]
+    KladnoDistrict,
+    #[strum(serialize = "322")]
+    KlatovyDistrict,
+    #[strum(serialize = "204")]
+    KolinDistrict,
+    #[strum(serialize = "721")]
+    KromerizDistrict,
+    #[strum(serialize = "513")]
+    LiberecDistrict,
+    #[strum(serialize = "51")]
+    LiberecRegion,
+    #[strum(serialize = "423")]
+    LitomericeDistrict,
+    #[strum(serialize = "424")]
+    LounyDistrict,
+    #[strum(serialize = "207")]
+    MladaBoleslavDistrict,
+    #[strum(serialize = "80")]
+    MoravianSilesianRegion,
+    #[strum(serialize = "425")]
+    MostDistrict,
+    #[strum(serialize = "206")]
+    MelnikDistrict,
+    #[strum(serialize = "804")]
+    NovyJicinDistrict,
+    #[strum(serialize = "208")]
+    NymburkDistrict,
+    #[strum(serialize = "523")]
+    NachodDistrict,
+    #[strum(serialize = "712")]
+    OlomoucDistrict,
+    #[strum(serialize = "71")]
+    OlomoucRegion,
+    #[strum(serialize = "805")]
+    OpavaDistrict,
+    #[strum(serialize = "806")]
+    OstravaCityDistrict,
+    #[strum(serialize = "532")]
+    PardubiceDistrict,
+    #[strum(serialize = "53")]
+    PardubiceRegion,
+    #[strum(serialize = "633")]
+    PelhrimovDistrict,
+    #[strum(serialize = "32")]
+    PlzenRegion,
+    #[strum(serialize = "323")]
+    PlzenCityDistrict,
+    #[strum(serialize = "325")]
+    PlzenNorthDistrict,
+    #[strum(serialize = "324")]
+    PlzenSouthDistrict,
+    #[strum(serialize = "315")]
+    PrachaticeDistrict,
+    #[strum(serialize = "10")]
+    Prague,
+    #[strum(serialize = "101")]
+    Prague1,
+    #[strum(serialize = "110")]
+    Prague10,
+    #[strum(serialize = "111")]
+    Prague11,
+    #[strum(serialize = "112")]
+    Prague12,
+    #[strum(serialize = "113")]
+    Prague13,
+    #[strum(serialize = "114")]
+    Prague14,
+    #[strum(serialize = "115")]
+    Prague15,
+    #[strum(serialize = "116")]
+    Prague16,
+    #[strum(serialize = "102")]
+    Prague2,
+    #[strum(serialize = "121")]
+    Prague21,
+    #[strum(serialize = "103")]
+    Prague3,
+    #[strum(serialize = "104")]
+    Prague4,
+    #[strum(serialize = "105")]
+    Prague5,
+    #[strum(serialize = "106")]
+    Prague6,
+    #[strum(serialize = "107")]
+    Prague7,
+    #[strum(serialize = "108")]
+    Prague8,
+    #[strum(serialize = "109")]
+    Prague9,
+    #[strum(serialize = "209")]
+    PragueEastDistrict,
+    #[strum(serialize = "20A")]
+    PragueWestDistrict,
+    #[strum(serialize = "713")]
+    ProstejovDistrict,
+    #[strum(serialize = "314")]
+    PisekDistrict,
+    #[strum(serialize = "714")]
+    PrerovDistrict,
+    #[strum(serialize = "20B")]
+    PribramDistrict,
+    #[strum(serialize = "20C")]
+    RakovnikDistrict,
+    #[strum(serialize = "326")]
+    RokycanyDistrict,
+    #[strum(serialize = "524")]
+    RychnovNadKneznouDistrict,
+    #[strum(serialize = "514")]
+    SemilyDistrict,
+    #[strum(serialize = "413")]
+    SokolovDistrict,
+    #[strum(serialize = "31")]
+    SouthBohemianRegion,
+    #[strum(serialize = "64")]
+    SouthMoravianRegion,
+    #[strum(serialize = "316")]
+    StrakoniceDistrict,
+    #[strum(serialize = "533")]
+    SvitavyDistrict,
+    #[strum(serialize = "327")]
+    TachovDistrict,
+    #[strum(serialize = "426")]
+    TepliceDistrict,
+    #[strum(serialize = "525")]
+    TrutnovDistrict,
+    #[strum(serialize = "317")]
+    TaborDistrict,
+    #[strum(serialize = "634")]
+    TrebicDistrict,
+    #[strum(serialize = "722")]
+    UherskeHradisteDistrict,
+    #[strum(serialize = "723")]
+    VsetinDistrict,
+    #[strum(serialize = "63")]
+    VysocinaRegion,
+    #[strum(serialize = "646")]
+    VyskovDistrict,
+    #[strum(serialize = "724")]
+    ZlinDistrict,
+    #[strum(serialize = "72")]
+    ZlinRegion,
+    #[strum(serialize = "647")]
+    ZnojmoDistrict,
+    #[strum(serialize = "427")]
+    UstiNadLabemDistrict,
+    #[strum(serialize = "42")]
+    UstiNadLabemRegion,
+    #[strum(serialize = "534")]
+    UstiNadOrliciDistrict,
+    #[strum(serialize = "511")]
+    CeskaLipaDistrict,
+    #[strum(serialize = "311")]
+    CeskeBudejoviceDistrict,
+    #[strum(serialize = "312")]
+    CeskyKrumlovDistrict,
+    #[strum(serialize = "715")]
+    SumperkDistrict,
+    #[strum(serialize = "635")]
+    ZdarNadSazavouDistrict,
+}
+
+#[derive(
+    Debug, Clone, PartialEq, Eq, Serialize, Deserialize, strum::Display, strum::EnumString,
+)]
+pub enum DenmarkStatesAbbreviation {
+    #[strum(serialize = "84")]
+    CapitalRegionOfDenmark,
+    #[strum(serialize = "82")]
+    CentralDenmarkRegion,
+    #[strum(serialize = "81")]
+    NorthDenmarkRegion,
+    #[strum(serialize = "85")]
+    RegionZealand,
+    #[strum(serialize = "83")]
+    RegionOfSouthernDenmark,
+}
+
+#[derive(
+    Debug, Clone, PartialEq, Eq, Serialize, Deserialize, strum::Display, strum::EnumString,
+)]
+pub enum FinlandStatesAbbreviation {
+    #[strum(serialize = "08")]
+    CentralFinland,
+    #[strum(serialize = "07")]
+    CentralOstrobothnia,
+    #[strum(serialize = "IS")]
+    EasternFinlandProvince,
+    #[strum(serialize = "19")]
+    FinlandProper,
+    #[strum(serialize = "05")]
+    Kainuu,
+    #[strum(serialize = "09")]
+    Kymenlaakso,
+    #[strum(serialize = "LL")]
+    Lapland,
+    #[strum(serialize = "13")]
+    NorthKarelia,
+    #[strum(serialize = "14")]
+    NorthernOstrobothnia,
+    #[strum(serialize = "15")]
+    NorthernSavonia,
+    #[strum(serialize = "12")]
+    Ostrobothnia,
+    #[strum(serialize = "OL")]
+    OuluProvince,
+    #[strum(serialize = "11")]
+    Pirkanmaa,
+    #[strum(serialize = "16")]
+    PaijanneTavastia,
+    #[strum(serialize = "17")]
+    Satakunta,
+    #[strum(serialize = "02")]
+    SouthKarelia,
+    #[strum(serialize = "03")]
+    SouthernOstrobothnia,
+    #[strum(serialize = "04")]
+    SouthernSavonia,
+    #[strum(serialize = "06")]
+    TavastiaProper,
+    #[strum(serialize = "18")]
+    Uusimaa,
+    #[strum(serialize = "01")]
+    AlandIslands,
+}
+
+#[derive(
+    Debug, Clone, PartialEq, Eq, Serialize, Deserialize, strum::Display, strum::EnumString,
+)]
+pub enum FranceStatesAbbreviation {
+    #[strum(serialize = "WF-AL")]
+    Alo,
+    #[strum(serialize = "A")]
+    Alsace,
+    #[strum(serialize = "B")]
+    Aquitaine,
+    #[strum(serialize = "C")]
+    Auvergne,
+    #[strum(serialize = "ARA")]
+    AuvergneRhoneAlpes,
+    #[strum(serialize = "BFC")]
+    BourgogneFrancheComte,
+    #[strum(serialize = "BRE")]
+    Brittany,
+    #[strum(serialize = "D")]
+    Burgundy,
+    #[strum(serialize = "CVL")]
+    CentreValDeLoire,
+    #[strum(serialize = "G")]
+    ChampagneArdenne,
+    #[strum(serialize = "COR")]
+    Corsica,
+    #[strum(serialize = "I")]
+    FrancheComte,
+    #[strum(serialize = "GF")]
+    FrenchGuiana,
+    #[strum(serialize = "PF")]
+    FrenchPolynesia,
+    #[strum(serialize = "GES")]
+    GrandEst,
+    #[strum(serialize = "GP")]
+    Guadeloupe,
+    #[strum(serialize = "HDF")]
+    HautsDeFrance,
+    #[strum(serialize = "K")]
+    LanguedocRoussillon,
+    #[strum(serialize = "L")]
+    Limousin,
+    #[strum(serialize = "M")]
+    Lorraine,
+    #[strum(serialize = "P")]
+    LowerNormandy,
+    #[strum(serialize = "MQ")]
+    Martinique,
+    #[strum(serialize = "YT")]
+    Mayotte,
+    #[strum(serialize = "O")]
+    NordPasDeCalais,
+    #[strum(serialize = "NOR")]
+    Normandy,
+    #[strum(serialize = "NAQ")]
+    NouvelleAquitaine,
+    #[strum(serialize = "OCC")]
+    Occitania,
+    #[strum(serialize = "75")]
+    Paris,
+    #[strum(serialize = "PDL")]
+    PaysDeLaLoire,
+    #[strum(serialize = "S")]
+    Picardy,
+    #[strum(serialize = "T")]
+    PoitouCharentes,
+    #[strum(serialize = "PAC")]
+    ProvenceAlpesCoteDAzur,
+    #[strum(serialize = "V")]
+    RhoneAlpes,
+    #[strum(serialize = "RE")]
+    Reunion,
+    #[strum(serialize = "BL")]
+    SaintBarthelemy,
+    #[strum(serialize = "MF")]
+    SaintMartin,
+    #[strum(serialize = "PM")]
+    SaintPierreAndMiquelon,
+    #[strum(serialize = "WF-SG")]
+    Sigave,
+    #[strum(serialize = "Q")]
+    UpperNormandy,
+    #[strum(serialize = "WF-UV")]
+    Uvea,
+    #[strum(serialize = "WF")]
+    WallisAndFutuna,
+    #[strum(serialize = "IDF")]
+    IleDeFrance,
+}
+
+#[derive(
+    Debug, Clone, PartialEq, Eq, Serialize, Deserialize, strum::Display, strum::EnumString,
+)]
+pub enum GermanyStatesAbbreviation {
+    #[strum(serialize = "BW")]
+    BadenWurttemberg,
+    #[strum(serialize = "BY")]
+    Bavaria,
+    #[strum(serialize = "BE")]
+    Berlin,
+    #[strum(serialize = "BB")]
+    Brandenburg,
+    #[strum(serialize = "HB")]
+    Bremen,
+    #[strum(serialize = "HH")]
+    Hamburg,
+    #[strum(serialize = "HE")]
+    Hesse,
+    #[strum(serialize = "NI")]
+    LowerSaxony,
+    #[strum(serialize = "MV")]
+    MecklenburgVorpommern,
+    #[strum(serialize = "NW")]
+    NorthRhineWestphalia,
+    #[strum(serialize = "RP")]
+    RhinelandPalatinate,
+    #[strum(serialize = "SL")]
+    Saarland,
+    #[strum(serialize = "SN")]
+    Saxony,
+    #[strum(serialize = "ST")]
+    SaxonyAnhalt,
+    #[strum(serialize = "SH")]
+    SchleswigHolstein,
+    #[strum(serialize = "TH")]
+    Thuringia,
+}
+
+#[derive(
+    Debug, Clone, PartialEq, Eq, Serialize, Deserialize, strum::Display, strum::EnumString,
+)]
+pub enum GreeceStatesAbbreviation {
+    #[strum(serialize = "13")]
+    AchaeaRegionalUnit,
+    #[strum(serialize = "01")]
+    AetoliaAcarnaniaRegionalUnit,
+    #[strum(serialize = "12")]
+    ArcadiaPrefecture,
+    #[strum(serialize = "11")]
+    ArgolisRegionalUnit,
+    #[strum(serialize = "I")]
+    AtticaRegion,
+    #[strum(serialize = "03")]
+    BoeotiaRegionalUnit,
+    #[strum(serialize = "H")]
+    CentralGreeceRegion,
+    #[strum(serialize = "B")]
+    CentralMacedonia,
+    #[strum(serialize = "94")]
+    ChaniaRegionalUnit,
+    #[strum(serialize = "22")]
+    CorfuPrefecture,
+    #[strum(serialize = "15")]
+    CorinthiaRegionalUnit,
+    #[strum(serialize = "M")]
+    CreteRegion,
+    #[strum(serialize = "52")]
+    DramaRegionalUnit,
+    #[strum(serialize = "A2")]
+    EastAtticaRegionalUnit,
+    #[strum(serialize = "A")]
+    EastMacedoniaAndThrace,
+    #[strum(serialize = "D")]
+    EpirusRegion,
+    #[strum(serialize = "04")]
+    Euboea,
+    #[strum(serialize = "51")]
+    GrevenaPrefecture,
+    #[strum(serialize = "53")]
+    ImathiaRegionalUnit,
+    #[strum(serialize = "33")]
+    IoanninaRegionalUnit,
+    #[strum(serialize = "F")]
+    IonianIslandsRegion,
+    #[strum(serialize = "41")]
+    KarditsaRegionalUnit,
+    #[strum(serialize = "56")]
+    KastoriaRegionalUnit,
+    #[strum(serialize = "23")]
+    KefaloniaPrefecture,
+    #[strum(serialize = "57")]
+    KilkisRegionalUnit,
+    #[strum(serialize = "58")]
+    KozaniPrefecture,
+    #[strum(serialize = "16")]
+    Laconia,
+    #[strum(serialize = "42")]
+    LarissaPrefecture,
+    #[strum(serialize = "24")]
+    LefkadaRegionalUnit,
+    #[strum(serialize = "59")]
+    PellaRegionalUnit,
+    #[strum(serialize = "J")]
+    PeloponneseRegion,
+    #[strum(serialize = "06")]
+    PhthiotisPrefecture,
+    #[strum(serialize = "34")]
+    PrevezaPrefecture,
+    #[strum(serialize = "62")]
+    SerresPrefecture,
+    #[strum(serialize = "L")]
+    SouthAegean,
+    #[strum(serialize = "54")]
+    ThessalonikiRegionalUnit,
+    #[strum(serialize = "G")]
+    WestGreeceRegion,
+    #[strum(serialize = "C")]
+    WestMacedoniaRegion,
+}
+
+#[derive(
+    Debug, Clone, PartialEq, Eq, Serialize, Deserialize, strum::Display, strum::EnumString,
+)]
+pub enum HungaryStatesAbbreviation {
+    #[strum(serialize = "BA")]
+    BaranyaCounty,
+    #[strum(serialize = "BZ")]
+    BorsodAbaujZemplenCounty,
+    #[strum(serialize = "BU")]
+    Budapest,
+    #[strum(serialize = "BK")]
+    BacsKiskunCounty,
+    #[strum(serialize = "BE")]
+    BekesCounty,
+    #[strum(serialize = "BC")]
+    Bekescsaba,
+    #[strum(serialize = "CS")]
+    CsongradCounty,
+    #[strum(serialize = "DE")]
+    Debrecen,
+    #[strum(serialize = "DU")]
+    Dunaujvaros,
+    #[strum(serialize = "EG")]
+    Eger,
+    #[strum(serialize = "FE")]
+    FejerCounty,
+    #[strum(serialize = "GY")]
+    Gyor,
+    #[strum(serialize = "GS")]
+    GyorMosonSopronCounty,
+    #[strum(serialize = "HB")]
+    HajduBiharCounty,
+    #[strum(serialize = "HE")]
+    HevesCounty,
+    #[strum(serialize = "HV")]
+    Hodmezovasarhely,
+    #[strum(serialize = "JN")]
+    JaszNagykunSzolnokCounty,
+    #[strum(serialize = "KV")]
+    Kaposvar,
+    #[strum(serialize = "KM")]
+    Kecskemet,
+    #[strum(serialize = "MI")]
+    Miskolc,
+    #[strum(serialize = "NK")]
+    Nagykanizsa,
+    #[strum(serialize = "NY")]
+    Nyiregyhaza,
+    #[strum(serialize = "NO")]
+    NogradCounty,
+    #[strum(serialize = "PE")]
+    PestCounty,
+    #[strum(serialize = "PS")]
+    Pecs,
+    #[strum(serialize = "ST")]
+    Salgotarjan,
+    #[strum(serialize = "SO")]
+    SomogyCounty,
+    #[strum(serialize = "SN")]
+    Sopron,
+    #[strum(serialize = "SZ")]
+    SzabolcsSzatmarBeregCounty,
+    #[strum(serialize = "SD")]
+    Szeged,
+    #[strum(serialize = "SS")]
+    Szekszard,
+    #[strum(serialize = "SK")]
+    Szolnok,
+    #[strum(serialize = "SH")]
+    Szombathely,
+    #[strum(serialize = "SF")]
+    Szekesfehervar,
+    #[strum(serialize = "TB")]
+    Tatabanya,
+    #[strum(serialize = "TO")]
+    TolnaCounty,
+    #[strum(serialize = "VA")]
+    VasCounty,
+    #[strum(serialize = "VM")]
+    Veszprem,
+    #[strum(serialize = "VE")]
+    VeszpremCounty,
+    #[strum(serialize = "ZA")]
+    ZalaCounty,
+    #[strum(serialize = "ZE")]
+    Zalaegerszeg,
+    #[strum(serialize = "ER")]
+    Erd,
+}
+
+#[derive(
+    Debug, Clone, PartialEq, Eq, Serialize, Deserialize, strum::Display, strum::EnumString,
+)]
+pub enum IcelandStatesAbbreviation {
+    #[strum(serialize = "1")]
+    CapitalRegion,
+    #[strum(serialize = "7")]
+    EasternRegion,
+    #[strum(serialize = "6")]
+    NortheasternRegion,
+    #[strum(serialize = "5")]
+    NorthwesternRegion,
+    #[strum(serialize = "2")]
+    SouthernPeninsulaRegion,
+    #[strum(serialize = "8")]
+    SouthernRegion,
+    #[strum(serialize = "3")]
+    WesternRegion,
+    #[strum(serialize = "4")]
+    Westfjords,
+}
+
+#[derive(
+    Debug, Clone, PartialEq, Eq, Serialize, Deserialize, strum::Display, strum::EnumString,
+)]
+pub enum IrelandStatesAbbreviation {
+    #[strum(serialize = "C")]
+    Connacht,
+    #[strum(serialize = "CW")]
+    CountyCarlow,
+    #[strum(serialize = "CN")]
+    CountyCavan,
+    #[strum(serialize = "CE")]
+    CountyClare,
+    #[strum(serialize = "CO")]
+    CountyCork,
+    #[strum(serialize = "DL")]
+    CountyDonegal,
+    #[strum(serialize = "D")]
+    CountyDublin,
+    #[strum(serialize = "G")]
+    CountyGalway,
+    #[strum(serialize = "KY")]
+    CountyKerry,
+    #[strum(serialize = "KE")]
+    CountyKildare,
+    #[strum(serialize = "KK")]
+    CountyKilkenny,
+    #[strum(serialize = "LS")]
+    CountyLaois,
+    #[strum(serialize = "LK")]
+    CountyLimerick,
+    #[strum(serialize = "LD")]
+    CountyLongford,
+    #[strum(serialize = "LH")]
+    CountyLouth,
+    #[strum(serialize = "MO")]
+    CountyMayo,
+    #[strum(serialize = "MH")]
+    CountyMeath,
+    #[strum(serialize = "MN")]
+    CountyMonaghan,
+    #[strum(serialize = "OY")]
+    CountyOffaly,
+    #[strum(serialize = "RN")]
+    CountyRoscommon,
+    #[strum(serialize = "SO")]
+    CountySligo,
+    #[strum(serialize = "TA")]
+    CountyTipperary,
+    #[strum(serialize = "WD")]
+    CountyWaterford,
+    #[strum(serialize = "WH")]
+    CountyWestmeath,
+    #[strum(serialize = "WX")]
+    CountyWexford,
+    #[strum(serialize = "WW")]
+    CountyWicklow,
+    #[strum(serialize = "L")]
+    Leinster,
+    #[strum(serialize = "M")]
+    Munster,
+    #[strum(serialize = "U")]
+    Ulster,
+}
+
+#[derive(
+    Debug, Clone, PartialEq, Eq, Serialize, Deserialize, strum::Display, strum::EnumString,
+)]
+pub enum LatviaStatesAbbreviation {
+    #[strum(serialize = "001")]
+    AglonaMunicipality,
+    #[strum(serialize = "002")]
+    AizkraukleMunicipality,
+    #[strum(serialize = "003")]
+    AizputeMunicipality,
+    #[strum(serialize = "004")]
+    AknīsteMunicipality,
+    #[strum(serialize = "005")]
+    AlojaMunicipality,
+    #[strum(serialize = "006")]
+    AlsungaMunicipality,
+    #[strum(serialize = "007")]
+    AlūksneMunicipality,
+    #[strum(serialize = "008")]
+    AmataMunicipality,
+    #[strum(serialize = "009")]
+    ApeMunicipality,
+    #[strum(serialize = "010")]
+    AuceMunicipality,
+    #[strum(serialize = "012")]
+    BabīteMunicipality,
+    #[strum(serialize = "013")]
+    BaldoneMunicipality,
+    #[strum(serialize = "014")]
+    BaltinavaMunicipality,
+    #[strum(serialize = "015")]
+    BalviMunicipality,
+    #[strum(serialize = "016")]
+    BauskaMunicipality,
+    #[strum(serialize = "017")]
+    BeverīnaMunicipality,
+    #[strum(serialize = "018")]
+    BrocēniMunicipality,
+    #[strum(serialize = "019")]
+    BurtniekiMunicipality,
+    #[strum(serialize = "020")]
+    CarnikavaMunicipality,
+    #[strum(serialize = "021")]
+    CesvaineMunicipality,
+    #[strum(serialize = "023")]
+    CiblaMunicipality,
+    #[strum(serialize = "022")]
+    CēsisMunicipality,
+    #[strum(serialize = "024")]
+    DagdaMunicipality,
+    #[strum(serialize = "DGV")]
+    Daugavpils,
+    #[strum(serialize = "025")]
+    DaugavpilsMunicipality,
+    #[strum(serialize = "026")]
+    DobeleMunicipality,
+    #[strum(serialize = "027")]
+    DundagaMunicipality,
+    #[strum(serialize = "028")]
+    DurbeMunicipality,
+    #[strum(serialize = "029")]
+    EngureMunicipality,
+    #[strum(serialize = "031")]
+    GarkalneMunicipality,
+    #[strum(serialize = "032")]
+    GrobiņaMunicipality,
+    #[strum(serialize = "033")]
+    GulbeneMunicipality,
+    #[strum(serialize = "034")]
+    IecavaMunicipality,
+    #[strum(serialize = "035")]
+    IkšķileMunicipality,
+    #[strum(serialize = "036")]
+    IlūksteMunicipality,
+    #[strum(serialize = "037")]
+    InčukalnsMunicipality,
+    #[strum(serialize = "038")]
+    JaunjelgavaMunicipality,
+    #[strum(serialize = "039")]
+    JaunpiebalgaMunicipality,
+    #[strum(serialize = "040")]
+    JaunpilsMunicipality,
+    #[strum(serialize = "JEL")]
+    Jelgava,
+    #[strum(serialize = "041")]
+    JelgavaMunicipality,
+    #[strum(serialize = "JKB")]
+    Jēkabpils,
+    #[strum(serialize = "042")]
+    JēkabpilsMunicipality,
+    #[strum(serialize = "JUR")]
+    Jūrmala,
+    #[strum(serialize = "043")]
+    KandavaMunicipality,
+    #[strum(serialize = "045")]
+    KocēniMunicipality,
+    #[strum(serialize = "046")]
+    KokneseMunicipality,
+    #[strum(serialize = "048")]
+    KrimuldaMunicipality,
+    #[strum(serialize = "049")]
+    KrustpilsMunicipality,
+    #[strum(serialize = "047")]
+    KrāslavaMunicipality,
+    #[strum(serialize = "050")]
+    KuldīgaMunicipality,
+    #[strum(serialize = "044")]
+    KārsavaMunicipality,
+    #[strum(serialize = "053")]
+    LielvārdeMunicipality,
+    #[strum(serialize = "LPX")]
+    Liepāja,
+    #[strum(serialize = "054")]
+    LimbažiMunicipality,
+    #[strum(serialize = "057")]
+    LubānaMunicipality,
+    #[strum(serialize = "058")]
+    LudzaMunicipality,
+    #[strum(serialize = "055")]
+    LīgatneMunicipality,
+    #[strum(serialize = "056")]
+    LīvāniMunicipality,
+    #[strum(serialize = "059")]
+    MadonaMunicipality,
+    #[strum(serialize = "060")]
+    MazsalacaMunicipality,
+    #[strum(serialize = "061")]
+    MālpilsMunicipality,
+    #[strum(serialize = "062")]
+    MārupeMunicipality,
+    #[strum(serialize = "063")]
+    MērsragsMunicipality,
+    #[strum(serialize = "064")]
+    NaukšēniMunicipality,
+    #[strum(serialize = "065")]
+    NeretaMunicipality,
+    #[strum(serialize = "066")]
+    NīcaMunicipality,
+    #[strum(serialize = "067")]
+    OgreMunicipality,
+    #[strum(serialize = "068")]
+    OlaineMunicipality,
+    #[strum(serialize = "069")]
+    OzolniekiMunicipality,
+    #[strum(serialize = "073")]
+    PreiļiMunicipality,
+    #[strum(serialize = "074")]
+    PriekuleMunicipality,
+    #[strum(serialize = "075")]
+    PriekuļiMunicipality,
+    #[strum(serialize = "070")]
+    PārgaujaMunicipality,
+    #[strum(serialize = "071")]
+    PāvilostaMunicipality,
+    #[strum(serialize = "072")]
+    PļaviņasMunicipality,
+    #[strum(serialize = "076")]
+    RaunaMunicipality,
+    #[strum(serialize = "078")]
+    RiebiņiMunicipality,
+    #[strum(serialize = "RIX")]
+    Riga,
+    #[strum(serialize = "079")]
+    RojaMunicipality,
+    #[strum(serialize = "080")]
+    RopažiMunicipality,
+    #[strum(serialize = "081")]
+    RucavaMunicipality,
+    #[strum(serialize = "082")]
+    RugājiMunicipality,
+    #[strum(serialize = "083")]
+    RundāleMunicipality,
+    #[strum(serialize = "REZ")]
+    Rēzekne,
+    #[strum(serialize = "077")]
+    RēzekneMunicipality,
+    #[strum(serialize = "084")]
+    RūjienaMunicipality,
+    #[strum(serialize = "085")]
+    SalaMunicipality,
+    #[strum(serialize = "086")]
+    SalacgrīvaMunicipality,
+    #[strum(serialize = "087")]
+    SalaspilsMunicipality,
+    #[strum(serialize = "088")]
+    SaldusMunicipality,
+    #[strum(serialize = "089")]
+    SaulkrastiMunicipality,
+    #[strum(serialize = "091")]
+    SiguldaMunicipality,
+    #[strum(serialize = "093")]
+    SkrundaMunicipality,
+    #[strum(serialize = "092")]
+    SkrīveriMunicipality,
+    #[strum(serialize = "094")]
+    SmilteneMunicipality,
+    #[strum(serialize = "095")]
+    StopiņiMunicipality,
+    #[strum(serialize = "096")]
+    StrenčiMunicipality,
+    #[strum(serialize = "090")]
+    SējaMunicipality,
+}
+
+#[derive(
+    Debug, Clone, PartialEq, Eq, Serialize, Deserialize, strum::Display, strum::EnumString,
+)]
+pub enum ItalyStatesAbbreviation {
+    #[strum(serialize = "65")]
+    Abruzzo,
+    #[strum(serialize = "23")]
+    AostaValley,
+    #[strum(serialize = "75")]
+    Apulia,
+    #[strum(serialize = "77")]
+    Basilicata,
+    #[strum(serialize = "BN")]
+    BeneventoProvince,
+    #[strum(serialize = "78")]
+    Calabria,
+    #[strum(serialize = "72")]
+    Campania,
+    #[strum(serialize = "45")]
+    EmiliaRomagna,
+    #[strum(serialize = "36")]
+    FriuliVeneziaGiulia,
+    #[strum(serialize = "62")]
+    Lazio,
+    #[strum(serialize = "42")]
+    Liguria,
+    #[strum(serialize = "25")]
+    Lombardy,
+    #[strum(serialize = "57")]
+    Marche,
+    #[strum(serialize = "67")]
+    Molise,
+    #[strum(serialize = "21")]
+    Piedmont,
+    #[strum(serialize = "88")]
+    Sardinia,
+    #[strum(serialize = "82")]
+    Sicily,
+    #[strum(serialize = "32")]
+    TrentinoSouthTyrol,
+    #[strum(serialize = "52")]
+    Tuscany,
+    #[strum(serialize = "55")]
+    Umbria,
+    #[strum(serialize = "34")]
+    Veneto,
+    #[strum(serialize = "AG")]
+    Agrigento,
+    #[strum(serialize = "CL")]
+    Caltanissetta,
+    #[strum(serialize = "EN")]
+    Enna,
+    #[strum(serialize = "RG")]
+    Ragusa,
+    #[strum(serialize = "SR")]
+    Siracusa,
+    #[strum(serialize = "TP")]
+    Trapani,
+    #[strum(serialize = "BA")]
+    Bari,
+    #[strum(serialize = "BO")]
+    Bologna,
+    #[strum(serialize = "CA")]
+    Cagliari,
+    #[strum(serialize = "CT")]
+    Catania,
+    #[strum(serialize = "FI")]
+    Florence,
+    #[strum(serialize = "GE")]
+    Genoa,
+    #[strum(serialize = "ME")]
+    Messina,
+    #[strum(serialize = "MI")]
+    Milan,
+    #[strum(serialize = "NA")]
+    Naples,
+    #[strum(serialize = "PA")]
+    Palermo,
+    #[strum(serialize = "RC")]
+    ReggioCalabria,
+    #[strum(serialize = "RM")]
+    Rome,
+    #[strum(serialize = "TO")]
+    Turin,
+    #[strum(serialize = "VE")]
+    Venice,
+}
+
+#[derive(
+    Debug, Clone, PartialEq, Eq, Serialize, Deserialize, strum::Display, strum::EnumString,
+)]
+pub enum LiechtensteinStatesAbbreviation {
+    #[strum(serialize = "01")]
+    Balzers,
+    #[strum(serialize = "02")]
+    Eschen,
+    #[strum(serialize = "03")]
+    Gamprin,
+    #[strum(serialize = "04")]
+    Mauren,
+    #[strum(serialize = "05")]
+    Planken,
+    #[strum(serialize = "06")]
+    Ruggell,
+    #[strum(serialize = "07")]
+    Schaan,
+    #[strum(serialize = "08")]
+    Schellenberg,
+    #[strum(serialize = "09")]
+    Triesen,
+    #[strum(serialize = "10")]
+    Triesenberg,
+    #[strum(serialize = "11")]
+    Vaduz,
+}
+
+#[derive(
+    Debug, Clone, PartialEq, Eq, Serialize, Deserialize, strum::Display, strum::EnumString,
+)]
+pub enum LithuaniaStatesAbbreviation {
+    #[strum(serialize = "01")]
+    AkmeneDistrictMunicipality,
+    #[strum(serialize = "02")]
+    AlytusCityMunicipality,
+    #[strum(serialize = "AL")]
+    AlytusCounty,
+    #[strum(serialize = "03")]
+    AlytusDistrictMunicipality,
+    #[strum(serialize = "05")]
+    BirstonasMunicipality,
+    #[strum(serialize = "06")]
+    BirzaiDistrictMunicipality,
+    #[strum(serialize = "07")]
+    DruskininkaiMunicipality,
+    #[strum(serialize = "08")]
+    ElektrenaiMunicipality,
+    #[strum(serialize = "09")]
+    IgnalinaDistrictMunicipality,
+    #[strum(serialize = "10")]
+    JonavaDistrictMunicipality,
+    #[strum(serialize = "11")]
+    JoniskisDistrictMunicipality,
+    #[strum(serialize = "12")]
+    JurbarkasDistrictMunicipality,
+    #[strum(serialize = "13")]
+    KaisiadorysDistrictMunicipality,
+    #[strum(serialize = "14")]
+    KalvarijaMunicipality,
+    #[strum(serialize = "15")]
+    KaunasCityMunicipality,
+    #[strum(serialize = "KU")]
+    KaunasCounty,
+    #[strum(serialize = "16")]
+    KaunasDistrictMunicipality,
+    #[strum(serialize = "17")]
+    KazluRudaMunicipality,
+    #[strum(serialize = "19")]
+    KelmeDistrictMunicipality,
+    #[strum(serialize = "20")]
+    KlaipedaCityMunicipality,
+    #[strum(serialize = "KL")]
+    KlaipedaCounty,
+    #[strum(serialize = "21")]
+    KlaipedaDistrictMunicipality,
+    #[strum(serialize = "22")]
+    KretingaDistrictMunicipality,
+    #[strum(serialize = "23")]
+    KupiskisDistrictMunicipality,
+    #[strum(serialize = "18")]
+    KedainiaiDistrictMunicipality,
+    #[strum(serialize = "24")]
+    LazdijaiDistrictMunicipality,
+    #[strum(serialize = "MR")]
+    MarijampoleCounty,
+    #[strum(serialize = "25")]
+    MarijampoleMunicipality,
+    #[strum(serialize = "26")]
+    MazeikiaiDistrictMunicipality,
+    #[strum(serialize = "27")]
+    MoletaiDistrictMunicipality,
+    #[strum(serialize = "28")]
+    NeringaMunicipality,
+    #[strum(serialize = "29")]
+    PagegiaiMunicipality,
+    #[strum(serialize = "30")]
+    PakruojisDistrictMunicipality,
+    #[strum(serialize = "31")]
+    PalangaCityMunicipality,
+    #[strum(serialize = "32")]
+    PanevezysCityMunicipality,
+    #[strum(serialize = "PN")]
+    PanevezysCounty,
+    #[strum(serialize = "33")]
+    PanevezysDistrictMunicipality,
+    #[strum(serialize = "34")]
+    PasvalysDistrictMunicipality,
+    #[strum(serialize = "35")]
+    PlungeDistrictMunicipality,
+    #[strum(serialize = "36")]
+    PrienaiDistrictMunicipality,
+    #[strum(serialize = "37")]
+    RadviliskisDistrictMunicipality,
+    #[strum(serialize = "38")]
+    RaseiniaiDistrictMunicipality,
+    #[strum(serialize = "39")]
+    RietavasMunicipality,
+    #[strum(serialize = "40")]
+    RokiskisDistrictMunicipality,
+    #[strum(serialize = "48")]
+    SkuodasDistrictMunicipality,
+    #[strum(serialize = "TA")]
+    TaurageCounty,
+    #[strum(serialize = "50")]
+    TaurageDistrictMunicipality,
+    #[strum(serialize = "TE")]
+    TelsiaiCounty,
+    #[strum(serialize = "51")]
+    TelsiaiDistrictMunicipality,
+    #[strum(serialize = "52")]
+    TrakaiDistrictMunicipality,
+    #[strum(serialize = "53")]
+    UkmergeDistrictMunicipality,
+    #[strum(serialize = "UT")]
+    UtenaCounty,
+    #[strum(serialize = "54")]
+    UtenaDistrictMunicipality,
+    #[strum(serialize = "55")]
+    VarenaDistrictMunicipality,
+    #[strum(serialize = "56")]
+    VilkaviskisDistrictMunicipality,
+    #[strum(serialize = "57")]
+    VilniusCityMunicipality,
+    #[strum(serialize = "VL")]
+    VilniusCounty,
+    #[strum(serialize = "58")]
+    VilniusDistrictMunicipality,
+    #[strum(serialize = "59")]
+    VisaginasMunicipality,
+    #[strum(serialize = "60")]
+    ZarasaiDistrictMunicipality,
+    #[strum(serialize = "41")]
+    SakiaiDistrictMunicipality,
+    #[strum(serialize = "42")]
+    SalcininkaiDistrictMunicipality,
+    #[strum(serialize = "43")]
+    SiauliaiCityMunicipality,
+    #[strum(serialize = "SA")]
+    SiauliaiCounty,
+    #[strum(serialize = "44")]
+    SiauliaiDistrictMunicipality,
+    #[strum(serialize = "45")]
+    SilaleDistrictMunicipality,
+    #[strum(serialize = "46")]
+    SiluteDistrictMunicipality,
+    #[strum(serialize = "47")]
+    SirvintosDistrictMunicipality,
+    #[strum(serialize = "49")]
+    SvencionysDistrictMunicipality,
+}
+
+#[derive(
+    Debug, Clone, PartialEq, Eq, Serialize, Deserialize, strum::Display, strum::EnumString,
+)]
+pub enum MaltaStatesAbbreviation {
+    #[strum(serialize = "01")]
+    Attard,
+    #[strum(serialize = "02")]
+    Balzan,
+    #[strum(serialize = "03")]
+    Birgu,
+    #[strum(serialize = "04")]
+    Birkirkara,
+    #[strum(serialize = "05")]
+    Birzebbuga,
+    #[strum(serialize = "06")]
+    Cospicua,
+    #[strum(serialize = "07")]
+    Dingli,
+    #[strum(serialize = "08")]
+    Fgura,
+    #[strum(serialize = "09")]
+    Floriana,
+    #[strum(serialize = "10")]
+    Fontana,
+    #[strum(serialize = "11")]
+    Gudja,
+    #[strum(serialize = "12")]
+    Gzira,
+    #[strum(serialize = "13")]
+    Ghajnsielem,
+    #[strum(serialize = "14")]
+    Gharb,
+    #[strum(serialize = "15")]
+    Gharghur,
+    #[strum(serialize = "16")]
+    Ghasri,
+    #[strum(serialize = "17")]
+    Ghaxaq,
+    #[strum(serialize = "18")]
+    Hamrun,
+    #[strum(serialize = "19")]
+    Iklin,
+    #[strum(serialize = "20")]
+    Senglea,
+    #[strum(serialize = "21")]
+    Kalkara,
+    #[strum(serialize = "22")]
+    Kercem,
+    #[strum(serialize = "23")]
+    Kirkop,
+    #[strum(serialize = "24")]
+    Lija,
+    #[strum(serialize = "25")]
+    Luqa,
+    #[strum(serialize = "26")]
+    Marsa,
+    #[strum(serialize = "27")]
+    Marsaskala,
+    #[strum(serialize = "28")]
+    Marsaxlokk,
+    #[strum(serialize = "29")]
+    Mdina,
+    #[strum(serialize = "30")]
+    Mellieha,
+    #[strum(serialize = "31")]
+    Mgarr,
+    #[strum(serialize = "32")]
+    Mosta,
+    #[strum(serialize = "33")]
+    Mqabba,
+    #[strum(serialize = "34")]
+    Msida,
+    #[strum(serialize = "35")]
+    Mtarfa,
+    #[strum(serialize = "36")]
+    Munxar,
+    #[strum(serialize = "37")]
+    Nadur,
+    #[strum(serialize = "38")]
+    Naxxar,
+    #[strum(serialize = "39")]
+    Paola,
+    #[strum(serialize = "40")]
+    Pembroke,
+    #[strum(serialize = "41")]
+    Pieta,
+    #[strum(serialize = "42")]
+    Qala,
+    #[strum(serialize = "43")]
+    Qormi,
+    #[strum(serialize = "44")]
+    Qrendi,
+    #[strum(serialize = "45")]
+    Victoria,
+    #[strum(serialize = "46")]
+    Rabat,
+    #[strum(serialize = "48")]
+    StJulians,
+    #[strum(serialize = "49")]
+    SanGwann,
+    #[strum(serialize = "50")]
+    SaintLawrence,
+    #[strum(serialize = "51")]
+    StPaulsBay,
+    #[strum(serialize = "52")]
+    Sannat,
+    #[strum(serialize = "53")]
+    SantaLucija,
+    #[strum(serialize = "54")]
+    SantaVenera,
+    #[strum(serialize = "55")]
+    Siggiewi,
+    #[strum(serialize = "56")]
+    Sliema,
+    #[strum(serialize = "57")]
+    Swieqi,
+    #[strum(serialize = "58")]
+    TaXbiex,
+    #[strum(serialize = "59")]
+    Tarxien,
+    #[strum(serialize = "60")]
+    Valletta,
+    #[strum(serialize = "61")]
+    Xaghra,
+    #[strum(serialize = "62")]
+    Xewkija,
+    #[strum(serialize = "63")]
+    Xghajra,
+    #[strum(serialize = "64")]
+    Zabbar,
+    #[strum(serialize = "65")]
+    ZebbugGozo,
+    #[strum(serialize = "66")]
+    ZebbugMalta,
+    #[strum(serialize = "67")]
+    Zejtun,
+    #[strum(serialize = "68")]
+    Zurrieq,
+}
+
+#[derive(
+    Debug, Clone, PartialEq, Eq, Serialize, Deserialize, strum::Display, strum::EnumString,
+)]
+pub enum MoldovaStatesAbbreviation {
+    #[strum(serialize = "AN")]
+    AneniiNoiDistrict,
+    #[strum(serialize = "BS")]
+    BasarabeascaDistrict,
+    #[strum(serialize = "BD")]
+    BenderMunicipality,
+    #[strum(serialize = "BR")]
+    BriceniDistrict,
+    #[strum(serialize = "BA")]
+    BaltiMunicipality,
+    #[strum(serialize = "CA")]
+    CahulDistrict,
+    #[strum(serialize = "CT")]
+    CantemirDistrict,
+    #[strum(serialize = "CU")]
+    ChisinauMunicipality,
+    #[strum(serialize = "CM")]
+    CimisliaDistrict,
+    #[strum(serialize = "CR")]
+    CriuleniDistrict,
+    #[strum(serialize = "CL")]
+    CalarasiDistrict,
+    #[strum(serialize = "CS")]
+    CauseniDistrict,
+    #[strum(serialize = "DO")]
+    DonduseniDistrict,
+    #[strum(serialize = "DR")]
+    DrochiaDistrict,
+    #[strum(serialize = "DU")]
+    DubasariDistrict,
+    #[strum(serialize = "ED")]
+    EdinetDistrict,
+    #[strum(serialize = "FL")]
+    FlorestiDistrict,
+    #[strum(serialize = "FA")]
+    FalestiDistrict,
+    #[strum(serialize = "GA")]
+    Gagauzia,
+    #[strum(serialize = "GL")]
+    GlodeniDistrict,
+    #[strum(serialize = "HI")]
+    HincestiDistrict,
+    #[strum(serialize = "IA")]
+    IaloveniDistrict,
+    #[strum(serialize = "NI")]
+    NisporeniDistrict,
+    #[strum(serialize = "OC")]
+    OcnitaDistrict,
+    #[strum(serialize = "OR")]
+    OrheiDistrict,
+    #[strum(serialize = "RE")]
+    RezinaDistrict,
+    #[strum(serialize = "RI")]
+    RiscaniDistrict,
+    #[strum(serialize = "SO")]
+    SorocaDistrict,
+    #[strum(serialize = "ST")]
+    StraseniDistrict,
+    #[strum(serialize = "SI")]
+    SingereiDistrict,
+    #[strum(serialize = "TA")]
+    TaracliaDistrict,
+    #[strum(serialize = "TE")]
+    TelenestiDistrict,
+    #[strum(serialize = "SN")]
+    TransnistriaAutonomousTerritorialUnit,
+    #[strum(serialize = "UN")]
+    UngheniDistrict,
+    #[strum(serialize = "SD")]
+    SoldanestiDistrict,
+    #[strum(serialize = "SV")]
+    StefanVodaDistrict,
+}
+
+#[derive(
+    Debug, Clone, PartialEq, Eq, Serialize, Deserialize, strum::Display, strum::EnumString,
+)]
+pub enum MonacoStatesAbbreviation {
+    Monaco,
+}
+
+#[derive(
+    Debug, Clone, PartialEq, Eq, Serialize, Deserialize, strum::Display, strum::EnumString,
+)]
+pub enum MontenegroStatesAbbreviation {
+    #[strum(serialize = "01")]
+    AndrijevicaMunicipality,
+    #[strum(serialize = "02")]
+    BarMunicipality,
+    #[strum(serialize = "03")]
+    BeraneMunicipality,
+    #[strum(serialize = "04")]
+    BijeloPoljeMunicipality,
+    #[strum(serialize = "05")]
+    BudvaMunicipality,
+    #[strum(serialize = "07")]
+    DanilovgradMunicipality,
+    #[strum(serialize = "22")]
+    GusinjeMunicipality,
+    #[strum(serialize = "09")]
+    KolasinMunicipality,
+    #[strum(serialize = "10")]
+    KotorMunicipality,
+    #[strum(serialize = "11")]
+    MojkovacMunicipality,
+    #[strum(serialize = "12")]
+    NiksicMunicipality,
+    #[strum(serialize = "06")]
+    OldRoyalCapitalCetinje,
+    #[strum(serialize = "23")]
+    PetnjicaMunicipality,
+    #[strum(serialize = "13")]
+    PlavMunicipality,
+    #[strum(serialize = "14")]
+    PljevljaMunicipality,
+    #[strum(serialize = "15")]
+    PluzineMunicipality,
+    #[strum(serialize = "16")]
+    PodgoricaMunicipality,
+    #[strum(serialize = "17")]
+    RozajeMunicipality,
+    #[strum(serialize = "19")]
+    TivatMunicipality,
+    #[strum(serialize = "20")]
+    UlcinjMunicipality,
+    #[strum(serialize = "18")]
+    SavnikMunicipality,
+    #[strum(serialize = "21")]
+    ZabljakMunicipality,
+}
+
+#[derive(
+    Debug, Clone, PartialEq, Eq, Serialize, Deserialize, strum::Display, strum::EnumString,
+)]
+pub enum NetherlandsStatesAbbreviation {
+    #[strum(serialize = "BQ1")]
+    Bonaire,
+    #[strum(serialize = "DR")]
+    Drenthe,
+    #[strum(serialize = "FL")]
+    Flevoland,
+    #[strum(serialize = "FR")]
+    Friesland,
+    #[strum(serialize = "GE")]
+    Gelderland,
+    #[strum(serialize = "GR")]
+    Groningen,
+    #[strum(serialize = "LI")]
+    Limburg,
+    #[strum(serialize = "NB")]
+    NorthBrabant,
+    #[strum(serialize = "NH")]
+    NorthHolland,
+    #[strum(serialize = "OV")]
+    Overijssel,
+    #[strum(serialize = "BQ2")]
+    Saba,
+    #[strum(serialize = "BQ3")]
+    SintEustatius,
+    #[strum(serialize = "ZH")]
+    SouthHolland,
+    #[strum(serialize = "UT")]
+    Utrecht,
+    #[strum(serialize = "ZE")]
+    Zeeland,
+}
+
+#[derive(
+    Debug, Clone, PartialEq, Eq, Serialize, Deserialize, strum::Display, strum::EnumString,
+)]
+pub enum NorthMacedoniaStatesAbbreviation {
+    #[strum(serialize = "01")]
+    AerodromMunicipality,
+    #[strum(serialize = "02")]
+    AracinovoMunicipality,
+    #[strum(serialize = "03")]
+    BerovoMunicipality,
+    #[strum(serialize = "04")]
+    BitolaMunicipality,
+    #[strum(serialize = "05")]
+    BogdanciMunicipality,
+    #[strum(serialize = "06")]
+    BogovinjeMunicipality,
+    #[strum(serialize = "07")]
+    BosilovoMunicipality,
+    #[strum(serialize = "08")]
+    BrvenicaMunicipality,
+    #[strum(serialize = "09")]
+    ButelMunicipality,
+    #[strum(serialize = "77")]
+    CentarMunicipality,
+    #[strum(serialize = "78")]
+    CentarZupaMunicipality,
+    #[strum(serialize = "22")]
+    DebarcaMunicipality,
+    #[strum(serialize = "23")]
+    DelcevoMunicipality,
+    #[strum(serialize = "25")]
+    DemirHisarMunicipality,
+    #[strum(serialize = "24")]
+    DemirKapijaMunicipality,
+    #[strum(serialize = "26")]
+    DojranMunicipality,
+    #[strum(serialize = "27")]
+    DolneniMunicipality,
+    #[strum(serialize = "28")]
+    DrugovoMunicipality,
+    #[strum(serialize = "17")]
+    GaziBabaMunicipality,
+    #[strum(serialize = "18")]
+    GevgelijaMunicipality,
+    #[strum(serialize = "29")]
+    GjorcePetrovMunicipality,
+    #[strum(serialize = "19")]
+    GostivarMunicipality,
+    #[strum(serialize = "20")]
+    GradskoMunicipality,
+    #[strum(serialize = "85")]
+    GreaterSkopje,
+    #[strum(serialize = "34")]
+    IlindenMunicipality,
+    #[strum(serialize = "35")]
+    JegunovceMunicipality,
+    #[strum(serialize = "37")]
+    Karbinci,
+    #[strum(serialize = "38")]
+    KarposMunicipality,
+    #[strum(serialize = "36")]
+    KavadarciMunicipality,
+    #[strum(serialize = "39")]
+    KiselaVodaMunicipality,
+    #[strum(serialize = "40")]
+    KicevoMunicipality,
+    #[strum(serialize = "41")]
+    KonceMunicipality,
+    #[strum(serialize = "42")]
+    KocaniMunicipality,
+    #[strum(serialize = "43")]
+    KratovoMunicipality,
+    #[strum(serialize = "44")]
+    KrivaPalankaMunicipality,
+    #[strum(serialize = "45")]
+    KrivogastaniMunicipality,
+    #[strum(serialize = "46")]
+    KrusevoMunicipality,
+    #[strum(serialize = "47")]
+    KumanovoMunicipality,
+    #[strum(serialize = "48")]
+    LipkovoMunicipality,
+    #[strum(serialize = "49")]
+    LozovoMunicipality,
+    #[strum(serialize = "51")]
+    MakedonskaKamenicaMunicipality,
+    #[strum(serialize = "52")]
+    MakedonskiBrodMunicipality,
+    #[strum(serialize = "50")]
+    MavrovoAndRostusaMunicipality,
+    #[strum(serialize = "53")]
+    MogilaMunicipality,
+    #[strum(serialize = "54")]
+    NegotinoMunicipality,
+    #[strum(serialize = "55")]
+    NovaciMunicipality,
+    #[strum(serialize = "56")]
+    NovoSeloMunicipality,
+    #[strum(serialize = "58")]
+    OhridMunicipality,
+    #[strum(serialize = "57")]
+    OslomejMunicipality,
+    #[strum(serialize = "60")]
+    PehcevoMunicipality,
+    #[strum(serialize = "59")]
+    PetrovecMunicipality,
+    #[strum(serialize = "61")]
+    PlasnicaMunicipality,
+    #[strum(serialize = "62")]
+    PrilepMunicipality,
+    #[strum(serialize = "63")]
+    ProbistipMunicipality,
+    #[strum(serialize = "64")]
+    RadovisMunicipality,
+    #[strum(serialize = "65")]
+    RankovceMunicipality,
+    #[strum(serialize = "66")]
+    ResenMunicipality,
+    #[strum(serialize = "67")]
+    RosomanMunicipality,
+    #[strum(serialize = "68")]
+    SarajMunicipality,
+    #[strum(serialize = "70")]
+    SopisteMunicipality,
+    #[strum(serialize = "71")]
+    StaroNagoricaneMunicipality,
+    #[strum(serialize = "72")]
+    StrugaMunicipality,
+    #[strum(serialize = "73")]
+    StrumicaMunicipality,
+    #[strum(serialize = "74")]
+    StudenicaniMunicipality,
+    #[strum(serialize = "69")]
+    SvetiNikoleMunicipality,
+    #[strum(serialize = "75")]
+    TearceMunicipality,
+    #[strum(serialize = "76")]
+    TetovoMunicipality,
+    #[strum(serialize = "10")]
+    ValandovoMunicipality,
+    #[strum(serialize = "11")]
+    VasilevoMunicipality,
+    #[strum(serialize = "13")]
+    VelesMunicipality,
+    #[strum(serialize = "12")]
+    VevcaniMunicipality,
+    #[strum(serialize = "14")]
+    VinicaMunicipality,
+    #[strum(serialize = "15")]
+    VranesticaMunicipality,
+    #[strum(serialize = "16")]
+    VrapcisteMunicipality,
+    #[strum(serialize = "31")]
+    ZajasMunicipality,
+    #[strum(serialize = "32")]
+    ZelenikovoMunicipality,
+    #[strum(serialize = "33")]
+    ZrnovciMunicipality,
+    #[strum(serialize = "79")]
+    CairMunicipality,
+    #[strum(serialize = "80")]
+    CaskaMunicipality,
+    #[strum(serialize = "81")]
+    CesinovoOblesevoMunicipality,
+    #[strum(serialize = "82")]
+    CucerSandevoMunicipality,
+    #[strum(serialize = "83")]
+    StipMunicipality,
+    #[strum(serialize = "84")]
+    SutoOrizariMunicipality,
+    #[strum(serialize = "30")]
+    ZelinoMunicipality,
+}
+
+#[derive(
+    Debug, Clone, PartialEq, Eq, Serialize, Deserialize, strum::Display, strum::EnumString,
+)]
+pub enum NorwayStatesAbbreviation {
+    #[strum(serialize = "02")]
+    Akershus,
+    #[strum(serialize = "06")]
+    Buskerud,
+    #[strum(serialize = "20")]
+    Finnmark,
+    #[strum(serialize = "04")]
+    Hedmark,
+    #[strum(serialize = "12")]
+    Hordaland,
+    #[strum(serialize = "22")]
+    JanMayen,
+    #[strum(serialize = "15")]
+    MoreOgRomsdal,
+    #[strum(serialize = "17")]
+    NordTrondelag,
+    #[strum(serialize = "18")]
+    Nordland,
+    #[strum(serialize = "05")]
+    Oppland,
+    #[strum(serialize = "03")]
+    Oslo,
+    #[strum(serialize = "11")]
+    Rogaland,
+    #[strum(serialize = "14")]
+    SognOgFjordane,
+    #[strum(serialize = "21")]
+    Svalbard,
+    #[strum(serialize = "16")]
+    SorTrondelag,
+    #[strum(serialize = "08")]
+    Telemark,
+    #[strum(serialize = "19")]
+    Troms,
+    #[strum(serialize = "50")]
+    Trondelag,
+    #[strum(serialize = "10")]
+    VestAgder,
+    #[strum(serialize = "07")]
+    Vestfold,
+    #[strum(serialize = "01")]
+    Ostfold,
+}
+
+#[derive(
+    Debug, Clone, PartialEq, Eq, Serialize, Deserialize, strum::Display, strum::EnumString,
+)]
+pub enum PolandStatesAbbreviation {
+    #[strum(serialize = "WP")]
+    GreaterPolandVoivodeship,
+    #[strum(serialize = "KI")]
+    Kielce,
+    #[strum(serialize = "KP")]
+    KuyavianPomeranianVoivodeship,
+    #[strum(serialize = "MA")]
+    LesserPolandVoivodeship,
+    #[strum(serialize = "DS")]
+    LowerSilesianVoivodeship,
+    #[strum(serialize = "LU")]
+    LublinVoivodeship,
+    #[strum(serialize = "LB")]
+    LubuszVoivodeship,
+    #[strum(serialize = "MZ")]
+    MasovianVoivodeship,
+    #[strum(serialize = "OP")]
+    OpoleVoivodeship,
+    #[strum(serialize = "PK")]
+    PodkarpackieVoivodeship,
+    #[strum(serialize = "PD")]
+    PodlaskieVoivodeship,
+    #[strum(serialize = "PM")]
+    PomeranianVoivodeship,
+    #[strum(serialize = "SL")]
+    SilesianVoivodeship,
+    #[strum(serialize = "WN")]
+    WarmianMasurianVoivodeship,
+    #[strum(serialize = "ZP")]
+    WestPomeranianVoivodeship,
+    #[strum(serialize = "LD")]
+    LodzVoivodeship,
+    #[strum(serialize = "SK")]
+    SwietokrzyskieVoivodeship,
+}
+
+#[derive(
+    Debug, Clone, PartialEq, Eq, Serialize, Deserialize, strum::Display, strum::EnumString,
+)]
+pub enum PortugalStatesAbbreviation {
+    #[strum(serialize = "01")]
+    AveiroDistrict,
+    #[strum(serialize = "20")]
+    Azores,
+    #[strum(serialize = "02")]
+    BejaDistrict,
+    #[strum(serialize = "03")]
+    BragaDistrict,
+    #[strum(serialize = "04")]
+    BragancaDistrict,
+    #[strum(serialize = "05")]
+    CasteloBrancoDistrict,
+    #[strum(serialize = "06")]
+    CoimbraDistrict,
+    #[strum(serialize = "08")]
+    FaroDistrict,
+    #[strum(serialize = "09")]
+    GuardaDistrict,
+    #[strum(serialize = "10")]
+    LeiriaDistrict,
+    #[strum(serialize = "11")]
+    LisbonDistrict,
+    #[strum(serialize = "30")]
+    Madeira,
+    #[strum(serialize = "12")]
+    PortalegreDistrict,
+    #[strum(serialize = "13")]
+    PortoDistrict,
+    #[strum(serialize = "14")]
+    SantaremDistrict,
+    #[strum(serialize = "15")]
+    SetubalDistrict,
+    #[strum(serialize = "16")]
+    VianaDoCasteloDistrict,
+    #[strum(serialize = "17")]
+    VilaRealDistrict,
+    #[strum(serialize = "18")]
+    ViseuDistrict,
+    #[strum(serialize = "07")]
+    EvoraDistrict,
+}
+
+#[derive(
+    Debug, Clone, PartialEq, Eq, Serialize, Deserialize, strum::Display, strum::EnumString,
+)]
+pub enum SpainStatesAbbreviation {
+    #[strum(serialize = "C")]
+    ACorunaProvince,
+    #[strum(serialize = "AB")]
+    AlbaceteProvince,
+    #[strum(serialize = "A")]
+    AlicanteProvince,
+    #[strum(serialize = "AL")]
+    AlmeriaProvince,
+    #[strum(serialize = "AN")]
+    Andalusia,
+    #[strum(serialize = "VI")]
+    ArabaAlava,
+    #[strum(serialize = "AR")]
+    Aragon,
+    #[strum(serialize = "BA")]
+    BadajozProvince,
+    #[strum(serialize = "PM")]
+    BalearicIslands,
+    #[strum(serialize = "B")]
+    BarcelonaProvince,
+    #[strum(serialize = "PV")]
+    BasqueCountry,
+    #[strum(serialize = "BI")]
+    Biscay,
+    #[strum(serialize = "BU")]
+    BurgosProvince,
+    #[strum(serialize = "CN")]
+    CanaryIslands,
+    #[strum(serialize = "S")]
+    Cantabria,
+    #[strum(serialize = "CS")]
+    CastellonProvince,
+    #[strum(serialize = "CL")]
+    CastileAndLeon,
+    #[strum(serialize = "CM")]
+    CastileLaMancha,
+    #[strum(serialize = "CT")]
+    Catalonia,
+    #[strum(serialize = "CE")]
+    Ceuta,
+    #[strum(serialize = "CR")]
+    CiudadRealProvince,
+    #[strum(serialize = "MD")]
+    CommunityOfMadrid,
+    #[strum(serialize = "CU")]
+    CuencaProvince,
+    #[strum(serialize = "CC")]
+    CaceresProvince,
+    #[strum(serialize = "CA")]
+    CadizProvince,
+    #[strum(serialize = "CO")]
+    CordobaProvince,
+    #[strum(serialize = "EX")]
+    Extremadura,
+    #[strum(serialize = "GA")]
+    Galicia,
+    #[strum(serialize = "SS")]
+    Gipuzkoa,
+    #[strum(serialize = "GI")]
+    GironaProvince,
+    #[strum(serialize = "GR")]
+    GranadaProvince,
+    #[strum(serialize = "GU")]
+    GuadalajaraProvince,
+    #[strum(serialize = "H")]
+    HuelvaProvince,
+    #[strum(serialize = "HU")]
+    HuescaProvince,
+    #[strum(serialize = "J")]
+    JaenProvince,
+    #[strum(serialize = "RI")]
+    LaRioja,
+    #[strum(serialize = "GC")]
+    LasPalmasProvince,
+    #[strum(serialize = "LE")]
+    LeonProvince,
+    #[strum(serialize = "L")]
+    LleidaProvince,
+    #[strum(serialize = "LU")]
+    LugoProvince,
+    #[strum(serialize = "M")]
+    MadridProvince,
+    #[strum(serialize = "ML")]
+    Melilla,
+    #[strum(serialize = "MU")]
+    MurciaProvince,
+    #[strum(serialize = "MA")]
+    MalagaProvince,
+    #[strum(serialize = "NC")]
+    Navarre,
+    #[strum(serialize = "OR")]
+    OurenseProvince,
+    #[strum(serialize = "P")]
+    PalenciaProvince,
+    #[strum(serialize = "PO")]
+    PontevedraProvince,
+    #[strum(serialize = "O")]
+    ProvinceOfAsturias,
+    #[strum(serialize = "AV")]
+    ProvinceOfAvila,
+    #[strum(serialize = "MC")]
+    RegionOfMurcia,
+    #[strum(serialize = "SA")]
+    SalamancaProvince,
+    #[strum(serialize = "TF")]
+    SantaCruzDeTenerifeProvince,
+    #[strum(serialize = "SG")]
+    SegoviaProvince,
+    #[strum(serialize = "SE")]
+    SevilleProvince,
+    #[strum(serialize = "SO")]
+    SoriaProvince,
+    #[strum(serialize = "T")]
+    TarragonaProvince,
+    #[strum(serialize = "TE")]
+    TeruelProvince,
+    #[strum(serialize = "TO")]
+    ToledoProvince,
+    #[strum(serialize = "V")]
+    ValenciaProvince,
+    #[strum(serialize = "VC")]
+    ValencianCommunity,
+    #[strum(serialize = "VA")]
+    ValladolidProvince,
+    #[strum(serialize = "ZA")]
+    ZamoraProvince,
+    #[strum(serialize = "Z")]
+    ZaragozaProvince,
+}
+
+#[derive(
+    Debug, Clone, PartialEq, Eq, Serialize, Deserialize, strum::Display, strum::EnumString,
+)]
+pub enum SwitzerlandStatesAbbreviation {
+    #[strum(serialize = "AG")]
+    Aargau,
+    #[strum(serialize = "AR")]
+    AppenzellAusserrhoden,
+    #[strum(serialize = "AI")]
+    AppenzellInnerrhoden,
+    #[strum(serialize = "BL")]
+    BaselLandschaft,
+    #[strum(serialize = "FR")]
+    CantonOfFribourg,
+    #[strum(serialize = "GE")]
+    CantonOfGeneva,
+    #[strum(serialize = "JU")]
+    CantonOfJura,
+    #[strum(serialize = "LU")]
+    CantonOfLucerne,
+    #[strum(serialize = "NE")]
+    CantonOfNeuchatel,
+    #[strum(serialize = "SH")]
+    CantonOfSchaffhausen,
+    #[strum(serialize = "SO")]
+    CantonOfSolothurn,
+    #[strum(serialize = "SG")]
+    CantonOfStGallen,
+    #[strum(serialize = "VS")]
+    CantonOfValais,
+    #[strum(serialize = "VD")]
+    CantonOfVaud,
+    #[strum(serialize = "ZG")]
+    CantonOfZug,
+    #[strum(serialize = "GL")]
+    Glarus,
+    #[strum(serialize = "GR")]
+    Graubunden,
+    #[strum(serialize = "NW")]
+    Nidwalden,
+    #[strum(serialize = "OW")]
+    Obwalden,
+    #[strum(serialize = "SZ")]
+    Schwyz,
+    #[strum(serialize = "TG")]
+    Thurgau,
+    #[strum(serialize = "TI")]
+    Ticino,
+    #[strum(serialize = "UR")]
+    Uri,
+    #[strum(serialize = "BE")]
+    CantonOfBern,
+    #[strum(serialize = "ZH")]
+    CantonOfZurich,
+}
+
+#[derive(
+    Debug, Clone, PartialEq, Eq, Serialize, Deserialize, strum::Display, strum::EnumString,
+)]
+pub enum UnitedKingdomStatesAbbreviation {
+    #[strum(serialize = "ABE")]
+    AberdeenCity,
+    #[strum(serialize = "ABD")]
+    Aberdeenshire,
+    #[strum(serialize = "ANS")]
+    Angus,
+    #[strum(serialize = "ANN")]
+    AntrimAndNewtownabbey,
+    #[strum(serialize = "AND")]
+    ArdsAndNorthDown,
+    #[strum(serialize = "AGB")]
+    ArgyllAndBute,
+    #[strum(serialize = "ABC")]
+    ArmaghCityBanbridgeAndCraigavon,
+    #[strum(serialize = "BDG")]
+    BarkingAndDagenham,
+    #[strum(serialize = "BNE")]
+    Barnet,
+    #[strum(serialize = "BNS")]
+    Barnsley,
+    #[strum(serialize = "BAS")]
+    BathAndNorthEastSomerset,
+    #[strum(serialize = "BDF")]
+    Bedford,
+    #[strum(serialize = "BFS")]
+    BelfastCity,
+    #[strum(serialize = "BEX")]
+    Bexley,
+    #[strum(serialize = "BIR")]
+    Birmingham,
+    #[strum(serialize = "BBD")]
+    BlackburnWithDarwen,
+    #[strum(serialize = "BPL")]
+    Blackpool,
+    #[strum(serialize = "BGW")]
+    BlaenauGwent,
+    #[strum(serialize = "BOL")]
+    Bolton,
+    #[strum(serialize = "BCP")]
+    BournemouthChristchurchAndPoole,
+    #[strum(serialize = "BRC")]
+    BracknellForest,
+    #[strum(serialize = "BRD")]
+    Bradford,
+    #[strum(serialize = "BEN")]
+    Brent,
+    #[strum(serialize = "BGE")]
+    Bridgend,
+    #[strum(serialize = "BNH")]
+    BrightonAndHove,
+    #[strum(serialize = "BST")]
+    BristolCityOf,
+    #[strum(serialize = "BRY")]
+    Bromley,
+    #[strum(serialize = "BKM")]
+    Buckinghamshire,
+    #[strum(serialize = "BUR")]
+    Bury,
+    #[strum(serialize = "CAY")]
+    Caerphilly,
+    #[strum(serialize = "CLD")]
+    Calderdale,
+    #[strum(serialize = "CAM")]
+    Cambridgeshire,
+    #[strum(serialize = "CMD")]
+    Camden,
+    #[strum(serialize = "CRF")]
+    Cardiff,
+    #[strum(serialize = "CMN")]
+    Carmarthenshire,
+    #[strum(serialize = "CCG")]
+    CausewayCoastAndGlens,
+    #[strum(serialize = "CBF")]
+    CentralBedfordshire,
+    #[strum(serialize = "CGN")]
+    Ceredigion,
+    #[strum(serialize = "CHE")]
+    CheshireEast,
+    #[strum(serialize = "CHW")]
+    CheshireWestAndChester,
+    #[strum(serialize = "CLK")]
+    Clackmannanshire,
+    #[strum(serialize = "CWY")]
+    Conwy,
+    #[strum(serialize = "CON")]
+    Cornwall,
+    #[strum(serialize = "COV")]
+    Coventry,
+    #[strum(serialize = "CRY")]
+    Croydon,
+    #[strum(serialize = "CMA")]
+    Cumbria,
+    #[strum(serialize = "DAL")]
+    Darlington,
+    #[strum(serialize = "DEN")]
+    Denbighshire,
+    #[strum(serialize = "DER")]
+    Derby,
+    #[strum(serialize = "DBY")]
+    Derbyshire,
+    #[strum(serialize = "DRS")]
+    DerryAndStrabane,
+    #[strum(serialize = "DEV")]
+    Devon,
+    #[strum(serialize = "DNC")]
+    Doncaster,
+    #[strum(serialize = "DOR")]
+    Dorset,
+    #[strum(serialize = "DUD")]
+    Dudley,
+    #[strum(serialize = "DGY")]
+    DumfriesAndGalloway,
+    #[strum(serialize = "DND")]
+    DundeeCity,
+    #[strum(serialize = "DUR")]
+    DurhamCounty,
+    #[strum(serialize = "EAL")]
+    Ealing,
+    #[strum(serialize = "EAY")]
+    EastAyrshire,
+    #[strum(serialize = "EDU")]
+    EastDunbartonshire,
+    #[strum(serialize = "ELN")]
+    EastLothian,
+    #[strum(serialize = "ERW")]
+    EastRenfrewshire,
+    #[strum(serialize = "ERY")]
+    EastRidingOfYorkshire,
+    #[strum(serialize = "ESX")]
+    EastSussex,
+    #[strum(serialize = "EDH")]
+    EdinburghCityOf,
+    #[strum(serialize = "ELS")]
+    EileanSiar,
+    #[strum(serialize = "ENF")]
+    Enfield,
+    #[strum(serialize = "ESS")]
+    Essex,
+    #[strum(serialize = "FAL")]
+    Falkirk,
+    #[strum(serialize = "FMO")]
+    FermanaghAndOmagh,
+    #[strum(serialize = "FIF")]
+    Fife,
+    #[strum(serialize = "FLN")]
+    Flintshire,
+    #[strum(serialize = "GAT")]
+    Gateshead,
+    #[strum(serialize = "GLG")]
+    GlasgowCity,
+    #[strum(serialize = "GLS")]
+    Gloucestershire,
+    #[strum(serialize = "GRE")]
+    Greenwich,
+    #[strum(serialize = "GWN")]
+    Gwynedd,
+    #[strum(serialize = "HCK")]
+    Hackney,
+    #[strum(serialize = "HAL")]
+    Halton,
+    #[strum(serialize = "HMF")]
+    HammersmithAndFulham,
+    #[strum(serialize = "HAM")]
+    Hampshire,
+    #[strum(serialize = "HRY")]
+    Haringey,
+    #[strum(serialize = "HRW")]
+    Harrow,
+    #[strum(serialize = "HPL")]
+    Hartlepool,
+    #[strum(serialize = "HAV")]
+    Havering,
+    #[strum(serialize = "HEF")]
+    Herefordshire,
+    #[strum(serialize = "HRT")]
+    Hertfordshire,
+    #[strum(serialize = "HLD")]
+    Highland,
+    #[strum(serialize = "HIL")]
+    Hillingdon,
+    #[strum(serialize = "HNS")]
+    Hounslow,
+    #[strum(serialize = "IVC")]
+    Inverclyde,
+    #[strum(serialize = "AGY")]
+    IsleOfAnglesey,
+    #[strum(serialize = "IOW")]
+    IsleOfWight,
+    #[strum(serialize = "IOS")]
+    IslesOfScilly,
+    #[strum(serialize = "ISL")]
+    Islington,
+    #[strum(serialize = "KEC")]
+    KensingtonAndChelsea,
+    #[strum(serialize = "KEN")]
+    Kent,
+    #[strum(serialize = "KHL")]
+    KingstonUponHull,
+    #[strum(serialize = "KTT")]
+    KingstonUponThames,
+    #[strum(serialize = "KIR")]
+    Kirklees,
+    #[strum(serialize = "KWL")]
+    Knowsley,
+    #[strum(serialize = "LBH")]
+    Lambeth,
+    #[strum(serialize = "LAN")]
+    Lancashire,
+    #[strum(serialize = "LDS")]
+    Leeds,
+    #[strum(serialize = "LCE")]
+    Leicester,
+    #[strum(serialize = "LEC")]
+    Leicestershire,
+    #[strum(serialize = "LEW")]
+    Lewisham,
+    #[strum(serialize = "LIN")]
+    Lincolnshire,
+    #[strum(serialize = "LBC")]
+    LisburnAndCastlereagh,
+    #[strum(serialize = "LIV")]
+    Liverpool,
+    #[strum(serialize = "LND")]
+    LondonCityOf,
+    #[strum(serialize = "LUT")]
+    Luton,
+    #[strum(serialize = "MAN")]
+    Manchester,
+    #[strum(serialize = "MDW")]
+    Medway,
+    #[strum(serialize = "MTY")]
+    MerthyrTydfil,
+    #[strum(serialize = "MRT")]
+    Merton,
+    #[strum(serialize = "MEA")]
+    MidAndEastAntrim,
+    #[strum(serialize = "MUL")]
+    MidUlster,
+    #[strum(serialize = "MDB")]
+    Middlesbrough,
+    #[strum(serialize = "MLN")]
+    Midlothian,
+    #[strum(serialize = "MIK")]
+    MiltonKeynes,
+    #[strum(serialize = "MON")]
+    Monmouthshire,
+    #[strum(serialize = "MRY")]
+    Moray,
+    #[strum(serialize = "NTL")]
+    NeathPortTalbot,
+    #[strum(serialize = "NET")]
+    NewcastleUponTyne,
+    #[strum(serialize = "NWM")]
+    Newham,
+    #[strum(serialize = "NWP")]
+    Newport,
+    #[strum(serialize = "NMD")]
+    NewryMourneAndDown,
+    #[strum(serialize = "NFK")]
+    Norfolk,
+    #[strum(serialize = "NAY")]
+    NorthAyrshire,
+    #[strum(serialize = "NEL")]
+    NorthEastLincolnshire,
+    #[strum(serialize = "NLK")]
+    NorthLanarkshire,
+    #[strum(serialize = "NLN")]
+    NorthLincolnshire,
+    #[strum(serialize = "NSM")]
+    NorthSomerset,
+    #[strum(serialize = "NTY")]
+    NorthTyneside,
+    #[strum(serialize = "NYK")]
+    NorthYorkshire,
+    #[strum(serialize = "NTH")]
+    Northamptonshire,
+    #[strum(serialize = "NBL")]
+    Northumberland,
+    #[strum(serialize = "NGM")]
+    Nottingham,
+    #[strum(serialize = "NTT")]
+    Nottinghamshire,
+    #[strum(serialize = "OLD")]
+    Oldham,
+    #[strum(serialize = "ORK")]
+    OrkneyIslands,
+    #[strum(serialize = "OXF")]
+    Oxfordshire,
+    #[strum(serialize = "PEM")]
+    Pembrokeshire,
+    #[strum(serialize = "PKN")]
+    PerthAndKinross,
+    #[strum(serialize = "PTE")]
+    Peterborough,
+    #[strum(serialize = "PLY")]
+    Plymouth,
+    #[strum(serialize = "POR")]
+    Portsmouth,
+    #[strum(serialize = "POW")]
+    Powys,
+    #[strum(serialize = "RDG")]
+    Reading,
+    #[strum(serialize = "RDB")]
+    Redbridge,
+    #[strum(serialize = "RCC")]
+    RedcarAndCleveland,
+    #[strum(serialize = "RFW")]
+    Renfrewshire,
+    #[strum(serialize = "RCT")]
+    RhonddaCynonTaff,
+    #[strum(serialize = "RIC")]
+    RichmondUponThames,
+    #[strum(serialize = "RCH")]
+    Rochdale,
+    #[strum(serialize = "ROT")]
+    Rotherham,
+    #[strum(serialize = "RUT")]
+    Rutland,
+    #[strum(serialize = "SLF")]
+    Salford,
+    #[strum(serialize = "SAW")]
+    Sandwell,
+    #[strum(serialize = "SCB")]
+    ScottishBorders,
+    #[strum(serialize = "SFT")]
+    Sefton,
+    #[strum(serialize = "SHF")]
+    Sheffield,
+    #[strum(serialize = "ZET")]
+    ShetlandIslands,
+    #[strum(serialize = "SHR")]
+    Shropshire,
+    #[strum(serialize = "SLG")]
+    Slough,
+    #[strum(serialize = "SOL")]
+    Solihull,
+    #[strum(serialize = "SOM")]
+    Somerset,
+    #[strum(serialize = "SAY")]
+    SouthAyrshire,
+    #[strum(serialize = "SGC")]
+    SouthGloucestershire,
+    #[strum(serialize = "SLK")]
+    SouthLanarkshire,
+    #[strum(serialize = "STY")]
+    SouthTyneside,
+    #[strum(serialize = "STH")]
+    Southampton,
+    #[strum(serialize = "SOS")]
+    SouthendOnSea,
+    #[strum(serialize = "SWK")]
+    Southwark,
+    #[strum(serialize = "SHN")]
+    StHelens,
+    #[strum(serialize = "STS")]
+    Staffordshire,
+    #[strum(serialize = "STG")]
+    Stirling,
+    #[strum(serialize = "SKP")]
+    Stockport,
+    #[strum(serialize = "STT")]
+    StocktonOnTees,
+    #[strum(serialize = "STE")]
+    StokeOnTrent,
+    #[strum(serialize = "SFK")]
+    Suffolk,
+    #[strum(serialize = "SND")]
+    Sunderland,
+    #[strum(serialize = "SRY")]
+    Surrey,
+    #[strum(serialize = "STN")]
+    Sutton,
+    #[strum(serialize = "SWA")]
+    Swansea,
+    #[strum(serialize = "SWD")]
+    Swindon,
+    #[strum(serialize = "TAM")]
+    Tameside,
+    #[strum(serialize = "TFW")]
+    TelfordAndWrekin,
+    #[strum(serialize = "THR")]
+    Thurrock,
+    #[strum(serialize = "TOB")]
+    Torbay,
+    #[strum(serialize = "TOF")]
+    Torfaen,
+    #[strum(serialize = "TWH")]
+    TowerHamlets,
+    #[strum(serialize = "TRF")]
+    Trafford,
+    #[strum(serialize = "VGL")]
+    ValeOfGlamorgan,
+    #[strum(serialize = "WKF")]
+    Wakefield,
+    #[strum(serialize = "WLL")]
+    Walsall,
+    #[strum(serialize = "WFT")]
+    WalthamForest,
+    #[strum(serialize = "WND")]
+    Wandsworth,
+    #[strum(serialize = "WRT")]
+    Warrington,
+    #[strum(serialize = "WAR")]
+    Warwickshire,
+    #[strum(serialize = "WBK")]
+    WestBerkshire,
+    #[strum(serialize = "WDU")]
+    WestDunbartonshire,
+    #[strum(serialize = "WLN")]
+    WestLothian,
+    #[strum(serialize = "WSX")]
+    WestSussex,
+    #[strum(serialize = "WSM")]
+    Westminster,
+    #[strum(serialize = "WGN")]
+    Wigan,
+    #[strum(serialize = "WIL")]
+    Wiltshire,
+    #[strum(serialize = "WNM")]
+    WindsorAndMaidenhead,
+    #[strum(serialize = "WRL")]
+    Wirral,
+    #[strum(serialize = "WOK")]
+    Wokingham,
+    #[strum(serialize = "WLV")]
+    Wolverhampton,
+    #[strum(serialize = "WOR")]
+    Worcestershire,
+    #[strum(serialize = "WRX")]
+    Wrexham,
+    #[strum(serialize = "YOR")]
+    York,
+}
+
+#[derive(
+    Debug, Clone, PartialEq, Eq, Serialize, Deserialize, strum::Display, strum::EnumString,
+)]
+pub enum RomaniaStatesAbbreviation {
+    #[strum(serialize = "AB")]
+    Alba,
+    #[strum(serialize = "AR")]
+    AradCounty,
+    #[strum(serialize = "AG")]
+    Arges,
+    #[strum(serialize = "BC")]
+    BacauCounty,
+    #[strum(serialize = "BH")]
+    BihorCounty,
+    #[strum(serialize = "BN")]
+    BistritaNasaudCounty,
+    #[strum(serialize = "BT")]
+    BotosaniCounty,
+    #[strum(serialize = "BR")]
+    Braila,
+    #[strum(serialize = "BV")]
+    BrasovCounty,
+    #[strum(serialize = "B")]
+    Bucharest,
+    #[strum(serialize = "BZ")]
+    BuzauCounty,
+    #[strum(serialize = "CS")]
+    CarasSeverinCounty,
+    #[strum(serialize = "CJ")]
+    ClujCounty,
+    #[strum(serialize = "CT")]
+    ConstantaCounty,
+    #[strum(serialize = "CV")]
+    CovasnaCounty,
+    #[strum(serialize = "CL")]
+    CalarasiCounty,
+    #[strum(serialize = "DJ")]
+    DoljCounty,
+    #[strum(serialize = "DB")]
+    DambovitaCounty,
+    #[strum(serialize = "GL")]
+    GalatiCounty,
+    #[strum(serialize = "GR")]
+    GiurgiuCounty,
+    #[strum(serialize = "GJ")]
+    GorjCounty,
+    #[strum(serialize = "HR")]
+    HarghitaCounty,
+    #[strum(serialize = "HD")]
+    HunedoaraCounty,
+    #[strum(serialize = "IL")]
+    IalomitaCounty,
+    #[strum(serialize = "IS")]
+    IasiCounty,
+    #[strum(serialize = "IF")]
+    IlfovCounty,
+    #[strum(serialize = "MH")]
+    MehedintiCounty,
+    #[strum(serialize = "MM")]
+    MuresCounty,
+    #[strum(serialize = "NT")]
+    NeamtCounty,
+    #[strum(serialize = "OT")]
+    OltCounty,
+    #[strum(serialize = "PH")]
+    PrahovaCounty,
+    #[strum(serialize = "SM")]
+    SatuMareCounty,
+    #[strum(serialize = "SB")]
+    SibiuCounty,
+    #[strum(serialize = "SV")]
+    SuceavaCounty,
+    #[strum(serialize = "SJ")]
+    SalajCounty,
+    #[strum(serialize = "TR")]
+    TeleormanCounty,
+    #[strum(serialize = "TM")]
+    TimisCounty,
+    #[strum(serialize = "TL")]
+    TulceaCounty,
+    #[strum(serialize = "VS")]
+    VasluiCounty,
+    #[strum(serialize = "VN")]
+    VranceaCounty,
+    #[strum(serialize = "VL")]
+    ValceaCounty,
+}
+
+#[derive(
     Clone,
     Copy,
     Debug,

--- a/crates/hyperswitch_connectors/src/utils.rs
+++ b/crates/hyperswitch_connectors/src/utils.rs
@@ -6,7 +6,21 @@ use api_models::payouts::PayoutVendorAccountDetails;
 use base64::Engine;
 use common_enums::{
     enums,
-    enums::{AttemptStatus, CanadaStatesAbbreviation, FutureUsage, UsStatesAbbreviation},
+    enums::{
+        AlbaniaStatesAbbreviation, AndorraStatesAbbreviation, AttemptStatus,
+        AustriaStatesAbbreviation, BelarusStatesAbbreviation,
+        BosniaAndHerzegovinaStatesAbbreviation, BulgariaStatesAbbreviation,
+        CanadaStatesAbbreviation, CroatiaStatesAbbreviation, CzechRepublicStatesAbbreviation,
+        DenmarkStatesAbbreviation, FinlandStatesAbbreviation, FranceStatesAbbreviation,
+        FutureUsage, GermanyStatesAbbreviation, GreeceStatesAbbreviation,
+        HungaryStatesAbbreviation, IcelandStatesAbbreviation, IrelandStatesAbbreviation,
+        ItalyStatesAbbreviation, LatviaStatesAbbreviation, LiechtensteinStatesAbbreviation,
+        LithuaniaStatesAbbreviation, MaltaStatesAbbreviation, MoldovaStatesAbbreviation,
+        MonacoStatesAbbreviation, MontenegroStatesAbbreviation, NetherlandsStatesAbbreviation,
+        NorthMacedoniaStatesAbbreviation, NorwayStatesAbbreviation, PolandStatesAbbreviation,
+        PortugalStatesAbbreviation, RomaniaStatesAbbreviation, SpainStatesAbbreviation,
+        SwitzerlandStatesAbbreviation, UnitedKingdomStatesAbbreviation, UsStatesAbbreviation,
+    },
 };
 use common_utils::{
     consts::BASE64_ENGINE,
@@ -1343,6 +1357,111 @@ impl AddressDetailsData for AddressDetails {
             api_models::enums::CountryAlpha2::CA => Ok(Secret::new(
                 CanadaStatesAbbreviation::foreign_try_from(state.peek().to_string())?.to_string(),
             )),
+            api_models::enums::CountryAlpha2::AL => Ok(Secret::new(
+                AlbaniaStatesAbbreviation::foreign_try_from(state.peek().to_string())?.to_string(),
+            )),
+            api_models::enums::CountryAlpha2::AD => Ok(Secret::new(
+                AndorraStatesAbbreviation::foreign_try_from(state.peek().to_string())?.to_string(),
+            )),
+            api_models::enums::CountryAlpha2::AT => Ok(Secret::new(
+                AustriaStatesAbbreviation::foreign_try_from(state.peek().to_string())?.to_string(),
+            )),
+            api_models::enums::CountryAlpha2::BY => Ok(Secret::new(
+                BelarusStatesAbbreviation::foreign_try_from(state.peek().to_string())?.to_string(),
+            )),
+            api_models::enums::CountryAlpha2::BA => Ok(Secret::new(
+                BosniaAndHerzegovinaStatesAbbreviation::foreign_try_from(state.peek().to_string())?
+                    .to_string(),
+            )),
+            api_models::enums::CountryAlpha2::BG => Ok(Secret::new(
+                BulgariaStatesAbbreviation::foreign_try_from(state.peek().to_string())?.to_string(),
+            )),
+            api_models::enums::CountryAlpha2::HR => Ok(Secret::new(
+                CroatiaStatesAbbreviation::foreign_try_from(state.peek().to_string())?.to_string(),
+            )),
+            api_models::enums::CountryAlpha2::CZ => Ok(Secret::new(
+                CzechRepublicStatesAbbreviation::foreign_try_from(state.peek().to_string())?
+                    .to_string(),
+            )),
+            api_models::enums::CountryAlpha2::DK => Ok(Secret::new(
+                DenmarkStatesAbbreviation::foreign_try_from(state.peek().to_string())?.to_string(),
+            )),
+            api_models::enums::CountryAlpha2::FI => Ok(Secret::new(
+                FinlandStatesAbbreviation::foreign_try_from(state.peek().to_string())?.to_string(),
+            )),
+            api_models::enums::CountryAlpha2::FR => Ok(Secret::new(
+                FranceStatesAbbreviation::foreign_try_from(state.peek().to_string())?.to_string(),
+            )),
+            api_models::enums::CountryAlpha2::DE => Ok(Secret::new(
+                GermanyStatesAbbreviation::foreign_try_from(state.peek().to_string())?.to_string(),
+            )),
+            api_models::enums::CountryAlpha2::GR => Ok(Secret::new(
+                GreeceStatesAbbreviation::foreign_try_from(state.peek().to_string())?.to_string(),
+            )),
+            api_models::enums::CountryAlpha2::HU => Ok(Secret::new(
+                HungaryStatesAbbreviation::foreign_try_from(state.peek().to_string())?.to_string(),
+            )),
+            api_models::enums::CountryAlpha2::IS => Ok(Secret::new(
+                IcelandStatesAbbreviation::foreign_try_from(state.peek().to_string())?.to_string(),
+            )),
+            api_models::enums::CountryAlpha2::IE => Ok(Secret::new(
+                IrelandStatesAbbreviation::foreign_try_from(state.peek().to_string())?.to_string(),
+            )),
+            api_models::enums::CountryAlpha2::LV => Ok(Secret::new(
+                LatviaStatesAbbreviation::foreign_try_from(state.peek().to_string())?.to_string(),
+            )),
+            api_models::enums::CountryAlpha2::IT => Ok(Secret::new(
+                ItalyStatesAbbreviation::foreign_try_from(state.peek().to_string())?.to_string(),
+            )),
+            api_models::enums::CountryAlpha2::LI => Ok(Secret::new(
+                LiechtensteinStatesAbbreviation::foreign_try_from(state.peek().to_string())?
+                    .to_string(),
+            )),
+            api_models::enums::CountryAlpha2::LT => Ok(Secret::new(
+                LithuaniaStatesAbbreviation::foreign_try_from(state.peek().to_string())?
+                    .to_string(),
+            )),
+            api_models::enums::CountryAlpha2::MT => Ok(Secret::new(
+                MaltaStatesAbbreviation::foreign_try_from(state.peek().to_string())?.to_string(),
+            )),
+            api_models::enums::CountryAlpha2::MD => Ok(Secret::new(
+                MoldovaStatesAbbreviation::foreign_try_from(state.peek().to_string())?.to_string(),
+            )),
+            api_models::enums::CountryAlpha2::MC => Ok(Secret::new(
+                MonacoStatesAbbreviation::foreign_try_from(state.peek().to_string())?.to_string(),
+            )),
+            api_models::enums::CountryAlpha2::ME => Ok(Secret::new(
+                MontenegroStatesAbbreviation::foreign_try_from(state.peek().to_string())?
+                    .to_string(),
+            )),
+            api_models::enums::CountryAlpha2::NL => Ok(Secret::new(
+                NetherlandsStatesAbbreviation::foreign_try_from(state.peek().to_string())?
+                    .to_string(),
+            )),
+            api_models::enums::CountryAlpha2::MK => Ok(Secret::new(
+                NorthMacedoniaStatesAbbreviation::foreign_try_from(state.peek().to_string())?
+                    .to_string(),
+            )),
+            api_models::enums::CountryAlpha2::NO => Ok(Secret::new(
+                NorwayStatesAbbreviation::foreign_try_from(state.peek().to_string())?.to_string(),
+            )),
+            api_models::enums::CountryAlpha2::PL => Ok(Secret::new(
+                PolandStatesAbbreviation::foreign_try_from(state.peek().to_string())?.to_string(),
+            )),
+            api_models::enums::CountryAlpha2::PT => Ok(Secret::new(
+                PortugalStatesAbbreviation::foreign_try_from(state.peek().to_string())?.to_string(),
+            )),
+            api_models::enums::CountryAlpha2::ES => Ok(Secret::new(
+                SpainStatesAbbreviation::foreign_try_from(state.peek().to_string())?.to_string(),
+            )),
+            api_models::enums::CountryAlpha2::CH => Ok(Secret::new(
+                SwitzerlandStatesAbbreviation::foreign_try_from(state.peek().to_string())?
+                    .to_string(),
+            )),
+            api_models::enums::CountryAlpha2::GB => Ok(Secret::new(
+                UnitedKingdomStatesAbbreviation::foreign_try_from(state.peek().to_string())?
+                    .to_string(),
+            )),
             _ => Ok(state.clone()),
         }
     }
@@ -2307,6 +2426,1952 @@ impl ForeignTryFrom<String> for CanadaStatesAbbreviation {
                     "quebec" => Ok(Self::QC),
                     "saskatchewan" => Ok(Self::SK),
                     "yukon" => Ok(Self::YT),
+                    _ => Err(errors::ConnectorError::InvalidDataFormat {
+                        field_name: "address.state",
+                    }
+                    .into()),
+                }
+            }
+        }
+    }
+}
+
+impl ForeignTryFrom<String> for PolandStatesAbbreviation {
+    type Error = error_stack::Report<errors::ConnectorError>;
+    fn foreign_try_from(value: String) -> Result<Self, Self::Error> {
+        let state_abbreviation_check =
+            StringExt::<Self>::parse_enum(value.to_uppercase().clone(), "PolandStatesAbbreviation");
+        match state_abbreviation_check {
+            Ok(state_abbreviation) => Ok(state_abbreviation),
+            Err(_) => {
+                let binding = value.as_str().to_lowercase();
+                let state = binding.as_str();
+                match state {
+                    "greater poland voivodeship" => Ok(Self::GreaterPolandVoivodeship),
+                    "kielce" => Ok(Self::Kielce),
+                    "kuyavian pomeranian voivodeship" => Ok(Self::KuyavianPomeranianVoivodeship),
+                    "lesser poland voivodeship" => Ok(Self::LesserPolandVoivodeship),
+                    "lower silesian voivodeship" => Ok(Self::LowerSilesianVoivodeship),
+                    "lublin voivodeship" => Ok(Self::LublinVoivodeship),
+                    "lubusz voivodeship" => Ok(Self::LubuszVoivodeship),
+                    "masovian voivodeship" => Ok(Self::MasovianVoivodeship),
+                    "opole voivodeship" => Ok(Self::OpoleVoivodeship),
+                    "podkarpackie voivodeship" => Ok(Self::PodkarpackieVoivodeship),
+                    "podlaskie voivodeship" => Ok(Self::PodlaskieVoivodeship),
+                    "pomeranian voivodeship" => Ok(Self::PomeranianVoivodeship),
+                    "silesian voivodeship" => Ok(Self::SilesianVoivodeship),
+                    "warmian masurian voivodeship" => Ok(Self::WarmianMasurianVoivodeship),
+                    "west pomeranian voivodeship" => Ok(Self::WestPomeranianVoivodeship),
+                    "lodz voivodeship" => Ok(Self::LodzVoivodeship),
+                    "swietokrzyskie voivodeship" => Ok(Self::SwietokrzyskieVoivodeship),
+                    _ => Err(errors::ConnectorError::InvalidDataFormat {
+                        field_name: "address.state",
+                    }
+                    .into()),
+                }
+            }
+        }
+    }
+}
+
+impl ForeignTryFrom<String> for FranceStatesAbbreviation {
+    type Error = error_stack::Report<errors::ConnectorError>;
+    fn foreign_try_from(value: String) -> Result<Self, Self::Error> {
+        let state_abbreviation_check =
+            StringExt::<Self>::parse_enum(value.to_uppercase().clone(), "FranceStatesAbbreviation");
+        match state_abbreviation_check {
+            Ok(state_abbreviation) => Ok(state_abbreviation),
+            Err(_) => {
+                let binding = value.as_str().to_lowercase();
+                let state = binding.as_str();
+                match state {
+                    "alo" => Ok(Self::Alo),
+                    "alsace" => Ok(Self::Alsace),
+                    "aquitaine" => Ok(Self::Aquitaine),
+                    "auvergne" => Ok(Self::Auvergne),
+                    "auvergne rhone alpes" => Ok(Self::AuvergneRhoneAlpes),
+                    "bourgogne franche comte" => Ok(Self::BourgogneFrancheComte),
+                    "brittany" => Ok(Self::Brittany),
+                    "burgundy" => Ok(Self::Burgundy),
+                    "centre val de loire" => Ok(Self::CentreValDeLoire),
+                    "champagne ardenne" => Ok(Self::ChampagneArdenne),
+                    "corsica" => Ok(Self::Corsica),
+                    "franche comte" => Ok(Self::FrancheComte),
+                    "french guiana" => Ok(Self::FrenchGuiana),
+                    "french polynesia" => Ok(Self::FrenchPolynesia),
+                    "grand est" => Ok(Self::GrandEst),
+                    "guadeloupe" => Ok(Self::Guadeloupe),
+                    "hauts de france" => Ok(Self::HautsDeFrance),
+                    "ile de france" => Ok(Self::IleDeFrance),
+                    "normandy" => Ok(Self::Normandy),
+                    "nouvelle aquitaine" => Ok(Self::NouvelleAquitaine),
+                    "occitania" => Ok(Self::Occitania),
+                    "paris" => Ok(Self::Paris),
+                    "pays de la loire" => Ok(Self::PaysDeLaLoire),
+                    "provence alpes cote d azur" => Ok(Self::ProvenceAlpesCoteDAzur),
+                    "reunion" => Ok(Self::Reunion),
+                    "saint barthelemy" => Ok(Self::SaintBarthelemy),
+                    "saint martin" => Ok(Self::SaintMartin),
+                    "saint pierre and miquelon" => Ok(Self::SaintPierreAndMiquelon),
+                    "upper normandy" => Ok(Self::UpperNormandy),
+                    "wallis and futuna" => Ok(Self::WallisAndFutuna),
+                    _ => Err(errors::ConnectorError::InvalidDataFormat {
+                        field_name: "address.state",
+                    }
+                    .into()),
+                }
+            }
+        }
+    }
+}
+
+impl ForeignTryFrom<String> for GermanyStatesAbbreviation {
+    type Error = error_stack::Report<errors::ConnectorError>;
+    fn foreign_try_from(value: String) -> Result<Self, Self::Error> {
+        let state_abbreviation_check = StringExt::<Self>::parse_enum(
+            value.to_uppercase().clone(),
+            "GermanyStatesAbbreviation",
+        );
+        match state_abbreviation_check {
+            Ok(state_abbreviation) => Ok(state_abbreviation),
+            Err(_) => {
+                let binding = value.as_str().to_lowercase();
+                let state = binding.as_str();
+                match state {
+                    "baden wurttemberg" => Ok(Self::BadenWurttemberg),
+                    "bavaria" => Ok(Self::Bavaria),
+                    "berlin" => Ok(Self::Berlin),
+                    "brandenburg" => Ok(Self::Brandenburg),
+                    "bremen" => Ok(Self::Bremen),
+                    "hamburg" => Ok(Self::Hamburg),
+                    "hesse" => Ok(Self::Hesse),
+                    "lower saxony" => Ok(Self::LowerSaxony),
+                    "mecklenburg vorpommern" => Ok(Self::MecklenburgVorpommern),
+                    "north rhine westphalia" => Ok(Self::NorthRhineWestphalia),
+                    "rhineland palatinate" => Ok(Self::RhinelandPalatinate),
+                    "saarland" => Ok(Self::Saarland),
+                    "saxony" => Ok(Self::Saxony),
+                    "saxony anhalt" => Ok(Self::SaxonyAnhalt),
+                    "schleswig holstein" => Ok(Self::SchleswigHolstein),
+                    "thuringia" => Ok(Self::Thuringia),
+                    _ => Err(errors::ConnectorError::InvalidDataFormat {
+                        field_name: "address.state",
+                    }
+                    .into()),
+                }
+            }
+        }
+    }
+}
+
+impl ForeignTryFrom<String> for SpainStatesAbbreviation {
+    type Error = error_stack::Report<errors::ConnectorError>;
+    fn foreign_try_from(value: String) -> Result<Self, Self::Error> {
+        let state_abbreviation_check =
+            StringExt::<Self>::parse_enum(value.to_uppercase().clone(), "SpainStatesAbbreviation");
+        match state_abbreviation_check {
+            Ok(state_abbreviation) => Ok(state_abbreviation),
+            Err(_) => {
+                let binding = value.as_str().to_lowercase();
+                let state = binding.as_str();
+                match state {
+                    "a coruna province" => Ok(Self::ACorunaProvince),
+                    "albacete province" => Ok(Self::AlbaceteProvince),
+                    "alicante province" => Ok(Self::AlicanteProvince),
+                    "almeria province" => Ok(Self::AlmeriaProvince),
+                    "andalusia" => Ok(Self::Andalusia),
+                    "araba alava" => Ok(Self::ArabaAlava),
+                    "aragon" => Ok(Self::Aragon),
+                    "badajoz province" => Ok(Self::BadajozProvince),
+                    "balearic islands" => Ok(Self::BalearicIslands),
+                    "barcelona province" => Ok(Self::BarcelonaProvince),
+                    "basque country" => Ok(Self::BasqueCountry),
+                    "biscay" => Ok(Self::Biscay),
+                    "burgos province" => Ok(Self::BurgosProvince),
+                    "canary islands" => Ok(Self::CanaryIslands),
+                    "cantabria" => Ok(Self::Cantabria),
+                    "castellon province" => Ok(Self::CastellonProvince),
+                    "castile and leon" => Ok(Self::CastileAndLeon),
+                    "castile la mancha" => Ok(Self::CastileLaMancha),
+                    "catalonia" => Ok(Self::Catalonia),
+                    "ceuta" => Ok(Self::Ceuta),
+                    "ciudad real province" => Ok(Self::CiudadRealProvince),
+                    "community of madrid" => Ok(Self::CommunityOfMadrid),
+                    "cuenca province" => Ok(Self::CuencaProvince),
+                    "caceres province" => Ok(Self::CaceresProvince),
+                    "cadiz province" => Ok(Self::CadizProvince),
+                    "cordoba province" => Ok(Self::CordobaProvince),
+                    "extremadura" => Ok(Self::Extremadura),
+                    "galicia" => Ok(Self::Galicia),
+                    "gipuzkoa" => Ok(Self::Gipuzkoa),
+                    "girona province" => Ok(Self::GironaProvince),
+                    "granada province" => Ok(Self::GranadaProvince),
+                    "guadalajara province" => Ok(Self::GuadalajaraProvince),
+                    "huelva province" => Ok(Self::HuelvaProvince),
+                    "huesca province" => Ok(Self::HuescaProvince),
+                    "jaen province" => Ok(Self::JaenProvince),
+                    "la rioja" => Ok(Self::LaRioja),
+                    "las palmas province" => Ok(Self::LasPalmasProvince),
+                    "leon province" => Ok(Self::LeonProvince),
+                    "lleida province" => Ok(Self::LleidaProvince),
+                    "lugo province" => Ok(Self::LugoProvince),
+                    "madrid province" => Ok(Self::MadridProvince),
+                    "melilla" => Ok(Self::Melilla),
+                    "murcia province" => Ok(Self::MurciaProvince),
+                    "malaga province" => Ok(Self::MalagaProvince),
+                    "navarre" => Ok(Self::Navarre),
+                    "ourense province" => Ok(Self::OurenseProvince),
+                    "palencia province" => Ok(Self::PalenciaProvince),
+                    "pontevedra province" => Ok(Self::PontevedraProvince),
+                    "province of asturias" => Ok(Self::ProvinceOfAsturias),
+                    "province of avila" => Ok(Self::ProvinceOfAvila),
+                    "region of murcia" => Ok(Self::RegionOfMurcia),
+                    "salamanca province" => Ok(Self::SalamancaProvince),
+                    "santa cruz de tenerife province" => Ok(Self::SantaCruzDeTenerifeProvince),
+                    "segovia province" => Ok(Self::SegoviaProvince),
+                    "seville province" => Ok(Self::SevilleProvince),
+                    "soria province" => Ok(Self::SoriaProvince),
+                    "tarragona province" => Ok(Self::TarragonaProvince),
+                    "teruel province" => Ok(Self::TeruelProvince),
+                    "toledo province" => Ok(Self::ToledoProvince),
+                    "valencia province" => Ok(Self::ValenciaProvince),
+                    "valencian community" => Ok(Self::ValencianCommunity),
+                    "valladolid province" => Ok(Self::ValladolidProvince),
+                    "zamora province" => Ok(Self::ZamoraProvince),
+                    "zaragoza province" => Ok(Self::ZaragozaProvince),
+                    _ => Err(errors::ConnectorError::InvalidDataFormat {
+                        field_name: "address.state",
+                    }
+                    .into()),
+                }
+            }
+        }
+    }
+}
+
+impl ForeignTryFrom<String> for ItalyStatesAbbreviation {
+    type Error = error_stack::Report<errors::ConnectorError>;
+    fn foreign_try_from(value: String) -> Result<Self, Self::Error> {
+        let state_abbreviation_check =
+            StringExt::<Self>::parse_enum(value.to_uppercase().clone(), "ItalyStatesAbbreviation");
+        match state_abbreviation_check {
+            Ok(state_abbreviation) => Ok(state_abbreviation),
+            Err(_) => {
+                let binding = value.as_str().to_lowercase();
+                let state = binding.as_str();
+                match state {
+                    "abruzzo" => Ok(Self::Abruzzo),
+                    "aosta valley" => Ok(Self::AostaValley),
+                    "apulia" => Ok(Self::Apulia),
+                    "basilicata" => Ok(Self::Basilicata),
+                    "benevento province" => Ok(Self::BeneventoProvince),
+                    "calabria" => Ok(Self::Calabria),
+                    "campania" => Ok(Self::Campania),
+                    "emilia romagna" => Ok(Self::EmiliaRomagna),
+                    "friuli venezia giulia" => Ok(Self::FriuliVeneziaGiulia),
+                    "lazio" => Ok(Self::Lazio),
+                    "liguria" => Ok(Self::Liguria),
+                    "lombardy" => Ok(Self::Lombardy),
+                    "marche" => Ok(Self::Marche),
+                    "molise" => Ok(Self::Molise),
+                    "piedmont" => Ok(Self::Piedmont),
+                    "sardinia" => Ok(Self::Sardinia),
+                    "sicily" => Ok(Self::Sicily),
+                    "trentino south tyrol" => Ok(Self::TrentinoSouthTyrol),
+                    "tuscany" => Ok(Self::Tuscany),
+                    "umbria" => Ok(Self::Umbria),
+                    "veneto" => Ok(Self::Veneto),
+                    "agrigento" => Ok(Self::Agrigento),
+                    "caltanissetta" => Ok(Self::Caltanissetta),
+                    "enna" => Ok(Self::Enna),
+                    "ragusa" => Ok(Self::Ragusa),
+                    "siracusa" => Ok(Self::Siracusa),
+                    "trapani" => Ok(Self::Trapani),
+                    "bari" => Ok(Self::Bari),
+                    "bologna" => Ok(Self::Bologna),
+                    "cagliari" => Ok(Self::Cagliari),
+                    "catania" => Ok(Self::Catania),
+                    "florence" => Ok(Self::Florence),
+                    "genoa" => Ok(Self::Genoa),
+                    "messina" => Ok(Self::Messina),
+                    "milan" => Ok(Self::Milan),
+                    "naples" => Ok(Self::Naples),
+                    "palermo" => Ok(Self::Palermo),
+                    "reggio calabria" => Ok(Self::ReggioCalabria),
+                    "rome" => Ok(Self::Rome),
+                    "turin" => Ok(Self::Turin),
+                    "venice" => Ok(Self::Venice),
+                    _ => Err(errors::ConnectorError::InvalidDataFormat {
+                        field_name: "address.state",
+                    }
+                    .into()),
+                }
+            }
+        }
+    }
+}
+
+impl ForeignTryFrom<String> for NorwayStatesAbbreviation {
+    type Error = error_stack::Report<errors::ConnectorError>;
+    fn foreign_try_from(value: String) -> Result<Self, Self::Error> {
+        let state_abbreviation_check =
+            StringExt::<Self>::parse_enum(value.to_uppercase().clone(), "NorwayStatesAbbreviation");
+        match state_abbreviation_check {
+            Ok(state_abbreviation) => Ok(state_abbreviation),
+            Err(_) => {
+                let binding = value.as_str().to_lowercase();
+                let state = binding.as_str();
+                match state {
+                    "akershus" => Ok(Self::Akershus),
+                    "buskerud" => Ok(Self::Buskerud),
+                    "finnmark" => Ok(Self::Finnmark),
+                    "hedmark" => Ok(Self::Hedmark),
+                    "hordaland" => Ok(Self::Hordaland),
+                    "janmayen" => Ok(Self::JanMayen),
+                    "nordtrondelag" => Ok(Self::NordTrondelag),
+                    "nordland" => Ok(Self::Nordland),
+                    "oppland" => Ok(Self::Oppland),
+                    "oslo" => Ok(Self::Oslo),
+                    "rogaland" => Ok(Self::Rogaland),
+                    "sognogfjordane" => Ok(Self::SognOgFjordane),
+                    "svalbard" => Ok(Self::Svalbard),
+                    "sortrondelag" => Ok(Self::SorTrondelag),
+                    "telemark" => Ok(Self::Telemark),
+                    "troms" => Ok(Self::Troms),
+                    "trondelag" => Ok(Self::Trondelag),
+                    "vestagder" => Ok(Self::VestAgder),
+                    "vestfold" => Ok(Self::Vestfold),
+                    "ostfold" => Ok(Self::Ostfold),
+                    _ => Err(errors::ConnectorError::InvalidDataFormat {
+                        field_name: "address.state",
+                    }
+                    .into()),
+                }
+            }
+        }
+    }
+}
+
+impl ForeignTryFrom<String> for AlbaniaStatesAbbreviation {
+    type Error = error_stack::Report<errors::ConnectorError>;
+    fn foreign_try_from(value: String) -> Result<Self, Self::Error> {
+        let state_abbreviation_check = StringExt::<Self>::parse_enum(
+            value.to_uppercase().clone(),
+            "AlbaniaStatesAbbreviation",
+        );
+        match state_abbreviation_check {
+            Ok(state_abbreviation) => Ok(state_abbreviation),
+            Err(_) => {
+                let binding = value.as_str().to_lowercase();
+                let state = binding.as_str();
+                match state {
+                    "berat" => Ok(Self::Berat),
+                    "diber" => Ok(Self::Diber),
+                    "durres" => Ok(Self::Durres),
+                    "elbasan" => Ok(Self::Elbasan),
+                    "fier" => Ok(Self::Fier),
+                    "gjirokaster" => Ok(Self::Gjirokaster),
+                    "korce" => Ok(Self::Korce),
+                    "kukes" => Ok(Self::Kukes),
+                    "lezhe" => Ok(Self::Lezhe),
+                    "shkoder" => Ok(Self::Shkoder),
+                    "tirane" => Ok(Self::Tirane),
+                    "vlore" => Ok(Self::Vlore),
+                    _ => Err(errors::ConnectorError::InvalidDataFormat {
+                        field_name: "address.state",
+                    }
+                    .into()),
+                }
+            }
+        }
+    }
+}
+
+impl ForeignTryFrom<String> for AndorraStatesAbbreviation {
+    type Error = error_stack::Report<errors::ConnectorError>;
+    fn foreign_try_from(value: String) -> Result<Self, Self::Error> {
+        let state_abbreviation_check = StringExt::<Self>::parse_enum(
+            value.to_uppercase().clone(),
+            "AndorraStatesAbbreviation",
+        );
+        match state_abbreviation_check {
+            Ok(state_abbreviation) => Ok(state_abbreviation),
+            Err(_) => {
+                let binding = value.as_str().to_lowercase();
+                let state = binding.as_str();
+                match state {
+                    "andorra la vella" => Ok(Self::AndorraLaVella),
+                    "canillo" => Ok(Self::Canillo),
+                    "encamp" => Ok(Self::Encamp),
+                    "escaldes engordany" => Ok(Self::EscaldesEngordany),
+                    "la massana" => Ok(Self::LaMassana),
+                    "ordino" => Ok(Self::Ordino),
+                    "sant julia de loria" => Ok(Self::SantJuliaDeLoria),
+                    _ => Err(errors::ConnectorError::InvalidDataFormat {
+                        field_name: "address.state",
+                    }
+                    .into()),
+                }
+            }
+        }
+    }
+}
+
+impl ForeignTryFrom<String> for AustriaStatesAbbreviation {
+    type Error = error_stack::Report<errors::ConnectorError>;
+    fn foreign_try_from(value: String) -> Result<Self, Self::Error> {
+        let state_abbreviation_check = StringExt::<Self>::parse_enum(
+            value.to_uppercase().clone(),
+            "AustriaStatesAbbreviation",
+        );
+        match state_abbreviation_check {
+            Ok(state_abbreviation) => Ok(state_abbreviation),
+            Err(_) => {
+                let binding = value.as_str().to_lowercase();
+                let state = binding.as_str();
+                match state {
+                    "burgenland" => Ok(Self::Burgenland),
+                    "carinthia" => Ok(Self::Carinthia),
+                    "lower austria" => Ok(Self::LowerAustria),
+                    "salzburg" => Ok(Self::Salzburg),
+                    "styria" => Ok(Self::Styria),
+                    "tyrol" => Ok(Self::Tyrol),
+                    "upper austria" => Ok(Self::UpperAustria),
+                    "vienna" => Ok(Self::Vienna),
+                    "vorarlberg" => Ok(Self::Vorarlberg),
+                    _ => Err(errors::ConnectorError::InvalidDataFormat {
+                        field_name: "address.state",
+                    }
+                    .into()),
+                }
+            }
+        }
+    }
+}
+
+impl ForeignTryFrom<String> for RomaniaStatesAbbreviation {
+    type Error = error_stack::Report<errors::ConnectorError>;
+    fn foreign_try_from(value: String) -> Result<Self, Self::Error> {
+        let state_abbreviation_check = StringExt::<Self>::parse_enum(
+            value.to_uppercase().clone(),
+            "RomaniaStatesAbbreviation",
+        );
+        match state_abbreviation_check {
+            Ok(state_abbreviation) => Ok(state_abbreviation),
+            Err(_) => {
+                let binding = value.as_str().to_lowercase();
+                let state = binding.as_str();
+                match state {
+                    "alba" => Ok(Self::Alba),
+                    "arad county" => Ok(Self::AradCounty),
+                    "arges" => Ok(Self::Arges),
+                    "bacau county" => Ok(Self::BacauCounty),
+                    "bihor county" => Ok(Self::BihorCounty),
+                    "bistrita nasaud county" => Ok(Self::BistritaNasaudCounty),
+                    "botosani county" => Ok(Self::BotosaniCounty),
+                    "braila" => Ok(Self::Braila),
+                    "brasov county" => Ok(Self::BrasovCounty),
+                    "bucharest" => Ok(Self::Bucharest),
+                    "buzau county" => Ok(Self::BuzauCounty),
+                    "caras severin county" => Ok(Self::CarasSeverinCounty),
+                    "cluj county" => Ok(Self::ClujCounty),
+                    "constanta county" => Ok(Self::ConstantaCounty),
+                    "covasna county" => Ok(Self::CovasnaCounty),
+                    "calarasi county" => Ok(Self::CalarasiCounty),
+                    "dolj county" => Ok(Self::DoljCounty),
+                    "dambovita county" => Ok(Self::DambovitaCounty),
+                    "galati county" => Ok(Self::GalatiCounty),
+                    "giurgiu county" => Ok(Self::GiurgiuCounty),
+                    "gorj county" => Ok(Self::GorjCounty),
+                    "harghita county" => Ok(Self::HarghitaCounty),
+                    "hunedoara county" => Ok(Self::HunedoaraCounty),
+                    "ialomita county" => Ok(Self::IalomitaCounty),
+                    "iasi county" => Ok(Self::IasiCounty),
+                    "ilfov county" => Ok(Self::IlfovCounty),
+                    "mehedinti county" => Ok(Self::MehedintiCounty),
+                    "mures county" => Ok(Self::MuresCounty),
+                    "neamt county" => Ok(Self::NeamtCounty),
+                    "olt county" => Ok(Self::OltCounty),
+                    "prahova county" => Ok(Self::PrahovaCounty),
+                    "satu mare county" => Ok(Self::SatuMareCounty),
+                    "sibiu county" => Ok(Self::SibiuCounty),
+                    "suceava county" => Ok(Self::SuceavaCounty),
+                    "salaj county" => Ok(Self::SalajCounty),
+                    "teleorman county" => Ok(Self::TeleormanCounty),
+                    "timis county" => Ok(Self::TimisCounty),
+                    "tulcea county" => Ok(Self::TulceaCounty),
+                    "vaslui county" => Ok(Self::VasluiCounty),
+                    "vrancea county" => Ok(Self::VranceaCounty),
+                    "valcea county" => Ok(Self::ValceaCounty),
+                    _ => Err(errors::ConnectorError::InvalidDataFormat {
+                        field_name: "address.state",
+                    }
+                    .into()),
+                }
+            }
+        }
+    }
+}
+
+impl ForeignTryFrom<String> for PortugalStatesAbbreviation {
+    type Error = error_stack::Report<errors::ConnectorError>;
+    fn foreign_try_from(value: String) -> Result<Self, Self::Error> {
+        let state_abbreviation_check = StringExt::<Self>::parse_enum(
+            value.to_uppercase().clone(),
+            "PortugalStatesAbbreviation",
+        );
+        match state_abbreviation_check {
+            Ok(state_abbreviation) => Ok(state_abbreviation),
+            Err(_) => {
+                let binding = value.as_str().to_lowercase();
+                let state = binding.as_str();
+                match state {
+                    "aveiro district" => Ok(Self::AveiroDistrict),
+                    "azores" => Ok(Self::Azores),
+                    "beja district" => Ok(Self::BejaDistrict),
+                    "braga district" => Ok(Self::BragaDistrict),
+                    "braganca district" => Ok(Self::BragancaDistrict),
+                    "castelo branco district" => Ok(Self::CasteloBrancoDistrict),
+                    "coimbra district" => Ok(Self::CoimbraDistrict),
+                    "faro district" => Ok(Self::FaroDistrict),
+                    "guarda district" => Ok(Self::GuardaDistrict),
+                    "leiria district" => Ok(Self::LeiriaDistrict),
+                    "lisbon district" => Ok(Self::LisbonDistrict),
+                    "madeira" => Ok(Self::Madeira),
+                    "portalegre district" => Ok(Self::PortalegreDistrict),
+                    "porto district" => Ok(Self::PortoDistrict),
+                    "santarem district" => Ok(Self::SantaremDistrict),
+                    "setubal district" => Ok(Self::SetubalDistrict),
+                    "viana do castelo district" => Ok(Self::VianaDoCasteloDistrict),
+                    "vila real district" => Ok(Self::VilaRealDistrict),
+                    "viseu district" => Ok(Self::ViseuDistrict),
+                    "evora district" => Ok(Self::EvoraDistrict),
+                    _ => Err(errors::ConnectorError::InvalidDataFormat {
+                        field_name: "address.state",
+                    }
+                    .into()),
+                }
+            }
+        }
+    }
+}
+
+impl ForeignTryFrom<String> for SwitzerlandStatesAbbreviation {
+    type Error = error_stack::Report<errors::ConnectorError>;
+    fn foreign_try_from(value: String) -> Result<Self, Self::Error> {
+        let state_abbreviation_check = StringExt::<Self>::parse_enum(
+            value.to_uppercase().clone(),
+            "SwitzerlandStatesAbbreviation",
+        );
+        match state_abbreviation_check {
+            Ok(state_abbreviation) => Ok(state_abbreviation),
+            Err(_) => {
+                let binding = value.as_str().to_lowercase();
+                let state = binding.as_str();
+                match state {
+                    "aargau" => Ok(Self::Aargau),
+                    "appenzell ausserrhoden" => Ok(Self::AppenzellAusserrhoden),
+                    "appenzell innerrhoden" => Ok(Self::AppenzellInnerrhoden),
+                    "basel landschaft" => Ok(Self::BaselLandschaft),
+                    "canton of fribourg" => Ok(Self::CantonOfFribourg),
+                    "canton of geneva" => Ok(Self::CantonOfGeneva),
+                    "canton of jura" => Ok(Self::CantonOfJura),
+                    "canton of lucerne" => Ok(Self::CantonOfLucerne),
+                    "canton of neuchatel" => Ok(Self::CantonOfNeuchatel),
+                    "canton of schaffhausen" => Ok(Self::CantonOfSchaffhausen),
+                    "canton of solothurn" => Ok(Self::CantonOfSolothurn),
+                    "canton of st gallen" => Ok(Self::CantonOfStGallen),
+                    "canton of valais" => Ok(Self::CantonOfValais),
+                    "canton of vaud" => Ok(Self::CantonOfVaud),
+                    "canton of zug" => Ok(Self::CantonOfZug),
+                    "glarus" => Ok(Self::Glarus),
+                    "graubunden" => Ok(Self::Graubunden),
+                    "nidwalden" => Ok(Self::Nidwalden),
+                    "obwalden" => Ok(Self::Obwalden),
+                    "schwyz" => Ok(Self::Schwyz),
+                    "thurgau" => Ok(Self::Thurgau),
+                    "ticino" => Ok(Self::Ticino),
+                    "uri" => Ok(Self::Uri),
+                    "canton of bern" => Ok(Self::CantonOfBern),
+                    "canton of zurich" => Ok(Self::CantonOfZurich),
+                    _ => Err(errors::ConnectorError::InvalidDataFormat {
+                        field_name: "address.state",
+                    }
+                    .into()),
+                }
+            }
+        }
+    }
+}
+
+impl ForeignTryFrom<String> for NorthMacedoniaStatesAbbreviation {
+    type Error = error_stack::Report<errors::ConnectorError>;
+    fn foreign_try_from(value: String) -> Result<Self, Self::Error> {
+        let state_abbreviation_check = StringExt::<Self>::parse_enum(
+            value.to_uppercase().clone(),
+            "NorthMacedoniaStatesAbbreviation",
+        );
+        match state_abbreviation_check {
+            Ok(state_abbreviation) => Ok(state_abbreviation),
+            Err(_) => {
+                let binding = value.as_str().to_lowercase();
+                let state = binding.as_str();
+                match state {
+                    "aerodrom municipality" => Ok(Self::AerodromMunicipality),
+                    "aracinovo municipality" => Ok(Self::AracinovoMunicipality),
+                    "berovo municipality" => Ok(Self::BerovoMunicipality),
+                    "bitola municipality" => Ok(Self::BitolaMunicipality),
+                    "bogdanci municipality" => Ok(Self::BogdanciMunicipality),
+                    "bogovinje municipality" => Ok(Self::BogovinjeMunicipality),
+                    "bosilovo municipality" => Ok(Self::BosilovoMunicipality),
+                    "brvenica municipality" => Ok(Self::BrvenicaMunicipality),
+                    "butel municipality" => Ok(Self::ButelMunicipality),
+                    "centar municipality" => Ok(Self::CentarMunicipality),
+                    "centar zupa municipality" => Ok(Self::CentarZupaMunicipality),
+                    "debarca municipality" => Ok(Self::DebarcaMunicipality),
+                    "delcevo municipality" => Ok(Self::DelcevoMunicipality),
+                    "demir hisar municipality" => Ok(Self::DemirHisarMunicipality),
+                    "demir kapija municipality" => Ok(Self::DemirKapijaMunicipality),
+                    "dojran municipality" => Ok(Self::DojranMunicipality),
+                    "dolneni municipality" => Ok(Self::DolneniMunicipality),
+                    "drugovo municipality" => Ok(Self::DrugovoMunicipality),
+                    "gazi baba municipality" => Ok(Self::GaziBabaMunicipality),
+                    "gevgelija municipality" => Ok(Self::GevgelijaMunicipality),
+                    "gjorce petrov municipality" => Ok(Self::GjorcePetrovMunicipality),
+                    "gostivar municipality" => Ok(Self::GostivarMunicipality),
+                    "gradsko municipality" => Ok(Self::GradskoMunicipality),
+                    "greater skopje" => Ok(Self::GreaterSkopje),
+                    "ilinden municipality" => Ok(Self::IlindenMunicipality),
+                    "jegunovce municipality" => Ok(Self::JegunovceMunicipality),
+                    "karbinci" => Ok(Self::Karbinci),
+                    "karpos municipality" => Ok(Self::KarposMunicipality),
+                    "kavadarci municipality" => Ok(Self::KavadarciMunicipality),
+                    "kisela voda municipality" => Ok(Self::KiselaVodaMunicipality),
+                    "kicevo municipality" => Ok(Self::KicevoMunicipality),
+                    "konce municipality" => Ok(Self::KonceMunicipality),
+                    _ => Err(errors::ConnectorError::InvalidDataFormat {
+                        field_name: "address.state",
+                    }
+                    .into()),
+                }
+            }
+        }
+    }
+}
+
+impl ForeignTryFrom<String> for MontenegroStatesAbbreviation {
+    type Error = error_stack::Report<errors::ConnectorError>;
+    fn foreign_try_from(value: String) -> Result<Self, Self::Error> {
+        let state_abbreviation_check = StringExt::<Self>::parse_enum(
+            value.to_uppercase().clone(),
+            "MontenegroStatesAbbreviation",
+        );
+        match state_abbreviation_check {
+            Ok(state_abbreviation) => Ok(state_abbreviation),
+            Err(_) => {
+                let binding = value.as_str().to_lowercase();
+                let state = binding.as_str();
+                match state {
+                    "andrijevica municipality" => Ok(Self::AndrijevicaMunicipality),
+                    "bar municipality" => Ok(Self::BarMunicipality),
+                    "berane municipality" => Ok(Self::BeraneMunicipality),
+                    "bijelo polje municipality" => Ok(Self::BijeloPoljeMunicipality),
+                    "budva municipality" => Ok(Self::BudvaMunicipality),
+                    "danilovgrad municipality" => Ok(Self::DanilovgradMunicipality),
+                    "gusinje municipality" => Ok(Self::GusinjeMunicipality),
+                    "kolasin municipality" => Ok(Self::KolasinMunicipality),
+                    "kotor municipality" => Ok(Self::KotorMunicipality),
+                    "mojkovac municipality" => Ok(Self::MojkovacMunicipality),
+                    "niksic municipality" => Ok(Self::NiksicMunicipality),
+                    "old royal capital cetinje" => Ok(Self::OldRoyalCapitalCetinje),
+                    "petnjica municipality" => Ok(Self::PetnjicaMunicipality),
+                    "plav municipality" => Ok(Self::PlavMunicipality),
+                    "pljevlja municipality" => Ok(Self::PljevljaMunicipality),
+                    "pluzine municipality" => Ok(Self::PluzineMunicipality),
+                    "podgorica municipality" => Ok(Self::PodgoricaMunicipality),
+                    "rozaje municipality" => Ok(Self::RozajeMunicipality),
+                    "tivat municipality" => Ok(Self::TivatMunicipality),
+                    "ulcinj municipality" => Ok(Self::UlcinjMunicipality),
+                    "savnik municipality" => Ok(Self::SavnikMunicipality),
+                    "zabljak municipality" => Ok(Self::ZabljakMunicipality),
+                    _ => Err(errors::ConnectorError::InvalidDataFormat {
+                        field_name: "address.state",
+                    }
+                    .into()),
+                }
+            }
+        }
+    }
+}
+
+impl ForeignTryFrom<String> for MonacoStatesAbbreviation {
+    type Error = error_stack::Report<errors::ConnectorError>;
+    fn foreign_try_from(value: String) -> Result<Self, Self::Error> {
+        let state_abbreviation_check =
+            StringExt::<Self>::parse_enum(value.to_uppercase().clone(), "MonacoStatesAbbreviation");
+        match state_abbreviation_check {
+            Ok(state_abbreviation) => Ok(state_abbreviation),
+            Err(_) => {
+                let binding = value.as_str().to_lowercase();
+                let state = binding.as_str();
+                match state {
+                    "monaco" => Ok(Self::Monaco),
+                    _ => Err(errors::ConnectorError::InvalidDataFormat {
+                        field_name: "address.state",
+                    }
+                    .into()),
+                }
+            }
+        }
+    }
+}
+
+impl ForeignTryFrom<String> for NetherlandsStatesAbbreviation {
+    type Error = error_stack::Report<errors::ConnectorError>;
+    fn foreign_try_from(value: String) -> Result<Self, Self::Error> {
+        let state_abbreviation_check = StringExt::<Self>::parse_enum(
+            value.to_uppercase().clone(),
+            "NetherlandsStatesAbbreviation",
+        );
+        match state_abbreviation_check {
+            Ok(state_abbreviation) => Ok(state_abbreviation),
+            Err(_) => {
+                let binding = value.as_str().to_lowercase();
+                let state = binding.as_str();
+                match state {
+                    "bonaire" => Ok(Self::Bonaire),
+                    "drenthe" => Ok(Self::Drenthe),
+                    "flevoland" => Ok(Self::Flevoland),
+                    "friesland" => Ok(Self::Friesland),
+                    "gelderland" => Ok(Self::Gelderland),
+                    "groningen" => Ok(Self::Groningen),
+                    "limburg" => Ok(Self::Limburg),
+                    "north brabant" => Ok(Self::NorthBrabant),
+                    "north holland" => Ok(Self::NorthHolland),
+                    "overijssel" => Ok(Self::Overijssel),
+                    "saba" => Ok(Self::Saba),
+                    "sint eustatius" => Ok(Self::SintEustatius),
+                    "south holland" => Ok(Self::SouthHolland),
+                    "utrecht" => Ok(Self::Utrecht),
+                    "zeeland" => Ok(Self::Zeeland),
+                    _ => Err(errors::ConnectorError::InvalidDataFormat {
+                        field_name: "address.state",
+                    }
+                    .into()),
+                }
+            }
+        }
+    }
+}
+
+impl ForeignTryFrom<String> for MoldovaStatesAbbreviation {
+    type Error = error_stack::Report<errors::ConnectorError>;
+    fn foreign_try_from(value: String) -> Result<Self, Self::Error> {
+        let state_abbreviation_check = StringExt::<Self>::parse_enum(
+            value.to_uppercase().clone(),
+            "MoldovaStatesAbbreviation",
+        );
+        match state_abbreviation_check {
+            Ok(state_abbreviation) => Ok(state_abbreviation),
+            Err(_) => {
+                let binding = value.as_str().to_lowercase();
+                let state = binding.as_str();
+                match state {
+                    "anenii noi district" => Ok(Self::AneniiNoiDistrict),
+                    "basarabeasca district" => Ok(Self::BasarabeascaDistrict),
+                    "bender municipality" => Ok(Self::BenderMunicipality),
+                    "briceni district" => Ok(Self::BriceniDistrict),
+                    "balti municipality" => Ok(Self::BaltiMunicipality),
+                    "cahul district" => Ok(Self::CahulDistrict),
+                    "cantemir district" => Ok(Self::CantemirDistrict),
+                    "chisinau municipality" => Ok(Self::ChisinauMunicipality),
+                    "cimislia district" => Ok(Self::CimisliaDistrict),
+                    "criuleni district" => Ok(Self::CriuleniDistrict),
+                    "calarasi district" => Ok(Self::CalarasiDistrict),
+                    "causeni district" => Ok(Self::CauseniDistrict),
+                    "donduseni district" => Ok(Self::DonduseniDistrict),
+                    "drochia district" => Ok(Self::DrochiaDistrict),
+                    "dubasari district" => Ok(Self::DubasariDistrict),
+                    "edinet district" => Ok(Self::EdinetDistrict),
+                    "floresti district" => Ok(Self::FlorestiDistrict),
+                    "falesti district" => Ok(Self::FalestiDistrict),
+                    "gagauzia" => Ok(Self::Gagauzia),
+                    "glodeni district" => Ok(Self::GlodeniDistrict),
+                    "hincesti district" => Ok(Self::HincestiDistrict),
+                    "ialoveni district" => Ok(Self::IaloveniDistrict),
+                    "nisporeni district" => Ok(Self::NisporeniDistrict),
+                    "ocnita district" => Ok(Self::OcnitaDistrict),
+                    "orhei district" => Ok(Self::OrheiDistrict),
+                    "rezina district" => Ok(Self::RezinaDistrict),
+                    "riscani district" => Ok(Self::RiscaniDistrict),
+                    "soroca district" => Ok(Self::SorocaDistrict),
+                    "straseni district" => Ok(Self::StraseniDistrict),
+                    "singerei district" => Ok(Self::SingereiDistrict),
+                    "taraclia district" => Ok(Self::TaracliaDistrict),
+                    "telenesti district" => Ok(Self::TelenestiDistrict),
+                    "transnistria autonomous territorial unit" => {
+                        Ok(Self::TransnistriaAutonomousTerritorialUnit)
+                    }
+                    "ungheni district" => Ok(Self::UngheniDistrict),
+                    "soldanesti district" => Ok(Self::SoldanestiDistrict),
+                    "stefan voda district" => Ok(Self::StefanVodaDistrict),
+                    _ => Err(errors::ConnectorError::InvalidDataFormat {
+                        field_name: "address.state",
+                    }
+                    .into()),
+                }
+            }
+        }
+    }
+}
+
+impl ForeignTryFrom<String> for LithuaniaStatesAbbreviation {
+    type Error = error_stack::Report<errors::ConnectorError>;
+    fn foreign_try_from(value: String) -> Result<Self, Self::Error> {
+        let state_abbreviation_check = StringExt::<Self>::parse_enum(
+            value.to_uppercase().clone(),
+            "LithuaniaStatesAbbreviation",
+        );
+        match state_abbreviation_check {
+            Ok(state_abbreviation) => Ok(state_abbreviation),
+            Err(_) => {
+                let binding = value.as_str().to_lowercase();
+                let state = binding.as_str();
+                match state {
+                    "akmene district municipality" => Ok(Self::AkmeneDistrictMunicipality),
+                    "alytus city municipality" => Ok(Self::AlytusCityMunicipality),
+                    "alytus county" => Ok(Self::AlytusCounty),
+                    "alytus district municipality" => Ok(Self::AlytusDistrictMunicipality),
+                    "birstonas municipality" => Ok(Self::BirstonasMunicipality),
+                    "birzai district municipality" => Ok(Self::BirzaiDistrictMunicipality),
+                    "druskininkai municipality" => Ok(Self::DruskininkaiMunicipality),
+                    "elektrenai municipality" => Ok(Self::ElektrenaiMunicipality),
+                    "ignalina district municipality" => Ok(Self::IgnalinaDistrictMunicipality),
+                    "jonava district municipality" => Ok(Self::JonavaDistrictMunicipality),
+                    "joniskis district municipality" => Ok(Self::JoniskisDistrictMunicipality),
+                    "jurbarkas district municipality" => Ok(Self::JurbarkasDistrictMunicipality),
+                    "kaisiadorys district municipality" => {
+                        Ok(Self::KaisiadorysDistrictMunicipality)
+                    }
+                    "kalvarija municipality" => Ok(Self::KalvarijaMunicipality),
+                    "kaunas city municipality" => Ok(Self::KaunasCityMunicipality),
+                    "kaunas county" => Ok(Self::KaunasCounty),
+                    "kaunas district municipality" => Ok(Self::KaunasDistrictMunicipality),
+                    "kazlu ruda municipality" => Ok(Self::KazluRudaMunicipality),
+                    "kelme district municipality" => Ok(Self::KelmeDistrictMunicipality),
+                    "klaipeda city municipality" => Ok(Self::KlaipedaCityMunicipality),
+                    "klaipeda county" => Ok(Self::KlaipedaCounty),
+                    "klaipeda district municipality" => Ok(Self::KlaipedaDistrictMunicipality),
+                    "kretinga district municipality" => Ok(Self::KretingaDistrictMunicipality),
+                    "kupiskis district municipality" => Ok(Self::KupiskisDistrictMunicipality),
+                    "kedainiai district municipality" => Ok(Self::KedainiaiDistrictMunicipality),
+                    "lazdijai district municipality" => Ok(Self::LazdijaiDistrictMunicipality),
+                    "marijampole county" => Ok(Self::MarijampoleCounty),
+                    "marijampole municipality" => Ok(Self::MarijampoleMunicipality),
+                    "mazeikiai district municipality" => Ok(Self::MazeikiaiDistrictMunicipality),
+                    "moletai district municipality" => Ok(Self::MoletaiDistrictMunicipality),
+                    "neringa municipality" => Ok(Self::NeringaMunicipality),
+                    "pagegiai municipality" => Ok(Self::PagegiaiMunicipality),
+                    "pakruojis district municipality" => Ok(Self::PakruojisDistrictMunicipality),
+                    "palanga city municipality" => Ok(Self::PalangaCityMunicipality),
+                    "panevezys city municipality" => Ok(Self::PanevezysCityMunicipality),
+                    "panevezys county" => Ok(Self::PanevezysCounty),
+                    "panevezys district municipality" => Ok(Self::PanevezysDistrictMunicipality),
+                    "pasvalys district municipality" => Ok(Self::PasvalysDistrictMunicipality),
+                    "plunge district municipality" => Ok(Self::PlungeDistrictMunicipality),
+                    "prienai district municipality" => Ok(Self::PrienaiDistrictMunicipality),
+                    "radviliskis district municipality" => {
+                        Ok(Self::RadviliskisDistrictMunicipality)
+                    }
+                    "raseiniai district municipality" => Ok(Self::RaseiniaiDistrictMunicipality),
+                    "rietavas municipality" => Ok(Self::RietavasMunicipality),
+                    "rokiskis district municipality" => Ok(Self::RokiskisDistrictMunicipality),
+                    "skuodas district municipality" => Ok(Self::SkuodasDistrictMunicipality),
+                    "taurage county" => Ok(Self::TaurageCounty),
+                    "taurage district municipality" => Ok(Self::TaurageDistrictMunicipality),
+                    "telsiai county" => Ok(Self::TelsiaiCounty),
+                    "telsiai district municipality" => Ok(Self::TelsiaiDistrictMunicipality),
+                    "trakai district municipality" => Ok(Self::TrakaiDistrictMunicipality),
+                    "ukmerge district municipality" => Ok(Self::UkmergeDistrictMunicipality),
+                    "utena county" => Ok(Self::UtenaCounty),
+                    "utena district municipality" => Ok(Self::UtenaDistrictMunicipality),
+                    "varena district municipality" => Ok(Self::VarenaDistrictMunicipality),
+                    "vilkaviskis district municipality" => {
+                        Ok(Self::VilkaviskisDistrictMunicipality)
+                    }
+                    "vilnius city municipality" => Ok(Self::VilniusCityMunicipality),
+                    "vilnius county" => Ok(Self::VilniusCounty),
+                    "vilnius district municipality" => Ok(Self::VilniusDistrictMunicipality),
+                    "visaginas municipality" => Ok(Self::VisaginasMunicipality),
+                    "zarasai district municipality" => Ok(Self::ZarasaiDistrictMunicipality),
+                    "sakiai district municipality" => Ok(Self::SakiaiDistrictMunicipality),
+                    "salcininkai district municipality" => {
+                        Ok(Self::SalcininkaiDistrictMunicipality)
+                    }
+                    "siauliai city municipality" => Ok(Self::SiauliaiCityMunicipality),
+                    "siauliai county" => Ok(Self::SiauliaiCounty),
+                    "siauliai district municipality" => Ok(Self::SiauliaiDistrictMunicipality),
+                    "silale district municipality" => Ok(Self::SilaleDistrictMunicipality),
+                    "silute district municipality" => Ok(Self::SiluteDistrictMunicipality),
+                    "sirvintos district municipality" => Ok(Self::SirvintosDistrictMunicipality),
+                    "svencionys district municipality" => Ok(Self::SvencionysDistrictMunicipality),
+                    _ => Err(errors::ConnectorError::InvalidDataFormat {
+                        field_name: "address.state",
+                    }
+                    .into()),
+                }
+            }
+        }
+    }
+}
+
+impl ForeignTryFrom<String> for LiechtensteinStatesAbbreviation {
+    type Error = error_stack::Report<errors::ConnectorError>;
+    fn foreign_try_from(value: String) -> Result<Self, Self::Error> {
+        let state_abbreviation_check = StringExt::<Self>::parse_enum(
+            value.to_uppercase().clone(),
+            "LiechtensteinStatesAbbreviation",
+        );
+        match state_abbreviation_check {
+            Ok(state_abbreviation) => Ok(state_abbreviation),
+            Err(_) => {
+                let binding = value.as_str().to_lowercase();
+                let state = binding.as_str();
+                match state {
+                    "balzers" => Ok(Self::Balzers),
+                    "eschen" => Ok(Self::Eschen),
+                    "gamprin" => Ok(Self::Gamprin),
+                    "mauren" => Ok(Self::Mauren),
+                    "planken" => Ok(Self::Planken),
+                    "ruggell" => Ok(Self::Ruggell),
+                    "schaan" => Ok(Self::Schaan),
+                    "schellenberg" => Ok(Self::Schellenberg),
+                    "triesen" => Ok(Self::Triesen),
+                    "triesenberg" => Ok(Self::Triesenberg),
+                    "vaduz" => Ok(Self::Vaduz),
+                    _ => Err(errors::ConnectorError::InvalidDataFormat {
+                        field_name: "address.state",
+                    }
+                    .into()),
+                }
+            }
+        }
+    }
+}
+
+impl ForeignTryFrom<String> for LatviaStatesAbbreviation {
+    type Error = error_stack::Report<errors::ConnectorError>;
+    fn foreign_try_from(value: String) -> Result<Self, Self::Error> {
+        let state_abbreviation_check =
+            StringExt::<Self>::parse_enum(value.to_uppercase().clone(), "LatviaStatesAbbreviation");
+        match state_abbreviation_check {
+            Ok(state_abbreviation) => Ok(state_abbreviation),
+            Err(_) => {
+                let binding = value.as_str().to_lowercase();
+                let state = binding.as_str();
+                match state {
+                    "aglona municipality" => Ok(Self::AglonaMunicipality),
+                    "aizkraukle municipality" => Ok(Self::AizkraukleMunicipality),
+                    "aizpute municipality" => Ok(Self::AizputeMunicipality),
+                    "akniiste municipality" => Ok(Self::AknīsteMunicipality),
+                    "aloja municipality" => Ok(Self::AlojaMunicipality),
+                    "alsunga municipality" => Ok(Self::AlsungaMunicipality),
+                    "aluksne municipality" => Ok(Self::AlūksneMunicipality),
+                    "amata municipality" => Ok(Self::AmataMunicipality),
+                    "ape municipality" => Ok(Self::ApeMunicipality),
+                    "auce municipality" => Ok(Self::AuceMunicipality),
+                    "babite municipality" => Ok(Self::BabīteMunicipality),
+                    "baldone municipality" => Ok(Self::BaldoneMunicipality),
+                    "baltinava municipality" => Ok(Self::BaltinavaMunicipality),
+                    "balvi municipality" => Ok(Self::BalviMunicipality),
+                    "bauska municipality" => Ok(Self::BauskaMunicipality),
+                    "beverina municipality" => Ok(Self::BeverīnaMunicipality),
+                    "broceni municipality" => Ok(Self::BrocēniMunicipality),
+                    "burtnieki municipality" => Ok(Self::BurtniekiMunicipality),
+                    "carnikava municipality" => Ok(Self::CarnikavaMunicipality),
+                    "cesvaine municipality" => Ok(Self::CesvaineMunicipality),
+                    "cibla municipality" => Ok(Self::CiblaMunicipality),
+                    "cesis municipality" => Ok(Self::CēsisMunicipality),
+                    "dagda municipality" => Ok(Self::DagdaMunicipality),
+                    "daugavpils" => Ok(Self::Daugavpils),
+                    "daugavpils municipality" => Ok(Self::DaugavpilsMunicipality),
+                    "dobele municipality" => Ok(Self::DobeleMunicipality),
+                    "dundaga municipality" => Ok(Self::DundagaMunicipality),
+                    "durbe municipality" => Ok(Self::DurbeMunicipality),
+                    "engure municipality" => Ok(Self::EngureMunicipality),
+                    "garkalne municipality" => Ok(Self::GarkalneMunicipality),
+                    "grobina municipality" => Ok(Self::GrobiņaMunicipality),
+                    "gulbene municipality" => Ok(Self::GulbeneMunicipality),
+                    "iecava municipality" => Ok(Self::IecavaMunicipality),
+                    "ikskile municipality" => Ok(Self::IkšķileMunicipality),
+                    "ilukste municipality" => Ok(Self::IlūksteMunicipality),
+                    "incukalns municipality" => Ok(Self::InčukalnsMunicipality),
+                    "jaunjelgava municipality" => Ok(Self::JaunjelgavaMunicipality),
+                    "jaunpiebalga municipality" => Ok(Self::JaunpiebalgaMunicipality),
+                    "jaunpils municipality" => Ok(Self::JaunpilsMunicipality),
+                    "jelgava" => Ok(Self::Jelgava),
+                    "jelgava municipality" => Ok(Self::JelgavaMunicipality),
+                    "jekabpils" => Ok(Self::Jēkabpils),
+                    "jekabpils municipality" => Ok(Self::JēkabpilsMunicipality),
+                    "jurmala" => Ok(Self::Jūrmala),
+                    "kandava municipality" => Ok(Self::KandavaMunicipality),
+                    "koceni municipality" => Ok(Self::KocēniMunicipality),
+                    "koknese municipality" => Ok(Self::KokneseMunicipality),
+                    "krimulda municipality" => Ok(Self::KrimuldaMunicipality),
+                    "kustpils municipality" => Ok(Self::KrustpilsMunicipality),
+                    "kraslava municipality" => Ok(Self::KrāslavaMunicipality),
+                    "kuldiga municipality" => Ok(Self::KuldīgaMunicipality),
+                    "karsava municipality" => Ok(Self::KārsavaMunicipality),
+                    "lielvarde municipality" => Ok(Self::LielvārdeMunicipality),
+                    "liepaja" => Ok(Self::Liepāja),
+                    "limbazi municipality" => Ok(Self::LimbažiMunicipality),
+                    "lubana municipality" => Ok(Self::LubānaMunicipality),
+                    "ludza municipality" => Ok(Self::LudzaMunicipality),
+                    "ligatne municipality" => Ok(Self::LīgatneMunicipality),
+                    "livani municipality" => Ok(Self::LīvāniMunicipality),
+                    "madona municipality" => Ok(Self::MadonaMunicipality),
+                    "mazsalaca municipality" => Ok(Self::MazsalacaMunicipality),
+                    "malpils municipality" => Ok(Self::MālpilsMunicipality),
+                    "marupe municipality" => Ok(Self::MārupeMunicipality),
+                    "mersrags municipality" => Ok(Self::MērsragsMunicipality),
+                    "naukseni municipality" => Ok(Self::NaukšēniMunicipality),
+                    "nereta municipality" => Ok(Self::NeretaMunicipality),
+                    "nica municipality" => Ok(Self::NīcaMunicipality),
+                    "ogre municipality" => Ok(Self::OgreMunicipality),
+                    "olaine municipality" => Ok(Self::OlaineMunicipality),
+                    "ozolnieki municipality" => Ok(Self::OzolniekiMunicipality),
+                    "preili municipality" => Ok(Self::PreiļiMunicipality),
+                    "priekule municipality" => Ok(Self::PriekuleMunicipality),
+                    "priekuli municipality" => Ok(Self::PriekuļiMunicipality),
+                    "pargauja municipality" => Ok(Self::PārgaujaMunicipality),
+                    "pavilosta municipality" => Ok(Self::PāvilostaMunicipality),
+                    "plavinas municipality" => Ok(Self::PļaviņasMunicipality),
+                    "rauna municipality" => Ok(Self::RaunaMunicipality),
+                    "riebini municipality" => Ok(Self::RiebiņiMunicipality),
+                    "riga" => Ok(Self::Riga),
+                    "roja municipality" => Ok(Self::RojaMunicipality),
+                    "ropazi municipality" => Ok(Self::RopažiMunicipality),
+                    "rucava municipality" => Ok(Self::RucavaMunicipality),
+                    "rugaji municipality" => Ok(Self::RugājiMunicipality),
+                    "rundale municipality" => Ok(Self::RundāleMunicipality),
+                    "rezekne" => Ok(Self::Rēzekne),
+                    "rezekne municipality" => Ok(Self::RēzekneMunicipality),
+                    "rujiena municipality" => Ok(Self::RūjienaMunicipality),
+                    "sala municipality" => Ok(Self::SalaMunicipality),
+                    "salacgriva municipality" => Ok(Self::SalacgrīvaMunicipality),
+                    "salaspils municipality" => Ok(Self::SalaspilsMunicipality),
+                    "saldus municipality" => Ok(Self::SaldusMunicipality),
+                    "saulkrasti municipality" => Ok(Self::SaulkrastiMunicipality),
+                    "sigulda municipality" => Ok(Self::SiguldaMunicipality),
+                    "skrunda municipality" => Ok(Self::SkrundaMunicipality),
+                    "skriveri municipality" => Ok(Self::SkrīveriMunicipality),
+                    "smiltene municipality" => Ok(Self::SmilteneMunicipality),
+                    "stopini municipality" => Ok(Self::StopiņiMunicipality),
+                    "strenci municipality" => Ok(Self::StrenčiMunicipality),
+                    "seja municipality" => Ok(Self::SējaMunicipality),
+                    _ => Err(errors::ConnectorError::InvalidDataFormat {
+                        field_name: "address.state",
+                    }
+                    .into()),
+                }
+            }
+        }
+    }
+}
+
+impl ForeignTryFrom<String> for MaltaStatesAbbreviation {
+    type Error = error_stack::Report<errors::ConnectorError>;
+    fn foreign_try_from(value: String) -> Result<Self, Self::Error> {
+        let state_abbreviation_check =
+            StringExt::<Self>::parse_enum(value.to_uppercase().clone(), "MaltaStatesAbbreviation");
+
+        match state_abbreviation_check {
+            Ok(municipality) => Ok(municipality),
+            Err(_) => {
+                let binding = value.as_str().to_lowercase();
+                let municipality = binding.as_str();
+                match municipality {
+                    "attard" => Ok(Self::Attard),
+                    "balzan" => Ok(Self::Balzan),
+                    "birgu" => Ok(Self::Birgu),
+                    "birkirkara" => Ok(Self::Birkirkara),
+                    "birzebbuga" => Ok(Self::Birzebbuga),
+                    "cospicua" => Ok(Self::Cospicua),
+                    "dingli" => Ok(Self::Dingli),
+                    "fgura" => Ok(Self::Fgura),
+                    "floriana" => Ok(Self::Floriana),
+                    "fontana" => Ok(Self::Fontana),
+                    "gudja" => Ok(Self::Gudja),
+                    "gzira" => Ok(Self::Gzira),
+                    "ghajnsielem" => Ok(Self::Ghajnsielem),
+                    "gharb" => Ok(Self::Gharb),
+                    "gharghur" => Ok(Self::Gharghur),
+                    "ghasri" => Ok(Self::Ghasri),
+                    "ghaxaq" => Ok(Self::Ghaxaq),
+                    "hamrun" => Ok(Self::Hamrun),
+                    "iklin" => Ok(Self::Iklin),
+                    "senglea" => Ok(Self::Senglea),
+                    "kalkara" => Ok(Self::Kalkara),
+                    "kercem" => Ok(Self::Kercem),
+                    "kirkop" => Ok(Self::Kirkop),
+                    "lija" => Ok(Self::Lija),
+                    "luqa" => Ok(Self::Luqa),
+                    "marsa" => Ok(Self::Marsa),
+                    "marsaskala" => Ok(Self::Marsaskala),
+                    "marsaxlokk" => Ok(Self::Marsaxlokk),
+                    "mdina" => Ok(Self::Mdina),
+                    "mellieha" => Ok(Self::Mellieha),
+                    "mgarr" => Ok(Self::Mgarr),
+                    "mosta" => Ok(Self::Mosta),
+                    "mqabba" => Ok(Self::Mqabba),
+                    "msida" => Ok(Self::Msida),
+                    "mtarfa" => Ok(Self::Mtarfa),
+                    "munxar" => Ok(Self::Munxar),
+                    "nadur" => Ok(Self::Nadur),
+                    "naxxar" => Ok(Self::Naxxar),
+                    "paola" => Ok(Self::Paola),
+                    "pembroke" => Ok(Self::Pembroke),
+                    "pieta" => Ok(Self::Pieta),
+                    "qala" => Ok(Self::Qala),
+                    "qormi" => Ok(Self::Qormi),
+                    "qrendi" => Ok(Self::Qrendi),
+                    "victoria" => Ok(Self::Victoria),
+                    "rabat" => Ok(Self::Rabat),
+                    "st julians" => Ok(Self::StJulians),
+                    "san gwann" => Ok(Self::SanGwann),
+                    "saint lawrence" => Ok(Self::SaintLawrence),
+                    "st pauls bay" => Ok(Self::StPaulsBay),
+                    "sannat" => Ok(Self::Sannat),
+                    "santa lucija" => Ok(Self::SantaLucija),
+                    "santa venera" => Ok(Self::SantaVenera),
+                    "siggiewi" => Ok(Self::Siggiewi),
+                    "sliema" => Ok(Self::Sliema),
+                    "swieqi" => Ok(Self::Swieqi),
+                    "ta xbiex" => Ok(Self::TaXbiex),
+                    "tarxien" => Ok(Self::Tarxien),
+                    "valletta" => Ok(Self::Valletta),
+                    "xaghra" => Ok(Self::Xaghra),
+                    "xewkija" => Ok(Self::Xewkija),
+                    "xghajra" => Ok(Self::Xghajra),
+                    "zabbar" => Ok(Self::Zabbar),
+                    "zebbug gozo" => Ok(Self::ZebbugGozo),
+                    "zebbug malta" => Ok(Self::ZebbugMalta),
+                    "zejtun" => Ok(Self::Zejtun),
+                    "zurrieq" => Ok(Self::Zurrieq),
+                    _ => Err(errors::ConnectorError::InvalidDataFormat {
+                        field_name: "address.state",
+                    }
+                    .into()),
+                }
+            }
+        }
+    }
+}
+
+impl ForeignTryFrom<String> for BelarusStatesAbbreviation {
+    type Error = error_stack::Report<errors::ConnectorError>;
+    fn foreign_try_from(value: String) -> Result<Self, Self::Error> {
+        let state_abbreviation_check = StringExt::<Self>::parse_enum(
+            value.to_uppercase().clone(),
+            "BelarusStatesAbbreviation",
+        );
+        match state_abbreviation_check {
+            Ok(state_abbreviation) => Ok(state_abbreviation),
+            Err(_) => {
+                let binding = value.as_str().to_lowercase();
+                let state = binding.as_str();
+                match state {
+                    "brest region" => Ok(Self::BrestRegion),
+                    "gomel region" => Ok(Self::GomelRegion),
+                    "grodno region" => Ok(Self::GrodnoRegion),
+                    "minsk" => Ok(Self::Minsk),
+                    "minsk region" => Ok(Self::MinskRegion),
+                    "mogilev region" => Ok(Self::MogilevRegion),
+                    "vitebsk region" => Ok(Self::VitebskRegion),
+                    _ => Err(errors::ConnectorError::InvalidDataFormat {
+                        field_name: "address.state",
+                    }
+                    .into()),
+                }
+            }
+        }
+    }
+}
+
+impl ForeignTryFrom<String> for IrelandStatesAbbreviation {
+    type Error = error_stack::Report<errors::ConnectorError>;
+    fn foreign_try_from(value: String) -> Result<Self, Self::Error> {
+        let state_abbreviation_check = StringExt::<Self>::parse_enum(
+            value.to_uppercase().clone(),
+            "IrelandStatesAbbreviation",
+        );
+        match state_abbreviation_check {
+            Ok(state_abbreviation) => Ok(state_abbreviation),
+            Err(_) => {
+                let binding = value.as_str().to_lowercase();
+                let state = binding.as_str();
+                match state {
+                    "connacht" => Ok(Self::Connacht),
+                    "county carlow" => Ok(Self::CountyCarlow),
+                    "county cavan" => Ok(Self::CountyCavan),
+                    "county clare" => Ok(Self::CountyClare),
+                    "county cork" => Ok(Self::CountyCork),
+                    "county donegal" => Ok(Self::CountyDonegal),
+                    "county dublin" => Ok(Self::CountyDublin),
+                    "county galway" => Ok(Self::CountyGalway),
+                    "county kerry" => Ok(Self::CountyKerry),
+                    "county kildare" => Ok(Self::CountyKildare),
+                    "county kilkenny" => Ok(Self::CountyKilkenny),
+                    "county laois" => Ok(Self::CountyLaois),
+                    "county limerick" => Ok(Self::CountyLimerick),
+                    "county longford" => Ok(Self::CountyLongford),
+                    "county louth" => Ok(Self::CountyLouth),
+                    "county mayo" => Ok(Self::CountyMayo),
+                    "county meath" => Ok(Self::CountyMeath),
+                    "county monaghan" => Ok(Self::CountyMonaghan),
+                    "county offaly" => Ok(Self::CountyOffaly),
+                    "county roscommon" => Ok(Self::CountyRoscommon),
+                    "county sligo" => Ok(Self::CountySligo),
+                    "county tipperary" => Ok(Self::CountyTipperary),
+                    "county waterford" => Ok(Self::CountyWaterford),
+                    "county westmeath" => Ok(Self::CountyWestmeath),
+                    "county wexford" => Ok(Self::CountyWexford),
+                    "county wicklow" => Ok(Self::CountyWicklow),
+                    "leinster" => Ok(Self::Leinster),
+                    "munster" => Ok(Self::Munster),
+                    "ulster" => Ok(Self::Ulster),
+                    _ => Err(errors::ConnectorError::InvalidDataFormat {
+                        field_name: "address.state",
+                    }
+                    .into()),
+                }
+            }
+        }
+    }
+}
+
+impl ForeignTryFrom<String> for IcelandStatesAbbreviation {
+    type Error = error_stack::Report<errors::ConnectorError>;
+    fn foreign_try_from(value: String) -> Result<Self, Self::Error> {
+        let state_abbreviation_check = StringExt::<Self>::parse_enum(
+            value.to_uppercase().clone(),
+            "IcelandStatesAbbreviation",
+        );
+        match state_abbreviation_check {
+            Ok(state_abbreviation) => Ok(state_abbreviation),
+            Err(_) => {
+                let binding = value.as_str().to_lowercase();
+                let state = binding.as_str();
+                match state {
+                    "capital region" => Ok(Self::CapitalRegion),
+                    "eastern region" => Ok(Self::EasternRegion),
+                    "northeastern region" => Ok(Self::NortheasternRegion),
+                    "northwestern region" => Ok(Self::NorthwesternRegion),
+                    "southern peninsula region" => Ok(Self::SouthernPeninsulaRegion),
+                    "southern region" => Ok(Self::SouthernRegion),
+                    "western region" => Ok(Self::WesternRegion),
+                    "westfjords" => Ok(Self::Westfjords),
+                    _ => Err(errors::ConnectorError::InvalidDataFormat {
+                        field_name: "address.state",
+                    }
+                    .into()),
+                }
+            }
+        }
+    }
+}
+
+impl ForeignTryFrom<String> for HungaryStatesAbbreviation {
+    type Error = error_stack::Report<errors::ConnectorError>;
+    fn foreign_try_from(value: String) -> Result<Self, Self::Error> {
+        let state_abbreviation_check = StringExt::<Self>::parse_enum(
+            value.to_uppercase().clone(),
+            "HungaryStatesAbbreviation",
+        );
+        match state_abbreviation_check {
+            Ok(state_abbreviation) => Ok(state_abbreviation),
+            Err(_) => {
+                let binding = value.as_str().to_lowercase();
+                let state = binding.as_str();
+                match state {
+                    "baranya county" => Ok(Self::BaranyaCounty),
+                    "borsod abauj zemplen county" => Ok(Self::BorsodAbaujZemplenCounty),
+                    "budapest" => Ok(Self::Budapest),
+                    "bacs kiskun county" => Ok(Self::BacsKiskunCounty),
+                    "bekes county" => Ok(Self::BekesCounty),
+                    "bekescsaba" => Ok(Self::Bekescsaba),
+                    "csongrad county" => Ok(Self::CsongradCounty),
+                    "debrecen" => Ok(Self::Debrecen),
+                    "dunaujvaros" => Ok(Self::Dunaujvaros),
+                    "eger" => Ok(Self::Eger),
+                    "fejer county" => Ok(Self::FejerCounty),
+                    "gyor" => Ok(Self::Gyor),
+                    "gyor moson sopron county" => Ok(Self::GyorMosonSopronCounty),
+                    "hajdu bihar county" => Ok(Self::HajduBiharCounty),
+                    "heves county" => Ok(Self::HevesCounty),
+                    "hodmezovasarhely" => Ok(Self::Hodmezovasarhely),
+                    "jasz nagykun szolnok county" => Ok(Self::JaszNagykunSzolnokCounty),
+                    "kaposvar" => Ok(Self::Kaposvar),
+                    "kecskemet" => Ok(Self::Kecskemet),
+                    "miskolc" => Ok(Self::Miskolc),
+                    "nagykanizsa" => Ok(Self::Nagykanizsa),
+                    "nyiregyhaza" => Ok(Self::Nyiregyhaza),
+                    "nograd county" => Ok(Self::NogradCounty),
+                    "pest county" => Ok(Self::PestCounty),
+                    "pecs" => Ok(Self::Pecs),
+                    "salgotarjan" => Ok(Self::Salgotarjan),
+                    "somogy county" => Ok(Self::SomogyCounty),
+                    "sopron" => Ok(Self::Sopron),
+                    "szabolcs szatmar bereg county" => Ok(Self::SzabolcsSzatmarBeregCounty),
+                    "szeged" => Ok(Self::Szeged),
+                    "szekszard" => Ok(Self::Szekszard),
+                    "szolnok" => Ok(Self::Szolnok),
+                    "szombathely" => Ok(Self::Szombathely),
+                    "szekesfehervar" => Ok(Self::Szekesfehervar),
+                    "tatabanya" => Ok(Self::Tatabanya),
+                    "tolna county" => Ok(Self::TolnaCounty),
+                    "vas county" => Ok(Self::VasCounty),
+                    "veszprem" => Ok(Self::Veszprem),
+                    "veszprem county" => Ok(Self::VeszpremCounty),
+                    "zala county" => Ok(Self::ZalaCounty),
+                    "zalaegerszeg" => Ok(Self::Zalaegerszeg),
+                    "erd" => Ok(Self::Erd),
+                    _ => Err(errors::ConnectorError::InvalidDataFormat {
+                        field_name: "address.state",
+                    }
+                    .into()),
+                }
+            }
+        }
+    }
+}
+
+impl ForeignTryFrom<String> for GreeceStatesAbbreviation {
+    type Error = error_stack::Report<errors::ConnectorError>;
+    fn foreign_try_from(value: String) -> Result<Self, Self::Error> {
+        let state_abbreviation_check =
+            StringExt::<Self>::parse_enum(value.to_uppercase().clone(), "GreeceStatesAbbreviation");
+        match state_abbreviation_check {
+            Ok(state_abbreviation) => Ok(state_abbreviation),
+            Err(_) => {
+                let binding = value.as_str().to_lowercase();
+                let state = binding.as_str();
+                match state {
+                    "achaea regional unit" => Ok(Self::AchaeaRegionalUnit),
+                    "aetolia acarnania regional unit" => Ok(Self::AetoliaAcarnaniaRegionalUnit),
+                    "arcadia prefecture" => Ok(Self::ArcadiaPrefecture),
+                    "argolis regional unit" => Ok(Self::ArgolisRegionalUnit),
+                    "attica region" => Ok(Self::AtticaRegion),
+                    "boeotia regional unit" => Ok(Self::BoeotiaRegionalUnit),
+                    "central greece region" => Ok(Self::CentralGreeceRegion),
+                    "central macedonia" => Ok(Self::CentralMacedonia),
+                    "chania regional unit" => Ok(Self::ChaniaRegionalUnit),
+                    "corfu prefecture" => Ok(Self::CorfuPrefecture),
+                    "corinthia regional unit" => Ok(Self::CorinthiaRegionalUnit),
+                    "crete region" => Ok(Self::CreteRegion),
+                    "drama regional unit" => Ok(Self::DramaRegionalUnit),
+                    "east attica regional unit" => Ok(Self::EastAtticaRegionalUnit),
+                    "east macedonia and thrace" => Ok(Self::EastMacedoniaAndThrace),
+                    "epirus region" => Ok(Self::EpirusRegion),
+                    "euboea" => Ok(Self::Euboea),
+                    "grevena prefecture" => Ok(Self::GrevenaPrefecture),
+                    "imathia regional unit" => Ok(Self::ImathiaRegionalUnit),
+                    "ioannina regional unit" => Ok(Self::IoanninaRegionalUnit),
+                    "ionian islands region" => Ok(Self::IonianIslandsRegion),
+                    "karditsa regional unit" => Ok(Self::KarditsaRegionalUnit),
+                    "kastoria regional unit" => Ok(Self::KastoriaRegionalUnit),
+                    "kefalonia prefecture" => Ok(Self::KefaloniaPrefecture),
+                    "kilkis regional unit" => Ok(Self::KilkisRegionalUnit),
+                    "kozani prefecture" => Ok(Self::KozaniPrefecture),
+                    "laconia" => Ok(Self::Laconia),
+                    "larissa prefecture" => Ok(Self::LarissaPrefecture),
+                    "lefkada regional unit" => Ok(Self::LefkadaRegionalUnit),
+                    "pella regional unit" => Ok(Self::PellaRegionalUnit),
+                    "peloponnese region" => Ok(Self::PeloponneseRegion),
+                    "phthiotis prefecture" => Ok(Self::PhthiotisPrefecture),
+                    "preveza prefecture" => Ok(Self::PrevezaPrefecture),
+                    "serres prefecture" => Ok(Self::SerresPrefecture),
+                    "south aegean" => Ok(Self::SouthAegean),
+                    "thessaloniki regional unit" => Ok(Self::ThessalonikiRegionalUnit),
+                    "west greece region" => Ok(Self::WestGreeceRegion),
+                    "west macedonia region" => Ok(Self::WestMacedoniaRegion),
+                    _ => Err(errors::ConnectorError::InvalidDataFormat {
+                        field_name: "address.state",
+                    }
+                    .into()),
+                }
+            }
+        }
+    }
+}
+
+impl ForeignTryFrom<String> for FinlandStatesAbbreviation {
+    type Error = error_stack::Report<errors::ConnectorError>;
+    fn foreign_try_from(value: String) -> Result<Self, Self::Error> {
+        let state_abbreviation_check = StringExt::<Self>::parse_enum(
+            value.to_uppercase().clone(),
+            "FinlandStatesAbbreviation",
+        );
+        match state_abbreviation_check {
+            Ok(state_abbreviation) => Ok(state_abbreviation),
+            Err(_) => {
+                let binding = value.as_str().to_lowercase();
+                let state = binding.as_str();
+                match state {
+                    "central finland" => Ok(Self::CentralFinland),
+                    "central ostrobothnia" => Ok(Self::CentralOstrobothnia),
+                    "eastern finland province" => Ok(Self::EasternFinlandProvince),
+                    "finland proper" => Ok(Self::FinlandProper),
+                    "kainuu" => Ok(Self::Kainuu),
+                    "kymenlaakso" => Ok(Self::Kymenlaakso),
+                    "lapland" => Ok(Self::Lapland),
+                    "north karelia" => Ok(Self::NorthKarelia),
+                    "northern ostrobothnia" => Ok(Self::NorthernOstrobothnia),
+                    "northern savonia" => Ok(Self::NorthernSavonia),
+                    "ostrobothnia" => Ok(Self::Ostrobothnia),
+                    "oulu province" => Ok(Self::OuluProvince),
+                    "pirkanmaa" => Ok(Self::Pirkanmaa),
+                    "paijanne tavastia" => Ok(Self::PaijanneTavastia),
+                    "satakunta" => Ok(Self::Satakunta),
+                    "south karelia" => Ok(Self::SouthKarelia),
+                    "southern ostrobothnia" => Ok(Self::SouthernOstrobothnia),
+                    "southern savonia" => Ok(Self::SouthernSavonia),
+                    "tavastia proper" => Ok(Self::TavastiaProper),
+                    "uusimaa" => Ok(Self::Uusimaa),
+                    "aland islands" => Ok(Self::AlandIslands),
+                    _ => Err(errors::ConnectorError::InvalidDataFormat {
+                        field_name: "address.state",
+                    }
+                    .into()),
+                }
+            }
+        }
+    }
+}
+
+impl ForeignTryFrom<String> for DenmarkStatesAbbreviation {
+    type Error = error_stack::Report<errors::ConnectorError>;
+    fn foreign_try_from(value: String) -> Result<Self, Self::Error> {
+        let state_abbreviation_check = StringExt::<Self>::parse_enum(
+            value.to_uppercase().clone(),
+            "DenmarkStatesAbbreviation",
+        );
+        match state_abbreviation_check {
+            Ok(state_abbreviation) => Ok(state_abbreviation),
+            Err(_) => {
+                let binding = value.as_str().to_lowercase();
+                let state = binding.as_str();
+                match state {
+                    "capital region of denmark" => Ok(Self::CapitalRegionOfDenmark),
+                    "central denmark region" => Ok(Self::CentralDenmarkRegion),
+                    "north denmark region" => Ok(Self::NorthDenmarkRegion),
+                    "region zealand" => Ok(Self::RegionZealand),
+                    "region of southern denmark" => Ok(Self::RegionOfSouthernDenmark),
+                    _ => Err(errors::ConnectorError::InvalidDataFormat {
+                        field_name: "address.state",
+                    }
+                    .into()),
+                }
+            }
+        }
+    }
+}
+
+impl ForeignTryFrom<String> for CzechRepublicStatesAbbreviation {
+    type Error = error_stack::Report<errors::ConnectorError>;
+    fn foreign_try_from(value: String) -> Result<Self, Self::Error> {
+        let state_abbreviation_check = StringExt::<Self>::parse_enum(
+            value.to_uppercase().clone(),
+            "CzechRepublicStatesAbbreviation",
+        );
+        match state_abbreviation_check {
+            Ok(state_abbreviation) => Ok(state_abbreviation),
+            Err(_) => {
+                let binding = value.as_str().to_lowercase();
+                let state = binding.as_str();
+                match state {
+                    "benesov district" => Ok(Self::BenesovDistrict),
+                    "beroun district" => Ok(Self::BerounDistrict),
+                    "blansko district" => Ok(Self::BlanskoDistrict),
+                    "brno city district" => Ok(Self::BrnoCityDistrict),
+                    "brno country district" => Ok(Self::BrnoCountryDistrict),
+                    "bruntal district" => Ok(Self::BruntalDistrict),
+                    "breclav district" => Ok(Self::BreclavDistrict),
+                    "central bohemian region" => Ok(Self::CentralBohemianRegion),
+                    "cheb district" => Ok(Self::ChebDistrict),
+                    "chomutov district" => Ok(Self::ChomutovDistrict),
+                    "chrudim district" => Ok(Self::ChrudimDistrict),
+                    "domazlice district" => Ok(Self::DomazliceDistrict),
+                    "decin district" => Ok(Self::DecinDistrict),
+                    "frydek mistek district" => Ok(Self::FrydekMistekDistrict),
+                    "havlickuv brod district" => Ok(Self::HavlickuvBrodDistrict),
+                    "hodonin district" => Ok(Self::HodoninDistrict),
+                    "horni pocernice" => Ok(Self::HorniPocernice),
+                    "hradec kralove district" => Ok(Self::HradecKraloveDistrict),
+                    "hradec kralove region" => Ok(Self::HradecKraloveRegion),
+                    "jablonec nad nisou district" => Ok(Self::JablonecNadNisouDistrict),
+                    "jesenik district" => Ok(Self::JesenikDistrict),
+                    "jihlava district" => Ok(Self::JihlavaDistrict),
+                    "jindrichuv hradec district" => Ok(Self::JindrichuvHradecDistrict),
+                    "jicin district" => Ok(Self::JicinDistrict),
+                    "karlovy vary district" => Ok(Self::KarlovyVaryDistrict),
+                    "karlovy vary region" => Ok(Self::KarlovyVaryRegion),
+                    "karvina district" => Ok(Self::KarvinaDistrict),
+                    "kladno district" => Ok(Self::KladnoDistrict),
+                    "klatovy district" => Ok(Self::KlatovyDistrict),
+                    "kolin district" => Ok(Self::KolinDistrict),
+                    "kromeriz district" => Ok(Self::KromerizDistrict),
+                    "liberec district" => Ok(Self::LiberecDistrict),
+                    "liberec region" => Ok(Self::LiberecRegion),
+                    "litomerice district" => Ok(Self::LitomericeDistrict),
+                    "louny district" => Ok(Self::LounyDistrict),
+                    "mlada boleslav district" => Ok(Self::MladaBoleslavDistrict),
+                    "moravian silesian region" => Ok(Self::MoravianSilesianRegion),
+                    "most district" => Ok(Self::MostDistrict),
+                    "melnik district" => Ok(Self::MelnikDistrict),
+                    "novy jicin district" => Ok(Self::NovyJicinDistrict),
+                    "nymburk district" => Ok(Self::NymburkDistrict),
+                    "nachod district" => Ok(Self::NachodDistrict),
+                    "olomouc district" => Ok(Self::OlomoucDistrict),
+                    "olomouc region" => Ok(Self::OlomoucRegion),
+                    "opava district" => Ok(Self::OpavaDistrict),
+                    "ostrava city district" => Ok(Self::OstravaCityDistrict),
+                    "pardubice district" => Ok(Self::PardubiceDistrict),
+                    "pardubice region" => Ok(Self::PardubiceRegion),
+                    "pelhrimov district" => Ok(Self::PelhrimovDistrict),
+                    "plzen region" => Ok(Self::PlzenRegion),
+                    "plzen city district" => Ok(Self::PlzenCityDistrict),
+                    "plzen north district" => Ok(Self::PlzenNorthDistrict),
+                    "plzen south district" => Ok(Self::PlzenSouthDistrict),
+                    "prachatice district" => Ok(Self::PrachaticeDistrict),
+                    "prague" => Ok(Self::Prague),
+                    "prague1" => Ok(Self::Prague1),
+                    "prague10" => Ok(Self::Prague10),
+                    "prague11" => Ok(Self::Prague11),
+                    "prague12" => Ok(Self::Prague12),
+                    "prague13" => Ok(Self::Prague13),
+                    "prague14" => Ok(Self::Prague14),
+                    "prague15" => Ok(Self::Prague15),
+                    "prague16" => Ok(Self::Prague16),
+                    "prague2" => Ok(Self::Prague2),
+                    "prague21" => Ok(Self::Prague21),
+                    "prague3" => Ok(Self::Prague3),
+                    "prague4" => Ok(Self::Prague4),
+                    "prague5" => Ok(Self::Prague5),
+                    "prague6" => Ok(Self::Prague6),
+                    "prague7" => Ok(Self::Prague7),
+                    "prague8" => Ok(Self::Prague8),
+                    "prague9" => Ok(Self::Prague9),
+                    "prague east district" => Ok(Self::PragueEastDistrict),
+                    "prague west district" => Ok(Self::PragueWestDistrict),
+                    "prostejov district" => Ok(Self::ProstejovDistrict),
+                    "pisek district" => Ok(Self::PisekDistrict),
+                    "prerov district" => Ok(Self::PrerovDistrict),
+                    "pribram district" => Ok(Self::PribramDistrict),
+                    "rakovnik district" => Ok(Self::RakovnikDistrict),
+                    "rokycany district" => Ok(Self::RokycanyDistrict),
+                    "rychnov nad kneznou district" => Ok(Self::RychnovNadKneznouDistrict),
+                    "semily district" => Ok(Self::SemilyDistrict),
+                    "sokolov district" => Ok(Self::SokolovDistrict),
+                    "south bohemian region" => Ok(Self::SouthBohemianRegion),
+                    "south moravian region" => Ok(Self::SouthMoravianRegion),
+                    "strakonice district" => Ok(Self::StrakoniceDistrict),
+                    "svitavy district" => Ok(Self::SvitavyDistrict),
+                    "tachov district" => Ok(Self::TachovDistrict),
+                    "teplice district" => Ok(Self::TepliceDistrict),
+                    "trutnov district" => Ok(Self::TrutnovDistrict),
+                    "tabor district" => Ok(Self::TaborDistrict),
+                    "trebic district" => Ok(Self::TrebicDistrict),
+                    "uherske hradiste district" => Ok(Self::UherskeHradisteDistrict),
+                    "vsetin district" => Ok(Self::VsetinDistrict),
+                    "vysocina region" => Ok(Self::VysocinaRegion),
+                    "vyskov district" => Ok(Self::VyskovDistrict),
+                    "zlin district" => Ok(Self::ZlinDistrict),
+                    "zlin region" => Ok(Self::ZlinRegion),
+                    "znojmo district" => Ok(Self::ZnojmoDistrict),
+                    "usti nad labem district" => Ok(Self::UstiNadLabemDistrict),
+                    "usti nad labem region" => Ok(Self::UstiNadLabemRegion),
+                    "usti nad orlici district" => Ok(Self::UstiNadOrliciDistrict),
+                    "ceska lipa district" => Ok(Self::CeskaLipaDistrict),
+                    "ceske budejovice district" => Ok(Self::CeskeBudejoviceDistrict),
+                    "cesky krumlov district" => Ok(Self::CeskyKrumlovDistrict),
+                    "sumperk district" => Ok(Self::SumperkDistrict),
+                    "zdar nad sazavou district" => Ok(Self::ZdarNadSazavouDistrict),
+                    _ => Err(errors::ConnectorError::InvalidDataFormat {
+                        field_name: "address.state",
+                    }
+                    .into()),
+                }
+            }
+        }
+    }
+}
+
+impl ForeignTryFrom<String> for CroatiaStatesAbbreviation {
+    type Error = error_stack::Report<errors::ConnectorError>;
+    fn foreign_try_from(value: String) -> Result<Self, Self::Error> {
+        let state_abbreviation_check = StringExt::<Self>::parse_enum(
+            value.to_uppercase().clone(),
+            "CroatiaStatesAbbreviation",
+        );
+        match state_abbreviation_check {
+            Ok(state_abbreviation) => Ok(state_abbreviation),
+            Err(_) => {
+                let binding = value.as_str().to_lowercase();
+                let state = binding.as_str();
+                match state {
+                    "bjelovar bilogora county" => Ok(Self::BjelovarBilogoraCounty),
+                    "brod posavina county" => Ok(Self::BrodPosavinaCounty),
+                    "dubrovnik neretva county" => Ok(Self::DubrovnikNeretvaCounty),
+                    "istria county" => Ok(Self::IstriaCounty),
+                    "koprivnica krizevci county" => Ok(Self::KoprivnicaKrizevciCounty),
+                    "krapina zagorje county" => Ok(Self::KrapinaZagorjeCounty),
+                    "lika senj county" => Ok(Self::LikaSenjCounty),
+                    "medimurje county" => Ok(Self::MedimurjeCounty),
+                    "osijek baranja county" => Ok(Self::OsijekBaranjaCounty),
+                    "pozega slavonian county" => Ok(Self::PozegaSlavoniaCounty),
+                    "primorje gorski kotar county" => Ok(Self::PrimorjeGorskiKotarCounty),
+                    "sisak moslavina county" => Ok(Self::SisakMoslavinaCounty),
+                    "split dalmatia county" => Ok(Self::SplitDalmatiaCounty),
+                    "varazdin county" => Ok(Self::VarazdinCounty),
+                    "virovitica podravina county" => Ok(Self::ViroviticaPodravinaCounty),
+                    "vukovar syrmia county" => Ok(Self::VukovarSyrmiaCounty),
+                    "zadar county" => Ok(Self::ZadarCounty),
+                    "zagreb" => Ok(Self::Zagreb),
+                    "zagreb county" => Ok(Self::ZagrebCounty),
+                    "sibenik knin county" => Ok(Self::SibenikKninCounty),
+                    _ => Err(errors::ConnectorError::InvalidDataFormat {
+                        field_name: "address.state",
+                    }
+                    .into()),
+                }
+            }
+        }
+    }
+}
+
+impl ForeignTryFrom<String> for BulgariaStatesAbbreviation {
+    type Error = error_stack::Report<errors::ConnectorError>;
+    fn foreign_try_from(value: String) -> Result<Self, Self::Error> {
+        let state_abbreviation_check = StringExt::<Self>::parse_enum(
+            value.to_uppercase().clone(),
+            "BulgariaStatesAbbreviation",
+        );
+        match state_abbreviation_check {
+            Ok(state_abbreviation) => Ok(state_abbreviation),
+            Err(_) => {
+                let binding = value.as_str().to_lowercase();
+                let state = binding.as_str();
+                match state {
+                    "blagoevgrad province" => Ok(Self::BlagoevgradProvince),
+                    "burgas province" => Ok(Self::BurgasProvince),
+                    "dobrich province" => Ok(Self::DobrichProvince),
+                    "gabrovo province" => Ok(Self::GabrovoProvince),
+                    "haskovo province" => Ok(Self::HaskovoProvince),
+                    "kardzhali province" => Ok(Self::KardzhaliProvince),
+                    "kyustendil province" => Ok(Self::KyustendilProvince),
+                    "lovech province" => Ok(Self::LovechProvince),
+                    "montana province" => Ok(Self::MontanaProvince),
+                    "pazardzhik province" => Ok(Self::PazardzhikProvince),
+                    "pernik province" => Ok(Self::PernikProvince),
+                    "pleven province" => Ok(Self::PlevenProvince),
+                    "plovdiv province" => Ok(Self::PlovdivProvince),
+                    "razgrad province" => Ok(Self::RazgradProvince),
+                    "ruse province" => Ok(Self::RuseProvince),
+                    "shumen" => Ok(Self::Shumen),
+                    "silistra province" => Ok(Self::SilistraProvince),
+                    "sliven province" => Ok(Self::SlivenProvince),
+                    "smolyan province" => Ok(Self::SmolyanProvince),
+                    "sofia city province" => Ok(Self::SofiaCityProvince),
+                    "sofia province" => Ok(Self::SofiaProvince),
+                    "stara zagora province" => Ok(Self::StaraZagoraProvince),
+                    "targovishte province" => Ok(Self::TargovishteProvince),
+                    "varna province" => Ok(Self::VarnaProvince),
+                    "veliko tarnovo province" => Ok(Self::VelikoTarnovoProvince),
+                    "vidin province" => Ok(Self::VidinProvince),
+                    "vratsa province" => Ok(Self::VratsaProvince),
+                    "yambol province" => Ok(Self::YambolProvince),
+                    _ => Err(errors::ConnectorError::InvalidDataFormat {
+                        field_name: "address.state",
+                    }
+                    .into()),
+                }
+            }
+        }
+    }
+}
+
+impl ForeignTryFrom<String> for BosniaAndHerzegovinaStatesAbbreviation {
+    type Error = error_stack::Report<errors::ConnectorError>;
+    fn foreign_try_from(value: String) -> Result<Self, Self::Error> {
+        let state_abbreviation_check = StringExt::<Self>::parse_enum(
+            value.to_uppercase().clone(),
+            "BosniaAndHerzegovinaStatesAbbreviation",
+        );
+        match state_abbreviation_check {
+            Ok(state_abbreviation) => Ok(state_abbreviation),
+            Err(_) => {
+                let binding = value.as_str().to_lowercase();
+                let state = binding.as_str();
+                match state {
+                    "bosnian podrinje canton" => Ok(Self::BosnianPodrinjeCanton),
+                    "brcko district" => Ok(Self::BrckoDistrict),
+                    "canton 10" => Ok(Self::Canton10),
+                    "central bosnia canton" => Ok(Self::CentralBosniaCanton),
+                    "federation of bosnia and herzegovina" => {
+                        Ok(Self::FederationOfBosniaAndHerzegovina)
+                    }
+                    "herzegovina neretva canton" => Ok(Self::HerzegovinaNeretvaCanton),
+                    "posavina canton" => Ok(Self::PosavinaCanton),
+                    "republika srpska" => Ok(Self::RepublikaSrpska),
+                    "sarajevo canton" => Ok(Self::SarajevoCanton),
+                    "tuzla canton" => Ok(Self::TuzlaCanton),
+                    "una sana canton" => Ok(Self::UnaSanaCanton),
+                    "west herzegovina canton" => Ok(Self::WestHerzegovinaCanton),
+                    "zenica doboj canton" => Ok(Self::ZenicaDobojCanton),
+                    _ => Err(errors::ConnectorError::InvalidDataFormat {
+                        field_name: "address.state",
+                    }
+                    .into()),
+                }
+            }
+        }
+    }
+}
+
+impl ForeignTryFrom<String> for UnitedKingdomStatesAbbreviation {
+    type Error = error_stack::Report<errors::ConnectorError>;
+    fn foreign_try_from(value: String) -> Result<Self, Self::Error> {
+        let state_abbreviation_check = StringExt::<Self>::parse_enum(
+            value.to_uppercase().clone(),
+            "UnitedKingdomStatesAbbreviation",
+        );
+        match state_abbreviation_check {
+            Ok(state_abbreviation) => Ok(state_abbreviation),
+            Err(_) => {
+                let binding = value.as_str().to_lowercase();
+                let state = binding.as_str();
+                match state {
+                    "aberdeen city" => Ok(Self::AberdeenCity),
+                    "aberdeenshire" => Ok(Self::Aberdeenshire),
+                    "angus" => Ok(Self::Angus),
+                    "antrim and newtownabbey" => Ok(Self::AntrimAndNewtownabbey),
+                    "ards and north down" => Ok(Self::ArdsAndNorthDown),
+                    "argyll and bute" => Ok(Self::ArgyllAndBute),
+                    "armagh city banbridge and craigavon" => {
+                        Ok(Self::ArmaghCityBanbridgeAndCraigavon)
+                    }
+                    "barking and dagenham" => Ok(Self::BarkingAndDagenham),
+                    "barnet" => Ok(Self::Barnet),
+                    "barnsley" => Ok(Self::Barnsley),
+                    "bath and north east somerset" => Ok(Self::BathAndNorthEastSomerset),
+                    "bedford" => Ok(Self::Bedford),
+                    "belfast city" => Ok(Self::BelfastCity),
+                    "bexley" => Ok(Self::Bexley),
+                    "birmingham" => Ok(Self::Birmingham),
+                    "blackburn with darwen" => Ok(Self::BlackburnWithDarwen),
+                    "blackpool" => Ok(Self::Blackpool),
+                    "blaenau gwent" => Ok(Self::BlaenauGwent),
+                    "bolton" => Ok(Self::Bolton),
+                    "bournemouth christchurch and poole" => {
+                        Ok(Self::BournemouthChristchurchAndPoole)
+                    }
+                    "bracknell forest" => Ok(Self::BracknellForest),
+                    "bradford" => Ok(Self::Bradford),
+                    "brent" => Ok(Self::Brent),
+                    "bridgend" => Ok(Self::Bridgend),
+                    "brighton and hove" => Ok(Self::BrightonAndHove),
+                    "bristol city of" => Ok(Self::BristolCityOf),
+                    "bromley" => Ok(Self::Bromley),
+                    "buckinghamshire" => Ok(Self::Buckinghamshire),
+                    "bury" => Ok(Self::Bury),
+                    "caerphilly" => Ok(Self::Caerphilly),
+                    "calderdale" => Ok(Self::Calderdale),
+                    "cambridgeshire" => Ok(Self::Cambridgeshire),
+                    "camden" => Ok(Self::Camden),
+                    "cardiff" => Ok(Self::Cardiff),
+                    "carmarthenshire" => Ok(Self::Carmarthenshire),
+                    "causeway coast and glens" => Ok(Self::CausewayCoastAndGlens),
+                    "central bedfordshire" => Ok(Self::CentralBedfordshire),
+                    "ceredigion" => Ok(Self::Ceredigion),
+                    "cheshire east" => Ok(Self::CheshireEast),
+                    "cheshire west and chester" => Ok(Self::CheshireWestAndChester),
+                    "clackmannanshire" => Ok(Self::Clackmannanshire),
+                    "conwy" => Ok(Self::Conwy),
+                    "cornwall" => Ok(Self::Cornwall),
+                    "coventry" => Ok(Self::Coventry),
+                    "croydon" => Ok(Self::Croydon),
+                    "cumbria" => Ok(Self::Cumbria),
+                    "darlington" => Ok(Self::Darlington),
+                    "denbighshire" => Ok(Self::Denbighshire),
+                    "derby" => Ok(Self::Derby),
+                    "derbyshire" => Ok(Self::Derbyshire),
+                    "derry and strabane" => Ok(Self::DerryAndStrabane),
+                    "devon" => Ok(Self::Devon),
+                    "doncaster" => Ok(Self::Doncaster),
+                    "dorset" => Ok(Self::Dorset),
+                    "dudley" => Ok(Self::Dudley),
+                    "dumfries and galloway" => Ok(Self::DumfriesAndGalloway),
+                    "dundee city" => Ok(Self::DundeeCity),
+                    "durham county" => Ok(Self::DurhamCounty),
+                    "ealing" => Ok(Self::Ealing),
+                    "east ayrshire" => Ok(Self::EastAyrshire),
+                    "east dunbartonshire" => Ok(Self::EastDunbartonshire),
+                    "east lothian" => Ok(Self::EastLothian),
+                    "east renfrewshire" => Ok(Self::EastRenfrewshire),
+                    "east riding of yorkshire" => Ok(Self::EastRidingOfYorkshire),
+                    "east sussex" => Ok(Self::EastSussex),
+                    "edinburgh city of" => Ok(Self::EdinburghCityOf),
+                    "eilean siar" => Ok(Self::EileanSiar),
+                    "enfield" => Ok(Self::Enfield),
+                    "essex" => Ok(Self::Essex),
+                    "falkirk" => Ok(Self::Falkirk),
+                    "fermanagh and omagh" => Ok(Self::FermanaghAndOmagh),
+                    "fife" => Ok(Self::Fife),
+                    "flintshire" => Ok(Self::Flintshire),
+                    "gateshead" => Ok(Self::Gateshead),
+                    "glasgow city" => Ok(Self::GlasgowCity),
+                    "gloucestershire" => Ok(Self::Gloucestershire),
+                    "greenwich" => Ok(Self::Greenwich),
+                    "gwynedd" => Ok(Self::Gwynedd),
+                    "hackney" => Ok(Self::Hackney),
+                    "halton" => Ok(Self::Halton),
+                    "hammersmith and fulham" => Ok(Self::HammersmithAndFulham),
+                    "hampshire" => Ok(Self::Hampshire),
+                    "haringey" => Ok(Self::Haringey),
+                    "harrow" => Ok(Self::Harrow),
+                    "hartlepool" => Ok(Self::Hartlepool),
+                    "havering" => Ok(Self::Havering),
+                    "herefordshire" => Ok(Self::Herefordshire),
+                    "hertfordshire" => Ok(Self::Hertfordshire),
+                    "highland" => Ok(Self::Highland),
+                    "hillingdon" => Ok(Self::Hillingdon),
+                    "hounslow" => Ok(Self::Hounslow),
+                    "inverclyde" => Ok(Self::Inverclyde),
+                    "isle of anglesey" => Ok(Self::IsleOfAnglesey),
+                    "isle of wight" => Ok(Self::IsleOfWight),
+                    "isles of scilly" => Ok(Self::IslesOfScilly),
+                    "islington" => Ok(Self::Islington),
+                    "kensington and chelsea" => Ok(Self::KensingtonAndChelsea),
+                    "kent" => Ok(Self::Kent),
+                    "kingston upon hull" => Ok(Self::KingstonUponHull),
+                    "kingston upon thames" => Ok(Self::KingstonUponThames),
+                    "kirklees" => Ok(Self::Kirklees),
+                    "knowsley" => Ok(Self::Knowsley),
+                    "lambeth" => Ok(Self::Lambeth),
+                    "lancashire" => Ok(Self::Lancashire),
+                    "leeds" => Ok(Self::Leeds),
+                    "leicester" => Ok(Self::Leicester),
+                    "leicestershire" => Ok(Self::Leicestershire),
+                    "lewisham" => Ok(Self::Lewisham),
+                    "lincolnshire" => Ok(Self::Lincolnshire),
+                    "lisburn and castlereagh" => Ok(Self::LisburnAndCastlereagh),
+                    "liverpool" => Ok(Self::Liverpool),
+                    "london city of" => Ok(Self::LondonCityOf),
+                    "luton" => Ok(Self::Luton),
+                    "manchester" => Ok(Self::Manchester),
+                    "medway" => Ok(Self::Medway),
+                    "merthyr tydfil" => Ok(Self::MerthyrTydfil),
+                    "merton" => Ok(Self::Merton),
+                    "mid and east antrim" => Ok(Self::MidAndEastAntrim),
+                    "mid ulster" => Ok(Self::MidUlster),
+                    "middlesbrough" => Ok(Self::Middlesbrough),
+                    "midlothian" => Ok(Self::Midlothian),
+                    "milton keynes" => Ok(Self::MiltonKeynes),
+                    "monmouthshire" => Ok(Self::Monmouthshire),
+                    "moray" => Ok(Self::Moray),
+                    "neath port talbot" => Ok(Self::NeathPortTalbot),
+                    "newcastle upon tyne" => Ok(Self::NewcastleUponTyne),
+                    "newham" => Ok(Self::Newham),
+                    "newport" => Ok(Self::Newport),
+                    "newry mourne and down" => Ok(Self::NewryMourneAndDown),
+                    "norfolk" => Ok(Self::Norfolk),
+                    "north ayrshire" => Ok(Self::NorthAyrshire),
+                    "north east lincolnshire" => Ok(Self::NorthEastLincolnshire),
+                    "north lanarkshire" => Ok(Self::NorthLanarkshire),
+                    "north lincolnshire" => Ok(Self::NorthLincolnshire),
+                    "north somerset" => Ok(Self::NorthSomerset),
+                    "north tyneside" => Ok(Self::NorthTyneside),
+                    "north yorkshire" => Ok(Self::NorthYorkshire),
+                    "northamptonshire" => Ok(Self::Northamptonshire),
+                    "northumberland" => Ok(Self::Northumberland),
+                    "nottingham" => Ok(Self::Nottingham),
+                    "nottinghamshire" => Ok(Self::Nottinghamshire),
+                    "oldham" => Ok(Self::Oldham),
+                    "orkney islands" => Ok(Self::OrkneyIslands),
+                    "oxfordshire" => Ok(Self::Oxfordshire),
+                    "pembrokeshire" => Ok(Self::Pembrokeshire),
+                    "perth and kinross" => Ok(Self::PerthAndKinross),
+                    "peterborough" => Ok(Self::Peterborough),
+                    "plymouth" => Ok(Self::Plymouth),
+                    "portsmouth" => Ok(Self::Portsmouth),
+                    "powys" => Ok(Self::Powys),
+                    "reading" => Ok(Self::Reading),
+                    "redbridge" => Ok(Self::Redbridge),
+                    "redcar and cleveland" => Ok(Self::RedcarAndCleveland),
+                    "renfrewshire" => Ok(Self::Renfrewshire),
+                    "rhondda cynon taff" => Ok(Self::RhonddaCynonTaff),
+                    "richmond upon thames" => Ok(Self::RichmondUponThames),
+                    "rochdale" => Ok(Self::Rochdale),
+                    "rotherham" => Ok(Self::Rotherham),
+                    "rutland" => Ok(Self::Rutland),
+                    "salford" => Ok(Self::Salford),
+                    "sandwell" => Ok(Self::Sandwell),
+                    "scottish borders" => Ok(Self::ScottishBorders),
+                    "sefton" => Ok(Self::Sefton),
+                    "sheffield" => Ok(Self::Sheffield),
+                    "shetland islands" => Ok(Self::ShetlandIslands),
+                    "shropshire" => Ok(Self::Shropshire),
+                    "slough" => Ok(Self::Slough),
+                    "solihull" => Ok(Self::Solihull),
+                    "somerset" => Ok(Self::Somerset),
+                    "south ayrshire" => Ok(Self::SouthAyrshire),
+                    "south gloucestershire" => Ok(Self::SouthGloucestershire),
+                    "south lanarkshire" => Ok(Self::SouthLanarkshire),
+                    "south tyneside" => Ok(Self::SouthTyneside),
+                    "southampton" => Ok(Self::Southampton),
+                    "southend on sea" => Ok(Self::SouthendOnSea),
+                    "southwark" => Ok(Self::Southwark),
+                    "st helens" => Ok(Self::StHelens),
+                    "staffordshire" => Ok(Self::Staffordshire),
+                    "stirling" => Ok(Self::Stirling),
+                    "stockport" => Ok(Self::Stockport),
+                    "stockton on tees" => Ok(Self::StocktonOnTees),
+                    "stoke on trent" => Ok(Self::StokeOnTrent),
+                    "suffolk" => Ok(Self::Suffolk),
+                    "sunderland" => Ok(Self::Sunderland),
+                    "surrey" => Ok(Self::Surrey),
+                    "sutton" => Ok(Self::Sutton),
+                    "swansea" => Ok(Self::Swansea),
+                    "swindon" => Ok(Self::Swindon),
+                    "tameside" => Ok(Self::Tameside),
+                    "telford and wrekin" => Ok(Self::TelfordAndWrekin),
+                    "thurrock" => Ok(Self::Thurrock),
+                    "torbay" => Ok(Self::Torbay),
+                    "torfaen" => Ok(Self::Torfaen),
+                    "tower hamlets" => Ok(Self::TowerHamlets),
+                    "trafford" => Ok(Self::Trafford),
+                    "vale of glamorgan" => Ok(Self::ValeOfGlamorgan),
+                    "wakefield" => Ok(Self::Wakefield),
+                    "walsall" => Ok(Self::Walsall),
+                    "waltham forest" => Ok(Self::WalthamForest),
+                    "wandsworth" => Ok(Self::Wandsworth),
+                    "warrington" => Ok(Self::Warrington),
+                    "warwickshire" => Ok(Self::Warwickshire),
+                    "west berkshire" => Ok(Self::WestBerkshire),
+                    "west dunbartonshire" => Ok(Self::WestDunbartonshire),
+                    "west lothian" => Ok(Self::WestLothian),
+                    "west sussex" => Ok(Self::WestSussex),
+                    "westminster" => Ok(Self::Westminster),
+                    "wigan" => Ok(Self::Wigan),
+                    "wiltshire" => Ok(Self::Wiltshire),
+                    "windsor and maidenhead" => Ok(Self::WindsorAndMaidenhead),
+                    "wirral" => Ok(Self::Wirral),
+                    "wokingham" => Ok(Self::Wokingham),
+                    "wolverhampton" => Ok(Self::Wolverhampton),
+                    "worcestershire" => Ok(Self::Worcestershire),
+                    "wrexham" => Ok(Self::Wrexham),
+                    "york" => Ok(Self::York),
                     _ => Err(errors::ConnectorError::InvalidDataFormat {
                         field_name: "address.state",
                     }

--- a/crates/hyperswitch_domain_models/src/mandates.rs
+++ b/crates/hyperswitch_domain_models/src/mandates.rs
@@ -60,7 +60,7 @@ pub struct MandateAmountData {
 pub struct MandateData {
     /// A way to update the mandate's payment method details
     pub update_mandate_id: Option<String>,
-    /// A concent from the customer to store the payment method
+    /// A consent from the customer to store the payment method
     pub customer_acceptance: Option<CustomerAcceptance>,
     /// A way to select the type of mandate used
     pub mandate_type: Option<MandateDataType>,

--- a/crates/router/src/core/payments.rs
+++ b/crates/router/src/core/payments.rs
@@ -6928,7 +6928,10 @@ pub async fn payment_external_authentication<F: Clone + Sync>(
     let billing_address = helpers::create_or_find_address_for_payment_by_request(
         &state,
         None,
-        payment_intent.billing_address_id.as_deref(),
+        payment_attempt
+            .payment_method_billing_address_id
+            .as_deref()
+            .or(payment_intent.billing_address_id.as_deref()),
         merchant_id,
         payment_intent.customer_id.as_ref(),
         &key_store,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
For each countries present in Europe, their states are converted to ISO Standard 
[Source for standard](https://github.com/juspay/hyperswitch-web/blob/main/src/States.json)

Note: A bugfix is present as well for address_id used to fetch billing_address for external authentication

Note: hotfix against https://github.com/juspay/hyperswitch/pull/7273

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Sanity External 3DS payment, by sending billing_address in payment_method_data for Poland country address
CURL
```
curl --location 'localhost:8080/payments/pay_MRVy1jlxGGGZafdE7xsJ/3ds/authentication' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: pk_dev_d3a60dc7950549aa954219ca29746442' \
--data '{
    "client_secret": "pay_MRVy1jlxGGGZafdE7xsJ_secret_at05FqOzGfMCtJ3bRw4Y",
    "device_channel": "BRW",
    "threeds_method_comp_ind": "Y"
}'
```

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
