### PR TITLE
refactor(webhook): add jwt authenticated endpoint to list unique webhook events for a profile

### DIFF
--- a/api-reference/openapi_spec.json
+++ b/api-reference/openapi_spec.json
@@ -5411,6 +5411,92 @@
         ]
       }
     },
+    "/events/profile/list": {
+      "get": {
+        "tags": [
+          "Event"
+        ],
+        "summary": "Events - List",
+        "description": "List all Events associated with a Profile.",
+        "operationId": "List all Events associated with a Profile",
+        "parameters": [
+          {
+            "name": "created_after",
+            "in": "query",
+            "description": "Only include Events created after the specified time. Either only `object_id` must be specified, or one or more of `created_after`, `created_before`, `limit` and `offset` must be specified.",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "date-time",
+              "nullable": true
+            }
+          },
+          {
+            "name": "created_before",
+            "in": "query",
+            "description": "Only include Events created before the specified time. Either only `object_id` must be specified, or one or more of `created_after`, `created_before`, `limit` and `offset` must be specified.",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "date-time",
+              "nullable": true
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "The maximum number of Events to include in the response. Either only `object_id` must be specified, or one or more of `created_after`, `created_before`, `limit` and `offset` must be specified.",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int64",
+              "nullable": true
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "description": "The number of Events to skip when retrieving the list of Events.\n                           Either only `object_id` must be specified, or one or more of `created_after`, `created_before`, `limit` and `offset` must be specified.",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int64",
+              "nullable": true
+            }
+          },
+          {
+            "name": "object_id",
+            "in": "query",
+            "description": "Only include Events associated with the specified object (Payment Intent ID, Refund ID, etc.). Either only `object_id` must be specified, or one or more of `created_after`, `created_before`, `limit` and `offset` must be specified.",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of Events retrieved successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/EventListItemResponse"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "jwt_key": []
+          }
+        ]
+      }
+    },
     "/events/{merchant_id}/{event_id}/attempts": {
       "get": {
         "tags": [

--- a/crates/openapi/src/routes/webhook_events.rs
+++ b/crates/openapi/src/routes/webhook_events.rs
@@ -55,6 +55,53 @@
 )]
 pub fn list_initial_webhook_delivery_attempts() {}
 
+/// Events - List
+///
+/// List all Events associated with a Profile.
+#[utoipa::path(
+    get,
+    path = "/events/profile/list",
+    params(
+        (
+            "created_after" = Option<PrimitiveDateTime>,
+            Query,
+            description = "Only include Events created after the specified time. \
+                           Either only `object_id` must be specified, or one or more of `created_after`, `created_before`, `limit` and `offset` must be specified."
+        ),
+        (
+            "created_before" = Option<PrimitiveDateTime>,
+            Query,
+            description = "Only include Events created before the specified time. \
+                           Either only `object_id` must be specified, or one or more of `created_after`, `created_before`, `limit` and `offset` must be specified."
+        ),
+        (
+            "limit" = Option<i64>,
+            Query,
+            description = "The maximum number of Events to include in the response. \
+                           Either only `object_id` must be specified, or one or more of `created_after`, `created_before`, `limit` and `offset` must be specified."
+        ),
+        (
+            "offset" = Option<i64>,
+            Query,
+            description = "The number of Events to skip when retrieving the list of Events.
+                           Either only `object_id` must be specified, or one or more of `created_after`, `created_before`, `limit` and `offset` must be specified."
+        ),
+        (
+            "object_id" = Option<String>,
+            Query,
+            description = "Only include Events associated with the specified object (Payment Intent ID, Refund ID, etc.). \
+                           Either only `object_id` must be specified, or one or more of `created_after`, `created_before`, `limit` and `offset` must be specified."
+        ),
+    ),
+    responses(
+        (status = 200, description = "List of Events retrieved successfully", body = Vec<EventListItemResponse>),
+    ),
+    tag = "Event",
+    operation_id = "List all Events associated with a Profile",
+    security(("jwt_key" = []))
+)]
+pub fn list_initial_webhook_delivery_attempts_with_jwtauth() {}
+
 /// Events - Delivery Attempt List
 ///
 /// List all delivery attempts for the specified Event.

--- a/crates/router/src/routes/app.rs
+++ b/crates/router/src/routes/app.rs
@@ -2302,21 +2302,24 @@ pub struct WebhookEvents;
 #[cfg(all(feature = "olap", feature = "v1"))]
 impl WebhookEvents {
     pub fn server(config: AppState) -> Scope {
-        web::scope("/events/{merchant_id}")
+        web::scope("/events")
             .app_data(web::Data::new(config))
+            .service(web::scope("/profile/list").service(web::resource("").route(
+                web::get().to(webhook_events::list_initial_webhook_delivery_attempts_with_jwtauth),
+            )))
             .service(
-                web::resource("")
-                    .route(web::get().to(webhook_events::list_initial_webhook_delivery_attempts)),
-            )
-            .service(
-                web::scope("/{event_id}")
+                web::scope("/{merchant_id}")
+                    .service(web::resource("").route(
+                        web::get().to(webhook_events::list_initial_webhook_delivery_attempts),
+                    ))
                     .service(
-                        web::resource("attempts")
-                            .route(web::get().to(webhook_events::list_webhook_delivery_attempts)),
-                    )
-                    .service(
-                        web::resource("retry")
-                            .route(web::post().to(webhook_events::retry_webhook_delivery_attempt)),
+                        web::scope("/{event_id}")
+                            .service(web::resource("attempts").route(
+                                web::get().to(webhook_events::list_webhook_delivery_attempts),
+                            ))
+                            .service(web::resource("retry").route(
+                                web::post().to(webhook_events::retry_webhook_delivery_attempt),
+                            )),
                     ),
             )
     }

--- a/crates/router/src/services/authorization/permissions.rs
+++ b/crates/router/src/services/authorization/permissions.rs
@@ -65,7 +65,7 @@ generate_permissions! {
         },
         WebhookEvent: {
             scopes: [Read, Write],
-            entities: [Merchant]
+            entities: [Profile, Merchant]
         },
         ReconToken: {
             scopes: [Read],


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
This PR introduces a new JWT authenticated endpoint for listing unique webhook events for a profile. The endpoint URL is `/events/profile/list` and it will support only JWT authentication. 
The profile ID and merchant ID will be extracted directly from JWT token. The router handler will call the existing `list_initial_delivery_attempts()` supporting other filtering constraints, same as in the existing endpoint.

### Additional Changes

- [x] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
- List initial delivery attempts 
```
curl --location 'http://localhost:8080/events/profile/list' \
--header 'Authorization: Bearer eyJBdXRob3JpemF0aW9uIjoicnJyIiwiYWxnIjoiSFMyNTYifQ.eyJ1c2VyX2lkIjoiZDk1NTcyN2ItNDQxYi1iNjVmLWE2NTA5ZWZiYjQ0YiIsIm1lcmNoYW50X2lkIjoibWVyY2hhbnRfMTczOTUyMDc2NSIsInJvbGVfaWQiOiJvcmdfYWRtaW4iLCJleHAiOjE3NDAxMzYxNTUsIm9yZ19pZCI6Im9yZ19IY3gzRUlMcWVXSFhGN2V3bE91dyIsInByb2ZpbGVfaWQiOiJwcm9fWHpGb2lhaDFNbHNDbVJqY3ViUXEiLCJ0ZW5hbnRfaWQiOiJwdWJsaWMifQ.UwdflL4JuswgoPSLDFEGkXg0IUHMdqiftn1HS5arGhc' \
--header 'Cookie: login_token=eyJBdXRob3JpemF0aW9uIjoicnJyIiwiYWxnIjoiSFMyNTYifQ.eyJ1c2VyX2lkIjoiZDk1NTcyN2ItNDQxYi1iNjVmLWE2NTA5ZWZiYjQ0YiIsIm1lcmNoYW50X2lkIjoibWVyY2hhbnRfMTczOTUyMDc2NSIsInJvbGVfaWQiOiJvcmdfYWRtaW4iLCJleHAiOjE3NDAxMzYxNTUsIm9yZ19pZCI6Im9yZ19IY3gzRUlMcWVXSFhGN2V3bE91dyIsInByb2ZpbGVfaWQiOiJwcm9fWHpGb2lhaDFNbHNDbVJqY3ViUXEiLCJ0ZW5hbnRfaWQiOiJwdWJsaWMifQ.UwdflL4JuswgoPSLDFEGkXg0IUHMdqiftn1HS5arGhc' \
--data ''
```
- Response
```
[{"event_id":"evt_019503a21ce676f186def372c1678519","merchant_id":"merchant_1739520765","profile_id":"pro_XzFoiah1MlsCmRjcubQq","object_id":"pay_qF1JybZlZBLKU1m42nua","event_type":"payment_succeeded","event_class":"payments","is_delivery_successful":false,"initial_attempt_id":"evt_019503a21ce676f186def372c1678519","created":"2025-02-14T08:45:10.758Z"},{"event_id":"evt_0195039d99d47f519cb63e7752618825","merchant_id":"merchant_1739520765","profile_id":"pro_XzFoiah1MlsCmRjcubQq","object_id":"ref_dU8Rx4P5Mz25wtT7xIKS","event_type":"refund_succeeded","event_class":"refunds","is_delivery_successful":false,"initial_attempt_id":"evt_0195039d99d47f519cb63e7752618825","created":"2025-02-14T08:40:15.060Z"},{"event_id":"evt_0195039d6d6e79c1a407f83fe42ad994","merchant_id":"merchant_1739520765","profile_id":"pro_XzFoiah1MlsCmRjcubQq","object_id":"pay_uqIiFNnnpEOci2zPypY7","event_type":"payment_succeeded","event_class":"payments","is_delivery_successful":false,"initial_attempt_id":"evt_0195039d6d6e79c1a407f83fe42ad994","created":"2025-02-14T08:40:03.694Z"}]
```
- List initial delivery attempts with constraints
```
curl --location 'http://localhost:8080/events/profile/list?limit=2&offset=1' \
--header 'Authorization: Bearer eyJBdXRob3JpemF0aW9uIjoicnJyIiwiYWxnIjoiSFMyNTYifQ.eyJ1c2VyX2lkIjoiZDk1NTcyN2ItNDQxYi1iNjVmLWE2NTA5ZWZiYjQ0YiIsIm1lcmNoYW50X2lkIjoibWVyY2hhbnRfMTczOTUyMDc2NSIsInJvbGVfaWQiOiJvcmdfYWRtaW4iLCJleHAiOjE3NDAxMzYxNTUsIm9yZ19pZCI6Im9yZ19IY3gzRUlMcWVXSFhGN2V3bE91dyIsInByb2ZpbGVfaWQiOiJwcm9fWHpGb2lhaDFNbHNDbVJqY3ViUXEiLCJ0ZW5hbnRfaWQiOiJwdWJsaWMifQ.UwdflL4JuswgoPSLDFEGkXg0IUHMdqiftn1HS5arGhc' \
--header 'Cookie: login_token=eyJBdXRob3JpemF0aW9uIjoicnJyIiwiYWxnIjoiSFMyNTYifQ.eyJ1c2VyX2lkIjoiZDk1NTcyN2ItNDQxYi1iNjVmLWE2NTA5ZWZiYjQ0YiIsIm1lcmNoYW50X2lkIjoibWVyY2hhbnRfMTczOTUyMDc2NSIsInJvbGVfaWQiOiJvcmdfYWRtaW4iLCJleHAiOjE3NDAxMzYxNTUsIm9yZ19pZCI6Im9yZ19IY3gzRUlMcWVXSFhGN2V3bE91dyIsInByb2ZpbGVfaWQiOiJwcm9fWHpGb2lhaDFNbHNDbVJqY3ViUXEiLCJ0ZW5hbnRfaWQiOiJwdWJsaWMifQ.UwdflL4JuswgoPSLDFEGkXg0IUHMdqiftn1HS5arGhc' \
--data ''
```
- Response
```
[{"event_id":"evt_0195039d99d47f519cb63e7752618825","merchant_id":"merchant_1739520765","profile_id":"pro_XzFoiah1MlsCmRjcubQq","object_id":"ref_dU8Rx4P5Mz25wtT7xIKS","event_type":"refund_succeeded","event_class":"refunds","is_delivery_successful":false,"initial_attempt_id":"evt_0195039d99d47f519cb63e7752618825","created":"2025-02-14T08:40:15.060Z"},{"event_id":"evt_0195039d6d6e79c1a407f83fe42ad994","merchant_id":"merchant_1739520765","profile_id":"pro_XzFoiah1MlsCmRjcubQq","object_id":"pay_uqIiFNnnpEOci2zPypY7","event_type":"payment_succeeded","event_class":"payments","is_delivery_successful":false,"initial_attempt_id":"evt_0195039d6d6e79c1a407f83fe42ad994","created":"2025-02-14T08:40:03.694Z"}]
```


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
