### PR TITLE
ci(CI-pr): disable `cargo-hack` step for hotfix PRs

### DIFF
--- a/.github/workflows/CI-pr.yml
+++ b/.github/workflows/CI-pr.yml
@@ -87,6 +87,7 @@ jobs:
   check-msrv:
     name: Check compilation on MSRV toolchain
     runs-on: ${{ matrix.runner }}
+    if: ${{ ! startsWith(github.event.pull_request.base.ref, 'hotfix-') }}
 
     env:
       # Use `sccache` for caching compilation artifacts
@@ -284,10 +285,16 @@ jobs:
           fi
 
       - name: Run cargo check
+        if: ${{ ! startsWith(github.event.pull_request.base.ref, 'hotfix-') }}
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
         run: just ci_hack
+
+      - name: Cargo build release
+        if: ${{ startsWith(github.event.pull_request.base.ref, 'hotfix-') }}
+        shell: bash
+        run: cargo check --features release
 
   typos:
     name: Spell check


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [x] CI/CD

## Description
<!-- Describe your changes in detail -->

This PR disables the `cargo-hack` step for PRs opened against hotfix branches, and in such cases `cargo check --features release` would be run instead. This is done to (hopefully) reduce the time required to get the hotfixes merged, and thus, deployed to our hosted environments.

Additionally, I've completely disabled the MSRV check for hotfix PRs, since the workflow only runs a `cargo-hack` step. And I didn't modify the v2 check, since it only runs `just clippy_v2` and a command like `cargo check --features release,v2`.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->

This would hopefully reduce the time required to get the hotfixes merged, and thus, deployed to our hosted environments.


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
N/A

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
