### PR TITLE
fix(cybersource): Add truncation logic for administrative area

### DIFF
--- a/crates/scheduler/src/utils.rs
+++ b/crates/scheduler/src/utils.rs
@@ -288,7 +288,7 @@ pub fn add_histogram_metrics(
     #[warn(clippy::option_map_unit_fn)]
     if let Some((schedule_time, runner)) = task.schedule_time.as_ref().zip(task.runner.as_ref()) {
         let pickup_schedule_delta = (*pickup_time - *schedule_time).as_seconds_f64();
-        logger::error!("Time delta for scheduled tasks: {pickup_schedule_delta} seconds");
+        logger::info!("Time delta for scheduled tasks: {pickup_schedule_delta} seconds");
         let runner_name = runner.clone();
         metrics::CONSUMER_OPS.record(
             pickup_schedule_delta,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
Cybersource throws error if state length exceeds 20 characters, to fix this this PR addes truncation of state  at Hyperswitch end

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

### Make /payments with state greater than 20 characters
```
curl --location --request POST 'http://localhost:8080/payments' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: dev_eM1Lq0Ebo27JrIBD9t71RWadvwqQzRuDLoLNSYsYYJkFE6SfIpHzGbxFF3MVedWL' \
--data-raw '{
    "amount": 700,
    "currency": "USD",
    "confirm": true,
    "payment_link": false,
    "amount_to_capture": 700,
    "name": "John Doe",
    "email": "dg@example.com",
    "phone": "999999999",
    "phone_country_code": "+1",
    "description": "Its my first payment request",
    "authentication_type": "no_three_ds",
    "return_url": "https://google.com",
    "payment_method_data": {
        "card": {
            "card_number": "4917610000000000",
            "card_exp_month": "03",
            "card_exp_year": "30",
            "card_cvc": "737"
        },
        "billing": {
            "address": {
                "line1": "1467",
                "line2": "CA",
                "city": "ABCD",
                "state": "Bourgogne-Franche-Comte",
                "zip": "94122",
                "country": "FR",
                "first_name": "john",
                "last_name": "doe"
            }
        }
    },
    "payment_method": "card",
    "payment_method_type": "credit",
    "browser_info": {
        "color_depth": 24,
        "java_enabled": true,
        "java_script_enabled": true,
        "language": "en-GB",
        "screen_height": 720,
        "screen_width": 1280,
        "time_zone": -330,
        "ip_address": "208.127.127.193",
        "accept_header": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8",
        "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36 Edg/126.0.0.0"
    }
}'
```

### Output
<img width="882" alt="Screenshot 2025-02-21 at 16 42 43" src="https://github.com/user-attachments/assets/4009b8b8-5174-419b-b82a-c96b402f9881" />


<img width="913" alt="Screenshot 2025-02-21 at 16 53 45" src="https://github.com/user-attachments/assets/7a1caa4a-f5bb-4bd0-a6cd-5090f72f2dba" />

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [X] I formatted the code `cargo +nightly fmt --all`
- [X] I addressed lints thrown by `cargo clippy`
- [X] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
