### PR TITLE
ci(hotfix-pr-check): conditionally enforce requirement of main branch PR being merged

### DIFF
--- a/.github/workflows/hotfix-pr-check.yml
+++ b/.github/workflows/hotfix-pr-check.yml
@@ -6,8 +6,6 @@ on:
       - opened
       - edited
       - synchronize
-    branches:
-      - "hotfix-*"
 
 jobs:
   hotfix_pr_check:

--- a/.github/workflows/hotfix-pr-check.yml
+++ b/.github/workflows/hotfix-pr-check.yml
@@ -16,6 +16,7 @@ jobs:
     env:
       HOTFIX_PR_AUTHOR: ${{ github.event.pull_request.user.login }}
       HOTFIX_PR_TITLE: ${{ github.event.pull_request.title }}
+      HOTFIX_PR_NEEDS_MAIN_BRANCH_PR_MERGED: ${{ vars.HOTFIX_PR_NEEDS_MAIN_BRANCH_PR_MERGED }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -33,8 +34,8 @@ jobs:
           # Extract a list of lines with the format 'juspay/hyperswitch/pull/1200' or '#1200' using 'sed'.
           # If empty, then error out and exit.
           # else, use 'grep' to extract out 'juspay/hyperswitch/pull/1200' or '#1200' patterns from each line.
-          # Use 'sed' to remove the part of the matched strings that precedes the last "/" character (in cases like, juspay/hyperswitch/pull/1200 - 1200) 
-          # and sed again to remove any "#" characters from the extracted numeric part (in cases like #1200 - 1200), ultimately getting PR/issue number. 
+          # Use 'sed' to remove the part of the matched strings that precedes the last "/" character (in cases like, juspay/hyperswitch/pull/1200 - 1200)
+          # and sed again to remove any "#" characters from the extracted numeric part (in cases like #1200 - 1200), ultimately getting PR/issue number.
           # Finally, remove (if any) duplicates from the list
 
           SED_OUTPUT=$(sed -E '/\/juspay\/hyperswitch\/pull\/[0-9]+|#[0-9]+/!d' hotfix_pr_body.txt)
@@ -73,10 +74,11 @@ jobs:
               pr_base_ref=$(echo "${pr_info}" | jq -r '.baseRefName')
               pr_state=$(echo "${pr_info}" | jq -r '.state')
 
-              if [[ "${pr_author}" == "${HOTFIX_PR_AUTHOR}" && \
-                    "${pr_title}" == "${HOTFIX_PR_TITLE}" && \
-                    "${pr_base_ref}" == "main" && \
-                    "${pr_state}" == "MERGED" ]]; then
+              if [[ "${pr_author}" == "${HOTFIX_PR_AUTHOR}" &&
+                    "${pr_title}" == "${HOTFIX_PR_TITLE}" &&
+                    "${pr_base_ref}" == "main" &&
+                    (("${HOTFIX_PR_NEEDS_MAIN_BRANCH_PR_MERGED}" == 'true' && "${pr_state}" == "MERGED") ||
+                    ("${HOTFIX_PR_NEEDS_MAIN_BRANCH_PR_MERGED}" != 'true')) ]]; then
 
                 all_checks_failed=0
                 break
@@ -86,7 +88,6 @@ jobs:
               PR_TITLES+=("$pr_title")
               PR_BASE_REFS+=("$pr_base_ref")
               PR_STATES+=("$pr_state")
-              
             fi
           done
 
@@ -143,13 +144,15 @@ jobs:
             # Set a flag to track if any of the original PR's state is 'MERGED'
             original_pr_merged=0
 
-            for ((i = 0; i < ${#PR_STATES[@]}; i++)); do
-              if [[ "${PR_STATES[i]}" == "MERGED" ]]; then
-                # If a match is found, set the flag to 1 and break out of the loop
-                original_pr_merged=1
-                break
-              fi
-            done
+            if [[ "${HOTFIX_PR_NEEDS_MAIN_BRANCH_PR_MERGED}" == 'true' ]]; then
+              for ((i = 0; i < ${#PR_STATES[@]}; i++)); do
+                if [[ "${PR_STATES[i]}" == "MERGED" ]]; then
+                  # If a match is found, set the flag to 1 and break out of the loop
+                  original_pr_merged=1
+                  break
+                fi
+              done
+            fi
 
             if [[ $original_pr_merged -eq 0 ]]; then
               echo "::error::None of the Original PR is merged"

--- a/.github/workflows/hotfix-pr-check.yml
+++ b/.github/workflows/hotfix-pr-check.yml
@@ -78,7 +78,7 @@ jobs:
                     "${pr_title}" == "${HOTFIX_PR_TITLE}" &&
                     "${pr_base_ref}" == "main" &&
                     (("${HOTFIX_PR_NEEDS_MAIN_BRANCH_PR_MERGED}" == 'true' && "${pr_state}" == "MERGED") ||
-                    ("${HOTFIX_PR_NEEDS_MAIN_BRANCH_PR_MERGED}" != 'true')) ]]; then
+                     ("${HOTFIX_PR_NEEDS_MAIN_BRANCH_PR_MERGED}" != 'true')) ]]; then
 
                 all_checks_failed=0
                 break
@@ -141,10 +141,10 @@ jobs:
             fi
 
 
-            # Set a flag to track if any of the original PR's state is 'MERGED'
-            original_pr_merged=0
-
             if [[ "${HOTFIX_PR_NEEDS_MAIN_BRANCH_PR_MERGED}" == 'true' ]]; then
+              # Set a flag to track if any of the original PR's state is 'MERGED'
+              original_pr_merged=0
+
               for ((i = 0; i < ${#PR_STATES[@]}; i++)); do
                 if [[ "${PR_STATES[i]}" == "MERGED" ]]; then
                   # If a match is found, set the flag to 1 and break out of the loop
@@ -152,10 +152,10 @@ jobs:
                   break
                 fi
               done
-            fi
 
-            if [[ $original_pr_merged -eq 0 ]]; then
-              echo "::error::None of the Original PR is merged"
+              if [[ $original_pr_merged -eq 0 ]]; then
+                echo "::error::None of the Original PR is merged"
+              fi
             fi
 
             # Print all Original PR's (number), (pr_title), (pr_author), (pr_base_ref) and (pr_state)

--- a/.github/workflows/hotfix-pr-check.yml
+++ b/.github/workflows/hotfix-pr-check.yml
@@ -6,6 +6,8 @@ on:
       - opened
       - edited
       - synchronize
+    branches:
+      - "hotfix-*"
 
 jobs:
   hotfix_pr_check:


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [x] CI/CD

## Description
<!-- Describe your changes in detail -->

This PR updates the hotfix PR check workflow to conditionally enforce the requirement of the `main` branch PR being merged, based on the value of a repository variable.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->

This change would allow us to enforce the requirement by changing the repository variable, without having to make workflow file changes across multiple branches.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

Temporarily removed the branch filter from the workflow to run on all pull requests, and then checked the errors reported with different values for the repository variable.

| Repository Variable | Workflow Output | Remarks |
|--------|--------|--------|
| ![Screenshot of repository variable set to true](https://github.com/user-attachments/assets/ffdb0073-67cd-4a1f-8022-9b1cb1ae7966) true | ![Screenshot of workflow output](https://github.com/user-attachments/assets/40cbf39d-dd87-404b-9cd1-005ab7382e7b) https://github.com/juspay/hyperswitch/actions/runs/13482283192/job/37669000183 | Note that there are two errors reported, one about the title being different, the other about the PR not being merged. |
| ![Screenshot of repository variable set to true](https://github.com/user-attachments/assets/a43baa4c-61f0-4420-84fe-afad80a4a83e) false | ![Screenshot of workflow output](https://github.com/user-attachments/assets/75912804-bd98-49ca-9d30-c5003c283eb7) https://github.com/juspay/hyperswitch/actions/runs/13482283192/job/37669038298 | Note that there is only one error reported, about the title being different, there is no error about the PR not being merged. | 


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
