### PR TITLE
fix(routing): Fixed 5xx error logs in dynamic routing metrics

### DIFF
--- a/crates/router/src/core/routing/helpers.rs
+++ b/crates/router/src/core/routing/helpers.rs
@@ -727,70 +727,71 @@ pub async fn push_metrics_with_update_window_for_success_based_routing(
     dynamic_routing_algo_ref: routing_types::DynamicRoutingAlgorithmRef,
     dynamic_routing_config_params_interpolator: DynamicRoutingConfigParamsInterpolator,
 ) -> RouterResult<()> {
-    let success_based_algo_ref = dynamic_routing_algo_ref
-        .success_based_algorithm
-        .ok_or(errors::ApiErrorResponse::InternalServerError)
-        .attach_printable("success_based_algorithm not found in dynamic_routing_algorithm from business_profile table")?;
+    if let Some(success_based_algo_ref) = dynamic_routing_algo_ref.success_based_algorithm {
+        if success_based_algo_ref.enabled_feature != routing_types::DynamicRoutingFeatures::None {
+            let client = state
+                .grpc_client
+                .dynamic_routing
+                .success_rate_client
+                .as_ref()
+                .ok_or(errors::ApiErrorResponse::GenericNotFoundError {
+                    message: "success_rate gRPC client not found".to_string(),
+                })?;
 
-    if success_based_algo_ref.enabled_feature != routing_types::DynamicRoutingFeatures::None {
-        let client = state
-            .grpc_client
-            .dynamic_routing
-            .success_rate_client
-            .as_ref()
-            .ok_or(errors::ApiErrorResponse::GenericNotFoundError {
-                message: "success_rate gRPC client not found".to_string(),
-            })?;
+            let payment_connector = &payment_attempt.connector.clone().ok_or(
+                errors::ApiErrorResponse::GenericNotFoundError {
+                    message: "unable to derive payment connector from payment attempt".to_string(),
+                },
+            )?;
 
-        let payment_connector = &payment_attempt.connector.clone().ok_or(
-            errors::ApiErrorResponse::GenericNotFoundError {
-                message: "unable to derive payment connector from payment attempt".to_string(),
-            },
-        )?;
-
-        let success_based_routing_configs =
-            fetch_dynamic_routing_configs::<routing_types::SuccessBasedRoutingConfig>(
+            let success_based_routing_configs = fetch_dynamic_routing_configs::<
+                routing_types::SuccessBasedRoutingConfig,
+            >(
                 state,
                 profile_id,
                 success_based_algo_ref
                     .algorithm_id_with_timestamp
                     .algorithm_id
-                    .ok_or(errors::ApiErrorResponse::InternalServerError)
+                    .ok_or(errors::ApiErrorResponse::GenericNotFoundError {
+                        message: "success_rate algorithm_id not found".to_string(),
+                    })
                     .attach_printable(
                         "success_based_routing_algorithm_id not found in business_profile",
                     )?,
             )
             .await
-            .change_context(errors::ApiErrorResponse::InternalServerError)
+            .change_context(errors::ApiErrorResponse::GenericNotFoundError {
+                message: "success_rate based dynamic routing configs not found".to_string(),
+            })
             .attach_printable("unable to retrieve success_rate based dynamic routing configs")?;
 
-        let success_based_routing_config_params = dynamic_routing_config_params_interpolator
-            .get_string_val(
-                success_based_routing_configs
-                    .params
-                    .as_ref()
-                    .ok_or(errors::RoutingError::SuccessBasedRoutingParamsNotFoundError)
-                    .change_context(errors::ApiErrorResponse::InternalServerError)?,
-            );
+            let success_based_routing_config_params = dynamic_routing_config_params_interpolator
+                .get_string_val(
+                    success_based_routing_configs
+                        .params
+                        .as_ref()
+                        .ok_or(errors::RoutingError::SuccessBasedRoutingParamsNotFoundError)
+                        .change_context(errors::ApiErrorResponse::InternalServerError)?,
+                );
 
-        let success_based_connectors = client
-            .calculate_entity_and_global_success_rate(
-                profile_id.get_string_repr().into(),
-                success_based_routing_configs.clone(),
-                success_based_routing_config_params.clone(),
-                routable_connectors.clone(),
-                state.get_grpc_headers(),
-            )
-            .await
-            .change_context(errors::ApiErrorResponse::InternalServerError)
-            .attach_printable(
-                "unable to calculate/fetch success rate from dynamic routing service",
-            )?;
+            let success_based_connectors = client
+                .calculate_entity_and_global_success_rate(
+                    profile_id.get_string_repr().into(),
+                    success_based_routing_configs.clone(),
+                    success_based_routing_config_params.clone(),
+                    routable_connectors.clone(),
+                    state.get_grpc_headers(),
+                )
+                .await
+                .change_context(errors::ApiErrorResponse::InternalServerError)
+                .attach_printable(
+                    "unable to calculate/fetch success rate from dynamic routing service",
+                )?;
 
-        let payment_status_attribute =
-            get_desired_payment_status_for_dynamic_routing_metrics(payment_attempt.status);
+            let payment_status_attribute =
+                get_desired_payment_status_for_dynamic_routing_metrics(payment_attempt.status);
 
-        let first_merchant_success_based_connector = &success_based_connectors
+            let first_merchant_success_based_connector = &success_based_connectors
             .entity_scores_with_labels
             .first()
             .ok_or(errors::ApiErrorResponse::InternalServerError)
@@ -798,7 +799,7 @@ pub async fn push_metrics_with_update_window_for_success_based_routing(
                 "unable to fetch the first connector from list of connectors obtained from dynamic routing service",
             )?;
 
-        let (first_merchant_success_based_connector_label, _) = first_merchant_success_based_connector.label
+            let (first_merchant_success_based_connector_label, _) = first_merchant_success_based_connector.label
             .split_once(':')
             .ok_or(errors::ApiErrorResponse::InternalServerError)
             .attach_printable(format!(
@@ -806,7 +807,7 @@ pub async fn push_metrics_with_update_window_for_success_based_routing(
                 first_merchant_success_based_connector.label
             ))?;
 
-        let first_global_success_based_connector = &success_based_connectors
+            let first_global_success_based_connector = &success_based_connectors
             .global_scores_with_labels
             .first()
             .ok_or(errors::ApiErrorResponse::InternalServerError)
@@ -814,138 +815,143 @@ pub async fn push_metrics_with_update_window_for_success_based_routing(
                 "unable to fetch the first global connector from list of connectors obtained from dynamic routing service",
             )?;
 
-        let outcome = get_dynamic_routing_based_metrics_outcome_for_payment(
-            payment_status_attribute,
-            payment_connector.to_string(),
-            first_merchant_success_based_connector_label.to_string(),
-        );
+            let outcome = get_dynamic_routing_based_metrics_outcome_for_payment(
+                payment_status_attribute,
+                payment_connector.to_string(),
+                first_merchant_success_based_connector_label.to_string(),
+            );
 
-        let dynamic_routing_stats = DynamicRoutingStatsNew {
-            payment_id: payment_attempt.payment_id.to_owned(),
-            attempt_id: payment_attempt.attempt_id.clone(),
-            merchant_id: payment_attempt.merchant_id.to_owned(),
-            profile_id: payment_attempt.profile_id.to_owned(),
-            amount: payment_attempt.get_total_amount(),
-            success_based_routing_connector: first_merchant_success_based_connector_label
-                .to_string(),
-            payment_connector: payment_connector.to_string(),
-            payment_method_type: payment_attempt.payment_method_type,
-            currency: payment_attempt.currency,
-            payment_method: payment_attempt.payment_method,
-            capture_method: payment_attempt.capture_method,
-            authentication_type: payment_attempt.authentication_type,
-            payment_status: payment_attempt.status,
-            conclusive_classification: outcome,
-            created_at: common_utils::date_time::now(),
-            global_success_based_connector: Some(
-                first_global_success_based_connector.label.to_string(),
-            ),
-        };
-
-        core_metrics::DYNAMIC_SUCCESS_BASED_ROUTING.add(
-            1,
-            router_env::metric_attributes!(
-                (
-                    "tenant",
-                    state.tenant.tenant_id.get_string_repr().to_owned(),
-                ),
-                (
-                    "merchant_profile_id",
-                    format!(
-                        "{}:{}",
-                        payment_attempt.merchant_id.get_string_repr(),
-                        payment_attempt.profile_id.get_string_repr()
-                    ),
-                ),
-                (
-                    "merchant_specific_success_based_routing_connector",
-                    first_merchant_success_based_connector_label.to_string(),
-                ),
-                (
-                    "merchant_specific_success_based_routing_connector_score",
-                    first_merchant_success_based_connector.score.to_string(),
-                ),
-                (
-                    "global_success_based_routing_connector",
+            let dynamic_routing_stats = DynamicRoutingStatsNew {
+                payment_id: payment_attempt.payment_id.to_owned(),
+                attempt_id: payment_attempt.attempt_id.clone(),
+                merchant_id: payment_attempt.merchant_id.to_owned(),
+                profile_id: payment_attempt.profile_id.to_owned(),
+                amount: payment_attempt.get_total_amount(),
+                success_based_routing_connector: first_merchant_success_based_connector_label
+                    .to_string(),
+                payment_connector: payment_connector.to_string(),
+                payment_method_type: payment_attempt.payment_method_type,
+                currency: payment_attempt.currency,
+                payment_method: payment_attempt.payment_method,
+                capture_method: payment_attempt.capture_method,
+                authentication_type: payment_attempt.authentication_type,
+                payment_status: payment_attempt.status,
+                conclusive_classification: outcome,
+                created_at: common_utils::date_time::now(),
+                global_success_based_connector: Some(
                     first_global_success_based_connector.label.to_string(),
                 ),
-                (
-                    "global_success_based_routing_connector_score",
-                    first_global_success_based_connector.score.to_string(),
-                ),
-                ("payment_connector", payment_connector.to_string()),
-                (
-                    "currency",
-                    payment_attempt
-                        .currency
-                        .map_or_else(|| "None".to_string(), |currency| currency.to_string()),
-                ),
-                (
-                    "payment_method",
-                    payment_attempt.payment_method.map_or_else(
-                        || "None".to_string(),
-                        |payment_method| payment_method.to_string(),
-                    ),
-                ),
-                (
-                    "payment_method_type",
-                    payment_attempt.payment_method_type.map_or_else(
-                        || "None".to_string(),
-                        |payment_method_type| payment_method_type.to_string(),
-                    ),
-                ),
-                (
-                    "capture_method",
-                    payment_attempt.capture_method.map_or_else(
-                        || "None".to_string(),
-                        |capture_method| capture_method.to_string(),
-                    ),
-                ),
-                (
-                    "authentication_type",
-                    payment_attempt.authentication_type.map_or_else(
-                        || "None".to_string(),
-                        |authentication_type| authentication_type.to_string(),
-                    ),
-                ),
-                ("payment_status", payment_attempt.status.to_string()),
-                ("conclusive_classification", outcome.to_string()),
-            ),
-        );
-        logger::debug!("successfully pushed success_based_routing metrics");
+            };
 
-        state
-            .store
-            .insert_dynamic_routing_stat_entry(dynamic_routing_stats)
-            .await
-            .change_context(errors::ApiErrorResponse::InternalServerError)
-            .attach_printable("Unable to push dynamic routing stats to db")?;
+            core_metrics::DYNAMIC_SUCCESS_BASED_ROUTING.add(
+                1,
+                router_env::metric_attributes!(
+                    (
+                        "tenant",
+                        state.tenant.tenant_id.get_string_repr().to_owned(),
+                    ),
+                    (
+                        "merchant_profile_id",
+                        format!(
+                            "{}:{}",
+                            payment_attempt.merchant_id.get_string_repr(),
+                            payment_attempt.profile_id.get_string_repr()
+                        ),
+                    ),
+                    (
+                        "merchant_specific_success_based_routing_connector",
+                        first_merchant_success_based_connector_label.to_string(),
+                    ),
+                    (
+                        "merchant_specific_success_based_routing_connector_score",
+                        first_merchant_success_based_connector.score.to_string(),
+                    ),
+                    (
+                        "global_success_based_routing_connector",
+                        first_global_success_based_connector.label.to_string(),
+                    ),
+                    (
+                        "global_success_based_routing_connector_score",
+                        first_global_success_based_connector.score.to_string(),
+                    ),
+                    ("payment_connector", payment_connector.to_string()),
+                    (
+                        "currency",
+                        payment_attempt
+                            .currency
+                            .map_or_else(|| "None".to_string(), |currency| currency.to_string()),
+                    ),
+                    (
+                        "payment_method",
+                        payment_attempt.payment_method.map_or_else(
+                            || "None".to_string(),
+                            |payment_method| payment_method.to_string(),
+                        ),
+                    ),
+                    (
+                        "payment_method_type",
+                        payment_attempt.payment_method_type.map_or_else(
+                            || "None".to_string(),
+                            |payment_method_type| payment_method_type.to_string(),
+                        ),
+                    ),
+                    (
+                        "capture_method",
+                        payment_attempt.capture_method.map_or_else(
+                            || "None".to_string(),
+                            |capture_method| capture_method.to_string(),
+                        ),
+                    ),
+                    (
+                        "authentication_type",
+                        payment_attempt.authentication_type.map_or_else(
+                            || "None".to_string(),
+                            |authentication_type| authentication_type.to_string(),
+                        ),
+                    ),
+                    ("payment_status", payment_attempt.status.to_string()),
+                    ("conclusive_classification", outcome.to_string()),
+                ),
+            );
+            logger::debug!("successfully pushed success_based_routing metrics");
 
-        client
-            .update_success_rate(
-                profile_id.get_string_repr().into(),
-                success_based_routing_configs,
-                success_based_routing_config_params,
-                vec![routing_types::RoutableConnectorChoiceWithStatus::new(
-                    routing_types::RoutableConnectorChoice {
-                        choice_kind: api_models::routing::RoutableChoiceKind::FullStruct,
-                        connector: common_enums::RoutableConnectors::from_str(
-                            payment_connector.as_str(),
-                        )
-                        .change_context(errors::ApiErrorResponse::InternalServerError)
-                        .attach_printable("unable to infer routable_connector from connector")?,
-                        merchant_connector_id: payment_attempt.merchant_connector_id.clone(),
-                    },
-                    payment_status_attribute == common_enums::AttemptStatus::Charged,
-                )],
-                state.get_grpc_headers(),
-            )
-            .await
-            .change_context(errors::ApiErrorResponse::InternalServerError)
-            .attach_printable(
-                "unable to update success based routing window in dynamic routing service",
-            )?;
-        Ok(())
+            state
+                .store
+                .insert_dynamic_routing_stat_entry(dynamic_routing_stats)
+                .await
+                .change_context(errors::ApiErrorResponse::InternalServerError)
+                .attach_printable("Unable to push dynamic routing stats to db")?;
+
+            client
+                .update_success_rate(
+                    profile_id.get_string_repr().into(),
+                    success_based_routing_configs,
+                    success_based_routing_config_params,
+                    vec![routing_types::RoutableConnectorChoiceWithStatus::new(
+                        routing_types::RoutableConnectorChoice {
+                            choice_kind: api_models::routing::RoutableChoiceKind::FullStruct,
+                            connector: common_enums::RoutableConnectors::from_str(
+                                payment_connector.as_str(),
+                            )
+                            .change_context(errors::ApiErrorResponse::InternalServerError)
+                            .attach_printable(
+                                "unable to infer routable_connector from connector",
+                            )?,
+                            merchant_connector_id: payment_attempt.merchant_connector_id.clone(),
+                        },
+                        payment_status_attribute == common_enums::AttemptStatus::Charged,
+                    )],
+                    state.get_grpc_headers(),
+                )
+                .await
+                .change_context(errors::ApiErrorResponse::InternalServerError)
+                .attach_printable(
+                    "unable to update success based routing window in dynamic routing service",
+                )?;
+            Ok(())
+        } else {
+            Ok(())
+        }
     } else {
         Ok(())
     }
@@ -962,194 +968,205 @@ pub async fn push_metrics_with_update_window_for_contract_based_routing(
     dynamic_routing_algo_ref: routing_types::DynamicRoutingAlgorithmRef,
     _dynamic_routing_config_params_interpolator: DynamicRoutingConfigParamsInterpolator,
 ) -> RouterResult<()> {
-    let contract_routing_algo_ref = dynamic_routing_algo_ref
-        .contract_based_routing
-        .ok_or(errors::ApiErrorResponse::InternalServerError)
-        .attach_printable("contract_routing_algorithm not found in dynamic_routing_algorithm from business_profile table")?;
+    if let Some(contract_routing_algo_ref) = dynamic_routing_algo_ref.contract_based_routing {
+        if contract_routing_algo_ref.enabled_feature != routing_types::DynamicRoutingFeatures::None
+        {
+            let client = state
+                .grpc_client
+                .dynamic_routing
+                .contract_based_client
+                .clone()
+                .ok_or(errors::ApiErrorResponse::GenericNotFoundError {
+                    message: "contract_routing gRPC client not found".to_string(),
+                })?;
 
-    if contract_routing_algo_ref.enabled_feature != routing_types::DynamicRoutingFeatures::None {
-        let client = state
-            .grpc_client
-            .dynamic_routing
-            .contract_based_client
-            .clone()
-            .ok_or(errors::ApiErrorResponse::GenericNotFoundError {
-                message: "contract_routing gRPC client not found".to_string(),
-            })?;
+            let payment_connector = &payment_attempt.connector.clone().ok_or(
+                errors::ApiErrorResponse::GenericNotFoundError {
+                    message: "unable to derive payment connector from payment attempt".to_string(),
+                },
+            )?;
 
-        let payment_connector = &payment_attempt.connector.clone().ok_or(
-            errors::ApiErrorResponse::GenericNotFoundError {
-                message: "unable to derive payment connector from payment attempt".to_string(),
-            },
-        )?;
+            let contract_based_routing_config =
+                fetch_dynamic_routing_configs::<routing_types::ContractBasedRoutingConfig>(
+                    state,
+                    profile_id,
+                    contract_routing_algo_ref
+                        .algorithm_id_with_timestamp
+                        .algorithm_id
+                        .ok_or(errors::ApiErrorResponse::GenericNotFoundError {
+                            message: "contract_routing algorithm_id not found".to_string(),
+                        })
+                        .attach_printable(
+                            "contract_based_routing_algorithm_id not found in business_profile",
+                        )?,
+                )
+                .await
+                .change_context(errors::ApiErrorResponse::GenericNotFoundError {
+                    message: "contract based dynamic routing configs not found".to_string(),
+                })
+                .attach_printable("unable to retrieve contract based dynamic routing configs")?;
 
-        let contract_based_routing_config =
-            fetch_dynamic_routing_configs::<routing_types::ContractBasedRoutingConfig>(
-                state,
-                profile_id,
-                contract_routing_algo_ref
-                    .algorithm_id_with_timestamp
-                    .algorithm_id
-                    .ok_or(errors::ApiErrorResponse::InternalServerError)
-                    .attach_printable(
-                        "contract_based_routing_algorithm_id not found in business_profile",
-                    )?,
-            )
-            .await
-            .change_context(errors::ApiErrorResponse::InternalServerError)
-            .attach_printable("unable to retrieve contract based dynamic routing configs")?;
+            let mut existing_label_info = None;
 
-        let mut existing_label_info = None;
-
-        contract_based_routing_config
-            .label_info
-            .as_ref()
-            .map(|label_info_vec| {
-                for label_info in label_info_vec {
-                    if Some(&label_info.mca_id) == payment_attempt.merchant_connector_id.as_ref() {
-                        existing_label_info = Some(label_info.clone());
+            contract_based_routing_config
+                .label_info
+                .as_ref()
+                .map(|label_info_vec| {
+                    for label_info in label_info_vec {
+                        if Some(&label_info.mca_id)
+                            == payment_attempt.merchant_connector_id.as_ref()
+                        {
+                            existing_label_info = Some(label_info.clone());
+                        }
                     }
-                }
-            });
+                });
 
-        let final_label_info = existing_label_info
-            .ok_or(errors::ApiErrorResponse::InternalServerError)
-            .attach_printable("unable to get LabelInformation from ContractBasedRoutingConfig")?;
+            let final_label_info = existing_label_info
+                .ok_or(errors::ApiErrorResponse::GenericNotFoundError {
+                    message: "LabelInformation from ContractBasedRoutingConfig not found"
+                        .to_string(),
+                })
+                .attach_printable(
+                    "unable to get LabelInformation from ContractBasedRoutingConfig",
+                )?;
 
-        logger::debug!(
-            "contract based routing: matched LabelInformation - {:?}",
-            final_label_info
-        );
+            logger::debug!(
+                "contract based routing: matched LabelInformation - {:?}",
+                final_label_info
+            );
 
-        let request_label_info = routing_types::LabelInformation {
-            label: format!(
-                "{}:{}",
-                final_label_info.label.clone(),
-                final_label_info.mca_id.get_string_repr()
-            ),
-            target_count: final_label_info.target_count,
-            target_time: final_label_info.target_time,
-            mca_id: final_label_info.mca_id.to_owned(),
-        };
+            let request_label_info = routing_types::LabelInformation {
+                label: format!(
+                    "{}:{}",
+                    final_label_info.label.clone(),
+                    final_label_info.mca_id.get_string_repr()
+                ),
+                target_count: final_label_info.target_count,
+                target_time: final_label_info.target_time,
+                mca_id: final_label_info.mca_id.to_owned(),
+            };
 
-        let payment_status_attribute =
-            get_desired_payment_status_for_dynamic_routing_metrics(payment_attempt.status);
+            let payment_status_attribute =
+                get_desired_payment_status_for_dynamic_routing_metrics(payment_attempt.status);
 
-        if payment_status_attribute == common_enums::AttemptStatus::Charged {
-            client
-                .update_contracts(
+            if payment_status_attribute == common_enums::AttemptStatus::Charged {
+                client
+                    .update_contracts(
+                        profile_id.get_string_repr().into(),
+                        vec![request_label_info],
+                        "".to_string(),
+                        vec![],
+                        state.get_grpc_headers(),
+                    )
+                    .await
+                    .change_context(errors::ApiErrorResponse::InternalServerError)
+                    .attach_printable(
+                        "unable to update contract based routing window in dynamic routing service",
+                    )?;
+            }
+
+            let contract_scores = client
+                .calculate_contract_score(
                     profile_id.get_string_repr().into(),
-                    vec![request_label_info],
+                    contract_based_routing_config.clone(),
                     "".to_string(),
-                    vec![],
+                    routable_connectors.clone(),
                     state.get_grpc_headers(),
                 )
                 .await
                 .change_context(errors::ApiErrorResponse::InternalServerError)
                 .attach_printable(
-                    "unable to update contract based routing window in dynamic routing service",
+                    "unable to calculate/fetch contract scores from dynamic routing service",
                 )?;
+
+            let first_contract_based_connector = &contract_scores
+                .labels_with_score
+                .first()
+                .ok_or(errors::ApiErrorResponse::InternalServerError)
+                .attach_printable(
+                    "unable to fetch the first connector from list of connectors obtained from dynamic routing service",
+                )?;
+
+            let (first_contract_based_connector, connector_score, current_payment_cnt) = (first_contract_based_connector.label
+                .split_once(':')
+                .ok_or(errors::ApiErrorResponse::InternalServerError)
+                .attach_printable(format!(
+                    "unable to split connector_name and mca_id from the first connector {:?} obtained from dynamic routing service",
+                    first_contract_based_connector
+                ))?
+                .0, first_contract_based_connector.score, first_contract_based_connector.current_count );
+
+            core_metrics::DYNAMIC_CONTRACT_BASED_ROUTING.add(
+                1,
+                router_env::metric_attributes!(
+                    (
+                        "tenant",
+                        state.tenant.tenant_id.get_string_repr().to_owned(),
+                    ),
+                    (
+                        "merchant_profile_id",
+                        format!(
+                            "{}:{}",
+                            payment_attempt.merchant_id.get_string_repr(),
+                            payment_attempt.profile_id.get_string_repr()
+                        ),
+                    ),
+                    (
+                        "contract_based_routing_connector",
+                        first_contract_based_connector.to_string(),
+                    ),
+                    (
+                        "contract_based_routing_connector_score",
+                        connector_score.to_string(),
+                    ),
+                    (
+                        "current_payment_count_contract_based_routing_connector",
+                        current_payment_cnt.to_string(),
+                    ),
+                    ("payment_connector", payment_connector.to_string()),
+                    (
+                        "currency",
+                        payment_attempt
+                            .currency
+                            .map_or_else(|| "None".to_string(), |currency| currency.to_string()),
+                    ),
+                    (
+                        "payment_method",
+                        payment_attempt.payment_method.map_or_else(
+                            || "None".to_string(),
+                            |payment_method| payment_method.to_string(),
+                        ),
+                    ),
+                    (
+                        "payment_method_type",
+                        payment_attempt.payment_method_type.map_or_else(
+                            || "None".to_string(),
+                            |payment_method_type| payment_method_type.to_string(),
+                        ),
+                    ),
+                    (
+                        "capture_method",
+                        payment_attempt.capture_method.map_or_else(
+                            || "None".to_string(),
+                            |capture_method| capture_method.to_string(),
+                        ),
+                    ),
+                    (
+                        "authentication_type",
+                        payment_attempt.authentication_type.map_or_else(
+                            || "None".to_string(),
+                            |authentication_type| authentication_type.to_string(),
+                        ),
+                    ),
+                    ("payment_status", payment_attempt.status.to_string()),
+                ),
+            );
+            logger::debug!("successfully pushed contract_based_routing metrics");
+
+            Ok(())
+        } else {
+            Ok(())
         }
-
-        let contract_scores = client
-            .calculate_contract_score(
-                profile_id.get_string_repr().into(),
-                contract_based_routing_config.clone(),
-                "".to_string(),
-                routable_connectors.clone(),
-                state.get_grpc_headers(),
-            )
-            .await
-            .change_context(errors::ApiErrorResponse::InternalServerError)
-            .attach_printable(
-                "unable to calculate/fetch contract scores from dynamic routing service",
-            )?;
-
-        let first_contract_based_connector = &contract_scores
-            .labels_with_score
-            .first()
-            .ok_or(errors::ApiErrorResponse::InternalServerError)
-            .attach_printable(
-                "unable to fetch the first connector from list of connectors obtained from dynamic routing service",
-            )?;
-
-        let (first_contract_based_connector, connector_score, current_payment_cnt) = (first_contract_based_connector.label
-            .split_once(':')
-            .ok_or(errors::ApiErrorResponse::InternalServerError)
-            .attach_printable(format!(
-                "unable to split connector_name and mca_id from the first connector {:?} obtained from dynamic routing service",
-                first_contract_based_connector
-            ))?
-            .0, first_contract_based_connector.score, first_contract_based_connector.current_count );
-
-        core_metrics::DYNAMIC_CONTRACT_BASED_ROUTING.add(
-            1,
-            router_env::metric_attributes!(
-                (
-                    "tenant",
-                    state.tenant.tenant_id.get_string_repr().to_owned(),
-                ),
-                (
-                    "merchant_profile_id",
-                    format!(
-                        "{}:{}",
-                        payment_attempt.merchant_id.get_string_repr(),
-                        payment_attempt.profile_id.get_string_repr()
-                    ),
-                ),
-                (
-                    "contract_based_routing_connector",
-                    first_contract_based_connector.to_string(),
-                ),
-                (
-                    "contract_based_routing_connector_score",
-                    connector_score.to_string(),
-                ),
-                (
-                    "current_payment_count_contract_based_routing_connector",
-                    current_payment_cnt.to_string(),
-                ),
-                ("payment_connector", payment_connector.to_string()),
-                (
-                    "currency",
-                    payment_attempt
-                        .currency
-                        .map_or_else(|| "None".to_string(), |currency| currency.to_string()),
-                ),
-                (
-                    "payment_method",
-                    payment_attempt.payment_method.map_or_else(
-                        || "None".to_string(),
-                        |payment_method| payment_method.to_string(),
-                    ),
-                ),
-                (
-                    "payment_method_type",
-                    payment_attempt.payment_method_type.map_or_else(
-                        || "None".to_string(),
-                        |payment_method_type| payment_method_type.to_string(),
-                    ),
-                ),
-                (
-                    "capture_method",
-                    payment_attempt.capture_method.map_or_else(
-                        || "None".to_string(),
-                        |capture_method| capture_method.to_string(),
-                    ),
-                ),
-                (
-                    "authentication_type",
-                    payment_attempt.authentication_type.map_or_else(
-                        || "None".to_string(),
-                        |authentication_type| authentication_type.to_string(),
-                    ),
-                ),
-                ("payment_status", payment_attempt.status.to_string()),
-            ),
-        );
-        logger::debug!("successfully pushed contract_based_routing metrics");
-
-        Ok(())
     } else {
         Ok(())
     }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
A 5xx error log in DR metrics was spamming in alerts. 
Have removed the log
Main PR - https://github.com/juspay/hyperswitch/pull/7335

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
make a payment with dynamic routing enabled
5xx error log now converted to 4xx
<img width="1056" alt="image" src="https://github.com/user-attachments/assets/df763221-d26b-47a0-927a-83a5d38d0457" />


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
