### PR TITLE
ci: ignore running against `vergen`, `stripe compatibility`, `detailed_errors` and combine few others

### DIFF
--- a/scripts/ci-checks.sh
+++ b/scripts/ci-checks.sh
@@ -4,18 +4,38 @@ set -euo pipefail
 # The below script is run on the github actions CI
 # Obtain a list of workspace members
 workspace_members="$(
-  cargo metadata --format-version 1 --no-deps \
-    | jq \
+  cargo metadata --format-version 1 --no-deps |
+    jq \
       --compact-output \
       --monochrome-output \
       --raw-output \
       '(.workspace_members | sort) as $package_ids | .packages[] | select(IN(.id; $package_ids[])) | .name'
 )"
 
+# Arrays to track which packages are checked or skipped
 PACKAGES_CHECKED=()
 PACKAGES_SKIPPED=()
 
-# If we are running this on a pull request, then only check for packages that are modified
+# Define packages to skip processing entirely
+skip_packages=("detailed_errors" "vergen" "stripe_compatibility")
+
+# Define packages that will be combined under one group
+encryption_group=("encryption_service" "key_manager" "key_manager_mtls" "key_manager_forward_x_request_id")
+# We will only run key_manager once (with an aggregated set of features) when any of these change.
+# (Remove the others so they are not processed individually.)
+encryption_group_set=()
+
+# Function to check if an element exists in an array
+contains() {
+  local needle="$1"
+  shift
+  for item in "$@"; do
+    [[ "$item" == "$needle" ]] && return 0
+  done
+  return 1
+}
+
+# If we are on a pull request, then only check for packages that are modified
 if [[ "${GITHUB_EVENT_NAME:-}" == 'pull_request' ]]; then
   # Obtain the pull request number and files modified in the pull request
   pull_request_number="$(jq --raw-output '.pull_request.number' "${GITHUB_EVENT_PATH}")"
@@ -29,43 +49,73 @@ if [[ "${GITHUB_EVENT_NAME:-}" == 'pull_request' ]]; then
   )"
 
   while IFS= read -r package_name; do
-    # Obtain pipe-separated list of transitive workspace dependencies for each workspace member
-    change_paths="$(cargo tree --all-features --no-dedupe --prefix none --package "${package_name}" \
-      | grep 'crates/' \
-      | sort --unique \
-      | awk --field-separator ' ' '{ printf "crates/%s\n", $1 }' | paste -d '|' -s -)"
+    # If this package is in the skip list, then skip even if files changed.
+    if contains "${package_name}" "${skip_packages[@]}"; then
+      printf '::debug::Skipping `%s` (in skip list)\n' "${package_name}"
+      PACKAGES_SKIPPED+=("${package_name}")
+      continue
+    fi
 
-    # A package must be checked if any of its transitive dependencies (or itself) has been modified
-    if grep --quiet --extended-regexp "^(${change_paths})" <<< "${files_modified}"; then
-      printf '::debug::Checking `%s` since at least one of these paths was modified: %s\n' "${package_name}" "${change_paths[*]//|/ }"
+    # For packages in the encryption group, we “remember” that one of them changed
+    if contains "${package_name}" "${encryption_group[@]}"; then
+      encryption_group_set+=("${package_name}")
+      # (Do not process individually)
+      printf '::debug::Marking `%s` for encryption group aggregation\n' "${package_name}"
+      continue
+    fi
+
+    # Obtain a pipe-separated list of transitive workspace dependencies for this package
+    change_paths="$(
+      cargo tree --all-features --no-dedupe --prefix none --package "${package_name}" |
+        grep 'crates/' |
+        sort --unique |
+        awk '{ printf "crates/%s\n", $1 }' |
+        paste -d '|' -s -
+    )"
+
+    # Check if any modified file affects the package or any of its dependencies.
+    if grep --quiet --extended-regexp "^(${change_paths})" <<<"${files_modified}"; then
+      printf '::debug::Checking `%s` since a relevant file changed (paths: %s)\n' "${package_name}" "${change_paths//|/ }"
       PACKAGES_CHECKED+=("${package_name}")
     else
-      printf '::debug::Skipping `%s` since none of these paths were modified: %s\n' "${package_name}" "${change_paths[*]//|/ }"
+      printf '::debug::Skipping `%s` since no modified paths match (%s)\n' "${package_name}" "${change_paths//|/ }"
       PACKAGES_SKIPPED+=("${package_name}")
     fi
   done <<< "${workspace_members}"
+
+  # If any of the encryption group packages changed, always run key_manager
+  if ((${#encryption_group_set[@]})); then
+    if ! contains "key_manager" "${PACKAGES_CHECKED[@]}"; then
+      PACKAGES_CHECKED+=("key_manager")
+      printf '::debug:: Aggregating encryption-related packages into `key_manager`\n'
+    fi
+    # Optionally, log which encryption packages were merged:
+    printf '::debug:: Encryption group changed: %s\n' "${encryption_group_set[*]}"
+  fi
+
   printf '::notice::Packages checked: %s; Packages skipped: %s\n' "${PACKAGES_CHECKED[*]}" "${PACKAGES_SKIPPED[*]}"
 
   packages_checked="$(jq --compact-output --null-input '$ARGS.positional' --args -- "${PACKAGES_CHECKED[@]}")"
 
-  crates_with_features="$(cargo metadata --format-version 1 --no-deps \
-    | jq \
+  crates_with_features="$(cargo metadata --format-version 1 --no-deps |
+    jq \
       --compact-output \
       --monochrome-output \
       --raw-output \
       --argjson packages_checked "${packages_checked}" \
       '[ ( .workspace_members | sort ) as $package_ids | .packages[] | select( IN( .name; $packages_checked[] ) ) | { name: .name, features: ( .features | keys ) } ]')"
 else
-  # If we are doing this locally or on merge queue, then check for all the crates
-  crates_with_features="$(cargo metadata --format-version 1 --no-deps \
-    | jq \
-      --compact-output \
-      --monochrome-output \
-      --raw-output \
-      '[ ( .workspace_members | sort ) as $package_ids | .packages[] | select( IN( .id; $package_ids[] ) ) | { name: .name, features: ( .features | keys ) } ]')"
+  # Run for all workspace packages when not on a PR.
+  crates_with_features="$(cargo metadata --format-version 1 --no-deps | jq --compact-output --monochrome-output --raw-output \
+    '[ ( .workspace_members | sort ) as $package_ids | .packages[]
+         | { name: .name, features: ( .features | keys ) }
+     ]')"
 fi
 
-# List of cargo commands that will be executed
+# Build commands array. We now separate commands into two groups:
+# (a) For crates that support v1 and have feature combinations
+# (b) For crates that do not have a v1 feature (which use cargo hack)
+
 all_commands=()
 
 # Process the metadata to generate the cargo check commands for crates which have v1 features
@@ -77,15 +127,20 @@ crates_with_v1_feature="$(
     --null-input \
     '$crates_with_features[]
     | select( IN("v1"; .features[]))  # Select crates with `v1` feature
-    | { name, features: ( .features | del( .[] | select( any( . ; test("(([a-z_]+)_)?v2|v1|default") ) ) ) ) }  # Remove specific features to generate feature combinations
+    | { name, features: ( .features | del( .[] | select( test("(([a-z_]+)_)?v2|v1|default") ) ) ) }  # Remove specific features to generate feature combinations
     | { name, features: ( .features | map([., "v1"] | join(",")) ) }  # Add `v1` to remaining features and join them by comma
     | .name as $name | .features[] | { $name, features: . }  # Expand nested features object to have package - features combinations
     | "\(.name) \(.features)" # Print out package name and features separated by space'
 )"
+
 while IFS=' ' read -r crate features && [[ -n "${crate}" && -n "${features}" ]]; do
+  # If somehow a skipped or aggregated package sneaked in, skip it.
+  if contains "${crate}" "${skip_packages[@]}"; then
+    continue
+  fi
   command="cargo check --all-targets --package \"${crate}\" --no-default-features --features \"${features}\""
   all_commands+=("$command")
-done <<< "${crates_with_v1_feature}"
+done <<<"${crates_with_v1_feature}"
 
 # For crates which do not have v1 feature, we can run the usual cargo hack command
 crates_without_v1_feature="$(
@@ -95,10 +150,20 @@ crates_without_v1_feature="$(
     '$crates_with_features[] | select(IN("v1"; .features[]) | not ) # Select crates without `v1` feature
     | "\(.name)" # Print out package name'
 )"
+
 while IFS= read -r crate && [[ -n "${crate}" ]]; do
+  # Again, avoid skipped or encryption-group packages.
+  if contains "${crate}" "${skip_packages[@]}"; then
+    continue
+  fi
+  if contains "${crate}" "${encryption_group[@]}" && [[ "${crate}" != "key_manager" ]]; then
+    # only run key_manager for encryption group so skip individual encryption group crates other than key_manager
+    continue
+  fi
+
   command="cargo hack check --all-targets --each-feature --package \"${crate}\""
   all_commands+=("$command")
-done <<< "${crates_without_v1_feature}"
+done <<<"${crates_without_v1_feature}"
 
 if ((${#all_commands[@]} == 0)); then
   echo "There are no commands to be executed"


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [x] CI/CD

## Description
<!-- Describe your changes in detail -->

this pr stops running ci checks (`cargo hack`) against `vergen`, `detailed_errors` and `stripe_compatibility` since it makes no sense to run against them.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->

reduce check time.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

ci should consume less time

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
