### PR TITLE
feat(core) : add additional revenue recovery call flow

### DIFF
--- a/config/config.example.toml
+++ b/config/config.example.toml
@@ -833,3 +833,6 @@ entity_logo_url = "https://example.com/logo.svg" # Logo URL of the entity to be 
 foreground_color = "#000000"                     # Foreground color of email text
 primary_color = "#006DF9"                        # Primary color of email body
 background_color = "#FFFFFF"                     # Background color of email body
+
+[additonal_recovery_details_call]
+connectors_with_additional_revenue_recovery_details_call = "" # List of connectors which has additional revenue recovery details api-call

--- a/config/development.toml
+++ b/config/development.toml
@@ -681,6 +681,9 @@ connectors_with_delayed_session_response = "trustpay,payme"
 [webhook_source_verification_call]
 connectors_with_webhook_source_verification_call = "paypal"
 
+[additonal_recovery_details_call]
+connectors_with_additional_revenue_recovery_details_call = ""
+
 [mandates.supported_payment_methods]
 bank_debit.ach = { connector_list = "gocardless,adyen,stripe" }
 bank_debit.becs = { connector_list = "gocardless,stripe,adyen" }

--- a/config/docker_compose.toml
+++ b/config/docker_compose.toml
@@ -314,6 +314,9 @@ connectors_with_delayed_session_response = "trustpay,payme"
 [webhook_source_verification_call]
 connectors_with_webhook_source_verification_call = "paypal"
 
+[additonal_recovery_details_call]
+connectors_with_additional_revenue_recovery_details_call = ""
+
 [scheduler]
 stream = "SCHEDULER_STREAM"
 

--- a/crates/hyperswitch_connectors/src/default_implementations.rs
+++ b/crates/hyperswitch_connectors/src/default_implementations.rs
@@ -33,7 +33,7 @@ use hyperswitch_domain_models::{
             PreProcessing, Reject, SdkSessionUpdate,
         },
         webhooks::VerifyWebhookSource,
-        Authenticate, AuthenticationConfirmation, PostAuthenticate, PreAuthenticate,
+        Authenticate, AuthenticationConfirmation, PostAuthenticate, PreAuthenticate, GetAdditionalRevenueRecoveryDetails
     },
     router_request_types::{
         unified_authentication_service::{
@@ -47,11 +47,13 @@ use hyperswitch_domain_models::{
         PaymentsPostSessionTokensData, PaymentsPreProcessingData, PaymentsRejectData,
         PaymentsTaxCalculationData, RetrieveFileRequestData, SdkPaymentsSessionUpdateData,
         SubmitEvidenceRequestData, UploadFileRequestData, VerifyWebhookSourceRequestData,
+        AdditionalRevenueRecoveryDetailsRequestData
     },
     router_response_types::{
         AcceptDisputeResponse, DefendDisputeResponse, MandateRevokeResponseData,
         PaymentsResponseData, RetrieveFileResponse, SubmitEvidenceResponse,
         TaxCalculationResponseData, UploadFileResponse, VerifyWebhookSourceResponseData,
+        AdditionalRevenueRecoveryDetailsResponseData
     },
 };
 #[cfg(feature = "frm")]
@@ -77,7 +79,7 @@ use hyperswitch_interfaces::{
         },
         ConnectorIntegration, ConnectorMandateRevoke, ConnectorRedirectResponse, UasAuthentication,
         UasAuthenticationConfirmation, UasPostAuthentication, UasPreAuthentication,
-        UnifiedAuthenticationService,
+        UnifiedAuthenticationService
     },
     errors::ConnectorError,
 };
@@ -3214,6 +3216,94 @@ default_imp_for_uas_authentication_confirmation!(
     connectors::Taxjar,
     connectors::Thunes,
     connectors::Tsys,
+    connectors::Worldline,
+    connectors::Worldpay,
+    connectors::Wellsfargo,
+    connectors::Volt,
+    connectors::Xendit,
+    connectors::Zen,
+    connectors::Zsl
+);
+
+
+macro_rules! default_imp_for_additional_revenue_recovery_call {
+    ($($path:ident::$connector:ident),*) => {
+        $( impl api::ConnectorAdditionalRevenueRecoveryDetailsCall for $path::$connector {}
+            impl
+                ConnectorIntegration<
+                GetAdditionalRevenueRecoveryDetails,
+                AdditionalRevenueRecoveryDetailsRequestData,
+                AdditionalRevenueRecoveryDetailsResponseData
+            > for $path::$connector
+            {}
+        )*
+    };
+}
+
+default_imp_for_additional_revenue_recovery_call!(
+    connectors::Aci,
+    connectors::Airwallex,
+    connectors::Amazonpay,
+    connectors::Bambora,
+    connectors::Bamboraapac,
+    connectors::Bankofamerica,
+    connectors::Billwerk,
+    connectors::Bluesnap,
+    connectors::Bitpay,
+    connectors::Braintree,
+    connectors::Boku,
+    connectors::Cashtocode,
+    connectors::Chargebee,
+    connectors::Coinbase,
+    connectors::Coingate,
+    connectors::Cryptopay,
+    connectors::CtpMastercard,
+    connectors::Cybersource,
+    connectors::Datatrans,
+    connectors::Deutschebank,
+    connectors::Digitalvirgo,
+    connectors::Dlocal,
+    connectors::Elavon,
+    connectors::Fiserv,
+    connectors::Fiservemea,
+    connectors::Fiuu,
+    connectors::Forte,
+    connectors::Getnet,
+    connectors::Globalpay,
+    connectors::Globepay,
+    connectors::Gocardless,
+    connectors::Helcim,
+    connectors::Iatapay,
+    connectors::Inespay,
+    connectors::Itaubank,
+    connectors::Jpmorgan,
+    connectors::Klarna,
+    connectors::Nomupay,
+    connectors::Novalnet,
+    connectors::Nexinets,
+    connectors::Nexixpay,
+    connectors::Nuvei,
+    connectors::Payeezy,
+    connectors::Payu,
+    connectors::Powertranz,
+    connectors::Prophetpay,
+    connectors::Mifinity,
+    connectors::Mollie,
+    connectors::Moneris,
+    connectors::Multisafepay,
+    connectors::Paybox,
+    connectors::Placetopay,
+    connectors::Rapyd,
+    connectors::Razorpay,
+    connectors::Redsys,
+    connectors::Shift4,
+    connectors::Stax,
+    connectors::Square,
+    connectors::Stripebilling,
+    connectors::Taxjar,
+    connectors::Thunes,
+    connectors::Tsys,
+    connectors::UnifiedAuthenticationService,
     connectors::Worldline,
     connectors::Worldpay,
     connectors::Wellsfargo,

--- a/crates/hyperswitch_domain_models/src/router_data_v2/flow_common_types.rs
+++ b/crates/hyperswitch_domain_models/src/router_data_v2/flow_common_types.rs
@@ -149,3 +149,5 @@ pub struct UasFlowData {
     pub authenticate_by: String,
     pub source_authentication_id: String,
 }
+
+pub struct AdditionalRevenueRecoveryCallFlowCommonData;

--- a/crates/hyperswitch_domain_models/src/router_flow_types/webhooks.rs
+++ b/crates/hyperswitch_domain_models/src/router_flow_types/webhooks.rs
@@ -19,3 +19,6 @@ impl ConnectorNetworkTxnId {
         &self.0
     }
 }
+
+#[derive(Debug, Clone)]
+pub struct GetAdditionalRevenueRecoveryDetails;

--- a/crates/hyperswitch_domain_models/src/router_request_types.rs
+++ b/crates/hyperswitch_domain_models/src/router_request_types.rs
@@ -913,3 +913,8 @@ pub struct SetupMandateRequestData {
     pub minor_amount: Option<MinorUnit>,
     pub shipping_cost: Option<MinorUnit>,
 }
+
+#[derive(Debug, Clone)]
+pub struct AdditionalRevenueRecoveryDetailsRequestData{
+    pub transaction_id : String,
+}

--- a/crates/hyperswitch_domain_models/src/router_response_types.rs
+++ b/crates/hyperswitch_domain_models/src/router_response_types.rs
@@ -1,6 +1,7 @@
 pub mod disputes;
 pub mod fraud_check;
 use std::collections::HashMap;
+use time::PrimitiveDateTime;
 
 use common_utils::{request::Method, types::MinorUnit};
 pub use disputes::{AcceptDisputeResponse, DefendDisputeResponse, SubmitEvidenceResponse};
@@ -602,4 +603,35 @@ impl SupportedPaymentMethodsExt for SupportedPaymentMethods {
             self.insert(payment_method, payment_method_type_metadata);
         }
     }
+}
+
+
+#[derive(Debug, Clone, serde::Deserialize,serde::Serialize)]
+pub struct AdditionalRevenueRecoveryDetailsResponseData {
+        /// transaction amount against invoice, accepted in minor unit.
+        pub amount: MinorUnit,
+        /// currency of the transaction
+        pub currency: common_enums::enums::Currency,
+        /// merchant reference id at billing connector. ex: invoice_id
+        pub merchant_reference_id: common_utils::id_type::PaymentReferenceId,
+        /// transaction id reference at payment connector
+        pub connector_transaction_id: Option<common_utils::types::ConnectorTransactionId>,
+        /// error code sent by billing connector.
+        pub error_code: Option<String>,
+        /// error message sent by billing connector.
+        pub error_message: Option<String>,
+        /// mandate token at payment processor end.
+        pub processor_payment_method_token: Option<String>,
+        /// customer id at payment connector for which mandate is attached.
+        pub connector_customer_id: Option<String>,
+        /// Payment gateway identifier id at billing processor.
+        pub connector_account_reference_id: Option<String>,
+        /// timestamp at which transaction has been created at billing connector
+        pub transaction_created_at: Option<PrimitiveDateTime>,
+        /// transaction status at billing connector equivalent to payment attempt status.
+        pub status: common_enums::enums::AttemptStatus,
+        /// payment method of payment attempt.
+        pub payment_method_type: common_enums::enums::PaymentMethod,
+        /// payment method sub type of the payment attempt.
+        pub payment_method_sub_type: common_enums::enums::PaymentMethodType,
 }

--- a/crates/hyperswitch_domain_models/src/types.rs
+++ b/crates/hyperswitch_domain_models/src/types.rs
@@ -3,28 +3,17 @@ pub use diesel_models::types::OrderDetailsWithAmount;
 use crate::{
     router_data::{AccessToken, RouterData},
     router_flow_types::{
-        mandate_revoke::MandateRevoke, AccessTokenAuth, Authenticate, AuthenticationConfirmation,
-        Authorize, AuthorizeSessionToken, CalculateTax, Capture, CompleteAuthorize,
-        CreateConnectorCustomer, Execute, IncrementalAuthorization, PSync, PaymentMethodToken,
-        PostAuthenticate, PostSessionTokens, PreAuthenticate, PreProcessing, RSync, Session,
-        SetupMandate, Void,
+        mandate_revoke::MandateRevoke, AccessTokenAuth, Authenticate, AuthenticationConfirmation, Authorize, AuthorizeSessionToken, CalculateTax, Capture, CompleteAuthorize, CreateConnectorCustomer, Execute, GetAdditionalRevenueRecoveryDetails, IncrementalAuthorization, PSync, PaymentMethodToken, PostAuthenticate, PostSessionTokens, PreAuthenticate, PreProcessing, RSync, Session, SetupMandate, Void
     },
     router_request_types::{
         unified_authentication_service::{
             UasAuthenticationRequestData, UasAuthenticationResponseData,
             UasConfirmationRequestData, UasPostAuthenticationRequestData,
             UasPreAuthenticationRequestData,
-        },
-        AccessTokenRequestData, AuthorizeSessionTokenData, CompleteAuthorizeData,
-        ConnectorCustomerData, MandateRevokeRequestData, PaymentMethodTokenizationData,
-        PaymentsAuthorizeData, PaymentsCancelData, PaymentsCaptureData,
-        PaymentsIncrementalAuthorizationData, PaymentsPostSessionTokensData,
-        PaymentsPreProcessingData, PaymentsSessionData, PaymentsSyncData,
-        PaymentsTaxCalculationData, RefundsData, SetupMandateRequestData,
+        }, AccessTokenRequestData, AdditionalRevenueRecoveryDetailsRequestData, AuthorizeSessionTokenData, CompleteAuthorizeData, ConnectorCustomerData, MandateRevokeRequestData, PaymentMethodTokenizationData, PaymentsAuthorizeData, PaymentsCancelData, PaymentsCaptureData, PaymentsIncrementalAuthorizationData, PaymentsPostSessionTokensData, PaymentsPreProcessingData, PaymentsSessionData, PaymentsSyncData, PaymentsTaxCalculationData, RefundsData, SetupMandateRequestData
     },
     router_response_types::{
-        MandateRevokeResponseData, PaymentsResponseData, RefundsResponseData,
-        TaxCalculationResponseData,
+        AdditionalRevenueRecoveryDetailsResponseData, MandateRevokeResponseData, PaymentsResponseData, RefundsResponseData, TaxCalculationResponseData
     },
 };
 #[cfg(feature = "payouts")]
@@ -81,3 +70,6 @@ pub type PayoutsRouterData<F> = RouterData<F, PayoutsData, PayoutsResponseData>;
 
 pub type UasAuthenticationRouterData =
     RouterData<Authenticate, UasAuthenticationRequestData, UasAuthenticationResponseData>;
+
+pub type AdditionalRevenueRecoveryDetailsRouterData =
+    RouterData<GetAdditionalRevenueRecoveryDetails,AdditionalRevenueRecoveryDetailsRequestData,AdditionalRevenueRecoveryDetailsResponseData>;

--- a/crates/hyperswitch_interfaces/src/api.rs
+++ b/crates/hyperswitch_interfaces/src/api.rs
@@ -30,24 +30,21 @@ use hyperswitch_domain_models::{
     payment_method_data::PaymentMethodData,
     router_data::{AccessToken, ConnectorAuthType, ErrorResponse, RouterData},
     router_data_v2::{
-        flow_common_types::WebhookSourceVerifyData, AccessTokenFlowData, MandateRevokeFlowData,
+        flow_common_types::{AdditionalRevenueRecoveryCallFlowCommonData, WebhookSourceVerifyData}, AccessTokenFlowData, MandateRevokeFlowData,
         UasFlowData,
     },
     router_flow_types::{
-        mandate_revoke::MandateRevoke, AccessTokenAuth, Authenticate, AuthenticationConfirmation,
-        PostAuthenticate, PreAuthenticate, VerifyWebhookSource,
+        mandate_revoke::MandateRevoke, AccessTokenAuth, Authenticate, AuthenticationConfirmation, GetAdditionalRevenueRecoveryDetails, PostAuthenticate, PreAuthenticate, VerifyWebhookSource
     },
     router_request_types::{
         unified_authentication_service::{
             UasAuthenticationRequestData, UasAuthenticationResponseData,
             UasConfirmationRequestData, UasPostAuthenticationRequestData,
             UasPreAuthenticationRequestData,
-        },
-        AccessTokenRequestData, MandateRevokeRequestData, VerifyWebhookSourceRequestData,
+        }, AccessTokenRequestData, AdditionalRevenueRecoveryDetailsRequestData, MandateRevokeRequestData, VerifyWebhookSourceRequestData
     },
     router_response_types::{
-        ConnectorInfo, MandateRevokeResponseData, PaymentMethodDetails, SupportedPaymentMethods,
-        VerifyWebhookSourceResponseData,
+        AdditionalRevenueRecoveryDetailsResponseData, ConnectorInfo, MandateRevokeResponseData, PaymentMethodDetails, SupportedPaymentMethods, VerifyWebhookSourceResponseData
     },
 };
 use masking::Maskable;
@@ -368,6 +365,27 @@ pub trait ConnectorVerifyWebhookSourceV2:
     VerifyWebhookSourceResponseData,
 >
 {
+}
+
+/// trait ConnectorAdditionalRevenueRecoveryDetailsCall
+pub trait ConnectorAdditionalRevenueRecoveryDetailsCall: 
+    ConnectorIntegration<
+    GetAdditionalRevenueRecoveryDetails,
+    AdditionalRevenueRecoveryDetailsRequestData,
+    AdditionalRevenueRecoveryDetailsResponseData
+>
+{   
+}
+
+/// trait ConnectorAdditionalRevenueRecoveryDetailsCallV2
+pub trait ConnectorAdditionalRevenueRecoveryDetailsCallV2 : 
+    ConnectorIntegrationV2<
+    GetAdditionalRevenueRecoveryDetails,
+    AdditionalRevenueRecoveryCallFlowCommonData,
+    AdditionalRevenueRecoveryDetailsRequestData,
+    AdditionalRevenueRecoveryDetailsResponseData
+>
+{   
 }
 
 /// trait UnifiedAuthenticationService

--- a/crates/hyperswitch_interfaces/src/types.rs
+++ b/crates/hyperswitch_interfaces/src/types.rs
@@ -17,7 +17,7 @@ use hyperswitch_domain_models::{
         unified_authentication_service::{
             Authenticate, AuthenticationConfirmation, PostAuthenticate, PreAuthenticate,
         },
-        webhooks::VerifyWebhookSource,
+        webhooks::{VerifyWebhookSource,GetAdditionalRevenueRecoveryDetails},
     },
     router_request_types::{
         unified_authentication_service::{
@@ -33,11 +33,13 @@ use hyperswitch_domain_models::{
         PaymentsSessionData, PaymentsSyncData, PaymentsTaxCalculationData, RefundsData,
         RetrieveFileRequestData, SdkPaymentsSessionUpdateData, SetupMandateRequestData,
         SubmitEvidenceRequestData, UploadFileRequestData, VerifyWebhookSourceRequestData,
+        AdditionalRevenueRecoveryDetailsRequestData
     },
     router_response_types::{
         AcceptDisputeResponse, DefendDisputeResponse, MandateRevokeResponseData,
         PaymentsResponseData, RefundsResponseData, RetrieveFileResponse, SubmitEvidenceResponse,
         TaxCalculationResponseData, UploadFileResponse, VerifyWebhookSourceResponseData,
+        AdditionalRevenueRecoveryDetailsResponseData
     },
 };
 #[cfg(feature = "payouts")]
@@ -221,4 +223,11 @@ pub type UasAuthenticationType = dyn ConnectorIntegration<
     Authenticate,
     UasAuthenticationRequestData,
     UasAuthenticationResponseData,
+>;
+
+///Type alias for `ConnectorIntegration<GetAdditionalRevenueRecoveryDetails, AdditionalRevenueRecoveryDetailsRequestData, AdditionalRevenueRecoveryDetailsResponseData>`
+pub type AdditionalRevenueRecoveryCallType = dyn ConnectorIntegration<
+    GetAdditionalRevenueRecoveryDetails,
+    AdditionalRevenueRecoveryDetailsRequestData,
+    AdditionalRevenueRecoveryDetailsResponseData
 >;

--- a/crates/router/src/configs/secrets_transformers.rs
+++ b/crates/router/src/configs/secrets_transformers.rs
@@ -506,6 +506,7 @@ pub(crate) async fn fetch_raw_secrets(
         required_fields: conf.required_fields,
         delayed_session_response: conf.delayed_session_response,
         webhook_source_verification_call: conf.webhook_source_verification_call,
+        additonal_recovery_details_call : conf.additonal_recovery_details_call,
         payment_method_auth,
         connector_request_reference_id_config: conf.connector_request_reference_id_config,
         #[cfg(feature = "payouts")]

--- a/crates/router/src/configs/settings.rs
+++ b/crates/router/src/configs/settings.rs
@@ -96,6 +96,7 @@ pub struct Settings<S: SecretState> {
     pub required_fields: RequiredFields,
     pub delayed_session_response: DelayedSessionConfig,
     pub webhook_source_verification_call: WebhookSourceVerificationCall,
+    pub additonal_recovery_details_call : GetAdditionalRecoveryDetailsCall,
     pub payment_method_auth: SecretStateContainer<PaymentMethodAuth, S>,
     pub connector_request_reference_id_config: ConnectorRequestReferenceIdConfig,
     #[cfg(feature = "payouts")]
@@ -845,6 +846,12 @@ pub struct DelayedSessionConfig {
 pub struct WebhookSourceVerificationCall {
     #[serde(deserialize_with = "deserialize_hashset")]
     pub connectors_with_webhook_source_verification_call: HashSet<enums::Connector>,
+}
+
+#[derive(Debug, Deserialize, Clone, Default)]
+pub struct GetAdditionalRecoveryDetailsCall{
+    #[serde(deserialize_with = "deserialize_hashset")]
+    pub connectors_with_additional_revenue_recovery_details_call : HashSet<enums::Connector>
 }
 
 #[derive(Debug, Deserialize, Clone, Default)]

--- a/crates/router/src/core/payments/flows.rs
+++ b/crates/router/src/core/payments/flows.rs
@@ -15,7 +15,7 @@ use async_trait::async_trait;
 use hyperswitch_domain_models::{
     mandates::CustomerAcceptance,
     router_flow_types::{
-        Authenticate, AuthenticationConfirmation, PostAuthenticate, PreAuthenticate,
+        Authenticate, AuthenticationConfirmation, PostAuthenticate, PreAuthenticate, GetAdditionalRevenueRecoveryDetails
     },
     router_request_types::PaymentsCaptureData,
 };
@@ -2492,3 +2492,55 @@ fn handle_post_capture_response(
         }
     }
 }
+
+macro_rules! default_imp_for_additional_revenue_recovery_call {
+    ($($path:ident::$connector:ident),*) => {
+        $( impl api::ConnectorAdditionalRevenueRecoveryDetailsCall for $path::$connector {}
+            impl
+            services::ConnectorIntegration<
+                GetAdditionalRevenueRecoveryDetails,
+                types::AdditionalRevenueRecoveryDetailsRequestData,
+                types::AdditionalRevenueRecoveryDetailsResponseData,
+        > for $path::$connector
+        {}
+    )*
+    };
+}
+
+#[cfg(feature = "dummy_connector")]
+impl<const T: u8> api::ConnectorAdditionalRevenueRecoveryDetailsCall for connector::DummyConnector<T> {}
+#[cfg(feature = "dummy_connector")]
+impl<const T: u8>
+    services::ConnectorIntegration<
+        GetAdditionalRevenueRecoveryDetails,
+        types::AdditionalRevenueRecoveryDetailsRequestData,
+        types::AdditionalRevenueRecoveryDetailsResponseData,
+    > for connector::DummyConnector<T>
+{
+}
+
+default_imp_for_additional_revenue_recovery_call!(
+    connector::Adyen,
+    connector::Adyenplatform,
+    connector::Authorizedotnet,
+    connector::Checkout,
+    connector::Ebanx,
+    connector::Gpayments,
+    connector::Netcetera,
+    connector::Nmi,
+    connector::Noon,
+    connector::Opayo,
+    connector::Opennode,
+    connector::Payme,
+    connector::Payone,
+    connector::Paypal,
+    connector::Plaid,
+    connector::Riskified,
+    connector::Signifyd,
+    connector::Stripe,
+    connector::Threedsecureio,
+    connector::Trustpay,
+    connector::Wellsfargopayout,
+    connector::Wise
+);
+

--- a/crates/router/src/services/api.rs
+++ b/crates/router/src/services/api.rs
@@ -108,6 +108,9 @@ pub type BoxedFilesConnectorIntegrationInterface<T, Req, Resp> =
 pub type BoxedUnifiedAuthenticationServiceInterface<T, Req, Resp> =
     BoxedConnectorIntegrationInterface<T, common_types::UasFlowData, Req, Resp>;
 
+pub type BoxedGetAdditionalRecoveryRecoveryDetailsIntegrationInterface<T,Req,Res> =
+    BoxedConnectorIntegrationInterface<T, common_types::AdditionalRevenueRecoveryCallFlowCommonData, Req, Res>;
+
 /// Handle the flow by interacting with connector module
 /// `connector_request` is applicable only in case if the `CallConnectorAction` is `Trigger`
 /// In other cases, It will be created if required, even if it is not passed

--- a/crates/router/src/types.rs
+++ b/crates/router/src/types.rs
@@ -73,14 +73,14 @@ pub use hyperswitch_domain_models::{
         PaymentsSessionData, PaymentsSyncData, PaymentsTaxCalculationData, RefundsData, ResponseId,
         RetrieveFileRequestData, SdkPaymentsSessionUpdateData, SetupMandateRequestData,
         SplitRefundsRequest, SubmitEvidenceRequestData, SyncRequestType, UploadFileRequestData,
-        VerifyWebhookSourceRequestData,
+        VerifyWebhookSourceRequestData, AdditionalRevenueRecoveryDetailsRequestData
     },
     router_response_types::{
         AcceptDisputeResponse, CaptureSyncResponse, DefendDisputeResponse, MandateReference,
         MandateRevokeResponseData, PaymentsResponseData, PreprocessingResponseId,
         RefundsResponseData, RetrieveFileResponse, SubmitEvidenceResponse,
         TaxCalculationResponseData, UploadFileResponse, VerifyWebhookSourceResponseData,
-        VerifyWebhookStatus,
+        VerifyWebhookStatus, AdditionalRevenueRecoveryDetailsResponseData
     },
 };
 #[cfg(feature = "payouts")]

--- a/crates/router/src/types/api.rs
+++ b/crates/router/src/types/api.rs
@@ -48,7 +48,7 @@ pub use hyperswitch_domain_models::router_flow_types::{
 pub use hyperswitch_interfaces::api::{
     ConnectorAccessToken, ConnectorAccessTokenV2, ConnectorCommon, ConnectorCommonExt,
     ConnectorMandateRevoke, ConnectorMandateRevokeV2, ConnectorVerifyWebhookSource,
-    ConnectorVerifyWebhookSourceV2, CurrencyUnit,
+    ConnectorVerifyWebhookSourceV2, CurrencyUnit, ConnectorAdditionalRevenueRecoveryDetailsCall,ConnectorAdditionalRevenueRecoveryDetailsCallV2
 };
 use hyperswitch_interfaces::api::{UnifiedAuthenticationService, UnifiedAuthenticationServiceV2};
 
@@ -108,6 +108,7 @@ pub trait Connector:
     + ExternalAuthentication
     + TaxCalculation
     + UnifiedAuthenticationService
+    + ConnectorAdditionalRevenueRecoveryDetailsCall
 {
 }
 
@@ -127,7 +128,9 @@ impl<
             + ConnectorMandateRevoke
             + ExternalAuthentication
             + TaxCalculation
-            + UnifiedAuthenticationService,
+            + UnifiedAuthenticationService
+            + ConnectorAdditionalRevenueRecoveryDetailsCall
+            
     > Connector for T
 {
 }
@@ -148,6 +151,7 @@ pub trait ConnectorV2:
     + ConnectorMandateRevokeV2
     + ExternalAuthenticationV2
     + UnifiedAuthenticationServiceV2
+    + ConnectorAdditionalRevenueRecoveryDetailsCallV2
 {
 }
 impl<
@@ -165,7 +169,8 @@ impl<
             + FraudCheckV2
             + ConnectorMandateRevokeV2
             + ExternalAuthenticationV2
-            + UnifiedAuthenticationServiceV2,
+            + UnifiedAuthenticationServiceV2
+            +ConnectorAdditionalRevenueRecoveryDetailsCallV2,
     > ConnectorV2 for T
 {
 }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
For some billing connectors, we get limited data in the webhook that is not sufficient to use. So we need to make an additional api call for this extra data. This pr adds that flow.


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
No testing required since its just defining the flow not using it.


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
