### PR TITLE
fix(connector): [Braintree] Consume merchant_account_id and merchant_config_currency in payment requests

### DIFF
--- a/api-reference-v2/openapi_spec.json
+++ b/api-reference-v2/openapi_spec.json
@@ -6372,6 +6372,23 @@
           }
         }
       },
+      "BraintreeData": {
+        "type": "object",
+        "required": [
+          "merchant_account_id",
+          "merchant_config_currency"
+        ],
+        "properties": {
+          "merchant_account_id": {
+            "type": "string",
+            "description": "Information about the merchant_account_id that merchant wants to specify at connector level."
+          },
+          "merchant_config_currency": {
+            "type": "string",
+            "description": "Information about the merchant_config_currency that merchant wants to specify at connector level."
+          }
+        }
+      },
       "BrowserInformation": {
         "type": "object",
         "description": "Browser information to be used for 3DS 2.0",
@@ -7649,6 +7666,14 @@
             "allOf": [
               {
                 "$ref": "#/components/schemas/NoonData"
+              }
+            ],
+            "nullable": true
+          },
+          "braintree": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BraintreeData"
               }
             ],
             "nullable": true
@@ -15301,12 +15326,28 @@
             "description": "The return url to which the user should be redirected to",
             "nullable": true
           },
-          "associated_payment": {
+          "next_action": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/PaymentsResponse"
+                "$ref": "#/components/schemas/NextActionData"
               }
             ],
+            "nullable": true
+          },
+          "authentication_details": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AuthenticationDetails"
+              }
+            ],
+            "nullable": true
+          },
+          "associated_payment_methods": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/id_type.GlobalPaymentMethodId"
+            },
+            "description": "The payment method that was created using this payment method session",
             "nullable": true
           }
         }
@@ -15541,60 +15582,6 @@
           }
         },
         "additionalProperties": false
-      },
-      "PaymentMethodsSessionResponse": {
-        "type": "object",
-        "required": [
-          "id",
-          "customer_id",
-          "expires_at",
-          "client_secret"
-        ],
-        "properties": {
-          "id": {
-            "type": "string",
-            "example": "12345_pms_01926c58bc6e77c09e809964e72af8c8"
-          },
-          "customer_id": {
-            "type": "string",
-            "description": "The customer id for which the payment methods session is to be created",
-            "example": "12345_cus_01926c58bc6e77c09e809964e72af8c8"
-          },
-          "billing": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Address"
-              }
-            ],
-            "nullable": true
-          },
-          "psp_tokenization": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/PspTokenization"
-              }
-            ],
-            "nullable": true
-          },
-          "network_tokenization": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/NetworkTokenization"
-              }
-            ],
-            "nullable": true
-          },
-          "expires_at": {
-            "type": "string",
-            "format": "date-time",
-            "description": "The iso timestamp when the session will expire\nTrying to retrieve the session or any operations on the session after this time will result in an error",
-            "example": "2023-01-18T11:04:09.922Z"
-          },
-          "client_secret": {
-            "type": "string",
-            "description": "Client Secret"
-          }
-        }
       },
       "PaymentMethodsSessionUpdateRequest": {
         "type": "object",

--- a/api-reference-v2/openapi_spec.json
+++ b/api-reference-v2/openapi_spec.json
@@ -15326,28 +15326,12 @@
             "description": "The return url to which the user should be redirected to",
             "nullable": true
           },
-          "next_action": {
+          "associated_payment": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/NextActionData"
+                "$ref": "#/components/schemas/PaymentsResponse"
               }
             ],
-            "nullable": true
-          },
-          "authentication_details": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/AuthenticationDetails"
-              }
-            ],
-            "nullable": true
-          },
-          "associated_payment_methods": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/id_type.GlobalPaymentMethodId"
-            },
-            "description": "The payment method that was created using this payment method session",
             "nullable": true
           }
         }
@@ -15582,6 +15566,60 @@
           }
         },
         "additionalProperties": false
+      },
+      "PaymentMethodsSessionResponse": {
+        "type": "object",
+        "required": [
+          "id",
+          "customer_id",
+          "expires_at",
+          "client_secret"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "example": "12345_pms_01926c58bc6e77c09e809964e72af8c8"
+          },
+          "customer_id": {
+            "type": "string",
+            "description": "The customer id for which the payment methods session is to be created",
+            "example": "12345_cus_01926c58bc6e77c09e809964e72af8c8"
+          },
+          "billing": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Address"
+              }
+            ],
+            "nullable": true
+          },
+          "psp_tokenization": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PspTokenization"
+              }
+            ],
+            "nullable": true
+          },
+          "network_tokenization": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/NetworkTokenization"
+              }
+            ],
+            "nullable": true
+          },
+          "expires_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "The iso timestamp when the session will expire\nTrying to retrieve the session or any operations on the session after this time will result in an error",
+            "example": "2023-01-18T11:04:09.922Z"
+          },
+          "client_secret": {
+            "type": "string",
+            "description": "Client Secret"
+          }
+        }
       },
       "PaymentMethodsSessionUpdateRequest": {
         "type": "object",

--- a/api-reference/openapi_spec.json
+++ b/api-reference/openapi_spec.json
@@ -8510,6 +8510,23 @@
           }
         }
       },
+      "BraintreeData": {
+        "type": "object",
+        "required": [
+          "merchant_account_id",
+          "merchant_config_currency"
+        ],
+        "properties": {
+          "merchant_account_id": {
+            "type": "string",
+            "description": "Information about the merchant_account_id that merchant wants to specify at connector level."
+          },
+          "merchant_config_currency": {
+            "type": "string",
+            "description": "Information about the merchant_config_currency that merchant wants to specify at connector level."
+          }
+        }
+      },
       "BrowserInformation": {
         "type": "object",
         "description": "Browser information to be used for 3DS 2.0",
@@ -9756,6 +9773,14 @@
             "allOf": [
               {
                 "$ref": "#/components/schemas/NoonData"
+              }
+            ],
+            "nullable": true
+          },
+          "braintree": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BraintreeData"
               }
             ],
             "nullable": true

--- a/crates/api_models/src/payments.rs
+++ b/crates/api_models/src/payments.rs
@@ -6526,6 +6526,7 @@ pub struct ConnectorMetadata {
     pub apple_pay: Option<ApplepayConnectorMetadataRequest>,
     pub airwallex: Option<AirwallexData>,
     pub noon: Option<NoonData>,
+    pub braintree: Option<BraintreeData>,
 }
 
 impl ConnectorMetadata {
@@ -6564,6 +6565,13 @@ pub struct AirwallexData {
 pub struct NoonData {
     /// Information about the order category that merchant wants to specify at connector level. (e.g. In Noon Payments it can take values like "pay", "food", or any other custom string set by the merchant in Noon's Dashboard)
     pub order_category: Option<String>,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, ToSchema)]
+pub struct BraintreeData {
+    /// Information about the merchant_accountid and merchant_config_currency that merchant wants to specify at connector level.
+    pub merchant_account_id: Option<Secret<String>>,
+    pub merchant_config_currency: Option<api_enums::Currency>,
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, ToSchema)]

--- a/crates/api_models/src/payments.rs
+++ b/crates/api_models/src/payments.rs
@@ -6569,8 +6569,11 @@ pub struct NoonData {
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, ToSchema)]
 pub struct BraintreeData {
-    /// Information about the merchant_accountid and merchant_config_currency that merchant wants to specify at connector level.
+    /// Information about the merchant_account_id that merchant wants to specify at connector level.
+    #[schema(value_type = String)]
     pub merchant_account_id: Option<Secret<String>>,
+    /// Information about the merchant_config_currency that merchant wants to specify at connector level.
+    #[schema(value_type = String)]
     pub merchant_config_currency: Option<api_enums::Currency>,
 }
 

--- a/crates/diesel_models/src/payment_attempt.rs
+++ b/crates/diesel_models/src/payment_attempt.rs
@@ -3507,6 +3507,7 @@ pub enum RedirectForm {
         client_token: String,
         card_token: String,
         bin: String,
+        acs_url: String,
     },
     Nmi {
         amount: String,

--- a/crates/hyperswitch_connectors/src/connectors/braintree/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/braintree/transformers.rs
@@ -279,7 +279,7 @@ impl TryFrom<&BraintreeRouterData<&types::PaymentsAuthorizeRouterData>>
             Some(merchant_config_currency),
         ) = (
             item.router_data.request.merchant_account_id.clone(),
-            item.router_data.request.merchant_config_currency.clone(),
+            item.router_data.request.merchant_config_currency,
         ) {
             router_env::logger::info!(
                 "BRAINTREE: Picking merchant_account_id and merchant_config_currency from payments request"
@@ -864,23 +864,20 @@ pub struct BraintreeRefundInput {
 impl<F> TryFrom<BraintreeRouterData<&RefundsRouterData<F>>> for BraintreeRefundRequest {
     type Error = error_stack::Report<errors::ConnectorError>;
     fn try_from(item: BraintreeRouterData<&RefundsRouterData<F>>) -> Result<Self, Self::Error> {
-        let metadata: BraintreeMeta = if item.router_data.request.merchant_account_id.is_some()
-            && item.router_data.request.merchant_config_currency.is_some()
-        {
+        let metadata: BraintreeMeta = if let (
+            Some(merchant_account_id),
+            Some(merchant_config_currency),
+        ) = (
+            item.router_data.request.merchant_account_id.clone(),
+            item.router_data.request.merchant_config_currency,
+        ) {
             router_env::logger::info!(
                 "BRAINTREE: Picking merchant_account_id and merchant_config_currency from payments request"
             );
+
             BraintreeMeta {
-                merchant_account_id: item.router_data.request.merchant_account_id.clone().ok_or(
-                    errors::ConnectorError::MissingRequiredField {
-                        field_name: "merchant_account_id",
-                    },
-                )?,
-                merchant_config_currency: item.router_data.request.merchant_config_currency.ok_or(
-                    errors::ConnectorError::MissingRequiredField {
-                        field_name: "merchant_config_currency",
-                    },
-                )?,
+                merchant_account_id,
+                merchant_config_currency,
             }
         } else {
             utils::to_connector_meta_from_secret(item.router_data.connector_meta_data.clone())
@@ -994,23 +991,20 @@ pub struct RefundSearchInput {
 impl TryFrom<&types::RefundSyncRouterData> for BraintreeRSyncRequest {
     type Error = error_stack::Report<errors::ConnectorError>;
     fn try_from(item: &types::RefundSyncRouterData) -> Result<Self, Self::Error> {
-        let metadata: BraintreeMeta = if item.request.merchant_account_id.is_some()
-            && item.request.merchant_config_currency.is_some()
-        {
+        let metadata: BraintreeMeta = if let (
+            Some(merchant_account_id),
+            Some(merchant_config_currency),
+        ) = (
+            item.request.merchant_account_id.clone(),
+            item.request.merchant_config_currency,
+        ) {
             router_env::logger::info!(
                 "BRAINTREE: Picking merchant_account_id and merchant_config_currency from payments request"
             );
+
             BraintreeMeta {
-                merchant_account_id: item.request.merchant_account_id.clone().ok_or(
-                    errors::ConnectorError::MissingRequiredField {
-                        field_name: "merchant_account_id",
-                    },
-                )?,
-                merchant_config_currency: item.request.merchant_config_currency.ok_or(
-                    errors::ConnectorError::MissingRequiredField {
-                        field_name: "merchant_config_currency",
-                    },
-                )?,
+                merchant_account_id,
+                merchant_config_currency,
             }
         } else {
             utils::to_connector_meta_from_secret(item.connector_meta_data.clone()).change_context(
@@ -1673,23 +1667,20 @@ impl TryFrom<&BraintreeRouterData<&types::PaymentsCompleteAuthorizeRouterData>>
     fn try_from(
         item: &BraintreeRouterData<&types::PaymentsCompleteAuthorizeRouterData>,
     ) -> Result<Self, Self::Error> {
-        let metadata: BraintreeMeta = if item.router_data.request.merchant_account_id.is_some()
-            && item.router_data.request.merchant_config_currency.is_some()
-        {
+        let metadata: BraintreeMeta = if let (
+            Some(merchant_account_id),
+            Some(merchant_config_currency),
+        ) = (
+            item.router_data.request.merchant_account_id.clone(),
+            item.router_data.request.merchant_config_currency,
+        ) {
             router_env::logger::info!(
                 "BRAINTREE: Picking merchant_account_id and merchant_config_currency from payments request"
             );
+
             BraintreeMeta {
-                merchant_account_id: item.router_data.request.merchant_account_id.clone().ok_or(
-                    errors::ConnectorError::MissingRequiredField {
-                        field_name: "merchant_account_id",
-                    },
-                )?,
-                merchant_config_currency: item.router_data.request.merchant_config_currency.ok_or(
-                    errors::ConnectorError::MissingRequiredField {
-                        field_name: "merchant_config_currency",
-                    },
-                )?,
+                merchant_account_id,
+                merchant_config_currency,
             }
         } else {
             utils::to_connector_meta_from_secret(item.router_data.connector_meta_data.clone())

--- a/crates/hyperswitch_connectors/src/connectors/braintree/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/braintree/transformers.rs
@@ -274,23 +274,20 @@ impl TryFrom<&BraintreeRouterData<&types::PaymentsAuthorizeRouterData>>
     fn try_from(
         item: &BraintreeRouterData<&types::PaymentsAuthorizeRouterData>,
     ) -> Result<Self, Self::Error> {
-        let metadata: BraintreeMeta = if item.router_data.request.merchant_account_id.is_some()
-            && item.router_data.request.merchant_config_currency.is_some()
-        {
+        let metadata: BraintreeMeta = if let (
+            Some(merchant_account_id),
+            Some(merchant_config_currency),
+        ) = (
+            item.router_data.request.merchant_account_id.clone(),
+            item.router_data.request.merchant_config_currency.clone(),
+        ) {
             router_env::logger::info!(
                 "BRAINTREE: Picking merchant_account_id and merchant_config_currency from payments request"
             );
+
             BraintreeMeta {
-                merchant_account_id: item.router_data.request.merchant_account_id.clone().ok_or(
-                    errors::ConnectorError::MissingRequiredField {
-                        field_name: "merchant_account_id",
-                    },
-                )?,
-                merchant_config_currency: item.router_data.request.merchant_config_currency.ok_or(
-                    errors::ConnectorError::MissingRequiredField {
-                        field_name: "merchant_config_currency",
-                    },
-                )?,
+                merchant_account_id,
+                merchant_config_currency,
             }
         } else {
             utils::to_connector_meta_from_secret(item.router_data.connector_meta_data.clone())

--- a/crates/hyperswitch_connectors/src/connectors/braintree/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/braintree/transformers.rs
@@ -1639,11 +1639,33 @@ impl TryFrom<&BraintreeRouterData<&types::PaymentsCompleteAuthorizeRouterData>>
     fn try_from(
         item: &BraintreeRouterData<&types::PaymentsCompleteAuthorizeRouterData>,
     ) -> Result<Self, Self::Error> {
-        let metadata: BraintreeMeta =
+        let metadata: BraintreeMeta = if item.router_data.request.merchant_account_id.is_some()
+            && item.router_data.request.merchant_config_currency.is_some()
+        {
+            router_env::logger::info!(
+                "BRAINTREE: Picking merchant_account_id and merchant_config_currency from payments request"
+            );
+            BraintreeMeta {
+                merchant_account_id: item.router_data.request.merchant_account_id.clone().ok_or(
+                    errors::ConnectorError::MissingRequiredField {
+                        field_name: "merchant_account_id",
+                    },
+                )?,
+                merchant_config_currency: item
+                    .router_data
+                    .request
+                    .merchant_config_currency
+                    .clone()
+                    .ok_or(errors::ConnectorError::MissingRequiredField {
+                        field_name: "merchant_config_currency",
+                    })?,
+            }
+        } else {
             utils::to_connector_meta_from_secret(item.router_data.connector_meta_data.clone())
                 .change_context(errors::ConnectorError::InvalidConnectorConfig {
                     config: "metadata",
-                })?;
+                })?
+        };
         utils::validate_currency(
             item.router_data.request.currency,
             Some(metadata.merchant_config_currency),

--- a/crates/hyperswitch_domain_models/src/router_request_types.rs
+++ b/crates/hyperswitch_domain_models/src/router_request_types.rs
@@ -641,6 +641,8 @@ pub struct RefundsData {
     pub minor_refund_amount: MinorUnit,
     pub integrity_object: Option<RefundIntegrityObject>,
     pub refund_status: storage_enums::RefundStatus,
+    pub merchant_account_id: Option<Secret<String>>,
+    pub merchant_config_currency: Option<storage_enums::Currency>,
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/crates/hyperswitch_domain_models/src/router_request_types.rs
+++ b/crates/hyperswitch_domain_models/src/router_request_types.rs
@@ -71,6 +71,8 @@ pub struct PaymentsAuthorizeData {
     pub integrity_object: Option<AuthoriseIntegrityObject>,
     pub shipping_cost: Option<MinorUnit>,
     pub additional_payment_method_data: Option<AdditionalPaymentData>,
+    pub merchant_account_id: Option<Secret<String>>,
+    pub merchant_config_currency: Option<storage_enums::Currency>,
 }
 
 #[derive(Debug, Clone)]
@@ -418,6 +420,8 @@ pub struct CompleteAuthorizeData {
     pub customer_acceptance: Option<mandates::CustomerAcceptance>,
     // New amount for amount frame work
     pub minor_amount: MinorUnit,
+    pub merchant_account_id: Option<Secret<String>>,
+    pub merchant_config_currency: Option<storage_enums::Currency>,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/hyperswitch_domain_models/src/router_response_types.rs
+++ b/crates/hyperswitch_domain_models/src/router_response_types.rs
@@ -271,6 +271,7 @@ pub enum RedirectForm {
         client_token: String,
         card_token: String,
         bin: String,
+        acs_url: String,
     },
     Nmi {
         amount: String,
@@ -351,10 +352,12 @@ impl From<RedirectForm> for diesel_models::payment_attempt::RedirectForm {
                 client_token,
                 card_token,
                 bin,
+                acs_url,
             } => Self::Braintree {
                 client_token,
                 card_token,
                 bin,
+                acs_url,
             },
             RedirectForm::Nmi {
                 amount,
@@ -433,10 +436,12 @@ impl From<diesel_models::payment_attempt::RedirectForm> for RedirectForm {
                 client_token,
                 card_token,
                 bin,
+                acs_url,
             } => Self::Braintree {
                 client_token,
                 card_token,
                 bin,
+                acs_url,
             },
             diesel_models::payment_attempt::RedirectForm::Nmi {
                 amount,

--- a/crates/openapi/src/openapi.rs
+++ b/crates/openapi/src/openapi.rs
@@ -401,6 +401,7 @@ Never share your secret api keys. Keep them guarded and secure.
         api_models::payments::KlarnaSdkPaymentMethodResponse,
         api_models::payments::SwishQrData,
         api_models::payments::AirwallexData,
+        api_models::payments::BraintreeData,
         api_models::payments::NoonData,
         api_models::payments::OrderDetailsWithAmount,
         api_models::payments::NextActionType,

--- a/crates/openapi/src/openapi_v2.rs
+++ b/crates/openapi/src/openapi_v2.rs
@@ -367,6 +367,7 @@ Never share your secret api keys. Keep them guarded and secure.
         api_models::payments::KlarnaSdkPaymentMethodResponse,
         api_models::payments::SwishQrData,
         api_models::payments::AirwallexData,
+        api_models::payments::BraintreeData,
         api_models::payments::NoonData,
         api_models::payments::OrderDetailsWithAmount,
         api_models::payments::NextActionType,

--- a/crates/router/src/core/payments/transformers.rs
+++ b/crates/router/src/core/payments/transformers.rs
@@ -3035,7 +3035,7 @@ impl<F: Clone> TryFrom<PaymentAdditionalData<'_, F>> for types::PaymentsAuthoriz
             .transpose()?
             .and_then(|cm| cm.noon.and_then(|noon| noon.order_category));
 
-        let merchant_account_id = additional_data
+        let braintree_metadata = additional_data
             .payment_data
             .payment_intent
             .connector_metadata
@@ -3046,24 +3046,13 @@ impl<F: Clone> TryFrom<PaymentAdditionalData<'_, F>> for types::PaymentsAuthoriz
                     .attach_printable("Failed parsing ConnectorMetadata")
             })
             .transpose()?
-            .and_then(|cm| {
-                cm.braintree
-                    .and_then(|braintree| braintree.merchant_account_id)
-            });
-        let merchant_config_currency = additional_data
-            .payment_data
-            .payment_intent
-            .connector_metadata
-            .map(|cm| {
-                cm.parse_value::<api_models::payments::ConnectorMetadata>("ConnectorMetadata")
-                    .change_context(errors::ApiErrorResponse::InternalServerError)
-                    .attach_printable("Failed parsing ConnectorMetadata")
-            })
-            .transpose()?
-            .and_then(|cm| {
-                cm.braintree
-                    .and_then(|braintree| braintree.merchant_config_currency)
-            });
+            .and_then(|cm| cm.braintree);
+
+        let merchant_account_id = braintree_metadata
+            .as_ref()
+            .and_then(|braintree| braintree.merchant_account_id.clone());
+        let merchant_config_currency =
+            braintree_metadata.and_then(|braintree| braintree.merchant_config_currency);
 
         let order_details = additional_data
             .payment_data
@@ -4058,7 +4047,7 @@ impl<F: Clone> TryFrom<PaymentAdditionalData<'_, F>> for types::CompleteAuthoriz
             attempt,
             connector_name,
         ));
-        let merchant_account_id = payment_data
+        let braintree_metadata = payment_data
             .payment_intent
             .connector_metadata
             .clone()
@@ -4068,23 +4057,13 @@ impl<F: Clone> TryFrom<PaymentAdditionalData<'_, F>> for types::CompleteAuthoriz
                     .attach_printable("Failed parsing ConnectorMetadata")
             })
             .transpose()?
-            .and_then(|cm| {
-                cm.braintree
-                    .and_then(|braintree| braintree.merchant_account_id)
-            });
-        let merchant_config_currency = payment_data
-            .payment_intent
-            .connector_metadata
-            .map(|cm| {
-                cm.parse_value::<api_models::payments::ConnectorMetadata>("ConnectorMetadata")
-                    .change_context(errors::ApiErrorResponse::InternalServerError)
-                    .attach_printable("Failed parsing ConnectorMetadata")
-            })
-            .transpose()?
-            .and_then(|cm| {
-                cm.braintree
-                    .and_then(|braintree| braintree.merchant_config_currency)
-            });
+            .and_then(|cm| cm.braintree);
+
+        let merchant_account_id = braintree_metadata
+            .as_ref()
+            .and_then(|braintree| braintree.merchant_account_id.clone());
+        let merchant_config_currency =
+            braintree_metadata.and_then(|braintree| braintree.merchant_config_currency);
         Ok(Self {
             setup_future_usage: payment_data.payment_intent.setup_future_usage,
             mandate_id: payment_data.mandate_id.clone(),

--- a/crates/router/src/core/payments/transformers.rs
+++ b/crates/router/src/core/payments/transformers.rs
@@ -4032,7 +4032,7 @@ impl<F: Clone> TryFrom<PaymentAdditionalData<'_, F>> for types::CompleteAuthoriz
     type Error = error_stack::Report<errors::ApiErrorResponse>;
 
     fn try_from(additional_data: PaymentAdditionalData<'_, F>) -> Result<Self, Self::Error> {
-        let payment_data = additional_data.payment_data.clone();
+        let payment_data = additional_data.payment_data;
         let router_base_url = &additional_data.router_base_url;
         let connector_name = &additional_data.connector_name;
         let attempt = &payment_data.payment_attempt;
@@ -4058,8 +4058,7 @@ impl<F: Clone> TryFrom<PaymentAdditionalData<'_, F>> for types::CompleteAuthoriz
             attempt,
             connector_name,
         ));
-        let merchant_account_id = additional_data
-            .payment_data
+        let merchant_account_id = payment_data
             .payment_intent
             .connector_metadata
             .clone()
@@ -4073,8 +4072,7 @@ impl<F: Clone> TryFrom<PaymentAdditionalData<'_, F>> for types::CompleteAuthoriz
                 cm.braintree
                     .and_then(|braintree| braintree.merchant_account_id)
             });
-        let merchant_config_currency = additional_data
-            .payment_data
+        let merchant_config_currency = payment_data
             .payment_intent
             .connector_metadata
             .map(|cm| {

--- a/crates/router/src/core/payments/transformers.rs
+++ b/crates/router/src/core/payments/transformers.rs
@@ -308,6 +308,8 @@ pub async fn construct_payment_router_data_for_authorize<'a>(
         integrity_object: None,
         shipping_cost: payment_data.payment_intent.amount_details.shipping_cost,
         additional_payment_method_data: None,
+        merchant_account_id: None,
+        merchant_config_currency: None,
     };
     let connector_mandate_request_reference_id = payment_data
         .payment_attempt

--- a/crates/router/src/core/relay/utils.rs
+++ b/crates/router/src/core/relay/utils.rs
@@ -107,6 +107,8 @@ pub async fn construct_relay_refund_router_data<F>(
             split_refunds: None,
             integrity_object: None,
             refund_status: common_enums::RefundStatus::from(relay_record.status),
+            merchant_account_id: None,
+            merchant_config_currency: None,
         },
 
         response: Err(ErrorResponse::default()),

--- a/crates/router/src/core/utils.rs
+++ b/crates/router/src/core/utils.rs
@@ -339,7 +339,6 @@ pub async fn construct_refund_router_data<'a, F>(
     let connector_refund_id = refund.get_optional_connector_refund_id().cloned();
 
     let merchant_account_id = payment_intent
-        .clone()
         .connector_metadata
         .clone()
         .map(|cm| {

--- a/crates/router/src/services/api.rs
+++ b/crates/router/src/services/api.rs
@@ -1588,6 +1588,7 @@ pub fn build_redirection_form(
             client_token,
             card_token,
             bin,
+            acs_url,
         } => {
             maud::html! {
             (maud::DOCTYPE)
@@ -1664,7 +1665,7 @@ pub fn build_redirection_form(
                                                 }} else {{
                                                     // console.log(payload);
                                                     var f = document.createElement('form');
-                                                    f.action=window.location.pathname.replace(/payments\\/redirect\\/(\\w+)\\/(\\w+)\\/\\w+/, \"payments/$1/$2/redirect/complete/braintree\");
+                                                    f.action=\"{acs_url}\";
                                                     var i = document.createElement('input');
                                                     i.type = 'hidden';
                                                     f.method='POST';

--- a/crates/router/src/types.rs
+++ b/crates/router/src/types.rs
@@ -905,6 +905,8 @@ impl ForeignFrom<&SetupMandateRouterData> for PaymentsAuthorizeData {
             integrity_object: None,
             additional_payment_method_data: None,
             shipping_cost: data.request.shipping_cost,
+            merchant_account_id: None,
+            merchant_config_currency: None,
         }
     }
 }

--- a/crates/router/src/types/api/verify_connector.rs
+++ b/crates/router/src/types/api/verify_connector.rs
@@ -60,6 +60,8 @@ impl VerifyConnectorData {
             integrity_object: None,
             additional_payment_method_data: None,
             shipping_cost: None,
+            merchant_account_id: None,
+            merchant_config_currency: None,
         }
     }
 

--- a/crates/router/tests/connectors/utils.rs
+++ b/crates/router/tests/connectors/utils.rs
@@ -406,6 +406,8 @@ pub trait ConnectorActions: Connector {
                 split_refunds: None,
                 integrity_object: None,
                 refund_status: enums::RefundStatus::Pending,
+                merchant_account_id: None,
+                merchant_config_currency: None,
             }),
             payment_info,
         );
@@ -980,6 +982,8 @@ impl Default for PaymentAuthorizeType {
             merchant_order_reference_id: None,
             additional_payment_method_data: None,
             shipping_cost: None,
+            merchant_account_id: None,
+            merchant_config_currency: None,
         };
         Self(data)
     }
@@ -1069,6 +1073,8 @@ impl Default for PaymentRefundType {
             split_refunds: None,
             integrity_object: None,
             refund_status: enums::RefundStatus::Pending,
+            merchant_account_id: None,
+            merchant_config_currency: None,
         };
         Self(data)
     }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Consume merchant_account_id and merchant_config_currency from payment requests for braintree.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
