### PR TITLE
fix(payment_methods): payment method type not being stored in payment method

### DIFF
--- a/crates/router/src/core/payment_methods.rs
+++ b/crates/router/src/core/payment_methods.rs
@@ -914,7 +914,7 @@ pub async fn create_payment_method_core(
             .change_context(errors::ApiErrorResponse::InternalServerError)
             .attach_printable("Unable to generate GlobalPaymentMethodId")?;
 
-    let mut payment_method = create_payment_method_for_intent(
+    let payment_method = create_payment_method_for_intent(
         state,
         req.metadata.clone(),
         &customer_id,
@@ -964,9 +964,6 @@ pub async fn create_payment_method_core(
 
     let (response, payment_method) = match vaulting_result {
         Ok((vaulting_resp, fingerprint_id)) => {
-            payment_method.set_payment_method_type(req.payment_method_type);
-            payment_method.set_payment_method_subtype(req.payment_method_subtype);
-
             let pm_update = create_pm_additional_data_update(
                 Some(&payment_method_data),
                 state,
@@ -976,6 +973,8 @@ pub async fn create_payment_method_core(
                 &payment_method,
                 None,
                 network_tokenization_resp,
+                Some(req.payment_method_type),
+                Some(req.payment_method_subtype),
             )
             .await
             .attach_printable("Unable to create Payment method data")?;
@@ -1546,6 +1545,8 @@ pub async fn create_pm_additional_data_update(
     payment_method: &domain::PaymentMethod,
     connector_token_details: Option<payment_methods::ConnectorTokenDetails>,
     nt_data: Option<NetworkTokenPaymentMethodDetails>,
+    payment_method_type: Option<common_enums::PaymentMethod>,
+    payment_method_subtype: Option<common_enums::PaymentMethodType>,
 ) -> RouterResult<storage::PaymentMethodUpdate> {
     let encrypted_payment_method_data = payment_method_vaulting_data
         .map(
@@ -1585,9 +1586,8 @@ pub async fn create_pm_additional_data_update(
     let pm_update = storage::PaymentMethodUpdate::GenericUpdate {
         status: Some(enums::PaymentMethodStatus::Active),
         locker_id: vault_id,
-        // Payment method type remains the same, only card details are updated
-        payment_method_type_v2: None,
-        payment_method_subtype: None,
+        payment_method_type_v2: payment_method_type,
+        payment_method_subtype,
         payment_method_data: encrypted_payment_method_data,
         network_token_requestor_reference_id: nt_data
             .clone()
@@ -1896,6 +1896,8 @@ pub async fn update_payment_method_core(
         fingerprint_id,
         &payment_method,
         request.connector_token_details,
+        None,
+        None,
         None,
     )
     .await


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix

## Description
<!-- Describe your changes in detail -->
This PR fixes the `payment_method_type` and `payment_method_subtype` not being populated when the payment method is added via the payment methods session endpoint.

Previously, whenever a payment method was added via the payment methods session confirm endpoint, on listing the payment method for the customer, we get an error because the `payment_method_type` and `payment_method_subtype` not being populated.

- Add a payment method using the payment methods session endpoint.
```bash
curl --location 'https://integ-api.hyperswitch.io/v2/payment-methods-session/12345_pms_019560e38b7a7e6389e1495f1ffa8521/confirm' \
--header 'x-profile-id: pro_VSm7frQcpOKQxveHtg8Q' \
--header 'Authorization: publishable-key=pk_snd_6e6f84710fa849a08b6fe739b7492ca0,client-secret=cs_019560e38b7c7783a4ed501baa0eca17' \
--header 'Content-Type: application/json' \
--header 'api-key: snd_t7AzLX1DXYMv6vfqlo5aQvE60lPEJgvtnFJ1U0twmoCs1LC7gaPzxdVs1g60yFEk' \
--data '{
    "payment_method_data": {
        "card": {
            "card_number": "4242424242424242",
            "card_exp_month": "01",
            "card_exp_year": "26",
            "card_holder_name": "John Doe",
            "card_cvc": "100"
        }
    },
    "payment_method_type": "card",
    "payment_method_subtype": "credit"
}'
```

- List the saved payment methods for the customer.
```bash
curl --location 'https://integ-api.hyperswitch.io/v2/customers/12345_cus_019560e3806e75b2a269766612073c02/saved-payment-methods' \
--header 'api-key:<key>' \
--header 'Content-Type: application/json' \
--header 'x-profile-id: pro_VSm7frQcpOKQxveHtg8Q'
```

- Response
```json
{
    "error": {
        "type": "api",
        "message": "Something went wrong",
        "code": "HE_00"
    }
}
```


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
- Create a payment method session
```bash
curl --location 'http://localhost:8080/v2/payment-methods-session' \
--header 'x-profile-id: pro_yREq7JPVRt3a8QSObAbp' \
--header 'Authorization: api-key=dev_u6NPsC0W6C18Etu0guoaH17CqAiscQmLlkxBHK0cR1e8BAUvadRO7hFAQUwzdlLR' \
--header 'Content-Type: application/json' \
--header 'api-key: dev_u6NPsC0W6C18Etu0guoaH17CqAiscQmLlkxBHK0cR1e8BAUvadRO7hFAQUwzdlLR' \
--data-raw '{
    "customer_id": "12345_cus_019560fbf3f371a1a05d37ac13636651",
     "billing": {
        "address": {
            "first_name": "John",
            "last_name": "Dough"
        },
        "email": "example@example.com"
    },
    "psp_tokenization": {
        "tokenization_type": "multi_use"
    }
}'
``
- Confirm the payment method session
```bash
curl --location 'http://localhost:8080/v2/payment-methods-session/12345_pms_019560fc15667e12bcf8061c760dd8a1/confirm' \
--header 'x-profile-id: pro_yREq7JPVRt3a8QSObAbp' \
--header 'Authorization: publishable-key=pk_dev_5063c664da414fac9bdb2b660f2c1999,client-secret=cs_019560fc156871a1a7b27206170dadc4' \
--header 'Content-Type: application/json' \
--header 'api-key: dev_u6NPsC0W6C18Etu0guoaH17CqAiscQmLlkxBHK0cR1e8BAUvadRO7hFAQUwzdlLR' \
--data '{
    "payment_method_data": {
        "card": {
            "card_number": "4242424242424242",
            "card_exp_month": "01",
            "card_exp_year": "26",
            "card_holder_name": "John Doe",
            "card_cvc": "100"
        }
    },
    "payment_method_type": "card",
    "payment_method_subtype": "credit"
}'
```
- List the saved payment methods for customer
```bash
curl --location 'http://localhost:8080/v2/customers/12345_cus_019560fbf3f371a1a05d37ac13636651/saved-payment-methods' \
--header 'api-key: dev_u6NPsC0W6C18Etu0guoaH17CqAiscQmLlkxBHK0cR1e8BAUvadRO7hFAQUwzdlLR' \
--header 'Content-Type: application/json' \
--header 'x-profile-id: pro_yREq7JPVRt3a8QSObAbp'
```

- Response
```json
{
    "customer_payment_methods": [
        {
            "id": "12345_pm_019560ff070477f092cb279a8e40edfa",
            "customer_id": "12345_cus_019560fbf3f371a1a05d37ac13636651",
            "payment_method_type": "card",
            "payment_method_subtype": "credit",
            "recurring_enabled": true,
            "payment_method_data": {
                "card": {
                    "issuer_country": null,
                    "last4_digits": "4242",
                    "expiry_month": "01",
                    "expiry_year": "26",
                    "card_holder_name": "John Doe",
                    "card_fingerprint": null,
                    "nick_name": null,
                    "card_network": null,
                    "card_isin": null,
                    "card_issuer": null,
                    "card_type": null,
                    "saved_to_locker": true
                }
            },
            "bank": null,
            "created": "2025-03-04T11:51:21.093Z",
            "requires_cvv": true,
            "last_used_at": "2025-03-04T11:51:21.093Z",
            "is_default": false,
            "billing": {
                "address": {
                    "city": null,
                    "country": null,
                    "line1": null,
                    "line2": null,
                    "line3": null,
                    "zip": null,
                    "state": null,
                    "first_name": "John",
                    "last_name": "Dough"
                },
                "phone": null,
                "email": "example@example.com"
            }
        }
    ]
}
```

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
