### PR TITLE
fix(router): Add support for API key authentication in the v2 APIs - filter and aggregate

### DIFF
--- a/crates/router/src/routes/payments.rs
+++ b/crates/router/src/routes/payments.rs
@@ -1396,9 +1396,13 @@ pub async fn get_payment_filters(
         |state, auth: auth::AuthenticationData, _, _| {
             payments::get_payment_filters(state, auth.merchant_account, None)
         },
-        &auth::JWTAuth {
-            permission: Permission::MerchantPaymentRead,
-        },
+        auth::auth_type(
+            &auth::HeaderAuth(auth::ApiKeyAuth),
+            &auth::JWTAuth {
+                permission: Permission::MerchantPaymentRead,
+            },
+            req.headers(),
+        ),
         api_locking::LockAction::NotApplicable,
     ))
     .await
@@ -1423,9 +1427,13 @@ pub async fn get_payment_filters_profile(
                 Some(vec![auth.profile.get_id().clone()]),
             )
         },
-        &auth::JWTAuth {
-            permission: Permission::ProfilePaymentRead,
-        },
+        auth::auth_type(
+            &auth::HeaderAuth(auth::ApiKeyAuth),
+            &auth::JWTAuth {
+                permission: Permission::ProfilePaymentRead,
+            },
+            req.headers(),
+        ),
         api_locking::LockAction::NotApplicable,
     ))
     .await
@@ -1475,9 +1483,13 @@ pub async fn get_payments_aggregates(
         |state, auth: auth::AuthenticationData, req, _| {
             payments::get_aggregates_for_payments(state, auth.merchant_account, None, req)
         },
-        &auth::JWTAuth {
-            permission: Permission::MerchantPaymentRead,
-        },
+        auth::auth_type(
+            &auth::HeaderAuth(auth::ApiKeyAuth),
+            &auth::JWTAuth {
+                permission: Permission::MerchantPaymentRead,
+            },
+            req.headers(),
+        ),
         api_locking::LockAction::NotApplicable,
     ))
     .await
@@ -2302,9 +2314,13 @@ pub async fn get_payments_aggregates_profile(
                 req,
             )
         },
-        &auth::JWTAuth {
-            permission: Permission::ProfilePaymentRead,
-        },
+        auth::auth_type(
+            &auth::HeaderAuth(auth::ApiKeyAuth),
+            &auth::JWTAuth {
+                permission: Permission::ProfilePaymentRead,
+            },
+            req.headers(),
+        ),
         api_locking::LockAction::NotApplicable,
     ))
     .await


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Added support for API key authentication for the v2 APIs: filter and aggregate. API key authentication is the only way to access v2 APIs.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
profile/filter--
```
curl --location 'http://localhost:8080/v2/payments/profile/filter' \
--header 'X-Profile-Id: pro_buNPcwYFBTewUPbjAdrC' \
--header 'X-Merchant-Id: cloth_seller_V8nYQTSxz1LVXpLHlOo1' \
--header 'api-key: dev_qbKadyYwPTlnQ0xcatw0PMifWXw0NY6Hg0fLZODaf4SChCwvtcqJmNm0tfUmr1th'
```

```
{
    "connector": {
        "stripe": [
            {
                "connector_label": "stripe_business22",
                "merchant_connector_id": "mca_DyKxIWwvR2gti0V4KQT1"
            }
        ]
    },
    "currency": [
        "AED",
        "AFN",
        "ALL",
        "AMD",
        "ANG",
        "AOA",
        "ARS",
        "AUD",
        "AWG",
        "AZN",
        "BAM",
        "BBD",
        "BDT",
        "BGN",
        "BHD",
        "BIF",
        "BMD",
        "BND",
        "BOB",
        "BRL",
        "BSD",
        "BTN",
        "BWP",
        "BYN",
        "BZD",
        "CAD",
        "CDF",
        "CHF",
        "CLP",
        "CNY",
        "COP",
        "CRC",
        "CUP",
        "CVE",
        "CZK",
        "DJF",
        "DKK",
        "DOP",
        "DZD",
        "EGP",
        "ERN",
        "ETB",
        "EUR",
        "FJD",
        "FKP",
        "GBP",
        "GEL",
        "GHS",
        "GIP",
        "GMD",
        "GNF",
        "GTQ",
        "GYD",
        "HKD",
        "HNL",
        "HRK",
        "HTG",
        "HUF",
        "IDR",
        "ILS",
        "INR",
        "IQD",
        "IRR",
        "ISK",
        "JMD",
        "JOD",
        "JPY",
        "KES",
        "KGS",
        "KHR",
        "KMF",
        "KPW",
        "KRW",
        "KWD",
        "KYD",
        "KZT",
        "LAK",
        "LBP",
        "LKR",
        "LRD",
        "LSL",
        "LYD",
        "MAD",
        "MDL",
        "MGA",
        "MKD",
        "MMK",
        "MNT",
        "MOP",
        "MRU",
        "MUR",
        "MVR",
        "MWK",
        "MXN",
        "MYR",
        "MZN",
        "NAD",
        "NGN",
        "NIO",
        "NOK",
        "NPR",
        "NZD",
        "OMR",
        "PAB",
        "PEN",
        "PGK",
        "PHP",
        "PKR",
        "PLN",
        "PYG",
        "QAR",
        "RON",
        "RSD",
        "RUB",
        "RWF",
        "SAR",
        "SBD",
        "SCR",
        "SDG",
        "SEK",
        "SGD",
        "SHP",
        "SLE",
        "SLL",
        "SOS",
        "SRD",
        "SSP",
        "STN",
        "SVC",
        "SYP",
        "SZL",
        "THB",
        "TJS",
        "TMT",
        "TND",
        "TOP",
        "TRY",
        "TTD",
        "TWD",
        "TZS",
        "UAH",
        "UGX",
        "USD",
        "UYU",
        "UZS",
        "VES",
        "VND",
        "VUV",
        "WST",
        "XAF",
        "XCD",
        "XOF",
        "XPF",
        "YER",
        "ZAR",
        "ZMW",
        "ZWL"
    ],
    "status": [
        "succeeded",
        "failed",
        "cancelled",
        "processing",
        "requires_customer_action",
        "requires_merchant_action",
        "requires_payment_method",
        "requires_confirmation",
        "requires_capture",
        "partially_captured",
        "partially_captured_and_capturable"
    ],
    "payment_method": {
        "card": [
            "credit",
            "debit"
        ]
    },
    "authentication_type": [
        "three_ds",
        "no_three_ds"
    ],
    "card_network": [
        "Visa",
        "Mastercard",
        "AmericanExpress",
        "JCB",
        "DinersClub",
        "Discover",
        "CartesBancaires",
        "UnionPay",
        "Interac",
        "RuPay",
        "Maestro"
    ],
    "card_discovery": [
        "manual",
        "saved_card",
        "click_to_pay"
    ]
}
```
filter 
```
curl --location 'http://localhost:8080/v2/payments/filter' \
--header 'X-Profile-Id: pro_buNPcwYFBTewUPbjAdrC' \
--header 'X-Merchant-Id: cloth_seller_V8nYQTSxz1LVXpLHlOo1' \
--header 'api-key: dev_qbKadyYwPTlnQ0xcatw0PMifWXw0NY6Hg0fLZODaf4SChCwvtcqJmNm0tfUmr1th'
```
```
{
    "connector": {
        "stripe": [
            {
                "connector_label": "stripe_business",
                "merchant_connector_id": "mca_mBNmU4i5sWBG2P2rqFIz"
            },
            {
                "connector_label": "stripe_business22",
                "merchant_connector_id": "mca_DyKxIWwvR2gti0V4KQT1"
            }
        ]
    },
    "currency": [
        "AED",
        "AFN",
        "ALL",
        "AMD",
        "ANG",
        "AOA",
        "ARS",
        "AUD",
        "AWG",
        "AZN",
        "BAM",
        "BBD",
        "BDT",
        "BGN",
        "BHD",
        "BIF",
        "BMD",
        "BND",
        "BOB",
        "BRL",
        "BSD",
        "BTN",
        "BWP",
        "BYN",
        "BZD",
        "CAD",
        "CDF",
        "CHF",
        "CLP",
        "CNY",
        "COP",
        "CRC",
        "CUP",
        "CVE",
        "CZK",
        "DJF",
        "DKK",
        "DOP",
        "DZD",
        "EGP",
        "ERN",
        "ETB",
        "EUR",
        "FJD",
        "FKP",
        "GBP",
        "GEL",
        "GHS",
        "GIP",
        "GMD",
        "GNF",
        "GTQ",
        "GYD",
        "HKD",
        "HNL",
        "HRK",
        "HTG",
        "HUF",
        "IDR",
        "ILS",
        "INR",
        "IQD",
        "IRR",
        "ISK",
        "JMD",
        "JOD",
        "JPY",
        "KES",
        "KGS",
        "KHR",
        "KMF",
        "KPW",
        "KRW",
        "KWD",
        "KYD",
        "KZT",
        "LAK",
        "LBP",
        "LKR",
        "LRD",
        "LSL",
        "LYD",
        "MAD",
        "MDL",
        "MGA",
        "MKD",
        "MMK",
        "MNT",
        "MOP",
        "MRU",
        "MUR",
        "MVR",
        "MWK",
        "MXN",
        "MYR",
        "MZN",
        "NAD",
        "NGN",
        "NIO",
        "NOK",
        "NPR",
        "NZD",
        "OMR",
        "PAB",
        "PEN",
        "PGK",
        "PHP",
        "PKR",
        "PLN",
        "PYG",
        "QAR",
        "RON",
        "RSD",
        "RUB",
        "RWF",
        "SAR",
        "SBD",
        "SCR",
        "SDG",
        "SEK",
        "SGD",
        "SHP",
        "SLE",
        "SLL",
        "SOS",
        "SRD",
        "SSP",
        "STN",
        "SVC",
        "SYP",
        "SZL",
        "THB",
        "TJS",
        "TMT",
        "TND",
        "TOP",
        "TRY",
        "TTD",
        "TWD",
        "TZS",
        "UAH",
        "UGX",
        "USD",
        "UYU",
        "UZS",
        "VES",
        "VND",
        "VUV",
        "WST",
        "XAF",
        "XCD",
        "XOF",
        "XPF",
        "YER",
        "ZAR",
        "ZMW",
        "ZWL"
    ],
    "status": [
        "succeeded",
        "failed",
        "cancelled",
        "processing",
        "requires_customer_action",
        "requires_merchant_action",
        "requires_payment_method",
        "requires_confirmation",
        "requires_capture",
        "partially_captured",
        "partially_captured_and_capturable"
    ],
    "payment_method": {
        "card": [
            "credit",
            "debit"
        ]
    },
    "authentication_type": [
        "three_ds",
        "no_three_ds"
    ],
    "card_network": [
        "Visa",
        "Mastercard",
        "AmericanExpress",
        "JCB",
        "DinersClub",
        "Discover",
        "CartesBancaires",
        "UnionPay",
        "Interac",
        "RuPay",
        "Maestro"
    ],
    "card_discovery": [
        "manual",
        "saved_card",
        "click_to_pay"
    ]
}
```

 profile/aggregate
```
curl --location 'http://localhost:8080/v2/payments/profile/aggregate?start_time=2025-01-05T18%3A30%3A00Z&end_time=2025-03-08T13%3A05%3A00Z' \
--header 'X-Profile-Id: pro_buNPcwYFBTewUPbjAdrC' \
--header 'api-key: dev_qbKadyYwPTlnQ0xcatw0PMifWXw0NY6Hg0fLZODaf4SChCwvtcqJmNm0tfUmr1th'
```
```
{
    "status_with_count": {
        "requires_payment_method": 1,
        "requires_merchant_action": 0,
        "processing": 0,
        "succeeded": 0,
        "requires_confirmation": 0,
        "requires_capture": 0,
        "cancelled": 0,
        "requires_customer_action": 0,
        "partially_captured": 0,
        "failed": 0,
        "partially_captured_and_capturable": 0
    }
}
```

aggregate
```
curl --location 'http://localhost:8080/v2/payments/aggregate?start_time=2025-01-05T18%3A30%3A00Z&end_time=2025-03-08T13%3A05%3A00Z' \
--header 'X-Profile-Id: pro_buNPcwYFBTewUPbjAdrC' \
--header 'api-key: dev_qbKadyYwPTlnQ0xcatw0PMifWXw0NY6Hg0fLZODaf4SChCwvtcqJmNm0tfUmr1th'
```
```
{
    "status_with_count": {
        "partially_captured_and_capturable": 0,
        "requires_payment_method": 2,
        "requires_customer_action": 0,
        "succeeded": 0,
        "requires_merchant_action": 0,
        "requires_confirmation": 0,
        "cancelled": 0,
        "failed": 1,
        "partially_captured": 0,
        "processing": 0,
        "requires_capture": 0
    }
}
```

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
