### PR TITLE
refactor(core): Added payment id in authentication router data

### DIFF
--- a/crates/router/src/core/authentication.rs
+++ b/crates/router/src/core/authentication.rs
@@ -40,6 +40,7 @@ pub async fn perform_authentication(
     webhook_url: String,
     three_ds_requestor_url: String,
     psd2_sca_exemption_type: Option<common_enums::ScaExemptionType>,
+    payment_id: common_utils::id_type::PaymentId,
 ) -> CustomResult<api::authentication::AuthenticationResponse, ApiErrorResponse> {
     let router_data = transformers::construct_authentication_router_data(
         state,
@@ -63,6 +64,7 @@ pub async fn perform_authentication(
         webhook_url,
         three_ds_requestor_url,
         psd2_sca_exemption_type,
+        payment_id,
     )?;
     let response = Box::pin(utils::do_auth_connector_call(
         state,
@@ -89,6 +91,7 @@ pub async fn perform_post_authentication(
     key_store: &domain::MerchantKeyStore,
     business_profile: domain::Profile,
     authentication_id: String,
+    payment_id: &common_utils::id_type::PaymentId,
 ) -> CustomResult<storage::Authentication, ApiErrorResponse> {
     let (authentication_connector, three_ds_connector_account) =
         utils::get_authentication_connector_data(state, key_store, &business_profile).await?;
@@ -114,6 +117,7 @@ pub async fn perform_post_authentication(
             business_profile,
             three_ds_connector_account,
             &authentication,
+            payment_id,
         )?;
         let router_data =
             utils::do_auth_connector_call(state, authentication_connector.to_string(), router_data)
@@ -132,7 +136,7 @@ pub async fn perform_pre_authentication(
     token: String,
     business_profile: &domain::Profile,
     acquirer_details: Option<types::AcquirerDetails>,
-    payment_id: Option<common_utils::id_type::PaymentId>,
+    payment_id: common_utils::id_type::PaymentId,
     organization_id: common_utils::id_type::OrganizationId,
 ) -> CustomResult<storage::Authentication, ApiErrorResponse> {
     let (authentication_connector, three_ds_connector_account) =
@@ -144,7 +148,7 @@ pub async fn perform_pre_authentication(
         authentication_connector_name.clone(),
         token,
         business_profile.get_id().to_owned(),
-        payment_id,
+        payment_id.clone(),
         three_ds_connector_account
             .get_mca_id()
             .ok_or(ApiErrorResponse::InternalServerError)
@@ -161,6 +165,7 @@ pub async fn perform_pre_authentication(
                 card.clone(),
                 &three_ds_connector_account,
                 business_profile.merchant_id.clone(),
+                payment_id.clone(),
             )?;
         let router_data = utils::do_auth_connector_call(
             state,
@@ -189,6 +194,7 @@ pub async fn perform_pre_authentication(
             card,
             &three_ds_connector_account,
             business_profile.merchant_id.clone(),
+            payment_id,
         )?;
     let router_data =
         utils::do_auth_connector_call(state, authentication_connector_name, router_data).await?;

--- a/crates/router/src/core/authentication/transformers.rs
+++ b/crates/router/src/core/authentication/transformers.rs
@@ -46,6 +46,7 @@ pub fn construct_authentication_router_data(
     webhook_url: String,
     three_ds_requestor_url: String,
     psd2_sca_exemption_type: Option<common_enums::ScaExemptionType>,
+    payment_id: common_utils::id_type::PaymentId,
 ) -> RouterResult<types::authentication::ConnectorAuthenticationRouterData> {
     let router_request = types::authentication::ConnectorAuthenticationRequestData {
         payment_method_data,
@@ -75,6 +76,7 @@ pub fn construct_authentication_router_data(
         router_request,
         &merchant_connector_account,
         psd2_sca_exemption_type,
+        payment_id,
     )
 }
 
@@ -84,6 +86,7 @@ pub fn construct_post_authentication_router_data(
     business_profile: domain::Profile,
     merchant_connector_account: payments_helpers::MerchantConnectorAccountType,
     authentication_data: &storage::Authentication,
+    payment_id: &common_utils::id_type::PaymentId,
 ) -> RouterResult<types::authentication::ConnectorPostAuthenticationRouterData> {
     let threeds_server_transaction_id = authentication_data
         .threeds_server_transaction_id
@@ -102,6 +105,7 @@ pub fn construct_post_authentication_router_data(
         router_request,
         &merchant_connector_account,
         None,
+        payment_id.clone(),
     )
 }
 
@@ -111,6 +115,7 @@ pub fn construct_pre_authentication_router_data<F: Clone>(
     card: hyperswitch_domain_models::payment_method_data::Card,
     merchant_connector_account: &payments_helpers::MerchantConnectorAccountType,
     merchant_id: common_utils::id_type::MerchantId,
+    payment_id: common_utils::id_type::PaymentId,
 ) -> RouterResult<
     types::RouterData<
         F,
@@ -128,6 +133,7 @@ pub fn construct_pre_authentication_router_data<F: Clone>(
         router_request,
         merchant_connector_account,
         None,
+        payment_id,
     )
 }
 
@@ -141,6 +147,7 @@ pub fn construct_router_data<F: Clone, Req, Res>(
     request_data: Req,
     merchant_connector_account: &payments_helpers::MerchantConnectorAccountType,
     psd2_sca_exemption_type: Option<common_enums::ScaExemptionType>,
+    payment_id: common_utils::id_type::PaymentId,
 ) -> RouterResult<types::RouterData<F, Req, Res>> {
     let test_mode: Option<bool> = merchant_connector_account.is_test_mode_on();
     let auth_type: types::ConnectorAuthType = merchant_connector_account
@@ -154,9 +161,7 @@ pub fn construct_router_data<F: Clone, Req, Res>(
         tenant_id: state.tenant.tenant_id.clone(),
         connector_customer: None,
         connector: authentication_connector_name,
-        payment_id: common_utils::id_type::PaymentId::get_irrelevant_id("authentication")
-            .get_string_repr()
-            .to_owned(),
+        payment_id: payment_id.get_string_repr().to_owned(),
         attempt_id: IRRELEVANT_ATTEMPT_ID_IN_AUTHENTICATION_FLOW.to_owned(),
         status: common_enums::AttemptStatus::default(),
         payment_method,

--- a/crates/router/src/core/authentication/utils.rs
+++ b/crates/router/src/core/authentication/utils.rs
@@ -181,7 +181,7 @@ pub async fn create_new_authentication(
     authentication_connector: String,
     token: String,
     profile_id: common_utils::id_type::ProfileId,
-    payment_id: Option<common_utils::id_type::PaymentId>,
+    payment_id: common_utils::id_type::PaymentId,
     merchant_connector_id: common_utils::id_type::MerchantConnectorAccountId,
     organization_id: common_utils::id_type::OrganizationId,
 ) -> RouterResult<storage::Authentication> {
@@ -216,7 +216,7 @@ pub async fn create_new_authentication(
         acs_trans_id: None,
         acs_signed_content: None,
         profile_id,
-        payment_id,
+        payment_id: Some(payment_id),
         merchant_connector_id,
         ds_trans_id: None,
         directory_server_id: None,

--- a/crates/router/src/core/payments.rs
+++ b/crates/router/src/core/payments.rs
@@ -7608,6 +7608,7 @@ pub async fn payment_external_authentication<F: Clone + Sync>(
                 webhook_url,
                 authentication_details.three_ds_requestor_url.clone(),
                 payment_intent.psd2_sca_exemption_type,
+                payment_intent.payment_id,
             ))
             .await?
         };

--- a/crates/router/src/core/payments/operations/payment_confirm.rs
+++ b/crates/router/src/core/payments/operations/payment_confirm.rs
@@ -1022,7 +1022,7 @@ impl<F: Clone + Send + Sync> Domain<F, api::PaymentsRequest, PaymentData<F>> for
                     token,
                     business_profile,
                     acquirer_details,
-                    Some(payment_data.payment_attempt.payment_id.clone()),
+                    payment_data.payment_attempt.payment_id.clone(),
                     payment_data.payment_attempt.organization_id.clone(),
                 ))
                 .await?;
@@ -1063,6 +1063,7 @@ impl<F: Clone + Send + Sync> Domain<F, api::PaymentsRequest, PaymentData<F>> for
                     key_store,
                     business_profile.clone(),
                     authentication_id.clone(),
+                    &payment_data.payment_intent.payment_id,
                 ))
                 .await?;
                 //If authentication is not successful, skip the payment connector flows and mark the payment as failure
@@ -1280,7 +1281,7 @@ impl<F: Clone + Send + Sync> Domain<F, api::PaymentsRequest, PaymentData<F>> for
                     authentication_connector_name.clone(),
                     token,
                     business_profile.get_id().to_owned(),
-                    Some(payment_data.payment_intent.payment_id.clone()),
+                    payment_data.payment_intent.payment_id.clone(),
                     three_ds_connector_account
                         .get_mca_id()
                         .ok_or(errors::ApiErrorResponse::InternalServerError)


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->
- [x] Refactoring

## Description
<!-- Describe your changes in detail -->
Add payment id in authentication router data

This change is done to populate payment id in clickhouse authentication table and kafka to get authentication analytics since analytics is dependent on payment_id.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
logs screenshots

kafka UI :

<img width="568" alt="Screenshot 2025-03-06 at 3 38 55 PM" src="https://github.com/user-attachments/assets/4fbb5442-76ba-4f9e-82be-a53a9da40b85" />

Clickhouse table:

<img width="479" alt="Screenshot 2025-03-06 at 3 40 38 PM" src="https://github.com/user-attachments/assets/f4bd774c-a003-4b9a-9ac7-eb8d54875377" />



## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
