### PR TITLE
refactor(connector): [Rapyd] fix amount conversion framework

### DIFF
--- a/crates/hyperswitch_connectors/src/connectors/rapyd.rs
+++ b/crates/hyperswitch_connectors/src/connectors/rapyd.rs
@@ -9,7 +9,7 @@ use common_utils::{
     errors::CustomResult,
     ext_traits::{ByteSliceExt, BytesExt, Encode, StringExt},
     request::{Method, Request, RequestBuilder, RequestContent},
-    types::{AmountConvertor, MinorUnit, MinorUnitForConnector},
+    types::{AmountConvertor, FloatMajorUnit, FloatMajorUnitForConnector},
 };
 use error_stack::{Report, ResultExt};
 use hyperswitch_domain_models::{
@@ -55,12 +55,12 @@ use crate::{
 
 #[derive(Clone)]
 pub struct Rapyd {
-    amount_converter: &'static (dyn AmountConvertor<Output = MinorUnit> + Sync),
+    amount_converter: &'static (dyn AmountConvertor<Output = FloatMajorUnit> + Sync),
 }
 impl Rapyd {
     pub fn new() -> &'static Self {
         &Self {
-            amount_converter: &MinorUnitForConnector,
+            amount_converter: &FloatMajorUnitForConnector,
         }
     }
 }
@@ -97,7 +97,7 @@ impl ConnectorCommon for Rapyd {
     }
 
     fn get_currency_unit(&self) -> api::CurrencyUnit {
-        api::CurrencyUnit::Minor
+        api::CurrencyUnit::Base
     }
 
     fn common_get_content_type(&self) -> &'static str {

--- a/crates/hyperswitch_connectors/src/connectors/rapyd/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/rapyd/transformers.rs
@@ -1,5 +1,5 @@
 use common_enums::enums;
-use common_utils::{ext_traits::OptionExt, request::Method, types::MinorUnit};
+use common_utils::{ext_traits::OptionExt, request::Method, types::FloatMajorUnit};
 use error_stack::ResultExt;
 use hyperswitch_domain_models::{
     payment_method_data::{PaymentMethodData, WalletData},
@@ -22,12 +22,12 @@ use crate::{
 
 #[derive(Debug, Serialize)]
 pub struct RapydRouterData<T> {
-    pub amount: MinorUnit,
+    pub amount: FloatMajorUnit,
     pub router_data: T,
 }
 
-impl<T> From<(MinorUnit, T)> for RapydRouterData<T> {
-    fn from((amount, router_data): (MinorUnit, T)) -> Self {
+impl<T> From<(FloatMajorUnit, T)> for RapydRouterData<T> {
+    fn from((amount, router_data): (FloatMajorUnit, T)) -> Self {
         Self {
             amount,
             router_data,
@@ -37,7 +37,7 @@ impl<T> From<(MinorUnit, T)> for RapydRouterData<T> {
 
 #[derive(Default, Debug, Serialize)]
 pub struct RapydPaymentsRequest {
-    pub amount: MinorUnit,
+    pub amount: FloatMajorUnit,
     pub currency: enums::Currency,
     pub payment_method: PaymentMethod,
     pub payment_method_options: Option<PaymentMethodOptions>,
@@ -304,7 +304,7 @@ pub struct DisputeResponseData {
 #[derive(Default, Debug, Serialize)]
 pub struct RapydRefundRequest {
     pub payment: String,
-    pub amount: Option<MinorUnit>,
+    pub amount: Option<FloatMajorUnit>,
     pub currency: Option<enums::Currency>,
 }
 
@@ -409,7 +409,7 @@ impl TryFrom<RefundsResponseRouterData<RSync, RefundResponse>> for types::Refund
 
 #[derive(Debug, Serialize, Clone)]
 pub struct CaptureRequest {
-    amount: Option<MinorUnit>,
+    amount: Option<FloatMajorUnit>,
     receipt_email: Option<Secret<String>>,
     statement_descriptor: Option<String>,
 }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
fix amount conversion framework for Rapyd 
According to doc - https://docs.rapyd.net/en/create-payment.html , amount should be of FloatType (BaseUnit).

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
We can not test it, as we dont have credentials for Rapyd connector


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
