### PR TITLE
ci(cypress): fix paypal failures

### DIFF
--- a/cypress-tests/cypress/e2e/configs/Payment/Paypal.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Paypal.js
@@ -9,7 +9,7 @@ const successfulNo3DSCardDetails = {
 };
 
 const successfulThreeDSTestCardDetails = {
-  card_number: "4868719460707704",
+  card_number: "5329879786234393",
   card_exp_month: "01",
   card_exp_year: "50",
   card_holder_name: "joseph Doe",
@@ -89,7 +89,7 @@ export const connectorDetails = {
           status: "failed",
           error_code: "AMOUNT_MISMATCH",
           error_message:
-            "description - Should equal item_total + tax_total + shipping + handling + insurance - shipping_discount - discount., value - 65.50, field - value;",
+            "description - Should equal item_total + tax_total + shipping + handling + insurance - shipping_discount - discount., value - 60.50, field - value;",
         },
       },
     },
@@ -392,7 +392,7 @@ export const connectorDetails = {
       Response: {
         status: 200,
         body: {
-          status: "succeeded",
+          status: "requires_customer_action",
         },
       },
     },


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [x] CI/CD

## Description
<!-- Describe your changes in detail -->

<img width="861" alt="image" src="https://github.com/user-attachments/assets/d85ea702-cd5d-444b-86bd-1f5f50363d40" />

connector throws above error when using VISA card. Replacing that with MasterCard fixes it:

<img width="1206" alt="image" src="https://github.com/user-attachments/assets/de44fa13-695b-4198-ba82-d603a9bafbe1" />

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->

paypal ci is failing.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

`CYPRESS_CONNECTOR=paypal npm run cypress:payments`

![image](https://github.com/user-attachments/assets/d8f52cc9-3bbb-45f3-97fc-6cdd713f6dc1)

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `npm run format`
- [x] I addressed lints thrown by `npm run lint`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
