### PR TITLE
fix(connector): fix incorrect mapping of attempt status in AuthorizeDotNet connector

### DIFF
--- a/crates/hyperswitch_connectors/src/connectors/authorizedotnet/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/authorizedotnet/transformers.rs
@@ -1587,8 +1587,8 @@ pub struct AuthorizedotnetRSyncResponse {
 impl From<SyncStatus> for enums::AttemptStatus {
     fn from(transaction_status: SyncStatus) -> Self {
         match transaction_status {
-            SyncStatus::SettledSuccessfully => Self::Charged,
-            SyncStatus::CapturedPendingSettlement => Self::CaptureInitiated,
+            SyncStatus::SettledSuccessfully
+            | SyncStatus::CapturedPendingSettlement => Self::Charged,
             SyncStatus::AuthorizedPendingCapture => Self::Authorized,
             SyncStatus::Declined => Self::AuthenticationFailed,
             SyncStatus::Voided => Self::Voided,

--- a/crates/hyperswitch_connectors/src/connectors/authorizedotnet/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/authorizedotnet/transformers.rs
@@ -1587,8 +1587,9 @@ pub struct AuthorizedotnetRSyncResponse {
 impl From<SyncStatus> for enums::AttemptStatus {
     fn from(transaction_status: SyncStatus) -> Self {
         match transaction_status {
-            SyncStatus::SettledSuccessfully
-            | SyncStatus::CapturedPendingSettlement => Self::Charged,
+            SyncStatus::SettledSuccessfully | SyncStatus::CapturedPendingSettlement => {
+                Self::Charged
+            }
             SyncStatus::AuthorizedPendingCapture => Self::Authorized,
             SyncStatus::Declined => Self::AuthenticationFailed,
             SyncStatus::Voided => Self::Voided,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

Closes this [issue](https://github.com/juspay/hyperswitch/issues/7522)

## Description
<!-- Describe your changes in detail -->

Changed the attempt status mapping of `CapturedPendingSettlement` given by AuthorizeDotNet from `ChargeInitiated` to `Charged`

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->

When the capture_method is automatic, AuthorizeDotNet connector first sends a `CapturedPendingSettlement` status which is mapped to `ChargeInitiated` in our codebase. That results in `processing` transaction status in the Hyperswitch's response (in production environment).

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

Postman tests are not valid since AuthorizeDotNet directly sends `SettledSuccessfully` status in local/sandbox environment.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
