### PR TITLE
feat(connector): [BRAINTREE] Add revoke mandate flow

### DIFF
--- a/crates/hyperswitch_connectors/src/connectors/braintree.rs
+++ b/crates/hyperswitch_connectors/src/connectors/braintree.rs
@@ -640,7 +640,7 @@ impl ConnectorIntegration<MandateRevoke, MandateRevokeRequestData, MandateRevoke
         event_builder: Option<&mut ConnectorEvent>,
         res: Response,
     ) -> CustomResult<MandateRevokeRouterData, errors::ConnectorError> {
-        let response: BraintreeRevokeMandateResponse = res
+        let response: transformers::BraintreeRevokeMandateResponse = res
             .response
             .parse_struct("BraintreeRevokeMandateResponse")
             .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;

--- a/crates/hyperswitch_connectors/src/connectors/braintree/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/braintree/transformers.rs
@@ -6,9 +6,12 @@ use hyperswitch_domain_models::{
     payment_method_data::PaymentMethodData,
     router_data::{ConnectorAuthType, PaymentMethodToken, RouterData},
     router_flow_types::refunds::{Execute, RSync},
-    router_request_types::{CompleteAuthorizeData, PaymentsAuthorizeData, ResponseId},
+    router_request_types::{
+        CompleteAuthorizeData, MandateRevokeRequestData, PaymentsAuthorizeData, ResponseId,
+    },
     router_response_types::{
-        MandateReference, PaymentsResponseData, RedirectForm, RefundsResponseData,
+        MandateReference, MandateRevokeResponseData, PaymentsResponseData, RedirectForm,
+        RefundsResponseData,
     },
     types::{self, RefundsRouterData},
 };
@@ -38,6 +41,7 @@ pub const VOID_TRANSACTION_MUTATION: &str = "mutation voidTransaction($input:  R
 pub const REFUND_TRANSACTION_MUTATION: &str = "mutation refundTransaction($input:  RefundTransactionInput!) { refundTransaction(input: $input) {clientMutationId refund { id legacyId amount { value currencyCode } status } } }";
 pub const AUTHORIZE_AND_VAULT_CREDIT_CARD_MUTATION: &str="mutation authorizeCreditCard($input: AuthorizeCreditCardInput!) { authorizeCreditCard(input: $input) { transaction { id status createdAt paymentMethod { id } } } }";
 pub const CHARGE_AND_VAULT_TRANSACTION_MUTATION: &str ="mutation ChargeCreditCard($input: ChargeCreditCardInput!) { chargeCreditCard(input: $input) { transaction { id status createdAt paymentMethod { id } } } }";
+pub const DELETE_PAYMENT_METHOD_FROM_VAULT_MUTATION: &str = "mutation deletePaymentMethodFromVault($input: DeletePaymentMethodFromVaultInput!) { deletePaymentMethodFromVault(input: $input) { clientMutationId }";
 pub const TRANSACTION_QUERY: &str = "query($input: TransactionSearchInput!) { search { transactions(input: $input) { edges { node { id status } } } } }";
 pub const REFUND_QUERY: &str = "query($input: RefundSearchInput!) { search { refunds(input: $input, first: 1) { edges { node { id status createdAt amount { value currencyCode } orderId } } } } }";
 
@@ -1353,6 +1357,94 @@ impl TryFrom<PaymentsCaptureResponseRouterData<BraintreeCaptureResponse>>
             }),
         }
     }
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DeletePaymentMethodFromVaultInputData {
+    payment_method_id: Secret<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct VariableDeletePaymentMethodFromVaultInput {
+    input: DeletePaymentMethodFromVaultInputData,
+}
+
+#[derive(Debug, Serialize)]
+pub struct BraintreeRevokeMandateRequest {
+    query: String,
+    variables: VariableDeletePaymentMethodFromVaultInput,
+}
+
+impl TryFrom<&types::MandateRevokeRouterData> for BraintreeRevokeMandateRequest {
+    type Error = error_stack::Report<errors::ConnectorError>;
+    fn try_from(item: &types::MandateRevokeRouterData) -> Result<Self, Self::Error> {
+        let query = DELETE_PAYMENT_METHOD_FROM_VAULT_MUTATION.to_string();
+        let variables = VariableDeletePaymentMethodFromVaultInput {
+            input: DeletePaymentMethodFromVaultInputData {
+                payment_method_id: Secret::new(
+                    item.request
+                        .connector_mandate_id
+                        .clone()
+                        .ok_or(errors::ConnectorError::MissingConnectorMandateID)?,
+                ),
+            },
+        };
+        Ok(Self { query, variables })
+    }
+}
+
+impl<F>
+    TryFrom<
+        ResponseRouterData<
+            F,
+            BraintreeRevokeMandateResponse,
+            MandateRevokeRequestData,
+            MandateRevokeResponseData,
+        >,
+    > for RouterData<F, MandateRevokeRequestData, MandateRevokeResponseData>
+{
+    type Error = error_stack::Report<errors::ConnectorError>;
+    fn try_from(
+        item: ResponseRouterData<
+            F,
+            BraintreeRevokeMandateResponse,
+            MandateRevokeRequestData,
+            MandateRevokeResponseData,
+        >,
+    ) -> Result<Self, Self::Error> {
+        Ok(Self {
+            response: match item.response {
+                BraintreeRevokeMandateResponse::ErrorResponse(error_response) => {
+                    build_error_response(error_response.errors.as_ref(), item.http_code)
+                }
+                BraintreeRevokeMandateResponse::RevokeMandateResponse(..) => {
+                    Ok(MandateRevokeResponseData {
+                        mandate_status: common_enums::MandateStatus::Revoked,
+                    })
+                }
+            },
+            ..item.data
+        })
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum BraintreeRevokeMandateResponse {
+    RevokeMandateResponse(Box<RevokeMandateResponse>),
+    ErrorResponse(Box<ErrorResponse>),
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct RevokeMandateResponse {
+    data: DeletePaymentMethodFromVault,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DeletePaymentMethodFromVault {
+    client_mutation_id: Option<String>,
 }
 
 #[derive(Debug, Serialize)]

--- a/crates/hyperswitch_connectors/src/connectors/braintree/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/braintree/transformers.rs
@@ -41,7 +41,7 @@ pub const VOID_TRANSACTION_MUTATION: &str = "mutation voidTransaction($input:  R
 pub const REFUND_TRANSACTION_MUTATION: &str = "mutation refundTransaction($input:  RefundTransactionInput!) { refundTransaction(input: $input) {clientMutationId refund { id legacyId amount { value currencyCode } status } } }";
 pub const AUTHORIZE_AND_VAULT_CREDIT_CARD_MUTATION: &str="mutation authorizeCreditCard($input: AuthorizeCreditCardInput!) { authorizeCreditCard(input: $input) { transaction { id status createdAt paymentMethod { id } } } }";
 pub const CHARGE_AND_VAULT_TRANSACTION_MUTATION: &str ="mutation ChargeCreditCard($input: ChargeCreditCardInput!) { chargeCreditCard(input: $input) { transaction { id status createdAt paymentMethod { id } } } }";
-pub const DELETE_PAYMENT_METHOD_FROM_VAULT_MUTATION: &str = "mutation deletePaymentMethodFromVault($input: DeletePaymentMethodFromVaultInput!) { deletePaymentMethodFromVault(input: $input) { clientMutationId }";
+pub const DELETE_PAYMENT_METHOD_FROM_VAULT_MUTATION: &str = "mutation deletePaymentMethodFromVault($input: DeletePaymentMethodFromVaultInput!) { deletePaymentMethodFromVault(input: $input) { clientMutationId } }";
 pub const TRANSACTION_QUERY: &str = "query($input: TransactionSearchInput!) { search { transactions(input: $input) { edges { node { id status } } } } }";
 pub const REFUND_QUERY: &str = "query($input: RefundSearchInput!) { search { refunds(input: $input, first: 1) { edges { node { id status createdAt amount { value currencyCode } orderId } } } } }";
 

--- a/crates/hyperswitch_connectors/src/default_implementations.rs
+++ b/crates/hyperswitch_connectors/src/default_implementations.rs
@@ -3187,7 +3187,6 @@ default_imp_for_revoking_mandates!(
     connectors::Billwerk,
     connectors::Bitpay,
     connectors::Bluesnap,
-    connectors::Braintree,
     connectors::Boku,
     connectors::Cashtocode,
     connectors::Chargebee,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Add mandate revoke flow to Braintree
https://developer.paypal.com/braintree/graphql/guides/payment_methods/#delete

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
https://github.com/juspay/hyperswitch/issues/7526

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Revoking an existing mandate using tunnel needs to be tested:
Request:
```
curl --location 'http://localhost:8080/vs/v1/payment_methods/man_OVY39ecmn6QDAxh18qIe/detach' \
--header 'Content-Type: application/x-www-form-urlencoded' \
--header 'User-Agent: helloMozilla/5.0 (Linux; Android 12; SM-S906N Build/QP1A.190711.020; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/80.0.3987.119 Mobile Safari/537.36' \
--header 'api-key: HIDDEN' \
--data-urlencode 'merchant_connector_details%5Bencoded_data%5D=HIDDEN'
```

Response:
```
{
    "mandate_id": "man_OVY39ecmn6QDAxh18qIe",
    "status": "revoked",
    "error_code": null,
    "error_message": null
}
```

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
