### PR TITLE
fix(router): pass card network for external 3DS from additional_payment_method_data

### DIFF
--- a/crates/common_enums/src/connector_enums.rs
+++ b/crates/common_enums/src/connector_enums.rs
@@ -443,8 +443,9 @@ impl Connector {
             | Self::Netcetera
             | Self::CtpMastercard
             | Self::Noon
-            | Self::Stripe => false,
-            Self::Checkout | Self::Nmi |Self::Datatrans|Self::Cybersource => true,
+            | Self::Stripe
+            | Self::Datatrans => false,
+            Self::Checkout | Self::Nmi |Self::Cybersource => true,
         }
     }
 

--- a/crates/hyperswitch_connectors/src/connectors/cybersource/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/cybersource/transformers.rs
@@ -1228,11 +1228,21 @@ impl
         let bill_to = build_bill_to(item.router_data.get_optional_billing(), email)?;
         let order_information = OrderInformationWithBill::from((item, Some(bill_to)));
 
-        let card_type = match ccard
-            .card_network
-            .clone()
-            .and_then(get_cybersource_card_type)
-        {
+        let additional_card_network = item
+            .router_data
+            .request
+            .get_card_network_from_additional_payment_method_data()
+            .map_err(|err| {
+                router_env::logger::info!(
+                    "Error while getting card network from additional payment method data: {}",
+                    err
+                );
+            })
+            .ok();
+
+        let raw_card_type = ccard.card_network.clone().or(additional_card_network);
+
+        let card_type = match raw_card_type.clone().and_then(get_cybersource_card_type) {
             Some(card_network) => Some(card_network.to_string()),
             None => ccard.get_card_issuer().ok().map(String::from),
         };
@@ -1258,7 +1268,11 @@ impl
             },
         }));
 
-        let processing_information = ProcessingInformation::try_from((item, None, card_type))?;
+        let processing_information = ProcessingInformation::try_from((
+            item,
+            None,
+            raw_card_type.map(|network| network.to_string()),
+        ))?;
         let client_reference_information = ClientReferenceInformation::from(item);
         let merchant_defined_information = item
             .router_data
@@ -1273,14 +1287,18 @@ impl
             .authentication_data
             .as_ref()
             .map(|authn_data| {
-                let (ucaf_authentication_data, cavv) =
+                let (ucaf_authentication_data, cavv, ucaf_collection_indicator) =
                     if ccard.card_network == Some(common_enums::CardNetwork::Mastercard) {
-                        (Some(Secret::new(authn_data.cavv.clone())), None)
+                        (
+                            Some(Secret::new(authn_data.cavv.clone())),
+                            None,
+                            Some("1".to_string()),
+                        )
                     } else {
-                        (None, Some(authn_data.cavv.clone()))
+                        (None, Some(authn_data.cavv.clone()), None)
                     };
                 CybersourceConsumerAuthInformation {
-                    ucaf_collection_indicator: None,
+                    ucaf_collection_indicator,
                     cavv,
                     ucaf_authentication_data,
                     xid: authn_data.threeds_server_transaction_id.clone(),

--- a/crates/hyperswitch_connectors/src/utils.rs
+++ b/crates/hyperswitch_connectors/src/utils.rs
@@ -1626,6 +1626,9 @@ pub trait PaymentsAuthorizeRequestData {
     fn is_cit_mandate_payment(&self) -> bool;
     fn get_optional_network_transaction_id(&self) -> Option<String>;
     fn get_optional_email(&self) -> Option<Email>;
+    fn get_card_network_from_additional_payment_method_data(
+        &self,
+    ) -> Result<enums::CardNetwork, Error>;
 }
 
 impl PaymentsAuthorizeRequestData for PaymentsAuthorizeData {
@@ -1829,6 +1832,22 @@ impl PaymentsAuthorizeRequestData for PaymentsAuthorizeData {
     }
     fn get_optional_email(&self) -> Option<Email> {
         self.email.clone()
+    }
+    fn get_card_network_from_additional_payment_method_data(
+        &self,
+    ) -> Result<enums::CardNetwork, Error> {
+        match &self.additional_payment_method_data {
+            Some(payments::AdditionalPaymentData::Card(card_data)) => Ok(card_data
+                .card_network
+                .clone()
+                .ok_or_else(|| errors::ConnectorError::MissingRequiredField {
+                    field_name: "card_network",
+                })?),
+            _ => Err(errors::ConnectorError::MissingRequiredFields {
+                field_names: vec!["card_network"],
+            }
+            .into()),
+        }
     }
 }
 

--- a/crates/hyperswitch_domain_models/src/business_profile.rs
+++ b/crates/hyperswitch_domain_models/src/business_profile.rs
@@ -223,7 +223,7 @@ pub struct ProfileGeneralUpdate {
     pub card_testing_guard_config: Option<CardTestingGuardConfig>,
     pub card_testing_secret_key: OptionalEncryptableName,
     pub is_clear_pan_retries_enabled: Option<bool>,
-    pub force_3ds_challenge: bool,
+    pub force_3ds_challenge: Option<bool>,
 }
 
 #[cfg(feature = "v1")]
@@ -338,7 +338,7 @@ impl From<ProfileUpdate> for ProfileUpdateInternal {
                     card_testing_guard_config,
                     card_testing_secret_key: card_testing_secret_key.map(Encryption::from),
                     is_clear_pan_retries_enabled,
-                    force_3ds_challenge: Some(force_3ds_challenge),
+                    force_3ds_challenge,
                 }
             }
             ProfileUpdate::RoutingAlgorithmUpdate {

--- a/crates/router/src/core/admin.rs
+++ b/crates/router/src/core/admin.rs
@@ -4233,7 +4233,7 @@ impl ProfileUpdateBridge for api::ProfileUpdate {
                     .map(ForeignInto::foreign_into),
                 card_testing_secret_key,
                 is_clear_pan_retries_enabled: self.is_clear_pan_retries_enabled,
-                force_3ds_challenge: self.force_3ds_challenge.unwrap_or_default(),
+                force_3ds_challenge: self.force_3ds_challenge,
             },
         )))
     }

--- a/crates/router/src/core/payments/transformers.rs
+++ b/crates/router/src/core/payments/transformers.rs
@@ -3135,18 +3135,14 @@ impl<F: Clone> TryFrom<PaymentAdditionalData<'_, F>> for types::PaymentsAuthoriz
             payment_data.creds_identifier.as_deref(),
         ));
 
-        let additional_payment_method_data = if payment_data.mandate_id.is_some() {
-            let parsed_additional_payment_data: Option<api_models::payments::AdditionalPaymentData> =
-                payment_data.payment_attempt
-                    .payment_method_data
-                    .as_ref().map(|data| data.clone().parse_value("AdditionalPaymentData"))
-                    .transpose()
-                    .change_context(errors::ApiErrorResponse::InternalServerError)
-                    .attach_printable("Failed to parse AdditionalPaymentData from payment_data.payment_attempt.payment_method_data")?;
-            parsed_additional_payment_data
-        } else {
-            None
-        };
+        let additional_payment_method_data: Option<api_models::payments::AdditionalPaymentData> =
+            payment_data.payment_attempt
+                .payment_method_data
+                .as_ref().map(|data| data.clone().parse_value("AdditionalPaymentData"))
+                .transpose()
+                .change_context(errors::ApiErrorResponse::InternalServerError)
+                .attach_printable("Failed to parse AdditionalPaymentData from payment_data.payment_attempt.payment_method_data")?;
+
         let payment_method_data = payment_data.payment_method_data.or_else(|| {
             if payment_data.mandate_id.is_some() {
                 Some(domain::PaymentMethodData::MandatePayment)


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
- card network fetch from db was not being populated in payment call resulting in sending the default value which failed the payment
- util function have been added to collect the card network from additional_payment_method_data
- ucaf_indicator is being populated for mastercard 
- profile generic update is made optional to not update the force_3ds_challenge if it is passed as null
- External authentication is disabled for Datatrans

Note: hotfix raised against https://github.com/juspay/hyperswitch/pull/7473

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Tested through Postman:
- Create MCA(Cybersource):
- Create MCA(Netcetera):
- Create a payment call (enable external 3ds):
```
{
    "amount": 499,
    "currency": "USD",
    "confirm": true,
    "capture_method": "automatic",
    "customer_id": "test_rec7",
    "email": "guest@example.com",
    "request_external_three_ds_authentication": true,
    "customer_acceptance": {
        "acceptance_type": "online"
    },
    "payment_method": "card",
    "payment_method_type": "credit",
    "payment_method_data": {
        "card": {
            "card_number": "5512459816707531",
            "card_exp_month": "03",
            "card_exp_year": "2030",
            "card_holder_name": "Sakil Mostak",
            "card_cvc": "737"
        }
    },
    "billing": {
        "address": {
            "city": "test",
            "country": "US",
            "line1": "here is some \n there is some \n none is some? \n ",
            "line2": "there",
            "line3": "anywhere",
            "zip": "560095",
            "state": "CA",
            "first_name": "Sakil",
            "last_name": "Mostak"
        },
        "phone": {
            "number": "1234567890",
            "country_code": "+1"
        },
        "email": "guest@example.com"
    },
    "browser_info": {
        "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Safari/537.36",
        "accept_header": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8",
        "language": "nl-NL",
        "color_depth": 24,
        "screen_height": 723,
        "screen_width": 1536,
        "time_zone": 0,
        "java_enabled": true,
        "java_script_enabled": true,
        "ip_address": "127.0.0.1"
    },
    "authentication_type": "three_ds"
}
```
Response should have the following data:
```
{
    "payment_id": "pay_DJzWCB8vpM2nl6tti5q5",
    "merchant_id": "merchant_1741687051",
    "status": "requires_customer_action",
    "amount": 499,
    "net_amount": 499,
    "shipping_cost": null,
    "amount_capturable": 499,
    "amount_received": null,
    "connector": "cybersource",
    "client_secret": "pay_DJzWCB8vpM2nl6tti5q5_secret_JwlJcjRW9Q5TRrlNKNrf",
    "created": "2025-03-11T10:43:06.966Z",
    "currency": "USD",
    "customer_id": "test_rec7",
    "customer": {
        "id": "test_rec7",
        "name": null,
        "email": "guest@example.com",
        "phone": null,
        "phone_country_code": null
    },
    "description": null,
    "refunds": null,
    "disputes": null,
    "mandate_id": null,
    "mandate_data": null,
    "setup_future_usage": null,
    "off_session": null,
    "capture_on": null,
    "capture_method": "automatic",
    "payment_method": "card",
    "payment_method_data": {
        "card": {
            "last4": "7531",
            "card_type": null,
            "card_network": "Mastercard",
            "card_issuer": null,
            "card_issuing_country": null,
            "card_isin": "551245",
            "card_extended_bin": null,
            "card_exp_month": "03",
            "card_exp_year": "2030",
            "card_holder_name": "Sakil Mostak",
            "payment_checks": null,
            "authentication_data": null
        },
        "billing": null
    },
    "payment_token": "token_eappafndmAWU8SvNsaoy",
    "shipping": null,
    "billing": {
        "address": {
            "city": "test",
            "country": "US",
            "line1": "here is some \n there is some \n none is some? \n ",
            "line2": "there",
            "line3": "anywhere",
            "zip": "560095",
            "state": "CA",
            "first_name": "Sakil",
            "last_name": "Mostak"
        },
        "phone": {
            "number": "1234567890",
            "country_code": "+1"
        },
        "email": "guest@example.com"
    },
    "order_details": null,
    "email": "guest@example.com",
    "name": null,
    "phone": null,
    "return_url": null,
    "authentication_type": "three_ds",
    "statement_descriptor_name": null,
    "statement_descriptor_suffix": null,
    "next_action": {
        "type": "three_ds_invoke",
        "three_ds_data": {
            "three_ds_authentication_url": "http://localhost:8080/payments/pay_DJzWCB8vpM2nl6tti5q5/3ds/authentication",
            "three_ds_authorize_url": "http://localhost:8080/payments/pay_DJzWCB8vpM2nl6tti5q5/merchant_1741687051/authorize/cybersource",
            "three_ds_method_details": {
                "three_ds_method_key": "threeDSMethodData",
                "three_ds_method_data_submission": true,
                "three_ds_method_data": "eyJ0aHJlZURTTWV0aG9kTm90aWZpY2F0aW9uVVJMIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS8zZHMtbWV0aG9kLW5vdGlmaWNhdGlvbi11cmwiLCJ0aHJlZURTU2VydmVyVHJhbnNJRCI6ImVkNmQ4Y2M1LWU2YTgtNDg4ZC05NDI4LWM2ZDRkZWY2ZDFlNiJ9",
                "three_ds_method_url": "https://ndm-prev.3dss-non-prod.cloud.netcetera.com/acs/3ds-method"
            },
            "poll_config": {
                "poll_id": "external_authentication_pay_DJzWCB8vpM2nl6tti5q5",
                "delay_in_secs": 2,
                "frequency": 5
            },
            "message_version": "2.3.1",
            "directory_server_id": "A000000004"
        }
    },
    "cancellation_reason": null,
    "error_code": null,
    "error_message": null,
    "unified_code": null,
    "unified_message": null,
    "payment_experience": null,
    "payment_method_type": "credit",
    "connector_label": null,
    "business_country": null,
    "business_label": "default",
    "business_sub_label": null,
    "allowed_payment_method_types": null,
    "ephemeral_key": {
        "customer_id": "test_rec7",
        "created_at": 1741689786,
        "expires": 1741693386,
        "secret": "epk_71a1ecdc177e48a2af0172ad2bb14fc8"
    },
    "manual_retry_allowed": null,
    "connector_transaction_id": null,
    "frm_message": null,
    "metadata": null,
    "connector_metadata": null,
    "feature_metadata": null,
    "reference_id": null,
    "payment_link": null,
    "profile_id": "pro_IauTXmHo2gR6Cufm1fXK",
    "surcharge_details": null,
    "attempt_count": 1,
    "merchant_decision": null,
    "merchant_connector_id": "mca_qJi1npMpCWiTuiL0rGOK",
    "incremental_authorization_allowed": null,
    "authorization_count": null,
    "incremental_authorizations": null,
    "external_authentication_details": {
        "authentication_flow": null,
        "electronic_commerce_indicator": null,
        "status": "pending",
        "ds_transaction_id": "ed6d8cc5-e6a8-488d-9428-c6d4def6d1e6",
        "version": "2.3.1",
        "error_code": null,
        "error_message": null
    },
    "external_3ds_authentication_attempted": true,
    "expires_on": "2025-03-11T10:58:06.966Z",
    "fingerprint": null,
    "browser_info": {
        "language": "nl-NL",
        "time_zone": 0,
        "ip_address": "127.0.0.1",
        "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Safari/537.36",
        "color_depth": 24,
        "java_enabled": true,
        "screen_width": 1536,
        "accept_header": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8",
        "screen_height": 723,
        "java_script_enabled": true
    },
    "payment_method_id": null,
    "payment_method_status": null,
    "updated": "2025-03-11T10:43:07.760Z",
    "split_payments": null,
    "frm_metadata": null,
    "extended_authorization_applied": null,
    "capture_before": null,
    "merchant_order_reference_id": null,
    "order_tax_amount": null,
    "connector_mandate_id": null,
    "card_discovery": "manual"
}
```
- Create Challenge
```
curl --location '{{baseurl}}/payments/{{payment_id}}/3ds/authentication' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key:{{api_key}}' \
--data '{
    "client_secret": "{{client_secret}}",
    "device_channel": "BRW",
    "threeds_method_comp_ind": "Y"
}'
```
- Response should contain following data:
```
{
    "trans_status": "Y",
    "acs_url": null,
    "challenge_request": null,
    "acs_reference_number": null,
    "acs_trans_id": null,
    "three_dsserver_trans_id": "ed6d8cc5-e6a8-488d-9428-c6d4def6d1e6",
    "acs_signed_content": null,
    "three_ds_requestor_url": "https://google.com"
}
```
- Authorize from Netcetera:
```
curl --location --request POST '{{baseurl}}/payments/{{payment_id}}/{{merchant_id}}/authorize/checkout' \
--header 'api-key:{{api_Key}}'
```

- Retrieve the transaction, the status should be succeeded in response, below is an example:
```
{
    "payment_id": "pay_lTIv7ZbWr5Y237CqHXxq",
    "merchant_id": "merchant_1741687051",
    "status": "succeeded",
    "amount": 499,
    "net_amount": 499,
    "shipping_cost": null,
    "amount_capturable": 0,
    "amount_received": 499,
    "connector": "cybersource",
    "client_secret": "pay_lTIv7ZbWr5Y237CqHXxq_secret_cYx3O8cQMGUR2O1RVta9",
    "created": "2025-03-11T10:28:34.005Z",
    "currency": "USD",
    "customer_id": "test_rec7",
    "customer": {
        "id": "test_rec7",
        "name": null,
        "email": "guest@example.com",
        "phone": null,
        "phone_country_code": null
    },
    "description": null,
    "refunds": null,
    "disputes": null,
    "mandate_id": null,
    "mandate_data": null,
    "setup_future_usage": null,
    "off_session": null,
    "capture_on": null,
    "capture_method": "automatic",
    "payment_method": "card",
    "payment_method_data": {
        "card": {
            "last4": "7531",
            "card_type": null,
            "card_network": null,
            "card_issuer": null,
            "card_issuing_country": null,
            "card_isin": "551245",
            "card_extended_bin": null,
            "card_exp_month": "03",
            "card_exp_year": "2030",
            "card_holder_name": "Sakil Mostak",
            "payment_checks": {
                "avs_response": {
                    "code": "X",
                    "codeRaw": "I1"
                },
                "card_verification": null
            },
            "authentication_data": null
        },
        "billing": null
    },
    "payment_token": "token_P8rNgP3WpYuJWLRgRWaz",
    "shipping": null,
    "billing": {
        "address": {
            "city": "test",
            "country": "US",
            "line1": "here is some \n there is some \n none is some? \n ",
            "line2": "there",
            "line3": "anywhere",
            "zip": "560095",
            "state": "CA",
            "first_name": "Sakil",
            "last_name": "Mostak"
        },
        "phone": {
            "number": "1234567890",
            "country_code": "+1"
        },
        "email": "guest@example.com"
    },
    "order_details": null,
    "email": "guest@example.com",
    "name": null,
    "phone": null,
    "return_url": null,
    "authentication_type": "three_ds",
    "statement_descriptor_name": null,
    "statement_descriptor_suffix": null,
    "next_action": null,
    "cancellation_reason": null,
    "error_code": null,
    "error_message": null,
    "unified_code": null,
    "unified_message": null,
    "payment_experience": null,
    "payment_method_type": "credit",
    "connector_label": null,
    "business_country": null,
    "business_label": "default",
    "business_sub_label": null,
    "allowed_payment_method_types": null,
    "ephemeral_key": null,
    "manual_retry_allowed": false,
    "connector_transaction_id": "7416889232566498604807",
    "frm_message": null,
    "metadata": null,
    "connector_metadata": null,
    "feature_metadata": null,
    "reference_id": "pay_lTIv7ZbWr5Y237CqHXxq_1",
    "payment_link": null,
    "profile_id": "pro_IauTXmHo2gR6Cufm1fXK",
    "surcharge_details": null,
    "attempt_count": 1,
    "merchant_decision": null,
    "merchant_connector_id": "mca_qJi1npMpCWiTuiL0rGOK",
    "incremental_authorization_allowed": false,
    "authorization_count": null,
    "incremental_authorizations": null,
    "external_authentication_details": {
        "authentication_flow": "frictionless",
        "electronic_commerce_indicator": null,
        "status": "success",
        "ds_transaction_id": "19329442-7532-4e25-bc88-a5f1d99c1f5e",
        "version": "2.3.1",
        "error_code": null,
        "error_message": null
    },
    "external_3ds_authentication_attempted": true,
    "expires_on": "2025-03-11T10:43:34.005Z",
    "fingerprint": null,
    "browser_info": {
        "language": "nl-NL",
        "time_zone": 0,
        "ip_address": "127.0.0.1",
        "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Safari/537.36",
        "color_depth": 24,
        "java_enabled": true,
        "screen_width": 1536,
        "accept_header": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8",
        "screen_height": 723,
        "java_script_enabled": true
    },
    "payment_method_id": "pm_Wfs6CcChddyjlx99kQKU",
    "payment_method_status": "active",
    "updated": "2025-03-11T10:28:43.771Z",
    "split_payments": null,
    "frm_metadata": null,
    "extended_authorization_applied": null,
    "capture_before": null,
    "merchant_order_reference_id": null,
    "order_tax_amount": null,
    "connector_mandate_id": null,
    "card_discovery": "manual"
}
```


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
