### PR TITLE
feat(router): add local card networks & field in PM data in domain models

### DIFF
--- a/crates/common_enums/src/enums.rs
+++ b/crates/common_enums/src/enums.rs
@@ -1915,6 +1915,14 @@ pub enum CardNetwork {
     RuPay,
     #[serde(alias = "MAESTRO")]
     Maestro,
+    #[serde(alias = "STAR")]
+    Star,
+    #[serde(alias = "PULSE")]
+    Pulse,
+    #[serde(alias = "ACCEL")]
+    Accel,
+    #[serde(alias = "NYCE")]
+    Nyce,
 }
 
 /// Stage of the dispute

--- a/crates/hyperswitch_connectors/src/connectors/adyen/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/adyen/transformers.rs
@@ -2024,7 +2024,11 @@ fn get_adyen_card_network(card_network: common_enums::CardNetwork) -> Option<Car
         common_enums::CardNetwork::UnionPay => Some(CardBrand::Cup),
         common_enums::CardNetwork::RuPay => Some(CardBrand::Rupay),
         common_enums::CardNetwork::Maestro => Some(CardBrand::Maestro),
-        common_enums::CardNetwork::Interac => None,
+        common_enums::CardNetwork::Interac
+        | common_enums::CardNetwork::Star
+        | common_enums::CardNetwork::Accel
+        | common_enums::CardNetwork::Pulse
+        | common_enums::CardNetwork::Nyce => None,
     }
 }
 

--- a/crates/hyperswitch_connectors/src/connectors/bankofamerica/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/bankofamerica/transformers.rs
@@ -548,7 +548,12 @@ fn get_boa_card_type(card_network: common_enums::CardNetwork) -> Option<&'static
         common_enums::CardNetwork::UnionPay => Some("062"),
         //"042" is the type code for Masetro Cards(International). For Maestro Cards(UK-Domestic) the mapping should be "024"
         common_enums::CardNetwork::Maestro => Some("042"),
-        common_enums::CardNetwork::Interac | common_enums::CardNetwork::RuPay => None,
+        common_enums::CardNetwork::Interac
+        | common_enums::CardNetwork::RuPay
+        | common_enums::CardNetwork::Star
+        | common_enums::CardNetwork::Accel
+        | common_enums::CardNetwork::Pulse
+        | common_enums::CardNetwork::Nyce => None,
     }
 }
 

--- a/crates/hyperswitch_connectors/src/connectors/cybersource/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/cybersource/transformers.rs
@@ -4183,7 +4183,12 @@ fn get_cybersource_card_type(card_network: common_enums::CardNetwork) -> Option<
         common_enums::CardNetwork::UnionPay => Some("062"),
         //"042" is the type code for Masetro Cards(International). For Maestro Cards(UK-Domestic) the mapping should be "024"
         common_enums::CardNetwork::Maestro => Some("042"),
-        common_enums::CardNetwork::Interac | common_enums::CardNetwork::RuPay => None,
+        common_enums::CardNetwork::Interac
+        | common_enums::CardNetwork::RuPay
+        | common_enums::CardNetwork::Star
+        | common_enums::CardNetwork::Accel
+        | common_enums::CardNetwork::Pulse
+        | common_enums::CardNetwork::Nyce => None,
     }
 }
 

--- a/crates/hyperswitch_connectors/src/connectors/hipay/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/hipay/transformers.rs
@@ -121,7 +121,11 @@ impl TryFrom<&HipayRouterData<&PaymentsAuthorizeRouterData>> for HipayPaymentsRe
                     Some(CardNetwork::Interac) => "interac".to_string(),
                     Some(CardNetwork::RuPay) => "rupay".to_string(),
                     Some(CardNetwork::Maestro) => "maestro".to_string(),
-                    None => "".to_string(),
+                    Some(CardNetwork::Star)
+                    | Some(CardNetwork::Accel)
+                    | Some(CardNetwork::Pulse)
+                    | Some(CardNetwork::Nyce)
+                    | None => "".to_string(),
                 },
                 amount: item.amount.clone(),
                 description: item

--- a/crates/hyperswitch_domain_models/src/payment_method_data.rs
+++ b/crates/hyperswitch_domain_models/src/payment_method_data.rs
@@ -90,6 +90,7 @@ pub struct Card {
     pub bank_code: Option<String>,
     pub nick_name: Option<Secret<String>>,
     pub card_holder_name: Option<Secret<String>>,
+    pub secondary_card_networks: Option<Vec<common_enums::CardNetwork>>,
 }
 
 #[derive(Eq, PartialEq, Clone, Debug, Serialize, Deserialize, Default)]
@@ -118,6 +119,7 @@ pub struct CardDetail {
     pub bank_code: Option<String>,
     pub nick_name: Option<Secret<String>>,
     pub card_holder_name: Option<Secret<String>>,
+    pub secondary_card_networks: Option<Vec<common_enums::CardNetwork>>,
 }
 
 impl CardDetailsForNetworkTransactionId {
@@ -160,6 +162,7 @@ impl From<&Card> for CardDetail {
             bank_code: item.bank_code.to_owned(),
             nick_name: item.nick_name.to_owned(),
             card_holder_name: item.card_holder_name.to_owned(),
+            secondary_card_networks: None,
         }
     }
 }
@@ -769,6 +772,7 @@ impl From<api_models::payments::Card> for Card {
             bank_code,
             nick_name,
             card_holder_name,
+            secondary_card_networks: None,
         }
     }
 }
@@ -1822,6 +1826,7 @@ pub struct NetworkTokenDetailsPaymentMethod {
     pub card_isin: Option<String>,
     pub card_issuer: Option<String>,
     pub card_network: Option<api_enums::CardNetwork>,
+    pub secondary_card_networks: Option<Vec<api_enums::CardNetwork>>,
     pub card_type: Option<String>,
     #[serde(default = "saved_in_locker_default")]
     pub saved_to_locker: bool,
@@ -1842,6 +1847,7 @@ pub struct CardDetailsPaymentMethod {
     pub card_isin: Option<String>,
     pub card_issuer: Option<String>,
     pub card_network: Option<api_enums::CardNetwork>,
+    pub secondary_card_networks: Option<Vec<api_enums::CardNetwork>>,
     pub card_type: Option<String>,
     #[serde(default = "saved_in_locker_default")]
     pub saved_to_locker: bool,

--- a/crates/kgraph_utils/src/transformers.rs
+++ b/crates/kgraph_utils/src/transformers.rs
@@ -335,6 +335,10 @@ impl IntoDirValue for api_enums::CardNetwork {
             Self::Interac => Ok(dirval!(CardNetwork = Interac)),
             Self::RuPay => Ok(dirval!(CardNetwork = RuPay)),
             Self::Maestro => Ok(dirval!(CardNetwork = Maestro)),
+            Self::Star => Ok(dirval!(CardNetwork = Star)),
+            Self::Accel => Ok(dirval!(CardNetwork = Accel)),
+            Self::Pulse => Ok(dirval!(CardNetwork = Pulse)),
+            Self::Nyce => Ok(dirval!(CardNetwork = Nyce)),
         }
     }
 }

--- a/crates/router/src/connector/stripe/transformers.rs
+++ b/crates/router/src/connector/stripe/transformers.rs
@@ -1388,7 +1388,11 @@ fn get_stripe_card_network(card_network: common_enums::CardNetwork) -> Option<St
         | common_enums::CardNetwork::UnionPay
         | common_enums::CardNetwork::Interac
         | common_enums::CardNetwork::RuPay
-        | common_enums::CardNetwork::Maestro => None,
+        | common_enums::CardNetwork::Maestro
+        | common_enums::CardNetwork::Star
+        | common_enums::CardNetwork::Accel
+        | common_enums::CardNetwork::Pulse
+        | common_enums::CardNetwork::Nyce => None,
     }
 }
 

--- a/crates/router/src/core/payment_methods/tokenize/card_executor.rs
+++ b/crates/router/src/core/payment_methods/tokenize/card_executor.rs
@@ -101,6 +101,7 @@ impl<'a> NetworkTokenizationBuilder<'a, CardRequestValidated> {
         optional_card_info: Option<diesel_models::CardInfo>,
     ) -> NetworkTokenizationBuilder<'a, CardDetailsAssigned> {
         let card = domain::CardDetail {
+            secondary_card_networks: None,
             card_number: card_req.raw_card_number.clone(),
             card_exp_month: card_req.card_expiry_month.clone(),
             card_exp_year: card_req.card_expiry_year.clone(),

--- a/crates/router/src/core/payment_methods/tokenize/payment_method_executor.rs
+++ b/crates/router/src/core/payment_methods/tokenize/payment_method_executor.rs
@@ -128,6 +128,7 @@ impl<'a> NetworkTokenizationBuilder<'a, PmValidated> {
         card_cvc: Option<Secret<String>>,
     ) -> NetworkTokenizationBuilder<'a, PmAssigned> {
         let card = domain::CardDetail {
+            secondary_card_networks: None,
             card_number: card_from_locker.card_number.clone(),
             card_exp_month: card_from_locker.card_exp_month.clone(),
             card_exp_year: card_from_locker.card_exp_year.clone(),

--- a/crates/router/src/core/payment_methods/vault.rs
+++ b/crates/router/src/core/payment_methods/vault.rs
@@ -108,6 +108,7 @@ impl Vaultable for domain::Card {
             .attach_printable("Could not deserialize into card value2")?;
 
         let card = Self {
+            secondary_card_networks: None,
             card_number: cards::CardNumber::try_from(value1.card_number)
                 .change_context(errors::VaultError::ResponseDeserializationFailed)
                 .attach_printable("Invalid card number format from the mock locker")?,

--- a/crates/router/src/utils/verify_connector.rs
+++ b/crates/router/src/utils/verify_connector.rs
@@ -10,6 +10,7 @@ pub fn generate_card_from_details(
     card_cvv: String,
 ) -> errors::RouterResult<domain::Card> {
     Ok(domain::Card {
+        secondary_card_networks: None,
         card_number: card_number
             .parse::<cards::CardNumber>()
             .change_context(errors::ApiErrorResponse::InternalServerError)


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
We are adding the support for local card networks such as Pulse, Nyce, Accel and Star inside the enums Card Networks. 
We are also introducing a new field "secondary_card_networks" inside Payment Method Data for domain models. 


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
Closes https://github.com/juspay/hyperswitch-cloud/issues/8843


## How did you test it?

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
