### PR TITLE
refactor(core): Revert "filter default routing config response based on connector type"

### DIFF
--- a/crates/router/src/core/routing.rs
+++ b/crates/router/src/core/routing.rs
@@ -1,6 +1,6 @@
 pub mod helpers;
 pub mod transformers;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 
 #[cfg(all(feature = "v1", feature = "dynamic_routing"))]
 use api_models::routing::DynamicRoutingAlgoAccessor;
@@ -11,7 +11,6 @@ use api_models::{
 use async_trait::async_trait;
 #[cfg(all(feature = "v1", feature = "dynamic_routing"))]
 use common_utils::ext_traits::AsyncExt;
-use common_utils::id_type::MerchantConnectorAccountId;
 use diesel_models::routing_algorithm::RoutingAlgorithm;
 use error_stack::ResultExt;
 #[cfg(all(feature = "v1", feature = "dynamic_routing"))]
@@ -19,9 +18,7 @@ use external_services::grpc_client::dynamic_routing::{
     contract_routing_client::ContractBasedDynamicRouting,
     success_rate_client::SuccessBasedDynamicRouting,
 };
-use hyperswitch_domain_models::{
-    mandates, merchant_connector_account::MerchantConnectorAccount, payment_address,
-};
+use hyperswitch_domain_models::{mandates, payment_address};
 #[cfg(all(feature = "v1", feature = "dynamic_routing"))]
 use router_env::logger;
 use rustc_hash::FxHashSet;
@@ -979,66 +976,16 @@ pub async fn retrieve_default_routing_config(
 ) -> RouterResponse<Vec<routing_types::RoutableConnectorChoice>> {
     metrics::ROUTING_RETRIEVE_DEFAULT_CONFIG.add(1, &[]);
     let db = state.store.as_ref();
-    let key_manager_state = &(&state).into();
-    let key_store = state
-        .store
-        .get_merchant_key_store_by_merchant_id(
-            key_manager_state,
-            merchant_account.get_id(),
-            &state.store.get_master_key().to_vec().into(),
-        )
-        .await
-        .to_not_found_response(errors::ApiErrorResponse::MerchantAccountNotFound)?;
-
     let id = profile_id
         .map(|profile_id| profile_id.get_string_repr().to_owned())
         .unwrap_or_else(|| merchant_account.get_id().get_string_repr().to_string());
 
-    let mut merchant_connector_details: HashMap<
-        MerchantConnectorAccountId,
-        MerchantConnectorAccount,
-    > = HashMap::new();
-    state
-        .store
-        .find_merchant_connector_account_by_merchant_id_and_disabled_list(
-            key_manager_state,
-            merchant_account.get_id(),
-            false,
-            &key_store,
-        )
+    helpers::get_merchant_default_config(db, &id, transaction_type)
         .await
-        .to_not_found_response(errors::ApiErrorResponse::GenericNotFoundError {
-            message: format!(
-                "Unable to find merchant_connector_accounts associate with merchant_id: {}",
-                merchant_account.get_id().get_string_repr()
-            ),
-        })?
-        .iter()
-        .for_each(|mca| {
-            merchant_connector_details.insert(mca.get_id(), mca.clone());
-        });
-
-    let connectors = helpers::get_merchant_default_config(db, &id, transaction_type)
-        .await?
-        .iter()
-        .filter(|connector| {
-            connector
-                .merchant_connector_id
-                .as_ref()
-                .is_some_and(|mca_id| {
-                    merchant_connector_details.get(mca_id).is_some_and(|mca| {
-                        (*transaction_type == common_enums::TransactionType::Payment
-                            && mca.connector_type == common_enums::ConnectorType::PaymentProcessor)
-                            || (*transaction_type == common_enums::TransactionType::Payout
-                                && mca.connector_type
-                                    == common_enums::ConnectorType::PayoutProcessor)
-                    })
-                })
+        .map(|conn_choice| {
+            metrics::ROUTING_RETRIEVE_DEFAULT_CONFIG_SUCCESS_RESPONSE.add(1, &[]);
+            service_api::ApplicationResponse::Json(conn_choice)
         })
-        .cloned()
-        .collect::<Vec<routing_types::RoutableConnectorChoice>>();
-    metrics::ROUTING_RETRIEVE_DEFAULT_CONFIG_SUCCESS_RESPONSE.add(1, &[]);
-    Ok(service_api::ApplicationResponse::Json(connectors))
 }
 
 #[cfg(feature = "v2")]


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
main pr: https://github.com/juspay/hyperswitch/pull/7556

We are reverting the filtering of response for payment and payout processors.
So this works as follows:
If Payment's route is hit all the PaymentProcessors will be listed like PayoutConnectors etc.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Tested after creating JWT locally and adding 1 payment and 1 payout connector.
Payment :
```
curl --location 'http://localhost:8080/routing/default/profile' \
--header 'Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoiMWMyMTJhODgtOGFmYy00YjJjLWIwYWQtODY3MmQ2NTI3MzdlIiwibWVyY2hhbnRfaWQiOiJtZXJjaGFudF8xNzQxMDAzMjgwIiwicm9sZV9pZCI6Im9yZ19hZG1pbiIsImV4cCI6MTc0MTE3NjE1Miwib3JnX2lkIjoib3JnX1c4MkFMNTZ6VVE1dXFHcEEyYzFkIiwicHJvZmlsZV9pZCI6InByb19NcUlMcDAwdUFJeW5JZDdtUTNUTyIsInRlbmFudF9pZCI6InB1YmxpYyJ9.RoPyIG-JGrH6QmM6Gqd9gh03hOqy6MuC9Our9EHYGNk' \
--header 'Cookie: login_token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoiMWMyMTJhODgtOGFmYy00YjJjLWIwYWQtODY3MmQ2NTI3MzdlIiwibWVyY2hhbnRfaWQiOiJtZXJjaGFudF8xNzQxMDAzMjgwIiwicm9sZV9pZCI6Im9yZ19hZG1pbiIsImV4cCI6MTc0MTE3NjE1Miwib3JnX2lkIjoib3JnX1c4MkFMNTZ6VVE1dXFHcEEyYzFkIiwicHJvZmlsZV9pZCI6InByb19NcUlMcDAwdUFJeW5JZDdtUTNUTyIsInRlbmFudF9pZCI6InB1YmxpYyJ9.RoPyIG-JGrH6QmM6Gqd9gh03hOqy6MuC9Our9EHYGNk'
```

Payout :
```
curl --location 'http://localhost:8080/routing/payout/default/profile' \
--header 'Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoiMWMyMTJhODgtOGFmYy00YjJjLWIwYWQtODY3MmQ2NTI3MzdlIiwibWVyY2hhbnRfaWQiOiJtZXJjaGFudF8xNzQxMDAzMjgwIiwicm9sZV9pZCI6Im9yZ19hZG1pbiIsImV4cCI6MTc0MTE3NjE1Miwib3JnX2lkIjoib3JnX1c4MkFMNTZ6VVE1dXFHcEEyYzFkIiwicHJvZmlsZV9pZCI6InByb19NcUlMcDAwdUFJeW5JZDdtUTNUTyIsInRlbmFudF9pZCI6InB1YmxpYyJ9.RoPyIG-JGrH6QmM6Gqd9gh03hOqy6MuC9Our9EHYGNk' \
--header 'Cookie: login_token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoiMWMyMTJhODgtOGFmYy00YjJjLWIwYWQtODY3MmQ2NTI3MzdlIiwibWVyY2hhbnRfaWQiOiJtZXJjaGFudF8xNzQxMDAzMjgwIiwicm9sZV9pZCI6Im9yZ19hZG1pbiIsImV4cCI6MTc0MTE3NjE1Miwib3JnX2lkIjoib3JnX1c4MkFMNTZ6VVE1dXFHcEEyYzFkIiwicHJvZmlsZV9pZCI6InByb19NcUlMcDAwdUFJeW5JZDdtUTNUTyIsInRlbmFudF9pZCI6InB1YmxpYyJ9.RoPyIG-JGrH6QmM6Gqd9gh03hOqy6MuC9Our9EHYGNk'
```



## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
