### PR TITLE
chore(docker): prefix Hyperswitch Docker image URIs with `docker.juspay.io`

### DIFF
--- a/aws/hyperswitch_aws_setup.sh
+++ b/aws/hyperswitch_aws_setup.sh
@@ -215,7 +215,7 @@ sudo amazon-linux-extras install docker
 sudo service docker start
 sudo usermod -a -G docker ec2-user
 
-docker pull juspaydotin/hyperswitch-router:beta
+docker pull docker.juspay.io/juspaydotin/hyperswitch-router:beta
 
 curl https://raw.githubusercontent.com/juspay/hyperswitch/v1.55.0/config/development.toml > production.toml
 
@@ -265,7 +265,7 @@ echo "ROUTER__SERVER__BASE_URL=\$(curl ifconfig.me)" >> user_data.sh
 echo "ROUTER__SECRETS__ADMIN_API_KEY=$ADMIN_API_KEY" >> user_data.sh
 echo "EOF" >> user_data.sh
 
-echo "docker run --env-file .env -p 80:8080 -v \`pwd\`/:/local/config juspaydotin/hyperswitch-router:beta ./router -f /local/config/production.toml
+echo "docker run --env-file .env -p 80:8080 -v \`pwd\`/:/local/config docker.juspay.io/juspaydotin/hyperswitch-router:beta ./router -f /local/config/production.toml
 " >> user_data.sh
 
 echo "Retrieving AWS AMI ID..."

--- a/config/deployments/README.md
+++ b/config/deployments/README.md
@@ -103,7 +103,7 @@ To run the router, you can use the following snippet in the `docker-compose.yml`
 ```yaml
 ### Application services
 hyperswitch-server:
-  image: juspaydotin/hyperswitch-router:latest # This pulls the latest image from Docker Hub. If you wish to use a version without added features (like KMS), you can replace `latest` with `standalone`. However, please note that the standalone version is not recommended for production use.
+  image: docker.juspay.io/juspaydotin/hyperswitch-router:latest # This pulls the latest image from Docker Hub. If you wish to use a version without added features (like KMS), you can replace `latest` with `standalone`. However, please note that the standalone version is not recommended for production use.
   command: /local/bin/router --config-path /local/config/deployments/sandbox_release.toml # <--- Change this to the config file that is generated for the environment.
   ports:
     - "8080:8080"
@@ -115,7 +115,7 @@ To run the producer, you can use the following snippet in the `docker-compose.ym
 
 ```yaml
 hyperswitch-producer:
-  image: juspaydotin/hyperswitch-producer:latest
+  image: docker.juspay.io/juspaydotin/hyperswitch-producer:latest
   command: /local/bin/scheduler --config-path /local/config/deployments/producer_sandbox_release.toml # <--- Change this to the config file that is generated for the environment.
   volumes:
     - ./config:/local/config
@@ -127,7 +127,7 @@ To run the consumer, you can use the following snippet in the `docker-compose.ym
 
 ```yaml
 hyperswitch-consumer:
-  image: juspaydotin/hyperswitch-consumer:latest
+  image: docker.juspay.io/juspaydotin/hyperswitch-consumer:latest
   command: /local/bin/scheduler --config-path /local/config/deployments/consumer_sandbox_release.toml # <--- Change this to the config file that is generated for the environment
   volumes:
     - ./config:/local/config
@@ -139,7 +139,7 @@ To run the drainer, you can use the following snippet in the `docker-compose.yml
 
 ```yaml
 hyperswitch-drainer:
-  image: juspaydotin/hyperswitch-drainer:latest
+  image: docker.juspay.io/juspaydotin/hyperswitch-drainer:latest
   command: /local/bin/drainer --config-path /local/config/deployments/drainer.toml
   volumes:
     - ./config:/local/config

--- a/docker-compose-development.yml
+++ b/docker-compose-development.yml
@@ -316,7 +316,7 @@ services:
       - redisinsight_store:/db
 
   hyperswitch-control-center:
-    image: juspaydotin/hyperswitch-control-center:latest
+    image: docker.juspay.io/juspaydotin/hyperswitch-control-center:latest
     pull_policy: always
     networks:
       - router_net

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,7 +62,7 @@ services:
 
   ### Application services
   hyperswitch-server:
-    image: juspaydotin/hyperswitch-router:standalone
+    image: docker.juspay.io/juspaydotin/hyperswitch-router:standalone
     pull_policy: always
     command: /local/bin/router -f /local/config/docker_compose.toml
     ports:
@@ -87,7 +87,7 @@ services:
       timeout: 5s
 
   hyperswitch-producer:
-    image: juspaydotin/hyperswitch-producer:standalone
+    image: docker.juspay.io/juspaydotin/hyperswitch-producer:standalone
     pull_policy: always
     command: /local/bin/scheduler -f /local/config/docker_compose.toml
     networks:
@@ -105,7 +105,7 @@ services:
       logs: "promtail"
 
   hyperswitch-consumer:
-    image: juspaydotin/hyperswitch-consumer:standalone
+    image: docker.juspay.io/juspaydotin/hyperswitch-consumer:standalone
     pull_policy: always
     command: /local/bin/scheduler -f /local/config/docker_compose.toml
     networks:
@@ -129,7 +129,7 @@ services:
       timeout: 10s
 
   hyperswitch-drainer:
-    image: juspaydotin/hyperswitch-drainer:standalone
+    image: docker.juspay.io/juspaydotin/hyperswitch-drainer:standalone
     pull_policy: always
     command: /local/bin/drainer -f /local/config/docker_compose.toml
     deploy:
@@ -176,7 +176,7 @@ services:
 
   ### Control Center
   hyperswitch-control-center:
-    image: juspaydotin/hyperswitch-control-center:latest
+    image: docker.juspay.io/juspaydotin/hyperswitch-control-center:latest
     pull_policy: always
     ports:
       - "9000:9000"


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->

This PR updates Hyperswitch Docker images to be prefixed by `docker.juspay.io`. This includes the same changes as #7368, I've cherry picked the same commit.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->

N/A

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
N/A

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
