### PR TITLE
refactor(connector): [BRAINTREE] Pass email in payment requests

### DIFF
--- a/crates/hyperswitch_connectors/src/connectors/braintree/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/braintree/transformers.rs
@@ -206,10 +206,18 @@ impl TryFrom<&Option<pii::SecretSerdeValue>> for BraintreeMeta {
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
+pub struct CustomerBody {
+    email: pii::Email,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct RegularTransactionBody {
     amount: StringMajorUnit,
     merchant_account_id: Secret<String>,
     channel: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    customer_details: Option<CustomerBody>,
 }
 
 #[derive(Debug, Serialize)]
@@ -218,6 +226,8 @@ pub struct VaultTransactionBody {
     amount: StringMajorUnit,
     merchant_account_id: Secret<String>,
     vault_payment_method_after_transacting: TransactionTiming,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    customer_details: Option<CustomerBody>,
 }
 
 #[derive(Debug, Serialize)]
@@ -257,6 +267,7 @@ impl
                 amount: item.amount.to_owned(),
                 merchant_account_id: metadata.merchant_account_id,
                 channel: CHANNEL_CODE.to_string(),
+                customer_details: None,
             }),
         );
         Ok(Self {
@@ -1715,6 +1726,11 @@ impl
                     vault_payment_method_after_transacting: TransactionTiming {
                         when: "ALWAYS".to_string(),
                     },
+                    customer_details: item
+                        .router_data
+                        .get_billing_email()
+                        .ok()
+                        .map(|email| CustomerBody { email }),
                 }),
             )
         } else {
@@ -1727,6 +1743,11 @@ impl
                     amount: item.amount.to_owned(),
                     merchant_account_id: metadata.merchant_account_id,
                     channel: CHANNEL_CODE.to_string(),
+                    customer_details: item
+                        .router_data
+                        .get_billing_email()
+                        .ok()
+                        .map(|email| CustomerBody { email }),
                 }),
             )
         };
@@ -1814,6 +1835,11 @@ impl TryFrom<&BraintreeRouterData<&types::PaymentsCompleteAuthorizeRouterData>>
                     vault_payment_method_after_transacting: TransactionTiming {
                         when: "ALWAYS".to_string(),
                     },
+                    customer_details: item
+                        .router_data
+                        .get_billing_email()
+                        .ok()
+                        .map(|email| CustomerBody { email }),
                 }),
             )
         } else {
@@ -1826,6 +1852,11 @@ impl TryFrom<&BraintreeRouterData<&types::PaymentsCompleteAuthorizeRouterData>>
                     amount: item.amount.to_owned(),
                     merchant_account_id: metadata.merchant_account_id,
                     channel: CHANNEL_CODE.to_string(),
+                    customer_details: item
+                        .router_data
+                        .get_billing_email()
+                        .ok()
+                        .map(|email| CustomerBody { email }),
                 }),
             )
         };


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
ORIGINAL PR: https://github.com/juspay/hyperswitch/pull/7591
Pass email in payment request body of Braintree as  it is mandatory field for sending receipts in braintree

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
https://github.com/juspay/hyperswitch/issues/7590

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Payment Request:
```
{
    "amount": 1233,
    "currency": "EUR",
    "confirm": true,
    "customer_id": "abcdef",
    "billing": {
        "email": "guest@example.com"
    }
    "name": "John Doe",
    "authentication_type": "no_three_ds",
    "payment_method": "card",
    "payment_method_type": "credit",
    "payment_method_data": {
        "card": {
            "card_number": "5200000000001096",
            "card_exp_month": "10",
            "card_exp_year": "25",
            "card_holder_name": "joseph Doe",
            "card_cvc": "123"
        }
    }
}
```

Payment Response:
```
{
    "payment_id": "pay_o6SLsqlZ6J049AiPkHwW",
    "merchant_id": "postman_merchant_GHAction_ec4bf644-13b4-420a-9747-5a91dc33c1b5",
    "status": "requires_customer_action",
    "amount": 100,
    "net_amount": 100,
    "shipping_cost": null,
    "amount_capturable": 100,
    "amount_received": null,
    "connector": "braintree",
    "client_secret": "pay_o6SLsqlZ6J049AiPkHwW_secret_Bv6iGp8QmWWfywJd7jOO",
    "created": "2025-03-21T11:15:04.414Z",
    "currency": "EUR",
    "customer_id": "deepanshu",
    "customer": {
        "id": "deepanshu",
        "name": null,
        "email": "deepanshubansal515@gmail.com",
        "phone": null,
        "phone_country_code": null
    },
    "description": "Its my first payment request",
    "refunds": null,
    "disputes": null,
    "mandate_id": null,
    "mandate_data": null,
    "setup_future_usage": "off_session",
    "off_session": null,
    "capture_on": null,
    "capture_method": null,
    "payment_method": "card",
    "payment_method_data": {
        "card": {
            "last4": "1096",
            "card_type": null,
            "card_network": null,
            "card_issuer": null,
            "card_issuing_country": null,
            "card_isin": "520000",
            "card_extended_bin": null,
            "card_exp_month": "10",
            "card_exp_year": "25",
            "card_holder_name": "Deepanshu Bansal",
            "payment_checks": null,
            "authentication_data": null
        },
        "billing": null
    },
    "payment_token": null,
    "shipping": null,
    "billing": {
        "address": null,
        "phone": null,
        "email": "guest@example.com"
    },
    "order_details": null,
    "email": "deepanshubansal515@gmail.com",
    "name": null,
    "phone": null,
    "return_url": "https://duck.com/",
    "authentication_type": "three_ds",
    "statement_descriptor_name": null,
    "statement_descriptor_suffix": null,
    "next_action": {
        "type": "redirect_to_url",
        "redirect_to_url": "http://localhost:8080/payments/redirect/pay_o6SLsqlZ6J049AiPkHwW/postman_merchant_GHAction_ec4bf644-13b4-420a-9747-5a91dc33c1b5/pay_o6SLsqlZ6J049AiPkHwW_1"
    },
    "cancellation_reason": null,
    "error_code": null,
    "error_message": null,
    "unified_code": null,
    "unified_message": null,
    "payment_experience": null,
    "payment_method_type": "credit",
    "connector_label": null,
    "business_country": null,
    "business_label": "default",
    "business_sub_label": null,
    "allowed_payment_method_types": null,
    "ephemeral_key": {
        "customer_id": "deepanshu",
        "created_at": 1742555704,
        "expires": 1742559304,
        "secret": "epk_cc70c871e62f4f0a9a0fb797bb433941"
    },
    "manual_retry_allowed": null,
    "connector_transaction_id": null,
    "frm_message": null,
    "metadata": null,
    "connector_metadata": null,
    "feature_metadata": null,
    "reference_id": null,
    "payment_link": null,
    "profile_id": "pro_pzlYtlAD7YgNLdXLPSlq",
    "surcharge_details": null,
    "attempt_count": 1,
    "merchant_decision": null,
    "merchant_connector_id": "mca_CSJaSjj2gRnDoaSDRndr",
    "incremental_authorization_allowed": null,
    "authorization_count": null,
    "incremental_authorizations": null,
    "external_authentication_details": null,
    "external_3ds_authentication_attempted": false,
    "expires_on": "2025-03-21T11:30:04.414Z",
    "fingerprint": null,
    "browser_info": null,
    "payment_method_id": "pm_xp0BCgE81c2YO7G4Zan5",
    "payment_method_status": "inactive",
    "updated": "2025-03-21T11:15:06.916Z",
    "split_payments": null,
    "frm_metadata": null,
    "extended_authorization_applied": null,
    "capture_before": null,
    "merchant_order_reference_id": null,
    "order_tax_amount": null,
    "connector_mandate_id": null,
    "card_discovery": "manual",
    "issuer_error_code": null,
    "issuer_error_message": null
}
```

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
