### PR TITLE
feat(connector): change ucaf_collection_indicator for mastercard payments via netcetera

### DIFF
--- a/crates/hyperswitch_connectors/src/connectors/cybersource/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/cybersource/transformers.rs
@@ -1292,7 +1292,7 @@ impl
                         (
                             Some(Secret::new(authn_data.cavv.clone())),
                             None,
-                            Some("1".to_string()),
+                            Some("2".to_string()),
                         )
                     } else {
                         (None, Some(authn_data.cavv.clone()), None)
@@ -1375,14 +1375,18 @@ impl
             .authentication_data
             .as_ref()
             .map(|authn_data| {
-                let (ucaf_authentication_data, cavv) =
+                let (ucaf_authentication_data, cavv, ucaf_collection_indicator) =
                     if ccard.card_network == Some(common_enums::CardNetwork::Mastercard) {
-                        (Some(Secret::new(authn_data.cavv.clone())), None)
+                        (
+                            Some(Secret::new(authn_data.cavv.clone())),
+                            None,
+                            Some("2".to_string()),
+                        )
                     } else {
-                        (None, Some(authn_data.cavv.clone()))
+                        (None, Some(authn_data.cavv.clone()), None)
                     };
                 CybersourceConsumerAuthInformation {
-                    ucaf_collection_indicator: None,
+                    ucaf_collection_indicator,
                     cavv,
                     ucaf_authentication_data,
                     xid: None,
@@ -1457,14 +1461,18 @@ impl
             .authentication_data
             .as_ref()
             .map(|authn_data| {
-                let (ucaf_authentication_data, cavv) =
+                let (ucaf_authentication_data, cavv, ucaf_collection_indicator) =
                     if token_data.card_network == Some(common_enums::CardNetwork::Mastercard) {
-                        (Some(Secret::new(authn_data.cavv.clone())), None)
+                        (
+                            Some(Secret::new(authn_data.cavv.clone())),
+                            None,
+                            Some("2".to_string()),
+                        )
                     } else {
-                        (None, Some(authn_data.cavv.clone()))
+                        (None, Some(authn_data.cavv.clone()), None)
                     };
                 CybersourceConsumerAuthInformation {
-                    ucaf_collection_indicator: None,
+                    ucaf_collection_indicator,
                     cavv,
                     ucaf_authentication_data,
                     xid: None,


### PR DESCRIPTION
…ents via netcetera

## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
External 3ds payments for cybersource via netcetera external authentication is not working currently. To fix it, correct ucaf_collection_indicator has to be passed which is "2" according to cybersource doc. This PR introduces this correction.

<img width="604" alt="Screenshot 2025-03-25 at 3 53 43 PM" src="https://github.com/user-attachments/assets/53f38f3f-733a-45bc-8c68-ce9c7a536bd4" />


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

### Configure business profile
**Curl**

`curl --location 'http://localhost:8080/account/merchant_1742896618/business_profile/pro_ddmS9vKQBtVtjx1wOyxr' \
--header 'Content-Type: application/json' \
--header 'api-key: test_admin' \
--data '{  
    "authentication_connector_details": {
        "authentication_connectors": [
            "netcetera"
        ],
        "three_ds_requestor_url": "https://my.flowbirdapp.com/"
    }
}'`

### Create payment request via Cybersoucrce with 3ds external auth enabled
**Curl**

`curl --location 'http://localhost:8080/payments' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: dev_fqPovCsMoQb3EKJiZacxsXxoTN1bXCMrez3vwgYASVHPS9bKmtBONGbJ8LrcNVMo' \
--data-raw '{
    "amount": 10000,
    "currency": "EUR",
    "confirm": true,
    "payment_link": false,
    "capture_method": "automatic",
    "capture_on": "2022-09-10T10:11:12Z",
    "amount_to_capture": 10000,
    "customer_id": "StripeCustomer",
    "email": "guest@example.com",
    "name": "John Doe",
    "phone": "999999999",
    "phone_country_code": "+1",
    "description": "Its my first payment request",
    "request_external_three_ds_authentication": true,
    "authentication_type": "three_ds",
    "return_url": "https://google.com",
    "payment_method": "card",
    "payment_method_type": "credit",
    "payment_method_data": {
        "card": {
            "card_number": "5512459816707531",
            "card_exp_month": "12",
            "card_exp_year": "2025",
            "card_cvc": "000",
            "card_network": "Mastercard"
        }
    },
    "billing": {
        "address": {
            "line1": "1467",
            "line2": "CA",
            "line3": "CA",
            "city": "Musterhausen",
            "state": "California",
            "zip": "12345",
            "country": "US",
            "first_name": "Debarati",
            "last_name": "Ghatak"
        },
        "phone": {
            "number": "8056594427",
            "country_code": "+91"
        }
    },
    "browser_info": {
        "user_agent": "Mozilla\/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/70.0.3538.110 Safari\/537.36",
        "accept_header": "text\/html,application\/xhtml+xml,application\/xml;q=0.9,image\/webp,image\/apng,\/;q=0.8",
        "language": "nl-NL",
        "color_depth": 24,
        "ip_address": "103.77.139.95",
        "screen_height": 723,
        "screen_width": 1536,
        "time_zone": 0,
        "java_enabled": true,
        "java_script_enabled": true
    },
    "statement_descriptor_name": "joseph",
    "statement_descriptor_suffix": "JS",
    "metadata": {
        "dg": "value1",
        "new_customer": "true",
        "login_date": "2019-09-10T10:11:12Z"
    }
}'`

<img width="1189" alt="Screenshot 2025-03-25 at 3 59 46 PM" src="https://github.com/user-attachments/assets/97ebf01c-5ceb-4839-a5bf-8329d05e7f5b" />

### Call 3ds authentication endpoint
**Curl**

`curl --location 'http://localhost:8080/payments/pay_MfhkesST2jWyAXJkN0ap/3ds/authentication' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: pk_dev_89bfdedf18374b27b59ab42dc6508c57' \
--data '{
    "client_secret": "pay_MfhkesST2jWyAXJkN0ap_secret_CCOCh7UEtByCqtmBYmq9",
    "device_channel": "BRW",
    "threeds_method_comp_ind": "Y"
}'`

<img width="1189" alt="Screenshot 2025-03-25 at 3 59 31 PM" src="https://github.com/user-attachments/assets/e1822eca-cd1d-47ce-8942-b06acd60c003" />


### Call authorize for Cybersource 
**Curl**

`curl --location --request POST 'http://localhost:8080/payments/pay_MfhkesST2jWyAXJkN0ap/merchant_1742896618/authorize/cybersource'`
<img width="1189" alt="Screenshot 2025-03-25 at 3 59 15 PM" src="https://github.com/user-attachments/assets/19ed38f2-4283-4cd3-990b-2ca90c8f080e" />


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [X] I formatted the code `cargo +nightly fmt --all`
- [X] I addressed lints thrown by `cargo clippy`
- [X] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
