### PR TITLE
feat(wasm): fetch list of country codes and country names

### DIFF
--- a/crates/euclid_wasm/src/lib.rs
+++ b/crates/euclid_wasm/src/lib.rs
@@ -32,6 +32,9 @@ use wasm_bindgen::prelude::*;
 
 use crate::utils::JsResultExt;
 type JsResult = Result<JsValue, JsValue>;
+use api_models::payment_methods::CountryCodeWithName;
+use common_enums::CountryAlpha2;
+use strum::IntoEnumIterator;
 
 struct SeedData {
     cgraph: hyperswitch_constraint_graph::ConstraintGraph<dir::DirValue>,
@@ -71,6 +74,20 @@ pub fn convert_forex_value(amount: i64, from_currency: JsValue, to_currency: JsV
         .err_to_js()?;
 
     Ok(serde_wasm_bindgen::to_value(&converted_amount)?)
+}
+
+/// This function can be used by the frontend to get all the two letter country codes
+/// along with their country names.
+#[wasm_bindgen(js_name=getTwoLetterCountryCode)]
+pub fn get_two_letter_country_code() -> JsResult {
+    let country_code_with_name = CountryAlpha2::iter()
+        .map(|country_code| CountryCodeWithName {
+            code: country_code,
+            name: common_enums::Country::from_alpha2(country_code),
+        })
+        .collect::<Vec<_>>();
+
+    Ok(serde_wasm_bindgen::to_value(&country_code_with_name)?)
 }
 
 /// This function can be used by the frontend to provide the WASM with information about


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
Added a function `get_two_letter_country_code()` which fetches a list of country codes and country names for the FrontEnd to create a drop down so that the Merchant can select the country from the country list in the Dashboard.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
