### PR TITLE
feat(docker): add webhook notifiers for installation tracking

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
   prestart-hook:
     image: curlimages/curl-base:latest
     container_name: prestart-hook
-    entrypoint: ["/bin/sh", "-c", "chmod +x /prestart_hook.sh && /prestart_hook.sh"]
+    entrypoint: ["/bin/sh", "-c", "apk add --no-cache bash && /bin/bash /prestart_hook.sh"]
     volumes:
       - ./scripts/prestart_hook.sh:/prestart_hook.sh
     networks:
@@ -101,7 +101,7 @@ services:
     depends_on:
       hyperswitch-server:
         condition: service_healthy  # Ensures it only starts when `hyperswitch-server` is healthy
-    entrypoint: ["/bin/sh", "-c", "apk add --no-cache jq && chmod +x /poststart_hook.sh && /poststart_hook.sh"]
+    entrypoint: ["/bin/sh", "-c", "apk add --no-cache bash jq && /bin/bash /poststart_hook.sh"]
     volumes:
       - ./scripts/poststart_hook.sh:/poststart_hook.sh
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,15 @@ networks:
 
 services:
   ### Dependencies
+  prestart-hook:
+    image: curlimages/curl:latest
+    container_name: prestart-hook
+    entrypoint: ["/bin/sh", "-c", "chmod +x /prestart_hook.sh && /prestart_hook.sh"]
+    volumes:
+      - ./scripts/prestart_hook.sh:/prestart_hook.sh
+    networks:
+      - router_net
+
   pg:
     image: postgres:latest
     ports:
@@ -86,6 +95,18 @@ services:
       start_period: 5s
       timeout: 5s
 
+  poststart-hook:
+    image: alpine:latest
+    container_name: poststart-hook
+    depends_on:
+      hyperswitch-server:
+        condition: service_healthy  # Ensures it only starts when `hyperswitch-server` is healthy
+    entrypoint: ["/bin/sh", "-c", "apk add --no-cache curl jq && chmod +x /poststart_hook.sh && /poststart_hook.sh"]
+    volumes:
+      - ./scripts/poststart_hook.sh:/poststart_hook.sh
+    networks:
+      - router_net 
+      
   hyperswitch-producer:
     image: docker.juspay.io/juspaydotin/hyperswitch-producer:standalone
     pull_policy: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -101,7 +101,7 @@ services:
     depends_on:
       hyperswitch-server:
         condition: service_healthy  # Ensures it only starts when `hyperswitch-server` is healthy
-    entrypoint: ["/bin/sh", "-c", "apk add --no-cache curl jq && chmod +x /poststart_hook.sh && /poststart_hook.sh"]
+    entrypoint: ["/bin/sh", "-c", "apk add --no-cache jq && chmod +x /poststart_hook.sh && /poststart_hook.sh"]
     volumes:
       - ./scripts/poststart_hook.sh:/poststart_hook.sh
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ networks:
 services:
   ### Dependencies
   prestart-hook:
-    image: curlimages/curl:latest
+    image: curlimages/curl-base:latest
     container_name: prestart-hook
     entrypoint: ["/bin/sh", "-c", "chmod +x /prestart_hook.sh && /prestart_hook.sh"]
     volumes:
@@ -96,7 +96,7 @@ services:
       timeout: 5s
 
   poststart-hook:
-    image: alpine:latest
+    image: curlimages/curl-base:latest
     container_name: poststart-hook
     depends_on:
       hyperswitch-server:

--- a/scripts/poststart_hook.sh
+++ b/scripts/poststart_hook.sh
@@ -1,0 +1,57 @@
+#!/bin/sh
+
+# Configuration
+PLATFORM="docker"  # Change to "helm" or "cdk" as needed
+VERSION="1.113.0"
+STATUS=""
+SERVER_HEALTH_URL="http://hyperswitch-server:8080/health"
+HYPERSWITCH_URL="http://hyperswitch-server:8080/health/ready"
+WEBHOOK_URL="https://hyperswitch.gateway.scarf.sh/$PLATFORM"
+
+
+# Fetch health status
+echo "Fetching app server health status..."
+HEALTH_RESPONSE=$(curl -s --fail "$SERVER_HEALTH_URL") || HEALTH_RESPONSE="connection_error"
+
+if [ "$HEALTH_RESPONSE" = "connection_error" ]; then
+    STATUS="error"
+    ERROR_MESSAGE=$(echo "404 response" | jq -sRr @uri)
+    PARAMS="$PARAMS&status=$STATUS"
+    PARAMS="$PARAMS&error_message=$ERROR_MESSAGE"
+    curl -G "$WEBHOOK_URL?$PARAMS"
+    exit 0
+fi
+
+echo "Fetching Hyperswitch health status..."
+HEALTH_RESPONSE=$(curl -s "$HYPERSWITCH_URL")
+
+echo "Raw response: $HEALTH_RESPONSE"
+
+# Initialize parameters
+PARAMS="platform=$PLATFORM&version=$VERSION&status=$STATUS"
+
+# Check if the response contains an error
+if echo "$HEALTH_RESPONSE" | grep -q '"error"'; then
+    STATUS="error"
+    ERROR_TYPE=$(echo "$HEALTH_RESPONSE" | jq -r '.error.type' | jq -sRr @uri)
+    ERROR_MESSAGE=$(echo "$HEALTH_RESPONSE" | jq -r '.error.message' | jq -sRr @uri)
+    ERROR_CODE=$(echo "$HEALTH_RESPONSE" | jq -r '.error.code' | jq -sRr @uri)
+
+    PARAMS="$PARAMS&status=$STATUS"
+    PARAMS="$PARAMS&error_type=$ERROR_TYPE"
+    PARAMS="$PARAMS&error_message=$ERROR_MESSAGE"
+    PARAMS="$PARAMS&error_code=$ERROR_CODE"
+else
+    STATUS="success"
+    for key in $(echo "$HEALTH_RESPONSE" | jq -r 'keys_unsorted[]'); do
+        value=$(echo "$HEALTH_RESPONSE" | jq -r --arg key "$key" '.[$key]' | jq -sRr @uri)
+        PARAMS="$PARAMS&$key=$value"
+    done
+fi
+
+echo "Final URL Parameters: $PARAMS"
+
+# Send GET request to the webhook
+curl -G "$WEBHOOK_URL?$PARAMS"
+
+echo "Webhook notification sent."

--- a/scripts/poststart_hook.sh
+++ b/scripts/poststart_hook.sh
@@ -1,19 +1,20 @@
-#! /usr/bin/env sh
+#! /usr/bin/env bash
 set -euo pipefail
 
 # Configuration
-PLATFORM="docker"  # Change to "helm" or "cdk" as needed
+PLATFORM="docker-compose" # Change to "helm" or "cdk" as needed
 VERSION="unknown"
 STATUS=""
-HYPERSWITCH_HEALTH_URL="http://hyperswitch-server:8080/health"
-HYPERSWITCH_DEEP_HEALTH_URL="http://hyperswitch-server:8080/health/ready"
+SERVER_BASE_URL="http://hyperswitch-server:8080"
+HYPERSWITCH_HEALTH_URL="${SERVER_BASE_URL}/health"
+HYPERSWITCH_DEEP_HEALTH_URL="${SERVER_BASE_URL}/health/ready"
 WEBHOOK_URL="https://hyperswitch.gateway.scarf.sh/${PLATFORM}"
 
 # Fetch health status
 echo "Fetching app server health status..."
 HEALTH_RESPONSE=$(curl --silent --fail "${HYPERSWITCH_HEALTH_URL}") || HEALTH_RESPONSE="connection_error"
 
-if [ "$HEALTH_RESPONSE" = "connection_error" ]; then
+if [[ "${HEALTH_RESPONSE}" == "connection_error" ]]; then
     STATUS="error"
     ERROR_MESSAGE="404 response"
 
@@ -33,30 +34,32 @@ echo "Fetching Hyperswitch health status..."
 HEALTH_RESPONSE=$(curl --silent "${HYPERSWITCH_DEEP_HEALTH_URL}")
 
 # Prepare curl command
-CURL_COMMAND="curl --get '${WEBHOOK_URL}' --data-urlencode 'version=${VERSION}'"
+CURL_COMMAND=("curl" "--get" "${WEBHOOK_URL}" "--data-urlencode" "version=${VERSION}")
 
 # Check if the response contains an error
-if echo "${HEALTH_RESPONSE}" | grep -q '"error"'; then
+if [[ "$(echo "${HEALTH_RESPONSE}" | jq --raw-output '.error')" != 'null' ]]; then
     STATUS="error"
     ERROR_TYPE=$(echo "${HEALTH_RESPONSE}" | jq --raw-output '.error.type')
     ERROR_MESSAGE=$(echo "${HEALTH_RESPONSE}" | jq --raw-output '.error.message')
     ERROR_CODE=$(echo "${HEALTH_RESPONSE}" | jq --raw-output '.error.code')
 
-    CURL_COMMAND="${CURL_COMMAND} --data-urlencode 'status=${STATUS}'"
-    CURL_COMMAND="${CURL_COMMAND} --data-urlencode 'error_type=${ERROR_TYPE}'"
-    CURL_COMMAND="${CURL_COMMAND} --data-urlencode 'error_message=${ERROR_MESSAGE}'"
-    CURL_COMMAND="${CURL_COMMAND} --data-urlencode 'error_code=${ERROR_CODE}'"
+    CURL_COMMAND+=(
+        "--data-urlencode" "status=${STATUS}"
+        "--data-urlencode" "error_type=${ERROR_TYPE}"
+        "--data-urlencode" "error_message=${ERROR_MESSAGE}"
+        "--data-urlencode" "error_code=${ERROR_CODE}"
+    )
 else
     STATUS="success"
-    CURL_COMMAND="${CURL_COMMAND} --data-urlencode 'status=${STATUS}'"
+    CURL_COMMAND+=("--data-urlencode" "status=${STATUS}")
 
     for key in $(echo "${HEALTH_RESPONSE}" | jq --raw-output 'keys_unsorted[]'); do
         value=$(echo "${HEALTH_RESPONSE}" | jq --raw-output --arg key "${key}" '.[$key]')
-        CURL_COMMAND="${CURL_COMMAND} --data-urlencode '${key}=${value}'"
+        CURL_COMMAND+=("--data-urlencode" "'${key}=${value}'")
     done
 fi
 
 # Send the webhook request
-sh -c "${CURL_COMMAND}"
+bash -c "${CURL_COMMAND[*]}"
 
 echo "Webhook notification sent."

--- a/scripts/poststart_hook.sh
+++ b/scripts/poststart_hook.sh
@@ -1,55 +1,62 @@
-#!/bin/sh
+#! /usr/bin/env sh
+set -euo pipefail
 
 # Configuration
 PLATFORM="docker"  # Change to "helm" or "cdk" as needed
 VERSION="unknown"
 STATUS=""
-SERVER_HEALTH_URL="http://hyperswitch-server:8080/health"
-HYPERSWITCH_URL="http://hyperswitch-server:8080/health/ready"
-WEBHOOK_URL="https://hyperswitch.gateway.scarf.sh/$PLATFORM"
+HYPERSWITCH_HEALTH_URL="http://hyperswitch-server:8080/health"
+HYPERSWITCH_DEEP_HEALTH_URL="http://hyperswitch-server:8080/health/ready"
+WEBHOOK_URL="https://hyperswitch.gateway.scarf.sh/${PLATFORM}"
 
 # Fetch health status
 echo "Fetching app server health status..."
-HEALTH_RESPONSE=$(curl -s --fail "$SERVER_HEALTH_URL") || HEALTH_RESPONSE="connection_error"
+HEALTH_RESPONSE=$(curl --silent --fail "${HYPERSWITCH_HEALTH_URL}") || HEALTH_RESPONSE="connection_error"
 
 if [ "$HEALTH_RESPONSE" = "connection_error" ]; then
     STATUS="error"
-    ERROR_MESSAGE=$(echo "404 response" | jq -sRr @uri)
-    PARAMS="$PARAMS&status=$STATUS"
-    PARAMS="$PARAMS&error_message=$ERROR_MESSAGE"
-    curl -G "$WEBHOOK_URL?$PARAMS"
+    ERROR_MESSAGE="404 response"
+
+    curl --get "${WEBHOOK_URL}" \
+        --data-urlencode "version=${VERSION}" \
+        --data-urlencode "status=${STATUS}" \
+        --data-urlencode "error_message=${ERROR_MESSAGE}"
+
+    echo "Webhook sent with connection error."
     exit 0
 fi
 
-#fetch hyperswitch version
-VERSION=$(curl --silent --output /dev/null --request GET --write-out '%header{x-hyperswitch-version}' "$HYPERSWITCH_URL" | sed 's/-.*//' | jq -sRr @uri)
+# Fetch Hyperswitch version
+VERSION=$(curl --silent --output /dev/null --request GET --write-out '%header{x-hyperswitch-version}' "${HYPERSWITCH_DEEP_HEALTH_URL}" | sed 's/-dirty$//')
 
 echo "Fetching Hyperswitch health status..."
-HEALTH_RESPONSE=$(curl -s "$HYPERSWITCH_URL")
+HEALTH_RESPONSE=$(curl --silent "${HYPERSWITCH_DEEP_HEALTH_URL}")
 
-# Initialize parameters
-PARAMS="version=$VERSION"
+# Prepare curl command
+CURL_COMMAND="curl --get '${WEBHOOK_URL}' --data-urlencode 'version=${VERSION}'"
 
 # Check if the response contains an error
-if echo "$HEALTH_RESPONSE" | grep -q '"error"'; then
+if echo "${HEALTH_RESPONSE}" | grep -q '"error"'; then
     STATUS="error"
-    ERROR_TYPE=$(echo "$HEALTH_RESPONSE" | jq -r '.error.type' | jq -sRr @uri)
-    ERROR_MESSAGE=$(echo "$HEALTH_RESPONSE" | jq -r '.error.message' | jq -sRr @uri)
-    ERROR_CODE=$(echo "$HEALTH_RESPONSE" | jq -r '.error.code' | jq -sRr @uri)
+    ERROR_TYPE=$(echo "${HEALTH_RESPONSE}" | jq --raw-output '.error.type')
+    ERROR_MESSAGE=$(echo "${HEALTH_RESPONSE}" | jq --raw-output '.error.message')
+    ERROR_CODE=$(echo "${HEALTH_RESPONSE}" | jq --raw-output '.error.code')
 
-    PARAMS="$PARAMS&status=$STATUS"
-    PARAMS="$PARAMS&error_type=$ERROR_TYPE"
-    PARAMS="$PARAMS&error_message=$ERROR_MESSAGE"
-    PARAMS="$PARAMS&error_code=$ERROR_CODE"
+    CURL_COMMAND="${CURL_COMMAND} --data-urlencode 'status=${STATUS}'"
+    CURL_COMMAND="${CURL_COMMAND} --data-urlencode 'error_type=${ERROR_TYPE}'"
+    CURL_COMMAND="${CURL_COMMAND} --data-urlencode 'error_message=${ERROR_MESSAGE}'"
+    CURL_COMMAND="${CURL_COMMAND} --data-urlencode 'error_code=${ERROR_CODE}'"
 else
     STATUS="success"
-    for key in $(echo "$HEALTH_RESPONSE" | jq -r 'keys_unsorted[]'); do
-        value=$(echo "$HEALTH_RESPONSE" | jq -r --arg key "$key" '.[$key]' | jq -sRr @uri)
-        PARAMS="$PARAMS&$key=$value"
+    CURL_COMMAND="${CURL_COMMAND} --data-urlencode 'status=${STATUS}'"
+
+    for key in $(echo "${HEALTH_RESPONSE}" | jq --raw-output 'keys_unsorted[]'); do
+        value=$(echo "${HEALTH_RESPONSE}" | jq --raw-output --arg key "${key}" '.[$key]')
+        CURL_COMMAND="${CURL_COMMAND} --data-urlencode '${key}=${value}'"
     done
 fi
 
-# Send GET request to the webhook
-curl -G "$WEBHOOK_URL?$PARAMS"
+# Send the webhook request
+sh -c "${CURL_COMMAND}"
 
 echo "Webhook notification sent."

--- a/scripts/prestart_hook.sh
+++ b/scripts/prestart_hook.sh
@@ -1,13 +1,14 @@
-#!/bin/sh
+#! /usr/bin/env sh
+set -euo pipefail
 
 # Define the URL and parameters
 PLATFORM="docker"
-URL="https://hyperswitch.gateway.scarf.sh/$PLATFORM"
+WEBHOOK_URL="https://hyperswitch.gateway.scarf.sh/${PLATFORM}"
 VERSION="unknown"
 STATUS="initiated"
 
 # Send the GET request
-curl -G "$URL" --data-urlencode "version=$VERSION" --data-urlencode "status=$STATUS"
+curl --get "${WEBHOOK_URL}" --data-urlencode "version=${VERSION}" --data-urlencode "status=${STATUS}"
 
 # Print confirmation
-echo "Request sent to $URL with version=$VERSION and status=$STATUS"
+echo "Request sent to $WEBHOOK_URL with version=$VERSION and status=$STATUS"

--- a/scripts/prestart_hook.sh
+++ b/scripts/prestart_hook.sh
@@ -1,8 +1,8 @@
-#! /usr/bin/env sh
+#! /usr/bin/env bash
 set -euo pipefail
 
 # Define the URL and parameters
-PLATFORM="docker"
+PLATFORM="docker-compose"
 WEBHOOK_URL="https://hyperswitch.gateway.scarf.sh/${PLATFORM}"
 VERSION="unknown"
 STATUS="initiated"
@@ -11,4 +11,4 @@ STATUS="initiated"
 curl --get "${WEBHOOK_URL}" --data-urlencode "version=${VERSION}" --data-urlencode "status=${STATUS}"
 
 # Print confirmation
-echo "Request sent to $WEBHOOK_URL with version=$VERSION and status=$STATUS"
+echo "Request sent to ${WEBHOOK_URL} with version=${VERSION} and status=${STATUS}"

--- a/scripts/prestart_hook.sh
+++ b/scripts/prestart_hook.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+# Define the URL and parameters
+PLATFORM="docker"
+URL="https://hyperswitch.gateway.scarf.sh/$PLATFORM"
+VERSION="1.113.0"
+STATUS="initiated"
+
+# Send the GET request
+curl -G "$URL" --data-urlencode "version=$VERSION" --data-urlencode "status=$STATUS"
+
+# Print confirmation
+echo "Request sent to $URL with version=$VERSION and status=$STATUS"

--- a/scripts/prestart_hook.sh
+++ b/scripts/prestart_hook.sh
@@ -3,7 +3,7 @@
 # Define the URL and parameters
 PLATFORM="docker"
 URL="https://hyperswitch.gateway.scarf.sh/$PLATFORM"
-VERSION="1.113.0"
+VERSION="unknown"
 STATUS="initiated"
 
 # Send the GET request


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Added a webhook notifier for pre- and post-installation of `hyperswitch` using docker compose. This webhook sends the following API call to `https://hyperswitch.gateway.scarf.sh`:
 - **initiated** (when a user tries to install hyperswitch)
 - **success** (when all the components are successfully up and running)
 - **error** (when any of the component fails or the server is unreachable)

The API calls include information about the platform(docker/helm/cdk), version and additional information about success/failure.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
This change enables tracking of installation attempts, providing valuable insights into user adoption and setup experience. By monitoring success and failure rates, we can identify and resolve potential setup issues, ultimately improving user experience.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
1. Create a mock server and replace the url of the mock server inplace of `WEBHOOK_URL` in `scripts/prestart_hook.sh` and `scripts/poststart_hook.sh`
2. Run `docker compose up -d`
3. You can verify the status responses about your installation in your mock server.
<img width="726" alt="Screenshot 2025-03-26 at 7 19 16 PM" src="https://github.com/user-attachments/assets/c175b069-36de-4476-8ae0-cbd7a05c17e9" />


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
