### PR TITLE
ci(cypress): verify existence of `payment_id` after redirection

### DIFF
--- a/cypress-tests/cypress/support/redirectionHandler.js
+++ b/cypress-tests/cypress/support/redirectionHandler.js
@@ -468,12 +468,24 @@ function verifyReturnUrl(redirectionUrl, expectedUrl, forwardFlow) {
         try {
           const redirectionHost = new URL(redirectionUrl).host;
           const expectedHost = new URL(expectedUrl).host;
-          if (redirectionHost.endsWith(expectedHost)) {
-            cy.wait(constants.WAIT_TIME / 2);
 
-            cy.window()
-              .its("location")
-              .then((location) => {
+          cy.window()
+            .its("location")
+            .then((location) => {
+              // Check for payment_id in the URL
+              const urlParams = new URLSearchParams(location.search);
+              const paymentId = urlParams.get("payment_id");
+
+              if (!paymentId) {
+                // eslint-disable-next-line cypress/assertion-before-screenshot
+                cy.screenshot("missing-payment-id-error");
+                throw new Error("URL does not contain payment_id parameter");
+              }
+
+              // Proceed with other verifications based on whether redirection host ends with expected host
+              if (redirectionHost.endsWith(expectedHost)) {
+                cy.wait(constants.WAIT_TIME / 2);
+
                 // Check page state before taking screenshots
                 cy.document().then((doc) => {
                   const pageText = doc.body.innerText.toLowerCase();
@@ -495,7 +507,6 @@ function verifyReturnUrl(redirectionUrl, expectedUrl, forwardFlow) {
                   }
                 });
 
-                const urlParams = new URLSearchParams(location.search);
                 const paymentStatus = urlParams.get("status");
 
                 if (
@@ -507,21 +518,21 @@ function verifyReturnUrl(redirectionUrl, expectedUrl, forwardFlow) {
                     `Redirection failed with payment status: ${paymentStatus}`
                   );
                 }
-              });
-          } else {
-            cy.window().its("location.origin").should("eq", expectedUrl);
+              } else {
+                cy.window().its("location.origin").should("eq", expectedUrl);
 
-            Cypress.on("uncaught:exception", (err, runnable) => {
-              // Log the error details
-              // eslint-disable-next-line no-console
-              console.error(
-                `Error: ${err.message}\nOccurred in: ${runnable.title}\nStack: ${err.stack}`
-              );
+                Cypress.on("uncaught:exception", (err, runnable) => {
+                  // Log the error details
+                  // eslint-disable-next-line no-console
+                  console.error(
+                    `Error: ${err.message}\nOccurred in: ${runnable.title}\nStack: ${err.stack}`
+                  );
 
-              // Return false to prevent the error from failing the test
-              return false;
+                  // Return false to prevent the error from failing the test
+                  return false;
+                });
+              }
             });
-          }
         } catch (error) {
           throw new Error(`Redirection verification failed: ${error}`);
         }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [x] CI/CD

## Description
<!-- Describe your changes in detail -->

This PR adds a check in Cypress `redirectionHandler` to verify that `payment_id` exists after the redirection completes without which it throws an error!

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->

We need to check if we get `payment_id` in return url after the redirection completes.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

tested by inverting the check:

<img width="246" alt="image" src="https://github.com/user-attachments/assets/8d3462cf-c02b-48fa-98f8-75d191a982c3" />

since i asked cypress to throw an error if `payment_id` exist, it threw me an error:

<img width="402" alt="image" src="https://github.com/user-attachments/assets/afeacebe-b455-4eaf-abcb-5c66f1779ca6" />

so, the check works as expected.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `npm run format`
- [x] I addressed lints thrown by `npm run lint`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
