### PR TITLE
feat(dashboard): Added wasm changes to collect metadata for visa_ctp

### DIFF
--- a/crates/connector_configs/toml/development.toml
+++ b/crates/connector_configs/toml/development.toml
@@ -5709,6 +5709,63 @@ key1="API password"
 [ctp_visa]
 [ctp_visa.connector_auth.NoKey]
 
+[ctp_visa.metadata.dpa_id]
+name="dpa_id"
+label="DPA Id"
+placeholder="Enter DPA Id"
+required=true
+type="Text"
+
+[ctp_visa.metadata.dpa_name]
+name="dpa_name"
+label="DPA Name"
+placeholder="Enter DPA Name"
+required=true
+type="Text"
+
+[ctp_visa.metadata.locale]
+name="locale"
+label="Locale"
+placeholder="Enter locale"
+required=true
+type="Text"
+
+[ctp_visa.metadata.card_brands]
+name="card_brands"
+label="Card Brands"
+placeholder="Enter Card Brands"
+required=true
+type="MultiSelect"
+options=["visa","mastercard"]
+
+[ctp_visa.metadata.acquirer_bin]
+name="acquirer_bin"
+label="Acquire Bin"
+placeholder="Enter Acquirer Bin"
+required=true
+type="Text"
+
+[ctp_visa.metadata.acquirer_merchant_id]
+name="acquirer_merchant_id"
+label="Acquire Merchant Id"
+placeholder="Enter Acquirer Merchant Id"
+required=true
+type="Text"
+
+[ctp_visa.metadata.merchant_category_code]
+name="merchant_category_code"
+label="Merchant Category Code"
+placeholder="Enter Merchant Category Code"
+required=true
+type="Text"
+
+[ctp_visa.metadata.merchant_country_code]
+name="merchant_country_code"
+label="Merchant Country Code"
+placeholder="Enter Merchant Country Code"
+required=true
+type="Text"
+
 [redsys]
 [[redsys.credit]]
   payment_method_type = "Mastercard"

--- a/crates/connector_configs/toml/production.toml
+++ b/crates/connector_configs/toml/production.toml
@@ -4389,6 +4389,63 @@ key1="API password"
 [ctp_visa]
 [ctp_visa.connector_auth.NoKey]
 
+[ctp_visa.metadata.dpa_id]
+name="dpa_id"
+label="DPA Id"
+placeholder="Enter DPA Id"
+required=true
+type="Text"
+
+[ctp_visa.metadata.dpa_name]
+name="dpa_name"
+label="DPA Name"
+placeholder="Enter DPA Name"
+required=true
+type="Text"
+
+[ctp_visa.metadata.locale]
+name="locale"
+label="Locale"
+placeholder="Enter locale"
+required=true
+type="Text"
+
+[ctp_visa.metadata.card_brands]
+name="card_brands"
+label="Card Brands"
+placeholder="Enter Card Brands"
+required=true
+type="MultiSelect"
+options=["visa","mastercard"]
+
+[ctp_visa.metadata.acquirer_bin]
+name="acquirer_bin"
+label="Acquire Bin"
+placeholder="Enter Acquirer Bin"
+required=true
+type="Text"
+
+[ctp_visa.metadata.acquirer_merchant_id]
+name="acquirer_merchant_id"
+label="Acquire Merchant Id"
+placeholder="Enter Acquirer Merchant Id"
+required=true
+type="Text"
+
+[ctp_visa.metadata.merchant_category_code]
+name="merchant_category_code"
+label="Merchant Category Code"
+placeholder="Enter Merchant Category Code"
+required=true
+type="Text"
+
+[ctp_visa.metadata.merchant_country_code]
+name="merchant_country_code"
+label="Merchant Country Code"
+placeholder="Enter Merchant Country Code"
+required=true
+type="Text"
+
 [redsys]
 [[redsys.credit]]
 payment_method_type = "Mastercard"

--- a/crates/connector_configs/toml/sandbox.toml
+++ b/crates/connector_configs/toml/sandbox.toml
@@ -5652,6 +5652,64 @@ key1="API password"
 [ctp_visa]
 [ctp_visa.connector_auth.NoKey]
 
+
+[ctp_visa.metadata.dpa_id]
+name="dpa_id"
+label="DPA Id"
+placeholder="Enter DPA Id"
+required=true
+type="Text"
+
+[ctp_visa.metadata.dpa_name]
+name="dpa_name"
+label="DPA Name"
+placeholder="Enter DPA Name"
+required=true
+type="Text"
+
+[ctp_visa.metadata.locale]
+name="locale"
+label="Locale"
+placeholder="Enter locale"
+required=true
+type="Text"
+
+[ctp_visa.metadata.card_brands]
+name="card_brands"
+label="Card Brands"
+placeholder="Enter Card Brands"
+required=true
+type="MultiSelect"
+options=["visa","mastercard"]
+
+[ctp_visa.metadata.acquirer_bin]
+name="acquirer_bin"
+label="Acquire Bin"
+placeholder="Enter Acquirer Bin"
+required=true
+type="Text"
+
+[ctp_visa.metadata.acquirer_merchant_id]
+name="acquirer_merchant_id"
+label="Acquire Merchant Id"
+placeholder="Enter Acquirer Merchant Id"
+required=true
+type="Text"
+
+[ctp_visa.metadata.merchant_category_code]
+name="merchant_category_code"
+label="Merchant Category Code"
+placeholder="Enter Merchant Category Code"
+required=true
+type="Text"
+
+[ctp_visa.metadata.merchant_country_code]
+name="merchant_country_code"
+label="Merchant Country Code"
+placeholder="Enter Merchant Country Code"
+required=true
+type="Text"
+
 [redsys]
 [[redsys.credit]]
 payment_method_type = "Mastercard"


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Enhancement

## Description
<!-- Describe your changes in detail -->

Added wasm changes to collect metadata for visa_ctp


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

Once this PR is merged check for `ctp_visa` connector addition and look for input field in metadata in dashboard. Should look similar toh ctp_mastercard metadata input fields 


```shell
  "metadata": {
        "dpa_id": "DPA-ID",
        "dpa_name": "TestMerchant",
        "locale": "en_AU",
        "card_brands": [
            "mastercard",
            "visa"
        ],
        "acquirer_bin": "BIN",
        "acquirer_merchant_id": "MERCHANT-ID",
        "merchant_category_code": "0001",
        "merchant_country_code": "US"
    }
```


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
