### PR TITLE
refactor(openapi): modify profile-delete auth to AdminAPIKey in API doc

### DIFF
--- a/api-reference/openapi_spec.json
+++ b/api-reference/openapi_spec.json
@@ -3324,7 +3324,7 @@
         },
         "security": [
           {
-            "api_key": []
+            "admin_api_key": []
           }
         ]
       }

--- a/crates/openapi/src/routes/profile.rs
+++ b/crates/openapi/src/routes/profile.rs
@@ -108,7 +108,7 @@ pub async fn profile_retrieve() {}
     ),
     tag = "Profile",
     operation_id = "Delete the Profile",
-    security(("api_key" = []))
+    security(("admin_api_key" = []))
 )]
 pub async fn profile_delete() {}
 


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Need to update the API doc to display Admin API Key instead of API key for Profile - Delete.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
Correct Information to be displayed in the API docs.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Cannot be tested.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
