### PR TITLE
ci(cypress): fix iatapay upi payments

### DIFF
--- a/cypress-tests/cypress/e2e/configs/Payment/Iatapay.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Iatapay.js
@@ -6,6 +6,20 @@ const successfulNo3DSCardDetails = {
   card_cvc: "737",
 };
 
+const billingAddress = {
+  address: {
+    line1: "1467",
+    line2: "Harrison Street",
+    line3: "Harrison Street",
+    city: "San Fransico",
+    state: "California",
+    zip: "94122",
+    country: "IN",
+    first_name: "john",
+    last_name: "doe",
+  },
+};
+
 export const connectorDetails = {
   bank_redirect_pm: {
     Ideal: {
@@ -133,6 +147,7 @@ export const connectorDetails = {
             },
           },
         },
+        billing: billingAddress,
       },
       Response: {
         status: 200,

--- a/cypress-tests/cypress/e2e/spec/Payment/00022-Variations.cy.js
+++ b/cypress-tests/cypress/e2e/spec/Payment/00022-Variations.cy.js
@@ -763,6 +763,21 @@ describe("Corner cases", () => {
       }
     });
 
+    it("Create new payment", () => {
+      const data = getConnectorDetails(globalState.get("connectorId"))[
+        "card_pm"
+      ]["No3DSAutoCapture"];
+
+      cy.createConfirmPaymentTest(
+        fixtures.createConfirmPaymentBody,
+        data,
+        "no_three_ds",
+        "automatic",
+        globalState
+      );
+      if (shouldContinue) shouldContinue = utils.should_continue_further(data);
+    });
+
     it("Create new refund", () => {
       const data = getConnectorDetails(globalState.get("connectorId"))[
         "card_pm"

--- a/cypress-tests/cypress/e2e/spec/Payment/00022-Variations.cy.js
+++ b/cypress-tests/cypress/e2e/spec/Payment/00022-Variations.cy.js
@@ -705,8 +705,12 @@ describe("Corner cases", () => {
 
   context("Duplicate Payment ID", () => {
     let shouldContinue = true; // variable that will be used to skip tests if a previous test fails
+    let createConfirmBody;
 
     beforeEach(function () {
+      createConfirmBody = Cypress._.cloneDeep(
+        fixtures.createConfirmPaymentBody
+      );
       if (!shouldContinue) {
         this.skip();
       }
@@ -718,7 +722,7 @@ describe("Corner cases", () => {
       ]["No3DSAutoCapture"];
 
       cy.createConfirmPaymentTest(
-        fixtures.createConfirmPaymentBody,
+        createConfirmBody,
         data,
         "no_three_ds",
         "automatic",
@@ -743,7 +747,7 @@ describe("Corner cases", () => {
       data.Request.payment_id = globalState.get("paymentID");
 
       cy.createConfirmPaymentTest(
-        fixtures.createConfirmPaymentBody,
+        createConfirmBody,
         data,
         "no_three_ds",
         "automatic",


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [x] CI/CD

## Description

Fixed the IataPay Cypress test cases as UPI_Collect payments were failing due to an invalid billing.address.country.


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
Cypress test cases were failing 

## How did you test it?
Cypress 

Before
![image](https://github.com/user-attachments/assets/aa666e0e-1b36-4ec5-bab9-5266daa46310)

After
![image](https://github.com/user-attachments/assets/d5dbf622-4fed-4c91-8148-61eb6182647b)

Adyen 
<img width="723" alt="image" src="https://github.com/user-attachments/assets/c411d896-a9b6-42a1-828f-3d0e54820606" />

Bluesnap
<img width="799" alt="image" src="https://github.com/user-attachments/assets/9f7adb21-0dfd-4bab-af1a-92e22733b526" />



## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
