### PR TITLE
fix: web-docker pull from docker hub

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -149,15 +149,14 @@ services:
 
   ### Web Client
   hyperswitch-web:
+    image: docker.juspay.io/juspaydotin/hyperswitch-web:latest
+    pull_policy: always
     ports:
       - "9050:9050"
       - "9060:9060"
       - "5252:5252"
-    networks:
-      - router_net
-    build:
-      context: ./docker
-      dockerfile: web.Dockerfile
+      networks:
+        - router_net
     depends_on:
       hyperswitch-server:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -155,8 +155,8 @@ services:
       - "9050:9050"
       - "9060:9060"
       - "5252:5252"
-      networks:
-        - router_net
+    networks:
+      - router_net
     depends_on:
       hyperswitch-server:
         condition: service_healthy


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
Docker pull from latest stable tag


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->

Web Docker Image was not working properly 

<img width="1043" alt="Screenshot 2025-04-02 at 3 40 52 PM" src="https://github.com/user-attachments/assets/514b49c8-6a63-4c5b-934b-9d2f0709fc5f" />

Now with this fix its working


## How did you test it?
Via locally running Docker Image


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [x] I added unit tests for my changes where possible
