### PR TITLE
fix: add billing payment sync configs to integ, sandbox and integ

### DIFF
--- a/config/deployments/integration_test.toml
+++ b/config/deployments/integration_test.toml
@@ -560,3 +560,6 @@ connector_list = "cybersource"
 
 [platform]
 enabled = true
+
+[billing_connectors_payment_sync]
+billing_connectors_which_require_payment_sync = "stripebilling, recurly"

--- a/config/deployments/production.toml
+++ b/config/deployments/production.toml
@@ -575,3 +575,6 @@ connector_list = "cybersource"
 
 [platform]
 enabled = false
+
+[billing_connectors_payment_sync]
+billing_connectors_which_require_payment_sync = "stripebilling, recurly"

--- a/config/deployments/sandbox.toml
+++ b/config/deployments/sandbox.toml
@@ -576,3 +576,6 @@ connector_list = "cybersource"
 
 [platform]
 enabled = false
+
+[billing_connectors_payment_sync]
+billing_connectors_which_require_payment_sync = "stripebilling, recurly"


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
Adds the billing_connector_payment_sync config to sandbox, integ and  production.toml

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context


## How did you test it?
No testing required


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
