### PR TITLE
chore(postman): update `Stripe` response `status`, `error_code`, and `error_message` for deprecated `Sofort`

### DIFF
--- a/postman/collection-dir/stripe/Flow Testcases/Happy Cases/Scenario16-Bank Redirect-sofort/Payments - Confirm/event.test.js
+++ b/postman/collection-dir/stripe/Flow Testcases/Happy Cases/Scenario16-Bank Redirect-sofort/Payments - Confirm/event.test.js
@@ -63,21 +63,21 @@ if (jsonData?.client_secret) {
   );
 }
 
-// Response body should have value "requires_customer_action" for "status"
+// Response body should have value "failed" for "status"
 if (jsonData?.status) {
   pm.test(
-    "[POST]::/payments/:id/confirm - Content check if value for 'status' matches 'requires_customer_action'",
+    "[POST]::/payments/:id/confirm - Content check if value for 'status' matches 'failed'",
     function () {
-      pm.expect(jsonData.status).to.eql("requires_customer_action");
+      pm.expect(jsonData.status).to.eql("failed");
     },
   );
 }
 
-// Response body should have "next_action.redirect_to_url"
+// Response body should have "next_action"
 pm.test(
-  "[POST]::/payments - Content check if 'next_action.redirect_to_url' exists",
+  "[POST]::/payments - Content check if 'next_action' exists",
   function () {
-    pm.expect(typeof jsonData.next_action.redirect_to_url !== "undefined").to.be
+    pm.expect(typeof jsonData.next_action !== "undefined").to.be
       .true;
   },
 );
@@ -88,6 +88,26 @@ if (jsonData?.payment_method_type) {
     "[POST]::/payments/:id/confirm - Content check if value for 'payment_method_type' matches 'sofort'",
     function () {
       pm.expect(jsonData.payment_method_type).to.eql("sofort");
+    },
+  );
+}
+
+// Response body should have value "payment_method_not_available" for "error_code"
+if (jsonData?.error_code) {
+  pm.test(
+    "[POST]::/payments/:id/confirm - Content check if value for 'error_code' matches 'payment_method_not_available'",
+    function () {
+      pm.expect(jsonData.error_code).to.eql("payment_method_not_available");
+    },
+  );
+}
+
+// Response body should have value "Sofort is deprecated and can no longer be used for payment acceptance. Please refer to https://docs.stripe.com/payments/sofort" for "error_message"
+if (jsonData?.error_message) {
+  pm.test(
+    "[POST]::/payments/:id/confirm - Content check if value for 'error_message' matches 'Sofort is deprecated and can no longer be used for payment acceptance. Please refer to https://docs.stripe.com/payments/sofort'",
+    function () {
+      pm.expect(jsonData.error_message).to.eql("Sofort is deprecated and can no longer be used for payment acceptance. Please refer to https://docs.stripe.com/payments/sofort");
     },
   );
 }

--- a/postman/collection-dir/stripe/Flow Testcases/Happy Cases/Scenario16-Bank Redirect-sofort/Payments - Retrieve/event.test.js
+++ b/postman/collection-dir/stripe/Flow Testcases/Happy Cases/Scenario16-Bank Redirect-sofort/Payments - Retrieve/event.test.js
@@ -60,12 +60,32 @@ if (jsonData?.client_secret) {
   );
 }
 
-// Response body should have value "requires_customer_action" for "status"
+// Response body should have value "failed" for "status"
 if (jsonData?.status) {
   pm.test(
-    "[POST]::/payments:id - Content check if value for 'status' matches 'requires_customer_action'",
+    "[POST]::/payments:id - Content check if value for 'status' matches 'failed'",
     function () {
-      pm.expect(jsonData.status).to.eql("requires_customer_action");
+      pm.expect(jsonData.status).to.eql("failed");
+    },
+  );
+}
+
+// Response body should have value "payment_method_not_available" for "error_code"
+if (jsonData?.error_code) {
+  pm.test(
+    "[POST]::/payments/:id/confirm - Content check if value for 'error_code' matches 'payment_method_not_available'",
+    function () {
+      pm.expect(jsonData.error_code).to.eql("payment_method_not_available");
+    },
+  );
+}
+
+// Response body should have value "Sofort is deprecated and can no longer be used for payment acceptance. Please refer to https://docs.stripe.com/payments/sofort" for "error_message"
+if (jsonData?.error_message) {
+  pm.test(
+    "[POST]::/payments/:id/confirm - Content check if value for 'error_message' matches 'Sofort is deprecated and can no longer be used for payment acceptance. Please refer to https://docs.stripe.com/payments/sofort'",
+    function () {
+      pm.expect(jsonData.error_message).to.eql("Sofort is deprecated and can no longer be used for payment acceptance. Please refer to https://docs.stripe.com/payments/sofort");
     },
   );
 }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [x] CI/CD

## Description
<!-- Describe your changes in detail -->
Mapping `status`, `error_code`, and `error_message` for `Stripe` Payment Processor `Sofort` Bank Transfer Payment Method as `Sofort` has been deprecated by `Stripe`.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
`Stripe` Payment Processor has deprecated `Sofort` Bank Transfer Payment Method.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

_Before_

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/96c27305-04fb-4839-a91b-84ed69bc4ced" />

_After_

<img width="1727" alt="image" src="https://github.com/user-attachments/assets/50881bf2-8fb0-4b7f-8a96-2742e55d6c76" />


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
