### PR TITLE
refactor(connector): [STRIPE] Remove sofort bank redirect from stripe

### DIFF
--- a/config/config.example.toml
+++ b/config/config.example.toml
@@ -480,7 +480,7 @@ bank_debit.becs = { connector_list = "gocardless" }                             
 bank_debit.bacs = { connector_list = "adyen" }                                        # Mandate supported payment method type and connector for bank_debit
 bank_debit.sepa = { connector_list = "gocardless,adyen" }                             # Mandate supported payment method type and connector for bank_debit
 bank_redirect.ideal = { connector_list = "stripe,adyen,globalpay" }                   # Mandate supported payment method type and connector for bank_redirect
-bank_redirect.sofort = { connector_list = "stripe,globalpay" }
+bank_redirect.sofort = { connector_list = "globalpay" }
 wallet.apple_pay = { connector_list = "stripe,adyen,cybersource,noon,bankofamerica,authorizedotnet,novalnet" }
 wallet.samsung_pay = { connector_list = "cybersource" }
 wallet.google_pay = { connector_list = "bankofamerica,authorizedotnet,novalnet" }

--- a/config/deployments/integration_test.toml
+++ b/config/deployments/integration_test.toml
@@ -193,7 +193,7 @@ wallet.twint.connector_list = "adyen"
 wallet.vipps.connector_list = "adyen"
 
 bank_redirect.ideal.connector_list = "stripe,adyen,globalpay,multisafepay,nexinets"   
-bank_redirect.sofort.connector_list = "stripe,globalpay"  
+bank_redirect.sofort.connector_list = "globalpay"  
 bank_redirect.giropay.connector_list = "globalpay,multisafepay,nexinets"        
 bank_redirect.bancontact_card.connector_list="adyen,stripe"
 bank_redirect.trustly.connector_list="adyen"
@@ -392,7 +392,8 @@ giropay = { country = "DE", currency = "EUR" }
 google_pay.country = "AL,DZ,AS,AO,AG,AR,AU,AT,AZ,BH,BY,BE,BR,BG,CA,CL,CO,HR,CZ,DK,DO,EG,EE,FI,FR,DE,GR,HK,HU,IN,ID,IE,IL,IT,JP,JO,KZ,KE,KW,LV,LB,LT,LU,MY,MX,NL,NZ,NO,OM,PK,PA,PE,PH,PL,PT,QA,RO,RU,SA,SG,SK,ZA,ES,LK,SE,CH,TW,TH,TR,UA,AE,GB,US,UY,VN"
 ideal = { country = "NL", currency = "EUR" }
 klarna = { country = "AU,AT,BE,CA,CZ,DK,FI,FR,DE,GR,IE,IT,NL,NZ,NO,PL,PT,ES,SE,CH,GB,US", currency = "AUD,CAD,CHF,CZK,DKK,EUR,GBP,NOK,NZD,PLN,SEK,USD" }
-sofort = { country = "AT,BE,DE,IT,NL,ES", currency = "EUR" }
+multibanco = { country = "PT", currency = "EUR" }
+ach = { country = "US", currency = "USD" }
 
 [pm_filters.cybersource]
 credit = { currency = "USD,GBP,EUR,PLN" }

--- a/config/deployments/production.toml
+++ b/config/deployments/production.toml
@@ -193,7 +193,7 @@ wallet.twint.connector_list = "adyen"
 wallet.vipps.connector_list = "adyen"
 
 bank_redirect.ideal.connector_list = "stripe,adyen,globalpay,multisafepay,nexinets"   
-bank_redirect.sofort.connector_list = "stripe,globalpay"  
+bank_redirect.sofort.connector_list = "globalpay"  
 bank_redirect.giropay.connector_list = "globalpay,multisafepay,nexinets"        
 bank_redirect.bancontact_card.connector_list="adyen,stripe"
 bank_redirect.trustly.connector_list="adyen"
@@ -442,7 +442,8 @@ giropay = { country = "DE", currency = "EUR" }
 google_pay.country = "AL,DZ,AS,AO,AG,AR,AU,AT,AZ,BH,BY,BE,BR,BG,CA,CL,CO,HR,CZ,DK,DO,EG,EE,FI,FR,DE,GR,HK,HU,IN,ID,IE,IL,IT,JP,JO,KZ,KE,KW,LV,LB,LT,LU,MY,MX,NL,NZ,NO,OM,PK,PA,PE,PH,PL,PT,QA,RO,RU,SA,SG,SK,ZA,ES,LK,SE,CH,TW,TH,TR,UA,AE,GB,US,UY,VN"
 ideal = { country = "NL", currency = "EUR" }
 klarna = { country = "AU,AT,BE,CA,CZ,DK,FI,FR,DE,GR,IE,IT,NL,NZ,NO,PL,PT,ES,SE,CH,GB,US", currency = "AUD,CAD,CHF,CZK,DKK,EUR,GBP,NOK,NZD,PLN,SEK,USD" }
-sofort = { country = "AT,BE,DE,IT,NL,ES", currency = "EUR" }
+multibanco = { country = "PT", currency = "EUR" }
+ach = { country = "US", currency = "USD" }
 
 [pm_filters.volt]
 open_banking_uk = {country = "DE,GB,AT,BE,CY,EE,ES,FI,FR,GR,HR,IE,IT,LT,LU,LV,MT,NL,PT,SI,SK,BG,CZ,DK,HU,NO,PL,RO,SE,AU,BR", currency = "EUR,GBP,DKK,NOK,PLN,SEK,AUD,BRL"}

--- a/config/deployments/sandbox.toml
+++ b/config/deployments/sandbox.toml
@@ -193,7 +193,7 @@ wallet.twint.connector_list = "adyen"
 wallet.vipps.connector_list = "adyen"
 
 bank_redirect.ideal.connector_list = "stripe,adyen,globalpay,multisafepay,nexinets"   
-bank_redirect.sofort.connector_list = "stripe,globalpay"  
+bank_redirect.sofort.connector_list = "globalpay"  
 bank_redirect.giropay.connector_list = "globalpay,multisafepay,nexinets"        
 bank_redirect.bancontact_card.connector_list="adyen,stripe"
 bank_redirect.trustly.connector_list="adyen"
@@ -444,7 +444,8 @@ giropay = { country = "DE", currency = "EUR" }
 google_pay.country = "AL,DZ,AS,AO,AG,AR,AU,AT,AZ,BH,BY,BE,BR,BG,CA,CL,CO,HR,CZ,DK,DO,EG,EE,FI,FR,DE,GR,HK,HU,IN,ID,IE,IL,IT,JP,JO,KZ,KE,KW,LV,LB,LT,LU,MY,MX,NL,NZ,NO,OM,PK,PA,PE,PH,PL,PT,QA,RO,RU,SA,SG,SK,ZA,ES,LK,SE,CH,TW,TH,TR,UA,AE,GB,US,UY,VN"
 ideal = { country = "NL", currency = "EUR" }
 klarna = { country = "AU,AT,BE,CA,CZ,DK,FI,FR,DE,GR,IE,IT,NL,NZ,NO,PL,PT,ES,SE,CH,GB,US", currency = "AUD,CAD,CHF,CZK,DKK,EUR,GBP,NOK,NZD,PLN,SEK,USD" }
-sofort = { country = "AT,BE,DE,IT,NL,ES", currency = "EUR" }
+multibanco = { country = "PT", currency = "EUR" }
+ach = { country = "US", currency = "USD" }
 
 [pm_filters.volt]
 open_banking_uk = { country = "DE,GB,AT,BE,CY,EE,ES,FI,FR,GR,HR,IE,IT,LT,LU,LV,MT,NL,PT,SI,SK,BG,CZ,DK,HU,NO,PL,RO,SE,AU,BR", currency = "EUR,GBP,DKK,NOK,PLN,SEK,AUD,BRL" }

--- a/config/development.toml
+++ b/config/development.toml
@@ -454,9 +454,10 @@ affirm = { country = "US", currency = "USD" }
 afterpay_clearpay = { country = "US,CA,GB,AU,NZ,FR,ES", currency = "USD,CAD,GBP,AUD,NZD" }
 giropay = { country = "DE", currency = "EUR" }
 eps = { country = "AT", currency = "EUR" }
-sofort = { country = "AT,BE,DE,IT,NL,ES", currency = "EUR" }
 ideal = { country = "NL", currency = "EUR" }
 cashapp = { country = "US", currency = "USD" }
+multibanco = { country = "PT", currency = "EUR" }
+ach = { country = "US", currency = "USD" }
 
 [pm_filters.volt]
 open_banking_uk = { country = "DE,GB,AT,BE,CY,EE,ES,FI,FR,GR,HR,IE,IT,LT,LU,LV,MT,NL,PT,SI,SK,BG,CZ,DK,HU,NO,PL,RO,SE,AU,BR", currency = "EUR,GBP,DKK,NOK,PLN,SEK,AUD,BRL" }

--- a/config/docker_compose.toml
+++ b/config/docker_compose.toml
@@ -681,7 +681,7 @@ bank_debit.becs = { connector_list = "gocardless" }
 bank_debit.bacs = { connector_list = "adyen" }
 bank_debit.sepa = { connector_list = "gocardless,adyen" }
 bank_redirect.ideal = { connector_list = "stripe,adyen,globalpay" }
-bank_redirect.sofort = { connector_list = "stripe,globalpay" }
+bank_redirect.sofort = { connector_list = "globalpay" }
 bank_redirect.giropay = { connector_list = "globalpay" }
 
 [mandates.update_mandate_supported]

--- a/crates/connector_configs/toml/development.toml
+++ b/crates/connector_configs/toml/development.toml
@@ -3975,8 +3975,6 @@ merchant_secret="Source verification key"
 [[stripe.bank_redirect]]
   payment_method_type = "giropay"
 [[stripe.bank_redirect]]
-  payment_method_type = "sofort"
-[[stripe.bank_redirect]]
   payment_method_type = "eps"
 [[stripe.bank_redirect]]
   payment_method_type = "bancontact_card"

--- a/crates/connector_configs/toml/production.toml
+++ b/crates/connector_configs/toml/production.toml
@@ -2966,8 +2966,6 @@ merchant_secret="Source verification key"
 [[stripe.bank_redirect]]
   payment_method_type = "giropay"
 [[stripe.bank_redirect]]
-  payment_method_type = "sofort"
-[[stripe.bank_redirect]]
   payment_method_type = "eps"
 [[stripe.bank_debit]]
   payment_method_type = "ach"

--- a/crates/connector_configs/toml/sandbox.toml
+++ b/crates/connector_configs/toml/sandbox.toml
@@ -3937,8 +3937,6 @@ merchant_secret="Source verification key"
 [[stripe.bank_redirect]]
   payment_method_type = "giropay"
 [[stripe.bank_redirect]]
-  payment_method_type = "sofort"
-[[stripe.bank_redirect]]
   payment_method_type = "eps"
 [[stripe.bank_redirect]]
   payment_method_type = "bancontact_card"

--- a/crates/router/src/connector/stripe/transformers.rs
+++ b/crates/router/src/connector/stripe/transformers.rs
@@ -307,21 +307,9 @@ pub enum StripeBankName {
 
 #[derive(Debug, Eq, PartialEq, Serialize)]
 #[serde(untagged)]
-pub enum BankSpecificData {
-    Sofort {
-        #[serde(rename = "payment_method_options[sofort][preferred_language]")]
-        preferred_language: String,
-        #[serde(rename = "payment_method_data[sofort][country]")]
-        country: api_enums::CountryAlpha2,
-    },
-}
-
-#[derive(Debug, Eq, PartialEq, Serialize)]
-#[serde(untagged)]
 pub enum StripeBankRedirectData {
     StripeGiropay(Box<StripeGiropay>),
     StripeIdeal(Box<StripeIdeal>),
-    StripeSofort(Box<StripeSofort>),
     StripeBancontactCard(Box<StripeBancontactCard>),
     StripePrezelewy24(Box<StripePrezelewy24>),
     StripeEps(Box<StripeEps>),
@@ -341,16 +329,6 @@ pub struct StripeIdeal {
     pub payment_method_data_type: StripePaymentMethodType,
     #[serde(rename = "payment_method_data[ideal][bank]")]
     ideal_bank_name: Option<StripeBankNames>,
-}
-
-#[derive(Debug, Eq, PartialEq, Serialize)]
-pub struct StripeSofort {
-    #[serde(rename = "payment_method_data[type]")]
-    pub payment_method_data_type: StripePaymentMethodType,
-    #[serde(rename = "payment_method_options[sofort][preferred_language]")]
-    preferred_language: Option<String>,
-    #[serde(rename = "payment_method_data[sofort][country]")]
-    country: api_enums::CountryAlpha2,
 }
 
 #[derive(Debug, Eq, PartialEq, Serialize)]
@@ -1226,10 +1204,7 @@ fn create_stripe_payment_method(
                 billing_address
             };
             let pm_type = StripePaymentMethodType::try_from(bank_redirect_data)?;
-            let bank_redirect_data = StripePaymentMethodData::try_from((
-                bank_redirect_data,
-                Some(billing_address.to_owned()),
-            ))?;
+            let bank_redirect_data = StripePaymentMethodData::try_from(bank_redirect_data)?;
 
             Ok((bank_redirect_data, Some(pm_type), billing_address))
         }
@@ -1548,16 +1523,9 @@ impl TryFrom<(&domain::WalletData, Option<types::PaymentMethodToken>)> for Strip
     }
 }
 
-impl TryFrom<(&domain::BankRedirectData, Option<StripeBillingAddress>)>
-    for StripePaymentMethodData
-{
+impl TryFrom<&domain::BankRedirectData> for StripePaymentMethodData {
     type Error = error_stack::Report<errors::ConnectorError>;
-    fn try_from(
-        (bank_redirect_data, billing_address): (
-            &domain::BankRedirectData,
-            Option<StripeBillingAddress>,
-        ),
-    ) -> Result<Self, Self::Error> {
+    fn try_from(bank_redirect_data: &domain::BankRedirectData) -> Result<Self, Self::Error> {
         let payment_method_data_type = StripePaymentMethodType::try_from(bank_redirect_data)?;
         match bank_redirect_data {
             domain::BankRedirectData::BancontactCard { .. } => Ok(Self::BankRedirect(
@@ -1610,19 +1578,6 @@ impl TryFrom<(&domain::BankRedirectData, Option<StripeBillingAddress>)>
                     })),
                 ))
             }
-            domain::BankRedirectData::Sofort {
-                preferred_language, ..
-            } => Ok(Self::BankRedirect(StripeBankRedirectData::StripeSofort(
-                Box::new(StripeSofort {
-                    payment_method_data_type,
-                    country: billing_address
-                        .and_then(|billing_data| billing_data.country)
-                        .ok_or(errors::ConnectorError::MissingRequiredField {
-                            field_name: "billing_address.country",
-                        })?,
-                    preferred_language: preferred_language.clone(),
-                }),
-            ))),
             domain::BankRedirectData::OnlineBankingFpx { .. } => {
                 Err(errors::ConnectorError::NotImplemented(
                     connector_util::get_unimplemented_payment_method_error_message("stripe"),
@@ -1638,6 +1593,7 @@ impl TryFrom<(&domain::BankRedirectData, Option<StripeBillingAddress>)>
             | domain::BankRedirectData::OnlineBankingSlovakia { .. }
             | domain::BankRedirectData::OnlineBankingThailand { .. }
             | domain::BankRedirectData::OpenBankingUk { .. }
+            | domain::BankRedirectData::Sofort { .. }
             | domain::BankRedirectData::Trustly { .. }
             | domain::BankRedirectData::LocalBankRedirect {} => {
                 Err(errors::ConnectorError::NotImplemented(
@@ -2335,12 +2291,9 @@ pub struct StripeAdditionalCardDetails {
 #[derive(Deserialize, Clone, Debug, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case", tag = "type")]
 pub enum StripePaymentMethodDetailsResponse {
-    //only ideal, sofort and bancontact is supported by stripe for recurring payment in bank redirect
+    //only ideal and bancontact is supported by stripe for recurring payment in bank redirect
     Ideal {
         ideal: StripeBankRedirectDetails,
-    },
-    Sofort {
-        sofort: StripeBankRedirectDetails,
     },
     Bancontact {
         bancontact: StripeBankRedirectDetails,
@@ -2402,7 +2355,6 @@ impl StripePaymentMethodDetailsResponse {
                 authentication_details: card.three_d_secure.clone(),
             }),
             Self::Ideal { .. }
-            | Self::Sofort { .. }
             | Self::Bancontact { .. }
             | Self::Blik
             | Self::Eps
@@ -2772,10 +2724,6 @@ where
                                     .unwrap_or(payment_method_id.expose())
                             }
                             Some(StripePaymentMethodDetailsResponse::Ideal { ideal }) => ideal
-                                .attached_payment_method
-                                .map(|attached_payment_method| attached_payment_method.expose())
-                                .unwrap_or(payment_method_id.expose()),
-                            Some(StripePaymentMethodDetailsResponse::Sofort { sofort }) => sofort
                                 .attached_payment_method
                                 .map(|attached_payment_method| attached_payment_method.expose())
                                 .unwrap_or(payment_method_id.expose()),
@@ -3893,7 +3841,7 @@ impl
                 payment_method_data_type: pm_type,
             })),
             domain::PaymentMethodData::BankRedirect(ref bank_redirect_data) => {
-                Ok(Self::try_from((bank_redirect_data, None))?)
+                Ok(Self::try_from(bank_redirect_data)?)
             }
             domain::PaymentMethodData::Wallet(ref wallet_data) => {
                 Ok(Self::try_from((wallet_data, None))?)
@@ -4076,7 +4024,7 @@ pub struct Evidence {
     pub submit: bool,
 }
 
-// Mandates for bank redirects - ideal and sofort happens through sepa direct debit in stripe
+// Mandates for bank redirects - ideal happens through sepa direct debit in stripe
 fn mandatory_parameters_for_sepa_bank_debit_mandates(
     billing_details: &Option<StripeBillingAddress>,
     is_customer_initiated_mandate_payment: Option<bool>,

--- a/cypress-tests/cypress/e2e/configs/Payment/Stripe.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Stripe.js
@@ -874,43 +874,6 @@ export const connectorDetails = {
         },
       },
     },
-    Sofort: {
-      Request: {
-        payment_method: "bank_redirect",
-        payment_method_type: "sofort",
-        payment_method_data: {
-          bank_redirect: {
-            sofort: {},
-          },
-        },
-        billing: {
-          address: {
-            line1: "1467",
-            line2: "Harrison Street",
-            line3: "Harrison Street",
-            city: "San Fransico",
-            state: "California",
-            zip: "94122",
-            country: "DE",
-            first_name: "joseph",
-            last_name: "Doe",
-          },
-          phone: {
-            number: "9123456789",
-            country_code: "+91",
-          },
-        },
-      },
-      Response: {
-        status: 200,
-        body: {
-          status: "failed",
-          error_code: "payment_method_not_available",
-          error_message:
-            "Sofort is deprecated and can no longer be used for payment acceptance. Please refer to https://docs.stripe.com/payments/sofort",
-        },
-      },
-    },
     Eps: {
       Request: {
         payment_method: "bank_redirect",

--- a/cypress-tests/cypress/e2e/configs/Routing/Stripe.js
+++ b/cypress-tests/cypress/e2e/configs/Routing/Stripe.js
@@ -453,40 +453,6 @@ export const connectorDetails = {
         },
       },
     },
-    sofort: {
-      Request: {
-        payment_method: "bank_redirect",
-        payment_method_type: "sofort",
-        payment_method_data: {
-          bank_redirect: {
-            sofort: {},
-          },
-        },
-        billing: {
-          address: {
-            line1: "1467",
-            line2: "Harrison Street",
-            line3: "Harrison Street",
-            city: "San Fransico",
-            state: "California",
-            zip: "94122",
-            country: "DE",
-            first_name: "joseph",
-            last_name: "Doe",
-          },
-          phone: {
-            number: "9123456789",
-            country_code: "+91",
-          },
-        },
-      },
-      Response: {
-        status: 200,
-        body: {
-          status: "requires_customer_action",
-        },
-      },
-    },
     eps: {
       Request: {
         payment_method: "bank_redirect",

--- a/loadtest/config/development.toml
+++ b/loadtest/config/development.toml
@@ -454,7 +454,7 @@ wallet.twint.connector_list = "adyen"
 wallet.vipps.connector_list = "adyen"
 
 bank_redirect.ideal.connector_list = "stripe,adyen,globalpay,multisafepay,nexinets"
-bank_redirect.sofort.connector_list = "stripe,globalpay"
+bank_redirect.sofort.connector_list = "globalpay"
 bank_redirect.giropay.connector_list = "globalpay,multisafepay,nexinets"
 bank_redirect.bancontact_card.connector_list = "adyen,stripe"
 bank_redirect.trustly.connector_list = "adyen"


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Removed sofort bank redirect from Stripe, as Stripe has deprecated sofort.
Also added configs for Stripe Ach and Multibanco.


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Nothing to test with sofort.
Test currencies in Ach and Multibanco for stripe to test the configs.


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
