### PR TITLE
fix(connector): handle edge case where currency comes as empty upon payment decline

### DIFF
--- a/crates/hyperswitch_connectors/src/connectors/globalpay.rs
+++ b/crates/hyperswitch_connectors/src/connectors/globalpay.rs
@@ -751,6 +751,8 @@ impl ConnectorIntegration<Authorize, PaymentsAuthorizeData, PaymentsResponseData
         event_builder: Option<&mut ConnectorEvent>,
         res: Response,
     ) -> CustomResult<PaymentsAuthorizeRouterData, errors::ConnectorError> {
+        println!(">>>>> {:#?}", res.response.clone());
+
         let response: GlobalpayPaymentsResponse = res
             .response
             .parse_struct("Globalpay PaymentsResponse")

--- a/crates/hyperswitch_connectors/src/connectors/globalpay.rs
+++ b/crates/hyperswitch_connectors/src/connectors/globalpay.rs
@@ -751,8 +751,6 @@ impl ConnectorIntegration<Authorize, PaymentsAuthorizeData, PaymentsResponseData
         event_builder: Option<&mut ConnectorEvent>,
         res: Response,
     ) -> CustomResult<PaymentsAuthorizeRouterData, errors::ConnectorError> {
-        println!(">>>>> {:#?}", res.response.clone());
-
         let response: GlobalpayPaymentsResponse = res
             .response
             .parse_struct("Globalpay PaymentsResponse")

--- a/crates/hyperswitch_connectors/src/connectors/globalpay/response.rs
+++ b/crates/hyperswitch_connectors/src/connectors/globalpay/response.rs
@@ -4,6 +4,7 @@ use masking::Secret;
 use serde::{Deserialize, Serialize};
 
 use super::requests;
+use crate::utils::deserialize_optional_currency;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct GlobalpayPaymentsResponse {
@@ -31,6 +32,7 @@ pub struct GlobalpayPaymentsResponse {
     /// The country in ISO-3166-1(alpha-2 code) format.
     pub country: Option<String>,
     /// The currency of the amount in ISO-4217(alpha-3)
+    #[serde(deserialize_with = "deserialize_optional_currency")]
     pub currency: Option<Currency>,
     /// Information relating to a currency conversion.
     pub currency_conversion: Option<requests::CurrencyConversion>,

--- a/crates/hyperswitch_connectors/src/utils.rs
+++ b/crates/hyperswitch_connectors/src/utils.rs
@@ -6073,3 +6073,24 @@ pub fn normalize_string(value: String) -> Result<String, regex::Error> {
     let normalized = regex.replace_all(&lowercase_value, "").to_string();
     Ok(normalized)
 }
+
+/// Custom deserializer for Option<Currency> that treats empty strings as None
+pub fn deserialize_optional_currency<'de, D>(
+    deserializer: D,
+) -> Result<Option<enums::Currency>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let string_data: Option<String> = Option::deserialize(deserializer)?;
+    match string_data {
+        Some(ref value) if !value.is_empty() => {
+            // Attempt to parse the non-empty string into Currency enum
+            value
+                .clone()
+                .parse_enum("Currency")
+                .map(Some)
+                .map_err(|_| serde::de::Error::custom(format!("Invalid currency code: {}", value)))
+        }
+        _ => Ok(None), // Treat empty string or None as Ok(None)
+    }
+}


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->

This PR fixes an edge case with GlobalPay where, upon payment decline, we get a deserialization error and that is because `currency` field is not expected to be empty but rather a valid `Currency` enum. 

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
