### PR TITLE
ci(cypress): Validate Payment Method Data in Saved Card Payments Response

### DIFF
--- a/cypress-tests/cypress/e2e/configs/Payment/BankOfAmerica.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/BankOfAmerica.js
@@ -36,6 +36,56 @@ const multiUseMandateData = {
     },
   },
 };
+const payment_method_data_no3ds = {
+  card: {
+    last4: "4242",
+    card_type: "CREDIT",
+    card_network: "Visa",
+    card_issuer: "STRIPE PAYMENTS UK LIMITED",
+    card_issuing_country: "UNITEDKINGDOM",
+    card_isin: "424242",
+    card_extended_bin: null,
+    card_exp_month: "01",
+    card_exp_year: "50",
+    card_holder_name: "joseph Doe",
+    payment_checks: {
+      approval_code: "831000",
+      cavv: null,
+      consumer_authentication_response: null,
+      eci: null,
+      eci_raw: null,
+      avs_response: {
+        code: "Y",
+        codeRaw: "Y",
+      },
+      card_verification: null,
+    },
+    authentication_data: {
+      acs_transaction_id: null,
+      retrieval_reference_number: null,
+      system_trace_audit_number: null,
+    },
+  },
+  billing: null,
+};
+
+const payment_method_data_no3ds_off_session = {
+  card: {
+    last4: "4242",
+    card_type: "CREDIT",
+    card_network: "Visa",
+    card_issuer: "STRIPE PAYMENTS UK LIMITED",
+    card_issuing_country: "UNITEDKINGDOM",
+    card_isin: "424242",
+    card_extended_bin: null,
+    card_exp_month: "01",
+    card_exp_year: "50",
+    card_holder_name: "joseph Doe",
+    payment_checks: null,
+    authentication_data: null,
+  },
+  billing: null,
+};
 
 export const connectorDetails = {
   card_pm: {
@@ -430,6 +480,7 @@ export const connectorDetails = {
         status: 200,
         body: {
           status: "succeeded",
+          payment_method_data: payment_method_data_no3ds,
         },
       },
     },
@@ -447,6 +498,7 @@ export const connectorDetails = {
         status: 200,
         body: {
           status: "succeeded",
+          payment_method_data: payment_method_data_no3ds,
         },
       },
     },
@@ -485,6 +537,7 @@ export const connectorDetails = {
         status: 200,
         body: {
           status: "succeeded",
+          payment_method_data: payment_method_data_no3ds_off_session,
         },
       },
     },
@@ -496,6 +549,7 @@ export const connectorDetails = {
         status: 200,
         body: {
           status: "requires_capture",
+          payment_method_data: payment_method_data_no3ds_off_session,
         },
       },
     },
@@ -513,6 +567,7 @@ export const connectorDetails = {
         status: 200,
         body: {
           status: "requires_capture",
+          payment_method_data: payment_method_data_no3ds,
         },
       },
     },

--- a/cypress-tests/cypress/e2e/configs/Payment/Cybersource.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Cybersource.js
@@ -1,6 +1,6 @@
 import {
-  customerAcceptance,
   connectorDetails as commonConnectorDetails,
+  customerAcceptance,
 } from "./Commons";
 import { getCustomExchange } from "./Modifiers";
 
@@ -72,6 +72,24 @@ const payment_method_data_3ds = {
     card_issuer: "INTL HDQTRS-CENTER OWNED",
     card_issuing_country: "UNITEDSTATES",
     card_isin: "400000",
+    card_extended_bin: null,
+    card_exp_month: "01",
+    card_exp_year: "50",
+    card_holder_name: "joseph Doe",
+    payment_checks: null,
+    authentication_data: null,
+  },
+  billing: null,
+};
+
+const payment_method_data_no3ds_off_session = {
+  card: {
+    last4: "4242",
+    card_type: "CREDIT",
+    card_network: "Visa",
+    card_issuer: "STRIPE PAYMENTS UK LIMITED",
+    card_issuing_country: "UNITEDKINGDOM",
+    card_isin: "424242",
     card_extended_bin: null,
     card_exp_month: "01",
     card_exp_year: "50",
@@ -708,6 +726,7 @@ export const connectorDetails = {
         status: 200,
         body: {
           status: "succeeded",
+          payment_method_data: payment_method_data_no3ds,
         },
       },
     },
@@ -730,6 +749,7 @@ export const connectorDetails = {
         status: 200,
         body: {
           status: "succeeded",
+          payment_method_data: payment_method_data_no3ds,
         },
       },
     },
@@ -752,6 +772,7 @@ export const connectorDetails = {
         status: 200,
         body: {
           status: "requires_customer_action",
+          payment_method_data: payment_method_data_3ds,
         },
       },
     },
@@ -775,6 +796,7 @@ export const connectorDetails = {
         status: 200,
         body: {
           status: "requires_capture",
+          payment_method_data: payment_method_data_no3ds,
         },
       },
     },
@@ -791,6 +813,7 @@ export const connectorDetails = {
         status: 200,
         body: {
           status: "succeeded",
+          payment_method_data: payment_method_data_no3ds_off_session,
         },
       },
     },
@@ -807,6 +830,7 @@ export const connectorDetails = {
         status: 200,
         body: {
           status: "requires_capture",
+          payment_method_data: payment_method_data_no3ds_off_session,
         },
       },
     },
@@ -829,6 +853,7 @@ export const connectorDetails = {
         status: 200,
         body: {
           status: "requires_capture",
+          payment_method_data: payment_method_data_no3ds,
         },
       },
     },

--- a/cypress-tests/cypress/e2e/configs/Payment/Stripe.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Stripe.js
@@ -69,6 +69,7 @@ const payment_method_data_3ds = {
 
 const payment_method_data_no3ds = {
   card: {
+    authentication_data: null,
     last4: "0005",
     card_type: "CREDIT",
     card_network: "AmericanExpress",
@@ -84,11 +85,27 @@ const payment_method_data_no3ds = {
       address_line1_check: "pass",
       address_postal_code_check: "pass",
     },
-    authentication_data: null,
   },
   billing: null,
 };
 
+const payment_method_data_no3ds_off_session = {
+  card: {
+    authentication_data: null,
+    last4: "0005",
+    card_type: "CREDIT",
+    card_network: "AmericanExpress",
+    card_issuer: "AmericanExpress",
+    card_issuing_country: "INDIA",
+    card_isin: "378282",
+    card_extended_bin: null,
+    card_exp_month: "10",
+    card_exp_year: "50",
+    card_holder_name: "morino",
+    payment_checks: null,
+  },
+  billing: null,
+};
 const requiredFields = {
   payment_methods: [
     {
@@ -597,6 +614,7 @@ export const connectorDetails = {
         status: 200,
         body: {
           status: "succeeded",
+          payment_method_data: payment_method_data_no3ds,
         },
       },
     },
@@ -614,6 +632,7 @@ export const connectorDetails = {
         status: 200,
         body: {
           status: "requires_capture",
+          payment_method_data: payment_method_data_no3ds,
         },
       },
     },
@@ -631,6 +650,7 @@ export const connectorDetails = {
         status: 200,
         body: {
           status: "succeeded",
+          payment_method_data: payment_method_data_no3ds,
         },
       },
     },
@@ -654,6 +674,7 @@ export const connectorDetails = {
         status: 200,
         body: {
           status: "succeeded",
+          payment_method_data: payment_method_data_no3ds,
         },
       },
     },
@@ -693,6 +714,7 @@ export const connectorDetails = {
         status: 200,
         body: {
           status: "requires_capture",
+          payment_method_data: payment_method_data_no3ds,
         },
       },
     },
@@ -710,6 +732,7 @@ export const connectorDetails = {
         status: 200,
         body: {
           status: "succeeded",
+          payment_method_data: payment_method_data_no3ds_off_session,
         },
       },
     },
@@ -721,6 +744,7 @@ export const connectorDetails = {
         status: 200,
         body: {
           status: "requires_capture",
+          payment_method_data: payment_method_data_no3ds_off_session,
         },
       },
     },
@@ -733,6 +757,7 @@ export const connectorDetails = {
         status: 200,
         body: {
           status: "succeeded",
+          payment_method_data: payment_method_data_no3ds_off_session,
         },
       },
     },
@@ -750,6 +775,7 @@ export const connectorDetails = {
         status: 200,
         body: {
           status: "requires_capture",
+          payment_method_data: payment_method_data_no3ds,
         },
       },
     },
@@ -768,6 +794,7 @@ export const connectorDetails = {
         status: 200,
         body: {
           status: "requires_customer_action",
+          payment_method_data: payment_method_data_3ds,
         },
       },
     },
@@ -785,6 +812,7 @@ export const connectorDetails = {
         status: 200,
         body: {
           status: "requires_customer_action",
+          payment_method_data: payment_method_data_3ds,
         },
       },
     },

--- a/cypress-tests/cypress/e2e/spec/Payment/00014-SaveCardFlow.cy.js
+++ b/cypress-tests/cypress/e2e/spec/Payment/00014-SaveCardFlow.cy.js
@@ -1,6 +1,6 @@
 import * as fixtures from "../../../fixtures/imports";
-import State from "../../../utils/State";
 import { generateRandomName } from "../../../utils/RequestBodyUtils";
+import State from "../../../utils/State";
 import getConnectorDetails, * as utils from "../../configs/Payment/Utils";
 
 let globalState;
@@ -719,7 +719,24 @@ describe("Card - SaveCard payment flow test", () => {
               },
             },
           },
+          Response: {
+            // Copy all top-level properties from the original 'data'.
+            ...data.Response,
+            body: {
+              payment_method_data: {
+                ...data.Response.body.payment_method_data,
+                card: {
+                  ...data.Response.body.payment_method_data.card,
+                  // Override the 'card_holder_name' field in the response.
+                  card_exp_year: "55", // Update expiry year.
+                  card_holder_name: card_holder_name, // Update card holder name.
+                },
+              },
+            },
+          },
         };
+
+        console.log(newData);
 
         cy.createConfirmPaymentTest(
           fixtures.createConfirmPaymentBody,

--- a/cypress-tests/cypress/e2e/spec/Payment/00023-PaymentMethods.cy.js
+++ b/cypress-tests/cypress/e2e/spec/Payment/00023-PaymentMethods.cy.js
@@ -199,7 +199,7 @@ describe("Payment Methods Tests", () => {
       it("confirm-save-card-payment-call-test", () => {
         const data = getConnectorDetails(globalState.get("connectorId"))[
           "card_pm"
-        ]["SaveCardUseNo3DSAutoCapture"];
+        ]["SaveCardUse3DSAutoCaptureOffSession"];
 
         const newData = {
           ...data,

--- a/cypress-tests/cypress/support/commands.js
+++ b/cypress-tests/cypress/support/commands.js
@@ -2090,26 +2090,27 @@ Cypress.Commands.add(
     } = data || {};
 
     const configInfo = execConfig(validateConfig(configs));
-    const merchant_connector_id = globalState.get(
+    const merchantConnectorId = globalState.get(
       `${configInfo.merchantConnectorPrefix}Id`
     );
     const paymentIntentID = globalState.get("paymentID");
-    const profile_id = globalState.get(`${configInfo.profilePrefix}Id`);
+    const profileId = globalState.get(`${configInfo.profilePrefix}Id`);
+    const url = `${globalState.get("baseUrl")}/payments/${paymentIntentID}/confirm`;
 
     if (reqData.setup_future_usage === "on_session") {
       saveCardConfirmBody.card_cvc = reqData.payment_method_data.card.card_cvc;
     }
     saveCardConfirmBody.client_secret = globalState.get("clientSecret");
     saveCardConfirmBody.payment_token = globalState.get("paymentToken");
-    saveCardConfirmBody.profile_id = profile_id;
+    saveCardConfirmBody.profile_id = profileId;
 
-    if (reqData.billing === null) {
-      saveCardConfirmBody.billing = null;
+    for (const key in reqData) {
+      saveCardConfirmBody[key] = reqData[key];
     }
 
     cy.request({
       method: "POST",
-      url: `${globalState.get("baseUrl")}/payments/${paymentIntentID}/confirm`,
+      url: url,
       headers: {
         "Content-Type": "application/json",
         "api-key": globalState.get("publishableKey"),
@@ -2123,8 +2124,6 @@ Cypress.Commands.add(
         expect(response.headers["content-type"]).to.include("application/json");
         if (response.status === 200) {
           globalState.set("paymentID", paymentIntentID);
-
-          globalState.set("paymentID", paymentIntentID);
           globalState.set("connectorId", response.body.connector);
           expect(response.body.connector, "connector").to.equal(
             globalState.get("connectorId")
@@ -2134,40 +2133,48 @@ Cypress.Commands.add(
           );
           expect(response.body.payment_method_data, "payment_method_data").to
             .not.be.empty;
-          expect(merchant_connector_id, "connector_id").to.equal(
+          expect(merchantConnectorId, "connector_id").to.equal(
             response.body.merchant_connector_id
           );
           expect(response.body.customer, "customer").to.not.be.empty;
           if (reqData.billing !== null) {
             expect(response.body.billing, "billing_address").to.not.be.empty;
           }
-          expect(response.body.profile_id, "profile_id").to.not.be.null;
+          expect(response.body.profile_id, "profile_id").to.equal(profileId).and
+            .to.not.be.null;
           expect(response.body.payment_token, "payment_token").to.not.be.null;
 
           validateErrorMessage(response, resData);
 
           if (response.body.capture_method === "automatic") {
             if (response.body.authentication_type === "three_ds") {
-              expect(response.body)
-                .to.have.property("next_action")
-                .to.have.property("redirect_to_url");
-              globalState.set(
-                "nextActionUrl",
-                response.body.next_action.redirect_to_url
-              );
+              for (const key in resData.body) {
+                expect(resData.body[key], [key]).to.deep.equal(
+                  response.body[key]
+                );
+                expect(response.body)
+                  .to.have.property("next_action")
+                  .to.have.property("redirect_to_url");
+                globalState.set(
+                  "nextActionUrl",
+                  response.body.next_action.redirect_to_url
+                );
 
-              if (
-                response.body?.payment_method_id &&
-                response.body.payment_method_id !== null
-              ) {
-                expect(
-                  response.body.payment_method_status,
-                  "payment_method_status"
-                ).to.equal("active");
+                if (
+                  response.body?.payment_method_id &&
+                  response.body.payment_method_id !== null
+                ) {
+                  expect(
+                    response.body.payment_method_status,
+                    "payment_method_status"
+                  ).to.equal("active");
+                }
               }
             } else if (response.body.authentication_type === "no_three_ds") {
               for (const key in resData.body) {
-                expect(resData.body[key]).to.equal(response.body[key]);
+                expect(resData.body[key], [key]).to.deep.equal(
+                  response.body[key]
+                );
               }
               expect(response.body.customer_id).to.equal(
                 globalState.get("customerId")
@@ -2205,13 +2212,20 @@ Cypress.Commands.add(
               expect(response.body)
                 .to.have.property("next_action")
                 .to.have.property("redirect_to_url");
+              for (const key in resData.body) {
+                expect(resData.body[key], [key]).to.deep.equal(
+                  response.body[key]
+                );
+              }
               globalState.set(
                 "nextActionUrl",
                 response.body.next_action.redirect_to_url
               );
             } else if (response.body.authentication_type === "no_three_ds") {
               for (const key in resData.body) {
-                expect(resData.body[key]).to.equal(response.body[key]);
+                expect(resData.body[key], [key]).to.deep.equal(
+                  response.body[key]
+                );
               }
               expect(response.body.customer_id).to.equal(
                 globalState.get("customerId")
@@ -2599,17 +2613,11 @@ Cypress.Commands.add(
               );
               cy.log(nextActionUrl);
               for (const key in resData.body) {
-                expect(resData.body[key]).to.equal(response.body[key]);
+                expect(resData.body[key]).to.deep.equal(response.body[key]);
               }
             } else if (response.body.authentication_type === "no_three_ds") {
               for (const key in resData.body) {
-                expect(resData.body[key]).to.equal(response.body[key]);
-                if (setupFutureUsage === "off_session") {
-                  expect(
-                    response.body.connector_mandate_id,
-                    "connector_mandate_id"
-                  ).to.not.be.null;
-                }
+                expect(resData.body[key]).to.deep.equal(response.body[key]);
               }
             } else {
               throw new Error(
@@ -2628,17 +2636,11 @@ Cypress.Commands.add(
               );
               cy.log(nextActionUrl);
               for (const key in resData.body) {
-                expect(resData.body[key]).to.equal(response.body[key]);
+                expect(resData.body[key]).to.deep.equal(response.body[key]);
               }
             } else if (response.body.authentication_type === "no_three_ds") {
               for (const key in resData.body) {
-                expect(resData.body[key]).to.equal(response.body[key]);
-                if (setupFutureUsage === "off_session") {
-                  expect(
-                    response.body.connector_mandate_id,
-                    "connector_mandate_id"
-                  ).to.not.be.null;
-                }
+                expect(resData.body[key]).to.deep.equal(response.body[key]);
               }
             } else {
               throw new Error(


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [x] CI/CD

## Description
This PR adds verification for the payment_method_data object in the response of saved card payments. It ensures that the created Payment Method Data (PMD) matches the saved card's payment_method_data, and that all fields are correctly populated.

## Motivation and Context
To ensure that all relevant fields are accurately populated in the saved card payment response. This enhances field-level validation and overall data integrity in our tests.


## How did you test it?
All scenarios have been tested locally

<img width="538" alt="Screenshot 2025-04-15 at 4 34 52 PM" src="https://github.com/user-attachments/assets/709b1895-0718-4637-b299-7e054e290979" />
<img width="564" alt="Screenshot 2025-04-15 at 5 10 34 PM" src="https://github.com/user-attachments/assets/8b06ddeb-3d1b-49d0-bcbe-d34a81bd8f38" />
<img width="534" alt="Screenshot 2025-04-15 at 5 17 31 PM" src="https://github.com/user-attachments/assets/b2e44dc5-b0ce-462b-a00a-3269fca05e2d" />
<img width="539" alt="Screenshot 2025-04-15 at 5 25 59 PM" src="https://github.com/user-attachments/assets/75c6be4f-e61f-4897-9ec5-675c87bd8123" />







## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
