### PR TITLE
fix(connector): [Cybersource] send type selection indicator for co-batch cards

### DIFF
--- a/crates/hyperswitch_connectors/src/connectors/cybersource/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/cybersource/transformers.rs
@@ -173,6 +173,18 @@ impl TryFrom<&SetupMandateRouterData> for CybersourceZeroMandateRequest {
                     Some(card_network) => Some(card_network.to_string()),
                     None => ccard.get_card_issuer().ok().map(String::from),
                 };
+                let is_cobadged_card = ccard
+                    .card_number
+                    .clone()
+                    .is_cobadged_card()
+                    .change_context(errors::ConnectorError::RequestEncodingFailed)
+                    .attach_printable("error while checking is_cobadged_card")?;
+
+                let type_selection_indicator = if is_cobadged_card {
+                    Some("1".to_owned())
+                } else {
+                    None
+                };
                 (
                     PaymentInformation::Cards(Box::new(CardPaymentInformation {
                         card: Card {
@@ -181,6 +193,7 @@ impl TryFrom<&SetupMandateRouterData> for CybersourceZeroMandateRequest {
                             expiration_year: ccard.card_exp_year,
                             security_code: Some(ccard.card_cvc),
                             card_type,
+                            type_selection_indicator,
                         },
                     })),
                     None,
@@ -562,6 +575,7 @@ pub struct Card {
     security_code: Option<Secret<String>>,
     #[serde(rename = "type")]
     card_type: Option<String>,
+    type_selection_indicator: Option<String>,
 }
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -1258,6 +1272,19 @@ impl
             Some(ccard.card_cvc)
         };
 
+        let is_cobadged_card = ccard
+            .card_number
+            .clone()
+            .is_cobadged_card()
+            .change_context(errors::ConnectorError::RequestEncodingFailed)
+            .attach_printable("error while checking is_cobadged_card")?;
+
+        let type_selection_indicator = if is_cobadged_card {
+            Some("1".to_owned())
+        } else {
+            None
+        };
+
         let payment_information = PaymentInformation::Cards(Box::new(CardPaymentInformation {
             card: Card {
                 number: ccard.card_number,
@@ -1265,6 +1292,7 @@ impl
                 expiration_year: ccard.card_exp_year,
                 security_code,
                 card_type: card_type.clone(),
+                type_selection_indicator,
             },
         }));
 
@@ -1349,6 +1377,18 @@ impl
             Ok(issuer) => Some(String::from(issuer)),
             Err(_) => None,
         };
+        let is_cobadged_card = ccard
+            .card_number
+            .clone()
+            .is_cobadged_card()
+            .change_context(errors::ConnectorError::RequestEncodingFailed)
+            .attach_printable("error while checking is_cobadged_card")?;
+
+        let type_selection_indicator = if is_cobadged_card {
+            Some("1".to_owned())
+        } else {
+            None
+        };
 
         let payment_information = PaymentInformation::Cards(Box::new(CardPaymentInformation {
             card: Card {
@@ -1357,6 +1397,7 @@ impl
                 expiration_year: ccard.card_exp_year,
                 security_code: None,
                 card_type: card_type.clone(),
+                type_selection_indicator,
             },
         }));
 
@@ -1613,6 +1654,19 @@ impl
             None => ccard.get_card_issuer().ok().map(String::from),
         };
 
+        let is_cobadged_card = ccard
+            .card_number
+            .clone()
+            .is_cobadged_card()
+            .change_context(errors::ConnectorError::RequestEncodingFailed)
+            .attach_printable("error while checking is_cobadged_card")?;
+
+        let type_selection_indicator = if is_cobadged_card {
+            Some("1".to_owned())
+        } else {
+            None
+        };
+
         let payment_information = PaymentInformation::Cards(Box::new(CardPaymentInformation {
             card: Card {
                 number: ccard.card_number,
@@ -1620,6 +1674,7 @@ impl
                 expiration_year: ccard.card_exp_year,
                 security_code: Some(ccard.card_cvc),
                 card_type,
+                type_selection_indicator,
             },
         }));
         let client_reference_information = ClientReferenceInformation::from(item);
@@ -2255,6 +2310,19 @@ impl TryFrom<&CybersourceRouterData<&PaymentsAuthorizeRouterData>> for Cybersour
                     Some(card_network) => Some(card_network.to_string()),
                     None => ccard.get_card_issuer().ok().map(String::from),
                 };
+                let is_cobadged_card = ccard
+                    .card_number
+                    .clone()
+                    .is_cobadged_card()
+                    .change_context(errors::ConnectorError::RequestEncodingFailed)
+                    .attach_printable("error while checking is_cobadged_card")?;
+
+                let type_selection_indicator = if is_cobadged_card {
+                    Some("1".to_owned())
+                } else {
+                    None
+                };
+
                 let payment_information =
                     PaymentInformation::Cards(Box::new(CardPaymentInformation {
                         card: Card {
@@ -2263,6 +2331,7 @@ impl TryFrom<&CybersourceRouterData<&PaymentsAuthorizeRouterData>> for Cybersour
                             expiration_year: ccard.card_exp_year,
                             security_code: Some(ccard.card_cvc),
                             card_type,
+                            type_selection_indicator,
                         },
                     }));
                 let client_reference_information = ClientReferenceInformation::from(item);
@@ -2944,6 +3013,18 @@ impl TryFrom<&CybersourceRouterData<&PaymentsPreProcessingRouterData>>
                     Some(card_network) => Some(card_network.to_string()),
                     None => ccard.get_card_issuer().ok().map(String::from),
                 };
+                let is_cobadged_card = ccard
+                    .card_number
+                    .clone()
+                    .is_cobadged_card()
+                    .change_context(errors::ConnectorError::RequestEncodingFailed)
+                    .attach_printable("error while checking is_cobadged_card")?;
+
+                let type_selection_indicator = if is_cobadged_card {
+                    Some("1".to_owned())
+                } else {
+                    None
+                };
                 Ok(PaymentInformation::Cards(Box::new(
                     CardPaymentInformation {
                         card: Card {
@@ -2952,6 +3033,7 @@ impl TryFrom<&CybersourceRouterData<&PaymentsPreProcessingRouterData>>
                             expiration_year: ccard.card_exp_year,
                             security_code: Some(ccard.card_cvc),
                             card_type,
+                            type_selection_indicator,
                         },
                     },
                 )))
@@ -3978,6 +4060,7 @@ impl TryFrom<PayoutMethodData> for PaymentInformation {
                     expiration_year: card_details.expiry_year,
                     security_code: None,
                     card_type,
+                    type_selection_indicator: None,
                 };
                 Ok(Self::Cards(Box::new(CardPaymentInformation { card })))
             }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Authentication with Netcetera was successful, but authorization with Cybersource failed with the below error:
`Declined - The request is missing one or more fields, detailed_error_information: paymentInformation.card.typeSelectionIndicator : MISSING_FIELD`

Need to send card.typeSelectionIndicator as 1, for all co-badged cards txns with Cybersource (authorization).

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
This can be tested with below payments create call:
```
curl --location 'http://localhost:8080/payments' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: dev_mXJTgJCTejZ008jnb3EAXyinnyiMyLmFt2PMVRkc8W6vYXQX2g5VXPNoH5Mr6Kae' \
--data-raw '{
    "amount": 499,
    "currency": "USD",
    "confirm": true,
    "capture_method": "automatic",
    "customer_id": "test_rec7",
    "email": "guest@example.com",
    
    "customer_acceptance": {
        "acceptance_type": "online"
    },
    "payment_method": "card",
    "payment_method_type": "credit",
    "payment_method_data": {
        "card": {
            "card_number": "5512459816707531",
            "card_exp_month": "03",
            "card_exp_year": "2030",
            "card_holder_name": "Sakil Mostak",
            "card_cvc": "737"
        }
    },
    "billing": {
        "address": {
            "city": "test",
            "country": "US",
            "line1": "here is some \n there is some \n none is some? \n ",
            "line2": "there",
            "line3": "anywhere",
            "zip": "560095",
            "state": "CA",
            "first_name": "Sakil",
            "last_name": "Mostak"
        },
        "phone": {
            "number": "1234567890",
            "country_code": "+1"
        },
        "email": "guest@example.com"
    },
    "browser_info": {
        "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Safari/537.36",
        "accept_header": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8",
        "language": "nl-NL",
        "color_depth": 24,
        "screen_height": 723,
        "screen_width": 1536,
        "time_zone": 0,
        "java_enabled": true,
        "java_script_enabled": true,
        "ip_address": "127.0.0.1"
    },
    "authentication_type": "three_ds"
}'
```
Response:
```
{
    "payment_id": "pay_d1USlFlsD0nGFIrt5V5m",
    "merchant_id": "merchant_1744872465",
    "status": "succeeded",
    "amount": 499,
    "net_amount": 499,
    "shipping_cost": null,
    "amount_capturable": 0,
    "amount_received": 499,
    "connector": "cybersource",
    "client_secret": "pay_d1USlFlsD0nGFIrt5V5m_secret_FTgdv5fx3nuvVctWmAWI",
    "created": "2025-04-17T11:37:35.337Z",
    "currency": "EUR",
    "customer_id": "test_rec7",
    "customer": {
        "id": "test_rec7",
        "name": null,
        "email": "guest@example.com",
        "phone": null,
        "phone_country_code": null
    },
    "description": null,
    "refunds": null,
    "disputes": null,
    "mandate_id": null,
    "mandate_data": null,
    "setup_future_usage": null,
    "off_session": null,
    "capture_on": null,
    "capture_method": "automatic",
    "payment_method": "card",
    "payment_method_data": {
        "card": {
            "last4": "0021",
            "card_type": null,
            "card_network": null,
            "card_issuer": null,
            "card_issuing_country": null,
            "card_isin": "401006",
            "card_extended_bin": null,
            "card_exp_month": "03",
            "card_exp_year": "2030",
            "card_holder_name": "joseph Doe",
            "payment_checks": {
                "avs_response": {
                    "code": "1",
                    "codeRaw": null
                },
                "card_verification": null
            },
            "authentication_data": null
        },
        "billing": null
    },
    "payment_token": "token_MWKCZLuTE3damNeB9hcU",
    "shipping": null,
    "billing": {
        "address": {
            "city": "test",
            "country": "NL",
            "line1": "here is some \n there is some \n none is some? \n ",
            "line2": "there",
            "line3": "anywhere",
            "zip": "560095",
            "state": "CA",
            "first_name": "Sakil",
            "last_name": "Mostak"
        },
        "phone": {
            "number": "1234567890",
            "country_code": "+1"
        },
        "email": "guest@example.com"
    },
    "order_details": null,
    "email": "guest@example.com",
    "name": null,
    "phone": null,
    "return_url": "https://google.com/",
    "authentication_type": "no_three_ds",
    "statement_descriptor_name": null,
    "statement_descriptor_suffix": null,
    "next_action": null,
    "cancellation_reason": null,
    "error_code": null,
    "error_message": null,
    "unified_code": null,
    "unified_message": null,
    "payment_experience": null,
    "payment_method_type": "credit",
    "connector_label": null,
    "business_country": null,
    "business_label": "default",
    "business_sub_label": null,
    "allowed_payment_method_types": null,
    "ephemeral_key": {
        "customer_id": "test_rec7",
        "created_at": 1744889855,
        "expires": 1744893455,
        "secret": "epk_b60cc9768ad548a18c657655eb0df03b"
    },
    "manual_retry_allowed": false,
    "connector_transaction_id": "7448898561876807704807",
    "frm_message": null,
    "metadata": null,
    "connector_metadata": null,
    "feature_metadata": null,
    "reference_id": "pay_d1USlFlsD0nGFIrt5V5m_1",
    "payment_link": null,
    "profile_id": "pro_l9RjpBHrXPJh0rd22HR3",
    "surcharge_details": null,
    "attempt_count": 1,
    "merchant_decision": null,
    "merchant_connector_id": "mca_24seS16YfPySDk29q02E",
    "incremental_authorization_allowed": false,
    "authorization_count": null,
    "incremental_authorizations": null,
    "external_authentication_details": null,
    "external_3ds_authentication_attempted": false,
    "expires_on": "2025-04-17T11:52:35.337Z",
    "fingerprint": null,
    "browser_info": {
        "language": "nl-NL",
        "time_zone": 0,
        "ip_address": "127.0.0.1",
        "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Safari/537.36",
        "color_depth": 24,
        "java_enabled": true,
        "screen_width": 1536,
        "accept_header": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8",
        "screen_height": 723,
        "java_script_enabled": true
    },
    "payment_method_id": null,
    "payment_method_status": null,
    "updated": "2025-04-17T11:37:36.608Z",
    "split_payments": null,
    "frm_metadata": null,
    "extended_authorization_applied": null,
    "capture_before": null,
    "merchant_order_reference_id": null,
    "order_tax_amount": null,
    "connector_mandate_id": null,
    "card_discovery": "manual",
    "force_3ds_challenge": false,
    "force_3ds_challenge_trigger": false,
    "issuer_error_code": null,
    "issuer_error_message": null
}
```

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
