### PR TITLE
refactor(cypress): do not update `card_expiry` while updating card info

### DIFF
--- a/cypress-tests/cypress/e2e/spec/Payment/00014-SaveCardFlow.cy.js
+++ b/cypress-tests/cypress/e2e/spec/Payment/00014-SaveCardFlow.cy.js
@@ -714,7 +714,6 @@ describe("Card - SaveCard payment flow test", () => {
                 // Copy all properties from the original card details.
                 ...data.Request.payment_method_data.card,
                 // Set the desired modifications for this specific test case.
-                card_exp_year: "55", // Update expiry year.
                 card_holder_name: card_holder_name, // Update card holder name.
               },
             },


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->

the reason behind this pr is that there are a few connectors like adyen that expects the user to pass specific card expiry year and having it hard coded like we had until now results in unintended issues resulting the tests to fail.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->

updating card expiry resulted in unintended after effects for specific connectors like adyen where it expects the user to pass a specific card expiry year.
we cannot hard code connector names in spec files. neither we can go ahead and pull in another set of connector configs for this.

so, it is more viable to remove the entire field from getting update since updating one field should be more than enough.

closes https://github.com/juspay/hyperswitch/issues/7833

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

ran test against adyen since it was the one threw this error. not sure about other connectors but yeah, this change should fix them as well:

<img width="524" alt="image" src="https://github.com/user-attachments/assets/3a9cf73f-0e60-4e0a-9e29-a2af8a63db3f" />

<img width="952" alt="image" src="https://github.com/user-attachments/assets/283eaf66-9233-4a20-83e1-e4eb808110fb" />

(failure is from ideal bank redirect redirection)


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `npm run format`
- [x] I addressed lints thrown by `npm run lint -- --fix`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
