### PR TITLE
fix(connector): [Cybersource] send type selection indicator for co-batch cards

### DIFF
--- a/crates/hyperswitch_connectors/src/connectors/cybersource/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/cybersource/transformers.rs
@@ -173,6 +173,18 @@ impl TryFrom<&SetupMandateRouterData> for CybersourceZeroMandateRequest {
                     Some(card_network) => Some(card_network.to_string()),
                     None => ccard.get_card_issuer().ok().map(String::from),
                 };
+                let is_cobadged_card = ccard
+                    .card_number
+                    .clone()
+                    .is_cobadged_card()
+                    .change_context(errors::ConnectorError::RequestEncodingFailed)
+                    .attach_printable("error while checking is_cobadged_card")?;
+
+                let type_selection_indicator = if is_cobadged_card {
+                    Some("1".to_owned())
+                } else {
+                    None
+                };
                 (
                     PaymentInformation::Cards(Box::new(CardPaymentInformation {
                         card: Card {
@@ -181,6 +193,7 @@ impl TryFrom<&SetupMandateRouterData> for CybersourceZeroMandateRequest {
                             expiration_year: ccard.card_exp_year,
                             security_code: Some(ccard.card_cvc),
                             card_type,
+                            type_selection_indicator,
                         },
                     })),
                     None,
@@ -562,6 +575,7 @@ pub struct Card {
     security_code: Option<Secret<String>>,
     #[serde(rename = "type")]
     card_type: Option<String>,
+    type_selection_indicator: Option<String>,
 }
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -1258,6 +1272,19 @@ impl
             Some(ccard.card_cvc)
         };
 
+        let is_cobadged_card = ccard
+            .card_number
+            .clone()
+            .is_cobadged_card()
+            .change_context(errors::ConnectorError::RequestEncodingFailed)
+            .attach_printable("error while checking is_cobadged_card")?;
+
+        let type_selection_indicator = if is_cobadged_card {
+            Some("1".to_owned())
+        } else {
+            None
+        };
+
         let payment_information = PaymentInformation::Cards(Box::new(CardPaymentInformation {
             card: Card {
                 number: ccard.card_number,
@@ -1265,6 +1292,7 @@ impl
                 expiration_year: ccard.card_exp_year,
                 security_code,
                 card_type: card_type.clone(),
+                type_selection_indicator,
             },
         }));
 
@@ -1349,6 +1377,18 @@ impl
             Ok(issuer) => Some(String::from(issuer)),
             Err(_) => None,
         };
+        let is_cobadged_card = ccard
+            .card_number
+            .clone()
+            .is_cobadged_card()
+            .change_context(errors::ConnectorError::RequestEncodingFailed)
+            .attach_printable("error while checking is_cobadged_card")?;
+
+        let type_selection_indicator = if is_cobadged_card {
+            Some("1".to_owned())
+        } else {
+            None
+        };
 
         let payment_information = PaymentInformation::Cards(Box::new(CardPaymentInformation {
             card: Card {
@@ -1357,6 +1397,7 @@ impl
                 expiration_year: ccard.card_exp_year,
                 security_code: None,
                 card_type: card_type.clone(),
+                type_selection_indicator,
             },
         }));
 
@@ -1613,6 +1654,19 @@ impl
             None => ccard.get_card_issuer().ok().map(String::from),
         };
 
+        let is_cobadged_card = ccard
+            .card_number
+            .clone()
+            .is_cobadged_card()
+            .change_context(errors::ConnectorError::RequestEncodingFailed)
+            .attach_printable("error while checking is_cobadged_card")?;
+
+        let type_selection_indicator = if is_cobadged_card {
+            Some("1".to_owned())
+        } else {
+            None
+        };
+
         let payment_information = PaymentInformation::Cards(Box::new(CardPaymentInformation {
             card: Card {
                 number: ccard.card_number,
@@ -1620,6 +1674,7 @@ impl
                 expiration_year: ccard.card_exp_year,
                 security_code: Some(ccard.card_cvc),
                 card_type,
+                type_selection_indicator,
             },
         }));
         let client_reference_information = ClientReferenceInformation::from(item);
@@ -2255,6 +2310,19 @@ impl TryFrom<&CybersourceRouterData<&PaymentsAuthorizeRouterData>> for Cybersour
                     Some(card_network) => Some(card_network.to_string()),
                     None => ccard.get_card_issuer().ok().map(String::from),
                 };
+                let is_cobadged_card = ccard
+                    .card_number
+                    .clone()
+                    .is_cobadged_card()
+                    .change_context(errors::ConnectorError::RequestEncodingFailed)
+                    .attach_printable("error while checking is_cobadged_card")?;
+
+                let type_selection_indicator = if is_cobadged_card {
+                    Some("1".to_owned())
+                } else {
+                    None
+                };
+
                 let payment_information =
                     PaymentInformation::Cards(Box::new(CardPaymentInformation {
                         card: Card {
@@ -2263,6 +2331,7 @@ impl TryFrom<&CybersourceRouterData<&PaymentsAuthorizeRouterData>> for Cybersour
                             expiration_year: ccard.card_exp_year,
                             security_code: Some(ccard.card_cvc),
                             card_type,
+                            type_selection_indicator,
                         },
                     }));
                 let client_reference_information = ClientReferenceInformation::from(item);
@@ -2934,6 +3003,18 @@ impl TryFrom<&CybersourceRouterData<&PaymentsPreProcessingRouterData>>
                     Some(card_network) => Some(card_network.to_string()),
                     None => ccard.get_card_issuer().ok().map(String::from),
                 };
+                let is_cobadged_card = ccard
+                    .card_number
+                    .clone()
+                    .is_cobadged_card()
+                    .change_context(errors::ConnectorError::RequestEncodingFailed)
+                    .attach_printable("error while checking is_cobadged_card")?;
+
+                let type_selection_indicator = if is_cobadged_card {
+                    Some("1".to_owned())
+                } else {
+                    None
+                };
                 Ok(PaymentInformation::Cards(Box::new(
                     CardPaymentInformation {
                         card: Card {
@@ -2942,6 +3023,7 @@ impl TryFrom<&CybersourceRouterData<&PaymentsPreProcessingRouterData>>
                             expiration_year: ccard.card_exp_year,
                             security_code: Some(ccard.card_cvc),
                             card_type,
+                            type_selection_indicator,
                         },
                     },
                 )))
@@ -3962,6 +4044,7 @@ impl TryFrom<PayoutMethodData> for PaymentInformation {
                     expiration_year: card_details.expiry_year,
                     security_code: None,
                     card_type,
+                    type_selection_indicator: None,
                 };
                 Ok(Self::Cards(Box::new(CardPaymentInformation { card })))
             }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Hotfix for https://github.com/juspay/hyperswitch/pull/7828

Authentication with Netcetera was successful, but authorization with Cybersource failed with the below error:
Declined - The request is missing one or more fields, detailed_error_information: paymentInformation.card.typeSelectionIndicator : MISSING_FIELD

Need to send card.typeSelectionIndicator as 1, for all co-badged cards txns with Cybersource (authorization).
### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
This can be tested with below payments call:
```
curl --location 'http://localhost:8080/payments' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: dev_4KJPCRL8DJ8dAo0l8hF7TnL7j8TKkbreziz4Zebyv23PtZJOptiK5vpAZjh7eESn' \
--data-raw '{
    "amount": 499,
    "currency": "EUR",
    "confirm": true,
    "capture_method": "automatic",
    "customer_id": "test_rec7",
    "email": "guest@example.com",
    "customer_acceptance": {
        "acceptance_type": "online"
    },
     "return_url": "https://google.com",
    "payment_method": "card",
    "payment_method_type": "credit",
    "payment_method_data": {
        "card": {
            "card_number": "4010061700000021",
            "card_exp_month": "03",
            "card_exp_year": "2030",
            "card_holder_name": "joseph Doe",
            "card_cvc": "737"
        }
    },
    "billing": {
        "address": {
            "city": "test",
            "country": "NL",
            "line1": "here is some \n there is some \n none is some? \n ",
            "line2": "there",
            "line3": "anywhere",
            "zip": "560095",
            "state": "CA",
            "first_name": "Sakil",
            "last_name": "Mostak"
        },
        "phone": {
            "number": "1234567890",
            "country_code": "+1"
        },
        "email": "guest@example.com"
    },
    "browser_info": {
        "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Safari/537.36",
        "accept_header": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8",
        "language": "nl-NL",
        "color_depth": 24,
        "screen_height": 723,
        "screen_width": 1536,
        "time_zone": 0,
        "java_enabled": true,
        "java_script_enabled": true,
        "ip_address": "127.0.0.1"
    }
    
}'
```
Cargo clippy:
<img width="1728" alt="Screenshot 2025-04-17 at 1 57 25 PM" src="https://github.com/user-attachments/assets/1c30fce3-13f0-48f4-80ef-890f3cda6f71" />


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
