### PR TITLE
chore: address Rust 1.86.0 clippy lints

### DIFF
--- a/crates/common_utils/src/types.rs
+++ b/crates/common_utils/src/types.rs
@@ -125,7 +125,7 @@ impl<const PRECISION: u8> Percentage<PRECISION> {
     fn is_valid_precision_length(value: &str) -> bool {
         if value.contains('.') {
             // if string has '.' then take the decimal part and verify precision length
-            match value.split('.').last() {
+            match value.split('.').next_back() {
                 Some(decimal_part) => {
                     decimal_part.trim_end_matches('0').len() <= <u8 as Into<usize>>::into(PRECISION)
                 }

--- a/crates/common_utils/src/validation.rs
+++ b/crates/common_utils/src/validation.rs
@@ -26,6 +26,8 @@ pub fn validate_phone_number(phone_number: &str) -> Result<(), ValidationError> 
 pub fn validate_email(email: &str) -> CustomResult<(), ValidationError> {
     #[deny(clippy::invalid_regex)]
     static EMAIL_REGEX: Lazy<Option<Regex>> = Lazy::new(|| {
+        #[allow(unknown_lints)]
+        #[allow(clippy::manual_ok_err)]
         match Regex::new(
             r"^(?i)[a-z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)+$",
         ) {

--- a/crates/euclid/src/backend/vir_interpreter.rs
+++ b/crates/euclid/src/backend/vir_interpreter.rs
@@ -40,13 +40,15 @@ where
     }
 
     fn eval_statement(stmt: &vir::ValuedIfStatement, ctx: &types::Context) -> bool {
-        Self::eval_condition(&stmt.condition, ctx)
-            .then(|| {
+        if Self::eval_condition(&stmt.condition, ctx) {
+            {
                 stmt.nested.as_ref().map_or(true, |nested_stmts| {
                     nested_stmts.iter().any(|s| Self::eval_statement(s, ctx))
                 })
-            })
-            .unwrap_or(false)
+            }
+        } else {
+            false
+        }
     }
 
     fn eval_rule(rule: &vir::ValuedRule<O>, ctx: &types::Context) -> bool {

--- a/crates/hyperswitch_connectors/src/connectors/bluesnap.rs
+++ b/crates/hyperswitch_connectors/src/connectors/bluesnap.rs
@@ -747,7 +747,7 @@ impl ConnectorIntegration<Authorize, PaymentsAuthorizeData, PaymentsResponseData
                     .change_context(errors::ConnectorError::ResponseHandlingFailed)?; // If location headers are not present connector will return 4XX so this error will never be propagated
                 let payment_fields_token = location
                     .split('/')
-                    .last()
+                    .next_back()
                     .ok_or(errors::ConnectorError::ResponseHandlingFailed)?
                     .to_string();
 

--- a/crates/hyperswitch_connectors/src/connectors/bluesnap/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/bluesnap/transformers.rs
@@ -308,7 +308,7 @@ impl TryFrom<&BluesnapRouterData<&types::PaymentsAuthorizeRouterData>> for Blues
                     let apple_pay_payment_data =
                         payment_method_data.get_applepay_decoded_payment_data()?;
                     let apple_pay_payment_data: ApplePayEncodedPaymentData = apple_pay_payment_data
-                        .expose()[..]
+                        .expose()
                         .as_bytes()
                         .parse_struct("ApplePayEncodedPaymentData")
                         .change_context(errors::ConnectorError::InvalidWalletToken {

--- a/crates/hyperswitch_connectors/src/connectors/chargebee/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/chargebee/transformers.rs
@@ -402,7 +402,7 @@ impl ChargebeeCustomer {
                     .ok_or(errors::ConnectorError::WebhookBodyDecodingFailed)?
                     .to_string();
                 let mandate_id = parts
-                    .last()
+                    .next_back()
                     .ok_or(errors::ConnectorError::WebhookBodyDecodingFailed)?
                     .to_string();
                 Ok(ChargebeeMandateDetails {

--- a/crates/hyperswitch_connectors/src/connectors/checkout/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/checkout/transformers.rs
@@ -1373,7 +1373,7 @@ pub fn construct_file_upload_request(
                 .file_type
                 .as_ref()
                 .split('/')
-                .last()
+                .next_back()
                 .unwrap_or_default()
         ))
         .mime_str(request.file_type.as_ref())

--- a/crates/hyperswitch_connectors/src/connectors/cryptopay/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/cryptopay/transformers.rs
@@ -78,8 +78,8 @@ impl TryFrom<&CryptopayRouterData<&types::PaymentsAuthorizeRouterData>>
             | PaymentMethodData::BankRedirect(_)
             | PaymentMethodData::BankDebit(_)
             | PaymentMethodData::BankTransfer(_)
-            | PaymentMethodData::MandatePayment {}
-            | PaymentMethodData::Reward {}
+            | PaymentMethodData::MandatePayment
+            | PaymentMethodData::Reward
             | PaymentMethodData::RealTimePayment(_)
             | PaymentMethodData::Upi(_)
             | PaymentMethodData::MobilePayment(_)

--- a/crates/hyperswitch_connectors/src/connectors/forte/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/forte/transformers.rs
@@ -137,8 +137,8 @@ impl TryFrom<&ForteRouterData<&types::PaymentsAuthorizeRouterData>> for FortePay
             | PaymentMethodData::BankDebit(_)
             | PaymentMethodData::BankTransfer(_)
             | PaymentMethodData::Crypto(_)
-            | PaymentMethodData::MandatePayment {}
-            | PaymentMethodData::Reward {}
+            | PaymentMethodData::MandatePayment
+            | PaymentMethodData::Reward
             | PaymentMethodData::RealTimePayment(_)
             | PaymentMethodData::MobilePayment(_)
             | PaymentMethodData::Upi(_)

--- a/crates/hyperswitch_connectors/src/connectors/noon/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/noon/transformers.rs
@@ -353,8 +353,8 @@ impl TryFrom<&NoonRouterData<&PaymentsAuthorizeRouterData>> for NoonPaymentsRequ
                     | PaymentMethodData::BankDebit(_)
                     | PaymentMethodData::BankTransfer(_)
                     | PaymentMethodData::Crypto(_)
-                    | PaymentMethodData::MandatePayment {}
-                    | PaymentMethodData::Reward {}
+                    | PaymentMethodData::MandatePayment
+                    | PaymentMethodData::Reward
                     | PaymentMethodData::RealTimePayment(_)
                     | PaymentMethodData::MobilePayment(_)
                     | PaymentMethodData::Upi(_)

--- a/crates/hyperswitch_connectors/src/connectors/paypal.rs
+++ b/crates/hyperswitch_connectors/src/connectors/paypal.rs
@@ -148,7 +148,7 @@ impl Paypal {
                     if let Some(field) = error
                         .field
                         .as_ref()
-                        .and_then(|field| field.split('/').last())
+                        .and_then(|field| field.split('/').next_back())
                     {
                         reason.push_str(&format!(", field - {field}"));
                     }

--- a/crates/hyperswitch_connectors/src/connectors/square/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/square/transformers.rs
@@ -331,8 +331,8 @@ impl TryFrom<&ConnectorAuthType> for SquareAuthType {
             | ConnectorAuthType::SignatureKey { .. }
             | ConnectorAuthType::MultiAuthKey { .. }
             | ConnectorAuthType::CurrencyAuthKey { .. }
-            | ConnectorAuthType::TemporaryAuth { .. }
-            | ConnectorAuthType::NoKey { .. }
+            | ConnectorAuthType::TemporaryAuth
+            | ConnectorAuthType::NoKey
             | ConnectorAuthType::CertificateAuth { .. } => {
                 Err(errors::ConnectorError::FailedToObtainAuthType.into())
             }

--- a/crates/hyperswitch_connectors/src/connectors/volt.rs
+++ b/crates/hyperswitch_connectors/src/connectors/volt.rs
@@ -663,7 +663,7 @@ impl webhooks::IncomingWebhook for Volt {
         let user_agent = utils::get_header_key_value(webhook_headers::USER_AGENT, request.headers)?;
         let version = user_agent
             .split('/')
-            .last()
+            .next_back()
             .ok_or(errors::ConnectorError::WebhookSourceVerificationFailed)?;
         Ok(format!(
             "{}|{}|{}",

--- a/crates/hyperswitch_connectors/src/connectors/worldpay.rs
+++ b/crates/hyperswitch_connectors/src/connectors/worldpay.rs
@@ -1099,13 +1099,14 @@ impl IncomingWebhook for Worldpay {
         request: &IncomingWebhookRequestDetails<'_>,
         _connector_webhook_secrets: &api_models::webhooks::ConnectorWebhookSecrets,
     ) -> CustomResult<Vec<u8>, errors::ConnectorError> {
-        let event_signature = get_header_key_value("Event-Signature", request.headers)?.split(',');
+        let mut event_signature =
+            get_header_key_value("Event-Signature", request.headers)?.split(',');
         let sign_header = event_signature
-            .last()
+            .next_back()
             .ok_or(errors::ConnectorError::WebhookSignatureNotFound)?;
         let signature = sign_header
             .split('/')
-            .last()
+            .next_back()
             .ok_or(errors::ConnectorError::WebhookSignatureNotFound)?;
         hex::decode(signature).change_context(errors::ConnectorError::WebhookResponseEncodingFailed)
     }

--- a/crates/hyperswitch_connectors/src/connectors/zen/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/zen/transformers.rs
@@ -282,7 +282,7 @@ impl
             VoucherData::PagoEfectivo => ZenPaymentChannels::PclBoacompraPagoefectivo,
             VoucherData::RedCompra => ZenPaymentChannels::PclBoacompraRedcompra,
             VoucherData::RedPagos => ZenPaymentChannels::PclBoacompraRedpagos,
-            VoucherData::Oxxo { .. }
+            VoucherData::Oxxo
             | VoucherData::Alfamart { .. }
             | VoucherData::Indomaret { .. }
             | VoucherData::SevenEleven { .. }

--- a/crates/router/src/connector/netcetera/netcetera_types.rs
+++ b/crates/router/src/connector/netcetera/netcetera_types.rs
@@ -1113,8 +1113,8 @@ pub struct MerchantRiskIndicator {
     /// New field introduced:
     /// - transChar -> Indicates to the ACS specific transactions identified by the Merchant.
     ///      - Size: Variable, 1-2 elements. JSON Data Type: Array of String. Accepted values:
-    ///                     - 01 -> Cryptocurrency transaction
-    ///                     - 02 -> NFT transaction
+    ///          - 01 -> Cryptocurrency transaction
+    ///          - 02 -> NFT transaction
     trans_char: Option<String>,
 }
 
@@ -1558,19 +1558,19 @@ pub struct Sdk {
     ///    Creates a JSON object of the following data as the JWS payload to be signed:
     ///
     ///    - SDK Reference Number -> Identifies the vendor and version of the 3DS SDK that is utilised for a specific
-    ///                              transaction. The value is assigned by EMVCo when the Letter of Approval of the
-    ///                              specific 3DS SDK is issued. The field is limited to 32 characters.
+    ///      transaction. The value is assigned by EMVCo when the Letter of Approval of the
+    ///      specific 3DS SDK is issued. The field is limited to 32 characters.
     ///    - SDK Signature Timestamp -> Date and time indicating when the 3DS SDK generated the Split-SDK Server Signed
-    ///                                 Content converted into UTC. The value is limited to 14 characters. Accepted
-    ///                                 format: YYYYMMDDHHMMSS.
+    ///      Content converted into UTC. The value is limited to 14 characters. Accepted
+    ///      format: YYYYMMDDHHMMSS.
     ///    - SDK Transaction ID -> Universally unique transaction identifier assigned by the 3DS SDK to identify a
-    ///                            single transaction. The field is limited to 36 characters and it shall be in a
-    ///                            canonical format as defined in IETF RFC 4122. This may utilize any of the specified
-    ///                            versions as long as the output meets specific requirements.
+    ///      single transaction. The field is limited to 36 characters and it shall be in a
+    ///      canonical format as defined in IETF RFC 4122. This may utilize any of the specified
+    ///      versions as long as the output meets specific requirements.
     ///    - Split-SDK Server ID -> DS assigned Split-SDK Server identifier. Each DS can provide a unique ID to each
-    ///                             Split-SDK Server on an individual basis. The field is limited to 32 characters.
-    ///                             Any individual DS may impose specific formatting and character requirements on the
-    ///                             contents of this field.
+    ///      Split-SDK Server on an individual basis. The field is limited to 32 characters.
+    ///      Any individual DS may impose specific formatting and character requirements on the
+    ///      contents of this field.
     ///
     ///    Generates a digital signature of the full JSON object according to JWS (RFC 7515) using JWS Compact
     ///    Serialization. The parameter values for this version of the specification and to be included in the JWS
@@ -1705,7 +1705,7 @@ pub struct SplitSdkType {
     /// Limited Split-SDK Indicator: If the Split-SDK client has limited capabilities
     ///    - Length: 1 character
     ///    - Value accepted:
-    ///       • Y = Limited
+    ///      • Y = Limited
     ///    - Only present if value = Y
     limited_ind: Option<String>,
 }

--- a/crates/router/src/connector/netcetera/transformers.rs
+++ b/crates/router/src/connector/netcetera/transformers.rs
@@ -700,9 +700,9 @@ pub struct ResultsResponseData {
     /// - `U`: Authentication / Account verification could not be performed; technical or other problem.
     /// - `C`: A challenge is required to complete the authentication.
     /// - `R`: Authentication / Account verification Rejected. Issuer is rejecting authentication/verification
-    ///       and request that authorization not be attempted.
+    ///   and request that authorization not be attempted.
     /// - `A`: Attempts processing performed; Not authenticated / verified, but a proof of attempt
-    ///       authentication / verification is provided.
+    ///   authentication / verification is provided.
     /// - `D`: A challenge is required to complete the authentication. Decoupled Authentication confirmed.
     /// - `I`: Informational Only; 3DS Requestor challenge preference acknowledged.
     pub trans_status: Option<common_enums::TransactionStatus>,

--- a/crates/router/src/core/errors/utils.rs
+++ b/crates/router/src/core/errors/utils.rs
@@ -178,7 +178,7 @@ impl<T> ConnectorErrorExt<T> for error_stack::Result<T, errors::ConnectorError> 
             | errors::ConnectorError::RequestTimeoutReceived
             | errors::ConnectorError::CurrencyNotSupported { .. }
             | errors::ConnectorError::InvalidConnectorConfig { .. }
-            | errors::ConnectorError::AmountConversionFailed { .. }
+            | errors::ConnectorError::AmountConversionFailed
             | errors::ConnectorError::GenericError { .. } => {
                 err.change_context(errors::ApiErrorResponse::RefundFailed { data: None })
             }
@@ -369,7 +369,7 @@ impl<T> ConnectorErrorExt<T> for error_stack::Result<T, errors::ConnectorError> 
                 | errors::ConnectorError::RequestTimeoutReceived
                 | errors::ConnectorError::CurrencyNotSupported { .. }
                 | errors::ConnectorError::ProcessingStepFailed(None)
-                | errors::ConnectorError::AmountConversionFailed { .. }
+                | errors::ConnectorError::AmountConversionFailed
                 | errors::ConnectorError::GenericError { .. } => {
                     logger::error!(%error,"Setup Mandate flow failed");
                     errors::ApiErrorResponse::PaymentAuthorizationFailed { data: None }

--- a/crates/router/src/events/audit_events.rs
+++ b/crates/router/src/events/audit_events.rs
@@ -78,9 +78,9 @@ impl Event for AuditEvent {
             AuditEventType::RefundFail => "refund_fail",
             AuditEventType::PaymentCancelled { .. } => "payment_cancelled",
             AuditEventType::PaymentUpdate { .. } => "payment_update",
-            AuditEventType::PaymentApprove { .. } => "payment_approve",
-            AuditEventType::PaymentCreate { .. } => "payment_create",
-            AuditEventType::PaymentStatus { .. } => "payment_status",
+            AuditEventType::PaymentApprove => "payment_approve",
+            AuditEventType::PaymentCreate => "payment_create",
+            AuditEventType::PaymentStatus => "payment_status",
             AuditEventType::PaymentCompleteAuthorize => "payment_complete_authorize",
             AuditEventType::PaymentReject { .. } => "payment_rejected",
         };

--- a/crates/router/tests/connectors/cashtocode.rs
+++ b/crates/router/tests/connectors/cashtocode.rs
@@ -68,7 +68,7 @@ impl CashtocodeTest {
             router_return_url: Some(String::from("https://google.com")),
             webhook_url: None,
             complete_authorize_url: None,
-            customer_id: if let Ok(id) = cust_id { Some(id) } else { None },
+            customer_id: cust_id.ok(),
             surcharge_details: None,
             request_incremental_authorization: false,
             metadata: None,


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->

Original PR: https://github.com/juspay/hyperswitch/pull/7735

This PR addresses the clippy lints occurring due to new rust version 1.86.0
https://rust-lang.github.io/rust-clippy/master/index.html

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
CI checks should pass as this PR addresses clippy lints.
1. ran `rustc --version`
![image](https://github.com/user-attachments/assets/b154032b-dff4-4582-b525-9b97ce83ce55)

3. ran `just clippy` with new rust version (1.86.0)
<img width="1004" alt="Screenshot 2025-04-07 at 5 46 05 PM" src="https://github.com/user-attachments/assets/5951c74e-8f3d-44e2-8172-e376c01c2e9d" />

4. ran `just clippy_v2` with new rust version (1.86.0)
<img width="1019" alt="Screenshot 2025-04-07 at 5 46 38 PM" src="https://github.com/user-attachments/assets/ecdf5c2a-dc31-45b4-be01-cedc041cf59d" />


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
