### PR TITLE
chore: add cardholder name as mandatory field for Worldpay card transactions

### DIFF
--- a/crates/hyperswitch_connectors/src/connectors/worldpay.rs
+++ b/crates/hyperswitch_connectors/src/connectors/worldpay.rs
@@ -285,6 +285,7 @@ impl ConnectorIntegration<SetupMandate, SetupMandateRequestData, PaymentsRespons
                 http_code: res.status_code,
             },
             optional_correlation_id,
+            data.request.amount.unwrap_or(0),
         ))
         .change_context(errors::ConnectorError::ResponseHandlingFailed)
     }
@@ -759,6 +760,7 @@ impl ConnectorIntegration<Authorize, PaymentsAuthorizeData, PaymentsResponseData
                 http_code: res.status_code,
             },
             optional_correlation_id,
+            data.request.amount,
         ))
         .change_context(errors::ConnectorError::ResponseHandlingFailed)
     }
@@ -870,6 +872,7 @@ impl ConnectorIntegration<CompleteAuthorize, CompleteAuthorizeData, PaymentsResp
                 http_code: res.status_code,
             },
             optional_correlation_id,
+            data.request.amount,
         ))
         .change_context(errors::ConnectorError::ResponseHandlingFailed)
     }

--- a/crates/hyperswitch_connectors/src/connectors/worldpay/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/worldpay/transformers.rs
@@ -86,34 +86,24 @@ fn fetch_payment_instrument(
             },
             cvc: card.card_cvc,
             card_holder_name: billing_address.and_then(|address| address.get_optional_full_name()),
-            billing_address: if let Some(address) =
-                billing_address.and_then(|addr| addr.address.clone())
-            {
-                Some(BillingAddress {
-                    address1: address.line1.get_required_value("line1").change_context(
-                        errors::ConnectorError::MissingRequiredField {
-                            field_name: "line1",
-                        },
-                    )?,
-                    address2: address.line2,
-                    address3: address.line3,
-                    city: address.city.get_required_value("city").change_context(
-                        errors::ConnectorError::MissingRequiredField { field_name: "city" },
-                    )?,
-                    state: address.state,
-                    postal_code: address.zip.get_required_value("zip").change_context(
-                        errors::ConnectorError::MissingRequiredField { field_name: "zip" },
-                    )?,
-                    country_code: address
-                        .country
-                        .get_required_value("country_code")
-                        .change_context(errors::ConnectorError::MissingRequiredField {
-                            field_name: "country_code",
-                        })?,
-                })
-            } else {
-                None
-            },
+            billing_address: billing_address
+                .and_then(|addr| addr.address.clone())
+                .and_then(|address| {
+                    match (address.line1, address.city, address.zip, address.country) {
+                        (Some(address1), Some(city), Some(postal_code), Some(country_code)) => {
+                            Some(BillingAddress {
+                                address1,
+                                address2: address.line2,
+                                address3: address.line3,
+                                city,
+                                state: address.state,
+                                postal_code,
+                                country_code,
+                            })
+                        }
+                        _ => None,
+                    }
+                }),
         })),
         PaymentMethodData::CardDetailsForNetworkTransactionId(raw_card_details) => {
             Ok(PaymentInstrument::RawCardForNTI(RawCardDetails {
@@ -264,7 +254,7 @@ impl WorldpayPaymentsRequestData
     for RouterData<SetupMandate, SetupMandateRequestData, PaymentsResponseData>
 {
     fn get_return_url(&self) -> Result<String, error_stack::Report<errors::ConnectorError>> {
-        self.request.get_router_return_url()
+        self.request.get_complete_authorize_url()
     }
 
     fn get_auth_type(&self) -> &enums::AuthenticationType {
@@ -681,6 +671,7 @@ impl<F, T>
     ForeignTryFrom<(
         ResponseRouterData<F, WorldpayPaymentsResponse, T, PaymentsResponseData>,
         Option<String>,
+        i64,
     )> for RouterData<F, T, PaymentsResponseData>
 {
     type Error = error_stack::Report<errors::ConnectorError>;
@@ -688,9 +679,10 @@ impl<F, T>
         item: (
             ResponseRouterData<F, WorldpayPaymentsResponse, T, PaymentsResponseData>,
             Option<String>,
+            i64,
         ),
     ) -> Result<Self, Self::Error> {
-        let (router_data, optional_correlation_id) = item;
+        let (router_data, optional_correlation_id, amount) = item;
         let (description, redirection_data, mandate_reference, network_txn_id, error) = router_data
             .response
             .other_fields
@@ -770,7 +762,11 @@ impl<F, T>
             PaymentOutcome::FraudHighRisk => Some("Transaction marked as high risk".to_string()),
             _ => None,
         };
-        let status = enums::AttemptStatus::from(worldpay_status.clone());
+        let status = if amount == 0 && worldpay_status == PaymentOutcome::Authorized {
+            enums::AttemptStatus::Charged
+        } else {
+            enums::AttemptStatus::from(worldpay_status.clone())
+        };
         let response = match (optional_error_message, error) {
             (None, None) => Ok(PaymentsResponseData::TransactionResponse {
                 resource_id: ResponseId::foreign_try_from((

--- a/crates/payment_methods/src/configs/payment_connector_required_fields.rs
+++ b/crates/payment_methods/src/configs/payment_connector_required_fields.rs
@@ -1450,6 +1450,7 @@ fn get_cards_required_fields() -> HashMap<Connector, RequiredFieldFinal> {
                     RequiredField::CardNumber,
                     RequiredField::CardExpMonth,
                     RequiredField::CardExpYear,
+                    RequiredField::BillingUserFirstName,
                 ],
             ),
         ),


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
Hotfix for https://github.com/juspay/hyperswitch/pull/7897


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
Card holder name is a mandatory field which is required by WP during card transactions.
Fixing the 3DS SetupMandate flow for Worldpay allows merchants to consume the functionality.

## How did you test it?
Same as in https://github.com/juspay/hyperswitch/pull/7897

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
