### PR TITLE
refactor(connector): use utility functions in ACI transformer

### DIFF
--- a/crates/hyperswitch_connectors/src/connectors/aci/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/aci/transformers.rs
@@ -478,7 +478,7 @@ impl TryFrom<(&AciRouterData<&PaymentsAuthorizeRouterData>, &WalletData)> for Ac
             txn_details,
             payment_method,
             instruction: None,
-            shopper_result_url: item.router_data.request.router_return_url.clone(),
+            shopper_result_url: item.router_data.request.get_router_return_url().ok(),
         })
     }
 }
@@ -504,7 +504,7 @@ impl
             txn_details,
             payment_method,
             instruction: None,
-            shopper_result_url: item.router_data.request.router_return_url.clone(),
+            shopper_result_url: item.router_data.request.get_router_return_url().ok(),
         })
     }
 }
@@ -522,27 +522,7 @@ impl TryFrom<(&AciRouterData<&PaymentsAuthorizeRouterData>, &PayLaterData)> for 
             txn_details,
             payment_method,
             instruction: None,
-            shopper_result_url: item.router_data.request.router_return_url.clone(),
-        })
-    }
-}
-
-impl TryFrom<(&AciRouterData<&PaymentsAuthorizeRouterData>, &Card)> for AciPaymentsRequest {
-    type Error = Error;
-    fn try_from(
-        value: (&AciRouterData<&PaymentsAuthorizeRouterData>, &Card),
-    ) -> Result<Self, Self::Error> {
-        let (item, card_data) = value;
-        let card_holder_name = item.router_data.get_optional_billing_full_name();
-        let txn_details = get_transaction_details(item)?;
-        let payment_method = PaymentDetails::try_from((card_data.clone(), card_holder_name))?;
-        let instruction = get_instruction_details(item);
-
-        Ok(Self {
-            txn_details,
-            payment_method,
-            instruction,
-            shopper_result_url: None,
+            shopper_result_url: item.router_data.request.get_router_return_url().ok(),
         })
     }
 }
@@ -568,7 +548,27 @@ impl
             txn_details,
             payment_method: PaymentDetails::Mandate,
             instruction,
-            shopper_result_url: item.router_data.request.router_return_url.clone(),
+            shopper_result_url: item.router_data.request.get_router_return_url().ok(),
+        })
+    }
+}
+
+impl TryFrom<(&AciRouterData<&PaymentsAuthorizeRouterData>, &Card)> for AciPaymentsRequest {
+    type Error = Error;
+    fn try_from(
+        value: (&AciRouterData<&PaymentsAuthorizeRouterData>, &Card),
+    ) -> Result<Self, Self::Error> {
+        let (item, card_data) = value;
+        let card_holder_name = item.router_data.get_optional_billing_full_name();
+        let txn_details = get_transaction_details(item)?;
+        let payment_method = PaymentDetails::try_from((card_data.clone(), card_holder_name))?;
+        let instruction = get_instruction_details(item);
+
+        Ok(Self {
+            txn_details,
+            payment_method,
+            instruction,
+            shopper_result_url: None,
         })
     }
 }


### PR DESCRIPTION
## Description

This PR refactors the ACI connector to use utility functions from the connector utils module rather than reimplementing them. Specifically, it replaces direct access to `router_return_url` with calls to `get_router_return_url()`.

## Why is this change required?

This change improves code maintainability and consistency by:
1. Reusing existing utility functions instead of duplicating functionality
2. Following the same patterns as other connectors
3. Ensuring consistent error handling through the utility functions

## How Has This Been Tested?

Verified the code compiles without any errors.

## Related Issue(s)

Fixes #7927

## Type of Change
- [x] Refactor (non-breaking change that improves code quality)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings