### PR TITLE
Fix/authorizedotnet 3ds rejection

### DIFF
--- a/crates/hyperswitch_connectors/src/connectors/authorizedotnet.rs
+++ b/crates/hyperswitch_connectors/src/connectors/authorizedotnet.rs
@@ -441,6 +441,13 @@ impl ConnectorIntegration<Authorize, PaymentsAuthorizeData, PaymentsResponseData
         req: &PaymentsAuthorizeRouterData,
         _connectors: &Connectors,
     ) -> CustomResult<RequestContent, errors::ConnectorError> {
+        // Check if 3DS authentication is requested
+        if req.request.authentication_type == Some(enums::AuthenticationType::ThreeDs) {
+            return Err(errors::ConnectorError::NotImplemented {
+                message: "3DS authentication is not supported by Authorize.net since October 2022".to_string(),
+            });
+        }
+
         let connector_router_data = authorizedotnet::AuthorizedotnetRouterData::try_from((
             &self.get_currency_unit(),
             req.request.currency,
@@ -801,6 +808,13 @@ impl ConnectorIntegration<CompleteAuthorize, CompleteAuthorizeData, PaymentsResp
         req: &PaymentsCompleteAuthorizeRouterData,
         _connectors: &Connectors,
     ) -> CustomResult<RequestContent, errors::ConnectorError> {
+        // Check if 3DS authentication is requested
+        if req.request.authentication_type == Some(enums::AuthenticationType::ThreeDs) {
+            return Err(errors::ConnectorError::NotImplemented {
+                message: "3DS authentication is not supported by Authorize.net since October 2022".to_string(),
+            });
+        }
+
         let connector_router_data = authorizedotnet::AuthorizedotnetRouterData::try_from((
             &self.get_currency_unit(),
             req.request.currency,


### PR DESCRIPTION
## Description
This PR fixes issue #7295 where Authorize.net processes 3DS payments without authentication, instead of rejecting them with an informative message.

Authorize.net discontinued 3DS support after October 2022, but our current implementation was silently processing these payments without any 3DS authentication or notifying users of this limitation.

## Changes
- Added validation in the Authorize.net connector to check for 3DS authentication requests
- Now returns a clear error message when a 3DS payment is attempted with Authorize.net

## Testing
1. Tested with 3DS payment requests to Authorize.net
2. Verified that the payment is rejected with a clear error message
3. Ensured existing functionality for non-3DS payments works correctly

Fixes #7295