### PR TITLE
fix(connector): [Novalnet] send decoded token for apple pay payment

### DIFF
--- a/crates/hyperswitch_connectors/src/connectors/novalnet/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/novalnet/transformers.rs
@@ -1577,8 +1577,7 @@ impl TryFrom<&SetupMandateRouterData> for NovalnetPaymentsRequest {
                         return_url: None,
                         error_return_url: None,
                         payment_data: Some(NovalNetPaymentData::ApplePay(NovalnetApplePay {
-                            wallet_data: payment_method_data
-                                .get_applepay_decoded_payment_data()?,
+                            wallet_data: payment_method_data.get_applepay_decoded_payment_data()?,
                         })),
                         enforce_3d: None,
                         create_token,

--- a/crates/hyperswitch_connectors/src/connectors/novalnet/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/novalnet/transformers.rs
@@ -1577,7 +1577,8 @@ impl TryFrom<&SetupMandateRouterData> for NovalnetPaymentsRequest {
                         return_url: None,
                         error_return_url: None,
                         payment_data: Some(NovalNetPaymentData::ApplePay(NovalnetApplePay {
-                            wallet_data: Secret::new(payment_method_data.payment_data.clone()),
+                            wallet_data: payment_method_data
+                                .get_applepay_decoded_payment_data()?,
                         })),
                         enforce_3d: None,
                         create_token,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
We're passing base64 encoded data in SetupMandate flow for apple pay token, but Novalnet expects apple pay token as decoded raw string. This PR fixes this.



### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Cannot be tested locally.


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [X] I formatted the code `cargo +nightly fmt --all`
- [X] I addressed lints thrown by `cargo clippy`
- [X] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
