### PR TITLE
refactor(connector): [Noon] auth header

### DIFF
--- a/crates/hyperswitch_connectors/src/connectors/noon.rs
+++ b/crates/hyperswitch_connectors/src/connectors/noon.rs
@@ -103,7 +103,7 @@ where
                 .to_string()
                 .into(),
         )];
-        let mut api_key = get_auth_header(&req.connector_auth_type, connectors, req.test_mode)?;
+        let mut api_key = get_auth_header(&req.connector_auth_type, connectors)?;
         header.append(&mut api_key);
         Ok(header)
     }
@@ -111,8 +111,7 @@ where
 
 fn get_auth_header(
     auth_type: &ConnectorAuthType,
-    connectors: &Connectors,
-    test_mode: Option<bool>,
+    _connectors: &Connectors,
 ) -> CustomResult<Vec<(String, masking::Maskable<String>)>, errors::ConnectorError> {
     let auth = noon::NoonAuthType::try_from(auth_type)?;
 
@@ -126,17 +125,10 @@ fn get_auth_header(
                 business_identifier, application_identifier, api_key
             ))
         });
-    let key_mode = test_mode.map_or(connectors.noon.key_mode.clone(), |is_test_mode| {
-        if is_test_mode {
-            "Test".to_string()
-        } else {
-            "Live".to_string()
-        }
-    });
 
     Ok(vec![(
         headers::AUTHORIZATION.to_string(),
-        format!("Key_{} {}", key_mode, encoded_api_key.peek()).into_masked(),
+        format!("Key {}", encoded_api_key.peek()).into_masked(),
     )])
 }
 

--- a/crates/hyperswitch_connectors/src/connectors/noon.rs
+++ b/crates/hyperswitch_connectors/src/connectors/noon.rs
@@ -95,7 +95,7 @@ where
     fn build_headers(
         &self,
         req: &RouterData<Flow, Request, Response>,
-        connectors: &Connectors,
+        _connectors: &Connectors,
     ) -> CustomResult<Vec<(String, masking::Maskable<String>)>, errors::ConnectorError> {
         let mut header = vec![(
             headers::CONTENT_TYPE.to_string(),
@@ -103,7 +103,7 @@ where
                 .to_string()
                 .into(),
         )];
-        let mut api_key = get_auth_header(&req.connector_auth_type, connectors)?;
+        let mut api_key = get_auth_header(&req.connector_auth_type)?;
         header.append(&mut api_key);
         Ok(header)
     }
@@ -111,7 +111,6 @@ where
 
 fn get_auth_header(
     auth_type: &ConnectorAuthType,
-    _connectors: &Connectors,
 ) -> CustomResult<Vec<(String, masking::Maskable<String>)>, errors::ConnectorError> {
     let auth = noon::NoonAuthType::try_from(auth_type)?;
 


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
Noon has updated there Authentication api
- The mode selector has been deprecated because there is no more segregation of authentication for TEST/LIVE environment via the authorization header,
the endpoint used will take care of routing the request to the relevant environment.

Current
Mode selector is mandatory in the authorization header to authenticate credentials:
• Key_test Base64(BusinessIdentifier.ApplicationIdentifier:ApplicationKey)
• Key_live Base64(BusinessIdentifier.ApplicationIdentifier:ApplicationKey)

New
Mode selector no more required, for both environments the new format is:
• Key Base64(BusinessIdentifier.ApplicationIdentifier:ApplicationKey

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
1. Create a Noon Payment 
```
curl --location 'http://localhost:8080/payments' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: dev_Q44fvQRgqucXVPYBqH7SuDJu2Mxr1QvhcDD3DC294pEMjSXTi3vvy8CI2msLiKjO' \
--data-raw '{
    "amount": 390,
    "currency": "AED",
    "confirm": true,
    
    
    "capture_method": "automatic",
    
    "customer_id": "sammantest2722",
    "capture_on": "2022-09-10T10:11:12Z",
    "authentication_type": "three_ds",
    "return_url": "https://google.com",
    "email": "something@gmail.com",
    "name": "Joseph Doe",
    "phone": "999999999",
    "phone_country_code": "+65",
    "description": "Its my first payment",
    "statement_descriptor_name": "Juspay",
    "statement_descriptor_suffix": "Router",
    "payment_method": "card",
    "payment_method_type": "credit",
    "payment_method_data": {
        "card": {
            "card_number": "4000000000002701",
            "card_exp_month": "01",
            "card_exp_year": "2035",
            "card_holder_name": "joseph Doe",
            "card_cvc": "100"
        }
    },
    "billing": {
        "address": {
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "city": "San Fransico",
            "state": "California",
            "zip": "94122",
            "country": "AE",
            "first_name": "joseph",
            "last_name": "Doe"
        },
        "phone": {
            "number": "____",
            "country_code": "+91"
        }
    },
    "browser_info": {
        "user_agent": "Mozilla\/5.0 (iPhone NT 10.0; Win64; x64) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/70.0.3538.110 Safari\/537.36",
        "accept_header": "text\/html,application\/xhtml+xml,application\/xml;q=0.9,image\/webp,image\/apng,*\/*;q=0.8",
        "language": "nl-NL",
        "color_depth": 24,
        "screen_height": 723,
        "screen_width": 1536,
        "time_zone": 0,
        "java_enabled": true,
        "java_script_enabled": true,
        "ip_address": "128.0.0.1"
    },
    "connector_metadata": {
        "noon": {
            "order_category": "pay"
        }
    },
    "order_details": [
        {
            "product_name": "Apple iphone 15",
            "quantity": 1,
            "amount": 390,
            "account_name": "transaction_processing"
        }
    ]
}'
```
Response
```
{
    "payment_id": "pay_6FveKOlMd627skf71HZz",
    "merchant_id": "postman_merchant_GHAction_2f8ca629-c8b2-4a0b-bcbd-7bf563aad333",
    "status": "requires_customer_action",
    "amount": 390,
    "net_amount": 390,
    "shipping_cost": null,
    "amount_capturable": 390,
    "amount_received": null,
    "connector": "noon",
    "client_secret": "pay_6FveKOlMd627skf71HZz_secret_Rga6hxuBO9r5VX5EvQAE",
    "created": "2025-05-07T11:51:44.853Z",
    "currency": "AED",
    "customer_id": "sammantest2722",
    "customer": {
        "id": "sammantest2722",
        "name": "Joseph Doe",
        "email": "something@gmail.com",
        "phone": "999999999",
        "phone_country_code": "+65"
    },
    "description": "Its my first payment",
    "refunds": null,
    "disputes": null,
    "mandate_id": null,
    "mandate_data": null,
    "setup_future_usage": null,
    "off_session": null,
    "capture_on": null,
    "capture_method": "automatic",
    "payment_method": "card",
    "payment_method_data": {
        "card": {
            "last4": "2701",
            "card_type": null,
            "card_network": null,
            "card_issuer": null,
            "card_issuing_country": null,
            "card_isin": "400000",
            "card_extended_bin": null,
            "card_exp_month": "01",
            "card_exp_year": "2035",
            "card_holder_name": "joseph Doe",
            "payment_checks": null,
            "authentication_data": null
        },
        "billing": null
    },
    "payment_token": null,
    "shipping": null,
    "billing": {
        "address": {
            "city": "San Fransico",
            "country": "AE",
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "zip": "94122",
            "state": "California",
            "first_name": "joseph",
            "last_name": "Doe"
        },
        "phone": {
            "number": "____",
            "country_code": "+91"
        },
        "email": null
    },
    "order_details": [
        {
            "brand": null,
            "amount": 390,
            "category": null,
            "quantity": 1,
            "tax_rate": null,
            "product_id": null,
            "product_name": "Apple iphone 15",
            "product_type": null,
            "sub_category": null,
            "product_img_link": null,
            "product_tax_code": null,
            "total_tax_amount": null,
            "requires_shipping": null
        }
    ],
    "email": "something@gmail.com",
    "name": "Joseph Doe",
    "phone": "999999999",
    "return_url": "https://google.com/",
    "authentication_type": "three_ds",
    "statement_descriptor_name": "Juspay",
    "statement_descriptor_suffix": "Router",
    "next_action": {
        "type": "redirect_to_url",
        "redirect_to_url": "http://localhost:8080/payments/redirect/pay_6FveKOlMd627skf71HZz/postman_merchant_GHAction_2f8ca629-c8b2-4a0b-bcbd-7bf563aad333/pay_6FveKOlMd627skf71HZz_1"
    },
    "cancellation_reason": null,
    "error_code": null,
    "error_message": null,
    "unified_code": null,
    "unified_message": null,
    "payment_experience": null,
    "payment_method_type": "credit",
    "connector_label": null,
    "business_country": null,
    "business_label": "default",
    "business_sub_label": null,
    "allowed_payment_method_types": null,
    "ephemeral_key": {
        "customer_id": "sammantest2722",
        "created_at": 1746618704,
        "expires": 1746622304,
        "secret": "epk_3c5e17e1540748e0bd25c7b3ff6e078d"
    },
    "manual_retry_allowed": null,
    "connector_transaction_id": "212023029912",
    "frm_message": null,
    "metadata": null,
    "connector_metadata": {
        "apple_pay": null,
        "airwallex": null,
        "noon": {
            "order_category": "pay"
        },
        "braintree": null,
        "adyen": null
    },
    "feature_metadata": null,
    "reference_id": "pay_6FveKOlMd627skf71HZz_1",
    "payment_link": null,
    "profile_id": "pro_YntNRehGguMsFvDKQtyr",
    "surcharge_details": null,
    "attempt_count": 1,
    "merchant_decision": null,
    "merchant_connector_id": "mca_Le64ohGhH3eJbLsBjfbA",
    "incremental_authorization_allowed": null,
    "authorization_count": null,
    "incremental_authorizations": null,
    "external_authentication_details": null,
    "external_3ds_authentication_attempted": false,
    "expires_on": "2025-05-07T12:06:44.853Z",
    "fingerprint": null,
    "browser_info": {
        "language": "nl-NL",
        "time_zone": 0,
        "ip_address": "128.0.0.1",
        "user_agent": "Mozilla/5.0 (iPhone NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Safari/537.36",
        "color_depth": 24,
        "java_enabled": true,
        "screen_width": 1536,
        "accept_header": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8",
        "screen_height": 723,
        "java_script_enabled": true
    },
    "payment_method_id": null,
    "payment_method_status": null,
    "updated": "2025-05-07T11:51:46.598Z",
    "split_payments": null,
    "frm_metadata": null,
    "extended_authorization_applied": null,
    "capture_before": null,
    "merchant_order_reference_id": null,
    "order_tax_amount": null,
    "connector_mandate_id": null,
    "card_discovery": "manual",
    "force_3ds_challenge": false,
    "force_3ds_challenge_trigger": false,
    "issuer_error_code": null,
    "issuer_error_message": null
}
```
Complete Payment using redirection

2. Psync 
```
curl --location 'http://localhost:8080/payments/pay_6FveKOlMd627skf71HZz?force_sync=true' \
--header 'Accept: application/json' \
--header 'api-key: _'
```

Response
```
{
    "payment_id": "pay_6FveKOlMd627skf71HZz",
    "merchant_id": "postman_merchant_GHAction_2f8ca629-c8b2-4a0b-bcbd-7bf563aad333",
    "status": "succeeded",
    "amount": 390,
    "net_amount": 390,
    "shipping_cost": null,
    "amount_capturable": 0,
    "amount_received": 390,
    "connector": "noon",
    "client_secret": "pay_6FveKOlMd627skf71HZz_secret_Rga6hxuBO9r5VX5EvQAE",
    "created": "2025-05-07T11:51:44.853Z",
    "currency": "AED",
    "customer_id": "sammantest2722",
    "customer": {
        "id": "sammantest2722",
        "name": "Joseph Doe",
        "email": "something@gmail.com",
        "phone": "999999999",
        "phone_country_code": "+65"
    },
    "description": "Its my first payment",
    "refunds": null,
    "disputes": null,
    "mandate_id": null,
    "mandate_data": null,
    "setup_future_usage": null,
    "off_session": null,
    "capture_on": null,
    "capture_method": "automatic",
    "payment_method": "card",
    "payment_method_data": {
        "card": {
            "last4": "2701",
            "card_type": null,
            "card_network": null,
            "card_issuer": null,
            "card_issuing_country": null,
            "card_isin": "400000",
            "card_extended_bin": null,
            "card_exp_month": "01",
            "card_exp_year": "2035",
            "card_holder_name": "joseph Doe",
            "payment_checks": null,
            "authentication_data": null
        },
        "billing": null
    },
    "payment_token": null,
    "shipping": null,
    "billing": {
        "address": {
            "city": "San Fransico",
            "country": "AE",
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "zip": "94122",
            "state": "California",
            "first_name": "joseph",
            "last_name": "Doe"
        },
        "phone": {
            "number": "_",
            "country_code": "+91"
        },
        "email": null
    },
    "order_details": [
        {
            "brand": null,
            "amount": 390,
            "category": null,
            "quantity": 1,
            "tax_rate": null,
            "product_id": null,
            "product_name": "Apple iphone 15",
            "product_type": null,
            "sub_category": null,
            "product_img_link": null,
            "product_tax_code": null,
            "total_tax_amount": null,
            "requires_shipping": null
        }
    ],
    "email": "something@gmail.com",
    "name": "Joseph Doe",
    "phone": "999999999",
    "return_url": "https://google.com/",
    "authentication_type": "three_ds",
    "statement_descriptor_name": "Juspay",
    "statement_descriptor_suffix": "Router",
    "next_action": null,
    "cancellation_reason": null,
    "error_code": null,
    "error_message": null,
    "unified_code": null,
    "unified_message": null,
    "payment_experience": null,
    "payment_method_type": "credit",
    "connector_label": null,
    "business_country": null,
    "business_label": "default",
    "business_sub_label": null,
    "allowed_payment_method_types": null,
    "ephemeral_key": null,
    "manual_retry_allowed": false,
    "connector_transaction_id": "212023029912",
    "frm_message": null,
    "metadata": null,
    "connector_metadata": {
        "apple_pay": null,
        "airwallex": null,
        "noon": {
            "order_category": "pay"
        },
        "braintree": null,
        "adyen": null
    },
    "feature_metadata": null,
    "reference_id": "pay_6FveKOlMd627skf71HZz_1",
    "payment_link": null,
    "profile_id": "pro_YntNRehGguMsFvDKQtyr",
    "surcharge_details": null,
    "attempt_count": 1,
    "merchant_decision": null,
    "merchant_connector_id": "mca_Le64ohGhH3eJbLsBjfbA",
    "incremental_authorization_allowed": null,
    "authorization_count": null,
    "incremental_authorizations": null,
    "external_authentication_details": null,
    "external_3ds_authentication_attempted": false,
    "expires_on": "2025-05-07T12:06:44.853Z",
    "fingerprint": null,
    "browser_info": {
        "language": "nl-NL",
        "time_zone": 0,
        "ip_address": "128.0.0.1",
        "user_agent": "Mozilla/5.0 (iPhone NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Safari/537.36",
        "color_depth": 24,
        "java_enabled": true,
        "screen_width": 1536,
        "accept_header": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8",
        "screen_height": 723,
        "java_script_enabled": true
    },
    "payment_method_id": null,
    "payment_method_status": null,
    "updated": "2025-05-07T11:51:58.623Z",
    "split_payments": null,
    "frm_metadata": null,
    "extended_authorization_applied": null,
    "capture_before": null,
    "merchant_order_reference_id": null,
    "order_tax_amount": null,
    "connector_mandate_id": null,
    "card_discovery": "manual",
    "force_3ds_challenge": false,
    "force_3ds_challenge_trigger": false,
    "issuer_error_code": null,
    "issuer_error_message": null
}
```



## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
