### PR TITLE
ci(cypress): Fix Bank Redirects for stripe test

### DIFF
--- a/cypress-tests/cypress/support/redirectionHandler.js
+++ b/cypress-tests/cypress/support/redirectionHandler.js
@@ -193,7 +193,27 @@ function bankRedirectRedirection(
               paymentMethodType
             )
           ) {
-            cy.get('a[name="success"]').click();
+            // scroll down and click on the authorize test payment button
+            cy.get("body").then(($body) => {
+              cy.get("#frame-warning-container").then(($el) => {
+                if ($el.is(":visible")) {
+                  // Frame warning is visible — use test payment button
+                  cy.get("#authorize-test-payment")
+                    .scrollIntoView()
+                    .should("be.visible")
+                    .click();
+                } else {
+                  // Frame warning is hidden — use the success link
+                  cy.contains(
+                    'a.common-Button[name="success"]',
+                    "Authorize Test Payment"
+                  )
+                    .scrollIntoView()
+                    .should("be.visible")
+                    .click();
+                }
+              });
+            });
             verifyUrl = true;
           } else {
             throw new Error(


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
Stripe introduced changes in how bank redirects are handled within iframes, so the corresponding Cypress test has been updated to reflect this.

## Motivation and Context
The previous test setup was failing due to changes in Stripe’s redirect behavior. This update ensures compatibility with the new flow and resolves the failing checks.


## How did you test it?

Ran locally

<img width="517" alt="Screenshot 2025-05-12 at 4 45 48 PM" src="https://github.com/user-attachments/assets/bd0e8747-7e83-462e-bc2d-20c9a373defd" />



## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
