### PR TITLE
feat(core): add a procedural macro for validating schema attributes for a struct

### DIFF
--- a/crates/api_models/src/payments.rs
+++ b/crates/api_models/src/payments.rs
@@ -847,6 +847,7 @@ impl AmountDetailsUpdate {
     Clone,
     ToSchema,
     router_derive::PolymorphicSchema,
+    router_derive::ValidateSchema,
 )]
 #[generate_schemas(PaymentsCreateRequest, PaymentsUpdateRequest, PaymentsConfirmRequest)]
 #[serde(deny_unknown_fields)]
@@ -963,7 +964,7 @@ pub struct PaymentsRequest {
     pub description: Option<String>,
 
     /// The URL to which you want the user to be redirected after the completion of the payment operation
-    #[schema(value_type = Option<String>, example = "https://hyperswitch.io")]
+    #[schema(value_type = Option<String>, example = "https://hyperswitch.io", max_length = 255)]
     pub return_url: Option<Url>,
 
     #[schema(value_type = Option<FutureUsage>, example = "off_session")]
@@ -1018,7 +1019,7 @@ pub struct PaymentsRequest {
     pub customer_acceptance: Option<CustomerAcceptance>,
 
     /// A unique identifier to link the payment to a mandate. To do Recurring payments after a mandate has been created, pass the mandate_id instead of payment_method_data
-    #[schema(max_length = 255, example = "mandate_iwer89rnjef349dni3")]
+    #[schema(max_length = 64, example = "mandate_iwer89rnjef349dni3")]
     #[remove_in(PaymentsUpdateRequest)]
     pub mandate_id: Option<String>,
 

--- a/crates/router/src/routes/payments.rs
+++ b/crates/router/src/routes/payments.rs
@@ -37,6 +37,12 @@ pub async fn payments_create(
 ) -> impl Responder {
     let flow = Flow::PaymentsCreate;
     let mut payload = json_payload.into_inner();
+    if let Err(err) = payload
+        .validate()
+        .map_err(|message| errors::ApiErrorResponse::InvalidRequestData { message })
+    {
+        return api::log_and_return_error_response(err.into());
+    };
 
     if let Some(api_enums::CaptureMethod::Scheduled) = payload.capture_method {
         return http_not_implemented();
@@ -574,6 +580,12 @@ pub async fn payments_update(
 ) -> impl Responder {
     let flow = Flow::PaymentsUpdate;
     let mut payload = json_payload.into_inner();
+    if let Err(err) = payload
+        .validate()
+        .map_err(|message| errors::ApiErrorResponse::InvalidRequestData { message })
+    {
+        return api::log_and_return_error_response(err.into());
+    };
 
     if let Some(api_enums::CaptureMethod::Scheduled) = payload.capture_method {
         return http_not_implemented();
@@ -754,6 +766,12 @@ pub async fn payments_confirm(
 ) -> impl Responder {
     let flow = Flow::PaymentsConfirm;
     let mut payload = json_payload.into_inner();
+    if let Err(err) = payload
+        .validate()
+        .map_err(|message| errors::ApiErrorResponse::InvalidRequestData { message })
+    {
+        return api::log_and_return_error_response(err.into());
+    };
 
     if let Some(api_enums::CaptureMethod::Scheduled) = payload.capture_method {
         return http_not_implemented();

--- a/crates/router/tests/macros.rs
+++ b/crates/router/tests/macros.rs
@@ -77,7 +77,7 @@ mod validate_schema_test {
             return_url: Some("https://example.com/return".parse().unwrap()),
         };
         let err = invalid_id.validate().unwrap_err();
-        assert!(err.contains("payment_id must be atleast 5 characters long. Received 3 characters"));
+        assert!(err.contains("payment_id must be at least 5 characters long. Received 3 characters"));
 
         // Invalid: payment_id too long
         let invalid_desc = Payment {


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
This PR adds automatic validation for string length constraints defined in schema attributes. The validation prevents 5xx errors that occur when strings exceeding database column length limits are passed to the database.

The implementation:
1. Creates a proc macro `ValidateSchema` that reads `min_length` and `max_length` parameters from schema attributes
2. Generates validation code that is invoked at runtime
3. Returns appropriate 4xx errors with helpful messages when validation fails

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
When API requests contain fields that exceed database column length limits, the application currently returns 5xx errors when those values are stored. This is incorrect behavior - it should be a 4xx error (invalid request) since the client provided invalid data.

This change implements the correct behavior, and also uses the same schema attributes for both OpenAPI spec generation and validation giving us a single source of truth. It also improves error handling - returning 4xx instead of 5xx errors for invalid requests

## How did you test it?
<details>
    <summary>1. Added unit test cases for the macro</summary>

<img width="1025" alt="Screenshot 2025-05-12 at 5 50 33 PM" src="https://github.com/user-attachments/assets/1659f4aa-6918-4db4-be3c-fd241dc0bf49" />


</details>

<details>
    <summary>2. Pass invalid return_url (length exceeding 255 characters)</summary>

cURL

    curl --location --request POST 'http://localhost:8080/payments' \
        --header 'Content-Type: application/json' \
        --header 'Accept: application/json' \
        --header 'Accept-Language: es-ES' \
        --header 'api-key: dev_tizBo0XFMZBNZ3jWBlkrc6C81CiCdliXrLXFoAg2fTgoTmKvOIk2oAP43Gwb3AGK' \
        --data-raw '{"customer_id":"cus_Wz8ND2QMGUTQCZBgO4Jx_1","profile_id":"pro_DC4DZ899zblYKajNmd0K","customer_acceptance":{"acceptance_type":"online","accepted_at":"1963-05-03T04:07:52.723Z","online":{"ip_address":"127.0.0.1","user_agent":"amet irure esse"}},"amount":12,"currency":"SGD","confirm":false,"payment_link":true,"setup_future_usage":"off_session","capture_method":"automatic","billing":{"address":{},"email":"random@juspay.in"},"return_url":"https://example.com?q=example.com&q=example.com&q=example.com&q=example.com&q=example.com&q=example.com&q=example.com&q=example.com&q=example.com&q=example.com&q=example.com&q=example.com&q=example.com&q=example.com&q=example.com&q=example.com&q=example.abc","payment_link_config":{"theme":"#111111","is_setup_mandate_flow":true,"background_image":{"url":"https://img.freepik.com/free-photo/abstract-blue-geometric-shapes-background_24972-1841.jpg","position":"bottom","size":"cover"}}}'

Response

    {
        "error": {
            "type": "invalid_request",
            "message": "return_url must be at most 255 characters long. Received 258 characters",
            "code": "IR_06"
        }
    }

</details>

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
