### PR TITLE
fix(router): fix Click to Pay cavv None error

### DIFF
--- a/config/deployments/integration_test.toml
+++ b/config/deployments/integration_test.toml
@@ -698,3 +698,6 @@ billing_connectors_which_require_payment_sync = "stripebilling, recurly"
 
 [billing_connectors_invoice_sync]
 billing_connectors_which_requires_invoice_sync_call = "recurly"
+
+[authentication_providers]
+click_to_pay = {connector_list = "adyen, cybersource"}

--- a/crates/hyperswitch_connectors/src/connectors/checkout/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/checkout/transformers.rs
@@ -271,7 +271,7 @@ pub struct CheckoutThreeDS {
     enabled: bool,
     force_3ds: bool,
     eci: Option<String>,
-    cryptogram: Option<String>,
+    cryptogram: Option<Secret<String>>,
     xid: Option<String>,
     version: Option<String>,
 }

--- a/crates/hyperswitch_connectors/src/connectors/cybersource/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/cybersource/transformers.rs
@@ -368,7 +368,7 @@ pub struct ProcessingInformation {
 #[serde(rename_all = "camelCase")]
 pub struct CybersourceConsumerAuthInformation {
     ucaf_collection_indicator: Option<String>,
-    cavv: Option<String>,
+    cavv: Option<Secret<String>>,
     ucaf_authentication_data: Option<Secret<String>>,
     xid: Option<String>,
     directory_server_transaction_id: Option<Secret<String>>,
@@ -1317,11 +1317,7 @@ impl
             .map(|authn_data| {
                 let (ucaf_authentication_data, cavv, ucaf_collection_indicator) =
                     if ccard.card_network == Some(common_enums::CardNetwork::Mastercard) {
-                        (
-                            Some(Secret::new(authn_data.cavv.clone())),
-                            None,
-                            Some("2".to_string()),
-                        )
+                        (Some(authn_data.cavv.clone()), None, Some("2".to_string()))
                     } else {
                         (None, Some(authn_data.cavv.clone()), None)
                     };
@@ -1418,11 +1414,7 @@ impl
             .map(|authn_data| {
                 let (ucaf_authentication_data, cavv, ucaf_collection_indicator) =
                     if ccard.card_network == Some(common_enums::CardNetwork::Mastercard) {
-                        (
-                            Some(Secret::new(authn_data.cavv.clone())),
-                            None,
-                            Some("2".to_string()),
-                        )
+                        (Some(authn_data.cavv.clone()), None, Some("2".to_string()))
                     } else {
                         (None, Some(authn_data.cavv.clone()), None)
                     };
@@ -1504,11 +1496,7 @@ impl
             .map(|authn_data| {
                 let (ucaf_authentication_data, cavv, ucaf_collection_indicator) =
                     if token_data.card_network == Some(common_enums::CardNetwork::Mastercard) {
-                        (
-                            Some(Secret::new(authn_data.cavv.clone())),
-                            None,
-                            Some("2".to_string()),
-                        )
+                        (Some(authn_data.cavv.clone()), None, Some("2".to_string()))
                     } else {
                         (None, Some(authn_data.cavv.clone()), None)
                     };
@@ -3192,7 +3180,7 @@ pub enum CybersourceAuthEnrollmentStatus {
 #[serde(rename_all = "camelCase")]
 pub struct CybersourceConsumerAuthValidateResponse {
     ucaf_collection_indicator: Option<String>,
-    cavv: Option<String>,
+    cavv: Option<Secret<String>>,
     ucaf_authentication_data: Option<Secret<String>>,
     xid: Option<String>,
     specification_version: Option<String>,

--- a/crates/hyperswitch_connectors/src/connectors/datatrans/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/datatrans/transformers.rs
@@ -458,7 +458,7 @@ fn create_card_details(
                 .threeds_server_transaction_id
                 .clone()
                 .map(Secret::new),
-            cavv: Secret::new(auth_data.cavv.clone()),
+            cavv: auth_data.cavv.clone(),
             eci: auth_data.eci.clone(),
             xid: auth_data.ds_trans_id.clone().map(Secret::new),
             three_ds_version: auth_data

--- a/crates/hyperswitch_connectors/src/connectors/nmi/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/nmi/transformers.rs
@@ -477,7 +477,7 @@ pub struct CardThreeDsData {
     ccexp: Secret<String>,
     email: Option<Email>,
     cardholder_auth: Option<String>,
-    cavv: Option<String>,
+    cavv: Option<Secret<String>>,
     eci: Option<String>,
     cvv: Secret<String>,
     three_ds_version: Option<String>,

--- a/crates/hyperswitch_connectors/src/connectors/wellsfargo/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/wellsfargo/transformers.rs
@@ -284,7 +284,7 @@ pub struct ProcessingInformation {
 #[serde(rename_all = "camelCase")]
 pub struct WellsfargoConsumerAuthInformation {
     ucaf_collection_indicator: Option<String>,
-    cavv: Option<String>,
+    cavv: Option<Secret<String>>,
     ucaf_authentication_data: Option<Secret<String>>,
     xid: Option<String>,
     directory_server_transaction_id: Option<Secret<String>>,
@@ -933,7 +933,7 @@ impl
             .map(|authn_data| {
                 let (ucaf_authentication_data, cavv) =
                     if ccard.card_network == Some(common_enums::CardNetwork::Mastercard) {
-                        (Some(Secret::new(authn_data.cavv.clone())), None)
+                        (Some(authn_data.cavv.clone()), None)
                     } else {
                         (None, Some(authn_data.cavv.clone()))
                     };

--- a/crates/hyperswitch_domain_models/src/router_request_types.rs
+++ b/crates/hyperswitch_domain_models/src/router_request_types.rs
@@ -623,7 +623,7 @@ impl
 #[derive(Debug, Clone)]
 pub struct AuthenticationData {
     pub eci: Option<String>,
-    pub cavv: String,
+    pub cavv: Secret<String>,
     pub threeds_server_transaction_id: Option<String>,
     pub message_version: Option<common_utils::types::SemanticVersion>,
     pub ds_trans_id: Option<String>,

--- a/crates/hyperswitch_domain_models/src/router_request_types/authentication.rs
+++ b/crates/hyperswitch_domain_models/src/router_request_types/authentication.rs
@@ -164,6 +164,6 @@ pub struct ExternalThreeDSConnectorMetadata {
 
 #[derive(Clone, Debug)]
 pub struct AuthenticationStore {
-    pub cavv: Option<String>,
+    pub cavv: Option<masking::Secret<String>>,
     pub authentication: diesel_models::authentication::Authentication,
 }

--- a/crates/router/src/core/authentication.rs
+++ b/crates/router/src/core/authentication.rs
@@ -155,7 +155,7 @@ pub async fn perform_post_authentication(
 
     let authentication_store =
         hyperswitch_domain_models::router_request_types::authentication::AuthenticationStore {
-            cavv: Some(tokenized_data.value1),
+            cavv: Some(masking::Secret::new(tokenized_data.value1)),
             authentication: authentication_update,
         };
 

--- a/crates/router/src/core/payments/operations/payment_confirm.rs
+++ b/crates/router/src/core/payments/operations/payment_confirm.rs
@@ -1227,12 +1227,12 @@ impl<F: Clone + Send + Sync> Domain<F, api::PaymentsRequest, PaymentData<F>> for
                             &authentication_id,
                             payment_data.service_details.clone(),
                             authentication_status,
-                            network_token,
+                            network_token.clone(),
                             payment_data.payment_attempt.organization_id.clone(),
                         )
                         .await?;
                         let authentication_store = hyperswitch_domain_models::router_request_types::authentication::AuthenticationStore {
-                            cavv: None, // since in case of CTP we will be storing all details in network token under payment_method_data
+                            cavv: network_token.and_then(|token| token.token_cryptogram),
                             authentication
                         };
                         payment_data.authentication = Some(authentication_store);
@@ -1406,7 +1406,7 @@ impl<F: Clone + Send + Sync> Domain<F, api::PaymentsRequest, PaymentData<F>> for
                 let tokenized_data = crate::core::payment_methods::vault::get_tokenized_data(state, &authentication_id, false, key_store.key.get_inner()).await?;
 
                 let authentication_store = hyperswitch_domain_models::router_request_types::authentication::AuthenticationStore {
-                    cavv: Some(tokenized_data.value1),
+                    cavv: Some(masking::Secret::new(tokenized_data.value1)),
                     authentication: updated_authentication
                 };
 

--- a/crates/router/src/core/unified_authentication_service.rs
+++ b/crates/router/src/core/unified_authentication_service.rs
@@ -21,7 +21,6 @@ use hyperswitch_domain_models::{
         UasPreAuthenticationRouterData,
     },
 };
-use masking::ExposeInterface;
 
 use super::{errors::RouterResult, payments::helpers::MerchantConnectorAccountType};
 use crate::{
@@ -512,9 +511,7 @@ pub async fn create_new_authentication(
         connector_metadata: None,
         maximum_supported_version: None,
         threeds_server_transaction_id: None,
-        cavv: network_token
-            .clone()
-            .and_then(|data| data.token_cryptogram.map(|cavv| cavv.expose())),
+        cavv: None,
         authentication_flow_type: None,
         message_version: None,
         eci: network_token.and_then(|data| data.eci),


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix

## Description
<!-- Describe your changes in detail -->
Currently Click to pay is breaking due to CAVV being populated as null in the flow this PR fixes it.

Pr to Main ->
https://github.com/juspay/hyperswitch/pull/8019

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
