### PR TITLE
fix(connector): [CYBERSOURCE] fix CartesBancaires card_type for Cybersource

### DIFF
--- a/crates/hyperswitch_connectors/src/connectors/adyen/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/adyen/transformers.rs
@@ -2164,6 +2164,7 @@ impl TryFrom<&utils::CardIssuer> for CardBrand {
             utils::CardIssuer::DinersClub => Ok(Self::Diners),
             utils::CardIssuer::JCB => Ok(Self::Jcb),
             utils::CardIssuer::CarteBlanche => Ok(Self::Cartebancaire),
+            utils::CardIssuer::CartesBancaires => Ok(Self::Cartebancaire),
         }
     }
 }

--- a/crates/hyperswitch_connectors/src/connectors/cybersource/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/cybersource/transformers.rs
@@ -95,6 +95,7 @@ impl From<CardIssuer> for String {
             CardIssuer::DinersClub => "005",
             CardIssuer::CarteBlanche => "006",
             CardIssuer::JCB => "007",
+            CardIssuer::CartesBancaires => "036",
         };
         card_type.to_string()
     }
@@ -4300,7 +4301,7 @@ fn get_cybersource_card_type(card_network: common_enums::CardNetwork) -> Option<
         common_enums::CardNetwork::JCB => Some("007"),
         common_enums::CardNetwork::DinersClub => Some("005"),
         common_enums::CardNetwork::Discover => Some("004"),
-        common_enums::CardNetwork::CartesBancaires => Some("006"),
+        common_enums::CardNetwork::CartesBancaires => Some("036"),
         common_enums::CardNetwork::UnionPay => Some("062"),
         //"042" is the type code for Masetro Cards(International). For Maestro Cards(UK-Domestic) the mapping should be "024"
         common_enums::CardNetwork::Maestro => Some("042"),

--- a/crates/hyperswitch_connectors/src/connectors/multisafepay/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/multisafepay/transformers.rs
@@ -468,7 +468,8 @@ impl TryFrom<utils::CardIssuer> for Gateway {
             utils::CardIssuer::Visa => Ok(Self::Visa),
             utils::CardIssuer::DinersClub
             | utils::CardIssuer::JCB
-            | utils::CardIssuer::CarteBlanche => Err(errors::ConnectorError::NotImplemented(
+            | utils::CardIssuer::CarteBlanche
+            | utils::CardIssuer::CartesBancaires => Err(errors::ConnectorError::NotImplemented(
                 utils::get_unimplemented_payment_method_error_message("Multisafe pay"),
             )
             .into()),

--- a/crates/hyperswitch_connectors/src/connectors/payeezy/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/payeezy/transformers.rs
@@ -76,7 +76,8 @@ impl TryFrom<CardIssuer> for PayeezyCardType {
             CardIssuer::Maestro
             | CardIssuer::DinersClub
             | CardIssuer::JCB
-            | CardIssuer::CarteBlanche => Err(ConnectorError::NotImplemented(
+            | CardIssuer::CarteBlanche
+            | CardIssuer::CartesBancaires => Err(ConnectorError::NotImplemented(
                 get_unimplemented_payment_method_error_message("Payeezy"),
             ))?,
         }

--- a/crates/hyperswitch_connectors/src/connectors/payone/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/payone/transformers.rs
@@ -196,7 +196,8 @@ impl TryFrom<CardIssuer> for PaymentProductId {
             | CardIssuer::Discover
             | CardIssuer::DinersClub
             | CardIssuer::JCB
-            | CardIssuer::CarteBlanche => Err(ConnectorError::NotImplemented(
+            | CardIssuer::CarteBlanche
+            | CardIssuer::CartesBancaires => Err(ConnectorError::NotImplemented(
                 get_unimplemented_payment_method_error_message("payone"),
             )
             .into()),

--- a/crates/hyperswitch_connectors/src/utils.rs
+++ b/crates/hyperswitch_connectors/src/utils.rs
@@ -1035,6 +1035,7 @@ pub enum CardIssuer {
     DinersClub,
     JCB,
     CarteBlanche,
+    CartesBancaires,
 }
 
 pub trait CardData {


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
Payment via CartesBancaires were failing via Cybersource, since the card_type passed was wrong. It was previously "006" ,but should be "036" - this PR introduces this fix.

source
https://developer.cybersource.com/library/documentation/dev_guides/Retail_SO_API/html/Topics/app_card_types.htm


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
### Request
**/payments curl via Cybersource**

`curl --location 'http://localhost:8080/payments' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: dev_NPIG8WP70mW0jR7lCFARlP4ca4QlG1h99wGNpagFQsVdID90RONd5m7DDChGTzBk' \
--data-raw '{
    "amount": 700,
    "currency": "EUR",
    "confirm": true,
    "payment_link": false,
    "capture_on": "2029-09-10T10:11:12Z",
    "amount_to_capture": 700,
    "name": "John Doe",
    "email": "dg@example.com",
    "phone": "999999999",
    "phone_country_code": "+1",
    "description": "Its my first payment request",
    "authentication_type": "no_three_ds",
    "return_url": "https://google.com",
    "payment_method_data": {
        "card": {
            "card_number": "4035 5014 2814 6300",
            "card_exp_month": "07",
            "card_exp_year": "2030",
            "card_holder_name": "joseph Doe",
            "card_cvc": "737",
            "card_network": "CartesBancaires"
        },
        "billing": {
            "address": {
                "line1": "1467",
                "line2": "CA",
                "city": "San Fransico",
                "state": "Washington",
                "zip": "94122",
                "country": "US",
                "first_name": "Henry",
                "last_name": "Henry"
            }
        }
    },
    "payment_method": "card",
    "payment_method_type": "credit",
    "browser_info": {
        "color_depth": 24,
        "java_enabled": true,
        "java_script_enabled": true,
        "language": "en-GB",
        "screen_height": 720,
        "screen_width": 1280,
        "time_zone": -330,
        "ip_address": "208.127.127.193",
        "accept_header": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8",
        "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36 Edg/126.0.0.0"
    },
    "metadata": {
        "disable_avs": true,
        "udf1": "value1",
        "new_customer": "true",
        "login_date": "2019-09-10T10:11:12Z"
    },
    "order_details": [
        {
            "product_name": "Tea",
            "quantity": 1,
            "amount": 110,
            "product_img_link": "https://thumbs.dreamstime.com/b/indian-tea-spices-masala-chai-33827904.jpg"
        },
        {
            "product_name": "Tea",
            "quantity": 1,
            "amount": 110,
            "product_img_link": "https://thumbs.dreamstime.com/b/indian-tea-spices-masala-chai-33827904.jpg"
        },
        {
            "product_name": "Tea",
            "quantity": 1,
            "amount": 110,
            "product_img_link": "https://thumbs.dreamstime.com/b/indian-tea-spices-masala-chai-33827904.jpg"
        }
    ]
}'`

### Response
**Before PR changes**
<img width="1122" alt="Screenshot 2025-05-14 at 8 12 53 PM" src="https://github.com/user-attachments/assets/1d81cb99-9c56-49b3-875b-8305f9ebc294" />



**After PR changes**
<img width="1122" alt="Screenshot 2025-05-14 at 8 34 04 PM" src="https://github.com/user-attachments/assets/a33fee65-2eab-4360-a7e8-26ce364150d2" />



## Checklist
<!-- Put an `x` in the boxes that apply -->

- [X] I formatted the code `cargo +nightly fmt --all`
- [X] I addressed lints thrown by `cargo clippy`
- [X] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
