### PR TITLE
fix(router): fixed netcetera flow for backward flow cavv fetching

### DIFF
--- a/crates/router/src/core/authentication.rs
+++ b/crates/router/src/core/authentication.rs
@@ -151,11 +151,13 @@ pub async fn perform_post_authentication(
         false,
         key_store.key.get_inner(),
     )
-    .await?;
+    .await
+    .attach_printable("cavv not present after authentication flow")
+    .ok();
 
     let authentication_store =
         hyperswitch_domain_models::router_request_types::authentication::AuthenticationStore {
-            cavv: Some(tokenized_data.value1),
+            cavv: tokenized_data.map(|data| data.value1),
             authentication: authentication_update,
         };
 

--- a/crates/router/src/core/authentication.rs
+++ b/crates/router/src/core/authentication.rs
@@ -152,6 +152,7 @@ pub async fn perform_post_authentication(
         key_store.key.get_inner(),
     )
     .await
+    .inspect_err(|err| router_env::logger::error!(tokenized_data_result=?err))
     .attach_printable("cavv not present after authentication flow")
     .ok();
 


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix

## Description
<!-- Describe your changes in detail -->
Currently if we cancel the transaction after initiating with netcetera we are trying hard fetch cavv stored in temp locker, which is causing 5xx.

with this PR we will be ignoring the cavv fetch error since it will be fetched in authorisation flow if authorisation need to be done!

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Tested via sdk 

forward flow ( friction)

https://github.com/user-attachments/assets/0c1e56c1-b849-47b9-9a3a-734ba7675a33

forward flow ( friction less)

https://github.com/user-attachments/assets/b3daf207-3942-486d-b4eb-b351adf5c81e

backward flow 

https://github.com/user-attachments/assets/4e53d72b-584d-488b-b67b-8b1c3e1ca469


table screenshot

<img width="1464" alt="Screenshot 2025-05-15 at 3 07 09 PM" src="https://github.com/user-attachments/assets/d1eb4e1f-24cb-4ea5-928f-b9c71db24f5a" />


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
