### PR TITLE
refactor(connector): [Fiuu] enable refund ORF feature [RedSys] fix the request structure

### DIFF
--- a/crates/hyperswitch_connectors/src/connectors/fiuu/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/fiuu/transformers.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use api_models::payments::{self, AdditionalPaymentData};
+use api_models::payments;
 use cards::CardNumber;
 use common_enums::{enums, BankNames, CaptureMethod, Currency};
 use common_utils::{

--- a/crates/hyperswitch_connectors/src/connectors/fiuu/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/fiuu/transformers.rs
@@ -1073,8 +1073,6 @@ pub struct FiuuRefundRequest {
     pub signature: Secret<String>,
     #[serde(rename = "notify_url")]
     pub notify_url: Option<Url>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub bank_code: Option<BankCode>,
 }
 #[derive(Debug, Serialize, Display)]
 pub enum RefundType {
@@ -1107,28 +1105,6 @@ impl TryFrom<&FiuuRouterData<&RefundsRouterData<Execute>>> for FiuuRefundRequest
                 Url::parse(&item.router_data.request.get_webhook_url()?)
                     .change_context(errors::ConnectorError::RequestEncodingFailed)?,
             ),
-            bank_code: item
-                .router_data
-                .request
-                .additional_payment_method_data
-                .as_ref()
-                .and_then(|data| {
-                    if let AdditionalPaymentData::BankRedirect { bank_name, .. } = data {
-                        bank_name.and_then(|name| {
-                            BankCode::try_from(name)
-                                .map_err(|e| {
-                                    router_env::logger::error!(
-                                        "Error converting bank name to BankCode: {:?}",
-                                        e
-                                    );
-                                    e
-                                })
-                                .ok()
-                        })
-                    } else {
-                        None
-                    }
-                }),
         })
     }
 }

--- a/crates/hyperswitch_connectors/src/connectors/redsys/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/redsys/transformers.rs
@@ -139,7 +139,7 @@ impl EmvThreedsData {
             browser_accept_header: None,
             browser_user_agent: None,
             browser_java_enabled: None,
-            browser_java_script_enabled: None,
+            browser_javascript_enabled: None,
             browser_language: None,
             browser_color_depth: None,
             browser_screen_height: None,
@@ -159,7 +159,7 @@ impl EmvThreedsData {
         self.browser_accept_header = Some(browser_info.get_accept_header()?);
         self.browser_user_agent = Some(browser_info.get_user_agent()?);
         self.browser_java_enabled = Some(browser_info.get_java_enabled()?);
-        self.browser_java_script_enabled = browser_info.get_java_script_enabled().ok();
+        self.browser_javascript_enabled = browser_info.get_java_script_enabled().ok();
         self.browser_language = Some(browser_info.get_language()?);
         self.browser_color_depth = Some(browser_info.get_color_depth()?.to_string());
         self.browser_screen_height = Some(browser_info.get_screen_height()?.to_string());

--- a/crates/hyperswitch_connectors/src/connectors/redsys/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/redsys/transformers.rs
@@ -90,7 +90,7 @@ pub struct EmvThreedsData {
     browser_accept_header: Option<String>,
     browser_user_agent: Option<String>,
     browser_java_enabled: Option<bool>,
-    browser_java_script_enabled: Option<bool>,
+    browser_javascript_enabled: Option<bool>,
     browser_language: Option<String>,
     browser_color_depth: Option<String>,
     browser_screen_height: Option<String>,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
This PR contains changes for two connector integrations
1. Fiuu - omit `bank_code` from the refund request for enabling ORF feature from Fiuu's side
2. RedSys - fix the field for sending `browserJavascriptEnabled` field properly

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

## Motivation and Context
This change fixes the issues for Fiuu and RedSys integrations. Fiuu for refunds flow, and RedSys for 3ds card transactions.

## How did you test it?
Can only be tested in production.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
