### PR TITLE
refactor(success_rate): update the default configs

### DIFF
--- a/crates/api_models/src/routing.rs
+++ b/crates/api_models/src/routing.rs
@@ -889,12 +889,12 @@ impl Default for SuccessBasedRoutingConfig {
         Self {
             params: Some(vec![DynamicRoutingConfigParams::PaymentMethod]),
             config: Some(SuccessBasedRoutingConfigBody {
-                min_aggregates_size: Some(2),
+                min_aggregates_size: Some(5),
                 default_success_rate: Some(100.0),
-                max_aggregates_size: Some(3),
+                max_aggregates_size: Some(8),
                 current_block_threshold: Some(CurrentBlockThreshold {
-                    duration_in_mins: Some(5),
-                    max_total_count: Some(2),
+                    duration_in_mins: None,
+                    max_total_count: Some(5),
                 }),
                 specificity_level: SuccessRateSpecificityLevel::default(),
             }),

--- a/crates/router/src/core/payments/routing.rs
+++ b/crates/router/src/core/payments/routing.rs
@@ -1779,11 +1779,11 @@ pub async fn perform_decide_gateway_call_with_open_router(
                 );
                 routable_connectors.sort_by(|connector_choice_a, connector_choice_b| {
                     let connector_choice_a_score = gateway_priority_map
-                        .get(&connector_choice_a.connector.to_string())
+                        .get(&connector_choice_a.to_string())
                         .copied()
                         .unwrap_or(0.0);
                     let connector_choice_b_score = gateway_priority_map
-                        .get(&connector_choice_b.connector.to_string())
+                        .get(&connector_choice_b.to_string())
                         .copied()
                         .unwrap_or(0.0);
                     connector_choice_b_score


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
This pull request modifies the default configuration for `SuccessBasedRoutingConfig` in the `crates/api_models/src/routing.rs` file. The changes adjust the values for aggregate sizes, success rate thresholds, and block duration to better align with updated routing requirements.

Key changes to default routing configuration:

* Updated `min_aggregates_size` from `2` to `5` and `max_aggregates_size` from `3` to `8` to allow for larger aggregate sizes.
* Changed `current_block_threshold` to set `duration_in_mins` to `None` (previously `5`) and increased `max_total_count` from `2` to `5`, providing more flexibility in block thresholds.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
1. Toggle success based routing for a profile, Check the business profile table in DB, get the routing_algorithm_id active for that profile and check in routing_algorithm table. it should have default config as above numbers

```
curl --location --request POST 'http://localhost:8080/account/merchant_1747851996/business_profile/pro_Rbh3PEV8EITILLoKDC6N/dynamic_routing/success_based/toggle?enable=dynamic_connector_selection' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: xyz' \
--data ''
```

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
