### PR TITLE
fix(connector): [trustpay] change webhook deserialization error from 5xx to 4xx

### DIFF
--- a/crates/hyperswitch_connectors/src/connectors/trustpay/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/trustpay/transformers.rs
@@ -1896,7 +1896,7 @@ impl TryFrom<WebhookStatus> for enums::RefundStatus {
 #[derive(Default, Debug, Serialize, Deserialize, Eq, PartialEq, Clone)]
 #[serde(rename_all = "PascalCase")]
 pub struct WebhookReferences {
-    pub merchant_reference: String,
+    pub merchant_reference: Option<String>,
     pub payment_id: Option<String>,
     pub payment_request_id: Option<String>,
 }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
On TrustPay's SEPA redirection page, the customer is shown the necessary details to complete the bank transfer, including an E2E reference number. This reference is used by TrustPay to match the incoming payment with the original payment request. If the customer omits this number while paying, the payment cannot be linked to its corresponding request, resulting in the absence of both the Payment Request ID and the Merchant Reference in the notification.
Deserialization is triggered, and the notification cannot be identified by Hyperswitch.

This PR handles 5xx errors, but Hyperswitch won't be able to identify the webhook with any payment request due to insufficient information received from the TrustPay webhook.


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

Tested it manually


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
