### PR TITLE
fix(openapi): add NullObject wrapper to serialize NoSessionResponse as null

### DIFF
--- a/api-reference/openapi_spec.json
+++ b/api-reference/openapi_spec.json
@@ -6594,9 +6594,7 @@
             "$ref": "#/components/schemas/NoThirdPartySdkSessionResponse"
           },
           {
-            "type": "object",
-            "default": null,
-            "nullable": true
+            "$ref": "#/components/schemas/NullObject"
           }
         ]
       },
@@ -16518,6 +16516,10 @@
             "nullable": true
           }
         }
+      },
+      "NullObject": {
+        "default": null,
+        "nullable": true
       },
       "NumberComparison": {
         "type": "object",

--- a/crates/api_models/src/payments.rs
+++ b/crates/api_models/src/payments.rs
@@ -7213,7 +7213,7 @@ pub enum ApplePaySessionResponse {
     /// This is the common response most of the times
     NoThirdPartySdk(NoThirdPartySdkSessionResponse),
     /// This is for the empty session response
-    NoSessionResponse,
+    NoSessionResponse(NullObject),
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, serde::Serialize, ToSchema, serde::Deserialize)]
@@ -8761,4 +8761,16 @@ pub struct RecordAttemptErrorDetails {
     pub network_decline_code: Option<String>,
     /// A string indicating how to proceed with an network error if payment gateway provide one. This is used to understand the network error code better.
     pub network_error_message: Option<String>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, ToSchema)]
+pub struct NullObject;
+
+impl Serialize for NullObject {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_none() 
+    }
 }

--- a/crates/hyperswitch_connectors/src/connectors/payme/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/payme/transformers.rs
@@ -571,7 +571,7 @@ impl<F>
                     ))) => Some(api_models::payments::SessionToken::ApplePay(Box::new(
                         api_models::payments::ApplepaySessionTokenResponse {
                             session_token_data: Some(
-                                api_models::payments::ApplePaySessionResponse::NoSessionResponse,
+                                api_models::payments::ApplePaySessionResponse::NoSessionResponse(api_models::payments::NullObject),
                             ),
                             payment_request_data: Some(
                                 api_models::payments::ApplePayPaymentRequest {

--- a/crates/openapi/src/openapi.rs
+++ b/crates/openapi/src/openapi.rs
@@ -444,6 +444,7 @@ Never share your secret api keys. Keep them guarded and secure.
         api_models::payments::PazeWalletData,
         api_models::payments::SessionToken,
         api_models::payments::ApplePaySessionResponse,
+        api_models::payments::NullObject,
         api_models::payments::ThirdPartySdkSessionResponse,
         api_models::payments::NoThirdPartySdkSessionResponse,
         api_models::payments::SecretInfoToInitiateSdk,

--- a/crates/router/src/core/payments/flows/session_flow.rs
+++ b/crates/router/src/core/payments/flows/session_flow.rs
@@ -255,7 +255,7 @@ async fn create_applepay_session_token(
     let delayed_response = is_session_response_delayed(state, connector);
     if delayed_response {
         let delayed_response_apple_pay_session =
-            Some(payment_types::ApplePaySessionResponse::NoSessionResponse);
+            Some(payment_types::ApplePaySessionResponse::NoSessionResponse(api_models::payments::NullObject));
         create_apple_pay_session_response(
             router_data,
             delayed_response_apple_pay_session,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
SDK generation from Open API failed due to having a unitvariant in an untagged enum. In this PR, we have Refactored the `NoSessionResponse` variant to use Custom `NullObject` with serialize_none()


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
1.Initiate a payment with truspay with confirm false 
```
curl --location 'http://localhost:8080/payments' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: dev_nbKzEwDan8WKjKsjDuCexEjTqWm7udZh5EoE0GTvnzDTBeEtwGSglz8aNFVLmDod' \
--data-raw '{
    
    "return_url": "https://example.com",
    "confirm": false,
    "customer_acceptance": null,
    "description": "Test Payment",   
    "email": "hyperswitch_sdk_demo_id@gmail.com",
    "browser_info": {
        "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
        "accept_header": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8",
        "language": "en-US",
        "color_depth": 32,
        "screen_height": 1117,
        "screen_width": 1728,
        "time_zone": -330,
        "java_enabled": true,
        "java_script_enabled": true,
        "ip_address": "127.0.0.1"
    },

    "amount": 5000,

    "currency": "USD"
}'
```
Response
```
{"payment_id":"pay_6DfpEoQFBIIfWUfp93Y6","merchant_id":"postman_merchant_GHAction_0ff7d76e-ddc4-48fd-b678-9216d96591ab","status":"requires_payment_method","amount":5000,"net_amount":5000,"shipping_cost":null,"amount_capturable":0,"amount_received":null,"connector":null,"client_secret":"pay_6DfpEoQFBIIfWUfp93Y6_secret_Q0ayl2368c9dn6WEcTMA","created":"2025-05-23T15:02:34.158Z","currency":"USD","customer_id":null,"customer":{"id":null,"name":null,"email":"hyperswitch_sdk_demo_id@gmail.com","phone":null,"phone_country_code":null},"description":"Test Payment","refunds":null,"disputes":null,"mandate_id":null,"mandate_data":null,"setup_future_usage":null,"off_session":null,"capture_on":null,"capture_method":null,"payment_method":null,"payment_method_data":null,"payment_token":null,"shipping":null,"billing":null,"order_details":null,"email":null,"name":null,"phone":null,"return_url":"https://example.com/","authentication_type":null,"statement_descriptor_name":null,"statement_descriptor_suffix":null,"next_action":null,"cancellation_reason":null,"error_code":null,"error_message":null,"unified_code":null,"unified_message":null,"payment_experience":null,"payment_method_type":null,"connector_label":null,"business_country":null,"business_label":"default","business_sub_label":null,"allowed_payment_method_types":null,"ephemeral_key":null,"manual_retry_allowed":null,"connector_transaction_id":null,"frm_message":null,"metadata":null,"connector_metadata":null,"feature_metadata":null,"reference_id":null,"payment_link":null,"profile_id":"pro_CcwJ1BMBv33IsKYTsWEh","surcharge_details":null,"attempt_count":1,"merchant_decision":null,"merchant_connector_id":null,"incremental_authorization_allowed":null,"authorization_count":null,"incremental_authorizations":null,"external_authentication_details":null,"external_3ds_authentication_attempted":false,"expires_on":"2025-05-23T15:17:34.158Z","fingerprint":null,"browser_info":{"language":"en-US","time_zone":-330,"ip_address":"127.0.0.1","user_agent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36","color_depth":32,"java_enabled":true,"screen_width":1728,"accept_header":"text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8","screen_height":1117,"java_script_enabled":true},"payment_method_id":null,"payment_method_status":null,"updated":"2025-05-23T15:02:34.202Z","split_payments":null,"frm_metadata":null,"extended_authorization_applied":null,"capture_before":null,"merchant_order_reference_id":null,"order_tax_amount":null,"connector_mandate_id":null,"card_discovery":null,"force_3ds_challenge":false,"force_3ds_challenge_trigger":false,"issuer_error_code":null,"issuer_error_message":null,"is_iframe_redirection_enabled":null,"whole_connector_response":null}
```

Do a session call
```
curl --location 'http://localhost:8080/payments/session_tokens' \
--header 'Content-Type: application/json' \
--header 'api-key: pk_dev_0d3aa63ce9424a30998e0022739542cf' \
--data '{"payment_id":"pay_mPOZW9xuADD3lEM649O8","wallets":["apple_pay"],"client_secret":"pay_mPOZW9xuADD3lEM649O8_secret_1Y8UXoaiF6wXTJtaMP3T"}'
```
Response
```
{"payment_id":"pay_mPOZW9xuADD3lEM649O8","client_secret":"pay_mPOZW9xuADD3lEM649O8_secret_1Y8UXoaiF6wXTJtaMP3T","session_token":[{"wallet_name":"apple_pay","session_token_data":null,"payment_request_data":null,"connector":"trustpay","delayed_session_token":true,"sdk_next_action":{"next_action":"confirm"},"connector_reference_id":null,"connector_sdk_public_key":null,"connector_merchant_id":null}]}
```

There is no change reflected in the API Contract

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
