### PR TITLE
fix(connector): [Worldpay] add root CA certificate

### DIFF
--- a/crates/connector_configs/toml/development.toml
+++ b/crates/connector_configs/toml/development.toml
@@ -4597,10 +4597,11 @@ merchant_secret="Source verification key"
   payment_method_type = "google_pay"
 [[worldpay.wallet]]
   payment_method_type = "apple_pay"
-[worldpay.connector_auth.SignatureKey]
+[worldpay.connector_auth.MultiAuthKey]
 key1="Username"
 api_key="Password"
 api_secret="Merchant Identifier"
+key2="Worldpay's CA Certificate"
 [worldpay.connector_webhook_details]
 merchant_secret="Source verification key"
 [worldpay.metadata.merchant_name]

--- a/crates/connector_configs/toml/production.toml
+++ b/crates/connector_configs/toml/production.toml
@@ -3296,10 +3296,11 @@ merchant_secret="Source verification key"
   payment_method_type = "google_pay"
 [[worldpay.wallet]]
   payment_method_type = "apple_pay"
-[worldpay.connector_auth.SignatureKey]
+[worldpay.connector_auth.MultiAuthKey]
 key1="Username"
 api_key="Password"
 api_secret="Merchant Identifier"
+key2="Worldpay's CA Certificate"
 [worldpay.metadata.merchant_name]
 name="merchant_name"
 label="Name of the merchant to de displayed during 3DS challenge"

--- a/crates/connector_configs/toml/sandbox.toml
+++ b/crates/connector_configs/toml/sandbox.toml
@@ -4557,10 +4557,11 @@ merchant_secret="Source verification key"
   payment_method_type = "google_pay"
 [[worldpay.wallet]]
   payment_method_type = "apple_pay"
-[worldpay.connector_auth.SignatureKey]
+[worldpay.connector_auth.MultiAuthKey]
 key1="Username"
 api_key="Password"
 api_secret="Merchant Identifier"
+key2="Worldpay's CA Certificate"
 [worldpay.connector_webhook_details]
 merchant_secret="Source verification key"
 [worldpay.metadata.merchant_name]

--- a/crates/hyperswitch_connectors/src/connectors/worldpay.rs
+++ b/crates/hyperswitch_connectors/src/connectors/worldpay.rs
@@ -233,12 +233,15 @@ impl ConnectorIntegration<SetupMandate, SetupMandateRequestData, PaymentsRespons
         req: &SetupMandateRouterData,
         connectors: &Connectors,
     ) -> CustomResult<Option<Request>, errors::ConnectorError> {
+        let auth = worldpay::WorldpayAuthType::try_from(&req.connector_auth_type)
+            .change_context(errors::ConnectorError::FailedToObtainAuthType)?;
         Ok(Some(
             RequestBuilder::new()
                 .method(Method::Post)
                 .url(&types::SetupMandateType::get_url(self, req, connectors)?)
                 .attach_default_headers()
                 .headers(types::SetupMandateType::get_headers(self, req, connectors)?)
+                .add_ca_certificate_pem(auth.ca_certificate)
                 .set_body(types::SetupMandateType::get_request_body(
                     self, req, connectors,
                 )?)
@@ -336,12 +339,15 @@ impl ConnectorIntegration<Void, PaymentsCancelData, PaymentsResponseData> for Wo
         req: &PaymentsCancelRouterData,
         connectors: &Connectors,
     ) -> CustomResult<Option<Request>, errors::ConnectorError> {
+        let auth = worldpay::WorldpayAuthType::try_from(&req.connector_auth_type)
+            .change_context(errors::ConnectorError::FailedToObtainAuthType)?;
         Ok(Some(
             RequestBuilder::new()
                 .method(Method::Post)
                 .url(&PaymentsVoidType::get_url(self, req, connectors)?)
                 .attach_default_headers()
                 .headers(PaymentsVoidType::get_headers(self, req, connectors)?)
+                .add_ca_certificate_pem(auth.ca_certificate)
                 .build(),
         ))
     }
@@ -442,12 +448,15 @@ impl ConnectorIntegration<PSync, PaymentsSyncData, PaymentsResponseData> for Wor
         req: &PaymentsSyncRouterData,
         connectors: &Connectors,
     ) -> CustomResult<Option<Request>, errors::ConnectorError> {
+        let auth = worldpay::WorldpayAuthType::try_from(&req.connector_auth_type)
+            .change_context(errors::ConnectorError::FailedToObtainAuthType)?;
         Ok(Some(
             RequestBuilder::new()
                 .method(Method::Get)
                 .url(&types::PaymentsSyncType::get_url(self, req, connectors)?)
                 .attach_default_headers()
                 .headers(types::PaymentsSyncType::get_headers(self, req, connectors)?)
+                .add_ca_certificate_pem(auth.ca_certificate)
                 .build(),
         ))
     }
@@ -579,6 +588,8 @@ impl ConnectorIntegration<Capture, PaymentsCaptureData, PaymentsResponseData> fo
         req: &PaymentsCaptureRouterData,
         connectors: &Connectors,
     ) -> CustomResult<Option<Request>, errors::ConnectorError> {
+        let auth = worldpay::WorldpayAuthType::try_from(&req.connector_auth_type)
+            .change_context(errors::ConnectorError::FailedToObtainAuthType)?;
         Ok(Some(
             RequestBuilder::new()
                 .method(Method::Post)
@@ -587,6 +598,7 @@ impl ConnectorIntegration<Capture, PaymentsCaptureData, PaymentsResponseData> fo
                 .headers(types::PaymentsCaptureType::get_headers(
                     self, req, connectors,
                 )?)
+                .add_ca_certificate_pem(auth.ca_certificate)
                 .set_body(types::PaymentsCaptureType::get_request_body(
                     self, req, connectors,
                 )?)
@@ -704,6 +716,8 @@ impl ConnectorIntegration<Authorize, PaymentsAuthorizeData, PaymentsResponseData
         req: &PaymentsAuthorizeRouterData,
         connectors: &Connectors,
     ) -> CustomResult<Option<Request>, errors::ConnectorError> {
+        let auth = worldpay::WorldpayAuthType::try_from(&req.connector_auth_type)
+            .change_context(errors::ConnectorError::FailedToObtainAuthType)?;
         Ok(Some(
             RequestBuilder::new()
                 .method(Method::Post)
@@ -714,6 +728,7 @@ impl ConnectorIntegration<Authorize, PaymentsAuthorizeData, PaymentsResponseData
                 .headers(types::PaymentsAuthorizeType::get_headers(
                     self, req, connectors,
                 )?)
+                .add_ca_certificate_pem(auth.ca_certificate)
                 .set_body(types::PaymentsAuthorizeType::get_request_body(
                     self, req, connectors,
                 )?)
@@ -820,6 +835,8 @@ impl ConnectorIntegration<CompleteAuthorize, CompleteAuthorizeData, PaymentsResp
         req: &PaymentsCompleteAuthorizeRouterData,
         connectors: &Connectors,
     ) -> CustomResult<Option<Request>, errors::ConnectorError> {
+        let auth = worldpay::WorldpayAuthType::try_from(&req.connector_auth_type)
+            .change_context(errors::ConnectorError::FailedToObtainAuthType)?;
         let request = RequestBuilder::new()
             .method(Method::Post)
             .url(&types::PaymentsCompleteAuthorizeType::get_url(
@@ -828,6 +845,7 @@ impl ConnectorIntegration<CompleteAuthorize, CompleteAuthorizeData, PaymentsResp
             .headers(types::PaymentsCompleteAuthorizeType::get_headers(
                 self, req, connectors,
             )?)
+            .add_ca_certificate_pem(auth.ca_certificate)
             .set_body(types::PaymentsCompleteAuthorizeType::get_request_body(
                 self, req, connectors,
             )?)
@@ -931,6 +949,8 @@ impl ConnectorIntegration<Execute, RefundsData, RefundsResponseData> for Worldpa
         req: &RefundsRouterData<Execute>,
         connectors: &Connectors,
     ) -> CustomResult<Option<Request>, errors::ConnectorError> {
+        let auth = worldpay::WorldpayAuthType::try_from(&req.connector_auth_type)
+            .change_context(errors::ConnectorError::FailedToObtainAuthType)?;
         let request = RequestBuilder::new()
             .method(Method::Post)
             .url(&types::RefundExecuteType::get_url(self, req, connectors)?)
@@ -938,6 +958,7 @@ impl ConnectorIntegration<Execute, RefundsData, RefundsResponseData> for Worldpa
             .headers(types::RefundExecuteType::get_headers(
                 self, req, connectors,
             )?)
+            .add_ca_certificate_pem(auth.ca_certificate)
             .set_body(types::RefundExecuteType::get_request_body(
                 self, req, connectors,
             )?)
@@ -1028,12 +1049,15 @@ impl ConnectorIntegration<RSync, RefundsData, RefundsResponseData> for Worldpay 
         req: &RefundSyncRouterData,
         connectors: &Connectors,
     ) -> CustomResult<Option<Request>, errors::ConnectorError> {
+        let auth = worldpay::WorldpayAuthType::try_from(&req.connector_auth_type)
+            .change_context(errors::ConnectorError::FailedToObtainAuthType)?;
         Ok(Some(
             RequestBuilder::new()
                 .method(Method::Get)
                 .url(&types::RefundSyncType::get_url(self, req, connectors)?)
                 .attach_default_headers()
                 .headers(types::RefundSyncType::get_headers(self, req, connectors)?)
+                .add_ca_certificate_pem(auth.ca_certificate)
                 .build(),
         ))
     }

--- a/crates/hyperswitch_connectors/src/connectors/worldpay/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/worldpay/transformers.rs
@@ -562,6 +562,7 @@ impl<T: WorldpayPaymentsRequestData> TryFrom<(&WorldpayRouterData<&T>, &Secret<S
 pub struct WorldpayAuthType {
     pub(super) api_key: Secret<String>,
     pub(super) entity_id: Secret<String>,
+    pub(super) ca_certificate: Option<Secret<String>>,
 }
 
 impl TryFrom<&ConnectorAuthType> for WorldpayAuthType {
@@ -575,6 +576,7 @@ impl TryFrom<&ConnectorAuthType> for WorldpayAuthType {
                 Ok(Self {
                     api_key: Secret::new(auth_header),
                     entity_id: Secret::new("default".to_string()),
+                    ca_certificate: None,
                 })
             }
             ConnectorAuthType::SignatureKey {
@@ -587,6 +589,21 @@ impl TryFrom<&ConnectorAuthType> for WorldpayAuthType {
                 Ok(Self {
                     api_key: Secret::new(auth_header),
                     entity_id: api_secret.clone(),
+                    ca_certificate: None,
+                })
+            }
+            ConnectorAuthType::MultiAuthKey {
+                api_key,
+                key1,
+                api_secret,
+                key2,
+            } => {
+                let auth_key = format!("{}:{}", key1.peek(), api_key.peek());
+                let auth_header = format!("Basic {}", BASE64_ENGINE.encode(auth_key));
+                Ok(Self {
+                    api_key: Secret::new(auth_header),
+                    entity_id: api_secret.clone(),
+                    ca_certificate: Some(key2.clone()),
                 })
             }
             _ => Err(errors::ConnectorError::FailedToObtainAuthType)?,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
Hotfix for https://github.com/juspay/hyperswitch/pull/8205

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
This fixes the self signed certificate not trusted errors for Worldpay in production.

## How did you test it?
As mentioned in https://github.com/juspay/hyperswitch/pull/8205

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
