### PR TITLE
fix(routing): Add else arm in decide_connector function for straight through routing on eligibility failure

### DIFF
--- a/crates/router/src/core/payments.rs
+++ b/crates/router/src/core/payments.rs
@@ -6968,19 +6968,19 @@ where
             .await;
         } else {
             let connector_data = connectors
-            .into_iter()
-            .map(|conn| {
-                api::ConnectorData::get_connector_by_name(
-                    &state.conf.connectors,
-                    &conn.connector.to_string(),
-                    api::GetToken::Connector,
-                    conn.merchant_connector_id,
-                )
-                .map(|connector_data| connector_data.into())
-            })
-            .collect::<CustomResult<Vec<_>, _>>()
-            .change_context(errors::ApiErrorResponse::InternalServerError)
-            .attach_printable("Invalid connector name received")?;
+                .into_iter()
+                .map(|conn| {
+                    api::ConnectorData::get_connector_by_name(
+                        &state.conf.connectors,
+                        &conn.connector.to_string(),
+                        api::GetToken::Connector,
+                        conn.merchant_connector_id,
+                    )
+                    .map(|connector_data| connector_data.into())
+                })
+                .collect::<CustomResult<Vec<_>, _>>()
+                .change_context(errors::ApiErrorResponse::InternalServerError)
+                .attach_printable("Invalid connector name received")?;
 
             return decide_multiplex_connector_for_normal_or_recurring_payment(
                 &state,
@@ -6991,7 +6991,7 @@ where
                 business_profile.is_connector_agnostic_mit_enabled,
                 business_profile.is_network_tokenization_enabled,
             )
-            .await
+            .await;
         }
     }
 
@@ -7029,20 +7029,20 @@ where
             .await;
         } else {
             let connector_data = connectors
-            .into_iter()
-            .map(|conn| {
-                api::ConnectorData::get_connector_by_name(
-                    &state.conf.connectors,
-                    &conn.connector.to_string(),
-                    api::GetToken::Connector,
-                    conn.merchant_connector_id,
-                )
-                .map(|connector_data| connector_data.into())
-            })
-            .collect::<CustomResult<Vec<_>, _>>()
-            .change_context(errors::ApiErrorResponse::InternalServerError)
-            .attach_printable("Invalid connector name received")?;
-        
+                .into_iter()
+                .map(|conn| {
+                    api::ConnectorData::get_connector_by_name(
+                        &state.conf.connectors,
+                        &conn.connector.to_string(),
+                        api::GetToken::Connector,
+                        conn.merchant_connector_id,
+                    )
+                    .map(|connector_data| connector_data.into())
+                })
+                .collect::<CustomResult<Vec<_>, _>>()
+                .change_context(errors::ApiErrorResponse::InternalServerError)
+                .attach_printable("Invalid connector name received")?;
+
             return decide_multiplex_connector_for_normal_or_recurring_payment(
                 &state,
                 payment_data,
@@ -7052,7 +7052,7 @@ where
                 business_profile.is_connector_agnostic_mit_enabled,
                 business_profile.is_network_tokenization_enabled,
             )
-            .await
+            .await;
         }
     }
 


### PR DESCRIPTION

## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
This PR will add an else arm in the decide_connector function for straight through routing on failing eligibility check

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
Closes #8222 

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
