### PR TITLE
feat(core): add support for consuming eci for AuthNResponse in Authentication flow

### DIFF
--- a/crates/diesel_models/src/authentication.rs
+++ b/crates/diesel_models/src/authentication.rs
@@ -139,6 +139,7 @@ pub enum AuthenticationUpdate {
         connector_metadata: Option<serde_json::Value>,
         authentication_status: common_enums::AuthenticationStatus,
         ds_trans_id: Option<String>,
+        eci: Option<String>,
     },
     PostAuthenticationUpdate {
         trans_status: common_enums::TransactionStatus,
@@ -373,6 +374,7 @@ impl From<AuthenticationUpdate> for AuthenticationUpdateInternal {
                 connector_metadata,
                 authentication_status,
                 ds_trans_id,
+                eci,
             } => Self {
                 trans_status: Some(trans_status),
                 authentication_type: Some(authentication_type),
@@ -384,6 +386,7 @@ impl From<AuthenticationUpdate> for AuthenticationUpdateInternal {
                 connector_metadata,
                 authentication_status: Some(authentication_status),
                 ds_trans_id,
+                eci,
                 ..Default::default()
             },
             AuthenticationUpdate::PostAuthenticationUpdate {

--- a/crates/hyperswitch_connectors/src/connectors/archipel/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/archipel/transformers.rs
@@ -3,7 +3,7 @@ use common_enums::{
     self, AttemptStatus, AuthorizationStatus, CaptureMethod, Currency, FutureUsage,
     PaymentMethodStatus, RefundStatus,
 };
-use common_utils::{ext_traits::Encode, pii, types::MinorUnit};
+use common_utils::{date_time, ext_traits::Encode, pii, types::MinorUnit};
 use error_stack::ResultExt;
 use hyperswitch_domain_models::{
     address::AddressDetails,
@@ -163,23 +163,24 @@ pub struct Archipel3DS {
     three_ds_version: Option<common_utils::types::SemanticVersion>,
     authentication_value: Secret<String>,
     authentication_method: Option<Secret<String>>,
-    eci: Option<Secret<String>>,
+    eci: Option<String>,
 }
 
 impl From<AuthenticationData> for Archipel3DS {
     fn from(three_ds_data: AuthenticationData) -> Self {
+        let now = date_time::date_as_yyyymmddthhmmssmmmz().ok();
         Self {
             acs_trans_id: None,
             ds_trans_id: three_ds_data.ds_trans_id.map(Secret::new),
             three_ds_requestor_name: None,
-            three_ds_auth_date: None,
+            three_ds_auth_date: now,
             three_ds_auth_amt: None,
             three_ds_auth_status: None,
             three_ds_max_supported_version: THREE_DS_MAX_SUPPORTED_VERSION.into(),
             three_ds_version: three_ds_data.message_version,
             authentication_value: three_ds_data.cavv,
             authentication_method: None,
-            eci: three_ds_data.eci.map(Secret::new),
+            eci: three_ds_data.eci,
         }
     }
 }

--- a/crates/hyperswitch_connectors/src/connectors/gpayments/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/gpayments/transformers.rs
@@ -294,6 +294,7 @@ impl
                 authentication_value: response_auth.authentication_value,
                 ds_trans_id: Some(response_auth.ds_trans_id),
                 connector_metadata: None,
+                eci: None,
             });
         Ok(Self {
             response,

--- a/crates/hyperswitch_connectors/src/connectors/netcetera/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/netcetera/transformers.rs
@@ -163,6 +163,7 @@ impl
                     trans_status: response.trans_status,
                     connector_metadata: None,
                     ds_trans_id: response.authentication_response.ds_trans_id,
+                    eci: response.eci,
                 })
             }
             NetceteraAuthenticationResponse::Error(error_response) => Err(ErrorResponse {

--- a/crates/hyperswitch_connectors/src/connectors/threedsecureio/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/threedsecureio/transformers.rs
@@ -183,6 +183,7 @@ impl
                     authentication_value: response.authentication_value,
                     connector_metadata: None,
                     ds_trans_id: Some(response.ds_trans_id),
+                    eci: None,
                 })
             }
             ThreedsecureioAuthenticationResponse::Error(err_response) => match *err_response {

--- a/crates/hyperswitch_domain_models/src/router_request_types/unified_authentication_service.rs
+++ b/crates/hyperswitch_domain_models/src/router_request_types/unified_authentication_service.rs
@@ -110,6 +110,7 @@ pub struct AuthenticationDetails {
     pub trans_status: common_enums::TransactionStatus,
     pub connector_metadata: Option<serde_json::Value>,
     pub ds_trans_id: Option<String>,
+    pub eci: Option<String>,
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone)]

--- a/crates/hyperswitch_domain_models/src/router_response_types.rs
+++ b/crates/hyperswitch_domain_models/src/router_response_types.rs
@@ -542,6 +542,7 @@ pub enum AuthenticationResponseData {
         trans_status: common_enums::TransactionStatus,
         connector_metadata: Option<serde_json::Value>,
         ds_trans_id: Option<String>,
+        eci: Option<String>,
     },
     PostAuthNResponse {
         trans_status: common_enums::TransactionStatus,

--- a/crates/router/src/core/authentication/utils.rs
+++ b/crates/router/src/core/authentication/utils.rs
@@ -95,6 +95,7 @@ pub async fn update_trackers<F: Clone, Req>(
                 trans_status,
                 connector_metadata,
                 ds_trans_id,
+                eci,
             } => {
                 authentication_value
                     .async_map(|auth_val| {
@@ -123,6 +124,7 @@ pub async fn update_trackers<F: Clone, Req>(
                     authentication_status,
                     connector_metadata,
                     ds_trans_id,
+                    eci,
                 }
             }
             AuthenticationResponseData::PostAuthNResponse {

--- a/crates/router/src/core/unified_authentication_service/utils.rs
+++ b/crates/router/src/core/unified_authentication_service/utils.rs
@@ -217,6 +217,7 @@ pub async fn external_authentication_update_trackers<F: Clone, Req>(
                         authentication_status,
                         connector_metadata: authentication_details.connector_metadata,
                         ds_trans_id: authentication_details.ds_trans_id,
+                        eci: authentication_details.eci,
                     },
                 )
             }


### PR DESCRIPTION
…tication flow

## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [X] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
Added support for consuming eci for AuthNResponse in Authentication flow


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

### Create payment request via Archipel with 3ds external auth enabled via Netcetera
**Curl**

`curl --location 'http://localhost:8080/payments' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: dev_RjWWq6rhGEo3UkmUvEJjeduCwtMO5dsFDtL2ZjZDyOkM1ocKIkWKTm51bHgrPkDz' \
--data-raw '{
    "amount": 10000,
    "currency": "USD",
    "confirm": true,
    "payment_link": false,
    "profile_id": "pro_02kD3gH7YOnsSoiguC9h",
    "capture_method": "automatic",
    "capture_on": "2022-09-10T10:11:12Z",
    "amount_to_capture": 10000,
    "customer_id": "StripeCustomer",
    "email": "guest@example.com",
    "name": "John Doe",
    "phone": "999999999",
    "phone_country_code": "+1",
    "description": "Its my first payment request",
    "request_external_three_ds_authentication": true,
    "authentication_type": "three_ds",
    "return_url": "https://google.com",
    "payment_method": "card",
    "payment_method_type": "credit",
    "payment_method_data": {
        "card": {
            "card_number": "4242424242424242",
            "card_exp_month": "12",
            "card_exp_year": "2025",
            "card_cvc": "123",
            "card_network": "Visa"
        }
    },
    "billing": {
        "address": {
            "line1": "1467",
            "line2": "CA",
            "line3": "CA",
            "city": "Musterhausen",
            "state": "California",
            "zip": "12345",
            "country": "US",
            "first_name": "Debarati",
            "last_name": "Ghatak"
        },
        "phone": {
            "number": "8056594427",
            "country_code": "+91"
        }
    },
    "browser_info": {
        "user_agent": "Mozilla\/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/70.0.3538.110 Safari\/537.36",
        "accept_header": "text\/html,application\/xhtml+xml,application\/xml;q=0.9,image\/webp,image\/apng,\/;q=0.8",
        "language": "nl-NL",
        "color_depth": 24,
        "ip_address": "103.77.139.95",
        "screen_height": 723,
        "screen_width": 1536,
        "time_zone": 0,
        "java_enabled": true,
        "java_script_enabled": true
    },
    "statement_descriptor_name": "joseph",
    "statement_descriptor_suffix": "JS",
    "metadata": {
        "dg": "value1",
        "new_customer": "true",
        "login_date": "2019-09-10T10:11:12Z"
    }
}'`
<img width="940" alt="Screenshot 2025-06-03 at 4 20 52 PM" src="https://github.com/user-attachments/assets/876457c5-23e3-4517-ae8a-26201486b768" />


### Call 3ds authentication endpoint
**Curl**

`curl --location 'http://localhost:8080/payments/pay_RXcnxyQ4WX0ivbwJyd4V/3ds/authentication' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: pk_dev_89bfdedf18374b27b59ab42dc6508c57' \
--data '{
    "client_secret": "pay_RXcnxyQ4WX0ivbwJyd4V_secret_xl0oe5UNKzIBjUBSLdHw",
    "device_channel": "BRW",
    "threeds_method_comp_ind": "Y"
}'`

<img width="940" alt="Screenshot 2025-06-03 at 4 21 24 PM" src="https://github.com/user-attachments/assets/72abb5e3-a417-4f74-8a59-3e2d76aaa7eb" />



### Call authorize for Archipel 
**Curl**
<img width="940" alt="Screenshot 2025-06-03 at 4 21 40 PM" src="https://github.com/user-attachments/assets/7c4278c2-7bcd-42a9-afcd-36eb1532e8fb" />




## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
