### PR TITLE
feat(health): Health check for Decision engine

### DIFF
--- a/crates/api_models/src/health_check.rs
+++ b/crates/api_models/src/health_check.rs
@@ -12,6 +12,8 @@ pub struct RouterHealthCheckResponse {
     pub outgoing_request: bool,
     #[cfg(feature = "dynamic_routing")]
     pub grpc_health_check: HealthCheckMap,
+    #[cfg(feature = "dynamic_routing")]
+    pub decision_engine: bool,
 }
 
 impl common_utils::events::ApiEventMetric for RouterHealthCheckResponse {}

--- a/crates/router/src/routes/health.rs
+++ b/crates/router/src/routes/health.rs
@@ -108,6 +108,20 @@ async fn deep_health_check_func(
 
     logger::debug!("gRPC health check end");
 
+    logger::debug!("Decision Engine health check begin");
+
+    #[cfg(feature = "dynamic_routing")]
+    let decision_engine_health_check = state.health_check_decision_engine().await.map_err(|error| {
+        let message = error.to_string();
+        error.change_context(errors::ApiErrorResponse::HealthCheckError {
+            component: "Decision Engine service",
+            message,
+        })
+    })?;
+
+    logger::debug!("Decision Engine health check end");
+
+
     logger::debug!("Opensearch health check begin");
 
     #[cfg(feature = "olap")]
@@ -144,6 +158,8 @@ async fn deep_health_check_func(
         outgoing_request: outgoing_check.into(),
         #[cfg(feature = "dynamic_routing")]
         grpc_health_check,
+        #[cfg(feature = "dynamic_routing")]
+        decision_engine: decision_engine_health_check.into(),
     };
 
     Ok(api::ApplicationResponse::Json(response))

--- a/crates/storage_impl/src/errors.rs
+++ b/crates/storage_impl/src/errors.rs
@@ -280,3 +280,9 @@ pub enum RecoveryError {
     #[error("Failed to fetch billing connector account id")]
     BillingMerchantConnectorAccountIdNotFound,
 }
+
+#[derive(Debug, Clone, thiserror::Error)]
+pub enum HealthCheckDecisionEngineError {
+    #[error("Failed to establish Decision Engine connection")]
+    FailedToCallDecisionEngineService,
+}


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Added health check for Decision engine service


### Additional Changes

- [x] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Hit the health endpoint 

```
curl "http://localhost:8080/health/ready"
```

Response - 

```
{
  "database": true,
  "redis": true,
  "analytics": true,
  "opensearch": false,
  "outgoing_request": true,
  "grpc_health_check": {
    "dynamic_routing_service": false
  },
  "decision_engine": true
}
```


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
