### PR TITLE
fix: payment link styling for dynamic classes

### DIFF
--- a/crates/api_models/src/admin.rs
+++ b/crates/api_models/src/admin.rs
@@ -2958,6 +2958,8 @@ pub struct PaymentLinkConfigRequest {
     pub show_card_terms: Option<api_enums::PaymentLinkShowSdkTerms>,
     /// Boolean to control payment button text for setup mandate calls
     pub is_setup_mandate_flow: Option<bool>,
+    /// Hex color for the CVC icon during error state
+    pub color_icon_card_cvc_error: Option<String>,
 }
 
 #[derive(Clone, Debug, serde::Deserialize, serde::Serialize, PartialEq, ToSchema)]
@@ -3055,6 +3057,8 @@ pub struct PaymentLinkConfig {
     pub show_card_terms: Option<api_enums::PaymentLinkShowSdkTerms>,
     /// Boolean to control payment button text for setup mandate calls
     pub is_setup_mandate_flow: Option<bool>,
+    /// Hex color for the CVC icon during error state
+    pub color_icon_card_cvc_error: Option<String>,
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]

--- a/crates/api_models/src/payments.rs
+++ b/crates/api_models/src/payments.rs
@@ -8120,7 +8120,6 @@ pub struct PaymentLinkDetails {
     pub payment_button_text_colour: Option<String>,
     pub background_colour: Option<String>,
     pub sdk_ui_rules: Option<HashMap<String, HashMap<String, String>>>,
-    pub payment_link_ui_rules: Option<HashMap<String, HashMap<String, String>>>,
     pub status: api_enums::IntentStatus,
     pub enable_button_only_on_form_ready: bool,
     pub payment_form_header_text: Option<String>,
@@ -8129,6 +8128,7 @@ pub struct PaymentLinkDetails {
     pub is_setup_mandate_flow: Option<bool>,
     pub capture_method: Option<common_enums::CaptureMethod>,
     pub setup_future_usage_applied: Option<common_enums::FutureUsage>,
+    pub color_icon_card_cvc_error: Option<String>,
 }
 
 #[derive(Debug, serde::Serialize, Clone)]
@@ -8145,11 +8145,11 @@ pub struct SecurePaymentLinkDetails {
     pub payment_button_text_colour: Option<String>,
     pub background_colour: Option<String>,
     pub sdk_ui_rules: Option<HashMap<String, HashMap<String, String>>>,
-    pub payment_link_ui_rules: Option<HashMap<String, HashMap<String, String>>>,
     pub enable_button_only_on_form_ready: bool,
     pub payment_form_header_text: Option<String>,
     pub payment_form_label_type: Option<api_enums::PaymentLinkSdkLabelType>,
     pub show_card_terms: Option<api_enums::PaymentLinkShowSdkTerms>,
+    pub color_icon_card_cvc_error: Option<String>,
 }
 
 #[derive(Debug, serde::Serialize)]

--- a/crates/diesel_models/src/business_profile.rs
+++ b/crates/diesel_models/src/business_profile.rs
@@ -770,6 +770,7 @@ pub struct PaymentLinkConfigRequest {
     pub payment_form_label_type: Option<common_enums::PaymentLinkSdkLabelType>,
     pub show_card_terms: Option<common_enums::PaymentLinkShowSdkTerms>,
     pub is_setup_mandate_flow: Option<bool>,
+    pub color_icon_card_cvc_error: Option<String>,
 }
 
 #[derive(Clone, Debug, serde::Deserialize, serde::Serialize, PartialEq)]

--- a/crates/diesel_models/src/payment_intent.rs
+++ b/crates/diesel_models/src/payment_intent.rs
@@ -209,6 +209,8 @@ pub struct PaymentLinkConfigRequestForPayments {
     pub show_card_terms: Option<common_enums::PaymentLinkShowSdkTerms>,
     /// Boolean to control payment button text for setup mandate calls
     pub is_setup_mandate_flow: Option<bool>,
+    /// Hex color for the CVC icon during error state
+    pub color_icon_card_cvc_error: Option<String>,
 }
 
 common_utils::impl_to_sql_from_sql_json!(PaymentLinkConfigRequestForPayments);

--- a/crates/hyperswitch_domain_models/src/lib.rs
+++ b/crates/hyperswitch_domain_models/src/lib.rs
@@ -432,6 +432,7 @@ impl ApiModelToDieselModelConvertor<api_models::admin::PaymentLinkConfigRequest>
             payment_form_label_type: item.payment_form_label_type,
             show_card_terms: item.show_card_terms,
             is_setup_mandate_flow: item.is_setup_mandate_flow,
+            color_icon_card_cvc_error: item.color_icon_card_cvc_error,
         }
     }
     fn convert_back(self) -> api_models::admin::PaymentLinkConfigRequest {
@@ -460,6 +461,7 @@ impl ApiModelToDieselModelConvertor<api_models::admin::PaymentLinkConfigRequest>
             payment_form_label_type,
             show_card_terms,
             is_setup_mandate_flow,
+            color_icon_card_cvc_error,
         } = self;
         api_models::admin::PaymentLinkConfigRequest {
             theme,
@@ -492,6 +494,7 @@ impl ApiModelToDieselModelConvertor<api_models::admin::PaymentLinkConfigRequest>
             payment_form_label_type,
             show_card_terms,
             is_setup_mandate_flow,
+            color_icon_card_cvc_error,
         }
     }
 }

--- a/crates/router/src/core/payment_link.rs
+++ b/crates/router/src/core/payment_link.rs
@@ -14,6 +14,7 @@ use futures::future;
 use hyperswitch_domain_models::api::{GenericLinks, GenericLinksData};
 use masking::{PeekInterface, Secret};
 use router_env::logger;
+use std::collections::HashMap;
 use time::PrimitiveDateTime;
 
 use super::{
@@ -142,6 +143,7 @@ pub async fn form_payment_link_data(
                 payment_form_label_type: None,
                 show_card_terms: None,
                 is_setup_mandate_flow: None,
+                color_icon_card_cvc_error: None,
             }
         };
 
@@ -316,13 +318,13 @@ pub async fn form_payment_link_data(
         background_colour: payment_link_config.background_colour.clone(),
         payment_button_text_colour: payment_link_config.payment_button_text_colour.clone(),
         sdk_ui_rules: payment_link_config.sdk_ui_rules.clone(),
-        payment_link_ui_rules: payment_link_config.payment_link_ui_rules.clone(),
         status: payment_intent.status,
         enable_button_only_on_form_ready: payment_link_config.enable_button_only_on_form_ready,
         payment_form_header_text: payment_link_config.payment_form_header_text.clone(),
         payment_form_label_type: payment_link_config.payment_form_label_type,
         show_card_terms: payment_link_config.show_card_terms,
         is_setup_mandate_flow: payment_link_config.is_setup_mandate_flow,
+        color_icon_card_cvc_error: payment_link_config.color_icon_card_cvc_error.clone(),
         capture_method: payment_attempt.capture_method,
         setup_future_usage_applied: payment_attempt.setup_future_usage_applied,
     };
@@ -350,7 +352,7 @@ pub async fn initiate_secure_payment_link_flow(
         &payment_link_config,
     )?;
 
-    let css_script = get_color_scheme_css(&payment_link_config);
+    let css_script = get_payment_link_css_script(&payment_link_config)?;
 
     match payment_link_details {
         PaymentLinkData::PaymentLinkStatusDetails(ref status_details) => {
@@ -380,12 +382,12 @@ pub async fn initiate_secure_payment_link_flow(
                 background_colour: payment_link_config.background_colour,
                 payment_button_text_colour: payment_link_config.payment_button_text_colour,
                 sdk_ui_rules: payment_link_config.sdk_ui_rules,
-                payment_link_ui_rules: payment_link_config.payment_link_ui_rules,
                 enable_button_only_on_form_ready: payment_link_config
                     .enable_button_only_on_form_ready,
                 payment_form_header_text: payment_link_config.payment_form_header_text,
                 payment_form_label_type: payment_link_config.payment_form_label_type,
                 show_card_terms: payment_link_config.show_card_terms,
+                color_icon_card_cvc_error: payment_link_config.color_icon_card_cvc_error,
             };
             let payment_details_str = serde_json::to_string(&secure_payment_link_details)
                 .change_context(errors::ApiErrorResponse::InternalServerError)
@@ -446,7 +448,7 @@ pub async fn initiate_payment_link_flow(
     let (_, payment_details, payment_link_config) =
         form_payment_link_data(&state, merchant_context, merchant_id, payment_id).await?;
 
-    let css_script = get_color_scheme_css(&payment_link_config);
+    let css_script = get_payment_link_css_script(&payment_link_config)?;
     let js_script = get_js_script(&payment_details)?;
 
     match payment_details {
@@ -492,6 +494,85 @@ fn get_js_script(payment_details: &PaymentLinkData) -> RouterResult<String> {
         .attach_printable("Failed to serialize PaymentLinkData")?;
     let url_encoded_str = urlencoding::encode(&payment_details_str);
     Ok(format!("window.__PAYMENT_DETAILS = '{url_encoded_str}';"))
+}
+
+fn camel_to_kebab(s: &str) -> String {
+    let mut result = String::new();
+    if s.is_empty() {
+        return result;
+    }
+
+    let chars: Vec<char> = s.chars().collect();
+
+    for (i, &ch) in chars.iter().enumerate() {
+        if ch.is_uppercase() {
+            let should_add_dash = i > 0
+                && (chars.get(i - 1).map(|c| c.is_lowercase()).unwrap_or(false)
+                    || (i + 1 < chars.len()
+                        && chars.get(i + 1).map(|c| c.is_lowercase()).unwrap_or(false)
+                        && chars.get(i - 1).map(|c| c.is_uppercase()).unwrap_or(false)));
+
+            if should_add_dash {
+                result.push('-');
+            }
+            result.push(ch.to_ascii_lowercase());
+        } else {
+            result.push(ch);
+        }
+    }
+    result
+}
+
+fn generate_dynamic_css(
+    rules: &HashMap<String, HashMap<String, String>>,
+) -> Result<String, errors::ApiErrorResponse> {
+    if rules.is_empty() {
+        return Ok(String::new());
+    }
+
+    let mut css_string = String::new();
+    css_string.push_str("/* Dynamically Injected UI Rules */\n");
+
+    for (selector, styles_map) in rules {
+        if selector.trim().is_empty() {
+            return Err(errors::ApiErrorResponse::InvalidRequestData {
+                message: "CSS selector cannot be empty.".to_string(),
+            });
+        }
+
+        css_string.push_str(selector);
+        css_string.push_str(" {\n");
+
+        for (prop_camel_case, css_value) in styles_map {
+            let css_property = camel_to_kebab(prop_camel_case);
+
+            css_string.push_str("  ");
+            css_string.push_str(&css_property);
+            css_string.push_str(": ");
+            css_string.push_str(css_value);
+            css_string.push_str(";\n");
+        }
+        css_string.push_str("}\n");
+    }
+    Ok(css_string)
+}
+
+fn get_payment_link_css_script(
+    payment_link_config: &PaymentLinkConfig,
+) -> Result<String, errors::ApiErrorResponse> {
+    let custom_rules_css_option = payment_link_config
+        .payment_link_ui_rules
+        .as_ref()
+        .map(generate_dynamic_css)
+        .transpose()?;
+
+    let color_scheme_css = get_color_scheme_css(payment_link_config);
+
+    if let Some(custom_rules_css) = custom_rules_css_option {
+        Ok(format!("{}\n{}", color_scheme_css, custom_rules_css))
+    } else {
+        Ok(color_scheme_css)
+    }
 }
 
 fn get_color_scheme_css(payment_link_config: &PaymentLinkConfig) -> String {
@@ -706,6 +787,7 @@ pub fn get_payment_link_config_based_on_priority(
         payment_form_label_type,
         show_card_terms,
         is_setup_mandate_flow,
+        color_icon_card_cvc_error,
     ) = get_payment_link_config_value!(
         payment_create_link_config,
         business_theme_configs,
@@ -724,6 +806,7 @@ pub fn get_payment_link_config_based_on_priority(
         (payment_form_label_type),
         (show_card_terms),
         (is_setup_mandate_flow),
+        (color_icon_card_cvc_error),
     );
 
     let payment_link_config =
@@ -756,6 +839,7 @@ pub fn get_payment_link_config_based_on_priority(
             payment_form_label_type,
             show_card_terms,
             is_setup_mandate_flow,
+            color_icon_card_cvc_error,
         };
 
     Ok((payment_link_config, domain_name))
@@ -870,6 +954,7 @@ pub async fn get_payment_link_status(
             payment_form_label_type: None,
             show_card_terms: None,
             is_setup_mandate_flow: None,
+            color_icon_card_cvc_error: None,
         }
     };
 

--- a/crates/router/src/core/payment_link/payment_link_initiate/payment_link.css
+++ b/crates/router/src/core/payment_link/payment_link_initiate/payment_link.css
@@ -653,7 +653,7 @@ body {
 }
 
 #submit.not-ready {
-  background-color: #C2C2C2 !important;
+  background-color: #C2C2C2;
 }
 
 #submit-spinner {

--- a/crates/router/src/core/payment_link/payment_link_initiate/payment_link.js
+++ b/crates/router/src/core/payment_link/payment_link_initiate/payment_link.js
@@ -291,12 +291,6 @@ function boot() {
   // Add event listeners
   initializeEventListeners(paymentDetails);
 
-  // Update payment link styles
-  var paymentLinkUiRules = paymentDetails.payment_link_ui_rules;
-  if (isObject(paymentLinkUiRules)) {
-    updatePaymentLinkUi(paymentLinkUiRules);
-  }
-
   // Initialize SDK
   // @ts-ignore
   if (window.Hyper) {
@@ -358,11 +352,11 @@ function initializeEventListeners(paymentDetails) {
   if (payNowButtonText) {
     if (paymentDetails.payment_button_text) {
       payNowButtonText.textContent = paymentDetails.payment_button_text;
-    } else if (paymentDetails.is_setup_mandate_flow || (paymentDetails.amount==="0.00" && paymentDetails.setup_future_usage_applied ==="off_session")) {
+    } else if (paymentDetails.is_setup_mandate_flow || (paymentDetails.amount === "0.00" && paymentDetails.setup_future_usage_applied === "off_session")) {
       payNowButtonText.textContent = translations.addPaymentMethod;
     } else {
-      payNowButtonText.textContent = capture_type === "manual" ? translations.authorizePayment: translations.payNow;
-      
+      payNowButtonText.textContent = capture_type === "manual" ? translations.authorizePayment : translations.payNow;
+
     }
   }
 
@@ -1214,25 +1208,4 @@ function renderSDKHeader(paymentDetails) {
     // sdkHeaderNode.append(sdkHeaderLogoNode);
     sdkHeaderNode.append(sdkHeaderItemNode);
   }
-}
-
-/**
- * Trigger - post UI render
- * Use - add CSS rules for the payment link
- * @param {Object} paymentLinkUiRules
- */
-function updatePaymentLinkUi(paymentLinkUiRules) {
-  Object.keys(paymentLinkUiRules).forEach(function (selector) {
-    try {
-      var node = document.querySelector(selector);
-      if (node instanceof HTMLElement) {
-        var styles = paymentLinkUiRules[selector];
-        Object.keys(styles).forEach(function (property) {
-          node.style[property] = styles[property];
-        });
-      }
-    } catch (error) {
-      console.error("Failed to apply styles to selector", selector, error);
-    }
-  })
 }

--- a/crates/router/src/core/payment_link/payment_link_initiate/payment_link_initiator.js
+++ b/crates/router/src/core/payment_link/payment_link_initiate/payment_link_initiator.js
@@ -14,6 +14,7 @@ function initializeSDK() {
   var clientSecret = paymentDetails.client_secret;
   var sdkUiRules = paymentDetails.sdk_ui_rules;
   var labelType = paymentDetails.payment_form_label_type;
+  var colorIconCardCvcError = paymentDetails.color_icon_card_cvc_error;
   var appearance = {
     variables: {
       colorPrimary: paymentDetails.theme || "rgb(0, 109, 249)",
@@ -32,6 +33,9 @@ function initializeSDK() {
   }
   if (labelType !== null && typeof labelType === "string") {
     appearance.labels = labelType;
+  }
+  if (colorIconCardCvcError !== null && typeof colorIconCardCvcError === "string") {
+    appearance.variables.colorIconCardCvcError = colorIconCardCvcError;
   }
   // @ts-ignore
   hyper = window.Hyper(pub_key, {

--- a/crates/router/src/core/payment_link/payment_link_initiate/secure_payment_link_initiator.js
+++ b/crates/router/src/core/payment_link/payment_link_initiate/secure_payment_link_initiator.js
@@ -34,6 +34,7 @@ if (!isFramed) {
     var clientSecret = paymentDetails.client_secret;
     var sdkUiRules = paymentDetails.sdk_ui_rules;
     var labelType = paymentDetails.payment_form_label_type;
+    var colorIconCardCvcError = paymentDetails.color_icon_card_cvc_error;
     var appearance = {
       variables: {
         colorPrimary: paymentDetails.theme || "rgb(0, 109, 249)",
@@ -52,6 +53,9 @@ if (!isFramed) {
     }
     if (labelType !== null && typeof labelType === "string") {
       appearance.labels = labelType;
+    }
+    if (colorIconCardCvcError !== null && typeof colorIconCardCvcError === "string") {
+      appearance.variables.colorIconCardCvcError = colorIconCardCvcError;
     }
     // @ts-ignore
     hyper = window.Hyper(pub_key, {

--- a/crates/router/src/core/payments/transformers.rs
+++ b/crates/router/src/core/payments/transformers.rs
@@ -4967,6 +4967,7 @@ impl ForeignFrom<api_models::admin::PaymentLinkConfigRequest>
             payment_form_label_type: config.payment_form_label_type,
             show_card_terms: config.show_card_terms,
             is_setup_mandate_flow: config.is_setup_mandate_flow,
+            color_icon_card_cvc_error: config.color_icon_card_cvc_error,
         }
     }
 }
@@ -5042,6 +5043,7 @@ impl ForeignFrom<diesel_models::PaymentLinkConfigRequestForPayments>
             payment_form_label_type: config.payment_form_label_type,
             show_card_terms: config.show_card_terms,
             is_setup_mandate_flow: config.is_setup_mandate_flow,
+            color_icon_card_cvc_error: config.color_icon_card_cvc_error,
         }
     }
 }

--- a/crates/router/src/types/transformers.rs
+++ b/crates/router/src/types/transformers.rs
@@ -2235,6 +2235,7 @@ impl ForeignFrom<api_models::admin::PaymentLinkConfigRequest>
             payment_form_label_type: item.payment_form_label_type,
             show_card_terms: item.show_card_terms,
             is_setup_mandate_flow: item.is_setup_mandate_flow,
+            color_icon_card_cvc_error: item.color_icon_card_cvc_error,
         }
     }
 }
@@ -2270,6 +2271,7 @@ impl ForeignFrom<diesel_models::business_profile::PaymentLinkConfigRequest>
             payment_form_label_type: item.payment_form_label_type,
             show_card_terms: item.show_card_terms,
             is_setup_mandate_flow: item.is_setup_mandate_flow,
+            color_icon_card_cvc_error: item.color_icon_card_cvc_error,
         }
     }
 }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
This PR introduces
- modification of the behavior of appending the `payment_link_ui_rules` to the CSS instead of selecting and applying it to the retrieved elements at runtime.
- expose `color_icon_card_cvc_error` via API for SDK variables

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
This change allows for styling the payment link UI elements using CSS rules.

## How did you test it?


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
