### PR TITLE
refactor(refunds_v2): Change refunds v2 list request verb from GET to POST

### DIFF
--- a/api-reference-v2/openapi_spec.json
+++ b/api-reference-v2/openapi_spec.json
@@ -3365,7 +3365,7 @@
       }
     },
     "/v2/refunds/list": {
-      "get": {
+      "post": {
         "tags": [
           "Refunds"
         ],

--- a/crates/openapi/src/routes/refunds.rs
+++ b/crates/openapi/src/routes/refunds.rs
@@ -272,7 +272,7 @@ pub async fn refunds_retrieve() {}
 ///
 /// To list the refunds associated with a payment_id or with the merchant, if payment_id is not provided
 #[utoipa::path(
-    get,
+    post,
     path = "/v2/refunds/list",
     request_body=RefundListRequest,
     responses(

--- a/crates/router/src/routes/app.rs
+++ b/crates/router/src/routes/app.rs
@@ -1213,7 +1213,7 @@ impl Refunds {
         #[cfg(feature = "olap")]
         {
             route =
-                route.service(web::resource("/list").route(web::get().to(refunds::refunds_list)));
+                route.service(web::resource("/list").route(web::post().to(refunds::refunds_list)));
         }
         #[cfg(feature = "oltp")]
         {


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Currently to list refunds in v2, we are using GET verb, but we are passing filters through body which is not correct. Since listing requests are generally GET requests, we pass filters through query params.

In the current scenario, passing filters through query params may result in url length violation. Hence we are changing the route verb from GET to POST request.


### Additional Changes

- [x] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
Follow correct and semantic approach to list refunds in v2 apis.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Create some payments and refunds before hand.

- List all refunds API call
```
curl --location 'http://localhost:8080/v2/refunds/list' \
--header 'x-profile-id: pro_hB6oV5vfIHyqUVw1aetw' \
--header 'Content-Type: application/json' \
--header 'Authorization: api-key=dev_iNC2eYPgqnHNYoFG44nlmpp3ofzZqQ4wPOcx9r7IONCidqNmbVRLwXZwgctSQn4m' \
--data '{
    
}'
```

- Response from the above call
```
{
    "count": 3,
    "total_count": 3,
    "data": [
        {
            "id": "12345_ref_019754aecbb47921a9947612563466bd",
            "payment_id": "12345_pay_019754aeb06771c38815608e367ed6a2",
            "merchant_reference_id": "1749472431",
            "amount": 70,
            "currency": "EUR",
            "status": "pending",
            "reason": "CUSTOMER REQUEST",
            "metadata": {
                "foo": "bar"
            },
            "error_details": {
                "code": "",
                "message": ""
            },
            "created_at": "2025-06-09T12:33:51.053Z",
            "updated_at": "2025-06-09T12:33:51.363Z",
            "connector": "adyen",
            "profile_id": "pro_hB6oV5vfIHyqUVw1aetw",
            "merchant_connector_id": "mca_76RN9eoOT1pKjdBC8wU7",
            "connector_refund_reference_id": null
        },
        {
            "id": "12345_ref_019754ad614b7122b3f9c2b7c0af3ffa",
            "payment_id": "12345_pay_019754acd9797072ad358e2ddc41594f",
            "merchant_reference_id": "1749472338",
            "amount": 720,
            "currency": "USD",
            "status": "pending",
            "reason": "CUSTOMER REQUEST",
            "metadata": {
                "foo": "bar"
            },
            "error_details": {
                "code": "",
                "message": ""
            },
            "created_at": "2025-06-09T12:32:18.275Z",
            "updated_at": "2025-06-09T12:33:11.264Z",
            "connector": "adyen",
            "profile_id": "pro_hB6oV5vfIHyqUVw1aetw",
            "merchant_connector_id": "mca_76RN9eoOT1pKjdBC8wU7",
            "connector_refund_reference_id": null
        },
        {
            "id": "12345_ref_019754ad1149783385dda1328a50d9c9",
            "payment_id": "12345_pay_019754acd9797072ad358e2ddc41594f",
            "merchant_reference_id": "1749472318",
            "amount": 720,
            "currency": "USD",
            "status": "failed",
            "reason": "Paid by mistake",
            "metadata": {
                "foo": "bar"
            },
            "error_details": {
                "code": "000",
                "message": "Invalid merchant refund reason, the only valid values are :  [OTHER, RETURN, DUPLICATE, FRAUD, CUSTOMER REQUEST]"
            },
            "created_at": "2025-06-09T12:31:57.817Z",
            "updated_at": "2025-06-09T12:31:58.211Z",
            "connector": "adyen",
            "profile_id": "pro_hB6oV5vfIHyqUVw1aetw",
            "merchant_connector_id": "mca_76RN9eoOT1pKjdBC8wU7",
            "connector_refund_reference_id": null
        }
    ]
}
```

- List refund by payment id API Call
```
curl --location 'http://localhost:8080/v2/refunds/list' \
--header 'x-profile-id: pro_hB6oV5vfIHyqUVw1aetw' \
--header 'Content-Type: application/json' \
--header 'Authorization: api-key=dev_iNC2eYPgqnHNYoFG44nlmpp3ofzZqQ4wPOcx9r7IONCidqNmbVRLwXZwgctSQn4m' \
--data '{
    "payment_id":"12345_pay_019754aeb06771c38815608e367ed6a2"
}'
```

- Response from the above call
```
{
    "count": 1,
    "total_count": 1,
    "data": [
        {
            "id": "12345_ref_019754aecbb47921a9947612563466bd",
            "payment_id": "12345_pay_019754aeb06771c38815608e367ed6a2",
            "merchant_reference_id": "1749472431",
            "amount": 70,
            "currency": "EUR",
            "status": "pending",
            "reason": "CUSTOMER REQUEST",
            "metadata": {
                "foo": "bar"
            },
            "error_details": {
                "code": "",
                "message": ""
            },
            "created_at": "2025-06-09T12:33:51.053Z",
            "updated_at": "2025-06-09T12:33:51.363Z",
            "connector": "adyen",
            "profile_id": "pro_hB6oV5vfIHyqUVw1aetw",
            "merchant_connector_id": "mca_76RN9eoOT1pKjdBC8wU7",
            "connector_refund_reference_id": null
        }
    ]
}
```

- List refund by currencies API Call
```
curl --location 'http://localhost:8080/v2/refunds/list' \
--header 'x-profile-id: pro_hB6oV5vfIHyqUVw1aetw' \
--header 'Content-Type: application/json' \
--header 'Authorization: api-key=dev_iNC2eYPgqnHNYoFG44nlmpp3ofzZqQ4wPOcx9r7IONCidqNmbVRLwXZwgctSQn4m' \
--data '{
    "currency":["EUR","USD"]
}'
```

- Response from the above call
```
{
    "count": 3,
    "total_count": 3,
    "data": [
        {
            "id": "12345_ref_019754aecbb47921a9947612563466bd",
            "payment_id": "12345_pay_019754aeb06771c38815608e367ed6a2",
            "merchant_reference_id": "1749472431",
            "amount": 70,
            "currency": "EUR",
            "status": "pending",
            "reason": "CUSTOMER REQUEST",
            "metadata": {
                "foo": "bar"
            },
            "error_details": {
                "code": "",
                "message": ""
            },
            "created_at": "2025-06-09T12:33:51.053Z",
            "updated_at": "2025-06-09T12:33:51.363Z",
            "connector": "adyen",
            "profile_id": "pro_hB6oV5vfIHyqUVw1aetw",
            "merchant_connector_id": "mca_76RN9eoOT1pKjdBC8wU7",
            "connector_refund_reference_id": null
        },
        {
            "id": "12345_ref_019754ad614b7122b3f9c2b7c0af3ffa",
            "payment_id": "12345_pay_019754acd9797072ad358e2ddc41594f",
            "merchant_reference_id": "1749472338",
            "amount": 720,
            "currency": "USD",
            "status": "pending",
            "reason": "CUSTOMER REQUEST",
            "metadata": {
                "foo": "bar"
            },
            "error_details": {
                "code": "",
                "message": ""
            },
            "created_at": "2025-06-09T12:32:18.275Z",
            "updated_at": "2025-06-09T12:33:11.264Z",
            "connector": "adyen",
            "profile_id": "pro_hB6oV5vfIHyqUVw1aetw",
            "merchant_connector_id": "mca_76RN9eoOT1pKjdBC8wU7",
            "connector_refund_reference_id": null
        },
        {
            "id": "12345_ref_019754ad1149783385dda1328a50d9c9",
            "payment_id": "12345_pay_019754acd9797072ad358e2ddc41594f",
            "merchant_reference_id": "1749472318",
            "amount": 720,
            "currency": "USD",
            "status": "failed",
            "reason": "Paid by mistake",
            "metadata": {
                "foo": "bar"
            },
            "error_details": {
                "code": "000",
                "message": "Invalid merchant refund reason, the only valid values are :  [OTHER, RETURN, DUPLICATE, FRAUD, CUSTOMER REQUEST]"
            },
            "created_at": "2025-06-09T12:31:57.817Z",
            "updated_at": "2025-06-09T12:31:58.211Z",
            "connector": "adyen",
            "profile_id": "pro_hB6oV5vfIHyqUVw1aetw",
            "merchant_connector_id": "mca_76RN9eoOT1pKjdBC8wU7",
            "connector_refund_reference_id": null
        }
    ]
}
```

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
