### PR TITLE
feat(router): add `apply_three_ds_strategy` in payments confirm flow

### DIFF
--- a/crates/api_models/src/payments.rs
+++ b/crates/api_models/src/payments.rs
@@ -2956,6 +2956,15 @@ pub enum AdditionalPaymentData {
     },
 }
 
+impl AdditionalPaymentData {
+    pub fn get_additional_card_info(&self) -> Option<AdditionalCardInfo> {
+        match self {
+            Self::Card(additional_card_info) => Some(*additional_card_info.clone()),
+            _ => None,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct KlarnaSdkPaymentMethod {
     pub payment_type: Option<String>,

--- a/crates/common_types/src/three_ds_decision_rule_engine.rs
+++ b/crates/common_types/src/three_ds_decision_rule_engine.rs
@@ -37,6 +37,13 @@ pub enum ThreeDSDecision {
 }
 impl_to_sql_from_sql_json!(ThreeDSDecision);
 
+impl ThreeDSDecision {
+    /// Checks if the decision is to mandate a 3DS challenge
+    pub fn should_force_3ds_challenge(self) -> bool {
+        matches!(self, Self::ChallengeRequested)
+    }
+}
+
 /// Struct representing the output configuration for the 3DS Decision Rule Engine.
 #[derive(
     Serialize, Default, Deserialize, Debug, Clone, PartialEq, Eq, FromSqlRow, AsExpression, ToSchema,

--- a/crates/hyperswitch_domain_models/src/business_profile.rs
+++ b/crates/hyperswitch_domain_models/src/business_profile.rs
@@ -1,5 +1,5 @@
 use common_enums::enums as api_enums;
-use common_types::primitive_wrappers;
+use common_types::{domain::AcquirerConfig, primitive_wrappers};
 use common_utils::{
     crypto::{OptionalEncryptableName, OptionalEncryptableValue},
     date_time,
@@ -1193,6 +1193,23 @@ impl Profile {
     #[cfg(feature = "v2")]
     pub fn is_vault_sdk_enabled(&self) -> bool {
         self.external_vault_connector_details.is_some()
+    }
+
+    #[cfg(feature = "v1")]
+    pub fn get_acquirer_details_from_network(
+        &self,
+        network: common_enums::CardNetwork,
+    ) -> Option<AcquirerConfig> {
+        // iterate over acquirer_config_map and find the acquirer config for the given network
+        self.acquirer_config_map
+            .as_ref()
+            .and_then(|acquirer_config_map| {
+                acquirer_config_map
+                    .0
+                    .iter()
+                    .find(|&(_, acquirer_config)| acquirer_config.network == network)
+            })
+            .map(|(_, acquirer_config)| acquirer_config.clone())
     }
 }
 

--- a/crates/router/src/core/payments.rs
+++ b/crates/router/src/core/payments.rs
@@ -438,6 +438,11 @@ where
     )
     .await;
 
+    operation
+        .to_domain()?
+        .apply_three_ds_authentication_strategy(state, &mut payment_data, &business_profile)
+        .await?;
+
     let should_add_task_to_process_tracker = should_add_task_to_process_tracker(&payment_data);
 
     let locale = header_payload.locale.clone();

--- a/crates/router/src/core/payments/operations.rs
+++ b/crates/router/src/core/payments/operations.rs
@@ -384,6 +384,16 @@ pub trait Domain<F: Clone, R, D>: Send + Sync {
         Ok(())
     }
 
+    /// This function is used to apply the 3DS authentication strategy
+    async fn apply_three_ds_authentication_strategy<'a>(
+        &'a self,
+        _state: &SessionState,
+        _payment_data: &mut D,
+        _business_profile: &domain::Profile,
+    ) -> CustomResult<(), errors::ApiErrorResponse> {
+        Ok(())
+    }
+
     // #[cfg(feature = "v2")]
     // async fn call_connector<'a, RouterDataReq>(
     //     &'a self,

--- a/crates/router/src/core/payments/operations/payment_confirm.rs
+++ b/crates/router/src/core/payments/operations/payment_confirm.rs
@@ -38,6 +38,7 @@ use crate::{
             self, helpers, operations, populate_surcharge_details, CustomerDetails, PaymentAddress,
             PaymentData,
         },
+        three_ds_decision_rule,
         unified_authentication_service::{
             self as uas_utils,
             types::{ClickToPay, UnifiedAuthenticationService},
@@ -51,7 +52,7 @@ use crate::{
         api::{self, ConnectorCallType, PaymentIdTypeExt},
         domain::{self},
         storage::{self, enums as storage_enums},
-        transformers::ForeignFrom,
+        transformers::{ForeignFrom, ForeignInto},
     },
     utils::{self, OptionExt},
 };
@@ -1090,6 +1091,117 @@ impl<F: Clone + Send + Sync> Domain<F, api::PaymentsRequest, PaymentData<F>> for
             }
             None => None,
         };
+        Ok(())
+    }
+
+    async fn apply_three_ds_authentication_strategy<'a>(
+        &'a self,
+        state: &SessionState,
+        payment_data: &mut PaymentData<F>,
+        business_profile: &domain::Profile,
+    ) -> CustomResult<(), errors::ApiErrorResponse> {
+        // If the business profile has a three_ds_decision_rule_algorithm, we will use it to determine the 3DS strategy (authentication_type, exemption_type and force_three_ds_challenge)
+        if let Some(three_ds_decision_rule) =
+            business_profile.three_ds_decision_rule_algorithm.clone()
+        {
+            // Parse the three_ds_decision_rule to get the algorithm_id
+            let algorithm_id = three_ds_decision_rule
+                .parse_value::<api::routing::RoutingAlgorithmRef>("RoutingAlgorithmRef")
+                .change_context(errors::ApiErrorResponse::InternalServerError)
+                .attach_printable("Could not decode merchant routing algorithm ref")?
+                .algorithm_id
+                .ok_or(errors::ApiErrorResponse::InternalServerError)
+                .attach_printable("No algorithm_id found in three_ds_decision_rule_algorithm")?;
+            // get additional card info from payment data
+            let additional_card_info = payment_data
+                .payment_attempt
+                .payment_method_data
+                .as_ref()
+                .map(|payment_method_data| {
+                    payment_method_data
+                        .clone()
+                        .parse_value::<api_models::payments::AdditionalPaymentData>(
+                            "additional_payment_method_data",
+                        )
+                })
+                .transpose()
+                .change_context(errors::ApiErrorResponse::InternalServerError)
+                .attach_printable("unable to parse value into additional_payment_method_data")?
+                .and_then(|additional_payment_method_data| {
+                    additional_payment_method_data.get_additional_card_info()
+                });
+            // get acquirer details from business profile based on card network
+            let acquirer_config = additional_card_info.as_ref().and_then(|card_info| {
+                card_info
+                    .card_network
+                    .clone()
+                    .and_then(|network| business_profile.get_acquirer_details_from_network(network))
+            });
+            // get three_ds_decision_rule_output using algorithm_id and payment data
+            let decision = three_ds_decision_rule::get_three_ds_decision_rule_output(
+                state,
+                &business_profile.merchant_id,
+                api_models::three_ds_decision_rule::ThreeDsDecisionRuleExecuteRequest {
+                    routing_id: algorithm_id,
+                    payment: api_models::three_ds_decision_rule::PaymentData {
+                        amount: payment_data.payment_intent.amount,
+                        currency: payment_data
+                            .payment_intent
+                            .currency
+                            .ok_or(errors::ApiErrorResponse::InternalServerError)
+                            .attach_printable("currency is not set in payment intent")?,
+                    },
+                    payment_method: Some(
+                        api_models::three_ds_decision_rule::PaymentMethodMetaData {
+                            card_network: additional_card_info
+                                .as_ref()
+                                .and_then(|info| info.card_network.clone()),
+                        },
+                    ),
+                    issuer: Some(api_models::three_ds_decision_rule::IssuerData {
+                        name: additional_card_info
+                            .as_ref()
+                            .and_then(|info| info.card_issuer.clone()),
+                        country: additional_card_info
+                            .as_ref()
+                            .map(|info| info.card_issuing_country.clone().parse_enum("Country"))
+                            .transpose()
+                            .change_context(errors::ApiErrorResponse::InternalServerError)
+                            .attach_printable(
+                                "Error while getting country enum from issuer country",
+                            )?,
+                    }),
+                    customer_device: None,
+                    acquirer: acquirer_config.as_ref().map(|acquirer| {
+                        api_models::three_ds_decision_rule::AcquirerData {
+                            country: Some(common_enums::Country::from_alpha2(
+                                acquirer.merchant_country_code,
+                            )),
+                            fraud_rate: Some(acquirer.acquirer_fraud_rate),
+                        }
+                    }),
+                },
+            )
+            .await?;
+            // We should update authentication_type from the Three DS Decision if it is not already set
+            if payment_data.payment_attempt.authentication_type.is_none() {
+                payment_data.payment_attempt.authentication_type =
+                    Some(common_enums::AuthenticationType::foreign_from(decision));
+            }
+            // We should update psd2_sca_exemption_type from the Three DS Decision if it is not already set
+            if payment_data
+                .payment_intent
+                .psd2_sca_exemption_type
+                .is_none()
+            {
+                payment_data.payment_intent.psd2_sca_exemption_type = decision.foreign_into();
+            }
+            // We should update force_3ds_challenge from the Three DS Decision if it is not already set
+            if payment_data.payment_intent.force_3ds_challenge.is_none() {
+                payment_data.payment_intent.force_3ds_challenge =
+                    decision.should_force_3ds_challenge().then_some(true);
+            }
+        }
         Ok(())
     }
 

--- a/crates/router/src/core/payments/transformers.rs
+++ b/crates/router/src/core/payments/transformers.rs
@@ -5247,3 +5247,43 @@ impl From<pm_types::TokenResponse> for domain::NetworkTokenData {
         }
     }
 }
+
+impl ForeignFrom<common_types::three_ds_decision_rule_engine::ThreeDSDecision>
+    for common_enums::AuthenticationType
+{
+    fn foreign_from(
+        three_ds_decision: common_types::three_ds_decision_rule_engine::ThreeDSDecision,
+    ) -> Self {
+        match three_ds_decision {
+            common_types::three_ds_decision_rule_engine::ThreeDSDecision::NoThreeDs => Self::NoThreeDs,
+            common_types::three_ds_decision_rule_engine::ThreeDSDecision::ChallengeRequested
+            | common_types::three_ds_decision_rule_engine::ThreeDSDecision::ChallengePreferred
+            | common_types::three_ds_decision_rule_engine::ThreeDSDecision::ThreeDsExemptionRequestedTra
+            | common_types::three_ds_decision_rule_engine::ThreeDSDecision::ThreeDsExemptionRequestedLowValue
+            | common_types::three_ds_decision_rule_engine::ThreeDSDecision::IssuerThreeDsExemptionRequested => Self::ThreeDs,
+        }
+    }
+}
+
+impl ForeignFrom<common_types::three_ds_decision_rule_engine::ThreeDSDecision>
+    for Option<common_enums::ScaExemptionType>
+{
+    fn foreign_from(
+        three_ds_decision: common_types::three_ds_decision_rule_engine::ThreeDSDecision,
+    ) -> Self {
+        match three_ds_decision {
+            common_types::three_ds_decision_rule_engine::ThreeDSDecision::ThreeDsExemptionRequestedTra => {
+                Some(common_enums::ScaExemptionType::TransactionRiskAnalysis)
+            }
+            common_types::three_ds_decision_rule_engine::ThreeDSDecision::ThreeDsExemptionRequestedLowValue => {
+                Some(common_enums::ScaExemptionType::LowValue)
+            }
+            common_types::three_ds_decision_rule_engine::ThreeDSDecision::NoThreeDs
+            | common_types::three_ds_decision_rule_engine::ThreeDSDecision::ChallengeRequested
+            | common_types::three_ds_decision_rule_engine::ThreeDSDecision::ChallengePreferred
+            | common_types::three_ds_decision_rule_engine::ThreeDSDecision::IssuerThreeDsExemptionRequested => {
+                None
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
add `apply_three_ds_strategy` in payments confirm flow

In payments confirm flow, we are calling apply_three_ds_strategy which would decide the three ds strategy based on the rule configuration
1. authentication_type - three_ds / no_three_ds
2. exemption_type - low_value / tra
3. force_challenge - true / false



### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
5. `crates/router/src/configs`
6. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Tested manually

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
