### PR TITLE
feat(refunds): add new columns in refund table for vsaas

### DIFF
--- a/crates/diesel_models/src/refund.rs
+++ b/crates/diesel_models/src/refund.rs
@@ -66,6 +66,8 @@ pub struct Refund {
     pub processor_transaction_data: Option<String>,
     pub issuer_error_code: Option<String>,
     pub issuer_error_message: Option<String>,
+    pub processor_merchant_id: Option<common_utils::id_type::MerchantId>,
+    pub created_by: Option<String>,
 }
 
 #[cfg(all(feature = "v2", feature = "refunds_v2"))]
@@ -114,6 +116,8 @@ pub struct Refund {
     pub unified_message: Option<String>,
     pub processor_refund_data: Option<String>,
     pub processor_transaction_data: Option<String>,
+    pub processor_merchant_id: Option<common_utils::id_type::MerchantId>,
+    pub created_by: Option<String>,
     pub id: common_utils::id_type::GlobalRefundId,
     pub merchant_reference_id: common_utils::id_type::RefundReferenceId,
     pub connector_id: Option<common_utils::id_type::MerchantConnectorAccountId>,
@@ -164,6 +168,8 @@ pub struct RefundNew {
     pub split_refunds: Option<common_types::refunds::SplitRefund>,
     pub processor_refund_data: Option<String>,
     pub processor_transaction_data: Option<String>,
+    pub processor_merchant_id: Option<common_utils::id_type::MerchantId>,
+    pub created_by: Option<String>,
 }
 
 #[cfg(all(feature = "v2", feature = "refunds_v2"))]
@@ -211,6 +217,8 @@ pub struct RefundNew {
     pub split_refunds: Option<common_types::refunds::SplitRefund>,
     pub processor_refund_data: Option<String>,
     pub processor_transaction_data: Option<String>,
+    pub processor_merchant_id: Option<common_utils::id_type::MerchantId>,
+    pub created_by: Option<String>,
 }
 
 #[cfg(all(any(feature = "v1", feature = "v2"), not(feature = "refunds_v2")))]

--- a/crates/diesel_models/src/schema.rs
+++ b/crates/diesel_models/src/schema.rs
@@ -1316,6 +1316,10 @@ diesel::table! {
         #[max_length = 64]
         issuer_error_code -> Nullable<Varchar>,
         issuer_error_message -> Nullable<Text>,
+        #[max_length = 64]
+        processor_merchant_id -> Nullable<Varchar>,
+        #[max_length = 255]
+        created_by -> Nullable<Varchar>,
     }
 }
 

--- a/crates/diesel_models/src/schema_v2.rs
+++ b/crates/diesel_models/src/schema_v2.rs
@@ -1244,6 +1244,10 @@ diesel::table! {
         processor_refund_data -> Nullable<Text>,
         processor_transaction_data -> Nullable<Text>,
         #[max_length = 64]
+        processor_merchant_id -> Nullable<Varchar>,
+        #[max_length = 255]
+        created_by -> Nullable<Varchar>,
+        #[max_length = 64]
         id -> Varchar,
         #[max_length = 64]
         merchant_reference_id -> Varchar,

--- a/crates/router/src/core/refunds.rs
+++ b/crates/router/src/core/refunds.rs
@@ -927,6 +927,9 @@ pub async fn validate_and_create_refund(
             .clone(),
         processor_transaction_data,
         processor_refund_data: None,
+        // TODO: populate this from merchant_context after platform conxtext changes
+        processor_merchant_id: Some(payment_attempt.processor_merchant_id.clone()),
+        created_by: None,
     };
 
     let refund = match db

--- a/crates/router/src/core/refunds_v2.rs
+++ b/crates/router/src/core/refunds_v2.rs
@@ -938,6 +938,9 @@ pub async fn validate_and_create_refund(
             .clone(),
         processor_transaction_data,
         processor_refund_data: None,
+        // TODO: populate this from merchant_context after platform conxtext changes
+        processor_merchant_id: Some(payment_attempt.processor_merchant_id.clone()),
+        created_by: None,
     };
 
     let refund = match db

--- a/crates/router/src/db/refund.rs
+++ b/crates/router/src/db/refund.rs
@@ -579,6 +579,8 @@ mod storage {
                         // Below fields are deprecated. Please add any new fields above this line.
                         connector_refund_data: None,
                         connector_transaction_data: None,
+                        processor_merchant_id: new.processor_merchant_id.clone(),
+                        created_by: new.created_by.clone(),
                     };
 
                     let field = format!(
@@ -1202,6 +1204,8 @@ impl RefundInterface for MockDb {
             // Below fields are deprecated. Please add any new fields above this line.
             connector_refund_data: None,
             connector_transaction_data: None,
+            processor_merchant_id: new.processor_merchant_id,
+            created_by: new.created_by,
         };
         refunds.push(refund.clone());
         Ok(refund)
@@ -1250,6 +1254,8 @@ impl RefundInterface for MockDb {
             unified_message: None,
             processor_refund_data: new.processor_refund_data.clone(),
             processor_transaction_data: new.processor_transaction_data.clone(),
+            processor_merchant_id: new.processor_merchant_id,
+            created_by: new.created_by,
         };
         refunds.push(refund.clone());
         Ok(refund)

--- a/crates/router/src/utils/user/sample_data.rs
+++ b/crates/router/src/utils/user/sample_data.rs
@@ -422,6 +422,8 @@ pub async fn generate_sample_data(
                 organization_id: org_id.clone(),
                 processor_refund_data: None,
                 processor_transaction_data,
+                processor_merchant_id: Some(merchant_id.clone()),
+                created_by: None,
             })
         } else {
             None

--- a/migrations/2025-06-17-111224_add_new_columns_processor_mid_created_by_in_refund/down.sql
+++ b/migrations/2025-06-17-111224_add_new_columns_processor_mid_created_by_in_refund/down.sql
@@ -1,0 +1,3 @@
+-- This file should undo anything in `up.sql`
+ALTER TABLE refund DROP COLUMN IF EXISTS processor_merchant_id;
+ALTER TABLE refund DROP COLUMN IF EXISTS created_by;

--- a/migrations/2025-06-17-111224_add_new_columns_processor_mid_created_by_in_refund/up.sql
+++ b/migrations/2025-06-17-111224_add_new_columns_processor_mid_created_by_in_refund/up.sql
@@ -1,0 +1,4 @@
+-- Your SQL goes here
+ALTER TABLE refund ADD COLUMN IF NOT EXISTS processor_merchant_id VARCHAR(64);
+ALTER TABLE refund ADD COLUMN IF NOT EXISTS created_by VARCHAR(255);
+UPDATE refund SET processor_merchant_id = merchant_id where processor_merchant_id IS NULL;


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
This PR adds new columns to the `refund` table to support VSAAS functionality.

This PR introduces changes to add new columns (`processor_merchant_id`, `created_by`) to the `refund` table and integrate them into the application logic to support Vertical SaaS (VSAAS).

## Changes

- **Database Schema and Migrations:** Updated the database schema and added migrations to include the new `processor_mid` and `created_by` columns in the `refund` table.
- **Diesel Models:** Modified the `Refund` model and related structures to incorporate the new columns.
- **Router Logic:** Updated refund processing logic to handle the new `processor_mid` and `created_by` fields.

### Additional Changes

- [ ] This PR modifies the API contract
- [x] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
Closes #8366 


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
