### PR TITLE
fix(payment_method): update entity id used for Vault to global customer id

### DIFF
--- a/crates/router/src/core/payment_methods.rs
+++ b/crates/router/src/core/payment_methods.rs
@@ -38,8 +38,6 @@ use error_stack::{report, ResultExt};
 use futures::TryStreamExt;
 #[cfg(feature = "v1")]
 use hyperswitch_domain_models::api::{GenericLinks, GenericLinksData};
-#[cfg(feature = "v2")]
-use hyperswitch_domain_models::mandates::CommonMandateReference;
 use hyperswitch_domain_models::payments::{
     payment_attempt::PaymentAttempt, PaymentIntent, VaultData,
 };
@@ -49,8 +47,6 @@ use hyperswitch_domain_models::{
     router_data_v2::flow_common_types::VaultConnectorFlowData,
     router_flow_types::ExternalVaultInsertFlow, types::VaultRouterData,
 };
-#[cfg(feature = "v2")]
-use masking::ExposeOptionInterface;
 use masking::{PeekInterface, Secret};
 use router_env::{instrument, tracing};
 use time::Duration;
@@ -1100,6 +1096,7 @@ pub async fn network_tokenize_and_vault_the_pmd(
             merchant_context,
             &network_token_vaulting_data,
             None,
+            customer_id
         )
         .await
         .change_context(errors::NetworkTokenizationError::SaveNetworkTokenFailed)
@@ -1842,7 +1839,7 @@ pub async fn vault_payment_method_internal(
     )?;
 
     let mut resp_from_vault =
-        vault::add_payment_method_to_vault(state, merchant_context, pmd, existing_vault_id)
+        vault::add_payment_method_to_vault(state, merchant_context, pmd, existing_vault_id, customer_id)
             .await
             .change_context(errors::ApiErrorResponse::InternalServerError)
             .attach_printable("Failed to add payment method in vault")?;

--- a/crates/router/src/core/payment_methods.rs
+++ b/crates/router/src/core/payment_methods.rs
@@ -1096,7 +1096,7 @@ pub async fn network_tokenize_and_vault_the_pmd(
             merchant_context,
             &network_token_vaulting_data,
             None,
-            customer_id
+            customer_id,
         )
         .await
         .change_context(errors::NetworkTokenizationError::SaveNetworkTokenFailed)
@@ -1838,11 +1838,16 @@ pub async fn vault_payment_method_internal(
         },
     )?;
 
-    let mut resp_from_vault =
-        vault::add_payment_method_to_vault(state, merchant_context, pmd, existing_vault_id, customer_id)
-            .await
-            .change_context(errors::ApiErrorResponse::InternalServerError)
-            .attach_printable("Failed to add payment method in vault")?;
+    let mut resp_from_vault = vault::add_payment_method_to_vault(
+        state,
+        merchant_context,
+        pmd,
+        existing_vault_id,
+        customer_id,
+    )
+    .await
+    .change_context(errors::ApiErrorResponse::InternalServerError)
+    .attach_printable("Failed to add payment method in vault")?;
 
     // add fingerprint_id to the response
     resp_from_vault.fingerprint_id = Some(fingerprint_id_from_vault);

--- a/crates/router/src/core/payment_methods/vault.rs
+++ b/crates/router/src/core/payment_methods/vault.rs
@@ -1594,10 +1594,15 @@ pub async fn retrieve_payment_method_from_vault(
                 })
                 .change_context(errors::ApiErrorResponse::InternalServerError)
                 .attach_printable("Missing locker_id for VaultRetrieveRequest")?;
-            retrieve_payment_method_from_vault_internal(state, merchant_context, &vault_id, &pm.customer_id)
-                .await
-                .change_context(errors::ApiErrorResponse::InternalServerError)
-                .attach_printable("Failed to retrieve payment method from vault")
+            retrieve_payment_method_from_vault_internal(
+                state,
+                merchant_context,
+                &vault_id,
+                &pm.customer_id,
+            )
+            .await
+            .change_context(errors::ApiErrorResponse::InternalServerError)
+            .attach_printable("Failed to retrieve payment method from vault")
         }
     }
 }
@@ -1759,10 +1764,15 @@ pub async fn delete_payment_method_data_from_vault(
             )
             .await
         }
-        false => delete_payment_method_data_from_vault_internal(state, merchant_context, vault_id, &pm.customer_id)
-            .await
-            .change_context(errors::ApiErrorResponse::InternalServerError)
-            .attach_printable("Failed to delete payment method from vault"),
+        false => delete_payment_method_data_from_vault_internal(
+            state,
+            merchant_context,
+            vault_id,
+            &pm.customer_id,
+        )
+        .await
+        .change_context(errors::ApiErrorResponse::InternalServerError)
+        .attach_printable("Failed to delete payment method from vault"),
     }
 }
 

--- a/crates/router/src/core/proxy.rs
+++ b/crates/router/src/core/proxy.rs
@@ -17,7 +17,7 @@ pub async fn proxy_core(
 ) -> RouterResponse<proxy_api_models::ProxyResponse> {
     let req_wrapper = utils::ProxyRequestWrapper(req.clone());
     let proxy_record = req_wrapper
-        .get_payment_method_or_tokenization_record(
+        .get_proxy_record(
             &state,
             merchant_context.get_merchant_key_store(),
             merchant_context.get_merchant_account().storage_scheme,

--- a/crates/router/src/core/proxy.rs
+++ b/crates/router/src/core/proxy.rs
@@ -24,11 +24,19 @@ pub async fn proxy_core(
         )
         .await?;
 
+    let customer_id = req_wrapper
+        .get_customer_id(
+            &state,
+            merchant_context.get_merchant_key_store(),
+            merchant_context.get_merchant_account().storage_scheme,
+        )
+        .await?;
     let vault_response =
         super::payment_methods::vault::retrieve_payment_method_from_vault_internal(
             &state,
             &merchant_context,
             &vault_id,
+            &customer_id,
         )
         .await
         .change_context(errors::ApiErrorResponse::InternalServerError)

--- a/crates/router/src/core/proxy.rs
+++ b/crates/router/src/core/proxy.rs
@@ -16,21 +16,17 @@ pub async fn proxy_core(
     req: proxy_api_models::ProxyRequest,
 ) -> RouterResponse<proxy_api_models::ProxyResponse> {
     let req_wrapper = utils::ProxyRequestWrapper(req.clone());
-    let vault_id = req_wrapper
-        .get_vault_id(
+    let proxy_record = req_wrapper
+        .get_payment_method_or_tokenization_record(
             &state,
             merchant_context.get_merchant_key_store(),
             merchant_context.get_merchant_account().storage_scheme,
         )
         .await?;
 
-    let customer_id = req_wrapper
-        .get_customer_id(
-            &state,
-            merchant_context.get_merchant_key_store(),
-            merchant_context.get_merchant_account().storage_scheme,
-        )
-        .await?;
+    let vault_id = proxy_record.get_vault_id()?;
+    let customer_id = proxy_record.get_customer_id()?;
+
     let vault_response =
         super::payment_methods::vault::retrieve_payment_method_from_vault_internal(
             &state,

--- a/crates/router/src/core/proxy/utils.rs
+++ b/crates/router/src/core/proxy/utils.rs
@@ -82,8 +82,7 @@ impl ProxyRequestWrapper {
                     .find_payment_method(&((state).into()), key_store, &pm_id, storage_scheme)
                     .await
                     .change_context(errors::ApiErrorResponse::PaymentMethodNotFound)?
-                    .customer_id
-                )
+                    .customer_id)
             }
             proxy_api_models::TokenType::TokenizationId => {
                 Err(report!(errors::ApiErrorResponse::NotImplemented {

--- a/crates/router/src/core/proxy/utils.rs
+++ b/crates/router/src/core/proxy/utils.rs
@@ -48,7 +48,9 @@ impl ProxyRequestWrapper {
                     .find_payment_method(&((state).into()), key_store, &pm_id, storage_scheme)
                     .await
                     .change_context(errors::ApiErrorResponse::PaymentMethodNotFound)?;
-                Ok(ProxyRecord::PaymentMethodRecord(Box::new(payment_method_record)))
+                Ok(ProxyRecord::PaymentMethodRecord(Box::new(
+                    payment_method_record,
+                )))
             }
             proxy_api_models::TokenType::TokenizationId => {
                 Err(report!(errors::ApiErrorResponse::NotImplemented {

--- a/crates/router/src/core/proxy/utils.rs
+++ b/crates/router/src/core/proxy/utils.rs
@@ -49,7 +49,6 @@ impl ProxyRequestWrapper {
                     .await
                     .change_context(errors::ApiErrorResponse::PaymentMethodNotFound)?;
                 Ok(ProxyRecord::PaymentMethodRecord(payment_method_record))
-
             }
             proxy_api_models::TokenType::TokenizationId => {
                 Err(report!(errors::ApiErrorResponse::NotImplemented {
@@ -114,43 +113,31 @@ impl ProxyRequestWrapper {
     }
 }
 
-impl ProxyRecord{
-    pub fn get_vault_id(
-        &self,
-    ) -> RouterResult<payment_methods::VaultId>{
-
+impl ProxyRecord {
+    pub fn get_vault_id(&self) -> RouterResult<payment_methods::VaultId> {
         match self {
-            Self::PaymentMethodRecord(payment_method) => {
-                payment_method.locker_id.clone()
+            Self::PaymentMethodRecord(payment_method) => payment_method
+                .locker_id
+                .clone()
                 .get_required_value("vault_id")
                 .change_context(errors::ApiErrorResponse::InternalServerError)
-                .attach_printable("Locker id not present in Payment Method Entry")
-
-            }
-            Self::TokenizationRecord(_) => {
-                Err(report!(errors::ApiErrorResponse::NotImplemented {
-                    message: NotImplementedMessage::Reason(
-                        "Proxy flow using tokenization id".to_string(),
-                    ),
-                }))
-            }
+                .attach_printable("Locker id not present in Payment Method Entry"),
+            Self::TokenizationRecord(_) => Err(report!(errors::ApiErrorResponse::NotImplemented {
+                message: NotImplementedMessage::Reason(
+                    "Proxy flow using tokenization id".to_string(),
+                ),
+            })),
         }
     }
 
-    pub fn get_customer_id(
-        &self,
-    ) -> RouterResult<id_type::GlobalCustomerId> {
+    pub fn get_customer_id(&self) -> RouterResult<id_type::GlobalCustomerId> {
         match self {
-            Self::PaymentMethodRecord(payment_method) => {
-                Ok(payment_method.customer_id.clone())
-            }
-            Self::TokenizationRecord(_) => {
-                Err(report!(errors::ApiErrorResponse::NotImplemented {
-                    message: NotImplementedMessage::Reason(
-                        "Proxy flow using tokenization id".to_string(),
-                    ),
-                }))
-            }
+            Self::PaymentMethodRecord(payment_method) => Ok(payment_method.customer_id.clone()),
+            Self::TokenizationRecord(_) => Err(report!(errors::ApiErrorResponse::NotImplemented {
+                message: NotImplementedMessage::Reason(
+                    "Proxy flow using tokenization id".to_string(),
+                ),
+            })),
         }
     }
 }

--- a/crates/router/src/core/proxy/utils.rs
+++ b/crates/router/src/core/proxy/utils.rs
@@ -25,7 +25,7 @@ pub enum ProxyRecord {
 }
 
 impl ProxyRequestWrapper {
-    pub async fn get_payment_method_or_tokenization_record(
+    pub async fn get_proxy_record(
         &self,
         state: &SessionState,
         key_store: &domain::MerchantKeyStore,

--- a/crates/router/src/core/proxy/utils.rs
+++ b/crates/router/src/core/proxy/utils.rs
@@ -20,8 +20,8 @@ use crate::{
 
 pub struct ProxyRequestWrapper(pub proxy_api_models::ProxyRequest);
 pub enum ProxyRecord {
-    PaymentMethodRecord(domain::PaymentMethod),
-    TokenizationRecord(domain::Tokenization),
+    PaymentMethodRecord(Box<domain::PaymentMethod>),
+    TokenizationRecord(Box<domain::Tokenization>),
 }
 
 impl ProxyRequestWrapper {
@@ -48,7 +48,7 @@ impl ProxyRequestWrapper {
                     .find_payment_method(&((state).into()), key_store, &pm_id, storage_scheme)
                     .await
                     .change_context(errors::ApiErrorResponse::PaymentMethodNotFound)?;
-                Ok(ProxyRecord::PaymentMethodRecord(payment_method_record))
+                Ok(ProxyRecord::PaymentMethodRecord(Box::new(payment_method_record)))
             }
             proxy_api_models::TokenType::TokenizationId => {
                 Err(report!(errors::ApiErrorResponse::NotImplemented {

--- a/crates/router/src/core/tokenization.rs
+++ b/crates/router/src/core/tokenization.rs
@@ -52,7 +52,7 @@ pub async fn create_vault_token_core(
     let customer_id = req.customer_id.clone();
     // Create vault request
     let payload = pm_types::AddVaultRequest {
-        entity_id: merchant_account.get_id().to_owned(),
+        entity_id: req.customer_id.to_owned(),
         vault_id: vault_id.clone(),
         data: req.token_request.clone(),
         ttl: state.conf.locker.ttl_for_storage_in_secs,
@@ -135,7 +135,7 @@ pub async fn get_token_vault_core(
     }
 
     let vault_request = pm_types::VaultRetrieveRequest {
-        entity_id: tokenization_record.merchant_id.clone(),
+        entity_id: tokenization_record.customer_id.clone(),
         vault_id: hyperswitch_domain_models::payment_methods::VaultId::generate(
             tokenization_record.locker_id.clone(),
         ),

--- a/crates/router/src/types/domain.rs
+++ b/crates/router/src/types/domain.rs
@@ -56,6 +56,12 @@ pub mod vault {
     pub use hyperswitch_domain_models::vault::*;
 }
 
+#[cfg(feature = "v2")]
+pub mod tokenization {
+    pub use hyperswitch_domain_models::tokenization::*;
+}
+
+
 mod routing {
     pub use hyperswitch_domain_models::routing::*;
 }
@@ -83,3 +89,6 @@ pub use user::*;
 pub use user_key_store::*;
 #[cfg(feature = "v2")]
 pub use vault::*;
+
+#[cfg(feature = "v2")]
+pub use tokenization::*;

--- a/crates/router/src/types/domain.rs
+++ b/crates/router/src/types/domain.rs
@@ -61,7 +61,6 @@ pub mod tokenization {
     pub use hyperswitch_domain_models::tokenization::*;
 }
 
-
 mod routing {
     pub use hyperswitch_domain_models::routing::*;
 }
@@ -84,11 +83,10 @@ pub use network_tokenization::*;
 pub use payment_method_data::*;
 pub use payment_methods::*;
 pub use routing::*;
+#[cfg(feature = "v2")]
+pub use tokenization::*;
 #[cfg(feature = "olap")]
 pub use user::*;
 pub use user_key_store::*;
 #[cfg(feature = "v2")]
 pub use vault::*;
-
-#[cfg(feature = "v2")]
-pub use tokenization::*;

--- a/crates/router/src/types/payment_methods.rs
+++ b/crates/router/src/types/payment_methods.rs
@@ -44,7 +44,7 @@ pub struct VaultFingerprintResponse {
 #[cfg(any(feature = "v2", feature = "tokenization_v2"))]
 #[derive(Debug, serde::Deserialize, serde::Serialize)]
 pub struct AddVaultRequest<D> {
-    pub entity_id: id_type::MerchantId,
+    pub entity_id: id_type::GlobalCustomerId,
     pub vault_id: domain::VaultId,
     pub data: D,
     pub ttl: i64,
@@ -53,7 +53,7 @@ pub struct AddVaultRequest<D> {
 #[cfg(feature = "v2")]
 #[derive(Debug, serde::Deserialize, serde::Serialize)]
 pub struct AddVaultResponse {
-    pub entity_id: Option<id_type::MerchantId>,
+    pub entity_id: Option<id_type::GlobalCustomerId>,
     pub vault_id: domain::VaultId,
     pub fingerprint_id: Option<String>,
 }
@@ -130,7 +130,7 @@ pub struct SavedPMLPaymentsInfo {
 #[cfg(feature = "v2")]
 #[derive(Debug, serde::Deserialize, serde::Serialize)]
 pub struct VaultRetrieveRequest {
-    pub entity_id: id_type::MerchantId,
+    pub entity_id: id_type::GlobalCustomerId,
     pub vault_id: domain::VaultId,
 }
 
@@ -143,14 +143,14 @@ pub struct VaultRetrieveResponse {
 #[cfg(feature = "v2")]
 #[derive(Debug, serde::Deserialize, serde::Serialize)]
 pub struct VaultDeleteRequest {
-    pub entity_id: id_type::MerchantId,
+    pub entity_id: id_type::GlobalCustomerId,
     pub vault_id: domain::VaultId,
 }
 
 #[cfg(feature = "v2")]
 #[derive(Debug, serde::Deserialize, serde::Serialize)]
 pub struct VaultDeleteResponse {
-    pub entity_id: id_type::MerchantId,
+    pub entity_id: id_type::GlobalCustomerId,
     pub vault_id: domain::VaultId,
 }
 


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Currently, if payment method data is inserted in vault for customer c1, merchant id is being sent as entity id, this will not allow us to store same payment method data for customer c2.
Payment Method data is always tied to customer, not to merchant.

Hence updated entity id to Global customer id

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
test case - 
- create a payment method with 4242 card for a customer c1
- create new payment method with 4242 card for a customer c2
Both api should return 200

Initially for a diff customer under same merchant, api is returning duplication error.
with this fix, the api should return 2xx

```
curl --location 'http://localhost:8080/v2/payment-methods' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'X-Profile-Id: profile id' \
--header 'Authorization: api-key=api key' \
--data '{
    "customer_id": "12345_cus_0197ca90d3797040985aceb3da929431",
    "payment_method_type": "card",
    "payment_method_subtype": "credit",
    "payment_method_data": {
        "card": {
            "card_number": "card_number",
            "card_exp_month": "12",
            "card_exp_year": "2026",
            "card_holder_name": "joseph Doe"
        }
    },
    "network_tokenization":{
        "enable":"Enable"
    }

}'
```

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
