### PR TITLE
feat(payment-method): create payment_token for session confirm call

### DIFF
--- a/crates/api_models/src/payment_methods.rs
+++ b/crates/api_models/src/payment_methods.rs
@@ -2981,7 +2981,7 @@ pub struct PaymentMethodSessionResponse {
 
     /// The payment method that was created using this payment method session
     #[schema(value_type = Option<Vec<String>>)]
-    pub associated_payment_methods: Option<Vec<id_type::GlobalPaymentMethodId>>,
+    pub associated_payment_methods: Option<Vec<String>>,
 
     /// The token-id created if there is tokenization_data present
     #[schema(value_type = Option<String>, example = "12345_tok_01926c58bc6e77c09e809964e72af8c8")]

--- a/crates/diesel_models/src/payment_methods_session.rs
+++ b/crates/diesel_models/src/payment_methods_session.rs
@@ -12,7 +12,7 @@ pub struct PaymentMethodSession {
     pub return_url: Option<common_utils::types::Url>,
     #[serde(with = "common_utils::custom_serde::iso8601")]
     pub expires_at: time::PrimitiveDateTime,
-    pub associated_payment_methods: Option<Vec<common_utils::id_type::GlobalPaymentMethodId>>,
+    pub associated_payment_methods: Option<Vec<String>>,
     pub associated_payment: Option<common_utils::id_type::GlobalPaymentId>,
     pub associated_token_id: Option<common_utils::id_type::GlobalTokenId>,
 }

--- a/crates/external_services/src/http_client/client.rs
+++ b/crates/external_services/src/http_client/client.rs
@@ -30,10 +30,7 @@ pub fn create_client(
         }
 
         logger::debug!("Creating HTTP client with mutual TLS (client cert + key)");
-        let client_builder = get_client_builder(
-            proxy_config,
-            merchant_proxy_url.as_ref().map(|url| url.clone()),
-        )?;
+        let client_builder = get_client_builder(proxy_config, merchant_proxy_url.clone())?;
 
         let identity = create_identity_from_certificate_and_key(
             encoded_certificate.clone(),
@@ -60,11 +57,8 @@ pub fn create_client(
         let cert = reqwest::Certificate::from_pem(pem.as_bytes())
             .change_context(HttpClientError::ClientConstructionFailed)
             .attach_printable("Failed to parse CA certificate PEM block")?;
-        let client_builder = get_client_builder(
-            proxy_config,
-            merchant_proxy_url.as_ref().map(|url| url.clone()),
-        )?
-        .add_root_certificate(cert);
+        let client_builder = get_client_builder(proxy_config, merchant_proxy_url.clone())?
+            .add_root_certificate(cert);
         return client_builder
             .use_rustls_tls()
             .build()

--- a/crates/hyperswitch_domain_models/src/payment_methods.rs
+++ b/crates/hyperswitch_domain_models/src/payment_methods.rs
@@ -609,7 +609,7 @@ pub struct PaymentMethodSession {
     pub network_tokenization: Option<common_types::payment_methods::NetworkTokenization>,
     pub tokenization_data: Option<pii::SecretSerdeValue>,
     pub expires_at: PrimitiveDateTime,
-    pub associated_payment_methods: Option<Vec<id_type::GlobalPaymentMethodId>>,
+    pub associated_payment_methods: Option<Vec<String>>,
     pub associated_payment: Option<id_type::GlobalPaymentId>,
     pub associated_token_id: Option<id_type::GlobalTokenId>,
 }
@@ -847,10 +847,13 @@ pub trait PaymentMethodInterface {
 #[cfg(feature = "v2")]
 pub enum PaymentMethodsSessionUpdateEnum {
     GeneralUpdate {
-        billing: Option<Encryptable<Address>>,
+        billing: Box<Option<Encryptable<Address>>>,
         psp_tokenization: Option<common_types::payment_methods::PspTokenization>,
         network_tokenization: Option<common_types::payment_methods::NetworkTokenization>,
         tokenization_data: Option<pii::SecretSerdeValue>,
+    },
+    UpdateAssociatedPaymentMethods {
+        associated_payment_methods: Option<Vec<String>>,
     },
 }
 
@@ -864,10 +867,20 @@ impl From<PaymentMethodsSessionUpdateEnum> for PaymentMethodsSessionUpdateIntern
                 network_tokenization,
                 tokenization_data,
             } => Self {
-                billing,
+                billing: *billing,
                 psp_tokenization,
                 network_tokenization,
                 tokenization_data,
+                associated_payment_methods: None,
+            },
+            PaymentMethodsSessionUpdateEnum::UpdateAssociatedPaymentMethods {
+                associated_payment_methods,
+            } => Self {
+                billing: None,
+                psp_tokenization: None,
+                network_tokenization: None,
+                tokenization_data: None,
+                associated_payment_methods,
             },
         }
     }
@@ -898,7 +911,9 @@ impl PaymentMethodSession {
             tokenization_data: update_session.tokenization_data.or(tokenization_data),
             expires_at,
             return_url,
-            associated_payment_methods,
+            associated_payment_methods: update_session
+                .associated_payment_methods
+                .or(associated_payment_methods),
             associated_payment,
             associated_token_id,
         }
@@ -911,6 +926,7 @@ pub struct PaymentMethodsSessionUpdateInternal {
     pub psp_tokenization: Option<common_types::payment_methods::PspTokenization>,
     pub network_tokenization: Option<common_types::payment_methods::NetworkTokenization>,
     pub tokenization_data: Option<pii::SecretSerdeValue>,
+    pub associated_payment_methods: Option<Vec<String>>,
 }
 
 #[cfg(feature = "v1")]

--- a/crates/router/src/core/payment_methods.rs
+++ b/crates/router/src/core/payment_methods.rs
@@ -2756,7 +2756,7 @@ pub async fn payment_methods_session_update(
 
     let payment_method_session_domain_model =
         hyperswitch_domain_models::payment_methods::PaymentMethodsSessionUpdateEnum::GeneralUpdate{
-            billing,
+            billing: Box::new(billing),
             psp_tokenization: request.psp_tokenization,
             network_tokenization: request.network_tokenization,
             tokenization_data: request.tokenization_data,
@@ -3013,7 +3013,7 @@ pub async fn payment_methods_session_confirm(
     )
     .attach_printable("Failed to create payment method request")?;
 
-    let (payment_method_response, _payment_method) = create_payment_method_core(
+    let (payment_method_response, payment_method) = create_payment_method_core(
         &state,
         &req_state,
         create_payment_method_request.clone(),
@@ -3021,6 +3021,40 @@ pub async fn payment_methods_session_confirm(
         &profile,
     )
     .await?;
+
+    let parent_payment_method_token = generate_id(consts::ID_LENGTH, "token");
+
+    let token_data = get_pm_list_token_data(request.payment_method_type, &payment_method)?;
+
+    let intent_fulfillment_time = common_utils::consts::DEFAULT_INTENT_FULFILLMENT_TIME;
+
+    // insert the parent payment method token into the database
+    if let Some(token_data) = token_data {
+        pm_routes::ParentPaymentMethodToken::create_key_for_token((
+            &parent_payment_method_token,
+            request.payment_method_type,
+        ))
+        .insert(intent_fulfillment_time, token_data, &state)
+        .await?;
+    };
+
+    let update_payment_method_session = hyperswitch_domain_models::payment_methods::PaymentMethodsSessionUpdateEnum::UpdateAssociatedPaymentMethods {
+        associated_payment_methods:  Some(vec![parent_payment_method_token])
+    };
+
+    let payment_method_session = db
+        .update_payment_method_session(
+            key_manager_state,
+            merchant_context.get_merchant_key_store(),
+            &payment_method_session_id,
+            update_payment_method_session,
+            payment_method_session,
+        )
+        .await
+        .to_not_found_response(errors::ApiErrorResponse::GenericNotFoundError {
+            message: "payment methods session does not exist or has expired".to_string(),
+        })
+        .attach_printable("Failed to update payment methods session from db")?;
 
     let payments_response = match &payment_method_session.psp_tokenization {
         Some(common_types::payment_methods::PspTokenization {


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
- create a temporary payment_token for session confirm call and pass it in the response
- the payment_token is created against the payment_method_id and is saved in redis
- payment can be done using the payment_token generated by session confirm for the payment_method_data

### Additional Changes

- [x] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Locally tested

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
