### PR TITLE
feat(router): add confirm flag in kafka payment intent events

### DIFF
--- a/crates/common_utils/src/types/keymanager.rs
+++ b/crates/common_utils/src/types/keymanager.rs
@@ -52,6 +52,22 @@ pub struct KeyManagerState {
     pub infra_values: Option<serde_json::Value>,
 }
 
+impl KeyManagerState {
+    pub fn add_confirm_value_in_infra_values(
+        &self,
+        is_confirm_operation: bool,
+    ) -> Option<serde_json::Value> {
+        self.infra_values.clone().map(|mut infra_values| {
+            if is_confirm_operation {
+                infra_values
+                    .as_object_mut()
+                    .map(|obj| obj.insert("confirm".to_string(), serde_json::Value::Bool(true)));
+            }
+            infra_values
+        })
+    }
+}
+
 pub trait GetKeymanagerTenant {
     fn get_tenant_id(&self, state: &KeyManagerState) -> id_type::TenantId;
 }

--- a/crates/hyperswitch_domain_models/src/payments/payment_intent.rs
+++ b/crates/hyperswitch_domain_models/src/payments/payment_intent.rs
@@ -241,6 +241,7 @@ pub struct PaymentIntentUpdateFields {
     pub tax_details: Option<diesel_models::TaxDetails>,
     pub force_3ds_challenge: Option<bool>,
     pub is_iframe_redirection_enabled: Option<bool>,
+    pub is_confirm_operation: bool,
 }
 
 #[cfg(feature = "v1")]
@@ -322,6 +323,15 @@ pub enum PaymentIntentUpdate {
         updated_by: String,
         shipping_details: Option<Encryptable<Secret<serde_json::Value>>>,
     },
+}
+
+impl PaymentIntentUpdate {
+    pub fn is_confirm_operation(&self) -> bool {
+        match self {
+            Self::Update(value) => value.is_confirm_operation,
+            _ => false,
+        }
+    }
 }
 
 #[cfg(feature = "v2")]

--- a/crates/router/src/core/payments/operations/payment_confirm.rs
+++ b/crates/router/src/core/payments/operations/payment_confirm.rs
@@ -1881,6 +1881,7 @@ impl<F: Clone + Sync> UpdateTracker<F, PaymentData<F>, api::PaymentsRequest> for
                         is_iframe_redirection_enabled: payment_data
                             .payment_intent
                             .is_iframe_redirection_enabled,
+                        is_confirm_operation: true, // Indicates that this is a confirm operation
                     })),
                     &m_key_store,
                     storage_scheme,

--- a/crates/router/src/core/payments/operations/payment_update.rs
+++ b/crates/router/src/core/payments/operations/payment_update.rs
@@ -941,6 +941,7 @@ impl<F: Clone + Sync> UpdateTracker<F, PaymentData<F>, api::PaymentsRequest> for
                     is_iframe_redirection_enabled: payment_data
                         .payment_intent
                         .is_iframe_redirection_enabled,
+                    is_confirm_operation: false, // this is not a confirm operation
                 })),
                 key_store,
                 storage_scheme,

--- a/crates/router/src/db/kafka_store.rs
+++ b/crates/router/src/db/kafka_store.rs
@@ -1854,7 +1854,7 @@ impl PaymentIntentInterface for KafkaStore {
             .update_payment_intent(
                 state,
                 this.clone(),
-                payment_intent,
+                payment_intent.clone(),
                 key_store,
                 storage_scheme,
             )
@@ -1866,7 +1866,7 @@ impl PaymentIntentInterface for KafkaStore {
                 &intent,
                 Some(this),
                 self.tenant_id.clone(),
-                state.infra_values.clone(),
+                state.add_confirm_value_in_infra_values(payment_intent.is_confirm_operation()),
             )
             .await
         {


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
add confirm flag in kafka payment intent events

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Tested Manually
confirm flag sent as true in payment intent event in kafka
![image](https://github.com/user-attachments/assets/7c7b4d21-d2ad-4dea-9512-6535ee6251d2)

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
