### PR TITLE
feat(connector): [jpmorgan] implement refund flow

### DIFF
--- a/crates/hyperswitch_connectors/src/connectors/jpmorgan.rs
+++ b/crates/hyperswitch_connectors/src/connectors/jpmorgan.rs
@@ -665,9 +665,9 @@ impl ConnectorIntegration<Execute, RefundsData, RefundsResponseData> for Jpmorga
     fn get_url(
         &self,
         _req: &RefundsRouterData<Execute>,
-        _connectors: &Connectors,
+        connectors: &Connectors,
     ) -> CustomResult<String, errors::ConnectorError> {
-        Err(errors::ConnectorError::NotImplemented("Refunds".to_string()).into())
+        Ok(format!("{}/refunds", self.base_url(connectors)))
     }
 
     fn get_request_body(

--- a/crates/hyperswitch_connectors/src/connectors/jpmorgan/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/jpmorgan/transformers.rs
@@ -272,16 +272,8 @@ pub struct JpmorganPaymentsResponse {
 #[serde(rename_all = "camelCase")]
 pub struct Merchant {
     merchant_id: Option<String>,
-    merchant_software: MerchantSoftware,
+    merchant_software: JpmorganMerchantSoftware,
     merchant_category_code: Option<String>,
-}
-
-#[derive(Default, Debug, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct MerchantSoftware {
-    company_name: Secret<String>,
-    product_name: Secret<String>,
-    version: Option<Secret<String>>,
 }
 
 #[derive(Default, Debug, Deserialize, Serialize)]
@@ -528,7 +520,7 @@ pub struct JpmorganRefundRequest {
 #[derive(Default, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct MerchantRefundReq {
-    pub merchant_software: MerchantSoftware,
+    pub merchant_software: JpmorganMerchantSoftware,
 }
 
 impl<F> TryFrom<&JpmorganRouterData<&RefundsRouterData<F>>> for JpmorganRefundRequest {
@@ -582,12 +574,6 @@ impl From<RefundStatus> for common_enums::RefundStatus {
             RefundStatus::Processing => Self::Pending,
         }
     }
-}
-
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
-pub struct RefundResponse {
-    id: String,
-    status: RefundStatus,
 }
 
 pub fn refund_status_from_transaction_state(

--- a/cypress-tests/cypress/e2e/configs/Payment/Jpmorgan.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Jpmorgan.js
@@ -200,79 +200,59 @@ export const connectorDetails = {
     Void: voidCase,
     VoidAfterConfirm: voidCase,
     Refund: {
-      Configs: {
-        TRIGGER_SKIP: true,
-      },
       Request: {
         amount: 6000,
       },
       Response: {
-        status: 501,
+        status: 200,
         body: {
-          type: "invalid_request",
-          message: "Refunds is not implemented",
-          code: "IR_00",
+          reason: "FRAUD",
+          status: "pending",
         },
       },
     },
     manualPaymentRefund: {
-      Configs: {
-        TRIGGER_SKIP: true,
-      },
       Request: {
         amount: 6000,
       },
       Response: {
-        status: 501,
+        status: 200,
         body: {
-          type: "invalid_request",
-          message: "Refunds is not implemented",
-          code: "IR_00",
+          reason: "FRAUD",
+          status: "pending",
         },
       },
     },
     manualPaymentPartialRefund: {
-      Configs: {
-        TRIGGER_SKIP: true,
-      },
       Request: {
         amount: 2000,
       },
       Response: {
-        status: 501,
+        status: 200,
         body: {
-          type: "invalid_request",
-          message: "Refunds is not implemented",
-          code: "IR_00",
+          reason: "FRAUD",
+          status: "pending",
         },
       },
     },
     PartialRefund: {
-      Configs: {
-        TRIGGER_SKIP: true,
-      },
       Request: {
         amount: 2000,
       },
       Response: {
-        status: 501,
+        status: 200,
         body: {
-          type: "invalid_request",
-          message: "Refunds is not implemented",
-          code: "IR_00",
+          reason: "FRAUD",
+          status: "pending",
         },
       },
     },
     SyncRefund: {
-      Configs: {
-        TRIGGER_SKIP: true,
-      },
       Response: {
-        status: 404,
+        status: 200,
         body: {
-          type: "invalid_request",
-          message: "Refund does not exist in our records.",
-          code: "HE_02",
+          reason: "FRAUD",
+          status: "succeeded",
         },
       },
     },


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [x] CI/CD

## Description
<!-- Describe your changes in detail -->

This PR implements refund flow for JPMorgan connector. Connector returns `Authorized` state (`Pending`). Post RSync call, the status gets updated to `Success`.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->

The connector lacked this basic feature until now. Closes #8435 

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

Updated Cypress tests:

<img width="558" alt="image" src="https://github.com/user-attachments/assets/cb18d34e-d6d2-4145-8e94-773ab6638389" />

There exist an issue from the connector where it returns same `transaction_id` (`connector_transaction_id`) every single time which we have no control. Because of this, refunds tend to exceed the maximum refundable amount resulting in 4xx as shown below:

<img width="557" alt="image" src="https://github.com/user-attachments/assets/549c517b-cc54-4114-b034-5df64783bd68" />

<img width="477" alt="image" src="https://github.com/user-attachments/assets/47018470-5798-4a07-b480-1f0694540d68" />


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `just clippy && jut clippy_v2`
- [x] I reviewed the submitted code
- [x] I added unit tests for my changes where possible

<!-- @coderabbitai ignore -->