### PR TITLE
ci(cypress): Fix wellsfargo test

### DIFF
--- a/cypress-tests/cypress/e2e/configs/Payment/Utils.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Utils.js
@@ -362,8 +362,8 @@ export const CONNECTOR_LISTS = {
       "fiserv",
       "jpmorgan",
       "paypal",
-      "wellsfargo",
       "stax",
+      "wellsfargo",
     ],
     // Add more exclusion lists
   },

--- a/cypress-tests/cypress/e2e/configs/Payment/WellsFargo.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/WellsFargo.js
@@ -52,12 +52,6 @@ export const connectorDetails = {
       },
     },
     PaymentIntentOffSession: {
-      Configs: {
-        CONNECTOR_CREDENTIAL: {
-          specName: ["connectorAgnosticNTID"],
-          value: "connector_2",
-        },
-      },
       Request: {
         currency: "USD",
         customer_acceptance: null,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [x] CI/CD

## Description
Fixed the wellsfargo cypress test

## How did you test it?
<img width="482" alt="Screenshot 2025-07-01 at 7 26 17 PM" src="https://github.com/user-attachments/assets/863ea827-7e79-438d-9e64-ffd485241b1b" />

Failure Reason:
3ds payments silently falling back to no-3ds(Should throw validation)



## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
