### PR TITLE
feat(router): Add tokenization support for proxy and update the route for proxy

### DIFF
--- a/crates/common_utils/src/id_type/global_id/token.rs
+++ b/crates/common_utils/src/id_type/global_id/token.rs
@@ -1,3 +1,9 @@
+use error_stack::ResultExt;
+use std::borrow::Cow;
+use crate::{
+    errors::{CustomResult,ValidationError}
+};
+
 crate::global_id_type!(
     GlobalTokenId,
     "A global id that can be used to identify a token.
@@ -15,6 +21,16 @@ impl GlobalTokenId {
     /// Get string representation of the id
     pub fn get_string_repr(&self) -> &str {
         self.0.get_string_repr()
+    }
+
+    ///Get GlobalTokenId from a string
+    pub fn from_str(token_string: &str) -> CustomResult<Self, ValidationError>{
+        let token = super::GlobalId::from_string(Cow::Owned(token_string.to_string())).change_context(
+            ValidationError::IncorrectValueProvided {
+                field_name: "GlobalTokenId",
+            },
+        )?;
+        Ok(Self(token))
     }
 
     /// Generate a new GlobalTokenId from a cell id

--- a/crates/router/src/core/proxy.rs
+++ b/crates/router/src/core/proxy.rs
@@ -3,7 +3,7 @@ use crate::{logger, routes::SessionState, services, types::domain};
 pub mod utils;
 use api_models::proxy as proxy_api_models;
 use common_utils::{
-    ext_traits::{BytesExt, Encode},
+    ext_traits::BytesExt,
     request::{self, RequestBuilder},
 };
 use error_stack::ResultExt;
@@ -24,21 +24,11 @@ pub async fn proxy_core(
         )
         .await?;
 
-    let vault_response =
-        super::payment_methods::vault::retrieve_payment_method_from_vault_internal(
-            &state,
-            &merchant_context,
-            &vault_id,
-        )
-        .await
-        .change_context(errors::ApiErrorResponse::InternalServerError)
-        .attach_printable("Error while fetching data from vault")?;
-
-    let vault_data = vault_response
-        .data
-        .encode_to_value()
-        .change_context(errors::ApiErrorResponse::InternalServerError)
-        .attach_printable("Failed to serialize vault data")?;
+    let vault_data = req_wrapper.get_vault_data(
+        &state,
+        merchant_context,
+        &vault_id,
+    ).await?;
 
     let processed_body =
         interpolate_token_references_with_vault_data(req.request_body.clone(), &vault_data)?;


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Add tokenization support for proxy and update the route for proxy to `/v2/proxy`

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
test case - 
1. create customer
2. Create payment method
3. use the same payment method id in proxy api 
request - 
```
curl --location 'http://localhost:8080/v2/proxy' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'X-Profile-Id: profile id' \
--header 'Authorization: api-key=api key' \
--data '{
    "request_body": {
        "source": {
            "type": "card",
            "number": "{{$card_number}}",
            "expiry_month": "{{$card_exp_month}}",
            "expiry_year": "{{$card_exp_year}}",
        },
        "processing_channel_id": "< processing_channel_id >",
        "amount": 6540,
        "currency": "USD",
        "payment_type": "Regular",
        "reference": "ORD-5023-4E89",
        "description": "Set of 3 masks",
        "capture": true,
        "capture_on": "2019-09-10T10:11:12Z",
        "billing_descriptor": {
            "name": "Withdrawal",
            "city": "London"
        }
    },
    "destination_url": "https://api.sandbox.checkout.com/payments",
    "headers": {
        "Content-Type": "application/json",
        "Authorization": "Bearer sk_sbox_3uurpeatcw2jnf7hiijia5b62yd"
    },
"token": "pm_0197ca91742f72d3bac45e1f8cdf9836",
    "token_type": "payment_method_id",
    "method": "POST"
}'
```
response - 
```
{
    "response": {
        "id": "pay_onvfpnamhmnujkins23jzzyn6m",
        "action_id": "act_cllav3k4bveuvippsxvn3p3tim",
        "amount": 6540,
        "currency": "USD",
        "approved": true,
        "status": "Authorized",
        "auth_code": "727844",
        "response_code": "10000",
        "response_summary": "Approved",
        "balances": {
            "total_authorized": 6540,
            "total_voided": 0,
            "available_to_void": 6540,
            "total_captured": 0,
            "available_to_capture": 6540,
            "total_refunded": 0,
            "available_to_refund": 0
        },
        "risk": {
            "flagged": false,
            "score": 0.0
        },
        "source": {
            "id": "src_vtwe6mnu6pvepcnfhj337v2kk4",
            "type": "card",
            "expiry_month": 9,
            "expiry_year": 2025,
            "scheme": "Visa",
            "last4": "4242",
            "fingerprint": "0E532896E00C0A15DBE880E5BABF25A2F8080D577C4B37EFC391C2BC3629A3E4",
            "bin": "42424242",
            "card_type": "CREDIT",
            "card_category": "CONSUMER",
            "issuer": "CKO, WHERE THE WORLD CHECKS OUT",
            "issuer_country": "GB",
            "product_id": "F",
            "product_type": "Visa Classic",
            "avs_check": "G",
            "payment_account_reference": "V001827870003119243",
            "regulated_indicator": false
        },
        "processed_on": "2025-07-02T10:12:04.7916639Z",
        "reference": "ORD-5023-4E89",
        "scheme_id": "251583969481470",
        "processing": {
            "acquirer_transaction_id": "622040732846408761184",
            "retrieval_reference_number": "931975963629",
            "merchant_category_code": "5815",
            "scheme_merchant_id": "75155",
            "scheme": "VISA",
            "aft": false,
            "pan_type_processed": "fpan",
            "cko_network_token_available": false,
            "provision_network_token": false
        },
        "expires_on": "2025-08-01T10:12:04.7916639Z",
    },
    "status_code": 201,
    "response_headers": {
        "cko-version": "1.1129.0+0e5d53d72",
        "content-length": "1901",
        "cko-request-id": "e4919142-dd65-4b0f-8125-70e41d62076e",
        "content-type": "application/json; charset=utf-8",
        "connection": "keep-alive",
        "location": "https://api.sandbox.checkout.com/payments/pay_onvfpnamhmnujkins23jzzyn6m",
        "strict-transport-security": "max-age=16000000; includeSubDomains; preload;",
        "date": "Wed, 02 Jul 2025 10:12:04 GMT"
    }
}
```

4. Create tokenization entry with card data - 
request - 
```
curl --location 'http://localhost:8080/v2/tokenize' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'X-Profile-Id: profile id' \
--header 'Authorization: api-key=api key' \
--data '{
    "customer_id": "<customer_id>",
    "token_request":{
    "card_number":"<card number>",
    "card_exp_month": "09",
    "card_exp_year": "2025"
    }
}'
```
response - 
```
{
    "id": "12345_tok_0197ca91742f72d3bac45e1f8cdf9836",
    "created_at": "2025-07-02 09:56:59.567795",
    "flag": "enabled"
}
```
5. use this tokenization id in proxy
request - 
```
curl --location 'http://localhost:8080/v2/proxy' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'X-Profile-Id: profile id' \
--header 'Authorization: api-key=api key' \
--data '{
    "request_body": {
        "source": {
            "type": "card",
            "number": "{{$card_number}}",
            "expiry_month": "{{$card_exp_month}}",
            "expiry_year": "{{$card_exp_year}}",
        },
        "processing_channel_id": "pc_jx5lvimg4obe7nhoqnhptm6xoq",
        "amount": 6540,
        "currency": "USD",
        "payment_type": "Regular",
        "reference": "ORD-5023-4E89",
        "description": "Set of 3 masks",
        "capture": true,
        "capture_on": "2019-09-10T10:11:12Z",
        "billing_descriptor": {
            "name": "Withdrawal",
            "city": "London"
        }
    },
    "destination_url": "https://api.sandbox.checkout.com/payments",
    "headers": {
        "Content-Type": "application/json",
        "Authorization": "Bearer sk_sbox_3uurpeatcw2jnf7hiijia5b62yd"
    },
"token": "12345_tok_0197ca91742f72d3bac45e1f8cdf9836",
    "token_type": "tokenization_id",
    "method": "POST"

}'
```
response will be same when we used payment method id for proxy.


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
