### PR TITLE
feat(core): add authentication date in Authentication Flow

### DIFF
--- a/crates/hyperswitch_connectors/src/connectors/cybersource/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/cybersource/transformers.rs
@@ -4,7 +4,7 @@ use api_models::payouts::PayoutMethodData;
 use base64::Engine;
 use common_enums::{enums, FutureUsage};
 use common_utils::{
-    consts,
+    consts, date_time,
     ext_traits::{OptionExt, ValueExt},
     pii,
     types::{SemanticVersion, StringMajorUnit},
@@ -402,6 +402,8 @@ pub struct CybersourceConsumerAuthInformation {
     /// This field is supported only on Asia, Middle East, and Africa Gateway
     /// This field is only applicable for Mastercard and Visa Transactions
     pares_status: Option<CybersourceParesStatus>,
+    //This field is used to send the authentication date in yyyyMMDDHHMMSS format
+    authentication_date: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -1347,6 +1349,11 @@ impl
                     } else {
                         (None, Some(authn_data.cavv.clone()), None)
                     };
+                let authentication_date = date_time::format_date(
+                    authn_data.created_at,
+                    date_time::DateFormat::YYYYMMDDHHmmss,
+                )
+                .ok();
                 CybersourceConsumerAuthInformation {
                     pares_status,
                     ucaf_collection_indicator,
@@ -1361,6 +1368,7 @@ impl
                     pa_specification_version: authn_data.message_version.clone(),
                     veres_enrolled: Some("Y".to_string()),
                     eci_raw: authn_data.eci.clone(),
+                    authentication_date,
                 }
             });
 
@@ -1453,6 +1461,11 @@ impl
                     } else {
                         (None, Some(authn_data.cavv.clone()), None)
                     };
+                let authentication_date = date_time::format_date(
+                    authn_data.created_at,
+                    date_time::DateFormat::YYYYMMDDHHmmss,
+                )
+                .ok();
                 CybersourceConsumerAuthInformation {
                     pares_status,
                     ucaf_collection_indicator,
@@ -1467,6 +1480,7 @@ impl
                     pa_specification_version: authn_data.message_version.clone(),
                     veres_enrolled: Some("Y".to_string()),
                     eci_raw: authn_data.eci.clone(),
+                    authentication_date,
                 }
             });
 
@@ -1549,6 +1563,11 @@ impl
                     } else {
                         (None, Some(authn_data.cavv.clone()), None)
                     };
+                let authentication_date = date_time::format_date(
+                    authn_data.created_at,
+                    date_time::DateFormat::YYYYMMDDHHmmss,
+                )
+                .ok();
                 CybersourceConsumerAuthInformation {
                     pares_status,
                     ucaf_collection_indicator,
@@ -1563,6 +1582,7 @@ impl
                     pa_specification_version: authn_data.message_version.clone(),
                     veres_enrolled: Some("Y".to_string()),
                     eci_raw: authn_data.eci.clone(),
+                    authentication_date,
                 }
             });
 
@@ -1759,6 +1779,7 @@ impl
             pa_specification_version: None,
             veres_enrolled: None,
             eci_raw: None,
+            authentication_date: None,
         });
 
         let merchant_defined_information = item
@@ -1855,6 +1876,7 @@ impl
                 pa_specification_version: None,
                 veres_enrolled: None,
                 eci_raw: None,
+                authentication_date: None,
             }),
             merchant_defined_information,
         })
@@ -1998,6 +2020,7 @@ impl
                 pa_specification_version: None,
                 veres_enrolled: None,
                 eci_raw: None,
+                authentication_date: None,
             }),
             merchant_defined_information,
         })
@@ -2198,6 +2221,7 @@ impl TryFrom<&CybersourceRouterData<&PaymentsAuthorizeRouterData>> for Cybersour
                                                 pa_specification_version: None,
                                                 veres_enrolled: None,
                                                 eci_raw: None,
+                                                authentication_date: None,
                                             },
                                         ),
                                     })

--- a/crates/hyperswitch_domain_models/src/router_request_types.rs
+++ b/crates/hyperswitch_domain_models/src/router_request_types.rs
@@ -681,6 +681,7 @@ pub struct AuthenticationData {
     pub threeds_server_transaction_id: Option<String>,
     pub message_version: Option<common_utils::types::SemanticVersion>,
     pub ds_trans_id: Option<String>,
+    pub created_at: time::PrimitiveDateTime,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/router/src/core/payments/types.rs
+++ b/crates/router/src/core/payments/types.rs
@@ -385,6 +385,7 @@ impl
                 .attach_printable("cavv must not be null when authentication_status is success")?;
             Ok(Self {
                 eci: authentication.eci.clone(),
+                created_at: authentication.created_at,
                 cavv,
                 threeds_server_transaction_id,
                 message_version,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [X] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
1. Added   **created_at** (time at which authentication completed) in Authentication Flow
2. Reused **created_at** field from AuthenticationStore, since all 3ds connectors do not send this field in authentication response
3. Used this field  **created_at**  for 3ds external authentication payments for Cybersource.( See ref Pg 460
https://docs.cybersource.com/content/dam/new-documentation/documentation/en/reference/api-fields/api-fields-so.pdf ). Reason for this change - Without this field Visa card payments are currently failing for a france-based merchant acquirer CMCIC in prod for cybersource.


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Tested this for both Mastercard card and Visa card, for 3ds external authentication

### Step 1: call /payment with mastercard

`curl --location 'http://localhost:8080/payments' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: dev_vZhxm9YIR6AL29HJ6By1vUTW6vOsmBvT295BcGlhbmiM0CoTnQPFkUbExaOqYuLf' \
--data-raw '{
    "amount": 10000,
    "currency": "EUR",
    "confirm": true,
    "payment_link": false,
    "capture_method": "automatic",
    "capture_on": "2022-09-10T10:11:12Z",
    "amount_to_capture": 10000,
    "customer_id": "StripeCustomer",
    "email": "guest@example.com",
    "name": "John Doe",
    "phone": "999999999",
    "phone_country_code": "+1",
    "description": "Its my first payment request",
    "request_external_three_ds_authentication": true,
    "authentication_type": "three_ds",
    "return_url": "https://google.com",
    "payment_method": "card",
    "payment_method_type": "credit",
    "payment_method_data": {
        "card": {
            "card_number": "5512459816707531",
            "card_exp_month": "12",
            "card_exp_year": "2025",
            "card_cvc": "000",
            "card_network": "Mastercard"
        }
    },
    "billing": {
        "address": {
            "line1": "1467",
            "line2": "CA",
            "line3": "CA",
            "city": "Musterhausen",
            "state": "California",
            "zip": "12345",
            "country": "US",
            "first_name": "Debarati",
            "last_name": "Ghatak"
        },
        "phone": {
            "number": "8056594427",
            "country_code": "+91"
        }
    },
    "browser_info": {
        "user_agent": "Mozilla\/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/70.0.3538.110 Safari\/537.36",
        "accept_header": "text\/html,application\/xhtml+xml,application\/xml;q=0.9,image\/webp,image\/apng,\/;q=0.8",
        "language": "nl-NL",
        "color_depth": 24,
        "ip_address": "103.77.139.95",
        "screen_height": 723,
        "screen_width": 1536,
        "time_zone": 0,
        "java_enabled": true,
        "java_script_enabled": true
    },
    "statement_descriptor_name": "joseph",
    "statement_descriptor_suffix": "JS",
    "metadata": {
        "dg": "value1",
        "new_customer": "true",
        "login_date": "2019-09-10T10:11:12Z"
    }
}'
`
<img width="1203" height="721" alt="Screenshot 2025-07-16 at 3 14 49 PM" src="https://github.com/user-attachments/assets/7cf1aaa3-18b7-4814-9238-a27438c590ca" />

### Step 2: call /3ds/authentication with netcetera

`curl --location 'http://localhost:8080/payments/pay_PSx4kFvcV2b2ZpBfq6xe/3ds/authentication' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: pk_dev_e93c08fa617547b69cd87169c0cb016f' \
--data '{
    "client_secret": "pay_PSx4kFvcV2b2ZpBfq6xe_secret_kcT0vkHDtCig6M30dvuD",
    "device_channel": "BRW",
    "threeds_method_comp_ind": "Y"
}'
`
<img width="815" height="461" alt="Screenshot 2025-07-16 at 3 15 59 PM" src="https://github.com/user-attachments/assets/5ed2cd6b-81e6-47dd-ba04-2aeb6555ab6a" />


### Step 3: call /authorization for Cybersource

`curl --location --request POST 'http://localhost:8080/payments/pay_PSx4kFvcV2b2ZpBfq6xe/merchant_1752656162/authorize/cybersource'`
<img width="910" height="524" alt="Screenshot 2025-07-16 at 3 16 52 PM" src="https://github.com/user-attachments/assets/64f13cc9-08a5-4c01-adbc-22be467e5aba" />


### Testing with visa card
<img width="917" height="670" alt="Screenshot 2025-07-16 at 3 17 35 PM" src="https://github.com/user-attachments/assets/33374685-531a-4bd4-b716-73730aab27cf" />

<img width="1045" height="762" alt="Screenshot 2025-07-16 at 3 17 58 PM" src="https://github.com/user-attachments/assets/dd1a1136-ecc7-401b-a3d5-108bbc027e57" />

<img width="1045" height="762" alt="Screenshot 2025-07-16 at 3 18 07 PM" src="https://github.com/user-attachments/assets/871c8a31-6c43-4c80-911e-15397496caed" />

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
