### PR TITLE
fix: Remove write path for straight through

### DIFF
--- a/crates/common_enums/src/enums.rs
+++ b/crates/common_enums/src/enums.rs
@@ -8534,7 +8534,6 @@ impl RoutingApproach {
             "SR_SELECTION_V3_ROUTING" => Self::SuccessRateExploitation,
             "SR_V3_HEDGING" => Self::SuccessRateExploration,
             "NTW_BASED_ROUTING" => Self::DebitRouting,
-            "DEFAULT" => Self::StraightThroughRouting,
             _ => Self::DefaultFallback,
         }
     }

--- a/crates/router/src/core/payments.rs
+++ b/crates/router/src/core/payments.rs
@@ -7606,10 +7606,6 @@ where
         .change_context(errors::ApiErrorResponse::InternalServerError)
         .attach_printable("Failed execution of straight through routing")?;
 
-        payment_data.set_routing_approach_in_attempt(Some(
-            common_enums::RoutingApproach::StraightThroughRouting,
-        ));
-
         if check_eligibility {
             let transaction_data = core_routing::PaymentsDslInput::new(
                 payment_data.get_setup_mandate(),

--- a/crates/router/src/core/payments/routing.rs
+++ b/crates/router/src/core/payments/routing.rs
@@ -519,10 +519,7 @@ pub async fn perform_static_routing_v1(
     };
 
     let (routable_connectors, routing_approach) = match cached_algorithm.as_ref() {
-        CachedAlgorithm::Single(conn) => (
-            vec![(**conn).clone()],
-            Some(common_enums::RoutingApproach::StraightThroughRouting),
-        ),
+        CachedAlgorithm::Single(conn) => (vec![(**conn).clone()], None),
         CachedAlgorithm::Priority(plist) => (plist.clone(), None),
         CachedAlgorithm::VolumeSplit(splits) => (
             perform_volume_split(splits.to_vec())
@@ -1390,10 +1387,7 @@ async fn perform_session_routing_for_pm_type(
         .await?;
 
         match cached_algorithm.as_ref() {
-            CachedAlgorithm::Single(conn) => (
-                vec![(**conn).clone()],
-                Some(common_enums::RoutingApproach::StraightThroughRouting),
-            ),
+            CachedAlgorithm::Single(conn) => (vec![(**conn).clone()], None),
             CachedAlgorithm::Priority(plist) => (plist.clone(), None),
             CachedAlgorithm::VolumeSplit(splits) => (
                 perform_volume_split(splits.to_vec())


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Remove Write path for `StraightThroughRouting` from `RoutingApproach` enum


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->



## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
