### PR TITLE
fix(connector): refunds are supported by jpmorgan

### DIFF
--- a/crates/hyperswitch_connectors/src/connectors/jpmorgan.rs
+++ b/crates/hyperswitch_connectors/src/connectors/jpmorgan.rs
@@ -847,7 +847,7 @@ static JPMORGAN_SUPPORTED_PAYMENT_METHODS: LazyLock<SupportedPaymentMethods> =
             enums::PaymentMethodType::Debit,
             PaymentMethodDetails {
                 mandates: enums::FeatureStatus::NotSupported,
-                refunds: enums::FeatureStatus::NotSupported,
+                refunds: enums::FeatureStatus::Supported,
                 supported_capture_methods: supported_capture_methods.clone(),
                 specific_features: Some(
                     api_models::feature_matrix::PaymentMethodSpecificFeatures::Card({
@@ -866,7 +866,7 @@ static JPMORGAN_SUPPORTED_PAYMENT_METHODS: LazyLock<SupportedPaymentMethods> =
             enums::PaymentMethodType::Credit,
             PaymentMethodDetails {
                 mandates: enums::FeatureStatus::NotSupported,
-                refunds: enums::FeatureStatus::NotSupported,
+                refunds: enums::FeatureStatus::Supported,
                 supported_capture_methods: supported_capture_methods.clone(),
                 specific_features: Some(
                     api_models::feature_matrix::PaymentMethodSpecificFeatures::Card({


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->

This PR marks refunds as supported by JPMorgan connector. Although this does not affect refund flow, the feature matrix marking is wrong. 

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->

I added refunds support 3 weeks ago in #8436 and this was missed.
closes #8698

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

Hit feature matrix endpoint:

```sh
curl --location 'http://localhost:8080/feature_matrix' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json'
```
```json
{
...
            "supported_payment_methods": [
                {
                    "payment_method": "card",
                    "payment_method_type": "credit",
                    "payment_method_type_display_name": "Credit Card",
                    "mandates": "not_supported",
                    "refunds": "supported",
                    "supported_capture_methods": [
                        "automatic",
                        "manual"
                    ],
                    "three_ds": "not_supported",
                    "no_three_ds": "supported",
                    "supported_card_networks": [
                        "AmericanExpress",
                        "DinersClub",
                        "Discover",
                        "JCB",
                        "Mastercard",
...
                },
                {
                    "payment_method": "card",
                    "payment_method_type": "debit",
                    "payment_method_type_display_name": "Debit Card",
                    "mandates": "not_supported",
                    "refunds": "supported",
                    "supported_capture_methods": [
                        "automatic",
                        "manual"
                    ],
                    "three_ds": "not_supported",
                    "no_three_ds": "supported",
                    "supported_card_networks": [
                        "AmericanExpress",
                        "DinersClub",
                        "Discover",
                        "JCB",
                        "Mastercard",
                        "UnionPay",
                        "Visa"
                    ],
                    "supported_countries": [
                        "FRA",
                        "BEL",
...
}
```

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `just clippy && just clippy_v2`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
