### PR TITLE
refactor(connector): [Adyen] map ssn and session validity for Pix

### DIFF
--- a/crates/api_models/src/payments.rs
+++ b/crates/api_models/src/payments.rs
@@ -3438,6 +3438,11 @@ pub enum BankTransferData {
         /// Destination bank account number
         #[schema(value_type = Option<String>, example = "9b95f84e-de61-460b-a14b-f23b4e71c97b")]
         destination_bank_account_id: Option<MaskedBankAccount>,
+
+        /// The expiration date and time for the Pix QR code in ISO 8601 format
+        #[schema(value_type = Option<String>, example = "2025-09-10T10:11:12Z")]
+        #[serde(default, with = "common_utils::custom_serde::iso8601::option")]
+        expiry_date: Option<PrimitiveDateTime>,
     },
     Pse {},
     LocalBankTransfer {

--- a/crates/api_models/src/payments/additional_info.rs
+++ b/crates/api_models/src/payments/additional_info.rs
@@ -177,6 +177,11 @@ pub struct PixBankTransferAdditionalData {
     /// Partially masked destination bank account number
     #[schema(value_type = Option<String>, example = "********-****-460b-****-f23b4e71c97b")]
     pub destination_bank_account_id: Option<MaskedBankAccount>,
+
+    /// The expiration date and time for the Pix QR code in ISO 8601 format
+    #[schema(value_type = Option<String>, example = "2025-09-10T10:11:12Z")]
+    #[serde(default, with = "common_utils::custom_serde::iso8601::option")]
+    pub expiry_date: Option<time::PrimitiveDateTime>,
 }
 
 #[derive(Eq, PartialEq, Clone, Debug, serde::Deserialize, serde::Serialize, ToSchema)]

--- a/crates/hyperswitch_connectors/src/connectors/adyen/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/adyen/transformers.rs
@@ -291,6 +291,8 @@ pub struct AdyenPaymentRequest<'a> {
     splits: Option<Vec<AdyenSplitData>>,
     store: Option<String>,
     device_fingerprint: Option<Secret<String>>,
+    #[serde(with = "common_utils::custom_serde::iso8601::option")]
+    session_validity: Option<PrimitiveDateTime>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -2922,6 +2924,7 @@ impl
             store,
             splits,
             device_fingerprint,
+            session_validity: None,
         })
     }
 }
@@ -3005,6 +3008,7 @@ impl TryFrom<(&AdyenRouterData<&PaymentsAuthorizeRouterData>, &Card)> for AdyenP
             store,
             splits,
             device_fingerprint,
+            session_validity: None,
         })
     }
 }
@@ -3092,6 +3096,7 @@ impl
             store,
             splits,
             device_fingerprint,
+            session_validity: None,
         };
         Ok(request)
     }
@@ -3167,6 +3172,7 @@ impl TryFrom<(&AdyenRouterData<&PaymentsAuthorizeRouterData>, &VoucherData)>
             store,
             splits,
             device_fingerprint,
+            session_validity: None,
         };
         Ok(request)
     }
@@ -3213,6 +3219,32 @@ impl
         let delivery_address =
             get_address_info(item.router_data.get_optional_shipping()).and_then(Result::ok);
         let telephone_number = item.router_data.get_optional_billing_phone_number();
+        let (session_validity, social_security_number) = match bank_transfer_data {
+            BankTransferData::Pix {
+                pix_key: _,
+                cpf,
+                cnpj,
+                source_bank_account_id: _,
+                destination_bank_account_id: _,
+                expiry_date,
+            } => (expiry_date.clone(), cpf.clone().or(cnpj.clone()).clone()),
+            BankTransferData::LocalBankTransfer { bank_code: _ } => (None, None),
+            BankTransferData::AchBankTransfer {}
+            | BankTransferData::SepaBankTransfer {}
+            | BankTransferData::BacsBankTransfer {}
+            | BankTransferData::MultibancoBankTransfer {}
+            | BankTransferData::PermataBankTransfer {}
+            | BankTransferData::BcaBankTransfer {}
+            | BankTransferData::BniVaBankTransfer {}
+            | BankTransferData::BriVaBankTransfer {}
+            | BankTransferData::CimbVaBankTransfer {}
+            | BankTransferData::DanamonVaBankTransfer {}
+            | BankTransferData::MandiriVaBankTransfer {}
+            | BankTransferData::Pse {}
+            | BankTransferData::InstantBankTransfer {}
+            | BankTransferData::InstantBankTransferFinland {}
+            | BankTransferData::InstantBankTransferPoland {} => (None, None),
+        };
 
         let request = AdyenPaymentRequest {
             amount,
@@ -3228,7 +3260,7 @@ impl
             shopper_name: None,
             shopper_locale: None,
             shopper_email: item.router_data.get_optional_billing_email(),
-            social_security_number: None,
+            social_security_number,
             telephone_number,
             billing_address,
             delivery_address,
@@ -3243,6 +3275,7 @@ impl
             store,
             splits,
             device_fingerprint,
+            session_validity,
         };
         Ok(request)
     }
@@ -3319,6 +3352,7 @@ impl
             store,
             splits,
             device_fingerprint,
+            session_validity: None,
         };
         Ok(request)
     }
@@ -3399,6 +3433,7 @@ impl
             store,
             splits,
             device_fingerprint,
+            session_validity: None,
         })
     }
 }
@@ -3529,6 +3564,7 @@ impl TryFrom<(&AdyenRouterData<&PaymentsAuthorizeRouterData>, &WalletData)>
             store,
             splits,
             device_fingerprint,
+            session_validity: None,
         })
     }
 }
@@ -3618,6 +3654,7 @@ impl
             store,
             splits,
             device_fingerprint,
+            session_validity: None,
         })
     }
 }
@@ -3699,6 +3736,7 @@ impl
             store,
             splits,
             device_fingerprint,
+            session_validity: None,
         })
     }
 }
@@ -5945,6 +5983,7 @@ impl
             store,
             splits,
             device_fingerprint,
+            session_validity: None,
         })
     }
 }

--- a/crates/hyperswitch_domain_models/src/payment_method_data.rs
+++ b/crates/hyperswitch_domain_models/src/payment_method_data.rs
@@ -710,6 +710,8 @@ pub enum BankTransferData {
         source_bank_account_id: Option<MaskedBankAccount>,
         /// Destination bank account UUID.
         destination_bank_account_id: Option<MaskedBankAccount>,
+        /// The expiration date and time for the Pix QR code
+        expiry_date: Option<time::PrimitiveDateTime>,
     },
     Pse {},
     LocalBankTransfer {
@@ -1618,12 +1620,14 @@ impl From<api_models::payments::BankTransferData> for BankTransferData {
                 cnpj,
                 source_bank_account_id,
                 destination_bank_account_id,
+                expiry_date,
             } => Self::Pix {
                 pix_key,
                 cpf,
                 cnpj,
                 source_bank_account_id,
                 destination_bank_account_id,
+                expiry_date,
             },
             api_models::payments::BankTransferData::Pse {} => Self::Pse {},
             api_models::payments::BankTransferData::LocalBankTransfer { bank_code } => {
@@ -1662,6 +1666,7 @@ impl From<BankTransferData> for api_models::payments::additional_info::BankTrans
                 cnpj,
                 source_bank_account_id,
                 destination_bank_account_id,
+                expiry_date,
             } => Self::Pix(Box::new(
                 api_models::payments::additional_info::PixBankTransferAdditionalData {
                     pix_key: pix_key.map(MaskedBankAccount::from),
@@ -1669,6 +1674,7 @@ impl From<BankTransferData> for api_models::payments::additional_info::BankTrans
                     cnpj: cnpj.map(MaskedBankAccount::from),
                     source_bank_account_id,
                     destination_bank_account_id,
+                    expiry_date,
                 },
             )),
             BankTransferData::Pse {} => Self::Pse {},

--- a/nix/modules/flake/devshell.nix
+++ b/nix/modules/flake/devshell.nix
@@ -21,6 +21,11 @@
               postgresql # for libpq
               protobuf
             ];
+            shellHook = ''
+              export OPENSSL_DIR="${pkgs.openssl.dev}"
+              export OPENSSL_LIB_DIR="${pkgs.openssl.out}/lib"
+              export OPENSSL_INCLUDE_DIR="${pkgs.openssl.dev}/include"
+            '';
           };
         dev = pkgs.mkShell {
           name = "hyperswitch-dev-shell";

--- a/nix/modules/flake/devshell.nix
+++ b/nix/modules/flake/devshell.nix
@@ -21,11 +21,6 @@
               postgresql # for libpq
               protobuf
             ];
-            shellHook = ''
-              export OPENSSL_DIR="${pkgs.openssl.dev}"
-              export OPENSSL_LIB_DIR="${pkgs.openssl.out}/lib"
-              export OPENSSL_INCLUDE_DIR="${pkgs.openssl.dev}/include"
-            '';
           };
         dev = pkgs.mkShell {
           name = "hyperswitch-dev-shell";


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->

Enhanced Pix payment support for Adyen connector with two changes:

1. **Expiry Date Support**: Added `expiry_date` field to `BankTransferData::Pix` variant in API and domain models and mapped it to Adyen's `sessionValidity`
2. **CPF/CNPJ Mapping**: Map CPF or CNPJ from Pix payment data to Adyen's `socialSecurityNumber` field

### Additional Changes

- [x] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

Enables merchants to specify expiry dates for Pix QR codes and ensures proper customer identification through CPF/CNPJ mapping as per Adyen's Pix API requirements.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
