### PR TITLE
refactor(webhooks): use REQUEST_TIME_OUT constant for outgoing webhooks

### DIFF
--- a/crates/router/src/core/webhooks/outgoing.rs
+++ b/crates/router/src/core/webhooks/outgoing.rs
@@ -45,8 +45,6 @@ use crate::{
     workflows::outgoing_webhook_retry,
 };
 
-const OUTGOING_WEBHOOK_TIMEOUT_SECS: u64 = 5;
-
 #[allow(clippy::too_many_arguments)]
 #[instrument(skip_all)]
 pub(crate) async fn create_event_and_trigger_outgoing_webhook(
@@ -338,7 +336,12 @@ async fn trigger_webhook_to_merchant(
 
     let response = state
         .api_client
-        .send_request(&state, request, Some(OUTGOING_WEBHOOK_TIMEOUT_SECS), false)
+        .send_request(
+            &state,
+            request,
+            Some(crate::consts::REQUEST_TIME_OUT),
+            false,
+        )
         .await;
 
     metrics::WEBHOOK_OUTGOING_COUNT.add(

--- a/crates/router/src/core/webhooks/outgoing_v2.rs
+++ b/crates/router/src/core/webhooks/outgoing_v2.rs
@@ -396,12 +396,7 @@ async fn build_and_send_request(
 
     state
         .api_client
-        .send_request(
-            state,
-            request,
-            Some(types::OUTGOING_WEBHOOK_TIMEOUT_SECS),
-            false,
-        )
+        .send_request(state, request, Some(crate::consts::REQUEST_TIME_OUT), false)
         .await
 }
 

--- a/crates/router/src/core/webhooks/types.rs
+++ b/crates/router/src/core/webhooks/types.rs
@@ -11,8 +11,6 @@ use crate::{
     types::storage::{self, enums},
 };
 
-pub const OUTGOING_WEBHOOK_TIMEOUT_SECS: u64 = 5;
-
 #[derive(Debug)]
 pub enum ScheduleWebhookRetry {
     WithProcessTracker(Box<storage::ProcessTracker>),


### PR DESCRIPTION
## Summary
- Replace hardcoded 5-second timeout with existing REQUEST_TIME_OUT constant (30s) for outgoing webhook requests
- Remove OUTGOING_WEBHOOK_TIMEOUT_SECS constant from webhook modules  
- Update both v1 and v2 webhook implementations to use consistent timeout behavior

## Problem
The current outgoing webhook timeout is hardcoded to 5 seconds, which is too restrictive and causes delivery failures for legacy systems that might take over 5 seconds to respond back.

## Solution
This PR addresses issue #8724 by:
1. Removing the hardcoded `OUTGOING_WEBHOOK_TIMEOUT_SECS` constant (5s) from:
   - `crates/router/src/core/webhooks/types.rs`
   - `crates/router/src/core/webhooks/outgoing.rs`
2. Using the existing `crate::consts::REQUEST_TIME_OUT` constant (30s) for consistency with other external API calls
3. Updating both `outgoing.rs` and `outgoing_v2.rs` implementations

## Files Changed
- `crates/router/src/core/webhooks/types.rs`: Removed OUTGOING_WEBHOOK_TIMEOUT_SECS constant
- `crates/router/src/core/webhooks/outgoing.rs`: Use REQUEST_TIME_OUT instead of hardcoded timeout
- `crates/router/src/core/webhooks/outgoing_v2.rs`: Use REQUEST_TIME_OUT instead of hardcoded timeout

## Test plan
- [x] Code compiles without errors for both v1 and v2 features
- [x] Code formatted and follows style guidelines (just fmt)
- [x] Clippy linting passes with no critical warnings
- [x] All hardcoded timeout references removed successfully
- [x] Both webhook implementations now use 30-second timeout consistently
- [ ] Manual testing with webhook endpoints (requires deployed environment)
- [ ] Verify 30-second timeout behavior works as expected with real webhook endpoints

Fixes #8724

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>