### PR TITLE
fix(connector): [Worldpay] handle multiple ddc submission for CompleteAuthorize

### DIFF
--- a/crates/hyperswitch_connectors/src/connectors/worldpay.rs
+++ b/crates/hyperswitch_connectors/src/connectors/worldpay.rs
@@ -800,9 +800,13 @@ impl ConnectorIntegration<CompleteAuthorize, CompleteAuthorizeData, PaymentsResp
             enums::AttemptStatus::DeviceDataCollectionPending => "3dsDeviceData".to_string(),
             enums::AttemptStatus::AuthenticationPending => "3dsChallenges".to_string(),
             _ => {
-                return Err(errors::ConnectorError::RequestEncodingFailedWithReason(
-                    format!("Invalid payment status for complete authorize: {:?}", req.status)
-                ).into());
+                return Err(
+                    errors::ConnectorError::RequestEncodingFailedWithReason(format!(
+                        "Invalid payment status for complete authorize: {:?}",
+                        req.status
+                    ))
+                    .into(),
+                );
             }
         };
         Ok(format!(

--- a/crates/hyperswitch_connectors/src/connectors/worldpay.rs
+++ b/crates/hyperswitch_connectors/src/connectors/worldpay.rs
@@ -798,7 +798,12 @@ impl ConnectorIntegration<CompleteAuthorize, CompleteAuthorizeData, PaymentsResp
             .ok_or(errors::ConnectorError::MissingConnectorTransactionID)?;
         let stage = match req.status {
             enums::AttemptStatus::DeviceDataCollectionPending => "3dsDeviceData".to_string(),
-            _ => "3dsChallenges".to_string(),
+            enums::AttemptStatus::AuthenticationPending => "3dsChallenges".to_string(),
+            _ => {
+                return Err(errors::ConnectorError::RequestEncodingFailedWithReason(
+                    format!("Invalid payment status for complete authorize: {:?}", req.status)
+                ).into());
+            }
         };
         Ok(format!(
             "{}api/payments/{connector_payment_id}/{stage}",

--- a/crates/hyperswitch_connectors/src/connectors/worldpay/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/worldpay/transformers.rs
@@ -883,7 +883,23 @@ impl TryFrom<&types::PaymentsCompleteAuthorizeRouterData> for WorldpayCompleteAu
             .as_ref()
             .and_then(|redirect_response| redirect_response.params.as_ref())
             .ok_or(errors::ConnectorError::ResponseDeserializationFailed)?;
-        serde_urlencoded::from_str::<Self>(params.peek())
-            .change_context(errors::ConnectorError::ResponseDeserializationFailed)
+        
+        let parsed_request = serde_urlencoded::from_str::<Self>(params.peek())
+            .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
+        
+        match item.status {
+            enums::AttemptStatus::DeviceDataCollectionPending => Ok(parsed_request),
+            enums::AttemptStatus::AuthenticationPending => {
+                if parsed_request.collection_reference.is_some() {
+                    return Err(errors::ConnectorError::InvalidDataFormat {
+                        field_name: "collection_reference not allowed in AuthenticationPending state"
+                    }.into());
+                }
+                Ok(parsed_request)
+            },
+            _ => Err(errors::ConnectorError::RequestEncodingFailedWithReason(
+                format!("Invalid payment status for complete authorize: {:?}", item.status)
+            ).into())
+        }
     }
 }

--- a/crates/hyperswitch_connectors/src/connectors/worldpay/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/worldpay/transformers.rs
@@ -883,23 +883,29 @@ impl TryFrom<&types::PaymentsCompleteAuthorizeRouterData> for WorldpayCompleteAu
             .as_ref()
             .and_then(|redirect_response| redirect_response.params.as_ref())
             .ok_or(errors::ConnectorError::ResponseDeserializationFailed)?;
-        
+
         let parsed_request = serde_urlencoded::from_str::<Self>(params.peek())
             .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
-        
+
         match item.status {
             enums::AttemptStatus::DeviceDataCollectionPending => Ok(parsed_request),
             enums::AttemptStatus::AuthenticationPending => {
                 if parsed_request.collection_reference.is_some() {
                     return Err(errors::ConnectorError::InvalidDataFormat {
-                        field_name: "collection_reference not allowed in AuthenticationPending state"
-                    }.into());
+                        field_name:
+                            "collection_reference not allowed in AuthenticationPending state",
+                    }
+                    .into());
                 }
                 Ok(parsed_request)
-            },
-            _ => Err(errors::ConnectorError::RequestEncodingFailedWithReason(
-                format!("Invalid payment status for complete authorize: {:?}", item.status)
-            ).into())
+            }
+            _ => Err(
+                errors::ConnectorError::RequestEncodingFailedWithReason(format!(
+                    "Invalid payment status for complete authorize: {:?}",
+                    item.status
+                ))
+                .into(),
+            ),
         }
     }
 }

--- a/crates/router/src/services/api.rs
+++ b/crates/router/src/services/api.rs
@@ -1181,7 +1181,7 @@ pub fn build_redirection_form(
                     #loader1 {
                         width: 500px,
                     }
-                    @media max-width: 600px {
+                    @media (max-width: 600px) {
                         #loader1 {
                             width: 200px
                         }
@@ -1748,7 +1748,7 @@ pub fn build_redirection_form(
                                 #loader1 {
                                     width: 500px;
                                 }
-                                @media max-width: 600px {
+                                @media (max-width: 600px) {
                                     #loader1 {
                                         width: 200px;
                                     }
@@ -1777,7 +1777,21 @@ pub fn build_redirection_form(
                     script {
                         (PreEscaped(format!(
                             r#"
+                                var ddcProcessed = false;
+                                var timeoutHandle = null;
+                                
                                 function submitCollectionReference(collectionReference) {{
+                                    if (ddcProcessed) {{
+                                        console.log("DDC already processed, ignoring duplicate submission");
+                                        return;
+                                    }}
+                                    ddcProcessed = true;
+                                    
+                                    if (timeoutHandle) {{
+                                        clearTimeout(timeoutHandle);
+                                        timeoutHandle = null;
+                                    }}
+                                    
                                     var redirectPathname = window.location.pathname.replace(/payments\/redirect\/([^\/]+)\/([^\/]+)\/[^\/]+/, "payments/$1/$2/redirect/complete/worldpay");
                                     var redirectUrl = window.location.origin + redirectPathname;
                                     try {{
@@ -1796,12 +1810,17 @@ pub fn build_redirection_form(
                                             window.location.replace(redirectUrl);
                                         }}
                                     }} catch (error) {{
+                                        console.error("Error submitting DDC:", error);
                                         window.location.replace(redirectUrl);
                                     }}
                                 }}
                                 var allowedHost = "{}";
                                 var collectionField = "{}";
                                 window.addEventListener("message", function(event) {{
+                                    if (ddcProcessed) {{
+                                        console.log("DDC already processed, ignoring message event");
+                                        return;
+                                    }}
                                     if (event.origin === allowedHost) {{
                                         try {{
                                             var data = JSON.parse(event.data);
@@ -1821,8 +1840,13 @@ pub fn build_redirection_form(
                                     submitCollectionReference("");
                                 }});
 
-                                // Redirect within 8 seconds if no collection reference is received
-                                window.setTimeout(submitCollectionReference, 8000);
+                                // Timeout after 10 seconds and will submit empty collection reference
+                                timeoutHandle = window.setTimeout(function() {{
+                                    if (!ddcProcessed) {{
+                                        console.log("DDC timeout reached, submitting empty collection reference");
+                                        submitCollectionReference("");
+                                    }}
+                                }}, 10000);
                             "#,
                             endpoint.host_str().map_or(endpoint.as_ref().split('/').take(3).collect::<Vec<&str>>().join("/"), |host| format!("{}://{}", endpoint.scheme(), host)),
                             collection_id.clone().unwrap_or("".to_string())))

--- a/cypress-tests/cypress/e2e/configs/Payment/Utils.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Utils.js
@@ -396,6 +396,8 @@ export const CONNECTOR_LISTS = {
       // "cybersource"    // issues with MULTIPLE_CONNECTORS handling
       "paypal",
     ],
+    DDC_RACE_CONDITION_SERVER_SIDE: ["worldpay"],
+    DDC_RACE_CONDITION_CLIENT_SIDE: ["worldpay"],
     // Add more inclusion lists
   },
 };

--- a/cypress-tests/cypress/e2e/configs/Payment/Utils.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Utils.js
@@ -396,8 +396,7 @@ export const CONNECTOR_LISTS = {
       // "cybersource"    // issues with MULTIPLE_CONNECTORS handling
       "paypal",
     ],
-    DDC_RACE_CONDITION_SERVER_SIDE: ["worldpay"],
-    DDC_RACE_CONDITION_CLIENT_SIDE: ["worldpay"],
+    DDC_RACE_CONDITION: ["worldpay"],
     // Add more inclusion lists
   },
 };

--- a/cypress-tests/cypress/e2e/configs/Payment/WorldPay.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/WorldPay.js
@@ -45,13 +45,21 @@ const successfulThreeDsTestCardDetailsRequest = {
   card_cvc: "737",
 };
 
+const failedNoThreeDsCardDetails = {
+  card_number: "4242424242424242",
+  card_exp_month: "10",
+  card_exp_year: "30",
+  card_holder_name: "REFUSED13",
+  card_cvc: "737",
+};
+
 const paymentMethodDataNoThreeDsResponse = {
   card: {
     last4: "4242",
-    card_type: "CREDIT",
-    card_network: "Visa",
-    card_issuer: "STRIPE PAYMENTS UK LIMITED",
-    card_issuing_country: "UNITEDKINGDOM",
+    card_type: null,
+    card_network: null,
+    card_issuer: null,
+    card_issuing_country: null,
     card_isin: "424242",
     card_extended_bin: null,
     card_exp_month: "10",
@@ -66,10 +74,10 @@ const paymentMethodDataNoThreeDsResponse = {
 const paymentMethodDataThreeDsResponse = {
   card: {
     last4: "1091",
-    card_type: "CREDIT",
-    card_network: "Visa",
-    card_issuer: "INTL HDQTRS-CENTER OWNED",
-    card_issuing_country: "UNITEDSTATES",
+    card_type: null,
+    card_network: null,
+    card_issuer: null,
+    card_issuing_country: null,
     card_isin: "400000",
     card_extended_bin: null,
     card_exp_month: "10",
@@ -119,7 +127,7 @@ export const connectorDetails = {
     No3DSManualCapture: {
       Request: {
         payment_method: "card",
-        payment_method_type: "debit",
+        payment_method_type: "credit",
         payment_method_data: {
           card: successfulNoThreeDsCardDetailsRequest,
         },
@@ -141,7 +149,7 @@ export const connectorDetails = {
     No3DSAutoCapture: {
       Request: {
         payment_method: "card",
-        payment_method_type: "debit",
+        payment_method_type: "credit",
         payment_method_data: {
           card: successfulNoThreeDsCardDetailsRequest,
         },
@@ -624,6 +632,7 @@ export const connectorDetails = {
     ZeroAuthConfirmPayment: {
       Request: {
         payment_method: "card",
+        payment_method_type: "debit",
         payment_method_data: {
           card: successfulNoThreeDsCardDetailsRequest,
         },
@@ -638,6 +647,27 @@ export const connectorDetails = {
             "There has been a problem with your boarding and you cannot use this API yet, please contact support.",
           status: "failed",
           payment_method_id: null,
+        },
+      },
+    },
+    No3DSFailPayment: {
+      Request: {
+        payment_method: "card",
+        payment_method_type: "debit",
+        payment_method_data: {
+          card: failedNoThreeDsCardDetails,
+        },
+        customer_acceptance: null,
+        setup_future_usage: "on_session",
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "failed",
+          error_code: "13",
+          error_message: "INVALID AMOUNT",
+          unified_code: "UE_9000",
+          unified_message: "Something went wrong",
         },
       },
     },
@@ -708,6 +738,116 @@ export const connectorDetails = {
         body: {
           status: "requires_customer_action",
         },
+      },
+    },
+    DDCRaceConditionServerSide: {
+      Request: {
+        payment_method: "card",
+        payment_method_type: "debit",
+        payment_method_data: {
+          card: successfulThreeDsTestCardDetailsRequest,
+        },
+        currency: "USD",
+        customer_acceptance: null,
+        setup_future_usage: "on_session",
+        billing: billing,
+        browser_info,
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "requires_customer_action",
+          setup_future_usage: "on_session",
+          payment_method_data: paymentMethodDataThreeDsResponse,
+        },
+      },
+      DDCConfig: {
+        completeUrlPath: "/redirect/complete/worldpay",
+        collectionReferenceParam: "collectionReference",
+        firstSubmissionValue: "",
+        secondSubmissionValue: "race_condition_test_ddc_123",
+        expectedError: {
+          status: 400,
+          body: {
+            error: {
+              code: "IR_07",
+              type: "invalid_request",
+              message:
+                "Invalid value provided: collection_reference not allowed in AuthenticationPending state",
+            },
+          },
+        },
+      },
+    },
+    DDCRaceConditionClientSide: {
+      Request: {
+        payment_method: "card",
+        payment_method_type: "debit",
+        payment_method_data: {
+          card: successfulThreeDsTestCardDetailsRequest,
+        },
+        currency: "USD",
+        customer_acceptance: null,
+        setup_future_usage: "on_session",
+        browser_info,
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "requires_customer_action",
+          setup_future_usage: "on_session",
+          payment_method_data: paymentMethodDataThreeDsResponse,
+        },
+      },
+      DDCConfig: {
+        redirectUrlPath: "/payments/redirect",
+        collectionReferenceParam: "collectionReference",
+        raceConditionScript: `
+          <script>
+            console.log("INJECTING_RACE_CONDITION_TEST");
+            
+            // Track submission attempts and ddcProcessed flag behavior
+            window.testResults = {
+              submissionAttempts: 0,
+              actualSubmissions: 0,
+              blockedSubmissions: 0
+            };
+            
+            // Override the submitCollectionReference function to test race conditions
+            var originalSubmit = window.submitCollectionReference;
+            
+            window.submitCollectionReference = function(collectionReference) {
+              window.testResults.submissionAttempts++;
+              console.log("SUBMISSION_ATTEMPT_" + window.testResults.submissionAttempts + ": " + collectionReference);
+              
+              // Check if ddcProcessed flag would block this
+              if (window.ddcProcessed) {
+                window.testResults.blockedSubmissions++;
+                console.log("SUBMISSION_BLOCKED_BY_DDC_PROCESSED_FLAG");
+                return;
+              }
+              
+              window.testResults.actualSubmissions++;
+              console.log("SUBMISSION_PROCEEDING: " + collectionReference);
+              
+              if (originalSubmit) {
+                return originalSubmit(collectionReference);
+              }
+            };
+            
+            // Submit first value at configured timing
+            setTimeout(function() {
+              console.log("FIRST_SUBMISSION_TRIGGERED_AT_100MS");
+              window.submitCollectionReference("");
+            }, 100);
+            
+            // Submit second value at configured timing (should be blocked)
+            setTimeout(function() {
+              console.log("SECOND_SUBMISSION_ATTEMPTED_AT_200MS");
+              window.submitCollectionReference("test_ddc_123");
+            }, 200);
+          </script>
+        `,
       },
     },
   },

--- a/cypress-tests/cypress/e2e/configs/Payment/WorldPay.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/WorldPay.js
@@ -741,26 +741,25 @@ export const connectorDetails = {
       },
     },
     DDCRaceConditionServerSide: {
-      Request: {
-        payment_method: "card",
-        payment_method_type: "debit",
-        payment_method_data: {
-          card: successfulThreeDsTestCardDetailsRequest,
-        },
-        currency: "USD",
-        customer_acceptance: null,
-        setup_future_usage: "on_session",
-        billing: billing,
-        browser_info,
-      },
-      Response: {
-        status: 200,
-        body: {
-          status: "requires_customer_action",
+      ...getCustomExchange({
+        Request: {
+          payment_method: "card",
+          payment_method_type: "debit",
+          payment_method_data: {
+            card: successfulThreeDsTestCardDetailsRequest,
+          },
+          currency: "USD",
+          customer_acceptance: null,
           setup_future_usage: "on_session",
-          payment_method_data: paymentMethodDataThreeDsResponse,
+          browser_info,
         },
-      },
+        Response: {
+          status: 200,
+          body: {
+            status: "requires_customer_action",
+          },
+        },
+      }),
       DDCConfig: {
         completeUrlPath: "/redirect/complete/worldpay",
         collectionReferenceParam: "collectionReference",
@@ -780,28 +779,29 @@ export const connectorDetails = {
       },
     },
     DDCRaceConditionClientSide: {
-      Request: {
-        payment_method: "card",
-        payment_method_type: "debit",
-        payment_method_data: {
-          card: successfulThreeDsTestCardDetailsRequest,
-        },
-        currency: "USD",
-        customer_acceptance: null,
-        setup_future_usage: "on_session",
-        browser_info,
-      },
-      Response: {
-        status: 200,
-        body: {
-          status: "requires_customer_action",
+      ...getCustomExchange({
+        Request: {
+          payment_method: "card",
+          payment_method_type: "debit",
+          payment_method_data: {
+            card: successfulThreeDsTestCardDetailsRequest,
+          },
+          currency: "USD",
+          customer_acceptance: null,
           setup_future_usage: "on_session",
-          payment_method_data: paymentMethodDataThreeDsResponse,
+          browser_info,
         },
-      },
+        Response: {
+          status: 200,
+          body: {
+            status: "requires_customer_action",
+          },
+        },
+      }),
       DDCConfig: {
         redirectUrlPath: "/payments/redirect",
         collectionReferenceParam: "collectionReference",
+        delayBeforeSubmission: 2000,
         raceConditionScript: `
           <script>
             console.log("INJECTING_RACE_CONDITION_TEST");

--- a/cypress-tests/cypress/e2e/configs/Payment/WorldPay.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/WorldPay.js
@@ -56,10 +56,10 @@ const failedNoThreeDsCardDetails = {
 const paymentMethodDataNoThreeDsResponse = {
   card: {
     last4: "4242",
-    card_type: null,
-    card_network: null,
-    card_issuer: null,
-    card_issuing_country: null,
+    card_type: "CREDIT",
+    card_network: "Visa",
+    card_issuer: "STRIPE PAYMENTS UK LIMITED",
+    card_issuing_country: "UNITEDKINGDOM",
     card_isin: "424242",
     card_extended_bin: null,
     card_exp_month: "10",
@@ -74,10 +74,10 @@ const paymentMethodDataNoThreeDsResponse = {
 const paymentMethodDataThreeDsResponse = {
   card: {
     last4: "1091",
-    card_type: null,
-    card_network: null,
-    card_issuer: null,
-    card_issuing_country: null,
+    card_type: "CREDIT",
+    card_network: "Visa",
+    card_issuer: "INTL HDQTRS-CENTER OWNED",
+    card_issuing_country: "UNITEDSTATES",
     card_isin: "400000",
     card_extended_bin: null,
     card_exp_month: "10",

--- a/cypress-tests/cypress/e2e/spec/Payment/00030-DDCRaceCondition.cy.js
+++ b/cypress-tests/cypress/e2e/spec/Payment/00030-DDCRaceCondition.cy.js
@@ -1,0 +1,180 @@
+/**
+ * DDC Race Condition Tests
+ * 
+ * These tests ensure that device data collection works properly during payment authentication
+ * and prevents issues when multiple requests happen at the same time.
+ * 
+ * Server-side validation:
+ * - Checks that our backend properly handles duplicate device data submissions
+ * - Makes sure that once device data is collected, any additional attempts are rejected
+ * 
+ * Client-side validation:
+ * - Verifies that the payment page prevents users from accidentally submitting data twice
+ * - Ensures that even if someone clicks multiple times, only one submission goes through
+ * - Tests that our JavaScript protection works as expected
+ */
+
+import * as fixtures from "../../../fixtures/imports";
+import State from "../../../utils/State";
+import getConnectorDetails, * as utils from "../../configs/Payment/Utils";
+
+let connector;
+let globalState;
+
+describe("[Payment] DDC Race Condition", () => {
+  before(function () {
+    let skip = false;
+
+    cy.task("getGlobalState")
+      .then((state) => {
+        globalState = new State(state);
+        connector = globalState.get("connectorId");
+
+        const connectorDetails = getConnectorDetails(connector);
+        if (
+          !connectorDetails["card_pm"]["DDCRaceConditionServerSide"] ||
+          !connectorDetails["card_pm"]["DDCRaceConditionClientSide"]
+        ) {
+          skip = true;
+        }
+      })
+      .then(() => {
+        if (skip) {
+          this.skip();
+        }
+      });
+  });
+
+  afterEach("flush global state", () => {
+    cy.task("setGlobalState", globalState.data);
+  });
+
+  context("[Payment] DDC Race Condition Tests", () => {
+    let shouldContinue = true;
+
+    beforeEach(function () {
+      if (!shouldContinue) {
+        this.skip();
+      }
+    });
+
+    it("[Payment] Server-side DDC race condition handling", () => {
+      const createData = getConnectorDetails(connector)["card_pm"]["PaymentIntent"];
+
+      cy.createPaymentIntentTest(
+        fixtures.createPaymentBody,
+        createData,
+        "three_ds",
+        "automatic",
+        globalState
+      );
+
+      if (shouldContinue)
+        shouldContinue = utils.should_continue_further(createData);
+
+      const confirmData = getConnectorDetails(connector)["card_pm"]["DDCRaceConditionServerSide"];
+
+      cy.confirmCallTest(fixtures.confirmBody, confirmData, true, globalState);
+
+      if (shouldContinue)
+        shouldContinue = utils.should_continue_further(confirmData);
+
+      const ddcConfig = confirmData.DDCConfig;
+      const paymentId = globalState.get("paymentID");
+      const merchantId = globalState.get("merchantId");
+      const completeUrl = `${Cypress.env("BASEURL")}/payments/${paymentId}/${merchantId}${ddcConfig.completeUrlPath}`;
+
+      cy.request({
+        method: "GET",
+        url: completeUrl,
+        qs: {
+          [ddcConfig.collectionReferenceParam]: ddcConfig.firstSubmissionValue,
+        },
+        failOnStatusCode: false,
+      }).then((firstResponse) => {
+        expect(firstResponse.status).to.be.oneOf([200, 302]);
+        cy.log(`First request status: ${firstResponse.status}`);
+
+        cy.request({
+          method: "GET",
+          url: completeUrl,
+          qs: {
+            [ddcConfig.collectionReferenceParam]:
+              ddcConfig.secondSubmissionValue,
+          },
+          failOnStatusCode: false,
+        }).then((secondResponse) => {
+          cy.log(`Second request status: ${secondResponse.status}`);
+
+          expect(secondResponse.status).to.eq(ddcConfig.expectedError.status);
+          expect(secondResponse.body).to.deep.equal(
+            ddcConfig.expectedError.body
+          );
+
+          cy.log(
+            "✅ Server-side race condition protection verified - second submission properly rejected"
+          );
+        });
+      });
+    });
+
+    it("[Payment] Client-side DDC race condition handling", () => {
+      const createData = getConnectorDetails(connector)["card_pm"]["PaymentIntent"];
+
+      cy.createPaymentIntentTest(
+        fixtures.createPaymentBody,
+        createData,
+        "three_ds",
+        "automatic",
+        globalState
+      );
+
+      if (shouldContinue)
+        shouldContinue = utils.should_continue_further(createData);
+
+      const confirmData = getConnectorDetails(connector)["card_pm"]["DDCRaceConditionClientSide"];
+
+      cy.confirmCallTest(fixtures.confirmBody, confirmData, true, globalState);
+
+      if (shouldContinue)
+        shouldContinue = utils.should_continue_further(confirmData);
+
+      const ddcConfig = confirmData.DDCConfig;
+      const paymentId = globalState.get("paymentID");
+      const merchantId = globalState.get("merchantId");
+      const nextActionUrl = `${Cypress.env("BASEURL")}${ddcConfig.redirectUrlPath}/${paymentId}/${merchantId}/${paymentId}_1`;
+
+      cy.intercept("GET", nextActionUrl, (req) => {
+        req.reply((res) => {
+          let modifiedHtml = res.body.toString();
+          modifiedHtml = modifiedHtml.replace(
+            "</body>",
+            ddcConfig.raceConditionScript + "</body>"
+          );
+          res.send(modifiedHtml);
+        });
+      }).as("ddcPageWithRaceCondition");
+
+      cy.intercept("GET", "**/redirect/complete/**").as("ddcSubmission");
+
+      cy.visit(nextActionUrl);
+      cy.wait("@ddcPageWithRaceCondition");
+      cy.wait("@ddcSubmission");
+      cy.wait(2000);
+
+      cy.get("@ddcSubmission.all").should("have.length", 1);
+
+      cy.get("@ddcSubmission").then((interception) => {
+        const collectionRef =
+          interception.request.query[ddcConfig.collectionReferenceParam] || "";
+        cy.log(
+          `Single submission detected with ${ddcConfig.collectionReferenceParam}: "${collectionRef}"`
+        );
+      });
+
+      cy.log(
+        "✅ Client-side race condition protection verified - only one submission occurred"
+      );
+    });
+  });
+});

--- a/cypress-tests/cypress/e2e/spec/Payment/00030-DDCRaceCondition.cy.js
+++ b/cypress-tests/cypress/e2e/spec/Payment/00030-DDCRaceCondition.cy.js
@@ -37,11 +37,7 @@ describe("[Payment] DDC Race Condition", () => {
         if (
           shouldIncludeConnector(
             connector,
-            CONNECTOR_LISTS.INCLUDE.DDC_RACE_CONDITION_SERVER_SIDE
-          ) &&
-          shouldIncludeConnector(
-            connector,
-            CONNECTOR_LISTS.INCLUDE.DDC_RACE_CONDITION_CLIENT_SIDE
+            CONNECTOR_LISTS.INCLUDE.DDC_RACE_CONDITION
           )
         ) {
           skip = true;

--- a/cypress-tests/cypress/e2e/spec/Payment/00030-DDCRaceCondition.cy.js
+++ b/cypress-tests/cypress/e2e/spec/Payment/00030-DDCRaceCondition.cy.js
@@ -1,13 +1,13 @@
 /**
  * DDC Race Condition Tests
- * 
+ *
  * These tests ensure that device data collection works properly during payment authentication
  * and prevents issues when multiple requests happen at the same time.
- * 
+ *
  * Server-side validation:
  * - Checks that our backend properly handles duplicate device data submissions
  * - Makes sure that once device data is collected, any additional attempts are rejected
- * 
+ *
  * Client-side validation:
  * - Verifies that the payment page prevents users from accidentally submitting data twice
  * - Ensures that even if someone clicks multiple times, only one submission goes through
@@ -59,7 +59,8 @@ describe("[Payment] DDC Race Condition", () => {
     });
 
     it("[Payment] Server-side DDC race condition handling", () => {
-      const createData = getConnectorDetails(connector)["card_pm"]["PaymentIntent"];
+      const createData =
+        getConnectorDetails(connector)["card_pm"]["PaymentIntent"];
 
       cy.createPaymentIntentTest(
         fixtures.createPaymentBody,
@@ -72,7 +73,8 @@ describe("[Payment] DDC Race Condition", () => {
       if (shouldContinue)
         shouldContinue = utils.should_continue_further(createData);
 
-      const confirmData = getConnectorDetails(connector)["card_pm"]["DDCRaceConditionServerSide"];
+      const confirmData =
+        getConnectorDetails(connector)["card_pm"]["DDCRaceConditionServerSide"];
 
       cy.confirmCallTest(fixtures.confirmBody, confirmData, true, globalState);
 
@@ -119,7 +121,8 @@ describe("[Payment] DDC Race Condition", () => {
     });
 
     it("[Payment] Client-side DDC race condition handling", () => {
-      const createData = getConnectorDetails(connector)["card_pm"]["PaymentIntent"];
+      const createData =
+        getConnectorDetails(connector)["card_pm"]["PaymentIntent"];
 
       cy.createPaymentIntentTest(
         fixtures.createPaymentBody,
@@ -132,7 +135,8 @@ describe("[Payment] DDC Race Condition", () => {
       if (shouldContinue)
         shouldContinue = utils.should_continue_further(createData);
 
-      const confirmData = getConnectorDetails(connector)["card_pm"]["DDCRaceConditionClientSide"];
+      const confirmData =
+        getConnectorDetails(connector)["card_pm"]["DDCRaceConditionClientSide"];
 
       cy.confirmCallTest(fixtures.confirmBody, confirmData, true, globalState);
 

--- a/cypress-tests/cypress/support/commands.js
+++ b/cypress-tests/cypress/support/commands.js
@@ -4074,19 +4074,6 @@ Cypress.Commands.add(
     const ddcConfig = confirmData.DDCConfig;
     const paymentId = globalState.get("paymentID");
     const merchantId = globalState.get("merchantId");
-
-    if (!merchantId) {
-      throw new Error(
-        "Missing merchantId - this indicates a critical state issue"
-      );
-    }
-
-    if (!paymentId) {
-      throw new Error(
-        "Failed to create payment intent - paymentID not found in globalState"
-      );
-    }
-
     const completeUrl = `${Cypress.env("BASEURL")}/payments/${paymentId}/${merchantId}${ddcConfig.completeUrlPath}`;
 
     cy.request({
@@ -4136,19 +4123,6 @@ Cypress.Commands.add(
     const ddcConfig = confirmData.DDCConfig;
     const paymentId = globalState.get("paymentID");
     const merchantId = globalState.get("merchantId");
-
-    if (!merchantId) {
-      throw new Error(
-        "Missing merchantId - this indicates a critical state issue"
-      );
-    }
-
-    if (!paymentId) {
-      throw new Error(
-        "Failed to create payment intent - paymentID not found in globalState"
-      );
-    }
-
     const nextActionUrl = `${Cypress.env("BASEURL")}${ddcConfig.redirectUrlPath}/${paymentId}/${merchantId}/${paymentId}_1`;
 
     cy.intercept("GET", nextActionUrl, (req) => {

--- a/cypress-tests/cypress/support/commands.js
+++ b/cypress-tests/cypress/support/commands.js
@@ -4066,3 +4066,122 @@ Cypress.Commands.add("setConfigs", (globalState, key, value, requestType) => {
     });
   });
 });
+
+// DDC Race Condition Test Commands
+Cypress.Commands.add(
+  "ddcServerSideRaceConditionTest",
+  (confirmData, globalState) => {
+    const ddcConfig = confirmData.DDCConfig;
+    const paymentId = globalState.get("paymentID");
+    const merchantId = globalState.get("merchantId");
+
+    if (!merchantId) {
+      throw new Error(
+        "Missing merchantId - this indicates a critical state issue"
+      );
+    }
+
+    if (!paymentId) {
+      throw new Error(
+        "Failed to create payment intent - paymentID not found in globalState"
+      );
+    }
+
+    const completeUrl = `${Cypress.env("BASEURL")}/payments/${paymentId}/${merchantId}${ddcConfig.completeUrlPath}`;
+
+    cy.request({
+      method: "GET",
+      url: completeUrl,
+      qs: {
+        [ddcConfig.collectionReferenceParam]: ddcConfig.firstSubmissionValue,
+      },
+      failOnStatusCode: false,
+    }).then((firstResponse) => {
+      if (
+        firstResponse.status === 400 &&
+        firstResponse.body?.error?.message?.includes("No eligible connector")
+      ) {
+        throw new Error(
+          `Connector configuration issue detected. Response: ${JSON.stringify(firstResponse.body)}`
+        );
+      }
+
+      expect(firstResponse.status).to.be.oneOf([200, 302]);
+      cy.log(`First request status: ${firstResponse.status}`);
+
+      cy.request({
+        method: "GET",
+        url: completeUrl,
+        qs: {
+          [ddcConfig.collectionReferenceParam]: ddcConfig.secondSubmissionValue,
+        },
+        failOnStatusCode: false,
+      }).then((secondResponse) => {
+        cy.log(`Second request status: ${secondResponse.status}`);
+
+        expect(secondResponse.status).to.eq(ddcConfig.expectedError.status);
+        expect(secondResponse.body).to.deep.equal(ddcConfig.expectedError.body);
+
+        cy.log(
+          "✅ Server-side race condition protection verified - second submission properly rejected"
+        );
+      });
+    });
+  }
+);
+
+Cypress.Commands.add(
+  "ddcClientSideRaceConditionTest",
+  (confirmData, globalState) => {
+    const ddcConfig = confirmData.DDCConfig;
+    const paymentId = globalState.get("paymentID");
+    const merchantId = globalState.get("merchantId");
+
+    if (!merchantId) {
+      throw new Error(
+        "Missing merchantId - this indicates a critical state issue"
+      );
+    }
+
+    if (!paymentId) {
+      throw new Error(
+        "Failed to create payment intent - paymentID not found in globalState"
+      );
+    }
+
+    const nextActionUrl = `${Cypress.env("BASEURL")}${ddcConfig.redirectUrlPath}/${paymentId}/${merchantId}/${paymentId}_1`;
+
+    cy.intercept("GET", nextActionUrl, (req) => {
+      req.reply((res) => {
+        let modifiedHtml = res.body.toString();
+        modifiedHtml = modifiedHtml.replace(
+          "</body>",
+          ddcConfig.raceConditionScript + "</body>"
+        );
+        res.send(modifiedHtml);
+      });
+    }).as("ddcPageWithRaceCondition");
+
+    cy.intercept("GET", "**/redirect/complete/**").as("ddcSubmission");
+    const delayBeforeSubmission = ddcConfig.delayBeforeSubmission || 2000;
+
+    cy.visit(nextActionUrl);
+    cy.wait("@ddcPageWithRaceCondition");
+    cy.wait("@ddcSubmission");
+    cy.wait(delayBeforeSubmission);
+
+    cy.get("@ddcSubmission.all").should("have.length", 1);
+
+    cy.get("@ddcSubmission").then((interception) => {
+      const collectionRef =
+        interception.request.query[ddcConfig.collectionReferenceParam] || "";
+      cy.log(
+        `Single submission detected with ${ddcConfig.collectionReferenceParam}: "${collectionRef}"`
+      );
+    });
+
+    cy.log(
+      "✅ Client-side race condition protection verified - only one submission occurred"
+    );
+  }
+);


### PR DESCRIPTION
## Type of Change
- [x] Bugfix

## Description

Fixes race condition in Worldpay 3DS Device Data Collection (DDC) flow causing `bodyDoesNotMatchSchema` errors.

**Changes made:**
- Extended DDC timeout from 8s to 10s in client-side JavaScript
- Added `ddcProcessed` flag to prevent duplicate submissions on client-side
- Reject `collectionReference` submissions when payment is in `AuthenticationPending` state
- Fixed CSS media query syntax (`@media (max-width: 600px)`)
- Added Cypress test case for both client and server-side race conditions for DDC submissions

### Additional Changes
- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema  
- [ ] This PR modifies application configuration/environment variables

## Motivation and Context

Race condition caused intermittent 3DS payment failures when DDC took > 8 seconds.

## How did you test it?

<details>
    <summary>1. DDC race case in isolation </summary>

<img width="797" height="156" alt="Screenshot 2025-07-24 at 12 02 50 PM" src="https://github.com/user-attachments/assets/70d14add-9742-4ad3-b72f-da97dae5b197" />

</details>

<details>
    <summary>2. All test cases for Worldpay</summary>

<img width="461" height="873" alt="Screenshot 2025-07-25 at 12 52 56 AM" src="https://github.com/user-attachments/assets/7458a378-c413-4c8a-9b0d-4c09b2705a41" />


Note
- PSync for WP fails due to 404 and WP sending back a HTML rather than a JSON response (https://github.com/juspay/hyperswitch/pull/8753)

</details>


## Checklist
- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy` 
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible