### PR TITLE
chore(env): revert wasm changes for payload connector

### DIFF
--- a/crates/connector_configs/toml/development.toml
+++ b/crates/connector_configs/toml/development.toml
@@ -6416,12 +6416,8 @@ type="Text"
 [[payload.debit]]
   payment_method_type = "Visa"
 
-[payload.connector_auth.CurrencyAuthKey.auth_key_map.USD]
-  processing_account_id = "processing_account_id"
-  api_key = "API Key"
-[payload.connector_auth.CurrencyAuthKey.auth_key_map.CAD]
-  processing_account_id = "processing_account_id"
-  api_key = "API Key"
+[payload.connector_auth.HeaderKey]
+api_key="API Key"
   
 [silverflow]
 [[silverflow.credit]]

--- a/crates/connector_configs/toml/production.toml
+++ b/crates/connector_configs/toml/production.toml
@@ -5029,13 +5029,9 @@ payment_method_type = "Mastercard"
 [[payload.debit]]
 payment_method_type = "Visa"
 
-[payload.connector_auth.CurrencyAuthKey.auth_key_map.USD]
-processing_account_id = "processing_account_id"
-api_key = "API Key"
-[payload.connector_auth.CurrencyAuthKey.auth_key_map.CAD]
-processing_account_id = "processing_account_id"
-api_key = "API Key"
-
+[payload.connector_auth.HeaderKey]
+api_key="API Key"
+  
 [silverflow]
 [[silverflow.credit]]
   payment_method_type = "Mastercard"

--- a/crates/connector_configs/toml/sandbox.toml
+++ b/crates/connector_configs/toml/sandbox.toml
@@ -6397,13 +6397,9 @@ payment_method_type = "Mastercard"
 [[payload.debit]]
 payment_method_type = "Visa"
 
-[payload.connector_auth.CurrencyAuthKey.auth_key_map.USD]
-processing_account_id = "processing_account_id"
-api_key = "API Key"
-[payload.connector_auth.CurrencyAuthKey.auth_key_map.CAD]
-processing_account_id = "processing_account_id"
-api_key = "API Key"
-
+[payload.connector_auth.HeaderKey]
+api_key="API Key"
+  
 [silverflow]
 [[silverflow.credit]]
   payment_method_type = "Mastercard"


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->

this pr reverts wasm changes for the payload connector that was introduced in https://github.com/juspay/hyperswitch/pull/8597

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [x] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->

crates/connector_configs/toml/*

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->

this change broke wasm.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

<img width="673" height="303" alt="image" src="https://github.com/user-attachments/assets/b8a266e9-842f-4a79-b25c-c2a97feadf79" />

this shouldn't pop-up during the wasm build.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `just clippy && just clippy_v2`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
