### PR TITLE
refactor(core): propagate network_transaction_id in response of payment

### DIFF
--- a/crates/api_models/src/mandates.rs
+++ b/crates/api_models/src/mandates.rs
@@ -185,4 +185,13 @@ impl RecurringDetails {
     pub fn is_network_transaction_id_and_card_details_flow(self) -> bool {
         matches!(self, Self::NetworkTransactionIdAndCardDetails(_))
     }
+
+    pub fn get_network_transaction_id(&self) -> Option<Secret<String>> {
+        match self {
+            Self::NetworkTransactionIdAndCardDetails(details) => {
+                Some(details.network_transaction_id.clone())
+            }
+            Self::MandateId(_) | Self::PaymentMethodId(_) | Self::ProcessorPaymentToken(_) => None,
+        }
+    }
 }

--- a/crates/api_models/src/payments.rs
+++ b/crates/api_models/src/payments.rs
@@ -5159,6 +5159,10 @@ pub struct PaymentsResponse {
     /// A unique identifier for the payment method used in this payment. If the payment method was saved or tokenized, this ID can be used to reference it for future transactions or recurring payments.
     pub payment_method_id: Option<String>,
 
+    /// The network transaction ID is a unique identifier for the transaction as recognized by the payment network (e.g., Visa, Mastercard), this ID can be used to reference it for future transactions or recurring payments.
+    #[schema(value_type = Option<String>)]
+    pub network_transaction_id: Option<Secret<String>>,
+
     /// Payment Method Status, refers to the status of the payment method used for this payment.
     #[schema(value_type = Option<PaymentMethodStatus>)]
     pub payment_method_status: Option<common_enums::PaymentMethodStatus>,

--- a/crates/router/src/core/payments.rs
+++ b/crates/router/src/core/payments.rs
@@ -9608,6 +9608,7 @@ pub trait OperationSessionGetters<F> {
     fn get_all_keys_required(&self) -> Option<bool>;
     fn get_capture_method(&self) -> Option<enums::CaptureMethod>;
     fn get_merchant_connector_id_in_attempt(&self) -> Option<id_type::MerchantConnectorAccountId>;
+    fn get_network_transaction_id(&self) -> Option<Secret<String>>;
     #[cfg(feature = "v2")]
     fn get_merchant_connector_details(
         &self,
@@ -9739,6 +9740,13 @@ impl<F: Clone> OperationSessionGetters<F> for PaymentData<F> {
     fn get_merchant_connector_id_in_attempt(&self) -> Option<id_type::MerchantConnectorAccountId> {
         self.payment_attempt.merchant_connector_id.clone()
     }
+
+    fn get_network_transaction_id(&self) -> Option<Secret<String>> {
+        self.recurring_details
+            .as_ref()
+            .and_then(|details| details.get_network_transaction_id())
+    }
+
     fn get_creds_identifier(&self) -> Option<&str> {
         self.creds_identifier.as_deref()
     }

--- a/crates/router/src/core/payments/transformers.rs
+++ b/crates/router/src/core/payments/transformers.rs
@@ -2964,6 +2964,7 @@ where
             fingerprint: payment_intent.fingerprint_id,
             browser_info: payment_attempt.browser_info,
             payment_method_id: payment_attempt.payment_method_id,
+            network_transaction_id: payment_data.get_network_transaction_id(),
             payment_method_status: payment_data
                 .get_payment_method_info()
                 .map(|info| info.status),
@@ -3276,7 +3277,8 @@ impl ForeignFrom<(storage::PaymentIntent, storage::PaymentAttempt)> for api::Pay
             whole_connector_response: None,
             issuer_error_code: pa.issuer_error_code,
             issuer_error_message: pa.issuer_error_message,
-            is_iframe_redirection_enabled:pi.is_iframe_redirection_enabled
+            is_iframe_redirection_enabled:pi.is_iframe_redirection_enabled,
+            network_transaction_id: None,
         }
     }
 }

--- a/crates/router/tests/payments.rs
+++ b/crates/router/tests/payments.rs
@@ -465,6 +465,7 @@ async fn payments_create_core() {
         issuer_error_message: None,
         is_iframe_redirection_enabled: None,
         whole_connector_response: None,
+        network_transaction_id: None,
     };
     let expected_response =
         services::ApplicationResponse::JsonWithHeaders((expected_response, vec![]));
@@ -743,6 +744,7 @@ async fn payments_create_core_adyen_no_redirect() {
             issuer_error_message: None,
             is_iframe_redirection_enabled: None,
             whole_connector_response: None,
+            network_transaction_id: None,
         },
         vec![],
     ));

--- a/crates/router/tests/payments2.rs
+++ b/crates/router/tests/payments2.rs
@@ -227,6 +227,7 @@ async fn payments_create_core() {
         issuer_error_message: None,
         is_iframe_redirection_enabled: None,
         whole_connector_response: None,
+        network_transaction_id: None,
     };
 
     let expected_response =
@@ -513,6 +514,7 @@ async fn payments_create_core_adyen_no_redirect() {
             issuer_error_message: None,
             is_iframe_redirection_enabled: None,
             whole_connector_response: None,
+            network_transaction_id: None,
         },
         vec![],
     ));


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
propagate network transaction id stored in payment method's table to response of payment.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
