### PR TITLE
fix(connector): Change Refund Reason Type in Adyen

### DIFF
--- a/crates/connector_configs/toml/production.toml
+++ b/crates/connector_configs/toml/production.toml
@@ -114,6 +114,8 @@ payment_method_type = "apple_pay"
 payment_method_type = "google_pay"
 [[adyen.wallet]]
 payment_method_type = "paypal"
+[[adyen.voucher]]
+  payment_method_type = "boleto"
 [adyen.connector_auth.BodyKey]
 api_key = "Adyen API Key"
 key1 = "Adyen Account Id"

--- a/crates/hyperswitch_connectors/src/connectors/adyen/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/adyen/transformers.rs
@@ -1419,9 +1419,7 @@ impl FromStr for AdyenRefundRequestReason {
             "RETURN" => Ok(Self::RETURN),
             "DUPLICATE" => Ok(Self::DUPLICATE),
             "OTHER" => Ok(Self::OTHER),
-            _ => Err(report!(errors::ConnectorError::InvalidDataFormat {
-                field_name: "refund_reason",
-            })),
+            _ => Ok(Self::OTHER),
         }
     }
 }

--- a/crates/hyperswitch_connectors/src/connectors/adyen/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/adyen/transformers.rs
@@ -1,3 +1,5 @@
+use std::str::FromStr;
+
 #[cfg(feature = "payouts")]
 use api_models::payouts::{self, PayoutMethodData};
 use api_models::{
@@ -15,7 +17,6 @@ use common_utils::{
     request::Method,
     types::MinorUnit,
 };
-use std::str::FromStr;
 use error_stack::{report, ResultExt};
 use hyperswitch_domain_models::{
     network_tokenization::NetworkTokenNumber,
@@ -1405,7 +1406,7 @@ pub enum AdyenRefundRequestReason {
     CUSTOMERREQUEST,
     RETURN,
     DUPLICATE,
-    OTHER
+    OTHER,
 }
 
 impl FromStr for AdyenRefundRequestReason {


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

Closes this [issue](https://github.com/juspay/hyperswitch/issues/8845)

## Description
<!-- Describe your changes in detail -->

This PR updates the reason field in AdyenRefundRequest from Option<String> to Option<AdyenRefundRequestReason>, a strongly typed enum. This change ensures only supported values (FRAUD, CUSTOMER REQUEST, RETURN, DUPLICATE, OTHER) are used.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

Postman Test

A. Refund(with valid reason):

Request:

```
curl --location 'http://localhost:8080/refunds' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: dev_Emxcc7NEApdtpDZyA54Hc0hN43a4wvBTlJ0wIGGeGquavEbsE4lhVWQcyPV8jMFu' \
--data '{
    "payment_id": "pay_aUwRQFUMFVSuIsfGRRiq",
    "amount": 100,
    "reason": "CUSTOMER REQUEST",
    "refund_type": "instant",
    "metadata": {
        "udf1": "value1",
        "new_customer": "true",
        "login_date": "2019-09-10T10:11:12Z"
    }  
}'
```

Response:

```
{
    "refund_id": "ref_3UOUCY4WziTz0iWhRGjT",
    "payment_id": "pay_aUwRQFUMFVSuIsfGRRiq",
    "amount": 100,
    "currency": "USD",
    "status": "pending",
    "reason": "CUSTOMER REQUEST",
    "metadata": {
        "udf1": "value1",
        "new_customer": "true",
        "login_date": "2019-09-10T10:11:12Z"
    },
    "error_message": null,
    "error_code": null,
    "unified_code": null,
    "unified_message": null,
    "created_at": "2025-08-06T04:02:37.782Z",
    "updated_at": "2025-08-06T04:02:39.280Z",
    "connector": "adyen",
    "profile_id": "pro_H4NAjXx3vY9NI4nQbXom",
    "merchant_connector_id": "mca_EC2PLdAi5hhl8zAKbt0G",
    "split_refunds": null,
    "issuer_error_code": null,
    "issuer_error_message": null
}
```

B. Refund (with invalid reason):

Request:

```
curl --location 'http://localhost:8080/refunds' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: dev_8rgdhjpDZyA54Hc0hN43a4wvBTlJ0wIGGeGquavEbsa.kjsfhgubdhrsj' \
--data '{
    "payment_id": "pay_dwfsrgdfnQSuIsfGRerjgh",
    "amount": 100,
    "reason": "customer returned product",
    "refund_type": "instant",
    "metadata": {
        "udf1": "value1",
        "new_customer": "true",
        "login_date": "2019-09-10T10:11:12Z"
    }  
}'
```

Response:

```
{
    "refund_id": "ref_7JGWziplkiWhRaSg",
    "payment_id": "pay_dwfsrgdfnQSuIsfGRerjgh",
    "amount": 100,
    "currency": "USD",
    "status": "pending",
    "reason": "OTHER",
    "metadata": {
        "udf1": "value1",
        "new_customer": "true",
        "login_date": "2019-09-10T10:11:12Z"
    },
    "error_message": null,
    "error_code": null,
    "unified_code": null,
    "unified_message": null,
    "created_at": "2025-08-06T04:02:37.782Z",
    "updated_at": "2025-08-06T04:02:39.280Z",
    "connector": "adyen",
    "profile_id": "pro_H4NAjXx3vY9NI4nQbXom",
    "merchant_connector_id": "mca_EC2PLdAi5hhl8zAKbt0G",
    "split_refunds": null,
    "issuer_error_code": null,
    "issuer_error_message": null
}
```

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
