### PR TITLE
fix(connector): [CYBERSOURCE] fix response field for netcetera authentication response

### DIFF
--- a/crates/hyperswitch_connectors/src/connectors/netcetera/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/netcetera/transformers.rs
@@ -158,6 +158,13 @@ impl
                     }
                     Some(ACSChallengeMandatedIndicator::N) | None => AuthNFlowType::Frictionless,
                 };
+
+                let challenge_code = response
+                    .authentication_request
+                    .as_ref()
+                    .and_then(|req| req.three_ds_requestor_challenge_ind.as_ref())
+                    .and_then(|v| v.first().cloned());
+
                 Ok(AuthenticationResponseData::AuthNResponse {
                     authn_flow_type,
                     authentication_value: response.authentication_value,
@@ -165,7 +172,7 @@ impl
                     connector_metadata: None,
                     ds_trans_id: response.authentication_response.ds_trans_id,
                     eci: response.eci,
-                    challenge_code: response.three_ds_requestor_challenge_ind,
+                    challenge_code,
                     challenge_cancel: response.challenge_cancel,
                     challenge_code_reason: response.trans_status_reason,
                     message_extension: response.message_extension.and_then(|v| {
@@ -653,13 +660,12 @@ pub struct NetceteraAuthenticationSuccessResponse {
     pub authentication_value: Option<Secret<String>>,
     pub eci: Option<String>,
     pub acs_challenge_mandated: Option<ACSChallengeMandatedIndicator>,
+    pub authentication_request: Option<AuthenticationRequest>,
     pub authentication_response: AuthenticationResponse,
     #[serde(rename = "base64EncodedChallengeRequest")]
     pub encoded_challenge_request: Option<String>,
     pub challenge_cancel: Option<String>,
     pub trans_status_reason: Option<String>,
-    #[serde(rename = "threeDSRequestorChallengeInd")]
-    pub three_ds_requestor_challenge_ind: Option<String>,
     pub message_extension: Option<Vec<MessageExtensionAttribute>>,
 }
 
@@ -667,6 +673,13 @@ pub struct NetceteraAuthenticationSuccessResponse {
 #[serde(rename_all = "camelCase")]
 pub struct NetceteraAuthenticationFailureResponse {
     pub error_details: NetceteraErrorDetails,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AuthenticationRequest {
+    #[serde(rename = "threeDSRequestorChallengeInd")]
+    pub three_ds_requestor_challenge_ind: Option<Vec<String>>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
Currently we are not recieving field **_three_ds_requestor_challenge_ind_** in Netcetera's authentication response since the struct is incorrectly declared in the transformers file.

1. **_three_ds_requestor_challenge_ind_** is currently a part of _**NetceteraAuthenticationSuccessResponse**_ enum, but it should be a field inside **_authenitcation_request_**
2. **_three_ds_requestor_challenge_ind_** has type optional string currently, but it should be a vector of string (ref documentation - https://3dss.netcetera.com/3dsserver/doc/2.5.2.1/3ds-authentication) 

**Current structure**
```
NetceteraAuthenticationSuccessResponse{
....
three_ds_requestor_challenge_ind: Option<String>
...}

```

**Correct structure**
```
NetceteraAuthenticationSuccessResponse{
....
authentication_request: {
three_ds_requestor_challenge_ind: Option<Vector<String>>,
}
...}

```
This PR introduces the above fix in the struct.



### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Tested netcetera's challenge via local hyperswitch sdk.
As expected, we are now able to get **_three_ds_requestor_challenge_ind_** field in the NetceteraAuthenticationSuccessResponse.

<img width="2560" height="135" alt="Screenshot 2025-08-06 at 4 29 03 PM" src="https://github.com/user-attachments/assets/45fee6c0-b785-4f3e-abb2-0d74468d2024" />


## Checklist
<!-- Put an `x` in the boxes that apply -->


- [x] I formatted the code `cargo +nightly fmt --all`
- [X] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
