### PR TITLE
feat(connector): add support of passing metadata in adyen payment request

### DIFF
--- a/crates/hyperswitch_connectors/src/connectors/adyen/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/adyen/transformers.rs
@@ -292,6 +292,7 @@ pub struct AdyenPaymentRequest<'a> {
     device_fingerprint: Option<Secret<String>>,
     #[serde(with = "common_utils::custom_serde::iso8601::option")]
     session_validity: Option<PrimitiveDateTime>,
+    metadata: Option<serde_json::Value>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -2936,6 +2937,7 @@ impl
             splits,
             device_fingerprint,
             session_validity: None,
+            metadata: item.router_data.request.metadata.clone(),
         })
     }
 }
@@ -3020,6 +3022,7 @@ impl TryFrom<(&AdyenRouterData<&PaymentsAuthorizeRouterData>, &Card)> for AdyenP
             splits,
             device_fingerprint,
             session_validity: None,
+            metadata: item.router_data.request.metadata.clone(),
         })
     }
 }
@@ -3108,6 +3111,7 @@ impl
             splits,
             device_fingerprint,
             session_validity: None,
+            metadata: item.router_data.request.metadata.clone(),
         };
         Ok(request)
     }
@@ -3184,6 +3188,7 @@ impl TryFrom<(&AdyenRouterData<&PaymentsAuthorizeRouterData>, &VoucherData)>
             splits,
             device_fingerprint,
             session_validity: None,
+            metadata: item.router_data.request.metadata.clone(),
         };
         Ok(request)
     }
@@ -3302,6 +3307,7 @@ impl
             splits,
             device_fingerprint,
             session_validity,
+            metadata: item.router_data.request.metadata.clone(),
         };
         Ok(request)
     }
@@ -3379,6 +3385,7 @@ impl
             splits,
             device_fingerprint,
             session_validity: None,
+            metadata: item.router_data.request.metadata.clone(),
         };
         Ok(request)
     }
@@ -3460,6 +3467,7 @@ impl
             splits,
             device_fingerprint,
             session_validity: None,
+            metadata: item.router_data.request.metadata.clone(),
         })
     }
 }
@@ -3591,6 +3599,7 @@ impl TryFrom<(&AdyenRouterData<&PaymentsAuthorizeRouterData>, &WalletData)>
             splits,
             device_fingerprint,
             session_validity: None,
+            metadata: item.router_data.request.metadata.clone(),
         })
     }
 }
@@ -3681,6 +3690,7 @@ impl
             splits,
             device_fingerprint,
             session_validity: None,
+            metadata: item.router_data.request.metadata.clone(),
         })
     }
 }
@@ -3763,6 +3773,7 @@ impl
             splits,
             device_fingerprint,
             session_validity: None,
+            metadata: item.router_data.request.metadata.clone(),
         })
     }
 }
@@ -6018,6 +6029,7 @@ impl
             splits,
             device_fingerprint,
             session_validity: None,
+            metadata: item.router_data.request.metadata.clone(),
         })
     }
 }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
Make a adyen payment request by passing metadata
```
curl --location 'http://localhost:8080/payments' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: dev_gfSvA66FtTOYRAET2roFlwpZII7Im5qV58tVCQ8nmgfvCGW34H7KOatZrmImGpJi' \
--data-raw '{
    "amount": 1000,
    "currency": "USD",
    "confirm": true,
    "capture_method": "automatic",
    "capture_on": "2022-09-10T10:11:12Z",
    "amount_to_capture": 1000,
    "customer_id": "StripeCustomer",
    "email": "guest@example.com",
    "name": "John Doe",
    "phone": "999999999",
    "phone_country_code": "+1",
    "description": "Its my first payment request",
    "authentication_type": "no_three_ds",
    "return_url": "https://duck.com",
    "payment_method": "card",
    "payment_method_type": "credit",
    "payment_method_data": {
        "card": {
            "card_number": "4917610000000000",
            "card_exp_month": "03",
            "card_exp_year": "2030",
            "card_holder_name": "joseph Doe",
            "card_cvc": "737"
        }
    },
    "metadata": {
        "order_id": "ORD-12345",
        "customer_segment": "premium",
        "purchase_platform": "web_store"
    },
    "routing": {
        "type": "single",
        "data": "adyen"
    },
    "billing": {
        "address": {
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "city": "San Fransico",
            "state": "California",
            "zip": "94122",
            "country": "US",
            "first_name": "PiX"
        }
    },
    "shipping": {
        "address": {
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "city": "San Fransico",
            "state": "California",
            "zip": "94122",
            "country": "US",
            "first_name": "PiX"
        }
    },
    "statement_descriptor_name": "joseph",
    "statement_descriptor_suffix": "JS",
    "merchant_order_reference_id" : "order_narvar12",
     "browser_info": {
    "os_type": "macOS",
    "language": "en-GB",
    "time_zone": -330,
    "ip_address": "103.159.11.202",
    "os_version": "10.15.7",
    "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/132.0.0.0 Safari/537.36",
    "color_depth": 24,
    "device_model": "Macintosh",
    "java_enabled": true,
    "screen_width": 1920,
    "accept_header": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8",
    "screen_height": 1080,
    "accept_language": "en",
    "java_script_enabled": true
  },
    "profile_id": "pro_16j8JOCurimvr2XXG9EE"
}'
```
Response
```
{
    "payment_id": "pay_hzlcxXX8nyJI66W4kWqV",
    "merchant_id": "merchant_1754636642",
    "status": "requires_customer_action",
    "amount": 1000,
    "net_amount": 1000,
    "shipping_cost": null,
    "amount_capturable": 1000,
    "amount_received": null,
    "connector": "adyen",
    "client_secret": "pay_hzlcxXX8nyJI66W4kWqV_secret_nCpTSGcFPShUZCI00wx1",
    "created": "2025-08-08T07:04:25.612Z",
    "currency": "USD",
    "customer_id": "StripeCustomer",
    "customer": {
        "id": "StripeCustomer",
        "name": "John Doe",
        "email": "guest@example.com",
        "phone": "999999999",
        "phone_country_code": "+1"
    },
    "description": "Its my first payment request",
    "refunds": null,
    "disputes": null,
    "mandate_id": null,
    "mandate_data": null,
    "setup_future_usage": null,
    "off_session": null,
    "capture_on": null,
    "capture_method": "automatic",
    "payment_method": "card",
    "payment_method_data": {
        "card": {
            "last4": "0000",
            "card_type": null,
            "card_network": null,
            "card_issuer": null,
            "card_issuing_country": null,
            "card_isin": "491761",
            "card_extended_bin": null,
            "card_exp_month": "03",
            "card_exp_year": "2030",
            "card_holder_name": "joseph Doe",
            "payment_checks": null,
            "authentication_data": null
        },
        "billing": null
    },
    "payment_token": null,
    "shipping": {
        "address": {
            "city": "San Fransico",
            "country": "US",
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "zip": "94122",
            "state": "California",
            "first_name": "PiX",
            "last_name": null,
            "origin_zip": null
        },
        "phone": null,
        "email": null
    },
    "billing": {
        "address": {
            "city": "San Fransico",
            "country": "US",
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "zip": "94122",
            "state": "California",
            "first_name": "PiX",
            "last_name": null,
            "origin_zip": null
        },
        "phone": null,
        "email": null
    },
    "order_details": null,
    "email": "guest@example.com",
    "name": "John Doe",
    "phone": "999999999",
    "return_url": "https://duck.com/",
    "authentication_type": "no_three_ds",
    "statement_descriptor_name": "joseph",
    "statement_descriptor_suffix": "JS",
    "next_action": {
        "type": "redirect_to_url",
        "redirect_to_url": "http://localhost:8080/payments/redirect/pay_hzlcxXX8nyJI66W4kWqV/merchant_1754636642/pay_hzlcxXX8nyJI66W4kWqV_1"
    },
    "cancellation_reason": null,
    "error_code": null,
    "error_message": null,
    "unified_code": null,
    "unified_message": null,
    "payment_experience": null,
    "payment_method_type": "credit",
    "connector_label": null,
    "business_country": null,
    "business_label": "default",
    "business_sub_label": null,
    "allowed_payment_method_types": null,
    "ephemeral_key": {
        "customer_id": "StripeCustomer",
        "created_at": 1754636665,
        "expires": 1754640265,
        "secret": "epk_4fc117f853654c8289fb1024aa8dbeed"
    },
    "manual_retry_allowed": null,
    "connector_transaction_id": "SPD59ZTRRZ9TPM75",
    "frm_message": null,
    "metadata": {
        "order_id": "ORD-12345",
        "customer_segment": "premium",
        "purchase_platform": "web_store"
    },
    "connector_metadata": null,
    "feature_metadata": null,
    "reference_id": "SPD59ZTRRZ9TPM75",
    "payment_link": null,
    "profile_id": "pro_BkMsi4kLNDDn7Occ4u2v",
    "surcharge_details": null,
    "attempt_count": 1,
    "merchant_decision": null,
    "merchant_connector_id": "mca_hwPRKWHa1C2kQQ9Y86sr",
    "incremental_authorization_allowed": null,
    "authorization_count": null,
    "incremental_authorizations": null,
    "external_authentication_details": null,
    "external_3ds_authentication_attempted": false,
    "expires_on": "2025-08-08T07:19:25.612Z",
    "fingerprint": null,
    "browser_info": {
        "os_type": "macOS",
        "language": "en-GB",
        "time_zone": -330,
        "ip_address": "103.159.11.202",
        "os_version": "10.15.7",
        "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/132.0.0.0 Safari/537.36",
        "color_depth": 24,
        "device_model": "Macintosh",
        "java_enabled": true,
        "screen_width": 1920,
        "accept_header": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8",
        "screen_height": 1080,
        "accept_language": "en",
        "java_script_enabled": true
    },
    "payment_channel": null,
    "payment_method_id": null,
    "network_transaction_id": null,
    "payment_method_status": null,
    "updated": "2025-08-08T07:04:26.048Z",
    "split_payments": null,
    "frm_metadata": null,
    "extended_authorization_applied": null,
    "capture_before": null,
    "merchant_order_reference_id": "order_narvar12",
    "order_tax_amount": null,
    "connector_mandate_id": null,
    "card_discovery": "manual",
    "force_3ds_challenge": false,
    "force_3ds_challenge_trigger": false,
    "issuer_error_code": null,
    "issuer_error_message": null,
    "is_iframe_redirection_enabled": null,
    "whole_connector_response": null,
    "enable_partial_authorization": null
}
```
In adyen dashboard it should show up like this:
<img width="696" height="210" alt="Screenshot 2025-08-08 at 12 50 13 PM" src="https://github.com/user-attachments/assets/5cee3d27-a810-49fe-a1d3-42fe43caac83" />

Cypress test
<img width="1912" height="1880" alt="Screenshot 2025-08-08 at 8 36 49 PM" src="https://github.com/user-attachments/assets/b012d628-f74d-4e3a-bd3c-3893bae9115a" />


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
