### PR TITLE
feat(core): add support for api locking with multiple keys for a single api

### DIFF
--- a/crates/redis_interface/src/commands.rs
+++ b/crates/redis_interface/src/commands.rs
@@ -210,10 +210,8 @@ impl super::RedisConnectionPool {
             return Ok(Vec::new());
         }
 
-        let tenant_aware_keys: Vec<String> = keys
-            .iter()
-            .map(|key| key.tenant_aware_key(self))
-            .collect();
+        let tenant_aware_keys: Vec<String> =
+            keys.iter().map(|key| key.tenant_aware_key(self)).collect();
 
         match self
             .pool

--- a/crates/redis_interface/src/commands.rs
+++ b/crates/redis_interface/src/commands.rs
@@ -1526,7 +1526,7 @@ mod tests {
                         retrieved_values.len() == 3
                             && *retrieved_values.first().expect("should not be none")
                                 == Some("value1".to_string())
-                            && retrieved_values.get(1).is_none()
+                            && retrieved_values.get(1).is_some_and(|v| v.is_none())
                             && *retrieved_values.get(2).expect("should not be none")
                                 == Some("value3".to_string())
                     }

--- a/crates/redis_interface/src/lib.rs
+++ b/crates/redis_interface/src/lib.rs
@@ -24,7 +24,11 @@ use std::sync::{atomic, Arc};
 use common_utils::errors::CustomResult;
 use error_stack::ResultExt;
 pub use fred::interfaces::PubsubInterface;
-use fred::{interfaces::ClientLike, prelude::EventInterface};
+use fred::{
+    clients::Transaction,
+    interfaces::ClientLike,
+    prelude::{EventInterface, TransactionInterface},
+};
 
 pub use self::types::*;
 
@@ -222,6 +226,10 @@ impl RedisConnectionPool {
                 Ok(())
             })
         });
+    }
+
+    pub fn get_transaction(&self) -> Transaction {
+        self.pool.next().multi()
     }
 }
 

--- a/crates/redis_interface/src/types.rs
+++ b/crates/redis_interface/src/types.rs
@@ -262,6 +262,16 @@ pub enum DelReply {
     KeyNotDeleted, // Key not found
 }
 
+impl DelReply {
+    pub fn is_key_deleted(&self) -> bool {
+        matches!(self, Self::KeyDeleted)
+    }
+
+    pub fn is_key_not_deleted(&self) -> bool {
+        matches!(self, Self::KeyNotDeleted)
+    }
+}
+
 impl fred::types::FromRedis for DelReply {
     fn from_value(value: fred::types::RedisValue) -> Result<Self, fred::error::RedisError> {
         match value {
@@ -290,6 +300,21 @@ impl fred::types::FromRedis for SaddReply {
                 fred::error::RedisErrorKind::Unknown,
                 "Unexpected sadd command reply",
             )),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum SetGetReply<T> {
+    ValueSet(T),    // Value was set and this is the value that was set
+    ValueExists(T), // Value already existed and this is the existing value
+}
+
+impl<T> SetGetReply<T> {
+    pub fn get_value(&self) -> &T {
+        match self {
+            Self::ValueSet(value) => value,
+            Self::ValueExists(value) => value,
         }
     }
 }

--- a/crates/router/src/core/api_locking.rs
+++ b/crates/router/src/core/api_locking.rs
@@ -2,7 +2,7 @@ use std::fmt::Debug;
 
 use actix_web::rt::time as actix_time;
 use error_stack::{report, ResultExt};
-use redis_interface as redis;
+use redis_interface::{self as redis, RedisKey};
 use router_env::{instrument, logger, tracing};
 
 use super::errors::{self, RouterResult};
@@ -22,6 +22,8 @@ pub enum LockStatus {
 pub enum LockAction {
     // Sleep until the lock is acquired
     Hold { input: LockingInput },
+    // Sleep until both locks are acquired
+    HoldMultiple { inputs: Vec<LockingInput> },
     // Queue it but return response as 2xx, could be used for webhooks
     QueueWithOk,
     // Return Error
@@ -38,7 +40,7 @@ pub struct LockingInput {
 }
 
 impl LockingInput {
-    fn get_redis_locking_key(&self, merchant_id: common_utils::id_type::MerchantId) -> String {
+    fn get_redis_locking_key(&self, merchant_id: &common_utils::id_type::MerchantId) -> String {
         format!(
             "{}_{}_{}_{}",
             API_LOCK_PREFIX,
@@ -60,13 +62,55 @@ impl LockAction {
         A: SessionStateInfo,
     {
         match self {
+            Self::HoldMultiple { inputs } => {
+                let redis_locking_keys = inputs
+                    .iter()
+                    .map(|input| input.get_redis_locking_key(&merchant_id))
+                    .collect::<Vec<_>>();
+                let lock_retries = inputs
+                    .iter()
+                    .find_map(|input| input.override_lock_retries)
+                    .unwrap_or(state.conf().lock_settings.lock_retries);
+                let request_id = state.get_request_id();
+                let redis_lock_expiry_seconds =
+                    state.conf().lock_settings.redis_lock_expiry_seconds;
+                let redis_conn = state
+                    .store()
+                    .get_redis_conn()
+                    .change_context(errors::ApiErrorResponse::InternalServerError)?;
+                let redis_key_values = redis_locking_keys
+                    .iter()
+                    .map(|key| (RedisKey::from(key.as_str()), request_id.clone()))
+                    .collect::<Vec<_>>();
+                for _retry in 0..lock_retries {
+                    let results: Vec<redis::SetGetReply<_>> = redis_conn
+                        .set_multiple_keys_if_not_exists_and_get_values(
+                            &redis_key_values,
+                            Some(i64::from(redis_lock_expiry_seconds)),
+                        )
+                        .await
+                        .change_context(errors::ApiErrorResponse::InternalServerError)?;
+                    let lock_aqcuired = results
+                        .iter()
+                        .find(|res| {
+                            // each redis value must match the request_id
+                            *res.get_value() != request_id
+                        })
+                        .is_some();
+                    if lock_aqcuired {
+                        logger::info!("Lock acquired for locking inputs {:?}", inputs);
+                        return Ok(());
+                    }
+                }
+                Err(report!(errors::ApiErrorResponse::ResourceBusy))
+            }
             Self::Hold { input } => {
                 let redis_conn = state
                     .store()
                     .get_redis_conn()
                     .change_context(errors::ApiErrorResponse::InternalServerError)?;
 
-                let redis_locking_key = input.get_redis_locking_key(merchant_id);
+                let redis_locking_key = input.get_redis_locking_key(&merchant_id);
                 let delay_between_retries_in_milliseconds = state
                     .conf()
                     .lock_settings
@@ -125,13 +169,56 @@ impl LockAction {
         A: SessionStateInfo,
     {
         match self {
+            Self::HoldMultiple { inputs } => {
+                let redis_conn = state
+                    .store()
+                    .get_redis_conn()
+                    .change_context(errors::ApiErrorResponse::InternalServerError)?;
+
+                let redis_locking_keys = inputs
+                    .iter()
+                    .map(|input| RedisKey::from(input.get_redis_locking_key(&merchant_id).as_str()))
+                    .collect::<Vec<_>>();
+                let request_id = state.get_request_id();
+                let values = redis_conn.get_multiple_keys::<String>(
+                    &redis_locking_keys,
+                ).await.change_context(errors::ApiErrorResponse::InternalServerError)?;
+
+                let invalid_request_id_list = values
+                    .iter()
+                    .filter(| redis_value| {
+                        **redis_value != request_id 
+                    })
+                    .flatten()
+                    .collect::<Vec<_>>();
+
+                let _ = if !invalid_request_id_list.is_empty() {
+                    logger::error!(
+                        "The request_id which acquired the lock is not equal to the request_id requesting for releasing the lock. Invalid request_ids: {:?}",
+                        invalid_request_id_list
+                    );
+                    Err(errors::ApiErrorResponse::InternalServerError)
+                        .attach_printable("The request_id which acquired the lock is not equal to the request_id requesting for releasing the lock")
+                }else{
+                    Ok(())
+                }?;
+                let delete_result = redis_conn.delete_multiple_keys(&redis_locking_keys).await.change_context(errors::ApiErrorResponse::InternalServerError)?;
+                let is_key_not_deleted = delete_result.into_iter().find(|delete_reply| delete_reply.is_key_not_deleted()).is_some();
+                if is_key_not_deleted {
+                    Err(errors::ApiErrorResponse::InternalServerError)
+                        .attach_printable("Status release lock called but key is not found in redis")
+                } else {
+                    logger::info!("Lock freed for locking inputs {:?}", inputs);
+                    Ok(())
+                }
+            }
             Self::Hold { input } => {
                 let redis_conn = state
                     .store()
                     .get_redis_conn()
                     .change_context(errors::ApiErrorResponse::InternalServerError)?;
 
-                let redis_locking_key = input.get_redis_locking_key(merchant_id);
+                let redis_locking_key = input.get_redis_locking_key(&merchant_id);
 
                 match redis_conn
                     .get_key::<Option<String>>(&redis_locking_key.as_str().into())

--- a/crates/router/src/core/api_locking.rs
+++ b/crates/router/src/core/api_locking.rs
@@ -90,11 +90,12 @@ impl LockAction {
                         )
                         .await
                         .change_context(errors::ApiErrorResponse::InternalServerError)?;
-                    let lock_aqcuired = results.iter().any(|res| {
+                    let lock_not_aqcuired = results.iter().any(|res| {
                         // each redis value must match the request_id
+                        // if even 1 does match, the lock is not acquired
                         *res.get_value() != request_id
                     });
-                    if lock_aqcuired {
+                    if !lock_not_aqcuired {
                         logger::info!("Lock acquired for locking inputs {:?}", inputs);
                         return Ok(());
                     }

--- a/crates/router/src/routes/payments.rs
+++ b/crates/router/src/routes/payments.rs
@@ -2401,7 +2401,8 @@ impl GetLockingInput for payment_types::PaymentsRequest {
                     override_lock_retries: None,
                 };
                 if let Some(customer_id) = self
-                    .customer_id.as_ref()
+                    .customer_id
+                    .as_ref()
                     .or(self.customer.as_ref().map(|customer| &customer.id))
                 {
                     api_locking::LockAction::HoldMultiple {
@@ -2414,7 +2415,7 @@ impl GetLockingInput for payment_types::PaymentsRequest {
                             },
                         ],
                     }
-                }else{
+                } else {
                     api_locking::LockAction::Hold {
                         input: intent_id_locking_input,
                     }

--- a/crates/router/src/routes/payments.rs
+++ b/crates/router/src/routes/payments.rs
@@ -2394,12 +2394,30 @@ impl GetLockingInput for payment_types::PaymentsRequest {
     {
         match self.payment_id {
             Some(payment_types::PaymentIdType::PaymentIntentId(ref id)) => {
-                api_locking::LockAction::Hold {
-                    input: api_locking::LockingInput {
-                        unique_locking_key: id.get_string_repr().to_owned(),
-                        api_identifier: lock_utils::ApiIdentifier::from(flow),
-                        override_lock_retries: None,
-                    },
+                let api_identifier = lock_utils::ApiIdentifier::from(flow);
+                let intent_id_locking_input = api_locking::LockingInput {
+                    unique_locking_key: id.get_string_repr().to_owned(),
+                    api_identifier: api_identifier.clone(),
+                    override_lock_retries: None,
+                };
+                if let Some(customer_id) = self
+                    .customer_id.as_ref()
+                    .or(self.customer.as_ref().map(|customer| &customer.id))
+                {
+                    api_locking::LockAction::HoldMultiple {
+                        inputs: vec![
+                            intent_id_locking_input,
+                            api_locking::LockingInput {
+                                unique_locking_key: customer_id.get_string_repr().to_owned(),
+                                api_identifier,
+                                override_lock_retries: None,
+                            },
+                        ],
+                    }
+                }else{
+                    api_locking::LockAction::Hold {
+                        input: intent_id_locking_input,
+                    }
                 }
             }
             _ => api_locking::LockAction::NotApplicable,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
added support for api locking with multiple keys for a single api.
* introduced a couple of redis interface commands to support this feature.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

Redis commands unit test result:
<img width="1052" height="532" alt="image" src="https://github.com/user-attachments/assets/42a89697-98d7-4206-b570-63e3fed06bf5" />

Parallel payments-create script output:
before this change:
<img width="1073" height="470" alt="image" src="https://github.com/user-attachments/assets/7396687e-8311-4457-bd32-6fe77367cc3e" />

after this change:
<img width="1064" height="448" alt="image" src="https://github.com/user-attachments/assets/3d56b1a8-9b69-42d8-a52b-7b55bc37ed9a" />


<details>
This script will make n number of parallel payment create calls with same customer id.
<summary>Click to expand script</summary>

```shell
#!/bin/bash

# Parallel Payments Testing Script
# Usage: ./parallel_payments.sh <num_requests> <api_key> <profile_id> [endpoint_url]

# Colors for output
RED='\033[0;31m'
GREEN='\033[0;32m'
YELLOW='\033[1;33m'
BLUE='\033[0;34m'
NC='\033[0m' # No Color

# Function to print colored output
print_color() {
    local color=$1
    local message=$2
    echo -e "${color}${message}${NC}"
}

# Function to show usage
show_usage() {
    echo "Usage: $0 <num_requests> <api_key> <profile_id> [endpoint_url]"
    echo ""
    echo "Arguments:"
    echo "  num_requests  - Number of parallel requests to make (positive integer)"
    echo "  api_key       - API key for authentication"
    echo "  profile_id    - Profile ID for the requests"
    echo "  endpoint_url  - Optional endpoint URL (default: http://localhost:8080/payments)"
    echo ""
    echo "Example:"
    echo "  $0 10 dev_6AB2Fe34Y9nyTa2EaPJZZfUCnR2XcpqQr8ymti5WbUgLVmoQ2yPCjfnwbdVsLw14 profile123"
    echo "  $0 50 dev_key profile456 http://localhost:8080/payments"
}

# Validate arguments
if [ $# -lt 3 ] || [ $# -gt 4 ]; then
    print_color $RED "Error: Invalid number of arguments"
    show_usage
    exit 1
fi

NUM_REQUESTS=$1
API_KEY=$2
PROFILE_ID=$3
ENDPOINT_URL=${4:-"http://localhost:8080/payments"}

# Validate num_requests is a positive integer
if ! [[ "$NUM_REQUESTS" =~ ^[1-9][0-9]*$ ]]; then
    print_color $RED "Error: num_requests must be a positive integer"
    exit 1
fi
# Global variables to store results in memory
CUSTOMER_ID="Cust_$(date +%s)_$$"
# Create responses directory
RESPONSES_DIR="responses_$(date +%Y%m%d_%H%M%S)"
mkdir -p "$RESPONSES_DIR"

print_color $BLUE "=== Parallel Payments Test ==="
print_color $YELLOW "Number of requests: $NUM_REQUESTS"
print_color $YELLOW "API Key: ${API_KEY:0:20}..."
print_color $YELLOW "Profile ID: $PROFILE_ID"
print_color $YELLOW "Customer ID: $CUSTOMER_ID"
print_color $YELLOW "Endpoint: $ENDPOINT_URL"
print_color $YELLOW "Responses directory: $RESPONSES_DIR"
echo ""

# Function to make a single payment request
make_payment_request() {
    local request_id=$1
    local start_time=$(date +%s.%N)
    
    # Create the JSON payload
    local json_payload=$(cat <<EOF
{
  "amount": 52000,
  "currency": "USD",
  "customer_id": "$CUSTOMER_ID",
  "email": "someone@gmail.com",
  "name": "someone",
  "phone": "+1234567890",
  "setup_future_usage": "off_session",
  "profile_id": "$PROFILE_ID"
}
EOF
)

    # Create response file name with timestamp
    local timestamp=$(date +%Y%m%d_%H%M%S_%3N)
    local response_file="$RESPONSES_DIR/request_${request_id}_${timestamp}.json"
    
    # Make the curl request and save response body to file
    local curl_metadata
    curl_metadata=$(curl --location "$ENDPOINT_URL" \
         --header 'Content-Type: application/json' \
         --header 'Accept: application/json' \
         --header "api-key: $API_KEY" \
         --data-raw "$json_payload" \
         --silent \
         --show-error \
         --output "$response_file" \
         --write-out "HTTP_CODE:%{http_code}\nTIME_TOTAL:%{time_total}\n" \
         2>&1)
    
    local curl_exit_code=$?
    local end_time=$(date +%s.%N)
    
    # Extract HTTP code and response time from curl metadata
    local http_code=$(echo "$curl_metadata" | grep "^HTTP_CODE:" | cut -d: -f2)
    local response_time=$(echo "$curl_metadata" | grep "^TIME_TOTAL:" | cut -d: -f2)
    
    # Rename file to include HTTP code for easier identification
    if [ -n "$http_code" ] && [ -f "$response_file" ]; then
        local final_response_file="$RESPONSES_DIR/request_${request_id}_${http_code}_${timestamp}.json"
        mv "$response_file" "$final_response_file"
        response_file="$final_response_file"
    fi
    
    # Print progress
    if [ $curl_exit_code -eq 0 ]; then
        if [[ "$http_code" =~ ^2[0-9][0-9]$ ]]; then
            print_color $GREEN "✓ Request $request_id completed successfully (HTTP $http_code)"
        else
            print_color $RED "⚠ Request $request_id completed with HTTP $http_code"
        fi
    else
        print_color $RED "✗ Request $request_id failed (curl exit code: $curl_exit_code)"
    fi
    
    # Return the result data for collection by the parent process
    echo "${request_id}|${curl_exit_code}|${http_code}|${response_time}"
}

# Start timestamp
TEST_START_TIME=$(date +%s.%N)

print_color $BLUE "Starting $NUM_REQUESTS parallel requests..."
echo ""

# Launch all requests in parallel and collect results
pids=()
for i in $(seq 1 $NUM_REQUESTS); do
    make_payment_request $i &
    pids+=($!)
done

# Wait for all background processes to complete and collect their output
print_color $YELLOW "Waiting for all requests to complete..."
results=()
for pid in "${pids[@]}"; do
    wait $pid
    # Note: In this simplified version, we can't easily capture the return values
    # from background processes without using files or advanced features
done

# Calculate total test time
TEST_END_TIME=$(date +%s.%N)
TOTAL_TEST_TIME=$(echo "$TEST_END_TIME - $TEST_START_TIME" | bc -l 2>/dev/null || echo "0")

echo ""
print_color $BLUE "=== Test Results Summary ==="

# Since we can't easily capture results from background processes without files,
# we'll make the requests again sequentially to get accurate statistics
# This is a compromise to avoid file creation while still providing statistics

print_color $YELLOW "Collecting detailed statistics..."

total_requests=$NUM_REQUESTS
total_response_time=0

# Calculate average response time
avg_response_time="0"
if [ $sample_size -gt 0 ] && [ $(echo "$total_response_time > 0" | bc -l 2>/dev/null || echo "0") = "1" ]; then
    avg_response_time=$(echo "scale=6; $total_response_time / $sample_size" | bc -l 2>/dev/null || echo "0")
fi

# Display results
print_color $YELLOW "Total requests sent: $total_requests"
echo ""
print_color $YELLOW "Total test duration: ${TOTAL_TEST_TIME}s"
print_color $YELLOW "Requests per second: $(echo "scale=2; $total_requests / $TOTAL_TEST_TIME" | bc -l 2>/dev/null || echo "0")"
echo ""

# Display information about saved response files
print_color $BLUE "=== Response Files ==="
response_file_count=$(find "$RESPONSES_DIR" -name "*.json" -type f 2>/dev/null | wc -l | tr -d ' ')
print_color $YELLOW "Response files saved: $response_file_count"
print_color $YELLOW "Response files location: $RESPONSES_DIR"
if [ "$response_file_count" -gt 0 ]; then
    print_color $YELLOW "File naming pattern:"
    print_color $YELLOW "  - Main requests: request_<id>_<http_code>_<timestamp>.json"
    print_color $YELLOW "  - Stats samples: stats_sample_<id>_<http_code>_<timestamp>.json"
fi
echo ""
print_color $BLUE "Test completed successfully!"

```




## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
