### PR TITLE
refactor(euclid): transform enum types to include sub-variants of payment method types

### DIFF
--- a/crates/router/src/core/payments/routing/utils.rs
+++ b/crates/router/src/core/payments/routing/utils.rs
@@ -597,8 +597,14 @@ pub fn convert_backend_input_to_routing_eval(
             Some(ValueType::EnumVariant(pm.to_string())),
         );
         if let Some(pmt) = input.payment_method.payment_method_type {
-            if let Ok(dv) = (pmt, pm).into_dir_value() {
-                insert_dirvalue_param(&mut params, dv);
+            match (pmt, pm).into_dir_value() {
+                Ok(dv) => insert_dirvalue_param(&mut params, dv),
+                Err(e) => logger::debug!(
+                    ?e,
+                    ?pmt,
+                    ?pm,
+                    "decision_engine_euclid: into_dir_value failed; skipping subset param"
+                ),
             }
         }
     }
@@ -748,9 +754,13 @@ fn insert_dirvalue_param(params: &mut HashMap<String, Option<ValueType>>, dv: di
                 Some(ValueType::EnumVariant(v.to_string())),
             );
         }
-        _ => {
+        other => {
             // all other values can be ignored for now as they don't converge with
             // payment method type
+            logger::warn!(
+                ?other,
+                "decision_engine_euclid: unmapped dir::DirValue; add a mapping here"
+            );
         }
     }
 }

--- a/crates/router/src/core/payments/routing/utils.rs
+++ b/crates/router/src/core/payments/routing/utils.rs
@@ -596,22 +596,17 @@ pub fn convert_backend_input_to_routing_eval(
             "payment_method".to_string(),
             Some(ValueType::EnumVariant(pm.to_string())),
         );
+        if let Some(pmt) = input.payment_method.payment_method_type {
+            if let Ok(dv) = (pmt, pm).into_dir_value() {
+                insert_dirvalue_param(&mut params, dv);
+            }
+        }
     }
     if let Some(pmt) = input.payment_method.payment_method_type {
         params.insert(
             "payment_method_type".to_string(),
             Some(ValueType::EnumVariant(pmt.to_string())),
         );
-    }
-    if let Some(pm) = input.payment_method.payment_method {
-        if let Some(pmt) = input.payment_method.payment_method_type {
-            logger::error!(">>>>>>>>>0>>>>>>>");
-            if let Ok(dv) = (pmt, pm).into_dir_value() {
-                logger::error!(">>>>>>>>>1>>>>>>>");
-                logger::error!(">>>>>>>>>>>>>>>>{:?}", dv);
-                insert_dirvalue_param(&mut params, dv);
-            }
-        }
     }
     if let Some(network) = input.payment_method.card_network {
         params.insert(


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

This PR refactors the Euclid routing parameter transformation logic to **include sub-variants of payment method types** in the Decision Engine evaluation request.  

Key updates:
- Added logic to **convert `(payment_method_type, payment_method)` pairs** into a `DirValue` representation.
- Introduced `insert_dirvalue_param()` to map each `DirValue` variant into a corresponding routing parameter key.
- Enhanced `convert_backend_input_to_routing_eval` to insert these sub-variant parameters alongside existing routing parameters.
- This ensures richer context is sent to Euclid for more granular routing decisions.

## Outcomes

- Enables **finer-grained routing rules** based on payment method sub-types (e.g., `WalletType`, `CryptoType`, `GiftCardType`).
- Improves compatibility with dashboard-configured payment method rules in Euclid.
- Makes routing evaluation requests **more descriptive and precise**, improving match accuracy.

## Diff Hunk Explanation

### `crates/router/src/core/payments/routing/utils.rs`
- **Modified** `convert_backend_input_to_routing_eval`:
  - Added check for both `payment_method_type` and `payment_method` presence.
  - Converted them into a `DirValue` using `into_dir_value()`.
  - Inserted the resulting parameters into the evaluation request map.
- **Added** new helper `insert_dirvalue_param()`:
  - Matches on each `DirValue` variant and inserts it as a `ValueType::EnumVariant` with an appropriate key (e.g., `"wallet"`, `"crypto"`, `"bank_transfer"`).
  - Ignores unsupported or non-converging variants for now.
- **No changes** to external APIs or DB schema — purely internal parameter transformation refactor.

This refactor lays the groundwork for **sub-type aware routing** in Euclid without requiring external schema changes.


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Testing isn't required as this is just an enum mapping change.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
