### PR TITLE
fix(core): connector customer id population dependency removed from config

### DIFF
--- a/config/config.example.toml
+++ b/config/config.example.toml
@@ -899,7 +899,7 @@ pix = { country = "BR", currency = "BRL" }
 bluecode = { country = "AT,BE,BG,HR,CY,CZ,DK,EE,FI,FR,DE,GR,HU,IE,IT,LV,LT,LU,MT,NL,PL,PT,RO,SK,SI,ES,SE,IS,LI,NO", currency = "EUR" }
 
 [connector_customer]
-connector_list = "adyen,authorizedotnet,facilitapay,gocardless,hyperswitch_vault,stax,stripe"
+connector_list = "authorizedotnet,facilitapay,gocardless,hyperswitch_vault,stax,stripe"
 payout_connector_list = "nomupay,stripe,wise"
 
 [bank_config.online_banking_fpx]

--- a/config/deployments/integration_test.toml
+++ b/config/deployments/integration_test.toml
@@ -193,7 +193,7 @@ force_cookies = true
 enabled = true
 
 [connector_customer]
-connector_list = "adyen,authorizedotnet,facilitapay,gocardless,hyperswitch_vault,stax,stripe"
+connector_list = "authorizedotnet,facilitapay,gocardless,hyperswitch_vault,stax,stripe"
 payout_connector_list = "nomupay,stripe,wise"
 
 [delayed_session_response]

--- a/config/deployments/production.toml
+++ b/config/deployments/production.toml
@@ -15,7 +15,7 @@ open_banking_uk.adyen.banks = "aib,bank_of_scotland,danske_bank,first_direct,fir
 przelewy24.stripe.banks = "alior_bank,bank_millennium,bank_nowy_bfg_sa,bank_pekao_sa,banki_spbdzielcze,blik,bnp_paribas,boz,citi,credit_agricole,e_transfer_pocztowy24,getin_bank,idea_bank,inteligo,mbank_mtransfer,nest_przelew,noble_pay,pbac_z_ipko,plus_bank,santander_przelew24,toyota_bank,volkswagen_bank"
 
 [connector_customer]
-connector_list = "adyen,authorizedotnet,facilitapay,gocardless,hyperswitch_vault,stax,stripe"
+connector_list = "authorizedotnet,facilitapay,gocardless,hyperswitch_vault,stax,stripe"
 payout_connector_list = "nomupay,stripe,wise"
 
 # Connector configuration, provided attributes will be used to fulfill API requests.

--- a/config/deployments/sandbox.toml
+++ b/config/deployments/sandbox.toml
@@ -15,7 +15,7 @@ open_banking_uk.adyen.banks = "aib,bank_of_scotland,danske_bank,first_direct,fir
 przelewy24.stripe.banks = "alior_bank,bank_millennium,bank_nowy_bfg_sa,bank_pekao_sa,banki_spbdzielcze,blik,bnp_paribas,boz,citi,credit_agricole,e_transfer_pocztowy24,getin_bank,idea_bank,inteligo,mbank_mtransfer,nest_przelew,noble_pay,pbac_z_ipko,plus_bank,santander_przelew24,toyota_bank,volkswagen_bank"
 
 [connector_customer]
-connector_list = "adyen,authorizedotnet,facilitapay,gocardless,hyperswitch_vault,stax,stripe"
+connector_list = "authorizedotnet,facilitapay,gocardless,hyperswitch_vault,stax,stripe"
 payout_connector_list = "nomupay,stripe,wise"
 
 # Connector configuration, provided attributes will be used to fulfill API requests.

--- a/config/development.toml
+++ b/config/development.toml
@@ -957,7 +957,7 @@ nexixpay = { payment_method = "card" }
 redsys = { payment_method = "card" }
 
 [connector_customer]
-connector_list = "adyen,authorizedotnet,facilitapay,gocardless,hyperswitch_vault,stax,stripe"
+connector_list = "authorizedotnet,facilitapay,gocardless,hyperswitch_vault,stax,stripe"
 payout_connector_list = "nomupay,stripe,wise"
 
 [dummy_connector]

--- a/config/docker_compose.toml
+++ b/config/docker_compose.toml
@@ -958,7 +958,7 @@ card.debit = { connector_list = "cybersource" }
 connector_list = "adyen,archipel,cybersource,novalnet,stripe,worldpay,worldpayvantiv"
 
 [connector_customer]
-connector_list = "adyen,authorizedotnet,facilitapay,gocardless,hyperswitch_vault,stax,stripe"
+connector_list = "authorizedotnet,facilitapay,gocardless,hyperswitch_vault,stax,stripe"
 payout_connector_list = "nomupay,stripe,wise"
 
 

--- a/crates/router/src/core/payments/customers.rs
+++ b/crates/router/src/core/payments/customers.rs
@@ -87,15 +87,16 @@ pub fn should_call_connector_create_customer<'a>(
         .connector_customer
         .connector_list
         .contains(&connector.connector_name);
-
+    let connector_customer_details = customer
+        .as_ref()
+        .and_then(|customer| customer.get_connector_customer_id(connector_label));
     if connector_needs_customer {
-        let connector_customer_details = customer
-            .as_ref()
-            .and_then(|customer| customer.get_connector_customer_id(connector_label));
         let should_call_connector = connector_customer_details.is_none();
         (should_call_connector, connector_customer_details)
     } else {
-        (false, None)
+        // Populates connector_customer_id if it is present after data migration
+        // For connector which does not have create connector customer flow
+        (false, connector_customer_details)
     }
 }
 

--- a/loadtest/config/development.toml
+++ b/loadtest/config/development.toml
@@ -639,7 +639,7 @@ billwerk = { long_lived_token = false, payment_method = "card" }
 globalpay = { long_lived_token = false, payment_method = "card", flow = "mandates" }
 
 [connector_customer]
-connector_list = "adyen,authorizedotnet,facilitapay,gocardless,hyperswitch_vault,stax,stripe"
+connector_list = "authorizedotnet,facilitapay,gocardless,hyperswitch_vault,stax,stripe"
 payout_connector_list = "nomupay,wise"
 
 [dummy_connector]


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->

- We were required to populate connector_customer_id after merchant migrates the data (data having connector_customer_id) in shopper_reference_id (customer_id for Adyen).

- But connector_customer_id gets populated in router_data only for connectors listed under:
```
[connector_customer]
connector_list = "adyen,facilitapay,gocardless,hyperswitch_vault,stax,stripe"

```
To ensure the value gets populated for Adyen (to populate in shopper_reference), we added Adyen to this list.

-  3.  But this list also controls whether the `CreateConnectorCustomer` flow is automatically triggered for the mentioned connectors. As a result, for every Adyen payment, the system attempts to trigger `CreateConnectorCustomer`, which is not implemented for Adyen.

 This caused the error to be repeatedly logged from `crates/router/src/core/payments/customers.rs`  line 69, but payments are still successful.
```
let connector_customer_id = match resp.response {
        Ok(response) => match response {
            types::PaymentsResponseData::ConnectorCustomerResponse {
                connector_customer_id,
            } => Some(connector_customer_id),
            _ => None,
        },
        Err(err) => {
            logger::error!(create_connector_customer_error=?err);
            None
        }
    };
```
In this PR, the dependency of `connector_customer_id` on connector_customer `config` for getting populated in RouterData  is been removed and also `Adyen` is removed from connector_customer config, which will prevent createConnectorCustomer flow getting triggered for Adyen, but still we can use `connector_customer_id` (if present after data migration).

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

<img width="1461" height="975" alt="Screenshot 2025-08-13 at 4 04 17 PM" src="https://github.com/user-attachments/assets/d11a7d64-9d27-4dbe-98d5-a8d122a850e0" />

2/31 failed

In main, 4/31 failed:
<img width="1277" height="1055" alt="Screenshot 2025-08-13 at 4 06 08 PM" src="https://github.com/user-attachments/assets/d86a7662-8408-4ae2-9cc9-6c0cc717e890" />


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
