### PR TITLE
fix(common_utils): Prevent logging sensitive information on deserialization failure

### DIFF
--- a/crates/common_utils/src/ext_traits.rs
+++ b/crates/common_utils/src/ext_traits.rs
@@ -175,7 +175,7 @@ impl BytesExt for bytes::Bytes {
             .change_context(errors::ParsingError::StructParseFailure(type_name))
             .attach_printable_lazy(|| {
                 let variable_type = std::any::type_name::<T>();
-                let value = serde_json::from_slice::<serde_json::Value>(&self)
+                let value = serde_json::from_slice::<serde_json::Value>(self)
                     .unwrap_or_else(|_| serde_json::Value::String(String::new()));
 
                 format!(
@@ -209,7 +209,7 @@ impl ByteSliceExt for [u8] {
         serde_json::from_slice(self)
             .change_context(errors::ParsingError::StructParseFailure(type_name))
             .attach_printable_lazy(|| {
-                let value = serde_json::from_slice::<serde_json::Value>(&self)
+                let value = serde_json::from_slice::<serde_json::Value>(self)
                     .unwrap_or_else(|_| serde_json::Value::String(String::new()));
 
                 format!(


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
- Modified `parse_value` method in `ValueExt` trait to log the JSON object after masking on deserialization failure.
- Modified `parse_struct` method in `BytesExt`, `ByteSliceExt` and `StringExt` to log values after converting them into a `serde_json::Value` and then masking

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
Closes #8969 

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Tested by supplying malformed data to the method and verified it logs data after masking.

Object:
<img width="1079" height="49" alt="image" src="https://github.com/user-attachments/assets/a7f917af-b356-475d-b3d8-c29fcae29fc0" />

String:
<img width="1079" height="47" alt="image" src="https://github.com/user-attachments/assets/d009c43d-f114-4d0b-bda2-4fc8797ee45d" />

Array:
<img width="728" height="47" alt="image" src="https://github.com/user-attachments/assets/10929436-aec4-45ef-bec3-8f653dc48cb3" />


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
