### PR TITLE
fix(redis): add support for fetching multiple keys for redis cluster

### DIFF
--- a/crates/redis_interface/src/commands.rs
+++ b/crates/redis_interface/src/commands.rs
@@ -198,6 +198,7 @@ impl super::RedisConnectionPool {
         }
     }
 
+    #[instrument(level = "DEBUG", skip(self))]
     async fn get_multiple_keys_with_mget<V>(
         &self,
         keys: &[RedisKey],
@@ -217,6 +218,7 @@ impl super::RedisConnectionPool {
             .change_context(errors::RedisError::GetFailed)
     }
 
+    #[instrument(level = "DEBUG", skip(self))]
     async fn get_multiple_keys_with_parallel_get<V>(
         &self,
         keys: &[RedisKey],
@@ -243,6 +245,7 @@ impl super::RedisConnectionPool {
     }
 
     /// Helper method to encapsulate the logic for choosing between cluster and non-cluster modes
+    #[instrument(level = "DEBUG", skip(self))]
     async fn get_keys_by_mode<V>(
         &self,
         keys: &[RedisKey],

--- a/crates/redis_interface/src/lib.rs
+++ b/crates/redis_interface/src/lib.rs
@@ -237,6 +237,7 @@ pub struct RedisConfig {
     default_ttl: u32,
     default_stream_read_count: u64,
     default_hash_ttl: u32,
+    cluster_enabled: bool,
 }
 
 impl From<&RedisSettings> for RedisConfig {
@@ -245,6 +246,7 @@ impl From<&RedisSettings> for RedisConfig {
             default_ttl: config.default_ttl,
             default_stream_read_count: config.stream_read_count,
             default_hash_ttl: config.default_hash_ttl,
+            cluster_enabled: config.cluster_enabled,
         }
     }
 }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
added support for fetching multiple keys for redis cluster.

Earlier, we were using `mget` to fetch multiple keys. While this works fine for standalone redis, it would fail for redis cluster(it won't work if redis keys are stored in multiple hash slots).


So, introduced a new redis interface function to use `mget` for standalone redis and parallel `get` calls for cluster redis.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
test cases same as this PR: https://github.com/juspay/hyperswitch/pull/8887

Tested in an internal environment with redis cluster setup enabled.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
