### PR TITLE
feat(router): Add payment_type to Get Intent response (v2)

### DIFF
--- a/api-reference/v2/openapi_spec_v2.json
+++ b/api-reference/v2/openapi_spec_v2.json
@@ -19157,7 +19157,8 @@
           "payment_link_enabled",
           "request_incremental_authorization",
           "expires_on",
-          "request_external_three_ds_authentication"
+          "request_external_three_ds_authentication",
+          "payment_type"
         ],
         "properties": {
           "id": {
@@ -19318,6 +19319,9 @@
           },
           "request_external_three_ds_authentication": {
             "$ref": "#/components/schemas/External3dsAuthenticationRequest"
+          },
+          "payment_type": {
+            "$ref": "#/components/schemas/PaymentType"
           }
         },
         "additionalProperties": false

--- a/crates/api_models/src/payments.rs
+++ b/crates/api_models/src/payments.rs
@@ -654,6 +654,10 @@ pub struct PaymentsIntentResponse {
     /// Whether to perform external authentication (if applicable)
     #[schema(value_type = External3dsAuthenticationRequest)]
     pub request_external_three_ds_authentication: common_enums::External3dsAuthenticationRequest,
+
+    /// The type of the payment that differentiates between normal and various types of mandate payments
+    #[schema(value_type = PaymentType)]
+    pub payment_type: api_enums::PaymentType,
 }
 
 #[cfg(feature = "v2")]

--- a/crates/router/src/core/payments/transformers.rs
+++ b/crates/router/src/core/payments/transformers.rs
@@ -2147,7 +2147,7 @@ where
         let payment_intent = payment_data.get_payment_intent();
         let client_secret = payment_data.get_client_secret();
 
-        let is_cit_transaction = payment_intent.setup_future_usage.is_off_session()
+        let is_cit_transaction = payment_intent.setup_future_usage.is_off_session();
 
         let mandate_type = if payment_intent.customer_present
             == common_enums::PresenceOfCustomerDuringPayment::Absent

--- a/crates/router/src/core/payments/transformers.rs
+++ b/crates/router/src/core/payments/transformers.rs
@@ -2147,8 +2147,7 @@ where
         let payment_intent = payment_data.get_payment_intent();
         let client_secret = payment_data.get_client_secret();
 
-        let is_cit_transaction =
-            payment_intent.setup_future_usage == common_enums::FutureUsage::OffSession;
+        let is_cit_transaction = payment_intent.setup_future_usage.is_off_session()
 
         let mandate_type = if payment_intent.customer_present
             == common_enums::PresenceOfCustomerDuringPayment::Absent


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
- Add `payment_type` to Payments Get Intent response

### Additional Changes

- [x] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
Closes #9065 

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

Request:
```
curl --location 'http://localhost:8080/v2/payments/create-intent' \
--header 'api-key: dev_5DkqRwXafcKhIFXyzwGtSjrnqsQuFWELuWJsepMgoRrjY1AxF7lhtNGeeja9BEHt' \
--header 'Content-Type: application/json' \
--header 'x-profile-id: pro_RAH6QGkLhuQfmi97QhPZ' \
--header 'Authorization: api-key=dev_5DkqRwXafcKhIFXyzwGtSjrnqsQuFWELuWJsepMgoRrjY1AxF7lhtNGeeja9BEHt' \
--data-raw '{
	"amount_details": {
		"order_amount": 1000,
		"currency": "USD"
	},
	"capture_method": "automatic",
	"authentication_type": "three_ds",
	"order_details": [
		{
			"product_name": "Apple iphone 15",
			"quantity": 1,
			"amount": 1000
		}
	],
	"billing": {
		"address": {
			"line1": "1467",
			"line2": "Harrison Street",
			"line3": "Harrison Street",
			"city": "San Fransico",
			"state": "California",
			"zip": "94122",
			"country": "US",
			"first_name": "joseph",
			"last_name": "Doe"
		},
		"phone": {
			"number": "123456789",
			"country_code": "+1"
		},
		"email": "user@gmail.com"
	},
	"shipping": {
		"address": {
			"first_name": "John",
			"last_name": "Dough",
			"city": "Karwar",
			"zip": "571201",
			"state": "California",
			"country": "US"
		},
		"email": "example@example.com",
		"phone": {
			"number": "123456789",
			"country_code": "+1"
		}
	},
    
	"customer_id": "12345_cus_0198e5ff10ea7622abbf89f383110c99"
}'
```

Response:

```json
{
    "id": "12345_pay_0198e5ff18b77a63ab0e91be36d6f9b7",
    "status": "requires_payment_method",
    "amount_details": {
        "order_amount": 1000,
        "currency": "USD",
        "shipping_cost": null,
        "order_tax_amount": null,
        "external_tax_calculation": "skip",
        "surcharge_calculation": "skip",
        "surcharge_amount": null,
        "tax_on_surcharge": null
    },
    "client_secret": "cs_0198e5ff18c57d729ec8fbbb03141331",
    "profile_id": "pro_RAH6QGkLhuQfmi97QhPZ",
    "merchant_reference_id": null,
    "routing_algorithm_id": null,
    "capture_method": "automatic",
    "authentication_type": "three_ds",
    "billing": {
        "address": {
            "city": "San Fransico",
            "country": "US",
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "zip": "94122",
            "state": "California",
            "first_name": "joseph",
            "last_name": "Doe",
            "origin_zip": null
        },
        "phone": {
            "number": "123456789",
            "country_code": "+1"
        },
        "email": "user@gmail.com"
    },
    "shipping": {
        "address": {
            "city": "Karwar",
            "country": "US",
            "line1": null,
            "line2": null,
            "line3": null,
            "zip": "571201",
            "state": "California",
            "first_name": "John",
            "last_name": "Dough",
            "origin_zip": null
        },
        "phone": {
            "number": "123456789",
            "country_code": "+1"
        },
        "email": "example@example.com"
    },
    "customer_id": "12345_cus_0198e5ff10ea7622abbf89f383110c99",
    "customer_present": "present",
    "description": null,
    "return_url": null,
    "setup_future_usage": "on_session",
    "apply_mit_exemption": "Skip",
    "statement_descriptor": null,
    "order_details": [
        {
            "product_name": "Apple iphone 15",
            "quantity": 1,
            "amount": 1000,
            "tax_rate": null,
            "total_tax_amount": null,
            "requires_shipping": null,
            "product_img_link": null,
            "product_id": null,
            "category": null,
            "sub_category": null,
            "brand": null,
            "product_type": null,
            "product_tax_code": null,
            "description": null,
            "sku": null,
            "upc": null,
            "commodity_code": null,
            "unit_of_measure": null,
            "total_amount": null,
            "unit_discount_amount": null
        }
    ],
    "allowed_payment_method_types": null,
    "metadata": null,
    "connector_metadata": null,
    "feature_metadata": null,
    "payment_link_enabled": "Skip",
    "payment_link_config": null,
    "request_incremental_authorization": "false",
    "expires_on": "2025-08-26T11:04:17.247Z",
    "frm_metadata": null,
    "request_external_three_ds_authentication": "Skip",
    "payment_type": "normal"
}
```

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
