### PR TITLE
fix(users): add bad request for openidconnect

### DIFF
--- a/crates/router/src/services/openidconnect.rs
+++ b/crates/router/src/services/openidconnect.rs
@@ -76,9 +76,13 @@ pub async fn get_user_email_from_oidc_provider(
         .exchange_code(oidc::AuthorizationCode::new(authorization_code.expose()))
         .request_async(|req| get_oidc_reqwest_client(state, req))
         .await
-        .map_err(|e| match e { 
-            oidc::RequestTokenError::ServerResponse(resp) if resp.error() == &oidc_core::CoreErrorResponseType::InvalidGrant => UserErrors::SSOFailed,
-            _ => UserErrors::InternalServerError
+        .map_err(|e| match e {
+            oidc::RequestTokenError::ServerResponse(resp)
+                if resp.error() == &oidc_core::CoreErrorResponseType::InvalidGrant =>
+            {
+                UserErrors::SSOFailed
+            }
+            _ => UserErrors::InternalServerError,
         })
         .attach_printable("Failed to exchange code and fetch oidc token")?;
 

--- a/crates/router/src/services/openidconnect.rs
+++ b/crates/router/src/services/openidconnect.rs
@@ -76,7 +76,10 @@ pub async fn get_user_email_from_oidc_provider(
         .exchange_code(oidc::AuthorizationCode::new(authorization_code.expose()))
         .request_async(|req| get_oidc_reqwest_client(state, req))
         .await
-        .change_context(UserErrors::InternalServerError)
+        .map_err(|e| match e { 
+            oidc::RequestTokenError::ServerResponse(resp) if resp.error() == &oidc_core::CoreErrorResponseType::InvalidGrant => UserErrors::SSOFailed,
+            _ => UserErrors::InternalServerError
+        })
         .attach_printable("Failed to exchange code and fetch oidc token")?;
 
     // Fetch id token from response


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
Added a BadRequest response for SSO login when an invalid authorization code is provided.
<!-- Describe your changes in detail -->


### Additional Changes

- [X] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
Currently, when users provide an invalid or expired code during SSO login, the system returns a 500 response. This is misleading, as the issue is with the client input rather than a server error. This change introduces a proper 400 BadRequest response to better reflect the actual problem and improve error handling.
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
```sh
curl --location '<BASE URL>/user/oidc' \
--header 'Content-Type: application/json' \
--data '{
    "state": "<correct state>",
    "code": "<wrong code>"
}'
```
This should give `400` instead of 500.

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [X] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
