### PR TITLE
refactor: alter subscription table to update primary key

### DIFF
--- a/crates/diesel_models/src/schema.rs
+++ b/crates/diesel_models/src/schema.rs
@@ -1469,8 +1469,7 @@ diesel::table! {
     use diesel::sql_types::*;
     use crate::enums::diesel_exports::*;
 
-    subscription (id) {
-        id -> Int4,
+    subscription (subscription_id, merchant_id) {
         #[max_length = 128]
         subscription_id -> Varchar,
         #[max_length = 128]
@@ -1480,7 +1479,7 @@ diesel::table! {
         #[max_length = 128]
         payment_method_id -> Nullable<Varchar>,
         #[max_length = 128]
-        mca_id -> Nullable<Varchar>,
+        merchant_connector_id -> Nullable<Varchar>,
         #[max_length = 128]
         client_secret -> Nullable<Varchar>,
         #[max_length = 128]
@@ -1492,6 +1491,8 @@ diesel::table! {
         metadata -> Nullable<Jsonb>,
         created_at -> Timestamp,
         modified_at -> Timestamp,
+        #[max_length = 128]
+        profile_id -> Varchar,
     }
 }
 

--- a/crates/diesel_models/src/schema_v2.rs
+++ b/crates/diesel_models/src/schema_v2.rs
@@ -1404,8 +1404,7 @@ diesel::table! {
     use diesel::sql_types::*;
     use crate::enums::diesel_exports::*;
 
-    subscription (id) {
-        id -> Int4,
+    subscription (subscription_id, merchant_id) {
         #[max_length = 128]
         subscription_id -> Varchar,
         #[max_length = 128]
@@ -1415,7 +1414,7 @@ diesel::table! {
         #[max_length = 128]
         payment_method_id -> Nullable<Varchar>,
         #[max_length = 128]
-        mca_id -> Nullable<Varchar>,
+        merchant_connector_id -> Nullable<Varchar>,
         #[max_length = 128]
         client_secret -> Nullable<Varchar>,
         #[max_length = 128]
@@ -1427,6 +1426,8 @@ diesel::table! {
         metadata -> Nullable<Jsonb>,
         created_at -> Timestamp,
         modified_at -> Timestamp,
+        #[max_length = 128]
+        profile_id -> Varchar,
     }
 }
 

--- a/crates/diesel_models/src/subscription.rs
+++ b/crates/diesel_models/src/subscription.rs
@@ -11,7 +11,7 @@ pub struct SubscriptionNew {
     status: String,
     billing_processor: Option<String>,
     payment_method_id: Option<String>,
-    mca_id: Option<String>,
+    merchant_connector_id: Option<String>,
     client_secret: Option<String>,
     connector_subscription_id: Option<String>,
     merchant_id: common_utils::id_type::MerchantId,
@@ -19,20 +19,19 @@ pub struct SubscriptionNew {
     metadata: Option<SecretSerdeValue>,
     created_at: time::PrimitiveDateTime,
     modified_at: time::PrimitiveDateTime,
+    profile_id: common_utils::id_type::ProfileId,
 }
 
 #[derive(
     Clone, Debug, Eq, PartialEq, Identifiable, Queryable, Selectable, Deserialize, Serialize,
 )]
-#[diesel(table_name = subscription, primary_key(id), check_for_backend(diesel::pg::Pg))]
+#[diesel(table_name = subscription, primary_key(subscription_id, merchant_id), check_for_backend(diesel::pg::Pg))]
 pub struct Subscription {
-    #[serde(skip_serializing, skip_deserializing)]
-    pub id: i32,
     pub subscription_id: String,
     pub status: String,
     pub billing_processor: Option<String>,
     pub payment_method_id: Option<String>,
-    pub mca_id: Option<String>,
+    pub merchant_connector_id: Option<String>,
     pub client_secret: Option<String>,
     pub connector_subscription_id: Option<String>,
     pub merchant_id: common_utils::id_type::MerchantId,
@@ -40,6 +39,7 @@ pub struct Subscription {
     pub metadata: Option<serde_json::Value>,
     pub created_at: time::PrimitiveDateTime,
     pub modified_at: time::PrimitiveDateTime,
+    profile_id: common_utils::id_type::ProfileId,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, AsChangeset, router_derive::DebugAsDisplay, Deserialize)]
@@ -57,12 +57,13 @@ impl SubscriptionNew {
         status: String,
         billing_processor: Option<String>,
         payment_method_id: Option<String>,
-        mca_id: Option<String>,
+        merchant_connector_id: Option<String>,
         client_secret: Option<String>,
         connector_subscription_id: Option<String>,
         merchant_id: common_utils::id_type::MerchantId,
         customer_id: common_utils::id_type::CustomerId,
         metadata: Option<SecretSerdeValue>,
+        profile_id: common_utils::id_type::ProfileId,
     ) -> Self {
         let now = common_utils::date_time::now();
         Self {
@@ -70,7 +71,7 @@ impl SubscriptionNew {
             status,
             billing_processor,
             payment_method_id,
-            mca_id,
+            merchant_connector_id,
             client_secret,
             connector_subscription_id,
             merchant_id,
@@ -78,6 +79,7 @@ impl SubscriptionNew {
             metadata,
             created_at: now,
             modified_at: now,
+            profile_id,
         }
     }
 }

--- a/migrations/2025-09-04-063109_update_subscription_table_with_profile_id/down.sql
+++ b/migrations/2025-09-04-063109_update_subscription_table_with_profile_id/down.sql
@@ -1,0 +1,12 @@
+ALTER TABLE subscription
+    DROP CONSTRAINT IF EXISTS subscription_pkey,
+    DROP COLUMN IF EXISTS profile_id,
+    ADD COLUMN IF NOT EXISTS id SERIAL,
+    ALTER COLUMN id SET NOT NULL,
+    ADD CONSTRAINT subscription_pkey PRIMARY KEY (id);
+
+ALTER TABLE subscription
+    RENAME COLUMN merchant_connector_id TO mca_id;
+
+CREATE UNIQUE INDEX IF NOT EXISTS merchant_subscription_unique_index
+    ON subscription (merchant_id, subscription_id);

--- a/migrations/2025-09-04-063109_update_subscription_table_with_profile_id/up.sql
+++ b/migrations/2025-09-04-063109_update_subscription_table_with_profile_id/up.sql
@@ -1,0 +1,10 @@
+DROP INDEX IF EXISTS merchant_subscription_unique_index;
+
+ALTER TABLE subscription
+    DROP CONSTRAINT IF EXISTS subscription_pkey,
+    DROP COLUMN IF EXISTS id,
+    ADD COLUMN IF NOT EXISTS profile_id VARCHAR(128) NOT NULL,
+    ADD CONSTRAINT subscription_pkey PRIMARY KEY (subscription_id, merchant_id);
+
+ALTER TABLE subscription
+    RENAME COLUMN mca_id TO merchant_connector_id;


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
This PR refactors the **`subscription` table schema** to improve key management and alignment with business requirements.  
Key updates include:
- Changed the **primary key** from `id` to a **composite key**: `(subscription_id, merchant_id)`.
- Removed the old `id` field as a primary identifier.
- Added a new field: `profile_id` (`VARCHAR(128) NOT NULL`) to support profile-specific subscription handling.
- Renamed `mca_id` → `merchant_connector_id` for better clarity and consistency across schema and model definitions.
- Updated associated Diesel models (`Subscription`, `SubscriptionNew`, `SubscriptionUpdate`) to reflect the schema changes.

## Outcomes
- Ensures **subscriptions are uniquely identified** by merchant and subscription ID, preventing conflicts across merchants.
- Introduces **profile-level granularity** for subscriptions, enabling better multi-profile support.
- Aligns field naming (`merchant_connector_id`) with domain terminology for consistency across codebase.
- Strengthens schema constraints to reduce risk of duplicate or inconsistent subscription entries.

## Diff Hunk Explanation
- **`crates/diesel_models/src/schema.rs` & `schema_v2.rs`**
  - Modified `subscription` table definition to use `(subscription_id, merchant_id)` as composite primary key.
  - Added new column `profile_id`.
  - Renamed column `mca_id` → `merchant_connector_id`.

- **`crates/diesel_models/src/subscription.rs`**
  - Updated structs (`Subscription`, `SubscriptionNew`) to drop old `id` field and include `profile_id`.
  - Renamed field `mca_id` → `merchant_connector_id`.
  - Updated Diesel annotations to reflect composite primary key.

- **Migrations**
  - `up.sql`: drops old PK, removes `id`, adds `profile_id`, sets composite PK, renames column.
  - `down.sql`: restores old structure with `id` as PK, removes `profile_id`, renames column back to `mca_id`.

This refactor lays the foundation for **robust subscription handling with merchant-profile level uniqueness**.



## How did you test it?
Its just migration PR won't require testing


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
