### PR TITLE
feat(connector): Add support for get plan prices for Chargebee

### DIFF
--- a/crates/hyperswitch_connectors/src/connectors/chargebee/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/chargebee/transformers.rs
@@ -15,8 +15,9 @@ use hyperswitch_domain_models::{
     },
     router_request_types::{revenue_recovery::RevenueRecoveryRecordBackRequest, ResponseId},
     router_response_types::{
-        revenue_recovery::RevenueRecoveryRecordBackResponse, PaymentsResponseData,
-        RefundsResponseData,
+        revenue_recovery::RevenueRecoveryRecordBackResponse,
+        subscriptions::{self, GetSubscriptionPlanPricesResponse},
+        PaymentsResponseData, RefundsResponseData,
     },
     types::{PaymentsAuthorizeRouterData, RefundsRouterData, RevenueRecoveryRecordBackRouterData},
 };
@@ -769,6 +770,106 @@ impl
             response: Ok(RevenueRecoveryRecordBackResponse {
                 merchant_reference_id,
             }),
+            ..item.data
+        })
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChargebeeGetPlanPricesResponse {
+    pub list: Vec<ChargebeeGetPlanPriceList>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChargebeeGetPlanPriceList {
+    pub item_price: ChargebeePlanPriceItem,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChargebeePlanPriceItem {
+    pub id: String,
+    pub name: String,
+    pub currency_code: String,
+    pub free_quantity: i64,
+    #[serde(default, with = "common_utils::custom_serde::timestamp::option")]
+    pub created_at: Option<PrimitiveDateTime>,
+    pub deleted: bool,
+    pub item_id: Option<String>,
+    pub period: i64,
+    pub period_unit: ChargebeePeriodUnit,
+    pub trial_period: Option<i64>,
+    pub trial_period_unit: ChargebeeTrialPeriodUnit,
+    pub price: MinorUnit,
+    pub pricing_model: ChargebeePricingModel,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum ChargebeePricingModel {
+    FlatFee,
+    PerUnit,
+    Tiered,
+    Volume,
+    Stairstep,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum ChargebeePeriodUnit {
+    Day,
+    Week,
+    Month,
+    Year,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum ChargebeeTrialPeriodUnit {
+    Day,
+    Month,
+}
+
+impl<F, T>
+    TryFrom<
+        ResponseRouterData<F, ChargebeeGetPlanPricesResponse, T, GetSubscriptionPlanPricesResponse>,
+    > for RouterData<F, T, GetSubscriptionPlanPricesResponse>
+{
+    type Error = error_stack::Report<errors::ConnectorError>;
+    fn try_from(
+        item: ResponseRouterData<
+            F,
+            ChargebeeGetPlanPricesResponse,
+            T,
+            GetSubscriptionPlanPricesResponse,
+        >,
+    ) -> Result<Self, Self::Error> {
+        let plan_prices = item
+            .response
+            .list
+            .into_iter()
+            .map(|prices| {
+                subscriptions::SubscriptionPlanPrices {
+                    price_id: prices.item_price.id,
+                    plan_id: prices.item_price.item_id,
+                    amount: prices.item_price.price,
+                    currency: <common_enums::Currency as std::str::FromStr>::from_str(
+                        &prices.item_price.currency_code,
+                    )
+                    .unwrap_or(common_enums::Currency::USD), // defaulting to USD if parsing fails
+                    interval: match prices.item_price.period_unit {
+                        ChargebeePeriodUnit::Day => subscriptions::PeriodUnit::Day,
+                        ChargebeePeriodUnit::Week => subscriptions::PeriodUnit::Week,
+                        ChargebeePeriodUnit::Month => subscriptions::PeriodUnit::Month,
+                        ChargebeePeriodUnit::Year => subscriptions::PeriodUnit::Year,
+                    },
+                    interval_count: prices.item_price.period,
+                    trial_period: prices.item_price.trial_period,
+                    trial_period_unit: match prices.item_price.trial_period_unit {
+                        ChargebeeTrialPeriodUnit::Day => Some(subscriptions::PeriodUnit::Day),
+                        ChargebeeTrialPeriodUnit::Month => Some(subscriptions::PeriodUnit::Month),
+                    },
+                }
+            })
+            .collect();
+        Ok(Self {
+            response: Ok(GetSubscriptionPlanPricesResponse { list: plan_prices }),
             ..item.data
         })
     }

--- a/crates/hyperswitch_domain_models/src/router_flow_types.rs
+++ b/crates/hyperswitch_domain_models/src/router_flow_types.rs
@@ -8,10 +8,10 @@ pub mod payments;
 pub mod payouts;
 pub mod refunds;
 pub mod revenue_recovery;
+pub mod subscriptions;
 pub mod unified_authentication_service;
 pub mod vault;
 pub mod webhooks;
-
 pub use access_token_auth::*;
 pub use dispute::*;
 pub use files::*;

--- a/crates/hyperswitch_domain_models/src/router_flow_types/subscriptions.rs
+++ b/crates/hyperswitch_domain_models/src/router_flow_types/subscriptions.rs
@@ -1,0 +1,2 @@
+#[derive(Debug, Clone)]
+pub struct GetSubscriptionPlanPrices;

--- a/crates/hyperswitch_domain_models/src/router_request_types.rs
+++ b/crates/hyperswitch_domain_models/src/router_request_types.rs
@@ -1,6 +1,7 @@
 pub mod authentication;
 pub mod fraud_check;
 pub mod revenue_recovery;
+pub mod subscriptions;
 pub mod unified_authentication_service;
 use api_models::payments::{AdditionalPaymentData, RequestSurchargeDetails};
 use common_types::payments as common_payments_types;

--- a/crates/hyperswitch_domain_models/src/router_request_types/subscriptions.rs
+++ b/crates/hyperswitch_domain_models/src/router_request_types/subscriptions.rs
@@ -1,0 +1,4 @@
+#[derive(Debug, Clone)]
+pub struct GetSubscriptionPlanPricesRequest {
+    pub item_id: String,
+}

--- a/crates/hyperswitch_domain_models/src/router_response_types.rs
+++ b/crates/hyperswitch_domain_models/src/router_response_types.rs
@@ -1,6 +1,7 @@
 pub mod disputes;
 pub mod fraud_check;
 pub mod revenue_recovery;
+pub mod subscriptions;
 use std::collections::HashMap;
 
 use common_utils::{pii, request::Method, types::MinorUnit};

--- a/crates/hyperswitch_domain_models/src/router_response_types/subscriptions.rs
+++ b/crates/hyperswitch_domain_models/src/router_response_types/subscriptions.rs
@@ -1,0 +1,26 @@
+use common_enums::Currency;
+
+#[derive(Debug, Clone)]
+pub struct GetSubscriptionPlanPricesResponse {
+    pub list: Vec<SubscriptionPlanPrices>,
+}
+
+#[derive(Debug, Clone)]
+pub struct SubscriptionPlanPrices {
+    pub price_id: String,
+    pub plan_id: Option<String>,
+    pub amount: common_utils::types::MinorUnit,
+    pub currency: Currency,
+    pub interval: PeriodUnit,
+    pub interval_count: i64,
+    pub trial_period: Option<i64>,
+    pub trial_period_unit: Option<PeriodUnit>,
+}
+
+#[derive(Debug, Clone)]
+pub enum PeriodUnit {
+    Day,
+    Week,
+    Month,
+    Year,
+}

--- a/crates/hyperswitch_domain_models/src/types.rs
+++ b/crates/hyperswitch_domain_models/src/types.rs
@@ -4,19 +4,21 @@ use crate::{
     router_data::{AccessToken, AccessTokenAuthenticationResponse, RouterData},
     router_data_v2::{self, RouterDataV2},
     router_flow_types::{
-        mandate_revoke::MandateRevoke, revenue_recovery::RecoveryRecordBack, AccessTokenAuth,
-        AccessTokenAuthentication, Authenticate, AuthenticationConfirmation, Authorize,
-        AuthorizeSessionToken, BillingConnectorInvoiceSync, BillingConnectorPaymentsSync,
-        CalculateTax, Capture, CompleteAuthorize, CreateConnectorCustomer, CreateOrder, Execute,
-        ExternalVaultProxy, IncrementalAuthorization, PSync, PaymentMethodToken, PostAuthenticate,
-        PostCaptureVoid, PostSessionTokens, PreAuthenticate, PreProcessing, RSync,
-        SdkSessionUpdate, Session, SetupMandate, UpdateMetadata, VerifyWebhookSource, Void,
+        mandate_revoke::MandateRevoke, revenue_recovery::RecoveryRecordBack,
+        subscriptions::GetSubscriptionPlanPrices, AccessTokenAuth, AccessTokenAuthentication,
+        Authenticate, AuthenticationConfirmation, Authorize, AuthorizeSessionToken,
+        BillingConnectorInvoiceSync, BillingConnectorPaymentsSync, CalculateTax, Capture,
+        CompleteAuthorize, CreateConnectorCustomer, CreateOrder, Execute, ExternalVaultProxy,
+        IncrementalAuthorization, PSync, PaymentMethodToken, PostAuthenticate, PostCaptureVoid,
+        PostSessionTokens, PreAuthenticate, PreProcessing, RSync, SdkSessionUpdate, Session,
+        SetupMandate, UpdateMetadata, VerifyWebhookSource, Void,
     },
     router_request_types::{
         revenue_recovery::{
             BillingConnectorInvoiceSyncRequest, BillingConnectorPaymentsSyncRequest,
             RevenueRecoveryRecordBackRequest,
         },
+        subscriptions::GetSubscriptionPlanPricesRequest,
         unified_authentication_service::{
             UasAuthenticationRequestData, UasAuthenticationResponseData,
             UasConfirmationRequestData, UasPostAuthenticationRequestData,
@@ -37,6 +39,7 @@ use crate::{
             BillingConnectorInvoiceSyncResponse, BillingConnectorPaymentsSyncResponse,
             RevenueRecoveryRecordBackResponse,
         },
+        subscriptions::GetSubscriptionPlanPricesResponse,
         MandateRevokeResponseData, PaymentsResponseData, RefundsResponseData,
         TaxCalculationResponseData, VaultResponseData, VerifyWebhookSourceResponseData,
     },
@@ -154,6 +157,12 @@ pub type RevenueRecoveryRecordBackRouterDataV2 = RouterDataV2<
     router_data_v2::flow_common_types::RevenueRecoveryRecordBackData,
     RevenueRecoveryRecordBackRequest,
     RevenueRecoveryRecordBackResponse,
+>;
+
+pub type GetSubscriptionPlanPricesRouterData = RouterData<
+    GetSubscriptionPlanPrices,
+    GetSubscriptionPlanPricesRequest,
+    GetSubscriptionPlanPricesResponse,
 >;
 
 pub type VaultRouterData<F> = RouterData<F, VaultRequestData, VaultResponseData>;

--- a/crates/hyperswitch_interfaces/src/types.rs
+++ b/crates/hyperswitch_interfaces/src/types.rs
@@ -16,6 +16,7 @@ use hyperswitch_domain_models::{
         },
         refunds::{Execute, RSync},
         revenue_recovery::{BillingConnectorPaymentsSync, RecoveryRecordBack},
+        subscriptions::GetSubscriptionPlanPrices,
         unified_authentication_service::{
             Authenticate, AuthenticationConfirmation, PostAuthenticate, PreAuthenticate,
         },
@@ -31,6 +32,7 @@ use hyperswitch_domain_models::{
             BillingConnectorInvoiceSyncRequest, BillingConnectorPaymentsSyncRequest,
             RevenueRecoveryRecordBackRequest,
         },
+        subscriptions::GetSubscriptionPlanPricesRequest,
         unified_authentication_service::{
             UasAuthenticationRequestData, UasAuthenticationResponseData,
             UasConfirmationRequestData, UasPostAuthenticationRequestData,
@@ -53,6 +55,7 @@ use hyperswitch_domain_models::{
             BillingConnectorInvoiceSyncResponse, BillingConnectorPaymentsSyncResponse,
             RevenueRecoveryRecordBackResponse,
         },
+        subscriptions::GetSubscriptionPlanPricesResponse,
         AcceptDisputeResponse, DefendDisputeResponse, DisputeSyncResponse, FetchDisputesResponse,
         MandateRevokeResponseData, PaymentsResponseData, RefundsResponseData, RetrieveFileResponse,
         SubmitEvidenceResponse, TaxCalculationResponseData, UploadFileResponse, VaultResponseData,
@@ -155,6 +158,13 @@ pub type IncrementalAuthorizationType = dyn ConnectorIntegration<
     IncrementalAuthorization,
     PaymentsIncrementalAuthorizationData,
     PaymentsResponseData,
+>;
+
+/// Type alias for ConnectorIntegration<GetSubscriptionPlanPrices, GetSubscriptionPlanPricesRequest, GetSubscriptionPlanPricesResponse>
+pub type GetSubscriptionPlanPricesType = dyn ConnectorIntegration<
+    GetSubscriptionPlanPrices,
+    GetSubscriptionPlanPricesRequest,
+    GetSubscriptionPlanPricesResponse,
 >;
 
 /// Type alias for `ConnectorIntegration<CreateConnectorCustomer, ConnectorCustomerData, PaymentsResponseData>`


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
This PR integrates the get plan prices endpoint for chargebee, required to be called in the respective API handler for the same (not yet implemented)

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
Closes #9054 

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
