### PR TITLE
fix(gitattributes): enforce LF for `.patch` files to avoid CRLF parsing errors on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 * text=auto
+*.patch text eol=lf


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->

This PR adds the following rule to `.gitattributes` to ensure `.patch` files always use LF line endings, regardless of developer OS:

```gitattributes
*.patch text eol=lf
```

This rule overrides Windows’ default `core.autocrlf` behavior and prevents errors during migration when Diesel’s patch parser encounters CRLF line endings.

**Additionally**: For developers who have already cloned the repository and whose `.patch` files may still have CRLF endings, this PR provides a workaround:

```bash
git checkout -- crates/diesel_models/drop_id.patch
```

This ensures the `.patch` file is re-checked-out with the correct LF line endings, without requiring a full reclone.

Closes: #9120

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->

Diesel’s migration runner fails on Windows because CRLF line endings corrupt the patch file format (e.g., `diff --git a/file.rs b/file.rs\r\n`), causing “invalid char in unquoted filename” parsing errors. By forcing LF endings for patch files via `.gitattributes`, this PR ensures cross-platform consistency and prevents migration failures.

Issue: #9120 

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
* Applied the change on a Windows environment with `core.autocrlf=true` and confirmed `.patch` files now use `\n` instead of `\r\n`.
* Ran `scripts/setup.sh` and verified that the migration runner no longer exits with code 1.
* Provided the `git checkout -- <patch>` fix to confirm re-checkout resets line endings to LF without recloning.


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible

### Additional Context 

**CRLF vs LF Line Endings Explained**

* **LF (Line Feed)** – used by Unix/Linux/macOS; represented by `\n`
* **CRLF (Carriage Return + Line Feed)** – used by Windows; represented by `\r\n`

Git’s `core.autocrlf=true` (Windows default) can introduce CRLF line endings on checkout and convert them back to LF on commit. Explicit `.gitattributes` configuration (`*.patch text eol=lf`) guarantees LF regardless of platform, preventing CRLF-related parsing issues.

---

