### PR TITLE
fix(connector): [adyenplatform] update error mapping

### DIFF
--- a/crates/hyperswitch_connectors/src/connectors/adyenplatform/transformers/payouts.rs
+++ b/crates/hyperswitch_connectors/src/connectors/adyenplatform/transformers/payouts.rs
@@ -205,7 +205,7 @@ pub enum AdyenTransactionDirection {
     Outgoing,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, strum::Display)]
 #[serde(rename_all = "lowercase")]
 pub enum AdyenTransferStatus {
     Authorised,
@@ -581,10 +581,27 @@ impl<F> TryFrom<PayoutsResponseRouterData<F, AdyenTransferResponse>> for Payouts
         let response: AdyenTransferResponse = item.response;
         let status = enums::PayoutStatus::from(response.status);
 
-        let error_code = match status {
-            enums::PayoutStatus::Ineligible => Some(response.reason),
-            _ => None,
-        };
+        if matches!(status, enums::PayoutStatus::Failed) {
+            return Ok(Self {
+                response: Err(hyperswitch_domain_models::router_data::ErrorResponse {
+                    code: response.status.to_string(),
+                    message: if !response.reason.is_empty() {
+                        response.reason
+                    } else {
+                        response.status.to_string()
+                    },
+                    reason: None,
+                    status_code: item.http_code,
+                    attempt_status: None,
+                    connector_transaction_id: Some(response.id),
+                    network_advice_code: None,
+                    network_decline_code: None,
+                    network_error_message: None,
+                    connector_metadata: None,
+                }),
+                ..item.data
+            });
+        }
 
         Ok(Self {
             response: Ok(types::PayoutsResponseData {
@@ -592,7 +609,7 @@ impl<F> TryFrom<PayoutsResponseRouterData<F, AdyenTransferResponse>> for Payouts
                 connector_payout_id: Some(response.id),
                 payout_eligible: None,
                 should_add_next_step_to_process_tracker: false,
-                error_code,
+                error_code: None,
                 error_message: None,
             }),
             ..item.data
@@ -604,8 +621,7 @@ impl From<AdyenTransferStatus> for enums::PayoutStatus {
     fn from(adyen_status: AdyenTransferStatus) -> Self {
         match adyen_status {
             AdyenTransferStatus::Authorised => Self::Initiated,
-            AdyenTransferStatus::Refused => Self::Ineligible,
-            AdyenTransferStatus::Error => Self::Failed,
+            AdyenTransferStatus::Error | AdyenTransferStatus::Refused => Self::Failed,
         }
     }
 }

--- a/crates/router/src/core/payouts.rs
+++ b/crates/router/src/core/payouts.rs
@@ -705,14 +705,6 @@ pub async fn payouts_fulfill_core(
     .await
     .attach_printable("Payout fulfillment failed for given Payout request")?;
 
-    if helpers::is_payout_err_state(status) {
-        return Err(report!(errors::ApiErrorResponse::PayoutFailed {
-            data: Some(
-                serde_json::json!({"payout_status": status.to_string(), "error_message": payout_attempt.error_message, "error_code": payout_attempt.error_code})
-            ),
-        }));
-    }
-
     trigger_webhook_and_handle_response(&state, &merchant_context, &payout_data).await
 }
 
@@ -1324,9 +1316,65 @@ pub async fn create_recipient(
                         .attach_printable("Error updating payouts in db")?;
                 }
             }
-            Err(err) => Err(errors::ApiErrorResponse::PayoutFailed {
-                data: serde_json::to_value(err).ok(),
-            })?,
+            Err(err) => {
+                let status = storage_enums::PayoutStatus::Failed;
+                let (error_code, error_message) = (Some(err.code), Some(err.message));
+                let (unified_code, unified_message) = helpers::get_gsm_record(
+                    state,
+                    error_code.clone(),
+                    error_message.clone(),
+                    payout_data.payout_attempt.connector.clone(),
+                    consts::PAYOUT_FLOW_STR,
+                )
+                .await
+                .map_or(
+                    (
+                        Some(crate::consts::DEFAULT_UNIFIED_ERROR_CODE.to_string()),
+                        Some(crate::consts::DEFAULT_UNIFIED_ERROR_MESSAGE.to_string()),
+                    ),
+                    |gsm| (gsm.unified_code, gsm.unified_message),
+                );
+                let updated_payout_attempt = storage::PayoutAttemptUpdate::StatusUpdate {
+                    connector_payout_id: payout_data.payout_attempt.connector_payout_id.to_owned(),
+                    status,
+                    error_code,
+                    error_message,
+                    is_eligible: None,
+                    unified_code: unified_code
+                        .map(UnifiedCode::try_from)
+                        .transpose()
+                        .change_context(errors::ApiErrorResponse::InvalidDataValue {
+                            field_name: "unified_code",
+                        })?,
+                    unified_message: unified_message
+                        .map(UnifiedMessage::try_from)
+                        .transpose()
+                        .change_context(errors::ApiErrorResponse::InvalidDataValue {
+                            field_name: "unified_message",
+                        })?,
+                };
+                let db = &*state.store;
+                payout_data.payout_attempt = db
+                    .update_payout_attempt(
+                        &payout_data.payout_attempt,
+                        updated_payout_attempt,
+                        &payout_data.payouts,
+                        merchant_context.get_merchant_account().storage_scheme,
+                    )
+                    .await
+                    .change_context(errors::ApiErrorResponse::InternalServerError)
+                    .attach_printable("Error updating payout_attempt in db")?;
+                payout_data.payouts = db
+                    .update_payout(
+                        &payout_data.payouts,
+                        storage::PayoutsUpdate::StatusUpdate { status },
+                        &payout_data.payout_attempt,
+                        merchant_context.get_merchant_account().storage_scheme,
+                    )
+                    .await
+                    .change_context(errors::ApiErrorResponse::InternalServerError)
+                    .attach_printable("Error updating payouts in db")?;
+            }
         }
     }
     Ok(())
@@ -1371,10 +1419,8 @@ pub async fn complete_payout_eligibility(
             .is_eligible
             .unwrap_or(state.conf.payouts.payout_eligibility),
         || {
-            Err(report!(errors::ApiErrorResponse::PayoutFailed {
-                data: Some(serde_json::json!({
-                    "message": "Payout method data is invalid"
-                }))
+            Err(report!(errors::ApiErrorResponse::InvalidRequestData {
+                message: "Payout method data is invalid".to_string(),
             })
             .attach_printable("Payout data provided is invalid"))
         },
@@ -1454,13 +1500,6 @@ pub async fn check_payout_eligibility(
                 .await
                 .change_context(errors::ApiErrorResponse::InternalServerError)
                 .attach_printable("Error updating payouts in db")?;
-            if helpers::is_payout_err_state(status) {
-                return Err(report!(errors::ApiErrorResponse::PayoutFailed {
-                    data: Some(
-                        serde_json::json!({"payout_status": status.to_string(), "error_message": payout_data.payout_attempt.error_message.as_ref(), "error_code": payout_data.payout_attempt.error_code.as_ref()})
-                    ),
-                }));
-            }
         }
         Err(err) => {
             let status = storage_enums::PayoutStatus::Failed;
@@ -1676,13 +1715,6 @@ pub async fn create_payout(
                 .await
                 .change_context(errors::ApiErrorResponse::InternalServerError)
                 .attach_printable("Error updating payouts in db")?;
-            if helpers::is_payout_err_state(status) {
-                return Err(report!(errors::ApiErrorResponse::PayoutFailed {
-                    data: Some(
-                        serde_json::json!({"payout_status": status.to_string(), "error_message": payout_data.payout_attempt.error_message.as_ref(), "error_code": payout_data.payout_attempt.error_code.as_ref()})
-                    ),
-                }));
-            }
         }
         Err(err) => {
             let status = storage_enums::PayoutStatus::Failed;
@@ -2407,13 +2439,7 @@ pub async fn fulfill_payout(
                 .await
                 .change_context(errors::ApiErrorResponse::InternalServerError)
                 .attach_printable("Error updating payouts in db")?;
-            if helpers::is_payout_err_state(status) {
-                return Err(report!(errors::ApiErrorResponse::PayoutFailed {
-                    data: Some(
-                        serde_json::json!({"payout_status": status.to_string(), "error_message": payout_data.payout_attempt.error_message.as_ref(), "error_code": payout_data.payout_attempt.error_code.as_ref()})
-                    ),
-                }));
-            } else if payout_data.payouts.recurring
+            if payout_data.payouts.recurring
                 && payout_data.payouts.payout_method_id.clone().is_none()
             {
                 let payout_method_data = payout_data


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->

This PR fixes two critical issues in Adyen Platform connector and payout core flow error handling:

1. **Enhanced error message construction**: Modified `build_error_response` in `crates/hyperswitch_connectors/src/connectors/adyenplatform.rs` to include the `detail` field when `invalid_fields` is not present. This provides users with comprehensive error information, especially for business logic errors where Adyen provides detailed explanations.

2. **Fixed improper PayoutFailed usage**: Removed multiple instances of `PayoutFailed` from core payouts flow that were being thrown after connector calls. This was bypassing proper connector error handling and preventing detailed error messages from reaching the API response.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

This PR allows mapping the right error codes and messages from Adyenplatform to HyperSwitch's payout API response in case of failures.

**Solution**:
This change ensures that all available error information from Adyen is properly communicated to users, improving the debugging experience and reducing support overhead.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible