### PR TITLE
ci(migration-check): install rustfmt to address migration run failures

### DIFF
--- a/.github/workflows/migration-check.yaml
+++ b/.github/workflows/migration-check.yaml
@@ -55,6 +55,7 @@ jobs:
       - uses: baptiste0928/cargo-install@v3.3.0
         with:
           crate: diesel_cli
+          version: 2.2.12
           features: postgres
           args: --no-default-features
 

--- a/.github/workflows/migration-check.yaml
+++ b/.github/workflows/migration-check.yaml
@@ -55,7 +55,6 @@ jobs:
       - uses: baptiste0928/cargo-install@v3.3.0
         with:
           crate: diesel_cli
-          version: 2.2.12
           features: postgres
           args: --no-default-features
 
@@ -63,6 +62,9 @@ jobs:
         with:
           tool: just
           checksum: true
+
+      - name: Install rustfmt
+        run: rustup component add rustfmt
 
       - name: Create database
         shell: bash

--- a/.github/workflows/migration-check.yaml
+++ b/.github/workflows/migration-check.yaml
@@ -51,6 +51,7 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable 2 weeks ago
+          components: rustfmt
 
       - uses: baptiste0928/cargo-install@v3.3.0
         with:
@@ -62,9 +63,6 @@ jobs:
         with:
           tool: just
           checksum: true
-
-      - name: Install rustfmt
-        run: rustup component add rustfmt
 
       - name: Create database
         shell: bash


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [x] CI/CD

## Description
<!-- Describe your changes in detail -->
- `diesel_cli` version `2.3.0` expects to call `rustfmt` to format its output. If `rustfmt` is not installed on the system it will give an error.
- Added a step to install `rustfmt` to fix the workflow

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
Closes #9385 


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Verified CI checks

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
