### PR TITLE
build: bump MSRV to 1.85.0

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -13,4 +13,4 @@ name = "rust"
 enabled = true
 
 [analyzers.meta]
-msrv = "1.80.0"
+msrv = "1.85.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 resolver = "2"
 members = ["crates/*"]
 package.edition = "2021"
-package.rust-version = "1.80.0"
+package.rust-version = "1.85.0"
 package.license = "Apache-2.0"
 
 [workspace.dependencies]

--- a/INSTALL_dependencies.sh
+++ b/INSTALL_dependencies.sh
@@ -9,7 +9,7 @@ if [[ "${TRACE-0}" == "1" ]]; then
     set -o xtrace
 fi
 
-RUST_MSRV="1.80.0"
+RUST_MSRV="1.85.0"
 _DB_NAME="hyperswitch_db"
 _DB_USER="db_user"
 _DB_PASS="db_password"


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
This PR bumps the Minimum Supported Rust Version (MSRV) from Rust 1.80 to 1.85.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
Superposition has dependencies on the `askama` crate, which now requires a minimum Rust version of 1.81. Our current setup is still on 1.80. Bumping up the MSRV to 1.85 should solve this issue.


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
N/A


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
