### PR TITLE
fix(webhooks): add idempotent_event_id generation using URL-safe Base64 (no padding) and SHA256 digest

### DIFF
--- a/crates/common_utils/src/consts.rs
+++ b/crates/common_utils/src/consts.rs
@@ -101,6 +101,7 @@ pub const BASE64_ENGINE_URL_SAFE: base64::engine::GeneralPurpose =
 /// URL Safe base64 engine without padding
 pub const BASE64_ENGINE_URL_SAFE_NO_PAD: base64::engine::GeneralPurpose =
     base64::engine::general_purpose::URL_SAFE_NO_PAD;
+
 /// Regex for matching a domain
 /// Eg -
 /// http://www.example.com

--- a/crates/common_utils/src/consts.rs
+++ b/crates/common_utils/src/consts.rs
@@ -97,6 +97,10 @@ pub const BASE64_ENGINE: base64::engine::GeneralPurpose = base64::engine::genera
 /// URL Safe base64 engine
 pub const BASE64_ENGINE_URL_SAFE: base64::engine::GeneralPurpose =
     base64::engine::general_purpose::URL_SAFE;
+
+/// URL Safe base64 engine without padding
+pub const BASE64_ENGINE_URL_SAFE_NO_PAD: base64::engine::GeneralPurpose =
+    base64::engine::general_purpose::URL_SAFE_NO_PAD;
 /// Regex for matching a domain
 /// Eg -
 /// http://www.example.com

--- a/crates/router/src/core/errors.rs
+++ b/crates/router/src/core/errors.rs
@@ -157,6 +157,8 @@ pub enum WebhooksFlowError {
     OutgoingWebhookRetrySchedulingFailed,
     #[error("Outgoing webhook response encoding failed")]
     OutgoingWebhookResponseEncodingFailed,
+    #[error("ID generation failed")]
+    IdGenerationFailed,
 }
 
 impl WebhooksFlowError {
@@ -174,7 +176,8 @@ impl WebhooksFlowError {
             | Self::DisputeWebhookValidationFailed
             | Self::OutgoingWebhookEncodingFailed
             | Self::OutgoingWebhookProcessTrackerTaskUpdateFailed
-            | Self::OutgoingWebhookRetrySchedulingFailed => true,
+            | Self::OutgoingWebhookRetrySchedulingFailed
+            | Self::IdGenerationFailed => true,
         }
     }
 }

--- a/crates/router/src/core/webhooks/outgoing.rs
+++ b/crates/router/src/core/webhooks/outgoing.rs
@@ -60,7 +60,9 @@ pub(crate) async fn create_event_and_trigger_outgoing_webhook(
 ) -> CustomResult<(), errors::ApiErrorResponse> {
     let delivery_attempt = enums::WebhookDeliveryAttempt::InitialAttempt;
     let idempotent_event_id =
-        utils::get_idempotent_event_id(&primary_object_id, event_type, delivery_attempt);
+        utils::get_idempotent_event_id(&primary_object_id, event_type, delivery_attempt)
+            .change_context(errors::ApiErrorResponse::WebhookProcessingFailure)
+            .attach_printable("Failed to generate idempotent event ID")?;
     let webhook_url_result = get_webhook_url_from_business_profile(&business_profile);
 
     if !state.conf.webhooks.outgoing_enabled

--- a/crates/router/src/core/webhooks/outgoing_v2.rs
+++ b/crates/router/src/core/webhooks/outgoing_v2.rs
@@ -48,7 +48,9 @@ pub(crate) async fn create_event_and_trigger_outgoing_webhook(
 ) -> CustomResult<(), errors::ApiErrorResponse> {
     let delivery_attempt = enums::WebhookDeliveryAttempt::InitialAttempt;
     let idempotent_event_id =
-        utils::get_idempotent_event_id(&primary_object_id, event_type, delivery_attempt);
+        utils::get_idempotent_event_id(&primary_object_id, event_type, delivery_attempt)
+            .change_context(errors::ApiErrorResponse::WebhookProcessingFailure)
+            .attach_printable("Failed to generate idempotent event ID")?;
     let webhook_url_result = business_profile
         .get_webhook_url_from_profile()
         .change_context(errors::WebhooksFlowError::MerchantWebhookUrlNotConfigured);

--- a/crates/router/src/core/webhooks/utils.rs
+++ b/crates/router/src/core/webhooks/utils.rs
@@ -1,15 +1,15 @@
 use std::marker::PhantomData;
 
+use base64::Engine;
 use common_utils::{
-    crypto::{GenerateDigest, Sha256},
     consts::BASE64_ENGINE_URL_SAFE_NO_PAD,
+    crypto::{GenerateDigest, Sha256},
     errors::CustomResult,
-    ext_traits::ValueExt
+    ext_traits::ValueExt,
 };
 use error_stack::{Report, ResultExt};
 use redis_interface as redis;
 use router_env::tracing;
-use base64::Engine;
 
 use super::MERCHANT_ID;
 use crate::{

--- a/crates/router/src/core/webhooks/utils.rs
+++ b/crates/router/src/core/webhooks/utils.rs
@@ -2,8 +2,8 @@ use std::marker::PhantomData;
 
 use base64::Engine;
 use common_utils::{
-    consts::BASE64_ENGINE_URL_SAFE_NO_PAD,
-    crypto::{GenerateDigest, Sha256},
+    consts,
+    crypto::{self, GenerateDigest},
     errors::CustomResult,
     ext_traits::ValueExt,
 };
@@ -160,11 +160,11 @@ pub(crate) fn get_idempotent_event_id(
     let common_prefix = format!("{primary_object_id}_{event_type}");
 
     // Hash the common prefix with SHA256 and encode with URL-safe base64 without padding
-    let digest = Sha256
+    let digest = crypto::Sha256
         .generate_digest(common_prefix.as_bytes())
         .change_context(errors::WebhooksFlowError::IdGenerationFailed)
         .attach_printable("Failed to generate idempotent event ID")?;
-    let base_encoded = BASE64_ENGINE_URL_SAFE_NO_PAD.encode(digest);
+    let base_encoded = consts::BASE64_ENGINE_URL_SAFE_NO_PAD.encode(digest);
 
     let result = match delivery_attempt {
         WebhookDeliveryAttempt::InitialAttempt => base_encoded,

--- a/crates/router/src/core/webhooks/webhook_events.rs
+++ b/crates/router/src/core/webhooks/webhook_events.rs
@@ -287,7 +287,9 @@ pub async fn retry_delivery_attempt(
         &event_to_retry.primary_object_id,
         event_to_retry.event_type,
         delivery_attempt,
-    );
+    )
+    .change_context(errors::ApiErrorResponse::WebhookProcessingFailure)
+    .attach_printable("Failed to generate idempotent event ID")?;
 
     let now = common_utils::date_time::now();
     let new_event = domain::Event {

--- a/crates/router/src/workflows/outgoing_webhook_retry.rs
+++ b/crates/router/src/workflows/outgoing_webhook_retry.rs
@@ -72,7 +72,9 @@ impl ProcessTrackerWorkflow<SessionState> for OutgoingWebhookRetryWorkflow {
             &tracking_data.primary_object_id,
             tracking_data.event_type,
             delivery_attempt,
-        );
+        )
+        .change_context(errors::ApiErrorResponse::WebhookProcessingFailure)
+        .attach_printable("Failed to generate idempotent event ID")?;
 
         let initial_event = match &tracking_data.initial_attempt_id {
             Some(initial_attempt_id) => {


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
This change updates the idempotent_event_id generation to first hash the base string with SHA256 and then encode it using URL-safe Base64 without padding. By doing this, the generated IDs are guaranteed to be short and deterministic, ensuring they always fit within the 64-character database column limit. This fix addresses the issue where long payment_ids combined with event types were exceeding the DB constraint and breaking the outgoing webhooks flow.


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
The idempotent_event_id column is a combination of payment_id and event_type. The DB column length is limited to 64 characters. Since payment_id itself can be up to 64 characters long, appending event_type causes the field to exceed the limit, leading to database constraint violations.

Currently, this breaks the outgoing webhooks flow.

Additionally, during staggered deployments and rollback, the uniqueness of these IDs may cause dual webhook dispatches.

closes #8460

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
1. Started the local Node.js Express webhook listener on port 3000 using the server.js script.
<details>
<summary>server.js script</summary>

```
mkdir -p /tmp/hs-webhooks && cd /tmp/hs-webhooks
npm init -y >/dev/null
npm i express >/dev/null

cat > server.js <<'JS'
const express = require('express');
const app = express();
app.use(express.json({ type: '*/*' }));

app.post('/webhooks/hs', (req, res) => {
  console.log('---- Webhook received ----');
  console.log('Headers:', req.headers);
  console.log('Body:', JSON.stringify(req.body, null, 2));
  res.sendStatus(200);
});

app.listen(3000, () => console.log('Webhook listener running on port 3000'));
JS

node server.js
```
</details>

2. **Merchant Creation**

<details>
<summary>Merchant creation Curl</summary>

```bash
curl --location 'http://localhost:8080/accounts' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: test_admin' \
--data-raw '{
  "merchant_id": "merchant_1758029612",
  "locker_id": "m0010",
  "merchant_name": "worldpay",
  "merchant_details": {
    "primary_contact_person": "John Test",
    "primary_email": "JohnTest@test.com",
    "primary_phone": "sunt laborum",
    "secondary_contact_person": "John Test2",
    "secondary_email": "JohnTest2@test.com",
    "secondary_phone": "cillum do dolor id",
    "website": "https://www.example.com",
    "about_business": "Online Retail with a wide selection of organic products for North America",
    "address": {
      "line1": "1467",
      "line2": "Harrison Street",
      "line3": "Harrison Street",
      "city": "San Fransico",
      "state": "California",
      "zip": "94122",
      "country": "US",
      "first_name":"john",
      "last_name":"Doe"
    }
  },
  "return_url": "https://google.com/success",
  "webhook_details": {
    "webhook_version": "1.0.1",
    "webhook_username": "ekart_retail",
    "webhook_password": "password_ekart@123",
    "webhook_url":"http://localhost:3000/webhooks/hs",
    "payment_created_enabled": true,
    "payment_succeeded_enabled": true,
    "payment_failed_enabled": true
  },
  "sub_merchants_enabled": false,
  "parent_merchant_id":"merchant_123",
  "metadata": {
    "city": "NY",
    "unit": "245",
    "merchant_name": "Acme Widgets LLC"
  },
  "primary_business_details": [
    {
      "country": "US",
      "business": "default"
    }
  ]
}'
```
</details>

After this when i created payment it created event with these idempotent_event_id.
<img width="533" height="165" alt="image" src="https://github.com/user-attachments/assets/6610ede4-6ffe-4de1-bde3-664ac00abec4" />


<details>
<summary>Manual Retry Curl</summary>

```
curl --location --request POST 'http://localhost:8080/events/merchant_1758190753/evt_01995ce5346575608391d7f8b825175d/retry' \
--header 'api-key: test_admin'
```

</details>

<img width="559" height="252" alt="image" src="https://github.com/user-attachments/assets/cb652d7b-5749-48f0-b2f7-78726411e789" />

For primary object id greater than 64 chars still generated idempotent_event_id will always be less than 64 characters in length.

<img width="831" height="33" alt="image" src="https://github.com/user-attachments/assets/3d7b838a-df61-401e-ac2c-fd7e5cd5b4c8" />


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible