### PR TITLE
chore(git): add code owner for payout modules

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -168,7 +168,6 @@ crates/router/src/workflows/attach_payout_account_workflow.rs @juspay/hyperswitc
 crates/api_models/src/payouts.rs @juspay/hyperswitch-payouts
 
 crates/common_utils/src/payout_method_utils.rs @juspay/hyperswitch-payouts
-crates/common_utils/src/id_type/payout.rs @juspay/hyperswitch-payouts
 
 crates/diesel_models/src/payouts.rs @juspay/hyperswitch-payouts
 crates/diesel_models/src/payout_attempt.rs @juspay/hyperswitch-payouts

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -153,3 +153,40 @@ Dockerfile @juspay/hyperswitch-infra
 docker-compose.yml @juspay/hyperswitch-infra
 .dockerignore @juspay/hyperswitch-infra
 monitoring/ @juspay/hyperswitch-infra
+
+# Payout related ownership rules
+crates/router/src/core/payouts.rs @juspay/hyperswitch-payouts
+crates/router/src/core/payouts/ @juspay/hyperswitch-payouts
+crates/router/src/core/payout_link.rs @juspay/hyperswitch-payouts
+crates/router/src/core/generic_link/payout_link/ @juspay/hyperswitch-payouts
+crates/router/src/routes/payouts.rs @juspay/hyperswitch-payouts
+crates/router/src/routes/payout_link.rs @juspay/hyperswitch-payouts
+crates/router/src/configs/defaults/payout_required_fields.rs @juspay/hyperswitch-payouts
+crates/router/src/services/kafka/payout.rs @juspay/hyperswitch-payouts
+crates/router/src/workflows/attach_payout_account_workflow.rs @juspay/hyperswitch-payouts
+
+crates/api_models/src/payouts.rs @juspay/hyperswitch-payouts
+
+crates/common_utils/src/payout_method_utils.rs @juspay/hyperswitch-payouts
+crates/common_utils/src/id_type/payout.rs @juspay/hyperswitch-payouts
+
+crates/diesel_models/src/payouts.rs @juspay/hyperswitch-payouts
+crates/diesel_models/src/payout_attempt.rs @juspay/hyperswitch-payouts
+crates/diesel_models/src/query/payouts.rs @juspay/hyperswitch-payouts
+crates/diesel_models/src/query/payout_attempt.rs @juspay/hyperswitch-payouts
+crates/hyperswitch_domain_models/src/payouts/ @juspay/hyperswitch-payouts
+crates/hyperswitch_domain_models/src/payouts.rs @juspay/hyperswitch-payouts
+crates/storage_impl/src/payouts/ @juspay/hyperswitch-payouts
+crates/storage_impl/src/mock_db/payouts.rs @juspay/hyperswitch-payouts
+crates/storage_impl/src/mock_db/payout_attempt.rs @juspay/hyperswitch-payouts
+
+crates/openapi/src/routes/payouts.rs @juspay/hyperswitch-payouts
+
+crates/hyperswitch_connectors/src/connectors/adyenplatform/ @juspay/hyperswitch-payouts
+crates/hyperswitch_connectors/src/connectors/adyenplatform.rs @juspay/hyperswitch-payouts
+crates/hyperswitch_connectors/src/connectors/wise/ @juspay/hyperswitch-payouts
+crates/hyperswitch_connectors/src/connectors/wise.rs @juspay/hyperswitch-payouts
+crates/hyperswitch_connectors/src/connectors/stripe/transformers/connect.rs @juspay/hyperswitch-payouts
+
+crates/router/tests/connectors/adyenplatform.rs @juspay/hyperswitch-payouts
+crates/router/tests/connectors/wise.rs @juspay/hyperswitch-payouts


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
This PR assigns the code owner to relevant modules for `hyperswitch-payouts`.

## Motivation and Context
- Helps offload PR review tasks for payout related modules to the respective team.

## How did you test it?
Not needed
