### PR TITLE
fix(payments): suppress card vaulting error for CIT flows

### DIFF
--- a/crates/router/src/core/payments/operations/payment_response.rs
+++ b/crates/router/src/core/payments/operations/payment_response.rs
@@ -244,11 +244,21 @@ impl<F: Send + Clone> PostUpdateTracker<F, PaymentData<F>, types::PaymentsAuthor
             Ok(())
         } else if is_connector_mandate {
             // The mandate is created on connector's end.
-            let tokenization::SavePaymentMethodDataResponse {
-                payment_method_id,
-                connector_mandate_reference_id,
-                ..
-            } = save_payment_call_future.await?;
+            let (payment_method_id, connector_mandate_reference_id) = match save_payment_call_future
+                .await
+            {
+                Ok(tokenization::SavePaymentMethodDataResponse {
+                    payment_method_id,
+                    connector_mandate_reference_id,
+                    ..
+                }) => (payment_method_id, connector_mandate_reference_id),
+                Err(err) => {
+                    // Suppress errors from save_payment_call_future and return Ok()
+                    logger::error!("Failed to save payment method during connector mandate flow, returning early {:?}", err);
+                    return Ok(());
+                }
+            };
+
             payment_data.payment_method_info = if let Some(payment_method_id) = &payment_method_id {
                 match state
                     .store
@@ -1184,11 +1194,7 @@ impl<F: Clone> PostUpdateTracker<F, PaymentData<F>, types::SetupMandateRequestDa
         let vault_operation = payment_data.vault_operation.clone();
         let payment_method_info = payment_data.payment_method_info.clone();
         let merchant_connector_id = payment_data.payment_attempt.merchant_connector_id.clone();
-        let tokenization::SavePaymentMethodDataResponse {
-            payment_method_id,
-            connector_mandate_reference_id,
-            ..
-        } = Box::pin(tokenization::save_payment_method(
+        let save_payment_call_future = Box::pin(tokenization::save_payment_method(
             state,
             connector_name,
             save_payment_data,
@@ -1202,8 +1208,24 @@ impl<F: Clone> PostUpdateTracker<F, PaymentData<F>, types::SetupMandateRequestDa
             merchant_connector_id.clone(),
             vault_operation,
             payment_method_info,
-        ))
-        .await?;
+        ));
+
+        let (payment_method_id, connector_mandate_reference_id) =
+            match save_payment_call_future.await {
+                Ok(tokenization::SavePaymentMethodDataResponse {
+                    payment_method_id,
+                    connector_mandate_reference_id,
+                    ..
+                }) => (payment_method_id, connector_mandate_reference_id),
+                Err(err) => {
+                    // Suppress errors from save_payment_call_future and return Ok()
+                    logger::error!(
+                    "Failed to save payment method during setup mandate flow, returning early {:?}",
+                    err
+                );
+                    return Ok(());
+                }
+            };
 
         payment_data.payment_method_info = if let Some(payment_method_id) = &payment_method_id {
             match state


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
This PR introduces the following changes
1. In CIT flows, if card vaulting step fails but connector event was successful instead of sending back a 5XX send back a 2XX.
2. Suppress card vaulting error, and log it.

Cargo clippy output
<img width="895" height="508" alt="Screenshot 2025-09-17 at 7 49 23 PM" src="https://github.com/user-attachments/assets/59c9c2c4-982f-416e-8f7e-66de9cace8ec" />


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Steps
1. Simulate locker service error (change locker url to an incorrect url)
2. Call CIT payment and confirm api for Authorize, SetupMandate flows

### CIT /payment and /confirm calls for Authorize
<img width="1093" height="901" alt="Screenshot 2025-09-16 at 12 47 47 PM" src="https://github.com/user-attachments/assets/20cf6bca-d931-49d0-9b25-6fbe882d3789" />

<img width="1093" height="901" alt="Screenshot 2025-09-16 at 12 47 58 PM" src="https://github.com/user-attachments/assets/0c0825a7-4eb8-4b7a-aa3a-5524aea6bb5f" />
Note -     "payment_method_id" is expected to be null in /confirm response, since saving payment method step failed
<img width="1728" height="214" alt="Screenshot 2025-09-16 at 12 39 51 PM" src="https://github.com/user-attachments/assets/8a2dc68a-d769-436f-85ca-8c391961ad32" />

### CIT /payment and /confirm calls for SetupMandate

<img width="1093" height="901" alt="Screenshot 2025-09-16 at 12 40 58 PM" src="https://github.com/user-attachments/assets/cf56ad95-7348-47cd-a778-112a8ccb6721" />

<img width="1093" height="901" alt="Screenshot 2025-09-16 at 12 40 49 PM" src="https://github.com/user-attachments/assets/5b7776ea-871d-471c-b8b9-ea89c47dbe18" />
Note -     "payment_method_id" is expected to be null in /confirm response, since saving payment method step failed
<img width="1728" height="214" alt="Screenshot 2025-09-16 at 12 40 34 PM" src="https://github.com/user-attachments/assets/19c12a8c-f494-4e66-aaf7-535d176416e9" />
 


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
