### PR TITLE
ci(cypress): fix braintree connector

### DIFF
--- a/cypress-tests/cypress/e2e/configs/Payment/Braintree.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Braintree.js
@@ -93,6 +93,21 @@ export const connectorDetails = {
         },
       },
     },
+    PaymentIntentOffSession: {
+      Request: {
+        amount: 6000,
+        authentication_type: "no_three_ds",
+        currency: "USD",
+        customer_acceptance: null,
+        setup_future_usage: "off_session",
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "requires_payment_method",
+        },
+      },
+    },
     No3DSAutoCapture: {
       Request: {
         payment_method: "card",


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [x] CI/CD

## Description

Fix save card flow for braintree , earlier we were passing on_session for off_session flow 


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
Test cases were failing

## How did you test it?

<img width="689" height="978" alt="image" src="https://github.com/user-attachments/assets/16b8a2da-2e79-47b3-87da-0f474d7741b6" />


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
