### PR TITLE
fix(connector): [CYBERSOURCE] Pass transaction type for only wallet MITs

### DIFF
--- a/crates/hyperswitch_connectors/src/connectors/cybersource/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/cybersource/transformers.rs
@@ -575,7 +575,8 @@ pub struct MandateCard {
 #[serde(rename_all = "camelCase")]
 pub struct MandatePaymentInformation {
     payment_instrument: CybersoucrePaymentInstrument,
-    tokenized_card: MandatePaymentTokenizedCard,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tokenized_card: Option<MandatePaymentTokenizedCard>,
     card: Option<MandateCard>,
 }
 
@@ -2584,6 +2585,15 @@ impl TryFrom<(&CybersourceRouterData<&PaymentsAuthorizeRouterData>, String)>
             _ => None,
         };
 
+        let tokenized_card = match item.router_data.request.payment_method_type {
+            Some(enums::PaymentMethodType::GooglePay)
+            | Some(enums::PaymentMethodType::ApplePay)
+            | Some(enums::PaymentMethodType::SamsungPay) => Some(MandatePaymentTokenizedCard {
+                transaction_type: TransactionType::StoredCredentials,
+            }),
+            _ => None,
+        };
+
         let bill_to = item
             .router_data
             .get_optional_billing_email()
@@ -2593,9 +2603,7 @@ impl TryFrom<(&CybersourceRouterData<&PaymentsAuthorizeRouterData>, String)>
         let payment_information =
             PaymentInformation::MandatePayment(Box::new(MandatePaymentInformation {
                 payment_instrument,
-                tokenized_card: MandatePaymentTokenizedCard {
-                    transaction_type: TransactionType::StoredCredentials,
-                },
+                tokenized_card,
                 card: mandate_card_information,
             }));
         let client_reference_information = ClientReferenceInformation::from(item);


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
This PR introduces the following fix:
HS should pass `paymentInformation.tokenizedCard.transactionType`  for only wallet MITs. Presently `paymentInformation.tokenizedCard.transactionType` is being passed for card MITs as well, which is incorrect according to cybersource docs.


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
1. Test MIT for connector mandate flow via Cybersource for cards, and check router logs. 
`paymentInformation.tokenizedCard.transactionType` should not be present.
Logs from localhost:
<img width="864" height="129" alt="Screenshot 2025-09-18 at 8 18 41 PM" src="https://github.com/user-attachments/assets/8db27d98-4257-4484-bdc3-503f47f9e887" />


2. Test MIT for setup mandate flow via Cybersource for cards, and check router logs. `paymentInformation.tokenizedCard.transactionType` should not be present. 
Logs from localhost:

<img width="864" height="141" alt="Screenshot 2025-09-18 at 8 37 42 PM" src="https://github.com/user-attachments/assets/d8d1c554-c57b-4e3a-a473-297f427c521c" />


## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
