### PR TITLE
refactor(routing): change payload to option

### DIFF
--- a/crates/api_models/src/routing.rs
+++ b/crates/api_models/src/routing.rs
@@ -943,7 +943,7 @@ pub struct ToggleDynamicRoutingPath {
 pub struct CreateDynamicRoutingWrapper {
     pub profile_id: common_utils::id_type::ProfileId,
     pub feature_to_enable: DynamicRoutingFeatures,
-    pub payload: DynamicRoutingPayload,
+    pub payload: Option<DynamicRoutingPayload>,
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, ToSchema)]

--- a/crates/router/src/core/routing.rs
+++ b/crates/router/src/core/routing.rs
@@ -1744,7 +1744,7 @@ pub async fn create_specific_dynamic_routing(
     feature_to_enable: routing::DynamicRoutingFeatures,
     profile_id: common_utils::id_type::ProfileId,
     dynamic_routing_type: routing::DynamicRoutingType,
-    payload: routing_types::DynamicRoutingPayload,
+    payload: Option<routing_types::DynamicRoutingPayload>,
 ) -> RouterResponse<routing_types::RoutingDictionaryRecord> {
     metrics::ROUTING_CREATE_REQUEST_RECEIVED.add(
         1,
@@ -1790,7 +1790,7 @@ pub async fn create_specific_dynamic_routing(
                 feature_to_enable,
                 dynamic_routing_algo_ref,
                 dynamic_routing_type,
-                Some(payload),
+                payload,
             ))
             .await
         }

--- a/crates/router/src/routes/routing.rs
+++ b/crates/router/src/routes/routing.rs
@@ -1247,15 +1247,17 @@ pub async fn create_success_based_routing(
     req: HttpRequest,
     query: web::Query<api_models::routing::CreateDynamicRoutingQuery>,
     path: web::Path<routing_types::ToggleDynamicRoutingPath>,
-    success_based_config: web::Json<routing_types::SuccessBasedRoutingConfig>,
+    success_based_config: Option<web::Json<routing_types::SuccessBasedRoutingConfig>>,
 ) -> impl Responder {
     let flow = Flow::CreateDynamicRoutingConfig;
+    let payload = success_based_config.map(|config| {
+    api_models::routing::DynamicRoutingPayload::SuccessBasedRoutingPayload(config.into_inner())
+});
+
     let wrapper = routing_types::CreateDynamicRoutingWrapper {
         feature_to_enable: query.into_inner().enable,
         profile_id: path.into_inner().profile_id,
-        payload: api_models::routing::DynamicRoutingPayload::SuccessBasedRoutingPayload(
-            success_based_config.into_inner(),
-        ),
+        payload,
     };
     Box::pin(oss_api::server_wrap(
         flow,
@@ -1541,15 +1543,17 @@ pub async fn create_elimination_routing(
     req: HttpRequest,
     query: web::Query<api_models::routing::CreateDynamicRoutingQuery>,
     path: web::Path<routing_types::ToggleDynamicRoutingPath>,
-    elimination_config: web::Json<routing_types::EliminationRoutingConfig>,
+    elimination_config: Option<web::Json<routing_types::EliminationRoutingConfig>>,
 ) -> impl Responder {
     let flow = Flow::CreateDynamicRoutingConfig;
+    let payload = elimination_config.map(|config| {
+        api_models::routing::DynamicRoutingPayload::EliminationRoutingPayload(config.into_inner())
+    });
+
     let wrapper = routing_types::CreateDynamicRoutingWrapper {
         feature_to_enable: query.into_inner().enable,
         profile_id: path.into_inner().profile_id,
-        payload: api_models::routing::DynamicRoutingPayload::EliminationRoutingPayload(
-            elimination_config.into_inner(),
-        ),
+        payload,
     };
     Box::pin(oss_api::server_wrap(
         flow,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD


## Description
This pull request updates the dynamic routing configuration APIs to make the payloads optional, improving flexibility when creating routing configurations. The changes affect both the API models and the routing logic, allowing configurations to be created without requiring a payload in certain cases.

### API Model Changes

* Made the `payload` field in the `CreateDynamicRoutingWrapper` struct optional, allowing creation requests to omit the payload if not needed.

### Routing Logic Updates

* Updated the `create_specific_dynamic_routing` function to accept an optional payload, reflecting the change in the API model and enabling more flexible routing configuration creation.
* Modified the logic in `create_specific_dynamic_routing` to pass the payload directly (as an `Option`) instead of always wrapping it in `Some()`.

### Endpoint Handler Adjustments

* Changed the `create_success_based_routing` endpoint to accept an optional `SuccessBasedRoutingConfig` and construct the payload only if provided.
* Updated the `create_elimination_routing` endpoint to accept an optional `EliminationRoutingConfig` and construct the payload only if provided.




## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
