### PR TITLE
fix(chat): alter encryption logic for ai service

### DIFF
--- a/crates/router/src/utils/chat.rs
+++ b/crates/router/src/utils/chat.rs
@@ -40,7 +40,7 @@ pub async fn construct_hyperswitch_ai_interaction(
         .and_then(|bytes| {
             GcmAes256
                 .encode_message(&key, &bytes)
-                .map_err(|e| e.change_context(errors::ApiErrorResponse::InternalServerError))
+                .change_context(errors::ApiErrorResponse::InternalServerError)
         })
         .attach_printable("Failed to encrypt response")?;
 


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
This PR addresses an issue where chat conversation history could not be decrypted in the `chat/ai/list` endpoint. The root cause was an inconsistency between the encryption method used when storing chat interactions (`chat/ai/data`) and the decryption method used when retrieving them (`chat/ai/list`).

This change standardizes the encryption process to use the direct `GcmAes256` utility, ensuring compatibility between encryption and decryption, and resolving the data retrieval failures.


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
Closes #9561


## How did you test it?
The list endpoint is working fine with new encryption logic:
```
curl --location 'http://localhost:8080/chat/ai/list?merchant_id=merchant_1758788495' \
--header 'Authorization: Bearer JWT' \
```


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
