### PR TITLE
fix(routing): add field length validation for the routing config name field

### DIFF
--- a/crates/api_models/src/routing.rs
+++ b/crates/api_models/src/routing.rs
@@ -73,7 +73,7 @@ impl RoutingConfigRequest {
         if let Some(name) = &self.name {
             if name.len() > 64 {
                 return Err(ValidationError::InvalidValue {
-                    message: "Name length must not exceed 64 characters".to_string()
+                    message: "Name length must not exceed 64 characters".to_string(),
                 });
             }
         }

--- a/crates/api_models/src/routing.rs
+++ b/crates/api_models/src/routing.rs
@@ -67,6 +67,20 @@ pub struct RoutingConfigRequest {
     pub transaction_type: Option<TransactionType>,
 }
 
+#[cfg(feature = "v1")]
+impl RoutingConfigRequest {
+    pub fn validate_name_length(&self) -> Result<(), ValidationError> {
+        if let Some(name) = &self.name {
+            if name.len() > 64 {
+                return Err(ValidationError::InvalidValue {
+                    message: "Name length must not exceed 64 characters".to_string()
+                });
+            }
+        }
+        Ok(())
+    }
+}
+
 #[derive(Debug, serde::Serialize, ToSchema)]
 pub struct ProfileDefaultRoutingConfig {
     #[schema(value_type = String)]

--- a/crates/router/src/core/routing.rs
+++ b/crates/router/src/core/routing.rs
@@ -355,11 +355,11 @@ pub async fn create_routing_algorithm_under_profile(
     let db = state.store.as_ref();
     let key_manager_state = &(&state).into();
 
-    request
-        .validate_name_length()
-        .change_context(errors::ApiErrorResponse::InvalidRequestData {
+    request.validate_name_length().change_context(
+        errors::ApiErrorResponse::InvalidRequestData {
             message: "Validation failed for routing config request".to_string(),
-        })?;
+        },
+    )?;
 
     let name = request
         .name

--- a/crates/router/src/core/routing.rs
+++ b/crates/router/src/core/routing.rs
@@ -355,6 +355,12 @@ pub async fn create_routing_algorithm_under_profile(
     let db = state.store.as_ref();
     let key_manager_state = &(&state).into();
 
+    request
+        .validate_name_length()
+        .change_context(errors::ApiErrorResponse::InvalidRequestData {
+            message: "Validation failed for routing config request".to_string(),
+        })?;
+
     let name = request
         .name
         .get_required_value("name")


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
This PR adds a length validation for the name field in the routing config to be less than 64 characters

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Hitting the /routing endpoint with config name lengthgreater than 64 chars
<img width="895" height="583" alt="Screenshot 2025-09-26 at 3 08 19 PM" src="https://github.com/user-attachments/assets/b68bacc9-24b4-48bb-b4d4-970c0fa9f792" />
<img width="1228" height="181" alt="Screenshot 2025-09-26 at 3 09 09 PM" src="https://github.com/user-attachments/assets/4a0d6c53-635d-47ac-b22c-307dfb742469" />

Hitting /routing endpoint with config name length less than 64 chars
<img width="921" height="805" alt="Screenshot 2025-09-26 at 3 10 41 PM" src="https://github.com/user-attachments/assets/d86f30b6-5565-4eee-8218-92ab04d361e0" />


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
