### PR TITLE
fix(authorizedotnet): refund via ucs missing connector_metadata

### DIFF
--- a/crates/hyperswitch_connectors/src/connectors/authorizedotnet/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/authorizedotnet/transformers.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 
-use api_models::webhooks::IncomingWebhookEvent;
+use api_models::{payments::AdditionalPaymentData, webhooks::IncomingWebhookEvent};
 use common_enums::enums;
 use common_utils::{
     errors::CustomResult,
@@ -1548,7 +1548,10 @@ impl<F, T>
                     .account_number
                     .as_ref()
                     .map(|acc_no| {
-                        construct_refund_payment_details(acc_no.clone().expose()).encode_to_value()
+                        construct_refund_payment_details(PaymentDetailAccountNumber::Masked(
+                            acc_no.clone().expose(),
+                        ))
+                        .encode_to_value()
                     })
                     .transpose()
                     .change_context(errors::ConnectorError::MissingRequiredField {
@@ -1649,7 +1652,10 @@ impl<F, T> TryFrom<ResponseRouterData<F, AuthorizedotnetVoidResponse, T, Payment
                     .account_number
                     .as_ref()
                     .map(|acc_no| {
-                        construct_refund_payment_details(acc_no.clone().expose()).encode_to_value()
+                        construct_refund_payment_details(PaymentDetailAccountNumber::Masked(
+                            acc_no.clone().expose(),
+                        ))
+                        .encode_to_value()
                     })
                     .transpose()
                     .change_context(errors::ConnectorError::MissingRequiredField {
@@ -1719,28 +1725,16 @@ impl<F> TryFrom<&AuthorizedotnetRouterData<&RefundsRouterData<F>>> for CreateRef
     fn try_from(
         item: &AuthorizedotnetRouterData<&RefundsRouterData<F>>,
     ) -> Result<Self, Self::Error> {
-        let payment_details = item
-            .router_data
-            .request
-            .connector_metadata
-            .as_ref()
-            .get_required_value("connector_metadata")
-            .change_context(errors::ConnectorError::MissingRequiredField {
-                field_name: "connector_metadata",
-            })?
-            .clone();
-
         let merchant_authentication =
             AuthorizedotnetAuthType::try_from(&item.router_data.connector_auth_type)?;
 
         let transaction_request = RefundTransactionRequest {
             transaction_type: TransactionType::Refund,
             amount: item.amount,
-            payment: payment_details
-                .parse_value("PaymentDetails")
-                .change_context(errors::ConnectorError::MissingRequiredField {
-                    field_name: "payment_details",
-                })?,
+            payment: get_refund_metadata(
+                &item.router_data.request.connector_metadata,
+                &item.router_data.request.additional_payment_method_data,
+            )?,
             currency_code: item.router_data.request.currency.to_string(),
             reference_transaction_id: item.router_data.request.connector_transaction_id.clone(),
         };
@@ -1754,6 +1748,42 @@ impl<F> TryFrom<&AuthorizedotnetRouterData<&RefundsRouterData<F>>> for CreateRef
     }
 }
 
+fn get_refund_metadata(
+    connector_metadata: &Option<Value>,
+    additional_payment_method: &Option<AdditionalPaymentData>,
+) -> Result<PaymentDetails, error_stack::Report<errors::ConnectorError>> {
+    let payment_details_from_metadata = connector_metadata
+        .as_ref()
+        .get_required_value("connector_metadata")
+        .ok()
+        .and_then(|value| {
+            value
+                .clone()
+                .parse_value::<PaymentDetails>("PaymentDetails")
+                .ok()
+        });
+    let payment_details_from_additional_payment_method = match additional_payment_method {
+        Some(AdditionalPaymentData::Card(additional_card_info)) => {
+            additional_card_info.last4.clone().map(|last4| {
+                construct_refund_payment_details(PaymentDetailAccountNumber::UnMasked(
+                    last4.to_string(),
+                ))
+            })
+        }
+        _ => None,
+    };
+    match (
+        payment_details_from_metadata,
+        payment_details_from_additional_payment_method,
+    ) {
+        (Some(payment_detail), _) => Ok(payment_detail),
+        (_, Some(payment_detail)) => Ok(payment_detail),
+        (None, None) => Err(errors::ConnectorError::MissingRequiredField {
+            field_name: "payment_details",
+        }
+        .into()),
+    }
+}
 impl From<AuthorizedotnetRefundStatus> for enums::RefundStatus {
     fn from(item: AuthorizedotnetRefundStatus) -> Self {
         match item {
@@ -2040,10 +2070,16 @@ pub struct ErrorDetails {
 pub struct AuthorizedotnetErrorResponse {
     pub error: ErrorDetails,
 }
-
-fn construct_refund_payment_details(masked_number: String) -> PaymentDetails {
+enum PaymentDetailAccountNumber {
+    Masked(String),
+    UnMasked(String),
+}
+fn construct_refund_payment_details(detail: PaymentDetailAccountNumber) -> PaymentDetails {
     PaymentDetails::CreditCard(CreditCardDetails {
-        card_number: masked_number.into(),
+        card_number: match detail {
+            PaymentDetailAccountNumber::Masked(masked) => masked.into(),
+            PaymentDetailAccountNumber::UnMasked(unmasked) => format!("XXXX{:}", unmasked).into(),
+        },
         expiration_date: "XXXX".to_string().into(),
         card_code: None,
     })


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->

- Refunds via authorizedot net are getting into `pending` state where no connector call is made
- This happens when `connector_metadata` is empty in attempt table
- In usual cases `connector_metadata` is not empty but this happened via ucs.

### solution
- `connector_metadata` contains last4 digits which can be fetched form payment_method_data

## how did i test

- make payment from old code , delete connector metadata in attempt table and make refund

1.  make payment

```json
{
    "amount": 689,
    "customer_id": "hello_world",
    "currency": "USD",
    "confirm": true,
    "capture_method": "automatic",
    "payment_method": "card",
    "payment_method_type": "debit",
    "authentication_type": "no_three_ds",

    "setup_future_usage": "off_session",
    "customer_acceptance": {
        "acceptance_type": "online",
        "accepted_at": "1963-05-03T04:07:52.723Z",
        "online": {
            "ip_address": "127.0.0.1",
            "user_agent": "amet irure esse"
        }
    },
    "email": "hello@gmail.com",
    "description": "hellow world",
    "connector": [
        "authorizedotnet"
    ],
    "billing": {
        "address": {
            "zip": "560095",
            "country": "US",
            "first_name": "Sakil",
            "last_name": "Mostak",
            "line1": "Fasdf",
            "line2": "Fasdf",
            "city": "Fasdf"
        }
    },
    "payment_method_data": {
        "card": {
            "card_number": "4111111111111111",
            "card_exp_month": "12",
            "card_exp_year": "2029",
            "card_holder_name": "John Doe",
            "card_cvc": "123",
            "card_network": "Visa"
        }
    }
}
```

```json
{
    "payment_id": "pay_n4mGvzhDDxV8ontN4pNa",
    "merchant_id": "merchant_1759037295",
    "status": "succeeded",
    "amount": 689,
    "net_amount": 689,
    "shipping_cost": null,
    "amount_capturable": 0,
    "amount_received": 689,
    "connector": "authorizedotnet",
    "client_secret": "pay_n4mGvzhDDxV8ontN4pNa_secret_nJprHzvgyCnAQQxGeSD9",
    "created": "2025-09-28T07:38:56.792Z",
    "currency": "USD",
    "customer_id": "hello_world",
    "customer": {
        "id": "hello_world",
        "name": null,
        "email": "hello@gmail.com",
        "phone": null,
        "phone_country_code": null
    },
    "description": "hellow world",
    "refunds": null,
    "disputes": null,
    "mandate_id": null,
    "mandate_data": null,
    "setup_future_usage": "off_session",
    "off_session": null,
    "capture_on": null,
    "capture_method": "automatic",
    "payment_method": "card",
    "payment_method_data": {
        "card": {
            "last4": "1111",
            "card_type": null,
            "card_network": null,
            "card_issuer": null,
            "card_issuing_country": null,
            "card_isin": "411111",
            "card_extended_bin": null,
            "card_exp_month": "12",
            "card_exp_year": "2029",
            "card_holder_name": "John Doe",
            "payment_checks": {
                "description": "The street address and postal code matched.",
                "avs_result_code": "Y"
            },
            "authentication_data": null
        },
        "billing": null
    },
    "payment_token": null,
    "shipping": null,
    "billing": {
        "address": {
            "city": "Fasdf",
            "country": "US",
            "line1": "Fasdf",
            "line2": "Fasdf",
            "line3": null,
            "zip": "560095",
            "state": null,
            "first_name": "Sakil",
            "last_name": "Mostak",
            "origin_zip": null
        },
        "phone": null,
        "email": null
    },
    "order_details": null,
    "email": "hello@gmail.com",
    "name": null,
    "phone": null,
    "return_url": null,
    "authentication_type": "no_three_ds",
    "statement_descriptor_name": null,
    "statement_descriptor_suffix": null,
    "next_action": null,
    "cancellation_reason": null,
    "error_code": null,
    "error_message": null,
    "unified_code": null,
    "unified_message": null,
    "payment_experience": null,
    "payment_method_type": "debit",
    "connector_label": null,
    "business_country": null,
    "business_label": "default",
    "business_sub_label": null,
    "allowed_payment_method_types": null,
    "ephemeral_key": {
        "customer_id": "hello_world",
        "created_at": 1759045136,
        "expires": 1759048736,
        "secret": "epk_d109625edc44483a9a0d6e034153633f"
    },
    "manual_retry_allowed": null,
    "connector_transaction_id": "120071750406",
    "frm_message": null,
    "metadata": null,
    "connector_metadata": null,
    "feature_metadata": {
        "redirect_response": null,
        "search_tags": null,
        "apple_pay_recurring_details": null,
        "gateway_system": "direct"
    },
    "reference_id": "120071750406",
    "payment_link": null,
    "profile_id": "pro_KP1SMsZKdiOrioYnjKO2",
    "surcharge_details": null,
    "attempt_count": 1,
    "merchant_decision": null,
    "merchant_connector_id": "mca_Ym77o958MRzqZWCyOQXt",
    "incremental_authorization_allowed": false,
    "authorization_count": null,
    "incremental_authorizations": null,
    "external_authentication_details": null,
    "external_3ds_authentication_attempted": false,
    "expires_on": "2025-09-28T07:53:56.792Z",
    "fingerprint": null,
    "browser_info": null,
    "payment_channel": null,
    "payment_method_id": "pm_BS4qjY5VS1ARCBexzcfb",
    "network_transaction_id": "ZKS4CMGOARXYQR4IVKIRAOE",
    "payment_method_status": "active",
    "updated": "2025-09-28T07:38:59.120Z",
    "split_payments": null,
    "frm_metadata": null,
    "extended_authorization_applied": null,
    "capture_before": null,
    "merchant_order_reference_id": null,
    "order_tax_amount": null,
    "connector_mandate_id": "932841928-932130361",
    "card_discovery": "manual",
    "force_3ds_challenge": false,
    "force_3ds_challenge_trigger": false,
    "issuer_error_code": null,
    "issuer_error_message": null,
    "is_iframe_redirection_enabled": null,
    "whole_connector_response": null,
    "enable_partial_authorization": null,
    "enable_overcapture": null,
    "is_overcapture_enabled": null,
    "network_details": null
}
```


 Delete connector metadata
 
<img width="1233" height="503" alt="Screenshot 2025-09-28 at 1 12 00 PM" src="https://github.com/user-attachments/assets/6fd10bd3-87a1-4798-81f3-e3707ee61ccc" />
<img width="1136" height="944" alt="Screenshot 2025-09-28 at 1 12 22 PM" src="https://github.com/user-attachments/assets/84d13528-a37f-4f2e-ab74-79f70344d49d" />

- manual update refund status into failed

```sh
curl --location --request PUT 'localhost:8080/refunds/ref_Ut6eGBd4ZUKJXMhn3NZz/manual-update' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: test_admin' \
--data '{
    "status": "failed",
    "merchant_id": "merchant_1759037295"
}'
```

- retrigger refund with new code

```json
curl --location 'localhost:8080/refunds' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: dev_IbxeUnL1qB3Fre0mdogERYiA4O4rQttdcxtzqzMjzWpVR6zafoOzCYvIdRz9X5bu' \
--data '{
    "payment_id": "pay_n4mGvzhDDxV8ontN4pNa",
    "amount":689,
    "reason":"pause"
}'
```
### NOTE THAT in sbx we cannot make successful refund , its skipped in cypress too. Now the api call is goign

```json
{
    "refund_id": "ref_KlllCvhIs4k7Twk6teXh",
    "payment_id": "pay_n4mGvzhDDxV8ontN4pNa",
    "amount": 689,
    "currency": "USD",
    "status": "failed",
    "reason": "pause",
    "metadata": null,
    "error_message": "The referenced transaction does not meet the criteria for issuing a credit.",
    "error_code": "54",
    "unified_code": "UE_9000",
    "unified_message": "Something went wrong",
    "created_at": "2025-09-28T07:46:51.621Z",
    "updated_at": "2025-09-28T07:46:53.144Z",
    "connector": "authorizedotnet",
    "profile_id": "pro_KP1SMsZKdiOrioYnjKO2",
    "merchant_connector_id": "mca_Ym77o958MRzqZWCyOQXt",
    "split_refunds": null,
    "issuer_error_code": null,
    "issuer_error_message": null
}
```

### Additional Changes

- [x] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
