### PR TITLE
fix(payment): add connector_request_reference_id to PaymentAttemptUpdate in ConfirmIntentTokenized flow

### DIFF
--- a/crates/hyperswitch_domain_models/src/payments/payment_attempt.rs
+++ b/crates/hyperswitch_domain_models/src/payments/payment_attempt.rs
@@ -2017,6 +2017,7 @@ pub enum PaymentAttemptUpdate {
         merchant_connector_id: id_type::MerchantConnectorAccountId,
         authentication_type: storage_enums::AuthenticationType,
         payment_method_id: id_type::GlobalPaymentMethodId,
+        connector_request_reference_id: Option<String>,
     },
     /// Update the payment attempt on confirming the intent, after calling the connector on success response
     ConfirmIntentResponse(Box<ConfirmIntentResponseUpdate>),
@@ -3041,6 +3042,7 @@ impl From<PaymentAttemptUpdate> for diesel_models::PaymentAttemptUpdateInternal 
                 merchant_connector_id,
                 authentication_type,
                 payment_method_id,
+                connector_request_reference_id,
             } => Self {
                 status: Some(status),
                 payment_method_id: Some(payment_method_id),
@@ -3066,7 +3068,7 @@ impl From<PaymentAttemptUpdate> for diesel_models::PaymentAttemptUpdateInternal 
                 network_advice_code: None,
                 network_decline_code: None,
                 network_error_message: None,
-                connector_request_reference_id: None,
+                connector_request_reference_id,
                 connector_response_reference_id: None,
             },
         }

--- a/crates/router/src/core/payments/operations/payment_confirm_intent.rs
+++ b/crates/router/src/core/payments/operations/payment_confirm_intent.rs
@@ -620,6 +620,7 @@ impl<F: Clone + Sync> UpdateTracker<F, PaymentConfirmData<F>, PaymentsConfirmInt
                             .attach_printable("Merchant connector id is none when constructing response")
                     })?,
                     authentication_type,
+                    connector_request_reference_id,
                     payment_method_id : payment_method.get_id().clone()
                 }
             }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->

In the payment tokenization confirm intent flow, the field `connector_request_reference_id` was not being updated in payment_attempt.


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
closes #9596 


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
1. Confirm Intent :
```
curl --location 'http://localhost:8080/v2/payments/12345_pay_019994e36a177e03b4024c1e86907ed0/confirm-intent' \
--header 'x-profile-id: pro_rn7g67NOZXIaqMQMjSWG' \
--header 'x-client-secret: cs_019994e36a2a771290eaaf9c5baba115' \
--header 'Authorization: api-key=dev_C9gNbgcEhMbQloVd4ASlr97dPXRvpcZP5iTrecc88qJA1UqMsJa0VPxqlz8lOcy9' \
--header 'Content-Type: application/json' \
--header 'api-key: pk_dev_aacd87682cc548e6a240c0a5e69c3771' \
--data '{
   "payment_method_data": {
        "card": {
            "card_cvc": "123",
            "card_exp_month": "10",
            "card_exp_year": "25",
            "card_number": "4111111111111111",
            "card_holder_name": "joseph Doe"
        }
    },
    "payment_method_type": "card",
    "payment_method_subtype": "credit",
    "browser_info": {
        "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36",
        "accept_header": "text\\/html,application\\/xhtml+xml,application\\/xml;q=0.9,image\\/webp,image\\/apng,*\\/*;q=0.8",
        "language": "en-GB",
        "color_depth": 24,
        "screen_height": 1440,
        "screen_width": 2560,
        "time_zone": -330,
        "java_enabled": true,
        "java_script_enabled": true,
        "ip_address": "0.0.0.0"
    },
    "customer_acceptance": {
        "acceptance_type": "online",
        "accepted_at": "2022-09-10T10:11:12Z",
        "online": {
            "ip_address": "123.32.25.123",
            "user_agent": "Mozilla/5.0 (Linux; Android 12; SM-S906N Build/QP1A.190711.020; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/80.0.3987.119 Mobile Safari/537.36"
        }
    }
}'
```

Response:
```
{
    "id": "12345_pay_019994e36a177e03b4024c1e86907ed0",
    "status": "requires_capture",
    "amount": {
        "order_amount": 10000,
        "currency": "USD",
        "shipping_cost": null,
        "order_tax_amount": null,
        "external_tax_calculation": "skip",
        "surcharge_calculation": "skip",
        "surcharge_amount": null,
        "tax_on_surcharge": null,
        "net_amount": 10000,
        "amount_to_capture": null,
        "amount_capturable": 10000,
        "amount_captured": 0
    },
    "customer_id": "12345_cus_019994e3438475c39db3fd368c7f5343",
    "connector": "authorizedotnet",
    "created": "2025-09-29T09:52:35.876Z",
    "modified_at": "2025-09-29T09:52:45.633Z",
    "payment_method_data": {
        "billing": null
    },
    "payment_method_type": "card",
    "payment_method_subtype": "credit",
    "connector_transaction_id": "120071794888",
    "connector_reference_id": "120071794888",
    "merchant_connector_id": "mca_wOvtWjK6SlBGig1M2MFQ",
    "browser_info": null,
    "error": null,
    "shipping": null,
    "billing": null,
    "attempts": null,
    "connector_token_details": null,
    "payment_method_id": "12345_pm_019994e387c677919b40d6062bff9935",
    "next_action": null,
    "return_url": "https://google.com/success",
    "authentication_type": "no_three_ds",
    "authentication_type_applied": "no_three_ds",
    "is_iframe_redirection_enabled": null,
    "merchant_reference_id": null,
    "raw_connector_response": null,
    "feature_metadata": null,
    "metadata": null
}
```

<img width="773" height="173" alt="image" src="https://github.com/user-attachments/assets/b07d60f5-ec3e-4419-ae38-4e922a955fe8" />



## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
