### PR TITLE
refactor(core): add cache redaction for cgraph

### DIFF
--- a/crates/router/src/core/admin.rs
+++ b/crates/router/src/core/admin.rs
@@ -23,6 +23,7 @@ use masking::{ExposeInterface, PeekInterface, Secret};
 use pm_auth::types as pm_auth_types;
 use uuid::Uuid;
 
+use super::routing::helpers::redact_cgraph_cache;
 #[cfg(any(feature = "v1", feature = "v2"))]
 use crate::types::transformers::ForeignFrom;
 use crate::{
@@ -2576,6 +2577,9 @@ pub async fn create_connector(
                     .unwrap_or_default(),
             },
         )?;
+
+    // redact cgraph cache on new connector creation
+    redact_cgraph_cache(&state, merchant_id, business_profile.get_id()).await?;
 
     #[cfg(feature = "v1")]
     disputes::schedule_dispute_sync_task(&state, &business_profile, &mca).await?;

--- a/crates/router/src/core/routing/helpers.rs
+++ b/crates/router/src/core/routing/helpers.rs
@@ -2731,3 +2731,42 @@ pub async fn delete_decision_engine_merchant(
 
     Ok(())
 }
+
+#[instrument(skip_all)]
+pub async fn redact_cgraph_cache(
+    state: &SessionState,
+    merchant_id: &id_type::MerchantId,
+    profile_id: &id_type::ProfileId,
+) -> RouterResult<()> {
+    let cgraph_payouts_key = format!(
+        "cgraph_po_{}_{}",
+        merchant_id.get_string_repr(),
+        profile_id.get_string_repr(),
+    );
+
+    let cgraph_payments_key = format!(
+        "cgraph_{}_{}",
+        merchant_id.get_string_repr(),
+        profile_id.get_string_repr(),
+    );
+
+    let config_payouts_key = cache::CacheKind::CGraph(cgraph_payouts_key.clone().into());
+    cache::redact_from_redis_and_publish(
+        state.store.get_cache_store().as_ref(),
+        [config_payouts_key],
+    )
+    .await
+    .change_context(errors::ApiErrorResponse::InternalServerError)
+    .attach_printable("Failed to invalidate the cgraph cache")?;
+
+    let config_payments_key = cache::CacheKind::CGraph(cgraph_payments_key.clone().into());
+    cache::redact_from_redis_and_publish(
+        state.store.get_cache_store().as_ref(),
+        [config_payments_key],
+    )
+    .await
+    .change_context(errors::ApiErrorResponse::InternalServerError)
+    .attach_printable("Failed to invalidate the cgraph cache")?;
+
+    Ok(())
+}


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
This pull request enhances cache management for connector creation by introducing a new mechanism to invalidate related cache entries whenever a new connector is added. The main change is the addition of the `redact_cgraph_cache` function, which ensures that outdated cgraph cache data is cleared for the relevant merchant and profile, preventing stale data issues.

**Cache invalidation improvements:**

* Added the `redact_cgraph_cache` function in `crates/router/src/core/routing/helpers.rs` to invalidate both payouts and payments cgraph cache entries for a given merchant and profile. This function uses Redis and publishes cache invalidation events.
* Integrated the `redact_cgraph_cache` call into the connector creation flow in `crates/router/src/core/admin.rs`, ensuring cache is redacted whenever a new connector is created.
* Imported the `redact_cgraph_cache` helper function in `crates/router/src/core/admin.rs` to enable its usage in the admin logic.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
Required for cache redaction.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
1. Create wise connector with sepa enabled.
2. Create/confirm a sepa payout link.
3. create adyen mca with card.
4. Create/confirm a card payout link(it should be processed with adyen and not wise).

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
