### PR TITLE
Feat(getnet): Add Integrity Check Support for core flows (Hacktoberfest)

### DIFF
--- a/crates/hyperswitch_connectors/src/connectors/getnet.rs
+++ b/crates/hyperswitch_connectors/src/connectors/getnet.rs
@@ -280,6 +280,14 @@ impl ConnectorIntegration<Authorize, PaymentsAuthorizeData, PaymentsResponseData
             .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
         event_builder.map(|i| i.set_response_body(&response));
         router_env::logger::info!(connector_response=?response);
+
+        let response = utils::get_authorise_integrity_object(
+            data.amount_converter.as_ref(),
+            data.request.minor_amount,
+            data.request.currency,
+            response,
+        )?;
+
         RouterData::try_from(ResponseRouterData {
             response,
             data: data.clone(),
@@ -357,6 +365,13 @@ impl ConnectorIntegration<PSync, PaymentsSyncData, PaymentsResponseData> for Get
             .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
         event_builder.map(|i| i.set_response_body(&response));
         router_env::logger::info!(connector_response=?response);
+
+        let response = utils::get_sync_integrity_object(
+            self.amount_converter.as_ref(),
+            data.request.minor_amount,
+            data.request.currency,
+            response,
+        )?;
         RouterData::try_from(ResponseRouterData {
             response,
             data: data.clone(),
@@ -443,6 +458,14 @@ impl ConnectorIntegration<Capture, PaymentsCaptureData, PaymentsResponseData> fo
             .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
         event_builder.map(|i| i.set_response_body(&response));
         router_env::logger::info!(connector_response=?response);
+
+        let response = utils::get_capture_integrity_object(
+            // <-- Capture function used
+            self.amount_converter.as_ref(),
+            data.request.minor_amount_to_capture, // <-- Capture specific amount used
+            data.request.currency,
+            response,
+        )?;
         RouterData::try_from(ResponseRouterData {
             response,
             data: data.clone(),
@@ -608,6 +631,13 @@ impl ConnectorIntegration<Execute, RefundsData, RefundsResponseData> for Getnet 
                 .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
         event_builder.map(|i| i.set_response_body(&response));
         router_env::logger::info!(connector_response=?response);
+
+        let response = utils::get_refund_integrity_object(
+            self.amount_converter.as_ref(),
+            data.request.minor_refund_amount,
+            data.request.currency,
+            response,
+        )?;
         RouterData::try_from(ResponseRouterData {
             response,
             data: data.clone(),
@@ -683,6 +713,13 @@ impl ConnectorIntegration<RSync, RefundsData, RefundsResponseData> for Getnet {
             .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
         event_builder.map(|i| i.set_response_body(&response));
         router_env::logger::info!(connector_response=?response);
+
+        let response = utils::get_refund_integrity_object(
+            self.amount_converter.as_ref(),
+            data.request.minor_amount,
+            data.request.currency,
+            response,
+        )?;
         RouterData::try_from(ResponseRouterData {
             response,
             data: data.clone(),


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
Implemented amount integrity check support for the GETNET connector. This ensures that the amounts received in the connector's response for Authorize, PSync, Refund Execute, and Refund Sync flows match the amounts sent in the Hyperswitch request.


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
Fixes #9178

This change is required to implement the critical security measure of amount integrity checks at the connector level, aligning GETNET with other Hyperswitch payment processors. This significantly enhances data consistency and security.


## How did you test it?
Code was successfully formatted using cargo +nightly fmt --all.


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
