### PR TITLE
ci(cypress): use postgres 17 images for service containers

### DIFF
--- a/.github/workflows/cypress-tests-runner.yml
+++ b/.github/workflows/cypress-tests-runner.yml
@@ -149,7 +149,7 @@ jobs:
         ports:
           - 6379:6379
       postgres:
-        image: "public.ecr.aws/docker/library/postgres:alpine"
+        image: "public.ecr.aws/docker/library/postgres:17-alpine"
         env:
           POSTGRES_USER: db_user
           POSTGRES_PASSWORD: db_pass
@@ -315,7 +315,7 @@ jobs:
         ports:
           - 6379:6379
       postgres:
-        image: "public.ecr.aws/docker/library/postgres:alpine"
+        image: "public.ecr.aws/docker/library/postgres:17-alpine"
         env:
           POSTGRES_USER: db_user
           POSTGRES_PASSWORD: db_pass
@@ -501,7 +501,7 @@ jobs:
         ports:
           - 6379:6379
       postgres:
-        image: "public.ecr.aws/docker/library/postgres:alpine"
+        image: "public.ecr.aws/docker/library/postgres:17-alpine"
         env:
           POSTGRES_USER: db_user
           POSTGRES_PASSWORD: db_pass


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
use postgres 17 images for service containers

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
CI cypress checks are failing due to database issue


## How did you test it?
CI checks should pass

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
