### PR TITLE
refactor(connector, stax): add centralized amount conversion using MajorUnit; update mappings and tests

### DIFF
--- a/crates/hyperswitch_connectors/src/connectors/stax/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/stax/transformers.rs
@@ -1,6 +1,5 @@
 use common_enums::enums;
-use common_utils::pii::Email;
-use error_stack::ResultExt;
+use common_utils::{pii::Email, types::FloatMajorUnit};
 use hyperswitch_domain_models::{
     payment_method_data::{BankDebitData, PaymentMethodData},
     router_data::{ConnectorAuthType, PaymentMethodToken, RouterData},
@@ -11,7 +10,7 @@ use hyperswitch_domain_models::{
     },
     types,
 };
-use hyperswitch_interfaces::{api, errors};
+use hyperswitch_interfaces::errors;
 use masking::{ExposeInterface, Secret};
 use serde::{Deserialize, Serialize};
 
@@ -26,16 +25,13 @@ use crate::{
 
 #[derive(Debug, Serialize)]
 pub struct StaxRouterData<T> {
-    pub amount: f64,
+    pub amount: FloatMajorUnit,
     pub router_data: T,
 }
 
-impl<T> TryFrom<(&api::CurrencyUnit, enums::Currency, i64, T)> for StaxRouterData<T> {
+impl<T> TryFrom<(FloatMajorUnit, T)> for StaxRouterData<T> {
     type Error = error_stack::Report<errors::ConnectorError>;
-    fn try_from(
-        (currency_unit, currency, amount, item): (&api::CurrencyUnit, enums::Currency, i64, T),
-    ) -> Result<Self, Self::Error> {
-        let amount = utils::get_amount_as_f64(currency_unit, amount, currency)?;
+    fn try_from((amount, item): (FloatMajorUnit, T)) -> Result<Self, Self::Error> {
         Ok(Self {
             amount,
             router_data: item,
@@ -51,7 +47,7 @@ pub struct StaxPaymentsRequestMetaData {
 #[derive(Debug, Serialize)]
 pub struct StaxPaymentsRequest {
     payment_method_id: Secret<String>,
-    total: f64,
+    total: FloatMajorUnit,
     is_refundable: bool,
     pre_auth: bool,
     meta: StaxPaymentsRequestMetaData,
@@ -333,14 +329,16 @@ pub struct StaxChildCapture {
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct StaxPaymentsResponse {
-    success: bool,
-    id: String,
-    is_captured: i8,
-    is_voided: bool,
-    child_captures: Vec<StaxChildCapture>,
+    pub success: bool,
+    pub id: String,
+    pub is_captured: i8,
+    pub is_voided: bool,
+    pub child_captures: Vec<StaxChildCapture>,
     #[serde(rename = "type")]
-    payment_response_type: StaxPaymentResponseTypes,
-    idempotency_id: Option<String>,
+    pub payment_response_type: StaxPaymentResponseTypes,
+    pub total: FloatMajorUnit,
+    pub currency: String,
+    pub idempotency_id: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -400,7 +398,7 @@ impl<F, T> TryFrom<ResponseRouterData<F, StaxPaymentsResponse, T, PaymentsRespon
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct StaxCaptureRequest {
-    total: Option<f64>,
+    total: Option<FloatMajorUnit>,
 }
 
 impl TryFrom<&StaxRouterData<&types::PaymentsCaptureRouterData>> for StaxCaptureRequest {
@@ -417,7 +415,7 @@ impl TryFrom<&StaxRouterData<&types::PaymentsCaptureRouterData>> for StaxCapture
 // Type definition for RefundRequest
 #[derive(Debug, Serialize)]
 pub struct StaxRefundRequest {
-    pub total: f64,
+    pub total: FloatMajorUnit,
 }
 
 impl<F> TryFrom<&StaxRouterData<&types::RefundsRouterData<F>>> for StaxRefundRequest {
@@ -429,16 +427,16 @@ impl<F> TryFrom<&StaxRouterData<&types::RefundsRouterData<F>>> for StaxRefundReq
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct ChildTransactionsInResponse {
-    id: String,
-    success: bool,
-    created_at: String,
-    total: f64,
+    pub id: String,
+    pub success: bool,
+    pub created_at: String,
+    pub total: FloatMajorUnit,
 }
 #[derive(Debug, Deserialize, Serialize)]
 pub struct RefundResponse {
-    id: String,
-    success: bool,
-    child_transactions: Vec<ChildTransactionsInResponse>,
+    pub id: String,
+    pub success: bool,
+    pub child_transactions: Vec<ChildTransactionsInResponse>,
 }
 
 impl TryFrom<RefundsResponseRouterData<Execute, RefundResponse>>
@@ -448,16 +446,22 @@ impl TryFrom<RefundsResponseRouterData<Execute, RefundResponse>>
     fn try_from(
         item: RefundsResponseRouterData<Execute, RefundResponse>,
     ) -> Result<Self, Self::Error> {
-        let refund_amount = utils::to_currency_base_unit_asf64(
-            item.data.request.refund_amount,
-            item.data.request.currency,
-        )
-        .change_context(errors::ConnectorError::ResponseHandlingFailed)?;
+        // Compare using minor units: expected is already available as minor_refund_amount
+        let expected_minor = item.data.request.minor_refund_amount;
+
         let filtered_txn: Vec<&ChildTransactionsInResponse> = item
             .response
             .child_transactions
             .iter()
-            .filter(|txn| txn.total == refund_amount)
+            .filter(|txn| {
+                let txn_minor = utils::convert_back_amount_to_minor_units(
+                    &common_utils::types::FloatMajorUnitForConnector,
+                    txn.total,
+                    item.data.request.currency,
+                )
+                .ok();
+                matches!(txn_minor, Some(m) if m == expected_minor)
+            })
             .collect();
 
         let mut refund_txn = filtered_txn

--- a/crates/router/src/types/api/connector_mapping.rs
+++ b/crates/router/src/types/api/connector_mapping.rs
@@ -390,8 +390,7 @@ impl ConnectorData {
                     Ok(ConnectorEnum::Old(Box::new(connector::Silverflow::new())))
                 }
                 enums::Connector::Square => Ok(ConnectorEnum::Old(Box::new(&connector::Square))),
-                enums::Connector::Stax =>
-                    Ok(ConnectorEnum::Old(Box::new(connector::Stax::new()))),
+                enums::Connector::Stax => Ok(ConnectorEnum::Old(Box::new(connector::Stax::new()))),
                 enums::Connector::Stripe => {
                     Ok(ConnectorEnum::Old(Box::new(connector::Stripe::new())))
                 }

--- a/crates/router/src/types/api/connector_mapping.rs
+++ b/crates/router/src/types/api/connector_mapping.rs
@@ -390,7 +390,8 @@ impl ConnectorData {
                     Ok(ConnectorEnum::Old(Box::new(connector::Silverflow::new())))
                 }
                 enums::Connector::Square => Ok(ConnectorEnum::Old(Box::new(&connector::Square))),
-                enums::Connector::Stax => Ok(ConnectorEnum::Old(Box::new(&connector::Stax))),
+                enums::Connector::Stax =>
+                    Ok(ConnectorEnum::Old(Box::new(connector::Stax::new()))),
                 enums::Connector::Stripe => {
                     Ok(ConnectorEnum::Old(Box::new(connector::Stripe::new())))
                 }

--- a/crates/router/src/types/api/feature_matrix.rs
+++ b/crates/router/src/types/api/feature_matrix.rs
@@ -311,8 +311,7 @@ impl FeatureMatrixConnectorData {
                     Ok(ConnectorEnum::Old(Box::new(connector::Shift4::new())))
                 }
                 enums::Connector::Square => Ok(ConnectorEnum::Old(Box::new(&connector::Square))),
-                enums::Connector::Stax =>
-                    Ok(ConnectorEnum::Old(Box::new(connector::Stax::new()))),
+                enums::Connector::Stax => Ok(ConnectorEnum::Old(Box::new(connector::Stax::new()))),
                 enums::Connector::Stripe => {
                     Ok(ConnectorEnum::Old(Box::new(connector::Stripe::new())))
                 }

--- a/crates/router/src/types/api/feature_matrix.rs
+++ b/crates/router/src/types/api/feature_matrix.rs
@@ -311,7 +311,8 @@ impl FeatureMatrixConnectorData {
                     Ok(ConnectorEnum::Old(Box::new(connector::Shift4::new())))
                 }
                 enums::Connector::Square => Ok(ConnectorEnum::Old(Box::new(&connector::Square))),
-                enums::Connector::Stax => Ok(ConnectorEnum::Old(Box::new(&connector::Stax))),
+                enums::Connector::Stax =>
+                    Ok(ConnectorEnum::Old(Box::new(connector::Stax::new()))),
                 enums::Connector::Stripe => {
                     Ok(ConnectorEnum::Old(Box::new(connector::Stripe::new())))
                 }

--- a/crates/router/tests/connectors/stax.rs
+++ b/crates/router/tests/connectors/stax.rs
@@ -13,7 +13,7 @@ impl utils::Connector for StaxTest {
     fn get_data(&self) -> types::api::ConnectorData {
         use router::connector::Stax;
         utils::construct_connector_data_old(
-            Box::new(&Stax),
+            Box::new(Stax::new()),
             types::Connector::Stax,
             types::api::GetToken::Connector,
             None,


### PR DESCRIPTION
### Type of Change
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

### Description
Refactor the Stax connector to use the centralized amount conversion framework with explicit denomination units, replacing ad-hoc f64 handling.

Edits:
- crates/hyperswitch_connectors/src/connectors/stax.rs
  - Add `amount_converter()` returning `FloatMajorUnitForConnector`.
  - Use centralized `convert_amount` for:
    - authorize: convert `minor_amount` to `FloatMajorUnit`
    - capture: convert `minor_amount_to_capture` to `FloatMajorUnit`
    - refund: convert `minor_refund_amount` to `FloatMajorUnit`
- crates/hyperswitch_connectors/src/connectors/stax/transformers.rs
  - `StaxRouterData.amount: FloatMajorUnit`
  - Request types expect `FloatMajorUnit` (e.g., `StaxPaymentsRequest.total`, `StaxCaptureRequest.total`, `StaxRefundRequest.total`).
- crates/router/src/types/api/connector_mapping.rs
  - Initialize Stax via `Stax::new()`.
- crates/router/src/types/api/feature_matrix.rs
  - Initialize Stax via `Stax::new()`.
- crates/router/tests/connectors/stax.rs
  - Update test construction to `Box::new(Stax::new())`.


### Additional Changes
- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

File references:
- `crates/hyperswitch_connectors/src/connectors/stax.rs`
- `crates/hyperswitch_connectors/src/connectors/stax/transformers.rs`
- `crates/router/src/types/api/connector_mapping.rs`
- `crates/router/src/types/api/feature_matrix.rs`
- `crates/router/tests/connectors/stax.rs`

### Motivation and Context

- Stax Developer API Overview: `https://api-docs.staxpayments.com/reference/overview`
- Reference PR 8878: refactor(connector): implement amount converter framework for authorizedotnet, bankofamerica

### How did you test it?
- Unit tests (connector crate):
  - Stax round-trip conversion tests for 0/2/3-decimal currencies:
    - USD (2-decimals) round-trip MinorUnit ↔ FloatMajorUnit
    - JPY (0-decimals) round-trip
    - BHD (3-decimals) round-trip
  - Assert Stax currency unit is Base (major) for request bodies.
- Local runs:
  - `cargo build --jobs 2 --bin router` (no build errors)
  - `cargo test -p hyperswitch_connectors --features v1` (10 passed; includes Stax tests)

### Checklist
- [ ] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy -p hyperswitch_connectors --features v1`
- [x] I reviewed the submitted code
- [x] I added unit tests for my changes where possible