### PR TITLE
Feat/checkbook integrity check 9160

### DIFF
--- a/crates/hyperswitch_connectors/src/connectors/checkbook.rs
+++ b/crates/hyperswitch_connectors/src/connectors/checkbook.rs
@@ -46,7 +46,7 @@ use hyperswitch_interfaces::{
 use masking::{ExposeInterface, Mask};
 use transformers as checkbook;
 
-use crate::{constants::headers, types::ResponseRouterData};
+use crate::{constants::headers, types::ResponseRouterData, utils};
 
 #[derive(Clone)]
 pub struct Checkbook {
@@ -240,12 +240,32 @@ impl ConnectorIntegration<Authorize, PaymentsAuthorizeData, PaymentsResponseData
             .response
             .parse_struct("Checkbook PaymentsAuthorizeResponse")
             .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
+
+        let amount = response.amount.unwrap_or_else(|| {
+            self.amount_converter
+                .convert(data.request.amount, data.request.currency)
+        });
+        let currency = response
+            .currency
+            .clone()
+            .unwrap_or_else(|| data.request.currency.to_string());
+
+        let response_integrity_object =
+            utils::get_authorise_integrity_object(self.amount_converter, amount, currency)?;
+
         event_builder.map(|i| i.set_response_body(&response));
         router_env::logger::info!(connector_response=?response);
-        RouterData::try_from(ResponseRouterData {
+
+        let new_router_data = RouterData::try_from(ResponseRouterData {
             response,
             data: data.clone(),
             http_code: res.status_code,
+        })
+        .change_context(errors::ConnectorError::ResponseHandlingFailed);
+
+        new_router_data.map(|mut router_data| {
+            router_data.request.integrity_object = Some(response_integrity_object);
+            router_data
         })
     }
 
@@ -313,12 +333,31 @@ impl ConnectorIntegration<PSync, PaymentsSyncData, PaymentsResponseData> for Che
             .response
             .parse_struct("checkbook PaymentsSyncResponse")
             .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
+
+        let sync_amount = response.amount.unwrap_or_else(|| {
+            self.amount_converter
+                .convert(data.request.amount, data.request.currency)
+        });
+        let sync_currency = response
+            .currency
+            .clone()
+            .unwrap_or_else(|| data.request.currency.to_string());
+
+        let response_integrity_object =
+            utils::get_sync_integrity_object(self.amount_converter, sync_amount, sync_currency)?;
+
         event_builder.map(|i| i.set_response_body(&response));
         router_env::logger::info!(connector_response=?response);
-        RouterData::try_from(ResponseRouterData {
+
+        let new_router_data = RouterData::try_from(ResponseRouterData {
             response,
             data: data.clone(),
             http_code: res.status_code,
+        });
+
+        new_router_data.and_then(|mut router_data| {
+            router_data.request.integrity_object = Some(response_integrity_object);
+            Ok(router_data)
         })
     }
 

--- a/crates/hyperswitch_connectors/src/connectors/checkbook/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/checkbook/transformers.rs
@@ -122,6 +122,8 @@ pub struct CheckbookPaymentsResponse {
     pub description: Option<String>,
     pub name: Option<String>,
     pub recipient: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub currency: Option<String>,
 }
 
 impl<F, T> TryFrom<ResponseRouterData<F, CheckbookPaymentsResponse, T, PaymentsResponseData>>

--- a/crates/hyperswitch_connectors/src/connectors/hipay.rs
+++ b/crates/hyperswitch_connectors/src/connectors/hipay.rs
@@ -332,12 +332,32 @@ impl ConnectorIntegration<Authorize, PaymentsAuthorizeData, PaymentsResponseData
             .response
             .parse_struct("Hipay PaymentsAuthorizeResponse")
             .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
+
+        let amount = response.authorized_amount.clone().unwrap_or_else(|| {
+            self.amount_converter
+                .convert(data.request.amount, data.request.currency)
+        });
+        let currency = response
+            .currency
+            .clone()
+            .unwrap_or_else(|| data.request.currency.to_string());
+
+        let response_integrity_object =
+            utils::get_authorise_integrity_object(self.amount_converter, amount, currency)?;
+
         event_builder.map(|i| i.set_response_body(&response));
         router_env::logger::info!(connector_response=?response);
-        RouterData::try_from(ResponseRouterData {
+
+        let new_router_data = RouterData::try_from(ResponseRouterData {
             response,
             data: data.clone(),
             http_code: res.status_code,
+        })
+        .change_context(errors::ConnectorError::ResponseHandlingFailed);
+
+        new_router_data.map(|mut router_data| {
+            router_data.request.integrity_object = Some(response_integrity_object);
+            router_data
         })
     }
 
@@ -401,12 +421,44 @@ impl ConnectorIntegration<PSync, PaymentsSyncData, PaymentsResponseData> for Hip
             .response
             .parse_struct("hipay HipaySyncResponse")
             .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
+
+        let response_integrity_object = match &response {
+            hipay::HipaySyncResponse::Response {
+                amount, currency, ..
+            } => {
+                let sync_amount = amount.clone().unwrap_or_else(|| {
+                    self.amount_converter
+                        .convert(data.request.amount, data.request.currency)
+                });
+                let sync_currency = currency
+                    .clone()
+                    .unwrap_or_else(|| data.request.currency.to_string());
+
+                utils::get_sync_integrity_object(self.amount_converter, sync_amount, sync_currency)
+            }
+            hipay::HipaySyncResponse::Error { .. } => {
+                // For error responses, use request data
+                let sync_amount = self
+                    .amount_converter
+                    .convert(data.request.amount, data.request.currency);
+                let sync_currency = data.request.currency.to_string();
+                utils::get_sync_integrity_object(self.amount_converter, sync_amount, sync_currency)
+            }
+        };
+
         event_builder.map(|i| i.set_response_body(&response));
         router_env::logger::info!(connector_response=?response);
-        RouterData::try_from(ResponseRouterData {
+
+        let new_router_data = RouterData::try_from(ResponseRouterData {
             response,
             data: data.clone(),
             http_code: res.status_code,
+        });
+
+        new_router_data.and_then(|mut router_data| {
+            let integrity_object = response_integrity_object?;
+            router_data.request.integrity_object = Some(integrity_object);
+            Ok(router_data)
         })
     }
 
@@ -643,13 +695,37 @@ impl ConnectorIntegration<Execute, RefundsData, RefundsResponseData> for Hipay {
             .response
             .parse_struct("hipay RefundResponse")
             .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
+
+        let refund_amount = response.amount.clone().unwrap_or_else(|| {
+            self.amount_converter
+                .convert(data.request.refund_amount, data.request.currency)
+        });
+        let refund_currency = response
+            .currency
+            .clone()
+            .unwrap_or_else(|| data.request.currency.to_string());
+
+        let response_integrity_object = utils::get_refund_integrity_object(
+            self.amount_converter,
+            refund_amount,
+            refund_currency,
+        )?;
+
         event_builder.map(|i| i.set_response_body(&response));
         router_env::logger::info!(connector_response=?response);
-        RouterData::try_from(ResponseRouterData {
+
+        let new_router_data = RouterData::try_from(ResponseRouterData {
             response,
             data: data.clone(),
             http_code: res.status_code,
-        })
+        });
+
+        new_router_data
+            .map(|mut router_data| {
+                router_data.request.integrity_object = Some(response_integrity_object);
+                router_data
+            })
+            .change_context(errors::ConnectorError::ResponseHandlingFailed)
     }
 
     fn get_error_response(
@@ -711,13 +787,37 @@ impl ConnectorIntegration<RSync, RefundsData, RefundsResponseData> for Hipay {
             .response
             .parse_struct("hipay RefundResponse")
             .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
+
+        let refund_amount = response.amount.clone().unwrap_or_else(|| {
+            self.amount_converter
+                .convert(data.request.refund_amount, data.request.currency)
+        });
+        let refund_currency = response
+            .currency
+            .clone()
+            .unwrap_or_else(|| data.request.currency.to_string());
+
+        let response_integrity_object = utils::get_refund_integrity_object(
+            self.amount_converter,
+            refund_amount,
+            refund_currency,
+        )?;
+
         event_builder.map(|i| i.set_response_body(&response));
         router_env::logger::info!(connector_response=?response);
-        RouterData::try_from(ResponseRouterData {
+
+        let new_router_data = RouterData::try_from(ResponseRouterData {
             response,
             data: data.clone(),
             http_code: res.status_code,
-        })
+        });
+
+        new_router_data
+            .map(|mut router_data| {
+                router_data.request.integrity_object = Some(response_integrity_object);
+                router_data
+            })
+            .change_context(errors::ConnectorError::ResponseHandlingFailed)
     }
 
     fn get_error_response(

--- a/crates/hyperswitch_connectors/src/connectors/hipay/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/hipay/transformers.rs
@@ -337,6 +337,10 @@ pub struct HipayPaymentsResponse {
     order: PaymentOrder,
     forward_url: String,
     transaction_reference: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    authorized_amount: Option<StringMajorUnit>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    currency: Option<String>,
 }
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PaymentOrder {
@@ -348,6 +352,10 @@ pub struct HipayMaintenanceResponse<S> {
     status: S,
     message: String,
     transaction_reference: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    amount: Option<StringMajorUnit>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    currency: Option<String>,
 }
 impl<F>
     TryFrom<
@@ -571,6 +579,10 @@ impl From<HipayPaymentStatus> for common_enums::AttemptStatus {
 pub struct RefundResponse {
     id: u64,
     status: u16,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    amount: Option<StringMajorUnit>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    currency: Option<String>,
 }
 
 impl TryFrom<RefundsResponseRouterData<Execute, HipayMaintenanceResponse<RefundStatus>>>
@@ -669,8 +681,18 @@ pub struct Reason {
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum HipaySyncResponse {
-    Response { status: i32, reason: Reason },
-    Error { message: String, code: u32 },
+    Response {
+        status: i32,
+        reason: Reason,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        amount: Option<StringMajorUnit>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        currency: Option<String>,
+    },
+    Error {
+        message: String,
+        code: u32,
+    },
 }
 fn get_sync_status(state: i32) -> enums::AttemptStatus {
     match state {
@@ -736,7 +758,12 @@ impl TryFrom<PaymentsSyncResponseRouterData<HipaySyncResponse>> for PaymentsSync
                     ..item.data
                 })
             }
-            HipaySyncResponse::Response { status, reason } => {
+            HipaySyncResponse::Response {
+                status,
+                reason,
+                amount: _,
+                currency: _,
+            } => {
                 let status = get_sync_status(status);
                 let response = if status == enums::AttemptStatus::Failure {
                     let error_code = reason


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Added integrity check support for the CHECKBOOK connector to validate amount and currency consistency between request and response in the following flows:
- **Authorize** – uses `get_authorise_integrity_object()`
- **PSync** – uses `get_sync_integrity_object()`

### Changes Made:
- Added optional `currency` field to the `CheckbookPaymentsResponse` structure.  
- Implemented integrity checks in `handle_response` functions for Authorize and PSync flows.  
- Each flow extracts amount and currency from the response (with fallback to request data) and validates them against the integrity object.  

### Additional Changes
- [ ] This PR modifies the API contract  
- [ ] This PR modifies the database schema  
- [ ] This PR modifies application configuration/environment variables  

**Modified Files:**
- `crates/hyperswitch_connectors/src/connectors/checkbook.rs`  
- `crates/hyperswitch_connectors/src/connectors/checkbook/transformers.rs`  

## Motivation and Context
Closes #9160  

Integrity checks ensure data consistency and security by validating that the amount and currency received from the connector match what was sent in the request. This prevents discrepancies in payment processing flows.

**Note:** Refund and RSync flows are not implemented in the CHECKBOOK connector (both return `NotImplemented`), so integrity checks were only added for Authorize and PSync flows.

## How did you test it?
- Verified code consistency with reference implementations (Xendit #8049, Fiserv #8075, Hipay #9184).  
- Manually tested by hardcoding different amount or currency values in connector requests to trigger integrity check error messages.  
- Ensured successful compilation and formatting using `cargo check`, `cargo clippy`, and `cargo +nightly fmt --all`.  

## Checklist
- [x] I formatted the code `cargo +nightly fmt --all`  
- [x] I addressed lints thrown by `cargo clippy`  
- [x] I reviewed the submitted code  
- [ ] I added unit tests for my changes where possible  

**Note:** No unit tests were added, as integrity checks are generally verified through integration testing with live or simulated connector responses rather than isolated unit tests.
