### PR TITLE
🔒 [SECURITY] Fix timing attack vulnerability in Braintree webhook verification

### DIFF
--- a/crates/hyperswitch_connectors/src/connectors/braintree.rs
+++ b/crates/hyperswitch_connectors/src/connectors/braintree.rs
@@ -1059,9 +1059,14 @@ impl IncomingWebhook for Braintree {
             hmac::HMAC_SHA1_FOR_LEGACY_USE_ONLY,
             sha1_hash_key.as_slice(),
         );
-        let signed_messaged = hmac::sign(&signing_key, &message);
-        let payload_sign: String = hex::encode(signed_messaged);
-        Ok(payload_sign.as_bytes().eq(&signature))
+        
+        // Use constant-time comparison to prevent timing attacks
+        // Decode the hex signature for comparison
+        let signature_bytes = hex::decode(&signature)
+            .change_context(errors::ConnectorError::WebhookSignatureNotFound)?;
+        
+        // hmac::verify performs constant-time comparison internally
+        Ok(hmac::verify(&signing_key, &message, &signature_bytes).is_ok())
     }
 
     fn get_webhook_object_reference_id(


### PR DESCRIPTION
## 🔐 Security Issue: Timing Attack in Webhook Signature Verification

### Problem Identified
The Braintree connector's webhook signature verification used **standard equality comparison (`eq()`)** instead of constant-time comparison, making it vulnerable to **timing side-channel attacks**.

**Vulnerable code:**
```rust
let signed_messaged = hmac::sign(&signing_key, &message);
let payload_sign: String = hex::encode(signed_messaged);
Ok(payload_sign.as_bytes().eq(&signature))  // ⚠️ NOT constant-time!
```

### Impact & Severity
- **Severity:** 🟡 **Medium**
- **Vulnerability Type:** Timing Side-Channel Attack
- **Attack Vector:** Remote timing analysis
- **Potential Impact:**
  - Attackers can exploit timing differences in string comparison
  - Allows byte-by-byte signature guessing through timing analysis  
  - Could forge valid webhook signatures without knowing the secret key
  - Sophisticated attack but cryptographically unsound implementation

### Technical Background
**Why is this a vulnerability?**

Standard equality comparisons (`eq()`, `==`) typically short-circuit—they return `false` as soon as they find a mismatched byte. This creates measurable timing differences:
- Correct first byte but wrong second byte: slightly longer execution time
- Wrong first byte: very short execution time

An attacker can measure these microsecond differences across thousands of requests to:
1. Determine the first byte of the correct signature
2. Move to the second byte, and so on
3. Eventually reconstruct the entire valid signature

### Solution Implemented
✅ Replaced string equality with **constant-time HMAC verification** using ring's `hmac::verify()`, which performs constant-time comparison internally.

**Secure implementation:**
```rust
// Use constant-time comparison to prevent timing attacks
// Decode the hex signature for comparison
let signature_bytes = hex::decode(&signature)
    .change_context(errors::ConnectorError::WebhookSignatureNotFound)?;

// hmac::verify performs constant-time comparison internally
Ok(hmac::verify(&signing_key, &message, &signature_bytes).is_ok())
```

### Why This Fix is Necessary
1. **Constant-Time Guarantee:** `hmac::verify()` always takes the same time regardless of input
2. **Cryptographically Sound:** Prevents timing side-channel attacks
3. **Industry Best Practice:** Standard approach for HMAC signature verification
4. **Security in Depth:** Eliminates entire class of timing vulnerabilities

### Code Flow Comparison

**Before (Vulnerable):**
1. Generate HMAC signature → `Vec<u8>`
2. Hex-encode the result → `String`  
3. Convert to bytes and compare using `eq()` → ⚠️ NOT constant-time
4. Early return on mismatch → ⚠️ Leaks timing info

**After (Secure):**
1. Decode hex signature to bytes
2. Use `hmac::verify()` with constant-time comparison → ✅ Always same duration
3. Return boolean result safely

### Testing & Validation
- ✅ No linter errors introduced
- ✅ Maintains exact function signature
- ✅ Compatible with existing webhook processing flow
- ✅ Uses established cryptographic library (ring/hmac)

### References
- OWASP: Timing Attack Prevention
- NIST SP 800-107: Recommendation for Applications Using Approved Hash Algorithms
- RFC 2104: HMAC specification

---

## 🎃 Hacktoberfest Contribution
This is a security contribution for Hacktoberfest 2025 focusing on cryptographic best practices.