### PR TITLE
feat(connector): [REDSYS] Added Integrity Check support for all Payment & Refund Flows

### DIFF
--- a/crates/common_utils/src/types.rs
+++ b/crates/common_utils/src/types.rs
@@ -447,7 +447,9 @@ impl MinorUnit {
     }
 
     ///Convert minor unit to string minor unit
-    fn to_minor_unit_as_string(self) -> Result<StringMinorUnit, error_stack::Report<ParsingError>> {
+    pub fn to_minor_unit_as_string(
+        self,
+    ) -> Result<StringMinorUnit, error_stack::Report<ParsingError>> {
         Ok(StringMinorUnit::new(self.0.to_string()))
     }
 }

--- a/crates/hyperswitch_connectors/src/connectors/redsys.rs
+++ b/crates/hyperswitch_connectors/src/connectors/redsys.rs
@@ -6,7 +6,7 @@ use common_utils::{
     errors::CustomResult,
     ext_traits::{BytesExt, XmlExt},
     request::{Method, Request, RequestBuilder, RequestContent},
-    types::{AmountConvertor, StringMinorUnit, StringMinorUnitForConnector},
+    types::{AmountConvertor, MinorUnit, StringMinorUnit, StringMinorUnitForConnector},
 };
 use error_stack::{report, ResultExt};
 use hyperswitch_domain_models::{
@@ -733,11 +733,40 @@ impl ConnectorIntegration<PSync, PaymentsSyncData, PaymentsResponseData> for Red
             .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
 
         event_builder.map(|i| i.set_response_body(&response));
+
+        let (response_amount_str, response_currency) =
+            redsys::extract_amount_from_sync_response(&response)
+                .map_err(|_| errors::ConnectorError::ResponseDeserializationFailed)?
+                .ok_or(errors::ConnectorError::MissingRequiredField {
+                    field_name: "amount and currency in response",
+                })?;
+
+        let response_amount = response_amount_str
+            .parse::<i64>()
+            .map_err(|_| errors::ConnectorError::ResponseDeserializationFailed)?;
+
+        let response_amount = MinorUnit::new(response_amount)
+            .to_minor_unit_as_string()
+            .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
+
+        let response_integrity_object = connector_utils::get_sync_integrity_object(
+            self.amount_converter,
+            response_amount,
+            response_currency,
+        )?;
+
         router_env::logger::info!(connector_response=?response);
-        RouterData::try_from(ResponseRouterData {
+
+        let new_router_data = RouterData::try_from(ResponseRouterData {
             response,
             data: data.clone(),
             http_code: res.status_code,
+        })
+        .change_context(errors::ConnectorError::ResponseHandlingFailed);
+
+        new_router_data.map(|mut router_data| {
+            router_data.request.integrity_object = Some(response_integrity_object);
+            router_data
         })
     }
     fn get_error_response(
@@ -809,11 +838,40 @@ impl ConnectorIntegration<RSync, RefundsData, RefundsResponseData> for Redsys {
             .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
 
         event_builder.map(|i| i.set_response_body(&response));
+
+        let (response_amount_str, response_currency) =
+            redsys::extract_amount_from_sync_response(&response)
+                .map_err(|_| errors::ConnectorError::ResponseDeserializationFailed)?
+                .ok_or(errors::ConnectorError::MissingRequiredField {
+                    field_name: "amount and currency in response",
+                })?;
+
+        let response_amount = response_amount_str
+            .parse::<i64>()
+            .map_err(|_| errors::ConnectorError::ResponseDeserializationFailed)?;
+
+        let response_amount = MinorUnit::new(response_amount)
+            .to_minor_unit_as_string()
+            .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
+
+        let response_integrity_object = connector_utils::get_refund_integrity_object(
+            self.amount_converter,
+            response_amount,
+            response_currency,
+        )?;
+
         router_env::logger::info!(connector_response=?response);
-        RouterData::try_from(ResponseRouterData {
+
+        let new_router_data = RouterData::try_from(ResponseRouterData {
             response,
             data: data.clone(),
             http_code: res.status_code,
+        })
+        .change_context(errors::ConnectorError::ResponseHandlingFailed);
+
+        new_router_data.map(|mut router_data| {
+            router_data.request.integrity_object = Some(response_integrity_object);
+            router_data
         })
     }
     fn get_error_response(

--- a/crates/hyperswitch_connectors/src/connectors/redsys/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/redsys/transformers.rs
@@ -589,6 +589,30 @@ pub struct RedsysTransaction {
     ds_signature: Secret<String>,
 }
 
+pub fn extract_amount_from_sync_response(
+    response: &RedsysSyncResponse,
+) -> Result<Option<(String, String)>, errors::ConnectorError> {
+    let message_data = &response
+        .body
+        .consultaoperacionesresponse
+        .consultaoperacionesreturn
+        .messages
+        .version
+        .message;
+
+    if let Some(ref response_data) = message_data.response {
+        let amount = response_data.ds_amount.clone();
+        let currency = response_data.ds_currency.clone();
+
+        match (amount, currency) {
+            (Some(amt), Some(curr)) => Ok(Some((amt, curr))),
+            _ => Ok(None),
+        }
+    } else {
+        Ok(None)
+    }
+}
+
 fn to_connector_response_data<T>(connector_response: &str) -> Result<T, Error>
 where
     T: serde::de::DeserializeOwned,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
Added integrity check in PSync and RSync flows.

#### Note
I have only added request integrity check to Authorize and Capture flows, as the response body returned
by Redsys does not contain the amount or currency.


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->

Closes #9220 


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

#### Note

I was not able to get any Redsys credentials to test the code from my side, 
@bsayak03 told me he will test it on his side


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy` 
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible

<details>
<summary> I was unable to run clippy because my cargo build kept failing</summary>
 
 ```bash
      error: failed to run custom build command for `grpc-api-types v0.1.0 (https://github.com/juspay/connector-service?rev=f719688943adf7bc17bb93dcb43f27485c17a96e#f7196889)`

Caused by:
  process didn't exit successfully: `/home/ghidora/hyperswitch/target/debug/build/grpc-api-types-0414af7d2bbc1720/build-script-build` (exit status: 1)
  --- stderr
  g2h: Incompatible dependency `axum`: expected `0.8.3`, found `0.7.9`
  Error: Custom { kind: Other, error: "protoc failed: payment.proto: This file contains proto3 optional fields, but --experimental_allow_proto3_optional was not set.\n" }
 ```
 
 </details>

