### PR TITLE
fix(ci): add rustfmt component to rust-toolchain installation

### DIFF
--- a/.github/workflows/cypress-tests-runner.yml
+++ b/.github/workflows/cypress-tests-runner.yml
@@ -665,12 +665,11 @@ jobs:
           ROUTER__SERVER__WORKERS: 4
           PAYMENTS_CONNECTORS: ${{ env.PAYMENTS_CONNECTORS }}
         shell: bash -leuo pipefail {0}
-        continue-on-error: true
         # We aren't specifying `command` and `jobs` arguments currently
         run: scripts/execute_cypress.sh "" "" "cypress-tests-v2"
 
       - name: Stop running server
-        if: ${{ env.RUN_TESTS == 'true' }} && always()
+        if: ${{ env.RUN_TESTS == 'true' && (success() || failure()) }}
         run: |
           kill "${{ env.PID }}"
 
@@ -689,12 +688,12 @@ jobs:
       #   to process the generated `.profraw` files.
       # - --keep-only argument is used to exclude external crates in generated lcov.info file (~500MiB -> ~70MiB)
       - name: Process coverage report
-        if: ${{ env.RUN_TESTS == 'true' && github.event_name != 'merge_group' }}
+        if: ${{ env.RUN_TESTS == 'true' && github.event_name != 'merge_group' && (success() || failure()) }}
         run: grcov . --source-dir . --output-types lcov --output-path ${{ env.CODECOV_FILE }} --binary-path ./target/debug --keep-only "crates/*"
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5
-        if: ${{ env.RUN_TESTS == 'true' && github.event_name != 'merge_group'}}
+        if: ${{ env.RUN_TESTS == 'true' && github.event_name != 'merge_group' && (success() || failure()) }}
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ${{ env.CODECOV_FILE }}


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
The `Run Cypress tests on v2 and generate coverage report` CI job was failing with a schema mismatch error when running database migrations with the `locked-schema` flag. The error indicated that the generated schema_v2.rs file differed from the committed version.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
closes #9806 

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
I tested this locally by running the Diesel migration both with and without rustfmt installed to verify the schema generation behavior.
	•Without rustfmt: the schema file was generated in a single-line unformatted style (similar to CI output).
	•With rustfmt: the schema file was properly formatted with multi-line macros.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
