### PR TITLE
ci(cypress): Fix Iatapay UPI redirection

### DIFF
--- a/cypress-tests/cypress/support/redirectionHandler.js
+++ b/cypress-tests/cypress/support/redirectionHandler.js
@@ -1225,6 +1225,7 @@ function upiRedirection(
       case "upi_collect":
         cy.visit(redirectionUrl.href);
         cy.wait(CONSTANTS.TIMEOUT).then(() => {
+          cy.contains("button", "Simulate").should("be.visible").click();
           verifyUrl = true;
         });
         break;


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [x] CI/CD

## Description

Fixed payment failures caused by changes in the Iatapay redirection page by triggering the Simulate button during the redirection flow.

## Motivation and Context
Iatapay UPI is failing due to new element added in the redirection page


## How did you test it?
Ran locally
<img width="1295" height="670" alt="Screenshot 2025-10-13 at 3 15 08 PM" src="https://github.com/user-attachments/assets/69fbed33-bcd6-474b-9d7f-f1824790c91c" />
<img width="772" height="622" alt="Screenshot 2025-10-13 at 3 17 03 PM" src="https://github.com/user-attachments/assets/391eb55e-8965-4e37-a541-3f9977482fa9" />

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
