### PR TITLE
ci(cypress): fix cypress api-key validation

### DIFF
--- a/cypress-tests/cypress/utils/RequestBodyUtils.js
+++ b/cypress-tests/cypress/utils/RequestBodyUtils.js
@@ -7,7 +7,6 @@ const keyPrefixes = {
     publishable_key: "pk_snd_",
     key_id: "snd_",
   },
-
 };
 
 export const setClientSecret = (requestBody, clientSecret) => {
@@ -62,7 +61,6 @@ export function validateEnv(baseUrl, keyIdType) {
   if (!environment) {
     throw new Error("Unsupported baseUrl");
   }
-  
 
   const prefix = keyPrefixes[environment][keyIdType];
 


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [x] CI/CD

## Description

This PR fixes the Cypress API key validation issue, where the validation was failing for key_prefixes in API keys.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context

Test cases were failing


## How did you test it?

<img width="628" height="400" alt="image" src="https://github.com/user-attachments/assets/fa28b7ab-6b5d-47d6-ac72-f84297ae1ecb" />


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
