### PR TITLE
fix(payments): add connector metadata parsing and order category to payment router data

### DIFF
--- a/crates/api_models/src/payments.rs
+++ b/crates/api_models/src/payments.rs
@@ -459,7 +459,7 @@ pub struct PaymentsUpdateIntentRequest {
 
     /// Some connectors like Apple pay, Airwallex and Noon might require some additional information, find specific details in the child attributes below.
     #[schema(value_type = Option<ConnectorMetadata>)]
-    pub connector_metadata: Option<pii::SecretSerdeValue>,
+    pub connector_metadata: Option<ConnectorMetadata>,
 
     /// Additional data that might be required by hyperswitch based on the requested features by the merchants.
     #[schema(value_type = Option<FeatureMetadata>)]
@@ -634,7 +634,7 @@ pub struct PaymentsIntentResponse {
 
     /// Some connectors like Apple pay, Airwallex and Noon might require some additional information, find specific details in the child attributes below.
     #[schema(value_type = Option<ConnectorMetadata>)]
-    pub connector_metadata: Option<pii::SecretSerdeValue>,
+    pub connector_metadata: Option<ConnectorMetadata>,
 
     /// Additional data that might be required by hyperswitch based on the requested features by the merchants.
     #[schema(value_type = Option<FeatureMetadata>)]
@@ -7543,7 +7543,7 @@ pub struct ApplepaySessionRequest {
 }
 
 /// Some connectors like Apple Pay, Airwallex and Noon might require some additional information, find specific details in the child attributes below.
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, ToSchema)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, ToSchema)]
 pub struct ConnectorMetadata {
     pub apple_pay: Option<ApplepayConnectorMetadataRequest>,
     pub airwallex: Option<AirwallexData>,
@@ -7578,18 +7578,18 @@ impl ConnectorMetadata {
     }
 }
 
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, ToSchema)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, ToSchema)]
 pub struct AirwallexData {
     /// payload required by airwallex
     payload: Option<String>,
 }
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, ToSchema)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, ToSchema)]
 pub struct NoonData {
     /// Information about the order category that merchant wants to specify at connector level. (e.g. In Noon Payments it can take values like "pay", "food", or any other custom string set by the merchant in Noon's Dashboard)
     pub order_category: Option<String>,
 }
 
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, ToSchema)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, ToSchema)]
 pub struct BraintreeData {
     /// Information about the merchant_account_id that merchant wants to specify at connector level.
     #[schema(value_type = String)]
@@ -7599,19 +7599,19 @@ pub struct BraintreeData {
     pub merchant_config_currency: Option<api_enums::Currency>,
 }
 
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, ToSchema)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, ToSchema)]
 pub struct AdyenConnectorMetadata {
     pub testing: AdyenTestingData,
 }
 
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, ToSchema)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, ToSchema)]
 pub struct AdyenTestingData {
     /// Holder name to be sent to Adyen for a card payment(CIT) or a generic payment(MIT). This value overrides the values for card.card_holder_name and applies during both CIT and MIT payment transactions.
     #[schema(value_type = String)]
     pub holder_name: Option<Secret<String>>,
 }
 
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, ToSchema)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, ToSchema)]
 pub struct ApplepayConnectorMetadataRequest {
     pub session_token_data: Option<SessionTokenInfo>,
 }
@@ -7659,7 +7659,7 @@ pub struct PaymentRequestMetadata {
     pub label: String,
 }
 
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, ToSchema)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, ToSchema)]
 pub struct SessionTokenInfo {
     #[schema(value_type = String)]
     pub certificate: Secret<String>,
@@ -7675,14 +7675,14 @@ pub struct SessionTokenInfo {
     pub payment_processing_details_at: Option<PaymentProcessingDetailsAt>,
 }
 
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, Display, ToSchema)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, Display, ToSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum ApplepayInitiative {
     Web,
     Ios,
 }
 
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, ToSchema)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, ToSchema)]
 #[serde(tag = "payment_processing_details_at")]
 pub enum PaymentProcessingDetailsAt {
     Hyperswitch(PaymentProcessingDetails),

--- a/crates/hyperswitch_domain_models/src/payments.rs
+++ b/crates/hyperswitch_domain_models/src/payments.rs
@@ -2,7 +2,7 @@
 use std::marker::PhantomData;
 
 #[cfg(feature = "v2")]
-use api_models::payments::{SessionToken, VaultSessionDetails};
+use api_models::payments::{ConnectorMetadata, SessionToken, VaultSessionDetails};
 use common_types::primitive_wrappers;
 #[cfg(feature = "v1")]
 use common_types::primitive_wrappers::{
@@ -478,8 +478,8 @@ pub struct PaymentIntent {
     /// This is the list of payment method types that are allowed for the payment intent.
     /// This field allows the merchant to restrict the payment methods that can be used for the payment intent.
     pub allowed_payment_method_types: Option<Vec<common_enums::PaymentMethodType>>,
-    /// This metadata contains details about
-    pub connector_metadata: Option<pii::SecretSerdeValue>,
+    /// This metadata contains connector-specific details like Apple Pay certificates, Airwallex data, Noon order category, Braintree merchant account ID, and Adyen testing data
+    pub connector_metadata: Option<ConnectorMetadata>,
     pub feature_metadata: Option<FeatureMetadata>,
     /// Number of attempts that have been made for the order
     pub attempt_count: i16,
@@ -635,10 +635,6 @@ impl PaymentIntent {
         request: api_models::payments::PaymentsCreateIntentRequest,
         decrypted_payment_intent: DecryptedPaymentIntent,
     ) -> CustomResult<Self, errors::api_error_response::ApiErrorResponse> {
-        let connector_metadata = request
-            .get_connector_metadata_as_value()
-            .change_context(errors::api_error_response::ApiErrorResponse::InternalServerError)
-            .attach_printable("Error getting connector metadata as value")?;
         let request_incremental_authorization =
             Self::get_request_incremental_authorization_value(&request)?;
         let allowed_payment_method_types = request.allowed_payment_method_types;
@@ -679,7 +675,7 @@ impl PaymentIntent {
             active_attempts_group_id: None,
             order_details,
             allowed_payment_method_types,
-            connector_metadata,
+            connector_metadata: request.connector_metadata,
             feature_metadata: request.feature_metadata.map(FeatureMetadata::convert_from),
             // Attempt count is 0 in create intent as no attempt is made yet
             attempt_count: 0,
@@ -826,20 +822,6 @@ impl PaymentIntent {
         self.customer_id
             .as_ref()
             .map(|customer_id| id_type::CustomerId::try_from(customer_id.clone()))
-            .transpose()
-    }
-
-    pub fn get_optional_connector_metadata(
-        &self,
-    ) -> CustomResult<
-        Option<api_models::payments::ConnectorMetadata>,
-        common_utils::errors::ParsingError,
-    > {
-        self.connector_metadata
-            .clone()
-            .map(|cm| {
-                cm.parse_value::<api_models::payments::ConnectorMetadata>("ConnectorMetadata")
-            })
             .transpose()
     }
 

--- a/crates/hyperswitch_domain_models/src/payments/payment_intent.rs
+++ b/crates/hyperswitch_domain_models/src/payments/payment_intent.rs
@@ -1790,7 +1790,15 @@ impl behaviour::Conversion for PaymentIntent {
                 })
                 .transpose()?
                 .map(Secret::new),
-            connector_metadata,
+            connector_metadata: connector_metadata
+                .map(|cm| {
+                    cm.encode_to_value()
+                        .change_context(ValidationError::InvalidValue {
+                            message: "Failed to serialize connector_metadata".to_string(),
+                        })
+                })
+                .transpose()?
+                .map(Secret::new),
             feature_metadata,
             attempt_count,
             profile_id,
@@ -1947,7 +1955,12 @@ impl behaviour::Conversion for PaymentIntent {
                         .collect::<Vec<_>>()
                 }),
                 allowed_payment_method_types,
-                connector_metadata: storage_model.connector_metadata,
+                connector_metadata: storage_model
+                    .connector_metadata
+                    .map(|cm| cm.parse_value("ConnectorMetadata"))
+                    .transpose()
+                    .change_context(common_utils::errors::CryptoError::DecodingFailed)
+                    .attach_printable("Failed to deserialize connector_metadata")?,
                 feature_metadata: storage_model.feature_metadata,
                 attempt_count: storage_model.attempt_count,
                 profile_id: storage_model.profile_id,
@@ -2038,7 +2051,16 @@ impl behaviour::Conversion for PaymentIntent {
                 })
                 .transpose()?
                 .map(Secret::new),
-            connector_metadata: self.connector_metadata,
+            connector_metadata: self
+                .connector_metadata
+                .map(|cm| {
+                    cm.encode_to_value()
+                        .change_context(ValidationError::InvalidValue {
+                            message: "Failed to serialize connector_metadata".to_string(),
+                        })
+                })
+                .transpose()?
+                .map(Secret::new),
             feature_metadata: self.feature_metadata,
             attempt_count: self.attempt_count,
             profile_id: self.profile_id,

--- a/crates/router/src/core/payments/operations/payment_update_intent.rs
+++ b/crates/router/src/core/payments/operations/payment_update_intent.rs
@@ -370,7 +370,13 @@ impl<F: Clone> UpdateTracker<F, payments::PaymentIntentData<F>, PaymentsUpdateIn
                 order_details: intent.order_details,
                 allowed_payment_method_types: intent.allowed_payment_method_types,
                 metadata: intent.metadata,
-                connector_metadata: intent.connector_metadata,
+                connector_metadata: intent
+                    .connector_metadata
+                    .map(|cm| cm.encode_to_value())
+                    .transpose()
+                    .change_context(errors::ApiErrorResponse::InternalServerError)
+                    .attach_printable("Failed to serialize connector_metadata")?
+                    .map(masking::Secret::new),
                 feature_metadata: intent.feature_metadata,
                 payment_link_config: intent.payment_link_config,
                 request_incremental_authorization: Some(intent.request_incremental_authorization),

--- a/crates/router/src/core/utils.rs
+++ b/crates/router/src/core/utils.rs
@@ -303,10 +303,9 @@ pub async fn construct_refund_router_data<'a, F>(
         .attach_printable("Failed to get optional customer id")?;
 
     let braintree_metadata = payment_intent
-        .get_optional_connector_metadata()
-        .change_context(errors::ApiErrorResponse::InternalServerError)
-        .attach_printable("Failed parsing ConnectorMetadata")?
-        .and_then(|cm| cm.braintree);
+        .connector_metadata
+        .as_ref()
+        .and_then(|cm| cm.braintree.clone());
 
     let merchant_account_id = braintree_metadata
         .as_ref()

--- a/crates/router/src/services/kafka/payment_intent.rs
+++ b/crates/router/src/services/kafka/payment_intent.rs
@@ -143,7 +143,7 @@ pub struct KafkaPaymentIntent<'a> {
     pub order_details: Option<&'a Vec<Secret<OrderDetailsWithAmount>>>,
 
     pub allowed_payment_method_types: Option<&'a Vec<common_enums::PaymentMethodType>>,
-    pub connector_metadata: Option<&'a Secret<Value>>,
+    pub connector_metadata: Option<&'a api_models::payments::ConnectorMetadata>,
     pub payment_link_id: Option<&'a String>,
     pub updated_by: &'a String,
     pub surcharge_applicable: Option<bool>,

--- a/crates/router/src/services/kafka/payment_intent_event.rs
+++ b/crates/router/src/services/kafka/payment_intent_event.rs
@@ -96,7 +96,7 @@ pub struct KafkaPaymentIntentEvent<'a> {
     pub order_details: Option<&'a Vec<Secret<OrderDetailsWithAmount>>>,
 
     pub allowed_payment_method_types: Option<&'a Vec<common_enums::PaymentMethodType>>,
-    pub connector_metadata: Option<&'a Secret<Value>>,
+    pub connector_metadata: Option<&'a api_models::payments::ConnectorMetadata>,
     pub payment_link_id: Option<&'a String>,
     pub updated_by: &'a String,
     pub surcharge_applicable: Option<bool>,


### PR DESCRIPTION


## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
The Noon Connector V2 API is failing in the payment flow with the error `Missing required param: order_category.` This happens because the connector_metadata is not being extracted in the V2 confirm-intent flow, which causes the order_category field to be None. The fix involves correctly parsing connector_metadata and ensuring the order_category value is passed from it.

### Additional Changes

- [x] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
closes #9824 

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Payment Create : 
```
curl --location 'http://localhost:8080/v2/payments' \
--header 'api-key: dev_xob8X5unmvgpvxyrojXCRCI7uDY4QnAA1K9keYrZ2SUdxd8R06fHfhw8Z0KrdMTY' \
--header 'Content-Type: application/json' \
--header 'x-profile-id: pro_ujMrnFy6c56AQkrp5QMn' \
--header 'Authorization: api-key=dev_xob8X5unmvgpvxyrojXCRCI7uDY4QnAA1K9keYrZ2SUdxd8R06fHfhw8Z0KrdMTY' \
--data-raw '{
    "amount_details": {
      "order_amount": 6540,
      "currency": "AED"
    },
    "capture_method": "automatic",
    "authentication_type": "no_three_ds",
    "customer_id": "12345_cus_0199e1767bb47751bb4bdead294553eb",
    "description": "CIT payment with multi-use mandate for Noon",
    "setup_future_usage": "off_session",
    "billing": {
      "address": {
        "first_name": "John",
        "last_name": "Doe",
        "city": "Dubai",
        "state": "Dubai",
        "zip": "94122",
        "country": "AE"
      },
      "email": "john.doe@example.com"
    },
    "shipping": {
      "address": {
        "first_name": "John",
        "last_name": "Doe",
        "city": "Dubai",
        "state": "Dubai",
        "zip": "94122",
        "country": "AE"
      },
      "email": "john.doe@example.com"
    },
    "connector_metadata": {
      "noon": {
        "order_category": "pay"
      }
    },
    "payment_method_data": {
      "card": {
        "card_number": "4000000000002701",
        "card_exp_month": "10",
        "card_exp_year": "2030",
        "card_holder_name": "John Doe",
        "card_cvc": "257"
      }
    },
    "payment_method_type": "card",
    "payment_method_subtype": "credit"
  }'
```
Response:
```
{
    "id": "12345_pay_0199e17e9b8e7131a34a1d74f75952d5",
    "status": "succeeded",
    "amount": {
        "order_amount": 6540,
        "currency": "AED",
        "shipping_cost": null,
        "order_tax_amount": null,
        "external_tax_calculation": "skip",
        "surcharge_calculation": "skip",
        "surcharge_amount": null,
        "tax_on_surcharge": null,
        "net_amount": 6540,
        "amount_to_capture": null,
        "amount_capturable": 0,
        "amount_captured": 6540
    },
    "customer_id": "12345_cus_0199e1767bb47751bb4bdead294553eb",
    "connector": "noon",
    "created": "2025-10-14T06:53:15.023Z",
    "modified_at": "2025-10-14T06:53:17.092Z",
    "payment_method_data": {
        "billing": null
    },
    "payment_method_type": "card",
    "payment_method_subtype": "credit",
    "connector_transaction_id": "280808415907",
    "connector_reference_id": "12345_att_0199e17e9ba37d21ae7bbe65208285a6",
    "merchant_connector_id": "mca_Jqv8Dg7oUHX3nrHFwCAZ",
    "browser_info": null,
    "error": null,
    "shipping": null,
    "billing": null,
    "attempts": null,
    "connector_token_details": null,
    "payment_method_id": null,
    "next_action": null,
    "return_url": "https://google.com/success",
    "authentication_type": "no_three_ds",
    "authentication_type_applied": "no_three_ds",
    "is_iframe_redirection_enabled": null,
    "merchant_reference_id": null,
    "raw_connector_response": null,
    "feature_metadata": null,
    "metadata": null
}
```


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
