### PR TITLE
fix: web-sdk command

### DIFF
--- a/docker-compose-development.yml
+++ b/docker-compose-development.yml
@@ -352,7 +352,7 @@ services:
         RUN git clone https://github.com/juspay/hyperswitch-web.git --depth 1
         WORKDIR hyperswitch-web
         RUN npm i --force
-    command: bash -c 'npm run re:build && npx run webpack serve --config webpack.dev.js --host 0.0.0.0'
+    command: bash -c 'npm run re:build && npx webpack serve --config webpack.dev.js --host 0.0.0.0'
     ports:
       - "9050:9050"
     environment:


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [x] CI/CD

## Description
<!-- Describe your changes in detail -->
`npx run webpack...` -> `npx webpack`
npx run webpack is not a valid command

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
I tried running `docker compose --file docker-compose-development.yml up -d` from https://github.com/juspay/hyperswitch/blob/main/docs/try_local_system.md#set-up-a-development-environment-using-docker-compose

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
the command failed earlier now it doesn't 

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
