### PR TITLE
feat(connector):  [JPMORGAN] Add Integrity Check Support for Authorize, PSync, Refund and RSync Flows 

### DIFF
--- a/crates/hyperswitch_connectors/src/connectors/jpmorgan.rs
+++ b/crates/hyperswitch_connectors/src/connectors/jpmorgan.rs
@@ -38,7 +38,6 @@ use hyperswitch_interfaces::{
     },
     configs::Connectors,
     consts, errors,
-    errors::ConnectorError,
     events::connector_api_logs::ConnectorEvent,
     types::{self, RefreshTokenType, Response},
     webhooks,

--- a/crates/hyperswitch_connectors/src/connectors/jpmorgan/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/jpmorgan/transformers.rs
@@ -1,7 +1,7 @@
 use std::str::FromStr;
 
 use common_enums::{enums::CaptureMethod, Currency};
-use common_utils::types::{FloatMajorUnit, MinorUnit};
+use common_utils::types::MinorUnit;
 use error_stack::{report, ResultExt};
 use hyperswitch_domain_models::{
     payment_method_data::PaymentMethodData,
@@ -84,7 +84,7 @@ impl<F, T> TryFrom<ResponseRouterData<F, JpmorganAuthUpdateResponse, T, AccessTo
 pub struct JpmorganPaymentsRequest {
     capture_method: CapMethod,
     amount: MinorUnit,
-    currency: common_enums::Currency,
+    currency: Currency,
     merchant: JpmorganMerchant,
     payment_method_type: JpmorganPaymentMethodType,
 }
@@ -377,7 +377,7 @@ impl<F, T> TryFrom<ResponseRouterData<F, JpmorganPaymentsResponse, T, PaymentsRe
 pub struct JpmorganCaptureRequest {
     capture_method: Option<CapMethod>,
     amount: MinorUnit,
-    currency: Option<common_enums::Currency>,
+    currency: Option<Currency>,
 }
 
 #[derive(Debug, Default, Copy, Serialize, Deserialize, Clone)]
@@ -516,7 +516,7 @@ pub struct TransactionData {
 pub struct JpmorganRefundRequest {
     pub merchant: MerchantRefundReq,
     pub amount: MinorUnit,
-    pub currency: common_enums::Currency,
+    pub currency: Currency,
 }
 
 #[derive(Default, Debug, Serialize, Deserialize)]


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Added integrity check support for Authorize, Capture, Refund, PSync, and RSync flows for the JPMorgan connector. Also added the fields `amount` and `currency` for `JpmorganPaymentsResponse` struct.

What is an integrity check?
A scenario where there is a discrepancy between the amount sent in the request and the amount received from the connector, which is checked during response handling.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

## Motivation and Context
This Pr holds the payment in a non-terminal state incase there is any data discrepancy in the above flows.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
