### PR TITLE
feat(connector): [HELCIM] add integrity checks for authorize, refunds, rsync, psync

### DIFF
--- a/crates/hyperswitch_connectors/src/connectors/helcim.rs
+++ b/crates/hyperswitch_connectors/src/connectors/helcim.rs
@@ -371,7 +371,7 @@ impl ConnectorIntegration<Authorize, PaymentsAuthorizeData, PaymentsResponseData
 
         let response_integrity_object = connector_utils::get_authorise_integrity_object(
             self.amount_convertor,
-            *approved_amount,
+            approved_amount,
             currency.to_string().clone(),
         )?;
 
@@ -470,7 +470,7 @@ impl ConnectorIntegration<PSync, PaymentsSyncData, PaymentsResponseData> for Hel
 
         let response_integrity_object = utils::get_sync_integrity_object(
             self.amount_convertor,
-            *approved_amount,
+            approved_amount,
             currency.to_string().clone(),
         )?;
 
@@ -744,7 +744,7 @@ impl ConnectorIntegration<Execute, RefundsData, RefundsResponseData> for Helcim 
 
         let response_integrity_object = utils::get_refund_integrity_object(
             self.amount_convertor,
-            *approved_amount,
+            approved_amount,
             currency.to_string().clone(),
         )?;
 
@@ -843,7 +843,7 @@ impl ConnectorIntegration<RSync, RefundsData, RefundsResponseData> for Helcim {
 
         let response_integrity_object = utils::get_refund_integrity_object(
             self.amount_convertor,
-            *approved_amount,
+            approved_amount,
             currency.to_string().clone(),
         )?;
 

--- a/crates/hyperswitch_connectors/src/connectors/helcim/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/helcim/transformers.rs
@@ -352,7 +352,7 @@ pub struct HelcimPaymentsResponse {
     invoice_number: Option<String>,
     #[serde(rename = "type")]
     transaction_type: HelcimTransactionType,
-    pub(crate) amount: f64,
+    pub(crate) amount: FloatMajorUnit,
     pub(crate) currency: String,
 }
 
@@ -679,7 +679,7 @@ pub struct RefundResponse {
     transaction_id: u64,
     #[serde(rename = "type")]
     transaction_type: HelcimRefundTransactionType,
-    pub(crate) amount: f64,
+    pub(crate) amount: FloatMajorUnit,
     pub(crate) currency: String,
 }
 


### PR DESCRIPTION
Fixed #9183 
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Add integrity checks for authorize, refunds, rsync and psync flows of `Helcim` connector

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->



## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
`cargo build` 
`cargo test`
```
 cargo test
   Compiling common_enums v0.1.0 (/Users/hp77/repos/hyperswitch-hp/crates/common_enums)
   Compiling router_env v0.1.0 (/Users/hp77/repos/hyperswitch-hp/crates/router_env)
   Compiling ucs_common_utils v0.1.0 (https://github.com/juspay/connector-service?rev=36731a85e6b7877139ca3b6ee5d6b919702df8b4#36731a85)
   Compiling grpc-api-types v0.1.0 (https://github.com/juspay/connector-service?rev=36731a85e6b7877139ca3b6ee5d6b919702df8b4#36731a85)
   Compiling external_services v0.1.0 (/Users/hp77/repos/hyperswitch-hp/crates/external_services)
   Compiling router v0.2.0 (/Users/hp77/repos/hyperswitch-hp/crates/router)
   Compiling events v0.1.0 (/Users/hp77/repos/hyperswitch-hp/crates/events)
   Compiling drainer v0.1.0 (/Users/hp77/repos/hyperswitch-hp/crates/drainer)
   Compiling ucs_cards v0.1.0 (https://github.com/juspay/connector-service?rev=36731a85e6b7877139ca3b6ee5d6b919702df8b4#36731a85)
   Compiling common_utils v0.1.0 (/Users/hp77/repos/hyperswitch-hp/crates/common_utils)
   Compiling currency_conversion v0.1.0 (/Users/hp77/repos/hyperswitch-hp/crates/currency_conversion)
   Compiling test_utils v0.1.0 (/Users/hp77/repos/hyperswitch-hp/crates/test_utils)
   Compiling rust-grpc-client v0.1.0 (https://github.com/juspay/connector-service?rev=36731a85e6b7877139ca3b6ee5d6b919702df8b4#36731a85)
   Compiling router_derive v0.1.0 (/Users/hp77/repos/hyperswitch-hp/crates/router_derive)
   Compiling cards v0.1.0 (/Users/hp77/repos/hyperswitch-hp/crates/cards)
   Compiling euclid v0.1.0 (/Users/hp77/repos/hyperswitch-hp/crates/euclid)
   Compiling redis_interface v0.1.0 (/Users/hp77/repos/hyperswitch-hp/crates/redis_interface)
   Compiling injector v0.1.0 (/Users/hp77/repos/hyperswitch-hp/crates/injector)
   Compiling common_types v0.1.0 (/Users/hp77/repos/hyperswitch-hp/crates/common_types)
   Compiling api_models v0.1.0 (/Users/hp77/repos/hyperswitch-hp/crates/api_models)
   Compiling diesel_models v0.1.0 (/Users/hp77/repos/hyperswitch-hp/crates/diesel_models)
   Compiling kgraph_utils v0.1.0 (/Users/hp77/repos/hyperswitch-hp/crates/kgraph_utils)
   Compiling pm_auth v0.1.0 (/Users/hp77/repos/hyperswitch-hp/crates/pm_auth)
   Compiling openapi v0.1.0 (/Users/hp77/repos/hyperswitch-hp/crates/openapi)
   Compiling connector_configs v0.1.0 (/Users/hp77/repos/hyperswitch-hp/crates/connector_configs)
   Compiling euclid_wasm v0.1.0 (/Users/hp77/repos/hyperswitch-hp/crates/euclid_wasm)
   Compiling smithy-generator v0.1.0 (/Users/hp77/repos/hyperswitch-hp/crates/smithy-generator)
   Compiling hyperswitch_domain_models v0.1.0 (/Users/hp77/repos/hyperswitch-hp/crates/hyperswitch_domain_models)
   Compiling hyperswitch_interfaces v0.1.0 (/Users/hp77/repos/hyperswitch-hp/crates/hyperswitch_interfaces)
   Compiling storage_impl v0.1.0 (/Users/hp77/repos/hyperswitch-hp/crates/storage_impl)
   Compiling hyperswitch_connectors v0.1.0 (/Users/hp77/repos/hyperswitch-hp/crates/hyperswitch_connectors)
warning: unnecessary qualification
   --> crates/hyperswitch_connectors/src/connectors/helcim.rs:210:17
    |
210 |                 crate::utils::construct_not_supported_error_report(capture_method, self.id()),
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: requested on the command line with `-W unused-qualifications`
help: remove the unnecessary path segments
    |
210 -                 crate::utils::construct_not_supported_error_report(capture_method, self.id()),
210 +                 utils::construct_not_supported_error_report(capture_method, self.id()),
    |

   Compiling scheduler v0.1.0 (/Users/hp77/repos/hyperswitch-hp/crates/scheduler)
   Compiling analytics v0.1.0 (/Users/hp77/repos/hyperswitch-hp/crates/analytics)
   Compiling subscriptions v0.1.0 (/Users/hp77/repos/hyperswitch-hp/crates/subscriptions)
   Compiling payment_methods v0.1.0 (/Users/hp77/repos/hyperswitch-hp/crates/payment_methods)
warning: `hyperswitch_connectors` (lib test) generated 1 warning (1 duplicate)
warning: `hyperswitch_connectors` (lib) generated 1 warning (run `cargo fix --lib -p hyperswitch_connectors` to apply 1 suggestion)
cargo(26622) MallocStackLogging: can't turn off malloc stack logging because it was not enabled. payouts(test), cache(test), router(bin), payments(test), connectors(test)                  
cargo(26629) MallocStackLogging: can't turn off malloc stack logging because it was not enabled.ents(test), customers(test), connectors(test)                                               
    Finished `test` profile [unoptimized + debuginfo] target(s) in 56m 55s
     Running unittests src/lib.rs (target/debug/deps/analytics-9ad168da9467d467)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running unittests src/lib.rs (target/debug/deps/api_models-7003248916711d47)

running 22 tests
test admin::__nutype_OrderFulfillmentTime__::should_have_consistent_lower_and_upper_boundaries ... ok
test enums::test::test_partialeq_for_field_type ... ok
test payments::billing_from_payment_method_data::test_card_payment_method_data_empty ... ok
test payments::billing_from_payment_method_data::test_card_payment_method_data_empty_string ... ok
test payments::billing_from_payment_method_data::test_card_payment_method_data ... ok
test payments::billing_from_payment_method_data::test_card_payment_method_data_full_name ... ok
test payments::null_object_test::test_null_object_serialization ... ok
test api_keys::api_key_expiration_tests::test_deserialization ... ok
test api_keys::api_key_expiration_tests::test_serialization ... ok
test api_keys::api_key_expiration_tests::test_null ... ok
test payments::billing_from_payment_method_data::test_bank_redirect_payment_method_data_eps ... ok
test payments::billing_from_payment_method_data::test_paylater_payment_method_data_klarna ... ok
test payments::billing_from_payment_method_data::test_wallet_payment_method_data_paypal ... ok
test payments::billing_from_payment_method_data::test_bank_debit_payment_method_data_ach ... ok
test payments::payments_response_api_contract::test_reward_payment_response ... ok
test payments::payments_request_test::test_valid_case_where_customer_details_are_passed_only_once ... ok
test payments::tests::test_mandate_type ... ok
test payments::payments_request_test::test_valid_case_where_customer_id_is_passed_in_both_places ... ok
test payments::payments_request_test::test_invalid_case_where_customer_id_is_passed_in_both_places ... ok
test payments::payments_request_api_contract::test_successful_payment_method_reward ... ok
test payments::payments_request_api_contract::test_successful_card_deser ... ok
test payments::payments_request_api_contract::test_payment_method_data_with_payment_method_billing ... ok

test result: ok. 22 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 5.50s

     Running unittests src/lib.rs (target/debug/deps/cards-36fd7309ce675954)

running 10 tests
test validate::tests::test_valid_card_number_masking ... ok
test validate::tests::card_number_with_non_digit_character ... ok
test validate::tests::invalid_card_number_length ... ok
test validate::tests::invalid_card_number ... ok
test validate::tests::test_invalid_card_number_masking ... ok
test validate::tests::card_number_no_whitespace ... ok
test validate::tests::test_valid_card_number_deserialization ... ok
test validate::tests::test_invalid_card_number_deserialization ... ok
test validate::tests::test_valid_card_number_strong_secret_masking ... ok
test validate::tests::valid_card_number ... ok

test result: ok. 10 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 3.47s

     Running tests/basic.rs (target/debug/deps/basic-5b6a03c5aa1538c5)

running 4 tests
test test_card_expiration_month ... ok
test test_card_security_code ... ok
test test_card_expiration_year ... ok
test test_card_expiration ... FAILED

failures:

---- test_card_expiration stdout ----

thread 'test_card_expiration' panicked at crates/cards/tests/basic.rs:89:5:
assertion `left == right` failed
  left: "{\"month\":10,\"year\":2025}"
 right: "{\"month\":3,\"year\":2025}"
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    test_card_expiration

test result: FAILED. 3 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

error: test failed, to rerun pass `-p cards --test basic`
```


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy` -- one warning is generated but that is not part of the code changes in this PR, so I have not changed it
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
