### PR TITLE
feat(core): core changes to support multiple outgoing webhooks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4394,7 +4394,6 @@ dependencies = [
  "serde_json",
  "serde_with",
  "strum 0.26.3",
- "strum_macros 0.26.4",
  "time",
  "url",
  "utoipa",

--- a/crates/diesel_models/src/events.rs
+++ b/crates/diesel_models/src/events.rs
@@ -27,6 +27,7 @@ pub struct EventNew {
     pub delivery_attempt: Option<storage_enums::WebhookDeliveryAttempt>,
     pub metadata: Option<EventMetadata>,
     pub is_overall_delivery_successful: Option<bool>,
+    pub webhook_endpoint_id: Option<common_utils::id_type::WebhookEndpointId>,
 }
 
 #[derive(Clone, Debug, Default, AsChangeset, router_derive::DebugAsDisplay)]
@@ -60,6 +61,7 @@ pub struct Event {
     pub delivery_attempt: Option<storage_enums::WebhookDeliveryAttempt>,
     pub metadata: Option<EventMetadata>,
     pub is_overall_delivery_successful: Option<bool>,
+    pub webhook_endpoint_id: Option<common_utils::id_type::WebhookEndpointId>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, AsExpression, diesel::FromSqlRow)]

--- a/crates/diesel_models/src/schema.rs
+++ b/crates/diesel_models/src/schema.rs
@@ -553,6 +553,8 @@ diesel::table! {
         delivery_attempt -> Nullable<WebhookDeliveryAttempt>,
         metadata -> Nullable<Jsonb>,
         is_overall_delivery_successful -> Nullable<Bool>,
+        #[max_length = 64]
+        webhook_endpoint_id -> Nullable<Varchar>,
     }
 }
 

--- a/crates/diesel_models/src/schema_v2.rs
+++ b/crates/diesel_models/src/schema_v2.rs
@@ -567,6 +567,8 @@ diesel::table! {
         delivery_attempt -> Nullable<WebhookDeliveryAttempt>,
         metadata -> Nullable<Jsonb>,
         is_overall_delivery_successful -> Nullable<Bool>,
+        #[max_length = 64]
+        webhook_endpoint_id -> Nullable<Varchar>,
     }
 }
 

--- a/crates/hyperswitch_domain_models/Cargo.toml
+++ b/crates/hyperswitch_domain_models/Cargo.toml
@@ -45,7 +45,6 @@ serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
 serde_with = "3.12.0"
 strum = { version = "0.26", features = ["derive"] }
-strum_macros = "0.26"
 time = { version = "0.3.41", features = ["serde", "serde-well-known", "std"] }
 url = { version = "2.5.4", features = ["serde"] }
 utoipa = { version = "4.2.3", features = ["preserve_order", "preserve_path_order", "time"] }

--- a/crates/hyperswitch_domain_models/src/business_profile.rs
+++ b/crates/hyperswitch_domain_models/src/business_profile.rs
@@ -39,7 +39,7 @@ impl ForeignFrom<storage_types::MultipleWebhookDetail> for MultipleWebhookDetail
             webhook_url: item.webhook_url,
             events: item.events,
             status: item.status,
-            is_legacy_url: false,
+            is_legacy_url: item.is_legacy_url,
         }
     }
 }
@@ -89,15 +89,25 @@ impl WebhookUrls {
     ) -> Self {
         let mut urls = Vec::new();
         let mut processed_urls = HashSet::new();
+        let existing_legacy_entry = multiple_urls
+            .as_ref()
+            .and_then(|list| list.iter().find(|detail| detail.is_legacy_url));
 
         if let Some(legacy_url_value) = legacy_url {
             if processed_urls.insert(legacy_url_value.peek().clone()) {
+                let webhook_endpoint_id = existing_legacy_entry
+                    .map(|entry| entry.webhook_endpoint_id.clone())
+                    .unwrap_or_else(common_utils::generate_webhook_endpoint_id_of_default_length);
+
                 urls.push(MultipleWebhookDetail {
-                    webhook_endpoint_id:
-                        common_utils::generate_webhook_endpoint_id_of_default_length(),
+                    webhook_endpoint_id,
                     webhook_url: legacy_url_value,
-                    events: common_enums::EventType::iter().collect(),
-                    status: common_enums::OutgoingWebhookEndpointStatus::Active,
+                    events: existing_legacy_entry
+                        .map(|entry| entry.events.clone())
+                        .unwrap_or_else(|| common_enums::EventType::iter().collect()),
+                    status: existing_legacy_entry
+                        .map(|entry| entry.status)
+                        .unwrap_or(common_enums::OutgoingWebhookEndpointStatus::Active),
                     is_legacy_url: true,
                 });
             }
@@ -105,12 +115,14 @@ impl WebhookUrls {
 
         if let Some(multiple_urls_list) = multiple_urls {
             for detail in multiple_urls_list {
+                if detail.is_legacy_url {
+                    continue;
+                }
                 if processed_urls.insert(detail.webhook_url.peek().clone()) {
                     urls.push(detail.foreign_into());
                 }
             }
         }
-
         Self(urls)
     }
 }
@@ -145,6 +157,65 @@ impl ForeignFrom<storage_types::WebhookDetails> for WebhookDetails {
             refund_statuses_enabled: item.refund_statuses_enabled,
             payout_statuses_enabled: item.payout_statuses_enabled,
             multiple_webhooks_list: Some(webhook_urls),
+        }
+    }
+}
+
+impl WebhookDetails {
+    pub fn merge(self, other: Self) -> Self {
+        Self {
+            webhook_version: other.webhook_version.or(self.webhook_version),
+            webhook_username: other.webhook_username.or(self.webhook_username),
+            webhook_password: other.webhook_password.or(self.webhook_password),
+            payment_created_enabled: other
+                .payment_created_enabled
+                .or(self.payment_created_enabled),
+            payment_succeeded_enabled: other
+                .payment_succeeded_enabled
+                .or(self.payment_succeeded_enabled),
+            payment_failed_enabled: other.payment_failed_enabled.or(self.payment_failed_enabled),
+            payment_statuses_enabled: other
+                .payment_statuses_enabled
+                .or(self.payment_statuses_enabled),
+            refund_statuses_enabled: other
+                .refund_statuses_enabled
+                .or(self.refund_statuses_enabled),
+            payout_statuses_enabled: other
+                .payout_statuses_enabled
+                .or(self.payout_statuses_enabled),
+            multiple_webhooks_list: other.multiple_webhooks_list.or(self.multiple_webhooks_list),
+        }
+    }
+
+    pub fn update_from_api(
+        existing: Option<Self>,
+        api_webhook: api_models::admin::WebhookDetails,
+    ) -> Self {
+        let mut existing_webhook_urls = existing
+            .as_ref()
+            .and_then(|d| d.multiple_webhooks_list.clone())
+            .unwrap_or_else(|| WebhookUrls::get_multiple_webhook_urls(None, None));
+
+        if let Some(new_url) = api_webhook.webhook_url {
+            existing_webhook_urls.update_legacy_webhook_url(new_url);
+        }
+
+        let api_webhook_as_domain = Self {
+            webhook_version: api_webhook.webhook_version,
+            webhook_username: api_webhook.webhook_username,
+            webhook_password: api_webhook.webhook_password,
+            payment_created_enabled: api_webhook.payment_created_enabled,
+            payment_failed_enabled: api_webhook.payment_failed_enabled,
+            payment_succeeded_enabled: api_webhook.payment_succeeded_enabled,
+            payment_statuses_enabled: api_webhook.payment_statuses_enabled,
+            refund_statuses_enabled: api_webhook.refund_statuses_enabled,
+            payout_statuses_enabled: api_webhook.payout_statuses_enabled,
+            multiple_webhooks_list: Some(existing_webhook_urls),
+        };
+
+        match existing {
+            Some(existing_details) => existing_details.merge(api_webhook_as_domain),
+            None => api_webhook_as_domain,
         }
     }
 }

--- a/crates/hyperswitch_domain_models/src/business_profile.rs
+++ b/crates/hyperswitch_domain_models/src/business_profile.rs
@@ -59,6 +59,21 @@ impl ForeignFrom<MultipleWebhookDetail> for storage_types::MultipleWebhookDetail
 #[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
 pub struct WebhookUrls(pub Vec<MultipleWebhookDetail>);
 
+impl Default for WebhookUrls {
+    fn default() -> Self {
+        Self(Vec::new())
+    }
+}
+
+impl IntoIterator for WebhookUrls {
+    type Item = MultipleWebhookDetail;
+    type IntoIter = std::vec::IntoIter<Self::Item>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
 impl From<Vec<MultipleWebhookDetail>> for WebhookUrls {
     fn from(item: Vec<MultipleWebhookDetail>) -> Self {
         Self(item)

--- a/crates/router/src/core/admin.rs
+++ b/crates/router/src/core/admin.rs
@@ -3820,20 +3820,12 @@ impl ProfileUpdateBridge for api::ProfileUpdate {
             helpers::validate_intent_fulfillment_expiry(intent_fulfillment_expiry)?;
         }
 
-        let webhook_details = self
-            .webhook_details
-            .map(|webhook_details| {
-                let existing_webhook_details = business_profile
-                    .webhook_details
-                    .clone()
-                    .map(|wh| api_models::admin::WebhookDetails::foreign_from(wh.clone()));
-
-                match existing_webhook_details {
-                    Some(existing_details) => existing_details.merge(webhook_details),
-                    None => webhook_details,
-                }
-            })
-            .map(ForeignInto::foreign_into);
+        let webhook_details = self.webhook_details.map(|api_webhook| {
+            hyperswitch_domain_models::business_profile::WebhookDetails::update_from_api(
+                business_profile.webhook_details.clone(),
+                api_webhook,
+            )
+        });
 
         if let Some(ref routing_algorithm) = self.routing_algorithm {
             let _: api_models::routing::StaticRoutingAlgorithm = routing_algorithm
@@ -4039,7 +4031,12 @@ impl ProfileUpdateBridge for api::ProfileUpdate {
             helpers::validate_session_expiry(session_expiry.to_owned())?;
         }
 
-        let webhook_details = self.webhook_details.map(ForeignInto::foreign_into);
+        let webhook_details = self.webhook_details.map(|api_webhook| {
+            hyperswitch_domain_models::business_profile::WebhookDetails::update_from_api(
+                business_profile.webhook_details.clone(),
+                api_webhook,
+            )
+        });
 
         let payment_link_config = self
             .payment_link_config

--- a/crates/router/src/core/disputes.rs
+++ b/crates/router/src/core/disputes.rs
@@ -933,18 +933,17 @@ pub async fn update_dispute_data(
     let disputes_response: dispute_models::DisputeResponse = dispute_object.clone().foreign_into();
     let event_type: storage_enums::EventType = dispute_details.dispute_status.into();
 
-    Box::pin(webhooks::create_event_and_trigger_outgoing_webhook(
+    Box::pin(webhooks::add_bulk_outgoing_webhook_task_to_process_tracker(
         state.clone(),
-        platform.get_processor().clone(),
-        business_profile,
+        &business_profile,
+        &dispute_object.dispute_id,
         event_type,
         storage_enums::EventClass::Disputes,
-        dispute_object.dispute_id.clone(),
         storage_enums::EventObjectType::DisputeDetails,
-        api::OutgoingWebhookContent::DisputeDetails(Box::new(disputes_response.clone())),
         Some(dispute_object.created_at),
     ))
-    .await?;
+    .await
+    .change_context(errors::ApiErrorResponse::WebhookProcessingFailure)?;
     Ok(disputes_response)
 }
 

--- a/crates/router/src/core/revenue_recovery/types.rs
+++ b/crates/router/src/core/revenue_recovery/types.rs
@@ -1592,15 +1592,13 @@ impl RevenueRecoveryOutgoingWebhook {
                     api_models::webhooks::OutgoingWebhookContent::PaymentDetails(Box::new(
                         response,
                     ));
-                create_event_and_trigger_outgoing_webhook(
+                add_bulk_outgoing_webhook_task_to_process_tracker(
                     state.clone(),
-                    profile.clone(),
-                    platform.get_processor().get_key_store(),
-                    event_status,
-                    event_class,
-                    payment_attempt_id,
-                    common_enums::EventObjectType::PaymentDetails,
-                    outgoing_webhook_content,
+                    &profile.clone(),
+                    &refund_id,
+                    outgoing_event_type,
+                    diesel_models::enums::EventClass::Payment,
+                    diesel_models::enums::EventObjectType::PaymentDetails,
                     payment_intent.created_at,
                 )
                 .await

--- a/crates/router/src/core/webhooks.rs
+++ b/crates/router/src/core/webhooks.rs
@@ -19,8 +19,10 @@ pub mod webhook_events;
 pub(crate) use self::{
     incoming::{incoming_webhooks_wrapper, network_token_incoming_webhooks_wrapper},
     outgoing::{
+        add_bulk_outgoing_webhook_task_to_process_tracker,
         create_event_and_trigger_outgoing_webhook, get_outgoing_webhook_request,
-        trigger_webhook_and_raise_event,
+        get_webhook_detail_by_webhook_endpoint_id, get_webhook_details_for_event_type,
+        trigger_webhook_and_raise_event, OUTGOING_WEBHOOK_BULK_TASK, OUTGOING_WEBHOOK_RETRY_TASK,
     },
 };
 #[cfg(feature = "v2")]

--- a/crates/router/src/core/webhooks/incoming.rs
+++ b/crates/router/src/core/webhooks/incoming.rs
@@ -1834,34 +1834,39 @@ async fn payout_incoming_webhook_update_status(
         })?;
     payout_data.payouts = updated_payouts;
 
+    let payout_attempt_id_for_error = payout_attempt.payout_attempt_id.clone();
+    let connector_payout_id = payout_attempt.connector_payout_id.clone();
+    let is_eligible = payout_attempt.is_eligible;
+    let payout_connector_metadata = payout_attempt.payout_connector_metadata.clone();
+
     // if status is failure then update the error_code and error_message as well
     let payout_attempt_update = if status.is_payout_failure() {
         PayoutAttemptUpdate::StatusUpdate {
-            connector_payout_id: payout_attempt.connector_payout_id.clone(),
+            connector_payout_id,
             status,
             error_message: payout_webhook_details.error_message,
             error_code: payout_webhook_details.error_code,
-            is_eligible: payout_attempt.is_eligible,
+            is_eligible,
             unified_code: None,
             unified_message: None,
-            payout_connector_metadata: payout_attempt.payout_connector_metadata.clone(),
+            payout_connector_metadata,
         }
     } else {
         PayoutAttemptUpdate::StatusUpdate {
-            connector_payout_id: payout_attempt.connector_payout_id.clone(),
+            connector_payout_id,
             status,
             error_message: None,
             error_code: None,
-            is_eligible: payout_data.payout_attempt.is_eligible,
+            is_eligible,
             unified_code: None,
             unified_message: None,
-            payout_connector_metadata: payout_attempt.payout_connector_metadata.clone(),
+            payout_connector_metadata,
         }
     };
 
     let updated_payout_attempt = db
         .update_payout_attempt(
-            payout_attempt,
+            &payout_data.payout_attempt,
             payout_attempt_update,
             &payout_data.payouts,
             platform.get_processor().get_account().storage_scheme,
@@ -1871,31 +1876,37 @@ async fn payout_incoming_webhook_update_status(
         .attach_printable_lazy(|| {
             format!(
                 "Failed while updating payout attempt: payout_attempt_id: {}",
-                payout_attempt.payout_attempt_id
+                payout_attempt_id_for_error
             )
         })?;
+
+    // Extract values needed for webhook before the mutable assignment
+    let payout_id_for_webhook = updated_payout_attempt.payout_id.clone();
+    let created_at_for_webhook = updated_payout_attempt.created_at;
+    let status_for_webhook = updated_payout_attempt.status;
+
     payout_data.payout_attempt = updated_payout_attempt;
 
-    let event_type: Option<enums::EventType> = payout_data.payout_attempt.status.into();
+    let event_type: Option<enums::EventType> = status_for_webhook.into();
 
     // If event is NOT an UnsupportedEvent, trigger Outgoing Webhook
     if let Some(outgoing_event_type) = event_type {
         Box::pin(super::add_bulk_outgoing_webhook_task_to_process_tracker(
             state,
             &business_profile,
-            payout_attempt.payout_id.get_string_repr(),
+            payout_id_for_webhook.get_string_repr(),
             outgoing_event_type,
             enums::EventClass::Payouts,
             enums::EventObjectType::PayoutDetails,
-            Some(payout_attempt.created_at),
+            Some(created_at_for_webhook),
         ))
         .await
         .change_context(errors::ApiErrorResponse::WebhookProcessingFailure)?;
     }
 
     Ok(WebhookResponseTracker::Payout {
-        payout_id: payout_data.payout_attempt.payout_id.clone(),
-        status: payout_data.payout_attempt.status,
+        payout_id: payout_id_for_webhook,
+        status: status_for_webhook,
     })
 }
 
@@ -1911,10 +1922,10 @@ async fn payout_incoming_webhook_retrieve_status(
 ) -> CustomResult<WebhookResponseTracker, errors::ApiErrorResponse> {
     metrics::INCOMING_PAYOUT_WEBHOOK_SIGNATURE_FAILURE_METRIC.add(1, &[]);
     // Form connector data
-    let connector_data = match &payout_data.payout_attempt.connector {
+    let connector_data = match payout_data.payout_attempt.connector.clone() {
         Some(connector) => ConnectorData::get_payout_connector_by_name(
             &state.conf.connectors,
-            connector,
+            &connector,
             GetToken::Connector,
             payout_data.payout_attempt.merchant_connector_id.clone(),
         )
@@ -1942,24 +1953,17 @@ async fn payout_incoming_webhook_retrieve_status(
 
     // If event is NOT an UnsupportedEvent, trigger Outgoing Webhook
     if let Some(outgoing_event_type) = event_type {
-        let payout_response = payouts::response_handler(&state, &platform, payout_data).await?;
-
-        Box::pin(super::create_event_and_trigger_outgoing_webhook(
+        Box::pin(super::add_bulk_outgoing_webhook_task_to_process_tracker(
             state,
-            platform.get_processor().clone(),
-            business_profile,
+            &business_profile,
+            payout_data.payout_attempt.payout_id.get_string_repr(),
             outgoing_event_type,
             enums::EventClass::Payouts,
-            payout_data
-                .payout_attempt
-                .payout_id
-                .get_string_repr()
-                .to_string(),
             enums::EventObjectType::PayoutDetails,
-            api::OutgoingWebhookContent::PayoutDetails(Box::new(payout_response)),
             Some(payout_data.payout_attempt.created_at),
         ))
-        .await?;
+        .await
+        .change_context(errors::ApiErrorResponse::WebhookProcessingFailure)?;
     }
 
     Ok(WebhookResponseTracker::Payout {

--- a/crates/router/src/core/webhooks/incoming.rs
+++ b/crates/router/src/core/webhooks/incoming.rs
@@ -62,13 +62,10 @@ use crate::{
         ConnectorValidation,
     },
     types::{
-        api::{
-            self, mandates::MandateResponseExt, ConnectorCommon, ConnectorData, GetToken,
-            IncomingWebhook,
-        },
+        api::{self, ConnectorCommon, ConnectorData, GetToken, IncomingWebhook},
         domain,
         storage::{self, enums},
-        transformers::{ForeignFrom, ForeignInto, ForeignTryFrom},
+        transformers::{ForeignFrom, ForeignTryFrom},
     },
     utils::{self as helper_utils, ext_traits::OptionExt, generate_id},
 };
@@ -1584,18 +1581,17 @@ async fn payments_incoming_webhook_flow(
             // If event is NOT an UnsupportedEvent, trigger Outgoing Webhook
             if let Some(outgoing_event_type) = event_type {
                 let primary_object_created_at = payments_response.created;
-                Box::pin(super::create_event_and_trigger_outgoing_webhook(
+                Box::pin(super::add_bulk_outgoing_webhook_task_to_process_tracker(
                     state,
-                    platform.get_processor().clone(),
-                    business_profile,
+                    &business_profile,
+                    payment_id.get_string_repr(),
                     outgoing_event_type,
                     enums::EventClass::Payments,
-                    payment_id.get_string_repr().to_owned(),
                     enums::EventObjectType::PaymentDetails,
-                    api::OutgoingWebhookContent::PaymentDetails(Box::new(payments_response)),
                     primary_object_created_at,
                 ))
-                .await?;
+                .await
+                .change_context(errors::ApiErrorResponse::WebhookProcessingFailure)?;
             };
 
             let response = WebhookResponseTracker::Payment { payment_id, status };
@@ -1884,25 +1880,17 @@ async fn payout_incoming_webhook_update_status(
 
     // If event is NOT an UnsupportedEvent, trigger Outgoing Webhook
     if let Some(outgoing_event_type) = event_type {
-        let payout_create_response =
-            payouts::response_handler(&state, &platform, payout_data).await?;
-
-        Box::pin(super::create_event_and_trigger_outgoing_webhook(
+        Box::pin(super::add_bulk_outgoing_webhook_task_to_process_tracker(
             state,
-            platform.get_processor().clone(),
-            business_profile,
+            &business_profile,
+            payout_attempt.payout_id.get_string_repr(),
             outgoing_event_type,
             enums::EventClass::Payouts,
-            payout_data
-                .payout_attempt
-                .payout_id
-                .get_string_repr()
-                .to_string(),
             enums::EventObjectType::PayoutDetails,
-            api::OutgoingWebhookContent::PayoutDetails(Box::new(payout_create_response)),
-            Some(payout_data.payout_attempt.created_at),
+            Some(payout_attempt.created_at),
         ))
-        .await?;
+        .await
+        .change_context(errors::ApiErrorResponse::WebhookProcessingFailure)?;
     }
 
     Ok(WebhookResponseTracker::Payout {
@@ -2181,20 +2169,17 @@ async fn refunds_incoming_webhook_flow(
 
     // If event is NOT an UnsupportedEvent, trigger Outgoing Webhook
     if let Some(outgoing_event_type) = event_type {
-        let refund_response: api_models::refunds::RefundResponse =
-            updated_refund.clone().foreign_into();
-        Box::pin(super::create_event_and_trigger_outgoing_webhook(
+        Box::pin(super::add_bulk_outgoing_webhook_task_to_process_tracker(
             state,
-            platform.get_processor().clone(),
-            business_profile,
+            &business_profile,
+            &refund_id,
             outgoing_event_type,
             enums::EventClass::Refunds,
-            refund_id,
             enums::EventObjectType::RefundDetails,
-            api::OutgoingWebhookContent::RefundDetails(Box::new(refund_response)),
-            Some(updated_refund.created_at),
+            Some(refund.created_at),
         ))
-        .await?;
+        .await
+        .change_context(errors::ApiErrorResponse::WebhookProcessingFailure)?;
     }
 
     Ok(WebhookResponseTracker::Refund {
@@ -2524,20 +2509,17 @@ async fn external_authentication_incoming_webhook_flow(
                         // If event is NOT an UnsupportedEvent, trigger Outgoing Webhook
                         if let Some(outgoing_event_type) = event_type {
                             let primary_object_created_at = payments_response.created;
-                            Box::pin(super::create_event_and_trigger_outgoing_webhook(
+                            Box::pin(super::add_bulk_outgoing_webhook_task_to_process_tracker(
                                 state,
-                                platform.get_processor().clone(),
-                                business_profile,
+                                &business_profile,
+                                payment_id.get_string_repr(),
                                 outgoing_event_type,
                                 enums::EventClass::Payments,
-                                payment_id.get_string_repr().to_owned(),
                                 enums::EventObjectType::PaymentDetails,
-                                api::OutgoingWebhookContent::PaymentDetails(Box::new(
-                                    payments_response,
-                                )),
                                 primary_object_created_at,
                             ))
-                            .await?;
+                            .await
+                            .change_context(errors::ApiErrorResponse::WebhookProcessingFailure)?;
                         };
                         let response = WebhookResponseTracker::Payment { payment_id, status };
                         Ok(response)
@@ -2601,6 +2583,7 @@ async fn mandates_incoming_webhook_flow(
             .change_context(errors::ApiErrorResponse::WebhookProcessingFailure)
             .attach_printable("event type to mandate status mapping failed")?;
         let mandate_id = mandate.mandate_id.clone();
+        let mandate_created_at = mandate.created_at;
         let updated_mandate = db
             .update_mandate_by_merchant_id_mandate_id(
                 platform.get_processor().get_account().get_id(),
@@ -2611,29 +2594,21 @@ async fn mandates_incoming_webhook_flow(
             )
             .await
             .to_not_found_response(errors::ApiErrorResponse::MandateNotFound)?;
-        let mandates_response = Box::new(
-            api::mandates::MandateResponse::from_db_mandate(
-                &state,
-                platform.get_processor().get_key_store().clone(),
-                updated_mandate.clone(),
-                platform.get_processor().get_account(),
-            )
-            .await?,
-        );
+
         let event_type: Option<enums::EventType> = updated_mandate.mandate_status.into();
         if let Some(outgoing_event_type) = event_type {
-            Box::pin(super::create_event_and_trigger_outgoing_webhook(
+            let primary_object_created_at = Some(mandate_created_at);
+            Box::pin(super::add_bulk_outgoing_webhook_task_to_process_tracker(
                 state,
-                platform.get_processor().clone(),
-                business_profile,
+                &business_profile,
+                &mandate_id,
                 outgoing_event_type,
                 enums::EventClass::Mandates,
-                updated_mandate.mandate_id.clone(),
                 enums::EventObjectType::MandateDetails,
-                api::OutgoingWebhookContent::MandateDetails(mandates_response),
-                Some(updated_mandate.created_at),
+                primary_object_created_at,
             ))
-            .await?;
+            .await
+            .change_context(errors::ApiErrorResponse::WebhookProcessingFailure)?;
         }
         Ok(WebhookResponseTracker::Mandate {
             mandate_id: updated_mandate.mandate_id,
@@ -2727,18 +2702,17 @@ async fn frm_incoming_webhook_flow(
                 let event_type: Option<enums::EventType> = payments_response.status.into();
                 if let Some(outgoing_event_type) = event_type {
                     let primary_object_created_at = payments_response.created;
-                    Box::pin(super::create_event_and_trigger_outgoing_webhook(
+                    Box::pin(super::add_bulk_outgoing_webhook_task_to_process_tracker(
                         state,
-                        platform.get_processor().clone(),
-                        business_profile,
+                        &business_profile,
+                        payment_id.get_string_repr(),
                         outgoing_event_type,
                         enums::EventClass::Payments,
-                        payment_id.get_string_repr().to_owned(),
                         enums::EventObjectType::PaymentDetails,
-                        api::OutgoingWebhookContent::PaymentDetails(Box::new(payments_response)),
                         primary_object_created_at,
                     ))
-                    .await?;
+                    .await
+                    .change_context(errors::ApiErrorResponse::WebhookProcessingFailure)?;
                 };
                 let response = WebhookResponseTracker::Payment { payment_id, status };
                 Ok(response)
@@ -2856,21 +2830,19 @@ async fn disputes_incoming_webhook_flow(
             });
         }
 
-        let disputes_response = Box::new(dispute_object.clone().foreign_into());
         let event_type: enums::EventType = dispute_object.dispute_status.into();
 
-        Box::pin(super::create_event_and_trigger_outgoing_webhook(
+        Box::pin(super::add_bulk_outgoing_webhook_task_to_process_tracker(
             state,
-            platform.get_processor().clone(),
-            business_profile,
+            &business_profile,
+            &dispute_object.dispute_id,
             event_type,
             enums::EventClass::Disputes,
-            dispute_object.dispute_id.clone(),
             enums::EventObjectType::DisputeDetails,
-            api::OutgoingWebhookContent::DisputeDetails(disputes_response),
             Some(dispute_object.created_at),
         ))
-        .await?;
+        .await
+        .change_context(errors::ApiErrorResponse::WebhookProcessingFailure)?;
         metrics::INCOMING_DISPUTE_WEBHOOK_MERCHANT_NOTIFIED_METRIC.add(1, &[]);
         Ok(WebhookResponseTracker::Dispute {
             dispute_id: dispute_object.dispute_id,
@@ -2946,18 +2918,17 @@ async fn bank_transfer_webhook_flow(
             // If event is NOT an UnsupportedEvent, trigger Outgoing Webhook
             if let Some(outgoing_event_type) = event_type {
                 let primary_object_created_at = payments_response.created;
-                Box::pin(super::create_event_and_trigger_outgoing_webhook(
+                Box::pin(super::add_bulk_outgoing_webhook_task_to_process_tracker(
                     state,
-                    platform.get_processor().clone(),
-                    business_profile,
+                    &business_profile,
+                    payment_id.get_string_repr(),
                     outgoing_event_type,
                     enums::EventClass::Payments,
-                    payment_id.get_string_repr().to_owned(),
                     enums::EventObjectType::PaymentDetails,
-                    api::OutgoingWebhookContent::PaymentDetails(Box::new(payments_response)),
                     primary_object_created_at,
                 ))
-                .await?;
+                .await
+                .change_context(errors::ApiErrorResponse::WebhookProcessingFailure)?;
             }
 
             Ok(WebhookResponseTracker::Payment { payment_id, status })

--- a/crates/router/src/core/webhooks/outgoing.rs
+++ b/crates/router/src/core/webhooks/outgoing.rs
@@ -12,13 +12,17 @@ use common_utils::{
 };
 use diesel_models::process_tracker::business_status;
 use error_stack::{report, ResultExt};
-use hyperswitch_domain_models::type_encryption::{crypto_operation, CryptoOperation};
+use hyperswitch_domain_models::{
+    business_profile::MultipleWebhookDetail,
+    type_encryption::{crypto_operation, CryptoOperation},
+};
 use hyperswitch_interfaces::consts;
 use masking::{ExposeInterface, Mask, PeekInterface, Secret};
 use router_env::{
     instrument,
     tracing::{self, Instrument},
 };
+use time::PrimitiveDateTime;
 
 use super::{types, utils, MERCHANT_ID};
 #[cfg(feature = "stripe")]
@@ -45,6 +49,122 @@ use crate::{
     workflows::outgoing_webhook_retry,
 };
 
+pub const OUTGOING_WEBHOOK_BULK_TASK: &str = "OUTGOING_WEBHOOK_BULK";
+pub const OUTGOING_WEBHOOK_RETRY_TASK: &str = "OUTGOING_WEBHOOK_RETRY";
+
+#[instrument(skip_all)]
+pub(crate) async fn add_bulk_outgoing_webhook_task_to_process_tracker(
+    state: SessionState,
+    business_profile: &domain::Profile,
+    primary_object_id: &str,
+    event_type: enums::EventType,
+    event_class: enums::EventClass,
+    primary_object_type: enums::EventObjectType,
+    primary_object_created_at: Option<PrimitiveDateTime>,
+) -> CustomResult<storage::ProcessTracker, errors::StorageError> {
+    let db: &dyn StorageInterface = state.store.as_ref();
+
+    let schedule_time = common_utils::date_time::now();
+
+    let tracking_data = types::OutgoingWebhookTrackingData {
+        merchant_id: business_profile.merchant_id.clone(),
+        business_profile_id: business_profile.get_id().to_owned(),
+        event_type,
+        event_class,
+        primary_object_id: primary_object_id.to_string(),
+        primary_object_type,
+        initial_attempt_id: None,
+        webhook_endpoint_id: None,
+        primary_object_created_at,
+    };
+
+    let runner = storage::ProcessTrackerRunner::OutgoingWebhookRetryWorkflow;
+    let task = OUTGOING_WEBHOOK_BULK_TASK;
+    let tag = ["OUTGOING_WEBHOOKS"];
+
+    let process_tracker_id = scheduler::utils::get_process_tracker_id(
+        runner,
+        task,
+        primary_object_id,
+        &business_profile.merchant_id,
+    );
+
+    let process_tracker_entry = storage::ProcessTrackerNew::new(
+        process_tracker_id,
+        task,
+        runner,
+        tag,
+        tracking_data,
+        None,
+        schedule_time,
+        common_types::consts::API_VERSION,
+    )
+    .map_err(errors::StorageError::from)?;
+
+    let attributes = router_env::metric_attributes!(("flow", "OutgoingWebhookRetry"));
+    match db.insert_process(process_tracker_entry).await {
+        Ok(process_tracker) => {
+            crate::routes::metrics::TASKS_ADDED_COUNT.add(1, attributes);
+            Ok(process_tracker)
+        }
+        Err(error) => {
+            crate::routes::metrics::TASK_ADDITION_FAILURES_COUNT.add(1, attributes);
+            Err(error)
+        }
+    }
+}
+
+pub(crate) fn get_webhook_details_for_event_type(
+    business_profile: &domain::Profile,
+    event_type: enums::EventType,
+) -> CustomResult<Vec<MultipleWebhookDetail>, errors::WebhooksFlowError> {
+    let webhook_details = business_profile
+        .webhook_details
+        .clone()
+        .get_required_value("webhook_details")
+        .change_context(errors::WebhooksFlowError::MerchantWebhookDetailsNotFound)?;
+
+    let webhook_list = webhook_details
+        .multiple_webhooks_list
+        .clone()
+        .unwrap_or_default();
+
+    let matching_details: Vec<MultipleWebhookDetail> = webhook_list
+        .into_iter()
+        .filter(|detail| {
+            detail.events.contains(&event_type)
+                && detail.status == common_enums::OutgoingWebhookEndpointStatus::Active
+        })
+        .collect();
+
+    Ok(matching_details)
+}
+
+pub(crate) fn get_webhook_detail_by_webhook_endpoint_id(
+    business_profile: &domain::Profile,
+    webhook_endpoint_id: &Option<common_utils::id_type::WebhookEndpointId>,
+) -> CustomResult<MultipleWebhookDetail, errors::WebhooksFlowError> {
+    let webhook_details = business_profile
+        .webhook_details
+        .clone()
+        .get_required_value("webhook_details")
+        .change_context(errors::WebhooksFlowError::MerchantWebhookDetailsNotFound)?;
+
+    let endpoint_id = webhook_endpoint_id
+        .as_ref()
+        .ok_or(errors::WebhooksFlowError::MerchantWebhookDetailsNotFound)?;
+
+    let webhooks = webhook_details
+        .multiple_webhooks_list
+        .clone()
+        .ok_or(errors::WebhooksFlowError::MerchantWebhookDetailsNotFound)?;
+
+    webhooks
+        .into_iter()
+        .find(|d| &d.webhook_endpoint_id == endpoint_id)
+        .ok_or(errors::WebhooksFlowError::MerchantWebhookDetailsNotFound.into())
+}
+
 #[allow(clippy::too_many_arguments)]
 #[instrument(skip_all)]
 pub(crate) async fn create_event_and_trigger_outgoing_webhook(
@@ -56,61 +176,32 @@ pub(crate) async fn create_event_and_trigger_outgoing_webhook(
     primary_object_id: String,
     primary_object_type: enums::EventObjectType,
     content: api::OutgoingWebhookContent,
-    primary_object_created_at: Option<time::PrimitiveDateTime>,
+    primary_object_created_at: Option<PrimitiveDateTime>,
+    webhook_detail: MultipleWebhookDetail,
 ) -> CustomResult<(), errors::ApiErrorResponse> {
     let delivery_attempt = enums::WebhookDeliveryAttempt::InitialAttempt;
-    let idempotent_event_id =
-        utils::get_idempotent_event_id(&primary_object_id, event_type, delivery_attempt)
-            .change_context(errors::ApiErrorResponse::WebhookProcessingFailure)
-            .attach_printable("Failed to generate idempotent event ID")?;
-    let webhook_url_result = get_webhook_url_from_business_profile(&business_profile);
 
-    if !state.conf.webhooks.outgoing_enabled
-        || webhook_url_result.is_err()
-        || webhook_url_result.as_ref().is_ok_and(String::is_empty)
-    {
-        logger::debug!(
-            business_profile_id=?business_profile.get_id(),
-            %idempotent_event_id,
-            "Outgoing webhooks are disabled in application configuration, or merchant webhook URL \
-             could not be obtained; skipping outgoing webhooks for event"
-        );
-        return Ok(());
-    }
+    if webhook_detail.events.contains(&event_type) {
+        let event_id = utils::generate_event_id();
+        let merchant_id = business_profile.merchant_id.clone();
+        let now = common_utils::date_time::now();
 
-    let event_id = utils::generate_event_id();
-    let merchant_id = business_profile.merchant_id.clone();
-    let now = common_utils::date_time::now();
+        let outgoing_webhook = api::OutgoingWebhook {
+            merchant_id: merchant_id.clone(),
+            event_id: event_id.clone(),
+            event_type,
+            content: content.clone(),
+            timestamp: now,
+        };
 
-    let outgoing_webhook = api::OutgoingWebhook {
-        merchant_id: merchant_id.clone(),
-        event_id: event_id.clone(),
-        event_type,
-        content: content.clone(),
-        timestamp: now,
-    };
+        let request_content =
+            get_outgoing_webhook_request(&processor, outgoing_webhook, &business_profile)
+                .change_context(errors::ApiErrorResponse::WebhookProcessingFailure)
+                .attach_printable("Failed to construct outgoing webhook request content")?;
 
-    let request_content =
-        get_outgoing_webhook_request(&processor, outgoing_webhook, &business_profile)
-            .change_context(errors::ApiErrorResponse::WebhookProcessingFailure)
-            .attach_printable("Failed to construct outgoing webhook request content")?;
+        let key_manager_state = &(&state).into();
 
-    let event_metadata = storage::EventMetadata::foreign_from(&content);
-    let key_manager_state = &(&state).into();
-    let new_event = domain::Event {
-        event_id: event_id.clone(),
-        event_type,
-        event_class,
-        is_webhook_notified: false,
-        primary_object_id,
-        primary_object_type,
-        created_at: now,
-        merchant_id: Some(business_profile.merchant_id.clone()),
-        business_profile_id: Some(business_profile.get_id().to_owned()),
-        primary_object_created_at,
-        idempotent_event_id: Some(idempotent_event_id.clone()),
-        initial_attempt_id: Some(event_id.clone()),
-        request: Some(
+        let request = Some(
             crypto_operation(
                 key_manager_state,
                 type_name!(domain::Event),
@@ -128,37 +219,89 @@ pub(crate) async fn create_event_and_trigger_outgoing_webhook(
             .and_then(|val| val.try_into_operation())
             .change_context(errors::ApiErrorResponse::WebhookProcessingFailure)
             .attach_printable("Failed to encrypt outgoing webhook request content")?,
-        ),
-        response: None,
-        delivery_attempt: Some(delivery_attempt),
-        metadata: Some(event_metadata),
-        is_overall_delivery_successful: Some(false),
-    };
-
-    let lock_value = utils::perform_redis_lock(
-        &state,
-        &idempotent_event_id,
-        processor.get_account().get_id().to_owned(),
-    )
-    .await?;
-
-    if lock_value.is_none() {
-        return Ok(());
-    }
-
-    if (state
-        .store
-        .find_event_by_merchant_id_idempotent_event_id(
-            &merchant_id,
-            &idempotent_event_id,
-            processor.get_key_store(),
-        )
-        .await)
-        .is_ok()
-    {
-        logger::debug!(
-            "Event with idempotent ID `{idempotent_event_id}` already exists in the database"
         );
+
+        let event_metadata = storage::EventMetadata::foreign_from(&content);
+
+        let webhook_endpoint_id = webhook_detail.webhook_endpoint_id.clone();
+
+        let idempotent_event_id = utils::get_idempotent_event_id(
+            &primary_object_id,
+            event_type,
+            delivery_attempt,
+            Some(webhook_detail.webhook_endpoint_id.get_string_repr()),
+        );
+
+        let new_event = domain::Event {
+            event_id: event_id.clone(),
+            event_type,
+            event_class,
+            is_webhook_notified: false,
+            primary_object_id: primary_object_id.clone(),
+            primary_object_type,
+            created_at: now,
+            merchant_id: Some(business_profile.merchant_id.clone()),
+            business_profile_id: Some(business_profile.get_id().to_owned()),
+            primary_object_created_at,
+            idempotent_event_id: Some(idempotent_event_id.clone()),
+            initial_attempt_id: Some(event_id.clone()),
+            webhook_endpoint_id: Some(webhook_endpoint_id.clone()),
+            request,
+            response: None,
+            delivery_attempt: Some(delivery_attempt),
+            metadata: Some(event_metadata),
+            is_overall_delivery_successful: Some(false),
+        };
+
+        let lock_value = utils::perform_redis_lock(
+            &state,
+            &idempotent_event_id,
+            processor.get_account().get_id().to_owned(),
+        )
+        .await?;
+
+        if lock_value.is_none() {
+            return Ok(());
+        }
+
+        if (state
+            .store
+            .find_event_by_merchant_id_idempotent_event_id(
+                &merchant_id,
+                &idempotent_event_id,
+                processor.get_key_store(),
+            )
+            .await)
+            .is_ok()
+        {
+            logger::debug!(
+                "Event with idempotent ID `{idempotent_event_id}` already exists in the database"
+            );
+            utils::free_redis_lock(
+                &state,
+                &idempotent_event_id,
+                processor.get_account().get_id().to_owned(),
+                lock_value,
+            )
+            .await?;
+            return Ok(());
+        }
+
+        let event_insert_result = state
+            .store
+            .insert_event(new_event, processor.get_key_store())
+            .await;
+
+        let event = match event_insert_result {
+            Ok(event) => Ok(event),
+            Err(error) => {
+                logger::error!(event_insertion_failure=?error);
+                Err(error
+                    .change_context(errors::ApiErrorResponse::WebhookProcessingFailure)
+                    .attach_printable("Failed to insert event in events table"))
+            }
+        }?;
+
         utils::free_redis_lock(
             &state,
             &idempotent_event_id,
@@ -166,68 +309,54 @@ pub(crate) async fn create_event_and_trigger_outgoing_webhook(
             lock_value,
         )
         .await?;
-        return Ok(());
-    }
 
-    let event_insert_result = state
-        .store
-        .insert_event(new_event, processor.get_key_store())
-        .await;
+        let process_tracker_retry = add_outgoing_webhook_retry_task_to_process_tracker(
+            &*state.store,
+            &business_profile,
+            &event,
+            state.conf.application_source,
+        )
+        .await
+        .inspect_err(|error| {
+            logger::error!(
+                ?error,
+                "Failed to add outgoing webhook retry task to process tracker"
+            );
+        })
+        .ok();
 
-    let event = match event_insert_result {
-        Ok(event) => Ok(event),
-        Err(error) => {
-            logger::error!(event_insertion_failure=?error);
-            Err(error
-                .change_context(errors::ApiErrorResponse::WebhookProcessingFailure)
-                .attach_printable("Failed to insert event in events table"))
-        }
-    }?;
+        let cloned_key_store = processor.get_key_store().clone();
 
-    utils::free_redis_lock(
-        &state,
-        &idempotent_event_id,
-        processor.get_account().get_id().to_owned(),
-        lock_value,
-    )
-    .await?;
-
-    let process_tracker = add_outgoing_webhook_retry_task_to_process_tracker(
-        &*state.store,
-        &business_profile,
-        &event,
-        state.conf.application_source,
-    )
-    .await
-    .inspect_err(|error| {
-        logger::error!(
-            ?error,
-            "Failed to add outgoing webhook retry task to process tracker"
+        // Using a tokio spawn here and not arbiter because not all caller of this function
+        // may have an actix arbiter
+        tokio::spawn(
+            async move {
+                Box::pin(trigger_webhook_and_raise_event(
+                    state,
+                    business_profile,
+                    &cloned_key_store,
+                    event,
+                    request_content,
+                    delivery_attempt,
+                    Some(content),
+                    process_tracker_retry,
+                    webhook_detail,
+                ))
+                .await;
+            }
+            .in_current_span(),
         );
-    })
-    .ok();
 
-    let cloned_key_store = processor.get_key_store().clone();
-    // Using a tokio spawn here and not arbiter because not all caller of this function
-    // may have an actix arbiter
-    tokio::spawn(
-        async move {
-            Box::pin(trigger_webhook_and_raise_event(
-                state,
-                business_profile,
-                &cloned_key_store,
-                event,
-                request_content,
-                delivery_attempt,
-                Some(content),
-                process_tracker,
-            ))
-            .await;
-        }
-        .in_current_span(),
-    );
-
-    Ok(())
+        Ok(())
+    } else {
+        logger::debug!(
+            business_profile_id=?business_profile.get_id(),
+            webhook_endpoint_id=?webhook_detail.webhook_endpoint_id,
+            events=?webhook_detail.events,
+            "Webhook detail doesn't match the event type; skipping outgoing webhook"
+        );
+        Ok(())
+    }
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -241,6 +370,7 @@ pub(crate) async fn trigger_webhook_and_raise_event(
     delivery_attempt: enums::WebhookDeliveryAttempt,
     content: Option<api::OutgoingWebhookContent>,
     process_tracker: Option<storage::ProcessTracker>,
+    webhook_detail: MultipleWebhookDetail,
 ) {
     logger::debug!(
         event_id=%event.event_id,
@@ -258,6 +388,7 @@ pub(crate) async fn trigger_webhook_and_raise_event(
         request_content,
         delivery_attempt,
         process_tracker,
+        webhook_detail,
     )
     .await;
 
@@ -280,32 +411,9 @@ async fn trigger_webhook_to_merchant(
     request_content: OutgoingWebhookRequestContent,
     delivery_attempt: enums::WebhookDeliveryAttempt,
     process_tracker: Option<storage::ProcessTracker>,
+    webhook_detail: MultipleWebhookDetail,
 ) -> CustomResult<(), errors::WebhooksFlowError> {
-    let webhook_url = match (
-        get_webhook_url_from_business_profile(&business_profile),
-        process_tracker.clone(),
-    ) {
-        (Ok(webhook_url), _) => Ok(webhook_url),
-        (Err(error), Some(process_tracker)) => {
-            if !error
-                .current_context()
-                .is_webhook_delivery_retryable_error()
-            {
-                logger::debug!("Failed to obtain merchant webhook URL, aborting retries");
-                state
-                    .store
-                    .as_scheduler()
-                    .finish_process_with_business_status(process_tracker, business_status::FAILURE)
-                    .await
-                    .change_context(
-                        errors::WebhooksFlowError::OutgoingWebhookProcessTrackerTaskUpdateFailed,
-                    )?;
-            }
-            Err(error)
-        }
-        (Err(error), None) => Err(error),
-    }?;
-
+    let webhook_url = webhook_detail.webhook_url.expose();
     let event_id = event.event_id;
 
     let headers = request_content
@@ -585,6 +693,8 @@ pub(crate) async fn add_outgoing_webhook_retry_task_to_process_tracker(
         primary_object_id: event.primary_object_id.clone(),
         primary_object_type: event.primary_object_type,
         initial_attempt_id: event.initial_attempt_id.clone(),
+        webhook_endpoint_id: event.webhook_endpoint_id.clone(),
+        primary_object_created_at: event.primary_object_created_at,
     };
 
     let runner = storage::ProcessTrackerRunner::OutgoingWebhookRetryWorkflow;

--- a/crates/router/src/core/webhooks/outgoing.rs
+++ b/crates/router/src/core/webhooks/outgoing.rs
@@ -98,6 +98,7 @@ pub(crate) async fn add_bulk_outgoing_webhook_task_to_process_tracker(
         None,
         schedule_time,
         common_types::consts::API_VERSION,
+        state.conf.application_source,
     )
     .map_err(errors::StorageError::from)?;
 
@@ -124,10 +125,7 @@ pub(crate) fn get_webhook_details_for_event_type(
         .get_required_value("webhook_details")
         .change_context(errors::WebhooksFlowError::MerchantWebhookDetailsNotFound)?;
 
-    let webhook_list = webhook_details
-        .multiple_webhooks_list
-        .clone()
-        .unwrap_or_default();
+    let webhook_list = webhook_details.multiple_webhooks_list.unwrap_or_default();
 
     let matching_details: Vec<MultipleWebhookDetail> = webhook_list
         .into_iter()
@@ -154,12 +152,13 @@ pub(crate) fn get_webhook_detail_by_webhook_endpoint_id(
         .as_ref()
         .ok_or(errors::WebhooksFlowError::MerchantWebhookDetailsNotFound)?;
 
-    let webhooks = webhook_details
+    let webhook_urls = webhook_details
         .multiple_webhooks_list
         .clone()
         .ok_or(errors::WebhooksFlowError::MerchantWebhookDetailsNotFound)?;
 
-    webhooks
+    webhook_urls
+        .0
         .into_iter()
         .find(|d| &d.webhook_endpoint_id == endpoint_id)
         .ok_or(errors::WebhooksFlowError::MerchantWebhookDetailsNotFound.into())

--- a/crates/router/src/core/webhooks/outgoing_v2.rs
+++ b/crates/router/src/core/webhooks/outgoing_v2.rs
@@ -116,6 +116,7 @@ pub(crate) async fn create_event_and_trigger_outgoing_webhook(
         delivery_attempt: Some(delivery_attempt),
         metadata: Some(event_metadata),
         is_overall_delivery_successful: Some(false),
+        webhook_endpoint_id: None,
     };
 
     let event_insert_result = state

--- a/crates/router/src/core/webhooks/types.rs
+++ b/crates/router/src/core/webhooks/types.rs
@@ -76,6 +76,8 @@ pub(crate) struct OutgoingWebhookTrackingData {
     pub(crate) primary_object_id: String,
     pub(crate) primary_object_type: enums::EventObjectType,
     pub(crate) initial_attempt_id: Option<String>,
+    pub(crate) webhook_endpoint_id: Option<common_utils::id_type::WebhookEndpointId>,
+    pub(crate) primary_object_created_at: Option<time::PrimitiveDateTime>,
 }
 
 pub struct WebhookResponse {

--- a/crates/router/src/core/webhooks/utils.rs
+++ b/crates/router/src/core/webhooks/utils.rs
@@ -1,12 +1,7 @@
 use std::marker::PhantomData;
 
 use base64::Engine;
-use common_utils::{
-    consts,
-    crypto::{self, GenerateDigest},
-    errors::CustomResult,
-    ext_traits::ValueExt,
-};
+use common_utils::{errors::CustomResult, ext_traits::ValueExt};
 use error_stack::{Report, ResultExt};
 use redis_interface as redis;
 use router_env::tracing;
@@ -151,33 +146,42 @@ pub async fn construct_webhook_router_data(
     Ok(router_data)
 }
 
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use sha2::{Digest, Sha256};
 #[inline]
 pub(crate) fn get_idempotent_event_id(
     primary_object_id: &str,
     event_type: types::storage::enums::EventType,
     delivery_attempt: types::storage::enums::WebhookDeliveryAttempt,
-) -> Result<String, Report<errors::WebhooksFlowError>> {
+    webhook_endpoint_id: Option<&str>,
+) -> String {
     use crate::types::storage::enums::WebhookDeliveryAttempt;
 
     const EVENT_ID_SUFFIX_LENGTH: usize = 8;
+    const MAX_PREFIX_LEN: usize = 64 - EVENT_ID_SUFFIX_LENGTH;
 
-    let common_prefix = format!("{primary_object_id}_{event_type}");
-
-    // Hash the common prefix with SHA256 and encode with URL-safe base64 without padding
-    let digest = crypto::Sha256
-        .generate_digest(common_prefix.as_bytes())
-        .change_context(errors::WebhooksFlowError::IdGenerationFailed)
-        .attach_printable("Failed to generate idempotent event ID")?;
-    let base_encoded = consts::BASE64_ENGINE_URL_SAFE_NO_PAD.encode(digest);
-
-    let result = match delivery_attempt {
-        WebhookDeliveryAttempt::InitialAttempt => base_encoded,
-        WebhookDeliveryAttempt::AutomaticRetry | WebhookDeliveryAttempt::ManualRetry => {
-            common_utils::generate_id(EVENT_ID_SUFFIX_LENGTH, &base_encoded)
-        }
+    let input = match webhook_endpoint_id {
+        Some(id) => format!("{primary_object_id}_{event_type}_{id}"),
+        None => format!("{primary_object_id}_{event_type}"),
     };
 
-    Ok(result)
+    // Hash and encode the input using SHA-256 and URL-safe base64 (without padding)
+    let hash = Sha256::digest(input.as_bytes());
+    let encoded = URL_SAFE_NO_PAD.encode(hash);
+
+    // Truncate to MAX_PREFIX_LEN (56) if needed
+    let common_prefix = if encoded.len() > MAX_PREFIX_LEN {
+        &encoded[..MAX_PREFIX_LEN]
+    } else {
+        &encoded
+    };
+
+    match delivery_attempt {
+        WebhookDeliveryAttempt::InitialAttempt => common_prefix.to_string(),
+        WebhookDeliveryAttempt::AutomaticRetry | WebhookDeliveryAttempt::ManualRetry => {
+            common_utils::generate_id(EVENT_ID_SUFFIX_LENGTH, common_prefix)
+        }
+    }
 }
 
 #[inline]

--- a/crates/router/src/core/webhooks/webhook_events.rs
+++ b/crates/router/src/core/webhooks/webhook_events.rs
@@ -299,9 +299,11 @@ pub async fn retry_delivery_attempt(
         &event_to_retry.primary_object_id,
         event_to_retry.event_type,
         delivery_attempt,
-    )
-    .change_context(errors::ApiErrorResponse::WebhookProcessingFailure)
-    .attach_printable("Failed to generate idempotent event ID")?;
+        event_to_retry
+            .webhook_endpoint_id
+            .as_ref()
+            .map(|id| id.get_string_repr()),
+    );
 
     let now = common_utils::date_time::now();
     let new_event = domain::Event {
@@ -322,6 +324,7 @@ pub async fn retry_delivery_attempt(
         delivery_attempt: Some(delivery_attempt),
         metadata: event_to_retry.metadata,
         is_overall_delivery_successful: Some(false),
+        webhook_endpoint_id: None,
     };
 
     let event = store
@@ -341,6 +344,20 @@ pub async fn retry_delivery_attempt(
         .change_context(errors::ApiErrorResponse::InternalServerError)
         .attach_printable("Failed to parse webhook event request information")?;
 
+    let webhook_detail = match super::get_webhook_detail_by_webhook_endpoint_id(
+        &business_profile,
+        &event_to_retry.webhook_endpoint_id,
+    ) {
+        Ok(detail) => detail,
+        Err(e) => {
+            return Err(e
+                .change_context(errors::ApiErrorResponse::WebhookProcessingFailure)
+                .attach_printable(
+                    "Failed to fetch webhook details for the given webhook endpoint ID",
+                ));
+        }
+    };
+
     Box::pin(super::outgoing::trigger_webhook_and_raise_event(
         state.clone(),
         business_profile,
@@ -350,6 +367,7 @@ pub async fn retry_delivery_attempt(
         delivery_attempt,
         None,
         None,
+        webhook_detail,
     ))
     .await;
 

--- a/crates/router/src/db/events.rs
+++ b/crates/router/src/db/events.rs
@@ -1082,6 +1082,7 @@ mod tests {
                         .unwrap(),
                     }),
                     is_overall_delivery_successful: Some(false),
+                    webhook_endpoint_id: None,
                 },
                 &merchant_key_store,
             )
@@ -1195,6 +1196,7 @@ mod tests {
                         .unwrap(),
                     }),
                     is_overall_delivery_successful: Some(false),
+                    webhook_endpoint_id: None,
                 },
                 &merchant_key_store,
             )
@@ -1553,16 +1555,15 @@ mod tests {
             let primary_object_id_clone = primary_object_id.clone();
 
             let handle = tokio::spawn(async move {
-                webhooks_core::create_event_and_trigger_outgoing_webhook(
+                webhooks_core::add_bulk_outgoing_webhook_task_to_process_tracker(
                     state_clone,
                     cloned_processor,
                     business_profile_clone,
-                    event_type,
-                    event_class,
                     (*primary_object_id_clone).to_string(),
-                    primary_object_type,
-                    content_clone,
-                    primary_object_created_at,
+                    outgoing_event_type,
+                    diesel_models::enums::EventClass::Payments,
+                    diesel_models::enums::EventObjectType::PaymentDetails,
+                    payment_intent.created_at,
                 )
                 .await
                 .map_err(|e| format!("create_event_and_trigger_outgoing_webhook failed: {e}"))

--- a/crates/router/src/types/domain/event.rs
+++ b/crates/router/src/types/domain/event.rs
@@ -71,6 +71,9 @@ pub struct Event {
 
     /// Indicates whether the event was ultimately delivered.
     pub is_overall_delivery_successful: Option<bool>,
+
+    /// The identifier for outgoing webhook endpoint.
+    pub webhook_endpoint_id: Option<common_utils::id_type::WebhookEndpointId>,
 }
 
 #[derive(Debug)]
@@ -130,6 +133,7 @@ impl super::behaviour::Conversion for Event {
             delivery_attempt: self.delivery_attempt,
             metadata: self.metadata,
             is_overall_delivery_successful: self.is_overall_delivery_successful,
+            webhook_endpoint_id: self.webhook_endpoint_id,
         })
     }
 
@@ -180,6 +184,7 @@ impl super::behaviour::Conversion for Event {
             delivery_attempt: item.delivery_attempt,
             metadata: item.metadata,
             is_overall_delivery_successful: item.is_overall_delivery_successful,
+            webhook_endpoint_id: item.webhook_endpoint_id,
         })
     }
 
@@ -202,6 +207,7 @@ impl super::behaviour::Conversion for Event {
             delivery_attempt: self.delivery_attempt,
             metadata: self.metadata,
             is_overall_delivery_successful: self.is_overall_delivery_successful,
+            webhook_endpoint_id: self.webhook_endpoint_id,
         })
     }
 }

--- a/crates/router/src/types/transformers.rs
+++ b/crates/router/src/types/transformers.rs
@@ -2214,36 +2214,6 @@ impl ForeignFrom<api_models::admin::WebhookDetails>
 }
 
 impl ForeignFrom<hyperswitch_domain_models::business_profile::WebhookDetails>
-    for diesel_models::business_profile::WebhookDetails
-{
-    fn foreign_from(item: hyperswitch_domain_models::business_profile::WebhookDetails) -> Self {
-        let webhook_url = item
-            .multiple_webhooks_list
-            .as_ref()
-            .and_then(|list| list.get_legacy_url());
-        Self {
-            webhook_version: item.webhook_version,
-            webhook_username: item.webhook_username,
-            webhook_password: item.webhook_password,
-            webhook_url,
-            payment_created_enabled: item.payment_created_enabled,
-            payment_succeeded_enabled: item.payment_succeeded_enabled,
-            payment_failed_enabled: item.payment_failed_enabled,
-            payment_statuses_enabled: item.payment_statuses_enabled,
-            refund_statuses_enabled: item.refund_statuses_enabled,
-            payout_statuses_enabled: item.payout_statuses_enabled,
-            multiple_webhooks_list: item.multiple_webhooks_list.map(|urls| {
-                urls.0
-                    .into_iter()
-                    .filter(|webhook_detail| !webhook_detail.is_legacy_url)
-                    .map(ForeignFrom::foreign_from)
-                    .collect()
-            }),
-        }
-    }
-}
-
-impl ForeignFrom<hyperswitch_domain_models::business_profile::WebhookDetails>
     for api_models::admin::WebhookDetails
 {
     fn foreign_from(item: hyperswitch_domain_models::business_profile::WebhookDetails) -> Self {
@@ -2262,22 +2232,6 @@ impl ForeignFrom<hyperswitch_domain_models::business_profile::WebhookDetails>
             payment_statuses_enabled: item.payment_statuses_enabled,
             refund_statuses_enabled: item.refund_statuses_enabled,
             payout_statuses_enabled: item.payout_statuses_enabled,
-        }
-    }
-}
-
-impl ForeignFrom<hyperswitch_domain_models::business_profile::MultipleWebhookDetail>
-    for diesel_models::business_profile::MultipleWebhookDetail
-{
-    fn foreign_from(
-        item: hyperswitch_domain_models::business_profile::MultipleWebhookDetail,
-    ) -> Self {
-        Self {
-            webhook_endpoint_id: item.webhook_endpoint_id,
-            webhook_url: item.webhook_url,
-            events: item.events,
-            status: item.status,
-            is_legacy_url: false,
         }
     }
 }

--- a/crates/router/src/utils.rs
+++ b/crates/router/src/utils.rs
@@ -1221,19 +1221,17 @@ where
                 tokio::spawn(
                     async move {
                         let primary_object_created_at = payments_response_json.created;
-                        Box::pin(webhooks_core::create_event_and_trigger_outgoing_webhook(
-                            cloned_state,
-                            cloned_processor,
-                            business_profile,
-                            event_type,
-                            diesel_models::enums::EventClass::Payments,
-                            payment_id.get_string_repr().to_owned(),
-                            common_enums::EventObjectType::PaymentDetails,
-                            webhooks::OutgoingWebhookContent::PaymentDetails(Box::new(
-                                payments_response_json,
-                            )),
-                            primary_object_created_at,
-                        ))
+                        Box::pin(
+                            webhooks_core::add_bulk_outgoing_webhook_task_to_process_tracker(
+                                cloned_state,
+                                &business_profile,
+                                payment_id.get_string_repr(),
+                                event_type,
+                                diesel_models::enums::EventClass::Payments,
+                                diesel_models::enums::EventObjectType::PaymentDetails,
+                                primary_object_created_at,
+                            ),
+                        )
                         .await
                     }
                     .in_current_span(),
@@ -1294,17 +1292,17 @@ pub async fn trigger_refund_outgoing_webhook(
             let processor = platform.get_processor().clone();
             tokio::spawn(
                 async move {
-                    Box::pin(webhooks_core::create_event_and_trigger_outgoing_webhook(
-                        cloned_state,
-                        processor,
-                        business_profile,
-                        outgoing_event_type,
-                        diesel_models::enums::EventClass::Refunds,
-                        refund_id.to_string(),
-                        common_enums::EventObjectType::RefundDetails,
-                        webhooks::OutgoingWebhookContent::RefundDetails(Box::new(refund_response)),
-                        primary_object_created_at,
-                    ))
+                    Box::pin(
+                        webhooks_core::add_bulk_outgoing_webhook_task_to_process_tracker(
+                            cloned_state,
+                            &business_profile,
+                            &refund_id,
+                            outgoing_event_type,
+                            diesel_models::enums::EventClass::Refunds,
+                            diesel_models::enums::EventObjectType::RefundDetails,
+                            primary_object_created_at,
+                        ),
+                    )
                     .await
                 }
                 .in_current_span(),
@@ -1371,17 +1369,17 @@ pub async fn trigger_payouts_webhook(
             tokio::spawn(
                 async move {
                     let primary_object_created_at = cloned_response.created;
-                    Box::pin(webhooks_core::create_event_and_trigger_outgoing_webhook(
-                        cloned_state,
-                        processor,
-                        business_profile,
-                        event_type,
-                        diesel_models::enums::EventClass::Payouts,
-                        cloned_response.payout_id.get_string_repr().to_owned(),
-                        common_enums::EventObjectType::PayoutDetails,
-                        webhooks::OutgoingWebhookContent::PayoutDetails(Box::new(cloned_response)),
-                        primary_object_created_at,
-                    ))
+                    Box::pin(
+                        webhooks_core::add_bulk_outgoing_webhook_task_to_process_tracker(
+                            cloned_state,
+                            &business_profile,
+                            &cloned_response.payout_id.get_string_repr(),
+                            event_type,
+                            enums::EventClass::Payouts,
+                            diesel_models::enums::EventObjectType::PayoutDetails,
+                            primary_object_created_at,
+                        ),
+                    )
                     .await
                 }
                 .in_current_span(),

--- a/crates/router/src/utils.rs
+++ b/crates/router/src/utils.rs
@@ -43,7 +43,7 @@ use nanoid::nanoid;
 use serde::de::DeserializeOwned;
 use serde_json::Value;
 #[cfg(feature = "v1")]
-use subscriptions::{subscription_handler::SubscriptionHandler, workflows::InvoiceSyncHandler};
+use subscriptions::subscription_handler::SubscriptionHandler;
 use tracing_futures::Instrument;
 
 pub use self::ext_traits::{OptionExt, ValidateCall};
@@ -1217,7 +1217,6 @@ where
             // So when server shutdown won't wait for this thread's completion.
 
             if let Some(event_type) = event_type {
-                let cloned_processor = processor.clone();
                 tokio::spawn(
                     async move {
                         let primary_object_created_at = payments_response_json.created;
@@ -1289,7 +1288,6 @@ pub async fn trigger_refund_outgoing_webhook(
         let cloned_state = state.clone();
         let primary_object_created_at = refund_response.created_at;
         if let Some(outgoing_event_type) = event_type {
-            let processor = platform.get_processor().clone();
             tokio::spawn(
                 async move {
                     Box::pin(
@@ -1361,7 +1359,6 @@ pub async fn trigger_payouts_webhook(
         if let Some(event_type) = event_type {
             let cloned_state = state.clone();
             let cloned_response = payout_response.clone();
-            let processor = platform.get_processor().clone();
 
             // This spawns this futures in a background thread, the exception inside this future won't affect
             // the current thread and the lifecycle of spawn thread is not handled by runtime.
@@ -1403,48 +1400,40 @@ pub async fn trigger_payouts_webhook(
 #[cfg(feature = "v1")]
 pub async fn trigger_subscriptions_outgoing_webhook(
     state: &SessionState,
-    payment_response: subscription_types::PaymentResponseData,
+    _payment_response: subscription_types::PaymentResponseData,
     invoice: &hyperswitch_domain_models::invoice::Invoice,
     subscription: &hyperswitch_domain_models::subscription::Subscription,
-    merchant_account: &domain::MerchantAccount,
-    key_store: &domain::MerchantKeyStore,
+    _merchant_account: &domain::MerchantAccount,
+    _key_store: &domain::MerchantKeyStore,
     profile: &domain::Profile,
 ) -> RouterResult<()> {
     if invoice.status != common_enums::enums::InvoiceStatus::InvoicePaid {
         logger::info!("Invoice not paid, skipping outgoing webhook trigger");
         return Ok(());
     }
-    let response = InvoiceSyncHandler::generate_response(subscription, invoice, &payment_response)
-        .attach_printable("Subscriptions: Failed to generate response for outgoing webhook")?;
-
-    let platform = domain::Platform::new(
-        merchant_account.clone(),
-        key_store.clone(),
-        merchant_account.clone(),
-        key_store.clone(),
-        None,
-    );
 
     let cloned_state = state.clone();
     let cloned_profile = profile.clone();
     let invoice_id = invoice.id.get_string_repr().to_owned();
-    let created_at = subscription.created_at;
-    let processor = platform.get_processor().clone();
+    let primary_object_created_at = subscription.created_at;
 
-    tokio::spawn(async move {
-        Box::pin(webhooks_core::create_event_and_trigger_outgoing_webhook(
-            cloned_state,
-            processor,
-            cloned_profile,
-            common_enums::enums::EventType::InvoicePaid,
-            common_enums::enums::EventClass::Subscriptions,
-            invoice_id,
-            common_enums::EventObjectType::SubscriptionDetails,
-            webhooks::OutgoingWebhookContent::SubscriptionDetails(Box::new(response)),
-            Some(created_at),
-        ))
-        .await
-    });
+    tokio::spawn(
+        async move {
+            Box::pin(
+                webhooks_core::add_bulk_outgoing_webhook_task_to_process_tracker(
+                    cloned_state,
+                    &cloned_profile,
+                    &invoice_id,
+                    common_enums::enums::EventType::InvoicePaid,
+                    diesel_models::enums::EventClass::Subscriptions,
+                    diesel_models::enums::EventObjectType::SubscriptionDetails,
+                    Some(primary_object_created_at),
+                ),
+            )
+            .await
+        }
+        .in_current_span(),
+    );
 
     Ok(())
 }

--- a/crates/router/src/workflows/outgoing_webhook_retry.rs
+++ b/crates/router/src/workflows/outgoing_webhook_retry.rs
@@ -89,31 +89,29 @@ pub async fn trigger_outgoing_webhook_bulk_workflow(
     let event_class = tracking_data.event_class;
     let primary_object_type = tracking_data.primary_object_type;
     let db = &*state.store;
-    let key_manager_state = &state.into();
 
     let merchant_key_store = db
-        .get_merchant_key_store_by_merchant_id(
-            key_manager_state,
-            &merchant_id,
-            &db.get_master_key().to_vec().into(),
-        )
+        .get_merchant_key_store_by_merchant_id(&merchant_id, &db.get_master_key().to_vec().into())
         .await?;
     let merchant_account = db
-        .find_merchant_account_by_merchant_id(key_manager_state, &merchant_id, &merchant_key_store)
+        .find_merchant_account_by_merchant_id(&tracking_data.merchant_id, &merchant_key_store)
         .await
         .to_not_found_response(errors::ApiErrorResponse::MerchantAccountNotFound)?;
 
-    let business_profile = utils::validate_and_get_business_profile(
-        db,
-        key_manager_state,
-        &merchant_key_store,
-        Some(&profile_id),
-        &merchant_id,
-    )
-    .await?
-    .ok_or(errors::ApiErrorResponse::ProfileNotFound {
-        id: profile_id.get_string_repr().to_string(),
-    })?;
+    let platform = domain::Platform::new(
+        merchant_account.clone(),
+        merchant_key_store.clone(),
+        merchant_account.clone(),
+        merchant_key_store.clone(),
+        None,
+    );
+
+    let business_profile =
+        utils::validate_and_get_business_profile(db, platform.get_processor(), Some(&profile_id))
+            .await?
+            .ok_or(errors::ApiErrorResponse::ProfileNotFound {
+                id: profile_id.get_string_repr().to_string(),
+            })?;
 
     let cloned_state = state.clone();
     let (content, _) = Box::pin(get_outgoing_webhook_content_and_event_type(
@@ -146,33 +144,37 @@ pub async fn trigger_outgoing_webhook_bulk_workflow(
 
     let key_store = db
         .get_merchant_key_store_by_merchant_id(
-            key_manager_state,
             &tracking_data.merchant_id,
             &db.get_master_key().to_vec().into(),
         )
         .await?;
+
+    let platform = domain::Platform::new(
+        merchant_account.clone(),
+        key_store.clone(),
+        merchant_account.clone(),
+        key_store.clone(),
+        None,
+    );
+
     for webhook_detail in webhook_details.iter() {
         let webhook_detail_clone = webhook_detail.clone();
         let cloned_state = cloned_state.clone();
-        let merchant_account = merchant_account.clone();
-        let business_profile = business_profile.clone();
-        let content = content.clone();
+        let processor = platform.get_processor().clone();
         let payment_id = primary_object_id.clone();
-        let merchant_context = domain::MerchantContext::NormalMerchant(Box::new(domain::Context(
-            merchant_account.clone(),
-            key_store.clone(),
-        )));
+        let business_profile_clone = business_profile.clone();
+        let content_clone = content.clone();
         tokio::spawn(
             async move {
                 webhooks_core::create_event_and_trigger_outgoing_webhook(
                     cloned_state,
-                    merchant_context,
-                    business_profile,
+                    processor,
+                    business_profile_clone,
                     event_type,
                     event_class,
                     payment_id,
                     primary_object_type,
-                    content,
+                    content_clone,
                     primary_object_created_at,
                     webhook_detail_clone,
                 )

--- a/crates/router/src/workflows/outgoing_webhook_retry.rs
+++ b/crates/router/src/workflows/outgoing_webhook_retry.rs
@@ -13,7 +13,7 @@ use common_utils::{
 use diesel_models::process_tracker::business_status;
 use error_stack::ResultExt;
 use masking::PeekInterface;
-use router_env::tracing::{self, instrument};
+use router_env::tracing::{self, instrument, Instrument};
 use scheduler::{
     consumer::{self, workflows::ProcessTrackerWorkflow},
     types::process_data,
@@ -26,8 +26,12 @@ use subscriptions::workflows::invoice_sync;
 use crate::core::payouts;
 use crate::{
     core::{
-        payments,
-        webhooks::{self as webhooks_core, types::OutgoingWebhookTrackingData},
+        errors::StorageErrorExt as _,
+        payments, utils,
+        webhooks::{
+            self as webhooks_core, types::OutgoingWebhookTrackingData, OUTGOING_WEBHOOK_BULK_TASK,
+            OUTGOING_WEBHOOK_RETRY_TASK,
+        },
     },
     db::StorageInterface,
     errors, logger,
@@ -36,6 +40,358 @@ use crate::{
 };
 
 pub struct OutgoingWebhookRetryWorkflow;
+
+#[cfg(feature = "v1")]
+#[instrument(skip_all)]
+pub async fn start_outgoing_webhook_workflow(
+    state: &SessionState,
+    process_tracker: &storage::ProcessTracker,
+) -> Result<(), errors::ProcessTrackerError> {
+    match process_tracker.name.as_deref() {
+        Some(OUTGOING_WEBHOOK_BULK_TASK) => {
+            Box::pin(trigger_outgoing_webhook_bulk_workflow(
+                state,
+                process_tracker,
+            ))
+            .await
+        }
+        Some(OUTGOING_WEBHOOK_RETRY_TASK) => {
+            Box::pin(trigger_outgoing_webhook_retry_workflow(
+                state,
+                process_tracker,
+            ))
+            .await
+        }
+        Some(unexpected_job) => Err(errors::ApiErrorResponse::WebhookProcessingFailure)
+            .attach_printable(format!(
+                "Unexpected task name encountered: `{}`",
+                unexpected_job
+            ))?,
+        _ => Err(errors::ProcessTrackerError::JobNotFound),
+    }
+}
+
+#[instrument(skip_all)]
+#[cfg(feature = "v1")]
+pub async fn trigger_outgoing_webhook_bulk_workflow(
+    state: &SessionState,
+    process: &storage::ProcessTracker,
+) -> Result<(), errors::ProcessTrackerError> {
+    let tracking_data: OutgoingWebhookTrackingData = process
+        .tracking_data
+        .clone()
+        .parse_value("OutgoingWebhookTrackingData")?;
+    let merchant_id = tracking_data.merchant_id.clone();
+    let profile_id = tracking_data.business_profile_id.clone();
+    let primary_object_id = tracking_data.primary_object_id.clone();
+    let primary_object_created_at = tracking_data.primary_object_created_at;
+    let event_type = tracking_data.event_type;
+    let event_class = tracking_data.event_class;
+    let primary_object_type = tracking_data.primary_object_type;
+    let db = &*state.store;
+    let key_manager_state = &state.into();
+
+    let merchant_key_store = db
+        .get_merchant_key_store_by_merchant_id(
+            key_manager_state,
+            &merchant_id,
+            &db.get_master_key().to_vec().into(),
+        )
+        .await?;
+    let merchant_account = db
+        .find_merchant_account_by_merchant_id(key_manager_state, &merchant_id, &merchant_key_store)
+        .await
+        .to_not_found_response(errors::ApiErrorResponse::MerchantAccountNotFound)?;
+
+    let business_profile = utils::validate_and_get_business_profile(
+        db,
+        key_manager_state,
+        &merchant_key_store,
+        Some(&profile_id),
+        &merchant_id,
+    )
+    .await?
+    .ok_or(errors::ApiErrorResponse::ProfileNotFound {
+        id: profile_id.get_string_repr().to_string(),
+    })?;
+
+    let cloned_state = state.clone();
+    let (content, _) = Box::pin(get_outgoing_webhook_content_and_event_type(
+        state.clone(),
+        state.get_req_state(),
+        merchant_account.clone(),
+        merchant_key_store.clone(),
+        &tracking_data,
+    ))
+    .await?;
+    let webhook_details = webhooks_core::get_webhook_details_for_event_type(
+        &business_profile,
+        event_type,
+    )
+    .map_err(|err| {
+        logger::error!(original_webhook_error=?err, business_profile_id=?business_profile.get_id(), "Failed to get webhook details for event type");
+        errors::ProcessTrackerError::ResourceFetchingFailed {
+            resource_name: "webhook_details".to_string(),
+        }
+    })?;
+
+    if webhook_details.is_empty() {
+        logger::debug!(
+            business_profile_id = ?business_profile.get_id(),
+            event_type = ?event_type,
+            "No active webhook details found for event type or list is empty"
+        );
+        return Ok(());
+    }
+
+    let key_store = db
+        .get_merchant_key_store_by_merchant_id(
+            key_manager_state,
+            &tracking_data.merchant_id,
+            &db.get_master_key().to_vec().into(),
+        )
+        .await?;
+    for webhook_detail in webhook_details.iter() {
+        let webhook_detail_clone = webhook_detail.clone();
+        let cloned_state = cloned_state.clone();
+        let merchant_account = merchant_account.clone();
+        let business_profile = business_profile.clone();
+        let content = content.clone();
+        let payment_id = primary_object_id.clone();
+        let merchant_context = domain::MerchantContext::NormalMerchant(Box::new(domain::Context(
+            merchant_account.clone(),
+            key_store.clone(),
+        )));
+        tokio::spawn(
+            async move {
+                webhooks_core::create_event_and_trigger_outgoing_webhook(
+                    cloned_state,
+                    merchant_context,
+                    business_profile,
+                    event_type,
+                    event_class,
+                    payment_id,
+                    primary_object_type,
+                    content,
+                    primary_object_created_at,
+                    webhook_detail_clone,
+                )
+                .await
+                .unwrap_or(())
+            }
+            .in_current_span(),
+        );
+    }
+    let _ = state
+        .store
+        .as_scheduler()
+        .finish_process_with_business_status(process.clone(), business_status::COMPLETED_BY_PT)
+        .await
+        .change_context(errors::WebhooksFlowError::OutgoingWebhookProcessTrackerTaskUpdateFailed);
+    Ok(())
+}
+
+#[cfg(feature = "v1")]
+#[instrument(skip_all)]
+pub async fn trigger_outgoing_webhook_retry_workflow(
+    state: &SessionState,
+    process: &storage::ProcessTracker,
+) -> Result<(), errors::ProcessTrackerError> {
+    let delivery_attempt = storage::enums::WebhookDeliveryAttempt::AutomaticRetry;
+    let tracking_data: OutgoingWebhookTrackingData = process
+        .tracking_data
+        .clone()
+        .parse_value("OutgoingWebhookTrackingData")?;
+
+    let db = &*state.store;
+    let key_store = db
+        .get_merchant_key_store_by_merchant_id(
+            &tracking_data.merchant_id,
+            &db.get_master_key().to_vec().into(),
+        )
+        .await?;
+    let business_profile = db
+        .find_business_profile_by_profile_id(&key_store, &tracking_data.business_profile_id)
+        .await?;
+
+    let event_id = webhooks_core::utils::generate_event_id();
+
+    let idempotent_event_id = webhooks_core::utils::get_idempotent_event_id(
+        &tracking_data.primary_object_id,
+        tracking_data.event_type,
+        delivery_attempt,
+        tracking_data
+            .webhook_endpoint_id
+            .as_ref()
+            .map(|id| id.get_string_repr()),
+    );
+
+    let initial_event = match &tracking_data.initial_attempt_id {
+        Some(initial_attempt_id) => {
+            db.find_event_by_merchant_id_event_id(
+                &business_profile.merchant_id,
+                initial_attempt_id,
+                &key_store,
+            )
+            .await?
+        }
+        // Tracking data inserted by old version of application, fetch event using old event ID
+        // format
+        None => {
+            let old_event_id = format!(
+                "{}_{}",
+                tracking_data.primary_object_id, tracking_data.event_type
+            );
+            db.find_event_by_merchant_id_event_id(
+                &business_profile.merchant_id,
+                &old_event_id,
+                &key_store,
+            )
+            .await?
+        }
+    };
+
+    let now = common_utils::date_time::now();
+    let new_event = domain::Event {
+        event_id,
+        event_type: initial_event.event_type,
+        event_class: initial_event.event_class,
+        is_webhook_notified: false,
+        primary_object_id: initial_event.primary_object_id,
+        primary_object_type: initial_event.primary_object_type,
+        created_at: now,
+        merchant_id: Some(business_profile.merchant_id.clone()),
+        business_profile_id: Some(business_profile.get_id().to_owned()),
+        primary_object_created_at: tracking_data.primary_object_created_at,
+        idempotent_event_id: Some(idempotent_event_id),
+        initial_attempt_id: Some(initial_event.event_id.clone()),
+        request: initial_event.request,
+        response: None,
+        delivery_attempt: Some(delivery_attempt),
+        metadata: initial_event.metadata,
+        webhook_endpoint_id: initial_event.webhook_endpoint_id,
+        is_overall_delivery_successful: Some(false),
+    };
+    let webhook_id = new_event.webhook_endpoint_id.clone();
+    let event = db
+        .insert_event(new_event, &key_store)
+        .await
+        .inspect_err(|error| {
+            logger::error!(?error, "Failed to insert event in events table");
+        })?;
+
+    let webhook_detail = match webhooks_core::get_webhook_detail_by_webhook_endpoint_id(
+        &business_profile,
+        &webhook_id,
+    ) {
+        Ok(detail) => detail,
+        Err(_e) => {
+            return Err(errors::ProcessTrackerError::UnexpectedFlow);
+        }
+    };
+
+    match &event.request {
+        Some(request) => {
+            let request_content: OutgoingWebhookRequestContent = request
+                .get_inner()
+                .peek()
+                .parse_struct("OutgoingWebhookRequestContent")?;
+
+            Box::pin(webhooks_core::trigger_webhook_and_raise_event(
+                state.clone(),
+                business_profile,
+                &key_store,
+                event,
+                request_content,
+                delivery_attempt,
+                None,
+                Some(process.clone()),
+                webhook_detail,
+            ))
+            .await;
+        }
+
+        // Event inserted by old version of application, fetch current information about
+        // resource
+        None => {
+            let merchant_account = db
+                .find_merchant_account_by_merchant_id(&tracking_data.merchant_id, &key_store)
+                .await?;
+
+            let platform = domain::Platform::new(
+                merchant_account.clone(),
+                key_store.clone(),
+                merchant_account.clone(),
+                key_store.clone(),
+                None,
+            );
+            // TODO: Add request state for the PT flows as well
+            let (content, event_type) = Box::pin(get_outgoing_webhook_content_and_event_type(
+                state.clone(),
+                state.get_req_state(),
+                merchant_account.clone(),
+                key_store.clone(),
+                &tracking_data,
+            ))
+            .await?;
+
+            match event_type {
+                // Resource status is same as the event type of the current event
+                Some(event_type) if event_type == tracking_data.event_type => {
+                    let outgoing_webhook = OutgoingWebhook {
+                        merchant_id: tracking_data.merchant_id.clone(),
+                        event_id: event.event_id.clone(),
+                        event_type,
+                        content: content.clone(),
+                        timestamp: event.created_at,
+                    };
+
+                    let request_content = webhooks_core::get_outgoing_webhook_request(
+                        platform.get_processor(),
+                        outgoing_webhook,
+                        &business_profile,
+                    )
+                    .map_err(|error| {
+                        logger::error!(?error, "Failed to obtain outgoing webhook request content");
+                        errors::ProcessTrackerError::EApiErrorResponse
+                    })?;
+
+                    Box::pin(webhooks_core::trigger_webhook_and_raise_event(
+                        state.clone(),
+                        business_profile,
+                        &key_store,
+                        event,
+                        request_content,
+                        delivery_attempt,
+                        Some(content),
+                        Some(process.clone()),
+                        webhook_detail,
+                    ))
+                    .await;
+                }
+                // Resource status has changed since the event was created, finish task
+                _ => {
+                    logger::warn!(
+                        %event.event_id,
+                        "The current status of the resource `{:?}` (event type: {:?}) and the status of \
+                        the resource when the event was created (event type: {:?}) differ, finishing task",
+                        tracking_data.primary_object_id,
+                        event_type,
+                        tracking_data.event_type
+                    );
+                    db.as_scheduler()
+                        .finish_process_with_business_status(
+                            process.clone(),
+                            business_status::RESOURCE_STATUS_MISMATCH,
+                        )
+                        .await?;
+                }
+            }
+        }
+    };
+
+    Ok(())
+}
 
 #[async_trait::async_trait]
 impl ProcessTrackerWorkflow<SessionState> for OutgoingWebhookRetryWorkflow {
@@ -46,188 +402,9 @@ impl ProcessTrackerWorkflow<SessionState> for OutgoingWebhookRetryWorkflow {
         state: &'a SessionState,
         process: storage::ProcessTracker,
     ) -> Result<(), errors::ProcessTrackerError> {
-        let delivery_attempt = storage::enums::WebhookDeliveryAttempt::AutomaticRetry;
-        let tracking_data: OutgoingWebhookTrackingData = process
-            .tracking_data
-            .clone()
-            .parse_value("OutgoingWebhookTrackingData")?;
-
-        let db = &*state.store;
-        let key_store = db
-            .get_merchant_key_store_by_merchant_id(
-                &tracking_data.merchant_id,
-                &db.get_master_key().to_vec().into(),
-            )
-            .await?;
-        let business_profile = db
-            .find_business_profile_by_profile_id(&key_store, &tracking_data.business_profile_id)
-            .await?;
-
-        let event_id = webhooks_core::utils::generate_event_id();
-        let idempotent_event_id = webhooks_core::utils::get_idempotent_event_id(
-            &tracking_data.primary_object_id,
-            tracking_data.event_type,
-            delivery_attempt,
-        )
-        .change_context(errors::ApiErrorResponse::WebhookProcessingFailure)
-        .attach_printable("Failed to generate idempotent event ID")?;
-
-        let initial_event = match &tracking_data.initial_attempt_id {
-            Some(initial_attempt_id) => {
-                db.find_event_by_merchant_id_event_id(
-                    &business_profile.merchant_id,
-                    initial_attempt_id,
-                    &key_store,
-                )
-                .await?
-            }
-            // Tracking data inserted by old version of application, fetch event using old event ID
-            // format
-            None => {
-                let old_event_id = format!(
-                    "{}_{}",
-                    tracking_data.primary_object_id, tracking_data.event_type
-                );
-                db.find_event_by_merchant_id_event_id(
-                    &business_profile.merchant_id,
-                    &old_event_id,
-                    &key_store,
-                )
-                .await?
-            }
-        };
-
-        let now = common_utils::date_time::now();
-        let new_event = domain::Event {
-            event_id,
-            event_type: initial_event.event_type,
-            event_class: initial_event.event_class,
-            is_webhook_notified: false,
-            primary_object_id: initial_event.primary_object_id,
-            primary_object_type: initial_event.primary_object_type,
-            created_at: now,
-            merchant_id: Some(business_profile.merchant_id.clone()),
-            business_profile_id: Some(business_profile.get_id().to_owned()),
-            primary_object_created_at: initial_event.primary_object_created_at,
-            idempotent_event_id: Some(idempotent_event_id),
-            initial_attempt_id: Some(initial_event.event_id.clone()),
-            request: initial_event.request,
-            response: None,
-            delivery_attempt: Some(delivery_attempt),
-            metadata: initial_event.metadata,
-            is_overall_delivery_successful: Some(false),
-        };
-
-        let event = db
-            .insert_event(new_event, &key_store)
-            .await
-            .inspect_err(|error| {
-                logger::error!(?error, "Failed to insert event in events table");
-            })?;
-
-        match &event.request {
-            Some(request) => {
-                let request_content: OutgoingWebhookRequestContent = request
-                    .get_inner()
-                    .peek()
-                    .parse_struct("OutgoingWebhookRequestContent")?;
-
-                Box::pin(webhooks_core::trigger_webhook_and_raise_event(
-                    state.clone(),
-                    business_profile,
-                    &key_store,
-                    event,
-                    request_content,
-                    delivery_attempt,
-                    None,
-                    Some(process),
-                ))
-                .await;
-            }
-
-            // Event inserted by old version of application, fetch current information about
-            // resource
-            None => {
-                let merchant_account = db
-                    .find_merchant_account_by_merchant_id(&tracking_data.merchant_id, &key_store)
-                    .await?;
-
-                let platform = domain::Platform::new(
-                    merchant_account.clone(),
-                    key_store.clone(),
-                    merchant_account.clone(),
-                    key_store.clone(),
-                    None,
-                );
-                // TODO: Add request state for the PT flows as well
-                let (content, event_type) = Box::pin(get_outgoing_webhook_content_and_event_type(
-                    state.clone(),
-                    state.get_req_state(),
-                    merchant_account.clone(),
-                    key_store.clone(),
-                    &tracking_data,
-                ))
-                .await?;
-
-                match event_type {
-                    // Resource status is same as the event type of the current event
-                    Some(event_type) if event_type == tracking_data.event_type => {
-                        let outgoing_webhook = OutgoingWebhook {
-                            merchant_id: tracking_data.merchant_id.clone(),
-                            event_id: event.event_id.clone(),
-                            event_type,
-                            content: content.clone(),
-                            timestamp: event.created_at,
-                        };
-
-                        let request_content = webhooks_core::get_outgoing_webhook_request(
-                            platform.get_processor(),
-                            outgoing_webhook,
-                            &business_profile,
-                        )
-                        .map_err(|error| {
-                            logger::error!(
-                                ?error,
-                                "Failed to obtain outgoing webhook request content"
-                            );
-                            errors::ProcessTrackerError::EApiErrorResponse
-                        })?;
-
-                        Box::pin(webhooks_core::trigger_webhook_and_raise_event(
-                            state.clone(),
-                            business_profile,
-                            &key_store,
-                            event,
-                            request_content,
-                            delivery_attempt,
-                            Some(content),
-                            Some(process),
-                        ))
-                        .await;
-                    }
-                    // Resource status has changed since the event was created, finish task
-                    _ => {
-                        logger::warn!(
-                            %event.event_id,
-                            "The current status of the resource `{:?}` (event type: {:?}) and the status of \
-                            the resource when the event was created (event type: {:?}) differ, finishing task",
-                            tracking_data.primary_object_id,
-                            event_type,
-                            tracking_data.event_type
-                        );
-                        db.as_scheduler()
-                            .finish_process_with_business_status(
-                                process.clone(),
-                                business_status::RESOURCE_STATUS_MISMATCH,
-                            )
-                            .await?;
-                    }
-                }
-            }
-        };
-
-        Ok(())
+        Ok(Box::pin(start_outgoing_webhook_workflow(state, &process)).await?)
     }
+
     #[cfg(feature = "v2")]
     async fn execute_workflow<'a>(
         &'a self,

--- a/migrations/2025-10-19-105710_add_webhook_endpoint_id_in_events/down.sql
+++ b/migrations/2025-10-19-105710_add_webhook_endpoint_id_in_events/down.sql
@@ -1,0 +1,3 @@
+-- This file should undo anything in `up.sql`
+ALTER TABLE events
+  DROP COLUMN webhook_endpoint_id;

--- a/migrations/2025-10-19-105710_add_webhook_endpoint_id_in_events/up.sql
+++ b/migrations/2025-10-19-105710_add_webhook_endpoint_id_in_events/up.sql
@@ -1,0 +1,3 @@
+-- Your SQL goes here
+ALTER TABLE events
+  ADD COLUMN webhook_endpoint_id VARCHAR(64);


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
In the current system, merchants can configure only one webhook endpoint per profile. This PR introduces support for configuring multiple webhook endpoints based on the event_type. These changes include modifications to the database schema and alterations in the webhook triggering logic.

In payments.rs (for other flows as well), instead of triggering a single webhook directly, a `bulk_outgoing_webhook` job is now created. When this job is executed, it triggers multiple webhooks. Additionally, for each webhook, a corresponding `retry_job` is created in the `process_tracker`, ensuring that any failed webhook deliveries can be retried.

Database Schema Changes
1. Business Profile Schema Update:
The webhook_details column in the business_profile table is being updated from a JSON object to an array of JSON objects. This will allow each business profile to store multiple webhook endpoints that can be associated with different event types.

2. Merchant Account Schema Update:
In addition to the business_profile table, the `merchant_account` table will also include a `webhook_details` field to store webhook configurations for the merchant. Similar to the changes in the business_profile table, this field will be updated to store an array of webhook configurations rather than a single configuration.

3. **How old data would work with new code?**
Suppose we have webhook_details filled as 
```
"webhook_details": {
        "webhook_version": "1.0.1",
        "webhook_username": "ekart_retail",
        "webhook_password": "password_ekart@123",
        "webhook_url": "https://webhook.site",
        "payment_created_enabled": true,
        "payment_succeeded_enabled": true,
        "payment_failed_enabled": true,
       "multiple_webhooks_list": null
}
````
We have three functions which fetches webhook_details for outgoing_webhook_workflow.
1. `get_webhook_details_for_event_type()`: Here if `multiple_webhooks_list` is null, a struct multipleWebhooksList is created with present details and it is used up in `create_event_and_trigger_outgoing_webhook`, assuming that the single url present will receive webhooks for all events.
2. `get_webhook_detail_by_webhook_endpoint_id()`: If webhook_endpoint_id` is None, it represents an older form of data, and hence `webhook_url` present is returned.
3. `get_idempotent_event_id()`: Previous version of this fn formed id with form `{primary_object_id}_{event_type}`, now it is base encoded of `{primary_object_id}_{event_type}_{webhook_endpoint_id}`. In case `webhook_endpoint_id` passed is None, it refers to older form of data, then id generated would be base64 of `{primary_object_id}_{event_type}`.

4. **How already stored tasks stored in process_tracker work?** 
If the task is already stored, it means `trigger_outgoing_webhook_bulk_workflow()` will not be called for that outgoing_webhook. 
For `trigger_outgoing_webhook_retry_workflow()`,  granular description of functions used here are described above for  `get_idempotent_event_id`, `get_webhook_detail_by_webhook_endpoint_id`




### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


After doing a payment with status succeeded, bulk webhook added to process_tracker
<img width="2846" alt="image" src="https://github.com/user-attachments/assets/009a9403-22c4-4f3d-856c-53b09bfcc9fb" />

This bulk task, adds all the multiple outgoing webhooks (three for the merchant created) in process_tracker, two outgoing webhooks notified, one is pending as the endpoint was wrong 
<img width="3048" alt="image" src="https://github.com/user-attachments/assets/c0535876-bb0b-4684-8c56-17dc96e82788" />

Three events created initially for corresponding tasks of process tracker above. One notification failed,  so there is one more entry in events table for automatic retry.
Events created by process_tracker:
<img width="2575" alt="image" src="https://github.com/user-attachments/assets/2dbe9ed3-d39f-4dee-8b7c-61ff9dda64bb" />

Two webhooks received in different endpoints which were correctly configured
<img width="1657" alt="Screenshot 2025-05-29 at 1 56 00 AM" src="https://github.com/user-attachments/assets/3023539c-f20d-4458-ba20-272cded2db9a" />

<img width="1716" alt="Screenshot 2025-05-29 at 1 56 17 AM" src="https://github.com/user-attachments/assets/ab983042-fff2-4749-a9e4-7fa71330c2a0" />

4. Manual retry to first webhook endpoint
```
curl --location --request POST 'http://localhost:8080/events/merchant_1748463854/evt_01971892575c7c5395780fbd740e6b00/retry' \
--header 'api-key: test_admin'
```

Response
```
{
    "event_id": "evt_019718a1f5f170c3954a3fc958337e51",
    "merchant_id": "merchant_1748463854",
    "profile_id": "pro_UfVajfSqskx9FjWfP5cP",
    "webhook_endpoint_id": "whe_qolIdtZFQfWNmUg2i7X2",
    "object_id": "pay_6vacj5lnQX9BKSLeXYUy",
    "event_type": "payment_succeeded",
    "event_class": "payments",
    "is_delivery_successful": false,
    "initial_attempt_id": "evt_01971892575c7c5395780fbd740e6b00",
    "created": "2025-05-28T20:42:36.914Z",
    "request": {
        "body": "{\"merchant_id\":\"merchant_1748463854\",\"event_id\":\"evt_01971892575c7c5395780fbd740e6b00\",\"event_type\":\"payment_succeeded\",\"content\":{\"type\":\"payment_details\",\"object\":{\"payment_id\":\"pay_6vacj5lnQX9BKSLeXYUy\",\"merchant_id\":\"merchant_1748463854\",\"status\":\"succeeded\",\"amount\":6540,\"net_amount\":6540,\"shipping_cost\":null,\"amount_capturable\":0,\"amount_received\":6540,\"connector\":\"adyen\",\"client_secret\":\"pay_6vacj5lnQX9BKSLeXYUy_secret_GxdazMB1wOxZdf6UJ11l\",\"created\":\"2025-05-28T20:24:28.821Z\",\"currency\":\"USD\",\"customer_id\":\"customer123\",\"customer\":{\"id\":\"customer123\",\"name\":\"John Doe\",\"email\":\"customer@gmail.com\",\"phone\":\"9999999999\",\"phone_country_code\":\"+1\"},\"description\":\"Its my first payment request\",\"refunds\":null,\"disputes\":null,\"mandate_id\":null,\"mandate_data\":null,\"setup_future_usage\":\"on_session\",\"off_session\":null,\"capture_on\":null,\"capture_method\":\"automatic\",\"payment_method\":\"card\",\"payment_method_data\":{\"card\":{\"last4\":\"1111\",\"card_type\":null,\"card_network\":null,\"card_issuer\":null,\"card_issuing_country\":null,\"card_isin\":\"411111\",\"card_extended_bin\":null,\"card_exp_month\":\"03\",\"card_exp_year\":\"2030\",\"card_holder_name\":null,\"payment_checks\":null,\"authentication_data\":null},\"billing\":null},\"payment_token\":null,\"shipping\":{\"address\":{\"city\":\"San Fransico\",\"country\":\"US\",\"line1\":\"1467\",\"line2\":\"Harrison Street\",\"line3\":\"Harrison Street\",\"zip\":\"94122\",\"state\":\"California\",\"first_name\":\"joseph\",\"last_name\":\"Doe\"},\"phone\":{\"number\":\"8056594427\",\"country_code\":\"+91\"},\"email\":\"guest@example.com\"},\"billing\":{\"address\":{\"city\":\"San Fransico\",\"country\":\"US\",\"line1\":\"1467\",\"line2\":\"Harrison Street\",\"line3\":\"Harrison Street\",\"zip\":\"94122\",\"state\":\"California\",\"first_name\":\"joseph\",\"last_name\":\"Doe\"},\"phone\":{\"number\":\"8056594427\",\"country_code\":\"+91\"},\"email\":\"guest@example.com\"},\"order_details\":[{\"brand\":null,\"amount\":6540,\"category\":null,\"quantity\":1,\"tax_rate\":null,\"product_id\":null,\"product_name\":\"Apple iphone 15\",\"product_type\":null,\"sub_category\":null,\"product_img_link\":null,\"product_tax_code\":null,\"total_tax_amount\":null,\"requires_shipping\":null}],\"email\":\"customer@gmail.com\",\"name\":\"John Doe\",\"phone\":\"9999999999\",\"return_url\":\"https://google.com/\",\"authentication_type\":\"no_three_ds\",\"statement_descriptor_name\":\"joseph\",\"statement_descriptor_suffix\":\"JS\",\"next_action\":null,\"cancellation_reason\":null,\"error_code\":null,\"error_message\":null,\"unified_code\":null,\"unified_message\":null,\"payment_experience\":null,\"payment_method_type\":\"credit\",\"connector_label\":null,\"business_country\":null,\"business_label\":\"default\",\"business_sub_label\":null,\"allowed_payment_method_types\":null,\"ephemeral_key\":null,\"manual_retry_allowed\":false,\"connector_transaction_id\":\"GQ7N5P2BQCPFMZ65\",\"frm_message\":null,\"metadata\":{\"udf1\":\"value1\",\"login_date\":\"2019-09-10T10:11:12Z\",\"new_customer\":\"true\"},\"connector_metadata\":{\"apple_pay\":null,\"airwallex\":null,\"noon\":{\"order_category\":\"pay\"},\"braintree\":null,\"adyen\":null},\"feature_metadata\":null,\"reference_id\":\"pay_6vacj5lnQX9BKSLeXYUy_1\",\"payment_link\":null,\"profile_id\":\"pro_UfVajfSqskx9FjWfP5cP\",\"surcharge_details\":null,\"attempt_count\":1,\"merchant_decision\":null,\"merchant_connector_id\":\"mca_FzqxnIqNjwC9MRSHnl9p\",\"incremental_authorization_allowed\":false,\"authorization_count\":null,\"incremental_authorizations\":null,\"external_authentication_details\":null,\"external_3ds_authentication_attempted\":false,\"expires_on\":\"2025-05-28T20:39:28.821Z\",\"fingerprint\":null,\"browser_info\":{\"language\":\"nl-NL\",\"time_zone\":0,\"ip_address\":\"128.0.0.1\",\"user_agent\":\"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Safari/537.36\",\"color_depth\":24,\"java_enabled\":true,\"screen_width\":1536,\"accept_header\":\"text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8\",\"screen_height\":723,\"java_script_enabled\":true},\"payment_method_id\":\"pm_x8ICuV0PsnuaK8ERCkxH\",\"payment_method_status\":\"active\",\"updated\":\"2025-05-28T20:24:31.305Z\",\"split_payments\":null,\"frm_metadata\":null,\"extended_authorization_applied\":null,\"capture_before\":null,\"merchant_order_reference_id\":\"test_ord\",\"order_tax_amount\":null,\"connector_mandate_id\":null,\"card_discovery\":\"manual\",\"force_3ds_challenge\":false,\"force_3ds_challenge_trigger\":false,\"issuer_error_code\":null,\"issuer_error_message\":null}},\"timestamp\":\"2025-05-28T20:25:33.276Z\"}",
        "headers": [
            [
                "content-type",
                "application/json"
            ],
            [
                "user-agent",
                "Hyperswitch-Backend-Server"
            ],
            [
                "X-Webhook-Signature-512",
                "b81594a37e46cd58c24c04d2b96aaa658c82d0007f3c967c1f62d8bb9d72f1d418bec651900fc0076816720f2dc0d6bb93cbd92915b00b68d6c6eca7772ca84a"
            ]
        ]
    },
    "response": {
        "body": "This URL has no default content configured. <a href=\"https://webhook.site/#!/edit/6f2bb1bd-dbb9-432c-b4a2-c76b801f2609\">Change response in Webhook.site</a>.",
        "headers": [
            [
                "server",
                "nginx"
            ],
            [
                "content-type",
                "text/html; charset=UTF-8"
            ],
            [
                "transfer-encoding",
                "chunked"
            ],
            [
                "x-request-id",
                "fd416e97-ea7b-4cc2-9678-ee7fcd68849e"
            ],
            [
                "x-token-id",
                "6f2bb1bd-dbb9-432c-b4a2-c76b801f2609"
            ],
            [
                "cache-control",
                "no-cache, private"
            ],
            [
                "date",
                "Wed, 28 May 2025 20:42:37 GMT"
            ]
        ],
        "status_code": 200,
        "error_message": null
    },
    "delivery_attempt": "manual_retry"
}
```
Webhook received for manual retry in first endpoint
<img width="1727" alt="Screenshot 2025-05-29 at 2 13 59 AM" src="https://github.com/user-attachments/assets/4a985870-686d-407b-af7d-d03d390dd69d" />


4. Manual retry to second webhook endpoint
```
curl --location --request POST 'http://localhost:8080/events/merchant_1748463854/evt_01971892575c7c5395780fc76469ec8c/retry' \
--header 'api-key: test_admin'
```

Response
```
{
    "event_id": "evt_01971894d5157c22a1e1e148e6518bda",
    "merchant_id": "merchant_1748463854",
    "profile_id": "pro_UfVajfSqskx9FjWfP5cP",
    "webhook_endpoint_id": "whe_9ugRQr1n3vO4ehmJ80Kx",
    "object_id": "pay_6vacj5lnQX9BKSLeXYUy",
    "event_type": "payment_succeeded",
    "event_class": "payments",
    "is_delivery_successful": false,
    "initial_attempt_id": "evt_01971892575c7c5395780fc76469ec8c",
    "created": "2025-05-28T20:28:16.535Z",
    "request": {
        "body": "{\"merchant_id\":\"merchant_1748463854\",\"event_id\":\"evt_01971892575c7c5395780fc76469ec8c\",\"event_type\":\"payment_succeeded\",\"content\":{\"type\":\"payment_details\",\"object\":{\"payment_id\":\"pay_6vacj5lnQX9BKSLeXYUy\",\"merchant_id\":\"merchant_1748463854\",\"status\":\"succeeded\",\"amount\":6540,\"net_amount\":6540,\"shipping_cost\":null,\"amount_capturable\":0,\"amount_received\":6540,\"connector\":\"adyen\",\"client_secret\":\"pay_6vacj5lnQX9BKSLeXYUy_secret_GxdazMB1wOxZdf6UJ11l\",\"created\":\"2025-05-28T20:24:28.821Z\",\"currency\":\"USD\",\"customer_id\":\"customer123\",\"customer\":{\"id\":\"customer123\",\"name\":\"John Doe\",\"email\":\"customer@gmail.com\",\"phone\":\"9999999999\",\"phone_country_code\":\"+1\"},\"description\":\"Its my first payment request\",\"refunds\":null,\"disputes\":null,\"mandate_id\":null,\"mandate_data\":null,\"setup_future_usage\":\"on_session\",\"off_session\":null,\"capture_on\":null,\"capture_method\":\"automatic\",\"payment_method\":\"card\",\"payment_method_data\":{\"card\":{\"last4\":\"1111\",\"card_type\":null,\"card_network\":null,\"card_issuer\":null,\"card_issuing_country\":null,\"card_isin\":\"411111\",\"card_extended_bin\":null,\"card_exp_month\":\"03\",\"card_exp_year\":\"2030\",\"card_holder_name\":null,\"payment_checks\":null,\"authentication_data\":null},\"billing\":null},\"payment_token\":null,\"shipping\":{\"address\":{\"city\":\"San Fransico\",\"country\":\"US\",\"line1\":\"1467\",\"line2\":\"Harrison Street\",\"line3\":\"Harrison Street\",\"zip\":\"94122\",\"state\":\"California\",\"first_name\":\"joseph\",\"last_name\":\"Doe\"},\"phone\":{\"number\":\"8056594427\",\"country_code\":\"+91\"},\"email\":\"guest@example.com\"},\"billing\":{\"address\":{\"city\":\"San Fransico\",\"country\":\"US\",\"line1\":\"1467\",\"line2\":\"Harrison Street\",\"line3\":\"Harrison Street\",\"zip\":\"94122\",\"state\":\"California\",\"first_name\":\"joseph\",\"last_name\":\"Doe\"},\"phone\":{\"number\":\"8056594427\",\"country_code\":\"+91\"},\"email\":\"guest@example.com\"},\"order_details\":[{\"brand\":null,\"amount\":6540,\"category\":null,\"quantity\":1,\"tax_rate\":null,\"product_id\":null,\"product_name\":\"Apple iphone 15\",\"product_type\":null,\"sub_category\":null,\"product_img_link\":null,\"product_tax_code\":null,\"total_tax_amount\":null,\"requires_shipping\":null}],\"email\":\"customer@gmail.com\",\"name\":\"John Doe\",\"phone\":\"9999999999\",\"return_url\":\"https://google.com/\",\"authentication_type\":\"no_three_ds\",\"statement_descriptor_name\":\"joseph\",\"statement_descriptor_suffix\":\"JS\",\"next_action\":null,\"cancellation_reason\":null,\"error_code\":null,\"error_message\":null,\"unified_code\":null,\"unified_message\":null,\"payment_experience\":null,\"payment_method_type\":\"credit\",\"connector_label\":null,\"business_country\":null,\"business_label\":\"default\",\"business_sub_label\":null,\"allowed_payment_method_types\":null,\"ephemeral_key\":null,\"manual_retry_allowed\":false,\"connector_transaction_id\":\"GQ7N5P2BQCPFMZ65\",\"frm_message\":null,\"metadata\":{\"udf1\":\"value1\",\"login_date\":\"2019-09-10T10:11:12Z\",\"new_customer\":\"true\"},\"connector_metadata\":{\"apple_pay\":null,\"airwallex\":null,\"noon\":{\"order_category\":\"pay\"},\"braintree\":null,\"adyen\":null},\"feature_metadata\":null,\"reference_id\":\"pay_6vacj5lnQX9BKSLeXYUy_1\",\"payment_link\":null,\"profile_id\":\"pro_UfVajfSqskx9FjWfP5cP\",\"surcharge_details\":null,\"attempt_count\":1,\"merchant_decision\":null,\"merchant_connector_id\":\"mca_FzqxnIqNjwC9MRSHnl9p\",\"incremental_authorization_allowed\":false,\"authorization_count\":null,\"incremental_authorizations\":null,\"external_authentication_details\":null,\"external_3ds_authentication_attempted\":false,\"expires_on\":\"2025-05-28T20:39:28.821Z\",\"fingerprint\":null,\"browser_info\":{\"language\":\"nl-NL\",\"time_zone\":0,\"ip_address\":\"128.0.0.1\",\"user_agent\":\"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Safari/537.36\",\"color_depth\":24,\"java_enabled\":true,\"screen_width\":1536,\"accept_header\":\"text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8\",\"screen_height\":723,\"java_script_enabled\":true},\"payment_method_id\":\"pm_x8ICuV0PsnuaK8ERCkxH\",\"payment_method_status\":\"active\",\"updated\":\"2025-05-28T20:24:31.305Z\",\"split_payments\":null,\"frm_metadata\":null,\"extended_authorization_applied\":null,\"capture_before\":null,\"merchant_order_reference_id\":\"test_ord\",\"order_tax_amount\":null,\"connector_mandate_id\":null,\"card_discovery\":\"manual\",\"force_3ds_challenge\":false,\"force_3ds_challenge_trigger\":false,\"issuer_error_code\":null,\"issuer_error_message\":null}},\"timestamp\":\"2025-05-28T20:25:33.276Z\"}",
        "headers": [
            [
                "content-type",
                "application/json"
            ],
            [
                "user-agent",
                "Hyperswitch-Backend-Server"
            ],
            [
                "X-Webhook-Signature-512",
                "d63a92f145268741a83bf41db24769f401a000254906391bd581ca8b4be99734e5731711b693e8cfc44703014dfcc60fd73105f593ee7dbffe7687ee07134d4e"
            ]
        ]
    },
    "response": {
        "body": "This URL has no default content configured. <a href=\"https://webhook.site/#!/edit/381773c7-c3bd-406e-bda3-dfc5d2fea979\">Change response in Webhook.site</a>.",
        "headers": [
            [
                "server",
                "nginx"
            ],
            [
                "content-type",
                "text/html; charset=UTF-8"
            ],
            [
                "transfer-encoding",
                "chunked"
            ],
            [
                "x-request-id",
                "18b3a013-caf2-4667-ab91-29cffa99ce86"
            ],
            [
                "x-token-id",
                "381773c7-c3bd-406e-bda3-dfc5d2fea979"
            ],
            [
                "cache-control",
                "no-cache, private"
            ],
            [
                "date",
                "Wed, 28 May 2025 20:28:17 GMT"
            ]
        ],
        "status_code": 200,
        "error_message": null
    },
    "delivery_attempt": "manual_retry"
}
```

Webhook received for manual retry in the second endpoint
<img width="1727" alt="Screenshot 2025-05-29 at 1 58 28 AM" src="https://github.com/user-attachments/assets/5b9e6223-90ed-46d9-aabf-24e2c7a137e2" />



## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
