### PR TITLE
feat(connector): [POWERTRANZ] Added Integrity Checks

### DIFF
--- a/crates/hyperswitch_connectors/src/connectors/powertranz/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/powertranz/transformers.rs
@@ -285,6 +285,8 @@ pub struct PowertranzBaseResponse {
     redirect_data: Option<Secret<String>>,
     response_message: String,
     order_identifier: String,
+    pub amount: FloatMajorUnit,
+    pub currency_code: String,
 }
 
 fn get_status((transaction_type, approved, is_3ds): (u8, bool, bool)) -> enums::AttemptStatus {
@@ -351,7 +353,10 @@ impl<F, T> TryFrom<ResponseRouterData<F, PowertranzBaseResponse, T, PaymentsResp
                 resource_id: ResponseId::ConnectorTransactionId(connector_transaction_id),
                 redirection_data: Box::new(redirection_data),
                 mandate_reference: Box::new(None),
-                connector_metadata: None,
+                connector_metadata: Some(serde_json::json!({
+                    "amount": item.response.amount,
+                    "currency": item.response.currency_code
+                })),
                 network_txn_id: None,
                 connector_response_reference_id: Some(item.response.order_identifier),
                 incremental_authorization_allowed: None,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
For the Powertranz connector, I have added the integrity checks for the Authorize, PSync, RSync, Capture, and Refund flows by using the respective integrity object function from utils. Also I have modified the corresponding transformer for getting the payment and refund amount object in the response for integrity check.

## Motivation and Context
The PR adds the feature of integrity checks in this connector which has to be done in all the connectors.

What is an integrity check?
A scenario where there is a discrepancy between the amount sent in the request and the amount received from the connector, which is checked during response handling.
Closes #9216 


## How did you test it?
Pending tests due to local server deployment issues

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [x] I added unit tests for my changes where possible
