### PR TITLE
ci(cypress): Fix iatapay redirection flow

### DIFF
--- a/cypress-tests/cypress/support/redirectionHandler.js
+++ b/cypress-tests/cypress/support/redirectionHandler.js
@@ -1225,7 +1225,6 @@ function upiRedirection(
       case "upi_collect":
         cy.visit(redirectionUrl.href);
         cy.wait(CONSTANTS.TIMEOUT).then(() => {
-          cy.contains("button", "Simulate").should("be.visible").click();
           verifyUrl = true;
         });
         break;


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [x] CI/CD

## Description
Fix iatapay redirection flow in cypress test.



## Motivation and Context
To fix the iatapay connector test


## How did you test it?
<img width="1512" height="886" alt="image" src="https://github.com/user-attachments/assets/c7c099a4-d9c8-4d53-8d2c-1beedb341936" />


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
