### PR TITLE
fix: use updated session state for refund ucs shadow mode using mitm proxy

### DIFF
--- a/crates/router/src/core/refunds.rs
+++ b/crates/router/src/core/refunds.rs
@@ -229,7 +229,7 @@ pub async fn trigger_refund_to_gateway(
         // Access token available or not needed - proceed with execution
 
         // Check which gateway system to use for refunds
-        let (execution_path, _session_state) =
+        let (execution_path, updated_state) =
             unified_connector_service::should_call_unified_connector_service(
                 state,
                 merchant_context,
@@ -273,7 +273,7 @@ pub async fn trigger_refund_to_gateway(
             }
             common_enums::ExecutionPath::ShadowUnifiedConnectorService => {
                 Box::pin(execute_refund_execute_via_direct_with_ucs_shadow(
-                    state,
+                    &updated_state,
                     &connector,
                     merchant_context,
                     refund,
@@ -831,7 +831,7 @@ pub async fn sync_refund_with_gateway(
         // Access token available or not needed - proceed with execution
 
         // Check which gateway system to use for refund sync
-        let (execution_path, _session_state) =
+        let (execution_path, updated_state) =
             unified_connector_service::should_call_unified_connector_service(
                 state,
                 merchant_context,
@@ -873,7 +873,7 @@ pub async fn sync_refund_with_gateway(
             }
             common_enums::ExecutionPath::ShadowUnifiedConnectorService => {
                 Box::pin(execute_refund_sync_via_direct_with_ucs_shadow(
-                    state,
+                    &updated_state,
                     &connector,
                     merchant_context,
                     router_data,


### PR DESCRIPTION

## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
Passing updated state with updated proxy for ucs refund shadow mode.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
Recently shadow mode is changed to use proxy url from rolloutconfig, but it is missed for refund flow.

## How did you test it?

**Config update for stripe refund shadow with proxy url**

```bash
curl --location 'http://localhost:8080/configs/ucs_rollout_config_merchant_1761026746_stripe_Execute_shadow' \
--header 'Content-Type: application/json' \
--header 'api-key: test_admin' \
--data '{
    "key": "ucs_rollout_config_merchant_1761026746_stripe_Execute_shadow", 
    "value": "{\"rollout_percent\": 1.0, \"http_url\": \"http://localhost:8084\", \"https_url\":\"https://localhost:8084\"}"
}
'
```

```bash
curl --location 'http://localhost:8080/configs/ucs_rollout_config_merchant_1761026746_stripe_Execute' \
--header 'Content-Type: application/json' \
--header 'api-key: test_admin' \
--data '{
    "key": "ucs_rollout_config_merchant_1761026746_stripe_Execute", 
    "value": "{\"rollout_percent\": 1.0, \"http_url\": \"http://localhost:8084\", \"https_url\":\"https://localhost:8084\"}"
}
'
```

**refund stripe request**

```bash
{
    "payment_id": "{{payment_id}}",
    "amount": 100,
    "reason": "OTHER",
    "refund_type": "instant",
    "metadata": {
        "udf1": "value1",
        "new_customer": "true",
        "login_date": "2019-09-10T10:11:12Z"
    }
}
```

**Received request through mitm proxy running in localhost:8084**
<img width="1212" height="106" alt="image" src="https://github.com/user-attachments/assets/56936410-85b4-4e31-9755-3726d01949b9" />


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
