### PR TITLE
fix(workflow): pin cocogitto version to 6.3.0 in release-stable-version workflow

### DIFF
--- a/.github/workflows/release-stable-version.yml
+++ b/.github/workflows/release-stable-version.yml
@@ -106,7 +106,7 @@ jobs:
       - name: Install cocogitto
         uses: taiki-e/install-action@v2
         with:
-          tool: cocogitto
+          tool: cocogitto@6.3.0
           checksum: true
 
       - name: Obtain previous and next tag information


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->

This pull request makes a small update to the GitHub Actions workflow by specifying the exact version of the `cocogitto` tool to be installed. This change helps ensure consistent and reproducible builds.

- Workflow tooling:
  * Updated the installation step for `cocogitto` in `.github/workflows/release-stable-version.yml` to use version `6.3.0`, ensuring version consistency in CI runs.


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->

The release-stable-version workflow was failing with "Reference already exists" errors when attempting to create SemVer tags. 

### Root Cause
Newer versions of cocogitto (>6.3.0) are incorrectly detecting the previous stable version:
- **Expected behavior (cocogitto@6.3.0)**: Returns the correct last stable version (e.g., 1.118.1)
- **Actual behavior (newer versions)**: Returns incorrect version (1.108.0), causing tag conflicts

### Evidence
```bash
# With cocogitto >6.3.0
git checkout hotfix-2025.10.15.0
cog --verbose get-version  # Returns: 1.108.0

git checkout main
cog --verbose get-version  # Returns: 1.108.0 (incorrect)
```

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
 