### PR TITLE
feat(store): store id for adyen

### DIFF
--- a/crates/hyperswitch_connectors/src/connectors/adyen/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/adyen/transformers.rs
@@ -297,6 +297,7 @@ pub struct AdyenPaymentRequest<'a> {
     channel: Option<Channel>,
     merchant_order_reference: Option<String>,
     splits: Option<Vec<AdyenSplitData>>,
+    /// metadata.store
     store: Option<String>,
     device_fingerprint: Option<Secret<String>>,
     #[serde(with = "common_utils::custom_serde::iso8601::option")]
@@ -1413,6 +1414,7 @@ pub struct AdyenRefundRequest {
     merchant_refund_reason: Option<AdyenRefundRequestReason>,
     reference: String,
     splits: Option<Vec<AdyenSplitData>>,
+    /// refund_connector_metadata.store
     store: Option<String>,
 }
 
@@ -2830,6 +2832,12 @@ fn get_device_fingerprint(metadata: serde_json::Value) -> Option<Secret<String>>
         .map(|fingerprint| Secret::new(fingerprint.to_string()))
 }
 
+fn get_store_id(metadata: serde_json::Value) -> Option<String> {
+    metadata
+        .get("store")
+        .and_then(|store| store.as_str())
+        .map(|store| store.to_string())
+}
 impl
     TryFrom<(
         &AdyenRouterData<&PaymentsAuthorizeRouterData>,
@@ -2987,7 +2995,14 @@ impl
             Some(common_types::payments::SplitPaymentsRequest::AdyenSplitPayment(
                 adyen_split_payment,
             )) => get_adyen_split_request(adyen_split_payment, item.router_data.request.currency),
-            _ => (None, None),
+            _ => (
+                item.router_data
+                    .request
+                    .metadata
+                    .clone()
+                    .and_then(get_store_id),
+                None,
+            ),
         };
 
         let device_fingerprint = item
@@ -3074,7 +3089,14 @@ impl TryFrom<(&AdyenRouterData<&PaymentsAuthorizeRouterData>, &Card)> for AdyenP
             Some(common_types::payments::SplitPaymentsRequest::AdyenSplitPayment(
                 adyen_split_payment,
             )) => get_adyen_split_request(adyen_split_payment, item.router_data.request.currency),
-            _ => (None, None),
+            _ => (
+                item.router_data
+                    .request
+                    .metadata
+                    .clone()
+                    .and_then(get_store_id),
+                None,
+            ),
         };
 
         let device_fingerprint = item
@@ -3155,7 +3177,14 @@ impl
             Some(common_types::payments::SplitPaymentsRequest::AdyenSplitPayment(
                 adyen_split_payment,
             )) => get_adyen_split_request(adyen_split_payment, item.router_data.request.currency),
-            _ => (None, None),
+            _ => (
+                item.router_data
+                    .request
+                    .metadata
+                    .clone()
+                    .and_then(get_store_id),
+                None,
+            ),
         };
 
         let device_fingerprint = item
@@ -3240,7 +3269,14 @@ impl TryFrom<(&AdyenRouterData<&PaymentsAuthorizeRouterData>, &VoucherData)>
             Some(common_types::payments::SplitPaymentsRequest::AdyenSplitPayment(
                 adyen_split_payment,
             )) => get_adyen_split_request(adyen_split_payment, item.router_data.request.currency),
-            _ => (None, None),
+            _ => (
+                item.router_data
+                    .request
+                    .metadata
+                    .clone()
+                    .and_then(get_store_id),
+                None,
+            ),
         };
 
         let device_fingerprint = item
@@ -3317,7 +3353,14 @@ impl
             Some(common_types::payments::SplitPaymentsRequest::AdyenSplitPayment(
                 adyen_split_payment,
             )) => get_adyen_split_request(adyen_split_payment, item.router_data.request.currency),
-            _ => (None, None),
+            _ => (
+                item.router_data
+                    .request
+                    .metadata
+                    .clone()
+                    .and_then(get_store_id),
+                None,
+            ),
         };
 
         let device_fingerprint = item
@@ -3435,7 +3478,14 @@ impl
             Some(common_types::payments::SplitPaymentsRequest::AdyenSplitPayment(
                 adyen_split_payment,
             )) => get_adyen_split_request(adyen_split_payment, item.router_data.request.currency),
-            _ => (None, None),
+            _ => (
+                item.router_data
+                    .request
+                    .metadata
+                    .clone()
+                    .and_then(get_store_id),
+                None,
+            ),
         };
 
         let device_fingerprint = item
@@ -3520,7 +3570,14 @@ impl
             Some(common_types::payments::SplitPaymentsRequest::AdyenSplitPayment(
                 adyen_split_payment,
             )) => get_adyen_split_request(adyen_split_payment, item.router_data.request.currency),
-            _ => (None, None),
+            _ => (
+                item.router_data
+                    .request
+                    .metadata
+                    .clone()
+                    .and_then(get_store_id),
+                None,
+            ),
         };
         let device_fingerprint = item
             .router_data
@@ -3651,7 +3708,14 @@ impl TryFrom<(&AdyenRouterData<&PaymentsAuthorizeRouterData>, &WalletData)>
             Some(common_types::payments::SplitPaymentsRequest::AdyenSplitPayment(
                 adyen_split_payment,
             )) => get_adyen_split_request(adyen_split_payment, item.router_data.request.currency),
-            _ => (None, None),
+            _ => (
+                item.router_data
+                    .request
+                    .metadata
+                    .clone()
+                    .and_then(get_store_id),
+                None,
+            ),
         };
 
         let device_fingerprint = item
@@ -3747,7 +3811,14 @@ impl
             Some(common_types::payments::SplitPaymentsRequest::AdyenSplitPayment(
                 adyen_split_payment,
             )) => get_adyen_split_request(adyen_split_payment, item.router_data.request.currency),
-            _ => (None, None),
+            _ => (
+                item.router_data
+                    .request
+                    .metadata
+                    .clone()
+                    .and_then(get_store_id),
+                None,
+            ),
         };
         let device_fingerprint = item
             .router_data
@@ -3827,7 +3898,14 @@ impl
             Some(common_types::payments::SplitPaymentsRequest::AdyenSplitPayment(
                 adyen_split_payment,
             )) => get_adyen_split_request(adyen_split_payment, item.router_data.request.currency),
-            _ => (None, None),
+            _ => (
+                item.router_data
+                    .request
+                    .metadata
+                    .clone()
+                    .and_then(get_store_id),
+                None,
+            ),
         };
         let device_fingerprint = item
             .router_data
@@ -5017,7 +5095,14 @@ impl<F> TryFrom<&AdyenRouterData<&RefundsRouterData<F>>> for AdyenRefundRequest 
         .as_ref()
         {
                 Some(hyperswitch_domain_models::router_request_types::SplitRefundsRequest::AdyenSplitRefund(adyen_split_data)) =>  get_adyen_split_request(adyen_split_data, item.router_data.request.currency),
-                _ => (None, None),
+                _ => (
+                item.router_data
+                    .request
+                    .refund_connector_metadata
+                    .clone()
+                    .and_then(|metadata| get_store_id(metadata.expose())),
+                None,
+            ),
         };
 
         Ok(Self {
@@ -6366,7 +6451,14 @@ impl
             Some(common_types::payments::SplitPaymentsRequest::AdyenSplitPayment(
                 adyen_split_payment,
             )) => get_adyen_split_request(adyen_split_payment, item.router_data.request.currency),
-            _ => (None, None),
+            _ => (
+                item.router_data
+                    .request
+                    .metadata
+                    .clone()
+                    .and_then(get_store_id),
+                None,
+            ),
         };
         let device_fingerprint = item
             .router_data


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
 We need an arbitary field named store (`metadata.store`) to be passed in adyen payment request and refund request 
- create store by menu>in-person payments> store
NOTE 1: SPLIT-payment cannot be tested we will get error as adyen needs to enable this ([related pr](https://github.com/juspay/hyperswitch/issues/6952))
NOTE 2: for split payments we are taking this field from `split_payments.adyen_split_payment.store`, for normal payments we will take from metadata.store

## TEST CASES

<details>
<summary> Normal Payments (`metadata.store`) </summary>

## request

```json
{
    "amount": 1000,
    "customer_id": "hello_world",
    "currency": "EUR",
    "connector": [
        "adyen"
    ],
    "confirm": true,
    "capture_method": "automatic",
    "payment_method": "card",
    "payment_method_type": "credit",
    "description": "hellow world",
    "billing": {
        "address": {
            "zip": "560095",
            "country": "US",
            "first_name": "Sakil",
            "last_name": "Mostak",
            "line1": "Fasdf",
            "line2": "Fasdf",
            "city": "Fasdf"
        }
    },
    "payment_method_data": {
        "card": {
            "card_number": "4111111111111111",
            "card_exp_month": "03",
            "card_exp_year": "30",
            "card_holder_name": "John Doe",
            "card_cvc": "737"
        }
    },
    "metadata": {
        "store":"ST3298F22322955NDWVDWCWG6"
    },
    "browser_info": {
        "accept_header": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
        "ip_address": "192.168.1.1",
        "java_enabled": false,
        "java_script_enabled": true,
        "language": "en-US",
        "color_depth": 24,
        "screen_height": 1080,
        "screen_width": 1920,
        "time_zone": 330,
        "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36"
    }
}
```

## connector request

```json
 raw_connector_request: Object {"amount": Object {"currency": String("EUR"), "value": Number(1000)}, "merchantAccount": String("*** alloc::string::String ***"), "paymentMethod": Object {"type": String("scheme"), "number": String("411111**********"), "expiryMonth": String("*** alloc::string::String ***"), "expiryYear": String("*** alloc::string::String ***"), "cvc": String("*** alloc::string::String ***"), "holderName": String("*** alloc::string::String ***"), "brand": String("visa")}, "reference": String("pay_ZfCNj8uPeJmEcoVfswf5_1"), "returnUrl": String("http://localhost:8080/payments/pay_ZfCNj8uPeJmEcoVfswf5/merchant_1762169799/redirect/response/adyen"), "browserInfo": Object {"userAgent": String("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36"), "acceptHeader": String("text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8"), "language": String("en-US"), "colorDepth": Number(24), "screenHeight": Number(1080), "screenWidth": Number(1920), "timeZoneOffset": Number(330), "javaEnabled": Bool(false)}, "shopperInteraction": String("Ecommerce"), "additionalData": Object {"executeThreeD": String("false")}, "shopperReference": String("merchant_1762169799_hello_world"), "shopperName": Object {"firstName": String("*** alloc::string::String ***"), "lastName": String("*** alloc::string::String ***")}, "shopperIP": String("192.**.**.**"), "shopperLocale": String("en"), "billingAddress": Object {"city": String("Fasdf"), "country": String("US"), "houseNumberOrName": String("*** alloc::string::String ***"), "postalCode": String("*** alloc::string::String ***"), "street": String("*** alloc::string::String ***")}, "countryCode": String("US"), "splits": Array [Object {"amount": Object {"currency": String("EUR"), "value": Number(500)}, "type": String("BalanceAccount"), "account": String("BA32CKZ223228H5LRZSTV7DB7"), "reference": String("0.2980249078510626_1"), "description": Null}, Object {"amount": Object {"currency": String("EUR"), "value": Number(500)}, "type": String("Commission"), "account": Null, "reference": String("0.2980249078510626_2"), "description": Null}, Object {"amount": Object {"currency": String("EUR"), "value": Number(0)}, "type": String("PaymentFee"), "account": String("BA32272223222H5HRD2MBBFSM"), "reference": String("0.2980249078510626_3"), "description": String("Payment fees")}], "store": String("ST3298F22322955NDWVDWCWG6")}

// store being passed
```

### response

```json
{
    "payment_id": "pay_mytXqc3EST2PFIwevvPG",
    "merchant_id": "merchant_1762169799",
    "status": "succeeded",
    "amount": 1000,
    "net_amount": 1000,
    "shipping_cost": null,
    "amount_capturable": 0,
    "amount_received": 1000,
    "connector": "adyen",
    "client_secret": "pay_mytXqc3EST2PFIwevvPG_secret_RZSsPgQoALaB8peBKRcf",
    "created": "2025-11-03T12:14:36.762Z",
    "currency": "EUR",
    "customer_id": "hello_world",
    "customer": {
        "id": "hello_world",
        "name": null,
        "email": null,
        "phone": null,
        "phone_country_code": null
    },
    "description": "hellow world",
    "refunds": null,
    "disputes": null,
    "mandate_id": null,
    "mandate_data": null,
    "setup_future_usage": null,
    "off_session": null,
    "capture_on": null,
    "capture_method": "automatic",
    "payment_method": "card",
    "payment_method_data": {
        "card": {
            "last4": "1111",
            "card_type": "CREDIT",
            "card_network": "Visa",
            "card_issuer": "JP Morgan",
            "card_issuing_country": "INDIA",
            "card_isin": "411111",
            "card_extended_bin": null,
            "card_exp_month": "03",
            "card_exp_year": "30",
            "card_holder_name": "John Doe",
            "payment_checks": null,
            "authentication_data": null
        },
        "billing": null
    },
    "payment_token": null,
    "shipping": null,
    "billing": {
        "address": {
            "city": "Fasdf",
            "country": "US",
            "line1": "Fasdf",
            "line2": "Fasdf",
            "line3": null,
            "zip": "560095",
            "state": null,
            "first_name": "Sakil",
            "last_name": "Mostak",
            "origin_zip": null
        },
        "phone": null,
        "email": null
    },
    "order_details": null,
    "email": null,
    "name": null,
    "phone": null,
    "return_url": null,
    "authentication_type": "no_three_ds",
    "statement_descriptor_name": null,
    "statement_descriptor_suffix": null,
    "next_action": null,
    "cancellation_reason": null,
    "error_code": null,
    "error_message": null,
    "unified_code": null,
    "unified_message": null,
    "payment_experience": null,
    "payment_method_type": "credit",
    "connector_label": null,
    "business_country": null,
    "business_label": "default",
    "business_sub_label": null,
    "allowed_payment_method_types": null,
    "ephemeral_key": {
        "customer_id": "hello_world",
        "created_at": 1762172076,
        "expires": 1762175676,
        "secret": "epk_20f76d2ca16949529f36ab961c7b9996"
    },
    "manual_retry_allowed": null,
    "connector_transaction_id": "H6WPZRHWSJBH3275",
    "frm_message": null,
    "metadata": {
        "store": "ST3298F22322955NDWVDWCWG6"
    },
    "connector_metadata": null,
    "feature_metadata": {
        "redirect_response": null,
        "search_tags": null,
        "apple_pay_recurring_details": null,
        "gateway_system": "direct"
    },
    "reference_id": "pay_mytXqc3EST2PFIwevvPG_1",
    "payment_link": null,
    "profile_id": "pro_AlrOEedUTS0P12YvfA3M",
    "surcharge_details": null,
    "attempt_count": 1,
    "merchant_decision": null,
    "merchant_connector_id": "mca_nLzFD4WPAIZMbssaiHQf",
    "incremental_authorization_allowed": false,
    "authorization_count": null,
    "incremental_authorizations": null,
    "external_authentication_details": null,
    "external_3ds_authentication_attempted": false,
    "expires_on": "2025-11-03T12:29:36.762Z",
    "fingerprint": null,
    "browser_info": {
        "language": "en-US",
        "time_zone": 330,
        "ip_address": "192.168.1.1",
        "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36",
        "color_depth": 24,
        "java_enabled": false,
        "screen_width": 1920,
        "accept_header": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
        "screen_height": 1080,
        "java_script_enabled": true
    },
    "payment_channel": null,
    "payment_method_id": null,
    "network_transaction_id": "366589793729776",
    "payment_method_status": null,
    "updated": "2025-11-03T12:14:39.495Z",
    "split_payments": null,
    "frm_metadata": null,
    "extended_authorization_applied": null,
    "request_extended_authorization": null,
    "capture_before": null,
    "merchant_order_reference_id": null,
    "order_tax_amount": null,
    "connector_mandate_id": null,
    "card_discovery": "manual",
    "force_3ds_challenge": false,
    "force_3ds_challenge_trigger": false,
    "issuer_error_code": null,
    "issuer_error_message": null,
    "is_iframe_redirection_enabled": null,
    "whole_connector_response": null,
    "enable_partial_authorization": null,
    "enable_overcapture": null,
    "is_overcapture_enabled": null,
    "network_details": null,
    "is_stored_credential": null,
    "mit_category": null
}
```

</details>

<details>
<summary> Split payment (`split_payments.adyen_split_payment.store`) </summary>

## request

```json
{
    "amount": 1000,
    "customer_id": "hello_world",
    "currency": "EUR",
    "connector": [
        "adyen"
    ],
    "confirm": true,
    "capture_method": "automatic",
    "payment_method": "card",
    "payment_method_type": "credit",
    "description": "hellow world",
    "billing": {
        "address": {
            "zip": "560095",
            "country": "US",
            "first_name": "Sakil",
            "last_name": "Mostak",
            "line1": "Fasdf",
            "line2": "Fasdf",
            "city": "Fasdf"
        }
    },
    "payment_method_data": {
        "card": {
            "card_number": "4111111111111111",
            "card_exp_month": "03",
            "card_exp_year": "30",
            "card_holder_name": "John Doe",
            "card_cvc": "737"
        }
    },
    "split_payments": {
        "adyen_split_payment": {
          "store":  "ST3298F22322955NDWVDWCWG6",
          "split_items": [
            {
              "amount": 500,
              "split_type": "BalanceAccount",
              "account": "BA32CKZ223228H5LRZSTV7DB7",
              "reference": "0.2980249078510626_1"
            },
            {
              "amount": 500,
              "split_type": "Commission",
              "reference": "0.2980249078510626_2"
            },
            {
              "amount": 0,
              "split_type": "PaymentFee",
              "account": "BA32272223222H5HRD2MBBFSM",
              "reference": "0.2980249078510626_3",
              "description": "Payment fees"
            }
          ]
        }
      },
    // "metadata": {
    //     "store":"4935y84385736"
    // },
    "browser_info": {
        "accept_header": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
        "ip_address": "192.168.1.1",
        "java_enabled": false,
        "java_script_enabled": true,
        "language": "en-US",
        "color_depth": 24,
        "screen_height": 1080,
        "screen_width": 1920,
        "time_zone": 330,
        "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36"
    }
}
```

## connector request

```json
INFO hyperswitch_interfaces::api_client: raw_connector_request: Object {"amount": Object {"currency": String("EUR"), "value": Number(1000)}, "merchantAccount": String("*** alloc::string::String ***"), "paymentMethod": Object {"type": String("scheme"), "number": String("411111**********"), "expiryMonth": String("*** alloc::string::String ***"), "expiryYear": String("*** alloc::string::String ***"), "cvc": String("*** alloc::string::String ***"), "holderName": String("*** alloc::string::String ***"), "brand": String("visa")}, "reference": String("pay_k7CUtTkbOFDpxPC2bs2m_1"), "returnUrl": String("http://localhost:8080/payments/pay_k7CUtTkbOFDpxPC2bs2m/merchant_1762169799/redirect/response/adyen"), "browserInfo": Object {"userAgent": String("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36"), "acceptHeader": String("text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8"), "language": String("en-US"), "colorDepth": Number(24), "screenHeight": Number(1080), "screenWidth": Number(1920), "timeZoneOffset": Number(330), "javaEnabled": Bool(false)}, "shopperInteraction": String("Ecommerce"), "additionalData": Object {"executeThreeD": String("false")}, "shopperReference": String("merchant_1762169799_hello_world"), "shopperName": Object {"firstName": String("*** alloc::string::String ***"), "lastName": String("*** alloc::string::String ***")}, "shopperIP": String("192.**.**.**"), "shopperLocale": String("en"), "billingAddress": Object {"city": String("Fasdf"), "country": String("US"), "houseNumberOrName": String("*** alloc::string::String ***"), "postalCode": String("*** alloc::string::String ***"), "street": String("*** alloc::string::String ***")}, "countryCode": String("US"), "splits": Array [Object {"amount": Object {"currency": String("EUR"), "value": Number(500)}, "type": String("BalanceAccount"), "account": String("BA32CKZ223228H5LRZSTV7DB7"), "reference": String("0.2980249078510626_1"), "description": Null}, Object {"amount": Object {"currency": String("EUR"), "value": Number(500)}, "type": String("Commission"), "account": Null, "reference": String("0.2980249078510626_2"), "description": Null}, Object {"amount": Object {"currency": String("EUR"), "value": Number(0)}, "type": String("PaymentFee"), "account": String("BA32272223222H5HRD2MBBFSM"), "reference": String("0.2980249078510626_3"), "description": String("Payment fees")}], "store": String("xxxxxxddddddddd")}
```

</details>

<details>
<summary> REFUND (metadata.store)</summary>

## request 

```json
{
    "payment_id": "{{payment_id}}",
    "amount":200,
    "metadata":{"store":"ST3298F22322955NDWVDWCWG6"}
}
```
## connector request

```json
 Object {"merchantAccount": String("*** alloc::string::String ***"), "amount": Object {"currency": String("EUR"), "value": Number(200)}, "reference": String("ref_3uMyyahlpMDkl1gkEqOV"), "store": String("ST3298F22322955NDWVDWCWG6")}
```

## response

```json
{
    "refund_id": "ref_3uMyyahlpMDkl1gkEqOV",
    "payment_id": "pay_IveyzhbBIzF58qDDlbmK",
    "amount": 200,
    "currency": "EUR",
    "status": "succeeded",
    "reason": null,
    "metadata": {
        "store": "ST3298F22322955NDWVDWCWG6"
    },
    "error_message": null,
    "error_code": null,
    "unified_code": null,
    "unified_message": null,
    "created_at": "2025-11-03T12:26:44.581Z",
    "updated_at": "2025-11-03T12:26:45.157Z",
    "connector": "adyen",
    "profile_id": "pro_AlrOEedUTS0P12YvfA3M",
    "merchant_connector_id": "mca_nLzFD4WPAIZMbssaiHQf",
    "split_refunds": null,
    "issuer_error_code": null,
    "issuer_error_message": null
}
```

## a


</details>

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
