### PR TITLE
feat(connector): Add support for get entitlements for Chargebee

### DIFF
--- a/crates/hyperswitch_connectors/src/connectors/chargebee/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/chargebee/transformers.rs
@@ -1508,3 +1508,70 @@ convert_connector_response_to_domain_response!(
         })
     }
 );
+
+// Entitlement
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Entitlement {
+    pub feature_id: Option<String>,
+    pub feature_name: Option<String>,
+    pub id: String,
+    pub entity_id: Option<String>,
+    pub entity_type: Option<String>,
+    pub name: Option<String>,
+    pub object: Option<String>,
+    pub value: Option<bool>,
+}
+
+impl From<Entitlement> for subscriptions::Entitlement {
+    fn from(value: Entitlement) -> Self {
+        Self {
+            feature_id: value.feature_id,
+            feature_name: value.feature_name,
+            id: value.id,
+            entity_id: value.entity_id,
+            entity_type: value.entity_type,
+            name: value.name,
+            object: value.object,
+            value: value.value,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct GetSubscriptionEntitlementResponse {
+    pub entitlement: Vec<Entitlement>,
+}
+
+impl<F, T>
+    TryFrom<
+        ResponseRouterData<
+            F,
+            GetSubscriptionEntitlementResponse,
+            T,
+            subscriptions::GetSubscriptionEntitlementResponse,
+        >,
+    > for RouterData<F, T, subscriptions::GetSubscriptionEntitlementResponse>
+{
+    type Error = error_stack::Report<errors::ConnectorError>;
+
+    fn try_from(
+        item: ResponseRouterData<
+            F,
+            GetSubscriptionEntitlementResponse,
+            T,
+            subscriptions::GetSubscriptionEntitlementResponse,
+        >,
+    ) -> Result<Self, Self::Error> {
+        Ok(Self {
+            response: Ok(subscriptions::GetSubscriptionEntitlementResponse {
+                entitlement: item
+                    .response
+                    .entitlement
+                    .into_iter()
+                    .map(Into::into)
+                    .collect(),
+            }),
+            ..item.data
+        })
+    }
+}

--- a/crates/hyperswitch_connectors/src/connectors/recurly.rs
+++ b/crates/hyperswitch_connectors/src/connectors/recurly.rs
@@ -11,9 +11,10 @@ use hyperswitch_domain_models::{
     router_data::{ConnectorAuthType, ErrorResponse},
     router_data_v2::{
         flow_common_types::{
-            GetSubscriptionEstimateData, GetSubscriptionPlanPricesData, GetSubscriptionPlansData,
-            InvoiceRecordBackData, SubscriptionCancelData, SubscriptionCreateData,
-            SubscriptionCustomerData, SubscriptionPauseData, SubscriptionResumeData,
+            GetSubscriptionEntitlementData, GetSubscriptionEstimateData,
+            GetSubscriptionPlanPricesData, GetSubscriptionPlansData, InvoiceRecordBackData,
+            SubscriptionCancelData, SubscriptionCreateData, SubscriptionCustomerData,
+            SubscriptionPauseData, SubscriptionResumeData,
         },
         UasFlowData,
     },
@@ -25,14 +26,15 @@ use hyperswitch_domain_models::{
         unified_authentication_service::{
             Authenticate, AuthenticationConfirmation, PostAuthenticate, PreAuthenticate,
         },
-        CreateConnectorCustomer, InvoiceRecordBack,
+        CreateConnectorCustomer, GetSubscriptionEntitlements, InvoiceRecordBack,
     },
     router_request_types::{
         revenue_recovery::InvoiceRecordBackRequest,
         subscriptions::{
-            GetSubscriptionEstimateRequest, GetSubscriptionPlanPricesRequest,
-            GetSubscriptionPlansRequest, SubscriptionCancelRequest, SubscriptionCreateRequest,
-            SubscriptionPauseRequest, SubscriptionResumeRequest,
+            GetSubscriptionEntitlementRequest, GetSubscriptionEstimateRequest,
+            GetSubscriptionPlanPricesRequest, GetSubscriptionPlansRequest,
+            SubscriptionCancelRequest, SubscriptionCreateRequest, SubscriptionPauseRequest,
+            SubscriptionResumeRequest,
         },
         unified_authentication_service::{
             UasAuthenticationRequestData, UasAuthenticationResponseData,
@@ -44,9 +46,10 @@ use hyperswitch_domain_models::{
     router_response_types::{
         revenue_recovery::InvoiceRecordBackResponse,
         subscriptions::{
-            GetSubscriptionEstimateResponse, GetSubscriptionPlanPricesResponse,
-            GetSubscriptionPlansResponse, SubscriptionCancelResponse, SubscriptionCreateResponse,
-            SubscriptionPauseResponse, SubscriptionResumeResponse,
+            GetSubscriptionEntitlementResponse, GetSubscriptionEstimateResponse,
+            GetSubscriptionPlanPricesResponse, GetSubscriptionPlansResponse,
+            SubscriptionCancelResponse, SubscriptionCreateResponse, SubscriptionPauseResponse,
+            SubscriptionResumeResponse,
         },
         PaymentsResponseData,
     },
@@ -168,6 +171,7 @@ impl api::subscriptions_v2::SubscriptionsV2 for Recurly {}
 impl api::subscriptions_v2::GetSubscriptionPlansV2 for Recurly {}
 impl api::subscriptions_v2::SubscriptionRecordBackV2 for Recurly {}
 impl api::subscriptions_v2::SubscriptionConnectorCustomerV2 for Recurly {}
+impl api::subscriptions_v2::GetSubscriptionEntitlementsV2 for Recurly {}
 
 impl
     ConnectorIntegrationV2<
@@ -195,6 +199,16 @@ impl
         SubscriptionCustomerData,
         ConnectorCustomerData,
         PaymentsResponseData,
+    > for Recurly
+{
+}
+
+impl
+    ConnectorIntegrationV2<
+        GetSubscriptionEntitlements,
+        GetSubscriptionEntitlementData,
+        GetSubscriptionEntitlementRequest,
+        GetSubscriptionEntitlementResponse,
     > for Recurly
 {
 }

--- a/crates/hyperswitch_connectors/src/connectors/stripebilling.rs
+++ b/crates/hyperswitch_connectors/src/connectors/stripebilling.rs
@@ -157,6 +157,16 @@ impl
 {
 }
 
+impl subscriptions_api::GetSubscriptionEntitlementsFlow for Stripebilling {}
+impl
+    ConnectorIntegration<
+        subscription_flow_types::GetSubscriptionEntitlements,
+        subscription_request_types::GetSubscriptionEntitlementRequest,
+        subscription_response_types::GetSubscriptionEntitlementResponse,
+    > for Stripebilling
+{
+}
+
 impl<Flow, Request, Response> ConnectorCommonExt<Flow, Request, Response> for Stripebilling
 where
     Self: ConnectorIntegration<Flow, Request, Response>,

--- a/crates/hyperswitch_connectors/src/default_implementations.rs
+++ b/crates/hyperswitch_connectors/src/default_implementations.rs
@@ -38,8 +38,8 @@ use hyperswitch_domain_models::{
             PreProcessing, Reject, SdkSessionUpdate, UpdateMetadata,
         },
         subscriptions::{
-            GetSubscriptionEstimate, GetSubscriptionPlanPrices, GetSubscriptionPlans,
-            SubscriptionCancel, SubscriptionPause, SubscriptionResume,
+            GetSubscriptionEntitlements, GetSubscriptionEstimate, GetSubscriptionPlanPrices,
+            GetSubscriptionPlans, SubscriptionCancel, SubscriptionPause, SubscriptionResume,
         },
         webhooks::VerifyWebhookSource,
         AccessTokenAuthentication, Authenticate, AuthenticationConfirmation,
@@ -51,9 +51,10 @@ use hyperswitch_domain_models::{
         authentication,
         revenue_recovery::InvoiceRecordBackRequest,
         subscriptions::{
-            GetSubscriptionEstimateRequest, GetSubscriptionPlanPricesRequest,
-            GetSubscriptionPlansRequest, SubscriptionCancelRequest, SubscriptionCreateRequest,
-            SubscriptionPauseRequest, SubscriptionResumeRequest,
+            GetSubscriptionEntitlementRequest, GetSubscriptionEstimateRequest,
+            GetSubscriptionPlanPricesRequest, GetSubscriptionPlansRequest,
+            SubscriptionCancelRequest, SubscriptionCreateRequest, SubscriptionPauseRequest,
+            SubscriptionResumeRequest,
         },
         unified_authentication_service::{
             UasAuthenticationRequestData, UasAuthenticationResponseData,
@@ -75,9 +76,10 @@ use hyperswitch_domain_models::{
     router_response_types::{
         revenue_recovery::InvoiceRecordBackResponse,
         subscriptions::{
-            GetSubscriptionEstimateResponse, GetSubscriptionPlanPricesResponse,
-            GetSubscriptionPlansResponse, SubscriptionCancelResponse, SubscriptionCreateResponse,
-            SubscriptionPauseResponse, SubscriptionResumeResponse,
+            GetSubscriptionEntitlementResponse, GetSubscriptionEstimateResponse,
+            GetSubscriptionPlanPricesResponse, GetSubscriptionPlansResponse,
+            SubscriptionCancelResponse, SubscriptionCreateResponse, SubscriptionPauseResponse,
+            SubscriptionResumeResponse,
         },
         AcceptDisputeResponse, AuthenticationResponseData, DefendDisputeResponse,
         DisputeSyncResponse, FetchDisputesResponse, GiftCardBalanceCheckResponseData,
@@ -144,9 +146,10 @@ use hyperswitch_interfaces::{
         },
         revenue_recovery::RevenueRecovery,
         subscriptions::{
-            GetSubscriptionEstimateFlow, GetSubscriptionPlanPricesFlow, GetSubscriptionPlansFlow,
-            SubscriptionCancelFlow, SubscriptionCreate, SubscriptionPauseFlow,
-            SubscriptionRecordBackFlow, SubscriptionResumeFlow, Subscriptions,
+            GetSubscriptionEntitlementsFlow, GetSubscriptionEstimateFlow,
+            GetSubscriptionPlanPricesFlow, GetSubscriptionPlansFlow, SubscriptionCancelFlow,
+            SubscriptionCreate, SubscriptionPauseFlow, SubscriptionRecordBackFlow,
+            SubscriptionResumeFlow, Subscriptions,
         },
         vault::{
             ExternalVault, ExternalVaultCreate, ExternalVaultDelete, ExternalVaultInsert,
@@ -7399,11 +7402,19 @@ macro_rules! default_imp_for_subscriptions {
            ConnectorIntegration<InvoiceRecordBack, InvoiceRecordBackRequest, InvoiceRecordBackResponse> for $path::$connector
             {}
             impl GetSubscriptionPlanPricesFlow for $path::$connector {}
+            impl GetSubscriptionEntitlementsFlow for $path::$connector {}
             impl
             ConnectorIntegration<
             GetSubscriptionPlanPrices,
             GetSubscriptionPlanPricesRequest,
             GetSubscriptionPlanPricesResponse
+            > for $path::$connector
+            {}
+            impl
+            ConnectorIntegration<
+            GetSubscriptionEntitlements,
+            GetSubscriptionEntitlementRequest,
+            GetSubscriptionEntitlementResponse
             > for $path::$connector
             {}
             impl
@@ -9816,11 +9827,22 @@ impl<const T: u8> Subscriptions for connectors::DummyConnector<T> {}
 #[cfg(feature = "dummy_connector")]
 impl<const T: u8> GetSubscriptionPlanPricesFlow for connectors::DummyConnector<T> {}
 #[cfg(feature = "dummy_connector")]
+impl<const T: u8> GetSubscriptionEntitlementsFlow for connectors::DummyConnector<T> {}
+#[cfg(feature = "dummy_connector")]
 impl<const T: u8>
     ConnectorIntegration<
         GetSubscriptionPlanPrices,
         GetSubscriptionPlanPricesRequest,
         GetSubscriptionPlanPricesResponse,
+    > for connectors::DummyConnector<T>
+{
+}
+#[cfg(feature = "dummy_connector")]
+impl<const T: u8>
+    ConnectorIntegration<
+        GetSubscriptionEntitlements,
+        GetSubscriptionEntitlementRequest,
+        GetSubscriptionEntitlementResponse,
     > for connectors::DummyConnector<T>
 {
 }

--- a/crates/hyperswitch_domain_models/src/router_data_v2/flow_common_types.rs
+++ b/crates/hyperswitch_domain_models/src/router_data_v2/flow_common_types.rs
@@ -164,12 +164,22 @@ pub struct SubscriptionCreateData {
 }
 
 #[derive(Debug, Clone)]
+pub struct SubscriptionEntitlementData {
+    pub connector_meta_data: Option<pii::SecretSerdeValue>,
+}
+
+#[derive(Debug, Clone)]
 pub struct GetSubscriptionPlansData {
     pub connector_meta_data: Option<pii::SecretSerdeValue>,
 }
 
 #[derive(Debug, Clone)]
 pub struct GetSubscriptionPlanPricesData {
+    pub connector_meta_data: Option<pii::SecretSerdeValue>,
+}
+
+#[derive(Debug, Clone)]
+pub struct GetSubscriptionEntitlementData {
     pub connector_meta_data: Option<pii::SecretSerdeValue>,
 }
 

--- a/crates/hyperswitch_domain_models/src/router_flow_types/subscriptions.rs
+++ b/crates/hyperswitch_domain_models/src/router_flow_types/subscriptions.rs
@@ -16,6 +16,9 @@ pub struct GetSubscriptionPlanPrices;
 #[derive(Debug, Clone)]
 pub struct GetSubscriptionEstimate;
 
+#[derive(Debug, Clone)]
+pub struct GetSubscriptionEntitlements;
+
 /// Generic structure for subscription MIT (Merchant Initiated Transaction) payment data
 #[derive(Debug, Clone)]
 pub struct SubscriptionMitPaymentData {

--- a/crates/hyperswitch_domain_models/src/router_request_types/subscriptions.rs
+++ b/crates/hyperswitch_domain_models/src/router_request_types/subscriptions.rs
@@ -81,3 +81,6 @@ pub struct SubscriptionCancelRequest {
 pub struct GetSubscriptionEstimateRequest {
     pub price_id: String,
 }
+
+#[derive(Debug, Clone)]
+pub struct GetSubscriptionEntitlementRequest;

--- a/crates/hyperswitch_domain_models/src/router_response_types/subscriptions.rs
+++ b/crates/hyperswitch_domain_models/src/router_response_types/subscriptions.rs
@@ -148,6 +148,24 @@ pub struct GetSubscriptionEstimateResponse {
     pub customer_id: Option<id_type::CustomerId>,
 }
 
+#[derive(Debug, Clone)]
+pub struct GetSubscriptionEntitlementResponse {
+    pub entitlement: Vec<Entitlement>,
+}
+
+// Entitlement
+#[derive(Debug, Clone)]
+pub struct Entitlement {
+    pub feature_id: Option<String>,
+    pub feature_name: Option<String>,
+    pub id: String,
+    pub entity_id: Option<String>,
+    pub entity_type: Option<String>,
+    pub name: Option<String>,
+    pub object: Option<String>,
+    pub value: Option<bool>,
+}
+
 impl From<GetSubscriptionEstimateResponse>
     for api_models::subscription::EstimateSubscriptionResponse
 {

--- a/crates/hyperswitch_domain_models/src/types.rs
+++ b/crates/hyperswitch_domain_models/src/types.rs
@@ -14,9 +14,10 @@ use crate::{
         Authorize, AuthorizeSessionToken, BillingConnectorInvoiceSync,
         BillingConnectorPaymentsSync, CalculateTax, Capture, CompleteAuthorize,
         CreateConnectorCustomer, CreateOrder, Execute, ExtendAuthorization, ExternalVaultProxy,
-        GiftCardBalanceCheck, IncrementalAuthorization, PSync, PaymentMethodToken,
-        PostAuthenticate, PostCaptureVoid, PostSessionTokens, PreAuthenticate, PreProcessing,
-        RSync, SdkSessionUpdate, Session, SetupMandate, UpdateMetadata, VerifyWebhookSource, Void,
+        GetSubscriptionEntitlements, GiftCardBalanceCheck, IncrementalAuthorization, PSync,
+        PaymentMethodToken, PostAuthenticate, PostCaptureVoid, PostSessionTokens, PreAuthenticate,
+        PreProcessing, RSync, SdkSessionUpdate, Session, SetupMandate, UpdateMetadata,
+        VerifyWebhookSource, Void,
     },
     router_request_types::{
         revenue_recovery::{
@@ -24,9 +25,10 @@ use crate::{
             InvoiceRecordBackRequest,
         },
         subscriptions::{
-            GetSubscriptionEstimateRequest, GetSubscriptionPlanPricesRequest,
-            GetSubscriptionPlansRequest, SubscriptionCancelRequest, SubscriptionCreateRequest,
-            SubscriptionPauseRequest, SubscriptionResumeRequest,
+            GetSubscriptionEntitlementRequest, GetSubscriptionEstimateRequest,
+            GetSubscriptionPlanPricesRequest, GetSubscriptionPlansRequest,
+            SubscriptionCancelRequest, SubscriptionCreateRequest, SubscriptionPauseRequest,
+            SubscriptionResumeRequest,
         },
         unified_authentication_service::{
             UasAuthenticationRequestData, UasAuthenticationResponseData,
@@ -51,9 +53,10 @@ use crate::{
             InvoiceRecordBackResponse,
         },
         subscriptions::{
-            GetSubscriptionEstimateResponse, GetSubscriptionPlanPricesResponse,
-            GetSubscriptionPlansResponse, SubscriptionCancelResponse, SubscriptionCreateResponse,
-            SubscriptionPauseResponse, SubscriptionResumeResponse,
+            GetSubscriptionEntitlementResponse, GetSubscriptionEstimateResponse,
+            GetSubscriptionPlanPricesResponse, GetSubscriptionPlansResponse,
+            SubscriptionCancelResponse, SubscriptionCreateResponse, SubscriptionPauseResponse,
+            SubscriptionResumeResponse,
         },
         GiftCardBalanceCheckResponseData, MandateRevokeResponseData, PaymentsResponseData,
         RefundsResponseData, TaxCalculationResponseData, VaultResponseData,
@@ -227,3 +230,9 @@ pub type ExternalVaultProxyPaymentsRouterDataV2 = RouterDataV2<
 
 pub type SubscriptionCreateRouterData =
     RouterData<SubscriptionCreate, SubscriptionCreateRequest, SubscriptionCreateResponse>;
+
+pub type SubscriptionEntitlementRouterData = RouterData<
+    GetSubscriptionEntitlements,
+    GetSubscriptionEntitlementRequest,
+    GetSubscriptionEntitlementResponse,
+>;

--- a/crates/hyperswitch_interfaces/src/api/subscriptions.rs
+++ b/crates/hyperswitch_interfaces/src/api/subscriptions.rs
@@ -6,20 +6,22 @@ use hyperswitch_domain_models::{
             GetSubscriptionEstimate, GetSubscriptionPlanPrices, GetSubscriptionPlans,
             SubscriptionCreate as SubscriptionCreateFlow,
         },
-        InvoiceRecordBack,
+        GetSubscriptionEntitlements, InvoiceRecordBack,
     },
     router_request_types::{
         revenue_recovery::InvoiceRecordBackRequest,
         subscriptions::{
-            GetSubscriptionEstimateRequest, GetSubscriptionPlanPricesRequest,
-            GetSubscriptionPlansRequest, SubscriptionCreateRequest,
+            GetSubscriptionEntitlementRequest, GetSubscriptionEstimateRequest,
+            GetSubscriptionPlanPricesRequest, GetSubscriptionPlansRequest,
+            SubscriptionCreateRequest,
         },
     },
     router_response_types::{
         revenue_recovery::InvoiceRecordBackResponse,
         subscriptions::{
-            GetSubscriptionEstimateResponse, GetSubscriptionPlanPricesResponse,
-            GetSubscriptionPlansResponse, SubscriptionCreateResponse,
+            GetSubscriptionEntitlementResponse, GetSubscriptionEstimateResponse,
+            GetSubscriptionPlanPricesResponse, GetSubscriptionPlansResponse,
+            SubscriptionCreateResponse,
         },
     },
 };
@@ -99,6 +101,17 @@ pub trait GetSubscriptionEstimateFlow:
 >
 {
 }
+
+/// trait GetSubscriptionEstimate for V1
+pub trait GetSubscriptionEntitlementsFlow:
+    ConnectorIntegration<
+    GetSubscriptionEntitlements,
+    GetSubscriptionEntitlementRequest,
+    GetSubscriptionEntitlementResponse,
+>
+{
+}
+
 /// trait Subscriptions
 pub trait Subscriptions:
     ConnectorCommon
@@ -111,5 +124,6 @@ pub trait Subscriptions:
     + SubscriptionPauseFlow
     + SubscriptionResumeFlow
     + SubscriptionCancelFlow
+    + GetSubscriptionEntitlementsFlow
 {
 }

--- a/crates/hyperswitch_interfaces/src/api/subscriptions_v2.rs
+++ b/crates/hyperswitch_interfaces/src/api/subscriptions_v2.rs
@@ -1,33 +1,37 @@
 //! SubscriptionsV2
 use hyperswitch_domain_models::{
     router_data_v2::flow_common_types::{
-        GetSubscriptionEstimateData, GetSubscriptionPlanPricesData, GetSubscriptionPlansData,
-        InvoiceRecordBackData, SubscriptionCancelData, SubscriptionCreateData,
-        SubscriptionCustomerData, SubscriptionPauseData, SubscriptionResumeData,
+        GetSubscriptionEntitlementData, GetSubscriptionEstimateData, GetSubscriptionPlanPricesData,
+        GetSubscriptionPlansData, InvoiceRecordBackData, SubscriptionCancelData,
+        SubscriptionCreateData, SubscriptionCustomerData, SubscriptionPauseData,
+        SubscriptionResumeData,
     },
     router_flow_types::{
         revenue_recovery::InvoiceRecordBack,
         subscriptions::{
-            GetSubscriptionEstimate, GetSubscriptionPlanPrices, GetSubscriptionPlans,
-            SubscriptionCancel, SubscriptionCreate, SubscriptionPause, SubscriptionResume,
+            GetSubscriptionEntitlements, GetSubscriptionEstimate, GetSubscriptionPlanPrices,
+            GetSubscriptionPlans, SubscriptionCancel, SubscriptionCreate, SubscriptionPause,
+            SubscriptionResume,
         },
         CreateConnectorCustomer,
     },
     router_request_types::{
         revenue_recovery::InvoiceRecordBackRequest,
         subscriptions::{
-            GetSubscriptionEstimateRequest, GetSubscriptionPlanPricesRequest,
-            GetSubscriptionPlansRequest, SubscriptionCancelRequest, SubscriptionCreateRequest,
-            SubscriptionPauseRequest, SubscriptionResumeRequest,
+            GetSubscriptionEntitlementRequest, GetSubscriptionEstimateRequest,
+            GetSubscriptionPlanPricesRequest, GetSubscriptionPlansRequest,
+            SubscriptionCancelRequest, SubscriptionCreateRequest, SubscriptionPauseRequest,
+            SubscriptionResumeRequest,
         },
         ConnectorCustomerData,
     },
     router_response_types::{
         revenue_recovery::InvoiceRecordBackResponse,
         subscriptions::{
-            GetSubscriptionEstimateResponse, GetSubscriptionPlanPricesResponse,
-            GetSubscriptionPlansResponse, SubscriptionCancelResponse, SubscriptionCreateResponse,
-            SubscriptionPauseResponse, SubscriptionResumeResponse,
+            GetSubscriptionEntitlementResponse, GetSubscriptionEstimateResponse,
+            GetSubscriptionPlanPricesResponse, GetSubscriptionPlansResponse,
+            SubscriptionCancelResponse, SubscriptionCreateResponse, SubscriptionPauseResponse,
+            SubscriptionResumeResponse,
         },
         PaymentsResponseData,
     },
@@ -102,6 +106,7 @@ pub trait SubscriptionConnectorCustomerV2:
 >
 {
 }
+
 /// trait GetSubscriptionEstimate for V2
 pub trait GetSubscriptionEstimateV2:
     ConnectorIntegrationV2<
@@ -141,6 +146,17 @@ pub trait SubscriptionResumeV2:
     SubscriptionResumeData,
     SubscriptionResumeRequest,
     SubscriptionResumeResponse,
+>
+{
+}
+
+/// trait GetSubscriptionEntitlements for V2
+pub trait GetSubscriptionEntitlementsV2:
+    ConnectorIntegrationV2<
+    GetSubscriptionEntitlements,
+    GetSubscriptionEntitlementData,
+    GetSubscriptionEntitlementRequest,
+    GetSubscriptionEntitlementResponse,
 >
 {
 }

--- a/crates/hyperswitch_interfaces/src/conversion_impls.rs
+++ b/crates/hyperswitch_interfaces/src/conversion_impls.rs
@@ -11,12 +11,12 @@ use hyperswitch_domain_models::{
         flow_common_types::{
             AccessTokenFlowData, AuthenticationTokenFlowData, BillingConnectorInvoiceSyncFlowData,
             BillingConnectorPaymentsSyncFlowData, DisputesFlowData, ExternalAuthenticationFlowData,
-            ExternalVaultProxyFlowData, FilesFlowData, GetSubscriptionEstimateData,
-            GetSubscriptionPlanPricesData, GetSubscriptionPlansData, GiftCardBalanceCheckFlowData,
-            InvoiceRecordBackData, MandateRevokeFlowData, PaymentFlowData, RefundFlowData,
-            SubscriptionCancelData, SubscriptionCreateData, SubscriptionCustomerData,
-            SubscriptionPauseData, SubscriptionResumeData, UasFlowData, VaultConnectorFlowData,
-            WebhookSourceVerifyData,
+            ExternalVaultProxyFlowData, FilesFlowData, GetSubscriptionEntitlementData,
+            GetSubscriptionEstimateData, GetSubscriptionPlanPricesData, GetSubscriptionPlansData,
+            GiftCardBalanceCheckFlowData, InvoiceRecordBackData, MandateRevokeFlowData,
+            PaymentFlowData, RefundFlowData, SubscriptionCancelData, SubscriptionCreateData,
+            SubscriptionCustomerData, SubscriptionPauseData, SubscriptionResumeData, UasFlowData,
+            VaultConnectorFlowData, WebhookSourceVerifyData,
         },
         RouterDataV2,
     },
@@ -901,6 +901,7 @@ default_router_data_conversion!(GetSubscriptionEstimateData);
 default_router_data_conversion!(SubscriptionResumeData);
 default_router_data_conversion!(SubscriptionPauseData);
 default_router_data_conversion!(SubscriptionCancelData);
+default_router_data_conversion!(GetSubscriptionEntitlementData);
 
 impl<T, Req: Clone, Resp: Clone> RouterDataConversion<T, Req, Resp> for UasFlowData {
     fn from_old_router_data(

--- a/crates/hyperswitch_interfaces/src/types.rs
+++ b/crates/hyperswitch_interfaces/src/types.rs
@@ -18,8 +18,9 @@ use hyperswitch_domain_models::{
         refunds::{Execute, RSync},
         revenue_recovery::{BillingConnectorPaymentsSync, InvoiceRecordBack},
         subscriptions::{
-            GetSubscriptionEstimate, GetSubscriptionPlanPrices, GetSubscriptionPlans,
-            SubscriptionCancel, SubscriptionCreate, SubscriptionPause, SubscriptionResume,
+            GetSubscriptionEntitlements, GetSubscriptionEstimate, GetSubscriptionPlanPrices,
+            GetSubscriptionPlans, SubscriptionCancel, SubscriptionCreate, SubscriptionPause,
+            SubscriptionResume,
         },
         unified_authentication_service::{
             Authenticate, AuthenticationConfirmation, PostAuthenticate, PreAuthenticate,
@@ -37,9 +38,10 @@ use hyperswitch_domain_models::{
             InvoiceRecordBackRequest,
         },
         subscriptions::{
-            GetSubscriptionEstimateRequest, GetSubscriptionPlanPricesRequest,
-            GetSubscriptionPlansRequest, SubscriptionCancelRequest, SubscriptionCreateRequest,
-            SubscriptionPauseRequest, SubscriptionResumeRequest,
+            GetSubscriptionEntitlementRequest, GetSubscriptionEstimateRequest,
+            GetSubscriptionPlanPricesRequest, GetSubscriptionPlansRequest,
+            SubscriptionCancelRequest, SubscriptionCreateRequest, SubscriptionPauseRequest,
+            SubscriptionResumeRequest,
         },
         unified_authentication_service::{
             UasAuthenticationRequestData, UasAuthenticationResponseData,
@@ -66,9 +68,10 @@ use hyperswitch_domain_models::{
             InvoiceRecordBackResponse,
         },
         subscriptions::{
-            GetSubscriptionEstimateResponse, GetSubscriptionPlanPricesResponse,
-            GetSubscriptionPlansResponse, SubscriptionCancelResponse, SubscriptionCreateResponse,
-            SubscriptionPauseResponse, SubscriptionResumeResponse,
+            GetSubscriptionEntitlementResponse, GetSubscriptionEstimateResponse,
+            GetSubscriptionPlanPricesResponse, GetSubscriptionPlansResponse,
+            SubscriptionCancelResponse, SubscriptionCreateResponse, SubscriptionPauseResponse,
+            SubscriptionResumeResponse,
         },
         AcceptDisputeResponse, DefendDisputeResponse, DisputeSyncResponse, FetchDisputesResponse,
         GiftCardBalanceCheckResponseData, MandateRevokeResponseData, PaymentsResponseData,
@@ -206,6 +209,13 @@ pub type GetSubscriptionPlanPricesType = dyn ConnectorIntegration<
     GetSubscriptionPlanPrices,
     GetSubscriptionPlanPricesRequest,
     GetSubscriptionPlanPricesResponse,
+>;
+
+/// Type alias for ConnectorIntegration<GetSubscriptionEntitlements, GetSubscriptionEntitlementRequest, GetSubscriptionEntitlementResponse>
+pub type GetSubscriptionEntitlementType = dyn ConnectorIntegration<
+    GetSubscriptionEntitlements,
+    GetSubscriptionEntitlementRequest,
+    GetSubscriptionEntitlementResponse,
 >;
 
 /// Type alias for `ConnectorIntegration<CreateConnectorCustomer, ConnectorCustomerData, PaymentsResponseData>`

--- a/crates/router/src/services/api.rs
+++ b/crates/router/src/services/api.rs
@@ -104,6 +104,8 @@ pub type BoxedGetSubscriptionPlansInterface<T, Req, Res> =
     BoxedConnectorIntegrationInterface<T, common_types::GetSubscriptionPlansData, Req, Res>;
 pub type BoxedGetSubscriptionPlanPricesInterface<T, Req, Res> =
     BoxedConnectorIntegrationInterface<T, common_types::GetSubscriptionPlanPricesData, Req, Res>;
+pub type BoxedGetSubscriptionEntitlementInterface<T, Req, Res> =
+    BoxedConnectorIntegrationInterface<T, common_types::SubscriptionEntitlementData, Req, Res>;
 pub type BoxedGetSubscriptionEstimateInterface<T, Req, Res> =
     BoxedConnectorIntegrationInterface<T, common_types::GetSubscriptionEstimateData, Req, Res>;
 pub type BoxedSubscriptionPauseInterface<T, Req, Res> =


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
This pull request introduces support for retrieving subscription entitlements across multiple connectors in the codebase. The main changes include adding new types and integration flows for subscription entitlements, updating imports and macro implementations to support this feature, and providing connector-specific implementations for Chargebee, Stripebilling, Recurly, and the DummyConnector.

### Subscription Entitlements Feature Integration

* Added new types: `GetSubscriptionEntitlements`, `GetSubscriptionEntitlementRequest`, `GetSubscriptionEntitlementResponse`, and associated data structures in `hyperswitch_domain_models` to represent subscription entitlements. [[1]](diffhunk://#diff-94a86b6a06927a07f57cc41dba476d9c84040b2d3617af7ba3f2c077e2485f30R166-R170) [[2]](diffhunk://#diff-94a86b6a06927a07f57cc41dba476d9c84040b2d3617af7ba3f2c077e2485f30R181-R185) [[3]](diffhunk://#diff-2b69f94c9fb962a689185e78440efa0fc8354fa86493d44dcf86676c013b67fbR19-R21)
* Updated imports and usage throughout connector files (`chargebee.rs`, `recurly.rs`, `stripebilling.rs`, `default_implementations.rs`) to include the new entitlement types for requests, responses, and router data. [[1]](diffhunk://#diff-805dd853d554bb072ad3427d6b5ed7dc7b9ed62ee278f5adbf389a08266996b0L30-R38) [[2]](diffhunk://#diff-805dd853d554bb072ad3427d6b5ed7dc7b9ed62ee278f5adbf389a08266996b0L46-R50) [[3]](diffhunk://#diff-805dd853d554bb072ad3427d6b5ed7dc7b9ed62ee278f5adbf389a08266996b0L57-R60) [[4]](diffhunk://#diff-987be7b07b93a35ac0316f1eb8ad93ece84e5280d37e5566964238d1c969a3fdL14-R17) [[5]](diffhunk://#diff-987be7b07b93a35ac0316f1eb8ad93ece84e5280d37e5566964238d1c969a3fdL28-R37) [[6]](diffhunk://#diff-987be7b07b93a35ac0316f1eb8ad93ece84e5280d37e5566964238d1c969a3fdL47-R52) [[7]](diffhunk://#diff-ee28a7003b898fbf15bb25eb102e2310a4c52ba46d3961e3f929f4cf6bd1f6beL41-R42) [[8]](diffhunk://#diff-ee28a7003b898fbf15bb25eb102e2310a4c52ba46d3961e3f929f4cf6bd1f6beL54-R57) [[9]](diffhunk://#diff-ee28a7003b898fbf15bb25eb102e2310a4c52ba46d3961e3f929f4cf6bd1f6beL78-R82) [[10]](diffhunk://#diff-ee28a7003b898fbf15bb25eb102e2310a4c52ba46d3961e3f929f4cf6bd1f6beL147-R152)

### Connector Implementations

* Implemented the `GetSubscriptionEntitlementsFlow` and `ConnectorIntegration` traits for Chargebee, Stripebilling, Recurly, and DummyConnector, enabling these connectors to process entitlement requests and responses. [[1]](diffhunk://#diff-805dd853d554bb072ad3427d6b5ed7dc7b9ed62ee278f5adbf389a08266996b0R893-R983) [[2]](diffhunk://#diff-987be7b07b93a35ac0316f1eb8ad93ece84e5280d37e5566964238d1c969a3fdR174) [[3]](diffhunk://#diff-987be7b07b93a35ac0316f1eb8ad93ece84e5280d37e5566964238d1c969a3fdR206-R215) [[4]](diffhunk://#diff-80fa165bf3f7bf40a500b26643d2e679a354bfb3e3c8a8a82b6f79fbe734b549R160-R169) [[5]](diffhunk://#diff-ee28a7003b898fbf15bb25eb102e2310a4c52ba46d3961e3f929f4cf6bd1f6beR7405) [[6]](diffhunk://#diff-ee28a7003b898fbf15bb25eb102e2310a4c52ba46d3961e3f929f4cf6bd1f6beR7415-R7421) [[7]](diffhunk://#diff-ee28a7003b898fbf15bb25eb102e2310a4c52ba46d3961e3f929f4cf6bd1f6beR9830-R9831) [[8]](diffhunk://#diff-ee28a7003b898fbf15bb25eb102e2310a4c52ba46d3961e3f929f4cf6bd1f6beR9840-R9848)

### Chargebee-Specific Implementation

* Added full request/response handling for entitlement retrieval in Chargebee, including URL construction, header building, response parsing, and error handling. Also introduced new data structures for entitlement mapping and response transformation. [[1]](diffhunk://#diff-805dd853d554bb072ad3427d6b5ed7dc7b9ed62ee278f5adbf389a08266996b0R893-R983) [[2]](diffhunk://#diff-ea1ff6b5aee50334f546d6ac0c13c276b9c2c14070cee7b454f4c61262078765R1511-R1577)

### Macro and Default Implementations

* Extended macros and default trait implementations to support the new entitlement flow, ensuring consistency and easier onboarding for new connectors. [[1]](diffhunk://#diff-ee28a7003b898fbf15bb25eb102e2310a4c52ba46d3961e3f929f4cf6bd1f6beR7405) [[2]](diffhunk://#diff-ee28a7003b898fbf15bb25eb102e2310a4c52ba46d3961e3f929f4cf6bd1f6beR7415-R7421) [[3]](diffhunk://#diff-ee28a7003b898fbf15bb25eb102e2310a4c52ba46d3961e3f929f4cf6bd1f6beR9830-R9831) [[4]](diffhunk://#diff-ee28a7003b898fbf15bb25eb102e2310a4c52ba46d3961e3f929f4cf6bd1f6beR9840-R9848)

These changes collectively enable the platform to support querying subscription entitlements from various connectors, laying the groundwork for entitlement-based features in the subscription domain.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
This can be tested once, the routes PR are in place for Entitlements.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
