### PR TITLE
refactor(core): add support for IP address getting from HTTP request in payout browser info

### DIFF
--- a/crates/router/src/routes/payouts.rs
+++ b/crates/router/src/routes/payouts.rs
@@ -2,18 +2,24 @@ use actix_web::{
     body::{BoxBody, MessageBody},
     web, HttpRequest, HttpResponse, Responder,
 };
+#[cfg(feature = "v1")]
+use api_models::payments::BrowserInformation;
 use common_utils::id_type;
+#[cfg(feature = "v2")]
+use common_utils::types::BrowserInformation;
+use hyperswitch_domain_models::payments::HeaderPayload;
 use router_env::{instrument, tracing, Flow};
 
 use super::app::AppState;
 use crate::{
-    core::{api_locking, payouts::*},
+    core::{api_locking, errors::RouterResult, payouts::*},
+    logger,
     services::{
         api,
         authentication::{self as auth},
         authorization::permissions::Permission,
     },
-    types::{api::payouts as payout_types, domain},
+    types::{api::payouts as payout_types, domain, transformers::ForeignTryFrom},
 };
 
 /// Payouts - Create
@@ -25,11 +31,22 @@ pub async fn payouts_create(
 ) -> HttpResponse {
     let flow = Flow::PayoutsCreate;
 
+    let header_payload = match HeaderPayload::foreign_try_from(req.headers()) {
+        Ok(headers) => headers,
+        Err(err) => return api::log_and_return_error_response(err),
+    };
+
+    let mut payload = json_payload.into_inner();
+
+    if let Err(err) = populate_browser_info_for_payouts(&req, &mut payload, &header_payload) {
+        return api::log_and_return_error_response(err);
+    }
+
     Box::pin(api::server_wrap(
         flow,
         state,
         &req,
-        json_payload.into_inner(),
+        payload,
         |state, auth: auth::AuthenticationData, req, _| {
             let merchant_context = domain::MerchantContext::NormalMerchant(Box::new(
                 domain::Context(auth.merchant_account, auth.key_store),
@@ -465,4 +482,59 @@ pub async fn payouts_accounts() -> impl Responder {
 
 fn http_response<T: MessageBody + 'static>(response: T) -> HttpResponse<BoxBody> {
     HttpResponse::Ok().body(response)
+}
+
+pub fn populate_browser_info_for_payouts(
+    req: &HttpRequest,
+    payload: &mut payout_types::PayoutCreateRequest,
+    header_payload: &HeaderPayload,
+) -> RouterResult<()> {
+    let mut browser_info = payload.browser_info.clone().unwrap_or(BrowserInformation {
+        color_depth: None,
+        java_enabled: None,
+        java_script_enabled: None,
+        language: None,
+        screen_height: None,
+        screen_width: None,
+        time_zone: None,
+        ip_address: None,
+        accept_header: None,
+        user_agent: None,
+        os_type: None,
+        os_version: None,
+        device_model: None,
+        accept_language: None,
+        referer: None,
+    });
+
+    let ip_address = req
+        .connection_info()
+        .realip_remote_addr()
+        .map(ToOwned::to_owned);
+
+    if ip_address.is_some() {
+        logger::debug!("Extracted IP address from payout request");
+    }
+
+    browser_info.ip_address = browser_info.ip_address.or_else(|| {
+        ip_address
+            .as_ref()
+            .map(|ip| ip.parse())
+            .transpose()
+            .unwrap_or_else(|error| {
+                logger::error!(
+                    ?error,
+                    "Failed to parse IP address extracted from payout request"
+                );
+                None
+            })
+    });
+
+    if let Some(locale) = &header_payload.locale {
+        browser_info.accept_language = browser_info.accept_language.or(Some(locale.clone()));
+    }
+
+    payload.browser_info = Some(browser_info);
+
+    Ok(())
 }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
add support for IP address getting from HTTP request in payout browser info

For Interac payouts confirm call, we currently need to send the IP address, but since it’s not possible to get it from client-side JS. 
So in this PR we have added support for extracting ip address from http request. 

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
1. create MCA for gigadat payout

```
curl --location 'http://localhost:8080/account/merchant_1762412893/connectors' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: dev_rB2jHz4Pc1PjympltMlX86hhg5QMwxxyFWQDVqxXMDwm1AstElZqETebohwPhWAq' \
--data '{
    "connector_type": "payout_processor",
    "connector_name": "gigadat",
    "connector_account_details": {
        "auth_type": "SignatureKey",
        "api_key": "_",
        "key1": "_",
        "api_secret" : "_"
    },
    "test_mode": true,
    "disabled": false,
    "payment_methods_enabled": [
        {
            "payment_method": "bank_redirect",
            "payment_method_types": [
                {
                    "payment_method_type": "interac",
                    "payment_experience": "redirect_to_url",
                    "minimum_amount": 1,
                    "maximum_amount": 68607706,
                    "recurring_enabled": true,
                    "installment_payment_enabled": true
                }
            ]
        }
    ],
    "metadata": {
        "site" : "https://google.com/"
    }
}
'
```
2. Create a Payout request - ip_address is mandatory for gigadat payout, but here we are not passing browser_info in request, but it should still work, as it will fetch ip_addess from http request. 
```
curl --location 'http://localhost:8080/payouts/create' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: dev_rB2jHz4Pc1PjympltMlX86hhg5QMwxxyFWQDVqxXMDwm1AstElZqETebohwPhWAq' \
--data-raw '{
    "amount": 1,
    "currency": "CAD",
    "customer_id": "cus_YsmZlIiD75bf96yGFZVJ",
    "email": "payout_customer@example.com",
    "name": "Doest John",
    "phone": "6168205366",
    "phone_country_code": "+1",
    "description": "Its my first payout request",
    "payout_type": "bank_redirect",
    "payout_method_data": {
        "bank_redirect": {
            "interac": {
                "email": "example@example.com"
            }
        }
    },
    "connector": [
        "gigadat"
    ],
    "billing": {
        "address": {
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "city": "San Fransico",
            "state": "CA",
            "zip": "94122",
            "country": "US",
            "first_name": "Doest",
            "last_name": "John"
        },
        "phone": {
            "number": "6168205366",
            "country_code": "1"
        }
    },
    "entity_type": "Individual",
    "recurring": false,
    "confirm": true,
    "auto_fulfill": true
}
'
```
Response
```
{
    "payout_id": "payout_6mFEV8cXkDqAgoTecuJE",
    "merchant_id": "merchant_1762412893",
    "merchant_order_reference_id": null,
    "amount": 1,
    "currency": "CAD",
    "connector": "gigadat",
    "payout_type": "bank_redirect",
    "payout_method_data": {
        "bank_redirect": {
            "email": "ex*****@example.com"
        }
    },
    "billing": {
        "address": {
            "city": "San Fransico",
            "country": "US",
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "zip": "94122",
            "state": "CA",
            "first_name": "Doest",
            "last_name": "John",
            "origin_zip": null
        },
        "phone": {
            "number": "6168205366",
            "country_code": "1"
        },
        "email": null
    },
    "auto_fulfill": true,
    "customer_id": "cus_YsmZlIiD75bf96yGFZVJ",
    "customer": {
        "id": "cus_YsmZlIiD75bf96yGFZVJ",
        "name": "Doest John",
        "email": "payout_customer@example.com",
        "phone": "6168205366",
        "phone_country_code": "+1"
    },
    "client_secret": "payout_payout_6mFEV8cXkDqAgoTecuJE_secret_7S7Hhk3TvSyfXgcflKBA",
    "return_url": null,
    "business_country": null,
    "business_label": null,
    "description": "Its my first payout request",
    "entity_type": "Individual",
    "recurring": false,
    "metadata": {},
    "merchant_connector_id": "mca_use9n42RgAic1nrqp3cr",
    "status": "pending",
    "error_message": null,
    "error_code": null,
    "profile_id": "pro_8sMxHU2OCyrWtnHOA68x",
    "created": "2025-11-06T07:08:55.692Z",
    "connector_transaction_id": "payout_6mFEV8cXkDqAgoTecuJE_1",
    "priority": null,
    "payout_link": null,
    "email": "payout_customer@example.com",
    "name": "Doest John",
    "phone": "6168205366",
    "phone_country_code": "+1",
    "unified_code": null,
    "unified_message": null,
    "payout_method_id": null
}
```

Before this change if we make a payout request without passing browser_info in request 
We will get the error
```
{
    "error": {
        "type": "invalid_request",
        "message": "Missing required param: browser_info",
        "code": "IR_04"
    }
}
```


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
