### PR TITLE
ci(cypress): Remove card holder name as required field for adyen

### DIFF
--- a/cypress-tests/cypress/e2e/configs/Payment/Adyen.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Adyen.js
@@ -933,7 +933,6 @@ export const connectorDetails = {
                     field_type: "user_card_cvc",
                     value: null,
                   },
-              
                 },
               },
             ],
@@ -977,7 +976,6 @@ export const connectorDetails = {
                     field_type: "user_card_expiry_year",
                     value: null,
                   },
-                 
                 },
               },
             ],
@@ -996,8 +994,7 @@ export const connectorDetails = {
                     eligible_connectors: ["adyen"],
                   },
                 ],
-                required_fields: {
-                },
+                required_fields: {},
               },
             ],
           },


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [x] CI/CD

## Description
Remove card holder name as required field for adyen in cypress test


## Motivation and Context
Code changes is made in the PR(https://github.com/juspay/hyperswitch/pull/10148) which breaks cypress tests


## How did you test it?
Ran locally

<img width="1726" height="1108" alt="image" src="https://github.com/user-attachments/assets/0dc34a08-c7a5-4d7d-8f27-1e24391b6e71" />



## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
