### PR TITLE
fix(connector): Nuvie psync + rsync delay exception

### DIFF
--- a/crates/hyperswitch_connectors/src/connectors/nuvei/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/nuvei/transformers.rs
@@ -3542,7 +3542,7 @@ impl TryFrom<RefundsResponseRouterData<RSync, NuveiTransactionSyncResponse>>
     fn try_from(
         item: RefundsResponseRouterData<RSync, NuveiTransactionSyncResponse>,
     ) -> Result<Self, Self::Error> {
-        if bypass_error_for_no_payments_found(item.data.response.err_code) {
+        if bypass_error_for_no_payments_found(item.response.err_code) {
             return Ok(item.data);
         };
         let txn_id = item


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->




- If we make immediately after auth nuvie might return txn not found (9146) 
- we have to bypass psync and rsync if we get this error
- this change is tested by creating a mock server 
- usual issue in manual capture

```ts
const express = require("express");
const app = express();
const PORT = 8081;

// Middleware to parse JSON body
app.use(express.json());

// POST API endpoint
app.post("/post", (req, res) => {
  console.log("received");
  // Sample JSON responsea
  const response = {
    paymentOption: null,
    partialApproval: null,
    isCurrencyConverted: null,
    transactionDetails: null,
    fraudDetails: null,
    clientUniqueId: null,
    internalRequestId: 23456789,
    status: "ERROR",
    errCode: 9146,
    reason: "No transaction details returned for the provided id.",
    merchantId: "*** alloc::string::String ***",
    merchantSiteId: "*** alloc::string::String ***",
    version: "1.0",
    clientRequestId: null,
    merchantAdviceCode: null,
  };

  res.json(response);
});

// Start the server
app.listen(PORT, () => {
  console.log(`Server is running on http://localhost:${PORT}`);
  console.log(`POST endpoint available at http://localhost:${PORT}/post`);
});

```

## -------- AUTH REQUEST

```json
{
    "amount": 4000,
    "currency": "EUR",
    "confirm": true,
    "capture_method":"manual",
    "customer_acceptance": {
        "acceptance_type": "online",
        "accepted_at": "1963-05-03T04:07:52.723Z",
        "online": {
            "ip_address": "in sit",
            "user_agent": "amet irure esse"
        }
    },
    // "enable_partial_authorization":true,
    // "order_tax_amount": 100,
    "setup_future_usage": "off_session",
    "connector":["nuvei"],
    "customer_id": "nidthhxxinn",
    "return_url": "https://www.google.com",
    "payment_method": "card",
    "payment_method_type": "credit",
    "authentication_type": "no_three_ds",
    "description": "hellow world",
    "billing": {
        "address": {
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "city": "San Fransico",
            "state": "California",
            "zip": "94122",
            "country": "US",
            "first_name": "joseph",
            "last_name": "Doe"
        },
        "phone": {
            "number": "8056594427",
            "country_code": "+91"
        }
    },
    "browser_info": {
        "accept_header": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
        "ip_address": "192.168.1.1",
        "java_enabled": false,
        "java_script_enabled": true,
        "language": "en-US",
        "color_depth": 24,
        "screen_height": 1080,
        "screen_width": 1920,
        "time_zone": 330,
        "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36"
    },
    "email": "hello@gmail.com",
    "payment_method_data": {
        "card": {
            "card_number": "4761344136141390",
            "card_exp_month": "01",
            "card_exp_year": "2026",
            "card_holder_name": "John Smith",
            "card_cvc": "100"
        }
    }
}
````

## --------AUTH res

```json

{
    "payment_id": "pay_xJ7OzeAucltceZCt98BU",
    "merchant_id": "merchant_1763200415",
    "status": "requires_capture",
    "amount": 4000,
    "net_amount": 4000,
    "shipping_cost": null,
    "amount_capturable": 4000,
    "amount_received": null,
    "connector": "nuvei",
    "client_secret": "pay_xJ7OzeAucltceZCt98BU_secret_nvmwwQXmfYpXzqwz9CdU",
    "created": "2025-11-15T11:38:19.845Z",
    "currency": "EUR",
    "customer_id": "nidthhxxinn",
    "customer": {
        "id": "nidthhxxinn",
        "name": null,
        "email": "hello@gmail.com",
        "phone": null,
        "phone_country_code": null
    },
    "description": "hellow world",
    "refunds": null,
    "disputes": null,
    "mandate_id": null,
    "mandate_data": null,
    "setup_future_usage": "off_session",
    "off_session": null,
    "capture_on": null,
    "capture_method": "manual",
    "payment_method": "card",
    "payment_method_data": {
        "card": {
            "last4": "1390",
            "card_type": null,
            "card_network": null,
            "card_issuer": null,
            "card_issuing_country": null,
            "card_isin": "476134",
            "card_extended_bin": null,
            "card_exp_month": "01",
            "card_exp_year": "2026",
            "card_holder_name": "John Smith",
            "payment_checks": {
                "avs_result": "",
                "avs_description": null,
                "card_validation_result": "",
                "card_validation_description": null
            },
            "authentication_data": {
                "challengePreferenceReason": "12"
            }
        },
        "billing": null
    },
    "payment_token": "token_tdfV21cbyHbeMNU30sGI",
    "shipping": null,
    "billing": {
        "address": {
            "city": "San Fransico",
            "country": "US",
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "zip": "94122",
            "state": "California",
            "first_name": "joseph",
            "last_name": "Doe",
            "origin_zip": null
        },
        "phone": {
            "number": "8056594427",
            "country_code": "+91"
        },
        "email": null
    },
    "order_details": null,
    "email": "hello@gmail.com",
    "name": null,
    "phone": null,
    "return_url": "https://www.google.com/",
    "authentication_type": "no_three_ds",
    "statement_descriptor_name": null,
    "statement_descriptor_suffix": null,
    "next_action": null,
    "cancellation_reason": null,
    "error_code": null,
    "error_message": null,
    "unified_code": null,
    "unified_message": null,
    "payment_experience": null,
    "payment_method_type": "credit",
    "connector_label": null,
    "business_country": null,
    "business_label": "default",
    "business_sub_label": null,
    "allowed_payment_method_types": null,
    "ephemeral_key": {
        "customer_id": "nidthhxxinn",
        "created_at": 1763206699,
        "expires": 1763210299,
        "secret": "epk_bb552808a6f64cb69acb52e9f591dbac"
    },
    "manual_retry_allowed": null,
    "connector_transaction_id": "8110000000017858228",
    "frm_message": null,
    "metadata": null,
    "connector_metadata": null,
    "feature_metadata": {
        "redirect_response": null,
        "search_tags": null,
        "apple_pay_recurring_details": null,
        "gateway_system": "direct"
    },
    "reference_id": "10614278111",
    "payment_link": null,
    "profile_id": "pro_ge8OuDgVCUf9xllylJsC",
    "surcharge_details": null,
    "attempt_count": 1,
    "merchant_decision": null,
    "merchant_connector_id": "mca_DfmApTTIAlVuCCQ6W2sy",
    "incremental_authorization_allowed": false,
    "authorization_count": null,
    "incremental_authorizations": null,
    "external_authentication_details": null,
    "external_3ds_authentication_attempted": false,
    "expires_on": "2025-11-15T11:53:19.845Z",
    "fingerprint": null,
    "browser_info": {
        "language": "en-US",
        "time_zone": 330,
        "ip_address": "192.168.1.1",
        "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36",
        "color_depth": 24,
        "java_enabled": false,
        "screen_width": 1920,
        "accept_header": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
        "screen_height": 1080,
        "java_script_enabled": true
    },
    "payment_channel": null,
    "payment_method_id": "pm_GQUh4Z4xq2J9om0ZssBP",
    "network_transaction_id": "483297487231504",
    "payment_method_status": "active",
    "updated": "2025-11-15T11:38:23.604Z",
    "split_payments": null,
    "frm_metadata": null,
    "extended_authorization_applied": null,
    "extended_authorization_last_applied_at": null,
    "request_extended_authorization": null,
    "capture_before": null,
    "merchant_order_reference_id": null,
    "order_tax_amount": null,
    "connector_mandate_id": "2945618111",
    "card_discovery": "manual",
    "force_3ds_challenge": false,
    "force_3ds_challenge_trigger": false,
    "issuer_error_code": null,
    "issuer_error_message": null,
    "is_iframe_redirection_enabled": null,
    "whole_connector_response": null,
    "enable_partial_authorization": null,
    "enable_overcapture": null,
    "is_overcapture_enabled": null,
    "network_details": null,
    "is_stored_credential": null,
    "mit_category": null,
    "billing_descriptor": null
}
``` 

## ------psync 

```json
{
    "payment_id": "pay_xJ7OzeAucltceZCt98BU",
    "merchant_id": "merchant_1763200415",
    "status": "requires_capture",
    "amount": 4000,
    "net_amount": 4000,
    "shipping_cost": null,
    "amount_capturable": 4000,
    "amount_received": null,
    "connector": "nuvei",
    "client_secret": "pay_xJ7OzeAucltceZCt98BU_secret_nvmwwQXmfYpXzqwz9CdU",
    "created": "2025-11-15T11:38:19.845Z",
    "currency": "EUR",
    "customer_id": "nidthhxxinn",
    "customer": {
        "id": "nidthhxxinn",
        "name": null,
        "email": "hello@gmail.com",
        "phone": null,
        "phone_country_code": null
    },
    "description": "hellow world",
    "refunds": null,
    "disputes": null,
    "mandate_id": null,
    "mandate_data": null,
    "setup_future_usage": "off_session",
    "off_session": null,
    "capture_on": null,
    "capture_method": "manual",
    "payment_method": "card",
    "payment_method_data": {
        "card": {
            "last4": "1390",
            "card_type": null,
            "card_network": null,
            "card_issuer": null,
            "card_issuing_country": null,
            "card_isin": "476134",
            "card_extended_bin": null,
            "card_exp_month": "01",
            "card_exp_year": "2026",
            "card_holder_name": "John Smith",
            "payment_checks": {
                "avs_result": "",
                "avs_description": null,
                "card_validation_result": "",
                "card_validation_description": null
            },
            "authentication_data": {
                "challengePreferenceReason": "12"
            }
        },
        "billing": null
    },
    "payment_token": "token_tdfV21cbyHbeMNU30sGI",
    "shipping": null,
    "billing": {
        "address": {
            "city": "San Fransico",
            "country": "US",
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "zip": "94122",
            "state": "California",
            "first_name": "joseph",
            "last_name": "Doe",
            "origin_zip": null
        },
        "phone": {
            "number": "8056594427",
            "country_code": "+91"
        },
        "email": null
    },
    "order_details": null,
    "email": "hello@gmail.com",
    "name": null,
    "phone": null,
    "return_url": "https://www.google.com/",
    "authentication_type": "no_three_ds",
    "statement_descriptor_name": null,
    "statement_descriptor_suffix": null,
    "next_action": null,
    "cancellation_reason": null,
    "error_code": null,
    "error_message": null,
    "unified_code": null,
    "unified_message": null,
    "payment_experience": null,
    "payment_method_type": "credit",
    "connector_label": null,
    "business_country": null,
    "business_label": "default",
    "business_sub_label": null,
    "allowed_payment_method_types": null,
    "ephemeral_key": null,
    "manual_retry_allowed": null,
    "connector_transaction_id": "8110000000017858228",
    "frm_message": null,
    "metadata": null,
    "connector_metadata": null,
    "feature_metadata": {
        "redirect_response": null,
        "search_tags": null,
        "apple_pay_recurring_details": null,
        "gateway_system": "direct"
    },
    "reference_id": "10614278111",
    "payment_link": null,
    "profile_id": "pro_ge8OuDgVCUf9xllylJsC",
    "surcharge_details": null,
    "attempt_count": 1,
    "merchant_decision": null,
    "merchant_connector_id": "mca_DfmApTTIAlVuCCQ6W2sy",
    "incremental_authorization_allowed": false,
    "authorization_count": null,
    "incremental_authorizations": null,
    "external_authentication_details": null,
    "external_3ds_authentication_attempted": false,
    "expires_on": "2025-11-15T11:53:19.845Z",
    "fingerprint": null,
    "browser_info": {
        "language": "en-US",
        "time_zone": 330,
        "ip_address": "192.168.1.1",
        "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36",
        "color_depth": 24,
        "java_enabled": false,
        "screen_width": 1920,
        "accept_header": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
        "screen_height": 1080,
        "java_script_enabled": true
    },
    "payment_channel": null,
    "payment_method_id": "pm_GQUh4Z4xq2J9om0ZssBP",
    "network_transaction_id": "483297487231504",
    "payment_method_status": "active",
    "updated": "2025-11-15T11:42:24.368Z",
    "split_payments": null,
    "frm_metadata": null,
    "extended_authorization_applied": null,
    "extended_authorization_last_applied_at": null,
    "request_extended_authorization": null,
    "capture_before": null,
    "merchant_order_reference_id": null,
    "order_tax_amount": null,
    "connector_mandate_id": "2945618111",
    "card_discovery": "manual",
    "force_3ds_challenge": false,
    "force_3ds_challenge_trigger": false,
    "issuer_error_code": null,
    "issuer_error_message": null,
    "is_iframe_redirection_enabled": null,
    "whole_connector_response": null,
    "enable_partial_authorization": null,
    "enable_overcapture": null,
    "is_overcapture_enabled": null,
    "network_details": null,
    "is_stored_credential": null,
    "mit_category": null,
    "billing_descriptor": null
}
```

## Mock psync

```sh
connector_response: NuveiApi(NuveiTransactionSyncResponse { payment_option: None, partial_approval: None, is_currency_converted: None, transaction_details: None, fraud_details: None, client_unique_id: None, internal_request_id: Some(1763192803414), status: Error, err_code: Some(9146), reason: Some("No transaction details returned for the provided id."), merchant_id: Some(*** alloc::string::String ***), merchant_site_id: Some(*** alloc::string::String ***), version: Some("1.0"), client_request_id: None, merchant_advice_code: None })
```

--- capture
curl --location 'localhost:8080/payments/pay_xJ7OzeAucltceZCt98BU/capture' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: dev_GcRH5eb5kBK65QGjssccBefDywwIA77ZcQXoiTAj4HmoRfVOpWR0xbnFiHJ9KMmV' \
--data '{
    "amount_to_capture": 4000
}'


```json

{
    "payment_id": "pay_xJ7OzeAucltceZCt98BU",
    "merchant_id": "merchant_1763200415",
    "status": "succeeded",
    "amount": 4000,
    "net_amount": 4000,
    "shipping_cost": null,
    "amount_capturable": 0,
    "amount_received": 4000,
    "connector": "nuvei",
    "client_secret": "pay_xJ7OzeAucltceZCt98BU_secret_nvmwwQXmfYpXzqwz9CdU",
    "created": "2025-11-15T11:38:19.845Z",
    "currency": "EUR",
    "customer_id": "nidthhxxinn",
    "customer": {
        "id": "nidthhxxinn",
        "name": null,
        "email": "hello@gmail.com",
        "phone": null,
        "phone_country_code": null
    },
    "description": "hellow world",
    "refunds": null,
    "disputes": null,
    "mandate_id": null,
    "mandate_data": null,
    "setup_future_usage": "off_session",
    "off_session": null,
    "capture_on": null,
    "capture_method": "manual",
    "payment_method": "card",
    "payment_method_data": {
        "card": {
            "last4": "1390",
            "card_type": null,
            "card_network": null,
            "card_issuer": null,
            "card_issuing_country": null,
            "card_isin": "476134",
            "card_extended_bin": null,
            "card_exp_month": "01",
            "card_exp_year": "2026",
            "card_holder_name": "John Smith",
            "payment_checks": {
                "avs_result": null,
                "avs_description": null,
                "card_validation_result": null,
                "card_validation_description": null
            },
            "authentication_data": {
                "isLiabilityOnIssuer": "False",
                "isExemptionRequestInAuthentication": "true"
            }
        },
        "billing": null
    },
    "payment_token": "token_tdfV21cbyHbeMNU30sGI",
    "shipping": null,
    "billing": {
        "address": {
            "city": "San Fransico",
            "country": "US",
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "zip": "94122",
            "state": "California",
            "first_name": "joseph",
            "last_name": "Doe",
            "origin_zip": null
        },
        "phone": {
            "number": "8056594427",
            "country_code": "+91"
        },
        "email": null
    },
    "order_details": null,
    "email": "hello@gmail.com",
    "name": null,
    "phone": null,
    "return_url": "https://www.google.com/",
    "authentication_type": "no_three_ds",
    "statement_descriptor_name": null,
    "statement_descriptor_suffix": null,
    "next_action": null,
    "cancellation_reason": null,
    "error_code": null,
    "error_message": null,
    "unified_code": null,
    "unified_message": null,
    "payment_experience": null,
    "payment_method_type": "credit",
    "connector_label": null,
    "business_country": null,
    "business_label": "default",
    "business_sub_label": null,
    "allowed_payment_method_types": null,
    "ephemeral_key": null,
    "manual_retry_allowed": null,
    "connector_transaction_id": "8110000000017858515",
    "frm_message": null,
    "metadata": null,
    "connector_metadata": null,
    "feature_metadata": {
        "redirect_response": null,
        "search_tags": null,
        "apple_pay_recurring_details": null,
        "gateway_system": "direct"
    },
    "reference_id": "10614278111",
    "payment_link": null,
    "profile_id": "pro_ge8OuDgVCUf9xllylJsC",
    "surcharge_details": null,
    "attempt_count": 1,
    "merchant_decision": null,
    "merchant_connector_id": "mca_DfmApTTIAlVuCCQ6W2sy",
    "incremental_authorization_allowed": false,
    "authorization_count": null,
    "incremental_authorizations": null,
    "external_authentication_details": null,
    "external_3ds_authentication_attempted": false,
    "expires_on": "2025-11-15T11:53:19.845Z",
    "fingerprint": null,
    "browser_info": {
        "language": "en-US",
        "time_zone": 330,
        "ip_address": "192.168.1.1",
        "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36",
        "color_depth": 24,
        "java_enabled": false,
        "screen_width": 1920,
        "accept_header": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
        "screen_height": 1080,
        "java_script_enabled": true
    },
    "payment_channel": null,
    "payment_method_id": "pm_GQUh4Z4xq2J9om0ZssBP",
    "network_transaction_id": "483297487231504",
    "payment_method_status": null,
    "updated": "2025-11-15T11:48:41.975Z",
    "split_payments": null,
    "frm_metadata": null,
    "extended_authorization_applied": null,
    "extended_authorization_last_applied_at": null,
    "request_extended_authorization": null,
    "capture_before": null,
    "merchant_order_reference_id": null,
    "order_tax_amount": null,
    "connector_mandate_id": null,
    "card_discovery": "manual",
    "force_3ds_challenge": false,
    "force_3ds_challenge_trigger": false,
    "issuer_error_code": null,
    "issuer_error_message": null,
    "is_iframe_redirection_enabled": null,
    "whole_connector_response": null,
    "enable_partial_authorization": null,
    "enable_overcapture": null,
    "is_overcapture_enabled": null,
    "network_details": null,
    "is_stored_credential": null,
    "mit_category": null,
    "billing_descriptor": null
}
```


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
