### PR TITLE
ci(cypress): fix redsys connector

### DIFF
--- a/cypress-tests/cypress/e2e/configs/Payment/Redsys.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Redsys.js
@@ -287,7 +287,7 @@ export const connectorDetails = {
       },
     },
     ZeroAuthPaymentIntent: {
-       Configs: {
+      Configs: {
         TRIGGER_SKIP: true,
       },
       Request: {
@@ -470,11 +470,11 @@ export const connectorDetails = {
         amount: 6000,
       },
     }),
-     PaymentWithBilling: {
+    PaymentWithBilling: {
       Request: {
         currency: "USD",
         setup_future_usage: "on_session",
-        billing: Address
+        billing: Address,
       },
       Response: {
         status: 200,

--- a/cypress-tests/cypress/support/redirectionHandler.js
+++ b/cypress-tests/cypress/support/redirectionHandler.js
@@ -1190,14 +1190,12 @@ function threeDsRedirection(redirectionUrl, expectedUrl, connectorId) {
         case "redsys":
           // Suppress cross-origin JavaScript errors from Redsys's website
           cy.on("uncaught:exception", (err) => {
-            if (
-              err.message.includes("$ is not defined")
-            ) {
+            if (err.message.includes("$ is not defined")) {
               return false; // Prevent test failure
             }
             return true;
           });
-          
+
           cy.get("div.autenticada").click();
           cy.get('input[value="Enviar"]').click();
           break;


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [x] CI/CD

## Description

This pr fixes the redsys connector in cypress test suits
- Dynamic field fixes 
- Remove zero auth mandates which doesn't support
- Handle redirection uncaught error


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context

Redsys connector was failing 


## How did you test it?

<img width="585" height="952" alt="image" src="https://github.com/user-attachments/assets/5752fa8b-5b4c-4f37-a348-c1235d415d93" />


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
