### PR TITLE
chore(env): enable platform feature flag for production

### DIFF
--- a/config/deployments/production.toml
+++ b/config/deployments/production.toml
@@ -936,7 +936,7 @@ card_networks = "Visa, AmericanExpress, Mastercard"
 connector_list = "cybersource,peachpayments"
 
 [platform]
-enabled = false
+enabled = true
 allow_connected_merchants = false
 
 [billing_connectors_payment_sync]


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
The PR enables the Platform feature flag in production. This is required for merchant onboarding as Platform and to allow current set of features supported by Platform.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


l## Motivation and Context
Closes #10392


## How did you test it?
The eature is already tested in integ and sandbox.  We are enabling it for production.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
