### PR TITLE
fix: Sending merchant_reference_payment_id

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3789,7 +3789,7 @@ dependencies = [
 [[package]]
 name = "grpc-api-types"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?rev=ad39fa982a5e018f3bef2f3c4e866adf8c954093#ad39fa982a5e018f3bef2f3c4e866adf8c954093"
+source = "git+https://github.com/juspay/connector-service?rev=353a686b17246eaa7e305fe77d1dab373d01cf3a#353a686b17246eaa7e305fe77d1dab373d01cf3a"
 dependencies = [
  "axum 0.8.4",
  "error-stack 0.5.0",
@@ -7463,7 +7463,7 @@ dependencies = [
 [[package]]
 name = "rust-grpc-client"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?rev=ad39fa982a5e018f3bef2f3c4e866adf8c954093#ad39fa982a5e018f3bef2f3c4e866adf8c954093"
+source = "git+https://github.com/juspay/connector-service?rev=353a686b17246eaa7e305fe77d1dab373d01cf3a#353a686b17246eaa7e305fe77d1dab373d01cf3a"
 dependencies = [
  "grpc-api-types",
 ]
@@ -10253,7 +10253,7 @@ checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
 [[package]]
 name = "ucs_cards"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?rev=ad39fa982a5e018f3bef2f3c4e866adf8c954093#ad39fa982a5e018f3bef2f3c4e866adf8c954093"
+source = "git+https://github.com/juspay/connector-service?rev=353a686b17246eaa7e305fe77d1dab373d01cf3a#353a686b17246eaa7e305fe77d1dab373d01cf3a"
 dependencies = [
  "bytes 1.10.1",
  "error-stack 0.4.1",
@@ -10269,7 +10269,7 @@ dependencies = [
 [[package]]
 name = "ucs_common_enums"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?rev=ad39fa982a5e018f3bef2f3c4e866adf8c954093#ad39fa982a5e018f3bef2f3c4e866adf8c954093"
+source = "git+https://github.com/juspay/connector-service?rev=353a686b17246eaa7e305fe77d1dab373d01cf3a#353a686b17246eaa7e305fe77d1dab373d01cf3a"
 dependencies = [
  "serde",
  "strum 0.26.3",
@@ -10280,7 +10280,7 @@ dependencies = [
 [[package]]
 name = "ucs_common_utils"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?rev=ad39fa982a5e018f3bef2f3c4e866adf8c954093#ad39fa982a5e018f3bef2f3c4e866adf8c954093"
+source = "git+https://github.com/juspay/connector-service?rev=353a686b17246eaa7e305fe77d1dab373d01cf3a#353a686b17246eaa7e305fe77d1dab373d01cf3a"
 dependencies = [
  "anyhow",
  "base64 0.21.7",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3789,14 +3789,14 @@ dependencies = [
 [[package]]
 name = "grpc-api-types"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?rev=b5a367c1c775c32503feb00cdc6cd063cc97ea3b#b5a367c1c775c32503feb00cdc6cd063cc97ea3b"
+source = "git+https://github.com/juspay/connector-service?rev=ad39fa982a5e018f3bef2f3c4e866adf8c954093#ad39fa982a5e018f3bef2f3c4e866adf8c954093"
 dependencies = [
  "axum 0.8.4",
  "error-stack 0.5.0",
  "g2h",
  "heck 0.5.0",
  "http 1.3.1",
- "masking 0.1.0 (git+https://github.com/juspay/hyperswitch?tag=2025.09.24.0)",
+ "masking 0.1.0 (git+https://github.com/juspay/hyperswitch?tag=2025.11.24.0)",
  "prost",
  "prost-build",
  "prost-types",
@@ -5162,6 +5162,21 @@ dependencies = [
 name = "masking"
 version = "0.1.0"
 source = "git+https://github.com/juspay/hyperswitch?tag=2025.09.24.0#85da1b2bc80d4befd392cf7a9d2060d1e2f5cbe9"
+dependencies = [
+ "diesel",
+ "erased-serde 0.4.6",
+ "serde",
+ "serde_json",
+ "subtle",
+ "time",
+ "url",
+ "zeroize",
+]
+
+[[package]]
+name = "masking"
+version = "0.1.0"
+source = "git+https://github.com/juspay/hyperswitch?tag=2025.11.24.0#19723f8c9c6c89057624061fef429f6f574dd358"
 dependencies = [
  "bytes 1.10.1",
  "diesel",
@@ -7312,7 +7327,7 @@ dependencies = [
  "jsonwebtoken",
  "kgraph_utils",
  "masking 0.1.0",
- "masking 0.1.0 (git+https://github.com/juspay/hyperswitch?tag=2025.09.24.0)",
+ "masking 0.1.0 (git+https://github.com/juspay/hyperswitch?tag=2025.11.24.0)",
  "maud",
  "mimalloc",
  "mime",
@@ -7448,7 +7463,7 @@ dependencies = [
 [[package]]
 name = "rust-grpc-client"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?rev=b5a367c1c775c32503feb00cdc6cd063cc97ea3b#b5a367c1c775c32503feb00cdc6cd063cc97ea3b"
+source = "git+https://github.com/juspay/connector-service?rev=ad39fa982a5e018f3bef2f3c4e866adf8c954093#ad39fa982a5e018f3bef2f3c4e866adf8c954093"
 dependencies = [
  "grpc-api-types",
 ]
@@ -10238,11 +10253,11 @@ checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
 [[package]]
 name = "ucs_cards"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?rev=b5a367c1c775c32503feb00cdc6cd063cc97ea3b#b5a367c1c775c32503feb00cdc6cd063cc97ea3b"
+source = "git+https://github.com/juspay/connector-service?rev=ad39fa982a5e018f3bef2f3c4e866adf8c954093#ad39fa982a5e018f3bef2f3c4e866adf8c954093"
 dependencies = [
  "bytes 1.10.1",
  "error-stack 0.4.1",
- "masking 0.1.0 (git+https://github.com/juspay/hyperswitch?tag=2025.09.24.0)",
+ "masking 0.1.0 (git+https://github.com/juspay/hyperswitch?tag=2025.11.24.0)",
  "prost",
  "regex",
  "serde",
@@ -10254,7 +10269,7 @@ dependencies = [
 [[package]]
 name = "ucs_common_enums"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?rev=b5a367c1c775c32503feb00cdc6cd063cc97ea3b#b5a367c1c775c32503feb00cdc6cd063cc97ea3b"
+source = "git+https://github.com/juspay/connector-service?rev=ad39fa982a5e018f3bef2f3c4e866adf8c954093#ad39fa982a5e018f3bef2f3c4e866adf8c954093"
 dependencies = [
  "serde",
  "strum 0.26.3",
@@ -10265,7 +10280,7 @@ dependencies = [
 [[package]]
 name = "ucs_common_utils"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?rev=b5a367c1c775c32503feb00cdc6cd063cc97ea3b#b5a367c1c775c32503feb00cdc6cd063cc97ea3b"
+source = "git+https://github.com/juspay/connector-service?rev=ad39fa982a5e018f3bef2f3c4e866adf8c954093#ad39fa982a5e018f3bef2f3c4e866adf8c954093"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -10275,7 +10290,7 @@ dependencies = [
  "error-stack 0.4.1",
  "hex",
  "http 1.3.1",
- "masking 0.1.0 (git+https://github.com/juspay/hyperswitch?tag=2025.09.24.0)",
+ "masking 0.1.0 (git+https://github.com/juspay/hyperswitch?tag=2025.11.24.0)",
  "md5",
  "nanoid",
  "once_cell",

--- a/crates/external_services/Cargo.toml
+++ b/crates/external_services/Cargo.toml
@@ -69,7 +69,7 @@ reqwest = { version = "0.11.27", features = ["rustls-tls"] }
 http = "0.2.12"
 url = { version = "2.5.4", features = ["serde"] }
 quick-xml = { version = "0.31.0", features = ["serialize"] }
-unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "b5a367c1c775c32503feb00cdc6cd063cc97ea3b", package = "rust-grpc-client" }
+unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "ad39fa982a5e018f3bef2f3c4e866adf8c954093", package = "rust-grpc-client" }
 open-feature = { version = "0.2.5", optional = true }
 superposition_provider = { version = "0.88.1", optional = true }
 

--- a/crates/external_services/Cargo.toml
+++ b/crates/external_services/Cargo.toml
@@ -69,7 +69,7 @@ reqwest = { version = "0.11.27", features = ["rustls-tls"] }
 http = "0.2.12"
 url = { version = "2.5.4", features = ["serde"] }
 quick-xml = { version = "0.31.0", features = ["serialize"] }
-unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "ad39fa982a5e018f3bef2f3c4e866adf8c954093", package = "rust-grpc-client" }
+unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "353a686b17246eaa7e305fe77d1dab373d01cf3a", package = "rust-grpc-client" }
 open-feature = { version = "0.2.5", optional = true }
 superposition_provider = { version = "0.88.1", optional = true }
 

--- a/crates/hyperswitch_interfaces/Cargo.toml
+++ b/crates/hyperswitch_interfaces/Cargo.toml
@@ -29,7 +29,7 @@ serde_json = "1.0.140"
 strum = { version = "0.26", features = ["derive"] }
 thiserror = "1.0.69"
 time = "0.3.41"
-unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "ad39fa982a5e018f3bef2f3c4e866adf8c954093", package = "rust-grpc-client" }
+unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "353a686b17246eaa7e305fe77d1dab373d01cf3a", package = "rust-grpc-client" }
 unified-connector-service-masking = { git = "https://github.com/juspay/hyperswitch", tag = "2025.09.24.0", package = "masking" }
 tokio = { version = "1.45.1", features = ["macros", "rt-multi-thread"] }
 # First party crates

--- a/crates/hyperswitch_interfaces/Cargo.toml
+++ b/crates/hyperswitch_interfaces/Cargo.toml
@@ -29,7 +29,7 @@ serde_json = "1.0.140"
 strum = { version = "0.26", features = ["derive"] }
 thiserror = "1.0.69"
 time = "0.3.41"
-unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "b5a367c1c775c32503feb00cdc6cd063cc97ea3b", package = "rust-grpc-client" }
+unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "ad39fa982a5e018f3bef2f3c4e866adf8c954093", package = "rust-grpc-client" }
 unified-connector-service-masking = { git = "https://github.com/juspay/hyperswitch", tag = "2025.09.24.0", package = "masking" }
 tokio = { version = "1.45.1", features = ["macros", "rt-multi-thread"] }
 # First party crates

--- a/crates/router/Cargo.toml
+++ b/crates/router/Cargo.toml
@@ -89,9 +89,9 @@ reqwest = { version = "0.11.27", features = ["json", "rustls-tls", "gzip", "mult
 ring = "0.17.14"
 rust_decimal = { version = "1.37.1", features = ["serde-with-float", "serde-with-str"] }
 rust-i18n = { git = "https://github.com/kashif-m/rust-i18n", rev = "f2d8096aaaff7a87a847c35a5394c269f75e077a" }
-unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "b5a367c1c775c32503feb00cdc6cd063cc97ea3b", package = "rust-grpc-client" }
-unified-connector-service-cards = { git = "https://github.com/juspay/connector-service", rev = "b5a367c1c775c32503feb00cdc6cd063cc97ea3b", package = "ucs_cards" }
-unified-connector-service-masking = { git = "https://github.com/juspay/hyperswitch", tag = "2025.09.24.0", package = "masking" }
+unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "ad39fa982a5e018f3bef2f3c4e866adf8c954093", package = "rust-grpc-client" }
+unified-connector-service-cards = { git = "https://github.com/juspay/connector-service", rev = "ad39fa982a5e018f3bef2f3c4e866adf8c954093", package = "ucs_cards" }
+unified-connector-service-masking = { git = "https://github.com/juspay/hyperswitch", tag = "2025.11.24.0", package = "masking" }
 rustc-hash = "1.1.0"
 rustls = "0.22"
 rustls-pemfile = "2"

--- a/crates/router/Cargo.toml
+++ b/crates/router/Cargo.toml
@@ -89,8 +89,8 @@ reqwest = { version = "0.11.27", features = ["json", "rustls-tls", "gzip", "mult
 ring = "0.17.14"
 rust_decimal = { version = "1.37.1", features = ["serde-with-float", "serde-with-str"] }
 rust-i18n = { git = "https://github.com/kashif-m/rust-i18n", rev = "f2d8096aaaff7a87a847c35a5394c269f75e077a" }
-unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "ad39fa982a5e018f3bef2f3c4e866adf8c954093", package = "rust-grpc-client" }
-unified-connector-service-cards = { git = "https://github.com/juspay/connector-service", rev = "ad39fa982a5e018f3bef2f3c4e866adf8c954093", package = "ucs_cards" }
+unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "353a686b17246eaa7e305fe77d1dab373d01cf3a", package = "rust-grpc-client" }
+unified-connector-service-cards = { git = "https://github.com/juspay/connector-service", rev = "353a686b17246eaa7e305fe77d1dab373d01cf3a", package = "ucs_cards" }
 unified-connector-service-masking = { git = "https://github.com/juspay/hyperswitch", tag = "2025.11.24.0", package = "masking" }
 rustc-hash = "1.1.0"
 rustls = "0.22"

--- a/crates/router/src/core/unified_connector_service/transformers.rs
+++ b/crates/router/src/core/unified_connector_service/transformers.rs
@@ -816,6 +816,7 @@ impl transformers::ForeignTryFrom<&RouterData<Capture, PaymentsCaptureData, Paym
                     router_data.connector_request_reference_id.clone(),
                 )),
             }),
+            merchant_reference_payment_id: Some(router_data.payment_id.clone()),
             amount_to_capture: router_data
                 .request
                 .minor_amount_to_capture


### PR DESCRIPTION
## Type of Change
Sending merchant_reference_payment_id as worldpay requires that as reference filed in cpature call (once connector service pr gets merge will update commit)

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?

before updation

<img width="1240" height="512" alt="Screenshot 2025-11-25 at 4 33 09 PM" src="https://github.com/user-attachments/assets/79b69cf1-3346-4610-b448-de13e0e27828" />



after updation
<img width="2526" height="1104" alt="Screenshot 2025-11-25 at 3 47 50 PM" src="https://github.com/user-attachments/assets/a9b79ba7-d443-4b32-898e-fa2016745914" />



## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
