### PR TITLE
ci(cypress): Fix paypal test

### DIFF
--- a/cypress-tests/cypress/e2e/configs/Payment/Paypal.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Paypal.js
@@ -89,8 +89,8 @@ export const connectorDetails = {
           status: "failed",
           error_code: "AMOUNT_MISMATCH",
           error_message:
-            "description - Should equal item_total + tax_total + shipping + handling + insurance + gratuity - shipping_discount - discount., value - 60.50, field - value;"        
-          },
+            "description - Should equal item_total + tax_total + shipping + handling + insurance + gratuity - shipping_discount - discount., value - 60.50, field - value;",
+        },
       },
     },
     "3DSManualCapture": {


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [x] CI/CD

## Description
Fixed the error message displayed for PayPal payments with shipping cost in the Cypress test suite.
## How did you test it?
<img width="1726" height="1108" alt="image" src="https://github.com/user-attachments/assets/8fd10dad-b84f-408e-9465-f32b3b6d3b13" />



## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
