### PR TITLE
fix(connector): checkout billing-descriptor-mandatory fields

### DIFF
--- a/crates/hyperswitch_connectors/src/connectors/checkout/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/checkout/transformers.rs
@@ -865,12 +865,6 @@ impl TryFrom<&CheckoutRouterData<&PaymentsAuthorizeRouterData>> for PaymentsRequ
 
         let billing_descriptor =
             if let Some(descriptor) = item.router_data.request.billing_descriptor.as_ref() {
-                if descriptor.name.is_none()
-                    && descriptor.city.is_none()
-                    && descriptor.reference.is_none()
-                {
-                    return None;
-                }
                 if descriptor.name.is_none() && descriptor.city.is_none() {
                     return Err(errors::ConnectorError::MissingRequiredFields {
                         field_names: vec!["billing_descriptor.name", "billing_descriptor.city"],


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->

Checkout has billing descriptor city and name both as mandatory field which was optional . Throw error from hyperswitch if these fields are not sent if billing_descriptor was sent

```json
{
    "amount": 4324,
    "currency": "EUR",
    "confirm": true,
    "setup_future_usage": "on_session",
    "customer_acceptance": {
        "acceptance_type": "offline",
        "accepted_at": "1963-05-03T04:07:52.723Z",
        "online": {
            "ip_address": "127.0.0.1",
            "user_agent": "amet irure esse"
        }
    },
    "connector": [
        "checkout"
    ],
    "customer_id": "nidthxxinn",
    "return_url": "https://www.google.com",
    "capture_method": "automatic",
    "payment_method": "card",
    "payment_method_type": "credit",
    "authentication_type": "no_three_ds",
    "description": "hellow world",
    "billing": {
        "address": {
            "zip": "560095",
            "country": "US",
            "first_name": "Sakil",
            "last_name": "Mostak",
            "line1": "Fasdf",
            "line2": "Fasdf",
            "city": "Fasdf"
        }
    },
    "browser_info": {
        "accept_header": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
        "ip_address": "192.168.1.1",
        "java_enabled": false,
        "java_script_enabled": true,
        "language": "en-US",
        "color_depth": 24,
        "screen_height": 1080,
        "screen_width": 1920,
        "time_zone": 330,
        "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36"
    },
    "email": "hello@gmail.com",
    "payment_method_data": {
        "card": {
            "card_number": "4000000000009995",
            "card_exp_month": "01",
            "card_exp_year": "2026",
            "card_holder_name": "John Smith",
            "card_cvc": "100"
        }
    },
    "statement_descriptor_name": "joseph",
    "billing_descriptor": {
        // "name": "abc",
        "email": "abc@gmail.com",
        // "city": "kolkata",
        "statement_descriptor": "order123",
        "reference":"reference_1234"
    },
    "merchant_order_reference_id": "fasdfasfasf",
    "order_tax_amount": 10000,
    "shipping_cost": 21,
    "discount_amount": 1,
    "duty_amount": 2,
    "shipping_amount_tax": 22,
    "order_details": [
        {
            "commodity_code": "8471",
            "unit_discount_amount": 1200,
            "product_name": "Laptop",
            "quantity": 1,
            "product_id": "fafasdfasdfdasdfsadfsadfrewfdscrwefdscerwfdasewfdsacxzfdsasdf",
            "total_tax_amount": 5000,
            "amount": 8000,
            "unit_of_measure": "EA",
            "unit_price": 8000
        },
        {
            "commodity_code": "471",
            "unit_discount_amount": 34,
            "product_name": "Laptop",
            "quantity": 1,
            "product_id": "fas22df",
            "total_tax_amount": 3000,
            "amount": 4000,
            "unit_of_measure": "EA",
            "unit_price": 8500
        }
    ]
}
```


```json
{
    "error": {
        "type": "invalid_request",
        "message": "Missing required params",
        "code": "IR_21",
        "data": [
            "billing_descriptor.name",
            "billing_descriptor.city"
        ]
    }
}
```

other edge cases

```json
{
    "error": {
        "type": "invalid_request",
        "message": "Missing required param: billing_descriptor.city",
        "code": "IR_04"
    }
}
```

```json
{
    "error": {
        "type": "invalid_request",
        "message": "Missing required param: billing_descriptor.name",
        "code": "IR_04"
    }
}
```

if billing_descriptor=null is sent

```json
{
    "payment_id": "pay_vtG64rRPMjP5nSmdefDo",
    "merchant_id": "merchant_1764068324",
    "status": "succeeded",
    "amount": 4324,
    "net_amount": 14345,
    "shipping_cost": 21,
    "amount_capturable": 0,
    "amount_received": 14345,
    "connector": "checkout",
    "client_secret": "pay_vtG64rRPMjP5nSmdefDo_secret_H5P5jfEyiYr8aAzIL5yN",
    "created": "2025-11-27T10:59:31.023Z",
    "currency": "EUR",
    "customer_id": "nidthxxinn",
    "customer": {
        "id": "nidthxxinn",
        "name": null,
        "email": "hello@gmail.com",
        "phone": null,
        "phone_country_code": null
    },
    "description": "hellow world",
    "refunds": null,
    "disputes": null,
    "mandate_id": null,
    "mandate_data": null,
    "setup_future_usage": "on_session",
    "off_session": null,
    "capture_on": null,
    "capture_method": "automatic",
    "payment_method": "card",
    "payment_method_data": {
        "card": {
            "last4": "9995",
            "card_type": null,
            "card_network": null,
            "card_issuer": null,
            "card_issuing_country": null,
            "card_isin": "400000",
            "card_extended_bin": null,
            "card_exp_month": "01",
            "card_exp_year": "2026",
            "card_holder_name": "John Smith",
            "payment_checks": {
                "avs_result": "G",
                "card_validation_result": "Y"
            },
            "authentication_data": null
        },
        "billing": null
    },
    "payment_token": null,
    "shipping": null,
    "billing": {
        "address": {
            "city": "Fasdf",
            "country": "US",
            "line1": "Fasdf",
            "line2": "Fasdf",
            "line3": null,
            "zip": "560095",
            "state": null,
            "first_name": "Sakil",
            "last_name": "Mostak",
            "origin_zip": null
        },
        "phone": null,
        "email": null
    },
    "order_details": [
        {
            "sku": null,
            "upc": null,
            "brand": null,
            "amount": 8000,
            "category": null,
            "quantity": 1,
            "tax_rate": null,
            "product_id": "fafasdfasdfdasdfsadfsadfrewfdscrwefdscerwfdasewfdsacxzfdsasdf",
            "description": null,
            "product_name": "Laptop",
            "product_type": null,
            "sub_category": null,
            "total_amount": null,
            "commodity_code": "8471",
            "unit_of_measure": "EA",
            "product_img_link": null,
            "product_tax_code": null,
            "total_tax_amount": 5000,
            "requires_shipping": null,
            "unit_discount_amount": 1200
        },
        {
            "sku": null,
            "upc": null,
            "brand": null,
            "amount": 4000,
            "category": null,
            "quantity": 1,
            "tax_rate": null,
            "product_id": "fas22df",
            "description": null,
            "product_name": "Laptop",
            "product_type": null,
            "sub_category": null,
            "total_amount": null,
            "commodity_code": "471",
            "unit_of_measure": "EA",
            "product_img_link": null,
            "product_tax_code": null,
            "total_tax_amount": 3000,
            "requires_shipping": null,
            "unit_discount_amount": 34
        }
    ],
    "email": "hello@gmail.com",
    "name": null,
    "phone": null,
    "return_url": "https://www.google.com/",
    "authentication_type": "no_three_ds",
    "statement_descriptor_name": "joseph",
    "statement_descriptor_suffix": null,
    "next_action": null,
    "cancellation_reason": null,
    "error_code": null,
    "error_message": null,
    "error_reason": null,
    "unified_code": null,
    "unified_message": null,
    "payment_experience": null,
    "payment_method_type": "credit",
    "connector_label": null,
    "business_country": null,
    "business_label": "default",
    "business_sub_label": null,
    "allowed_payment_method_types": null,
    "ephemeral_key": {
        "customer_id": "nidthxxinn",
        "created_at": 1764241170,
        "expires": 1764244770,
        "secret": "epk_77fd893c662b48ad961671bbf85488f8"
    },
    "manual_retry_allowed": null,
    "connector_transaction_id": "pay_c3x7ndegx7dunoflljjpd2irvi",
    "frm_message": null,
    "metadata": null,
    "connector_metadata": null,
    "feature_metadata": {
        "redirect_response": null,
        "search_tags": null,
        "apple_pay_recurring_details": null,
        "gateway_system": "direct"
    },
    "reference_id": "pay_vtG64rRPMjP5nSmdefDo_1",
    "payment_link": null,
    "profile_id": "pro_s4auyzGYxY2UaTMJ4LVF",
    "surcharge_details": null,
    "attempt_count": 1,
    "merchant_decision": null,
    "merchant_connector_id": "mca_lJVcvA7h5Iw0Me2JsDyh",
    "incremental_authorization_allowed": false,
    "authorization_count": null,
    "incremental_authorizations": null,
    "external_authentication_details": null,
    "external_3ds_authentication_attempted": false,
    "expires_on": "2025-11-27T11:14:31.023Z",
    "fingerprint": null,
    "browser_info": {
        "language": "en-US",
        "time_zone": 330,
        "ip_address": "192.168.1.1",
        "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36",
        "color_depth": 24,
        "java_enabled": false,
        "screen_width": 1920,
        "accept_header": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
        "screen_height": 1080,
        "java_script_enabled": true
    },
    "payment_channel": null,
    "payment_method_id": null,
    "network_transaction_id": "388322408813970",
    "payment_method_status": null,
    "updated": "2025-11-27T10:59:32.732Z",
    "split_payments": null,
    "frm_metadata": null,
    "extended_authorization_applied": null,
    "extended_authorization_last_applied_at": null,
    "request_extended_authorization": null,
    "capture_before": null,
    "merchant_order_reference_id": "fasdfasfasf",
    "order_tax_amount": 10000,
    "connector_mandate_id": null,
    "card_discovery": "manual",
    "force_3ds_challenge": false,
    "force_3ds_challenge_trigger": false,
    "issuer_error_code": null,
    "issuer_error_message": null,
    "is_iframe_redirection_enabled": null,
    "whole_connector_response": null,
    "enable_partial_authorization": null,
    "enable_overcapture": null,
    "is_overcapture_enabled": null,
    "network_details": null,
    "is_stored_credential": null,
    "mit_category": null,
    "billing_descriptor": null,
    "tokenization": null,
    "partner_merchant_identifier_details": null
}
```

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
