### PR TITLE
fix: changes reference field from payment_id to connector_request_reference_id for worldpay

### DIFF
--- a/crates/hyperswitch_connectors/src/connectors/worldpay/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/worldpay/transformers.rs
@@ -833,7 +833,10 @@ impl TryFrom<(&types::PaymentsCaptureRouterData, MinorUnit)> for WorldpayPartial
     fn try_from(req: (&types::PaymentsCaptureRouterData, MinorUnit)) -> Result<Self, Self::Error> {
         let (item, amount) = req;
         Ok(Self {
-            reference: item.connector_request_reference_id.clone().replace("_", "-"),
+            reference: item
+                .connector_request_reference_id
+                .clone()
+                .replace("_", "-"),
             value: PaymentValue {
                 amount: amount.get_amount_as_i64(),
                 currency: item.request.currency,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
changes reference field from payment_id to connector_request_reference_id for worldpay



### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
tested using diff checker in ucs that reference_id is going correct

previously
<img width="907" height="370" alt="Screenshot 2025-12-08 at 10 39 06 PM" src="https://github.com/user-attachments/assets/47747d9b-f85a-48de-a9f9-217503111dbc" />


Now
<img width="2551" height="1137" alt="Screenshot 2025-12-02 at 2 15 58 PM" src="https://github.com/user-attachments/assets/42e7ff29-f2d0-4c38-923f-b3a6f42a4da3" />


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
