### PR TITLE
fix(revenue_recovery): get recovery list and get recovery intent response missing values fix

### DIFF
--- a/crates/api_models/src/payments.rs
+++ b/crates/api_models/src/payments.rs
@@ -716,7 +716,7 @@ pub struct RevenueRecoveryGetIntentResponse {
     pub status: common_enums::RecoveryStatus,
 
     /// The amount details for the payment
-    pub amount_details: AmountDetailsResponse,
+    pub amount_details: PaymentAmountDetailsResponse,
 
     /// It's a token used for client side verification.
     #[schema(value_type = String, example = "cs_0195b34da95d75239c6a4bf514458896")]
@@ -831,6 +831,10 @@ pub struct RevenueRecoveryGetIntentResponse {
     ///Will be used to expire client secret after certain amount of time to be supplied in seconds
     #[serde(with = "common_utils::custom_serde::iso8601")]
     pub expires_on: PrimitiveDateTime,
+
+    /// Time when the payment was created
+    #[serde(with = "common_utils::custom_serde::iso8601")]
+    pub created_at: PrimitiveDateTime, // Add this new field
 
     /// Additional data related to some frm(Fraud Risk Management) connectors
     #[schema(value_type = Option<Object>, example = r#"{ "coverage_request" : "fraud", "fulfillment_method" : "delivery" }"#)]

--- a/crates/router/src/core/payments/transformers.rs
+++ b/crates/router/src/core/payments/transformers.rs
@@ -2177,6 +2177,7 @@ pub fn generate_revenue_recovery_get_intent_response<F, D>(
     payment_data: D,
     recovery_status: common_enums::RecoveryStatus,
     card_attached: u32,
+    payment_attempt: Option<&storage::PaymentAttempt>,
 ) -> RevenueRecoveryGetIntentResponse
 where
     F: Clone,
@@ -2188,10 +2189,12 @@ where
     RevenueRecoveryGetIntentResponse {
         id: payment_intent.id.clone(),
         profile_id: payment_intent.profile_id.clone(),
-        status: recovery_status, // Note: field is named 'status' not 'recovery_status'
-        amount_details: api_models::payments::AmountDetailsResponse::foreign_from(
-            payment_intent.amount_details.clone(),
-        ),
+        status: recovery_status,
+        amount_details: api_models::payments::PaymentAmountDetailsResponse::foreign_from((
+            &payment_intent.amount_details,
+            payment_attempt.map(|pa| &pa.amount_details), // Same pattern as list API
+        )),
+        created_at: payment_intent.created_at,
         client_secret: client_secret.clone(),
         merchant_reference_id: payment_intent.merchant_reference_id.clone(),
         routing_algorithm_id: payment_intent.routing_algorithm_id.clone(),


### PR DESCRIPTION
…onse missing value fixes

## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->

In revenue recovery get intent and get recovery payment list had some missing values due to missing active attempt id in payment intent which is not able to get the latest attempt even though payment having a payment attempt in the db. so this pr will fix that issues and related data is been populated in the response even though there's a missing active attempt id store in the payment intent 


**API Response Improvements**
* The `RevenueRecoveryGetIntentResponse` struct now uses `PaymentAmountDetailsResponse` for the `amount_details` field, allowing it to represent both intent-level and attempt-level amount details more accurately.
```json
        "amount": {
                "order_amount": 2250,
                "currency": "USD",
                "shipping_cost": null,
                "order_tax_amount": null,
                "external_tax_calculation": "skip",
                "surcharge_calculation": "skip",
                "surcharge_amount": null,
                "tax_on_surcharge": null,
                "net_amount": 2250,
                "amount_to_capture": null,
                "amount_capturable": 0,
                "amount_captured": 0
            },

```
* Added a new `created_at` field to `RevenueRecoveryGetIntentResponse` to expose the payment creation timestamp in API responses.
```json
"created": "2025-12-02T12:24:20.076Z",
```

**Payment Attempt Selection Logic**
* Updated the logic in `revenue_recovery_get_intent_core` and `revenue_recovery_list_payments` to fetch the most relevant payment attempt for each payment intent. The selection prioritizes the active attempt if available, otherwise the most recent attempt is chosen. This ensures downstream consumers receive the correct attempt data.
* The selected payment attempt is now passed to the response transformer, enabling amount details to reflect the correct attempt or intent context. 
**Transformer Signature Update**
* The `generate_revenue_recovery_get_intent_response` function signature has been updated to accept an optional `payment_attempt`, supporting the improved amount details logic and new fields.

### Additional Changes

- [x] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Get recovery list payments api 
```
curl --location 'http://localhost:8080/v2/payments/recovery-list' \
--header 'Content-Type: application/json' \
--header 'x-profile-id: ******' \
--header 'Authorization: api-key=******'
```

response 
```json 
{
    "count": 1,
    "total_count": 1,
    "data": [
        {
            "id": "12345_pay_019adf05556570019fa6d4ce294716b6",
            "merchant_id": "cloth_seller_FNV6DwhshGLsuQLgGQfM",
            "profile_id": "pro_0uwqqjOjujEd9pIlwPaJ",
            "customer_id": null,
            "status": "scheduled",
            "amount": {
                "order_amount": 2250,
                "currency": "USD",
                "shipping_cost": null,
                "order_tax_amount": null,
                "external_tax_calculation": "skip",
                "surcharge_calculation": "skip",
                "surcharge_amount": null,
                "tax_on_surcharge": null,
                "net_amount": 2250,
                "amount_to_capture": null,
                "amount_capturable": 0,
                "amount_captured": 0
            },
            "created": "2025-12-02T12:24:20.076Z",
            "payment_method_type": "card",
            "payment_method_subtype": "credit",
            "connector": "worldpayvantiv",
            "merchant_connector_id": "mca_VAT2dYqYmtgURuqDz42a",
            "customer": null,
            "merchant_reference_id": "12453444456762",
            "description": null,
            "attempt_count": 0,
            "error": {
                "code": "No error code",
                "message": "PaymentStatusNotFound",
                "reason": "PaymentStatusNotFound",
                "unified_code": null,
                "unified_message": null,
                "network_advice_code": null,
                "network_decline_code": null,
                "network_error_message": null
            },
            "cancellation_reason": null,
            "modified_at": "2025-12-02T12:24:22.201Z",
            "last_attempt_at": "2024-05-29T08:10:58.000Z"
        }
    ]
}
```

Get revenue recovery intent 
```
curl --location 'http://localhost:8080/v2/payments/12345_pay_019adec8a8177b70ba9d7916792da9f5/get-revenue-recovery-intent' \
--header 'x-profile-id: *******' \
--header 'Authorization: api-key=*******' \
--data ''
```

response
```json 
{
    "id": "12345_pay_019adec8a8177b70ba9d7916792da9f5",
    "status": "processing",
    "amount_details": {
        "order_amount": 2250,
        "currency": "USD",
        "shipping_cost": null,
        "order_tax_amount": null,
        "external_tax_calculation": "skip",
        "surcharge_calculation": "skip",
        "surcharge_amount": null,
        "tax_on_surcharge": null,
        "net_amount": 2250,
        "amount_to_capture": null,
        "amount_capturable": 2250,
        "amount_captured": 2250
    },
    "client_secret": null,
    "profile_id": "pro_0uwqqjOjujEd9pIlwPaJ",
    "merchant_reference_id": "12453444456762",
    "routing_algorithm_id": null,
    "capture_method": "automatic",
    "authentication_type": "no_three_ds",
    "billing": {
        "address": {
            "city": null,
            "country": "US",
            "line1": null,
            "line2": null,
            "line3": null,
            "zip": null,
            "state": "CA",
            "first_name": null,
            "last_name": null,
            "origin_zip": null
        },
        "phone": null,
        "email": null
    },
    "shipping": null,
    "customer_id": null,
    "customer_present": "present",
    "description": null,
    "return_url": null,
    "setup_future_usage": "off_session",
    "apply_mit_exemption": "Skip",
    "statement_descriptor": null,
    "order_details": null,
    "allowed_payment_method_types": null,
    "metadata": null,
    "connector_metadata": null,
    "feature_metadata": {
        "redirect_response": null,
        "search_tags": null,
        "apple_pay_recurring_details": null,
        "revenue_recovery": {
            "total_retry_count": 2,
            "payment_connector_transmission": "ConnectorCallSucceeded",
            "billing_connector_id": "mca_6GovbAMzXHjCpkmnGUsE",
            "active_attempt_payment_connector_id": "mca_VAT2dYqYmtgURuqDz42a",
            "billing_connector_payment_details": {
                "payment_processor_token": "271349160840009",
                "connector_customer_id": "853818"
            },
            "payment_method_type": "card",
            "payment_method_subtype": "credit",
            "connector": "worldpayvantiv",
            "billing_connector_payment_method_details": {
                "type": "card",
                "value": {
                    "card_network": "AmericanExpress",
                    "card_issuer": "Wells Fargo"
                }
            },
            "invoice_next_billing_time": null,
            "invoice_billing_started_at_time": null,
            "first_payment_attempt_pg_error_code": "No error code",
            "first_payment_attempt_network_decline_code": null,
            "first_payment_attempt_network_advice_code": null
        }
    },
    "payment_link_enabled": "Skip",
    "payment_link_config": null,
    "request_incremental_authorization": "false",
    "split_txns_enabled": "skip",
    "expires_on": "2025-12-02T11:33:03.544Z",
    "created_at": "2025-12-02T11:18:03.544Z",
    "frm_metadata": null,
    "request_external_three_ds_authentication": "Skip",
    "enable_partial_authorization": null,
    "card_attached": 3
}
```


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
