### PR TITLE
feat(webhooks): add payment methods related flows to analytics event tracking and IncomingWebhookReceive flow to refunds analytics filter

### DIFF
--- a/crates/analytics/src/api_event/events.rs
+++ b/crates/analytics/src/api_event/events.rs
@@ -53,6 +53,9 @@ where
                         Flow::AttachDisputeEvidence,
                         Flow::RetrieveDisputeEvidence,
                         Flow::IncomingWebhookReceive,
+                        Flow::PaymentMethodsList,
+                        Flow::CustomerPaymentMethodsList,
+                        Flow::PaymentsSessionToken,
                     ],
                 )
                 .switch()?;
@@ -68,7 +71,14 @@ where
                 .add_filter_clause("refund_id", refund_id)
                 .switch()?;
             query_builder
-                .add_filter_in_range_clause("api_flow", &[Flow::RefundsCreate, Flow::RefundsUpdate])
+                .add_filter_in_range_clause(
+                    "api_flow",
+                    &[
+                        Flow::RefundsCreate,
+                        Flow::RefundsUpdate,
+                        Flow::IncomingWebhookReceive,
+                    ],
+                )
                 .switch()?;
         }
         QueryType::Dispute {

--- a/crates/api_models/src/webhooks.rs
+++ b/crates/api_models/src/webhooks.rs
@@ -177,7 +177,7 @@ pub enum WebhookResponseTracker {
     #[cfg(feature = "v2")]
     Refund {
         payment_id: common_utils::id_type::GlobalPaymentId,
-        refund_id: String,
+        refund_id: common_utils::id_type::GlobalRefundId,
         status: common_enums::RefundStatus,
     },
     #[cfg(feature = "v1")]
@@ -223,6 +223,14 @@ impl WebhookResponseTracker {
     }
 
     #[cfg(feature = "v1")]
+    pub fn get_refund_id(&self) -> Option<String> {
+        match self {
+            Self::Refund { refund_id, .. } => Some(refund_id.to_owned()),
+            _ => None,
+        }
+    }
+
+    #[cfg(feature = "v1")]
     pub fn get_payment_method_id(&self) -> Option<String> {
         match self {
             Self::PaymentMethod {
@@ -249,6 +257,14 @@ impl WebhookResponseTracker {
             #[cfg(feature = "payouts")]
             Self::Payout { .. } => None,
             Self::Relay { .. } => None,
+        }
+    }
+
+    #[cfg(feature = "v2")]
+    pub fn get_refund_id(&self) -> Option<common_utils::id_type::GlobalRefundId> {
+        match self {
+            Self::Refund { refund_id, .. } => Some(refund_id.to_owned()),
+            _ => None,
         }
     }
 }

--- a/crates/common_utils/src/events.rs
+++ b/crates/common_utils/src/events.rs
@@ -74,6 +74,7 @@ pub enum ApiEventsType {
     Webhooks {
         connector: String,
         payment_id: Option<id_type::PaymentId>,
+        refund_id: Option<String>,
     },
     #[cfg(feature = "v1")]
     NetworkTokenWebhook {
@@ -83,6 +84,7 @@ pub enum ApiEventsType {
     Webhooks {
         connector: id_type::MerchantConnectorAccountId,
         payment_id: Option<id_type::GlobalPaymentId>,
+        refund_id: Option<id_type::GlobalRefundId>,
     },
     Routing,
     Subscription,

--- a/crates/router/src/core/webhooks/incoming.rs
+++ b/crates/router/src/core/webhooks/incoming.rs
@@ -107,6 +107,7 @@ pub async fn incoming_webhooks_wrapper<W: types::OutgoingWebhookType>(
     let api_event = ApiEventsType::Webhooks {
         connector: connector_name_or_mca_id.to_string(),
         payment_id: webhooks_response_tracker.get_payment_id(),
+        refund_id: webhooks_response_tracker.get_refund_id(),
     };
     let response_value = serde_json::to_value(&webhooks_response_tracker)
         .change_context(errors::ApiErrorResponse::InternalServerError)

--- a/crates/router/src/core/webhooks/incoming_v2.rs
+++ b/crates/router/src/core/webhooks/incoming_v2.rs
@@ -92,6 +92,7 @@ pub async fn incoming_webhooks_wrapper<W: types::OutgoingWebhookType>(
     let api_event = ApiEventsType::Webhooks {
         connector: connector_id.clone(),
         payment_id: webhooks_response_tracker.get_payment_id(),
+        refund_id: webhooks_response_tracker.get_refund_id(),
     };
     let response_value = serde_json::to_value(&webhooks_response_tracker)
         .change_context(errors::ApiErrorResponse::InternalServerError)


### PR DESCRIPTION
## Type of Change
- [ ] Bugfix
- [x] New feature
- [x] Enhancement
- [ ] Breaking change
- [ ] Refactor

## Description

This PR enhances audit trail visibility by adding new API flow types in payment audit trail and improves webhook traceability by including refund identifiers in webhook event tracking. It also strengthens type safety across refund-related flows.

## Key Changes

1. **Added new API flow tracking in analytics/audit trail:**
   - `PaymentMethodsList`
   - `CustomerPaymentMethodsList`
   - `PaymentsSessionToken`
   - `IncomingWebhookReceive`

2. **Added refund_id support in webhook audit events:**
   - v1: `String`
   - v2: `GlobalRefundId`

3. **Webhook handlers (v1 & v2) enriched to include refund_id**  
   Ensures refund webhook events can be linked to specific refund transactions.

4. **Improved type safety:**
   - Updated `WebhookResponseTracker::Refund` in v2 to use `GlobalRefundId`
   - Added helper methods to read refund_id consistently across v1/v2 flows

## Motivation and Context

Several API flows were previously missing in the audit trail, making debugging and monitoring difficult. Refund webhook events also lacked `refund_id`, preventing full traceability of refund operations.  
This PR introduces the missing audit events and adds refund identifiers to webhook logs to close these gaps.

## Use Cases

- Audit trail now shows payment method–related API calls (`PaymentMethodsList`, `CustomerPaymentMethodsList`)
- `PaymentsSessionToken` generation is now fully tracked
- Incoming webhook events include `refund_id` when applicable
- Refund-related issues can be traced end-to-end in the audit trail

## How did you test it?

- Verified audit trail entries for new flow types in payment:

<img width="2355" alt="Screenshot 2025-12-05 at 2 32 55 PM" src="https://github.com/user-attachments/assets/3a920bd5-60da-4111-9948-9be752117e68" />

- Verified refund webhook events calling api call for the `IncomingWebhookReceive`

<img width="2243" alt="Screenshot 2025-12-05 at 2 35 51 PM" src="https://github.com/user-attachments/assets/e9946003-78c4-4e79-bf5e-54d7cfee8cd5" />

## Impact

- Improved audit trail completeness for key payment flows  
- Refund webhooks now provide full traceability with refund_id  
- Stronger type guarantees with `GlobalRefundId` in v2  
- Backward compatible through v1/v2 feature-gating

## Checklist
- [x] I formatted the code (`cargo +nightly fmt --all`)
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [x] I added unit tests for my changes where possible
