### PR TITLE
feat: add associated_payment_method_id to payment method session confirm response

### DIFF
--- a/crates/api_models/src/payment_methods.rs
+++ b/crates/api_models/src/payment_methods.rs
@@ -3412,6 +3412,11 @@ pub struct NetworkTokenStatusCheckSuccessResponse {
     /// The customer ID associated with the payment method
     #[schema(value_type = String, example = "12345_cus_0195dc62bb8e7312a44484536da76aef")]
     pub customer_id: id_type::GlobalCustomerId,
+
+    /// The payment method ID that was created during this session confirmation
+    /// This can be used with the proxy endpoint using token_type: "payment_method_id"
+    #[schema(value_type = Option<String>, example = "12345_pm_01926c58bc6e77c09e809964e72af8c8")]
+    pub associated_payment_method_id: Option<id_type::GlobalPaymentMethodId>,
 }
 
 #[cfg(feature = "v2")]

--- a/crates/router/src/core/payment_methods.rs
+++ b/crates/router/src/core/payment_methods.rs
@@ -3296,6 +3296,7 @@ pub async fn payment_methods_session_create(
         client_secret.secret,
         None,
         None,
+        None,
     );
 
     Ok(services::ApplicationResponse::Json(response))
@@ -3363,6 +3364,7 @@ pub async fn payment_methods_session_update(
         Secret::new("CLIENT_SECRET_REDACTED".to_string()),
         None, // TODO: send associated payments response based on the expandable param
         None,
+        None,
     );
 
     Ok(services::ApplicationResponse::Json(response))
@@ -3390,6 +3392,7 @@ pub async fn payment_methods_session_retrieve(
         payment_method_session_domain_model,
         Secret::new("CLIENT_SECRET_REDACTED".to_string()),
         None, // TODO: send associated payments response based on the expandable param
+        None,
         None,
     );
 
@@ -3717,6 +3720,7 @@ pub async fn payment_methods_session_confirm(
         Secret::new("CLIENT_SECRET_REDACTED".to_string()),
         payments_response,
         (tokenization_response.flatten()),
+        Some(payment_method.id.clone()),
     );
 
     Ok(services::ApplicationResponse::Json(

--- a/crates/router/src/core/payment_methods/transformers.rs
+++ b/crates/router/src/core/payment_methods/transformers.rs
@@ -1069,6 +1069,7 @@ pub fn generate_payment_method_session_response(
     client_secret: Secret<String>,
     associated_payment: Option<api_models::payments::PaymentsResponse>,
     tokenization_service_response: Option<api_models::tokenization::GenericTokenizationResponse>,
+    payment_method_id: Option<id_type::GlobalPaymentMethodId>,
 ) -> api_models::payment_methods::PaymentMethodSessionResponse {
     let next_action = associated_payment
         .as_ref()
@@ -1103,6 +1104,7 @@ pub fn generate_payment_method_session_response(
         associated_payment_methods: payment_method_session.associated_payment_methods,
         authentication_details,
         associated_token_id: token_id,
+        associated_payment_method_id: payment_method_id,
     }
 }
 


### PR DESCRIPTION
…irm response

## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
Include the payment_method_id in the response returned by the payment-method-sessions/confirm endpoint.
Fixes https://github.com/juspay/hyperswitch/issues/10573

### Additional Changes

- [x] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
The /v2/payment-method-sessions/{id}/confirm endpoint returns associated_payment_methods containing temporary Redis tokens (e.g., "token_KpNynVfRrSoFound1nec"). These are for internal web SDK use and cannot be used with the proxy endpoint or other APIs that require permanent identifiers.
The proxy endpoint requires:
token_type: "payment_method_id" with a permanent payment method ID (e.g., 12345_pm_...)
token_type: "tokenization_id" with a tokenization ID (e.g., 12345_tok_...)
Since a payment method is created during session confirmation, we should include the permanent payment_method_id in the response so it can be used with the proxy endpoint and other APIs.
Use case:
After confirming a payment method session, users can now use associated_payment_method_id in the proxy endpoint:
{  "token": "12345_pm_01926c58bc6e77c09e809964e72af8c8",  "token_type": "payment_method_id"}

This change is backward compatible as the new field is optional and doesn't break existing clients.


## How did you test it?
<img width="978" height="845" alt="image" src="https://github.com/user-attachments/assets/f040e773-2111-47d7-8088-66d571afcfb4" />



## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
