### PR TITLE
feat(connector): Add transaction_code support across Zift payment flows

### DIFF
--- a/crates/hyperswitch_connectors/src/connectors/zift/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/zift/transformers.rs
@@ -135,6 +135,7 @@ pub struct ZiftCardPaymentRequest {
     account_type: AccountType,
     account_number: cards::CardNumber,
     account_accessory: Secret<String>,
+    transaction_code: String,
     csc: Secret<String>,
     transaction_industry_type: TransactionIndustryType,
     holder_name: Secret<String>,
@@ -171,6 +172,7 @@ pub struct ZiftMandatePaymentRequest {
     holder_type: HolderType,
     amount: StringMinorUnit,
     transaction_mode_type: TransactionModeType,
+    transaction_code: String,
 
     // Required for MIT
     transaction_category_type: TransactionCategoryType,
@@ -205,6 +207,7 @@ pub struct ZiftExternalThreeDsPaymentRequest {
     transaction_industry_type: TransactionIndustryType,
     holder_name: Secret<String>,
     holder_type: HolderType,
+    transaction_code: String,
     amount: StringMinorUnit,
     // 3DS authentication fields
     authentication_status: AuthenticationStatus,
@@ -332,6 +335,7 @@ impl TryFrom<&ZiftRouterData<&PaymentsAuthorizeRouterData>> for ZiftPaymentsRequ
                         country_code: item.router_data.get_optional_billing_country(),
                         email: item.router_data.get_optional_billing_email(),
                         phone: item.router_data.get_optional_billing_phone_number(),
+                        transaction_code: item.router_data.connector_request_reference_id.clone(),
                     };
                     Ok(Self::ExternalThreeDs(external_3ds_request))
                 } else {
@@ -353,6 +357,7 @@ impl TryFrom<&ZiftRouterData<&PaymentsAuthorizeRouterData>> for ZiftPaymentsRequ
                         country_code: item.router_data.get_optional_billing_country(),
                         email: item.router_data.get_optional_billing_email(),
                         phone: item.router_data.get_optional_billing_phone_number(),
+                        transaction_code: item.router_data.connector_request_reference_id.clone(),
                     };
                     Ok(Self::Card(card_request))
                 }
@@ -396,6 +401,7 @@ impl TryFrom<&ZiftRouterData<&PaymentsAuthorizeRouterData>> for ZiftPaymentsRequ
                     country_code: item.router_data.get_optional_billing_country(),
                     email: item.router_data.get_optional_billing_email(),
                     phone: item.router_data.get_optional_billing_phone_number(),
+                    transaction_code: item.router_data.connector_request_reference_id.clone(),
                 };
                 Ok(Self::Mandate(mandate_request))
             }
@@ -437,6 +443,7 @@ pub struct ZiftAuthPaymentsResponse {
     pub response_code: String,
     pub response_message: String,
     pub transaction_id: Option<i64>,
+    pub transaction_code: Option<String>,
     pub token: Option<String>,
 }
 
@@ -548,7 +555,7 @@ impl<F>
                     mandate_reference,
                     connector_metadata: None,
                     network_txn_id: None,
-                    connector_response_reference_id: None,
+                    connector_response_reference_id: item.response.transaction_code.clone(),
                     incremental_authorization_allowed: None,
                     charges: None,
                 }),


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->
hotfix https://github.com/juspay/hyperswitch/pull/10581
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
This PR introduces transaction_code as a first-class field across all Zift payment request types and adds it to relevant responses.
This enables better cross-referencing between Hyperswitch and Zift by passing through our internal payment_id into Zift requests and retrieving it back from responses.

### Additional Changes

- [x] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Verify the reference_id in the response

CIT
```
curl --location 'http://localhost:8080/payments' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: dev_anY9KHyqO06nkPg8AuKycs9Y3PEWXAuWwPvAax62rdOjDFsnPKyuriIY8gPOQs17' \
--data-raw '{
    "amount": 5000,
    "currency": "USD",
    "payment_id":"43423121-123111111",
    "confirm": true,
    "business_country": "US",
    "business_label": "default",
    
    "customer_id": "cu_1757579182",
    "capture_method": "automatic",
    "capture_on": "2022-09-10T10:11:12Z",
    "setup_future_usage": "off_session",
    "authentication_type": "no_three_ds",
    "return_url": "https://google.com",
    "email": "something@gmail.com",
    "name": "Joseph Doe",
    "phone": "999999999",
    "phone_country_code": "+65",
    "description": "Its my first payment request",
    "statement_descriptor_name": "Juspay",
    "statement_descriptor_suffix": "Router",
    "payment_method": "card",
    "payment_method_type": "credit",
    "payment_method_data": {
        "card": {
            "card_number": "4111111111111111",
            "card_exp_month": "04",
            "card_exp_year": "2026",
            "card_holder_name": "John Smith",
            "card_cvc": "123"
        }
    },
    "customer_acceptance": {
        "acceptance_type": "offline",
        "accepted_at": "1963-05-03T04:07:52.723Z",
        "online": {
            "ip_address": "in sit",
            "user_agent": "amet irure esse"
        }
    }
}'
```
Response
```
{
    "payment_id": "43423121-123111111",
    "merchant_id": "merchant_1765263539",
    "status": "succeeded",
    "amount": 5000,
    "net_amount": 5000,
    "shipping_cost": null,
    "amount_capturable": 0,
    "amount_received": 5000,
    "connector": "zift",
    "client_secret": "43423121-123111111_secret_0WDjiRI71qmsCoqGLkkP",
    "created": "2025-12-09T09:33:01.803Z",
    "modified_at": "2025-12-09T09:33:02.845Z",
    "currency": "USD",
    "customer_id": "cu_1757579182",
    "customer": {
        "id": "cu_1757579182",
        "name": "Joseph Doe",
        "email": "something@gmail.com",
        "phone": "999999999",
        "phone_country_code": "+65"
    },
    "description": "Its my first payment request",
    "refunds": null,
    "disputes": null,
    "mandate_id": null,
    "mandate_data": null,
    "setup_future_usage": "off_session",
    "off_session": null,
    "capture_on": null,
    "capture_method": "automatic",
    "payment_method": "card",
    "payment_method_data": {
        "card": {
            "last4": "1111",
            "card_type": null,
            "card_network": null,
            "card_issuer": null,
            "card_issuing_country": null,
            "card_isin": "411111",
            "card_extended_bin": null,
            "card_exp_month": "04",
            "card_exp_year": "2026",
            "card_holder_name": "John Smith",
            "payment_checks": null,
            "authentication_data": null
        },
        "billing": null
    },
    "payment_token": null,
    "shipping": null,
    "billing": null,
    "order_details": null,
    "email": "something@gmail.com",
    "name": "Joseph Doe",
    "phone": "999999999",
    "return_url": "https://google.com/",
    "authentication_type": "no_three_ds",
    "statement_descriptor_name": "Juspay",
    "statement_descriptor_suffix": "Router",
    "next_action": null,
    "cancellation_reason": null,
    "error_code": null,
    "error_message": null,
    "unified_code": null,
    "unified_message": null,
    "payment_experience": null,
    "payment_method_type": "credit",
    "connector_label": "zift_US_default",
    "business_country": "US",
    "business_label": "default",
    "business_sub_label": null,
    "allowed_payment_method_types": null,
    "ephemeral_key": {
        "customer_id": "cu_1757579182",
        "created_at": 1765272781,
        "expires": 1765276381,
        "secret": "epk_27f46382bc3540d0a86e37fad081e9e9"
    },
    "manual_retry_allowed": null,
    "connector_transaction_id": "8617335562",
    "frm_message": null,
    "metadata": null,
    "connector_metadata": null,
    "feature_metadata": {
        "redirect_response": null,
        "search_tags": null,
        "apple_pay_recurring_details": null,
        "gateway_system": "direct"
    },
    **"reference_id": "43423121-123111111_1"**,
    "payment_link": null,
    "profile_id": "pro_hOJSHGH8OhzP3Vp6LAXu",
    "surcharge_details": null,
    "attempt_count": 1,
    "merchant_decision": null,
    "merchant_connector_id": "mca_9ZvQkICQku3HCEWV3bb0",
    "incremental_authorization_allowed": false,
    "authorization_count": null,
    "incremental_authorizations": null,
    "external_authentication_details": null,
    "external_3ds_authentication_attempted": false,
    "expires_on": "2025-12-09T09:48:01.803Z",
    "fingerprint": null,
    "browser_info": null,
    "payment_channel": null,
    "payment_method_id": "pm_VtUS5m9aJnsDP9HkDg5y",
    "network_transaction_id": null,
    "payment_method_status": "active",
    "updated": "2025-12-09T09:33:02.845Z",
    "split_payments": null,
    "frm_metadata": null,
    "extended_authorization_applied": null,
    "extended_authorization_last_applied_at": null,
    "request_extended_authorization": null,
    "capture_before": null,
    "merchant_order_reference_id": null,
    "order_tax_amount": null,
    "connector_mandate_id": "VC10000000000015541111",
    "card_discovery": "manual",
    "force_3ds_challenge": false,
    "force_3ds_challenge_trigger": false,
    "issuer_error_code": null,
    "issuer_error_message": null,
    "is_iframe_redirection_enabled": null,
    "whole_connector_response": null,
    "enable_partial_authorization": null,
    "enable_overcapture": null,
    "is_overcapture_enabled": null,
    "network_details": null,
    "is_stored_credential": null,
    "mit_category": null,
    "billing_descriptor": null,
    "tokenization": null,
    "partner_merchant_identifier_details": null,
    "payment_method_tokenization_details": {
        "payment_method_id": "pm_VtUS5m9aJnsDP9HkDg5y",
        "payment_method_status": "active",
        "psp_tokenization": false,
        "network_tokenization": false,
        "network_transaction_id": null,
        "is_eligible_for_mit_payment": false
    }
}
```
MIT
````
curl --location 'http://localhost:8080/payments' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: dev_anY9KHyqO06nkPg8AuKycs9Y3PEWXAuWwPvAax62rdOjDFsnPKyuriIY8gPOQs17' \
--data '{
    "recurring_details": {
        "type": "payment_method_id",
        "data": "pm_mepGuLufz88sFGxdqc7K"
    },
"payment_id":"3123212",
    "customer": {
        "id": "cu_1757579182"
    },
    "description": "This is the test payment made through Mule API",
    "currency": "USD",
    "amount": 1216,
    "confirm": true,
    "capture_method": "automatic",
    "off_session": true
}'
```
Response
```
{
    "payment_id": "3123212",
    "merchant_id": "merchant_1765263539",
    "status": "succeeded",
    "amount": 1216,
    "net_amount": 1216,
    "shipping_cost": null,
    "amount_capturable": 0,
    "amount_received": 1216,
    "connector": "zift",
    "client_secret": "3123212_secret_R1N1o9IX8gKG722hizj5",
    "created": "2025-12-09T09:34:05.001Z",
    "modified_at": "2025-12-09T09:34:05.656Z",
    "currency": "USD",
    "customer_id": "cu_1757579182",
    "customer": {
        "id": "cu_1757579182",
        "name": "Joseph Doe",
        "email": "something@gmail.com",
        "phone": "999999999",
        "phone_country_code": "+65"
    },
    "description": "This is the test payment made through Mule API",
    "refunds": null,
    "disputes": null,
    "mandate_id": null,
    "mandate_data": null,
    "setup_future_usage": null,
    "off_session": true,
    "capture_on": null,
    "capture_method": "automatic",
    "payment_method": "card",
    "payment_method_data": {
        "card": {
            "last4": "1111",
            "card_type": null,
            "card_network": null,
            "card_issuer": null,
            "card_issuing_country": null,
            "card_isin": "411111",
            "card_extended_bin": null,
            "card_exp_month": "04",
            "card_exp_year": "2026",
            "card_holder_name": "John Smith",
            "payment_checks": null,
            "authentication_data": null
        },
        "billing": null
    },
    "payment_token": null,
    "shipping": null,
    "billing": null,
    "order_details": null,
    "email": "something@gmail.com",
    "name": "Joseph Doe",
    "phone": "999999999",
    "return_url": null,
    "authentication_type": "no_three_ds",
    "statement_descriptor_name": null,
    "statement_descriptor_suffix": null,
    "next_action": null,
    "cancellation_reason": null,
    "error_code": null,
    "error_message": null,
    "unified_code": null,
    "unified_message": null,
    "payment_experience": null,
    "payment_method_type": "credit",
    "connector_label": null,
    "business_country": null,
    "business_label": "default",
    "business_sub_label": null,
    "allowed_payment_method_types": null,
    "ephemeral_key": {
        "customer_id": "cu_1757579182",
        "created_at": 1765272844,
        "expires": 1765276444,
        "secret": "epk_c900faf39b784a70afeafd1da1bd3c6d"
    },
    "manual_retry_allowed": null,
    "connector_transaction_id": "8617335572",
    "frm_message": null,
    "metadata": null,
    "connector_metadata": null,
    "feature_metadata": {
        "redirect_response": null,
        "search_tags": null,
        "apple_pay_recurring_details": null,
        "gateway_system": "direct"
    },
    "reference_id": "3123212_1",
    "payment_link": null,
    "profile_id": "pro_hOJSHGH8OhzP3Vp6LAXu",
    "surcharge_details": null,
    "attempt_count": 1,
    "merchant_decision": null,
    "merchant_connector_id": "mca_9ZvQkICQku3HCEWV3bb0",
    "incremental_authorization_allowed": false,
    "authorization_count": null,
    "incremental_authorizations": null,
    "external_authentication_details": null,
    "external_3ds_authentication_attempted": false,
    "expires_on": "2025-12-09T09:49:05.001Z",
    "fingerprint": null,
    "browser_info": null,
    "payment_channel": null,
    "payment_method_id": "pm_mepGuLufz88sFGxdqc7K",
    "network_transaction_id": null,
    "payment_method_status": "active",
    "updated": "2025-12-09T09:34:05.656Z",
    "split_payments": null,
    "frm_metadata": null,
    "extended_authorization_applied": null,
    "extended_authorization_last_applied_at": null,
    "request_extended_authorization": null,
    "capture_before": null,
    "merchant_order_reference_id": null,
    "order_tax_amount": null,
    "connector_mandate_id": "VC10000000000015541111",
    "card_discovery": "manual",
    "force_3ds_challenge": false,
    "force_3ds_challenge_trigger": false,
    "issuer_error_code": null,
    "issuer_error_message": null,
    "is_iframe_redirection_enabled": null,
    "whole_connector_response": null,
    "enable_partial_authorization": null,
    "enable_overcapture": null,
    "is_overcapture_enabled": null,
    "network_details": null,
    "is_stored_credential": true,
    "mit_category": null,
    "billing_descriptor": null,
    "tokenization": null,
    "partner_merchant_identifier_details": null,
    "payment_method_tokenization_details": {
        "payment_method_id": "pm_mepGuLufz88sFGxdqc7K",
        "payment_method_status": "active",
        "psp_tokenization": true,
        "network_tokenization": false,
        "network_transaction_id": null,
        "is_eligible_for_mit_payment": true
    }
}
```

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
