### PR TITLE
fix(connector): Correct card brand mapping to match supported network list

### DIFF
--- a/crates/hyperswitch_connectors/src/connectors/nuvei/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/nuvei/transformers.rs
@@ -3415,13 +3415,9 @@ impl NuveiAmountExt for MinorUnit {
 pub enum NuveiCardType {
     Visa,
     MasterCard,
-    AmericanExpress,
+    Amex,
     Discover,
-    DinersClub,
-    Interac,
-    JCB,
-    UnionPay,
-    CartesBancaires,
+    Diners,
 }
 
 impl TryFrom<common_enums::CardNetwork> for NuveiCardType {
@@ -3430,13 +3426,9 @@ impl TryFrom<common_enums::CardNetwork> for NuveiCardType {
         match card_network {
             common_enums::CardNetwork::Visa => Ok(Self::Visa),
             common_enums::CardNetwork::Mastercard => Ok(Self::MasterCard),
-            common_enums::CardNetwork::AmericanExpress => Ok(Self::AmericanExpress),
+            common_enums::CardNetwork::AmericanExpress => Ok(Self::Amex),
             common_enums::CardNetwork::Discover => Ok(Self::Discover),
-            common_enums::CardNetwork::DinersClub => Ok(Self::DinersClub),
-            common_enums::CardNetwork::JCB => Ok(Self::JCB),
-            common_enums::CardNetwork::UnionPay => Ok(Self::UnionPay),
-            common_enums::CardNetwork::CartesBancaires => Ok(Self::CartesBancaires),
-            common_enums::CardNetwork::Interac => Ok(Self::Interac),
+            common_enums::CardNetwork::DinersClub => Ok(Self::Diners),
             _ => Err(errors::ConnectorError::NotSupported {
                 message: "Card network".to_string(),
                 connector: "nuvei",
@@ -3452,12 +3444,9 @@ impl TryFrom<&utils::CardIssuer> for NuveiCardType {
         match card_issuer {
             utils::CardIssuer::Visa => Ok(Self::Visa),
             utils::CardIssuer::Master => Ok(Self::MasterCard),
-            utils::CardIssuer::AmericanExpress => Ok(Self::AmericanExpress),
+            utils::CardIssuer::AmericanExpress => Ok(Self::Amex),
             utils::CardIssuer::Discover => Ok(Self::Discover),
-            utils::CardIssuer::DinersClub => Ok(Self::DinersClub),
-            utils::CardIssuer::JCB => Ok(Self::JCB),
-            utils::CardIssuer::CartesBancaires => Ok(Self::CartesBancaires),
-            &utils::CardIssuer::UnionPay => Ok(Self::UnionPay),
+            utils::CardIssuer::DinersClub => Ok(Self::Diners),
             _ => Err(errors::ConnectorError::NotSupported {
                 message: "Card network".to_string(),
                 connector: "nuvei",


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
This PR fixes the Nuvei card brand mapping by aligning our NuveiCardType enum and its corresponding TryFrom implementations with the actual list of card brands supported by Nuvei.

Background

Nuvei supports the following card brands (per API documentation):

VISA
MASTERCARD
AMEX
DINERS
DISCOVER
<img width="1104" height="379" alt="Screenshot 2025-12-10 at 2 53 38 PM" src="https://github.com/user-attachments/assets/6d20a6e9-b4fb-4539-9664-263d5432ff5b" />

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
NTID Request
```
curl --location 'http://localhost:8080/payments' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: dev_h76UGpWcPR1GEZvNPOf8Ki3n47nysfd9Hbjv9KW1qpREer3BoAHAQJdeaQhxkn1s' \
--data-raw '
{
    "amount": 10023,
    "currency": "EUR",
    "confirm": true,
    "customer_id": "nithxxinn",
    "return_url": "https://www.google.com",
    "capture_method": "automatic",
    "authentication_type": "no_three_ds",
    "description": "hellow world",
    "billing": {
        "address": {
            "zip": "560095",
            "country": "US",
            "first_name": "Sakil",
            "last_name": "Mostak",
            "line1": "Fasdf",
            "line2": "Fasdf",
            "city": "Fasdf"
        }
    },
    "browser_info": {
        "accept_header": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
        "ip_address": "192.168.1.1",
        "java_enabled": false,
        "java_script_enabled": true,
        "language": "en-US",
        "color_depth": 24,
        "screen_height": 1080,
        "screen_width": 1920,
        "time_zone": 330,
        "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36"
    },
    "email": "hello@gmail.com",
    "payment_method": "card",
    "payment_method_type": "credit",
    "off_session": true,
    "recurring_details": {
        "type": "network_transaction_id_and_card_details",
        "data": {
            "card_number": "4242424242424242",
            "card_exp_month": "03",
            "card_exp_year": "2030",
            "card_network":"Discover",
            "network_transaction_id": "347561493133251757587"
        }
    }
}
'
```
Response
```
{
    "payment_id": "pay_MrqqAuHSTchoE6s1WV7q",
    "merchant_id": "postman_merchant_GHAction_6c42a4eb-a0b4-4107-8fe8-0bdfa8e84654",
    "status": "succeeded",
    "amount": 10023,
    "net_amount": 10023,
    "shipping_cost": null,
    "amount_capturable": 0,
    "amount_received": 10023,
    "connector": "nuvei",
    "client_secret": "pay_MrqqAuHSTchoE6s1WV7q_secret_cUbHFPflPtOSm8RkWX2W",
    "created": "2025-12-10T09:19:13.894Z",
    "modified_at": "2025-12-10T09:19:16.512Z",
    "currency": "EUR",
    "customer_id": null,
    "customer": {
        "id": null,
        "name": null,
        "email": "hello@gmail.com",
        "phone": null,
        "phone_country_code": null
    },
    "description": "hellow world",
    "refunds": null,
    "disputes": null,
    "mandate_id": null,
    "mandate_data": null,
    "setup_future_usage": null,
    "off_session": true,
    "capture_on": null,
    "capture_method": "automatic",
    "payment_method": "card",
    "payment_method_data": {
        "card": {
            "last4": "4242",
            "card_type": null,
            "card_network": null,
            "card_issuer": null,
            "card_issuing_country": null,
            "card_isin": "424242",
            "card_extended_bin": null,
            "card_exp_month": "03",
            "card_exp_year": "2030",
            "card_holder_name": null,
            "payment_checks": null,
            "authentication_data": null
        },
        "billing": null
    },
    "payment_token": null,
    "shipping": null,
    "billing": {
        "address": {
            "city": "Fasdf",
            "country": "US",
            "line1": "Fasdf",
            "line2": "Fasdf",
            "line3": null,
            "zip": "560095",
            "state": null,
            "first_name": "Sakil",
            "last_name": "Mostak",
            "origin_zip": null
        },
        "phone": null,
        "email": null
    },
    "order_details": null,
    "email": null,
    "name": null,
    "phone": null,
    "return_url": "https://www.google.com/",
    "authentication_type": "no_three_ds",
    "statement_descriptor_name": null,
    "statement_descriptor_suffix": null,
    "next_action": null,
    "cancellation_reason": null,
    "error_code": null,
    "error_message": null,
    "unified_code": null,
    "unified_message": null,
    "payment_experience": null,
    "payment_method_type": null,
    "connector_label": null,
    "business_country": null,
    "business_label": "default",
    "business_sub_label": null,
    "allowed_payment_method_types": null,
    "manual_retry_allowed": null,
    "connector_transaction_id": "8110000000020112999",
    "frm_message": null,
    "metadata": null,
    "connector_metadata": null,
    "feature_metadata": null,
    "reference_id": "11322340111",
    "payment_link": null,
    "profile_id": "pro_5fdmh7BAbGMtIeCpUocc",
    "surcharge_details": null,
    "attempt_count": 1,
    "merchant_decision": null,
    "merchant_connector_id": "mca_W7LVozpPhXqfy34NNw8z",
    "incremental_authorization_allowed": false,
    "authorization_count": null,
    "incremental_authorizations": null,
    "external_authentication_details": null,
    "external_3ds_authentication_attempted": false,
    "expires_on": "2025-12-10T09:34:13.894Z",
    "fingerprint": null,
    "browser_info": {
        "language": "en-US",
        "time_zone": 330,
        "ip_address": "192.168.1.1",
        "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36",
        "color_depth": 24,
        "java_enabled": false,
        "screen_width": 1920,
        "accept_header": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
        "screen_height": 1080,
        "java_script_enabled": true
    },
    "payment_channel": null,
    "payment_method_id": null,
    "network_transaction_id": "347561493133251757587",
    "payment_method_status": null,
    "updated": "2025-12-10T09:19:16.512Z",
    "split_payments": null,
    "frm_metadata": null,
    "extended_authorization_applied": null,
    "extended_authorization_last_applied_at": null,
    "request_extended_authorization": null,
    "capture_before": null,
    "merchant_order_reference_id": null,
    "order_tax_amount": null,
    "connector_mandate_id": null,
    "card_discovery": "manual",
    "force_3ds_challenge": false,
    "force_3ds_challenge_trigger": false,
    "issuer_error_code": null,
    "issuer_error_message": null,
    "is_iframe_redirection_enabled": null,
    "whole_connector_response": null,
    "enable_partial_authorization": null,
    "enable_overcapture": null,
    "is_overcapture_enabled": null,
    "network_details": null,
    "is_stored_credential": true,
    "mit_category": null,
    "billing_descriptor": null,
    "tokenization": null,
    "partner_merchant_identifier_details": null,
    "payment_method_tokenization_details": null
}
```
<img width="1075" height="728" alt="Screenshot 2025-12-10 at 10 23 19 PM" src="https://github.com/user-attachments/assets/01d7b286-34a4-4ba8-aaed-7adbef053891" />
<img width="1061" height="757" alt="Screenshot 2025-12-10 at 10 23 26 PM" src="https://github.com/user-attachments/assets/5aeeb0e8-af15-4e30-a19b-dffaf2123f4f" />
<img width="980" height="776" alt="Screenshot 2025-12-10 at 10 23 35 PM" src="https://github.com/user-attachments/assets/f11f6351-4913-4b45-94b0-d7d2db89b1d8" />
<img width="906" height="413" alt="Screenshot 2025-12-10 at 10 23 40 PM" src="https://github.com/user-attachments/assets/c3a283d4-9909-4c77-9bb0-992cc7bc7554" />


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
