### PR TITLE
fix(payouts): concurrency issue in payout webhooks

### DIFF
--- a/crates/router/src/core/webhooks/incoming.rs
+++ b/crates/router/src/core/webhooks/incoming.rs
@@ -17,7 +17,7 @@ use common_utils::{
 use diesel_models::{refund as diesel_refund, ConnectorMandateReferenceId};
 use error_stack::{report, ResultExt};
 #[cfg(feature = "payouts")]
-use hyperswitch_domain_models::payouts::{payout_attempt::PayoutAttempt, payouts::PayoutsUpdate};
+use hyperswitch_domain_models::payouts::payouts::PayoutsUpdate;
 use hyperswitch_domain_models::{
     mandates::CommonMandateReference,
     merchant_key_store::MerchantKeyStore,
@@ -1477,10 +1477,89 @@ async fn payouts_incoming_webhook_flow(
     request_details: &IncomingWebhookRequestDetails<'_>,
     connector: &ConnectorEnum,
 ) -> CustomResult<WebhookResponseTracker, errors::ApiErrorResponse> {
-    metrics::INCOMING_PAYOUT_WEBHOOK_METRIC.add(1, &[]);
+    let payout_id =
+        get_payout_id_from_object_reference_id(&state, &platform, &webhook_details).await?;
+
+    let lock_action = api_locking::LockAction::Hold {
+        input: api_locking::LockingInput {
+            unique_locking_key: payout_id.get_string_repr().to_owned(),
+            api_identifier: lock_utils::ApiIdentifier::Payouts,
+            override_lock_retries: None,
+        },
+    };
+
+    lock_action
+        .clone()
+        .perform_locking_action(
+            &state,
+            platform.get_processor().get_account().get_id().to_owned(),
+        )
+        .await?;
+
+    let payout_response = Box::pin(process_payout_incoming_webhook(
+        state.clone(),
+        platform.clone(),
+        business_profile,
+        event_type,
+        payout_id,
+        source_verified,
+        request_details,
+        connector,
+    ))
+    .await;
+
+    lock_action
+        .free_lock_action(
+            &state,
+            platform.get_processor().get_account().get_id().to_owned(),
+        )
+        .await?;
+
+    payout_response
+}
+
+#[cfg(feature = "payouts")]
+struct PayoutWebhookPreCondition {
+    is_non_terminal_status: bool,
+    is_source_verified: bool,
+}
+
+#[cfg(feature = "payouts")]
+enum PaoyoutWebhookAction {
+    UpdateStatus,
+    RetrieveStatus,
+    NoAction,
+}
+
+#[cfg(feature = "payouts")]
+impl PayoutWebhookPreCondition {
+    pub fn new(is_non_terminal_status: bool, is_source_verified: bool) -> Self {
+        Self {
+            is_non_terminal_status,
+            is_source_verified,
+        }
+    }
+
+    // only update if the payout is in non-terminal status
+    // if source verified, update the payout attempt and trigger outgoing webhook
+    // if not source verified, do a payout retrieve call and update the status
+    pub fn get_payout_webhook_action(&self) -> PaoyoutWebhookAction {
+        match (self.is_non_terminal_status, self.is_source_verified) {
+            (true, true) => PaoyoutWebhookAction::UpdateStatus,
+            (true, false) => PaoyoutWebhookAction::RetrieveStatus,
+            (false, true) | (false, false) => PaoyoutWebhookAction::NoAction,
+        }
+    }
+}
+
+#[cfg(feature = "payouts")]
+async fn get_payout_id_from_object_reference_id(
+    state: &SessionState,
+    platform: &domain::Platform,
+    webhook_details: &api::IncomingWebhookDetails,
+) -> CustomResult<common_utils::id_type::PayoutId, errors::ApiErrorResponse> {
     let db = &*state.store;
-    //find payout_attempt by object_reference_id
-    let payout_attempt = match webhook_details.object_reference_id {
+    let payout_attempt = match webhook_details.object_reference_id.clone() {
         webhooks::ObjectReferenceId::PayoutId(payout_id_type) => match payout_id_type {
             webhooks::PayoutIdType::PayoutAttemptId(id) => db
                 .find_payout_attempt_by_merchant_id_payout_attempt_id(
@@ -1505,18 +1584,27 @@ async fn payouts_incoming_webhook_flow(
             .attach_printable("received a non-payout id when processing payout webhooks")?,
     };
 
-    let payouts = db
-        .find_payout_by_merchant_id_payout_id(
-            platform.get_processor().get_account().get_id(),
-            &payout_attempt.payout_id,
-            platform.get_processor().get_account().storage_scheme,
-        )
-        .await
-        .change_context(errors::ApiErrorResponse::WebhookResourceNotFound)
-        .attach_printable("Failed to fetch the payout")?;
+    Ok(payout_attempt.payout_id)
+}
+
+#[cfg(feature = "payouts")]
+#[instrument(skip_all)]
+#[allow(clippy::too_many_arguments)]
+async fn process_payout_incoming_webhook(
+    state: SessionState,
+    platform: domain::Platform,
+    business_profile: domain::Profile,
+    event_type: webhooks::IncomingWebhookEvent,
+    payout_id: common_utils::id_type::PayoutId,
+    source_verified: bool,
+    request_details: &IncomingWebhookRequestDetails<'_>,
+    connector: &ConnectorEnum,
+) -> CustomResult<WebhookResponseTracker, errors::ApiErrorResponse> {
+    metrics::INCOMING_PAYOUT_WEBHOOK_METRIC.add(1, &[]);
+
     let action_req =
         payout_models::PayoutRequest::PayoutActionRequest(payout_models::PayoutActionRequest {
-            payout_id: payouts.payout_id.clone(),
+            payout_id,
         });
 
     let mut payout_data = Box::pin(payouts::make_payout_data(
@@ -1528,10 +1616,11 @@ async fn payouts_incoming_webhook_flow(
     ))
     .await?;
 
-    let payout_webhook_action = get_payout_webhook_action(
-        payout_attempt.status.is_non_terminal_status(),
+    let payout_webhook_action = PayoutWebhookPreCondition::new(
+        payout_data.payout_attempt.status.is_non_terminal_status(),
         source_verified,
-    );
+    )
+    .get_payout_webhook_action();
     match payout_webhook_action {
         PaoyoutWebhookAction::UpdateStatus => {
             payout_incoming_webhook_update_status(
@@ -1541,44 +1630,17 @@ async fn payouts_incoming_webhook_flow(
                 event_type,
                 request_details,
                 connector,
-                payout_attempt,
                 &mut payout_data,
             )
             .await
         }
         PaoyoutWebhookAction::RetrieveStatus => {
-            payout_incoming_webhook_retrieve_status(
-                state,
-                platform,
-                payout_attempt,
-                &mut payout_data,
-            )
-            .await
+            payout_incoming_webhook_retrieve_status(state, platform, &mut payout_data).await
         }
         PaoyoutWebhookAction::NoAction => Ok(WebhookResponseTracker::Payout {
             payout_id: payout_data.payout_attempt.payout_id,
             status: payout_data.payout_attempt.status,
         }),
-    }
-}
-
-enum PaoyoutWebhookAction {
-    UpdateStatus,
-    RetrieveStatus,
-    NoAction,
-}
-
-// only update if the payout is in non-terminal status
-// if source verified, update the payout attempt and trigger outgoing webhook
-// if not source verified, do a payout retrieve call and update the status
-fn get_payout_webhook_action(
-    is_non_terminal_status: bool,
-    is_source_verified: bool,
-) -> PaoyoutWebhookAction {
-    match (is_non_terminal_status, is_source_verified) {
-        (true, true) => PaoyoutWebhookAction::UpdateStatus,
-        (true, false) => PaoyoutWebhookAction::RetrieveStatus,
-        (false, true) | (false, false) => PaoyoutWebhookAction::NoAction,
     }
 }
 
@@ -1592,9 +1654,9 @@ async fn payout_incoming_webhook_update_status(
     event_type: webhooks::IncomingWebhookEvent,
     request_details: &IncomingWebhookRequestDetails<'_>,
     connector: &ConnectorEnum,
-    payout_attempt: PayoutAttempt,
     payout_data: &mut payouts::PayoutData,
 ) -> CustomResult<WebhookResponseTracker, errors::ApiErrorResponse> {
+    let payout_attempt = &payout_data.payout_attempt;
     let db = &*state.store;
     let status = common_enums::PayoutStatus::foreign_try_from(event_type)
         .change_context(errors::ApiErrorResponse::WebhookProcessingFailure)
@@ -1611,7 +1673,7 @@ async fn payout_incoming_webhook_update_status(
         .update_payout(
             &payout_data.payouts,
             payouts_update,
-            &payout_attempt,
+            payout_attempt,
             platform.get_processor().get_account().storage_scheme,
         )
         .await
@@ -1642,7 +1704,7 @@ async fn payout_incoming_webhook_update_status(
             status,
             error_message: None,
             error_code: None,
-            is_eligible: payout_attempt.is_eligible,
+            is_eligible: payout_data.payout_attempt.is_eligible,
             unified_code: None,
             unified_message: None,
             payout_connector_metadata: payout_attempt.payout_connector_metadata.clone(),
@@ -1651,7 +1713,7 @@ async fn payout_incoming_webhook_update_status(
 
     let updated_payout_attempt = db
         .update_payout_attempt(
-            &payout_attempt,
+            payout_attempt,
             payout_attempt_update,
             &payout_data.payouts,
             platform.get_processor().get_account().storage_scheme,
@@ -1703,17 +1765,16 @@ async fn payout_incoming_webhook_update_status(
 async fn payout_incoming_webhook_retrieve_status(
     state: SessionState,
     platform: domain::Platform,
-    payout_attempt: PayoutAttempt,
     payout_data: &mut payouts::PayoutData,
 ) -> CustomResult<WebhookResponseTracker, errors::ApiErrorResponse> {
     metrics::INCOMING_PAYOUT_WEBHOOK_SIGNATURE_FAILURE_METRIC.add(1, &[]);
     // Form connector data
-    let connector_data = match &payout_attempt.connector {
+    let connector_data = match &payout_data.payout_attempt.connector {
         Some(connector) => ConnectorData::get_payout_connector_by_name(
             &state.conf.connectors,
             connector,
             GetToken::Connector,
-            payout_attempt.merchant_connector_id.clone(),
+            payout_data.payout_attempt.merchant_connector_id.clone(),
         )
         .change_context(errors::ApiErrorResponse::InternalServerError)
         .attach_printable("Failed to get the connector data")?,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
- Api lock is acquired while processing a webhook such that payout webhooks can be processed synchronously
- This could solve the concurrency issue since this will prevent multiple webhooks for the same payout_id to enter into critical section.

Note: hotfix raised against https://github.com/juspay/hyperswitch/pull/10523

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

### Sanity Test: 

Create an MCA(Paypal Payout):
Setup webhook url at Paypal Dashboard:
Create an payout:
```
{
    "amount": 1,
    "currency": "EUR",
    "customer_id": "payout_customer",
    "email": "payout_customer@example.com",
    "name": "John Doe",
    "phone": "999999999",
    "phone_country_code": "+65",
    "description": "Its my first payout request",
    "payout_type": "wallet",
    "payout_method_data": {
        "wallet": {
            "paypal": {
                "telephone_number": "16608213349"
            }
        }
       
    },
    "billing": {
        "address": {
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "city": "San Fransico",
            "state": "NY",
            "zip": "94122",
            "country": "US",
            "first_name": "John",
            "last_name": "Doe"
        },
        "phone": {
            "number": "8056594427",
            "country_code": "+91"
        }
    },
    "entity_type": "NaturalPerson",
    "recurring": false,
    "metadata": {
        "ref": "123"
    },
    "confirm": true,
    "auto_fulfill": true
}
```
You should receive following webhooks:
```
{
  "merchant_id": "merchant_1765183650",
  "event_id": "evt_019afd2739e17d108a5d078634399a6e",
  "event_type": "payout_success",
  "content": {
    "type": "payout_details",
    "object": {
      "payout_id": "payout_HK9CWGo7E5JvD6ECvdQv",
      "merchant_id": "merchant_1765183650",
      "merchant_order_reference_id": null,
      "amount": 1,
      "currency": "EUR",
      "connector": "paypal",
      "payout_type": "wallet",
      "payout_method_data": {
        "wallet": {
          "email": null,
          "telephone_number": "*********49",
          "paypal_id": null
        }
      },
      "billing": {
        "address": {
          "city": "San Fransico",
          "country": "US",
          "line1": "1467",
          "line2": "Harrison Street",
          "line3": "Harrison Street",
          "zip": "94122",
          "state": "NY",
          "first_name": "John",
          "last_name": "Doe",
          "origin_zip": null
        },
        "phone": {
          "number": "8056594427",
          "country_code": "+91"
        },
        "email": null
      },
      "auto_fulfill": true,
      "customer_id": "payout_customer",
      "customer": {
        "id": "payout_customer",
        "name": "John Doe",
        "email": "payout_customer@example.com",
        "phone": "999999999",
        "phone_country_code": "+65"
      },
      "client_secret": "payout_payout_HK9CWGo7E5JvD6ECvdQv_secret_MNzvzn93wJeMoOd76al9",
      "return_url": null,
      "business_country": null,
      "business_label": null,
      "description": "Its my first payout request",
      "entity_type": "NaturalPerson",
      "recurring": false,
      "metadata": {
        "ref": "123"
      },
      "merchant_connector_id": "mca_MGYROFVm7NulKZoG6Xlh",
      "status": "success",
      "error_message": null,
      "error_code": null,
      "profile_id": "pro_9K6pxxLNaaYcF9S0Jz4P",
      "created": "2025-12-08T08:49:13.973Z",
      "connector_transaction_id": "EUGXUNE2PWCDG",
      "priority": null,
      "payout_link": null,
      "email": "payout_customer@example.com",
      "name": "John Doe",
      "phone": "999999999",
      "phone_country_code": "+65",
      "unified_code": null,
      "unified_message": null,
      "payout_method_id": null
    }
  },
  "timestamp": "2025-12-08T08:49:57.729Z"
}
```

### Concurrency Test:

- Simulate the webhook endpoint using dummy data
- Create an script to hit the webhook endpoint multiple time at exactly same time
- Keep one of the api with status as terminal (success) and rest as pending 
- Run it and do a Payout Sync once executed
- the terminal status persists (success) in the response of Payout Sync


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
