### PR TITLE
fix(users): Check if the inviter role info entity type is greater than invitee

### DIFF
--- a/crates/router/src/core/user.rs
+++ b/crates/router/src/core/user.rs
@@ -669,10 +669,9 @@ async fn handle_invitation(
     let inviter_user = user_from_token.get_user_from_db(state).await?;
 
     if inviter_user.get_email() == request.email {
-        return Err(UserErrors::InvalidRoleOperationWithMessage(
+        Err(report!(UserErrors::InvalidRoleOperationWithMessage(
             "User Inviting themselves".to_string(),
-        )
-        .into());
+        )))?;
     }
 
     let inviter_role_info = roles::RoleInfo::from_role_id_in_lineage(
@@ -704,19 +703,19 @@ async fn handle_invitation(
     .to_not_found_response(UserErrors::InvalidRoleId)?;
 
     if inviter_role_info.get_entity_type() < req_role_info.get_entity_type() {
-        return Err(report!(UserErrors::InvalidRoleOperationWithMessage(
+        Err(report!(UserErrors::InvalidRoleOperationWithMessage(
             "Inviter role entity type is lower than requested role entity type".to_string(),
         )))
         .attach_printable(format!(
             "{} is trying to invite {}",
             inviter_role_info.get_entity_type(),
             req_role_info.get_entity_type()
-        ));
+        ))?;
     };
 
     if !req_role_info.is_invitable() {
-        return Err(report!(UserErrors::InvalidRoleId))
-            .attach_printable(format!("role_id = {} is not invitable", request.role_id));
+        Err(report!(UserErrors::InvalidRoleId))
+            .attach_printable(format!("role_id = {} is not invitable", request.role_id))?;
     }
 
     let invitee_email = domain::UserEmail::from_pii_email(request.email.clone())?;


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Currently in invite there is no check which checks if the inviter's entity type has ability to invite a user with the request's `role_id`.

This is giving ability invite org level users from merchant level. Similarly org, merchant from profile level. 

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
Closes [#3988](https://github.com/juspay/hyperswitch-control-center/issues/3988).

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
1. Invite a `org_admin` or `merchant_admin` using a profile level user.
  ```bash
  curl --location 'http://localhost:8080/user/user/invite_multiple' \
  --header 'Content-Type: application/json' \
  --header 'Authorization: Bearer <PROFILE_LEVEL_USER_JWT>' \
  --data-raw '[
      {
          "email": "newuser@gmail.com",
          "name": "New User",
          "role_id": "org_admin"
      }
  ]'
  ```

- Should throw error.
  ```json
  [
      {
          "email": "newuser@gmail.com",
          "is_email_sent": false,
          "error": "Inviter role entity type is lower than requested role entity type"
      }
  ]
  ```

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
