### PR TITLE
feat(connector): [Zift] Remove billing address fields and add mandate setup (account verification) support

### DIFF
--- a/crates/hyperswitch_connectors/src/connectors/zift.rs
+++ b/crates/hyperswitch_connectors/src/connectors/zift.rs
@@ -28,7 +28,7 @@ use hyperswitch_domain_models::{
     },
     types::{
         PaymentsAuthorizeRouterData, PaymentsCancelRouterData, PaymentsCaptureRouterData,
-        PaymentsSyncRouterData, RefundsRouterData,
+        PaymentsSyncRouterData, RefundsRouterData, SetupMandateRouterData,
     },
 };
 use hyperswitch_interfaces::{
@@ -62,7 +62,6 @@ impl Zift {
 impl api::Payment for Zift {}
 impl api::PaymentSession for Zift {}
 impl api::ConnectorAccessToken for Zift {}
-impl api::MandateSetup for Zift {}
 impl api::PaymentAuthorize for Zift {}
 impl api::PaymentSync for Zift {}
 impl api::PaymentCapture for Zift {}
@@ -71,6 +70,82 @@ impl api::Refund for Zift {}
 impl api::RefundExecute for Zift {}
 impl api::RefundSync for Zift {}
 impl api::PaymentToken for Zift {}
+impl api::MandateSetup for Zift {}
+
+impl ConnectorIntegration<SetupMandate, SetupMandateRequestData, PaymentsResponseData> for Zift {
+    fn get_headers(
+        &self,
+        req: &SetupMandateRouterData,
+        connectors: &Connectors,
+    ) -> CustomResult<Vec<(String, masking::Maskable<String>)>, errors::ConnectorError> {
+        self.build_headers(req, connectors)
+    }
+
+    fn get_content_type(&self) -> &'static str {
+        self.common_get_content_type()
+    }
+
+    fn get_url(
+        &self,
+        _req: &SetupMandateRouterData,
+        connectors: &Connectors,
+    ) -> CustomResult<String, errors::ConnectorError> {
+        Ok(format!("{}gates/xurl", self.base_url(connectors)))
+    }
+
+    fn get_request_body(
+        &self,
+        req: &SetupMandateRouterData,
+        _connectors: &Connectors,
+    ) -> CustomResult<RequestContent, errors::ConnectorError> {
+        let connector_req = zift::ZiftSetupMandateRequest::try_from(req)?;
+        Ok(RequestContent::FormUrlEncoded(Box::new(connector_req)))
+    }
+
+    fn build_request(
+        &self,
+        req: &SetupMandateRouterData,
+        connectors: &Connectors,
+    ) -> CustomResult<Option<Request>, errors::ConnectorError> {
+        Ok(Some(
+            RequestBuilder::new()
+                .method(Method::Post)
+                .url(&types::SetupMandateType::get_url(self, req, connectors)?)
+                .attach_default_headers()
+                .headers(types::SetupMandateType::get_headers(self, req, connectors)?)
+                .set_body(types::SetupMandateType::get_request_body(
+                    self, req, connectors,
+                )?)
+                .build(),
+        ))
+    }
+
+    fn handle_response(
+        &self,
+        data: &SetupMandateRouterData,
+        event_builder: Option<&mut ConnectorEvent>,
+        res: Response,
+    ) -> CustomResult<SetupMandateRouterData, errors::ConnectorError> {
+        let response: zift::ZiftAuthPaymentsResponse = serde_urlencoded::from_bytes(&res.response)
+            .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
+
+        event_builder.map(|i| i.set_response_body(&response));
+        router_env::logger::info!(connector_response=?response);
+        RouterData::try_from(ResponseRouterData {
+            response,
+            data: data.clone(),
+            http_code: res.status_code,
+        })
+    }
+
+    fn get_error_response(
+        &self,
+        res: Response,
+        event_builder: Option<&mut ConnectorEvent>,
+    ) -> CustomResult<ErrorResponse, errors::ConnectorError> {
+        self.build_error_response(res, event_builder)
+    }
+}
 
 impl ConnectorIntegration<PaymentMethodToken, PaymentMethodTokenizationData, PaymentsResponseData>
     for Zift
@@ -177,8 +252,6 @@ impl ConnectorIntegration<Session, PaymentsSessionData, PaymentsResponseData> fo
 }
 
 impl ConnectorIntegration<AccessTokenAuth, AccessTokenRequestData, AccessToken> for Zift {}
-
-impl ConnectorIntegration<SetupMandate, SetupMandateRequestData, PaymentsResponseData> for Zift {}
 
 impl ConnectorIntegration<Authorize, PaymentsAuthorizeData, PaymentsResponseData> for Zift {
     fn get_headers(
@@ -695,7 +768,7 @@ static ZIFT_SUPPORTED_PAYMENT_METHODS: LazyLock<SupportedPaymentMethods> = LazyL
             specific_features: Some(
                 api_models::feature_matrix::PaymentMethodSpecificFeatures::Card({
                     api_models::feature_matrix::CardSpecificFeatures {
-                        three_ds: common_enums::FeatureStatus::Supported,
+                        three_ds: common_enums::FeatureStatus::NotSupported,
                         no_three_ds: common_enums::FeatureStatus::Supported,
                         supported_card_networks: supported_card_network.clone(),
                     }

--- a/crates/hyperswitch_connectors/src/connectors/zift/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/zift/transformers.rs
@@ -1,16 +1,18 @@
 use api_models::payments::AdditionalPaymentData;
-use common_enums::{enums, CountryAlpha2};
-use common_utils::{pii, types::StringMinorUnit};
+use common_enums::enums;
+use common_utils::types::StringMinorUnit;
 use error_stack::ResultExt;
 use hyperswitch_domain_models::{
     payment_method_data::PaymentMethodData,
     router_data::{ConnectorAuthType, ErrorResponse, RouterData},
     router_flow_types::{refunds::Execute, PSync},
-    router_request_types::{PaymentsAuthorizeData, PaymentsSyncData, ResponseId},
+    router_request_types::{
+        PaymentsAuthorizeData, PaymentsSyncData, ResponseId, SetupMandateRequestData,
+    },
     router_response_types::{MandateReference, PaymentsResponseData, RefundsResponseData},
     types::{
         PaymentsAuthorizeRouterData, PaymentsCancelRouterData, PaymentsCaptureRouterData,
-        PaymentsSyncRouterData, RefundsRouterData,
+        PaymentsSyncRouterData, RefundsRouterData, SetupMandateRouterData,
     },
 };
 use hyperswitch_interfaces::{
@@ -79,6 +81,8 @@ pub enum RequestType {
     Refund,
     Find,
     Void,
+    #[serde(rename = "account-verification")]
+    AccountVerification,
 }
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -141,20 +145,7 @@ pub struct ZiftCardPaymentRequest {
     holder_name: Secret<String>,
     holder_type: HolderType,
     amount: StringMinorUnit,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    street: Option<Secret<String>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    city: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    state: Option<Secret<String>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    zip_code: Option<Secret<String>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    country_code: Option<CountryAlpha2>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    email: Option<pii::Email>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    phone: Option<Secret<String>>,
+    //Billing address fields are intentionally not passed to Zift.As confirmed by the Zift connector team, billing-related parameters must not be sent in payment or mandate requests. Passing billing address details was causing transaction failures in production. To ensure successful processing and alignment with Zift’s API expectations, all billing address fields have been removed.
 }
 // Mandate payment (MIT - Merchant Initiated)
 #[derive(Debug, Serialize)]
@@ -177,21 +168,7 @@ pub struct ZiftMandatePaymentRequest {
     // Required for MIT
     transaction_category_type: TransactionCategoryType,
     sequence_number: i32,
-    // Billing address
-    #[serde(skip_serializing_if = "Option::is_none")]
-    street: Option<Secret<String>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    city: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    state: Option<Secret<String>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    zip_code: Option<Secret<String>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    country_code: Option<CountryAlpha2>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    email: Option<pii::Email>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    phone: Option<Secret<String>>,
+    //Billing address fields are intentionally not passed to Zift.As confirmed by the Zift connector team, billing-related parameters must not be sent in payment or mandate requests. Passing billing address details was causing transaction failures in production. To ensure successful processing and alignment with Zift’s API expectations, all billing address fields have been removed.
 }
 
 // External 3DS payment request
@@ -216,21 +193,6 @@ pub struct ZiftExternalThreeDsPaymentRequest {
     authentication_verification_value: Secret<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     authentication_version: Option<Secret<String>>,
-    // Billing address
-    #[serde(skip_serializing_if = "Option::is_none")]
-    street: Option<Secret<String>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    city: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    state: Option<Secret<String>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    zip_code: Option<Secret<String>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    country_code: Option<CountryAlpha2>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    email: Option<pii::Email>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    phone: Option<Secret<String>>,
 }
 
 #[derive(Debug, Serialize)]
@@ -295,8 +257,17 @@ impl TryFrom<&ZiftRouterData<&PaymentsAuthorizeRouterData>> for ZiftPaymentsRequ
         };
         match item.router_data.request.payment_method_data.clone() {
             PaymentMethodData::Card(card) => {
-                // Check if this is an external 3DS payment - both is_three_ds() and authentication_data must be present
                 if item.router_data.is_three_ds()
+                    && item.router_data.request.authentication_data.is_none()
+                {
+                    Err(errors::ConnectorError::NotSupported {
+                        message: "3DS flow".to_string(),
+                        connector: "Zift",
+                    }
+                    .into())
+                }
+                // Check if this is an external 3DS payment - both is_three_ds() and authentication_data must be present
+                else if item.router_data.is_three_ds()
                     && item.router_data.request.authentication_data.is_some()
                 {
                     // Handle external 3DS authentication
@@ -328,13 +299,6 @@ impl TryFrom<&ZiftRouterData<&PaymentsAuthorizeRouterData>> for ZiftPaymentsRequ
                             .message_version
                             .as_ref()
                             .map(|v| Secret::new(v.to_string())),
-                        street: item.router_data.get_optional_billing_line1(),
-                        city: item.router_data.get_optional_billing_city(),
-                        state: item.router_data.get_optional_billing_state(),
-                        zip_code: item.router_data.get_optional_billing_zip(),
-                        country_code: item.router_data.get_optional_billing_country(),
-                        email: item.router_data.get_optional_billing_email(),
-                        phone: item.router_data.get_optional_billing_phone_number(),
                         transaction_code: item.router_data.connector_request_reference_id.clone(),
                     };
                     Ok(Self::ExternalThreeDs(external_3ds_request))
@@ -350,13 +314,6 @@ impl TryFrom<&ZiftRouterData<&PaymentsAuthorizeRouterData>> for ZiftPaymentsRequ
                         account_type: AccountType::PaymentCard,
                         holder_type: HolderType::Personal,
                         csc: card.card_cvc,
-                        street: item.router_data.get_optional_billing_line1(),
-                        city: item.router_data.get_optional_billing_city(),
-                        state: item.router_data.get_optional_billing_state(),
-                        zip_code: item.router_data.get_optional_billing_zip(),
-                        country_code: item.router_data.get_optional_billing_country(),
-                        email: item.router_data.get_optional_billing_email(),
-                        phone: item.router_data.get_optional_billing_phone_number(),
                         transaction_code: item.router_data.connector_request_reference_id.clone(),
                     };
                     Ok(Self::Card(card_request))
@@ -394,13 +351,6 @@ impl TryFrom<&ZiftRouterData<&PaymentsAuthorizeRouterData>> for ZiftPaymentsRequ
                     transaction_mode_type: TransactionModeType::CardNotPresent,
                     transaction_category_type: TransactionCategoryType::Recurring,
                     sequence_number: 2, // Its required for MIT
-                    street: item.router_data.get_optional_billing_line1(),
-                    city: item.router_data.get_optional_billing_city(),
-                    state: item.router_data.get_optional_billing_state(),
-                    zip_code: item.router_data.get_optional_billing_zip(),
-                    country_code: item.router_data.get_optional_billing_country(),
-                    email: item.router_data.get_optional_billing_email(),
-                    phone: item.router_data.get_optional_billing_phone_number(),
                     transaction_code: item.router_data.connector_request_reference_id.clone(),
                 };
                 Ok(Self::Mandate(mandate_request))
@@ -906,5 +856,154 @@ impl TryFrom<PaymentsCancelResponseRouterData<ZiftVoidResponse>> for PaymentsCan
             response,
             ..item.data
         })
+    }
+}
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ZiftSetupMandateRequest {
+    request_type: RequestType,
+    #[serde(flatten)]
+    auth: ZiftAuthType,
+    transaction_industry_type: TransactionIndustryType,
+    holder_name: Secret<String>,
+    holder_type: HolderType,
+    transaction_code: String,
+    #[serde(flatten)]
+    payment_method_details: SetupMandatePaymentMethod,
+    //Billing address fields are intentionally not passed to Zift.As confirmed by the Zift connector team, billing-related parameters must not be sent in payment or mandate requests. Passing billing address details was causing transaction failures in production. To ensure successful processing and alignment with Zift’s API expectations, all billing address fields have been removed.
+}
+
+// Enum for payment method specific fields
+#[derive(Debug, Serialize)]
+#[serde(untagged)]
+pub enum SetupMandatePaymentMethod {
+    Card(CardVerificationDetails),
+}
+
+// Card specific fields for account verification
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CardVerificationDetails {
+    account_type: AccountType,
+    account_number: cards::CardNumber,
+    account_accessory: Secret<String>,
+    csc: Secret<String>,
+}
+
+impl TryFrom<&SetupMandateRouterData> for ZiftSetupMandateRequest {
+    type Error = error_stack::Report<errors::ConnectorError>;
+
+    fn try_from(item: &SetupMandateRouterData) -> Result<Self, Self::Error> {
+        if let Some(amount) = item.request.amount {
+            if amount > 0 {
+                return Err(errors::ConnectorError::FlowNotSupported {
+                    flow: "Setup Mandate with non zero amount".to_string(),
+                    connector: "Zift".to_string(),
+                }
+                .into());
+            }
+        }
+        let auth = ZiftAuthType::try_from(&item.connector_auth_type)?;
+
+        let (transaction_industry_type, payment_method_details) =
+            match &item.request.payment_method_data {
+                PaymentMethodData::Card(card) => (
+                    TransactionIndustryType::CardPresent,
+                    SetupMandatePaymentMethod::Card(CardVerificationDetails {
+                        account_type: AccountType::PaymentCard,
+                        account_number: card.card_number.clone(),
+                        account_accessory: card.get_expiry_date_as_mmyy()?,
+                        csc: card.card_cvc.clone(),
+                    }),
+                ),
+                _ => Err(errors::ConnectorError::NotSupported {
+                    message: "Only card supported for mandate setup".to_string(),
+                    connector: "Zift",
+                })?,
+            };
+
+        Ok(Self {
+            request_type: RequestType::AccountVerification,
+            auth,
+            transaction_industry_type,
+            holder_name: item.get_billing_full_name()?,
+            holder_type: HolderType::Personal,
+            transaction_code: item.connector_request_reference_id.clone(),
+            payment_method_details,
+        })
+    }
+}
+impl<F>
+    TryFrom<
+        ResponseRouterData<
+            F,
+            ZiftAuthPaymentsResponse,
+            SetupMandateRequestData,
+            PaymentsResponseData,
+        >,
+    > for RouterData<F, SetupMandateRequestData, PaymentsResponseData>
+{
+    type Error = error_stack::Report<errors::ConnectorError>;
+    fn try_from(
+        item: ResponseRouterData<
+            F,
+            ZiftAuthPaymentsResponse,
+            SetupMandateRequestData,
+            PaymentsResponseData,
+        >,
+    ) -> Result<Self, Self::Error> {
+        let status = if item.response.response_code.is_approved() {
+            common_enums::AttemptStatus::Charged
+        } else if item.response.response_code.is_pending() {
+            common_enums::AttemptStatus::Pending
+        } else {
+            common_enums::AttemptStatus::Failure
+        };
+        if status != common_enums::AttemptStatus::Failure {
+            let transaction_id = item.response.transaction_id.ok_or_else(|| {
+                errors::ConnectorError::MissingRequiredField {
+                    field_name: "transaction_id",
+                }
+            })?;
+
+            Ok(Self {
+                status,
+                response: Ok(PaymentsResponseData::TransactionResponse {
+                    resource_id: ResponseId::ConnectorTransactionId(transaction_id.to_string()),
+                    redirection_data: Box::new(None),
+                    mandate_reference: Box::new(item.response.token.clone().map(|token| {
+                        MandateReference {
+                            connector_mandate_id: Some(token),
+                            payment_method_id: None,
+                            mandate_metadata: None,
+                            connector_mandate_request_reference_id: None,
+                        }
+                    })),
+                    connector_metadata: None,
+                    network_txn_id: None,
+                    connector_response_reference_id: item.response.transaction_code.clone(),
+                    incremental_authorization_allowed: None,
+                    charges: None,
+                }),
+                ..item.data
+            })
+        } else {
+            Ok(Self {
+                status: common_enums::AttemptStatus::Failure,
+                response: Err(ErrorResponse {
+                    code: item.response.response_code.clone(),
+                    message: item.response.response_message.clone(),
+                    reason: Some(item.response.response_message.clone()),
+                    status_code: item.http_code,
+                    attempt_status: None,
+                    connector_transaction_id: item.response.transaction_id.map(|id| id.to_string()),
+                    network_advice_code: None,
+                    network_decline_code: None,
+                    network_error_message: None,
+                    connector_metadata: None,
+                }),
+                ..item.data
+            })
+        }
     }
 }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

<!-- Describe your changes in detail -->
hotfix https://github.com/juspay/hyperswitch/pull/10665
### Key Changes
Note:  Billing address fields are intentionally not passed to Zift.As confirmed by the Zift connector team, billing-related parameters must not be sent in payment or mandate requests. Passing billing address details was causing transaction failures in production. To ensure successful processing and alignment with Zift’s API expectations, all billing address fields have been removed.

#### Removed billing address fields
The following billing address–related fields have been removed from Zift requests to align with updated connector requirements:

- **Card payments**
- **Mandate (MIT) payments**
- **External 3DS payment requests**

Removed fields:
- `street`
- `city`
- `state`
- `zip`
- `country`
- `email`
- `phone`

---

#### Added Setup Mandate (Account Verification) support
Introduced support for mandate setup using account verification for the Zift connector:

- Implemented `SetupMandate` connector integration
- Added request and response transformers for mandate setup
- Returns a **mandate reference token** upon successful account verification

---

#### Updated payment method capabilities
- Marked **3DS as Not Supported** for Zift card payments


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->



## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Setup Mandate Flow 
```
curl --location 'http://localhost:8080/payments' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: dev_WBqqL7X37hYosxZWIWMr9th8t18AJ4mASWV2IfDdn1KoBxJuspIG099RDujuFPri' \
--data '{
    "amount": 0,
    "currency": "USD",
    
    "payment_type":"setup_mandate",
    "confirm": true,
    "business_country": "US",
    "business_label": "default",
    
    "customer_id": "cu_17157579182",
    "capture_method": "manual",
    "capture_on": "2022-09-10T10:11:12Z",
    "setup_future_usage": "off_session",
    "authentication_type": "no_three_ds",
    "request_external_three_ds_authentication":true,
    "return_url": "https://google.com",
    
    
    
    
    "description": "Its my first payment request",
    "statement_descriptor_name": "Juspay",
    "statement_descriptor_suffix": "Router",
    "payment_method": "card",
    "payment_method_type": "credit",
    "payment_method_data": {
        "card": {
            "card_number": "4111111111111111",
            "card_exp_month": "04",
            "card_exp_year": "2026",
            "card_holder_name": "John Smith",
            "card_cvc": "123"
        }
    },
   
    "customer_acceptance": {
        "acceptance_type": "offline",
        "accepted_at": "1963-05-03T04:07:52.723Z",
        "online": {
            "ip_address": "in sit",
            "user_agent": "amet irure esse"
        }
    }
}'
```
Response
```
{
    "payment_id": "pay_wQMUv2B5ewE5zmkkgtSD",
    "merchant_id": "merchant_1765788634",
    "status": "succeeded",
    "amount": 0,
    "net_amount": 0,
    "shipping_cost": null,
    "amount_capturable": 0,
    "amount_received": null,
    "connector": "zift",
    "client_secret": "pay_wQMUv2B5ewE5zmkkgtSD_secret_9IkehgjkiEg1xyr1XBXJ",
    "created": "2025-12-15T10:12:06.630Z",
    "modified_at": "2025-12-15T10:12:07.378Z",
    "currency": "USD",
    "customer_id": "cu_17157579182",
    "customer": {
        "id": "cu_17157579182",
        "name": "Joseph Doe",
        "email": "something@gmail.com",
        "phone": "999999999",
        "phone_country_code": "+65"
    },
    "description": "Its my first payment request",
    "refunds": null,
    "disputes": null,
    "mandate_id": null,
    "mandate_data": null,
    "setup_future_usage": "off_session",
    "off_session": null,
    "capture_on": null,
    "capture_method": "manual",
    "payment_method": "card",
    "payment_method_data": {
        "card": {
            "last4": "1111",
            "card_type": null,
            "card_network": null,
            "card_issuer": null,
            "card_issuing_country": null,
            "card_isin": "411111",
            "card_extended_bin": null,
            "card_exp_month": "04",
            "card_exp_year": "2026",
            "card_holder_name": "John Smith",
            "payment_checks": null,
            "authentication_data": null
        },
        "billing": null
    },
    "payment_token": "token_SC9Pgh8v0Z7am0l7mjV2",
    "shipping": null,
    "billing": null,
    "order_details": null,
    "email": "something@gmail.com",
    "name": "Joseph Doe",
    "phone": "999999999",
    "return_url": "https://google.com/",
    "authentication_type": "no_three_ds",
    "statement_descriptor_name": "Juspay",
    "statement_descriptor_suffix": "Router",
    "next_action": null,
    "cancellation_reason": null,
    "error_code": null,
    "error_message": null,
    "unified_code": null,
    "unified_message": null,
    "payment_experience": null,
    "payment_method_type": "credit",
    "connector_label": "zift_US_default",
    "business_country": "US",
    "business_label": "default",
    "business_sub_label": null,
    "allowed_payment_method_types": null,
    "manual_retry_allowed": null,
    "connector_transaction_id": "8617453252",
    "frm_message": null,
    "metadata": null,
    "connector_metadata": null,
    "feature_metadata": {
        "redirect_response": null,
        "search_tags": null,
        "apple_pay_recurring_details": null,
        "gateway_system": "direct"
    },
    "reference_id": "pay_wQMUv2B5ewE5zmkkgtSD_1",
    "payment_link": null,
    "profile_id": "pro_2yJwq90VJvU94lGwBdZQ",
    "surcharge_details": null,
    "attempt_count": 1,
    "merchant_decision": null,
    "merchant_connector_id": "mca_6lnsZY6697zLe1lyih7L",
    "incremental_authorization_allowed": false,
    "authorization_count": null,
    "incremental_authorizations": null,
    "external_authentication_details": null,
    "external_3ds_authentication_attempted": false,
    "expires_on": "2025-12-15T10:27:06.630Z",
    "fingerprint": null,
    "browser_info": null,
    "payment_channel": null,
    "payment_method_id": "pm_OOWehp1uHYG6jJS3Zx3L",
    "network_transaction_id": null,
    "payment_method_status": "active",
    "updated": "2025-12-15T10:12:07.378Z",
    "split_payments": null,
    "frm_metadata": null,
    "extended_authorization_applied": null,
    "extended_authorization_last_applied_at": null,
    "request_extended_authorization": null,
    "capture_before": null,
    "merchant_order_reference_id": null,
    "order_tax_amount": null,
    "connector_mandate_id": "VC10000000000015541111",
    "card_discovery": "manual",
    "force_3ds_challenge": false,
    "force_3ds_challenge_trigger": false,
    "issuer_error_code": null,
    "issuer_error_message": null,
    "is_iframe_redirection_enabled": null,
    "whole_connector_response": null,
    "enable_partial_authorization": null,
    "enable_overcapture": null,
    "is_overcapture_enabled": null,
    "network_details": null,
    "is_stored_credential": null,
    "mit_category": null,
    "billing_descriptor": null,
    "tokenization": null,
    "partner_merchant_identifier_details": null,
    "payment_method_tokenization_details": {
        "payment_method_id": "pm_OOWehp1uHYG6jJS3Zx3L",
        "payment_method_status": "active",
        "psp_tokenization": false,
        "network_tokenization": false,
        "network_transaction_id": null,
        "is_eligible_for_mit_payment": false
    }
}
```

MIT using PMID
```
curl --location 'http://localhost:8080/payments' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: dev_WBqqL7X37hYosxZWIWMr9th8t18AJ4mASWV2IfDdn1KoBxJuspIG099RDujuFPri' \
--data '{
    "recurring_details": {
        "type": "payment_method_id",
        "data": "pm_OOWehp1uHYG6jJS3Zx3L"
    },
    "customer": {
        "id": "cu_17157579182"
    },
    "description": "This is the test payment made through Mule API",
    "currency": "USD",
    "amount": 1211,
    "confirm": true,
    "capture_method": "automatic",
    "off_session": true
}'
```
Response
```
{
    "payment_id": "pay_AiKnrLCr6w9hUzQp11CG",
    "merchant_id": "merchant_1765788634",
    "status": "succeeded",
    "amount": 1211,
    "net_amount": 1211,
    "shipping_cost": null,
    "amount_capturable": 0,
    "amount_received": 1211,
    "connector": "zift",
    "client_secret": "pay_AiKnrLCr6w9hUzQp11CG_secret_oIhYCCiw5p7oslR4r894",
    "created": "2025-12-15T10:13:54.070Z",
    "modified_at": "2025-12-15T10:13:55.005Z",
    "currency": "USD",
    "customer_id": "cu_17157579182",
    "customer": {
        "id": "cu_17157579182",
        "name": "Joseph Doe",
        "email": "something@gmail.com",
        "phone": "999999999",
        "phone_country_code": "+65"
    },
    "description": "This is the test payment made through Mule API",
    "refunds": null,
    "disputes": null,
    "mandate_id": null,
    "mandate_data": null,
    "setup_future_usage": null,
    "off_session": true,
    "capture_on": null,
    "capture_method": "automatic",
    "payment_method": "card",
    "payment_method_data": {
        "card": {
            "last4": "1111",
            "card_type": null,
            "card_network": null,
            "card_issuer": null,
            "card_issuing_country": null,
            "card_isin": "411111",
            "card_extended_bin": null,
            "card_exp_month": "04",
            "card_exp_year": "2026",
            "card_holder_name": "John Smith",
            "payment_checks": null,
            "authentication_data": null
        },
        "billing": null
    },
    "payment_token": null,
    "shipping": null,
    "billing": null,
    "order_details": null,
    "email": "something@gmail.com",
    "name": "Joseph Doe",
    "phone": "999999999",
    "return_url": null,
    "authentication_type": "no_three_ds",
    "statement_descriptor_name": null,
    "statement_descriptor_suffix": null,
    "next_action": null,
    "cancellation_reason": null,
    "error_code": null,
    "error_message": null,
    "unified_code": null,
    "unified_message": null,
    "payment_experience": null,
    "payment_method_type": "credit",
    "connector_label": null,
    "business_country": null,
    "business_label": "default",
    "business_sub_label": null,
    "allowed_payment_method_types": null,
    "manual_retry_allowed": null,
    "connector_transaction_id": "8617453262",
    "frm_message": null,
    "metadata": null,
    "connector_metadata": null,
    "feature_metadata": {
        "redirect_response": null,
        "search_tags": null,
        "apple_pay_recurring_details": null,
        "gateway_system": "direct"
    },
    "reference_id": "pay_AiKnrLCr6w9hUzQp11CG_1",
    "payment_link": null,
    "profile_id": "pro_2yJwq90VJvU94lGwBdZQ",
    "surcharge_details": null,
    "attempt_count": 1,
    "merchant_decision": null,
    "merchant_connector_id": "mca_6lnsZY6697zLe1lyih7L",
    "incremental_authorization_allowed": false,
    "authorization_count": null,
    "incremental_authorizations": null,
    "external_authentication_details": null,
    "external_3ds_authentication_attempted": false,
    "expires_on": "2025-12-15T10:28:54.070Z",
    "fingerprint": null,
    "browser_info": null,
    "payment_channel": null,
    "payment_method_id": "pm_OOWehp1uHYG6jJS3Zx3L",
    "network_transaction_id": null,
    "payment_method_status": "active",
    "updated": "2025-12-15T10:13:55.005Z",
    "split_payments": null,
    "frm_metadata": null,
    "extended_authorization_applied": null,
    "extended_authorization_last_applied_at": null,
    "request_extended_authorization": null,
    "capture_before": null,
    "merchant_order_reference_id": null,
    "order_tax_amount": null,
    "connector_mandate_id": "VC10000000000015541111",
    "card_discovery": "manual",
    "force_3ds_challenge": false,
    "force_3ds_challenge_trigger": false,
    "issuer_error_code": null,
    "issuer_error_message": null,
    "is_iframe_redirection_enabled": null,
    "whole_connector_response": null,
    "enable_partial_authorization": null,
    "enable_overcapture": null,
    "is_overcapture_enabled": null,
    "network_details": null,
    "is_stored_credential": true,
    "mit_category": null,
    "billing_descriptor": null,
    "tokenization": null,
    "partner_merchant_identifier_details": null,
    "payment_method_tokenization_details": {
        "payment_method_id": "pm_OOWehp1uHYG6jJS3Zx3L",
        "payment_method_status": "active",
        "psp_tokenization": true,
        "network_tokenization": false,
        "network_transaction_id": null,
        "is_eligible_for_mit_payment": true
    }
}
```

Handle 3DS 
```
curl --location 'http://localhost:8080/payments' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: dev_WBqqL7X37hYosxZWIWMr9th8t18AJ4mASWV2IfDdn1KoBxJuspIG099RDujuFPri' \
--data '{
    "amount": 10,
    "currency": "USD",
    "confirm": true,
    "business_country": "US",
    "business_label": "default",
    "customer_id": "cu_17157579182",
    "capture_method": "manual",
    "capture_on": "2022-09-10T10:11:12Z",
    "setup_future_usage": "off_session",
    "authentication_type": "three_ds",
    "return_url": "https://google.com",
    "description": "Its my first payment request",
    "statement_descriptor_name": "Juspay",
    "statement_descriptor_suffix": "Router",
    "payment_method": "card",
    "payment_method_type": "credit",
    "payment_method_data": {
        "card": {
            "card_number": "4111111111111111",
            "card_exp_month": "04",
            "card_exp_year": "2026",
            "card_holder_name": "John Smith",
            "card_cvc": "123"
        }
    },
    
    "customer_acceptance": {
        "acceptance_type": "offline",
        "accepted_at": "1963-05-03T04:07:52.723Z",
        "online": {
            "ip_address": "in sit",
            "user_agent": "amet irure esse"
        }
    }
}'
```
Response
```
{
    "error": {
        "type": "invalid_request",
        "message": "Payment method type not supported",
        "code": "IR_19",
        "reason": "3DS flow is not supported by Zift"
    }
}
```


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
