### PR TITLE
fix(oidc): registration of oidc paths

### DIFF
--- a/crates/router/src/lib.rs
+++ b/crates/router/src/lib.rs
@@ -235,7 +235,6 @@ pub fn mk_app(
                 .service(routes::Gsm::server(state.clone()))
                 .service(routes::RecoveryDataBackfill::server(state.clone()));
         }
-        server_app = server_app.service(routes::Oidc::server(state.clone()));
     }
 
     #[cfg(all(feature = "payouts", feature = "v1"))]
@@ -264,7 +263,11 @@ pub fn mk_app(
 
     server_app = server_app.service(routes::Cache::server(state.clone()));
     server_app = server_app.service(routes::Health::server(state.clone()));
-
+    // Registered at the end because this entry has an empty scope
+    #[cfg(feature = "olap")]
+    {
+        server_app = server_app.service(routes::Oidc::server(state.clone()));
+    }
     server_app
 }
 


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

The health endpoint was unreachable due to the ordering/placement of the OIDC service routes. This was because of the empty scope of oidc routes.


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context

Fix for routes.


## How did you test it?

locally.


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
