### PR TITLE
fix(router): Prevent panic when masking non-ASCII strings

### DIFF
--- a/crates/masking/src/secret.rs
+++ b/crates/masking/src/secret.rs
@@ -222,6 +222,10 @@ impl Strategy<serde_json::Value> for JsonMaskStrategy {
             }
             serde_json::Value::String(s) => {
                 // For strings, we show a masked version that gives a hint about the content
+                // String::chars().count() is an approximation and could be greater than
+                // the actual "character" count, since it does not consider graphemes (what we
+                // usually consider as a "character"). To be more accurate at the cost of some
+                // performance we can use "graphemes()" from the unicode-segmentation crate
                 let char_count = s.chars().count();
                 let masked = if char_count <= 2 {
                     "**".to_string()


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
- Changed `JsonMaskStrategy` to use `chars().count()` instead of `len()` to prevent panic when masking non-ASCII strings

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
When masking strings using `JsonMaskStrategy`, we use `String::len()` method to get the number of characters in the string. This approach is flawed as `len()` returns the number of bytes and not characters. As a result, slicing into the string using this value leads to panics.

There are two possible approaches for solving this.

1. Use `chars().count()`: Faster, but returns the number of unicode scalar values, which may differ from what is understood as a "character"

2. Use `graphemes` method from unicode segmentation crate: More technically accurate as it returns the number of unicode grapheme clusters. But it is slower.

A basic benchmark returns the following results:

## Benchmark Analysis

### String Masking Results

| Scenario            | Chars Time | Graphemes Time        | Performance Difference        |
|---------------------|------------|------------------------|-------------------------------|
| **ASCII Short**     | 64 ns      | 166 ns                 | **Graphemes 2.6× slower**     |
| **ASCII Medium**    | 92 ns      | 425 ns                 | **Graphemes 4.6× slower**     |
| **ASCII Long**      | 95 ns      | 1,012 ns (1 µs)        | **Graphemes 10.6× slower**    |
| **Unicode Simple**  | 93 ns      | 302 ns                 | **Graphemes 3.2× slower**     |
| **Unicode Emoji**   | 50 ns      | 99 ns                  | **Graphemes 2.0× slower**     |
| **Family Emoji**    | 110 ns     | 207 ns                 | **Graphemes 1.9× slower**     |
| **Unicode Flags**   | 64 ns      | 181 ns                 | **Graphemes 2.8× slower**     |
| **Combining Chars** | 50 ns      | 91 ns                  | **Graphemes 1.8× slower**     |
| **Mixed Complex**   | 106 ns     | 565 ns                 | **Graphemes 5.3× slower**     |


Due to the nature of masking usecase, performance is a priority over 100% unicode accuracy. So we are moving ahead with the faster (but less accurate approach)

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
- Added a new test
- Test by running the following command:

`cargo test -p masking`

<img width="801" height="480" alt="image" src="https://github.com/user-attachments/assets/32ded274-86d4-4d7b-b1dd-5f4810eeb7c5" />

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [x] I added unit tests for my changes where possible
