### PR TITLE
fix(router): Validate customer_id in payments_create for setup_future_usage

### DIFF
--- a/crates/router/src/core/payments/operations/payment_create.rs
+++ b/crates/router/src/core/payments/operations/payment_create.rs
@@ -1034,16 +1034,16 @@ impl<F: Send + Clone + Sync> ValidateRequest<F, api::PaymentsRequest, PaymentDat
                 &request.payment_token,
                 &request.ctp_service_details,
             )?;
-
-            helpers::validate_customer_id_mandatory_cases(
-                request.setup_future_usage.is_some(),
-                request.customer_id.as_ref().or(request
-                    .customer
-                    .as_ref()
-                    .map(|customer| customer.id.clone())
-                    .as_ref()),
-            )?;
         }
+
+        helpers::validate_customer_id_mandatory_cases(
+            request.setup_future_usage.is_some(),
+            request.customer_id.as_ref().or(request
+                .customer
+                .as_ref()
+                .map(|customer| customer.id.clone())
+                .as_ref()),
+        )?;
 
         if request.split_payments.is_some() {
             let amount = request.amount.get_required_value("amount")?;


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
- Moved the customer_id mandatory validation outside of the confirm == true condition.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
When `setup_future_usage` is not None, `customer_id` must be provided. Earlier this validation was only performed when `confirm` was set to `true` and was skipped in payments create when confirm was `false`. This behaviour is wrong. The validation needs to be performed in payments create as well.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Payments Create Request:

```
curl --location 'http://localhost:8080/payments' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: dev_FiYC9AJeznsEak4vtVLoEX5vKfxap2CWnrGZg5bc2oR320BwkPbu6UTV21izn33D' \
--data '{
    "amount": 180000,
    "currency": "USD",
    "setup_future_usage": "on_session"  
}'
```

Response:

```json
{
    "error": {
        "type": "invalid_request",
        "message": "customer_id is mandatory when setup_future_usage is given",
        "code": "IR_16"
    }
}
```
## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [x] I added unit tests for my changes where possible
