### PR TITLE
fix(user_auth_methods): Handle email domains not having any auth methods in terminate auth select

### DIFF
--- a/crates/router/src/core/user.rs
+++ b/crates/router/src/core/user.rs
@@ -3037,7 +3037,7 @@ pub async fn terminate_auth_select(
             .ok_or(UserErrors::InvalidUserAuthMethodOperation)?,
         (Some(id), true) => state
             .store
-            .get_user_authentication_method_by_id(id)
+            .get_user_authentication_method_by_id(&id)
             .await
             .to_not_found_response(UserErrors::InvalidUserAuthMethodOperation)?,
         (None, true) => DEFAULT_USER_AUTH_METHOD.clone(),


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Added a check to see if the auth methods list of the email domain of the user is empty. 

If it is empty, then we will allow the user to continue with the flow.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
Closes https://github.com/juspay/hyperswitch-control-center/issues/4004

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
```bash
curl 'http://localhost:9000/api/user/auth/select' \
  -H 'authorization: Bearer JWT' \
  --data-raw '{"id":"bcc53b5e-d97a-4249-855d-acf594755e1b"}'
```

Above API should give 200 OK in case of Okta setup without any email domain.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
