### PR TITLE
fix(core): RAW_BYTES Request Handling

### DIFF
--- a/crates/hyperswitch_interfaces/src/api_client.rs
+++ b/crates/hyperswitch_interfaces/src/api_client.rs
@@ -244,7 +244,10 @@ where
                             RequestContent::FormData((_, i)) => i
                                 .masked_serialize()
                                 .unwrap_or(json!({ "error": "failed to mask serialize"})),
-                            RequestContent::RawBytes(_) => json!({"request_type": "RAW_BYTES"}),
+                            RequestContent::RawBytes(bytes) => match String::from_utf8(bytes.clone()) {
+                                Ok(request) => json!({ "request_type": "RAW_BYTES", "request": request }),
+                                Err(_) => json!({ "request_type": "RAW_BYTES" }),
+                            }
                         },
                         None => serde_json::Value::Null,
                     };


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
This PR updates the handling of raw_connector_request in cases when the request is sent to the connector in RawBytes.
**Before:** `raw_connector_request` was output as { "request_type": "RAW_BYTES" } regardless of the content.

**After:** RequestContent::RawBytes(bytes) now attempts to decode the byte array into a UTF-8 string. If successful, the request is displayed as { "request_type": "RAW_BYTES", "request": <decoded_string> }. If decoding fails, it falls back to { "request_type": "RAW_BYTES" }.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
