### PR TITLE
fix(connector): Handle Mollie failed payments with error details from details object

### DIFF
--- a/crates/hyperswitch_connectors/src/connectors/mollie/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/mollie/transformers.rs
@@ -683,9 +683,7 @@ impl<F, T> TryFrom<ResponseRouterData<F, MolliePaymentsResponse, T, PaymentsResp
 
         // Handle failed payments: extract error details from the details object
         // Mollie returns 2xx but with status "failed" when payment fails after 3DS authentication
-        if item.response.status == MolliePaymentStatus::Failed
-            || item.response.status == MolliePaymentStatus::Expired
-        {
+        if crate::utils::is_payment_failure(status) {
             let (failure_reason, failure_message) = item
                 .response
                 .details


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Mollie can return HTTP 2xx responses even when a payment fails (for example, after a 3DS authentication flow). In such cases, the payment status is marked as failed or expired, and failure information is provided inside the details object.

Previously, these failures were not being surfaced correctly as connector errors in Hyperswitch.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
request create
```
curl --location 'http://localhost:8080/payments' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: dev_iZc5amc1LbErVU7bwagJXEa61TQ7K1OsLXTxsXiPHzclDUjiC1K05aSvgFPeJN21' \
--data-raw '{
    "amount": 100200,
    "currency": "EUR",
    "confirm": true,
    "business_country": "US",
    "business_label": "default",
    
    "customer_id": "cu_1757579182",
    "capture_method": "automatic",
    "capture_on": "2022-09-10T10:11:12Z",
    "setup_future_usage": "off_session",
    
    "return_url": "https://google.com",
    "email": "something@gmail.com",
    "name": "Joseph Doe",
    "phone": "999999999",
     "billing": {
        "address": {
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "city": "Zurich",
            "state": "asd",
            "zip": "8008",
            "country": "CH",
            "first_name": "joseph",
            "last_name": "Doe"
        }
    },
    "phone_country_code": "+65",
    "description": "Its my first payment request",
    "statement_descriptor_name": "Juspay",
    "statement_descriptor_suffix": "Router",
    "payment_method": "card",
    "payment_method_type": "credit",
    "browser_info": {
        "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Safari/537.36",
        "accept_header": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8",
        "language": "nl-NL",
        "color_depth": 24,
        "screen_height": 723,
        "screen_width": 1536,
        "time_zone": 0,
        "java_enabled": true,
        "java_script_enabled": true,
        "ip_address": "13.232.74.226"
    },
    "payment_method_data": {
        "card": {
            "card_number": "4543474002249996",
            "card_exp_month": "04",
            "card_exp_year": "2026",
            "card_holder_name": "John Smith",
            "card_cvc": "123"
        }
    },
    "customer_acceptance": {
        "acceptance_type": "offline",
        "accepted_at": "1963-05-03T04:07:52.723Z",
        "online": {
            "ip_address": "in sit",
            "user_agent": "amet irure esse"
        }
    }
}'
```
Response
```
{
    "payment_id": "pay_0GZt6OGeGveHduNPIZ9u",
    "merchant_id": "merchant_1767611044",
    "status": "requires_customer_action",
    "amount": 100100,
    "net_amount": 100100,
    "shipping_cost": null,
    "amount_capturable": 100100,
    "amount_received": null,
    "connector": "mollie",
    "client_secret": "pay_0GZt6OGeGveHduNPIZ9u_secret_n24ey5tpJ2Cl6eMDx450",
    "created": "2026-01-05T11:04:52.870Z",
    "modified_at": "2026-01-05T11:04:55.117Z",
    "currency": "EUR",
    "customer_id": "cu_1757579182",
    "customer": {
        "id": "cu_1757579182",
        "name": "Joseph Doe",
        "email": "something@gmail.com",
        "phone": "999999999",
        "phone_country_code": "+65"
    },
    "description": "Its my first payment request",
    "refunds": null,
    "disputes": null,
    "mandate_id": null,
    "mandate_data": null,
    "setup_future_usage": "off_session",
    "off_session": null,
    "capture_on": null,
    "capture_method": "automatic",
    "payment_method": "card",
    "payment_method_data": {
        "card": {
            "last4": "9996",
            "card_type": "CREDIT",
            "card_network": "Visa",
            "card_issuer": "SBM BANK (MAURITIUS) LTD",
            "card_issuing_country": "MAURITIUS",
            "card_isin": "454347",
            "card_extended_bin": null,
            "card_exp_month": "04",
            "card_exp_year": "2026",
            "card_holder_name": "John Smith",
            "payment_checks": null,
            "authentication_data": null
        },
        "billing": null
    },
    "payment_token": null,
    "shipping": null,
    "billing": {
        "address": {
            "city": "Zurich",
            "country": "CH",
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "zip": "8008",
            "state": "asd",
            "first_name": "joseph",
            "last_name": "Doe",
            "origin_zip": null
        },
        "phone": null,
        "email": null
    },
    "order_details": null,
    "email": "something@gmail.com",
    "name": "Joseph Doe",
    "phone": "999999999",
    "return_url": "https://google.com/",
    "authentication_type": "no_three_ds",
    "statement_descriptor_name": "Juspay",
    "statement_descriptor_suffix": "Router",
    "next_action": {
        "type": "redirect_to_url",
        "redirect_to_url": "http://localhost:8080/payments/redirect/pay_0GZt6OGeGveHduNPIZ9u/merchant_1767611044/pay_0GZt6OGeGveHduNPIZ9u_1"
    },
    "cancellation_reason": null,
    "error_code": null,
    "error_message": null,
    "unified_code": null,
    "unified_message": null,
    "payment_experience": null,
    "payment_method_type": "credit",
    "connector_label": "mollie_US_default",
    "business_country": "US",
    "business_label": "default",
    "business_sub_label": null,
    "allowed_payment_method_types": null,
    "manual_retry_allowed": null,
    "connector_transaction_id": "tr_Rv7Z6JUk4efZc2jDZ7LKJ",
    "frm_message": null,
    "metadata": null,
    "connector_metadata": null,
    "feature_metadata": {
        "redirect_response": null,
        "search_tags": null,
        "apple_pay_recurring_details": null,
        "gateway_system": "direct"
    },
    "reference_id": "tr_Rv7Z6JUk4efZc2jDZ7LKJ",
    "payment_link": null,
    "profile_id": "pro_4OfHOaiqvXxuG1b51A5r",
    "surcharge_details": null,
    "attempt_count": 1,
    "merchant_decision": null,
    "merchant_connector_id": "mca_KHuZ2ExQ0Nk7JLKdJR5h",
    "incremental_authorization_allowed": false,
    "authorization_count": null,
    "incremental_authorizations": null,
    "external_authentication_details": null,
    "external_3ds_authentication_attempted": false,
    "expires_on": "2026-01-05T11:19:52.870Z",
    "fingerprint": null,
    "browser_info": {
        "language": "nl-NL",
        "time_zone": 0,
        "ip_address": "13.232.74.226",
        "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Safari/537.36",
        "color_depth": 24,
        "java_enabled": true,
        "screen_width": 1536,
        "accept_header": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8",
        "screen_height": 723,
        "java_script_enabled": true
    },
    "payment_channel": null,
    "payment_method_id": "pm_rkcjppb82wF7wtiKKLQT",
    "network_transaction_id": null,
    "payment_method_status": "inactive",
    "updated": "2026-01-05T11:04:55.117Z",
    "split_payments": null,
    "frm_metadata": null,
    "extended_authorization_applied": null,
    "extended_authorization_last_applied_at": null,
    "request_extended_authorization": null,
    "capture_before": null,
    "merchant_order_reference_id": null,
    "order_tax_amount": null,
    "connector_mandate_id": "mdt_8Guc3hoYi4",
    "card_discovery": "manual",
    "force_3ds_challenge": false,
    "force_3ds_challenge_trigger": false,
    "issuer_error_code": null,
    "issuer_error_message": null,
    "is_iframe_redirection_enabled": null,
    "whole_connector_response": null,
    "enable_partial_authorization": null,
    "enable_overcapture": null,
    "is_overcapture_enabled": null,
    "network_details": null,
    "is_stored_credential": null,
    "mit_category": null,
    "billing_descriptor": null,
    "tokenization": null,
    "partner_merchant_identifier_details": null,
    "payment_method_tokenization_details": {
        "payment_method_id": "pm_rkcjppb82wF7wtiKKLQT",
        "payment_method_status": "inactive",
        "psp_tokenization": false,
        "network_tokenization": false,
        "network_transaction_id": null,
        "is_eligible_for_mit_payment": false
    }
}
```
Psync after Redirect Response
```
{
    "payment_id": "pay_0GZt6OGeGveHduNPIZ9u",
    "merchant_id": "merchant_1767611044",
    "status": "failed",
    "amount": 100100,
    "net_amount": 100100,
    "shipping_cost": null,
    "amount_capturable": 0,
    "amount_received": null,
    "connector": "mollie",
    "client_secret": "pay_0GZt6OGeGveHduNPIZ9u_secret_n24ey5tpJ2Cl6eMDx450",
    "created": "2026-01-05T11:04:52.870Z",
    "modified_at": "2026-01-05T11:05:12.856Z",
    "currency": "EUR",
    "customer_id": "cu_1757579182",
    "customer": {
        "id": "cu_1757579182",
        "name": "Joseph Doe",
        "email": "something@gmail.com",
        "phone": "999999999",
        "phone_country_code": "+65"
    },
    "description": "Its my first payment request",
    "refunds": null,
    "disputes": null,
    "attempts": [
        {
            "attempt_id": "pay_0GZt6OGeGveHduNPIZ9u_1",
            "status": "failure",
            "amount": 100100,
            "order_tax_amount": null,
            "currency": "EUR",
            "connector": "mollie",
            "error_message": "The card number provided is invalid.",
            "payment_method": "card",
            "connector_transaction_id": "tr_Rv7Z6JUk4efZc2jDZ7LKJ",
            "capture_method": "automatic",
            "authentication_type": "no_three_ds",
            "created_at": "2026-01-05T11:04:52.870Z",
            "modified_at": "2026-01-05T11:05:12.856Z",
            "cancellation_reason": null,
            "mandate_id": null,
            "error_code": "invalid_card_number",
            "payment_token": null,
            "connector_metadata": null,
            "payment_experience": null,
            "payment_method_type": "credit",
            "reference_id": "tr_Rv7Z6JUk4efZc2jDZ7LKJ",
            "unified_code": "UE_9000",
            "unified_message": "Something went wrong",
            "client_source": null,
            "client_version": null
        }
    ],
    "mandate_id": null,
    "mandate_data": null,
    "setup_future_usage": "off_session",
    "off_session": null,
    "capture_on": null,
    "capture_method": "automatic",
    "payment_method": "card",
    "payment_method_data": {
        "card": {
            "last4": "9996",
            "card_type": "CREDIT",
            "card_network": "Visa",
            "card_issuer": "SBM BANK (MAURITIUS) LTD",
            "card_issuing_country": "MAURITIUS",
            "card_isin": "454347",
            "card_extended_bin": null,
            "card_exp_month": "04",
            "card_exp_year": "2026",
            "card_holder_name": "John Smith",
            "payment_checks": null,
            "authentication_data": null
        },
        "billing": null
    },
    "payment_token": null,
    "shipping": null,
    "billing": {
        "address": {
            "city": "Zurich",
            "country": "CH",
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "zip": "8008",
            "state": "asd",
            "first_name": "joseph",
            "last_name": "Doe",
            "origin_zip": null
        },
        "phone": null,
        "email": null
    },
    "order_details": null,
    "email": "something@gmail.com",
    "name": "Joseph Doe",
    "phone": "999999999",
    "return_url": "https://google.com/",
    "authentication_type": "no_three_ds",
    "statement_descriptor_name": "Juspay",
    "statement_descriptor_suffix": "Router",
    "next_action": null,
    "cancellation_reason": null,
    "error_code": "invalid_card_number",
    "error_message": "The card number provided is invalid.",
    "unified_code": "UE_9000",
    "unified_message": "Something went wrong",
    "payment_experience": null,
    "payment_method_type": "credit",
    "connector_label": "mollie_US_default",
    "business_country": "US",
    "business_label": "default",
    "business_sub_label": null,
    "allowed_payment_method_types": null,
    "manual_retry_allowed": null,
    "connector_transaction_id": "tr_Rv7Z6JUk4efZc2jDZ7LKJ",
    "frm_message": null,
    "metadata": null,
    "connector_metadata": null,
    "feature_metadata": {
        "redirect_response": null,
        "search_tags": null,
        "apple_pay_recurring_details": null,
        "gateway_system": "direct"
    },
    "reference_id": "tr_Rv7Z6JUk4efZc2jDZ7LKJ",
    "payment_link": null,
    "profile_id": "pro_4OfHOaiqvXxuG1b51A5r",
    "surcharge_details": null,
    "attempt_count": 1,
    "merchant_decision": null,
    "merchant_connector_id": "mca_KHuZ2ExQ0Nk7JLKdJR5h",
    "incremental_authorization_allowed": false,
    "authorization_count": null,
    "incremental_authorizations": null,
    "external_authentication_details": null,
    "external_3ds_authentication_attempted": false,
    "expires_on": "2026-01-05T11:19:52.870Z",
    "fingerprint": null,
    "browser_info": {
        "language": "nl-NL",
        "time_zone": 0,
        "ip_address": "13.232.74.226",
        "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Safari/537.36",
        "color_depth": 24,
        "java_enabled": true,
        "screen_width": 1536,
        "accept_header": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8",
        "screen_height": 723,
        "java_script_enabled": true
    },
    "payment_channel": null,
    "payment_method_id": "pm_rkcjppb82wF7wtiKKLQT",
    "network_transaction_id": null,
    "payment_method_status": "inactive",
    "updated": "2026-01-05T11:05:12.856Z",
    "split_payments": null,
    "frm_metadata": null,
    "extended_authorization_applied": null,
    "extended_authorization_last_applied_at": null,
    "request_extended_authorization": null,
    "capture_before": null,
    "merchant_order_reference_id": null,
    "order_tax_amount": null,
    "connector_mandate_id": null,
    "card_discovery": "manual",
    "force_3ds_challenge": false,
    "force_3ds_challenge_trigger": false,
    "issuer_error_code": null,
    "issuer_error_message": null,
    "is_iframe_redirection_enabled": null,
    "whole_connector_response": null,
    "enable_partial_authorization": null,
    "enable_overcapture": null,
    "is_overcapture_enabled": null,
    "network_details": {
        "network_advice_code": null
    },
    "is_stored_credential": null,
    "mit_category": null,
    "billing_descriptor": null,
    "tokenization": null,
    "partner_merchant_identifier_details": null,
    "payment_method_tokenization_details": {
        "payment_method_id": "pm_rkcjppb82wF7wtiKKLQT",
        "payment_method_status": "inactive",
        "psp_tokenization": false,
        "network_tokenization": false,
        "network_transaction_id": null,
        "is_eligible_for_mit_payment": false
    }
}
```
<img width="1238" height="687" alt="Screenshot 2026-01-09 at 11 39 15 AM" src="https://github.com/user-attachments/assets/0cf555f1-50b9-4a16-a06f-ae0f07bac037" />
<img width="886" height="740" alt="Screenshot 2026-01-09 at 11 39 51 AM" src="https://github.com/user-attachments/assets/d96faa3a-84c6-46df-9a1a-4746bf87d3db" />
<img width="828" height="731" alt="Screenshot 2026-01-09 at 11 39 59 AM" src="https://github.com/user-attachments/assets/f9b7ff2a-4805-4794-8d4f-4e33217e03b6" />
<img width="976" height="471" alt="Screenshot 2026-01-09 at 11 40 03 AM" src="https://github.com/user-attachments/assets/d372571b-71a6-4be8-bc66-5ddc543f3160" />

few of the refund tests  are giving 4xx : capture calls were in processing state
<img width="792" height="739" alt="Screenshot 2026-01-09 at 11 48 45 AM" src="https://github.com/user-attachments/assets/c332e509-75d8-4131-b5e1-205f62f3361d" />
<img width="734" height="715" alt="Screenshot 2026-01-09 at 11 48 52 AM" src="https://github.com/user-attachments/assets/c2392cd5-7610-4fe2-8253-82e429c754e2" />
<img width="841" height="638" alt="Screenshot 2026-01-09 at 11 49 00 AM" src="https://github.com/user-attachments/assets/7630e39a-af11-4cce-957a-074a44e08a3e" />
<img width="767" height="670" alt="Screenshot 2026-01-09 at 11 49 08 AM" src="https://github.com/user-attachments/assets/aaed6b17-fd00-4d3d-b28e-b25c1fa08b2b" />


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
