### PR TITLE
fix(router): use intent to populate setup_future_usage in router_data

### DIFF
--- a/crates/router/src/core/payments/transformers.rs
+++ b/crates/router/src/core/payments/transformers.rs
@@ -3906,7 +3906,9 @@ where
             captures: captures_response,
             mandate_id,
             mandate_data,
-            setup_future_usage: payment_attempt.setup_future_usage_applied,
+            setup_future_usage: payment_attempt
+                .setup_future_usage_applied
+                .or(payment_intent.setup_future_usage),
             off_session: payment_intent.off_session,
             capture_on: None,
             capture_method: payment_attempt.capture_method,
@@ -4197,7 +4199,7 @@ impl ForeignFrom<(storage::PaymentIntent, storage::PaymentAttempt)> for api::Pay
             business_label: pi.business_label,
             business_country: pi.business_country,
             business_sub_label: pa.business_sub_label,
-            setup_future_usage: pi.setup_future_usage,
+            setup_future_usage: pa.setup_future_usage_applied.or(pi.setup_future_usage),
             capture_method: pa.capture_method,
             authentication_type: pa.authentication_type,
             connector_transaction_id,
@@ -5022,7 +5024,10 @@ impl<F: Clone> TryFrom<PaymentAdditionalData<'_, F>> for types::PaymentsSyncData
                 .payment_attempt
                 .connector_response_reference_id
                 .clone(),
-            setup_future_usage: payment_data.payment_intent.setup_future_usage,
+            setup_future_usage: payment_data
+                .payment_attempt
+                .setup_future_usage_applied
+                .or(payment_data.payment_intent.setup_future_usage),
         })
     }
 }
@@ -5478,7 +5483,10 @@ impl<F: Clone> TryFrom<PaymentAdditionalData<'_, F>> for types::PaymentsPostSess
             merchant_order_reference_id,
             capture_method: payment_data.payment_attempt.capture_method,
             shipping_cost: payment_data.payment_intent.shipping_cost,
-            setup_future_usage: payment_data.payment_attempt.setup_future_usage_applied,
+            setup_future_usage: payment_data
+                .payment_attempt
+                .setup_future_usage_applied
+                .or(payment_data.payment_intent.setup_future_usage),
             router_return_url,
         })
     }
@@ -5924,7 +5932,10 @@ impl<F: Clone> TryFrom<PaymentAdditionalData<'_, F>> for types::SetupMandateRequ
             payment_method_data: (payment_data
                 .payment_method_data
                 .get_required_value("payment_method_data")?),
-            setup_future_usage: payment_data.payment_attempt.setup_future_usage_applied,
+            setup_future_usage: payment_data
+                .payment_attempt
+                .setup_future_usage_applied
+                .or(payment_data.payment_intent.setup_future_usage),
             off_session: is_off_session,
             mandate_id: payment_data.mandate_id.clone(),
             setup_mandate_details: payment_data.setup_mandate,
@@ -6083,7 +6094,10 @@ impl<F: Clone> TryFrom<PaymentAdditionalData<'_, F>> for types::CompleteAuthoriz
             payment_data.clone().get_creds_identifier(),
         ));
         Ok(Self {
-            setup_future_usage: payment_data.payment_intent.setup_future_usage,
+            setup_future_usage: payment_data
+                .payment_attempt
+                .setup_future_usage_applied
+                .or(payment_data.payment_intent.setup_future_usage),
             mandate_id: payment_data.mandate_id.clone(),
             off_session: is_off_session,
             setup_mandate_details: payment_data.setup_mandate.clone(),
@@ -6232,7 +6246,10 @@ impl<F: Clone> TryFrom<PaymentAdditionalData<'_, F>> for types::PaymentsPreProce
             split_payments: payment_data.payment_intent.split_payments,
             metadata: payment_data.payment_intent.metadata.map(Secret::new),
             customer_acceptance: payment_data.customer_acceptance,
-            setup_future_usage: payment_data.payment_intent.setup_future_usage,
+            setup_future_usage: payment_data
+                .payment_attempt
+                .setup_future_usage_applied
+                .or(payment_data.payment_intent.setup_future_usage),
             is_stored_credential: payment_data.payment_attempt.is_stored_credential,
         })
     }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
router_data is being populated by setup_future_usage_applied from attempt which caused problem in manual retry because attempt doesn't have any value set in this field for at it take if from the request. 
Now the setup_future_usage will be populated from attempt as well as intent since it contain the merchant provided transaction data.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
#### Tested through Postman:

- Create an MCA(Cybersource)
- Enable manual retry in profile:
```
{
    "is_manual_retry_enabled": true
}
```

#### Prerequisite for Testing

Body for Payment Intent:
```
{
    "amount": 100,
    "currency": "USD",
    "confirm": false,
    "capture_method": "automatic",
    "capture_on": "2022-09-10T10:11:12Z",
    "customer_id": "{{customer_id}}",
    "email": "guest@example.com",
    "name": "John Doe",
    "phone": "999999999",
    "phone_country_code": "+65",
    "description": "Its my first payment request",
    "authentication_type": "no_three_ds",
    "return_url": "https://duck.com",
    "billing": {
        "address": {
            "city": "test",
            "country": "HR",
            "line1": "here is some \n there is some \n none is some? \n ",
            "line2": "there",
            "line3": "anywhere",
            "zip": "560095",
            "state": "Varaždin County",
            "first_name": "S@k!l",
            "last_name": "M*st@k"
        }
    },
    "shipping": {
        "address": {
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "city": "San Fransico",
            "state": "California",
            "zip": "94122",
            "country": "US",
            "first_name": "PiX"
        }
    },
    "statement_descriptor_name": "joseph",
    "statement_descriptor_suffix": "JS",
    "metadata": {
        "udf1": "value1",
        "new_customer": "true",
        "login_date": "2019-09-10T10:11:12Z"
    },
    "setup_future_usage": "off_session",
    "customer_acceptance": {
        "acceptance_type": "offline",
        "accepted_at": "1963-05-03T04:07:52.723Z",
        "online": {
            "ip_address": "125.0.0.1",
            "user_agent": "amet irure esse"
        }
    }
}
```

Success Body for Confirm:
```
{
    "payment_method": "card",
    "payment_method_type": "credit",
    "payment_method_data": {
        "billing": {
            "address": {
                "city": "sakilmostak",
                "country": "US",
                "line1": "here",
                "line2": "there",
                "line3": "anywhere",
                "zip": "560090",
                "state": "Washington",
                "first_name": "One",
                "last_name": "Two"
            },  
            "phone": {
                "number": "1234567890",
                "country_code": "+1"
            },
            "email": "guest@example.com"
        },
        "card": {
            "card_number": "4242424242424242",
            "card_exp_month": "02",
            "card_exp_year": "2026",
            "card_holder_name": "Sakil Mostak",
            "card_cvc": "999"
        }
    },
    "billing": {
        "address": {
            "city": "Mostak",
            "country": "GB",
            "line1": "here is some \n there is some \n none is some? \n ",
            "line2": "there",
            "line3": "anywhere",
            "zip": "560095",
            "state": "Varaždin County",
            "first_name": "Sakil",
            "last_name": "Mostak"
        }
    },
    "client_secret": "{{client_secret}}",
    "browser_info": {
        "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Safari/537.36",
        "accept_header": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8",
        "language": "nl-NL",
        "color_depth": 24,
        "screen_height": 723,
        "screen_width": 1536,
        "time_zone": 0,
        "java_enabled": true,
        "java_script_enabled": true,
        "ip_address": "125.0.0.1"
    }
}
```

Failure Body for Confirm: 
```
{
    "payment_method": "card",
    "payment_method_type": "credit",
    "payment_method_data": {
        "billing": {
            "address": {
                "city": "sakilmostak",
                "country": "US",
                "line1": "here",
                "line2": "there",
                "line3": "anywhere",
                "zip": "560090",
                "state": "Washingtonr//",
                "first_name": "One",
                "last_name": "Two"
            },  
            "phone": {
                "number": "1234567890",
                "country_code": "+1"
            },
            "email": "guest@example.com"
        },
        "card": {
            "card_number": "4000000000000002",
            "card_exp_month": "02",
            "card_exp_year": "2026",
            "card_holder_name": "Sakil Mostak",
            "card_cvc": "999"
        }
    },
    "billing": {
        "address": {
            "city": "Mostak",
            "country": "GB",
            "line1": "here is some \n there is some \n none is some? \n ",
            "line2": "there",
            "line3": "anywhere",
            "zip": "560095",
            "state": "Washingtonr//",
            "first_name": "Sakil",
            "last_name": "Mostak"
        }
    },
    "client_secret": "{{client_secret}}",
    "browser_info": {
        "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Safari/537.36",
        "accept_header": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8",
        "language": "nl-NL",
        "color_depth": 24,
        "screen_height": 723,
        "screen_width": 1536,
        "time_zone": 0,
        "java_enabled": true,
        "java_script_enabled": true,
        "ip_address": "125.0.0.1"
    }
}
```


#### Sanity Test:

Test 1:
- Create an Payment Intent with setup_future_usage as off_session
Request
```
curl --location '{{baseUrl}}/payments' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key:{{api_key}}' \
--data-raw '{
    "amount": 100,
    "currency": "USD",
    "confirm": false,
    "capture_method": "automatic",
    "capture_on": "2022-09-10T10:11:12Z",
    "customer_id": "cus_APIxbBDg98et0ejtYhNp",
    "email": "guest@example.com",
    "name": "John Doe",
    "phone": "999999999",
    "phone_country_code": "+65",
    "description": "Its my first payment request",
    "authentication_type": "no_three_ds",
    "return_url": "https://duck.com",
    "billing": {
        "address": {
            "city": "test",
            "country": "HR",
            "line1": "here is some \n there is some \n none is some? \n ",
            "line2": "there",
            "line3": "anywhere",
            "zip": "560095",
            "state": "Varaždin County",
            "first_name": "S@k!l",
            "last_name": "M*st@k"
        }
    },
    "shipping": {
        "address": {
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "city": "San Fransico",
            "state": "California",
            "zip": "94122",
            "country": "US",
            "first_name": "PiX"
        }
    },
    "statement_descriptor_name": "joseph",
    "statement_descriptor_suffix": "JS",
    "metadata": {
        "udf1": "value1",
        "new_customer": "true",
        "login_date": "2019-09-10T10:11:12Z"
    },
    "setup_future_usage": "off_session",
    "customer_acceptance": {
        "acceptance_type": "offline",
        "accepted_at": "1963-05-03T04:07:52.723Z",
        "online": {
            "ip_address": "125.0.0.1",
            "user_agent": "amet irure esse"
        }
    }
}'
```
Response
```
{
    "payment_id": "pay_wcpp4vWUJw7iWMycLPf0",
    "merchant_id": "merchant_1767677977",
    "status": "requires_payment_method",
    "amount": 100,
    "net_amount": 100,
    "shipping_cost": null,
    "amount_capturable": 0,
    "amount_received": null,
    "connector": null,
    "client_secret": "pay_wcpp4vWUJw7iWMycLPf0_secret_7DYuXJGN5BlrMS5701Az",
    "created": "2026-01-06T12:14:48.306Z",
    "modified_at": "2026-01-06T12:14:48.354Z",
    "currency": "USD",
    "customer_id": "cus_APIxbBDg98et0ejtYhNp",
    "customer": {
        "id": "cus_APIxbBDg98et0ejtYhNp",
        "name": "John Doe",
        "email": "guest@example.com",
        "phone": "999999999",
        "phone_country_code": "+65"
    },
    "description": "Its my first payment request",
    "refunds": null,
    "disputes": null,
    "mandate_id": null,
    "mandate_data": null,
    "setup_future_usage": "off_session",
    "off_session": null,
    "capture_on": null,
    "capture_method": "automatic",
    "payment_method": null,
    "payment_method_data": null,
    "payment_token": null,
    "shipping": {
        "address": {
            "city": "San Fransico",
            "country": "US",
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "zip": "94122",
            "state": "California",
            "first_name": "PiX",
            "last_name": null,
            "origin_zip": null
        },
        "phone": null,
        "email": null
    },
    "billing": {
        "address": {
            "city": "test",
            "country": "HR",
            "line1": "here is some \n there is some \n none is some? \n ",
            "line2": "there",
            "line3": "anywhere",
            "zip": "560095",
            "state": "Varaždin County",
            "first_name": "S@k!l",
            "last_name": "M*st@k",
            "origin_zip": null
        },
        "phone": null,
        "email": null
    },
    "order_details": null,
    "email": "guest@example.com",
    "name": "John Doe",
    "phone": "999999999",
    "return_url": "https://duck.com/",
    "authentication_type": "no_three_ds",
    "statement_descriptor_name": "joseph",
    "statement_descriptor_suffix": "JS",
    "next_action": null,
    "cancellation_reason": null,
    "error_code": null,
    "error_message": null,
    "unified_code": null,
    "unified_message": null,
    "payment_experience": null,
    "payment_method_type": null,
    "connector_label": null,
    "business_country": null,
    "business_label": "default",
    "business_sub_label": null,
    "allowed_payment_method_types": null,
    "manual_retry_allowed": null,
    "connector_transaction_id": null,
    "frm_message": null,
    "metadata": {
        "udf1": "value1",
        "login_date": "2019-09-10T10:11:12Z",
        "new_customer": "true"
    },
    "connector_metadata": null,
    "feature_metadata": null,
    "reference_id": null,
    "payment_link": null,
    "profile_id": "pro_Q1NkL463yzo1ncrtWUB6",
    "surcharge_details": null,
    "attempt_count": 1,
    "merchant_decision": null,
    "merchant_connector_id": null,
    "incremental_authorization_allowed": null,
    "authorization_count": null,
    "incremental_authorizations": null,
    "external_authentication_details": null,
    "external_3ds_authentication_attempted": false,
    "expires_on": "2026-01-06T12:29:48.306Z",
    "fingerprint": null,
    "browser_info": null,
    "payment_channel": null,
    "payment_method_id": null,
    "network_transaction_id": null,
    "payment_method_status": null,
    "updated": "2026-01-06T12:14:48.354Z",
    "split_payments": null,
    "frm_metadata": null,
    "extended_authorization_applied": null,
    "extended_authorization_last_applied_at": null,
    "request_extended_authorization": null,
    "capture_before": null,
    "merchant_order_reference_id": null,
    "order_tax_amount": null,
    "connector_mandate_id": null,
    "card_discovery": null,
    "force_3ds_challenge": false,
    "force_3ds_challenge_trigger": false,
    "issuer_error_code": null,
    "issuer_error_message": null,
    "is_iframe_redirection_enabled": null,
    "whole_connector_response": null,
    "enable_partial_authorization": null,
    "enable_overcapture": null,
    "is_overcapture_enabled": null,
    "network_details": null,
    "is_stored_credential": null,
    "mit_category": null,
    "billing_descriptor": null,
    "tokenization": null,
    "partner_merchant_identifier_details": null,
    "payment_method_tokenization_details": null
}
```
- Confirm the Intent with success object, the response should have setup_future_usage as off_session and status as success
Request
```
curl --location '{{baseUrl}}/payments/pay_wcpp4vWUJw7iWMycLPf0/confirm' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key:{{publishable_key}}' \
--data-raw '{
    "payment_method": "card",
    "payment_method_type": "credit",
    
    "payment_method_data": {
        "billing": {
            "address": {
                "city": "sakilmostak",
                "country": "US",
                "line1": "here",
                "line2": "there",
                "line3": "anywhere",
                "zip": "560090",
                "state": "Washington",
                "first_name": "One",
                "last_name": "Two"
            },  
            "phone": {
                "number": "1234567890",
                "country_code": "+1"
            },
            "email": "guest@example.com"
        },
        "card": {
            "card_number": "4242424242424242",
            "card_exp_month": "02",
            "card_exp_year": "2026",
            "card_holder_name": "Sakil Mostak",
            "card_cvc": "999"
            
        }
    },
    "billing": {
        "address": {
            "city": "Mostak",
            "country": "GB",
            "line1": "here is some \n there is some \n none is some? \n ",
            "line2": "there",
            "line3": "anywhere",
            "zip": "560095",
            "state": "Varaždin County",
            "first_name": "Sakil",
            "last_name": "Mostak"
        }
    },
    "client_secret": "pay_wcpp4vWUJw7iWMycLPf0_secret_7DYuXJGN5BlrMS5701Az",
    "browser_info": {
        "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Safari/537.36",
        "accept_header": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8",
        "language": "nl-NL",
        "color_depth": 24,
        "screen_height": 723,
        "screen_width": 1536,
        "time_zone": 0,
        "java_enabled": true,
        "java_script_enabled": true,
        "ip_address": "125.0.0.1"
    }
}'
```
Response
```
{
    "payment_id": "pay_wcpp4vWUJw7iWMycLPf0",
    "merchant_id": "merchant_1767677977",
    "status": "succeeded",
    "amount": 100,
    "net_amount": 100,
    "shipping_cost": null,
    "amount_capturable": 0,
    "amount_received": 100,
    "connector": "cybersource",
    "client_secret": "pay_wcpp4vWUJw7iWMycLPf0_secret_7DYuXJGN5BlrMS5701Az",
    "created": "2026-01-06T12:14:48.306Z",
    "modified_at": "2026-01-06T12:16:20.343Z",
    "currency": "USD",
    "customer_id": "cus_APIxbBDg98et0ejtYhNp",
    "customer": {
        "id": "cus_APIxbBDg98et0ejtYhNp",
        "name": "John Doe",
        "email": "guest@example.com",
        "phone": "999999999",
        "phone_country_code": "+65"
    },
    "description": "Its my first payment request",
    "refunds": null,
    "disputes": null,
    "mandate_id": null,
    "mandate_data": null,
    "setup_future_usage": "off_session",
    "off_session": null,
    "capture_on": null,
    "capture_method": "automatic",
    "payment_method": "card",
    "payment_method_data": {
        "card": {
            "last4": "4242",
            "card_type": null,
            "card_network": null,
            "card_issuer": null,
            "card_issuing_country": null,
            "card_isin": "424242",
            "card_extended_bin": null,
            "card_exp_month": "02",
            "card_exp_year": "2026",
            "card_holder_name": "Sakil Mostak",
            "payment_checks": {
                "avs_response": {
                    "code": "X",
                    "codeRaw": "I1"
                },
                "card_verification": null
            },
            "authentication_data": null
        },
        "billing": {
            "address": {
                "city": "sakilmostak",
                "country": "US",
                "line1": "here",
                "line2": "there",
                "line3": "anywhere",
                "zip": "560090",
                "state": "Washington",
                "first_name": "One",
                "last_name": "Two",
                "origin_zip": null
            },
            "phone": {
                "number": "1234567890",
                "country_code": "+1"
            },
            "email": "guest@example.com"
        }
    },
    "payment_token": "token_wFBo5qQ1Q0jGdSe7qitA",
    "shipping": {
        "address": {
            "city": "San Fransico",
            "country": "US",
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "zip": "94122",
            "state": "California",
            "first_name": "PiX",
            "last_name": null,
            "origin_zip": null
        },
        "phone": null,
        "email": null
    },
    "billing": {
        "address": {
            "city": "Mostak",
            "country": "GB",
            "line1": "here is some \n there is some \n none is some? \n ",
            "line2": "there",
            "line3": "anywhere",
            "zip": "560095",
            "state": "Varaždin County",
            "first_name": "Sakil",
            "last_name": "Mostak",
            "origin_zip": null
        },
        "phone": null,
        "email": null
    },
    "order_details": null,
    "email": "guest@example.com",
    "name": "John Doe",
    "phone": "999999999",
    "return_url": "https://duck.com/",
    "authentication_type": "no_three_ds",
    "statement_descriptor_name": "joseph",
    "statement_descriptor_suffix": "JS",
    "next_action": null,
    "cancellation_reason": null,
    "error_code": null,
    "error_message": null,
    "unified_code": null,
    "unified_message": null,
    "payment_experience": null,
    "payment_method_type": "credit",
    "connector_label": null,
    "business_country": null,
    "business_label": "default",
    "business_sub_label": null,
    "allowed_payment_method_types": null,
    "manual_retry_allowed": false,
    "connector_transaction_id": "7677017797076391904806",
    "frm_message": null,
    "metadata": {
        "udf1": "value1",
        "login_date": "2019-09-10T10:11:12Z",
        "new_customer": "true"
    },
    "connector_metadata": null,
    "feature_metadata": {
        "redirect_response": null,
        "search_tags": null,
        "apple_pay_recurring_details": null,
        "gateway_system": "direct"
    },
    "reference_id": "pay_wcpp4vWUJw7iWMycLPf0_1",
    "payment_link": null,
    "profile_id": "pro_Q1NkL463yzo1ncrtWUB6",
    "surcharge_details": null,
    "attempt_count": 1,
    "merchant_decision": null,
    "merchant_connector_id": "mca_AOeW6bai9mFXYVbwbKzj",
    "incremental_authorization_allowed": false,
    "authorization_count": null,
    "incremental_authorizations": null,
    "external_authentication_details": null,
    "external_3ds_authentication_attempted": false,
    "expires_on": "2026-01-06T12:29:48.306Z",
    "fingerprint": null,
    "browser_info": {
        "os_type": null,
        "referer": null,
        "language": "nl-NL",
        "time_zone": 0,
        "ip_address": "125.0.0.1",
        "os_version": null,
        "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Safari/537.36",
        "color_depth": 24,
        "device_model": null,
        "java_enabled": true,
        "screen_width": 1536,
        "accept_header": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8",
        "screen_height": 723,
        "accept_language": "en",
        "java_script_enabled": true
    },
    "payment_channel": null,
    "payment_method_id": "pm_irE5BbAb6IeF8TmHcyrf",
    "network_transaction_id": "123456789619999",
    "payment_method_status": "active",
    "updated": "2026-01-06T12:16:20.343Z",
    "split_payments": null,
    "frm_metadata": null,
    "extended_authorization_applied": null,
    "extended_authorization_last_applied_at": null,
    "request_extended_authorization": null,
    "capture_before": null,
    "merchant_order_reference_id": null,
    "order_tax_amount": null,
    "connector_mandate_id": "47B820402806BC9CE063AF598E0A2BAC",
    "card_discovery": "manual",
    "force_3ds_challenge": false,
    "force_3ds_challenge_trigger": false,
    "issuer_error_code": null,
    "issuer_error_message": null,
    "is_iframe_redirection_enabled": null,
    "whole_connector_response": null,
    "enable_partial_authorization": null,
    "enable_overcapture": null,
    "is_overcapture_enabled": null,
    "network_details": null,
    "is_stored_credential": null,
    "mit_category": null,
    "billing_descriptor": null,
    "tokenization": null,
    "partner_merchant_identifier_details": null,
    "payment_method_tokenization_details": {
        "payment_method_id": "pm_irE5BbAb6IeF8TmHcyrf",
        "payment_method_status": "active",
        "psp_tokenization": false,
        "network_tokenization": false,
        "network_transaction_id": "123456789619999",
        "is_eligible_for_mit_payment": true
    }
}
```

Test 2:
- Create an Payment Intent with setup_future_usage as on_session
- Confirm the Intent with success object, the response should have setup_future_usage as on_session and status as success

##### Variation Test: 

Test 1:
- Create an Payment Intent with setup_future_usage as on_session
- Confirm the Intent with failure object, the response should have setup_future_usage as on_session and status as failure
- Confirm the Intent with success object, the response should have setup_future_usage as on_session and status as success

Test 2:
- Create an Payment Intent with setup_future_usage as off_session
- Confirm the Intent with failure object, the response should have setup_future_usage as off_session and status as failure
- Confirm the Intent with success object, the response should have setup_future_usage as off_session and status as success

Test 3:
- Create an Payment Intent with setup_future_usage as off_session
- Confirm the Intent with success object which doesn't support mandate, the response should have setup_future_usage as on_session and status as failure

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
