### PR TITLE
fix(external_services): Mask sender_email

### DIFF
--- a/crates/external_services/src/email.rs
+++ b/crates/external_services/src/email.rs
@@ -151,7 +151,7 @@ pub struct EmailSettings {
     pub allowed_unverified_days: i64,
 
     /// Sender email
-    pub sender_email: String,
+    pub sender_email: pii::Email,
 
     #[serde(flatten)]
     /// The client specific configurations

--- a/crates/external_services/src/email/ses.rs
+++ b/crates/external_services/src/email/ses.rs
@@ -19,7 +19,7 @@ use crate::email::{EmailClient, EmailError, EmailResult, EmailSettings, Intermed
 /// Client for AWS SES operation
 #[derive(Debug, Clone)]
 pub struct AwsSes {
-    sender: String,
+    sender: pii::Email,
     ses_config: SESConfig,
     settings: EmailSettings,
 }
@@ -222,7 +222,7 @@ impl EmailClient for AwsSes {
 
         email_client
             .send_email()
-            .from_email_address(self.sender.to_owned())
+            .from_email_address(self.sender.peek())
             .destination(
                 Destination::builder()
                     .to_addresses(recipient.peek())

--- a/crates/external_services/src/email/smtp.rs
+++ b/crates/external_services/src/email/smtp.rs
@@ -17,7 +17,7 @@ use crate::email::{EmailClient, EmailError, EmailResult, EmailSettings, Intermed
 #[derive(Debug, Clone, Default, serde::Deserialize)]
 pub struct SmtpServer {
     /// sender email id
-    pub sender: String,
+    pub sender: pii::Email,
     /// SMTP server specific configs
     pub smtp_config: SmtpServerConfig,
 }
@@ -156,7 +156,7 @@ impl EmailClient for SmtpServer {
 
         let email = Message::builder()
             .to(Self::to_mail_box(recipient.peek().to_string())?)
-            .from(Self::to_mail_box(self.sender.clone())?)
+            .from(Self::to_mail_box(self.sender.peek().to_string())?)
             .subject(subject)
             .header(ContentType::TEXT_HTML)
             .body(body)


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
- Changed the type of `sender_email` to `pii::Email` in the `external_services` crate

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
Closes #10847 

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Build and run router. In the logged application config, verified that the `sender_email` is masked.

<img width="1214" height="69" alt="image" src="https://github.com/user-attachments/assets/65c9ef02-2460-4fc4-816c-2e7d7950f824" />

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
