### PR TITLE
fix(connector): [worldpaymodular] capture issue

### DIFF
--- a/crates/hyperswitch_connectors/src/connectors/worldpaymodular/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/worldpaymodular/transformers.rs
@@ -4,8 +4,7 @@ use api_models::payments::{MandateIds, MandateReferenceId};
 use base64::Engine;
 use common_enums::{enums, Currency, PaymentChannel};
 use common_utils::{
-    consts::BASE64_ENGINE, errors::CustomResult, ext_traits::OptionExt, pii::SecretSerdeValue,
-    types::MinorUnit,
+    consts::BASE64_ENGINE, errors::CustomResult, pii::SecretSerdeValue, types::MinorUnit,
 };
 use error_stack::ResultExt;
 use hyperswitch_domain_models::{
@@ -64,28 +63,24 @@ fn fetch_payment_instrument(
     billing_address: Option<&Address>,
     connector_mandate_id: Option<MandateIds>,
 ) -> CustomResult<PaymentInstrument, ConnectorError> {
-    let billing_address =
-        if let Some(address) = billing_address.and_then(|addr| addr.address.clone()) {
-            Some(BillingAddress {
-                address1: address.line1,
-                address2: address.line2,
-                address3: address.line3,
-                city: address.city,
-                state: address.state,
-                postal_code: address
-                    .zip
-                    .get_required_value("zip")
-                    .change_context(ConnectorError::MissingRequiredField { field_name: "zip" })?,
-                country_code: address
-                    .country
-                    .get_required_value("country_code")
-                    .change_context(ConnectorError::MissingRequiredField {
-                        field_name: "country_code",
-                    })?,
-            })
-        } else {
-            None
-        };
+    let billing_address = billing_address
+        .and_then(|addr| addr.address.clone())
+        .and_then(
+            |address| match (address.line1, address.city, address.zip, address.country) {
+                (Some(address1), Some(city), Some(postal_code), Some(country_code)) => {
+                    Some(BillingAddress {
+                        address1,
+                        address2: address.line2,
+                        address3: address.line3,
+                        city,
+                        state: address.state,
+                        postal_code,
+                        country_code,
+                    })
+                }
+                _ => None,
+            },
+        );
     match payment_method {
         PaymentMethodData::MandatePayment => {
             let mandate_id = connector_mandate_id
@@ -186,8 +181,13 @@ impl
         Ok(Self {
             instruction: Instruction {
                 request_auto_settlement: RequestAutoSettlement {
-                    enabled: item.router_data.request.capture_method.unwrap_or_default()
-                        == enums::CaptureMethod::Automatic,
+                    enabled: match item.router_data.request.capture_method.unwrap_or_default() {
+                        enums::CaptureMethod::Automatic
+                        | enums::CaptureMethod::SequentialAutomatic => true,
+                        enums::CaptureMethod::Manual
+                        | enums::CaptureMethod::ManualMultiple
+                        | enums::CaptureMethod::Scheduled => false,
+                    },
                 },
                 value: PaymentValue {
                     amount: item.amount,

--- a/crates/hyperswitch_connectors/src/connectors/worldpaymodular/transformers/request.rs
+++ b/crates/hyperswitch_connectors/src/connectors/worldpaymodular/transformers/request.rs
@@ -4,14 +4,12 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Debug, PartialEq, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct BillingAddress {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub address1: Option<Secret<String>>,
+    pub address1: Secret<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub address2: Option<Secret<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub address3: Option<Secret<String>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub city: Option<String>,
+    pub city: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub state: Option<Secret<String>>,
     pub postal_code: Secret<String>,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->

1. When capture method is sent as None in payment request , Authorize RouterData is propagating as None and in connector layer we should consume it as Default Automatic,

The change to use unwrap_or_default() correctly handles the case where capture_method is None by defaulting to Automatic (which enables auto-settlement). However verify that:


    When capture_method is None, enabled is set to true
    When capture_method is Some(CaptureMethod::Automatic, sequentialAutomatic), enabled is set to true
    When capture_method is Some(CaptureMethod::Manual) or other non-Automatic values, enabled is set to false


2. for back support for address fields make address behavior same as Worldpay ,  

Make 

```json
{
    "amount": 190,
    "currency": "GBP",
    "confirm": true,
    "customer_id": "akshadya",
    "return_url": "https://www.google.com",
    // "capture_method": "automatic",
    "payment_method": "wallet",
    "payment_method_type": "google_pay",
    "authentication_type": "no_three_ds",
    "description": "hellow world",
    "connector": [
        "worldpaymodular"
    ],
    "setup_future_usage": "off_session",
    "customer_acceptance": {
        "acceptance_type": "offline",
        "accepted_at": "1963-05-03T04:07:52.723Z",
        "online": {
            "ip_address": "127.0.0.1",
            "user_agent": "amet irure esse"
        }
    },
    "billing": {
        "address": {
            // "zip": "560095",
            // "country": "UA",
            "first_name": "Sakil",
            "last_name": "Mostak",
            "line1": "Fasdf",
            "line2": "Fasdf",
            "city": "Fasdf"
        },
        "email": "nithin@test.com"
    },
    "browser_info": {
        "accept_header": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
        "ip_address": "192.168.1.1",
        "java_enabled": false,
        "java_script_enabled": true,
        "language": "en-US",
        "color_depth": 24,
        "screen_height": 1080,
        "screen_width": 1920,
        "time_zone": 330,
        "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36"
    },
    "email": "hello@gmail.com",
    "payment_method_data": {
        "wallet": {
            "google_pay": {
                "description": "SG Visa Success: Visa •••• 1390",
                "info": {
                    "assuranceDetails": {
                        "account_verified": true,
                        "card_holder_authenticated": false
                    },
                    "card_details": "1390",
                    "card_network": "VISA"
                },
                "tokenization_data": {
                    "token":"{\"signature\":\"M***********************}",
                    "type": "PAYMENT_GATEWAY"
                },
                "type": "CARD"
            }
        }
    }
}
```

## Response 

```json
{
    "payment_id": "pay_PsQTeoigNDd5mtVvaELc",
    "merchant_id": "merchant_1767941900",
    "status": "succeeded",
    "amount": 190,
    "net_amount": 190,
    "shipping_cost": null,
    "amount_capturable": 0,
    "amount_received": 190,
    "processor_merchant_id": "merchant_1767941900",
    "initiator": null,
    "connector": "worldpaymodular",
    "client_secret": "pay_PsQTeoigNDd5mtVvaELc_secret_z0KQM7WrcVTFrAbRHh4o",
    "created": "2026-01-09T12:38:01.725Z",
    "modified_at": "2026-01-09T12:38:03.526Z",
    "currency": "GBP",
    "customer_id": "akshadya",
    "customer": {
        "id": "akshadya",
        "name": null,
        "email": "hello@gmail.com",
        "phone": null,
        "phone_country_code": null
    },
    "description": "hellow world",
    "refunds": null,
    "disputes": null,
    "mandate_id": null,
    "mandate_data": null,
    "setup_future_usage": "off_session",
    "off_session": null,
    "capture_on": null,
    "capture_method": null,
    "payment_method": "wallet",
    "payment_method_data": {
        "wallet": {
            "google_pay": {
                "last4": "1390",
                "card_network": "VISA",
                "type": "CARD",
                "card_exp_month": null,
                "card_exp_year": null
            }
        },
        "billing": null
    },
    "payment_token": null,
    "shipping": null,
    "billing": {
        "address": {
            "city": "Fasdf",
            "country": null,
            "line1": "Fasdf",
            "line2": "Fasdf",
            "line3": null,
            "zip": null,
            "state": null,
            "first_name": "Sakil",
            "last_name": "Mostak",
            "origin_zip": null
        },
        "phone": null,
        "email": "nithin@test.com"
    },
    "order_details": null,
    "email": "hello@gmail.com",
    "name": null,
    "phone": null,
    "return_url": "https://www.google.com/",
    "authentication_type": "no_three_ds",
    "statement_descriptor_name": null,
    "statement_descriptor_suffix": null,
    "next_action": null,
    "cancellation_reason": null,
    "error_code": null,
    "error_message": null,
    "unified_code": null,
    "unified_message": null,
    "payment_experience": null,
    "payment_method_type": "google_pay",
    "connector_label": null,
    "business_country": null,
    "business_label": "default",
    "business_sub_label": null,
    "allowed_payment_method_types": null,
    "manual_retry_allowed": null,
    "connector_transaction_id": "eyJrIjoiazNhYjYzMiIsImxpbmtWZXJzaW9uIjoiNi4wLjAifQ==.sN:g8wd64bwkbrp0md+bPxcanBnk2zLdsIqSa1pR99HBj426bdlJXCgTskLhNY5Ml0rXtEPNSyl2cbsnj4b2DZwiqL3HuQDxN:neVn+zbpclW4Z+fnZKMutoUGX3m1:mkLWnU9Mrd53iA8FrhTC5vvv2rq02+3YLbfi+OOkahE1zjKIQRbzxI8yOGj32nOM0XIe9pic4l22Rveu3MW0qpy6tPOUnIlTrMDU8yZkwnykzDOVuNV9Smp3TrKAPuNF+mGHv+EpbUsv07dKPa3jQZMZkSLOAGYpq4tIxEOnFazGmUvl1hzVO3RqVpuKx4kVXPlLPNica5QxNgeVNY7uumcCsmHkfRLbWQGkTddXbipzLc0TuQHKDoQC6SU:fsP0JnCEuusgNZ7h7Lihv9Uw39xzvJ6qwMtf8S5Yl:XtdQtxyhXUPmgYR7cbuoBVJuwzNtCYZ2heiv85G+l1EF57uJw==",
    "frm_message": null,
    "metadata": null,
    "connector_metadata": null,
    "feature_metadata": {
        "redirect_response": null,
        "search_tags": null,
        "apple_pay_recurring_details": null,
        "gateway_system": "direct"
    },
    "reference_id": null,
    "payment_link": null,
    "profile_id": "pro_iTOXZSwtMLduVo21ZYja",
    "surcharge_details": null,
    "attempt_count": 1,
    "merchant_decision": null,
    "merchant_connector_id": "mca_nbbdYk4CpX9sPYCrErwD",
    "incremental_authorization_allowed": false,
    "authorization_count": null,
    "incremental_authorizations": null,
    "external_authentication_details": null,
    "external_3ds_authentication_attempted": false,
    "expires_on": "2026-01-09T12:53:01.725Z",
    "fingerprint": null,
    "browser_info": {
        "language": "en-US",
        "time_zone": 330,
        "ip_address": "192.168.1.1",
        "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36",
        "color_depth": 24,
        "java_enabled": false,
        "screen_width": 1920,
        "accept_header": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
        "screen_height": 1080,
        "java_script_enabled": true
    },
    "payment_channel": null,
    "payment_method_id": "pm_MMAdYo6wKahuSglhmej2",
    "network_transaction_id": null,
    "payment_method_status": "active",
    "updated": "2026-01-09T12:38:03.526Z",
    "split_payments": null,
    "frm_metadata": null,
    "extended_authorization_applied": null,
    "extended_authorization_last_applied_at": null,
    "request_extended_authorization": null,
    "capture_before": null,
    "merchant_order_reference_id": null,
    "order_tax_amount": null,
    "connector_mandate_id": "https://try.access.worldpay.com/tokens/eyJrIjoxLCJkIjoieC91VTEvRGFWN1dyUHppbXpMZHAzaG9xc2ZDUUFhZkNveHZyRXJ1dGpGcz0ifQ",
    "card_discovery": null,
    "force_3ds_challenge": false,
    "force_3ds_challenge_trigger": false,
    "issuer_error_code": null,
    "issuer_error_message": null,
    "is_iframe_redirection_enabled": null,
    "whole_connector_response": null,
    "enable_partial_authorization": null,
    "enable_overcapture": null,
    "is_overcapture_enabled": null,
    "network_details": null,
    "is_stored_credential": null,
    "mit_category": null,
    "billing_descriptor": null,
    "tokenization": null,
    "partner_merchant_identifier_details": null,
    "payment_method_tokenization_details": {
        "payment_method_id": "pm_MMAdYo6wKahuSglhmej2",
        "payment_method_status": "active",
        "psp_tokenization": false,
        "network_tokenization": false,
        "network_transaction_id": null,
        "is_eligible_for_mit_payment": false
    }
}
```


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
