### PR TITLE
fix: update migration_runner base image to debian:bookworm-slim to fix xz sandbox error

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,7 +57,7 @@ services:
       timeout: 5s
 
   migration_runner:
-    image: docker.io/debian:trixie-slim
+    image: docker.io/debian:bookworm-slim
     pull_policy: always
     command: >
       bash -c "


### PR DESCRIPTION
Resolved Sandbox issue in Migrator

## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ X] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
Updated the migration_runner base image in docker-compose.yml from debian:trixie-slim to debian:bookworm-slim.

This change fixes a critical failure during the installation of diesel_cli. The xz-utils package (v5.8.0+) in Debian Trixie (Testing) attempts to enable Landlock sandboxing. This security feature is blocked by default Docker Seccomp profiles on many host kernels, causing the decompression of the diesel_cli binary to fail with the error: xz: Failed to enable the sandbox.

Switching to the Stable branch (bookworm-slim) provides a version of xz that does not require Landlock, ensuring the setup script works reliably across different host environments.


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ X] This PR modifies application configuration/environment variables

docker-compose.yml: Updated migration_runner image to debian:bookworm-slim.


## Motivation and Context

The current "One-Click Setup" fails for many users because the migration_runner base image is pinned to the experimental/testing branch (trixie). This PR ensures the migrator uses the stable Debian release, which is compatible with standard Docker security configurations. This solves the unrecoverable tar error during setup.


## How did you test it?
Manual verification:

    Re-ran scripts/setup.sh after applying the change to docker-compose.yml.

    Confirmed that diesel_cli downloads and extracts correctly without xz sandbox errors.

    Confirmed that just migrate completes successfully and the server becomes healthy.



## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
