### PR TITLE
fix(connector): Worldpay modular Rsync id issue

### DIFF
--- a/crates/hyperswitch_connectors/src/connectors/worldpaymodular.rs
+++ b/crates/hyperswitch_connectors/src/connectors/worldpaymodular.rs
@@ -659,7 +659,7 @@ impl ConnectorIntegration<RSync, RefundsData, RefundsResponseData> for Worldpaym
         router_env::logger::info!(connector_response=?response);
         Ok(RefundSyncRouterData {
             response: Ok(RefundsResponseData {
-                connector_refund_id: data.request.refund_id.clone(),
+                connector_refund_id: data.request.get_connector_refund_id()?,
                 refund_status: enums::RefundStatus::from(response.last_event),
             }),
             ..data.clone()


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->

Refund Sync issue:

the Connector was not returning refund id so the Rsync from second time fails,
Fix pass previous Refund ID only

- NOTE: Refund works when triggered after 15 min of capture , The refund will success but refund wont be triggered internally from worldpay.

---------------

# payment

```json
{
    "amount": 1800,
    "currency": "AUD",
    "confirm": true,
    "customer_id": "akshadsdsdya",
    "return_url": "https://www.google.com",
    "capture_method": "automatic",
    "payment_method": "wallet",
    "payment_method_type": "apple_pay",
    "authentication_type": "no_three_ds",
    "description": "hellow world",
    // "payment_link":true,
    "connector": [
        "worldpaymodular"
    ],
    "setup_future_usage": "off_session",
    "customer_acceptance": {
        "acceptance_type": "offline",
        "accepted_at": "1963-05-03T04:07:52.723Z",
        "online": {
            "ip_address": "127.0.0.1",
            "user_agent": "amet irure esse"
        }
    },
    "browser_info": {
        "accept_header": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
        "ip_address": "192.168.1.1",
        "java_enabled": false,
        "java_script_enabled": true,
        "language": "en-US",
        "color_depth": 24,
        "screen_height": 1080,
        "screen_width": 1920,
        "time_zone": 330,
        "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36"
    },
    "email": "hello@gmail.com",
    "payment_method_data": {
        "wallet": {
            "apple_pay": {
                "payment_data": "eyJkYXRhIjoiM**********X3YxIn0=",
                "payment_method": {
                    "display_name": "Visa 0465",
                    "network": "Visa",
                    "type": "credit"
                },
                "transaction_identifier": "4474a8174fde12ed1488850f53e7be5436b608759edca6591a33c023b9e2ebe2"
            }
        }
    }
}
```

# response

```json
{
    "payment_id": "pay_yQuHITfNy6MnMjLPxmqE",
    "merchant_id": "merchant_1768286785",
    "status": "succeeded",
    "amount": 1800,
    "net_amount": 1800,
    "shipping_cost": null,
    "amount_capturable": 0,
    "amount_received": 1800,
    "processor_merchant_id": "merchant_1768286785",
    "initiator": null,
    "connector": "worldpaymodular",
    "client_secret": "pay_yQuHITfNy6MnMjLPxmqE_secret_9socfNFj2dkJ3t3B2hnj",
    "created": "2026-01-13T11:13:03.727Z",
    "modified_at": "2026-01-13T11:13:05.522Z",
    "currency": "AUD",
    "customer_id": "akshadsdsdya",
    "customer": {
        "id": "akshadsdsdya",
        "name": null,
        "email": "hello@gmail.com",
        "phone": null,
        "phone_country_code": null
    },
    "description": "hellow world",
    "refunds": null,
    "disputes": null,
    "mandate_id": null,
    "mandate_data": null,
    "setup_future_usage": "off_session",
    "off_session": null,
    "capture_on": null,
    "capture_method": "automatic",
    "payment_method": "wallet",
    "payment_method_data": {
        "wallet": {
            "apple_pay": {
                "last4": "0465",
                "card_network": "Visa",
                "type": "credit",
                "card_exp_month": null,
                "card_exp_year": null
            }
        },
        "billing": null
    },
    "payment_token": null,
    "shipping": null,
    "billing": null,
    "order_details": null,
    "email": "hello@gmail.com",
    "name": null,
    "phone": null,
    "return_url": "https://www.google.com/",
    "authentication_type": "no_three_ds",
    "statement_descriptor_name": null,
    "statement_descriptor_suffix": null,
    "next_action": null,
    "cancellation_reason": null,
    "error_code": null,
    "error_message": null,
    "unified_code": null,
    "unified_message": null,
    "error_details": null,
    "payment_experience": null,
    "payment_method_type": "apple_pay",
    "connector_label": null,
    "business_country": null,
    "business_label": "default",
    "business_sub_label": null,
    "allowed_payment_method_types": null,
    "manual_retry_allowed": null,
    "connector_transaction_id": "eyJrIjoiazNhYjYzMiIsImxpbmtWZXJzaW9uIjoiNi4wLjAifQ==.sN:g8wd64bwkbrp0md+bPxcanBnk2zLdsIqSa1pR99HBj426bdlJXCgTskLhNY5Ml0rXtEPNSyl2cbsnj4b2DZwiqL3HuQDxN:neVn+zbpclW4Z+fnZKMutoUGX3m1:m6L6pnUUsYGic8tGWoZE+j8f70M7YHm+3FHDEmGaOZtBgZIiGvTleHlxxiFWURMx881VQ0:KjdVX14V+Q12mM8XuoJOz4x3D:6BaasUZxnA8rW66yFNGsWi87tzkRENLR8ix3NBfHPU2KlzlyTrmR0mwasA4zRNlfY:bG7Aaa:GZZGxq0FRmcF:Tv04QSppwZRNBVa9EcH36XLO0DYTs7Kybe7j173ivaECazAbPKNviCajQMslR:WAgFrfkhSWqcL5bBdW8OjEaavGUnO07DRkRXyD9CCh7uIvPJ9swDVN9k2tgiRE2ValhpV44mIhhgIGBEQpJkaFUDOS1O55Teig==",
    "frm_message": null,
    "metadata": null,
    "connector_metadata": null,
    "feature_metadata": {
        "redirect_response": null,
        "search_tags": null,
        "apple_pay_recurring_details": null,
        "gateway_system": "direct"
    },
    "reference_id": null,
    "payment_link": null,
    "profile_id": "pro_5kC2NAtGgtg170gsvUlk",
    "surcharge_details": null,
    "attempt_count": 1,
    "merchant_decision": null,
    "merchant_connector_id": "mca_qOUFmUj9nAAfAwUm8aYv",
    "incremental_authorization_allowed": false,
    "authorization_count": null,
    "incremental_authorizations": null,
    "external_authentication_details": null,
    "external_3ds_authentication_attempted": false,
    "expires_on": "2026-01-13T11:28:03.727Z",
    "fingerprint": null,
    "browser_info": {
        "language": "en-US",
        "time_zone": 330,
        "ip_address": "192.168.1.1",
        "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36",
        "color_depth": 24,
        "java_enabled": false,
        "screen_width": 1920,
        "accept_header": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
        "screen_height": 1080,
        "java_script_enabled": true
    },
    "payment_channel": null,
    "payment_method_id": "pm_nWrPVhJ1UCNR6yj0UUNo",
    "network_transaction_id": null,
    "payment_method_status": "active",
    "updated": "2026-01-13T11:13:05.522Z",
    "split_payments": null,
    "frm_metadata": null,
    "extended_authorization_applied": null,
    "extended_authorization_last_applied_at": null,
    "request_extended_authorization": null,
    "capture_before": null,
    "merchant_order_reference_id": null,
    "order_tax_amount": null,
    "connector_mandate_id": "https://try.access.worldpay.com/tokens/eyJrIjoxLCJkIjoiY2NCNUc1WlM0Ymp6MElYQk02S0hyaFllbW94UksxYkZKRnZqdDIvNFRTaz0ifQ",
    "card_discovery": null,
    "force_3ds_challenge": false,
    "force_3ds_challenge_trigger": false,
    "issuer_error_code": null,
    "issuer_error_message": null,
    "is_iframe_redirection_enabled": null,
    "whole_connector_response": null,
    "enable_partial_authorization": null,
    "enable_overcapture": null,
    "is_overcapture_enabled": null,
    "network_details": null,
    "is_stored_credential": null,
    "mit_category": null,
    "billing_descriptor": null,
    "tokenization": null,
    "partner_merchant_identifier_details": null,
    "payment_method_tokenization_details": {
        "payment_method_id": "pm_nWrPVhJ1UCNR6yj0UUNo",
        "payment_method_status": "active",
        "psp_tokenization": true,
        "network_tokenization": false,
        "network_transaction_id": null,
        "is_eligible_for_mit_payment": true
    }
}
```

# refund 

```sh
curl --location 'localhost:8080/refunds' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: dev_Nyrf4zcOSHovtGwuIqqJUSFffh9Wh76HoanZlSMUfrlwVEO27FtQBorsyBXYnN9y' \
--data '{
    "payment_id": "pay_yQuHITfNy6MnMjLPxmqE",
    "amount":1800,
    "metadata":{"store":"ST3298F22322955NDWVDWCWG6"}
}'
```

# response

```json
{
    "refund_id": "ref_36IDdNEkQwTmRTVaHCac",
    "payment_id": "pay_yQuHITfNy6MnMjLPxmqE",
    "amount": 1800,
    "currency": "AUD",
    "status": "pending",
    "reason": null,
    "metadata": {
        "store": "ST3298F22322955NDWVDWCWG6"
    },
    "error_message": null,
    "error_code": null,
    "unified_code": null,
    "unified_message": null,
    "created_at": "2026-01-13T11:30:17.455Z",
    "updated_at": "2026-01-13T11:30:19.604Z",
    "connector": "worldpaymodular",
    "profile_id": "pro_5kC2NAtGgtg170gsvUlk",
    "merchant_connector_id": "mca_qOUFmUj9nAAfAwUm8aYv",
    "split_refunds": null,
    "issuer_error_code": null,
    "issuer_error_message": null,
    "raw_connector_response": null
}
```

# Rsync 1

## connector response

```sh
 INFO hyperswitch_connectors::connectors::worldpaymodular: connector_response: WorldpaymodularEventResponse { last_event: SentForSettlement, links: Some(EventLinks { events: None }) }
```

```json
{
    "refund_id": "ref_36IDdNEkQwTmRTVaHCac",
    "payment_id": "pay_yQuHITfNy6MnMjLPxmqE",
    "amount": 1800,
    "currency": "AUD",
    "status": "pending",
    "reason": null,
    "metadata": {
        "store": "ST3298F22322955NDWVDWCWG6"
    },
    "error_message": null,
    "error_code": null,
    "unified_code": null,
    "unified_message": null,
    "created_at": "2026-01-13T11:30:17.455Z",
    "updated_at": "2026-01-13T11:31:56.659Z",
    "connector": "worldpaymodular",
    "profile_id": "pro_5kC2NAtGgtg170gsvUlk",
    "merchant_connector_id": "mca_qOUFmUj9nAAfAwUm8aYv",
    "split_refunds": null,
    "issuer_error_code": null,
    "issuer_error_message": null,
    "raw_connector_response": null
}
```

# Rsync 2 after few min


## connector response

```sh
INFO hyperswitch_connectors::connectors::worldpaymodular: connector_response: WorldpaymodularEventResponse { last_event: SentForRefund, links: None }
```

```json
{
    "refund_id": "ref_36IDdNEkQwTmRTVaHCac",
    "payment_id": "pay_yQuHITfNy6MnMjLPxmqE",
    "amount": 1800,
    "currency": "AUD",
    "status": "succeeded",
    "reason": null,
    "metadata": {
        "store": "ST3298F22322955NDWVDWCWG6"
    },
    "error_message": null,
    "error_code": null,
    "unified_code": null,
    "unified_message": null,
    "created_at": "2026-01-13T11:30:17.455Z",
    "updated_at": "2026-01-13T11:34:34.765Z",
    "connector": "worldpaymodular",
    "profile_id": "pro_5kC2NAtGgtg170gsvUlk",
    "merchant_connector_id": "mca_qOUFmUj9nAAfAwUm8aYv",
    "split_refunds": null,
    "issuer_error_code": null,
    "issuer_error_message": null,
    "raw_connector_response": null
}
```


-------------

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
