### PR TITLE
fix(connector): [Nuvei] Fixed Error handling in the redirection flow

### DIFF
--- a/crates/hyperswitch_connectors/src/connectors/nuvei/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/nuvei/transformers.rs
@@ -600,9 +600,20 @@ impl TransactionType {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-pub struct NuveiRedirectionResponse {
-    pub cres: Option<Secret<String>>,
-    pub error: Option<Secret<String>>,
+#[serde(untagged)]
+pub enum NuveiRedirectionResponse {
+    Redirection(NuveiCresRedirectResponse),
+    Error(NuveiErrorRedirectResponse),
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct NuveiCresRedirectResponse {
+    pub cres: Secret<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct NuveiErrorRedirectResponse {
+    pub error: Secret<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Previously, errors in the Payments Redirect flow were not handled. If redirection failed for 3DS payments, it led to a 5xx error caused by a deserialization failure. This PR adds proper handling for such error scenarios.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

Request:

```

{
    "amount": 15100,
    "currency": "EUR",
    "confirm": true,
    "customer_id": "test1234",
    "return_url": "https://www.google.com",
    "capture_method": "manual",
    "payment_method": "card",
    "payment_method_type": "credit",
    "authentication_type": "three_ds",
    "description": "hello world",
    "all_keys_required": true,
    "billing": {
        "address": {
            "zip": "560095",
            "country" : "NZ",
            "first_name": "Sakil",
            "last_name": "Mostak",
            "line1": "Fasdf",
            "line2": "Fasdf",
            "city": "Fasdf",
            "state" : "auckland"
        }
    },
    "shipping": {
        "address": {
            "first_name": "joseph",
            "last_name": "Doe"
        }
    },
    "browser_info": {
        "accept_header": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
        "ip_address": "192.168.1.1",
        "java_enabled": false,
        "java_script_enabled": true,
        "language": "en-US",
        "color_depth": 24,
        "screen_height": 1080,
        "screen_width": 1920,
        "time_zone": 330,
        "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36"
    },
    "email": "hello@gmail.com",
    "payment_method_data": {
        "card": {
            "card_number": "4000027891380961",
            "card_exp_month": "10",
            "card_exp_year": "30",
            "card_holder_name": "CL-BRW1", 
            "card_cvc": "123"
        }
    }
}

```

Response:

```

{
    "payment_id": "pay_6alVSTurTyY4RXNkFtJk",
    "merchant_id": "merchant_1768715572",
    "status": "requires_customer_action",
    "amount": 15100,
    "net_amount": 15100,
    "shipping_cost": null,
    "amount_capturable": 15100,
    "amount_received": null,
    "processor_merchant_id": "merchant_1768715572",
    "initiator": null,
    "connector": "nuvei",
    "client_secret": "pay_6alVSTurTyY4RXNkFtJk_secret_ekt4RaGZXmehLpLePjZJ",
    "created": "2026-01-18T08:15:02.805Z",
    "modified_at": "2026-01-18T08:15:07.962Z",
    "currency": "EUR",
    "customer_id": "test1234",
    "customer": {
        "id": "test1234",
        "name": null,
        "email": "hello@gmail.com",
        "phone": null,
        "phone_country_code": null
    },
    "description": "hellow world",
    "refunds": null,
    "disputes": null,
    "mandate_id": null,
    "mandate_data": null,
    "setup_future_usage": null,
    "off_session": null,
    "capture_on": null,
    "capture_method": "manual",
    "payment_method": "card",
    "payment_method_data": {
        "card": {
            "last4": "0961",
            "card_type": null,
            "card_network": null,
            "card_issuer": null,
            "card_issuing_country": null,
            "card_isin": "400002",
            "card_extended_bin": null,
            "card_exp_month": "10",
            "card_exp_year": "30",
            "card_holder_name": "CL-BRW1",
            "payment_checks": {
                "avs_result": "",
                "avs_description": null,
                "card_validation_result": "",
                "card_validation_description": null
            },
            "authentication_data": {
                "cReq": "eyJ0aHJlZURTU2VydmVyVHJhbnNJRCI6IjY5NDk4YjJkLTc3MzItNDhlYS05NDMxLWRmZTIwY2VlNzdlMyIsImFjc1RyYW5zSUQiOiIwODRiYjkyNS0yYmFiLTQ4M2UtOGRiMy1kMjQzYTg5MzRhZDQiLCJjaGFsbGVuZ2VXaW5kb3dTaXplIjoiMDUiLCJtZXNzYWdlVHlwZSI6IkNSZXEiLCJtZXNzYWdlVmVyc2lvbiI6IjIuMi4wIn0",
                "acsUrl": "https://3dsn.sandbox.safecharge.com/ThreeDSACSEmulatorChallenge/api/ThreeDSACSChallengeController/ChallengePage?eyJub3RpZmljYXRpb25VUkwiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvcGF5bWVudHMvcGF5XzZhbFZTVHVyVHlZNFJYTmtGdEprL21lcmNoYW50XzE3Njg3MTU1NzIvcmVkaXJlY3QvY29tcGxldGUvbnV2ZWkiLCJ0aHJlZURTU2VydmVyVHJhbnNJRCI6IjY5NDk4YjJkLTc3MzItNDhlYS05NDMxLWRmZTIwY2VlNzdlMyIsImFjc1RyYW5zSUQiOiIwODRiYjkyNS0yYmFiLTQ4M2UtOGRiMy1kMjQzYTg5MzRhZDQiLCJkc1RyYW5zSUQiOiI0ZDBlZTkyOC0xZTRmLTQzZjktYWQ1NS0zYmJmYmRmMGUxNjEiLCJkYXRhIjpudWxsLCJNZXNzYWdlVmVyc2lvbiI6IjIuMi4wIn0="
            }
        },
        "billing": null
    },
    "payment_token": "token_JZtMhAjfoZUZ0cPY1spg",
    "shipping": {
        "address": {
            "city": null,
            "country": null,
            "line1": null,
            "line2": null,
            "line3": null,
            "zip": null,
            "state": null,
            "first_name": "joseph",
            "last_name": "Doe",
            "origin_zip": null
        },
        "phone": null,
        "email": null
    },
    "billing": {
        "address": {
            "city": "Fasdf",
            "country": "NZ",
            "line1": "Fasdf",
            "line2": "Fasdf",
            "line3": null,
            "zip": "560095",
            "state": "auckland",
            "first_name": "Sakil",
            "last_name": "Mostak",
            "origin_zip": null
        },
        "phone": null,
        "email": null
    },
    "order_details": null,
    "email": "hello@gmail.com",
    "name": null,
    "phone": null,
    "return_url": "https://www.google.com/",
    "authentication_type": "three_ds",
    "statement_descriptor_name": null,
    "statement_descriptor_suffix": null,
    "next_action": {
        "type": "redirect_to_url",
        "redirect_to_url": "http://localhost:8080/payments/redirect/pay_6alVSTurTyY4RXNkFtJk/merchant_1768715572/pay_6alVSTurTyY4RXNkFtJk_1"
    },
    "cancellation_reason": null,
    "error_code": null,
    "error_message": null,
    "unified_code": null,
    "unified_message": null,
    "error_details": null,
    "payment_experience": null,
    "payment_method_type": "credit",
    "connector_label": null,
    "business_country": null,
    "business_label": "default",
    "business_sub_label": null,
    "allowed_payment_method_types": null,
    "manual_retry_allowed": null,
    "connector_transaction_id": "8110000000022682208",
    "frm_message": null,
    "metadata": null,
    "connector_metadata": null,
    "feature_metadata": {
        "redirect_response": null,
        "search_tags": null,
        "apple_pay_recurring_details": null,
        "gateway_system": "direct"
    },
    "reference_id": "12538082111",
    "payment_link": null,
    "profile_id": "pro_1Jt2rovGspFig544xVBr",
    "surcharge_details": null,
    "attempt_count": 1,
    "merchant_decision": null,
    "merchant_connector_id": "mca_KVBwOJjb7PElFWNgQnI6",
    "incremental_authorization_allowed": false,
    "authorization_count": null,
    "incremental_authorizations": null,
    "external_authentication_details": null,
    "external_3ds_authentication_attempted": false,
    "expires_on": "2026-01-18T08:30:02.805Z",
    "fingerprint": null,
    "browser_info": {
        "language": "en-US",
        "time_zone": 330,
        "ip_address": "192.168.1.1",
        "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36",
        "color_depth": 24,
        "java_enabled": false,
        "screen_width": 1920,
        "accept_header": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
        "screen_height": 1080,
        "java_script_enabled": true
    },
    "payment_channel": null,
    "payment_method_id": null,
    "network_transaction_id": "",
    "payment_method_status": null,
    "updated": "2026-01-18T08:15:07.962Z",
    "split_payments": null,
    "frm_metadata": null,
    "extended_authorization_applied": null,
    "extended_authorization_last_applied_at": null,
    "request_extended_authorization": null,
    "capture_before": null,
    "merchant_order_reference_id": null,
    "order_tax_amount": null,
    "connector_mandate_id": null,
    "card_discovery": "manual",
    "force_3ds_challenge": false,
    "force_3ds_challenge_trigger": false,
    "issuer_error_code": null,
    "issuer_error_message": null,
    "is_iframe_redirection_enabled": null,
    "enable_partial_authorization": null,
    "enable_overcapture": null,
    "is_overcapture_enabled": null,
    "network_details": null,
    "is_stored_credential": null,
    "mit_category": null,
    "billing_descriptor": null,
    "tokenization": null,
    "partner_merchant_identifier_details": null,
    "payment_method_tokenization_details": null
}

```

Failing the redirection :

```

curl --location 'http://localhost:8080/payments/pay_6alVSTurTyY4RXNkFtJk/merchant_1768715572/redirect/complete/nuvei' \
--header 'Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7' \
--header 'Accept-Language: en-US,en;q=0.9' \
--header 'Cache-Control: max-age=0' \
--header 'Connection: keep-alive' \
--header 'Content-Type: application/x-www-form-urlencoded' \
--header 'Origin: null' \
--header 'Sec-Fetch-Dest: document' \
--header 'Sec-Fetch-Mode: navigate' \
--header 'Sec-Fetch-Site: cross-site' \
--header 'Sec-Fetch-User: ?1' \
--header 'Upgrade-Insecure-Requests: 1' \
--header 'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Safari/537.36' \
--header 'sec-ch-ua: "Google Chrome";v="143", "Chromium";v="143", "Not A(Brand";v="24"' \
--header 'sec-ch-ua-mobile: ?0' \
--header 'sec-ch-ua-platform: "macOS"' \
--header 'api-key: dev_VlVeMouwsz6X6gDkpIj2s2dVzsx1hbk6vfhsPBXKIHRkO5aghBq2giZeWdiqndYd' \
--data-urlencode 'error=eyJ0aHJlZURTU2VydmVyVHJhbnNJRCI6ImEyMmRkYzkxLWQ5YTYtNGM0Yy1iNjA1LWVmNTFjZjBmNDVjMiIsImFjc1RyYW5zSUQiOiJhZGE3NWZhOS00OTE2LTQ4Y2UtOTExOS03ODA4YzBjMjkwMGQiLCJkc1RyYW5zSUQiOiJkZDk5NmQ0OS02OTc3LTQwZmYtYTU1Yy0yZjI0NDljZGJjYmQiLCJlcnJvckNvbXBvbmVudCI6IkEiLCJlcnJvck1lc3NhZ2VUeXBlIjoiQ1JlcSIsImVycm9yQ29kZSI6IjMwNSIsImVycm9yRGVzY3JpcHRpb24iOiJUcmFuc2FjdGlvbiBkYXRhIG5vdCB2YWxpZCIsImVycm9yRGV0YWlsIjoiVHJhbnNhY3Rpb24gY29ycmVzcG9uZGluZyB0byBicm93c2VyIGNoYWxsZW5nZSBoYXMgYmVlbiBwcm9jZXNzZWQgYWxyZWFkeS4iLCJtZXNzYWdlVHlwZSI6IkVycm8iLCJtZXNzYWdlVmVyc2lvbiI6IjIuMi4wIn0'

```

Response:
(payment failed)

https://www.google.com/%3Fstatus%3D**failed**%26payment_id%3Dpay_6alVSTurTyY4RXNkFtJk%26payment_intent_client_secret%3Dpay_6alVSTurTyY4RXNkFtJk_secret_ekt4RaGZXmehLpLePjZJ%26amount%3D15100%26manual_retry_allowed%3Dfalse%26signature%3D261038be5b5d8a701cef6f3124c585f5888cb0ade9c1c9b3c637fe004076f066d858548f7c8bf0d9aa7b0fda8ecdeba53aa7f90863ec195f7354cb9451e7eb18%26signature_algorithm%3DHMAC-SHA512

<img width="1161" height="939" alt="Screenshot 2026-01-18 at 1 47 20 PM" src="https://github.com/user-attachments/assets/f4d49e66-06e3-4d25-b54b-c81e555b4e34" />

2) Before this PR:

On redirection Failure : 

```

{
    "error": {
        "type": "api",
        "message": "Something went wrong",
        "code": "HE_00"
    }
}

```

Cypress : 

<img width="554" height="898" alt="Screenshot 2026-01-18 at 6 42 58 PM" src="https://github.com/user-attachments/assets/1ddf0f23-6e84-4bb2-8b26-78d28628814a" />

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
