### PR TITLE
feat(connector): Fix Payload PSync headers handling

### DIFF
--- a/crates/hyperswitch_connectors/src/connectors/payload.rs
+++ b/crates/hyperswitch_connectors/src/connectors/payload.rs
@@ -964,6 +964,7 @@ static PAYLOAD_SUPPORTED_PAYMENT_METHODS: LazyLock<SupportedPaymentMethods> = La
         common_enums::CardNetwork::Discover,
         common_enums::CardNetwork::Mastercard,
         common_enums::CardNetwork::Visa,
+        common_enums::CardNetwork::DinersClub,
     ];
 
     payload_supported_payment_methods.add(


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->

This PR fixes an issue in the PSync flow where request headers were being built using the generic build_headers method

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Payments Create
```
curl --location 'http://localhost:8080/payments' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key:' \
--data-raw '{
    "amount":100,
    "currency": "USD",
    "confirm": true,
    "business_country": "US",
    "business_label": "default",
    "customer_id": "777177177790111111",
    "metadata":{
         "processing_account_id": "****"
    },
    "capture_method": "manual",
    "capture_on": "2022-09-10T10:11:12Z",
    "setup_future_usage": "off_session",
    "authentication_type": "no_three_ds",
    "return_url": "https://google.com",
    "phone": "999999999",
    "phone_country_code": "+65",
    "description": "Its my first payment request",
    "statement_descriptor_name": "Juspay",
    "statement_descriptor_suffix": "Router",
    
    "email":"****@gmail.com",
    "name":"****",
    "billing": {
        "address": {
            "zip": "94122"
        }
    },
        "payment_method": "card",
    "payment_method_type": "credit",
    "payment_method_data": {
        "card": {
            "card_number": "41528***588",
            "card_exp_month": "01",
            "card_exp_year": "2026",
            "card_holder_name": "John Smith",
            "card_cvc": "100"
        }
    },
    "customer_acceptance": {
        "acceptance_type": "offline",
        "accepted_at": "1963-05-03T04:07:52.723Z",
        "online": {
            "ip_address": "in sit",
            "user_agent": "amet irure esse"
        }
    }
}
'
```
Response
```
{
    "payment_id": "pay_5kwOtXg9A8QIoIir8252",
    "merchant_id": "merchant_1769683408",
    "status": "requires_capture",
    "amount": 100,
    "net_amount": 100,
    "shipping_cost": null,
    "amount_capturable": 100,
    "amount_received": null,
    "processor_merchant_id": "merchant_1769683408",
    "initiator": null,
    "connector": "payload",
    "client_secret": "pay_5kwOtXg9A8QIoIir8252_secret_rJ4OzlL7rnopUpeLxiqA",
    "created": "2026-01-29T11:21:03.246Z",
    "modified_at": "2026-01-29T11:21:09.284Z",
    "currency": "USD",
    "customer_id": "777177177790111111",
    "customer": {
        "id": "777177177790111111",
        "name": "malay123",
        "email": "malay.awasth21@gmail.com",
        "phone": "999999999",
        "phone_country_code": "+65"
    },
    "description": "Its my first payment request",
    "refunds": null,
    "disputes": null,
    "mandate_id": null,
    "mandate_data": null,
    "setup_future_usage": "off_session",
    "off_session": null,
    "capture_on": null,
    "capture_method": "manual",
    "payment_method": "card",
    "payment_method_data": {
        "card": {
            "last4": "3588",
            "card_type": "CREDIT",
            "card_network": "Visa",
            "card_issuer": "BANCO SANTANDER-CHILE",
            "card_issuing_country": "CHILE",
            "card_isin": "415281",
            "card_extended_bin": null,
            "card_exp_month": "01",
            "card_exp_year": "2026",
            "card_holder_name": "John Smith",
            "payment_checks": {
                "avs_result": "zip"
            },
            "authentication_data": null,
            "auth_code": null
        },
        "billing": null
    },
    "payment_token": null,
    "shipping": null,
    "billing": {
        "address": {
            "city": null,
            "country": null,
            "line1": null,
            "line2": null,
            "line3": null,
            "zip": "94122",
            "state": null,
            "first_name": null,
            "last_name": null,
            "origin_zip": null
        },
        "phone": null,
        "email": null
    },
    "order_details": null,
    "email": "malay.awasth21@gmail.com",
    "name": "malay123",
    "phone": "999999999",
    "return_url": "https://google.com/",
    "authentication_type": "no_three_ds",
    "statement_descriptor_name": "Juspay",
    "statement_descriptor_suffix": "Router",
    "next_action": null,
    "cancellation_reason": null,
    "error_code": null,
    "error_message": null,
    "unified_code": null,
    "unified_message": null,
    "error_details": null,
    "payment_experience": null,
    "payment_method_type": "credit",
    "connector_label": "payload_US_default",
    "business_country": "US",
    "business_label": "default",
    "business_sub_label": null,
    "allowed_payment_method_types": null,
    "manual_retry_allowed": null,
    "connector_transaction_id": "txn_3f7hqt2jw9tbKm52xap2G",
    "frm_message": null,
    "metadata": {
        "processing_account_id": "acct_3epxuNyAtNd77zShIaaL1"
    },
    "connector_metadata": null,
    "feature_metadata": {
        "redirect_response": null,
        "search_tags": null,
        "apple_pay_recurring_details": null,
        "gateway_system": "direct"
    },
    "reference_id": "PL-FKP-X2T-5LW",
    "payment_link": null,
    "profile_id": "pro_DsyWOH36PC4OOIdiIRXb",
    "surcharge_details": null,
    "attempt_count": 1,
    "merchant_decision": null,
    "merchant_connector_id": "mca_FHxxy8aaUc7i0s2hwMhn",
    "incremental_authorization_allowed": false,
    "authorization_count": null,
    "incremental_authorizations": null,
    "external_authentication_details": null,
    "external_3ds_authentication_attempted": false,
    "expires_on": "2026-01-29T11:36:03.246Z",
    "fingerprint": null,
    "browser_info": null,
    "payment_channel": null,
    "payment_method_id": "pm_zxykPZBXUxbSmd7M9by8",
    "network_transaction_id": null,
    "payment_method_status": "active",
    "updated": "2026-01-29T11:21:09.284Z",
    "split_payments": null,
    "frm_metadata": null,
    "extended_authorization_applied": null,
    "extended_authorization_last_applied_at": null,
    "request_extended_authorization": null,
    "capture_before": null,
    "merchant_order_reference_id": null,
    "order_tax_amount": null,
    "connector_mandate_id": "pm_3f7hqt1Z3eKGMdeOLwvqv",
    "card_discovery": "manual",
    "force_3ds_challenge": false,
    "force_3ds_challenge_trigger": false,
    "issuer_error_code": null,
    "issuer_error_message": null,
    "is_iframe_redirection_enabled": null,
    "whole_connector_response": null,
    "enable_partial_authorization": null,
    "enable_overcapture": null,
    "is_overcapture_enabled": null,
    "network_details": null,
    "is_stored_credential": null,
    "mit_category": null,
    "billing_descriptor": null,
    "tokenization": null,
    "partner_merchant_identifier_details": null,
    "payment_method_tokenization_details": {
        "payment_method_id": "pm_zxykPZBXUxbSmd7M9by8",
        "payment_method_status": "active",
        "psp_tokenization": false,
        "network_tokenization": false,
        "network_transaction_id": null,
        "is_eligible_for_mit_payment": false
    }
}
```
Psync 
```
curl --location 'http://localhost:8080/payments/pay_5kwOtXg9A8QIoIir8252?force_sync=true' \
--header 'Accept: application/json' \
--header 'api-key: dev_0Apf4PBl6bSxijJgOOwWzUegRtHmutyd0hLdhcOjPToiyqbydP1EQD3TKtE0Aiom'
```
Response
```
{
    "payment_id": "pay_5kwOtXg9A8QIoIir8252",
    "merchant_id": "merchant_1769683408",
    "status": "requires_capture",
    "amount": 100,
    "net_amount": 100,
    "shipping_cost": null,
    "amount_capturable": 100,
    "amount_received": null,
    "processor_merchant_id": "merchant_1769683408",
    "initiator": null,
    "connector": "payload",
    "client_secret": "",
    "created": "2026-01-29T11:21:03.246Z",
    "modified_at": "2026-01-29T11:22:18.898Z",
    "currency": "USD",
    "customer_id": "",
    "customer": {
        "id": "",
        "name": "malay123",
        "email": "malay.awasth21@gmail.com",
        "phone": "999999999",
        "phone_country_code": "+65"
    },
    "description": "Its my first payment request",
    "refunds": null,
    "disputes": null,
    "mandate_id": null,
    "mandate_data": null,
    "setup_future_usage": "off_session",
    "off_session": null,
    "capture_on": null,
    "capture_method": "manual",
    "payment_method": "card",
    "payment_method_data": {
        "card": {
            "last4": "3588",
            "card_type": "CREDIT",
            "card_network": "Visa",
            "card_issuer": "BANCO SANTANDER-CHILE",
            "card_issuing_country": "CHILE",
            "card_isin": "415281",
            "card_extended_bin": null,
            "card_exp_month": "01",
            "card_exp_year": "2026",
            "card_holder_name": "John Smith",
            "payment_checks": {
                "avs_result": "zip"
            },
            "authentication_data": null,
            "auth_code": null
        },
        "billing": null
    },
    "payment_token": null,
    "shipping": null,
    "billing": {
        "address": {
            "city": null,
            "country": null,
            "line1": null,
            "line2": null,
            "line3": null,
            "zip": "94122",
            "state": null,
            "first_name": null,
            "last_name": null,
            "origin_zip": null
        },
        "phone": null,
        "email": null
    },
    "order_details": null,
    "email": "@gmail.com",
    "name": "",
    "phone": "999999999",
    "return_url": "https://google.com/",
    "authentication_type": "no_three_ds",
    "statement_descriptor_name": "Juspay",
    "statement_descriptor_suffix": "Router",
    "next_action": null,
    "cancellation_reason": null,
    "error_code": null,
    "error_message": null,
    "unified_code": null,
    "unified_message": null,
    "error_details": null,
    "payment_experience": null,
    "payment_method_type": "credit",
    "connector_label": "payload_US_default",
    "business_country": "US",
    "business_label": "default",
    "business_sub_label": null,
    "allowed_payment_method_types": null,
    "manual_retry_allowed": null,
    "connector_transaction_id": "txn_3f7hqt2jw9tbKm52xap2G",
    "frm_message": null,
    "metadata": {
        "processing_account_id": "acct_3epxuNyAtNd77zShIaaL1"
    },
    "connector_metadata": null,
    "feature_metadata": {
        "redirect_response": null,
        "search_tags": null,
        "apple_pay_recurring_details": null,
        "gateway_system": "direct"
    },
    "reference_id": "PL-FKP-X2T-5LW",
    "payment_link": null,
    "profile_id": "pro_DsyWOH36PC4OOIdiIRXb",
    "surcharge_details": null,
    "attempt_count": 1,
    "merchant_decision": null,
    "merchant_connector_id": "mca_FHxxy8aaUc7i0s2hwMhn",
    "incremental_authorization_allowed": false,
    "authorization_count": null,
    "incremental_authorizations": null,
    "external_authentication_details": null,
    "external_3ds_authentication_attempted": false,
    "expires_on": "2026-01-29T11:36:03.246Z",
    "fingerprint": null,
    "browser_info": null,
    "payment_channel": null,
    "payment_method_id": "pm_zxykPZBXUxbSmd7M9by8",
    "network_transaction_id": null,
    "payment_method_status": "active",
    "updated": "2026-01-29T11:22:18.898Z",
    "split_payments": null,
    "frm_metadata": null,
    "extended_authorization_applied": null,
    "extended_authorization_last_applied_at": null,
    "request_extended_authorization": null,
    "capture_before": null,
    "merchant_order_reference_id": null,
    "order_tax_amount": null,
    "connector_mandate_id": "pm_3f7hqt1Z3eKGMdeOLwvqv",
    "card_discovery": "manual",
    "force_3ds_challenge": false,
    "force_3ds_challenge_trigger": false,
    "issuer_error_code": null,
    "issuer_error_message": null,
    "is_iframe_redirection_enabled": null,
    "whole_connector_response": null,
    "enable_partial_authorization": null,
    "enable_overcapture": null,
    "is_overcapture_enabled": null,
    "network_details": null,
    "is_stored_credential": null,
    "mit_category": null,
    "billing_descriptor": null,
    "tokenization": null,
    "partner_merchant_identifier_details": null,
    "payment_method_tokenization_details": {
        "payment_method_id": "pm_zxykPZBXUxbSmd7M9by8",
        "payment_method_status": "active",
        "psp_tokenization": true,
        "network_tokenization": false,
        "network_transaction_id": null,
        "is_eligible_for_mit_payment": true
    }
}
```
<img width="1259" height="137" alt="Screenshot 2026-01-29 at 4 53 26 PM" src="https://github.com/user-attachments/assets/4c616a83-855e-4f00-a91b-5c11f5adb451" />

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
