### PR TITLE
fix(connector): map `Ds_State` to status in Redsys PSync when `Ds_Response` is absent

### DIFF
--- a/crates/hyperswitch_connectors/src/connectors/redsys/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/redsys/transformers.rs
@@ -1897,29 +1897,28 @@ pub struct SyncErrorCode {
     ds_errorcode: String,
 }
 
-/// Estado de la transacción (Ds_State)
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum DsState {
-    /// Solicitada (Requested)
+    /// Requested
     S,
-    /// En proceso de autorizar (Authorizing)
+    /// Authorizing
     P,
-    /// Autenticando (Authenticating)
+    /// Authenticating
     A,
-    /// Finalizada (Completed)
+    /// Completed
     F,
-    /// Sin respuesta / Error Técnico (No response / Technical Error)
+    /// No response / Technical Error
     T,
-    /// Transferencia, domiciliación o Paypal en proceso
+    /// Transfer, direct debit, or PayPal in progress
     E,
-    /// Domiciliación descargada
+    /// Direct debit downloaded.
     D,
-    /// Transferencia Línea Abierta
+    /// Online transfer
     L,
-    /// Redirigida a un Wallet
+    /// Redirected to a wallet
     W,
-    /// Redirigida a Iupay
+    /// Redirected to Iupay
     O,
 }
 


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->

This PR aims to fix status mapping of PSync Flow by mapping `Ds_State` to status in Redsys PSync when `Ds_Response` is absent.

When the `consultaOperaciones` SOAP response contains `Ds_State` but no `Ds_Response`, the connector now properly maps:

- `Ds_State`: A (Authenticating) → `AuthenticationPending`
- `Ds_State`: P/S → `Pending`
- `Ds_State`: F → `Charged`/`Authorized` based on `capture_method`

Previously, the existing status was preserved, causing incorrect status(e.g., `Pending` instead of `AuthenticationPending`) when polling for 3DSauthentication status.

This applies to both UCS and Hyperswitch OSS implementations.
And no fix needed for refunds. `Pending` is the appropriate fallback when `ds_response` is missing, since `Ds_State: F` (Completed) doesn't indicate success vs failure for refunds.

UCS PR raised here: https://github.com/juspay/connector-service/pull/464


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->

This is bug that breaks transaction when PSync is called before the authentication is done. 

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


<details>

<summary>Create Payment (should not be in terminal state since we want the PSync to actually trigger)</summary>

```bash
curl --location 'http://localhost:8080/payments' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: dev_imf2Q1rThSwwaRWpDbA9H3cHPemVMZ4ohpZsP7bnRzn1dFTUiCbfCYp2KBwEpoxx' \
--data '{
    "amount": 60159,
    "currency": "EUR",
    "confirm": true,
    "capture_method": "automatic",
    "capture_on": "2022-09-10T10:11:12Z",
    "customer_id": "First_Customer",
    "name": "John Doe",
    "authentication_type": "three_ds",
    "return_url": "https://duck.com",
    "payment_method": "card",
    "payment_method_type": "credit",
    "payment_method_data": {
        "card": {
            
            "card_number": "4548817212493017",
            
            

            "card_exp_month": "12",
            "card_exp_year": "49",
            "card_holder_name": "joseph Doe",
            "card_cvc": "123"
        }
    }, 
    "browser_info": {
        "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Safari/537.36",
        "accept_header": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8",
        "language": "nl-NL",
        "color_depth": 24,
        "screen_height": 723,
        "screen_width": 1536,
        "time_zone": 0,
        "java_enabled": true,
        "java_script_enabled": true,
        "ip_address": "13.232.74.226"
    }
    ,
    "billing": {
        "address": {
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "city": "San Fransico",
            "state": "Ceuta",
            "zip": "94122",
            "country": "ES",
            "first_name": "joseph",
            "last_name": "Doe"
        },
        "phone": {
            "number": "8056594427",
            "country_code": "+91"
        }
    },
    "shipping": {
        "address": {
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "city": "San Fransico",
            "state": "Ceuta",
            "zip": "94122",
            "country": "ES",
            "first_name": "John",
            "last_name": "Doe"
        }
    },
    "setup_future_usage":"on_session"
}'
```
```json
{
	"payment_id": "pay_Fq9TQNvFTcGIHJj3o3sB",
	"merchant_id": "postman_merchant_GHAction_1769760464",
	"status": "requires_customer_action",
	"amount": 60159,
	"net_amount": 60159,
	"shipping_cost": null,
	"amount_capturable": 60159,
	"amount_received": null,
	"processor_merchant_id": "postman_merchant_GHAction_1769760464",
	"initiator": null,
	"connector": "redsys",
	"client_secret": "pay_Fq9TQNvFTcGIHJj3o3sB_secret_dWZYmVciKXJviv0gBT2L",
	"created": "2026-01-30T08:07:47.145Z",
	"modified_at": "2026-01-30T08:07:51.693Z",
	"currency": "EUR",
	"customer_id": "First_Customer",
	"customer": {
		"id": "First_Customer",
		"name": "John Doe",
		"email": null,
		"phone": null,
		"phone_country_code": null
	},
	"description": null,
	"refunds": null,
	"disputes": null,
	"mandate_id": null,
	"mandate_data": null,
	"setup_future_usage": "on_session",
	"off_session": null,
	"capture_on": null,
	"capture_method": "automatic",
	"payment_method": "card",
	"payment_method_data": {
		"card": {
			"last4": "3017",
			"card_type": null,
			"card_network": null,
			"card_issuer": null,
			"card_issuing_country": null,
			"card_isin": "454881",
			"card_extended_bin": null,
			"card_exp_month": "12",
			"card_exp_year": "49",
			"card_holder_name": "joseph Doe",
			"payment_checks": null,
			"authentication_data": null,
			"auth_code": null
		},
		"billing": null
	},
	"payment_token": "token_SXe2n43IVuEHIQGmce13",
	"shipping": {
		"address": {
			"city": "San Fransico",
			"country": "ES",
			"line1": "1467",
			"line2": "Harrison Street",
			"line3": "Harrison Street",
			"zip": "94122",
			"state": "Ceuta",
			"first_name": "John",
			"last_name": "Doe",
			"origin_zip": null
		},
		"phone": null,
		"email": null
	},
	"billing": {
		"address": {
			"city": "San Fransico",
			"country": "ES",
			"line1": "1467",
			"line2": "Harrison Street",
			"line3": "Harrison Street",
			"zip": "94122",
			"state": "Ceuta",
			"first_name": "joseph",
			"last_name": "Doe",
			"origin_zip": null
		},
		"phone": {
			"number": "8056594427",
			"country_code": "+91"
		},
		"email": null
	},
	"order_details": null,
	"email": null,
	"name": "John Doe",
	"phone": null,
	"return_url": "https://duck.com/",
	"authentication_type": "three_ds",
	"statement_descriptor_name": null,
	"statement_descriptor_suffix": null,
	"next_action": {
		"type": "redirect_to_url",
		"redirect_to_url": "http://localhost:8080/payments/redirect/pay_Fq9TQNvFTcGIHJj3o3sB/postman_merchant_GHAction_1769760464/pay_Fq9TQNvFTcGIHJj3o3sB_1"
	},
	"cancellation_reason": null,
	"error_code": null,
	"error_message": null,
	"unified_code": null,
	"unified_message": null,
	"error_details": null,
	"payment_experience": null,
	"payment_method_type": "credit",
	"connector_label": null,
	"business_country": null,
	"business_label": "default",
	"business_sub_label": null,
	"allowed_payment_method_types": null,
	"manual_retry_allowed": null,
	"connector_transaction_id": "294810737293",
	"frm_message": null,
	"metadata": null,
	"connector_metadata": null,
	"feature_metadata": {
		"redirect_response": null,
		"search_tags": null,
		"apple_pay_recurring_details": null,
		"gateway_system": "direct"
	},
	"reference_id": "294810737293",
	"payment_link": null,
	"profile_id": "pro_AIrQ1ai69DxSmpoVOaRA",
	"surcharge_details": null,
	"attempt_count": 1,
	"merchant_decision": null,
	"merchant_connector_id": "mca_nKdHAkwru4RmrrLjj2xR",
	"incremental_authorization_allowed": false,
	"authorization_count": null,
	"incremental_authorizations": null,
	"external_authentication_details": null,
	"external_3ds_authentication_attempted": false,
	"expires_on": "2026-01-30T08:22:47.145Z",
	"fingerprint": null,
	"browser_info": {
		"language": "nl-NL",
		"time_zone": 0,
		"ip_address": "13.232.74.226",
		"user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Safari/537.36",
		"color_depth": 24,
		"java_enabled": true,
		"screen_width": 1536,
		"accept_header": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8",
		"screen_height": 723,
		"java_script_enabled": true
	},
	"payment_channel": null,
	"payment_method_id": null,
	"network_transaction_id": null,
	"payment_method_status": null,
	"updated": "2026-01-30T08:07:51.693Z",
	"split_payments": null,
	"frm_metadata": null,
	"extended_authorization_applied": null,
	"extended_authorization_last_applied_at": null,
	"request_extended_authorization": null,
	"capture_before": null,
	"merchant_order_reference_id": null,
	"order_tax_amount": null,
	"connector_mandate_id": null,
	"card_discovery": "manual",
	"force_3ds_challenge": false,
	"force_3ds_challenge_trigger": false,
	"issuer_error_code": null,
	"issuer_error_message": null,
	"is_iframe_redirection_enabled": null,
	"whole_connector_response": null,
	"enable_partial_authorization": null,
	"enable_overcapture": null,
	"is_overcapture_enabled": null,
	"network_details": null,
	"is_stored_credential": null,
	"mit_category": null,
	"billing_descriptor": null,
	"tokenization": null,
	"partner_merchant_identifier_details": null,
	"payment_method_tokenization_details": null
}
```

</details>

<details>

<summary>Retrieve Payment (Payment should not go to `Processing` state when PSync is called before redirection)</summary>

```bash
curl --location 'http://localhost:8080/payments/pay_Fq9TQNvFTcGIHJj3o3sB?force_sync=true' \
--header 'Accept: application/json' \
--header 'api-key: dev_BQP8GZFaxM87xQlebIOjdfMunw0Y3j77KYllQiciSSJ4zkm6RPmOAJIIcwKYrMeJ'
```
```json
{
	"payment_id": "pay_Fq9TQNvFTcGIHJj3o3sB",
	"merchant_id": "postman_merchant_GHAction_1769760464",
	"status": "requires_customer_action",
	"amount": 60159,
	"net_amount": 60159,
	"shipping_cost": null,
	"amount_capturable": 60159,
	"amount_received": null,
	"processor_merchant_id": "postman_merchant_GHAction_1769760464",
	"initiator": null,
	"connector": "redsys",
	"client_secret": "pay_Fq9TQNvFTcGIHJj3o3sB_secret_dWZYmVciKXJviv0gBT2L",
	"created": "2026-01-30T08:07:47.145Z",
	"modified_at": "2026-01-30T08:08:11.315Z",
	"currency": "EUR",
	"customer_id": "First_Customer",
	"customer": {
		"id": "First_Customer",
		"name": "John Doe",
		"email": null,
		"phone": null,
		"phone_country_code": null
	},
	"description": null,
	"refunds": null,
	"disputes": null,
	"mandate_id": null,
	"mandate_data": null,
	"setup_future_usage": "on_session",
	"off_session": null,
	"capture_on": null,
	"capture_method": "automatic",
	"payment_method": "card",
	"payment_method_data": {
		"card": {
			"last4": "3017",
			"card_type": null,
			"card_network": null,
			"card_issuer": null,
			"card_issuing_country": null,
			"card_isin": "454881",
			"card_extended_bin": null,
			"card_exp_month": "12",
			"card_exp_year": "49",
			"card_holder_name": "joseph Doe",
			"payment_checks": null,
			"authentication_data": null,
			"auth_code": null
		},
		"billing": null
	},
	"payment_token": "token_SXe2n43IVuEHIQGmce13",
	"shipping": {
		"address": {
			"city": "San Fransico",
			"country": "ES",
			"line1": "1467",
			"line2": "Harrison Street",
			"line3": "Harrison Street",
			"zip": "94122",
			"state": "Ceuta",
			"first_name": "John",
			"last_name": "Doe",
			"origin_zip": null
		},
		"phone": null,
		"email": null
	},
	"billing": {
		"address": {
			"city": "San Fransico",
			"country": "ES",
			"line1": "1467",
			"line2": "Harrison Street",
			"line3": "Harrison Street",
			"zip": "94122",
			"state": "Ceuta",
			"first_name": "joseph",
			"last_name": "Doe",
			"origin_zip": null
		},
		"phone": {
			"number": "8056594427",
			"country_code": "+91"
		},
		"email": null
	},
	"order_details": null,
	"email": null,
	"name": "John Doe",
	"phone": null,
	"return_url": "https://duck.com/",
	"authentication_type": "three_ds",
	"statement_descriptor_name": null,
	"statement_descriptor_suffix": null,
	"next_action": {
		"type": "redirect_to_url",
		"redirect_to_url": "http://localhost:8080/payments/redirect/pay_Fq9TQNvFTcGIHJj3o3sB/postman_merchant_GHAction_1769760464/pay_Fq9TQNvFTcGIHJj3o3sB_1"
	},
	"cancellation_reason": null,
	"error_code": null,
	"error_message": null,
	"unified_code": null,
	"unified_message": null,
	"error_details": null,
	"payment_experience": null,
	"payment_method_type": "credit",
	"connector_label": null,
	"business_country": null,
	"business_label": "default",
	"business_sub_label": null,
	"allowed_payment_method_types": null,
	"manual_retry_allowed": null,
	"connector_transaction_id": "294810737293",
	"frm_message": null,
	"metadata": null,
	"connector_metadata": null,
	"feature_metadata": {
		"redirect_response": null,
		"search_tags": null,
		"apple_pay_recurring_details": null,
		"gateway_system": "direct"
	},
	"reference_id": "294810737293",
	"payment_link": null,
	"profile_id": "pro_AIrQ1ai69DxSmpoVOaRA",
	"surcharge_details": null,
	"attempt_count": 1,
	"merchant_decision": null,
	"merchant_connector_id": "mca_nKdHAkwru4RmrrLjj2xR",
	"incremental_authorization_allowed": false,
	"authorization_count": null,
	"incremental_authorizations": null,
	"external_authentication_details": null,
	"external_3ds_authentication_attempted": false,
	"expires_on": "2026-01-30T08:22:47.145Z",
	"fingerprint": null,
	"browser_info": {
		"language": "nl-NL",
		"time_zone": 0,
		"ip_address": "13.232.74.226",
		"user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Safari/537.36",
		"color_depth": 24,
		"java_enabled": true,
		"screen_width": 1536,
		"accept_header": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8",
		"screen_height": 723,
		"java_script_enabled": true
	},
	"payment_channel": null,
	"payment_method_id": null,
	"network_transaction_id": null,
	"payment_method_status": null,
	"updated": "2026-01-30T08:08:11.315Z",
	"split_payments": null,
	"frm_metadata": null,
	"extended_authorization_applied": null,
	"extended_authorization_last_applied_at": null,
	"request_extended_authorization": null,
	"capture_before": null,
	"merchant_order_reference_id": null,
	"order_tax_amount": null,
	"connector_mandate_id": null,
	"card_discovery": "manual",
	"force_3ds_challenge": false,
	"force_3ds_challenge_trigger": false,
	"issuer_error_code": null,
	"issuer_error_message": null,
	"is_iframe_redirection_enabled": null,
	"whole_connector_response": null,
	"enable_partial_authorization": null,
	"enable_overcapture": null,
	"is_overcapture_enabled": null,
	"network_details": null,
	"is_stored_credential": null,
	"mit_category": null,
	"billing_descriptor": null,
	"tokenization": null,
	"partner_merchant_identifier_details": null,
	"payment_method_tokenization_details": null
}
```

</details>

<details>

<summary>And when you open the link, token should not be expired, you should be able to complete the Payment</summary>

<img width="442" height="102" alt="image" src="https://github.com/user-attachments/assets/53a9be20-0b0f-40cf-8c83-b1cada32e5d2" />

</details>

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `just clippy && just clippy_v2`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
