### PR TITLE
fix: webhook refactor HS<>UCS

### DIFF
--- a/crates/api_models/src/webhooks.rs
+++ b/crates/api_models/src/webhooks.rs
@@ -421,7 +421,6 @@ impl ObjectReferenceId {
     }
 }
 
-#[derive(Clone, Debug)]
 pub struct IncomingWebhookDetails {
     pub object_reference_id: ObjectReferenceId,
     pub resource_object: Vec<u8>,

--- a/crates/api_models/src/webhooks.rs
+++ b/crates/api_models/src/webhooks.rs
@@ -421,21 +421,9 @@ impl ObjectReferenceId {
     }
 }
 
-fn serialize_resource_object<S>(resource_object: &Vec<u8>, serializer: S) -> Result<S::Ok, S::Error>
-where
-    S: serde::Serializer,
-{
-    // Parse Vec<u8> as JSON and serialize it
-    // resource_object is always valid JSON (created from serde_json::to_vec)
-    serde_json::from_slice::<serde_json::Value>(resource_object)
-        .map_err(serde::ser::Error::custom)?
-        .serialize(serializer)
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 pub struct IncomingWebhookDetails {
     pub object_reference_id: ObjectReferenceId,
-    #[serde(serialize_with = "serialize_resource_object")]
     pub resource_object: Vec<u8>,
 }
 

--- a/crates/api_models/src/webhooks.rs
+++ b/crates/api_models/src/webhooks.rs
@@ -421,7 +421,7 @@ impl ObjectReferenceId {
     }
 }
 
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug)]
 pub struct IncomingWebhookDetails {
     pub object_reference_id: ObjectReferenceId,
     pub resource_object: Vec<u8>,

--- a/crates/api_models/src/webhooks.rs
+++ b/crates/api_models/src/webhooks.rs
@@ -421,8 +421,21 @@ impl ObjectReferenceId {
     }
 }
 
+fn serialize_resource_object<S>(resource_object: &Vec<u8>, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    // Parse Vec<u8> as JSON and serialize it
+    // resource_object is always valid JSON (created from serde_json::to_vec)
+    serde_json::from_slice::<serde_json::Value>(resource_object)
+        .map_err(serde::ser::Error::custom)?
+        .serialize(serializer)
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct IncomingWebhookDetails {
     pub object_reference_id: ObjectReferenceId,
+    #[serde(serialize_with = "serialize_resource_object")]
     pub resource_object: Vec<u8>,
 }
 

--- a/crates/router/src/core/webhooks/incoming.rs
+++ b/crates/router/src/core/webhooks/incoming.rs
@@ -656,7 +656,6 @@ pub struct WebhookProcessingResult<'a> {
     #[serde(skip)]
     pub shadow_ucs_data: Option<ShadowUcsData<'a>>,
     #[serde(skip)]
-    // From other PR - webhook context support for ACH returns/rejections
     pub webhook_resource_data: Option<WebhookResourceData>,
     pub object_reference_id: Option<api::ObjectReferenceId>,
     #[serde(skip)]


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
1. Refactored webhook in HS to separate the transformation and extraction logic which are done by hyperswitch and ucs into separate function for each. (Previously everything was there inside process_business_logic funciton and extraction happens interchangebly with fallback without clear dinstinction of which execution_path we are in.)

2. updated execution_mode to send ucs instead of hardcoded always primary mode.


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
4. `loadtest/config`
-->


## Motivation and Context
**problems**
1. HS always call ucs in primary mode even during shadow execution path.
2. Source verification happens in hs inside business logic., should be moved up to gateway code. Cause due to this, ucs shadow mode will not receive response from mitm as it hs source verification happens post receiving response from ucs.. (ucs call is not parallel)
3. Resource Object extraction also not part of business logic, so to move inside gateway code.
5. there was no response comparison currently through validation service for webhooks.
6. multiple logic uses hs extraction and fallback to ucs extraction interchangeably without clear distinction of which path we are in.
7. If UCS returns source_verified = false, currently we falls back to re-verification using hs source verification instead of trusting ucs
8. ucs should_call_unified_connector_service_for_webhooks dont return updated session state with updated proxy config., so mitm wasnt called from hyperswitch.


## How did you test it?
https://github.com/juspay/hyperswitch-cloud/issues/14178

paypal
https://github.com/juspay/hyperswitch-cloud/issues/14048#issuecomment-3853496877
nuvei
https://github.com/juspay/hyperswitch-cloud/issues/14047#issuecomment-3854245184

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
