### PR TITLE
fix(cypress): fix sync payment status in bank redirection flow for gigadat, volt and loonio

### DIFF
--- a/.github/workflows/cypress-tests-runner.yml
+++ b/.github/workflows/cypress-tests-runner.yml
@@ -17,7 +17,6 @@ env:
   CARGO_INCREMENTAL: 0
   CARGO_NET_RETRY: 10
   PAYMENTS_CONNECTORS: "stripe cybersource"
-  PARALLEL_PAYMENTS_CONNECTORS : "loonio gigadat volt"
   OPTIONAL_PAYMENTS_CONNECTORS_BATCH_1: "noon payload nmi"
   OPTIONAL_PAYMENTS_CONNECTORS_BATCH_2: "trustpay braintree adyen"
   OPTIONAL_PAYMENTS_CONNECTORS_BATCH_3: "nexixpay cryptopay finix"
@@ -590,10 +589,9 @@ jobs:
         env:
           CYPRESS_BASEURL: "http://localhost:8080"
           ROUTER__SERVER__WORKERS: 4
-          PAYMENTS_CONNECTORS: "${{ env.PARALLEL_PAYMENTS_CONNECTORS }}"
         shell: bash -leuo pipefail {0}
         run: |
-          scripts/execute_cypress.sh --parallel 3
+          scripts/execute_cypress.sh --parallel 2
 
           kill "${{ env.PID }}"
 
@@ -864,7 +862,7 @@ jobs:
 
   runner_alpha:
     name: Run optional Cypress tests for alpha connectors
-    needs: build-hyperswitch-runners
+    needs: build-hyperswitch
     if: |
       github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'S-test-ready')
     runs-on: hyperswitch-runners


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Local:-
Gigadat
<img width="836" height="1275" alt="Screenshot 2026-02-03 at 16 00 21" src="https://github.com/user-attachments/assets/5c0ee46d-6c91-4d4a-a4c7-f992bc9d2fb8" />

Volt
<img width="720" height="1337" alt="Screenshot 2026-02-03 at 17 15 43" src="https://github.com/user-attachments/assets/71ae504b-0102-49a1-8009-8de47ff05501" />

CI:-
<img width="681" height="316" alt="Screenshot 2026-02-09 at 20 30 51" src="https://github.com/user-attachments/assets/39208166-325d-4fad-9a08-7d18c7451015" />


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
