### PR TITLE
fix(injector): limit response size

### DIFF
--- a/crates/injector/Cargo.toml
+++ b/crates/injector/Cargo.toml
@@ -20,6 +20,7 @@ router_env = { version = "0.1.0", path = "../router_env" }
 async-trait = { version = "0.1.88" }
 base64 = { version = "0.22.1" }
 error-stack = { version = "0.4.1" }
+futures-util = { version = "0.3.30" }
 nom = { version = "7.1.3" }
 reqwest = { version = "0.12.0", features = ["json", "stream", "rustls-tls"] }
 serde = { version = "1.0.219", features = ["derive"] }

--- a/crates/injector/src/injector.rs
+++ b/crates/injector/src/injector.rs
@@ -323,6 +323,8 @@ pub mod core {
         TokenReplacementFailed(String),
         #[error("HTTP request failed")]
         HttpRequestFailed,
+        #[error("Response size exceeds limit of {limit} bytes (received at least {actual} bytes)")]
+        ResponseTooLarge { limit: usize, actual: usize },
         #[error("Serialization error: {0}")]
         SerializationError(String),
         #[error("Invalid template: {0}")]
@@ -759,7 +761,7 @@ pub mod core {
 
             // Convert reqwest::Response to InjectorResponse using trait
             response
-                .into_injector_response()
+                .into_injector_response_with_limit(config.max_response_size)
                 .await
                 .map_err(|e| error_stack::Report::new(e))
         }


### PR DESCRIPTION
## Summary
- enforce a configurable maximum response size for injector HTTP responses (default 10MB)
- stream response bytes and error out when the limit is exceeded
- wire the limit through to the injector call path

## Security impact
Prevents unbounded response bodies from causing excessive memory usage.

## Tests
- Not run (no local Rust toolchain installed)

Fixes juspay/hyperswitch#11148