### PR TITLE
fix(webhook): add missing recovery events in webhooks as event not supported gets returned

### DIFF
--- a/crates/api_models/src/webhooks.rs
+++ b/crates/api_models/src/webhooks.rs
@@ -128,6 +128,13 @@ impl IncomingWebhookEvent {
             35 => Self::PayoutExpired,
             #[cfg(feature = "payouts")]
             36 => Self::PayoutReversed,
+
+            // Recovery events
+            37 => Self::RecoveryPaymentFailure,
+            38 => Self::RecoveryPaymentSuccess,
+            39 => Self::RecoveryPaymentPending,
+            40 => Self::RecoveryInvoiceCancel,
+
             _ => Self::EventNotSupported,
         }
     }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->

when i was working on https://github.com/juspay/connector-service/pull/473, i observed that the recovery events were non-existent in webhook event list in hyperswitch side. so, if recovery webhook was triggered in the ucs side, this would result in `event not supported` error to be returned.

these fields already exist in ucs. it is just that it's missing in hyperswitch. added the mapping.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->

i observed these fields to be missing in hyperswitch side. so, added.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

no tests needed.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `just clippy && just clippy_v2`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
