### PR TITLE
fix(connector): Fix PayJustNow In-Store Payments when merchant_order_reference_id is Same

### DIFF
--- a/crates/hyperswitch_connectors/src/connectors/payjustnowinstore.rs
+++ b/crates/hyperswitch_connectors/src/connectors/payjustnowinstore.rs
@@ -53,6 +53,7 @@ use crate::{constants::headers, types::ResponseRouterData, utils};
 
 const PAYJUSTNOWINSTORE_MERCHANT_TERMINAL_ID: &str = "X-PayJustNow-Merchant-Terminal-ID";
 const SIGNATURE: &str = "X-Signature";
+const MERCHANT_REFERENCE_NON_UNIQUE: &str = "X-Merchant-Reference-Non-Unique";
 
 #[derive(Clone)]
 pub struct Payjustnowinstore {
@@ -118,6 +119,10 @@ where
                 self.get_content_type().to_string().into(),
             ),
             (SIGNATURE.to_string(), signature_hex.into_masked()),
+            (
+                MERCHANT_REFERENCE_NON_UNIQUE.to_string(),
+                "true".to_string().into(),
+            ),
         ];
         let mut api_key = self.get_auth_header(&req.connector_auth_type)?;
         header.append(&mut api_key);


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->

Fixed payjustnowinstore payments when merchant_order_reference_id is same by adding the required header.
Previously for same `merchant_order_reference_id`, payments in payjustnowinstore was failing. Now, after addition of the header the payments are working correctly as expected.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

Postman Tests

[https://docs.google.com/document/d/1-MUXSOZQHJhRbemiVQLrWYMPahOow6KogtPt0Jmz4fQ/edit?usp=sharing](https://docs.google.com/document/d/1-MUXSOZQHJhRbemiVQLrWYMPahOow6KogtPt0Jmz4fQ/edit?usp=sharing)

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible