### PR TITLE
fix(platform): add sdk_authorization support for remaining APIs

### DIFF
--- a/crates/router/src/compatibility/stripe/payment_intents.rs
+++ b/crates/router/src/compatibility/stripe/payment_intents.rs
@@ -212,10 +212,11 @@ pub async fn payment_intents_retrieve_with_gateway_creds(
         allow_platform_self_operation: false,
     };
 
-    let (auth_type, _auth_flow) = match auth::get_auth_type_and_flow(req.headers(), api_auth) {
-        Ok(auth) => auth,
-        Err(err) => return api::log_and_return_error_response(report!(err)),
-    };
+    let (auth_type, _auth_flow) =
+        match auth::check_authorization_header_or_get_auth(req.headers(), api_auth) {
+            Ok(auth) => auth,
+            Err(err) => return api::log_and_return_error_response(report!(err)),
+        };
 
     let flow = match json_payload.force_sync {
         Some(true) => Flow::PaymentsRetrieveForceSync,
@@ -302,10 +303,11 @@ pub async fn payment_intents_update(
         allow_platform_self_operation: false,
     };
 
-    let (auth_type, auth_flow) = match auth::get_auth_type_and_flow(req.headers(), api_auth) {
-        Ok(auth) => auth,
-        Err(err) => return api::log_and_return_error_response(report!(err)),
-    };
+    let (auth_type, auth_flow) =
+        match auth::check_authorization_header_or_get_auth(req.headers(), api_auth) {
+            Ok(auth) => auth,
+            Err(err) => return api::log_and_return_error_response(report!(err)),
+        };
 
     let flow = Flow::PaymentsUpdate;
     let locking_action = payload.get_locking_input(flow.clone());
@@ -555,10 +557,11 @@ pub async fn payment_intents_cancel(
         allow_platform_self_operation: false,
     };
 
-    let (auth_type, auth_flow) = match auth::get_auth_type_and_flow(req.headers(), api_auth) {
-        Ok(auth) => auth,
-        Err(err) => return api::log_and_return_error_response(report!(err)),
-    };
+    let (auth_type, auth_flow) =
+        match auth::check_authorization_header_or_get_auth(req.headers(), api_auth) {
+            Ok(auth) => auth,
+            Err(err) => return api::log_and_return_error_response(report!(err)),
+        };
 
     let flow = Flow::PaymentsCancel;
     let locking_action = payload.get_locking_input(flow.clone());

--- a/crates/router/src/routes/poll.rs
+++ b/crates/router/src/routes/poll.rs
@@ -34,16 +34,27 @@ pub async fn retrieve_poll_status(
     let poll_id = PollId {
         poll_id: path.into_inner(),
     };
+    // Determine auth type based on Authorization header presence
+    let auth: Box<dyn auth::AuthenticateAndFetch<auth::AuthenticationData, _>> =
+        match req.headers().get(actix_web::http::header::AUTHORIZATION) {
+            // If Authorization header is present, use SdkAuthorizationAuth
+            Some(_) => Box::new(auth::SdkAuthorizationAuth {
+                allow_connected_scope_operation: false,
+                allow_platform_self_operation: false,
+            }),
+            // If Authorization header is not present, use PublishableKeyAuth
+            None => Box::new(auth::HeaderAuth(auth::PublishableKeyAuth {
+                allow_connected_scope_operation: false,
+                allow_platform_self_operation: false,
+            })),
+        };
     Box::pin(api::server_wrap(
         flow,
         state,
         &req,
         poll_id,
         |state, auth, req, _| poll::retrieve_poll_status(state, req, auth.platform),
-        &auth::HeaderAuth(auth::PublishableKeyAuth {
-            allow_connected_scope_operation: false,
-            allow_platform_self_operation: false,
-        }),
+        &*auth,
         api_locking::LockAction::NotApplicable,
     ))
     .await

--- a/crates/router/src/routes/subscription.rs
+++ b/crates/router/src/routes/subscription.rs
@@ -426,10 +426,11 @@ pub async fn get_estimate(
         allow_connected_scope_operation: false,
         allow_platform_self_operation: false,
     };
-    let (auth_type, _auth_flow) = match auth::get_auth_type_and_flow(req.headers(), api_auth) {
-        Ok(auth) => auth,
-        Err(err) => return oss_api::log_and_return_error_response(report!(err)),
-    };
+    let (auth_type, _auth_flow) =
+        match auth::check_authorization_header_or_get_auth(req.headers(), api_auth) {
+            Ok(auth) => auth,
+            Err(err) => return oss_api::log_and_return_error_response(report!(err)),
+        };
     Box::pin(oss_api::server_wrap(
         flow,
         state,


### PR DESCRIPTION
## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

This PR adds SDK authorization support to the remaining APIs that were missing it. The changes enable these endpoints to work with both traditional authentication methods and the new SDK authorization flow introduced in PR #11187.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

## Motivation and Context

Following the implementation of dual authentication for SDK in PR #11187, several API endpoints needed to be updated to support the new SDK authorization mechanism. This PR completes that implementation by adding SDK authorization support to:

1. Stripe-compatible payment intents endpoints (retrieve with gateway creds, update, cancel)
2. Native payments retrieve with gateway credentials endpoint
3. Poll retrieve status endpoint (with dynamic auth selection)
4. Subscription estimate endpoint

This ensures consistent authentication handling across all SDK-facing APIs.

## How did you test it?

- Tested API endpoints with both Authorization header (SDK auth) and without (fallback to publishable key)
- Verified client_secret is properly extracted and passed through in the payments flow
- Confirmed backward compatibility with existing authentication methods


No test cases
## Checklist

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible

🤖 Generated with [Claude Code](https://claude.com/claude-code)