### PR TITLE
feat(connector): add integrity check support for Powertranz

### DIFF
--- a/crates/hyperswitch_connectors/src/connectors/powertranz/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/powertranz/transformers.rs
@@ -288,6 +288,8 @@ pub struct PowertranzBaseResponse {
     redirect_data: Option<Secret<String>>,
     response_message: String,
     order_identifier: String,
+    pub total_amount: Option<FloatMajorUnit>,
+    pub currency_code: Option<String>,
 }
 
 fn get_status((transaction_type, approved, is_3ds): (u8, bool, bool)) -> enums::AttemptStatus {


### PR DESCRIPTION
## Summary
- Adds `total_amount` and `currency_code` fields to `PowertranzBaseResponse` to capture amount/currency from connector responses
- Adds integrity verification to Authorize, Capture, and Refund Execute `handle_response` flows using `get_authorise_integrity_object`, `get_capture_integrity_object`, and `get_refund_integrity_object`
- Only constructs integrity objects when both amount and currency are present in the response, safely handling flows (like Void) that may not return these fields

## Test plan
- [ ] Verify compilation with `cargo check -p hyperswitch_connectors`
- [ ] Run `cargo clippy` for lint warnings
- [ ] Confirm existing Powertranz tests pass
- [ ] Validate integrity checks trigger correctly when amount/currency are present in responses
- [ ] Validate no integrity check is applied when amount/currency are absent (e.g., Void flow)

Closes #9216