### PR TITLE
fix(customers): add missing JWTAuth from customer PML in v2

### DIFF
--- a/crates/router/src/routes/payment_methods.rs
+++ b/crates/router/src/routes/payment_methods.rs
@@ -81,15 +81,14 @@ pub async fn create_payment_method_api(
         allow_connected_scope_operation: true,
         allow_platform_self_operation: true,
     };
-    let (auth_type, _api_key_type) =
-        match auth::check_internal_api_key_auth_no_client_secret(
-            req.headers(),
-            api_auth,
-            state.conf.internal_merchant_id_profile_id_auth.clone(),
-        ) {
-            Ok(auth) => auth,
-            Err(err) => return api::log_and_return_error_response(error_stack::report!(err)),
-        };
+    let (auth_type, _api_key_type) = match auth::check_internal_api_key_auth_no_client_secret(
+        req.headers(),
+        api_auth,
+        state.conf.internal_merchant_id_profile_id_auth.clone(),
+    ) {
+        Ok(auth) => auth,
+        Err(err) => return api::log_and_return_error_response(error_stack::report!(err)),
+    };
 
     Box::pin(api::server_wrap(
         flow,
@@ -850,15 +849,16 @@ pub async fn list_customer_payment_method_api(
     let jwt_auth = auth::JWTAuth {
         permission: Permission::MerchantCustomerRead,
     };
-    let (auth_type, api_key_type) = match auth::check_internal_api_key_or_dashboard_auth_no_client_secret(
-        req.headers(),
-        api_auth,
-        jwt_auth,
-        state.conf.internal_merchant_id_profile_id_auth.clone(),
-    ) {
-        Ok(auth) => auth,
-        Err(err) => return api::log_and_return_error_response(error_stack::report!(err)),
-    };
+    let (auth_type, api_key_type) =
+        match auth::check_internal_api_key_or_dashboard_auth_no_client_secret(
+            req.headers(),
+            api_auth,
+            jwt_auth,
+            state.conf.internal_merchant_id_profile_id_auth.clone(),
+        ) {
+            Ok(auth) => auth,
+            Err(err) => return api::log_and_return_error_response(error_stack::report!(err)),
+        };
 
     Box::pin(api::server_wrap(
         flow,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
Fixes https://github.com/juspay/hyperswitch/issues/11336

This PR modifies below v2 endpoints -
- extends JWTAuth for customer PML API
- removes JWTAuth for payment method creation

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
Customer PML needs to be tested via JWTAuth.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
