### PR TITLE
ci(cypress): revert refactor label-based trigger of cypress-tests

### DIFF
--- a/.github/workflows/cypress-tests-runner.yml
+++ b/.github/workflows/cypress-tests-runner.yml
@@ -33,36 +33,6 @@ env:
   RUST_MIN_STACK: 11534336
 
 jobs:
-  resolve-s-test-ready:
-    name: Resolve S-test-ready label
-    runs-on: ubuntu-latest
-    outputs:
-      s_test_ready: ${{ steps.check-s-test-ready.outputs.s_test_ready || steps.set-s-test-ready-for-skipped-tests.outputs.s_test_ready }}
-    steps:
-      - name: Check S-test-ready label
-        id: check-s-test-ready
-        if: ${{ env.RUN_TESTS == 'true' }}
-        env:
-          GH_TOKEN: ${{ github.token }}
-        shell: bash
-        run: |
-          if gh pr view ${{ github.event.pull_request.number }} \
-              --repo ${{ github.repository }} \
-              --json labels \
-              --jq '.labels[].name' | grep --quiet '^S-test-ready$'; then
-            echo "S-test-ready label found"
-            echo "s_test_ready=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "::error::S-test-ready label is missing. Add the label and re-run jobs to execute Cypress tests."
-            exit 1
-          fi
-
-      - name: Set S-test-ready output for skipped tests
-        id: set-s-test-ready-for-skipped-tests
-        if: ${{ env.RUN_TESTS == 'false' }}
-        shell: bash
-        run: echo "s_test_ready=false" >> "$GITHUB_OUTPUT"
-
   formatter:
     name: Run formatter on Cypress tests and address lints
     if: ${{ github.event_name == 'pull_request' }}
@@ -124,9 +94,10 @@ jobs:
 
   build-hyperswitch:
     name: Build hyperswitch server
-    needs: resolve-s-test-ready
+    if: |
+      github.event_name == 'merge_group' ||
+      (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'S-test-ready'))
     runs-on: ubuntu-latest
-
     env:
       # Use `sccache` for caching compilation artifacts
       RUSTC_WRAPPER: sccache
@@ -181,7 +152,9 @@ jobs:
   
   build-hyperswitch-runners:
     name: Build hyperswitch server(hyperswitch-runners)
-    needs: resolve-s-test-ready
+    if: |
+      github.event_name == 'merge_group' ||
+      (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'S-test-ready'))
     runs-on: hyperswitch-runners
     env:
       # Use `sccache` for caching compilation artifacts
@@ -237,7 +210,10 @@ jobs:
   
   runner:
     name: Run mandatory Cypress tests
-    needs: [resolve-s-test-ready, build-hyperswitch]
+    needs: build-hyperswitch
+    if: |
+      github.event_name == 'merge_group' ||
+      (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'S-test-ready'))
     permissions:
       pull-requests: write
     runs-on: ubuntu-latest
@@ -434,7 +410,10 @@ jobs:
 
   runner-hyperswitch-runners:
     name: Run mandatory Cypress tests (hyperswitch-runners)
-    needs: [resolve-s-test-ready, build-hyperswitch-runners]
+    needs: build-hyperswitch-runners
+    if: |
+      github.event_name == 'merge_group' ||
+      (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'S-test-ready'))
     permissions:
       pull-requests: write
     runs-on: hyperswitch-runners
@@ -901,8 +880,9 @@ jobs:
 
   runner_alpha:
     name: Run optional Cypress tests for alpha connectors
-    if: ${{ github.event_name == 'pull_request' && needs.resolve-s-test-ready.outputs.s_test_ready == 'true' }}
-    needs: [resolve-s-test-ready, build-hyperswitch-runners]
+    needs: build-hyperswitch-runners
+    if: |
+      github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'S-test-ready')
     runs-on: hyperswitch-runners
     env:
       # Use `sccache` for caching compilation artifacts
@@ -1108,8 +1088,7 @@ jobs:
 
   runner_v2:
     name: Run Cypress tests on v2 and generate coverage report
-    if: ${{ github.event_name == 'pull_request' && needs.resolve-s-test-ready.outputs.s_test_ready == 'true' }}
-    needs: resolve-s-test-ready
+    if: github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'S-test-ready')
     runs-on: hyperswitch-runners
     permissions:
       pull-requests: write


### PR DESCRIPTION
Reverts juspay/hyperswitch#11076
this PR will revert the changes introduced by pr `https://github.com/juspay/hyperswitch/pull/11076` because the mandatory cypress tests are not being checked in merge group due to [PR](https://github.com/juspay/hyperswitch/pull/11076)