### PR TITLE
feat(connector): [Adyen] add integrity check support for Capture, Authorize and PSync flows

### DIFF
--- a/crates/hyperswitch_connectors/src/connectors/adyen.rs
+++ b/crates/hyperswitch_connectors/src/connectors/adyen.rs
@@ -97,6 +97,7 @@ use crate::{
         AcceptDisputeRouterData, DefendDisputeRouterData, ResponseRouterData,
         SubmitEvidenceRouterData,
     },
+    utils as connector_utils,
     utils::{
         convert_amount, convert_payment_authorize_router_response,
         convert_setup_mandate_router_data_to_authorize_router_data, is_mandate_supported,
@@ -654,15 +655,26 @@ impl ConnectorIntegration<Capture, PaymentsCaptureData, PaymentsResponseData> fo
             .parse_struct("AdyenCaptureResponse")
             .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
 
+        let response_integrity_object = connector_utils::get_capture_integrity_object(
+            self.amount_converter,
+            Some(response.amount.value),
+            response.amount.currency.to_string(),
+        )?;
+
         event_builder.map(|i| i.set_response_body(&response));
         router_env::logger::info!(connector_response=?response);
 
-        RouterData::try_from(ResponseRouterData {
+        let new_router_data = RouterData::try_from(ResponseRouterData {
             response,
             data: data.clone(),
             http_code: res.status_code,
         })
-        .change_context(errors::ConnectorError::ResponseHandlingFailed)
+        .change_context(errors::ConnectorError::ResponseHandlingFailed);
+
+        new_router_data.map(|mut router_data| {
+            router_data.request.integrity_object = Some(response_integrity_object);
+            router_data
+        })
     }
     fn get_error_response(
         &self,
@@ -799,6 +811,18 @@ impl ConnectorIntegration<PSync, PaymentsSyncData, PaymentsResponseData> for Ady
             .parse_struct("AdyenPaymentResponse")
             .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
 
+        let response_amount = adyen::get_amount_from_payment_response(&response);
+
+        let response_integrity_object = response_amount
+            .map(|amount| {
+                connector_utils::get_sync_integrity_object(
+                    self.amount_converter,
+                    amount.value,
+                    amount.currency.to_string(),
+                )
+            })
+            .transpose()?;
+
         event_builder.map(|i| i.set_response_body(&response));
         router_env::logger::info!(connector_response=?response);
 
@@ -806,7 +830,8 @@ impl ConnectorIntegration<PSync, PaymentsSyncData, PaymentsResponseData> for Ady
             SyncRequestType::MultipleCaptureSync(_) => true,
             SyncRequestType::SinglePaymentSync => false,
         };
-        RouterData::foreign_try_from((
+
+        let new_router_data = RouterData::foreign_try_from((
             ResponseRouterData {
                 response,
                 data: data.clone(),
@@ -816,7 +841,12 @@ impl ConnectorIntegration<PSync, PaymentsSyncData, PaymentsResponseData> for Ady
             is_multiple_capture_sync,
             data.request.payment_method_type,
         ))
-        .change_context(errors::ConnectorError::ResponseHandlingFailed)
+        .change_context(errors::ConnectorError::ResponseHandlingFailed);
+
+        new_router_data.map(|mut router_data| {
+            router_data.request.integrity_object = response_integrity_object;
+            router_data
+        })
     }
 
     fn get_error_response(
@@ -917,9 +947,23 @@ impl ConnectorIntegration<Authorize, PaymentsAuthorizeData, PaymentsResponseData
             .response
             .parse_struct("AdyenPaymentResponse")
             .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
+
+        let response_amount = adyen::get_amount_from_payment_response(&response);
+
+        let response_integrity_object = response_amount
+            .map(|amount| {
+                connector_utils::get_authorise_integrity_object(
+                    self.amount_converter,
+                    amount.value,
+                    amount.currency.to_string(),
+                )
+            })
+            .transpose()?;
+
         event_builder.map(|i| i.set_response_body(&response));
         router_env::logger::info!(connector_response=?response);
-        RouterData::foreign_try_from((
+
+        let new_router_data = RouterData::foreign_try_from((
             ResponseRouterData {
                 response,
                 data: data.clone(),
@@ -929,7 +973,12 @@ impl ConnectorIntegration<Authorize, PaymentsAuthorizeData, PaymentsResponseData
             false,
             data.request.payment_method_type,
         ))
-        .change_context(errors::ConnectorError::ResponseHandlingFailed)
+        .change_context(errors::ConnectorError::ResponseHandlingFailed);
+
+        new_router_data.map(|mut router_data| {
+            router_data.request.integrity_object = response_integrity_object;
+            router_data
+        })
     }
 
     fn get_error_response(

--- a/crates/hyperswitch_connectors/src/connectors/adyen/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/adyen/transformers.rs
@@ -577,6 +577,17 @@ pub enum AdyenPaymentResponse {
     WebhookResponse(Box<AdyenWebhookResponse>),
 }
 
+pub fn get_amount_from_payment_response(response: &AdyenPaymentResponse) -> Option<Amount> {
+    match response {
+        AdyenPaymentResponse::Response(r) => r.amount.clone(),
+        AdyenPaymentResponse::PresentToShopper(r) => r.amount.clone(),
+        AdyenPaymentResponse::QrCodeResponse(r) => r.amount.clone(),
+        AdyenPaymentResponse::RedirectionResponse(r) => r.amount.clone(),
+        AdyenPaymentResponse::WebhookResponse(r) => r.amount.clone(),
+        AdyenPaymentResponse::RedirectionErrorResponse(_) => None,
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AdyenResponse {
@@ -5355,7 +5366,7 @@ pub struct AdyenCaptureResponse {
     psp_reference: String,
     reference: String,
     status: String,
-    amount: Amount,
+    pub amount: Amount,
     merchant_reference: Option<String>,
     store: Option<String>,
     splits: Option<Vec<AdyenSplitData>>,

--- a/crates/hyperswitch_connectors/src/connectors/adyen/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/adyen/transformers.rs
@@ -7119,3 +7119,41 @@ impl
         })
     }
 }
+
+#[cfg(test)]
+mod test_adyen_integrity {
+    use super::*;
+
+    #[test]
+    fn get_amount_from_response_variant_returns_some() {
+        let json = serde_json::json!({
+            "pspReference": "ABC123",
+            "resultCode": "Authorised",
+            "merchantReference": "ref_001",
+            "amount": { "currency": "EUR", "value": 1000 }
+        });
+        let response: AdyenResponse = serde_json::from_value(json).expect("valid json");
+        let payment_response = AdyenPaymentResponse::Response(Box::new(response));
+
+        let result = get_amount_from_payment_response(&payment_response);
+
+        assert!(result.is_some());
+        let amount = result.unwrap();
+        assert_eq!(amount.value, MinorUnit::new(1000));
+        assert_eq!(amount.currency.to_string(), "EUR");
+    }
+
+    #[test]
+    fn get_amount_from_redirection_error_returns_none() {
+        let json = serde_json::json!({
+            "resultCode": "Refused",
+            "refusalReason": "Not enough balance"
+        });
+        let response: RedirectionErrorResponse = serde_json::from_value(json).expect("valid json");
+        let payment_response = AdyenPaymentResponse::RedirectionErrorResponse(Box::new(response));
+
+        let result = get_amount_from_payment_response(&payment_response);
+
+        assert!(result.is_none());
+    }
+}


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Add integrity check support to the Adyen connector so that amounts returned by Adyen in API responses are validated against the amounts originally sent by Hyperswitch. On mismatch, payments are held in a non-terminal "review" state instead of silently succeeding with wrong amounts.

**Flows implemented:**
- **Capture** — `AdyenCaptureResponse` has non-optional `amount: Amount`, wrapped in `Some()` for `get_capture_integrity_object`
- **Authorize** — `AdyenPaymentResponse` enum variants have `amount: Option<Amount>`, extracted via helper before `foreign_try_from` consumes ownership
- **PSync** — Same `AdyenPaymentResponse` enum, same pattern as Authorize using `get_sync_integrity_object`

**Flows NOT implemented (with justification):**
- **Refund Execute** — `AdyenRefundResponse` has NO amount/currency fields. Adyen's refund API response only returns `psp_reference`, `reference`, and `status`.
- **RSync** — Empty `ConnectorIntegration` impl (`impl ConnectorIntegration<RSync, RefundsData, RefundsResponseData> for Adyen {}`) with no `handle_response` to modify.

**Key implementation details:**
- Made `AdyenCaptureResponse.amount` field `pub` for cross-module access (matches Stripe/Xendit convention)
- Added `get_amount_from_payment_response` helper with exhaustive match (no wildcard) — compiler will enforce updates on new enum variants
- When amount is `None` (e.g., `RedirectionErrorResponse`), integrity check is skipped gracefully via `.map().transpose()?`

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

## Motivation and Context

Closes #8149

Reference PRs:
- Xendit integrity check: #8049
- Fiserv integrity check: #8075

## How did you test it?

- `cargo check -p hyperswitch_connectors --features v1` — compiles clean with zero errors in modified files
- `cargo +nightly fmt --all` — passes
- Unit tests added for `get_amount_from_payment_response` helper (Response variant returns `Some`, RedirectionErrorResponse returns `None`)
- Verified pattern matches reference implementations (Stripe, Xendit, Fiserv)

## Checklist

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [x] I added unit tests for my changes where possible