### PR TITLE
feat(connector): [ACI] Add Apple Pay and Google Pay wallet support

### DIFF
--- a/config/deployments/integration_test.toml
+++ b/config/deployments/integration_test.toml
@@ -234,9 +234,9 @@ bank_debit.sepa = { connector_list = "gocardless,adyen" }
 card.credit.connector_list = "checkout,stripe,adyen,authorizedotnet,cybersource,datatrans,worldpay,nmi,bankofamerica,wellsfargo,bamboraapac,nexixpay,novalnet,paypal,archipel,tesouro,mollie"
 card.debit.connector_list = "checkout,stripe,adyen,authorizedotnet,cybersource,datatrans,worldpay,nmi,bankofamerica,wellsfargo,bamboraapac,nexixpay,novalnet,paypal,archipel,tesouro,mollie"
 pay_later.klarna.connector_list = "adyen"
-wallet.apple_pay.connector_list = "checkout,stripe,adyen,cybersource,bankofamerica,novalnet,nuvei,authorizedotnet,nmi,tesouro,worldpayxml"
-wallet.samsung_pay.connector_list = "cybersource"
-wallet.google_pay.connector_list = "checkout,stripe,adyen,cybersource,bankofamerica,novalnet,nuvei,authorizedotnet,nmi,tesouro,worldpayxml"
+wallet.apple_pay.connector_list = "aci,checkout,stripe,adyen,cybersource,bankofamerica,novalnet,nuvei,authorizedotnet,nmi,tesouro,worldpayxml"
+wallet.samsung_pay.connector_list = "aci,cybersource"
+wallet.google_pay.connector_list = "aci,checkout,stripe,adyen,cybersource,bankofamerica,novalnet,nuvei,authorizedotnet,nmi,tesouro,worldpayxml"
 wallet.paypal.connector_list = "adyen,novalnet"
 wallet.momo.connector_list = "adyen"
 wallet.kakao_pay.connector_list = "adyen"
@@ -258,9 +258,9 @@ bank_debit.sepa = { connector_list = "gocardless,adyen,stripe,deutschebank" }
 card.credit.connector_list = "aci,checkout,stripe,adyen,zift,authorizedotnet,cybersource,datatrans,globalpay,worldpay,multisafepay,nmi,nexinets,noon,bankofamerica,braintree,nuvei,payme,wellsfargo,bamboraapac,elavon,fiuu,nexixpay,novalnet,paybox,paypal,xendit,moneris,archipel,worldpayvantiv,payload,paysafe,finix,tesouro,mollie,airwallex"
 card.debit.connector_list = "aci,checkout,stripe,adyen,zift,authorizedotnet,cybersource,datatrans,globalpay,worldpay,multisafepay,nmi,nexinets,noon,bankofamerica,braintree,nuvei,payme,wellsfargo,bamboraapac,elavon,fiuu,nexixpay,novalnet,paybox,paypal,xendit,moneris,archipel,worldpayvantiv,payload,paysafe,finix,tesouro,mollie,airwallex"
 pay_later.klarna.connector_list = "adyen,aci"
-wallet.apple_pay.connector_list = "checkout,stripe,adyen,braintree,cybersource,noon,bankofamerica,nexinets,novalnet,nuvei,authorizedotnet,wellsfargo,finix,nmi,tesouro,worldpaymodular,worldpayxml"
-wallet.samsung_pay.connector_list = "cybersource"
-wallet.google_pay.connector_list = "checkout,stripe,adyen,cybersource,bankofamerica,noon,globalpay,multisafepay,novalnet,nuvei,authorizedotnet,wellsfargo,finix,nmi,tesouro,worldpaymodular,worldpayxml"
+wallet.apple_pay.connector_list = "aci,checkout,stripe,adyen,braintree,cybersource,noon,bankofamerica,nexinets,novalnet,nuvei,authorizedotnet,wellsfargo,finix,nmi,tesouro,worldpaymodular,worldpayxml"
+wallet.samsung_pay.connector_list = "aci,cybersource"
+wallet.google_pay.connector_list = "aci,checkout,stripe,adyen,cybersource,bankofamerica,noon,globalpay,multisafepay,novalnet,nuvei,authorizedotnet,wellsfargo,finix,nmi,tesouro,worldpaymodular,worldpayxml"
 wallet.paypal.connector_list = "adyen,globalpay,nexinets,novalnet,paypal,authorizedotnet"
 wallet.momo.connector_list = "adyen"
 wallet.kakao_pay.connector_list = "adyen"
@@ -828,7 +828,9 @@ interac = { country = "CA", currency = "CAD,USD"}
 przelewy24 = { country = "PL", currency = "CZK,EUR,GBP,PLN" }
 trustly = { country = "ES,GB,SE,NO,AT,NL,DE,DK,FI,EE,LT,LV", currency = "CZK,DKK,EUR,GBP,NOK,SEK" }
 klarna = { country = "AU,AT,BE,CA,CZ,DK,FI,FR,DE,GR,IE,IT,NL,NZ,NO,PL,PT,ES,SE,CH,GB,US", currency = "CHF,DKK,EUR,GBP,NOK,PLN,SEK,USD,AUD,NZD,CAD" }
-
+apple_pay = { country = "AU,CN,HK,JP,MO,MY,NZ,SG,TW,AM,AT,AZ,BY,BE,BG,HR,CY,CZ,DK,EE,FO,FI,FR,GE,DE,GR,GL,GG,HU,IS,IE,IM,IT,KZ,JE,LV,LI,LT,LU,MT,MD,MC,ME,NL,NO,PL,PT,RO,SM,RS,SK,SI,ES,SE,CH,UA,GB,AR,CO,CR,BR,MX,PE,BH,IL,JO,KW,PS,QA,SA,AE,CA,US,KR,VN,MA,ZA", currency = "AED,AUD,CAD,CHF,EUR,GBP,HKD,SGD,USD" }
+google_pay = { country = "AL,DZ,AS,AO,AG,AR,AU,AT,AZ,BH,BY,BE,BR,BG,CA,CL,CO,HR,CZ,DK,DO,EG,EE,FI,FR,DE,GR,HK,HU,IN,ID,IE,IL,IT,JP,JO,KZ,KE,KW,LV,LB,LT,LU,MY,MX,NL,NZ,NO,OM,PK,PA,PE,PH,PL,PT,QA,RO,SA,SG,SK,ZA,ES,LK,SE,CH,TW,TH,TR,UA,AE,GB,US,UY,VN" }
+samsung_pay = { country = "AU,BH,BR,CA,CN,DK,FI,FR,DE,HK,IN,IT,JP,KZ,KR,KW,MY,NZ,NO,OM,QA,SA,SG,ZA,ES,SE,CH,TW,AE,GB,US", currency = "AED,AUD,CAD,CHF,EUR,GBP,HKD,SGD,USD" }
 
 [pm_filters.gigadat]
 interac = { currency = "CAD"}

--- a/config/deployments/production.toml
+++ b/config/deployments/production.toml
@@ -234,9 +234,9 @@ bank_debit.sepa = { connector_list = "gocardless,adyen" }
 card.credit.connector_list = "checkout,stripe,adyen,authorizedotnet,cybersource,datatrans,worldpay,nmi,bankofamerica,wellsfargo,bamboraapac,nexixpay,novalnet,paypal,archipel,tesouro,mollie"
 card.debit.connector_list = "checkout,stripe,adyen,authorizedotnet,cybersource,datatrans,worldpay,nmi,bankofamerica,wellsfargo,bamboraapac,nexixpay,novalnet,paypal,archipel,tesouro,mollie"
 pay_later.klarna.connector_list = "adyen"
-wallet.apple_pay.connector_list = "checkout,stripe,adyen,cybersource,bankofamerica,novalnet,nuvei,authorizedotnet,nmi,tesouro,worldpaymodular,worldpayxml"
-wallet.samsung_pay.connector_list = "cybersource"
-wallet.google_pay.connector_list = "checkout,stripe,adyen,cybersource,bankofamerica,novalnet,nuvei,authorizedotnet,nmi,tesouro,worldpaymodular,worldpayxml"
+wallet.apple_pay.connector_list = "aci,checkout,stripe,adyen,cybersource,bankofamerica,novalnet,nuvei,authorizedotnet,nmi,tesouro,worldpaymodular,worldpayxml"
+wallet.samsung_pay.connector_list = "aci,cybersource"
+wallet.google_pay.connector_list = "aci,checkout,stripe,adyen,cybersource,bankofamerica,novalnet,nuvei,authorizedotnet,nmi,tesouro,worldpaymodular,worldpayxml"
 wallet.paypal.connector_list = "adyen,novalnet"
 wallet.momo.connector_list = "adyen"
 wallet.kakao_pay.connector_list = "adyen"
@@ -258,9 +258,9 @@ bank_debit.sepa = { connector_list = "gocardless,adyen,stripe,deutschebank" }
 card.credit.connector_list = "aci,checkout,stripe,zift,adyen,authorizedotnet,cybersource,datatrans,globalpay,worldpay,multisafepay,nmi,nexinets,noon,bankofamerica,braintree,nuvei,payme,wellsfargo,bamboraapac,elavon,fiuu,nexixpay,novalnet,paybox,paypal,xendit,moneris,archipel,worldpayvantiv,payload,paysafe,finix,tesouro,mollie,airwallex"
 card.debit.connector_list = "aci,checkout,stripe,zift,adyen,authorizedotnet,cybersource,datatrans,globalpay,worldpay,multisafepay,nmi,nexinets,noon,bankofamerica,braintree,nuvei,payme,wellsfargo,bamboraapac,elavon,fiuu,nexixpay,novalnet,paybox,paypal,xendit,moneris,archipel,worldpayvantiv,payload,paysafe,finix,tesouro,mollie,airwallex"
 pay_later.klarna.connector_list = "adyen,aci"
-wallet.apple_pay.connector_list = "checkout,stripe,adyen,braintree,cybersource,noon,bankofamerica,nexinets,novalnet,nuvei,authorizedotnet,wellsfargo,finix,nmi,tesouro,worldpayxml"
-wallet.samsung_pay.connector_list = "cybersource"
-wallet.google_pay.connector_list = "checkout,stripe,adyen,cybersource,bankofamerica,noon,globalpay,multisafepay,novalnet,nuvei,authorizedotnet,wellsfargo,finix,nmi,tesouro,worldpayxml"
+wallet.apple_pay.connector_list = "aci,checkout,stripe,adyen,braintree,cybersource,noon,bankofamerica,nexinets,novalnet,nuvei,authorizedotnet,wellsfargo,finix,nmi,tesouro,worldpayxml"
+wallet.samsung_pay.connector_list = "aci,cybersource"
+wallet.google_pay.connector_list = "aci,checkout,stripe,adyen,cybersource,bankofamerica,noon,globalpay,multisafepay,novalnet,nuvei,authorizedotnet,wellsfargo,finix,nmi,tesouro,worldpayxml"
 wallet.paypal.connector_list = "adyen,globalpay,nexinets,novalnet,paypal,authorizedotnet"
 wallet.momo.connector_list = "adyen"
 wallet.kakao_pay.connector_list = "adyen"
@@ -853,7 +853,9 @@ interac = { country = "CA", currency = "CAD,USD"}
 przelewy24 = { country = "PL", currency = "CZK,EUR,GBP,PLN" }
 trustly = { country = "ES,GB,SE,NO,AT,NL,DE,DK,FI,EE,LT,LV", currency = "CZK,DKK,EUR,GBP,NOK,SEK" }
 klarna = { country = "AU,AT,BE,CA,CZ,DK,FI,FR,DE,GR,IE,IT,NL,NZ,NO,PL,PT,ES,SE,CH,GB,US", currency = "CHF,DKK,EUR,GBP,NOK,PLN,SEK,USD,AUD,NZD,CAD" }
-
+apple_pay = { country = "AU,CN,HK,JP,MO,MY,NZ,SG,TW,AM,AT,AZ,BY,BE,BG,HR,CY,CZ,DK,EE,FO,FI,FR,GE,DE,GR,GL,GG,HU,IS,IE,IM,IT,KZ,JE,LV,LI,LT,LU,MT,MD,MC,ME,NL,NO,PL,PT,RO,SM,RS,SK,SI,ES,SE,CH,UA,GB,AR,CO,CR,BR,MX,PE,BH,IL,JO,KW,PS,QA,SA,AE,CA,US,KR,VN,MA,ZA", currency = "AED,AUD,CAD,CHF,EUR,GBP,HKD,SGD,USD" }
+google_pay = { country = "AL,DZ,AS,AO,AG,AR,AU,AT,AZ,BH,BY,BE,BR,BG,CA,CL,CO,HR,CZ,DK,DO,EG,EE,FI,FR,DE,GR,HK,HU,IN,ID,IE,IL,IT,JP,JO,KZ,KE,KW,LV,LB,LT,LU,MY,MX,NL,NZ,NO,OM,PK,PA,PE,PH,PL,PT,QA,RO,SA,SG,SK,ZA,ES,LK,SE,CH,TW,TH,TR,UA,AE,GB,US,UY,VN" }
+samsung_pay = { country = "AU,BH,BR,CA,CN,DK,FI,FR,DE,HK,IN,IT,JP,KZ,KR,KW,MY,NZ,NO,OM,QA,SA,SG,ZA,ES,SE,CH,TW,AE,GB,US", currency = "AED,AUD,CAD,CHF,EUR,GBP,HKD,SGD,USD" }
 
 [pm_filters.gigadat]
 interac = { currency = "CAD"}

--- a/config/deployments/sandbox.toml
+++ b/config/deployments/sandbox.toml
@@ -241,9 +241,9 @@ bank_debit.sepa = { connector_list = "gocardless,adyen" }
 card.credit.connector_list = "checkout,stripe,adyen,zift,authorizedotnet,cybersource,datatrans,worldpay,nmi,bankofamerica,wellsfargo,bamboraapac,nexixpay,novalnet,paypal,archipel,tesouro,mollie"
 card.debit.connector_list = "checkout,stripe,adyen,zift,authorizedotnet,cybersource,datatrans,worldpay,nmi,bankofamerica,wellsfargo,bamboraapac,nexixpay,novalnet,paypal,archipel,tesouro,mollie"
 pay_later.klarna.connector_list = "adyen"
-wallet.apple_pay.connector_list = "checkout,stripe,adyen,cybersource,bankofamerica,novalnet,nuvei,authorizedotnet,nmi,tesouro,worldpaymodular,worldpayxml"
-wallet.samsung_pay.connector_list = "cybersource"
-wallet.google_pay.connector_list = "checkout,stripe,adyen,cybersource,bankofamerica,novalnet,nuvei,authorizedotnet,nmi,tesouro,worldpaymodular,worldpayxml"
+wallet.apple_pay.connector_list = "aci,checkout,stripe,adyen,cybersource,bankofamerica,novalnet,nuvei,authorizedotnet,nmi,tesouro,worldpaymodular,worldpayxml"
+wallet.samsung_pay.connector_list = "aci,cybersource"
+wallet.google_pay.connector_list = "aci,checkout,stripe,adyen,cybersource,bankofamerica,novalnet,nuvei,authorizedotnet,nmi,tesouro,worldpaymodular,worldpayxml"
 wallet.paypal.connector_list = "adyen,novalnet"
 wallet.momo.connector_list = "adyen"
 wallet.kakao_pay.connector_list = "adyen"
@@ -265,9 +265,9 @@ bank_debit.sepa = { connector_list = "gocardless,adyen,stripe,deutschebank" }
 card.credit.connector_list = "aci,checkout,stripe,adyen,authorizedotnet,cybersource,datatrans,globalpay,worldpay,multisafepay,nmi,nexinets,noon,bankofamerica,braintree,nuvei,payme,wellsfargo,bamboraapac,elavon,fiuu,nexixpay,novalnet,paybox,paypal,xendit,moneris,archipel,worldpayvantiv,payload,paysafe,finix,tesouro,mollie,airwallex"
 card.debit.connector_list = "aci,checkout,stripe,adyen,authorizedotnet,cybersource,datatrans,globalpay,worldpay,multisafepay,nmi,nexinets,noon,bankofamerica,braintree,nuvei,payme,wellsfargo,bamboraapac,elavon,fiuu,nexixpay,novalnet,paybox,paypal,xendit,moneris,archipel,worldpayvantiv,payload,paysafe,finix,tesouro,mollie,airwallex"
 pay_later.klarna.connector_list = "adyen,aci"
-wallet.apple_pay.connector_list = "checkout,stripe,adyen,braintree,cybersource,noon,bankofamerica,nexinets,novalnet,nuvei,authorizedotnet,wellsfargo,worldpaymodular,worldpayvantiv,finix,nmi,tesouro,worldpayxml"
-wallet.samsung_pay.connector_list = "cybersource"
-wallet.google_pay.connector_list = "checkout,stripe,adyen,cybersource,bankofamerica,noon,globalpay,multisafepay,novalnet,nuvei,authorizedotnet,wellsfargo,worldpaymodular,worldpayvantiv,finix,nmi,tesouro,worldpayxml"
+wallet.apple_pay.connector_list = "aci,checkout,stripe,adyen,braintree,cybersource,noon,bankofamerica,nexinets,novalnet,nuvei,authorizedotnet,wellsfargo,worldpaymodular,worldpayvantiv,finix,nmi,tesouro,worldpayxml"
+wallet.samsung_pay.connector_list = "aci,cybersource"
+wallet.google_pay.connector_list = "aci,checkout,stripe,adyen,cybersource,bankofamerica,noon,globalpay,multisafepay,novalnet,nuvei,authorizedotnet,wellsfargo,worldpaymodular,worldpayvantiv,finix,nmi,tesouro,worldpayxml"
 wallet.paypal.connector_list = "adyen,globalpay,nexinets,novalnet,paypal,authorizedotnet"
 wallet.momo.connector_list = "adyen"
 wallet.kakao_pay.connector_list = "adyen"
@@ -866,6 +866,9 @@ interac = { country = "CA", currency = "CAD,USD"}
 przelewy24 = { country = "PL", currency = "CZK,EUR,GBP,PLN" }
 trustly = { country = "ES,GB,SE,NO,AT,NL,DE,DK,FI,EE,LT,LV", currency = "CZK,DKK,EUR,GBP,NOK,SEK" }
 klarna = { country = "AU,AT,BE,CA,CZ,DK,FI,FR,DE,GR,IE,IT,NL,NZ,NO,PL,PT,ES,SE,CH,GB,US", currency = "CHF,DKK,EUR,GBP,NOK,PLN,SEK,USD,AUD,NZD,CAD" }
+apple_pay = { country = "AU,CN,HK,JP,MO,MY,NZ,SG,TW,AM,AT,AZ,BY,BE,BG,HR,CY,CZ,DK,EE,FO,FI,FR,GE,DE,GR,GL,GG,HU,IS,IE,IM,IT,KZ,JE,LV,LI,LT,LU,MT,MD,MC,ME,NL,NO,PL,PT,RO,SM,RS,SK,SI,ES,SE,CH,UA,GB,AR,CO,CR,BR,MX,PE,BH,IL,JO,KW,PS,QA,SA,AE,CA,US,KR,VN,MA,ZA", currency = "AED,AUD,CAD,CHF,EUR,GBP,HKD,SGD,USD" }
+google_pay = { country = "AL,DZ,AS,AO,AG,AR,AU,AT,AZ,BH,BY,BE,BR,BG,CA,CL,CO,HR,CZ,DK,DO,EG,EE,FI,FR,DE,GR,HK,HU,IN,ID,IE,IL,IT,JP,JO,KZ,KE,KW,LV,LB,LT,LU,MY,MX,NL,NZ,NO,OM,PK,PA,PE,PH,PL,PT,QA,RO,SA,SG,SK,ZA,ES,LK,SE,CH,TW,TH,TR,UA,AE,GB,US,UY,VN" }
+samsung_pay = { country = "AU,BH,BR,CA,CN,DK,FI,FR,DE,HK,IN,IT,JP,KZ,KR,KW,MY,NZ,NO,OM,QA,SA,SG,ZA,ES,SE,CH,TW,AE,GB,US", currency = "AED,AUD,CAD,CHF,EUR,GBP,HKD,SGD,USD" }
 
 [pm_filters.gigadat]
 interac = { currency = "CAD"}

--- a/config/development.toml
+++ b/config/development.toml
@@ -849,6 +849,9 @@ interac = { country = "CA", currency = "CAD,USD"}
 przelewy24 = { country = "PL", currency = "CZK,EUR,GBP,PLN" }
 trustly = { country = "ES,GB,SE,NO,AT,NL,DE,DK,FI,EE,LT,LV", currency = "CZK,DKK,EUR,GBP,NOK,SEK" }
 klarna = { country = "AU,AT,BE,CA,CZ,DK,FI,FR,DE,GR,IE,IT,NL,NZ,NO,PL,PT,ES,SE,CH,GB,US", currency = "CHF,DKK,EUR,GBP,NOK,PLN,SEK,USD,AUD,NZD,CAD" }
+apple_pay = { country = "AU,CN,HK,JP,MO,MY,NZ,SG,TW,AM,AT,AZ,BY,BE,BG,HR,CY,CZ,DK,EE,FO,FI,FR,GE,DE,GR,GL,GG,HU,IS,IE,IM,IT,KZ,JE,LV,LI,LT,LU,MT,MD,MC,ME,NL,NO,PL,PT,RO,SM,RS,SK,SI,ES,SE,CH,UA,GB,AR,CO,CR,BR,MX,PE,BH,IL,JO,KW,PS,QA,SA,AE,CA,US,KR,VN,MA,ZA", currency = "AED,AUD,CAD,CHF,EUR,GBP,HKD,SGD,USD" }
+google_pay = { country = "AL,DZ,AS,AO,AG,AR,AU,AT,AZ,BH,BY,BE,BR,BG,CA,CL,CO,HR,CZ,DK,DO,EG,EE,FI,FR,DE,GR,HK,HU,IN,ID,IE,IL,IT,JP,JO,KZ,KE,KW,LV,LB,LT,LU,MY,MX,NL,NZ,NO,OM,PK,PA,PE,PH,PL,PT,QA,RO,SA,SG,SK,ZA,ES,LK,SE,CH,TW,TH,TR,UA,AE,GB,US,UY,VN" }
+samsung_pay = { country = "AU,BH,BR,CA,CN,DK,FI,FR,DE,HK,IN,IT,JP,KZ,KR,KW,MY,NZ,NO,OM,QA,SA,SG,ZA,ES,SE,CH,TW,AE,GB,US", currency = "AED,AUD,CAD,CHF,EUR,GBP,HKD,SGD,USD" }
 
 [pm_filters.gigadat]
 interac = { currency = "CAD"}
@@ -1165,9 +1168,9 @@ bank_debit.sepa = { connector_list = "gocardless,adyen" }
 card.credit.connector_list = "checkout,stripe,adyen,authorizedotnet,cybersource,datatrans,worldpay,nmi,bankofamerica,wellsfargo,bamboraapac,nexixpay,novalnet,paypal,archipel,tesouro,mollie"
 card.debit.connector_list = "checkout,stripe,adyen,authorizedotnet,cybersource,datatrans,worldpay,nmi,bankofamerica,wellsfargo,bamboraapac,nexixpay,novalnet,paypal,archipel,tesouro,mollie"
 pay_later.klarna.connector_list = "adyen"
-wallet.apple_pay.connector_list = "checkout,stripe,adyen,cybersource,bankofamerica,novalnet,authorizedotnet,nmi,tesouro,worldpayxml"
-wallet.samsung_pay.connector_list = "cybersource"
-wallet.google_pay.connector_list = "checkout,stripe,adyen,cybersource,bankofamerica,novalnet,authorizedotnet,nmi,tesouro,worldpayxml"
+wallet.apple_pay.connector_list = "aci,checkout,stripe,adyen,cybersource,bankofamerica,novalnet,authorizedotnet,nmi,tesouro,worldpayxml"
+wallet.samsung_pay.connector_list = "aci,cybersource"
+wallet.google_pay.connector_list = "aci,checkout,stripe,adyen,cybersource,bankofamerica,novalnet,authorizedotnet,nmi,tesouro,worldpayxml"
 wallet.paypal.connector_list = "adyen,novalnet"
 wallet.momo.connector_list = "adyen"
 wallet.kakao_pay.connector_list = "adyen"
@@ -1190,9 +1193,9 @@ bank_debit.sepa = { connector_list = "gocardless,adyen,stripe,deutschebank" }
 card.credit.connector_list = "aci,checkout,stripe,adyen,zift,authorizedotnet,cybersource,datatrans,globalpay,worldpay,multisafepay,nmi,nexinets,noon,bankofamerica,braintree,nuvei,payme,wellsfargo,bamboraapac,elavon,fiuu,nexixpay,novalnet,paybox,paypal,xendit,moneris,archipel,worldpayvantiv,payload,paysafe,finix,tesouro,mollie,airwallex"
 card.debit.connector_list = "aci,checkout,stripe,adyen,zift,authorizedotnet,cybersource,datatrans,globalpay,worldpay,multisafepay,nmi,nexinets,noon,bankofamerica,braintree,nuvei,payme,wellsfargo,bamboraapac,elavon,fiuu,nexixpay,novalnet,paybox,paypal,xendit,moneris,archipel,worldpayvantiv,payload,paysafe,finix,tesouro,mollie,airwallex"
 pay_later.klarna.connector_list = "adyen,aci"
-wallet.apple_pay.connector_list = "checkout,stripe,adyen,braintree,cybersource,noon,bankofamerica,nuvei,nexinets,novalnet,authorizedotnet,wellsfargo,worldpayvantiv,finix,nmi,tesouro,worldpaymodular,worldpayxml"
-wallet.samsung_pay.connector_list = "cybersource"
-wallet.google_pay.connector_list = "checkout,stripe,adyen,cybersource,bankofamerica,noon,globalpay,multisafepay,novalnet,nuvei,authorizedotnet,wellsfargo,worldpayvantiv,finix,nmi,tesouro,worldpaymodular,worldpayxml"
+wallet.apple_pay.connector_list = "aci,checkout,stripe,adyen,braintree,cybersource,noon,bankofamerica,nuvei,nexinets,novalnet,authorizedotnet,wellsfargo,worldpayvantiv,finix,nmi,tesouro,worldpaymodular,worldpayxml"
+wallet.samsung_pay.connector_list = "aci,cybersource"
+wallet.google_pay.connector_list = "aci,checkout,stripe,adyen,cybersource,bankofamerica,noon,globalpay,multisafepay,novalnet,nuvei,authorizedotnet,wellsfargo,worldpayvantiv,finix,nmi,tesouro,worldpaymodular,worldpayxml"
 wallet.paypal.connector_list = "adyen,globalpay,nexinets,novalnet,paypal,authorizedotnet"
 wallet.momo.connector_list = "adyen"
 wallet.kakao_pay.connector_list = "adyen"

--- a/config/docker_compose.toml
+++ b/config/docker_compose.toml
@@ -988,6 +988,9 @@ interac = { country = "CA", currency = "CAD,USD"}
 przelewy24 = { country = "PL", currency = "CZK,EUR,GBP,PLN" }
 trustly = { country = "ES,GB,SE,NO,AT,NL,DE,DK,FI,EE,LT,LV", currency = "CZK,DKK,EUR,GBP,NOK,SEK" }
 klarna = { country = "AU,AT,BE,CA,CZ,DK,FI,FR,DE,GR,IE,IT,NL,NZ,NO,PL,PT,ES,SE,CH,GB,US", currency = "CHF,DKK,EUR,GBP,NOK,PLN,SEK,USD,AUD,NZD,CAD" }
+apple_pay = { country = "AU,CN,HK,JP,MO,MY,NZ,SG,TW,AM,AT,AZ,BY,BE,BG,HR,CY,CZ,DK,EE,FO,FI,FR,GE,DE,GR,GL,GG,HU,IS,IE,IM,IT,KZ,JE,LV,LI,LT,LU,MT,MD,MC,ME,NL,NO,PL,PT,RO,SM,RS,SK,SI,ES,SE,CH,UA,GB,AR,CO,CR,BR,MX,PE,BH,IL,JO,KW,PS,QA,SA,AE,CA,US,KR,VN,MA,ZA", currency = "AED,AUD,CAD,CHF,EUR,GBP,HKD,SGD,USD" }
+google_pay = { country = "AL,DZ,AS,AO,AG,AR,AU,AT,AZ,BH,BY,BE,BR,BG,CA,CL,CO,HR,CZ,DK,DO,EG,EE,FI,FR,DE,GR,HK,HU,IN,ID,IE,IL,IT,JP,JO,KZ,KE,KW,LV,LB,LT,LU,MY,MX,NL,NZ,NO,OM,PK,PA,PE,PH,PL,PT,QA,RO,SA,SG,SK,ZA,ES,LK,SE,CH,TW,TH,TR,UA,AE,GB,US,UY,VN" }
+samsung_pay = { country = "AU,BH,BR,CA,CN,DK,FI,FR,DE,HK,IN,IT,JP,KZ,KR,KW,MY,NZ,NO,OM,QA,SA,SG,ZA,ES,SE,CH,TW,AE,GB,US", currency = "AED,AUD,CAD,CHF,EUR,GBP,HKD,SGD,USD" }
 
 [pm_filters.gigadat]
 interac = { currency = "CAD"}
@@ -1075,9 +1078,9 @@ bank_debit.sepa = { connector_list = "gocardless,adyen" }
 card.credit.connector_list = "checkout,stripe,adyen,authorizedotnet,cybersource,datatrans,worldpay,nmi,bankofamerica,wellsfargo,bamboraapac,nexixpay,novalnet,paypal,archipel,mollie"
 card.debit.connector_list = "checkout,stripe,adyen,authorizedotnet,cybersource,datatrans,worldpay,nmi,bankofamerica,wellsfargo,bamboraapac,nexixpay,novalnet,paypal,archipel,mollie"
 pay_later.klarna.connector_list = "adyen"
-wallet.apple_pay.connector_list = "stripe,adyen,cybersource,bankofamerica,novalnet,authorizedotnet,worldpayxml"
-wallet.samsung_pay.connector_list = "cybersource"
-wallet.google_pay.connector_list = "stripe,adyen,cybersource,bankofamerica,novalnet,authorizedotnet,worldpayxml"
+wallet.apple_pay.connector_list = "aci,stripe,adyen,cybersource,bankofamerica,novalnet,authorizedotnet,worldpayxml"
+wallet.samsung_pay.connector_list = "aci,cybersource"
+wallet.google_pay.connector_list = "aci,stripe,adyen,cybersource,bankofamerica,novalnet,authorizedotnet,worldpayxml"
 wallet.paypal.connector_list = "adyen,novalnet"
 wallet.momo.connector_list = "adyen"
 wallet.kakao_pay.connector_list = "adyen"

--- a/crates/connector_configs/toml/development.toml
+++ b/crates/connector_configs/toml/development.toml
@@ -39,6 +39,10 @@
   payment_method_type = "ali_pay"
 [[aci.wallet]]
   payment_method_type = "mb_way"
+[[aci.wallet]]
+  payment_method_type = "apple_pay"
+[[aci.wallet]]
+  payment_method_type = "google_pay"
 [[aci.bank_redirect]]
   payment_method_type = "ideal"
 [[aci.bank_redirect]]

--- a/crates/connector_configs/toml/development.toml
+++ b/crates/connector_configs/toml/development.toml
@@ -43,6 +43,8 @@
   payment_method_type = "apple_pay"
 [[aci.wallet]]
   payment_method_type = "google_pay"
+[[aci.wallet]]
+  payment_method_type = "samsung_pay"
 [[aci.bank_redirect]]
   payment_method_type = "ideal"
 [[aci.bank_redirect]]

--- a/crates/connector_configs/toml/development.toml
+++ b/crates/connector_configs/toml/development.toml
@@ -62,6 +62,150 @@ api_key="API Key"
 key1="Entity ID"
 [aci.connector_webhook_details]
 merchant_secret="Source verification key"
+[[aci.metadata.apple_pay]]
+name = "certificate"
+label = "Merchant Certificate (Base64 Encoded)"
+placeholder = "Enter Merchant Certificate (Base64 Encoded)"
+required = true
+type = "Text"
+[[aci.metadata.apple_pay]]
+name = "certificate_keys"
+label = "Merchant PrivateKey (Base64 Encoded)"
+placeholder = "Enter Merchant PrivateKey (Base64 Encoded)"
+required = true
+type = "Text"
+[[aci.metadata.apple_pay]]
+name = "merchant_identifier"
+label = "Apple Merchant Identifier"
+placeholder = "Enter Apple Merchant Identifier"
+required = true
+type = "Text"
+[[aci.metadata.apple_pay]]
+name = "display_name"
+label = "Display Name"
+placeholder = "Enter Display Name"
+required = true
+type = "Text"
+[[aci.metadata.apple_pay]]
+name = "initiative"
+label = "Domain"
+placeholder = "Enter Domain"
+required = true
+type = "Text"
+[[aci.metadata.apple_pay]]
+name = "initiative_context"
+label = "Domain Name"
+placeholder = "Enter Domain Name"
+required = true
+type = "Text"
+[[aci.metadata.apple_pay]]
+name = "merchant_business_country"
+label = "Merchant Business Country"
+placeholder = "Enter Merchant Business Country"
+required = true
+type = "Select"
+options = []
+[[aci.metadata.apple_pay]]
+name = "payment_processing_details_at"
+label = "Payment Processing Details At"
+placeholder = "Enter Payment Processing Details At"
+required = true
+type = "Radio"
+options = ["Connector", "Hyperswitch"]
+[[aci.metadata.google_pay]]
+name = "merchant_name"
+label = "Google Pay Merchant Name"
+placeholder = "Enter Google Pay Merchant Name"
+required = true
+type = "Text"
+[[aci.metadata.google_pay]]
+name = "merchant_id"
+label = "Google Pay Merchant Id"
+placeholder = "Enter Google Pay Merchant Id"
+required = true
+type = "Text"
+[[aci.metadata.google_pay]]
+name = "gateway_merchant_id"
+label = "Google Pay Merchant Key"
+placeholder = "Enter Google Pay Merchant Key"
+required = true
+type = "Text"
+[[aci.metadata.google_pay]]
+name = "allowed_auth_methods"
+label = "Allowed Auth Methods"
+placeholder = "Enter Allowed Auth Methods"
+required = true
+type = "MultiSelect"
+options = ["PAN_ONLY", "CRYPTOGRAM_3DS"]
+[[aci.connector_wallets_details.google_pay]]
+name = "merchant_name"
+label = "Google Pay Merchant Name"
+placeholder = "Enter Google Pay Merchant Name"
+required = true
+type = "Text"
+[[aci.connector_wallets_details.google_pay]]
+name = "merchant_id"
+label = "Google Pay Merchant Id"
+placeholder = "Enter Google Pay Merchant Id"
+required = true
+type = "Text"
+[[aci.connector_wallets_details.google_pay]]
+name = "gateway_merchant_id"
+label = "Google Pay Merchant Key"
+placeholder = "Enter Google Pay Merchant Key"
+required = true
+type = "Text"
+[[aci.connector_wallets_details.google_pay]]
+name = "public_key"
+label = "Google Pay Public Key"
+placeholder = "Enter Google Pay Public Key"
+required = true
+type = "Text"
+[[aci.connector_wallets_details.google_pay]]
+name = "private_key"
+label = "Google Pay Private Key"
+placeholder = "Enter Google Pay Private Key"
+required = true
+type = "Text"
+[[aci.connector_wallets_details.google_pay]]
+name = "recipient_id"
+label = "Recipient Id"
+placeholder = "Enter Recipient Id"
+required = true
+type = "Text"
+[[aci.connector_wallets_details.google_pay]]
+name = "allowed_auth_methods"
+label = "Allowed Auth Methods"
+placeholder = "Enter Allowed Auth Methods"
+required = true
+type = "MultiSelect"
+options = ["PAN_ONLY", "CRYPTOGRAM_3DS"]
+[[aci.connector_wallets_details.samsung_pay]]
+name = "service_id"
+label = "Samsung Pay Service Id"
+placeholder = "Enter Samsung Pay Service Id"
+required = true
+type = "Text"
+[[aci.connector_wallets_details.samsung_pay]]
+name = "merchant_display_name"
+label = "Display Name"
+placeholder = "Enter Display Name"
+required = true
+type = "Text"
+[[aci.connector_wallets_details.samsung_pay]]
+name = "merchant_business_country"
+label = "Merchant Business Country"
+placeholder = "Enter Merchant Business Country"
+required = true
+type = "Select"
+options = []
+[[aci.connector_wallets_details.samsung_pay]]
+name = "allowed_brands"
+label = "Allowed Brands"
+placeholder = "Enter Allowed Brands"
+required = true
+type = "MultiSelect"
+options = ["visa", "masterCard", "amex", "discover"]
 
 
 [adyen]

--- a/crates/connector_configs/toml/production.toml
+++ b/crates/connector_configs/toml/production.toml
@@ -39,6 +39,10 @@ payment_method_type = "UnionPay"
 payment_method_type = "ali_pay"
 [[aci.wallet]]
 payment_method_type = "mb_way"
+[[aci.wallet]]
+payment_method_type = "apple_pay"
+[[aci.wallet]]
+payment_method_type = "google_pay"
 [[aci.bank_redirect]]
 payment_method_type = "ideal"
 [[aci.bank_redirect]]

--- a/crates/connector_configs/toml/production.toml
+++ b/crates/connector_configs/toml/production.toml
@@ -43,6 +43,8 @@ payment_method_type = "mb_way"
 payment_method_type = "apple_pay"
 [[aci.wallet]]
 payment_method_type = "google_pay"
+[[aci.wallet]]
+payment_method_type = "samsung_pay"
 [[aci.bank_redirect]]
 payment_method_type = "ideal"
 [[aci.bank_redirect]]

--- a/crates/connector_configs/toml/production.toml
+++ b/crates/connector_configs/toml/production.toml
@@ -60,6 +60,150 @@ api_key = "API Key"
 key1 = "Entity ID"
 [aci.connector_webhook_details]
 merchant_secret = "Source verification key"
+[[aci.metadata.apple_pay]]
+name = "certificate"
+label = "Merchant Certificate (Base64 Encoded)"
+placeholder = "Enter Merchant Certificate (Base64 Encoded)"
+required = true
+type = "Text"
+[[aci.metadata.apple_pay]]
+name = "certificate_keys"
+label = "Merchant PrivateKey (Base64 Encoded)"
+placeholder = "Enter Merchant PrivateKey (Base64 Encoded)"
+required = true
+type = "Text"
+[[aci.metadata.apple_pay]]
+name = "merchant_identifier"
+label = "Apple Merchant Identifier"
+placeholder = "Enter Apple Merchant Identifier"
+required = true
+type = "Text"
+[[aci.metadata.apple_pay]]
+name = "display_name"
+label = "Display Name"
+placeholder = "Enter Display Name"
+required = true
+type = "Text"
+[[aci.metadata.apple_pay]]
+name = "initiative"
+label = "Domain"
+placeholder = "Enter Domain"
+required = true
+type = "Text"
+[[aci.metadata.apple_pay]]
+name = "initiative_context"
+label = "Domain Name"
+placeholder = "Enter Domain Name"
+required = true
+type = "Text"
+[[aci.metadata.apple_pay]]
+name = "merchant_business_country"
+label = "Merchant Business Country"
+placeholder = "Enter Merchant Business Country"
+required = true
+type = "Select"
+options = []
+[[aci.metadata.apple_pay]]
+name = "payment_processing_details_at"
+label = "Payment Processing Details At"
+placeholder = "Enter Payment Processing Details At"
+required = true
+type = "Radio"
+options = ["Connector", "Hyperswitch"]
+[[aci.metadata.google_pay]]
+name = "merchant_name"
+label = "Google Pay Merchant Name"
+placeholder = "Enter Google Pay Merchant Name"
+required = true
+type = "Text"
+[[aci.metadata.google_pay]]
+name = "merchant_id"
+label = "Google Pay Merchant Id"
+placeholder = "Enter Google Pay Merchant Id"
+required = true
+type = "Text"
+[[aci.metadata.google_pay]]
+name = "gateway_merchant_id"
+label = "Google Pay Merchant Key"
+placeholder = "Enter Google Pay Merchant Key"
+required = true
+type = "Text"
+[[aci.metadata.google_pay]]
+name = "allowed_auth_methods"
+label = "Allowed Auth Methods"
+placeholder = "Enter Allowed Auth Methods"
+required = true
+type = "MultiSelect"
+options = ["PAN_ONLY", "CRYPTOGRAM_3DS"]
+[[aci.connector_wallets_details.google_pay]]
+name = "merchant_name"
+label = "Google Pay Merchant Name"
+placeholder = "Enter Google Pay Merchant Name"
+required = true
+type = "Text"
+[[aci.connector_wallets_details.google_pay]]
+name = "merchant_id"
+label = "Google Pay Merchant Id"
+placeholder = "Enter Google Pay Merchant Id"
+required = true
+type = "Text"
+[[aci.connector_wallets_details.google_pay]]
+name = "gateway_merchant_id"
+label = "Google Pay Merchant Key"
+placeholder = "Enter Google Pay Merchant Key"
+required = true
+type = "Text"
+[[aci.connector_wallets_details.google_pay]]
+name = "public_key"
+label = "Google Pay Public Key"
+placeholder = "Enter Google Pay Public Key"
+required = true
+type = "Text"
+[[aci.connector_wallets_details.google_pay]]
+name = "private_key"
+label = "Google Pay Private Key"
+placeholder = "Enter Google Pay Private Key"
+required = true
+type = "Text"
+[[aci.connector_wallets_details.google_pay]]
+name = "recipient_id"
+label = "Recipient Id"
+placeholder = "Enter Recipient Id"
+required = true
+type = "Text"
+[[aci.connector_wallets_details.google_pay]]
+name = "allowed_auth_methods"
+label = "Allowed Auth Methods"
+placeholder = "Enter Allowed Auth Methods"
+required = true
+type = "MultiSelect"
+options = ["PAN_ONLY", "CRYPTOGRAM_3DS"]
+[[aci.connector_wallets_details.samsung_pay]]
+name = "service_id"
+label = "Samsung Pay Service Id"
+placeholder = "Enter Samsung Pay Service Id"
+required = true
+type = "Text"
+[[aci.connector_wallets_details.samsung_pay]]
+name = "merchant_display_name"
+label = "Display Name"
+placeholder = "Enter Display Name"
+required = true
+type = "Text"
+[[aci.connector_wallets_details.samsung_pay]]
+name = "merchant_business_country"
+label = "Merchant Business Country"
+placeholder = "Enter Merchant Business Country"
+required = true
+type = "Select"
+options = []
+[[aci.connector_wallets_details.samsung_pay]]
+name = "allowed_brands"
+label = "Allowed Brands"
+placeholder = "Enter Allowed Brands"
+required = true
+type = "MultiSelect"
+options = ["visa", "masterCard", "amex", "discover"]
 
 [adyen]
 [[adyen.credit]]

--- a/crates/connector_configs/toml/sandbox.toml
+++ b/crates/connector_configs/toml/sandbox.toml
@@ -62,6 +62,150 @@ api_key = "API Key"
 key1 = "Entity ID"
 [aci.connector_webhook_details]
 merchant_secret = "Source verification key"
+[[aci.metadata.apple_pay]]
+name = "certificate"
+label = "Merchant Certificate (Base64 Encoded)"
+placeholder = "Enter Merchant Certificate (Base64 Encoded)"
+required = true
+type = "Text"
+[[aci.metadata.apple_pay]]
+name = "certificate_keys"
+label = "Merchant PrivateKey (Base64 Encoded)"
+placeholder = "Enter Merchant PrivateKey (Base64 Encoded)"
+required = true
+type = "Text"
+[[aci.metadata.apple_pay]]
+name = "merchant_identifier"
+label = "Apple Merchant Identifier"
+placeholder = "Enter Apple Merchant Identifier"
+required = true
+type = "Text"
+[[aci.metadata.apple_pay]]
+name = "display_name"
+label = "Display Name"
+placeholder = "Enter Display Name"
+required = true
+type = "Text"
+[[aci.metadata.apple_pay]]
+name = "initiative"
+label = "Domain"
+placeholder = "Enter Domain"
+required = true
+type = "Text"
+[[aci.metadata.apple_pay]]
+name = "initiative_context"
+label = "Domain Name"
+placeholder = "Enter Domain Name"
+required = true
+type = "Text"
+[[aci.metadata.apple_pay]]
+name = "merchant_business_country"
+label = "Merchant Business Country"
+placeholder = "Enter Merchant Business Country"
+required = true
+type = "Select"
+options = []
+[[aci.metadata.apple_pay]]
+name = "payment_processing_details_at"
+label = "Payment Processing Details At"
+placeholder = "Enter Payment Processing Details At"
+required = true
+type = "Radio"
+options = ["Connector", "Hyperswitch"]
+[[aci.metadata.google_pay]]
+name = "merchant_name"
+label = "Google Pay Merchant Name"
+placeholder = "Enter Google Pay Merchant Name"
+required = true
+type = "Text"
+[[aci.metadata.google_pay]]
+name = "merchant_id"
+label = "Google Pay Merchant Id"
+placeholder = "Enter Google Pay Merchant Id"
+required = true
+type = "Text"
+[[aci.metadata.google_pay]]
+name = "gateway_merchant_id"
+label = "Google Pay Merchant Key"
+placeholder = "Enter Google Pay Merchant Key"
+required = true
+type = "Text"
+[[aci.metadata.google_pay]]
+name = "allowed_auth_methods"
+label = "Allowed Auth Methods"
+placeholder = "Enter Allowed Auth Methods"
+required = true
+type = "MultiSelect"
+options = ["PAN_ONLY", "CRYPTOGRAM_3DS"]
+[[aci.connector_wallets_details.google_pay]]
+name = "merchant_name"
+label = "Google Pay Merchant Name"
+placeholder = "Enter Google Pay Merchant Name"
+required = true
+type = "Text"
+[[aci.connector_wallets_details.google_pay]]
+name = "merchant_id"
+label = "Google Pay Merchant Id"
+placeholder = "Enter Google Pay Merchant Id"
+required = true
+type = "Text"
+[[aci.connector_wallets_details.google_pay]]
+name = "gateway_merchant_id"
+label = "Google Pay Merchant Key"
+placeholder = "Enter Google Pay Merchant Key"
+required = true
+type = "Text"
+[[aci.connector_wallets_details.google_pay]]
+name = "public_key"
+label = "Google Pay Public Key"
+placeholder = "Enter Google Pay Public Key"
+required = true
+type = "Text"
+[[aci.connector_wallets_details.google_pay]]
+name = "private_key"
+label = "Google Pay Private Key"
+placeholder = "Enter Google Pay Private Key"
+required = true
+type = "Text"
+[[aci.connector_wallets_details.google_pay]]
+name = "recipient_id"
+label = "Recipient Id"
+placeholder = "Enter Recipient Id"
+required = true
+type = "Text"
+[[aci.connector_wallets_details.google_pay]]
+name = "allowed_auth_methods"
+label = "Allowed Auth Methods"
+placeholder = "Enter Allowed Auth Methods"
+required = true
+type = "MultiSelect"
+options = ["PAN_ONLY", "CRYPTOGRAM_3DS"]
+[[aci.connector_wallets_details.samsung_pay]]
+name = "service_id"
+label = "Samsung Pay Service Id"
+placeholder = "Enter Samsung Pay Service Id"
+required = true
+type = "Text"
+[[aci.connector_wallets_details.samsung_pay]]
+name = "merchant_display_name"
+label = "Display Name"
+placeholder = "Enter Display Name"
+required = true
+type = "Text"
+[[aci.connector_wallets_details.samsung_pay]]
+name = "merchant_business_country"
+label = "Merchant Business Country"
+placeholder = "Enter Merchant Business Country"
+required = true
+type = "Select"
+options = []
+[[aci.connector_wallets_details.samsung_pay]]
+name = "allowed_brands"
+label = "Allowed Brands"
+placeholder = "Enter Allowed Brands"
+required = true
+type = "MultiSelect"
+options = ["visa", "masterCard", "amex", "discover"]
 
 
 [adyen]

--- a/crates/connector_configs/toml/sandbox.toml
+++ b/crates/connector_configs/toml/sandbox.toml
@@ -39,6 +39,10 @@ payment_method_type = "UnionPay"
 payment_method_type = "ali_pay"
 [[aci.wallet]]
 payment_method_type = "mb_way"
+[[aci.wallet]]
+payment_method_type = "apple_pay"
+[[aci.wallet]]
+payment_method_type = "google_pay"
 [[aci.bank_redirect]]
 payment_method_type = "ideal"
 [[aci.bank_redirect]]

--- a/crates/connector_configs/toml/sandbox.toml
+++ b/crates/connector_configs/toml/sandbox.toml
@@ -43,6 +43,8 @@ payment_method_type = "mb_way"
 payment_method_type = "apple_pay"
 [[aci.wallet]]
 payment_method_type = "google_pay"
+[[aci.wallet]]
+payment_method_type = "samsung_pay"
 [[aci.bank_redirect]]
 payment_method_type = "ideal"
 [[aci.bank_redirect]]

--- a/crates/hyperswitch_connectors/src/connectors/aci.rs
+++ b/crates/hyperswitch_connectors/src/connectors/aci.rs
@@ -1190,6 +1190,17 @@ static ACI_SUPPORTED_PAYMENT_METHODS: LazyLock<SupportedPaymentMethods> = LazyLo
         PaymentMethodDetails {
             mandates: enums::FeatureStatus::NotSupported,
             refunds: enums::FeatureStatus::Supported,
+            supported_capture_methods: supported_capture_methods.clone(),
+            specific_features: None,
+        },
+    );
+
+    aci_supported_payment_methods.add(
+        enums::PaymentMethod::Wallet,
+        enums::PaymentMethodType::SamsungPay,
+        PaymentMethodDetails {
+            mandates: enums::FeatureStatus::NotSupported,
+            refunds: enums::FeatureStatus::Supported,
             supported_capture_methods,
             specific_features: None,
         },

--- a/crates/hyperswitch_connectors/src/connectors/aci.rs
+++ b/crates/hyperswitch_connectors/src/connectors/aci.rs
@@ -1173,6 +1173,28 @@ static ACI_SUPPORTED_PAYMENT_METHODS: LazyLock<SupportedPaymentMethods> = LazyLo
         },
     );
 
+    aci_supported_payment_methods.add(
+        enums::PaymentMethod::Wallet,
+        enums::PaymentMethodType::ApplePay,
+        PaymentMethodDetails {
+            mandates: enums::FeatureStatus::NotSupported,
+            refunds: enums::FeatureStatus::Supported,
+            supported_capture_methods: supported_capture_methods.clone(),
+            specific_features: None,
+        },
+    );
+
+    aci_supported_payment_methods.add(
+        enums::PaymentMethod::Wallet,
+        enums::PaymentMethodType::GooglePay,
+        PaymentMethodDetails {
+            mandates: enums::FeatureStatus::NotSupported,
+            refunds: enums::FeatureStatus::Supported,
+            supported_capture_methods,
+            specific_features: None,
+        },
+    );
+
     aci_supported_payment_methods
 });
 

--- a/crates/hyperswitch_connectors/src/connectors/aci/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/aci/transformers.rs
@@ -260,50 +260,57 @@ impl
     ) -> Result<Self, Self::Error> {
         let (_item, apple_pay_wallet_data, payment_method_token) = value;
 
-        // Try to get decrypted data; if available, use tokenAccount.* flow
-        match get_apple_pay_data(apple_pay_wallet_data, payment_method_token) {
-            Ok(apple_pay_data) => {
-                let payment_brand =
-                    parse_wallet_card_network(&apple_pay_wallet_data.payment_method.network)
-                        .ok_or(errors::ConnectorError::MissingRequiredField {
-                            field_name: "apple_pay.payment_method.network",
-                        })?;
-
-                let aci_network_token_data = AciNetworkTokenData {
-                    token_type: AciTokenAccountType::Network,
-                    token_number: NetworkToken::from(
-                        apple_pay_data.application_primary_account_number.clone(),
-                    ),
-                    token_expiry_month: apple_pay_data.application_expiration_month.clone(),
-                    token_expiry_year: apple_pay_data.get_four_digit_expiry_year(),
-                    token_cryptogram: Some(
-                        apple_pay_data
-                            .payment_data
-                            .online_payment_cryptogram
-                            .clone(),
-                    ),
-                    eci: apple_pay_data.payment_data.eci_indicator.clone(),
-                    payment_brand,
-                };
-
-                Ok(Self::AciNetworkToken(Box::new(aci_network_token_data)))
-            }
-            // Fall back to encrypted passthrough — let ACI decrypt
-            Err(_) => {
-                let encrypted_token = apple_pay_wallet_data
-                    .payment_data
-                    .get_encrypted_apple_pay_payment_data_optional()
-                    .ok_or(errors::ConnectorError::MissingRequiredField {
-                        field_name: "apple_pay.payment_data (encrypted)",
-                    })?;
-
-                Ok(Self::AciApplePayEncrypted(Box::new(
+        // Check if we have decrypted data available (via payment_method_token or wallet data)
+        // If so, use the tokenAccount.* network token flow
+        // Otherwise, pass the encrypted token to ACI via applePay.paymentToken
+        if let Some(encrypted_token) = apple_pay_wallet_data
+            .payment_data
+            .get_encrypted_apple_pay_payment_data_optional()
+        {
+            // No decryption token available — check if it's truly encrypted
+            if payment_method_token
+                .and_then(|t| match t {
+                    PaymentMethodToken::ApplePayDecrypt(_) => Some(()),
+                    _ => None,
+                })
+                .is_none()
+            {
+                return Ok(Self::AciApplePayEncrypted(Box::new(
                     AciApplePayEncryptedData {
                         payment_token: Secret::new(encrypted_token.clone()),
                     },
-                )))
+                )));
             }
         }
+
+        // Decrypted flow — extract DPAN/cryptogram/ECI and use tokenAccount.*
+        let apple_pay_data = get_apple_pay_data(apple_pay_wallet_data, payment_method_token)?;
+
+        let payment_brand = parse_wallet_card_network(
+            &apple_pay_wallet_data.payment_method.network,
+        )
+        .ok_or(errors::ConnectorError::MissingRequiredField {
+            field_name: "apple_pay.payment_method.network",
+        })?;
+
+        let aci_network_token_data = AciNetworkTokenData {
+            token_type: AciTokenAccountType::Network,
+            token_number: NetworkToken::from(
+                apple_pay_data.application_primary_account_number.clone(),
+            ),
+            token_expiry_month: apple_pay_data.application_expiration_month.clone(),
+            token_expiry_year: apple_pay_data.get_four_digit_expiry_year(),
+            token_cryptogram: Some(
+                apple_pay_data
+                    .payment_data
+                    .online_payment_cryptogram
+                    .clone(),
+            ),
+            eci: apple_pay_data.payment_data.eci_indicator.clone(),
+            payment_brand,
+        };
+
+        Ok(Self::AciNetworkToken(Box::new(aci_network_token_data)))
     }
 }
 
@@ -325,50 +332,51 @@ impl
     ) -> Result<Self, Self::Error> {
         let (_item, google_pay_wallet_data, payment_method_token) = value;
 
-        // Try to get decrypted data; if available, use tokenAccount.* flow
-        match get_google_pay_data(google_pay_wallet_data, payment_method_token) {
-            Ok(google_pay_data) => {
-                let payment_brand = parse_wallet_card_network(
-                    &google_pay_wallet_data.info.card_network,
-                )
-                .ok_or(errors::ConnectorError::MissingRequiredField {
-                    field_name: "google_pay.info.card_network",
-                })?;
-
-                let aci_network_token_data = AciNetworkTokenData {
-                    token_type: AciTokenAccountType::Network,
-                    token_number: NetworkToken::from(
-                        google_pay_data.application_primary_account_number.clone(),
-                    ),
-                    token_expiry_month: google_pay_data.card_exp_month.clone(),
-                    token_expiry_year: google_pay_data.get_four_digit_expiry_year().map_err(
-                        |_| errors::ConnectorError::MissingRequiredField {
-                            field_name: "google_pay.card_exp_year",
-                        },
-                    )?,
-                    token_cryptogram: google_pay_data.cryptogram.clone(),
-                    eci: google_pay_data.eci_indicator.clone(),
-                    payment_brand,
-                };
-
-                Ok(Self::AciNetworkToken(Box::new(aci_network_token_data)))
-            }
-            // Fall back to encrypted passthrough — let ACI decrypt
-            Err(_) => {
-                let encrypted_token = google_pay_wallet_data
-                    .tokenization_data
-                    .get_encrypted_google_pay_token()
-                    .map_err(|_| errors::ConnectorError::MissingRequiredField {
-                        field_name: "google_pay.tokenization_data (encrypted)",
-                    })?;
-
-                Ok(Self::AciGooglePayEncrypted(Box::new(
+        // Check if we have encrypted data and no decryption token — use passthrough
+        if let Ok(encrypted_data) = google_pay_wallet_data
+            .tokenization_data
+            .get_encrypted_google_pay_payment_data_mandatory()
+        {
+            if payment_method_token
+                .and_then(|t| match t {
+                    PaymentMethodToken::GooglePayDecrypt(_) => Some(()),
+                    _ => None,
+                })
+                .is_none()
+            {
+                return Ok(Self::AciGooglePayEncrypted(Box::new(
                     AciGooglePayEncryptedData {
-                        payment_token: Secret::new(encrypted_token),
+                        payment_token: Secret::new(encrypted_data.token.clone()),
                     },
-                )))
+                )));
             }
         }
+
+        // Decrypted flow — extract DPAN/cryptogram/ECI and use tokenAccount.*
+        let google_pay_data = get_google_pay_data(google_pay_wallet_data, payment_method_token)?;
+
+        let payment_brand = parse_wallet_card_network(&google_pay_wallet_data.info.card_network)
+            .ok_or(errors::ConnectorError::MissingRequiredField {
+                field_name: "google_pay.info.card_network",
+            })?;
+
+        let aci_network_token_data = AciNetworkTokenData {
+            token_type: AciTokenAccountType::Network,
+            token_number: NetworkToken::from(
+                google_pay_data.application_primary_account_number.clone(),
+            ),
+            token_expiry_month: google_pay_data.card_exp_month.clone(),
+            token_expiry_year: google_pay_data.get_four_digit_expiry_year().map_err(|_| {
+                errors::ConnectorError::MissingRequiredField {
+                    field_name: "google_pay.card_exp_year",
+                }
+            })?,
+            token_cryptogram: google_pay_data.cryptogram.clone(),
+            eci: google_pay_data.eci_indicator.clone(),
+            payment_brand,
+        };
+
+        Ok(Self::AciNetworkToken(Box::new(aci_network_token_data)))
     }
 }
 
@@ -943,6 +951,7 @@ impl TryFrom<(&AciRouterData<&PaymentsAuthorizeRouterData>, &WalletData)> for Ac
                 let payment_method =
                     PaymentDetails::try_from((item, apple_pay_data, payment_method_token))?;
                 let instruction = get_instruction_details(item);
+                let recurring_type = get_recurring_type(item);
 
                 Ok(Self {
                     txn_details,
@@ -950,7 +959,7 @@ impl TryFrom<(&AciRouterData<&PaymentsAuthorizeRouterData>, &WalletData)> for Ac
                     instruction,
                     shopper_result_url: item.router_data.request.router_return_url.clone(),
                     three_ds_two_enrolled: None,
-                    recurring_type: None,
+                    recurring_type,
                 })
             }
             WalletData::GooglePay(google_pay_data) => {
@@ -958,6 +967,7 @@ impl TryFrom<(&AciRouterData<&PaymentsAuthorizeRouterData>, &WalletData)> for Ac
                 let payment_method =
                     PaymentDetails::try_from((item, google_pay_data, payment_method_token))?;
                 let instruction = get_instruction_details(item);
+                let recurring_type = get_recurring_type(item);
 
                 Ok(Self {
                     txn_details,
@@ -965,12 +975,13 @@ impl TryFrom<(&AciRouterData<&PaymentsAuthorizeRouterData>, &WalletData)> for Ac
                     instruction,
                     shopper_result_url: item.router_data.request.router_return_url.clone(),
                     three_ds_two_enrolled: None,
-                    recurring_type: None,
+                    recurring_type,
                 })
             }
             WalletData::SamsungPay(samsung_pay_data) => {
                 let payment_method = PaymentDetails::try_from(samsung_pay_data.as_ref())?;
                 let instruction = get_instruction_details(item);
+                let recurring_type = get_recurring_type(item);
 
                 Ok(Self {
                     txn_details,
@@ -978,7 +989,7 @@ impl TryFrom<(&AciRouterData<&PaymentsAuthorizeRouterData>, &WalletData)> for Ac
                     instruction,
                     shopper_result_url: item.router_data.request.router_return_url.clone(),
                     three_ds_two_enrolled: None,
-                    recurring_type: None,
+                    recurring_type,
                 })
             }
             // Handle other wallet types via PaymentDetails::try_from

--- a/crates/hyperswitch_connectors/src/connectors/aci/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/aci/transformers.rs
@@ -2,14 +2,16 @@ use std::str::FromStr;
 
 use cards::NetworkToken;
 use common_enums::enums;
+use common_types::payments::{ApplePayPredecryptData, GPayPredecryptData};
 use common_utils::{id_type, pii::Email, request::Method, types::StringMajorUnit};
 use error_stack::report;
 use hyperswitch_domain_models::{
     payment_method_data::{
-        BankRedirectData, Card, NetworkTokenData, PayLaterData, PaymentMethodData, WalletData,
+        ApplePayWalletData, BankRedirectData, Card, GooglePayWalletData, NetworkTokenData,
+        PayLaterData, PaymentMethodData, WalletData,
     },
     payment_methods::storage_enums::MitCategory,
-    router_data::{ConnectorAuthType, ErrorResponse, RouterData},
+    router_data::{ConnectorAuthType, ErrorResponse, PaymentMethodToken, RouterData},
     router_flow_types::SetupMandate,
     router_request_types::{
         PaymentsAuthorizeData, PaymentsCancelData, PaymentsSyncData, ResponseId,
@@ -192,6 +194,12 @@ impl TryFrom<(&WalletData, &PaymentsAuthorizeRouterData)> for PaymentDetails {
                 payment_brand: PaymentBrand::AliPay,
                 account_id: None,
             })),
+            WalletData::ApplePay(_) | WalletData::GooglePay(_) => {
+                Err(errors::ConnectorError::FlowNotSupported {
+                    flow: "Wallet via PaymentDetails".to_string(),
+                    connector: "ACI".to_string(),
+                })?
+            }
             WalletData::AliPayHkRedirect(_)
             | WalletData::AmazonPayRedirect(_)
             | WalletData::Paysera(_)
@@ -201,10 +209,8 @@ impl TryFrom<(&WalletData, &PaymentsAuthorizeRouterData)> for PaymentDetails {
             | WalletData::GoPayRedirect(_)
             | WalletData::GcashRedirect(_)
             | WalletData::AmazonPay(_)
-            | WalletData::ApplePay(_)
             | WalletData::ApplePayThirdPartySdk(_)
             | WalletData::DanaRedirect { .. }
-            | WalletData::GooglePay(_)
             | WalletData::BluecodeRedirect {}
             | WalletData::GooglePayThirdPartySdk(_)
             | WalletData::MobilePayRedirect(_)
@@ -228,6 +234,208 @@ impl TryFrom<(&WalletData, &PaymentsAuthorizeRouterData)> for PaymentDetails {
             ))?,
         };
         Ok(payment_data)
+    }
+}
+
+/// Convert Apple Pay decrypted data to ACI network token format
+impl
+    TryFrom<(
+        &AciRouterData<&PaymentsAuthorizeRouterData>,
+        &ApplePayWalletData,
+        Option<&PaymentMethodToken>,
+    )> for PaymentDetails
+{
+    type Error = Error;
+    fn try_from(
+        value: (
+            &AciRouterData<&PaymentsAuthorizeRouterData>,
+            &ApplePayWalletData,
+            Option<&PaymentMethodToken>,
+        ),
+    ) -> Result<Self, Self::Error> {
+        let (_item, apple_pay_wallet_data, payment_method_token) = value;
+
+        // Extract decrypted Apple Pay data
+        let apple_pay_data = get_apple_pay_data(apple_pay_wallet_data, payment_method_token)?;
+
+        // Get card network from wallet metadata
+        let payment_brand = apple_pay_wallet_data
+            .payment_method
+            .network
+            .as_ref()
+            .and_then(|n| parse_wallet_card_network(n))
+            .ok_or(errors::ConnectorError::MissingRequiredField {
+                field_name: "apple_pay.payment_method.network",
+            })?;
+
+        // Build ACI network token data from decrypted Apple Pay data
+        let aci_network_token_data = AciNetworkTokenData {
+            token_type: AciTokenAccountType::Network,
+            token_number: NetworkToken::from(
+                apple_pay_data
+                    .application_primary_account_number
+                    .clone()
+                    .get_card_no(),
+            ),
+            token_expiry_month: apple_pay_data.application_expiration_month.clone(),
+            token_expiry_year: apple_pay_data.get_four_digit_expiry_year(),
+            token_cryptogram: Some(apple_pay_data.payment_data.online_payment_cryptogram.clone()),
+            eci: apple_pay_data.payment_data.eci_indicator.clone(),
+            payment_brand,
+        };
+
+        Ok(Self::AciNetworkToken(Box::new(aci_network_token_data)))
+    }
+}
+
+/// Convert Google Pay decrypted data to ACI network token format
+impl
+    TryFrom<(
+        &AciRouterData<&PaymentsAuthorizeRouterData>,
+        &GooglePayWalletData,
+        Option<&PaymentMethodToken>,
+    )> for PaymentDetails
+{
+    type Error = Error;
+    fn try_from(
+        value: (
+            &AciRouterData<&PaymentsAuthorizeRouterData>,
+            &GooglePayWalletData,
+            Option<&PaymentMethodToken>,
+        ),
+    ) -> Result<Self, Self::Error> {
+        let (_item, google_pay_wallet_data, payment_method_token) = value;
+
+        // Extract decrypted Google Pay data
+        let google_pay_data = get_google_pay_data(google_pay_wallet_data, payment_method_token)?;
+
+        // Get card network from wallet metadata
+        let payment_brand = google_pay_wallet_data
+            .info
+            .card_network
+            .as_ref()
+            .and_then(|n| parse_wallet_card_network(n))
+            .ok_or(errors::ConnectorError::MissingRequiredField {
+                field_name: "google_pay.info.card_network",
+            })?;
+
+        // Build ACI network token data from decrypted Google Pay data
+        let aci_network_token_data = AciNetworkTokenData {
+            token_type: AciTokenAccountType::Network,
+            token_number: NetworkToken::from(
+                google_pay_data
+                    .application_primary_account_number
+                    .clone()
+                    .get_card_no(),
+            ),
+            token_expiry_month: google_pay_data.card_exp_month.clone(),
+            token_expiry_year: google_pay_data
+                .get_four_digit_expiry_year()
+                .map_err(|_| errors::ConnectorError::MissingRequiredField {
+                    field_name: "google_pay.card_exp_year",
+                })?,
+            token_cryptogram: google_pay_data.cryptogram.clone(),
+            eci: google_pay_data.eci_indicator.clone(),
+            payment_brand,
+        };
+
+        Ok(Self::AciNetworkToken(Box::new(aci_network_token_data)))
+    }
+}
+
+impl
+    TryFrom<(
+        &AciRouterData<&PaymentsAuthorizeRouterData>,
+        &ApplePayWalletData,
+        Option<&PaymentMethodToken>,
+    )> for PaymentDetails
+{
+    type Error = Error;
+    fn try_from(
+        value: (
+            &AciRouterData<&PaymentsAuthorizeRouterData>,
+            &ApplePayWalletData,
+            Option<&PaymentMethodToken>,
+        ),
+    ) -> Result<Self, Self::Error> {
+        let (_item, apple_pay_wallet_data, payment_method_token) = value;
+
+        let apple_pay_data = get_apple_pay_data(apple_pay_wallet_data, payment_method_token)?;
+
+        let payment_brand = apple_pay_wallet_data
+            .payment_method
+            .network
+            .as_ref()
+            .and_then(|n| parse_wallet_card_network(n))
+            .ok_or(errors::ConnectorError::MissingRequiredField {
+                field_name: "apple_pay.payment_method.network",
+            })?;
+
+        let aci_network_token_data = AciNetworkTokenData {
+            token_type: AciTokenAccountType::Network,
+            token_number: NetworkToken::from(
+                apple_pay_data
+                    .application_primary_account_number
+                    .clone()
+                    .get_card_no(),
+            ),
+            token_expiry_month: apple_pay_data.application_expiration_month.clone(),
+            token_expiry_year: apple_pay_data.get_four_digit_expiry_year(),
+            token_cryptogram: Some(apple_pay_data.payment_data.online_payment_cryptogram.clone()),
+            payment_brand,
+        };
+
+        Ok(Self::AciNetworkToken(Box::new(aci_network_token_data)))
+    }
+}
+
+impl
+    TryFrom<(
+        &AciRouterData<&PaymentsAuthorizeRouterData>,
+        &GooglePayWalletData,
+        Option<&PaymentMethodToken>,
+    )> for PaymentDetails
+{
+    type Error = Error;
+    fn try_from(
+        value: (
+            &AciRouterData<&PaymentsAuthorizeRouterData>,
+            &GooglePayWalletData,
+            Option<&PaymentMethodToken>,
+        ),
+    ) -> Result<Self, Self::Error> {
+        let (_item, google_pay_wallet_data, payment_method_token) = value;
+
+        let google_pay_data = get_google_pay_data(google_pay_wallet_data, payment_method_token)?;
+
+        let payment_brand = google_pay_wallet_data
+            .info
+            .card_network
+            .as_ref()
+            .and_then(|n| parse_wallet_card_network(n))
+            .ok_or(errors::ConnectorError::MissingRequiredField {
+                field_name: "google_pay.info.card_network",
+            })?;
+
+        let aci_network_token_data = AciNetworkTokenData {
+            token_type: AciTokenAccountType::Network,
+            token_number: NetworkToken::from(
+                google_pay_data
+                    .application_primary_account_number
+                    .clone()
+                    .get_card_no(),
+            ),
+            token_expiry_month: google_pay_data.card_exp_month.clone(),
+            token_expiry_year: google_pay_data
+                .get_four_digit_expiry_year()
+                .map_err(|_| errors::ConnectorError::MissingRequiredField {
+                    field_name: "google_pay.card_exp_year",
+                })?,
+            token_cryptogram: google_pay_data.cryptogram.clone(),
+            payment_brand,
+        };
+
+        Ok(Self::AciNetworkToken(Box::new(aci_network_token_data)))
     }
 }
 
@@ -403,6 +611,60 @@ fn get_aci_payment_brand(
     }
 }
 
+fn parse_wallet_card_network(network: &str) -> Option<PaymentBrand> {
+    match network.to_lowercase().as_str() {
+        "visa" => Some(PaymentBrand::Visa),
+        "mastercard" => Some(PaymentBrand::Mastercard),
+        "amex" | "americanexpress" | "american express" => Some(PaymentBrand::AmericanExpress),
+        "jcb" => Some(PaymentBrand::Jcb),
+        "diners" | "dinersclub" | "diners club" => Some(PaymentBrand::DinersClub),
+        "discover" => Some(PaymentBrand::Discover),
+        "unionpay" | "union pay" => Some(PaymentBrand::UnionPay),
+        "maestro" => Some(PaymentBrand::Maestro),
+        _ => None,
+    }
+}
+
+fn get_apple_pay_data(
+    apple_pay_wallet_data: &ApplePayWalletData,
+    payment_method_token: Option<&PaymentMethodToken>,
+) -> Result<ApplePayPredecryptData, error_stack::Report<errors::ConnectorError>> {
+    if let Some(PaymentMethodToken::ApplePayDecrypt(decrypted_data)) = payment_method_token {
+        return Ok(*decrypted_data.clone());
+    }
+
+    match &apple_pay_wallet_data.payment_data {
+        common_types::payments::ApplePayPaymentData::Decrypted(decrypted_data) => {
+            Ok(decrypted_data.clone())
+        }
+        common_types::payments::ApplePayPaymentData::Encrypted(_) => {
+            Err(errors::ConnectorError::MissingRequiredField {
+                field_name: "decrypted apple pay data",
+            })?
+        }
+    }
+}
+
+fn get_google_pay_data(
+    google_pay_wallet_data: &GooglePayWalletData,
+    payment_method_token: Option<&PaymentMethodToken>,
+) -> Result<GPayPredecryptData, error_stack::Report<errors::ConnectorError>> {
+    if let Some(PaymentMethodToken::GooglePayDecrypt(decrypted_data)) = payment_method_token {
+        return Ok(*decrypted_data.clone());
+    }
+
+    match &google_pay_wallet_data.tokenization_data {
+        common_types::payments::GpayTokenizationData::Decrypted(decrypted_data) => {
+            Ok(decrypted_data.clone())
+        }
+        common_types::payments::GpayTokenizationData::Encrypted(_) => {
+            Err(errors::ConnectorError::MissingRequiredField {
+                field_name: "decrypted google pay data",
+            })?
+        }
+    }
+}
+
 impl TryFrom<(Card, Option<Secret<String>>)> for PaymentDetails {
     type Error = Error;
     fn try_from(
@@ -452,6 +714,7 @@ impl
                     .clone()
                     .unwrap_or_default(),
             ),
+            eci: network_token_data.eci.clone(),
             payment_brand,
         };
         Ok(Self::AciNetworkToken(Box::new(aci_network_token_data)))
@@ -477,6 +740,9 @@ pub struct AciNetworkTokenData {
     pub token_expiry_year: Secret<String>,
     #[serde(rename = "tokenAccount.cryptogram")]
     pub token_cryptogram: Option<Secret<String>>,
+    #[serde(rename = "threeDSecure.eci")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub eci: Option<String>,
     #[serde(rename = "paymentBrand")]
     pub payment_brand: PaymentBrand,
 }
@@ -682,16 +948,52 @@ impl TryFrom<(&AciRouterData<&PaymentsAuthorizeRouterData>, &WalletData)> for Ac
     ) -> Result<Self, Self::Error> {
         let (item, wallet_data) = value;
         let txn_details = get_transaction_details(item)?;
-        let payment_method = PaymentDetails::try_from((wallet_data, item.router_data))?;
 
-        Ok(Self {
-            txn_details,
-            payment_method,
-            instruction: None,
-            shopper_result_url: item.router_data.request.router_return_url.clone(),
-            three_ds_two_enrolled: None,
-            recurring_type: None,
-        })
+        match wallet_data {
+            WalletData::ApplePay(apple_pay_data) => {
+                let payment_method_token = item.router_data.payment_method_token.as_ref();
+                let payment_method =
+                    PaymentDetails::try_from((item, apple_pay_data.as_ref(), payment_method_token))?;
+                let instruction = get_instruction_details(item);
+
+                Ok(Self {
+                    txn_details,
+                    payment_method,
+                    instruction,
+                    shopper_result_url: item.router_data.request.router_return_url.clone(),
+                    three_ds_two_enrolled: None,
+                    recurring_type: None,
+                })
+            }
+            WalletData::GooglePay(google_pay_data) => {
+                let payment_method_token = item.router_data.payment_method_token.as_ref();
+                let payment_method =
+                    PaymentDetails::try_from((item, google_pay_data.as_ref(), payment_method_token))?;
+                let instruction = get_instruction_details(item);
+
+                Ok(Self {
+                    txn_details,
+                    payment_method,
+                    instruction,
+                    shopper_result_url: item.router_data.request.router_return_url.clone(),
+                    three_ds_two_enrolled: None,
+                    recurring_type: None,
+                })
+            }
+            
+            _ => {
+                let payment_method = PaymentDetails::try_from((wallet_data, item.router_data))?;
+
+                Ok(Self {
+                    txn_details,
+                    payment_method,
+                    instruction: None,
+                    shopper_result_url: item.router_data.request.router_return_url.clone(),
+                    three_ds_two_enrolled: None,
+                    recurring_type: None,
+                })
+            }
+        }
     }
 }
 

--- a/crates/hyperswitch_connectors/src/connectors/aci/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/aci/transformers.rs
@@ -259,27 +259,27 @@ impl
         let apple_pay_data = get_apple_pay_data(apple_pay_wallet_data, payment_method_token)?;
 
         // Get card network from wallet metadata
-        let payment_brand = apple_pay_wallet_data
-            .payment_method
-            .network
-            .as_ref()
-            .and_then(|n| parse_wallet_card_network(n))
-            .ok_or(errors::ConnectorError::MissingRequiredField {
-                field_name: "apple_pay.payment_method.network",
-            })?;
+        let payment_brand = parse_wallet_card_network(
+            &apple_pay_wallet_data.payment_method.network,
+        )
+        .ok_or(errors::ConnectorError::MissingRequiredField {
+            field_name: "apple_pay.payment_method.network",
+        })?;
 
         // Build ACI network token data from decrypted Apple Pay data
         let aci_network_token_data = AciNetworkTokenData {
             token_type: AciTokenAccountType::Network,
             token_number: NetworkToken::from(
-                apple_pay_data
-                    .application_primary_account_number
-                    .clone()
-                    .get_card_no(),
+                apple_pay_data.application_primary_account_number.clone(),
             ),
             token_expiry_month: apple_pay_data.application_expiration_month.clone(),
             token_expiry_year: apple_pay_data.get_four_digit_expiry_year(),
-            token_cryptogram: Some(apple_pay_data.payment_data.online_payment_cryptogram.clone()),
+            token_cryptogram: Some(
+                apple_pay_data
+                    .payment_data
+                    .online_payment_cryptogram
+                    .clone(),
+            ),
             eci: apple_pay_data.payment_data.eci_indicator.clone(),
             payment_brand,
         };
@@ -310,11 +310,7 @@ impl
         let google_pay_data = get_google_pay_data(google_pay_wallet_data, payment_method_token)?;
 
         // Get card network from wallet metadata
-        let payment_brand = google_pay_wallet_data
-            .info
-            .card_network
-            .as_ref()
-            .and_then(|n| parse_wallet_card_network(n))
+        let payment_brand = parse_wallet_card_network(&google_pay_wallet_data.info.card_network)
             .ok_or(errors::ConnectorError::MissingRequiredField {
                 field_name: "google_pay.info.card_network",
             })?;
@@ -323,115 +319,16 @@ impl
         let aci_network_token_data = AciNetworkTokenData {
             token_type: AciTokenAccountType::Network,
             token_number: NetworkToken::from(
-                google_pay_data
-                    .application_primary_account_number
-                    .clone()
-                    .get_card_no(),
+                google_pay_data.application_primary_account_number.clone(),
             ),
             token_expiry_month: google_pay_data.card_exp_month.clone(),
-            token_expiry_year: google_pay_data
-                .get_four_digit_expiry_year()
-                .map_err(|_| errors::ConnectorError::MissingRequiredField {
+            token_expiry_year: google_pay_data.get_four_digit_expiry_year().map_err(|_| {
+                errors::ConnectorError::MissingRequiredField {
                     field_name: "google_pay.card_exp_year",
-                })?,
+                }
+            })?,
             token_cryptogram: google_pay_data.cryptogram.clone(),
             eci: google_pay_data.eci_indicator.clone(),
-            payment_brand,
-        };
-
-        Ok(Self::AciNetworkToken(Box::new(aci_network_token_data)))
-    }
-}
-
-impl
-    TryFrom<(
-        &AciRouterData<&PaymentsAuthorizeRouterData>,
-        &ApplePayWalletData,
-        Option<&PaymentMethodToken>,
-    )> for PaymentDetails
-{
-    type Error = Error;
-    fn try_from(
-        value: (
-            &AciRouterData<&PaymentsAuthorizeRouterData>,
-            &ApplePayWalletData,
-            Option<&PaymentMethodToken>,
-        ),
-    ) -> Result<Self, Self::Error> {
-        let (_item, apple_pay_wallet_data, payment_method_token) = value;
-
-        let apple_pay_data = get_apple_pay_data(apple_pay_wallet_data, payment_method_token)?;
-
-        let payment_brand = apple_pay_wallet_data
-            .payment_method
-            .network
-            .as_ref()
-            .and_then(|n| parse_wallet_card_network(n))
-            .ok_or(errors::ConnectorError::MissingRequiredField {
-                field_name: "apple_pay.payment_method.network",
-            })?;
-
-        let aci_network_token_data = AciNetworkTokenData {
-            token_type: AciTokenAccountType::Network,
-            token_number: NetworkToken::from(
-                apple_pay_data
-                    .application_primary_account_number
-                    .clone()
-                    .get_card_no(),
-            ),
-            token_expiry_month: apple_pay_data.application_expiration_month.clone(),
-            token_expiry_year: apple_pay_data.get_four_digit_expiry_year(),
-            token_cryptogram: Some(apple_pay_data.payment_data.online_payment_cryptogram.clone()),
-            payment_brand,
-        };
-
-        Ok(Self::AciNetworkToken(Box::new(aci_network_token_data)))
-    }
-}
-
-impl
-    TryFrom<(
-        &AciRouterData<&PaymentsAuthorizeRouterData>,
-        &GooglePayWalletData,
-        Option<&PaymentMethodToken>,
-    )> for PaymentDetails
-{
-    type Error = Error;
-    fn try_from(
-        value: (
-            &AciRouterData<&PaymentsAuthorizeRouterData>,
-            &GooglePayWalletData,
-            Option<&PaymentMethodToken>,
-        ),
-    ) -> Result<Self, Self::Error> {
-        let (_item, google_pay_wallet_data, payment_method_token) = value;
-
-        let google_pay_data = get_google_pay_data(google_pay_wallet_data, payment_method_token)?;
-
-        let payment_brand = google_pay_wallet_data
-            .info
-            .card_network
-            .as_ref()
-            .and_then(|n| parse_wallet_card_network(n))
-            .ok_or(errors::ConnectorError::MissingRequiredField {
-                field_name: "google_pay.info.card_network",
-            })?;
-
-        let aci_network_token_data = AciNetworkTokenData {
-            token_type: AciTokenAccountType::Network,
-            token_number: NetworkToken::from(
-                google_pay_data
-                    .application_primary_account_number
-                    .clone()
-                    .get_card_no(),
-            ),
-            token_expiry_month: google_pay_data.card_exp_month.clone(),
-            token_expiry_year: google_pay_data
-                .get_four_digit_expiry_year()
-                .map_err(|_| errors::ConnectorError::MissingRequiredField {
-                    field_name: "google_pay.card_exp_year",
-                })?,
-            token_cryptogram: google_pay_data.cryptogram.clone(),
             payment_brand,
         };
 
@@ -953,7 +850,7 @@ impl TryFrom<(&AciRouterData<&PaymentsAuthorizeRouterData>, &WalletData)> for Ac
             WalletData::ApplePay(apple_pay_data) => {
                 let payment_method_token = item.router_data.payment_method_token.as_ref();
                 let payment_method =
-                    PaymentDetails::try_from((item, apple_pay_data.as_ref(), payment_method_token))?;
+                    PaymentDetails::try_from((item, apple_pay_data, payment_method_token))?;
                 let instruction = get_instruction_details(item);
 
                 Ok(Self {
@@ -968,7 +865,7 @@ impl TryFrom<(&AciRouterData<&PaymentsAuthorizeRouterData>, &WalletData)> for Ac
             WalletData::GooglePay(google_pay_data) => {
                 let payment_method_token = item.router_data.payment_method_token.as_ref();
                 let payment_method =
-                    PaymentDetails::try_from((item, google_pay_data.as_ref(), payment_method_token))?;
+                    PaymentDetails::try_from((item, google_pay_data, payment_method_token))?;
                 let instruction = get_instruction_details(item);
 
                 Ok(Self {
@@ -980,7 +877,7 @@ impl TryFrom<(&AciRouterData<&PaymentsAuthorizeRouterData>, &WalletData)> for Ac
                     recurring_type: None,
                 })
             }
-            
+
             _ => {
                 let payment_method = PaymentDetails::try_from((wallet_data, item.router_data))?;
 

--- a/crates/hyperswitch_connectors/src/connectors/aci/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/aci/transformers.rs
@@ -8,7 +8,7 @@ use error_stack::report;
 use hyperswitch_domain_models::{
     payment_method_data::{
         ApplePayWalletData, BankRedirectData, Card, GooglePayWalletData, NetworkTokenData,
-        PayLaterData, PaymentMethodData, WalletData,
+        PayLaterData, PaymentMethodData, SamsungPayWalletData, WalletData,
     },
     payment_methods::storage_enums::MitCategory,
     router_data::{ConnectorAuthType, ErrorResponse, PaymentMethodToken, RouterData},
@@ -176,6 +176,9 @@ pub enum PaymentDetails {
     Klarna,
     Mandate,
     AciNetworkToken(Box<AciNetworkTokenData>),
+    AciApplePayEncrypted(Box<AciApplePayEncryptedData>),
+    AciGooglePayEncrypted(Box<AciGooglePayEncryptedData>),
+    AciSamsungPay(Box<AciSamsungPayData>),
 }
 
 impl TryFrom<(&WalletData, &PaymentsAuthorizeRouterData)> for PaymentDetails {
@@ -194,12 +197,15 @@ impl TryFrom<(&WalletData, &PaymentsAuthorizeRouterData)> for PaymentDetails {
                 payment_brand: PaymentBrand::AliPay,
                 account_id: None,
             })),
+            // ApplePay and GooglePay are handled separately in AciPaymentsRequest::try_from
+            // to extract decrypted token data
             WalletData::ApplePay(_) | WalletData::GooglePay(_) => {
                 Err(errors::ConnectorError::FlowNotSupported {
                     flow: "Wallet via PaymentDetails".to_string(),
                     connector: "ACI".to_string(),
                 })?
             }
+            WalletData::SamsungPay(samsung_pay_data) => Self::try_from(samsung_pay_data.as_ref())?,
             WalletData::AliPayHkRedirect(_)
             | WalletData::AmazonPayRedirect(_)
             | WalletData::Paysera(_)
@@ -217,7 +223,6 @@ impl TryFrom<(&WalletData, &PaymentsAuthorizeRouterData)> for PaymentDetails {
             | WalletData::PaypalRedirect(_)
             | WalletData::PaypalSdk(_)
             | WalletData::Paze(_)
-            | WalletData::SamsungPay(_)
             | WalletData::TwintRedirect { .. }
             | WalletData::VippsRedirect { .. }
             | WalletData::TouchNGoRedirect(_)
@@ -255,36 +260,50 @@ impl
     ) -> Result<Self, Self::Error> {
         let (_item, apple_pay_wallet_data, payment_method_token) = value;
 
-        // Extract decrypted Apple Pay data
-        let apple_pay_data = get_apple_pay_data(apple_pay_wallet_data, payment_method_token)?;
+        // Try to get decrypted data; if available, use tokenAccount.* flow
+        match get_apple_pay_data(apple_pay_wallet_data, payment_method_token) {
+            Ok(apple_pay_data) => {
+                let payment_brand =
+                    parse_wallet_card_network(&apple_pay_wallet_data.payment_method.network)
+                        .ok_or(errors::ConnectorError::MissingRequiredField {
+                            field_name: "apple_pay.payment_method.network",
+                        })?;
 
-        // Get card network from wallet metadata
-        let payment_brand = parse_wallet_card_network(
-            &apple_pay_wallet_data.payment_method.network,
-        )
-        .ok_or(errors::ConnectorError::MissingRequiredField {
-            field_name: "apple_pay.payment_method.network",
-        })?;
+                let aci_network_token_data = AciNetworkTokenData {
+                    token_type: AciTokenAccountType::Network,
+                    token_number: NetworkToken::from(
+                        apple_pay_data.application_primary_account_number.clone(),
+                    ),
+                    token_expiry_month: apple_pay_data.application_expiration_month.clone(),
+                    token_expiry_year: apple_pay_data.get_four_digit_expiry_year(),
+                    token_cryptogram: Some(
+                        apple_pay_data
+                            .payment_data
+                            .online_payment_cryptogram
+                            .clone(),
+                    ),
+                    eci: apple_pay_data.payment_data.eci_indicator.clone(),
+                    payment_brand,
+                };
 
-        // Build ACI network token data from decrypted Apple Pay data
-        let aci_network_token_data = AciNetworkTokenData {
-            token_type: AciTokenAccountType::Network,
-            token_number: NetworkToken::from(
-                apple_pay_data.application_primary_account_number.clone(),
-            ),
-            token_expiry_month: apple_pay_data.application_expiration_month.clone(),
-            token_expiry_year: apple_pay_data.get_four_digit_expiry_year(),
-            token_cryptogram: Some(
-                apple_pay_data
+                Ok(Self::AciNetworkToken(Box::new(aci_network_token_data)))
+            }
+            // Fall back to encrypted passthrough — let ACI decrypt
+            Err(_) => {
+                let encrypted_token = apple_pay_wallet_data
                     .payment_data
-                    .online_payment_cryptogram
-                    .clone(),
-            ),
-            eci: apple_pay_data.payment_data.eci_indicator.clone(),
-            payment_brand,
-        };
+                    .get_encrypted_apple_pay_payment_data_optional()
+                    .ok_or(errors::ConnectorError::MissingRequiredField {
+                        field_name: "apple_pay.payment_data (encrypted)",
+                    })?;
 
-        Ok(Self::AciNetworkToken(Box::new(aci_network_token_data)))
+                Ok(Self::AciApplePayEncrypted(Box::new(
+                    AciApplePayEncryptedData {
+                        payment_token: Secret::new(encrypted_token.clone()),
+                    },
+                )))
+            }
+        }
     }
 }
 
@@ -306,33 +325,66 @@ impl
     ) -> Result<Self, Self::Error> {
         let (_item, google_pay_wallet_data, payment_method_token) = value;
 
-        // Extract decrypted Google Pay data
-        let google_pay_data = get_google_pay_data(google_pay_wallet_data, payment_method_token)?;
+        // Try to get decrypted data; if available, use tokenAccount.* flow
+        match get_google_pay_data(google_pay_wallet_data, payment_method_token) {
+            Ok(google_pay_data) => {
+                let payment_brand = parse_wallet_card_network(
+                    &google_pay_wallet_data.info.card_network,
+                )
+                .ok_or(errors::ConnectorError::MissingRequiredField {
+                    field_name: "google_pay.info.card_network",
+                })?;
 
-        // Get card network from wallet metadata
-        let payment_brand = parse_wallet_card_network(&google_pay_wallet_data.info.card_network)
-            .ok_or(errors::ConnectorError::MissingRequiredField {
-                field_name: "google_pay.info.card_network",
-            })?;
+                let aci_network_token_data = AciNetworkTokenData {
+                    token_type: AciTokenAccountType::Network,
+                    token_number: NetworkToken::from(
+                        google_pay_data.application_primary_account_number.clone(),
+                    ),
+                    token_expiry_month: google_pay_data.card_exp_month.clone(),
+                    token_expiry_year: google_pay_data.get_four_digit_expiry_year().map_err(
+                        |_| errors::ConnectorError::MissingRequiredField {
+                            field_name: "google_pay.card_exp_year",
+                        },
+                    )?,
+                    token_cryptogram: google_pay_data.cryptogram.clone(),
+                    eci: google_pay_data.eci_indicator.clone(),
+                    payment_brand,
+                };
 
-        // Build ACI network token data from decrypted Google Pay data
-        let aci_network_token_data = AciNetworkTokenData {
-            token_type: AciTokenAccountType::Network,
-            token_number: NetworkToken::from(
-                google_pay_data.application_primary_account_number.clone(),
-            ),
-            token_expiry_month: google_pay_data.card_exp_month.clone(),
-            token_expiry_year: google_pay_data.get_four_digit_expiry_year().map_err(|_| {
-                errors::ConnectorError::MissingRequiredField {
-                    field_name: "google_pay.card_exp_year",
-                }
-            })?,
-            token_cryptogram: google_pay_data.cryptogram.clone(),
-            eci: google_pay_data.eci_indicator.clone(),
+                Ok(Self::AciNetworkToken(Box::new(aci_network_token_data)))
+            }
+            // Fall back to encrypted passthrough — let ACI decrypt
+            Err(_) => {
+                let encrypted_token = google_pay_wallet_data
+                    .tokenization_data
+                    .get_encrypted_google_pay_token()
+                    .map_err(|_| errors::ConnectorError::MissingRequiredField {
+                        field_name: "google_pay.tokenization_data (encrypted)",
+                    })?;
+
+                Ok(Self::AciGooglePayEncrypted(Box::new(
+                    AciGooglePayEncryptedData {
+                        payment_token: Secret::new(encrypted_token),
+                    },
+                )))
+            }
+        }
+    }
+}
+
+/// Convert Samsung Pay encrypted token to ACI Samsung Pay format
+impl TryFrom<&SamsungPayWalletData> for PaymentDetails {
+    type Error = Error;
+    fn try_from(samsung_pay_data: &SamsungPayWalletData) -> Result<Self, Self::Error> {
+        let payment_brand =
+            parse_samsung_pay_card_brand(&samsung_pay_data.payment_credential.card_brand)?;
+
+        let aci_samsung_pay_data = AciSamsungPayData {
+            payment_token: samsung_pay_data.payment_credential.token_data.data.clone(),
             payment_brand,
         };
 
-        Ok(Self::AciNetworkToken(Box::new(aci_network_token_data)))
+        Ok(Self::AciSamsungPay(Box::new(aci_samsung_pay_data)))
     }
 }
 
@@ -522,6 +574,22 @@ fn parse_wallet_card_network(network: &str) -> Option<PaymentBrand> {
     }
 }
 
+fn parse_samsung_pay_card_brand(
+    card_brand: &common_enums::SamsungPayCardBrand,
+) -> Result<PaymentBrand, Error> {
+    match card_brand {
+        common_enums::SamsungPayCardBrand::Visa => Ok(PaymentBrand::Visa),
+        common_enums::SamsungPayCardBrand::MasterCard => Ok(PaymentBrand::Mastercard),
+        common_enums::SamsungPayCardBrand::Amex => Ok(PaymentBrand::AmericanExpress),
+        common_enums::SamsungPayCardBrand::Discover => Ok(PaymentBrand::Discover),
+        common_enums::SamsungPayCardBrand::Unknown => {
+            Err(errors::ConnectorError::MissingRequiredField {
+                field_name: "samsung_pay.card_brand",
+            })?
+        }
+    }
+}
+
 fn get_apple_pay_data(
     apple_pay_wallet_data: &ApplePayWalletData,
     payment_method_token: Option<&PaymentMethodToken>,
@@ -640,6 +708,29 @@ pub struct AciNetworkTokenData {
     #[serde(rename = "threeDSecure.eci")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub eci: Option<String>,
+    #[serde(rename = "paymentBrand")]
+    pub payment_brand: PaymentBrand,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AciApplePayEncryptedData {
+    #[serde(rename = "applePay.paymentToken")]
+    pub payment_token: Secret<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AciGooglePayEncryptedData {
+    #[serde(rename = "googlePay.paymentToken")]
+    pub payment_token: Secret<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AciSamsungPayData {
+    #[serde(rename = "samsungPay.paymentToken")]
+    pub payment_token: Secret<String>,
     #[serde(rename = "paymentBrand")]
     pub payment_brand: PaymentBrand,
 }
@@ -877,7 +968,20 @@ impl TryFrom<(&AciRouterData<&PaymentsAuthorizeRouterData>, &WalletData)> for Ac
                     recurring_type: None,
                 })
             }
+            WalletData::SamsungPay(samsung_pay_data) => {
+                let payment_method = PaymentDetails::try_from(samsung_pay_data.as_ref())?;
+                let instruction = get_instruction_details(item);
 
+                Ok(Self {
+                    txn_details,
+                    payment_method,
+                    instruction,
+                    shopper_result_url: item.router_data.request.router_return_url.clone(),
+                    three_ds_two_enrolled: None,
+                    recurring_type: None,
+                })
+            }
+            // Handle other wallet types via PaymentDetails::try_from
             _ => {
                 let payment_method = PaymentDetails::try_from((wallet_data, item.router_data))?;
 

--- a/loadtest/config/development.toml
+++ b/loadtest/config/development.toml
@@ -634,7 +634,9 @@ interac = { country = "CA", currency = "CAD,USD" }
 przelewy24 = { country = "PL", currency = "CZK,EUR,GBP,PLN" }
 trustly = { country = "ES,GB,SE,NO,AT,NL,DE,DK,FI,EE,LT,LV", currency = "CZK,DKK,EUR,GBP,NOK,SEK" }
 klarna = { country = "AU,AT,BE,CA,CZ,DK,FI,FR,DE,GR,IE,IT,NL,NZ,NO,PL,PT,ES,SE,CH,GB,US", currency = "CHF,DKK,EUR,GBP,NOK,PLN,SEK,USD,AUD,NZD,CAD" }
-
+apple_pay = { country = "AU,CN,HK,JP,MO,MY,NZ,SG,TW,AM,AT,AZ,BY,BE,BG,HR,CY,CZ,DK,EE,FO,FI,FR,GE,DE,GR,GL,GG,HU,IS,IE,IM,IT,KZ,JE,LV,LI,LT,LU,MT,MD,MC,ME,NL,NO,PL,PT,RO,SM,RS,SK,SI,ES,SE,CH,UA,GB,AR,CO,CR,BR,MX,PE,BH,IL,JO,KW,PS,QA,SA,AE,CA,US,KR,VN,MA,ZA", currency = "AED,AUD,CAD,CHF,EUR,GBP,HKD,SGD,USD" }
+google_pay = { country = "AL,DZ,AS,AO,AG,AR,AU,AT,AZ,BH,BY,BE,BR,BG,CA,CL,CO,HR,CZ,DK,DO,EG,EE,FI,FR,DE,GR,HK,HU,IN,ID,IE,IL,IT,JP,JO,KZ,KE,KW,LV,LB,LT,LU,MY,MX,NL,NZ,NO,OM,PK,PA,PE,PH,PL,PT,QA,RO,SA,SG,SK,ZA,ES,LK,SE,CH,TW,TH,TR,UA,AE,GB,US,UY,VN" }
+samsung_pay = { country = "AU,BH,BR,CA,CN,DK,FI,FR,DE,HK,IN,IT,JP,KZ,KR,KW,MY,NZ,NO,OM,QA,SA,SG,ZA,ES,SE,CH,TW,AE,GB,US", currency = "AED,AUD,CAD,CHF,EUR,GBP,HKD,SGD,USD" }
 
 [pm_filters.gigadat]
 interac = { currency = "CAD"}
@@ -804,9 +806,9 @@ bank_debit.sepa = { connector_list = "gocardless,adyen,stripe,deutschebank" }
 card.credit.connector_list = "aci,checkout,stripe,adyen,authorizedotnet,cybersource,datatrans,globalpay,worldpay,multisafepay,nmi,nexinets,noon,bankofamerica,braintree,nuvei,payme,wellsfargo,bamboraapac,elavon,fiuu,nexixpay,novalnet,paybox,paypal,xendit,moneris,worldpayvantiv,payload,mollie,airwallex"
 card.debit.connector_list = "aci,checkout,stripe,adyen,authorizedotnet,cybersource,datatrans,globalpay,worldpay,multisafepay,nmi,nexinets,noon,bankofamerica,braintree,nuvei,payme,wellsfargo,bamboraapac,elavon,fiuu,nexixpay,novalnet,paybox,paypal,xendit,moneris,worldpayvantiv,payload,mollie,airwallex"
 pay_later.klarna.connector_list = "adyen,aci"
-wallet.apple_pay.connector_list = "stripe,adyen,braintree,cybersource,noon,bankofamerica,nexinets,novalnet,authorizedotnet,worldpayxml"
-wallet.samsung_pay.connector_list = "cybersource"
-wallet.google_pay.connector_list = "stripe,adyen,cybersource,bankofamerica,noon,globalpay,multisafepay,novalnet,authorizedotnet,worldpayxml"
+wallet.apple_pay.connector_list = "aci,stripe,adyen,braintree,cybersource,noon,bankofamerica,nexinets,novalnet,authorizedotnet,worldpayxml"
+wallet.samsung_pay.connector_list = "aci,cybersource"
+wallet.google_pay.connector_list = "aci,stripe,adyen,cybersource,bankofamerica,noon,globalpay,multisafepay,novalnet,authorizedotnet,worldpayxml"
 wallet.paypal.connector_list = "adyen,globalpay,nexinets,novalnet,paypal,authorizedotnet"
 wallet.momo.connector_list = "adyen"
 wallet.kakao_pay.connector_list = "adyen"


### PR DESCRIPTION
Summary

- Added Apple Pay support via decrypted token approach
- Added Google Pay support via decrypted token approach
- Added Samsung Pay support via decrypted psp approach
- Added standing instruction support for recurring wallet payments

Implementation Details

This PR adds Apple Pay and Google Pay support to the ACI connector by mapping Hyperswitch's decrypted wallet tokens to ACI's existing network token format (tokenAccount.*
parameters).

Changes

transformers.rs:
- Added imports for wallet predecrypt types and PaymentMethodToken
- Added parse_wallet_card_network() helper for network string to PaymentBrand conversion
- Added get_apple_pay_data() and get_google_pay_data() helper functions
- Added TryFrom implementations for Apple Pay and Google Pay → PaymentDetails::AciNetworkToken
- Updated AciPaymentsRequest::try_from for WalletData to handle Apple Pay and Google Pay with standing instruction support

aci.rs:
- Registered ApplePay and GooglePay in ACI_SUPPORTED_PAYMENT_METHODS

TOML configs:
- Added apple_pay and google_pay wallet entries

Data Mapping

```
┌────────────────────────────────────┬──────────────────────────┐
│       Decrypted Token Field        │        ACI Field         │
├────────────────────────────────────┼──────────────────────────┤
│ application_primary_account_number │ tokenAccount.number      │
├────────────────────────────────────┼──────────────────────────┤
│ Expiry month                       │ tokenAccount.expiryMonth │
├────────────────────────────────────┼──────────────────────────┤
│ Expiry year (4-digit)              │ tokenAccount.expiryYear  │
├────────────────────────────────────┼──────────────────────────┤
│ Cryptogram                         │ tokenAccount.cryptogram  │
├────────────────────────────────────┼──────────────────────────┤
│ Wallet network metadata            │ paymentBrand             │
└────────────────────────────────────┴──────────────────────────┘
```

Recurring Payment Support

Standing instructions (standingInstruction.mode, standingInstruction.type, standingInstruction.source) are included for wallet payments using the existing
get_instruction_details() function.

Test plan

- Build passes: cargo build -p hyperswitch_connectors --features v1
- Clippy passes: cargo clippy -p hyperswitch_connectors --features v1
- Verify Apple Pay payment flow with decrypted token
- Verify Google Pay payment flow with decrypted token
- Verify recurring wallet payment with standing instructions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Apple Pay, Google Pay, and Samsung Pay payments through the ACI connector across multiple deployment environments
  * Implemented country and currency filtering for wallet payment methods to enhance transaction eligibility and regional compliance
  * Expanded wallet payment method routing with new connector configuration options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->