### PR TITLE
chore(config): add installments supported payment methods config to deployment configs

### DIFF
--- a/config/deployments/integration_test.toml
+++ b/config/deployments/integration_test.toml
@@ -280,6 +280,10 @@ bank_redirect.eps.connector_list="globalpay,nexinets,aci,multisafepay"
 card.credit = { connector_list = "cybersource" }            # Update Mandate supported payment method type and connector for card
 card.debit = { connector_list = "cybersource" }             # Update Mandate supported payment method type and connector for card
 
+[installments.supported_payment_methods]
+card.credit = "adyen"
+card.debit = "adyen"
+
 [network_transaction_id_supported_connectors]
 connector_list = "adyen,archipel,checkout,cybersource,novalnet,nuvei,stripe,worldpay,worldpayvantiv"
 

--- a/config/deployments/production.toml
+++ b/config/deployments/production.toml
@@ -280,6 +280,10 @@ bank_redirect.eps.connector_list="globalpay,nexinets,aci,multisafepay"
 card.credit = { connector_list = "cybersource" }            # Update Mandate supported payment method type and connector for card
 card.debit = { connector_list = "cybersource" }             # Update Mandate supported payment method type and connector for card
 
+[installments.supported_payment_methods]
+card.credit = "adyen"
+card.debit = "adyen"
+
 [network_transaction_id_supported_connectors]
 connector_list = "adyen,archipel,checkout,cybersource,stripe,nuvei,worldpayvantiv"
 

--- a/config/deployments/sandbox.toml
+++ b/config/deployments/sandbox.toml
@@ -287,6 +287,10 @@ bank_redirect.eps.connector_list="globalpay,nexinets,aci,multisafepay"
 card.credit = { connector_list = "cybersource" }            # Update Mandate supported payment method type and connector for card
 card.debit = { connector_list = "cybersource" }             # Update Mandate supported payment method type and connector for card
 
+[installments.supported_payment_methods]
+card.credit = "adyen"
+card.debit = "adyen"
+
 [network_transaction_id_supported_connectors]
 connector_list = "adyen,archipel,checkout,cybersource,novalnet,nuvei,stripe,worldpay,worldpayvantiv"
 

--- a/config/docker_compose.toml
+++ b/config/docker_compose.toml
@@ -1104,6 +1104,10 @@ bank_redirect.giropay = { connector_list = "globalpay,aci" }
 card.credit = { connector_list = "cybersource" }
 card.debit = { connector_list = "cybersource" }
 
+[installments.supported_payment_methods]
+card.credit = "adyen"
+card.debit = "adyen"
+
 [network_transaction_id_supported_connectors]
 connector_list = "adyen,archipel,checkout,cybersource,novalnet,stripe,worldpay,worldpayvantiv"
 


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [x] CI/CD

## Description

Add `[installments.supported_payment_methods]` config section to sandbox, production, integration_test, and docker_compose TOML configs. This config was previously only present in `development.toml` and `config.example.toml`, causing installment payments to fail with IR_39 (no eligible connector) in deployed environments.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [x] This PR modifies application configuration/environment variables

## Motivation and Context

Installment payment routing requires the `installments.supported_payment_methods` config to identify which connectors support installments for each payment method type. Without this config in deployment environments, the installment connector filter returns an empty list, causing all installment payments to fail.

## How did you test it?

Verified the config matches the existing `development.toml` format.

## Checklist

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible