### PR TITLE
fix(connector): [ADYEN] Pass through split refund data when payment charges are unavailable

### DIFF
--- a/crates/router/src/core/utils.rs
+++ b/crates/router/src/core/utils.rs
@@ -715,7 +715,21 @@ pub fn get_split_refunds(
                         Ok(None)
                     }
                 }
-                _ => Ok(None),
+                // If charges data is unavailable, pass through merchant-provided split refund data without validation
+                _ => {
+                    if let Some(common_types::refunds::SplitRefund::AdyenSplitRefund(
+                        split_refund_request,
+                    )) = split_refund_input.refund_request.clone()
+                    {
+                        Ok(Some(
+                            router_request_types::SplitRefundsRequest::AdyenSplitRefund(
+                                split_refund_request,
+                            ),
+                        ))
+                    } else {
+                        Ok(None)
+                    }
+                }
             }
         }
         Some(common_types::payments::SplitPaymentsRequest::XenditSplitPayment(_)) => {

--- a/crates/router/src/core/utils/refunds_validator.rs
+++ b/crates/router/src/core/utils/refunds_validator.rs
@@ -239,19 +239,6 @@ pub fn validate_adyen_charge_refund(
             .find(|payment_split_item| refund_split_reference == payment_split_item.reference);
 
         if let Some(payment_split_item) = matching_payment_split_item {
-            if let Some((refund_amount, payment_amount)) =
-                refund_split_item.amount.zip(payment_split_item.amount)
-            {
-                if refund_amount > payment_amount {
-                    return Err(report!(errors::ApiErrorResponse::InvalidRequestData {
-                        message: format!(
-                            "Invalid refund amount for split item, reference: {refund_split_reference}",
-
-                        ),
-                    }));
-                }
-            }
-
             if let Some((refund_account, payment_account)) = refund_split_item
                 .account
                 .as_ref()


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
ORIGINAL PR: https://github.com/juspay/hyperswitch/pull/11473
Fixes an issue where Adyen split refund data provided by the merchant was silently dropped when payment_attempt.charges was empty, resulting in a plain refund (without splits or store) being sent to Adyen.

This affects merchants using captureDelayHours: 0, where Adyen captures asynchronously and returns split data only in the CAPTURE webhook which Hyperswitch does not currently parse. As a result, payment_attempt.charges is never populated, and the refund flow’s get_split_refunds() function was falling through to Ok(None), discarding the merchant’s split refund request.

Changes:

crates/router/src/core/utils.rs: When payment_attempt.charges is empty but the merchant provides AdyenSplitRefund data, pass it through to the connector instead of silently dropping it.

crates/router/src/core/utils/refunds_validator.rs: Removed the per-split-item amount validation in validate_adyen_charge_refund that rejected refund amounts exceeding the original payment split amount, giving the merchant full control over refund distribution.

Note: These changes are scoped to Adyen only. Stripe and Xendit split refund flows are unaffected.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
Without this fix, merchants using Adyen split payments with captureDelayHours: 0 have all their split refund data silently ignored. This causes Adyen to use the original payment's split configuration for the refund, which can debit incorrect balance accounts (e.g., reserve accounts) instead of the intended sub-merchant account.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
**PR Test Cases**

**Scenario 1: Split refund with empty `payment_attempt.charges`**

* Create a payment with `split_payments.adyen_split_payment` containing multiple split items.
* Ensure `payment_attempt.charges` is **NULL** in the database (simulating `captureDelayHours: 0` behavior).
* Create a refund with `split_refunds.adyen_split_refund` containing split items.

**Expected:**
The refund request sent to Adyen should include the **splits** and **store** fields from the merchant’s request.

**Before fix:**
The refund was sent as a plain refund without any split data.

---

**Scenario 2: Split refund with populated `payment_attempt.charges`**

* Create a payment with `split_payments.adyen_split_payment`.
* Ensure `payment_attempt.charges` is **populated** (manual capture flow).
* Create a refund with `split_refunds.adyen_split_refund`.

**Expected:**
The refund should go through **store, account, and split_type validations** as before, and the split data should be forwarded to Adyen.

---

**Scenario 3: Refund amount exceeding original split amount**

* Create a payment with a split item of amount **5000**.
* Create a refund with a split item for the same reference but amount **8000**.

**Expected:**
The refund should be **accepted** (amount validation removed) and sent to Adyen as-is.

**Before fix:**
This would have been rejected with **"Invalid refund amount for split item"**.

---

**Scenario 4: Non-Adyen connectors unaffected**

* Create a **Stripe/Xendit** split payment and refund.

**Expected:**
Behavior remains **unchanged**  no regressions.


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
