### PR TITLE
fix timing side-channel in auth and webhook signature verification

### DIFF
--- a/crates/cards/src/validate.rs
+++ b/crates/cards/src/validate.rs
@@ -321,7 +321,7 @@ where
             write!(f, "{}{}", value, "*".repeat(val_str.len() - 6))
         } else {
             #[cfg(not(target_arch = "wasm32"))]
-            logger::error!("Invalid card number {val_str}");
+            logger::error!("Invalid card number (masking failed for length {})", val_str.len());
             WithType::fmt(val, f)
         }
     }

--- a/crates/hyperswitch_connectors/Cargo.toml
+++ b/crates/hyperswitch_connectors/Cargo.toml
@@ -57,6 +57,7 @@ serde_with = "3.12.0"
 sha1 = { version = "0.10.6" }
 sha2 = "0.10"
 strum = { version = "0.26", features = ["derive"] }
+subtle = "2.6.1"
 time = { version = "0.3.41", features = ["macros"] }
 unicode-normalization = "0.1.24"
 utoipa = { version = "4.2.3", features = ["preserve_order", "preserve_path_order", "time"] }

--- a/crates/hyperswitch_connectors/src/connectors/adyen.rs
+++ b/crates/hyperswitch_connectors/src/connectors/adyen.rs
@@ -2,6 +2,7 @@ pub mod transformers;
 use std::sync::LazyLock;
 
 use base64::Engine;
+use subtle::ConstantTimeEq;
 use common_enums::enums::{self, PaymentMethodType};
 use common_utils::{
     consts,
@@ -2057,7 +2058,7 @@ impl IncomingWebhook for Adyen {
         let signing_key = hmac::Key::new(hmac::HMAC_SHA256, &raw_key);
         let signed_messaged = hmac::sign(&signing_key, &message);
         let payload_sign = consts::BASE64_ENGINE.encode(signed_messaged.as_ref());
-        Ok(payload_sign.as_bytes().eq(&signature))
+        Ok(bool::from(payload_sign.as_bytes().ct_eq(&signature)))
     }
 
     fn get_webhook_object_reference_id(

--- a/crates/hyperswitch_connectors/src/connectors/adyenplatform.rs
+++ b/crates/hyperswitch_connectors/src/connectors/adyenplatform.rs
@@ -1,5 +1,6 @@
 pub mod transformers;
 use api_models::{self, webhooks::IncomingWebhookEvent};
+use subtle::ConstantTimeEq;
 #[cfg(feature = "payouts")]
 use base64::Engine;
 #[cfg(feature = "payouts")]
@@ -361,7 +362,7 @@ impl IncomingWebhook for Adyenplatform {
         let signing_key = hmac::Key::new(hmac::HMAC_SHA256, &raw_key);
         let signed_messaged = hmac::sign(&signing_key, &message);
         let payload_sign = consts::BASE64_ENGINE.encode(signed_messaged.as_ref());
-        Ok(payload_sign.as_bytes().eq(&signature))
+        Ok(bool::from(payload_sign.as_bytes().ct_eq(&signature)))
     }
 
     #[cfg(feature = "payouts")]

--- a/crates/hyperswitch_connectors/src/connectors/braintree.rs
+++ b/crates/hyperswitch_connectors/src/connectors/braintree.rs
@@ -4,6 +4,7 @@ use std::sync::LazyLock;
 
 use api_models::webhooks::IncomingWebhookEvent;
 use base64::Engine;
+use subtle::ConstantTimeEq;
 use common_enums::{enums, CallConnectorAction, PaymentAction};
 use common_utils::{
     consts::BASE64_ENGINE,
@@ -1069,7 +1070,7 @@ impl IncomingWebhook for Braintree {
         );
         let signed_messaged = hmac::sign(&signing_key, &message);
         let payload_sign: String = hex::encode(signed_messaged);
-        Ok(payload_sign.as_bytes().eq(&signature))
+        Ok(bool::from(payload_sign.as_bytes().ct_eq(&signature)))
     }
 
     fn get_webhook_object_reference_id(

--- a/crates/hyperswitch_connectors/src/connectors/inespay.rs
+++ b/crates/hyperswitch_connectors/src/connectors/inespay.rs
@@ -3,6 +3,7 @@ pub mod transformers;
 use std::sync::LazyLock;
 
 use base64::Engine;
+use subtle::ConstantTimeEq;
 use common_enums::enums;
 use common_utils::{
     consts::BASE64_ENGINE,
@@ -666,7 +667,7 @@ impl webhooks::IncomingWebhook for Inespay {
         let signed_message = hmac::sign(&signing_key, &message);
         let computed_signature = hex::encode(signed_message.as_ref());
         let payload_sign = BASE64_ENGINE.encode(computed_signature);
-        Ok(payload_sign.as_bytes().eq(&signature))
+        Ok(bool::from(payload_sign.as_bytes().ct_eq(&signature)))
     }
 
     fn get_webhook_object_reference_id(

--- a/crates/hyperswitch_connectors/src/connectors/rapyd.rs
+++ b/crates/hyperswitch_connectors/src/connectors/rapyd.rs
@@ -3,6 +3,7 @@ use std::sync::LazyLock;
 
 use api_models::webhooks::IncomingWebhookEvent;
 use base64::Engine;
+use subtle::ConstantTimeEq;
 use common_enums::enums;
 use common_utils::{
     consts::BASE64_ENGINE_URL_SAFE,
@@ -827,7 +828,7 @@ impl IncomingWebhook for Rapyd {
         let key = hmac::Key::new(hmac::HMAC_SHA256, secret_key.peek().as_bytes());
         let tag = hmac::sign(&key, &message);
         let hmac_sign = hex::encode(tag);
-        Ok(hmac_sign.as_bytes().eq(&signature))
+        Ok(bool::from(hmac_sign.as_bytes().ct_eq(&signature)))
     }
 
     fn get_webhook_object_reference_id(

--- a/crates/hyperswitch_connectors/src/connectors/riskified.rs
+++ b/crates/hyperswitch_connectors/src/connectors/riskified.rs
@@ -68,6 +68,8 @@ use masking::{ExposeInterface, Mask, PeekInterface, Secret};
 #[cfg(feature = "frm")]
 use ring::hmac;
 #[cfg(feature = "frm")]
+use subtle::ConstantTimeEq;
+#[cfg(feature = "frm")]
 use transformers as riskified;
 
 #[cfg(feature = "frm")]
@@ -604,7 +606,7 @@ impl IncomingWebhook for Riskified {
         let signing_key = hmac::Key::new(hmac::HMAC_SHA256, &connector_webhook_secrets.secret);
         let signed_message = hmac::sign(&signing_key, &message);
         let payload_sign = BASE64_ENGINE.encode(signed_message.as_ref());
-        Ok(payload_sign.as_bytes().eq(&signature))
+        Ok(bool::from(payload_sign.as_bytes().ct_eq(&signature)))
     }
 
     fn get_webhook_source_verification_message(

--- a/crates/hyperswitch_connectors/src/connectors/signifyd.rs
+++ b/crates/hyperswitch_connectors/src/connectors/signifyd.rs
@@ -69,6 +69,8 @@ use masking::{PeekInterface, Secret};
 #[cfg(feature = "frm")]
 use ring::hmac;
 #[cfg(feature = "frm")]
+use subtle::ConstantTimeEq;
+#[cfg(feature = "frm")]
 use transformers as signifyd;
 
 use crate::constants::headers;
@@ -686,7 +688,7 @@ impl IncomingWebhook for Signifyd {
         let signing_key = hmac::Key::new(hmac::HMAC_SHA256, &connector_webhook_secrets.secret);
         let signed_message = hmac::sign(&signing_key, &message);
         let payload_sign = consts::BASE64_ENGINE.encode(signed_message.as_ref());
-        Ok(payload_sign.as_bytes().eq(&signature))
+        Ok(bool::from(payload_sign.as_bytes().ct_eq(&signature)))
     }
 
     fn get_webhook_object_reference_id(

--- a/crates/router/Cargo.toml
+++ b/crates/router/Cargo.toml
@@ -103,6 +103,7 @@ serde_qs = "0.12.0"
 serde_with = "3.12.0"
 sha2 = "0.10.9"
 strum = { version = "0.26", features = ["derive"] }
+subtle = "2.6.1"
 tera = "1.20.0"
 thiserror = "1.0.69"
 time = { version = "0.3.41", features = ["serde", "serde-well-known", "std", "parsing", "serde-human-readable"] }

--- a/crates/router/src/services/authentication.rs
+++ b/crates/router/src/services/authentication.rs
@@ -22,6 +22,7 @@ use jsonwebtoken::{
 #[cfg(feature = "v2")]
 use masking::ExposeInterface;
 use masking::PeekInterface;
+use subtle::ConstantTimeEq;
 use router_env::logger;
 use serde::Serialize;
 
@@ -567,7 +568,7 @@ where
         let (authenticated_entity, expected_secret) =
             P::get_credentials(state, &provided_identifier)?;
 
-        if provided_secret.peek() != expected_secret.peek() {
+        if !bool::from(provided_secret.peek().as_bytes().ct_eq(expected_secret.peek().as_bytes())) {
             return Err(errors::ApiErrorResponse::InvalidBasicAuth.into());
         }
 
@@ -1664,7 +1665,7 @@ where
 
         let admin_api_key = &conf.secrets.get_inner().admin_api_key;
 
-        if request_admin_api_key != admin_api_key.peek() {
+        if !bool::from(request_admin_api_key.as_bytes().ct_eq(admin_api_key.peek().as_bytes())) {
             Err(report!(errors::ApiErrorResponse::Unauthorized)
                 .attach_printable("Admin Authentication Failure"))?;
         }
@@ -1703,7 +1704,7 @@ where
 
         let admin_api_key = &conf.secrets.get_inner().admin_api_key;
 
-        if request_admin_api_key != admin_api_key.peek() {
+        if !bool::from(request_admin_api_key.as_bytes().ct_eq(admin_api_key.peek().as_bytes())) {
             Err(report!(errors::ApiErrorResponse::Unauthorized)
                 .attach_printable("Admin Authentication Failure"))?;
         }
@@ -1906,7 +1907,7 @@ where
 
         let admin_api_key = &conf.secrets.get_inner().admin_api_key;
 
-        if request_api_key == admin_api_key.peek() {
+        if bool::from(request_api_key.as_bytes().ct_eq(admin_api_key.peek().as_bytes())) {
             return Ok((None, AuthenticationType::AdminApiKey));
         }
         let Some(fallback_merchant_ids) = conf.fallback_merchant_ids_api_key_auth.as_ref() else {
@@ -2032,7 +2033,7 @@ where
 
         let admin_api_key: &masking::Secret<String> = &conf.secrets.get_inner().admin_api_key;
 
-        if request_api_key == admin_api_key.peek() {
+        if bool::from(request_api_key.as_bytes().ct_eq(admin_api_key.peek().as_bytes())) {
             let (key_store, merchant) =
                 Self::fetch_merchant_key_store_and_account(&merchant_id_from_route, state).await?;
 


### PR DESCRIPTION
## what this fixes

found that admin API key comparison, basic auth, and webhook signature verification across 7 connectors all use standard equality checks (`==`/`!=`) instead of constant-time comparison. this makes them vulnerable to timing side-channel attacks where an attacker can progressively determine the correct value by measuring response times.

the codebase already uses `subtle::ConstantTimeEq` for `StrongSecret` comparisons in the masking crate, so this just extends that same approach to the places that were missed.

### changes
- admin API key auth: 4 comparison sites switched to `ct_eq`
- basic auth (OIDC): 1 comparison site
- webhook HMAC verification: adyen, adyenplatform, braintree, inespay, rapyd, riskified, signifyd — all switched to `ct_eq`
- card number error log: removed raw card number from log message (PCI compliance)

### why this matters
timing attacks on webhook signatures are particularly dangerous — an attacker who can forge webhooks can fake payment confirmations, trigger false refund completions, or manipulate payment states.

### testing
all changes are drop-in replacements of the comparison operator. the `subtle` crate's `ct_eq` returns `Choice` which converts to `bool` the same way. no behavioral change except constant-time execution.