### PR TITLE
fix(xendit): pass through split refund data when charges is absent

### DIFF
--- a/crates/router/src/core/utils.rs
+++ b/crates/router/src/core/utils.rs
@@ -809,6 +809,17 @@ pub fn get_split_refunds(
                         Ok(None)
                     }
                 }
+                // If charges data is unavailable, pass through merchant-provided split refund data without validation
+                (
+                    _,
+                    Some(common_types::refunds::SplitRefund::XenditSplitRefund(
+                        split_refund_request,
+                    )),
+                ) => Ok(Some(
+                    router_request_types::SplitRefundsRequest::XenditSplitRefund(
+                        split_refund_request.clone(),
+                    ),
+                )),
                 _ => Ok(None),
             }
         }
@@ -914,6 +925,96 @@ mod tests {
             Object::new("p5"),
         ];
         assert_eq!(filtered_list, expected_result);
+    }
+
+    #[test]
+    fn test_get_split_refunds_xendit_passthrough_with_for_user_id() {
+        let input = refunds_transformers::SplitRefundInput {
+            split_payment_request: Some(
+                common_types::payments::SplitPaymentsRequest::XenditSplitPayment(
+                    common_types::payments::XenditSplitRequest::SingleSplit(
+                        common_types::domain::XenditSplitSubMerchantData {
+                            for_user_id: "test_uid".to_string(),
+                        },
+                    ),
+                ),
+            ),
+            payment_charges: None,
+            refund_request: Some(common_types::refunds::SplitRefund::XenditSplitRefund(
+                common_types::domain::XenditSplitSubMerchantData {
+                    for_user_id: "test_uid".to_string(),
+                },
+            )),
+            charge_id: None,
+        };
+
+        let result = get_split_refunds(input).unwrap();
+        assert!(matches!(
+            result,
+            Some(router_request_types::SplitRefundsRequest::XenditSplitRefund(
+                common_types::domain::XenditSplitSubMerchantData { for_user_id }
+            )) if for_user_id == "test_uid"
+        ));
+    }
+
+    #[test]
+    fn test_get_split_refunds_xendit_none_refund_request() {
+        let input = refunds_transformers::SplitRefundInput {
+            split_payment_request: Some(
+                common_types::payments::SplitPaymentsRequest::XenditSplitPayment(
+                    common_types::payments::XenditSplitRequest::SingleSplit(
+                        common_types::domain::XenditSplitSubMerchantData {
+                            for_user_id: "test_uid".to_string(),
+                        },
+                    ),
+                ),
+            ),
+            payment_charges: None,
+            refund_request: None,
+            charge_id: None,
+        };
+
+        let result = get_split_refunds(input).unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_get_split_refunds_xendit_validated_arm_with_charges() {
+        let input = refunds_transformers::SplitRefundInput {
+            split_payment_request: Some(
+                common_types::payments::SplitPaymentsRequest::XenditSplitPayment(
+                    common_types::payments::XenditSplitRequest::SingleSplit(
+                        common_types::domain::XenditSplitSubMerchantData {
+                            for_user_id: "test_uid".to_string(),
+                        },
+                    ),
+                ),
+            ),
+            payment_charges: Some(
+                common_types::payments::ConnectorChargeResponseData::XenditSplitPayment(
+                    common_types::payments::XenditChargeResponseData::SingleSplit(
+                        common_types::domain::XenditSplitSubMerchantData {
+                            for_user_id: "test_uid".to_string(),
+                        },
+                    ),
+                ),
+            ),
+            refund_request: Some(common_types::refunds::SplitRefund::XenditSplitRefund(
+                common_types::domain::XenditSplitSubMerchantData {
+                    for_user_id: "test_uid".to_string(),
+                },
+            )),
+            charge_id: None,
+        };
+
+        // Goes through the validator arm (charges present + refund_request present)
+        let result = get_split_refunds(input).unwrap();
+        assert!(matches!(
+            result,
+            Some(router_request_types::SplitRefundsRequest::XenditSplitRefund(
+                common_types::domain::XenditSplitSubMerchantData { for_user_id }
+            )) if for_user_id == "test_uid"
+        ));
     }
 }
 


### PR DESCRIPTION
## Problem

  When merchants provide `split_refunds.xendit_split_refund` but `payment_attempt.charges` is `NULL`, the `get_split_refunds()` function silently discarded the merchant-provided refund data via
  `_ => Ok(None)`. The refund was sent to Xendit without `for_user_id`, losing sub-merchant context.

  ## Fix

  Added an explicit match arm that forwards merchant-provided `XenditSplitRefund` data as-is when `payment_attempt.charges` is unavailable — mirroring the Adyen pass-through pattern.

  ## Changes
  - `crates/router/src/core/utils.rs`: New match arm in `get_split_refunds()`
  - Unit tests added for the new branch and surrounding Xendit arms

  ## Testing
  - `cargo check -p router` passes
  - Unit tests cover: pass-through with `for_user_id`, `None` refund request, and validated arm

  Closes #11485
  Related: #11473 (Adyen equivalent fix)