### PR TITLE
Add PaymentTrigger flow and PaymentsPaymentTrigger integration across router and connectors

### DIFF
--- a/crates/hyperswitch_connectors/src/connectors/dummyconnector.rs
+++ b/crates/hyperswitch_connectors/src/connectors/dummyconnector.rs
@@ -13,13 +13,13 @@ use error_stack::{report, ResultExt};
 use hyperswitch_domain_models::{
     router_data::{AccessToken, ConnectorAuthType, ErrorResponse, RouterData},
     router_flow_types::{
-        AccessTokenAuth, Authorize, Capture, Execute, PSync, PaymentMethodToken, RSync, Session,
-        SetupMandate, Void,
+        AccessTokenAuth, Authorize, Capture, Execute, PSync, PaymentMethodToken, PaymentTrigger,
+        RSync, Session, SetupMandate, Void,
     },
     router_request_types::{
         AccessTokenRequestData, PaymentMethodTokenizationData, PaymentsAuthorizeData,
-        PaymentsCancelData, PaymentsCaptureData, PaymentsSessionData, PaymentsSyncData,
-        RefundsData, SetupMandateRequestData,
+        PaymentsCancelData, PaymentsCaptureData, PaymentsPreProcessingData, PaymentsSessionData,
+        PaymentsSyncData, RefundsData, SetupMandateRequestData,
     },
     router_response_types::{PaymentsResponseData, RefundsResponseData},
     types::{
@@ -31,8 +31,8 @@ use hyperswitch_interfaces::{
     api::{
         ConnectorAccessToken, ConnectorCommon, ConnectorCommonExt, ConnectorIntegration,
         ConnectorSpecifications, ConnectorValidation, MandateSetup, Payment, PaymentAuthorize,
-        PaymentCapture, PaymentSession, PaymentSync, PaymentToken, PaymentVoid, Refund,
-        RefundExecute, RefundSync,
+        PaymentCapture, PaymentSession, PaymentSync, PaymentToken, PaymentVoid,
+        PaymentsPaymentTrigger, Refund, RefundExecute, RefundSync,
     },
     configs::Connectors,
     errors::ConnectorError,
@@ -77,6 +77,7 @@ impl<const T: u8> Refund for DummyConnector<T> {}
 impl<const T: u8> RefundExecute for DummyConnector<T> {}
 impl<const T: u8> RefundSync for DummyConnector<T> {}
 impl<const T: u8> PaymentToken for DummyConnector<T> {}
+impl<const T: u8> PaymentsPaymentTrigger for DummyConnector<T> {}
 
 impl<const T: u8>
     ConnectorIntegration<PaymentMethodToken, PaymentMethodTokenizationData, PaymentsResponseData>
@@ -190,6 +191,12 @@ impl<const T: u8> ConnectorIntegration<Session, PaymentsSessionData, PaymentsRes
     for DummyConnector<T>
 {
     //TODO: implement sessions flow
+}
+
+impl<const T: u8>
+    ConnectorIntegration<PaymentTrigger, PaymentsPreProcessingData, PaymentsResponseData>
+    for DummyConnector<T>
+{
 }
 
 impl<const T: u8> ConnectorIntegration<AccessTokenAuth, AccessTokenRequestData, AccessToken>

--- a/crates/hyperswitch_connectors/src/connectors/plaid.rs
+++ b/crates/hyperswitch_connectors/src/connectors/plaid.rs
@@ -13,13 +13,14 @@ use error_stack::ResultExt;
 use hyperswitch_domain_models::{
     router_data::{AccessToken, ConnectorAuthType, ErrorResponse, RouterData},
     router_flow_types::{
-        AccessTokenAuth, Authorize, Capture, Execute, PSync, PaymentMethodToken, PostProcessing,
-        RSync, Session, SetupMandate, Void,
+        AccessTokenAuth, Authorize, Capture, Execute, PSync, PaymentMethodToken, PaymentTrigger,
+        PostProcessing, RSync, Session, SetupMandate, Void,
     },
     router_request_types::{
         AccessTokenRequestData, PaymentMethodTokenizationData, PaymentsAuthorizeData,
-        PaymentsCancelData, PaymentsCaptureData, PaymentsPostProcessingData, PaymentsSessionData,
-        PaymentsSyncData, RefundsData, SetupMandateRequestData,
+        PaymentsCancelData, PaymentsCaptureData, PaymentsPostProcessingData,
+        PaymentsPreProcessingData, PaymentsSessionData, PaymentsSyncData, RefundsData,
+        SetupMandateRequestData,
     },
     router_response_types::{
         ConnectorInfo, PaymentMethodDetails, PaymentsResponseData, RefundsResponseData,
@@ -32,7 +33,7 @@ use hyperswitch_interfaces::{
         ConnectorAccessToken, ConnectorCommon, ConnectorCommonExt, ConnectorIntegration,
         ConnectorSpecifications, ConnectorValidation, CurrencyUnit, MandateSetup, Payment,
         PaymentAuthorize, PaymentCapture, PaymentSession, PaymentSync, PaymentToken, PaymentVoid,
-        PaymentsPostProcessing, Refund, RefundExecute, RefundSync,
+        PaymentsPaymentTrigger, PaymentsPostProcessing, Refund, RefundExecute, RefundSync,
     },
     configs::Connectors,
     consts::NO_ERROR_CODE,
@@ -75,12 +76,18 @@ impl Refund for Plaid {}
 impl RefundExecute for Plaid {}
 impl RefundSync for Plaid {}
 impl PaymentToken for Plaid {}
+impl PaymentsPaymentTrigger for Plaid {}
 impl PaymentsPostProcessing for Plaid {}
 
 impl ConnectorIntegration<PaymentMethodToken, PaymentMethodTokenizationData, PaymentsResponseData>
     for Plaid
 {
     // Not Implemented (R)
+}
+
+impl ConnectorIntegration<PaymentTrigger, PaymentsPreProcessingData, PaymentsResponseData>
+    for Plaid
+{
 }
 
 impl<Flow, Request, Response> ConnectorCommonExt<Flow, Request, Response> for Plaid

--- a/crates/hyperswitch_connectors/src/default_implementations.rs
+++ b/crates/hyperswitch_connectors/src/default_implementations.rs
@@ -35,8 +35,9 @@ use hyperswitch_domain_models::{
         payments::{
             Approve, AuthorizeSessionToken, CalculateTax, CompleteAuthorize,
             CreateConnectorCustomer, CreateOrder, ExtendAuthorization, GiftCardBalanceCheck,
-            IncrementalAuthorization, PostCaptureVoid, PostProcessing, PostSessionTokens,
-            PreProcessing, Reject, SdkSessionUpdate, SettlementSplitCreate, UpdateMetadata,
+            IncrementalAuthorization, PaymentTrigger, PostCaptureVoid, PostProcessing,
+            PostSessionTokens, PreProcessing, Reject, SdkSessionUpdate, SettlementSplitCreate,
+            UpdateMetadata,
         },
         subscriptions::{
             GetSubscriptionEstimate, GetSubscriptionItemPrices, GetSubscriptionItems,
@@ -143,8 +144,9 @@ use hyperswitch_interfaces::{
             PaymentIncrementalAuthorization, PaymentPostCaptureVoid, PaymentPostSessionTokens,
             PaymentReject, PaymentSessionUpdate, PaymentUpdateMetadata, PaymentsAuthenticate,
             PaymentsCompleteAuthorize, PaymentsCreateOrder, PaymentsGiftCardBalanceCheck,
-            PaymentsPostAuthenticate, PaymentsPostProcessing, PaymentsPreAuthenticate,
-            PaymentsPreProcessing, PaymentsSettlementSplitCreate, TaxCalculation,
+            PaymentsPaymentTrigger, PaymentsPostAuthenticate, PaymentsPostProcessing,
+            PaymentsPreAuthenticate, PaymentsPreProcessing, PaymentsSettlementSplitCreate,
+            TaxCalculation,
         },
         revenue_recovery::RevenueRecovery,
         subscriptions::{
@@ -2795,10 +2797,18 @@ macro_rules! default_imp_for_post_processing_steps{
     ($($path:ident::$connector:ident),*)=> {
         $(
             impl PaymentsPostProcessing for $path::$connector {}
+            impl PaymentsPaymentTrigger for $path::$connector {}
             impl
             ConnectorIntegration<
             PostProcessing,
             PaymentsPostProcessingData,
+            PaymentsResponseData,
+        > for $path::$connector
+        {}
+            impl
+            ConnectorIntegration<
+            PaymentTrigger,
+            PaymentsPreProcessingData,
             PaymentsResponseData,
         > for $path::$connector
         {}

--- a/crates/hyperswitch_connectors/src/default_implementations_v2.rs
+++ b/crates/hyperswitch_connectors/src/default_implementations_v2.rs
@@ -22,8 +22,9 @@ use hyperswitch_domain_models::{
             Approve, Authorize, AuthorizeSessionToken, CalculateTax, Capture, CompleteAuthorize,
             CreateConnectorCustomer, CreateOrder, ExtendAuthorization, ExternalVaultProxy,
             GiftCardBalanceCheck, IncrementalAuthorization, PSync, PaymentMethodToken,
-            PostCaptureVoid, PostProcessing, PostSessionTokens, PreProcessing, Reject,
-            SdkSessionUpdate, Session, SettlementSplitCreate, SetupMandate, UpdateMetadata, Void,
+            PaymentTrigger, PostCaptureVoid, PostProcessing, PostSessionTokens, PreProcessing,
+            Reject, SdkSessionUpdate, Session, SettlementSplitCreate, SetupMandate, UpdateMetadata,
+            Void,
         },
         refunds::{Execute, RSync},
         revenue_recovery::{
@@ -120,7 +121,7 @@ use hyperswitch_interfaces::{
             PaymentPostCaptureVoidV2, PaymentPostSessionTokensV2, PaymentRejectV2,
             PaymentSessionUpdateV2, PaymentSessionV2, PaymentSyncV2, PaymentTokenV2,
             PaymentUpdateMetadataV2, PaymentV2, PaymentVoidV2, PaymentsAuthenticateV2,
-            PaymentsCompleteAuthorizeV2, PaymentsGiftCardBalanceCheckV2,
+            PaymentsCompleteAuthorizeV2, PaymentsGiftCardBalanceCheckV2, PaymentsPaymentTriggerV2,
             PaymentsPostAuthenticateV2, PaymentsPostProcessingV2, PaymentsPreAuthenticateV2,
             PaymentsPreProcessingV2, PaymentsSettlementSplitCreate, TaxCalculationV2,
         },
@@ -167,6 +168,7 @@ macro_rules! default_imp_for_new_connector_integration_payment {
             impl PaymentsAuthenticateV2 for $path::$connector{}
             impl PaymentsPostAuthenticateV2 for $path::$connector{}
             impl PaymentsPostProcessingV2 for $path::$connector{}
+            impl PaymentsPaymentTriggerV2 for $path::$connector{}
             impl TaxCalculationV2 for $path::$connector{}
             impl PaymentSessionUpdateV2 for $path::$connector{}
             impl PaymentPostSessionTokensV2 for $path::$connector{}
@@ -261,6 +263,12 @@ macro_rules! default_imp_for_new_connector_integration_payment {
             PostProcessing,
             PaymentFlowData,
                 PaymentsPostProcessingData,
+                PaymentsResponseData,
+            > for $path::$connector{}
+            impl ConnectorIntegrationV2<
+            PaymentTrigger,
+            PaymentFlowData,
+                PaymentsPreProcessingData,
                 PaymentsResponseData,
             > for $path::$connector{}
             impl

--- a/crates/hyperswitch_domain_models/src/router_flow_types/payments.rs
+++ b/crates/hyperswitch_domain_models/src/router_flow_types/payments.rs
@@ -48,6 +48,9 @@ pub struct SetupMandate;
 pub struct PreProcessing;
 
 #[derive(Debug, Clone)]
+pub struct PaymentTrigger;
+
+#[derive(Debug, Clone)]
 pub struct IncrementalAuthorization;
 
 #[derive(Debug, Clone)]

--- a/crates/hyperswitch_domain_models/src/types.rs
+++ b/crates/hyperswitch_domain_models/src/types.rs
@@ -15,7 +15,7 @@ use crate::{
         Authorize, AuthorizeSessionToken, BillingConnectorInvoiceSync,
         BillingConnectorPaymentsSync, CalculateTax, Capture, CompleteAuthorize,
         CreateConnectorCustomer, CreateOrder, Execute, ExtendAuthorization, ExternalVaultProxy,
-        GiftCardBalanceCheck, IncrementalAuthorization, PSync, PaymentMethodToken,
+        GiftCardBalanceCheck, IncrementalAuthorization, PSync, PaymentMethodToken, PaymentTrigger,
         PostAuthenticate, PostCaptureVoid, PostSessionTokens, PreAuthenticate, PreProcessing,
         ProcessIncomingWebhook, RSync, SdkSessionUpdate, Session, SettlementSplitCreate,
         SetupMandate, UpdateMetadata, VerifyWebhookSource, Void,
@@ -75,6 +75,8 @@ pub type PaymentsAuthorizeSessionTokenRouterData =
     RouterData<AuthorizeSessionToken, AuthorizeSessionTokenData, PaymentsResponseData>;
 pub type PaymentsPreProcessingRouterData =
     RouterData<PreProcessing, PaymentsPreProcessingData, PaymentsResponseData>;
+pub type PaymentsPaymentTriggerRouterData =
+    RouterData<PaymentTrigger, PaymentsPreProcessingData, PaymentsResponseData>;
 pub type PaymentsPreAuthenticateRouterData =
     RouterData<PreAuthenticate, PaymentsPreAuthenticateData, PaymentsResponseData>;
 pub type PaymentsAuthenticateRouterData =

--- a/crates/hyperswitch_interfaces/src/api.rs
+++ b/crates/hyperswitch_interfaces/src/api.rs
@@ -494,8 +494,12 @@ pub trait ConnectorSpecifications {
     fn is_post_authentication_flow_required(&self, _current_flow: CurrentFlowInfo<'_>) -> bool {
         false
     }
-    /// Check if pre-authentication flow is required
+    /// Check if settlement split flow is required
     fn is_settlement_split_call_required(&self, _current_flow: CurrentFlowInfo<'_>) -> bool {
+        false
+    }
+    /// Check if payment trigger flow is required
+    fn is_payment_trigger_flow_required(&self, _current_flow: CurrentFlowInfo<'_>) -> bool {
         false
     }
     /// Preprocessing flow name if any, that must be made before the current flow.

--- a/crates/hyperswitch_interfaces/src/api/payments.rs
+++ b/crates/hyperswitch_interfaces/src/api/payments.rs
@@ -5,9 +5,9 @@ use hyperswitch_domain_models::{
         payments::{
             Approve, Authorize, AuthorizeSessionToken, CalculateTax, Capture, CompleteAuthorize,
             CreateConnectorCustomer, ExtendAuthorization, IncrementalAuthorization, PSync,
-            PaymentMethodToken, PostCaptureVoid, PostProcessing, PostSessionTokens, PreProcessing,
-            Reject, SdkSessionUpdate, Session, SettlementSplitCreate, SetupMandate, UpdateMetadata,
-            Void,
+            PaymentMethodToken, PaymentTrigger, PostCaptureVoid, PostProcessing, PostSessionTokens,
+            PreProcessing, Reject, SdkSessionUpdate, Session, SettlementSplitCreate, SetupMandate,
+            UpdateMetadata, Void,
         },
         Authenticate, CreateOrder, ExternalVaultProxy, GiftCardBalanceCheck, PostAuthenticate,
         PreAuthenticate,
@@ -52,6 +52,7 @@ pub trait Payment:
     + PaymentSession
     + PaymentToken
     + PaymentsPostProcessing
+    + PaymentsPaymentTrigger
     + ConnectorCustomer
     + PaymentIncrementalAuthorization
     + PaymentExtendAuthorization
@@ -214,6 +215,12 @@ pub trait PaymentsPostAuthenticate:
 /// trait PaymentsPostProcessing
 pub trait PaymentsPostProcessing:
     api::ConnectorIntegration<PostProcessing, PaymentsPostProcessingData, PaymentsResponseData>
+{
+}
+
+/// trait PaymentsPaymentTrigger
+pub trait PaymentsPaymentTrigger:
+    api::ConnectorIntegration<PaymentTrigger, PaymentsPreProcessingData, PaymentsResponseData>
 {
 }
 

--- a/crates/hyperswitch_interfaces/src/api/payments_v2.rs
+++ b/crates/hyperswitch_interfaces/src/api/payments_v2.rs
@@ -6,8 +6,8 @@ use hyperswitch_domain_models::{
         payments::{
             Approve, Authorize, AuthorizeSessionToken, CalculateTax, Capture, CompleteAuthorize,
             CreateConnectorCustomer, CreateOrder, ExtendAuthorization, ExternalVaultProxy,
-            IncrementalAuthorization, PSync, PaymentMethodToken, PostCaptureVoid, PostProcessing,
-            PostSessionTokens, PreProcessing, Reject, SdkSessionUpdate, Session,
+            IncrementalAuthorization, PSync, PaymentMethodToken, PaymentTrigger, PostCaptureVoid,
+            PostProcessing, PostSessionTokens, PreProcessing, Reject, SdkSessionUpdate, Session,
             SettlementSplitCreate, SetupMandate, UpdateMetadata, Void,
         },
         Authenticate, GiftCardBalanceCheck, PostAuthenticate, PreAuthenticate,
@@ -284,6 +284,17 @@ pub trait PaymentsPostProcessingV2:
 {
 }
 
+/// trait PaymentsPaymentTriggerV2
+pub trait PaymentsPaymentTriggerV2:
+    ConnectorIntegrationV2<
+    PaymentTrigger,
+    PaymentFlowData,
+    PaymentsPreProcessingData,
+    PaymentsResponseData,
+>
+{
+}
+
 /// trait ExternalVaultProxyPaymentsCreate
 pub trait ExternalVaultProxyPaymentsCreate:
     ConnectorIntegrationV2<
@@ -316,6 +327,7 @@ pub trait PaymentV2:
     + PaymentSessionV2
     + PaymentTokenV2
     + PaymentsPostProcessingV2
+    + PaymentsPaymentTriggerV2
     + ConnectorCustomerV2
     + PaymentIncrementalAuthorizationV2
     + PaymentExtendAuthorizationV2

--- a/crates/hyperswitch_interfaces/src/connector_integration_interface.rs
+++ b/crates/hyperswitch_interfaces/src/connector_integration_interface.rs
@@ -596,6 +596,12 @@ impl ConnectorSpecifications for ConnectorEnum {
             Self::New(connector) => connector.is_settlement_split_call_required(current_flow),
         }
     }
+    fn is_payment_trigger_flow_required(&self, current_flow: api::CurrentFlowInfo<'_>) -> bool {
+        match self {
+            Self::Old(connector) => connector.is_payment_trigger_flow_required(current_flow),
+            Self::New(connector) => connector.is_payment_trigger_flow_required(current_flow),
+        }
+    }
     fn get_preprocessing_flow_if_needed(
         &self,
         current_flow_info: api::CurrentFlowInfo<'_>,

--- a/crates/hyperswitch_interfaces/src/types.rs
+++ b/crates/hyperswitch_interfaces/src/types.rs
@@ -12,9 +12,9 @@ use hyperswitch_domain_models::{
         payments::{
             Authorize, AuthorizeSessionToken, Balance, CalculateTax, Capture, CompleteAuthorize,
             CreateConnectorCustomer, CreateOrder, ExtendAuthorization, IncrementalAuthorization,
-            InitPayment, PSync, PaymentMethodToken, PostCaptureVoid, PostProcessing,
-            PostSessionTokens, PreProcessing, SdkSessionUpdate, Session, SettlementSplitCreate,
-            SetupMandate, UpdateMetadata, Void,
+            InitPayment, PSync, PaymentMethodToken, PaymentTrigger, PostCaptureVoid,
+            PostProcessing, PostSessionTokens, PreProcessing, SdkSessionUpdate, Session,
+            SettlementSplitCreate, SetupMandate, UpdateMetadata, Void,
         },
         refunds::{Execute, RSync},
         revenue_recovery::{BillingConnectorPaymentsSync, InvoiceRecordBack},
@@ -157,6 +157,9 @@ pub type PaymentsPostAuthenticateType =
 /// Type alias for `ConnectorIntegration<PostProcessing, PaymentsPostProcessingData, PaymentsResponseData>`
 pub type PaymentsPostProcessingType =
     dyn ConnectorIntegration<PostProcessing, PaymentsPostProcessingData, PaymentsResponseData>;
+/// Type alias for `ConnectorIntegration<PaymentTrigger, PaymentsPreProcessingData, PaymentsResponseData>`
+pub type PaymentsPaymentTriggerType =
+    dyn ConnectorIntegration<PaymentTrigger, PaymentsPreProcessingData, PaymentsResponseData>;
 /// Type alias for `ConnectorIntegration<CompleteAuthorize, CompleteAuthorizeData, PaymentsResponseData>`
 pub type PaymentsCompleteAuthorizeType =
     dyn ConnectorIntegration<CompleteAuthorize, CompleteAuthorizeData, PaymentsResponseData>;

--- a/crates/router/src/core/payments.rs
+++ b/crates/router/src/core/payments.rs
@@ -4654,6 +4654,20 @@ where
             .ok();
     }
 
+    let (router_data, should_continue_further) = if should_continue_further {
+        router_data
+            .payment_trigger_step(state, &connector, &context)
+            .await?
+    } else {
+        (router_data, false)
+    };
+
+    let connector_request = if should_continue_further {
+        connector_request
+    } else {
+        None
+    };
+
     Ok((
         updated_customer,
         ConnectorServiceIntermediateState {
@@ -5115,6 +5129,20 @@ where
                 .await?
         }
         None => (None, false),
+    };
+
+    let (router_data, should_continue_further) = if should_continue_further {
+        router_data
+            .payment_trigger_step(state, &connector, &gateway_context)
+            .await?
+    } else {
+        (router_data, false)
+    };
+
+    let connector_request = if should_continue_further {
+        connector_request
+    } else {
+        None
     };
 
     Ok(ConnectorServiceIntermediateState {

--- a/crates/router/src/core/payments/flows.rs
+++ b/crates/router/src/core/payments/flows.rs
@@ -213,6 +213,19 @@ pub trait Feature<F, T> {
         Ok((self, true))
     }
 
+    async fn payment_trigger_step<'a>(
+        self,
+        _state: &SessionState,
+        _connector: &api::ConnectorData,
+        _gateway_context: &gateway_context::RouterGatewayContext,
+    ) -> RouterResult<(Self, bool)>
+    where
+        F: Clone,
+        Self: Sized,
+    {
+        Ok((self, true))
+    }
+
     async fn postprocessing_steps<'a>(
         self,
         _state: &SessionState,

--- a/crates/router/src/core/payments/flows/authorize_flow.rs
+++ b/crates/router/src/core/payments/flows/authorize_flow.rs
@@ -705,6 +705,67 @@ impl Feature<api::Authorize, types::PaymentsAuthorizeData> for types::PaymentsAu
         authorize_postprocessing_steps(state, &self, true, connector).await
     }
 
+    async fn payment_trigger_step<'a>(
+        self,
+        state: &SessionState,
+        connector: &api::ConnectorData,
+        _gateway_context: &gateway_context::RouterGatewayContext,
+    ) -> RouterResult<(Self, bool)>
+    where
+        Self: Sized,
+    {
+        if connector.connector.is_payment_trigger_flow_required(
+            api_interface::CurrentFlowInfo::Authorize {
+                auth_type: &self.auth_type,
+                request_data: &self.request,
+            },
+        ) {
+            logger::info!(
+                "Payment trigger flow is required for connector: {}",
+                connector.connector_name
+            );
+            let authorize_request_data = self.request.clone();
+            let payment_trigger_request_data =
+                types::PaymentsPreProcessingData::try_from(self.request.to_owned())?;
+            let payment_trigger_response_data: Result<
+                types::PaymentsResponseData,
+                types::ErrorResponse,
+            > = Err(types::ErrorResponse::default());
+            let payment_trigger_router_data =
+                helpers::router_data_type_conversion::<_, api::PaymentTrigger, _, _, _, _>(
+                    self.clone(),
+                    payment_trigger_request_data,
+                    payment_trigger_response_data,
+                );
+            let connector_integration: services::BoxedPaymentConnectorIntegrationInterface<
+                api::PaymentTrigger,
+                types::PaymentsPreProcessingData,
+                types::PaymentsResponseData,
+            > = connector.connector.get_connector_integration();
+            let payment_trigger_router_data = services::execute_connector_processing_step(
+                state,
+                connector_integration,
+                &payment_trigger_router_data,
+                payments::CallConnectorAction::Trigger,
+                None,
+                None,
+            )
+            .await
+            .to_payment_failed_response()?;
+            let payment_trigger_response = payment_trigger_router_data.response.clone();
+            let authorize_router_data =
+                helpers::router_data_type_conversion::<_, api::Authorize, _, _, _, _>(
+                    payment_trigger_router_data,
+                    authorize_request_data,
+                    payment_trigger_response,
+                );
+            let should_continue_payment = authorize_router_data.response.is_ok();
+            Ok((authorize_router_data, should_continue_payment))
+        } else {
+            Ok((self, true))
+        }
+    }
+
     async fn create_connector_customer<'a>(
         &self,
         state: &SessionState,

--- a/crates/router/src/core/payments/flows/complete_authorize_flow.rs
+++ b/crates/router/src/core/payments/flows/complete_authorize_flow.rs
@@ -525,6 +525,68 @@ impl Feature<api::CompleteAuthorize, types::CompleteAuthorizeData>
             Ok((self, true))
         }
     }
+
+    async fn payment_trigger_step<'a>(
+        self,
+        state: &SessionState,
+        connector: &api::ConnectorData,
+        _gateway_context: &gateway_context::RouterGatewayContext,
+    ) -> RouterResult<(Self, bool)>
+    where
+        Self: Sized,
+    {
+        if connector.connector.is_payment_trigger_flow_required(
+            api_interface::CurrentFlowInfo::CompleteAuthorize {
+                auth_type: &self.auth_type,
+                request_data: &self.request,
+                payment_method: Some(self.payment_method),
+            },
+        ) {
+            logger::info!(
+                "Payment trigger flow is required for connector: {}",
+                connector.connector_name
+            );
+            let complete_authorize_request_data = self.request.clone();
+            let payment_trigger_request_data =
+                types::PaymentsPreProcessingData::try_from(self.request.to_owned())?;
+            let payment_trigger_response_data: Result<
+                types::PaymentsResponseData,
+                types::ErrorResponse,
+            > = Err(types::ErrorResponse::default());
+            let payment_trigger_router_data =
+                helpers::router_data_type_conversion::<_, api::PaymentTrigger, _, _, _, _>(
+                    self.clone(),
+                    payment_trigger_request_data,
+                    payment_trigger_response_data,
+                );
+            let connector_integration: services::BoxedPaymentConnectorIntegrationInterface<
+                api::PaymentTrigger,
+                types::PaymentsPreProcessingData,
+                types::PaymentsResponseData,
+            > = connector.connector.get_connector_integration();
+            let payment_trigger_router_data = services::execute_connector_processing_step(
+                state,
+                connector_integration,
+                &payment_trigger_router_data,
+                payments::CallConnectorAction::Trigger,
+                None,
+                None,
+            )
+            .await
+            .to_payment_failed_response()?;
+            let payment_trigger_response = payment_trigger_router_data.response.clone();
+            let complete_authorize_router_data =
+                helpers::router_data_type_conversion::<_, api::CompleteAuthorize, _, _, _, _>(
+                    payment_trigger_router_data,
+                    complete_authorize_request_data,
+                    payment_trigger_response,
+                );
+            let should_continue_payment = complete_authorize_router_data.response.is_ok();
+            Ok((complete_authorize_router_data, should_continue_payment))
+        } else {
+            Ok((self, true))
+        }
+    }
 }
 
 fn transform_redirection_response_for_authenticate_flow(

--- a/crates/router/src/core/payments/flows/setup_mandate_flow.rs
+++ b/crates/router/src/core/payments/flows/setup_mandate_flow.rs
@@ -419,6 +419,67 @@ impl Feature<api::SetupMandate, types::SetupMandateRequestData> for types::Setup
         .await
     }
 
+    async fn payment_trigger_step<'a>(
+        self,
+        state: &SessionState,
+        connector: &api::ConnectorData,
+        _gateway_context: &gateway_context::RouterGatewayContext,
+    ) -> RouterResult<(Self, bool)>
+    where
+        Self: Sized,
+    {
+        if connector.connector.is_payment_trigger_flow_required(
+            api_interface::CurrentFlowInfo::SetupMandate {
+                auth_type: &self.auth_type,
+                request_data: &self.request,
+            },
+        ) {
+            logger::info!(
+                "Payment trigger flow is required for connector: {} for Setup Mandate flow",
+                connector.connector_name
+            );
+            let setup_mandate_request_data = self.request.clone();
+            let payment_trigger_request_data =
+                types::PaymentsPreProcessingData::try_from(self.request.to_owned())?;
+            let payment_trigger_response_data: Result<
+                types::PaymentsResponseData,
+                types::ErrorResponse,
+            > = Err(types::ErrorResponse::default());
+            let payment_trigger_router_data =
+                helpers::router_data_type_conversion::<_, api::PaymentTrigger, _, _, _, _>(
+                    self.clone(),
+                    payment_trigger_request_data,
+                    payment_trigger_response_data,
+                );
+            let connector_integration: services::BoxedPaymentConnectorIntegrationInterface<
+                api::PaymentTrigger,
+                types::PaymentsPreProcessingData,
+                types::PaymentsResponseData,
+            > = connector.connector.get_connector_integration();
+            let payment_trigger_router_data = services::execute_connector_processing_step(
+                state,
+                connector_integration,
+                &payment_trigger_router_data,
+                payments::CallConnectorAction::Trigger,
+                None,
+                None,
+            )
+            .await
+            .to_payment_failed_response()?;
+            let payment_trigger_response = payment_trigger_router_data.response.clone();
+            let setup_mandate_router_data =
+                helpers::router_data_type_conversion::<_, api::SetupMandate, _, _, _, _>(
+                    payment_trigger_router_data,
+                    setup_mandate_request_data,
+                    payment_trigger_response,
+                );
+            let should_continue_payment = setup_mandate_router_data.response.is_ok();
+            Ok((setup_mandate_router_data, should_continue_payment))
+        } else {
+            Ok((self, true))
+        }
+    }
+
     async fn build_flow_specific_connector_request(
         &mut self,
         state: &SessionState,

--- a/crates/router/src/types.rs
+++ b/crates/router/src/types.rs
@@ -39,9 +39,9 @@ use hyperswitch_domain_models::router_flow_types::{
     payments::{
         Approve, Authorize, AuthorizeSessionToken, Balance, CalculateTax, Capture,
         CompleteAuthorize, CreateConnectorCustomer, CreateOrder, ExtendAuthorization,
-        ExternalVaultProxy, IncrementalAuthorization, InitPayment, PSync, PostCaptureVoid,
-        PostProcessing, PostSessionTokens, PreProcessing, Reject, SdkSessionUpdate, Session,
-        SetupMandate, UpdateMetadata, Void,
+        ExternalVaultProxy, IncrementalAuthorization, InitPayment, PSync, PaymentTrigger,
+        PostCaptureVoid, PostProcessing, PostSessionTokens, PreProcessing, Reject,
+        SdkSessionUpdate, Session, SetupMandate, UpdateMetadata, Void,
     },
     refunds::{Execute, RSync},
     webhooks::VerifyWebhookSource,
@@ -116,11 +116,12 @@ pub use hyperswitch_interfaces::{
         AcceptDisputeType, ConnectorCustomerType, DefendDisputeType, FetchDisputesType,
         IncrementalAuthorizationType, MandateRevokeType, PaymentsAuthorizeType,
         PaymentsBalanceType, PaymentsCaptureType, PaymentsCompleteAuthorizeType, PaymentsInitType,
-        PaymentsPostCaptureVoidType, PaymentsPostProcessingType, PaymentsPostSessionTokensType,
-        PaymentsPreAuthorizeType, PaymentsPreProcessingType, PaymentsSessionType, PaymentsSyncType,
-        PaymentsUpdateMetadataType, PaymentsVoidType, RefreshTokenType, RefundExecuteType,
-        RefundSyncType, Response, RetrieveFileType, SdkSessionUpdateType, SetupMandateType,
-        SubmitEvidenceType, TokenizationType, UploadFileType, VerifyWebhookSourceType,
+        PaymentsPaymentTriggerType, PaymentsPostCaptureVoidType, PaymentsPostProcessingType,
+        PaymentsPostSessionTokensType, PaymentsPreAuthorizeType, PaymentsPreProcessingType,
+        PaymentsSessionType, PaymentsSyncType, PaymentsUpdateMetadataType, PaymentsVoidType,
+        RefreshTokenType, RefundExecuteType, RefundSyncType, Response, RetrieveFileType,
+        SdkSessionUpdateType, SetupMandateType, SubmitEvidenceType, TokenizationType,
+        UploadFileType, VerifyWebhookSourceType,
     },
 };
 
@@ -140,6 +141,8 @@ pub type ExternalVaultProxyPaymentsRouterData =
     RouterData<ExternalVaultProxy, ExternalVaultProxyPaymentsData, PaymentsResponseData>;
 pub type PaymentsPreProcessingRouterData =
     RouterData<PreProcessing, PaymentsPreProcessingData, PaymentsResponseData>;
+pub type PaymentsPaymentTriggerRouterData =
+    RouterData<PaymentTrigger, PaymentsPreProcessingData, PaymentsResponseData>;
 pub type PaymentsPostProcessingRouterData =
     RouterData<PostProcessing, PaymentsPostProcessingData, PaymentsResponseData>;
 pub type PaymentsAuthorizeSessionTokenRouterData =

--- a/crates/router/src/types/api/payments.rs
+++ b/crates/router/src/types/api/payments.rs
@@ -40,17 +40,17 @@ pub use hyperswitch_domain_models::router_flow_types::payments::{
     Approve, Authorize, AuthorizeSessionToken, Balance, CalculateTax, Capture, CompleteAuthorize,
     CreateConnectorCustomer, CreateOrder, ExtendAuthorization, ExternalVaultProxy,
     IncrementalAuthorization, InitPayment, PSync, PaymentCreateIntent, PaymentGetIntent,
-    PaymentMethodToken, PaymentUpdateIntent, PostCaptureVoid, PostProcessing, PostSessionTokens,
-    PreProcessing, RecordAttempt, Reject, SdkSessionUpdate, Session, SetupMandate, UpdateMetadata,
-    Void,
+    PaymentMethodToken, PaymentTrigger, PaymentUpdateIntent, PostCaptureVoid, PostProcessing,
+    PostSessionTokens, PreProcessing, RecordAttempt, Reject, SdkSessionUpdate, Session,
+    SetupMandate, UpdateMetadata, Void,
 };
 pub use hyperswitch_interfaces::api::payments::{
     ConnectorCustomer, MandateSetup, Payment, PaymentApprove, PaymentAuthorize,
     PaymentAuthorizeSessionToken, PaymentCapture, PaymentIncrementalAuthorization,
     PaymentPostCaptureVoid, PaymentPostSessionTokens, PaymentReject, PaymentSession,
     PaymentSessionUpdate, PaymentSync, PaymentToken, PaymentUpdateMetadata, PaymentVoid,
-    PaymentsCompleteAuthorize, PaymentsCreateOrder, PaymentsPostProcessing, PaymentsPreProcessing,
-    TaxCalculation,
+    PaymentsCompleteAuthorize, PaymentsCreateOrder, PaymentsPaymentTrigger, PaymentsPostProcessing,
+    PaymentsPreProcessing, TaxCalculation,
 };
 
 pub use super::payments_v2::{
@@ -59,7 +59,7 @@ pub use super::payments_v2::{
     PaymentIncrementalAuthorizationV2, PaymentPostCaptureVoidV2, PaymentPostSessionTokensV2,
     PaymentRejectV2, PaymentSessionUpdateV2, PaymentSessionV2, PaymentSyncV2, PaymentTokenV2,
     PaymentUpdateMetadataV2, PaymentV2, PaymentVoidV2, PaymentsCompleteAuthorizeV2,
-    PaymentsPostProcessingV2, PaymentsPreProcessingV2, TaxCalculationV2,
+    PaymentsPaymentTriggerV2, PaymentsPostProcessingV2, PaymentsPreProcessingV2, TaxCalculationV2,
 };
 use crate::core::errors;
 

--- a/crates/router/src/types/api/payments_v2.rs
+++ b/crates/router/src/types/api/payments_v2.rs
@@ -4,5 +4,5 @@ pub use hyperswitch_interfaces::api::payments_v2::{
     PaymentIncrementalAuthorizationV2, PaymentPostCaptureVoidV2, PaymentPostSessionTokensV2,
     PaymentRejectV2, PaymentSessionUpdateV2, PaymentSessionV2, PaymentSyncV2, PaymentTokenV2,
     PaymentUpdateMetadataV2, PaymentV2, PaymentVoidV2, PaymentsCompleteAuthorizeV2,
-    PaymentsPostProcessingV2, PaymentsPreProcessingV2, TaxCalculationV2,
+    PaymentsPaymentTriggerV2, PaymentsPostProcessingV2, PaymentsPreProcessingV2, TaxCalculationV2,
 };


### PR DESCRIPTION
### Motivation
- Introduce a generic pre-processing trigger flow that connectors can implement to perform actions before main payment flows like `Authorize`, `CompleteAuthorize`, and `SetupMandate`.
- Provide a typed integration point so connectors and the router can conditionally call connector-specific trigger logic prior to continuing the primary payment processing.

### Description
- Added a new flow type `PaymentTrigger` in domain flow types and corresponding router type aliases `PaymentsPaymentTriggerRouterData` and `PaymentsPaymentTriggerType`.
- Introduced `PaymentsPaymentTrigger` and `PaymentsPaymentTriggerV2` traits in the interfaces and exposed `is_payment_trigger_flow_required` in `ConnectorSpecifications` to allow connectors to opt into the flow.
- Plumbed the trigger into the router by adding `payment_trigger_step` to the `Feature` trait and calling it from the core flow points in `complete_connector_service` and the pre-processing paths; implemented trigger behavior for `Authorize`, `CompleteAuthorize`, and `SetupMandate` flows so the result can decide whether to continue the main flow.
- Updated connectors and default-implementation macros to surface the new trait and integration points (example changes in `dummyconnector.rs`, `plaid.rs`, and `default_implementations*`), and added no-op connector integration impl stubs for `PaymentTrigger` where appropriate.

### Testing
- Ran `cargo build --all` to verify compilation across crates and type changes, and it completed successfully.
- Ran `cargo test --all` to validate unit and integration tests, and the test suite passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bbb34f7998832f820c2cce889a619f)