### PR TITLE
Add Santander Pix Automático (push & QR) support and metadata handling

### DIFF
--- a/crates/hyperswitch_connectors/src/connectors/santander.rs
+++ b/crates/hyperswitch_connectors/src/connectors/santander.rs
@@ -63,7 +63,7 @@ use crate::{
     },
     constants::headers,
     types::{RefreshTokenRouterData, ResponseRouterData},
-    utils::{self as connector_utils, convert_amount},
+    utils::{self as connector_utils, convert_amount, PaymentsAuthorizeRequestData},
 };
 
 #[derive(Clone)]
@@ -584,6 +584,27 @@ impl ConnectorIntegration<SetupMandate, SetupMandateRequestData, PaymentsRespons
     }
 }
 
+fn is_santander_pix_automatico_push_authorize(req: &PaymentsAuthorizeRouterData) -> bool {
+    req.payment_method == enums::PaymentMethod::BankTransfer
+        && req.request.payment_method_type == Some(enums::PaymentMethodType::Pix)
+        && req.request.amount == 0
+        && req.request.setup_future_usage == Some(enums::FutureUsage::OffSession)
+        && req.request.customer_acceptance.is_some()
+        && req.request.setup_mandate_details.is_some()
+        && req.request.mandate_id.is_some()
+        && req.request.payment_experience != Some(enums::PaymentExperience::DisplayQrCode)
+}
+
+fn is_santander_pix_automatico_qr_authorize(req: &PaymentsAuthorizeRouterData) -> bool {
+    req.payment_method == enums::PaymentMethod::BankTransfer
+        && req.request.payment_method_type == Some(enums::PaymentMethodType::Pix)
+        && req.request.payment_experience == Some(enums::PaymentExperience::DisplayQrCode)
+        && (req.request.mandate_id.is_some()
+            || (req.request.amount == 0
+                && req.request.setup_future_usage == Some(enums::FutureUsage::OffSession)
+                && req.request.customer_acceptance.is_some()))
+}
+
 impl ConnectorIntegration<Authorize, PaymentsAuthorizeData, PaymentsResponseData> for Santander {
     fn get_headers(
         &self,
@@ -607,30 +628,41 @@ impl ConnectorIntegration<Authorize, PaymentsAuthorizeData, PaymentsResponseData
         match req.payment_method {
             enums::PaymentMethod::BankTransfer => match req.request.payment_method_type {
                 Some(enums::PaymentMethodType::Pix) => {
-                    match &req
-                        .request
-                        .feature_metadata
-                        .as_ref()
-                        .and_then(|f| f.pix_additional_details.as_ref())
-                    {
-                        Some(api_models::payments::PixAdditionalDetails::Immediate(_immediate)) => {
-                            Ok(format!(
+                    if is_santander_pix_automatico_push_authorize(req) {
+                        Ok(format!("{}api/v1/solicrec", self.base_url(connectors)))
+                    } else if is_santander_pix_automatico_qr_authorize(req) {
+                        Ok(format!(
+                            "{}api/v1/rec/{}?txid={}",
+                            self.base_url(connectors),
+                            req.request.get_connector_mandate_id()?,
+                            req.connector_request_reference_id
+                        ))
+                    } else {
+                        match &req
+                            .request
+                            .feature_metadata
+                            .as_ref()
+                            .and_then(|f| f.pix_additional_details.as_ref())
+                        {
+                            Some(api_models::payments::PixAdditionalDetails::Immediate(
+                                _immediate,
+                            )) => Ok(format!(
                                 "{}api/v1/cob/{}",
                                 self.base_url(connectors),
                                 req.connector_request_reference_id
-                            ))
-                        }
-                        Some(api_models::payments::PixAdditionalDetails::Scheduled(_scheduled)) => {
-                            Ok(format!(
+                            )),
+                            Some(api_models::payments::PixAdditionalDetails::Scheduled(
+                                _scheduled,
+                            )) => Ok(format!(
                                 "{}api/v1/cobv/{}",
                                 self.base_url(connectors),
                                 req.connector_request_reference_id
-                            ))
+                            )),
+                            None => Err(errors::ConnectorError::MissingRequiredField {
+                                field_name: "pix_additional_details",
+                            }
+                            .into()),
                         }
-                        None => Err(errors::ConnectorError::MissingRequiredField {
-                            field_name: "pix_additional_details",
-                        }
-                        .into()),
                     }
                 }
                 _ => Err(errors::ConnectorError::NotSupported {
@@ -676,15 +708,19 @@ impl ConnectorIntegration<Authorize, PaymentsAuthorizeData, PaymentsResponseData
         req: &PaymentsAuthorizeRouterData,
         _connectors: &Connectors,
     ) -> CustomResult<RequestContent, errors::ConnectorError> {
-        let amount = convert_amount(
-            self.amount_converter,
-            req.request.minor_amount,
-            req.request.currency,
-        )?;
+        if is_santander_pix_automatico_qr_authorize(req) {
+            Ok(RequestContent::Json(Box::new(serde_json::json!({}))))
+        } else {
+            let amount = convert_amount(
+                self.amount_converter,
+                req.request.minor_amount,
+                req.request.currency,
+            )?;
 
-        let connector_router_data = SantanderRouterData::from((amount, req));
-        let connector_req = SantanderPaymentRequest::try_from(&connector_router_data)?;
-        Ok(RequestContent::Json(Box::new(connector_req)))
+            let connector_router_data = SantanderRouterData::from((amount, req));
+            let connector_req = SantanderPaymentRequest::try_from(&connector_router_data)?;
+            Ok(RequestContent::Json(Box::new(connector_req)))
+        }
     }
 
     fn build_request(
@@ -695,6 +731,16 @@ impl ConnectorIntegration<Authorize, PaymentsAuthorizeData, PaymentsResponseData
         let auth_details = SantanderAuthType::try_from(&req.connector_auth_type)?;
         let method: Result<Method, error_stack::Report<errors::ConnectorError>> =
             match req.payment_method_type {
+                Some(enums::PaymentMethodType::Pix)
+                    if is_santander_pix_automatico_push_authorize(req) =>
+                {
+                    Ok(Method::Post)
+                }
+                Some(enums::PaymentMethodType::Pix)
+                    if is_santander_pix_automatico_qr_authorize(req) =>
+                {
+                    Ok(Method::Get)
+                }
                 Some(enums::PaymentMethodType::Pix) => Ok(Method::Put),
                 Some(enums::PaymentMethodType::Boleto) => Ok(Method::Post),
                 _ => Err(errors::ConnectorError::NotSupported {
@@ -703,23 +749,25 @@ impl ConnectorIntegration<Authorize, PaymentsAuthorizeData, PaymentsResponseData
                 }
                 .into()),
             };
-        Ok(Some(
-            RequestBuilder::new()
-                .method(method?)
-                .url(&types::PaymentsAuthorizeType::get_url(
-                    self, req, connectors,
-                )?)
-                .add_certificate(Some(auth_details.client_id))
-                .add_certificate_key(Some(auth_details.client_secret))
-                .attach_default_headers()
-                .headers(types::PaymentsAuthorizeType::get_headers(
-                    self, req, connectors,
-                )?)
-                .set_body(types::PaymentsAuthorizeType::get_request_body(
-                    self, req, connectors,
-                )?)
-                .build(),
-        ))
+        let mut request_builder = RequestBuilder::new()
+            .method(method?)
+            .url(&types::PaymentsAuthorizeType::get_url(
+                self, req, connectors,
+            )?)
+            .add_certificate(Some(auth_details.client_id))
+            .add_certificate_key(Some(auth_details.client_secret))
+            .attach_default_headers()
+            .headers(types::PaymentsAuthorizeType::get_headers(
+                self, req, connectors,
+            )?);
+
+        if !is_santander_pix_automatico_qr_authorize(req) {
+            request_builder = request_builder.set_body(
+                types::PaymentsAuthorizeType::get_request_body(self, req, connectors)?,
+            );
+        }
+
+        Ok(Some(request_builder.build()))
     }
 
     fn handle_response(
@@ -733,8 +781,16 @@ impl ConnectorIntegration<Authorize, PaymentsAuthorizeData, PaymentsResponseData
             .parse_struct("Santander PaymentsAuthorizeResponse")
             .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
 
+        let request_amount = convert_amount(
+            self.amount_converter,
+            data.request.minor_amount,
+            data.request.currency,
+        )?;
+
         let original_amount = match response {
             SantanderPaymentsResponse::PixQRCode(ref pix_data) => pix_data.valor.original.clone(),
+            SantanderPaymentsResponse::PixAutomaticoPush(_)
+            | SantanderPaymentsResponse::PixAutomaticoQr(_) => request_amount,
             SantanderPaymentsResponse::Boleto(ref boleto_data) => boleto_data.nominal_value.clone(),
         };
 

--- a/crates/hyperswitch_connectors/src/connectors/santander/requests.rs
+++ b/crates/hyperswitch_connectors/src/connectors/santander/requests.rs
@@ -74,6 +74,14 @@ pub struct PixMetadataObject {
     pub pix_key_type: responses::SantanderPixKeyType,
     pub merchant_name: String,
     pub merchant_city: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub automatico_agencia: Option<Secret<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub automatico_conta: Option<Secret<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub automatico_cnpj: Option<Secret<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub automatico_ispb_participante: Option<Secret<String>>,
 }
 
 pub struct SantanderRouterData<T> {
@@ -208,7 +216,34 @@ pub struct SantanderRefundRequest {
 #[serde(untagged)]
 pub enum SantanderPaymentRequest {
     PixQR(Box<SantanderPixQRPaymentRequest>),
+    PixAutomaticoPush(Box<SantanderPixAutomaticoPushRequest>),
     Boleto(Box<SantanderBoletoPaymentRequest>),
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SantanderPixAutomaticoPushRequest {
+    pub id_rec: String,
+    pub calendario: SantanderPixAutomaticoPushCalendar,
+    pub destinatario: SantanderPixAutomaticoDestinatario,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SantanderPixAutomaticoPushCalendar {
+    pub data_expiracao_solicitacao: String,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SantanderPixAutomaticoDestinatario {
+    pub agencia: Secret<String>,
+    pub conta: Secret<String>,
+    pub ispb_participante: Secret<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cpf: Option<Secret<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cnpj: Option<Secret<String>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/hyperswitch_connectors/src/connectors/santander/responses.rs
+++ b/crates/hyperswitch_connectors/src/connectors/santander/responses.rs
@@ -94,6 +94,8 @@ pub enum SantanderVoidStatus {
 #[serde(untagged)]
 pub enum SantanderPaymentsResponse {
     PixQRCode(Box<SantanderPixQRCodePaymentsResponse>),
+    PixAutomaticoPush(Box<SantanderPixAutomaticoPushResponse>),
+    PixAutomaticoQr(Box<SantanderPixAutomaticoQrResponse>),
     Boleto(Box<SantanderBoletoPaymentsResponse>),
 }
 
@@ -321,7 +323,40 @@ pub struct SantanderCalendarResponse {
 #[serde(untagged)]
 pub enum SantanderPaymentsSyncResponse {
     PixQRCode(Box<SantanderPixQRCodeSyncResponse>),
+    PixAutomaticoQr(Box<SantanderPixAutomaticoQrResponse>),
     Boleto(Box<SantanderBoletoPSyncResponse>),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SantanderPixAutomaticoPushResponse {
+    pub id_solic_rec: String,
+    pub id_rec: String,
+    pub status: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SantanderPixAutomaticoQrResponse {
+    pub id_rec: String,
+    pub status: String,
+    pub loc: Option<SantanderPixAutomaticoQrLocation>,
+    pub dados_qr: Option<SantanderPixAutomaticoQrData>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SantanderPixAutomaticoQrLocation {
+    pub id: i64,
+    pub location: String,
+    pub id_rec: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SantanderPixAutomaticoQrData {
+    pub jornada: String,
+    pub pix_copia_e_cola: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/crates/hyperswitch_connectors/src/connectors/santander/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/santander/transformers.rs
@@ -1,6 +1,6 @@
 use api_models::payments::{QrCodeInformation, SantanderData, VoucherNextStepData};
 use common_enums::{
-    enums, AttemptStatus, BoletoDocumentKind, BoletoPaymentType, ExpiryType, PixKey,
+    enums, AttemptStatus, BoletoDocumentKind, BoletoPaymentType, ExpiryType, FutureUsage, PixKey,
 };
 use common_utils::{
     errors::CustomResult,
@@ -13,7 +13,7 @@ use hyperswitch_domain_models::{
     payment_method_data::{BankTransferData, BoletoVoucherData, PaymentMethodData, VoucherData},
     router_data::{AccessToken, ConnectorAuthType, ErrorResponse, RouterData},
     router_request_types::{PaymentsUpdateMetadataData, ResponseId},
-    router_response_types::{PaymentsResponseData, RefundsResponseData},
+    router_response_types::{MandateReference, PaymentsResponseData, RefundsResponseData},
     types::{
         PaymentsAuthorizeRouterData, PaymentsCancelRouterData, PaymentsSyncRouterData,
         PaymentsUpdateMetadataRouterData, RefundsRouterData,
@@ -35,19 +35,21 @@ use crate::{
             SantanderBoletoCancelRequest, SantanderBoletoPaymentRequest,
             SantanderBoletoUpdateRequest, SantanderDebtor, SantanderGrantType,
             SantanderMetadataObject, SantanderPaymentRequest, SantanderPaymentsCancelRequest,
-            SantanderPixCancelRequest, SantanderPixDueDateCalendarRequest,
-            SantanderPixImmediateCalendarRequest, SantanderPixQRPaymentRequest,
-            SantanderPixRequestCalendar, SantanderRefundRequest, SantanderRouterData,
-            SantanderValue,
+            SantanderPixAutomaticoDestinatario, SantanderPixAutomaticoPushCalendar,
+            SantanderPixAutomaticoPushRequest, SantanderPixCancelRequest,
+            SantanderPixDueDateCalendarRequest, SantanderPixImmediateCalendarRequest,
+            SantanderPixQRPaymentRequest, SantanderPixRequestCalendar, SantanderRefundRequest,
+            SantanderRouterData, SantanderValue,
         },
         responses::{
             Key, NsuComposite, Payer, SanatanderAccessTokenResponse, SanatanderTokenResponse,
             SantanderAdditionalInfo, SantanderBoletoDocumentKind, SantanderBoletoPaymentType,
             SantanderBoletoStatus, SantanderDocumentKind, SantanderPaymentStatus,
-            SantanderPaymentsResponse, SantanderPaymentsSyncResponse, SantanderPixKeyType,
-            SantanderPixQRCodePaymentsResponse, SantanderPixQRCodeSyncResponse,
-            SantanderRefundResponse, SantanderRefundStatus, SantanderUpdateMetadataResponse,
-            SantanderVoidResponse, SantanderVoidStatus,
+            SantanderPaymentsResponse, SantanderPaymentsSyncResponse,
+            SantanderPixAutomaticoPushResponse, SantanderPixAutomaticoQrResponse,
+            SantanderPixKeyType, SantanderPixQRCodePaymentsResponse,
+            SantanderPixQRCodeSyncResponse, SantanderRefundResponse, SantanderRefundStatus,
+            SantanderUpdateMetadataResponse, SantanderVoidResponse, SantanderVoidStatus,
         },
     },
     types::{RefreshTokenRouterData, RefundsResponseRouterData, ResponseRouterData},
@@ -560,13 +562,6 @@ impl
             &BankTransferData,
         ),
     ) -> Result<Self, Self::Error> {
-        let santander_mca_metadata =
-            SantanderMetadataObject::try_from(&value.0.router_data.connector_meta_data)?;
-
-        let pix_mca_metadata = santander_mca_metadata
-            .pix
-            .ok_or(errors::ConnectorError::NoConnectorMetaData)?;
-
         let customer_document_details = value
             .0
             .router_data
@@ -575,6 +570,22 @@ impl
             .ok_or(errors::ConnectorError::MissingRequiredField {
                 field_name: "customer.document_details",
             })?;
+
+        if is_pix_automatico_push_authorize(value.0.router_data) {
+            return build_pix_automatico_push_request(
+                &value.0.router_data.connector_meta_data,
+                value.0.router_data.request.get_connector_mandate_id()?,
+                &customer_document_details,
+            );
+        }
+
+        let santander_mca_metadata =
+            SantanderMetadataObject::try_from(&value.0.router_data.connector_meta_data)?;
+
+        let pix_mca_metadata = santander_mca_metadata
+            .pix
+            .ok_or(errors::ConnectorError::NoConnectorMetaData)?;
+
         let (cpf, cnpj) = match customer_document_details.document_type {
             common_types::customers::DocumentKind::Cpf => {
                 (Some(customer_document_details.document_number), None)
@@ -690,6 +701,67 @@ impl
             info_adicionais,
         })))
     }
+}
+
+fn build_pix_automatico_push_request(
+    connector_meta_data: &Option<common_utils::pii::SecretSerdeValue>,
+    id_rec: String,
+    customer_document_details: &common_types::customers::CustomerDocumentDetails,
+) -> Result<SantanderPaymentRequest, Error> {
+    let santander_mca_metadata = SantanderMetadataObject::try_from(connector_meta_data)?;
+    let pix_metadata = santander_mca_metadata
+        .pix
+        .ok_or(errors::ConnectorError::NoConnectorMetaData)?;
+
+    let agencia =
+        pix_metadata
+            .automatico_agencia
+            .ok_or(errors::ConnectorError::MissingRequiredField {
+                field_name: "connector_metadata.pix.automatico_agencia",
+            })?;
+    let conta =
+        pix_metadata
+            .automatico_conta
+            .ok_or(errors::ConnectorError::MissingRequiredField {
+                field_name: "connector_metadata.pix.automatico_conta",
+            })?;
+    let ispb_participante = pix_metadata.automatico_ispb_participante.ok_or(
+        errors::ConnectorError::MissingRequiredField {
+            field_name: "connector_metadata.pix.automatico_ispb_participante",
+        },
+    )?;
+
+    let (cpf, cnpj) = match customer_document_details.document_type {
+        common_types::customers::DocumentKind::Cpf => (
+            Some(customer_document_details.document_number.clone()),
+            None,
+        ),
+        common_types::customers::DocumentKind::Cnpj => (
+            None,
+            Some(customer_document_details.document_number.clone()),
+        ),
+    };
+
+    let expiry = time::OffsetDateTime::now_utc()
+        .saturating_add(time::Duration::days(3))
+        .format(&time::format_description::well_known::Rfc3339)
+        .change_context(errors::ConnectorError::DateFormattingFailed)?;
+
+    Ok(SantanderPaymentRequest::PixAutomaticoPush(Box::new(
+        SantanderPixAutomaticoPushRequest {
+            id_rec,
+            calendario: SantanderPixAutomaticoPushCalendar {
+                data_expiracao_solicitacao: expiry,
+            },
+            destinatario: SantanderPixAutomaticoDestinatario {
+                agencia,
+                conta,
+                ispb_participante,
+                cpf,
+                cnpj,
+            },
+        },
+    )))
 }
 
 impl From<SantanderPaymentStatus> for AttemptStatus {
@@ -832,6 +904,26 @@ impl<F, T> TryFrom<ResponseRouterData<F, SantanderPaymentsSyncResponse, T, Payme
                     }
                 }
             }
+            SantanderPaymentsSyncResponse::PixAutomaticoQr(qr_data) => Ok(Self {
+                status: AttemptStatus::AuthenticationPending,
+                response: Ok(PaymentsResponseData::TransactionResponse {
+                    resource_id: ResponseId::ConnectorTransactionId(qr_data.id_rec.clone()),
+                    redirection_data: Box::new(None),
+                    mandate_reference: Box::new(Some(MandateReference {
+                        connector_mandate_id: Some(qr_data.id_rec.clone()),
+                        payment_method_id: None,
+                        mandate_metadata: None,
+                        connector_mandate_request_reference_id: Some(qr_data.id_rec.clone()),
+                    })),
+                    connector_metadata: get_pix_automatico_qr_code_data(&qr_data)?,
+                    network_txn_id: None,
+                    connector_response_reference_id: None,
+                    incremental_authorization_allowed: None,
+                    authentication_data: None,
+                    charges: None,
+                }),
+                ..item.data
+            }),
             SantanderPaymentsSyncResponse::Boleto(res) => {
                 let status = res.content.first().map(|data| data.status.clone()).ok_or(
                     errors::ConnectorError::MissingRequiredField {
@@ -928,6 +1020,48 @@ impl<F, T> TryFrom<ResponseRouterData<F, SantanderPaymentsResponse, T, PaymentsR
                     }),
                 }
             }
+            SantanderPaymentsResponse::PixAutomaticoPush(push_data) => Ok(Self {
+                status: AttemptStatus::AuthenticationPending,
+                response: Ok(PaymentsResponseData::TransactionResponse {
+                    resource_id: ResponseId::ConnectorTransactionId(push_data.id_solic_rec.clone()),
+                    redirection_data: Box::new(None),
+                    mandate_reference: Box::new(Some(MandateReference {
+                        connector_mandate_id: Some(push_data.id_rec.clone()),
+                        payment_method_id: None,
+                        mandate_metadata: None,
+                        connector_mandate_request_reference_id: Some(
+                            push_data.id_solic_rec.clone(),
+                        ),
+                    })),
+                    connector_metadata: None,
+                    network_txn_id: None,
+                    connector_response_reference_id: None,
+                    incremental_authorization_allowed: None,
+                    authentication_data: None,
+                    charges: None,
+                }),
+                ..item.data
+            }),
+            SantanderPaymentsResponse::PixAutomaticoQr(qr_data) => Ok(Self {
+                status: AttemptStatus::AuthenticationPending,
+                response: Ok(PaymentsResponseData::TransactionResponse {
+                    resource_id: ResponseId::ConnectorTransactionId(qr_data.id_rec.clone()),
+                    redirection_data: Box::new(None),
+                    mandate_reference: Box::new(Some(MandateReference {
+                        connector_mandate_id: Some(qr_data.id_rec.clone()),
+                        payment_method_id: None,
+                        mandate_metadata: None,
+                        connector_mandate_request_reference_id: Some(qr_data.id_rec.clone()),
+                    })),
+                    connector_metadata: get_pix_automatico_qr_code_data(&qr_data)?,
+                    network_txn_id: None,
+                    connector_response_reference_id: None,
+                    incremental_authorization_allowed: None,
+                    authentication_data: None,
+                    charges: None,
+                }),
+                ..item.data
+            }),
             SantanderPaymentsResponse::Boleto(boleto_data) => {
                 let qr_code_url = if let Some(data) = boleto_data.qr_code_pix.clone() {
                     let qr_image = QrImage::new_from_data(data)
@@ -1081,6 +1215,20 @@ fn extract_bank_number(value: Option<Value>) -> Result<String, errors::Connector
         .ok_or_else(|| errors::ConnectorError::NoConnectorMetaData)?
         .to_string();
     Ok(bank_number_str)
+}
+
+fn get_pix_automatico_qr_code_data(
+    qr_data: &SantanderPixAutomaticoQrResponse,
+) -> CustomResult<Option<Value>, errors::ConnectorError> {
+    let data = qr_data
+        .dados_qr
+        .as_ref()
+        .map(|dados_qr| dados_qr.pix_copia_e_cola.clone())
+        .ok_or(errors::ConnectorError::MissingRequiredField {
+            field_name: "dadosQR.pixCopiaECola",
+        })?;
+
+    convert_pix_data_to_value(data, Some(ExpiryType::Scheduled))
 }
 
 fn get_qr_code_data<F, T>(
@@ -1425,4 +1573,13 @@ pub fn format_as_date_only(
     let format = time::macros::format_description!("[year]-[month]-[day]");
     dt.format(&format)
         .map_err(|_| errors::ConnectorError::ParsingFailed)
+}
+
+fn is_pix_automatico_push_authorize(req: &PaymentsAuthorizeRouterData) -> bool {
+    req.payment_method == enums::PaymentMethod::BankTransfer
+        && req.request.payment_method_type == Some(enums::PaymentMethodType::Pix)
+        && req.request.amount == 0
+        && req.request.setup_future_usage == Some(FutureUsage::OffSession)
+        && req.request.customer_acceptance.is_some()
+        && req.request.setup_mandate_details.is_some()
 }


### PR DESCRIPTION
### Motivation
- Add support for Santander Pix Automático flows (push and QR) so the connector can create automatic payment requests and return QR data/mandate references for downstream processing.  
- Introduce connector metadata needed for automatico flows (agency/account/ispb/cnpj) and wire up request/response parsing for these new endpoints.  

### Description
- Add detection helpers `is_santander_pix_automatico_push_authorize` and `is_santander_pix_automatico_qr_authorize` and use them to pick URL, HTTP method, and whether to include a request body in `Authorize` flow.  
- Extend `requests.rs` with new metadata fields (`automatico_agencia`, `automatico_conta`, `automatico_cnpj`, `automatico_ispb_participante`) and new request types `SantanderPixAutomaticoPushRequest`, `SantanderPixAutomaticoPushCalendar`, and `SantanderPixAutomaticoDestinatario`.  
- Add new response variants and structs in `responses.rs` for `PixAutomaticoPush` and `PixAutomaticoQr` flows and update `SantanderPaymentsResponse`/`SantanderPaymentsSyncResponse` enums to include them.  
- Implement `build_pix_automatico_push_request` and route creation of `PixAutomaticoPush` requests in transformers, including expiry calculation and document handling, and update `TryFrom` implementations to return appropriate `SantanderPaymentRequest` variants.  
- Map new response types to `PaymentsResponseData` in `transformers.rs`, populate `mandate_reference` for automatico flows, and add `get_pix_automatico_qr_code_data` to convert connector QR payload into connector metadata.  
- Update request building in `connectors/santander.rs` to select `POST/PUT/GET` appropriately, avoid sending a body for QR `GET`, and adjust URL routing for `solicrec`, `rec`, `cob`, and `cobv` endpoints.  

### Testing
- Ran connector unit tests with `cargo test -p hyperswitch_connectors` and workspace tests with `cargo test`, and all tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc06655d58832fa0b7bed33770eb37)