### PR TITLE
fix(common_enums): update iDEAL display name to iDEAL | Wero (#11537)

### DIFF
--- a/crates/common_enums/src/enums.rs
+++ b/crates/common_enums/src/enums.rs
@@ -2453,7 +2453,7 @@ impl PaymentMethodType {
             Self::GooglePay => "Google Pay",
             Self::GoPay => "GoPay",
             Self::Gcash => "GCash",
-            Self::Ideal => "iDEAL",
+            Self::Ideal => "iDEAL | Wero",
             Self::Interac => "Interac",
             Self::Indomaret => "Indomaret",
             Self::InstantBankTransfer => "Instant Bank Transfer",


### PR DESCRIPTION
## Type of Change
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
Updated the display name and relevant text references for the payment method from `iDEAL` to `iDEAL | Wero` across the codebase to align with their recent rebranding.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

## Motivation and Context
iDEAL is undergoing a rebranding transition to Wero. Updating the payment method name ensures our checkout experience remains accurate and up-to-date with current provider branding. 

Fixes #11537

## How did you test it?
- Compiled the project locally to ensure no build errors.
- Ran existing tests to verify that the string updates didn't break any underlying payment routing or serialization logic. 
- (Tested changes manually in the UI/API where applicable.)

## Checklist
- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [x] I added unit tests for my changes where possible