### PR TITLE
feat: added locale support for user guidance message to be shown on SDK

### DIFF
--- a/crates/router/src/core/payments/operations/payment_response.rs
+++ b/crates/router/src/core/payments/operations/payment_response.rs
@@ -2098,12 +2098,9 @@ async fn payment_response_update_tracker<F: Clone, T: types::Capturable>(
 
                         // Translate user_guidance_message using standardised_code as the lookup key
                         // in unified_translations table: (standardised_code, user_guidance_message, locale) -> translation
-                        let translated_user_guidance_message = match (
-                            &gsm_standardised_code,
-                            &gsm_user_guidance_message,
-                        ) {
-                            (Some(code), Some(guidance_msg)) => {
-                                locale
+                        let translated_user_guidance_message =
+                            match (&gsm_standardised_code, &gsm_user_guidance_message) {
+                                (Some(code), Some(guidance_msg)) => locale
                                     .as_ref()
                                     .async_and_then(|locale_str| async {
                                         payments_helpers::get_unified_translation(
@@ -2115,10 +2112,9 @@ async fn payment_response_update_tracker<F: Clone, T: types::Capturable>(
                                         .await
                                     })
                                     .await
-                                    .or(gsm_user_guidance_message.clone())
-                            }
-                            _ => gsm_user_guidance_message.clone(),
-                        };
+                                    .or(gsm_user_guidance_message.clone()),
+                                _ => gsm_user_guidance_message.clone(),
+                            };
 
                         let status = match err.attempt_status {
                             // Use the status sent by connector in error_response if it's present


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [X] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
This PR returns the locale specific user_guidance_message in the confirm response.

1. Takes the locale from the Accept-Language header from the confirm request.
2. Takes standardised_code (e.g., "insufficient_funds") and user_guidance_message (English text from GSM)
3. Queries unified_translations table with key: (standardised_code, user_guidance_message, locale)
4. If translation found → returns translated text
5. If NOT found → falls back to original English user_guidance_message


### Additional Changes
- [ ] This PR modifies the API contract - No
- [ ] This PR modifies the database schema - No
- [ ] This PR modifies application configuration/environment variables - No

<!--
Provide links to the files with corresponding changes.
Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->

File location - https://github.com/juspay/hyperswitch/blob/main/crates/router/src/core/payments/operations/payment_response.rs

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->

The motivation for the PR is to provide the end user a user guidance message in the locale langauage sent. This endeavour is to let the user know what the exact payment failure reason was and how they can remedy it and ultimately increase authorization rates.


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

1. Create
```
curl -X POST http://localhost:8080/payments \
  -H "api-key: dev_OfQH" \
  -H "Content-Type: application/json" \
  -H "Accept: application/json" \
  -d '{
    "amount": 2999,
    "currency": "USD",
    "profile_id": "pro_FFqESCHEgUW5sy45ZQRB",
    "confirm": false,
    "capture_method": "automatic",
    "customer_id": "hyperswitch_sdk_demo_id",
    "description": "Test payment",
    "metadata": {
      "udf1": "value1",
      "new_customer": "true"
    }
  }'
```


2. Confirm request
```
curl -X POST "http://localhost:8080/payments/pay_YOUR_PAYMENT_ID/confirm" \
  -H "api-key: pk_dev_6524c450ea2d4fd0b1cbec5c3a398970" \
  -H "Content-Type: application/json" \
  -H "Accept-Language: de" \
  -d '{
    "client_secret": "pay_YOUR_PAYMENT_ID_secret_YOUR_SECRET",
    "payment_method": "card",
    "payment_method_type": "credit",
    "payment_method_data": {
      "card": {
        "card_number": "4000000000009987",
        "card_exp_month": "12",
        "card_exp_year": "2030",
        "card_cvc": "123"
      }
    }
  }'
```

3. Confirm response
```
{
    "payment_id": "pay_56hQaVK2BQqxCjV0hCSD",
    "merchant_id": "merchant_error_banner_test",
    "status": "failed",
    "amount": 2999,
    "net_amount": 2999,
    "shipping_cost": null,
    "amount_capturable": 0,
    "amount_received": null,
    "processor_merchant_id": "merchant_error_banner_test",
    "initiator": null,
    "sdk_authorization": "cHJvZmlsZV9pZD1wcm9fRkZxRVNDSEVnVVc1c3k0NVpRUkIscHVibGlzaGFibGVfa2V5PXBrX2Rldl82NTI0YzQ1MGVhMmQ0ZmQwYjFjYmVjNWMzYTM5ODk3MCxjbGllbnRfc2VjcmV0PXBheV81NmhRYVZLMkJRcXhDalYwaENTRF9zZWNyZXRfWDhidnhEcVVwNkFETDVZSHRtZlksY3VzdG9tZXJfaWQ9aHlwZXJzd2l0Y2hfc2RrX2RlbW9faWQ=",
    "connector": "stripe_test",
    "state_metadata": null,
    "client_secret": "pay_56hQaVK2BQqxCjV0hCSD_secret_X8bvxDqUp6ADL5YHtmfY",
    "error_code": "DC_08",
    "error_message": "Payment declined: Lost card",
    "unified_code": "UE_1000",
    "unified_message": "Payment was declined",
    "error_details": {
        "unified_details": {
            "category": "UE_1000",
            "message": "Payment was declined",
            "standardised_code": "insufficient_funds",
            "description": "Insufficient funds in the account",
            "user_guidance_message": "Unzureichende Mittel. Bitte überprüfen Sie Ihr Guthaben oder verwenden Sie eine andere Zahlungsmethode.",
            "recommended_action": null
        },
        "issuer_details": {
            "code": null,
            "message": null,
            "network_details": {
                "name": null,
                "advice_code": null,
                "advice_message": null
            }
        },
        "connector_details": {
            "code": "DC_08",
            "message": "Payment declined: Lost card",
            "reason": null
        }
    }
}
```

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [X] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
