### PR TITLE
fix(connector): [Nexinets] fix external 3DS request structure for delegated authentication

### DIFF
--- a/crates/hyperswitch_connectors/src/connectors/nexinets/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/nexinets/transformers.rs
@@ -227,20 +227,24 @@ impl TryFrom<&PaymentsAuthorizeRouterData> for NexinetsPaymentsRequest {
             }?,
             _ => None,
         };
-        let meta = item.request.authentication_data.as_ref().map(|auth_data| {
-            NexinetsMeta {
+        let meta = item
+            .request
+            .authentication_data
+            .as_ref()
+            .map(|auth_data| NexinetsMeta {
                 three_ds_data: NexinetsThreeDsData {
                     authentication_value: auth_data.cavv.clone(),
                     eci: auth_data.eci.clone(),
                     transaction_id: auth_data.ds_trans_id.clone(),
-                    version: Some(auth_data
-                        .message_version
-                        .as_ref()
-                        .map(|v| v.to_string())
-                        .unwrap_or_else(|| "2.1.0".to_string())),
+                    version: Some(
+                        auth_data
+                            .message_version
+                            .as_ref()
+                            .map(|v| v.to_string())
+                            .unwrap_or_else(|| "2.1.0".to_string()),
+                    ),
                 },
-            }
-        });
+            });
         Ok(Self {
             initial_amount: item.request.amount,
             currency: item.request.currency,
@@ -679,6 +683,7 @@ fn get_payment_details_and_product(
         | PaymentMethodData::CardToken(_)
         | PaymentMethodData::NetworkToken(_)
         | PaymentMethodData::CardDetailsForNetworkTransactionId(_)
+        | PaymentMethodData::CardWithNetworkTokenDetails(_)
         | PaymentMethodData::CardWithOptionalCVC(_)
         | PaymentMethodData::CardWithLimitedDetails(_)
         | PaymentMethodData::DecryptedWalletTokenDetailsForNetworkTransactionId(_)


### PR DESCRIPTION
## Summary
- Fixes external 3DS (delegated/pre-authenticated) payment flow for the Nexinets (PayEngine) connector
- Changes the 3DS data wrapper from `meta.authenticationResult` to `meta.threeDsData` per PayEngine OpenAPI spec
- Removes unsupported `status` field that caused `Unrecognized field` errors

## Technical Spec

### Problem
When merchants provide pre-authenticated 3DS data via `three_ds_data` in the payment request, Nexinets rejected the request with:
```
Error while creating order: Unrecognized field 'meta.authenticationResult.status'
```

### Root Cause
The PayEngine API's `MetaRequest` object does not have an `authenticationResult` sub-object. For delegated 3DS authentication, the correct wrapper is `threeDsData` (mapped to `ThreeDsMetaRequest` in the OpenAPI spec).

**Previous (incorrect) payload:**
```json
{
  "meta": {
    "authenticationResult": {
      "authenticationValue": "3q2+78r+ur7erb7vyv66vv////8=",
      "eci": "05",
      "transactionId": "c4e59ceb-...",
      "version": "2.1.0",
      "status": "Y"
    }
  }
}
```

**Fixed payload:**
```json
{
  "meta": {
    "threeDsData": {
      "authenticationValue": "3q2+78r+ur7erb7vyv66vv////8=",
      "eci": "05",
      "transactionId": "c4e59ceb-...",
      "version": "2.1.0"
    }
  }
}
```

### Changes
| File | Change |
|------|--------|
| `nexinets/transformers.rs` | Rename `NexinetsMeta.authentication_result` → `three_ds_data` |
| `nexinets/transformers.rs` | Rename struct `NexinetsAuthenticationResult` → `NexinetsThreeDsData` |
| `nexinets/transformers.rs` | Remove unsupported `status` field |
| `nexinets/transformers.rs` | Remove dead `map_nexinets_transaction_status` function |

### Verification
Tested against Nexinets sandbox — payment status: **succeeded**

## Test plan
- [ ] Run external 3DS payment with `three_ds_data` containing CAVV/ECI/dsTransId targeting Nexinets
- [ ] Verify payment succeeds without `Unrecognized field` error
- [ ] Verify non-3DS Nexinets payments still work (no regression)

Fixes #11662