### PR TITLE
fix(typo): correct spelling of 'successful' and 'received' in comments

### DIFF
--- a/crates/hyperswitch_interfaces/src/unified_connector_service/transformers.rs
+++ b/crates/hyperswitch_interfaces/src/unified_connector_service/transformers.rs
@@ -303,7 +303,7 @@ impl ForeignTryFrom<payments_grpc::MandateReference>
                     .connector_mandate_request_reference_id,
             }),
             _ => Err(UnifiedConnectorServiceError::ResponseDeserializationFailed)
-                .attach_printable("Recieved Invalid MandateReference from UCS"),
+                .attach_printable("Received Invalid MandateReference from UCS"),
         }
     }
 }

--- a/crates/router/src/core/payments/flows/authorize_flow.rs
+++ b/crates/router/src/core/payments/flows/authorize_flow.rs
@@ -344,7 +344,7 @@ impl Feature<api::Authorize, types::PaymentsAuthorizeData> for types::PaymentsAu
                         self.request.currency
                     );
                     logger::info!(
-                        "Balance amount and currency recieved from connector : {}, {}",
+                        "Balance amount and currency received from connector : {}, {}",
                         balance,
                         currency
                     );
@@ -376,7 +376,7 @@ impl Feature<api::Authorize, types::PaymentsAuthorizeData> for types::PaymentsAu
                 Err(err) => Err(err.clone()),
             };
             Ok(types::BalanceCheckResult {
-                // Continue with the payment only if ok response is recieved from balance check
+                // Continue with the payment only if ok response is received from balance check
                 should_continue_payment: balance_check_result.is_ok(),
                 balance_check_result,
             })

--- a/crates/router/src/core/payments/flows/complete_authorize_flow.rs
+++ b/crates/router/src/core/payments/flows/complete_authorize_flow.rs
@@ -231,7 +231,7 @@ impl Feature<api::CompleteAuthorize, types::CompleteAuthorizeData>
                         self.request.currency
                     );
                     logger::info!(
-                        "Balance amount and currency recieved from connector : {}, {}",
+                        "Balance amount and currency received from connector : {}, {}",
                         balance,
                         currency
                     );
@@ -263,7 +263,7 @@ impl Feature<api::CompleteAuthorize, types::CompleteAuthorizeData>
                 Err(err) => Err(err.clone()),
             };
             Ok(types::BalanceCheckResult {
-                // Continue with the payment only if ok response is recieved from balance check
+                // Continue with the payment only if ok response is received from balance check
                 should_continue_payment: balance_check_result.is_ok(),
                 balance_check_result,
             })

--- a/crates/router/src/core/payments/flows/setup_mandate_flow.rs
+++ b/crates/router/src/core/payments/flows/setup_mandate_flow.rs
@@ -215,7 +215,7 @@ impl Feature<api::SetupMandate, types::SetupMandateRequestData> for types::Setup
                         self.request.currency
                     );
                     logger::info!(
-                        "Balance amount and currency recieved from connector : {}, {}",
+                        "Balance amount and currency received from connector : {}, {}",
                         balance,
                         currency
                     );
@@ -247,7 +247,7 @@ impl Feature<api::SetupMandate, types::SetupMandateRequestData> for types::Setup
                 Err(err) => Err(err.clone()),
             };
             Ok(types::BalanceCheckResult {
-                // Continue with the payment only if ok response is recieved from balance check
+                // Continue with the payment only if ok response is received from balance check
                 should_continue_payment: balance_check_result.is_ok(),
                 balance_check_result,
             })

--- a/crates/router/src/core/split_payments.rs
+++ b/crates/router/src/core/split_payments.rs
@@ -333,8 +333,8 @@ pub(crate) async fn split_payments_execute_core(
         ))
         .await?;
 
-        // payments_operation_core marks the intent as succeeded when the attempt is succesful
-        // However, for split case, we can't mark the intent as succesful until all the attempts
+        // payments_operation_core marks the intent as succeeded when the attempt is successful
+        // However, for split case, we can't mark the intent as successful until all the attempts
         // have succeeded, so reverting the state of Payment Intent
         if payment_data.payment_intent.is_succeeded() {
             let payment_intent_update =
@@ -425,8 +425,8 @@ pub(crate) async fn split_payments_execute_core(
         ))
         .await?;
 
-        // payments_operation_core marks the intent as succeeded when the attempt is succesful
-        // However, for split case, we can't mark the intent as succesful until all the attempts
+        // payments_operation_core marks the intent as succeeded when the attempt is successful
+        // However, for split case, we can't mark the intent as successful until all the attempts
         // have succeeded, so reverting the state of Payment Intent
         if payment_data.payment_intent.is_succeeded() {
             let payment_intent_update =


### PR DESCRIPTION
## Summary
Fixes typos in code comments across multiple files.

## Changes
- Fixed 'succesful' → 'successful' in split_payments.rs (4 occurrences)
- Fixed 'recieved' → 'received' in payment flows (7 occurrences)

### Files Modified:
- \crates/router/src/core/split_payments.rs\
- \crates/router/src/core/payments/flows/setup_mandate_flow.rs\
- \crates/router/src/core/payments/flows/authorize_flow.rs\
- \crates/router/src/core/payments/flows/complete_authorize_flow.rs\
- \crates/hyperswitch_interfaces/src/unified_connector_service/transformers.rs\

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] I have read the contributing guidelines
- [x] No change in existing business logic or functionality