### PR TITLE
docs(router): add descriptive comment for initialization

### DIFF
--- a/crates/router/src/bin/router.rs
+++ b/crates/router/src/bin/router.rs
@@ -8,6 +8,7 @@ use router::{
 
 #[tokio::main]
 async fn main() -> ApplicationResult<()> {
+    // Initialize the Hyperswitch application
     // get commandline config before initializing config
     let cmd_line = <CmdLineConf as clap::Parser>::parse();
 


### PR DESCRIPTION
Summary: This PR adds a descriptive comment at the beginning of the main() function in crates/router/src/bin/router.rs.

Why is this change necessary? The main entry point of the router is a critical part of the codebase. Adding a clear initialization comment makes it easier for new contributors to understand that the application bootup process is starting from this point. It enhances code readability with zero impact on runtime logic.

Changes:

Added // Initialize the Hyperswitch application comment in crates/router/src/bin/router.rs.