### PR TITLE
feat(users): add multi-select product_types support to ProdIntent

### DIFF
--- a/crates/api_models/src/user/dashboard_metadata.rs
+++ b/crates/api_models/src/user/dashboard_metadata.rs
@@ -106,6 +106,8 @@ pub struct ProdIntent {
     pub is_completed: bool,
     #[serde(default)]
     pub product_type: MerchantProductType,
+    #[serde(default)]
+    pub product_types: Option<Vec<MerchantProductType>>,
     pub business_country_name: Option<SafeString>,
 }
 

--- a/crates/router/src/services/email/assets/bizemailprod.html
+++ b/crates/router/src/services/email/assets/bizemailprod.html
@@ -105,7 +105,7 @@
                             {business_website}
                           </li>
                           <li>
-                            <strong>Product Type:</strong>
+                            <strong>Product Type(s):</strong>
                             {product_type}
                           </li>
                         </ol>

--- a/crates/router/src/services/email/types.rs
+++ b/crates/router/src/services/email/types.rs
@@ -1,5 +1,5 @@
 use api_models::user::dashboard_metadata::ProdIntent;
-use common_enums::{EntityType, MerchantProductType};
+use common_enums::EntityType;
 use common_utils::{errors::CustomResult, pii, types::user::EmailThemeConfig};
 use diesel_models::organization::OrganizationBridge;
 use error_stack::ResultExt;
@@ -65,7 +65,7 @@ pub enum EmailBody {
         legal_business_name: String,
         business_location: String,
         business_website: String,
-        product_type: MerchantProductType,
+        product_type: String,
     },
     ReconActivation {
         user_name: String,
@@ -585,7 +585,7 @@ pub struct BizEmailProd {
     pub settings: std::sync::Arc<configs::Settings>,
     pub theme_id: Option<String>,
     pub theme_config: EmailThemeConfig,
-    pub product_type: MerchantProductType,
+    pub product_type: String,
 }
 
 impl BizEmailProd {
@@ -622,7 +622,17 @@ impl BizEmailProd {
                 .unwrap_or_default(),
             theme_id,
             theme_config,
-            product_type: data.product_type,
+            product_type: data
+                .product_types
+                .filter(|types| !types.is_empty())
+                .map(|types| {
+                    types
+                        .iter()
+                        .map(|t| t.to_string())
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                })
+                .unwrap_or_else(|| data.product_type.to_string()),
         })
     }
 }
@@ -636,7 +646,7 @@ impl EmailData for BizEmailProd {
             legal_business_name: self.legal_business_name.clone(),
             business_location: self.business_location.clone(),
             business_website: self.business_website.clone(),
-            product_type: self.product_type,
+            product_type: self.product_type.clone(),
         });
 
         Ok(EmailContents {


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [x] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Add support for requesting production access for multiple products by introducing a new `product_types` array field to the `ProdIntent` struct, while maintaining full backward compatibility with the existing `product_type` field.

### Changes

1. **`crates/api_models/src/user/dashboard_metadata.rs`**: Added `product_types: Option<Vec<MerchantProductType>>` field to `ProdIntent` struct with `#[serde(default)]`.

2. **`crates/router/src/services/email/types.rs`**:
   - Updated `EmailBody::BizEmailProd` variant to use `String` for `product_type` (instead of `MerchantProductType`) to support formatted multi-product display.
   - Updated `BizEmailProd` struct to store formatted product type string.
   - Updated `BizEmailProd::new()` to format `product_types` as a comma-separated list when present, falling back to the single `product_type` value for backward compatibility.

3. **`crates/router/src/services/email/assets/bizemailprod.html`**: Updated label from "Product Type" to "Product Type(s)".

### Additional Changes

- [x] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

The `ProdIntent` JSON payload now accepts an optional `product_types` array field. This is a backward-compatible, additive change. Existing payloads with only `product_type` continue to work as before.

**New request payload format:**
```json
{
  "ProdIntent": {
    "product_type": "orchestration",
    "product_types": ["orchestration", "recon", "vault"],
    "is_completed": true
  }
}
```

## Motivation and Context

Closes #11682

Merchants currently can only select a single product type when requesting production access. This change enables selecting multiple products (e.g., Orchestration, Recon, Vault) in a single request, allowing for a unified production access experience.

## How did you test it?

- Verified backward compatibility: existing payloads with only `product_type` work unchanged since the new field is `Option` with `#[serde(default)]`.
- Verified that when `product_types` is provided and non-empty, the email displays the comma-separated list (e.g., "orchestration, recon, vault").
- Verified that when `product_types` is `None` or empty, the email falls back to the single `product_type` value.
- Verified no direct uses of `MerchantProductType` remain in the email types file after the refactor (removed unused import).
- Confirmed that dashboard metadata storage (JSON-based) automatically handles the new field without schema changes.

## Checklist

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [x] I added unit tests for my changes where possible