### PR TITLE
fix(connector): [ADYEN] Remove recurringProcessingModel in CIT transactions

### DIFF
--- a/crates/hyperswitch_connectors/src/connectors/adyen/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/adyen/transformers.rs
@@ -2060,31 +2060,52 @@ fn get_recurring_processing_model(
 ) -> Result<RecurringDetails, Error> {
     let shopper_reference = item.get_connector_customer_id().ok();
 
-    match (item.request.setup_future_usage, item.request.off_session) {
-        // Setup for future off-session usage
-        (Some(storage_enums::FutureUsage::OffSession), _) => {
-            let store_payment_method = item.request.is_mandate_payment();
-            let shopper_reference =
-                shopper_reference.ok_or_else(missing_field_err("connector_customer_id"))?;
-            Ok((
-                Some(AdyenRecurringModel::UnscheduledCardOnFile),
-                Some(store_payment_method),
-                Some(shopper_reference),
-            ))
-        }
-        // Off-session payment
-        (_, Some(true)) => {
-            let shopper_reference =
-                shopper_reference.ok_or_else(missing_field_err("connector_customer_id"))?;
-            Ok((
-                Some(AdyenRecurringModel::UnscheduledCardOnFile),
-                None,
-                Some(shopper_reference),
-            ))
-        }
-        // On-session payment
-        _ => Ok((None, None, shopper_reference)),
+    let has_existing_mandate = item
+        .request
+        .mandate_id
+        .as_ref()
+        .and_then(|mandate| mandate.mandate_reference_id.as_ref())
+        .is_some();
+
+    let is_off_session_setup = matches!(
+        item.request.setup_future_usage,
+        Some(storage_enums::FutureUsage::OffSession)
+    );
+
+    let is_off_session_payment = item.request.off_session == Some(true);
+
+    // Case 1: Customer initiated mandate payment
+    if is_off_session_setup && has_existing_mandate {
+        let shopper_reference =
+            shopper_reference.ok_or_else(missing_field_err("connector_customer_id"))?;
+        return Ok((
+            Some(AdyenRecurringModel::UnscheduledCardOnFile),
+            None,
+            Some(shopper_reference),
+        ));
     }
+
+    // Case 2: Setup for future off-session usage
+    if is_off_session_setup {
+        let store_payment_method = item.request.is_mandate_payment();
+        let shopper_reference =
+            shopper_reference.ok_or_else(missing_field_err("connector_customer_id"))?;
+        return Ok((None, Some(store_payment_method), Some(shopper_reference)));
+    }
+
+    // Case 3: Off-session payment
+    if is_off_session_payment {
+        let shopper_reference =
+            shopper_reference.ok_or_else(missing_field_err("connector_customer_id"))?;
+        return Ok((
+            Some(AdyenRecurringModel::UnscheduledCardOnFile),
+            None,
+            Some(shopper_reference),
+        ));
+    }
+
+    // Case 4: On-session payment
+    Ok((None, None, shopper_reference))
 }
 
 fn get_browser_info(item: &PaymentsAuthorizeRouterData) -> Result<Option<AdyenBrowserInfo>, Error> {

--- a/cypress-tests/cypress/e2e/configs/Payment/Adyen.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Adyen.js
@@ -92,6 +92,7 @@ export const connectorDetails = {
     PaymentConfirmWithShippingCost: {
       Request: {
         payment_method: "card",
+        payment_method_type: "credit",
         payment_method_data: {
           card: successfulNo3DSCardDetails,
         },
@@ -112,6 +113,7 @@ export const connectorDetails = {
     "3DSManualCapture": {
       Request: {
         payment_method: "card",
+        payment_method_type: "debit",
         payment_method_data: {
           card: successfulThreeDSTestCardDetails,
         },
@@ -129,6 +131,7 @@ export const connectorDetails = {
     "3DSAutoCapture": {
       Request: {
         payment_method: "card",
+        payment_method_type: "debit",
         payment_method_data: {
           card: successfulThreeDSTestCardDetails,
         },
@@ -146,6 +149,7 @@ export const connectorDetails = {
     No3DSManualCapture: {
       Request: {
         payment_method: "card",
+        payment_method_type: "credit",
         payment_method_data: {
           card: successfulNo3DSCardDetails,
         },
@@ -163,6 +167,7 @@ export const connectorDetails = {
     No3DSAutoCapture: {
       Request: {
         payment_method: "card",
+        payment_method_type: "credit",
         payment_method_data: {
           card: successfulNo3DSCardDetails,
         },
@@ -319,6 +324,7 @@ export const connectorDetails = {
     MandateSingleUse3DSAutoCapture: {
       Request: {
         payment_method: "card",
+        payment_method_type: "debit",
         payment_method_data: {
           card: successfulThreeDSTestCardDetails,
         },
@@ -335,6 +341,7 @@ export const connectorDetails = {
     MandateSingleUse3DSManualCapture: {
       Request: {
         payment_method: "card",
+        payment_method_type: "debit",
         payment_method_data: {
           card: successfulThreeDSTestCardDetails,
         },
@@ -351,6 +358,7 @@ export const connectorDetails = {
     MandateSingleUseNo3DSAutoCapture: {
       Request: {
         payment_method: "card",
+        payment_method_type: "credit",
         payment_method_data: {
           card: successfulNo3DSCardDetails,
         },
@@ -367,6 +375,7 @@ export const connectorDetails = {
     MandateSingleUseNo3DSManualCapture: {
       Request: {
         payment_method: "card",
+        payment_method_type: "credit",
         payment_method_data: {
           card: successfulNo3DSCardDetails,
         },
@@ -383,6 +392,7 @@ export const connectorDetails = {
     MandateMultiUseNo3DSAutoCapture: {
       Request: {
         payment_method: "card",
+        payment_method_type: "credit",
         payment_method_data: {
           card: successfulNo3DSCardDetails,
         },
@@ -399,6 +409,7 @@ export const connectorDetails = {
     MandateMultiUseNo3DSManualCapture: {
       Request: {
         payment_method: "card",
+        payment_method_type: "credit",
         payment_method_data: {
           card: successfulNo3DSCardDetails,
         },
@@ -415,6 +426,7 @@ export const connectorDetails = {
     MandateMultiUse3DSAutoCapture: {
       Request: {
         payment_method: "card",
+        payment_method_type: "debit",
         payment_method_data: {
           card: successfulThreeDSTestCardDetails,
         },
@@ -431,6 +443,7 @@ export const connectorDetails = {
     MandateMultiUse3DSManualCapture: {
       Request: {
         payment_method: "card",
+        payment_method_type: "debit",
         payment_method_data: {
           card: successfulThreeDSTestCardDetails,
         },
@@ -465,6 +478,7 @@ export const connectorDetails = {
     ZeroAuthMandate: {
       Request: {
         payment_method: "card",
+        payment_method_type: "credit",
         payment_method_data: {
           card: successfulNo3DSCardDetails,
         },
@@ -514,6 +528,7 @@ export const connectorDetails = {
     SaveCardUseNo3DSAutoCapture: {
       Request: {
         payment_method: "card",
+        payment_method_type: "credit",
         payment_method_data: {
           card: successfulNo3DSCardDetails,
         },
@@ -566,6 +581,7 @@ export const connectorDetails = {
     SaveCardUseNo3DSManualCaptureOffSession: {
       Request: {
         payment_method: "card",
+        payment_method_type: "credit",
         payment_method_data: {
           card: successfulNo3DSCardDetails,
         },
@@ -604,6 +620,7 @@ export const connectorDetails = {
     SaveCardUseNo3DSManualCapture: {
       Request: {
         payment_method: "card",
+        payment_method_type: "credit",
         payment_method_data: {
           card: successfulNo3DSCardDetails,
         },
@@ -621,6 +638,7 @@ export const connectorDetails = {
     PaymentMethodIdMandateNo3DSAutoCapture: {
       Request: {
         payment_method: "card",
+        payment_method_type: "credit",
         payment_method_data: {
           card: successfulNo3DSCardDetails,
         },
@@ -638,6 +656,7 @@ export const connectorDetails = {
     PaymentMethodIdMandateNo3DSManualCapture: {
       Request: {
         payment_method: "card",
+        payment_method_type: "credit",
         payment_method_data: {
           card: successfulNo3DSCardDetails,
         },
@@ -655,6 +674,7 @@ export const connectorDetails = {
     PaymentMethodIdMandate3DSAutoCapture: {
       Request: {
         payment_method: "card",
+        payment_method_type: "debit",
         payment_method_data: {
           card: successfulThreeDSTestCardDetails,
         },
@@ -673,6 +693,7 @@ export const connectorDetails = {
     PaymentMethodIdMandate3DSManualCapture: {
       Request: {
         payment_method: "card",
+        payment_method_type: "debit",
         payment_method_data: {
           card: successfulThreeDSTestCardDetails,
         },
@@ -690,6 +711,7 @@ export const connectorDetails = {
     ManualRetryPaymentDisabled: {
       Request: {
         payment_method: "card",
+        payment_method_type: "credit",
         payment_method_data: {
           card: successfulNo3DSCardDetails,
         },
@@ -710,6 +732,7 @@ export const connectorDetails = {
     ManualRetryPaymentEnabled: {
       Request: {
         payment_method: "card",
+        payment_method_type: "credit",
         payment_method_data: {
           card: successfulNo3DSCardDetails,
         },
@@ -729,6 +752,7 @@ export const connectorDetails = {
     ManualRetryPaymentCutoffExpired: {
       Request: {
         payment_method: "card",
+        payment_method_type: "credit",
         payment_method_data: {
           card: successfulNo3DSCardDetails,
         },


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Hotfix For: https://github.com/juspay/hyperswitch/pull/11547
This PR resolves an issue where Adyen transactions were being refused with Error 88 ("Cryptographic failure").

Root Cause: In the initial transaction of a mandate setup (Customer Initiated Transaction), Hyperswitch was sending `recurringProcessingModel: UnscheduledCardOnFile`. Adyen has confirmed that this parameter is reserved for Merchant Initiated Transactions (MIT). Including it in a CIT request alongside `shopperInteraction: Ecommerce` leads to a validation failure on Adyen's side.

Changes:
Updated `get_recurring_processing_model` in `adyen/transformers.rs `to return None for the recurring model when the transaction is a setup flow for future off-session usage.
MIT (true off-session) payments remain unaffected and will still correctly send `UnscheduledCardOnFile`.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
https://github.com/juspay/hyperswitch/issues/11511

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
To test this change, perform a card payment with setup_future_usage set to off_session and verify in the connector logs that the recurringProcessingModel parameter is omitted from the outgoing Adyen request payload.
<img width="776" height="1334" alt="image" src="https://github.com/user-attachments/assets/e8db570e-ef44-40ea-93e5-ceddeb12b8bc" />

Payment Request:
```
curl --location 'http://localhost:8080/payments' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: dev_SEleQ6KQxwl0sCABRGH1n6KkMk5ZmuPT7wqeNAinE51jMkOmKORpAq12o8JGEAUS' \
--data-raw '{
    "amount": 6000,
    "currency": "USD",
    "confirm": true,
    "capture_method": "automatic",
    "customer_id": "tester",
    "email": "guest@example.com",
    "name": "John Doe",
    "authentication_type": "no_three_ds",
    "setup_future_usage": "off_session",
    "customer_acceptance": {
        "acceptance_type": "online"
    },
    "payment_method": "card",
    "payment_method_type": "debit",
    "payment_method_data": {
        "card": {
            "card_number": "4111111111111111",
            "card_exp_month": "03",
            "card_exp_year": "30",
            "card_holder_name": "John Doe",
            "card_cvc": "737"
        }
    },
    "billing": {
        "address": {
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "city": "San Fransico",
            "state": "California",
            "zip": "94122",
            "country": "US",
            "first_name": "john",
            "last_name": "doe"
        }
    },
    "browser_info": {
        "ip_address": "129.0.0.1",
        "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
        "accept_header": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8",
        "language": "en-US",
        "color_depth": 32,
        "screen_height": 1117,
        "screen_width": 1728,
        "time_zone": -330,
        "java_enabled": true,
        "java_script_enabled": true
    }
}'
```
<img width="1421" height="145" alt="image" src="https://github.com/user-attachments/assets/625a1977-a544-4346-8d78-9e8896bd1e79" />


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
