### PR TITLE
feat(users): add custom dashboard builder CRUD operations via dashboard_metadata

### DIFF
--- a/crates/api_models/src/user/dashboard_metadata.rs
+++ b/crates/api_models/src/user/dashboard_metadata.rs
@@ -29,6 +29,7 @@ pub enum SetMetaDataRequest {
     IsChangePasswordRequired,
     OnboardingSurvey(OnboardingSurvey),
     ReconStatus(ReconStatus),
+    CustomDashboards(DashboardOperation),
 }
 
 #[derive(Debug, serde::Deserialize, serde::Serialize)]
@@ -141,6 +142,7 @@ pub enum GetMetaDataRequest {
     IsChangePasswordRequired,
     OnboardingSurvey,
     ReconStatus,
+    CustomDashboards,
 }
 
 #[derive(Debug, serde::Deserialize, serde::Serialize)]
@@ -180,4 +182,138 @@ pub enum GetMetaDataResponse {
     IsChangePasswordRequired(bool),
     OnboardingSurvey(Option<OnboardingSurvey>),
     ReconStatus(Option<ReconStatus>),
+    CustomDashboards(Option<Vec<Dashboard>>),
+}
+
+// === Custom Dashboard API Types ===
+
+#[derive(Debug, serde::Deserialize, serde::Serialize)]
+#[serde(tag = "type", content = "data")]
+pub enum DashboardOperation {
+    Create(CreateDashboardRequest),
+    Update(UpdateDashboardRequest),
+    Delete(DeleteDashboardRequest),
+    AddWidget(AddWidgetRequest),
+    UpdateWidget(UpdateWidgetRequest),
+    RemoveWidget(RemoveWidgetRequest),
+    UpdateLayout(UpdateLayoutRequest),
+}
+
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+pub struct CreateDashboardRequest {
+    pub dashboard_name: String,
+    pub description: Option<String>,
+    pub widgets: Option<Vec<WidgetRequest>>,
+}
+
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+pub struct UpdateDashboardRequest {
+    pub dashboard_name: String,
+    pub new_dashboard_name: Option<String>,
+    pub description: Option<String>,
+    pub is_default: Option<bool>,
+}
+
+#[derive(Debug, serde::Deserialize, serde::Serialize)]
+pub struct DeleteDashboardRequest {
+    pub dashboard_name: String,
+}
+
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+pub struct AddWidgetRequest {
+    pub dashboard_name: String,
+    pub widget: WidgetRequest,
+}
+
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+pub struct UpdateWidgetRequest {
+    pub dashboard_name: String,
+    pub widget_id: String,
+    pub widget: WidgetRequest,
+}
+
+#[derive(Debug, serde::Deserialize, serde::Serialize)]
+pub struct RemoveWidgetRequest {
+    pub dashboard_name: String,
+    pub widget_id: String,
+}
+
+#[derive(Debug, serde::Deserialize, serde::Serialize)]
+pub struct UpdateLayoutRequest {
+    pub dashboard_name: String,
+    pub layout: Vec<WidgetLayoutEntry>,
+}
+
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+pub struct WidgetLayoutEntry {
+    pub widget_id: String,
+    pub position: WidgetPosition,
+}
+
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+pub struct WidgetRequest {
+    pub widget_name: String,
+    pub chart_type: ChartType,
+    pub position: WidgetPosition,
+    pub config: WidgetConfig,
+}
+
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ChartType {
+    LineChart,
+    BarChart,
+    ColumnChart,
+    PieChart,
+    StackedBarChart,
+    SankeyChart,
+    FunnelChart,
+}
+
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+pub struct WidgetPosition {
+    pub x: u32,
+    pub y: u32,
+    pub w: u32,
+    pub h: u32,
+}
+
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AnalyticsDomain {
+    Payments,
+    Refunds,
+    Disputes,
+    AuthEvents,
+}
+
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+pub struct WidgetConfig {
+    pub domain: AnalyticsDomain,
+    pub metrics: Vec<String>,
+    #[serde(default)]
+    pub group_by: Vec<String>,
+    #[serde(default)]
+    pub filters: serde_json::Value,
+    pub granularity: Option<String>,
+    pub time_range_preset: Option<String>,
+}
+
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+pub struct Dashboard {
+    pub dashboard_name: String,
+    pub description: Option<String>,
+    pub is_default: bool,
+    pub widgets: Vec<Widget>,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+pub struct Widget {
+    pub widget_id: String,
+    pub widget_name: String,
+    pub chart_type: ChartType,
+    pub position: WidgetPosition,
+    pub config: WidgetConfig,
 }

--- a/crates/api_models/src/user/dashboard_metadata.rs
+++ b/crates/api_models/src/user/dashboard_metadata.rs
@@ -268,6 +268,9 @@ pub enum ChartType {
     StackedBarChart,
     SankeyChart,
     FunnelChart,
+    Table,
+    StatNumber,
+    Gauge,
 }
 
 #[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
@@ -285,6 +288,8 @@ pub enum AnalyticsDomain {
     Refunds,
     Disputes,
     AuthEvents,
+    SmartRetries,
+    Routing,
 }
 
 #[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]

--- a/crates/diesel_models/src/enums.rs
+++ b/crates/diesel_models/src/enums.rs
@@ -237,6 +237,7 @@ pub enum DashboardMetadata {
     IsChangePasswordRequired,
     OnboardingSurvey,
     ReconStatus,
+    CustomDashboards,
 }
 
 #[derive(

--- a/crates/diesel_models/src/query/dashboard_metadata.rs
+++ b/crates/diesel_models/src/query/dashboard_metadata.rs
@@ -82,6 +82,29 @@ impl DashboardMetadata {
         .await
     }
 
+    pub async fn find_org_scoped_dashboard_metadata(
+        conn: &PgPooledConn,
+        user_id: String,
+        org_id: id_type::OrganizationId,
+        entity_type: String,
+        data_types: Vec<enums::DashboardMetadata>,
+    ) -> StorageResult<Vec<Self>> {
+        let predicate = dsl::user_id
+            .eq(user_id)
+            .and(dsl::org_id.eq(org_id))
+            .and(dsl::entity_type.eq(entity_type))
+            .and(dsl::data_key.eq_any(data_types));
+
+        generics::generic_filter::<<Self as HasTable>::Table, _, _, _>(
+            conn,
+            predicate,
+            None,
+            None,
+            Some(dsl::last_modified_at.asc()),
+        )
+        .await
+    }
+
     pub async fn find_merchant_scoped_dashboard_metadata(
         conn: &PgPooledConn,
         merchant_id: id_type::MerchantId,

--- a/crates/diesel_models/src/schema.rs
+++ b/crates/diesel_models/src/schema.rs
@@ -463,6 +463,10 @@ diesel::table! {
         #[max_length = 64]
         last_modified_by -> Varchar,
         last_modified_at -> Timestamp,
+        #[max_length = 64]
+        profile_id -> Nullable<Varchar>,
+        #[max_length = 32]
+        entity_type -> Nullable<Varchar>,
     }
 }
 

--- a/crates/diesel_models/src/user/dashboard_metadata.rs
+++ b/crates/diesel_models/src/user/dashboard_metadata.rs
@@ -18,6 +18,8 @@ pub struct DashboardMetadata {
     pub created_at: PrimitiveDateTime,
     pub last_modified_by: String,
     pub last_modified_at: PrimitiveDateTime,
+    pub profile_id: Option<id_type::ProfileId>,
+    pub entity_type: Option<String>,
 }
 
 #[derive(
@@ -34,6 +36,8 @@ pub struct DashboardMetadataNew {
     pub created_at: PrimitiveDateTime,
     pub last_modified_by: String,
     pub last_modified_at: PrimitiveDateTime,
+    pub profile_id: Option<id_type::ProfileId>,
+    pub entity_type: Option<String>,
 }
 
 #[derive(

--- a/crates/router/src/core/errors/user.rs
+++ b/crates/router/src/core/errors/user.rs
@@ -118,6 +118,18 @@ pub enum UserErrors {
     InvalidEmbeddedOperation(String),
     #[error("Invalid Platform Operation")]
     InvalidPlatformOperation,
+    #[error("MaxDashboardsReached")]
+    MaxDashboardsReached,
+    #[error("DashboardNameAlreadyExists")]
+    DashboardNameAlreadyExists,
+    #[error("DashboardNotFound")]
+    DashboardNotFound,
+    #[error("InvalidDashboardName")]
+    InvalidDashboardName,
+    #[error("MaxWidgetsReached")]
+    MaxWidgetsReached,
+    #[error("WidgetNotFound")]
+    WidgetNotFound,
 }
 
 impl common_utils::errors::ErrorSwitch<api_models::errors::types::ApiErrorResponse> for UserErrors {
@@ -308,6 +320,24 @@ impl common_utils::errors::ErrorSwitch<api_models::errors::types::ApiErrorRespon
             Self::InvalidPlatformOperation => {
                 AER::BadRequest(ApiError::new(sub_code, 61, self.get_error_message(), None))
             }
+            Self::MaxDashboardsReached => {
+                AER::BadRequest(ApiError::new(sub_code, 62, self.get_error_message(), None))
+            }
+            Self::DashboardNameAlreadyExists => {
+                AER::BadRequest(ApiError::new(sub_code, 63, self.get_error_message(), None))
+            }
+            Self::DashboardNotFound => {
+                AER::NotFound(ApiError::new(sub_code, 64, self.get_error_message(), None))
+            }
+            Self::InvalidDashboardName => {
+                AER::BadRequest(ApiError::new(sub_code, 65, self.get_error_message(), None))
+            }
+            Self::MaxWidgetsReached => {
+                AER::BadRequest(ApiError::new(sub_code, 66, self.get_error_message(), None))
+            }
+            Self::WidgetNotFound => {
+                AER::NotFound(ApiError::new(sub_code, 67, self.get_error_message(), None))
+            }
         }
     }
 }
@@ -388,6 +418,20 @@ impl UserErrors {
                 format!("Invalid Embedded Operation: {error_message}")
             }
             Self::InvalidPlatformOperation => "Invalid Platform Operation".to_string(),
+            Self::MaxDashboardsReached => {
+                "Maximum number of dashboards reached (limit: 10)".to_string()
+            }
+            Self::DashboardNameAlreadyExists => {
+                "A dashboard with this name already exists".to_string()
+            }
+            Self::DashboardNotFound => "Dashboard not found".to_string(),
+            Self::InvalidDashboardName => {
+                "The dashboard name cannot be empty or contain only whitespace".to_string()
+            }
+            Self::MaxWidgetsReached => {
+                "Maximum number of widgets per dashboard reached (limit: 20)".to_string()
+            }
+            Self::WidgetNotFound => "Widget not found in this dashboard".to_string(),
         }
     }
 }

--- a/crates/router/src/core/user/dashboard_metadata.rs
+++ b/crates/router/src/core/user/dashboard_metadata.rs
@@ -687,6 +687,7 @@ async fn insert_metadata(
             metadata
         }
         types::MetaData::CustomDashboards(operation) => {
+            let entity_type = utils::get_entity_type_from_role(&user.role_id);
             utils::handle_dashboard_operations(
                 state,
                 user.user_id,
@@ -694,6 +695,7 @@ async fn insert_metadata(
                 user.org_id,
                 metadata_key,
                 operation,
+                entity_type.to_string(),
             )
             .await
         }

--- a/crates/router/src/core/user/dashboard_metadata.rs
+++ b/crates/router/src/core/user/dashboard_metadata.rs
@@ -5,16 +5,20 @@ use diesel_models::{
 };
 use error_stack::{report, ResultExt};
 use hyperswitch_interfaces::crm::CrmPayload;
+#[cfg(feature = "email")]
+use hyperswitch_masking::ExposeInterface;
 use hyperswitch_masking::{PeekInterface, Secret};
 use router_env::logger;
 
 use crate::{
     core::errors::{UserErrors, UserResponse, UserResult},
     routes::{app::ReqState, SessionState},
-    services::{authentication::UserFromToken, ApplicationResponse, authorization::roles},
+    services::{authentication::UserFromToken, ApplicationResponse},
     types::domain::{self, user::dashboard_metadata as types, MerchantKeyStore},
     utils::user::{self as user_utils, dashboard_metadata as utils},
 };
+#[cfg(feature = "email")]
+use crate::{services::email::types as email_types, utils::user::theme as theme_utils};
 
 pub async fn set_metadata(
     state: SessionState,
@@ -682,7 +686,8 @@ async fn insert_metadata(
             metadata
         }
         types::MetaData::CustomDashboards(operation) => {
-            let entity_type = utils::get_entity_type_from_role(&user.role_id);
+            let entity_type =
+                utils::get_entity_type_for_dashboard(state, &user).await?;
             utils::handle_dashboard_operations(
                 state,
                 user.user_id,
@@ -690,7 +695,7 @@ async fn insert_metadata(
                 user.org_id,
                 metadata_key,
                 operation,
-                entity_type.to_string(),
+                entity_type,
             )
             .await
         }
@@ -704,7 +709,7 @@ async fn fetch_metadata(
 ) -> UserResult<Vec<DashboardMetadata>> {
     let mut dashboard_metadata = Vec::with_capacity(metadata_keys.len());
     let (merchant_scoped_enums, user_scoped_enums) =
-        utils::separate_metadata_type_based_on_scope(metadata_keys.clone());
+        utils::separate_metadata_type_based_on_scope(metadata_keys);
 
     if !merchant_scoped_enums.is_empty() {
         let mut res = utils::get_merchant_scoped_metadata_from_db(
@@ -718,49 +723,89 @@ async fn fetch_metadata(
     }
 
     if !user_scoped_enums.is_empty() {
-        let tenant_id = user
-            .tenant_id
-            .clone()
-            .unwrap_or(state.tenant.tenant_id.clone());
-        
-        let role_info = roles::RoleInfo::from_role_id_in_lineage(
-            state,
-            &user.role_id,
-            &user.merchant_id,
-            &user.org_id,
-            &user.profile_id,
-            &tenant_id,
-        )
-        .await
-        .change_context(UserErrors::InternalServerError)
-        .attach_printable("Failed to fetch role info for dashboard metadata")?;
+        // Check if any user-scoped key needs org-level resolution (CustomDashboards)
+        let has_dashboard_key = user_scoped_enums.contains(&DBEnum::CustomDashboards);
 
-        let mut res = match role_info.get_entity_type() {
-            EntityType::Organization => {
-                state
-                    .store
-                    .find_org_scoped_dashboard_metadata(
-                        &user.user_id,
-                        &user.org_id,
-                        "org",
-                        user_scoped_enums,
-                    )
-                    .await
-                    .change_context(UserErrors::InternalServerError)
-                    .attach_printable("Error fetching org-scoped dashboard metadata")?
+        if has_dashboard_key {
+            let entity_type =
+                utils::get_entity_type_for_dashboard(state, user).await?;
+
+            let (dashboard_keys, other_keys): (Vec<_>, Vec<_>) = user_scoped_enums
+                .into_iter()
+                .partition(|k| *k == DBEnum::CustomDashboards);
+
+            // Fetch dashboard metadata with proper scope
+            if !dashboard_keys.is_empty() {
+                let entity_type_str = match entity_type {
+                    EntityType::Organization | EntityType::Tenant => "org",
+                    EntityType::Merchant => "merchant",
+                    EntityType::Profile => "profile",
+                };
+
+                let mut res = match entity_type {
+                    EntityType::Organization | EntityType::Tenant => {
+                        match state
+                            .store
+                            .find_org_scoped_dashboard_metadata(
+                                &user.user_id,
+                                &user.org_id,
+                                entity_type_str,
+                                dashboard_keys,
+                            )
+                            .await
+                        {
+                            Ok(data) => data,
+                            Err(e) => {
+                                if e.current_context().is_db_not_found() {
+                                    vec![]
+                                } else {
+                                    return Err(e
+                                        .change_context(UserErrors::InternalServerError)
+                                        .attach_printable(
+                                            "Error fetching org-scoped dashboard metadata",
+                                        ));
+                                }
+                            }
+                        }
+                    }
+                    _ => {
+                        utils::get_user_scoped_metadata_from_db(
+                            state,
+                            user.user_id.to_owned(),
+                            user.merchant_id.to_owned(),
+                            user.org_id.to_owned(),
+                            dashboard_keys,
+                        )
+                        .await?
+                    }
+                };
+                dashboard_metadata.append(&mut res);
             }
-            _ => {
-                utils::get_user_scoped_metadata_from_db(
+
+            // Fetch remaining user-scoped keys normally
+            if !other_keys.is_empty() {
+                let mut res = utils::get_user_scoped_metadata_from_db(
                     state,
                     user.user_id.to_owned(),
                     user.merchant_id.to_owned(),
                     user.org_id.to_owned(),
-                    user_scoped_enums,
+                    other_keys,
                 )
-                .await?
+                .await?;
+                dashboard_metadata.append(&mut res);
             }
-        };
-        dashboard_metadata.append(&mut res);
+        } else {
+            // No dashboard keys — use standard user-scoped fetch
+            let mut res = utils::get_user_scoped_metadata_from_db(
+                state,
+                user.user_id.to_owned(),
+                user.merchant_id.to_owned(),
+                user.org_id.to_owned(),
+                user_scoped_enums,
+            )
+            .await?;
+            dashboard_metadata.append(&mut res);
+        }
     }
 
     Ok(dashboard_metadata)

--- a/crates/router/src/core/user/dashboard_metadata.rs
+++ b/crates/router/src/core/user/dashboard_metadata.rs
@@ -119,6 +119,9 @@ fn parse_set_request(data_enum: api::SetMetaDataRequest) -> UserResult<types::Me
             Ok(types::MetaData::OnboardingSurvey(req))
         }
         api::SetMetaDataRequest::ReconStatus(req) => Ok(types::MetaData::ReconStatus(req)),
+        api::SetMetaDataRequest::CustomDashboards(operation) => {
+            Ok(types::MetaData::CustomDashboards(operation))
+        }
     }
 }
 
@@ -148,6 +151,7 @@ fn parse_get_request(data_enum: api::GetMetaDataRequest) -> DBEnum {
         api::GetMetaDataRequest::IsChangePasswordRequired => DBEnum::IsChangePasswordRequired,
         api::GetMetaDataRequest::OnboardingSurvey => DBEnum::OnboardingSurvey,
         api::GetMetaDataRequest::ReconStatus => DBEnum::ReconStatus,
+        api::GetMetaDataRequest::CustomDashboards => DBEnum::CustomDashboards,
     }
 }
 
@@ -234,6 +238,33 @@ fn into_response(
         DBEnum::ReconStatus => {
             let resp = utils::deserialize_to_response(data)?;
             Ok(api::GetMetaDataResponse::ReconStatus(resp))
+        }
+        DBEnum::CustomDashboards => {
+            let resp: Option<types::CustomDashboardsValue> =
+                utils::deserialize_to_response(data)?;
+            Ok(api::GetMetaDataResponse::CustomDashboards(resp.map(|d| {
+                d.dashboards
+                    .into_iter()
+                    .map(|db| api::Dashboard {
+                        dashboard_name: db.dashboard_name,
+                        description: db.description,
+                        is_default: db.is_default,
+                        widgets: db
+                            .widgets
+                            .into_iter()
+                            .map(|w| api::Widget {
+                                widget_id: w.widget_id,
+                                widget_name: w.widget_name,
+                                chart_type: w.chart_type,
+                                position: w.position,
+                                config: w.config,
+                            })
+                            .collect(),
+                        created_at: db.created_at,
+                        updated_at: db.updated_at,
+                    })
+                    .collect()
+            })))
         }
     }
 }
@@ -654,6 +685,17 @@ async fn insert_metadata(
                 .await;
             }
             metadata
+        }
+        types::MetaData::CustomDashboards(operation) => {
+            utils::handle_dashboard_operations(
+                state,
+                user.user_id,
+                user.merchant_id,
+                user.org_id,
+                metadata_key,
+                operation,
+            )
+            .await
         }
     }
 }

--- a/crates/router/src/core/user/dashboard_metadata.rs
+++ b/crates/router/src/core/user/dashboard_metadata.rs
@@ -1,25 +1,20 @@
 use api_models::user::dashboard_metadata::{self as api, GetMultipleMetaDataPayload};
-#[cfg(feature = "email")]
 use common_enums::EntityType;
 use diesel_models::{
     enums::DashboardMetadata as DBEnum, user::dashboard_metadata::DashboardMetadata,
 };
 use error_stack::{report, ResultExt};
 use hyperswitch_interfaces::crm::CrmPayload;
-#[cfg(feature = "email")]
-use hyperswitch_masking::ExposeInterface;
 use hyperswitch_masking::{PeekInterface, Secret};
 use router_env::logger;
 
 use crate::{
     core::errors::{UserErrors, UserResponse, UserResult},
     routes::{app::ReqState, SessionState},
-    services::{authentication::UserFromToken, ApplicationResponse},
+    services::{authentication::UserFromToken, ApplicationResponse, authorization::roles},
     types::domain::{self, user::dashboard_metadata as types, MerchantKeyStore},
     utils::user::{self as user_utils, dashboard_metadata as utils},
 };
-#[cfg(feature = "email")]
-use crate::{services::email::types as email_types, utils::user::theme as theme_utils};
 
 pub async fn set_metadata(
     state: SessionState,
@@ -709,7 +704,7 @@ async fn fetch_metadata(
 ) -> UserResult<Vec<DashboardMetadata>> {
     let mut dashboard_metadata = Vec::with_capacity(metadata_keys.len());
     let (merchant_scoped_enums, user_scoped_enums) =
-        utils::separate_metadata_type_based_on_scope(metadata_keys);
+        utils::separate_metadata_type_based_on_scope(metadata_keys.clone());
 
     if !merchant_scoped_enums.is_empty() {
         let mut res = utils::get_merchant_scoped_metadata_from_db(
@@ -723,14 +718,48 @@ async fn fetch_metadata(
     }
 
     if !user_scoped_enums.is_empty() {
-        let mut res = utils::get_user_scoped_metadata_from_db(
+        let tenant_id = user
+            .tenant_id
+            .clone()
+            .unwrap_or(state.tenant.tenant_id.clone());
+        
+        let role_info = roles::RoleInfo::from_role_id_in_lineage(
             state,
-            user.user_id.to_owned(),
-            user.merchant_id.to_owned(),
-            user.org_id.to_owned(),
-            user_scoped_enums,
+            &user.role_id,
+            &user.merchant_id,
+            &user.org_id,
+            &user.profile_id,
+            &tenant_id,
         )
-        .await?;
+        .await
+        .change_context(UserErrors::InternalServerError)
+        .attach_printable("Failed to fetch role info for dashboard metadata")?;
+
+        let mut res = match role_info.get_entity_type() {
+            EntityType::Organization => {
+                state
+                    .store
+                    .find_org_scoped_dashboard_metadata(
+                        &user.user_id,
+                        &user.org_id,
+                        "org",
+                        user_scoped_enums,
+                    )
+                    .await
+                    .change_context(UserErrors::InternalServerError)
+                    .attach_printable("Error fetching org-scoped dashboard metadata")?
+            }
+            _ => {
+                utils::get_user_scoped_metadata_from_db(
+                    state,
+                    user.user_id.to_owned(),
+                    user.merchant_id.to_owned(),
+                    user.org_id.to_owned(),
+                    user_scoped_enums,
+                )
+                .await?
+            }
+        };
         dashboard_metadata.append(&mut res);
     }
 

--- a/crates/router/src/db/dashboard_metadata.rs
+++ b/crates/router/src/db/dashboard_metadata.rs
@@ -210,6 +210,8 @@ impl DashboardMetadataInterface for MockDb {
             created_at: metadata.created_at,
             last_modified_by: metadata.last_modified_by,
             last_modified_at: metadata.last_modified_at,
+            profile_id: metadata.profile_id,
+            entity_type: metadata.entity_type,
         };
         dashboard_metadata.push(metadata_new.clone());
         Ok(metadata_new)

--- a/crates/router/src/db/dashboard_metadata.rs
+++ b/crates/router/src/db/dashboard_metadata.rs
@@ -34,6 +34,14 @@ pub trait DashboardMetadataInterface {
         data_keys: Vec<enums::DashboardMetadata>,
     ) -> CustomResult<Vec<storage::DashboardMetadata>, errors::StorageError>;
 
+    async fn find_org_scoped_dashboard_metadata(
+        &self,
+        user_id: &str,
+        org_id: &id_type::OrganizationId,
+        entity_type: &str,
+        data_keys: Vec<enums::DashboardMetadata>,
+    ) -> CustomResult<Vec<storage::DashboardMetadata>, errors::StorageError>;
+
     async fn find_merchant_scoped_dashboard_metadata(
         &self,
         merchant_id: &id_type::MerchantId,
@@ -110,6 +118,26 @@ impl DashboardMetadataInterface for Store {
             user_id.to_owned(),
             merchant_id.to_owned(),
             org_id.to_owned(),
+            data_keys,
+        )
+        .await
+        .map_err(|error| report!(errors::StorageError::from(error)))
+    }
+
+    #[instrument(skip_all)]
+    async fn find_org_scoped_dashboard_metadata(
+        &self,
+        user_id: &str,
+        org_id: &id_type::OrganizationId,
+        entity_type: &str,
+        data_keys: Vec<enums::DashboardMetadata>,
+    ) -> CustomResult<Vec<storage::DashboardMetadata>, errors::StorageError> {
+        let conn = connection::pg_accounts_connection_read(self).await?;
+        storage::DashboardMetadata::find_org_scoped_dashboard_metadata(
+            &conn,
+            user_id.to_owned(),
+            org_id.to_owned(),
+            entity_type.to_owned(),
             data_keys,
         )
         .await
@@ -285,6 +313,39 @@ impl DashboardMetadataInterface for MockDb {
         Ok(query_result)
     }
 
+    async fn find_org_scoped_dashboard_metadata(
+        &self,
+        user_id: &str,
+        org_id: &id_type::OrganizationId,
+        entity_type: &str,
+        data_keys: Vec<enums::DashboardMetadata>,
+    ) -> CustomResult<Vec<storage::DashboardMetadata>, errors::StorageError> {
+        let dashboard_metadata = self.dashboard_metadata.lock().await;
+        let query_result = dashboard_metadata
+            .iter()
+            .filter(|metadata_inner| {
+                metadata_inner
+                    .user_id
+                    .clone()
+                    .map(|user_id_inner| user_id_inner == user_id)
+                    .unwrap_or(false)
+                    && metadata_inner.org_id == *org_id
+                    && metadata_inner.entity_type.as_deref() == Some(entity_type)
+                    && data_keys.contains(&metadata_inner.data_key)
+            })
+            .cloned()
+            .collect::<Vec<storage::DashboardMetadata>>();
+
+        if query_result.is_empty() {
+            return Err(errors::StorageError::ValueNotFound(format!(
+                "No dashboard_metadata available for user_id = {user_id},\
+                org_id = {org_id:?}, entity_type = {entity_type:?} and data_keys = {data_keys:?}",
+            ))
+            .into());
+        }
+        Ok(query_result)
+    }
+
     async fn find_merchant_scoped_dashboard_metadata(
         &self,
         merchant_id: &id_type::MerchantId,
@@ -311,6 +372,7 @@ impl DashboardMetadataInterface for MockDb {
         }
         Ok(query_result)
     }
+
     async fn delete_all_user_scoped_dashboard_metadata_by_merchant_id(
         &self,
         user_id: &str,

--- a/crates/router/src/db/kafka_store.rs
+++ b/crates/router/src/db/kafka_store.rs
@@ -3623,6 +3623,18 @@ impl DashboardMetadataInterface for KafkaStore {
             .await
     }
 
+    async fn find_org_scoped_dashboard_metadata(
+        &self,
+        user_id: &str,
+        org_id: &id_type::OrganizationId,
+        entity_type: &str,
+        data_keys: Vec<enums::DashboardMetadata>,
+    ) -> CustomResult<Vec<storage::DashboardMetadata>, errors::StorageError> {
+        self.diesel_store
+            .find_org_scoped_dashboard_metadata(user_id, org_id, entity_type, data_keys)
+            .await
+    }
+
     async fn find_merchant_scoped_dashboard_metadata(
         &self,
         merchant_id: &id_type::MerchantId,

--- a/crates/router/src/types/domain/user/dashboard_metadata.rs
+++ b/crates/router/src/types/domain/user/dashboard_metadata.rs
@@ -28,6 +28,7 @@ pub enum MetaData {
     IsChangePasswordRequired(bool),
     OnboardingSurvey(api::OnboardingSurvey),
     ReconStatus(api::ReconStatus),
+    CustomDashboards(api::DashboardOperation),
 }
 
 impl From<&MetaData> for DBEnum {
@@ -57,6 +58,7 @@ impl From<&MetaData> for DBEnum {
             MetaData::IsChangePasswordRequired(_) => Self::IsChangePasswordRequired,
             MetaData::OnboardingSurvey(_) => Self::OnboardingSurvey,
             MetaData::ReconStatus(_) => Self::ReconStatus,
+            MetaData::CustomDashboards(_) => Self::CustomDashboards,
         }
     }
 }
@@ -65,4 +67,28 @@ pub struct ProductionAgreementValue {
     pub version: String,
     pub ip_address: Secret<String, common_utils::pii::IpAddress>,
     pub timestamp: PrimitiveDateTime,
+}
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+pub struct CustomDashboardsValue {
+    pub dashboards: Vec<DashboardV1>,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct DashboardV1 {
+    pub dashboard_name: String,
+    pub description: Option<String>,
+    pub is_default: bool,
+    pub widgets: Vec<WidgetV1>,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct WidgetV1 {
+    pub widget_id: String,
+    pub widget_name: String,
+    pub chart_type: api::ChartType,
+    pub position: api::WidgetPosition,
+    pub config: api::WidgetConfig,
 }

--- a/crates/router/src/utils/user/dashboard_metadata.rs
+++ b/crates/router/src/utils/user/dashboard_metadata.rs
@@ -2,7 +2,8 @@ use std::{net::IpAddr, ops::Not, str::FromStr};
 
 use actix_web::http::header::HeaderMap;
 use api_models::user::dashboard_metadata::{
-    GetMetaDataRequest, GetMultipleMetaDataPayload, ProdIntent, SetMetaDataRequest,
+    DashboardOperation, GetMetaDataRequest, GetMultipleMetaDataPayload, ProdIntent,
+    SetMetaDataRequest,
 };
 use common_utils::id_type;
 use diesel_models::{
@@ -15,8 +16,13 @@ use router_env::logger;
 
 use crate::{
     core::errors::{UserErrors, UserResult},
-    headers, SessionState,
+    headers,
+    types::domain::user::dashboard_metadata as types,
+    SessionState,
 };
+
+pub const MAX_DASHBOARDS: usize = 10;
+pub const MAX_WIDGETS_PER_DASHBOARD: usize = 20;
 
 pub async fn insert_merchant_scoped_metadata_to_db(
     state: &SessionState,
@@ -220,7 +226,9 @@ pub fn separate_metadata_type_based_on_scope(
             | DBEnum::IsMultipleConfiguration
             | DBEnum::ReconStatus
             | DBEnum::ProdIntent => merchant_scoped.push(key),
-            DBEnum::Feedback | DBEnum::IsChangePasswordRequired => user_scoped.push(key),
+            DBEnum::Feedback | DBEnum::IsChangePasswordRequired | DBEnum::CustomDashboards => {
+                user_scoped.push(key)
+            }
         }
     }
     (merchant_scoped, user_scoped)
@@ -302,4 +310,417 @@ pub fn is_prod_email_required(data: &ProdIntent, user_email: String) -> bool {
     }
 
     poc_email_check && business_website_check && user_email_check
+}
+
+// === Custom Dashboard Operations ===
+
+/// Generic fetch-transform-persist for user-scoped dashboard metadata.
+pub async fn modify_dashboard_metadata<T, F>(
+    state: &SessionState,
+    user_id: String,
+    merchant_id: id_type::MerchantId,
+    org_id: id_type::OrganizationId,
+    metadata_key: DBEnum,
+    transform: F,
+) -> UserResult<DashboardMetadata>
+where
+    T: serde::Serialize + serde::de::DeserializeOwned,
+    F: FnOnce(Option<T>) -> UserResult<T>,
+{
+    let existing = state
+        .store
+        .find_user_scoped_dashboard_metadata(
+            &user_id,
+            &merchant_id,
+            &org_id,
+            vec![metadata_key],
+        )
+        .await
+        .change_context(UserErrors::InternalServerError)
+        .attach_printable("Error fetching dashboard metadata")?;
+
+    let existing_record = existing.first();
+
+    let existing_value: Option<T> = existing_record
+        .map(|m| serde_json::from_value(m.data_value.clone().expose()))
+        .transpose()
+        .change_context(UserErrors::InternalServerError)
+        .attach_printable("Error deserializing dashboard metadata")?;
+
+    let updated_value = transform(existing_value)?;
+    let data_value = serde_json::to_value(&updated_value)
+        .change_context(UserErrors::InternalServerError)
+        .attach_printable("Error serializing dashboard metadata")?;
+
+    match existing_record {
+        Some(_) => state
+            .store
+            .update_metadata(
+                Some(user_id.clone()),
+                merchant_id,
+                org_id,
+                metadata_key,
+                DashboardMetadataUpdate::UpdateData {
+                    data_key: metadata_key,
+                    data_value: Secret::new(data_value),
+                    last_modified_by: user_id,
+                },
+            )
+            .await
+            .change_context(UserErrors::InternalServerError)
+            .attach_printable("Error updating dashboard metadata"),
+        None => {
+            let now = common_utils::date_time::now();
+            state
+                .store
+                .insert_metadata(DashboardMetadataNew {
+                    user_id: Some(user_id.clone()),
+                    merchant_id,
+                    org_id,
+                    data_key: metadata_key,
+                    data_value: Secret::new(data_value),
+                    created_by: user_id.clone(),
+                    created_at: now,
+                    last_modified_by: user_id,
+                    last_modified_at: now,
+                })
+                .await
+                .change_context(UserErrors::InternalServerError)
+                .attach_printable("Error inserting dashboard metadata")
+        }
+    }
+}
+
+pub async fn handle_dashboard_operations(
+    state: &SessionState,
+    user_id: String,
+    merchant_id: id_type::MerchantId,
+    org_id: id_type::OrganizationId,
+    metadata_key: DBEnum,
+    operation: DashboardOperation,
+) -> UserResult<DashboardMetadata> {
+    match operation {
+        DashboardOperation::Create(request) => {
+            create_dashboard(state, user_id, merchant_id, org_id, metadata_key, request).await
+        }
+        DashboardOperation::Update(request) => {
+            update_dashboard(state, user_id, merchant_id, org_id, metadata_key, request).await
+        }
+        DashboardOperation::Delete(request) => {
+            delete_dashboard(state, user_id, merchant_id, org_id, metadata_key, request).await
+        }
+        DashboardOperation::AddWidget(request) => {
+            add_widget(state, user_id, merchant_id, org_id, metadata_key, request).await
+        }
+        DashboardOperation::UpdateWidget(request) => {
+            update_widget(state, user_id, merchant_id, org_id, metadata_key, request).await
+        }
+        DashboardOperation::RemoveWidget(request) => {
+            remove_widget(state, user_id, merchant_id, org_id, metadata_key, request).await
+        }
+        DashboardOperation::UpdateLayout(request) => {
+            update_layout(state, user_id, merchant_id, org_id, metadata_key, request).await
+        }
+    }
+}
+
+async fn create_dashboard(
+    state: &SessionState,
+    user_id: String,
+    merchant_id: id_type::MerchantId,
+    org_id: id_type::OrganizationId,
+    metadata_key: DBEnum,
+    request: api_models::user::dashboard_metadata::CreateDashboardRequest,
+) -> UserResult<DashboardMetadata> {
+    if request.dashboard_name.trim().is_empty() {
+        return Err(report!(UserErrors::InvalidDashboardName))
+            .attach_printable("Dashboard name cannot be empty");
+    }
+
+    let now = common_utils::date_time::now();
+    let widgets: Vec<types::WidgetV1> = request
+        .widgets
+        .unwrap_or_default()
+        .into_iter()
+        .map(|w| types::WidgetV1 {
+            widget_id: uuid::Uuid::new_v4().to_string(),
+            widget_name: w.widget_name,
+            chart_type: w.chart_type,
+            position: w.position,
+            config: w.config,
+        })
+        .collect();
+
+    let new_dashboard = types::DashboardV1 {
+        dashboard_name: request.dashboard_name.clone(),
+        description: request.description,
+        is_default: false,
+        widgets,
+        created_at: now.to_string(),
+        updated_at: now.to_string(),
+    };
+
+    modify_dashboard_metadata(
+        state,
+        user_id,
+        merchant_id,
+        org_id,
+        metadata_key,
+        |existing: Option<types::CustomDashboardsValue>| {
+            let mut data = existing.unwrap_or(types::CustomDashboardsValue {
+                dashboards: vec![],
+            });
+
+            if data.dashboards.len() >= MAX_DASHBOARDS {
+                return Err(report!(UserErrors::MaxDashboardsReached));
+            }
+
+            if data
+                .dashboards
+                .iter()
+                .any(|d| d.dashboard_name == request.dashboard_name)
+            {
+                return Err(report!(UserErrors::DashboardNameAlreadyExists));
+            }
+
+            data.dashboards.push(new_dashboard);
+            Ok(data)
+        },
+    )
+    .await
+}
+
+async fn update_dashboard(
+    state: &SessionState,
+    user_id: String,
+    merchant_id: id_type::MerchantId,
+    org_id: id_type::OrganizationId,
+    metadata_key: DBEnum,
+    request: api_models::user::dashboard_metadata::UpdateDashboardRequest,
+) -> UserResult<DashboardMetadata> {
+    modify_dashboard_metadata(
+        state,
+        user_id,
+        merchant_id,
+        org_id,
+        metadata_key,
+        |existing: Option<types::CustomDashboardsValue>| {
+            let mut data = existing.ok_or(report!(UserErrors::DashboardNotFound))?;
+
+            // Check for duplicate name before mutable borrow
+            if let Some(ref new_name) = request.new_dashboard_name {
+                if new_name.trim().is_empty() {
+                    return Err(report!(UserErrors::InvalidDashboardName));
+                }
+                if data.dashboards.iter().any(|d| {
+                    d.dashboard_name == *new_name && d.dashboard_name != request.dashboard_name
+                }) {
+                    return Err(report!(UserErrors::DashboardNameAlreadyExists));
+                }
+            }
+
+            if request.is_default == Some(true) {
+                for d in &mut data.dashboards {
+                    d.is_default = false;
+                }
+            }
+
+            let dashboard = data
+                .dashboards
+                .iter_mut()
+                .find(|d| d.dashboard_name == request.dashboard_name)
+                .ok_or(report!(UserErrors::DashboardNotFound))?;
+
+            if let Some(ref new_name) = request.new_dashboard_name {
+                dashboard.dashboard_name = new_name.clone();
+            }
+            if let Some(desc) = request.description {
+                dashboard.description = Some(desc);
+            }
+            if let Some(is_default) = request.is_default {
+                dashboard.is_default = is_default;
+            }
+            dashboard.updated_at = common_utils::date_time::now().to_string();
+
+            Ok(data)
+        },
+    )
+    .await
+}
+
+async fn delete_dashboard(
+    state: &SessionState,
+    user_id: String,
+    merchant_id: id_type::MerchantId,
+    org_id: id_type::OrganizationId,
+    metadata_key: DBEnum,
+    request: api_models::user::dashboard_metadata::DeleteDashboardRequest,
+) -> UserResult<DashboardMetadata> {
+    modify_dashboard_metadata(
+        state,
+        user_id,
+        merchant_id,
+        org_id,
+        metadata_key,
+        |existing: Option<types::CustomDashboardsValue>| {
+            let mut data = existing.ok_or(report!(UserErrors::DashboardNotFound))?;
+            let initial_len = data.dashboards.len();
+            data.dashboards
+                .retain(|d| d.dashboard_name != request.dashboard_name);
+            if data.dashboards.len() == initial_len {
+                return Err(report!(UserErrors::DashboardNotFound));
+            }
+            Ok(data)
+        },
+    )
+    .await
+}
+
+async fn add_widget(
+    state: &SessionState,
+    user_id: String,
+    merchant_id: id_type::MerchantId,
+    org_id: id_type::OrganizationId,
+    metadata_key: DBEnum,
+    request: api_models::user::dashboard_metadata::AddWidgetRequest,
+) -> UserResult<DashboardMetadata> {
+    modify_dashboard_metadata(
+        state,
+        user_id,
+        merchant_id,
+        org_id,
+        metadata_key,
+        |existing: Option<types::CustomDashboardsValue>| {
+            let mut data = existing.ok_or(report!(UserErrors::DashboardNotFound))?;
+            let dashboard = data
+                .dashboards
+                .iter_mut()
+                .find(|d| d.dashboard_name == request.dashboard_name)
+                .ok_or(report!(UserErrors::DashboardNotFound))?;
+
+            if dashboard.widgets.len() >= MAX_WIDGETS_PER_DASHBOARD {
+                return Err(report!(UserErrors::MaxWidgetsReached));
+            }
+
+            dashboard.widgets.push(types::WidgetV1 {
+                widget_id: uuid::Uuid::new_v4().to_string(),
+                widget_name: request.widget.widget_name,
+                chart_type: request.widget.chart_type,
+                position: request.widget.position,
+                config: request.widget.config,
+            });
+            dashboard.updated_at = common_utils::date_time::now().to_string();
+            Ok(data)
+        },
+    )
+    .await
+}
+
+async fn update_widget(
+    state: &SessionState,
+    user_id: String,
+    merchant_id: id_type::MerchantId,
+    org_id: id_type::OrganizationId,
+    metadata_key: DBEnum,
+    request: api_models::user::dashboard_metadata::UpdateWidgetRequest,
+) -> UserResult<DashboardMetadata> {
+    modify_dashboard_metadata(
+        state,
+        user_id,
+        merchant_id,
+        org_id,
+        metadata_key,
+        |existing: Option<types::CustomDashboardsValue>| {
+            let mut data = existing.ok_or(report!(UserErrors::DashboardNotFound))?;
+            let dashboard = data
+                .dashboards
+                .iter_mut()
+                .find(|d| d.dashboard_name == request.dashboard_name)
+                .ok_or(report!(UserErrors::DashboardNotFound))?;
+            let widget = dashboard
+                .widgets
+                .iter_mut()
+                .find(|w| w.widget_id == request.widget_id)
+                .ok_or(report!(UserErrors::WidgetNotFound))?;
+            widget.widget_name = request.widget.widget_name;
+            widget.chart_type = request.widget.chart_type;
+            widget.position = request.widget.position;
+            widget.config = request.widget.config;
+            dashboard.updated_at = common_utils::date_time::now().to_string();
+            Ok(data)
+        },
+    )
+    .await
+}
+
+async fn remove_widget(
+    state: &SessionState,
+    user_id: String,
+    merchant_id: id_type::MerchantId,
+    org_id: id_type::OrganizationId,
+    metadata_key: DBEnum,
+    request: api_models::user::dashboard_metadata::RemoveWidgetRequest,
+) -> UserResult<DashboardMetadata> {
+    modify_dashboard_metadata(
+        state,
+        user_id,
+        merchant_id,
+        org_id,
+        metadata_key,
+        |existing: Option<types::CustomDashboardsValue>| {
+            let mut data = existing.ok_or(report!(UserErrors::DashboardNotFound))?;
+            let dashboard = data
+                .dashboards
+                .iter_mut()
+                .find(|d| d.dashboard_name == request.dashboard_name)
+                .ok_or(report!(UserErrors::DashboardNotFound))?;
+            let initial_len = dashboard.widgets.len();
+            dashboard
+                .widgets
+                .retain(|w| w.widget_id != request.widget_id);
+            if dashboard.widgets.len() == initial_len {
+                return Err(report!(UserErrors::WidgetNotFound));
+            }
+            dashboard.updated_at = common_utils::date_time::now().to_string();
+            Ok(data)
+        },
+    )
+    .await
+}
+
+async fn update_layout(
+    state: &SessionState,
+    user_id: String,
+    merchant_id: id_type::MerchantId,
+    org_id: id_type::OrganizationId,
+    metadata_key: DBEnum,
+    request: api_models::user::dashboard_metadata::UpdateLayoutRequest,
+) -> UserResult<DashboardMetadata> {
+    modify_dashboard_metadata(
+        state,
+        user_id,
+        merchant_id,
+        org_id,
+        metadata_key,
+        |existing: Option<types::CustomDashboardsValue>| {
+            let mut data = existing.ok_or(report!(UserErrors::DashboardNotFound))?;
+            let dashboard = data
+                .dashboards
+                .iter_mut()
+                .find(|d| d.dashboard_name == request.dashboard_name)
+                .ok_or(report!(UserErrors::DashboardNotFound))?;
+            for entry in &request.layout {
+                if let Some(widget) = dashboard
+                    .widgets
+                    .iter_mut()
+                    .find(|w| w.widget_id == entry.widget_id)
+                {
+                    widget.position = entry.position.clone();
+                }
+            }
+            dashboard.updated_at = common_utils::date_time::now().to_string();
+            Ok(data)
+        },
+    )
+    .await
 }

--- a/crates/router/src/utils/user/dashboard_metadata.rs
+++ b/crates/router/src/utils/user/dashboard_metadata.rs
@@ -24,6 +24,16 @@ use crate::{
 pub const MAX_DASHBOARDS: usize = 10;
 pub const MAX_WIDGETS_PER_DASHBOARD: usize = 20;
 
+/// Maps role_id to entity_type for custom dashboard scoping
+pub fn get_entity_type_from_role(role_id: &str) -> &'static str {
+    match role_id {
+        "org_admin" => "org",
+        "merchant_admin" => "merchant", 
+        "profile_admin" | "profile_user" => "profile",
+        _ => "user",
+    }
+}
+
 pub async fn insert_merchant_scoped_metadata_to_db(
     state: &SessionState,
     user_id: String,
@@ -48,6 +58,8 @@ pub async fn insert_merchant_scoped_metadata_to_db(
             created_at: now,
             last_modified_by: user_id,
             last_modified_at: now,
+            profile_id: None,
+            entity_type: None,
         })
         .await
         .map_err(|e| {
@@ -81,6 +93,8 @@ pub async fn insert_user_scoped_metadata_to_db(
             created_at: now,
             last_modified_by: user_id,
             last_modified_at: now,
+            profile_id: None,
+            entity_type: None,
         })
         .await
         .map_err(|e| {
@@ -321,6 +335,7 @@ pub async fn modify_dashboard_metadata<T, F>(
     merchant_id: id_type::MerchantId,
     org_id: id_type::OrganizationId,
     metadata_key: DBEnum,
+    entity_type: String,
     transform: F,
 ) -> UserResult<DashboardMetadata>
 where
@@ -383,6 +398,8 @@ where
                     created_at: now,
                     last_modified_by: user_id,
                     last_modified_at: now,
+                    profile_id: None,
+                    entity_type: Some(entity_type),
                 })
                 .await
                 .change_context(UserErrors::InternalServerError)
@@ -398,28 +415,29 @@ pub async fn handle_dashboard_operations(
     org_id: id_type::OrganizationId,
     metadata_key: DBEnum,
     operation: DashboardOperation,
+    entity_type: String,
 ) -> UserResult<DashboardMetadata> {
     match operation {
         DashboardOperation::Create(request) => {
-            create_dashboard(state, user_id, merchant_id, org_id, metadata_key, request).await
+            create_dashboard(state, user_id, merchant_id, org_id, metadata_key, request, entity_type).await
         }
         DashboardOperation::Update(request) => {
-            update_dashboard(state, user_id, merchant_id, org_id, metadata_key, request).await
+            update_dashboard(state, user_id, merchant_id, org_id, metadata_key, request, entity_type).await
         }
         DashboardOperation::Delete(request) => {
-            delete_dashboard(state, user_id, merchant_id, org_id, metadata_key, request).await
+            delete_dashboard(state, user_id, merchant_id, org_id, metadata_key, request, entity_type).await
         }
         DashboardOperation::AddWidget(request) => {
-            add_widget(state, user_id, merchant_id, org_id, metadata_key, request).await
+            add_widget(state, user_id, merchant_id, org_id, metadata_key, request, entity_type).await
         }
         DashboardOperation::UpdateWidget(request) => {
-            update_widget(state, user_id, merchant_id, org_id, metadata_key, request).await
+            update_widget(state, user_id, merchant_id, org_id, metadata_key, request, entity_type).await
         }
         DashboardOperation::RemoveWidget(request) => {
-            remove_widget(state, user_id, merchant_id, org_id, metadata_key, request).await
+            remove_widget(state, user_id, merchant_id, org_id, metadata_key, request, entity_type).await
         }
         DashboardOperation::UpdateLayout(request) => {
-            update_layout(state, user_id, merchant_id, org_id, metadata_key, request).await
+            update_layout(state, user_id, merchant_id, org_id, metadata_key, request, entity_type).await
         }
     }
 }
@@ -431,6 +449,7 @@ async fn create_dashboard(
     org_id: id_type::OrganizationId,
     metadata_key: DBEnum,
     request: api_models::user::dashboard_metadata::CreateDashboardRequest,
+    entity_type: String,
 ) -> UserResult<DashboardMetadata> {
     if request.dashboard_name.trim().is_empty() {
         return Err(report!(UserErrors::InvalidDashboardName))
@@ -466,6 +485,7 @@ async fn create_dashboard(
         merchant_id,
         org_id,
         metadata_key,
+        entity_type,
         |existing: Option<types::CustomDashboardsValue>| {
             let mut data = existing.unwrap_or(types::CustomDashboardsValue {
                 dashboards: vec![],
@@ -497,6 +517,7 @@ async fn update_dashboard(
     org_id: id_type::OrganizationId,
     metadata_key: DBEnum,
     request: api_models::user::dashboard_metadata::UpdateDashboardRequest,
+    entity_type: String,
 ) -> UserResult<DashboardMetadata> {
     modify_dashboard_metadata(
         state,
@@ -504,10 +525,10 @@ async fn update_dashboard(
         merchant_id,
         org_id,
         metadata_key,
+        entity_type,
         |existing: Option<types::CustomDashboardsValue>| {
             let mut data = existing.ok_or(report!(UserErrors::DashboardNotFound))?;
 
-            // Check for duplicate name before mutable borrow
             if let Some(ref new_name) = request.new_dashboard_name {
                 if new_name.trim().is_empty() {
                     return Err(report!(UserErrors::InvalidDashboardName));
@@ -555,6 +576,7 @@ async fn delete_dashboard(
     org_id: id_type::OrganizationId,
     metadata_key: DBEnum,
     request: api_models::user::dashboard_metadata::DeleteDashboardRequest,
+    entity_type: String,
 ) -> UserResult<DashboardMetadata> {
     modify_dashboard_metadata(
         state,
@@ -562,6 +584,7 @@ async fn delete_dashboard(
         merchant_id,
         org_id,
         metadata_key,
+        entity_type,
         |existing: Option<types::CustomDashboardsValue>| {
             let mut data = existing.ok_or(report!(UserErrors::DashboardNotFound))?;
             let initial_len = data.dashboards.len();
@@ -583,6 +606,7 @@ async fn add_widget(
     org_id: id_type::OrganizationId,
     metadata_key: DBEnum,
     request: api_models::user::dashboard_metadata::AddWidgetRequest,
+    entity_type: String,
 ) -> UserResult<DashboardMetadata> {
     modify_dashboard_metadata(
         state,
@@ -590,6 +614,7 @@ async fn add_widget(
         merchant_id,
         org_id,
         metadata_key,
+        entity_type,
         |existing: Option<types::CustomDashboardsValue>| {
             let mut data = existing.ok_or(report!(UserErrors::DashboardNotFound))?;
             let dashboard = data
@@ -623,6 +648,7 @@ async fn update_widget(
     org_id: id_type::OrganizationId,
     metadata_key: DBEnum,
     request: api_models::user::dashboard_metadata::UpdateWidgetRequest,
+    entity_type: String,
 ) -> UserResult<DashboardMetadata> {
     modify_dashboard_metadata(
         state,
@@ -630,6 +656,7 @@ async fn update_widget(
         merchant_id,
         org_id,
         metadata_key,
+        entity_type,
         |existing: Option<types::CustomDashboardsValue>| {
             let mut data = existing.ok_or(report!(UserErrors::DashboardNotFound))?;
             let dashboard = data
@@ -660,6 +687,7 @@ async fn remove_widget(
     org_id: id_type::OrganizationId,
     metadata_key: DBEnum,
     request: api_models::user::dashboard_metadata::RemoveWidgetRequest,
+    entity_type: String,
 ) -> UserResult<DashboardMetadata> {
     modify_dashboard_metadata(
         state,
@@ -667,6 +695,7 @@ async fn remove_widget(
         merchant_id,
         org_id,
         metadata_key,
+        entity_type,
         |existing: Option<types::CustomDashboardsValue>| {
             let mut data = existing.ok_or(report!(UserErrors::DashboardNotFound))?;
             let dashboard = data
@@ -695,6 +724,7 @@ async fn update_layout(
     org_id: id_type::OrganizationId,
     metadata_key: DBEnum,
     request: api_models::user::dashboard_metadata::UpdateLayoutRequest,
+    entity_type: String,
 ) -> UserResult<DashboardMetadata> {
     modify_dashboard_metadata(
         state,
@@ -702,6 +732,7 @@ async fn update_layout(
         merchant_id,
         org_id,
         metadata_key,
+        entity_type,
         |existing: Option<types::CustomDashboardsValue>| {
             let mut data = existing.ok_or(report!(UserErrors::DashboardNotFound))?;
             let dashboard = data

--- a/crates/router/src/utils/user/dashboard_metadata.rs
+++ b/crates/router/src/utils/user/dashboard_metadata.rs
@@ -14,9 +14,12 @@ use error_stack::{report, ResultExt};
 use hyperswitch_masking::{ExposeInterface, PeekInterface, Secret};
 use router_env::logger;
 
+use common_enums::EntityType;
+
 use crate::{
     core::errors::{UserErrors, UserResult},
     headers,
+    services::{authentication::UserFromToken, authorization::roles::RoleInfo},
     types::domain::user::dashboard_metadata as types,
     SessionState,
 };
@@ -24,14 +27,29 @@ use crate::{
 pub const MAX_DASHBOARDS: usize = 10;
 pub const MAX_WIDGETS_PER_DASHBOARD: usize = 20;
 
-/// Maps role_id to entity_type for custom dashboard scoping
-pub fn get_entity_type_from_role(role_id: &str) -> &'static str {
-    match role_id {
-        "org_admin" => "org",
-        "merchant_admin" => "merchant",
-        "profile_admin" | "profile_user" => "profile",
-        _ => "user",
-    }
+/// Resolves the entity type from user's role for dashboard scoping.
+pub async fn get_entity_type_for_dashboard(
+    state: &SessionState,
+    user: &UserFromToken,
+) -> UserResult<EntityType> {
+    let tenant_id = user
+        .tenant_id
+        .clone()
+        .unwrap_or(state.tenant.tenant_id.clone());
+
+    let role_info = RoleInfo::from_role_id_in_lineage(
+        state,
+        &user.role_id,
+        &user.merchant_id,
+        &user.org_id,
+        &user.profile_id,
+        &tenant_id,
+    )
+    .await
+    .change_context(UserErrors::InternalServerError)
+    .attach_printable("Failed to fetch role info for dashboard scoping")?;
+
+    Ok(role_info.get_entity_type())
 }
 
 pub async fn insert_merchant_scoped_metadata_to_db(
@@ -328,24 +346,34 @@ pub fn is_prod_email_required(data: &ProdIntent, user_email: String) -> bool {
 
 // === Custom Dashboard Operations ===
 
-/// Generic fetch-transform-persist for user-scoped dashboard metadata.
+/// Generic fetch-transform-persist for dashboard metadata.
+/// Uses org-scoped query for Organization/Tenant roles, user-scoped for others.
+#[allow(clippy::too_many_arguments)]
 pub async fn modify_dashboard_metadata<T, F>(
     state: &SessionState,
     user_id: String,
     merchant_id: id_type::MerchantId,
     org_id: id_type::OrganizationId,
     metadata_key: DBEnum,
-    entity_type: String,
+    entity_type: EntityType,
     transform: F,
 ) -> UserResult<DashboardMetadata>
 where
     T: serde::Serialize + serde::de::DeserializeOwned,
     F: FnOnce(Option<T>) -> UserResult<T>,
 {
-    let existing = if entity_type == "org" {
+    let entity_type_str = entity_type_to_storage_str(entity_type);
+    let is_org_scoped = matches!(entity_type, EntityType::Organization | EntityType::Tenant);
+
+    let existing = if is_org_scoped {
         state
             .store
-            .find_org_scoped_dashboard_metadata(&user_id, &org_id, &entity_type, vec![metadata_key])
+            .find_org_scoped_dashboard_metadata(
+                &user_id,
+                &org_id,
+                entity_type_str,
+                vec![metadata_key],
+            )
             .await
     } else {
         state
@@ -357,9 +385,21 @@ where
                 vec![metadata_key],
             )
             .await
-    }
-    .change_context(UserErrors::InternalServerError)
-    .attach_printable("Error fetching dashboard metadata")?;
+    };
+
+    // Handle not-found gracefully — first create should work
+    let existing = match existing {
+        Ok(data) => data,
+        Err(e) => {
+            if e.current_context().is_db_not_found() {
+                vec![]
+            } else {
+                return Err(e
+                    .change_context(UserErrors::InternalServerError)
+                    .attach_printable("Error fetching dashboard metadata"));
+            }
+        }
+    };
 
     let existing_record = existing.first();
 
@@ -376,7 +416,8 @@ where
 
     match existing_record {
         Some(record) => {
-            let update_merchant_id = if entity_type == "org" {
+            // For org-scoped, use the merchant_id from the existing record
+            let update_merchant_id = if is_org_scoped {
                 record.merchant_id.clone()
             } else {
                 merchant_id
@@ -413,12 +454,21 @@ where
                     last_modified_by: user_id,
                     last_modified_at: now,
                     profile_id: None,
-                    entity_type: Some(entity_type),
+                    entity_type: Some(entity_type_str.to_string()),
                 })
                 .await
                 .change_context(UserErrors::InternalServerError)
                 .attach_printable("Error inserting dashboard metadata")
         }
+    }
+}
+
+/// Convert EntityType enum to storage string for the entity_type column.
+fn entity_type_to_storage_str(entity_type: EntityType) -> &'static str {
+    match entity_type {
+        EntityType::Tenant | EntityType::Organization => "org",
+        EntityType::Merchant => "merchant",
+        EntityType::Profile => "profile",
     }
 }
 
@@ -429,7 +479,7 @@ pub async fn handle_dashboard_operations(
     org_id: id_type::OrganizationId,
     metadata_key: DBEnum,
     operation: DashboardOperation,
-    entity_type: String,
+    entity_type: EntityType,
 ) -> UserResult<DashboardMetadata> {
     match operation {
         DashboardOperation::Create(request) => {
@@ -526,7 +576,7 @@ async fn create_dashboard(
     org_id: id_type::OrganizationId,
     metadata_key: DBEnum,
     request: api_models::user::dashboard_metadata::CreateDashboardRequest,
-    entity_type: String,
+    entity_type: EntityType,
 ) -> UserResult<DashboardMetadata> {
     if request.dashboard_name.trim().is_empty() {
         return Err(report!(UserErrors::InvalidDashboardName))
@@ -592,7 +642,7 @@ async fn update_dashboard(
     org_id: id_type::OrganizationId,
     metadata_key: DBEnum,
     request: api_models::user::dashboard_metadata::UpdateDashboardRequest,
-    entity_type: String,
+    entity_type: EntityType,
 ) -> UserResult<DashboardMetadata> {
     modify_dashboard_metadata(
         state,
@@ -651,7 +701,7 @@ async fn delete_dashboard(
     org_id: id_type::OrganizationId,
     metadata_key: DBEnum,
     request: api_models::user::dashboard_metadata::DeleteDashboardRequest,
-    entity_type: String,
+    entity_type: EntityType,
 ) -> UserResult<DashboardMetadata> {
     modify_dashboard_metadata(
         state,
@@ -681,7 +731,7 @@ async fn add_widget(
     org_id: id_type::OrganizationId,
     metadata_key: DBEnum,
     request: api_models::user::dashboard_metadata::AddWidgetRequest,
-    entity_type: String,
+    entity_type: EntityType,
 ) -> UserResult<DashboardMetadata> {
     modify_dashboard_metadata(
         state,
@@ -723,7 +773,7 @@ async fn update_widget(
     org_id: id_type::OrganizationId,
     metadata_key: DBEnum,
     request: api_models::user::dashboard_metadata::UpdateWidgetRequest,
-    entity_type: String,
+    entity_type: EntityType,
 ) -> UserResult<DashboardMetadata> {
     modify_dashboard_metadata(
         state,
@@ -762,7 +812,7 @@ async fn remove_widget(
     org_id: id_type::OrganizationId,
     metadata_key: DBEnum,
     request: api_models::user::dashboard_metadata::RemoveWidgetRequest,
-    entity_type: String,
+    entity_type: EntityType,
 ) -> UserResult<DashboardMetadata> {
     modify_dashboard_metadata(
         state,
@@ -799,7 +849,7 @@ async fn update_layout(
     org_id: id_type::OrganizationId,
     metadata_key: DBEnum,
     request: api_models::user::dashboard_metadata::UpdateLayoutRequest,
-    entity_type: String,
+    entity_type: EntityType,
 ) -> UserResult<DashboardMetadata> {
     modify_dashboard_metadata(
         state,

--- a/crates/router/src/utils/user/dashboard_metadata.rs
+++ b/crates/router/src/utils/user/dashboard_metadata.rs
@@ -28,7 +28,7 @@ pub const MAX_WIDGETS_PER_DASHBOARD: usize = 20;
 pub fn get_entity_type_from_role(role_id: &str) -> &'static str {
     match role_id {
         "org_admin" => "org",
-        "merchant_admin" => "merchant", 
+        "merchant_admin" => "merchant",
         "profile_admin" | "profile_user" => "profile",
         _ => "user",
     }
@@ -342,17 +342,24 @@ where
     T: serde::Serialize + serde::de::DeserializeOwned,
     F: FnOnce(Option<T>) -> UserResult<T>,
 {
-    let existing = state
-        .store
-        .find_user_scoped_dashboard_metadata(
-            &user_id,
-            &merchant_id,
-            &org_id,
-            vec![metadata_key],
-        )
-        .await
-        .change_context(UserErrors::InternalServerError)
-        .attach_printable("Error fetching dashboard metadata")?;
+    let existing = if entity_type == "org" {
+        state
+            .store
+            .find_org_scoped_dashboard_metadata(&user_id, &org_id, &entity_type, vec![metadata_key])
+            .await
+    } else {
+        state
+            .store
+            .find_user_scoped_dashboard_metadata(
+                &user_id,
+                &merchant_id,
+                &org_id,
+                vec![metadata_key],
+            )
+            .await
+    }
+    .change_context(UserErrors::InternalServerError)
+    .attach_printable("Error fetching dashboard metadata")?;
 
     let existing_record = existing.first();
 
@@ -368,22 +375,29 @@ where
         .attach_printable("Error serializing dashboard metadata")?;
 
     match existing_record {
-        Some(_) => state
-            .store
-            .update_metadata(
-                Some(user_id.clone()),
-                merchant_id,
-                org_id,
-                metadata_key,
-                DashboardMetadataUpdate::UpdateData {
-                    data_key: metadata_key,
-                    data_value: Secret::new(data_value),
-                    last_modified_by: user_id,
-                },
-            )
-            .await
-            .change_context(UserErrors::InternalServerError)
-            .attach_printable("Error updating dashboard metadata"),
+        Some(record) => {
+            let update_merchant_id = if entity_type == "org" {
+                record.merchant_id.clone()
+            } else {
+                merchant_id
+            };
+            state
+                .store
+                .update_metadata(
+                    Some(user_id.clone()),
+                    update_merchant_id,
+                    org_id,
+                    metadata_key,
+                    DashboardMetadataUpdate::UpdateData {
+                        data_key: metadata_key,
+                        data_value: Secret::new(data_value),
+                        last_modified_by: user_id,
+                    },
+                )
+                .await
+                .change_context(UserErrors::InternalServerError)
+                .attach_printable("Error updating dashboard metadata")
+        }
         None => {
             let now = common_utils::date_time::now();
             state
@@ -419,25 +433,88 @@ pub async fn handle_dashboard_operations(
 ) -> UserResult<DashboardMetadata> {
     match operation {
         DashboardOperation::Create(request) => {
-            create_dashboard(state, user_id, merchant_id, org_id, metadata_key, request, entity_type).await
+            create_dashboard(
+                state,
+                user_id,
+                merchant_id,
+                org_id,
+                metadata_key,
+                request,
+                entity_type,
+            )
+            .await
         }
         DashboardOperation::Update(request) => {
-            update_dashboard(state, user_id, merchant_id, org_id, metadata_key, request, entity_type).await
+            update_dashboard(
+                state,
+                user_id,
+                merchant_id,
+                org_id,
+                metadata_key,
+                request,
+                entity_type,
+            )
+            .await
         }
         DashboardOperation::Delete(request) => {
-            delete_dashboard(state, user_id, merchant_id, org_id, metadata_key, request, entity_type).await
+            delete_dashboard(
+                state,
+                user_id,
+                merchant_id,
+                org_id,
+                metadata_key,
+                request,
+                entity_type,
+            )
+            .await
         }
         DashboardOperation::AddWidget(request) => {
-            add_widget(state, user_id, merchant_id, org_id, metadata_key, request, entity_type).await
+            add_widget(
+                state,
+                user_id,
+                merchant_id,
+                org_id,
+                metadata_key,
+                request,
+                entity_type,
+            )
+            .await
         }
         DashboardOperation::UpdateWidget(request) => {
-            update_widget(state, user_id, merchant_id, org_id, metadata_key, request, entity_type).await
+            update_widget(
+                state,
+                user_id,
+                merchant_id,
+                org_id,
+                metadata_key,
+                request,
+                entity_type,
+            )
+            .await
         }
         DashboardOperation::RemoveWidget(request) => {
-            remove_widget(state, user_id, merchant_id, org_id, metadata_key, request, entity_type).await
+            remove_widget(
+                state,
+                user_id,
+                merchant_id,
+                org_id,
+                metadata_key,
+                request,
+                entity_type,
+            )
+            .await
         }
         DashboardOperation::UpdateLayout(request) => {
-            update_layout(state, user_id, merchant_id, org_id, metadata_key, request, entity_type).await
+            update_layout(
+                state,
+                user_id,
+                merchant_id,
+                org_id,
+                metadata_key,
+                request,
+                entity_type,
+            )
+            .await
         }
     }
 }
@@ -487,9 +564,7 @@ async fn create_dashboard(
         metadata_key,
         entity_type,
         |existing: Option<types::CustomDashboardsValue>| {
-            let mut data = existing.unwrap_or(types::CustomDashboardsValue {
-                dashboards: vec![],
-            });
+            let mut data = existing.unwrap_or(types::CustomDashboardsValue { dashboards: vec![] });
 
             if data.dashboards.len() >= MAX_DASHBOARDS {
                 return Err(report!(UserErrors::MaxDashboardsReached));

--- a/migrations/2026-04-06-100000_add_custom_dashboards_to_dashboard_metadata/down.sql
+++ b/migrations/2026-04-06-100000_add_custom_dashboards_to_dashboard_metadata/down.sql
@@ -1,0 +1,1 @@
+-- Enum values cannot be removed in PostgreSQL

--- a/migrations/2026-04-06-100000_add_custom_dashboards_to_dashboard_metadata/down.sql
+++ b/migrations/2026-04-06-100000_add_custom_dashboards_to_dashboard_metadata/down.sql
@@ -1,1 +1,8 @@
 -- Enum values cannot be removed in PostgreSQL
+
+-- Drop entity_type column
+ALTER TABLE dashboard_metadata 
+DROP COLUMN IF EXISTS entity_type;
+
+-- Drop index
+DROP INDEX IF EXISTS idx_dashboard_metadata_entity_type;

--- a/migrations/2026-04-06-100000_add_custom_dashboards_to_dashboard_metadata/up.sql
+++ b/migrations/2026-04-06-100000_add_custom_dashboards_to_dashboard_metadata/up.sql
@@ -1,1 +1,13 @@
+-- Add custom_dashboards enum value
 ALTER TYPE "DashboardMetadata" ADD VALUE IF NOT EXISTS 'custom_dashboards';
+
+-- Add entity_type column for scoping (org/merchant/profile level)
+-- This is nullable to maintain backward compatibility with existing data
+-- Only used for custom_dashboards feature
+ALTER TABLE dashboard_metadata 
+ADD COLUMN IF NOT EXISTS entity_type VARCHAR(32) NULL;
+
+-- Add index for efficient querying by entity_type
+CREATE INDEX IF NOT EXISTS idx_dashboard_metadata_entity_type 
+ON dashboard_metadata (entity_type) 
+WHERE entity_type IS NOT NULL;

--- a/migrations/2026-04-06-100000_add_custom_dashboards_to_dashboard_metadata/up.sql
+++ b/migrations/2026-04-06-100000_add_custom_dashboards_to_dashboard_metadata/up.sql
@@ -1,0 +1,1 @@
+ALTER TYPE "DashboardMetadata" ADD VALUE IF NOT EXISTS 'custom_dashboards';


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Add Custom Dashboard Builder CRUD operations to the dashboard metadata system. Merchants can create personalized analytics dashboards with configurable widgets, following the existing metadata storage pattern.

### Key design decisions

- **Reuses `dashboard_metadata` table** — no new tables, no new DB traits
- **User-scoped** — each user gets their own dashboards
- **JSON blob storage** — `CustomDashboardsValue { dashboards: Vec<DashboardV1> }`
- **Generic transform pattern** — new `modify_dashboard_metadata()` for fetch-transform-persist

### What's added

| Layer | Changes |
|-------|--------|
| **Migration** | `custom_dashboards` enum value |
| **API Models** | `DashboardOperation` (7 variants), 10 request types, 6 supporting types |
| **Domain Types** | `CustomDashboardsValue`, `DashboardV1`, `WidgetV1` |
| **Errors** | 6 new variants (codes 62-67) |
| **Utils** | `modify_dashboard_metadata()` + 8 CRUD functions (~427 lines) |
| **Core** | Wired into parse_set, parse_get, into_response, insert_metadata |

### API contract

```
POST /user/data
{ "CustomDashboards": { "type": "Create", "data": { "dashboard_name": "My Dashboard" } } }
{ "CustomDashboards": { "type": "AddWidget", "data": { "dashboard_name": "...", "widget": {...} } } }

GET /user/data?keys=CustomDashboards
```

### Validation

| Rule | Limit | Error |
|------|-------|-------|
| Max dashboards | 10 | MaxDashboardsReached |
| Max widgets/dashboard | 20 | MaxWidgetsReached |
| Unique dashboard name | Per user | DashboardNameAlreadyExists |
| Non-empty name | trim() | InvalidDashboardName |


## Motivation and Context

Closes #11737

Merchants need customizable analytics dashboards. Competitors (Checkout.com, Primer.io, Stripe) offer this. This PR adds the backend CRUD; frontend follows in a separate PR.

## How did you test it?

- `cargo check -p router` — passed clean
- Migration applied to local PostgreSQL
- Manual curl testing for all 7 operations

## Checklist

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible