### PR TITLE
fix(core): 3DS Setup Mandate Webhook Trigger Fix

### DIFF
--- a/crates/hyperswitch_domain_models/src/payments.rs
+++ b/crates/hyperswitch_domain_models/src/payments.rs
@@ -531,6 +531,12 @@ impl PaymentIntent {
             installment_options,
         })
     }
+
+    #[cfg(feature = "v1")]
+    pub fn is_setup_mandate(&self) -> bool {
+        self.amount == MinorUnit::zero()
+            && self.setup_future_usage == Some(common_enums::FutureUsage::OffSession)
+    }
 }
 
 #[cfg(feature = "v2")]

--- a/crates/router/src/core/payments.rs
+++ b/crates/router/src/core/payments.rs
@@ -4243,6 +4243,7 @@ impl PaymentRedirectFlow for PaymentAuthenticateCompleteAuthorize {
             None,
             &payment_intent
                 .profile_id
+                .clone()
                 .ok_or(errors::ApiErrorResponse::InternalServerError)
                 .attach_printable("missing profile_id in payment_intent")?,
             &payment_attempt
@@ -4280,9 +4281,7 @@ impl PaymentRedirectFlow for PaymentAuthenticateCompleteAuthorize {
                 }),
                 ..Default::default()
             };
-            let is_setup_mandate = payment_intent.amount == MinorUnit::zero()
-                && payment_intent.setup_future_usage
-                    == Some(storage_enums::FutureUsage::OffSession);
+            let is_setup_mandate = payment_intent.is_setup_mandate();
             if is_setup_mandate {
                 Box::pin(payments_core::<
                     api::SetupMandate,

--- a/crates/router/src/core/webhooks/incoming.rs
+++ b/crates/router/src/core/webhooks/incoming.rs
@@ -12,7 +12,7 @@ use common_utils::{
     errors::ReportSwitchExt,
     events::ApiEventsType,
     ext_traits::{AsyncExt, ByteSliceExt},
-    types::{AmountConvertor, StringMinorUnitForConnector},
+    types::{AmountConvertor, MinorUnit, StringMinorUnitForConnector},
 };
 use diesel_models::{refund as diesel_refund, ConnectorMandateReferenceId};
 use error_stack::{report, ResultExt};
@@ -2496,34 +2496,70 @@ async fn external_authentication_incoming_webhook_flow(
                     == Some(common_enums::DecoupledAuthenticationType::Challenge)
                 && event_type == webhooks::IncomingWebhookEvent::ExternalAuthenticationARes
             {
+                let payment_intent = state
+                    .store
+                    .find_payment_intent_by_payment_id_processor_merchant_id(
+                        &payment_id,
+                        platform.get_processor().get_account().get_id(),
+                        platform.get_processor().get_key_store(),
+                        platform.get_processor().get_account().storage_scheme,
+                    )
+                    .await
+                    .to_not_found_response(errors::ApiErrorResponse::PaymentNotFound)?;
                 let payment_confirm_req = api::PaymentsRequest {
                     payment_id: Some(api_models::payments::PaymentIdType::PaymentIntentId(
-                        payment_id,
+                        payment_intent.payment_id,
                     )),
                     merchant_id: Some(platform.get_processor().get_account().get_id().clone()),
                     ..Default::default()
                 };
-                let payments_response = Box::pin(payments::payments_core::<
-                    api::Authorize,
-                    api::PaymentsResponse,
-                    _,
-                    _,
-                    _,
-                    payments::PaymentData<api::Authorize>,
-                >(
-                    state.clone(),
-                    req_state,
-                    platform.clone(),
-                    None,
-                    payments::PaymentConfirm,
-                    payment_confirm_req,
-                    services::api::AuthFlow::Merchant,
-                    payments::CallConnectorAction::Trigger,
-                    None,
-                    None,
-                    HeaderPayload::with_source(enums::PaymentSource::ExternalAuthenticator),
-                ))
-                .await?;
+                let is_setup_mandate = payment_intent.amount == MinorUnit::zero()
+                    && payment_intent.setup_future_usage == Some(enums::FutureUsage::OffSession);
+                let payments_response = if is_setup_mandate {
+                    Box::pin(payments::payments_core::<
+                        api::SetupMandate,
+                        api::PaymentsResponse,
+                        _,
+                        _,
+                        _,
+                        payments::PaymentData<api::SetupMandate>,
+                    >(
+                        state.clone(),
+                        req_state,
+                        platform.clone(),
+                        None,
+                        payments::PaymentConfirm,
+                        payment_confirm_req,
+                        services::api::AuthFlow::Merchant,
+                        payments::CallConnectorAction::Trigger,
+                        None,
+                        None,
+                        HeaderPayload::with_source(enums::PaymentSource::ExternalAuthenticator),
+                    ))
+                    .await?
+                } else {
+                    Box::pin(payments::payments_core::<
+                        api::Authorize,
+                        api::PaymentsResponse,
+                        _,
+                        _,
+                        _,
+                        payments::PaymentData<api::Authorize>,
+                    >(
+                        state.clone(),
+                        req_state,
+                        platform.clone(),
+                        None,
+                        payments::PaymentConfirm,
+                        payment_confirm_req,
+                        services::api::AuthFlow::Merchant,
+                        payments::CallConnectorAction::Trigger,
+                        None,
+                        None,
+                        HeaderPayload::with_source(enums::PaymentSource::ExternalAuthenticator),
+                    ))
+                    .await?
+                };
                 match payments_response {
                     services::ApplicationResponse::JsonWithHeaders((payments_response, _)) => {
                         let payment_id = payments_response.payment_id.clone();

--- a/crates/router/src/core/webhooks/incoming.rs
+++ b/crates/router/src/core/webhooks/incoming.rs
@@ -12,7 +12,7 @@ use common_utils::{
     errors::ReportSwitchExt,
     events::ApiEventsType,
     ext_traits::{AsyncExt, ByteSliceExt},
-    types::{AmountConvertor, MinorUnit, StringMinorUnitForConnector},
+    types::{AmountConvertor, StringMinorUnitForConnector},
 };
 use diesel_models::{refund as diesel_refund, ConnectorMandateReferenceId};
 use error_stack::{report, ResultExt};
@@ -2508,13 +2508,12 @@ async fn external_authentication_incoming_webhook_flow(
                     .to_not_found_response(errors::ApiErrorResponse::PaymentNotFound)?;
                 let payment_confirm_req = api::PaymentsRequest {
                     payment_id: Some(api_models::payments::PaymentIdType::PaymentIntentId(
-                        payment_intent.payment_id,
+                        payment_intent.payment_id.clone(),
                     )),
                     merchant_id: Some(platform.get_processor().get_account().get_id().clone()),
                     ..Default::default()
                 };
-                let is_setup_mandate = payment_intent.amount == MinorUnit::zero()
-                    && payment_intent.setup_future_usage == Some(enums::FutureUsage::OffSession);
+                let is_setup_mandate = payment_intent.is_setup_mandate();
                 let payments_response = if is_setup_mandate {
                     Box::pin(payments::payments_core::<
                         api::SetupMandate,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
If the pull mechanism is true, the webhook trigger happens after 3DS authentication. Previously it was going through Authorize call, changed it to check if it is a zero mandate then route through Setup Mandate otherwise call Authorize.


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Same test pattern as this: https://github.com/juspay/hyperswitch/pull/11419
1. `"pull_mechanism_for_external_3ds_enabled": false` this is added in netcetera metadata
2. Retrieve Response:
```
{
    "payment_id": "pay_Ssx399QmtVy8d0VhBqEd",
    "merchant_id": "merchant_1773151834",
    "status": "succeeded",
    "amount": 0,
    "net_amount": 0,
    "shipping_cost": null,
    "amount_capturable": 0,
    "amount_received": null,
    "processor_merchant_id": "merchant_1773151834",
    "initiator": null,
    "sdk_authorization": "cHJvZmlsZV9pZD1wcm9fZm96ZlF0Q1BxblQxWkk0bmFsUkUscHVibGlzaGFibGVfa2V5PXBrX2Rldl8xMjRhNTg3ZTQyZWM0M2FmODg4ZjRlMDc0MDczYWU5YSxjbGllbnRfc2VjcmV0PXBheV9Tc3gzOTlRbXRWeThkMFZoQnFFZF9zZWNyZXRfaFp1Y0w4Yzlmd3c2ckdhWFowS0UsY3VzdG9tZXJfaWQ9c2FnbmlrMDA3LHBheW1lbnRfaWQ9cGF5X1NzeDM5OVFtdFZ5OGQwVmhCcUVk",
    "connector": "cybersource",
    "state_metadata": null,
    "client_secret": "pay_Ssx399QmtVy8d0VhBqEd_secret_hZucL8c9fww6rGaXZ0KE",
    "created": "2026-04-10T08:03:15.915Z",
    "modified_at": "2026-04-10T08:04:12.321Z",
    "currency": "USD",
    "customer_id": "sagnik007",
    "customer": {
        "id": "sagnik007",
        "name": "John Doe",
        "email": "guest@example.com",
        "phone": "999999999",
        "phone_country_code": "+65",
        "customer_document_details": null
    },
    "description": "Its my first payment request",
    "refunds": null,
    "disputes": null,
    "mandate_id": null,
    "mandate_data": null,
    "setup_future_usage": "off_session",
    "off_session": null,
    "capture_on": null,
    "capture_method": "automatic",
    "payment_method": "card",
    "payment_method_data": {
        "card": {
            "last4": "3340",
            "card_type": null,
            "card_network": null,
            "card_issuer": null,
            "card_issuing_country": null,
            "card_isin": "530688",
            "card_extended_bin": null,
            "card_exp_month": "10",
            "card_exp_year": "31",
            "card_holder_name": "joseph Doe",
            "payment_checks": {
                "avs_response": {
                    "code": "X",
                    "codeRaw": "I1"
                },
                "card_verification": null
            },
            "authentication_data": null,
            "auth_code": null
        },
        "billing": null
    },
    "payment_token": "token_JaJhbEm4CXove47kdv57",
    "shipping": {
        "address": {
            "city": "San Fransico",
            "country": "US",
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "zip": "94122",
            "state": "CA",
            "first_name": "PiX",
            "last_name": "Poddar",
            "origin_zip": null
        },
        "phone": {
            "number": "123456789",
            "country_code": "12"
        },
        "email": null
    },
    "billing": {
        "address": {
            "city": "San Fransico",
            "country": "US",
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "zip": "94122",
            "state": "CA",
            "first_name": "PiX",
            "last_name": "Poddar",
            "origin_zip": null
        },
        "phone": {
            "number": "123456789",
            "country_code": "12"
        },
        "email": null
    },
    "order_details": null,
    "email": "guest@example.com",
    "name": "John Doe",
    "phone": "999999999",
    "return_url": "https://duck.com/",
    "authentication_type": "three_ds",
    "statement_descriptor_name": "joseph",
    "statement_descriptor_suffix": "JS",
    "next_action": null,
    "cancellation_reason": null,
    "error_code": null,
    "error_message": null,
    "unified_code": null,
    "unified_message": null,
    "error_details": null,
    "payment_experience": null,
    "payment_method_type": "credit",
    "connector_label": null,
    "business_country": null,
    "business_label": "default",
    "business_sub_label": null,
    "allowed_payment_method_types": null,
    "manual_retry_allowed": null,
    "connector_transaction_id": "7758082516876249303812",
    "frm_message": null,
    "metadata": {
        "udf1": "value1",
        "login_date": "2019-09-10T10:11:12Z",
        "new_customer": "true"
    },
    "connector_metadata": null,
    "connector_response_metadata": null,
    "feature_metadata": {
        "redirect_response": null,
        "search_tags": null,
        "apple_pay_recurring_details": null,
        "pix_additional_details": null,
        "boleto_additional_details": null,
        "pix_automatico_additional_details": null
    },
    "reference_id": "pay_Ssx399QmtVy8d0VhBqEd_1",
    "payment_link": null,
    "profile_id": "pro_fozfQtCPqnT1ZI4nalRE",
    "surcharge_details": null,
    "attempt_count": 1,
    "merchant_decision": null,
    "merchant_connector_id": "mca_hMEOxzdlFS4P8kcMKzcN",
    "incremental_authorization_allowed": false,
    "authorization_count": null,
    "incremental_authorizations": null,
    "external_authentication_details": {
        "authentication_flow": "challenge",
        "electronic_commerce_indicator": "02",
        "status": "success",
        "ds_transaction_id": "5e885b12-ae39-4e95-8553-539bd3d0ecbc",
        "version": "2.3.1",
        "error_code": null,
        "error_message": null
    },
    "external_3ds_authentication_attempted": true,
    "expires_on": "2026-04-10T08:18:15.912Z",
    "fingerprint": null,
    "browser_info": {
        "os_type": null,
        "referer": null,
        "language": "nl-NL",
        "time_zone": 0,
        "ip_address": "115.99.183.2",
        "os_version": null,
        "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Safari/537.36",
        "color_depth": 24,
        "device_model": null,
        "java_enabled": true,
        "screen_width": 1536,
        "accept_header": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8",
        "screen_height": 723,
        "accept_language": "en",
        "java_script_enabled": true
    },
    "payment_channel": null,
    "payment_method_id": "pm_J6KG8B9J1yqVwamEWgKA",
    "network_transaction_id": "MCC1234561231",
    "payment_method_status": "active",
    "updated": "2026-04-10T08:04:12.321Z",
    "split_payments": null,
    "frm_metadata": null,
    "extended_authorization_applied": null,
    "extended_authorization_last_applied_at": null,
    "request_extended_authorization": null,
    "capture_before": null,
    "merchant_order_reference_id": null,
    "order_tax_amount": null,
    "connector_mandate_id": null,
    "card_discovery": "manual",
    "force_3ds_challenge": false,
    "force_3ds_challenge_trigger": false,
    "issuer_error_code": null,
    "issuer_error_message": null,
    "is_iframe_redirection_enabled": null,
    "whole_connector_response": null,
    "enable_partial_authorization": null,
    "enable_overcapture": null,
    "is_overcapture_enabled": null,
    "network_details": null,
    "is_stored_credential": null,
    "mit_category": null,
    "billing_descriptor": null,
    "tokenization": null,
    "partner_merchant_identifier_details": null,
    "payment_method_tokenization_details": {
        "payment_method_id": "pm_J6KG8B9J1yqVwamEWgKA",
        "payment_method_status": "active",
        "psp_tokenization": true,
        "network_tokenization": false,
        "network_transaction_id": "MCC1234561231",
        "is_eligible_for_mit_payment": true
    },
    "installment_options": null,
    "installment_data": null
}
```


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
