### PR TITLE
fix(connetors): [adyen] fix dispute_status deserialization error

### DIFF
--- a/crates/hyperswitch_connectors/src/connectors/adyen/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/adyen/transformers.rs
@@ -5562,6 +5562,9 @@ pub enum DisputeStatus {
     Lost,
     Accepted,
     Won,
+    Unresponded,
+    Responded,
+    Expired,
 }
 
 #[derive(Debug, Deserialize)]
@@ -5618,6 +5621,7 @@ pub enum WebhookEventCode {
     SecondChargeback,
     PrearbitrationWon,
     PrearbitrationLost,
+    RequestForInformation,
     OfferClosed,
     RecurringContract,
     #[cfg(feature = "payouts")]
@@ -5735,6 +5739,15 @@ pub(crate) fn get_adyen_webhook_event(
             }
             Some(_) => api_models::webhooks::IncomingWebhookEvent::DisputeOpened,
         },
+        WebhookEventCode::RequestForInformation => match dispute_status {
+            Some(DisputeStatus::Responded) => {
+                api_models::webhooks::IncomingWebhookEvent::DisputeChallenged
+            }
+            Some(DisputeStatus::Expired) | None => {
+                api_models::webhooks::IncomingWebhookEvent::DisputeExpired
+            }
+            Some(_) => api_models::webhooks::IncomingWebhookEvent::DisputeOpened,
+        },
         WebhookEventCode::ChargebackReversed => match dispute_status {
             Some(DisputeStatus::Pending) => {
                 api_models::webhooks::IncomingWebhookEvent::DisputeChallenged
@@ -5794,7 +5807,8 @@ pub(crate) fn get_adyen_webhook_event(
 impl From<WebhookEventCode> for storage_enums::DisputeStage {
     fn from(code: WebhookEventCode) -> Self {
         match code {
-            WebhookEventCode::NotificationOfChargeback => Self::PreDispute,
+            WebhookEventCode::NotificationOfChargeback
+            | WebhookEventCode::RequestForInformation => Self::PreDispute,
             WebhookEventCode::SecondChargeback => Self::PreArbitration,
             WebhookEventCode::PrearbitrationWon => Self::PreArbitration,
             WebhookEventCode::PrearbitrationLost => Self::PreArbitration,
@@ -5902,6 +5916,7 @@ impl From<AdyenNotificationRequestItemWH> for AdyenWebhookResponse {
                 | WebhookEventCode::RefundFailed
                 | WebhookEventCode::RefundReversed
                 | WebhookEventCode::NotificationOfChargeback
+                | WebhookEventCode::RequestForInformation
                 | WebhookEventCode::Chargeback
                 | WebhookEventCode::ChargebackReversed
                 | WebhookEventCode::SecondChargeback

--- a/crates/hyperswitch_connectors/src/connectors/adyen/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/adyen/transformers.rs
@@ -5744,10 +5744,13 @@ pub(crate) fn get_adyen_webhook_event(
             Some(DisputeStatus::Responded) => {
                 api_models::webhooks::IncomingWebhookEvent::DisputeChallenged
             }
-            Some(DisputeStatus::Expired) | None => {
+            Some(DisputeStatus::Expired) => {
                 api_models::webhooks::IncomingWebhookEvent::DisputeExpired
             }
-            Some(_) => api_models::webhooks::IncomingWebhookEvent::DisputeOpened,
+            Some(DisputeStatus::Unresponded) => {
+                api_models::webhooks::IncomingWebhookEvent::EventNotSupported
+            }
+            None | Some(_) => api_models::webhooks::IncomingWebhookEvent::DisputeOpened,
         },
         WebhookEventCode::ChargebackReversed => match dispute_status {
             Some(DisputeStatus::Pending) => {

--- a/crates/hyperswitch_connectors/src/connectors/adyen/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/adyen/transformers.rs
@@ -5674,6 +5674,7 @@ pub fn is_chargeback_event(event_code: &WebhookEventCode) -> bool {
             | WebhookEventCode::SecondChargeback
             | WebhookEventCode::PrearbitrationWon
             | WebhookEventCode::PrearbitrationLost
+            | WebhookEventCode::RequestForInformation
     )
 }
 


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Adyen's dispute_status in the response has an enum value , we are getting 5xx for values not included in the enum. This PR adds the missing enum values - Unresponded, Responded, Expired

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

Tested Manually 

Trigger a Webhook via terminal

To generate signature 

```
 DATA="Q6LZJ75GMH47JFV5:FXKLXXPT3X5P6KV5:JuspayDEECOM:testMerchantRef1:0:EUR:REQUEST_FOR_INFORMATION:true"
KEY="{{HMAC_KEY}}"

SIGNATURE=$(echo -n "$DATA" | openssl dgst -sha256 -mac HMAC -macopt hexkey:$KEY -binary | base64)
``` 

curl

```
curl -X POST "http://localhost:8080/webhooks/postman_merchant_GHAction_90647cd0-bea0-4a3f-b51d-0c1486f8ae70/mca_JZi6daNpYG5VEmQedHnK" \
  -H "Content-Type: application/json" \
  -d "{
    \"live\": \"false\",
    \"notificationItems\": [
      {
        \"NotificationRequestItem\": {
          \"additionalData\": {
            \"hmacSignature\": \"${SIGNATURE}\"
          },
          \"amount\": {
            \"currency\": \"EUR\",
            \"value\": 0
          },
          \"originalReference\": \"FXKLXXPT3X5P6KV5\",
          \"eventCode\": \"REQUEST_FOR_INFORMATION\",
          \"eventDate\": \"2026-04-14T11:37:10+02:00\",
          \"merchantAccountCode\": \"JuspayDEECOM\",
          \"merchantReference\": \"testMerchantRef1\",
          \"pspReference\": \"Q6LZJ75GMH47JFV5\",
          \"reason\": \"\",
          \"success\": \"true\"
        }
      }
    ]
  }"
```

This will create a dispute in opened state

<img width="1120" height="589" alt="Screenshot 2026-04-14 at 3 53 38 PM" src="https://github.com/user-attachments/assets/cdc2ee59-e1d3-408f-9a48-9fe4eb445f59" />

Now provide expired Dispute status

```
curl -X POST "http://localhost:8080/webhooks/postman_merchant_GHAction_90647cd0-bea0-4a3f-b51d-0c1486f8ae70/mca_JZi6daNpYG5VEmQedHnK" \
  -H "Content-Type: application/json" \
  -d "{
    \"live\": \"false\",
    \"notificationItems\": [
      {
        \"NotificationRequestItem\": {
          \"additionalData\": {
            \"hmacSignature\": \"${SIGNATURE}\",
            \"disputeStatus\": \"Expired\"
          },
          \"amount\": {
            \"currency\": \"EUR\",
            \"value\": 0
          },
          \"originalReference\": \"FXKLXXPT3X5P6KV5\",
          \"eventCode\": \"REQUEST_FOR_INFORMATION\",
          \"eventDate\": \"2026-04-14T11:37:10+02:00\",
          \"merchantAccountCode\": \"JuspayDEECOM\",
          \"merchantReference\": \"testMerchantRef1\",
          \"pspReference\": \"Q6LZJ75GMH47JFV5\",
          \"reason\": \"\",
          \"success\": \"true\"
        }
      }
    ]
  }"
```

Dispute Expired Updated

<img width="903" height="291" alt="Screenshot 2026-04-14 at 3 54 22 PM" src="https://github.com/user-attachments/assets/ae0634af-af70-4d9b-be48-526db5339081" />



## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
