### PR TITLE
feat(analytics): add platform context support for global search

### DIFF
--- a/crates/router/src/analytics.rs
+++ b/crates/router/src/analytics.rs
@@ -45,7 +45,7 @@ pub mod routes {
             authorization::{permissions::Permission, roles::RoleInfo},
             ApplicationResponse,
         },
-        types::{domain::UserEmail, storage::UserRole},
+        types::{domain, domain::UserEmail, storage::UserRole},
     };
 
     pub struct Analytics;
@@ -3512,29 +3512,121 @@ pub mod routes {
                     })
                     .collect();
 
+                // Collect unique merchant_ids to fetch merchant accounts for platform context
+                let merchant_ids: Vec<_> = filtered_user_roles
+                    .iter()
+                    .filter_map(|ur| ur.merchant_id.clone())
+                    .collect::<HashSet<_>>()
+                    .into_iter()
+                    .collect();
+
+                // Fetch merchant accounts to determine platform context
+                let merchant_account_map: HashMap<_, domain::MerchantAccount> =
+                    futures::future::try_join_all(merchant_ids.iter().map(|merchant_id| {
+                        let state = Arc::clone(&state);
+                        let merchant_id = merchant_id.clone();
+                        async move {
+                            let key_store = state
+                                .store
+                                .get_merchant_key_store_by_merchant_id(
+                                    &merchant_id,
+                                    &state.store.get_master_key().to_vec().into(),
+                                )
+                                .await
+                                .change_context(UserErrors::InternalServerError)
+                                .change_context(OpenSearchError::UnknownError)?;
+
+                            let merchant_account = state
+                                .store
+                                .find_merchant_account_by_merchant_id(&merchant_id, &key_store)
+                                .await
+                                .change_context(UserErrors::InternalServerError)
+                                .change_context(OpenSearchError::UnknownError)?;
+
+                            Ok::<_, error_stack::Report<OpenSearchError>>((
+                                merchant_id,
+                                merchant_account,
+                            ))
+                        }
+                    }))
+                    .await?
+                    .into_iter()
+                    .collect();
+
+                // Build AuthInfo with platform context support
                 let search_params: Vec<AuthInfo> = filtered_user_roles
                     .iter()
                     .filter_map(|user_role| {
                         user_role
                             .get_entity_id_and_type()
-                            .and_then(|(_, entity_type)| match entity_type {
-                                EntityType::Profile => Some(AuthInfo::ProfileLevel {
-                                    org_id: user_role.org_id.clone()?,
-                                    merchant_id: user_role.merchant_id.clone()?,
-                                    profile_ids: vec![user_role.profile_id.clone()?],
-                                    processor_merchant_id: None,
-                                }),
-                                EntityType::Merchant => Some(AuthInfo::MerchantLevel {
-                                    org_id: user_role.org_id.clone()?,
-                                    merchant_ids: vec![user_role.merchant_id.clone()?],
-                                    processor_merchant_ids: None,
-                                }),
-                                EntityType::Organization => Some(AuthInfo::OrgLevel {
-                                    org_id: user_role.org_id.clone()?,
-                                }),
-                                EntityType::Tenant => Some(AuthInfo::OrgLevel {
-                                    org_id: auth.org_id.clone(),
-                                }),
+                            .and_then(|(_, entity_type)| {
+                                let merchant_account = user_role
+                                    .merchant_id
+                                    .as_ref()
+                                    .and_then(|mid| merchant_account_map.get(mid));
+
+                                // Check if this is a connected merchant
+                                let is_connected = merchant_account
+                                    .map(|ma| {
+                                        ma.merchant_account_type
+                                            == common_enums::MerchantAccountType::Connected
+                                    })
+                                    .unwrap_or(false);
+
+                                let parent_merchant_id =
+                                    merchant_account.and_then(|ma| ma.parent_merchant_id.clone());
+
+                                match entity_type {
+                                    EntityType::Profile => {
+                                        let org_id = user_role.org_id.clone()?;
+                                        let profile_id = user_role.profile_id.clone()?;
+
+                                        if is_connected {
+                                            // Connected merchant: use parent as merchant_id, current as processor
+                                            Some(AuthInfo::ProfileLevel {
+                                                org_id,
+                                                merchant_id: parent_merchant_id?,
+                                                profile_ids: vec![profile_id],
+                                                processor_merchant_id: user_role.merchant_id.clone(),
+                                            })
+                                        } else {
+                                            // Standard/Platform merchant
+                                            Some(AuthInfo::ProfileLevel {
+                                                org_id,
+                                                merchant_id: user_role.merchant_id.clone()?,
+                                                profile_ids: vec![profile_id],
+                                                processor_merchant_id: None,
+                                            })
+                                        }
+                                    }
+                                    EntityType::Merchant => {
+                                        let org_id = user_role.org_id.clone()?;
+
+                                        if is_connected {
+                                            // Connected merchant: use parent as merchant_ids, current as processor
+                                            Some(AuthInfo::MerchantLevel {
+                                                org_id,
+                                                merchant_ids: vec![parent_merchant_id?],
+                                                processor_merchant_ids: Some(vec![user_role
+                                                    .merchant_id
+                                                    .clone()?]),
+                                            })
+                                        } else {
+                                            // Standard/Platform merchant
+                                            Some(AuthInfo::MerchantLevel {
+                                                org_id,
+                                                merchant_ids: vec![user_role.merchant_id.clone()?],
+                                                processor_merchant_ids: None,
+                                            })
+                                        }
+                                    }
+                                    EntityType::Organization => Some(AuthInfo::OrgLevel {
+                                        org_id: user_role.org_id.clone()?,
+                                    }),
+                                    EntityType::Tenant => Some(AuthInfo::OrgLevel {
+                                        org_id: auth.org_id.clone(),
+                                    }),
+                                }
                             })
                     })
                     .collect();
@@ -3668,32 +3760,125 @@ pub mod routes {
                     })
                     .collect();
 
+                // Collect unique merchant_ids to fetch merchant accounts for platform context
+                let merchant_ids: Vec<_> = filtered_user_roles
+                    .iter()
+                    .filter_map(|ur| ur.merchant_id.clone())
+                    .collect::<HashSet<_>>()
+                    .into_iter()
+                    .collect();
+
+                // Fetch merchant accounts to determine platform context
+                let merchant_account_map: HashMap<_, domain::MerchantAccount> =
+                    futures::future::try_join_all(merchant_ids.iter().map(|merchant_id| {
+                        let state = Arc::clone(&state);
+                        let merchant_id = merchant_id.clone();
+                        async move {
+                            let key_store = state
+                                .store
+                                .get_merchant_key_store_by_merchant_id(
+                                    &merchant_id,
+                                    &state.store.get_master_key().to_vec().into(),
+                                )
+                                .await
+                                .change_context(UserErrors::InternalServerError)
+                                .change_context(OpenSearchError::UnknownError)?;
+
+                            let merchant_account = state
+                                .store
+                                .find_merchant_account_by_merchant_id(&merchant_id, &key_store)
+                                .await
+                                .change_context(UserErrors::InternalServerError)
+                                .change_context(OpenSearchError::UnknownError)?;
+
+                            Ok::<_, error_stack::Report<OpenSearchError>>((
+                                merchant_id,
+                                merchant_account,
+                            ))
+                        }
+                    }))
+                    .await?
+                    .into_iter()
+                    .collect();
+
+                // Build AuthInfo with platform context support
                 let search_params: Vec<AuthInfo> = filtered_user_roles
                     .iter()
                     .filter_map(|user_role| {
                         user_role
                             .get_entity_id_and_type()
-                            .and_then(|(_, entity_type)| match entity_type {
-                                EntityType::Profile => Some(AuthInfo::ProfileLevel {
-                                    org_id: user_role.org_id.clone()?,
-                                    merchant_id: user_role.merchant_id.clone()?,
-                                    profile_ids: vec![user_role.profile_id.clone()?],
-                                    processor_merchant_id: None,
-                                }),
-                                EntityType::Merchant => Some(AuthInfo::MerchantLevel {
-                                    org_id: user_role.org_id.clone()?,
-                                    merchant_ids: vec![user_role.merchant_id.clone()?],
-                                    processor_merchant_ids: None,
-                                }),
-                                EntityType::Organization => Some(AuthInfo::OrgLevel {
-                                    org_id: user_role.org_id.clone()?,
-                                }),
-                                EntityType::Tenant => Some(AuthInfo::OrgLevel {
-                                    org_id: auth.org_id.clone(),
-                                }),
+                            .and_then(|(_, entity_type)| {
+                                let merchant_account = user_role
+                                    .merchant_id
+                                    .as_ref()
+                                    .and_then(|mid| merchant_account_map.get(mid));
+
+                                // Check if this is a connected merchant
+                                let is_connected = merchant_account
+                                    .map(|ma| {
+                                        ma.merchant_account_type
+                                            == common_enums::MerchantAccountType::Connected
+                                    })
+                                    .unwrap_or(false);
+
+                                let parent_merchant_id =
+                                    merchant_account.and_then(|ma| ma.parent_merchant_id.clone());
+
+                                match entity_type {
+                                    EntityType::Profile => {
+                                        let org_id = user_role.org_id.clone()?;
+                                        let profile_id = user_role.profile_id.clone()?;
+
+                                        if is_connected {
+                                            // Connected merchant: use parent as merchant_id, current as processor
+                                            Some(AuthInfo::ProfileLevel {
+                                                org_id,
+                                                merchant_id: parent_merchant_id?,
+                                                profile_ids: vec![profile_id],
+                                                processor_merchant_id: user_role.merchant_id.clone(),
+                                            })
+                                        } else {
+                                            // Standard/Platform merchant
+                                            Some(AuthInfo::ProfileLevel {
+                                                org_id,
+                                                merchant_id: user_role.merchant_id.clone()?,
+                                                profile_ids: vec![profile_id],
+                                                processor_merchant_id: None,
+                                            })
+                                        }
+                                    }
+                                    EntityType::Merchant => {
+                                        let org_id = user_role.org_id.clone()?;
+
+                                        if is_connected {
+                                            // Connected merchant: use parent as merchant_ids, current as processor
+                                            Some(AuthInfo::MerchantLevel {
+                                                org_id,
+                                                merchant_ids: vec![parent_merchant_id?],
+                                                processor_merchant_ids: Some(vec![user_role
+                                                    .merchant_id
+                                                    .clone()?]),
+                                            })
+                                        } else {
+                                            // Standard/Platform merchant
+                                            Some(AuthInfo::MerchantLevel {
+                                                org_id,
+                                                merchant_ids: vec![user_role.merchant_id.clone()?],
+                                                processor_merchant_ids: None,
+                                            })
+                                        }
+                                    }
+                                    EntityType::Organization => Some(AuthInfo::OrgLevel {
+                                        org_id: user_role.org_id.clone()?,
+                                    }),
+                                    EntityType::Tenant => Some(AuthInfo::OrgLevel {
+                                        org_id: auth.org_id.clone(),
+                                    }),
+                                }
                             })
                     })
                     .collect();
+
                 analytics::search::search_results(
                     state
                         .opensearch_client

--- a/crates/router/src/analytics.rs
+++ b/crates/router/src/analytics.rs
@@ -3587,7 +3587,9 @@ pub mod routes {
                                                 org_id,
                                                 merchant_id: parent_merchant_id?,
                                                 profile_ids: vec![profile_id],
-                                                processor_merchant_id: user_role.merchant_id.clone(),
+                                                processor_merchant_id: user_role
+                                                    .merchant_id
+                                                    .clone(),
                                             })
                                         } else {
                                             // Standard/Platform merchant
@@ -3615,7 +3617,9 @@ pub mod routes {
                                             // Standard/Platform merchant
                                             Some(AuthInfo::MerchantLevel {
                                                 org_id,
-                                                merchant_ids: vec![user_role.merchant_id.clone()?],
+                                                merchant_ids: vec![user_role
+                                                    .merchant_id
+                                                    .clone()?],
                                                 processor_merchant_ids: None,
                                             })
                                         }
@@ -3835,7 +3839,9 @@ pub mod routes {
                                                 org_id,
                                                 merchant_id: parent_merchant_id?,
                                                 profile_ids: vec![profile_id],
-                                                processor_merchant_id: user_role.merchant_id.clone(),
+                                                processor_merchant_id: user_role
+                                                    .merchant_id
+                                                    .clone(),
                                             })
                                         } else {
                                             // Standard/Platform merchant
@@ -3863,7 +3869,9 @@ pub mod routes {
                                             // Standard/Platform merchant
                                             Some(AuthInfo::MerchantLevel {
                                                 org_id,
-                                                merchant_ids: vec![user_role.merchant_id.clone()?],
+                                                merchant_ids: vec![user_role
+                                                    .merchant_id
+                                                    .clone()?],
                                                 processor_merchant_ids: None,
                                             })
                                         }


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [x] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

This PR adds platform context support to `get_global_search_results` and `get_search_results` functions in analytics.

### Problem
The search functions were not properly handling platform context for connected merchants. When constructing `AuthInfo` from user roles, the `processor_merchant_id` and `processor_merchant_ids` fields were always set to `None`, which meant search queries for connected merchants would not filter correctly by platform context.

### Solution
Both search functions now:
1. Fetch `MerchantAccount` for each unique merchant_id in the user's roles
2. Check if the merchant is a connected merchant by examining `merchant_account_type == Connected`
3. Build `AuthInfo` with proper platform context:
   - **Connected merchants**: Use `parent_merchant_id` (platform) as the `merchant_id` and the connected merchant's ID as `processor_merchant_id`
   - **Standard/Platform merchants**: Use the merchant's own ID with no `processor_merchant_id`

This aligns the global search behavior with other analytics endpoints that already use the `Platform::to_*_level_auth_info()` methods.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

## Motivation and Context


Global search needs to support platform context so that searches for connected merchants properly filter by both the platform merchant ID and the processor (connected) merchant ID.

## How did you test it?

- Verified code compiles successfully with `cargo check -p router --features olap`
- Logic follows the same pattern as `Platform::to_merchant_level_auth_info()` and `Platform::to_profile_level_auth_info()` methods

## Checklist

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible