### PR TITLE
feat: send error response to validation service for comparison of error case

### DIFF
--- a/crates/hyperswitch_interfaces/src/api/gateway.rs
+++ b/crates/hyperswitch_interfaces/src/api/gateway.rs
@@ -400,11 +400,11 @@ where
                 )
                 .await;
 
-            let direct_for_compare: Result<RouterData<F, Req, Resp>, String> =
-                match &direct_result {
-                    Ok(fo) => Ok(fo.get_router_data().clone()),
-                    Err(e) => Err(format!("{:?}", e)),
-                };
+            let direct_for_compare: Result<RouterData<F, Req, Resp>, String> = match &direct_result
+            {
+                Ok(fo) => Ok(fo.get_router_data().clone()),
+                Err(e) => Err(format!("{:?}", e)),
+            };
             let state_clone = state.clone();
             let router_data_clone = router_data.clone();
             let return_raw_connector_response_clone = return_raw_connector_response;
@@ -534,11 +534,11 @@ where
                 )
                 .await;
 
-            let direct_for_compare: Result<RouterData<F, Req, Resp>, String> =
-                match &direct_result {
-                    Ok(fo) => Ok(fo.get_router_data().clone()),
-                    Err(e) => Err(format!("{:?}", e)),
-                };
+            let direct_for_compare: Result<RouterData<F, Req, Resp>, String> = match &direct_result
+            {
+                Ok(fo) => Ok(fo.get_router_data().clone()),
+                Err(e) => Err(format!("{:?}", e)),
+            };
             let state_clone = state.clone();
             let router_data_clone = router_data.clone();
             let return_raw_connector_response_clone = return_raw_connector_response;

--- a/crates/hyperswitch_interfaces/src/api/gateway.rs
+++ b/crates/hyperswitch_interfaces/src/api/gateway.rs
@@ -388,7 +388,7 @@ where
             let gateway: Box<
                 dyn PaymentGateway<State, ConnectorData, F, Req, Resp, Context, FlowOutput>,
             > = F::get_gateway(ExecutionPath::Direct);
-            let direct_router_data = gateway
+            let direct_result = gateway
                 .execute(
                     state,
                     connector_integration.clone_box(),
@@ -398,12 +398,18 @@ where
                     return_raw_connector_response,
                     context.clone(),
                 )
-                .await?;
+                .await;
+
+            let direct_for_compare: Result<RouterData<F, Req, Resp>, String> =
+                match &direct_result {
+                    Ok(fo) => Ok(fo.get_router_data().clone()),
+                    Err(e) => Err(format!("{:?}", e)),
+                };
             let state_clone = state.clone();
             let router_data_clone = router_data.clone();
-            let direct_router_data_clone = direct_router_data.clone();
             let return_raw_connector_response_clone = return_raw_connector_response;
             let context_clone = context;
+            let connector_name = router_data.connector.clone();
             tokio::spawn(
                 async move {
                     let gateway: Box<
@@ -421,33 +427,27 @@ where
                         )
                         .await
                         .attach_printable("Gateway execution failed");
-                    // Send comparison data asynchronously
-                    match ucs_shadow_result {
-                        Ok(ucs_router_data) => {
-                            // Send comparison data asynchronously
-                            if let Some(comparison_service_config) =
-                                state_clone.get_comparison_service_config()
-                            {
-                                let request_id = state_clone.get_request_id_str();
-                                let _ =
-                                    helpers::serialize_router_data_and_send_to_comparison_service(
-                                        &state_clone,
-                                        direct_router_data_clone.get_router_data().clone(),
-                                        ucs_router_data.get_router_data().clone(),
-                                        comparison_service_config,
-                                        request_id,
-                                    )
-                                    .await;
-                            };
-                        }
-                        Err(e) => {
-                            logger::error!(error=?e, "UCS shadow execution failed");
-                        }
+
+                    if let Err(e) = &ucs_shadow_result {
+                        logger::error!(error=?e, "UCS shadow execution failed");
                     }
+
+                    let ucs_for_compare = match ucs_shadow_result {
+                        Ok(fo) => Ok(fo.get_router_data().clone()),
+                        Err(e) => Err(format!("{:?}", e)),
+                    };
+
+                    helpers::serialize_comparison_results_and_send(
+                        &state_clone,
+                        connector_name,
+                        direct_for_compare,
+                        ucs_for_compare,
+                    )
+                    .await;
                 }
                 .instrument(router_env::tracing::Span::current()),
             );
-            Ok(direct_router_data)
+            direct_result
         }
     }
 }
@@ -522,7 +522,7 @@ where
             let gateway: Box<
                 dyn PayoutGateway<State, ConnectorData, F, Req, Resp, Context, FlowOutput>,
             > = F::get_payout_gateway(ExecutionPath::Direct);
-            let direct_router_data = gateway
+            let direct_result = gateway
                 .execute(
                     state,
                     connector_integration.clone_box(),
@@ -532,12 +532,18 @@ where
                     return_raw_connector_response,
                     context.clone(),
                 )
-                .await?;
+                .await;
+
+            let direct_for_compare: Result<RouterData<F, Req, Resp>, String> =
+                match &direct_result {
+                    Ok(fo) => Ok(fo.get_router_data().clone()),
+                    Err(e) => Err(format!("{:?}", e)),
+                };
             let state_clone = state.clone();
             let router_data_clone = router_data.clone();
-            let direct_router_data_clone = direct_router_data.clone();
             let return_raw_connector_response_clone = return_raw_connector_response;
             let context_clone = context;
+            let connector_name = router_data.connector.clone();
             tokio::spawn(
                 async move {
                     let gateway: Box<
@@ -555,33 +561,27 @@ where
                         )
                         .await
                         .attach_printable("Gateway execution failed");
-                    // Send comparison data asynchronously
-                    match ucs_shadow_result {
-                        Ok(ucs_router_data) => {
-                            // Send comparison data asynchronously
-                            if let Some(comparison_service_config) =
-                                state_clone.get_comparison_service_config()
-                            {
-                                let request_id = state_clone.get_request_id_str();
-                                let _ =
-                                    helpers::serialize_router_data_and_send_to_comparison_service(
-                                        &state_clone,
-                                        direct_router_data_clone.get_router_data().clone(),
-                                        ucs_router_data.get_router_data().clone(),
-                                        comparison_service_config,
-                                        request_id,
-                                    )
-                                    .await;
-                            };
-                        }
-                        Err(e) => {
-                            logger::error!(error=?e, "UCS shadow execution failed");
-                        }
+
+                    if let Err(e) = &ucs_shadow_result {
+                        logger::error!(error=?e, "UCS shadow execution failed");
                     }
+
+                    let ucs_for_compare = match ucs_shadow_result {
+                        Ok(fo) => Ok(fo.get_router_data().clone()),
+                        Err(e) => Err(format!("{:?}", e)),
+                    };
+
+                    helpers::serialize_comparison_results_and_send(
+                        &state_clone,
+                        connector_name,
+                        direct_for_compare,
+                        ucs_for_compare,
+                    )
+                    .await;
                 }
                 .instrument(router_env::tracing::Span::current()),
             );
-            Ok(direct_router_data)
+            direct_result
         }
     }
 }

--- a/crates/hyperswitch_interfaces/src/helpers.rs
+++ b/crates/hyperswitch_interfaces/src/helpers.rs
@@ -60,17 +60,17 @@ pub async fn serialize_comparison_results_and_send<S, F, RouterDReq, RouterDResp
         return;
     };
 
-    let to_value =
-        |res: Result<router_data::RouterData<F, RouterDReq, RouterDResp>, String>, side: &str| {
-            match res {
-                Ok(rd) => serde_json::to_value(rd).unwrap_or_else(|e| {
-                    serde_json::json!({
-                        "error": format!("serialize {side} router_data failed: {e}")
-                    })
-                }),
-                Err(e) => serde_json::json!({ "error": e }),
-            }
-        };
+    let to_value = |res: Result<router_data::RouterData<F, RouterDReq, RouterDResp>, String>,
+                    side: &str| {
+        match res {
+            Ok(rd) => serde_json::to_value(rd).unwrap_or_else(|e| {
+                serde_json::json!({
+                    "error": format!("serialize {side} router_data failed: {e}")
+                })
+            }),
+            Err(e) => serde_json::json!({ "error": e }),
+        }
+    };
 
     let comparison_data = ComparisonData {
         hyperswitch_data: hyperswitch_masking::Secret::new(to_value(

--- a/crates/hyperswitch_interfaces/src/helpers.rs
+++ b/crates/hyperswitch_interfaces/src/helpers.rs
@@ -37,44 +37,54 @@ pub trait GetComparisonServiceConfig {
     fn get_comparison_service_config(&self) -> Option<types::ComparisonServiceConfig>;
 }
 
-/// Generic function to serialize router data and send comparison to external service
-/// Works for both payments and refunds
-pub async fn serialize_router_data_and_send_to_comparison_service<F, RouterDReq, RouterDResp>(
-    state: &dyn api_client::ApiClientWrapper,
-    hyperswitch_router_data: router_data::RouterData<F, RouterDReq, RouterDResp>,
-    unified_connector_service_router_data: router_data::RouterData<F, RouterDReq, RouterDResp>,
-    comparison_service_config: types::ComparisonServiceConfig,
-    request_id: Option<String>,
-) -> common_utils_errors::CustomResult<(), errors::HttpClientError>
-where
+/// Serialize `Result`-shaped router data for both sides and forward to the validation
+/// (comparison) service. Covers all four quadrants — (Ok,Ok), (Ok,Err), (Err,Ok), (Err,Err) —
+/// so error cases are still visible as a diff. No-op when the comparison service is not
+/// configured. Errors from the comparison service itself are logged and swallowed so they
+/// cannot affect the caller.
+pub async fn serialize_comparison_results_and_send<S, F, RouterDReq, RouterDResp>(
+    state: &S,
+    connector_name: String,
+    hyperswitch_result: Result<router_data::RouterData<F, RouterDReq, RouterDResp>, String>,
+    unified_connector_service_result: Result<
+        router_data::RouterData<F, RouterDReq, RouterDResp>,
+        String,
+    >,
+) where
+    S: api_client::ApiClientWrapper + GetComparisonServiceConfig,
     F: Send + Clone + Sync + 'static,
     RouterDReq: Send + Sync + Clone + 'static + serde::Serialize,
     RouterDResp: Send + Sync + Clone + 'static + serde::Serialize,
 {
-    logger::info!("Simulating UCS call for shadow mode comparison");
+    let Some(comparison_service_config) = state.get_comparison_service_config() else {
+        return;
+    };
 
-    let connector_name = hyperswitch_router_data.connector.clone();
-    let sub_flow_name = api_client::get_flow_name::<F>().ok();
-
-    let [hyperswitch_data, unified_connector_service_data] = [
-        (hyperswitch_router_data, "hyperswitch"),
-        (unified_connector_service_router_data, "ucs"),
-    ]
-    .map(|(data, source)| {
-        serde_json::to_value(data)
-            .map(hyperswitch_masking::Secret::new)
-            .unwrap_or_else(|e| {
-                hyperswitch_masking::Secret::new(serde_json::json!({
-                    "error": e.to_string(),
-                    "source": source
-                }))
-            })
-    });
+    let to_value =
+        |res: Result<router_data::RouterData<F, RouterDReq, RouterDResp>, String>, side: &str| {
+            match res {
+                Ok(rd) => serde_json::to_value(rd).unwrap_or_else(|e| {
+                    serde_json::json!({
+                        "error": format!("serialize {side} router_data failed: {e}")
+                    })
+                }),
+                Err(e) => serde_json::json!({ "error": e }),
+            }
+        };
 
     let comparison_data = ComparisonData {
-        hyperswitch_data,
-        unified_connector_service_data,
+        hyperswitch_data: hyperswitch_masking::Secret::new(to_value(
+            hyperswitch_result,
+            "hyperswitch",
+        )),
+        unified_connector_service_data: hyperswitch_masking::Secret::new(to_value(
+            unified_connector_service_result,
+            "ucs",
+        )),
     };
+
+    let sub_flow_name = api_client::get_flow_name::<F>().ok();
+    let request_id = state.get_request_id_str();
     let _ = send_comparison_data(
         state,
         comparison_data,
@@ -84,10 +94,7 @@ where
         request_id,
     )
     .await
-    .map_err(|e| {
-        logger::debug!("Failed to send comparison data: {:?}", e);
-    });
-    Ok(())
+    .inspect_err(|e| logger::debug!("Failed to send comparison data: {:?}", e));
 }
 
 /// Sends router data comparison to external service

--- a/crates/router/src/core/refunds.rs
+++ b/crates/router/src/core/refunds.rs
@@ -638,8 +638,10 @@ async fn execute_refund_execute_via_direct_with_ucs_shadow(
     let ucs_platform = platform.clone();
     let ucs_state = state.clone();
 
-    // Clone direct result for comparison (if successful)
-    let direct_router_data_for_comparison = direct_result.as_ref().ok().cloned();
+    // Capture direct result for comparison (Ok or Err) so the diff is sent in both cases.
+    let direct_for_compare: Result<types::RefundExecuteRouterData, String> =
+        direct_result.as_ref().map(|rd| rd.clone()).map_err(|e| format!("{:?}", e));
+    let connector_name = router_data.connector.clone();
 
     tokio::spawn(
         (
@@ -653,40 +655,23 @@ async fn execute_refund_execute_via_direct_with_ucs_shadow(
                         merchant_connector_account
                     ).await;
 
-                match (ucs_result, direct_router_data_for_comparison) {
-                    (Ok(ucs_router_data), Some(direct_router_data)) => {
-                        Box::pin(
-                            unified_connector_service::serialize_router_data_and_send_to_comparison_service(
-                                &ucs_state,
-                                direct_router_data,
-                                ucs_router_data
-                            )
-                        ).await
-                            .inspect_err(|e| {
-                                router_env::logger::debug!(
-                                    "Shadow UCS refund execute comparison failed: {:?}",
-                                    e
-                                );
-                            })
-                            .ok();
-                    }
-                    (Err(e), _) => {
-                        router_env::logger::debug!(
-                            "Skipping refund execute comparison - UCS shadow execute failed: {:?}",
-                            e
-                        );
-                    }
-                    (_, None) => {
-                        router_env::logger::debug!(
-                            "Skipping refund execute comparison - direct execute failed"
-                        );
-                    }
+                if let Err(e) = &ucs_result {
+                    router_env::logger::debug!("Shadow UCS refund execute failed: {:?}", e);
                 }
+                let ucs_for_compare = ucs_result.map_err(|e| format!("{:?}", e));
+
+                Box::pin(hyperswitch_interfaces::helpers::serialize_comparison_results_and_send(
+                    &ucs_state,
+                    connector_name,
+                    direct_for_compare,
+                    ucs_for_compare,
+                ))
+                .await;
             }
         ).instrument(tracing::Span::current())
     );
 
-    // Return PRIMARY result (Direct connector response)
+    // Return PRIMARY result (Direct connector response) — UCS shadow cannot affect this.
     direct_result
 }
 
@@ -1207,7 +1192,9 @@ async fn execute_refund_sync_via_direct_with_ucs_shadow(
     let state = state.clone();
     let processor = processor.clone();
     let merchant_connector_account = merchant_connector_account.clone();
-    let direct_router_data_for_comparison = direct_result.as_ref().ok().cloned();
+    let direct_for_compare: Result<types::RefundSyncRouterData, String> =
+        direct_result.as_ref().map(|rd| rd.clone()).map_err(|e| format!("{:?}", e));
+    let connector_name = router_data.connector.clone();
 
     tokio::spawn(
         (
@@ -1221,34 +1208,18 @@ async fn execute_refund_sync_via_direct_with_ucs_shadow(
                         merchant_connector_account
                     ).await;
 
-                match (ucs_result, direct_router_data_for_comparison) {
-                    (Ok(ucs_router_data), Some(direct_router_data)) => {
-                        Box::pin(
-                            unified_connector_service::serialize_router_data_and_send_to_comparison_service(
-                                &state,
-                                direct_router_data,
-                                ucs_router_data
-                            )
-                        ).await
-                            .inspect_err(|e| {
-                                router_env::logger::debug!(
-                                    "Shadow UCS sync comparison failed: {:?}",
-                                    e
-                                );
-                            })
-                            .ok();
-                    }
-                    (Err(_), _) => {
-                        router_env::logger::debug!(
-                            "Skipping refund sync comparison - UCS shadow sync failed"
-                        );
-                    }
-                    (_, None) => {
-                        router_env::logger::debug!(
-                            "Skipping refund sync comparison - direct sync failed"
-                        );
-                    }
+                if let Err(e) = &ucs_result {
+                    router_env::logger::debug!("Shadow UCS refund sync failed: {:?}", e);
                 }
+                let ucs_for_compare = ucs_result.map_err(|e| format!("{:?}", e));
+
+                Box::pin(hyperswitch_interfaces::helpers::serialize_comparison_results_and_send(
+                    &state,
+                    connector_name,
+                    direct_for_compare,
+                    ucs_for_compare,
+                ))
+                .await;
             }
         ).instrument(tracing::Span::current())
     );

--- a/crates/router/src/core/refunds.rs
+++ b/crates/router/src/core/refunds.rs
@@ -639,36 +639,40 @@ async fn execute_refund_execute_via_direct_with_ucs_shadow(
     let ucs_state = state.clone();
 
     // Capture direct result for comparison (Ok or Err) so the diff is sent in both cases.
-    let direct_for_compare: Result<types::RefundExecuteRouterData, String> =
-        direct_result.as_ref().map(|rd| rd.clone()).map_err(|e| format!("{:?}", e));
+    let direct_for_compare: Result<types::RefundExecuteRouterData, String> = direct_result
+        .as_ref()
+        .map(|rd| rd.clone())
+        .map_err(|e| format!("{:?}", e));
     let connector_name = router_data.connector.clone();
 
     tokio::spawn(
-        (
-            async move {
-                let ucs_result =
-                    unified_connector_service::call_unified_connector_service_for_refund_execute(
-                        &ucs_state,
-                        ucs_platform.get_processor(),
-                        ucs_router_data,
-                        ExecutionMode::Shadow,
-                        merchant_connector_account
-                    ).await;
+        (async move {
+            let ucs_result =
+                unified_connector_service::call_unified_connector_service_for_refund_execute(
+                    &ucs_state,
+                    ucs_platform.get_processor(),
+                    ucs_router_data,
+                    ExecutionMode::Shadow,
+                    merchant_connector_account,
+                )
+                .await;
 
-                if let Err(e) = &ucs_result {
-                    router_env::logger::debug!("Shadow UCS refund execute failed: {:?}", e);
-                }
-                let ucs_for_compare = ucs_result.map_err(|e| format!("{:?}", e));
+            if let Err(e) = &ucs_result {
+                router_env::logger::debug!("Shadow UCS refund execute failed: {:?}", e);
+            }
+            let ucs_for_compare = ucs_result.map_err(|e| format!("{:?}", e));
 
-                Box::pin(hyperswitch_interfaces::helpers::serialize_comparison_results_and_send(
+            Box::pin(
+                hyperswitch_interfaces::helpers::serialize_comparison_results_and_send(
                     &ucs_state,
                     connector_name,
                     direct_for_compare,
                     ucs_for_compare,
-                ))
-                .await;
-            }
-        ).instrument(tracing::Span::current())
+                ),
+            )
+            .await;
+        })
+        .instrument(tracing::Span::current()),
     );
 
     // Return PRIMARY result (Direct connector response) — UCS shadow cannot affect this.
@@ -1192,36 +1196,40 @@ async fn execute_refund_sync_via_direct_with_ucs_shadow(
     let state = state.clone();
     let processor = processor.clone();
     let merchant_connector_account = merchant_connector_account.clone();
-    let direct_for_compare: Result<types::RefundSyncRouterData, String> =
-        direct_result.as_ref().map(|rd| rd.clone()).map_err(|e| format!("{:?}", e));
+    let direct_for_compare: Result<types::RefundSyncRouterData, String> = direct_result
+        .as_ref()
+        .map(|rd| rd.clone())
+        .map_err(|e| format!("{:?}", e));
     let connector_name = router_data.connector.clone();
 
     tokio::spawn(
-        (
-            async move {
-                let ucs_result =
-                    unified_connector_service::call_unified_connector_service_for_refund_sync(
-                        &state,
-                        &processor,
-                        router_data,
-                        ExecutionMode::Shadow,
-                        merchant_connector_account
-                    ).await;
+        (async move {
+            let ucs_result =
+                unified_connector_service::call_unified_connector_service_for_refund_sync(
+                    &state,
+                    &processor,
+                    router_data,
+                    ExecutionMode::Shadow,
+                    merchant_connector_account,
+                )
+                .await;
 
-                if let Err(e) = &ucs_result {
-                    router_env::logger::debug!("Shadow UCS refund sync failed: {:?}", e);
-                }
-                let ucs_for_compare = ucs_result.map_err(|e| format!("{:?}", e));
+            if let Err(e) = &ucs_result {
+                router_env::logger::debug!("Shadow UCS refund sync failed: {:?}", e);
+            }
+            let ucs_for_compare = ucs_result.map_err(|e| format!("{:?}", e));
 
-                Box::pin(hyperswitch_interfaces::helpers::serialize_comparison_results_and_send(
+            Box::pin(
+                hyperswitch_interfaces::helpers::serialize_comparison_results_and_send(
                     &state,
                     connector_name,
                     direct_for_compare,
                     ucs_for_compare,
-                ))
-                .await;
-            }
-        ).instrument(tracing::Span::current())
+                ),
+            )
+            .await;
+        })
+        .instrument(tracing::Span::current()),
     );
 
     direct_result

--- a/crates/router/src/core/unified_connector_service.rs
+++ b/crates/router/src/core/unified_connector_service.rs
@@ -10,21 +10,13 @@ use common_enums::{
 #[cfg(feature = "v2")]
 use common_utils::consts::BASE64_ENGINE;
 use common_utils::{
-    consts::{X_CONNECTOR_NAME, X_FLOW_NAME, X_SUB_FLOW_NAME},
-    errors::CustomResult,
-    ext_traits::ValueExt,
-    id_type,
-    request::{Method, RequestBuilder, RequestContent},
-    ucs_types,
+    errors::CustomResult, ext_traits::ValueExt, id_type, request::Method, ucs_types,
 };
 use diesel_models::types::FeatureMetadata;
 use error_stack::ResultExt;
-use external_services::{
-    grpc_client::{
-        unified_connector_service::{ConnectorAuthMetadata, UnifiedConnectorServiceError},
-        LineageIds,
-    },
-    http_client,
+use external_services::grpc_client::{
+    unified_connector_service::{ConnectorAuthMetadata, UnifiedConnectorServiceError},
+    LineageIds,
 };
 use hyperswitch_connectors::utils::CardData;
 #[cfg(feature = "v2")]
@@ -62,7 +54,6 @@ use crate::{
         utils::get_flow_name,
     },
     events::connector_api_logs::ConnectorEvent,
-    headers::{CONTENT_TYPE, X_REQUEST_ID},
     routes::SessionState,
     types::{
         transformers::{ForeignFrom, ForeignTryFrom},
@@ -2831,111 +2822,6 @@ where
             Some(router_data.0.external_latency.unwrap_or(0) + external_latency);
         router_data
     })
-}
-
-#[derive(serde::Serialize)]
-pub struct ComparisonData {
-    pub hyperswitch_data: Secret<serde_json::Value>,
-    pub unified_connector_service_data: Secret<serde_json::Value>,
-}
-
-/// Generic function to serialize router data and send comparison to external service
-/// Works for both payments and refunds
-#[cfg(feature = "v1")]
-pub async fn serialize_router_data_and_send_to_comparison_service<F, RouterDReq, RouterDResp>(
-    state: &SessionState,
-    hyperswitch_router_data: RouterData<F, RouterDReq, RouterDResp>,
-    unified_connector_service_router_data: RouterData<F, RouterDReq, RouterDResp>,
-) -> RouterResult<()>
-where
-    F: Send + Clone + Sync + 'static,
-    RouterDReq: Send + Sync + Clone + 'static + serde::Serialize,
-    RouterDResp: Send + Sync + Clone + 'static + serde::Serialize,
-{
-    logger::info!("Simulating UCS call for shadow mode comparison");
-
-    let connector_name = hyperswitch_router_data.connector.clone();
-    let sub_flow_name = get_flow_name::<F>().ok();
-
-    let [hyperswitch_data, unified_connector_service_data] = [
-        (hyperswitch_router_data, "hyperswitch"),
-        (unified_connector_service_router_data, "ucs"),
-    ]
-    .map(|(data, source)| {
-        serde_json::to_value(data)
-            .map(Secret::new)
-            .unwrap_or_else(|e| {
-                Secret::new(serde_json::json!({
-                    "error": e.to_string(),
-                    "source": source
-                }))
-            })
-    });
-
-    let comparison_data = ComparisonData {
-        hyperswitch_data,
-        unified_connector_service_data,
-    };
-    let _ = send_comparison_data(state, comparison_data, connector_name, sub_flow_name)
-        .await
-        .map_err(|e| {
-            logger::debug!("Failed to send comparison data: {:?}", e);
-        });
-    Ok(())
-}
-
-/// Sends router data comparison to external service
-pub async fn send_comparison_data(
-    state: &SessionState,
-    comparison_data: ComparisonData,
-    connector_name: String,
-    sub_flow_name: Option<String>,
-) -> RouterResult<()> {
-    // Check if comparison service is enabled
-    let comparison_config = match state.conf.comparison_service.as_ref() {
-        Some(comparison_config) => comparison_config,
-        None => {
-            tracing::warn!(
-                "Comparison service configuration missing, skipping comparison data send"
-            );
-            return Ok(());
-        }
-    };
-
-    let mut request = RequestBuilder::new()
-        .method(Method::Post)
-        .url(comparison_config.url.get_string_repr())
-        .header(CONTENT_TYPE, "application/json")
-        .header(X_FLOW_NAME, "router-data")
-        .set_body(RequestContent::Json(Box::new(comparison_data)))
-        .build();
-
-    request.add_header(
-        X_CONNECTOR_NAME,
-        hyperswitch_masking::Maskable::Normal(connector_name),
-    );
-
-    if let Some(sub_flow_name) = sub_flow_name.filter(|name| !name.is_empty()) {
-        request.add_header(
-            X_SUB_FLOW_NAME,
-            hyperswitch_masking::Maskable::Normal(sub_flow_name),
-        );
-    }
-
-    if let Some(req_id) = &state.request_id {
-        request.add_header(
-            X_REQUEST_ID,
-            hyperswitch_masking::Maskable::Normal(req_id.to_string()),
-        );
-    }
-
-    let _ = http_client::send_request(&state.conf.proxy, request, comparison_config.timeout_secs)
-        .await
-        .map_err(|e| {
-            tracing::debug!("Error sending comparison data: {:?}", e);
-        });
-
-    Ok(())
 }
 
 // ============================================================================


### PR DESCRIPTION

## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
Send the error response of HS or UCS to the validation (comparison) service instead of dropping it and only logging.

Previously, the shadow-mode comparison call was only made when **both** HS (direct) and UCS returned `Ok`. If either side errored, we just logged the failure on the UCS side (and on the refund path we additionally short-circuited on a direct error), so no payload ever reached the validation service for that request.

This PR changes the comparison helper to take `Result<RouterData, String>` for both sides and forward all four quadrants — `(Ok, Ok)`, `(Ok, Err)`, `(Err, Ok)`, `(Err, Err)` — to the validation service. The error variant is serialized as `{ "error": "<debug-formatted error>" }` on whichever side failed. The primary (direct) result returned to the caller is unchanged; UCS shadow failures still cannot affect the response.

Key changes:
- `hyperswitch_interfaces::helpers`: replace `serialize_router_data_and_send_to_comparison_service` with `serialize_comparison_results_and_send`, which accepts `Result`s for both sides, takes `connector_name` explicitly (so we don't need a successful HS RouterData to read it from), and is a no-op when the comparison service isn't configured.
- The duplicate copy of this helper and `send_comparison_data` / `ComparisonData` in `crates/router/src/core/unified_connector_service.rs` is removed; payment, payout, and refund (execute + sync) shadow paths all go through the single helper in `hyperswitch_interfaces`.
- Payment/payout gateway shadow paths (`hyperswitch_interfaces::api::gateway`) and refund shadow paths (`crates/router/src/core/refunds.rs`) now build `direct_for_compare` and `ucs_for_compare` as `Result<_, String>` and always call the helper.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
Earlier, when UCS shadow execution returned an error (or, for refunds, when the direct call errored), we just logged it and skipped the comparison call entirely. As a result, the validation service never saw the request or RouterData for those cases, so diff alerts had nothing to compare against — the run looked indistinguishable from "RouterData not received." This hid real divergences: HS could transform/execute successfully while UCS errored (or vice versa), and we'd never get a diff for it.

After this change, the validation service receives the error-side RouterData (or the formatted error string) for every shadow run, so error-case mismatches show up as a real diff and we can actually triage and fix them.

## How did you test it?
tested with cypress for all connector locally

got this error router data diff as well
<img width="1555" height="1031" alt="image" src="https://github.com/user-attachments/assets/b5fe8b75-bab8-4ddd-8ed7-02099bad5b71" />



## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
