### PR TITLE
fix(router): fix 'recieved' -> 'received' in setup_mandate_flow log/comments

### DIFF
--- a/crates/router/src/core/payments/flows/setup_mandate_flow.rs
+++ b/crates/router/src/core/payments/flows/setup_mandate_flow.rs
@@ -215,7 +215,7 @@ impl Feature<api::SetupMandate, types::SetupMandateRequestData> for types::Setup
                         self.request.currency
                     );
                     logger::info!(
-                        "Balance amount and currency recieved from connector : {}, {}",
+                        "Balance amount and currency received from connector : {}, {}",
                         balance,
                         currency
                     );
@@ -247,7 +247,7 @@ impl Feature<api::SetupMandate, types::SetupMandateRequestData> for types::Setup
                 Err(err) => Err(err.clone()),
             };
             Ok(types::BalanceCheckResult {
-                // Continue with the payment only if ok response is recieved from balance check
+                // Continue with the payment only if ok response is received from balance check
                 should_continue_payment: balance_check_result.is_ok(),
                 balance_check_result,
             })


### PR DESCRIPTION
## Description
Log message and comment in `crates/router/src/core/payments/flows/setup_mandate_flow.rs` (lines 218, 250) read `recieved`. Fixed to `received`. String-literal and comment-only change.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`