### PR TITLE
fix(connector): propagate terminal_id from MCA metadata for fiserv UCS config

### DIFF
--- a/crates/router/src/core/unified_connector_service/connector_config.rs
+++ b/crates/router/src/core/unified_connector_service/connector_config.rs
@@ -106,6 +106,11 @@ pub struct PeachpaymentsMetadata {
     merchant_payment_method_route_id: Secret<String>,
 }
 
+#[derive(Debug, serde::Deserialize)]
+pub struct FiservMetadata {
+    terminal_id: Option<Secret<String>>,
+}
+
 /// Connector-specific configuration enum for all supported connectors
 #[derive(Debug, Clone, serde::Serialize)]
 pub enum ConnectorSpecificConfig {
@@ -1006,12 +1011,21 @@ impl ForeignTryFrom<(Connector, &ConnectorAuthType, Option<&serde_json::Value>)>
                     api_key,
                     key1,
                     api_secret,
-                } => Ok(Self::Fiserv {
-                    api_key: api_key.clone(),
-                    merchant_account: key1.clone(),
-                    api_secret: api_secret.clone(),
-                    terminal_id: None,
-                }),
+                } => {
+                    let fiserv_meta = metadata
+                        .map(|m| {
+                            serde_json::from_value::<FiservMetadata>(m.clone())
+                                .map_err(|_| err("Invalid Fiserv metadata format"))
+                        })
+                        .transpose()?;
+
+                    Ok(Self::Fiserv {
+                        api_key: api_key.clone(),
+                        merchant_account: key1.clone(),
+                        api_secret: api_secret.clone(),
+                        terminal_id: fiserv_meta.and_then(|m| m.terminal_id),
+                    })
+                }
                 _ => Err(err("Fiserv requires SignatureKey auth type")),
             },
             Connector::Fiservemea => match auth {
@@ -1439,4 +1453,90 @@ pub fn build_connector_config_header(
         .attach_printable("Failed to serialize ConnectorSpecificConfig")?;
 
     Ok(Some(config_string))
+}
+
+#[cfg(test)]
+mod tests {
+    use common_enums::connector_enums::Connector;
+    use hyperswitch_domain_models::router_data::ConnectorAuthType;
+    use hyperswitch_masking::{PeekInterface, Secret};
+    use serde_json::json;
+
+    use super::{build_connector_config_header, ConnectorSpecificConfig};
+    use crate::types::transformers::ForeignTryFrom;
+
+    fn fiserv_auth() -> ConnectorAuthType {
+        ConnectorAuthType::SignatureKey {
+            api_key: Secret::new("ak".to_string()),
+            key1: Secret::new("merchant".to_string()),
+            api_secret: Secret::new("sk".to_string()),
+        }
+    }
+
+    #[test]
+    fn fiserv_metadata_populated_sets_terminal_id() {
+        let auth = fiserv_auth();
+        let meta = json!({ "terminal_id": "T-123" });
+        let config = ConnectorSpecificConfig::foreign_try_from((
+            Connector::Fiserv,
+            &auth,
+            Some(&meta),
+        ))
+        .expect("populated metadata must parse");
+        match config {
+            ConnectorSpecificConfig::Fiserv { terminal_id, .. } => {
+                assert_eq!(
+                    terminal_id.as_ref().map(|s| s.peek().clone()),
+                    Some("T-123".to_string())
+                );
+            }
+            _ => panic!("expected Fiserv variant"),
+        }
+    }
+
+    #[test]
+    fn fiserv_metadata_absent_yields_none_without_error() {
+        let auth = fiserv_auth();
+        let config =
+            ConnectorSpecificConfig::foreign_try_from((Connector::Fiserv, &auth, None))
+                .expect("absent metadata must not error");
+        match config {
+            ConnectorSpecificConfig::Fiserv { terminal_id, .. } => {
+                assert!(terminal_id.is_none());
+            }
+            _ => panic!("expected Fiserv variant"),
+        }
+    }
+
+    fn extract_fiserv_terminal_id(header: &str) -> Option<serde_json::Value> {
+        let parsed: serde_json::Value =
+            serde_json::from_str(header).expect("header must be valid JSON");
+        parsed
+            .get("config")
+            .and_then(|config| config.get("Fiserv"))
+            .and_then(|fiserv| fiserv.get("terminal_id"))
+            .cloned()
+    }
+
+    #[test]
+    fn build_header_contains_terminal_id_when_populated() {
+        let auth = fiserv_auth();
+        let meta = json!({ "terminal_id": "T-42" });
+        let header = build_connector_config_header("fiserv", &auth, Some(&meta))
+            .expect("build header must succeed")
+            .expect("header must be produced for fiserv");
+        assert_eq!(extract_fiserv_terminal_id(&header), Some(json!("T-42")));
+    }
+
+    #[test]
+    fn build_header_serialises_null_terminal_id_when_absent() {
+        let auth = fiserv_auth();
+        let header = build_connector_config_header("fiserv", &auth, None)
+            .expect("build header must succeed")
+            .expect("header must be produced for fiserv");
+        assert_eq!(
+            extract_fiserv_terminal_id(&header),
+            Some(serde_json::Value::Null)
+        );
+    }
 }

--- a/crates/router/src/core/unified_connector_service/connector_config.rs
+++ b/crates/router/src/core/unified_connector_service/connector_config.rs
@@ -1477,12 +1477,9 @@ mod tests {
     fn fiserv_metadata_populated_sets_terminal_id() {
         let auth = fiserv_auth();
         let meta = json!({ "terminal_id": "T-123" });
-        let config = ConnectorSpecificConfig::foreign_try_from((
-            Connector::Fiserv,
-            &auth,
-            Some(&meta),
-        ))
-        .expect("populated metadata must parse");
+        let config =
+            ConnectorSpecificConfig::foreign_try_from((Connector::Fiserv, &auth, Some(&meta)))
+                .expect("populated metadata must parse");
         match config {
             ConnectorSpecificConfig::Fiserv { terminal_id, .. } => {
                 assert_eq!(
@@ -1497,9 +1494,8 @@ mod tests {
     #[test]
     fn fiserv_metadata_absent_yields_none_without_error() {
         let auth = fiserv_auth();
-        let config =
-            ConnectorSpecificConfig::foreign_try_from((Connector::Fiserv, &auth, None))
-                .expect("absent metadata must not error");
+        let config = ConnectorSpecificConfig::foreign_try_from((Connector::Fiserv, &auth, None))
+            .expect("absent metadata must not error");
         match config {
             ConnectorSpecificConfig::Fiserv { terminal_id, .. } => {
                 assert!(terminal_id.is_none());


### PR DESCRIPTION
## Type of Change

- [x] Bugfix

## Description

In UCS shadow mode, hyperswitch's `X-Connector-Config` header builder hard-codes `config.Fiserv.terminal_id: null` for the `Connector::Fiserv` arm of `ConnectorSpecificConfig::foreign_try_from`, ignoring the `merchant_account_metadata` parameter that the function already accepts. As a result, every Fiserv shadow Authorize/Capture/Void/Refund request emits `"terminalId": null` downstream, regardless of whether the MCA metadata has a populated `terminal_id`. This blocks Fiserv's graduation from `ExecutionMode::Shadow` to `ExecutionMode::Primary`.

Hyperswitch's own live (non-shadow) Fiserv Authorize path at `crates/hyperswitch_connectors/src/connectors/fiserv/transformers.rs:L396-L406` reads this same MCA metadata correctly via `get_connector_meta()` + `FiservSessionObject`. Shadow is the divergent path; this PR aligns it.

### Fix

Introduce a local `FiservMetadata { terminal_id: Option<Secret<String>> }` struct and wire it into the `Connector::Fiserv` arm using the same map-and-transpose idiom already applied to Peachpayments in #11690 (merged 2026-04-07), as well as to Adyen / Cybersource / Braintree / Truelayer / Paysafe. Scope: Fiserv arm only. 3 production-code lines of parsing logic + 4 unit tests.

The `ConnectorSpecificConfig::Fiserv` variant field `terminal_id: Option<Secret<String>>` (L230-L235) was already optional, so no enum reshape is required.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

## Motivation and Context

Closes #11836.

Root cause traced in parity RCA against `origin/main` HEAD `00bdf77a4` (matches the cited SHA in the linked issue).

## How did you test it?

Added 4 unit tests at `crates/router/src/core/unified_connector_service/connector_config.rs` covering:

- `fiserv_metadata_populated_sets_terminal_id` — MCA metadata with `terminal_id` yields `Some(terminal_id)` on the parsed variant.
- `fiserv_metadata_absent_yields_none_without_error` — absent metadata yields `None` with no error (legitimate "no terminal_id configured" case).
- `build_header_contains_terminal_id_when_populated` — end-to-end `build_connector_config_header("fiserv", ...)` emits `"terminal_id": "<value>"` in the header JSON.
- `build_header_serialises_null_terminal_id_when_absent` — same with absent metadata emits `"terminal_id": null`, no error.

Verification commands (all green against commit `67715f697`):

```
cargo build -p router --features v1
cargo clippy -p router --features v1 --tests -- -D warnings
cargo +nightly fmt --all -- --check
cargo test -p router --features v1 --lib core::unified_connector_service::connector_config::tests
```

Test output:

```
running 4 tests
test core::unified_connector_service::connector_config::tests::fiserv_metadata_absent_yields_none_without_error ... ok
test core::unified_connector_service::connector_config::tests::fiserv_metadata_populated_sets_terminal_id ... ok
test core::unified_connector_service::connector_config::tests::build_header_serialises_null_terminal_id_when_absent ... ok
test core::unified_connector_service::connector_config::tests::build_header_contains_terminal_id_when_populated ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 46 filtered out; finished in 0.00s
```

## Checklist

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [x] I added unit tests for my changes where possible
