### PR TITLE
feat(ucs): inline connector config header into shadow-mode ComparisonData

### DIFF
--- a/crates/router/src/core/unified_connector_service.rs
+++ b/crates/router/src/core/unified_connector_service.rs
@@ -2837,6 +2837,8 @@ where
 pub struct ComparisonData {
     pub hyperswitch_data: Secret<serde_json::Value>,
     pub unified_connector_service_data: Secret<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub connector_config_header: Option<serde_json::Value>,
 }
 
 /// Generic function to serialize router data and send comparison to external service
@@ -2846,6 +2848,32 @@ pub async fn serialize_router_data_and_send_to_comparison_service<F, RouterDReq,
     state: &SessionState,
     hyperswitch_router_data: RouterData<F, RouterDReq, RouterDResp>,
     unified_connector_service_router_data: RouterData<F, RouterDReq, RouterDResp>,
+) -> RouterResult<()>
+where
+    F: Send + Clone + Sync + 'static,
+    RouterDReq: Send + Sync + Clone + 'static + serde::Serialize,
+    RouterDResp: Send + Sync + Clone + 'static + serde::Serialize,
+{
+    serialize_router_data_with_config_and_send_to_comparison_service(
+        state,
+        hyperswitch_router_data,
+        unified_connector_service_router_data,
+        None,
+    )
+    .await
+}
+
+/// Serialize router data with an optional connector config snapshot and send to comparison service
+#[cfg(feature = "v1")]
+pub async fn serialize_router_data_with_config_and_send_to_comparison_service<
+    F,
+    RouterDReq,
+    RouterDResp,
+>(
+    state: &SessionState,
+    hyperswitch_router_data: RouterData<F, RouterDReq, RouterDResp>,
+    unified_connector_service_router_data: RouterData<F, RouterDReq, RouterDResp>,
+    connector_config_header: Option<serde_json::Value>,
 ) -> RouterResult<()>
 where
     F: Send + Clone + Sync + 'static,
@@ -2875,6 +2903,7 @@ where
     let comparison_data = ComparisonData {
         hyperswitch_data,
         unified_connector_service_data,
+        connector_config_header,
     };
     let _ = send_comparison_data(state, comparison_data, connector_name, sub_flow_name)
         .await
@@ -3125,4 +3154,35 @@ pub async fn call_unified_connector_service_for_refund_sync(
     ))
     .await
     .map(|(router_data, _flow_response)| router_data)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use hyperswitch_masking::Secret;
+
+    #[test]
+    fn comparison_data_serializes_connector_config_header_when_present() {
+        let config = serde_json::json!({"config": {"api_version": "2023-10-16"}});
+        let data = ComparisonData {
+            hyperswitch_data: Secret::new(serde_json::json!({"key": "hs"})),
+            unified_connector_service_data: Secret::new(serde_json::json!({"key": "ucs"})),
+            connector_config_header: Some(config.clone()),
+        };
+
+        let serialized = serde_json::to_value(&data).expect("serialization must succeed");
+        assert_eq!(serialized["connector_config_header"], config);
+    }
+
+    #[test]
+    fn comparison_data_omits_connector_config_header_when_none() {
+        let data = ComparisonData {
+            hyperswitch_data: Secret::new(serde_json::json!({"key": "hs"})),
+            unified_connector_service_data: Secret::new(serde_json::json!({"key": "ucs"})),
+            connector_config_header: None,
+        };
+
+        let serialized = serde_json::to_value(&data).expect("serialization must succeed");
+        assert!(serialized.get("connector_config_header").is_none());
+    }
 }


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Adds an optional `connector_config_header` field to the `ComparisonData` envelope serialized by the shadow-mode comparison path. This gives the parity-trace RPC immediate access to the connector-config snapshot without reconstructing it from `connector_auth_type`.

### Changes

1. **`ComparisonData` struct** — new `connector_config_header: Option<serde_json::Value>` field with `#[serde(skip_serializing_if = "Option::is_none")]` to preserve backward compatibility of the serialized envelope.

2. **Backward-compatible delegate** — existing `serialize_router_data_and_send_to_comparison_service` keeps its signature and delegates to the new `serialize_router_data_with_config_and_send_to_comparison_service`, passing `None`. Existing callers in `refunds.rs` require no changes.

3. **Unit tests** — two tests verify the field serializes correctly when `Some` and is omitted when `None`.

### Follow-up required

The callers in `refunds.rs` (L659, L1227) and the payment path in `gateway.rs` still pass `None` via the delegate. A follow-up change should thread the connector config from `build_unified_connector_service_auth_metadata` through to the comparison call sites.

## Additional Changes

- No schema or protocol changes
- Shadow-mode path only, no live-traffic impact

## Motivation and Context

Part of the UCS parity workstream. The parity-trace comparator needs the connector-config snapshot to reproduce UCS requests faithfully for shadow-diff analysis.

## How did you test it?

```
cargo check -p router --lib  # ✅ compiles
cargo test -p router --lib core::unified_connector_service::tests  # ✅ 2/2 pass
```

## Checklist

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [x] I added unit tests for my changes where possible