### PR TITLE
feat(ucs): thread connector_config_header through refund + gateway comparison paths

### DIFF
--- a/crates/hyperswitch_interfaces/src/api/gateway.rs
+++ b/crates/hyperswitch_interfaces/src/api/gateway.rs
@@ -32,6 +32,11 @@ pub trait GatewayContext: Clone + Send + Sync {
 
     /// Get the execution mode (Primary, Shadow, etc.)
     fn execution_mode(&self) -> ExecutionMode;
+
+    /// Get the connector config header for the comparison envelope, if available
+    fn connector_config_header(&self) -> Option<String> {
+        None
+    }
 }
 
 /// Trait to extract RouterData from various output types
@@ -406,6 +411,7 @@ where
             let context_clone = context;
             tokio::spawn(
                 async move {
+                    let connector_config_header = context_clone.connector_config_header();
                     let gateway: Box<
                         dyn PaymentGateway<State, ConnectorData, F, Req, Resp, Context, FlowOutput>,
                     > = F::get_gateway(ExecutionPath::ShadowUnifiedConnectorService);
@@ -421,21 +427,20 @@ where
                         )
                         .await
                         .attach_printable("Gateway execution failed");
-                    // Send comparison data asynchronously
                     match ucs_shadow_result {
                         Ok(ucs_router_data) => {
-                            // Send comparison data asynchronously
                             if let Some(comparison_service_config) =
                                 state_clone.get_comparison_service_config()
                             {
                                 let request_id = state_clone.get_request_id_str();
                                 let _ =
-                                    helpers::serialize_router_data_and_send_to_comparison_service(
+                                    helpers::serialize_router_data_with_config_and_send_to_comparison_service(
                                         &state_clone,
                                         direct_router_data_clone.get_router_data().clone(),
                                         ucs_router_data.get_router_data().clone(),
                                         comparison_service_config,
                                         request_id,
+                                        connector_config_header,
                                     )
                                     .await;
                             };
@@ -540,6 +545,7 @@ where
             let context_clone = context;
             tokio::spawn(
                 async move {
+                    let connector_config_header = context_clone.connector_config_header();
                     let gateway: Box<
                         dyn PayoutGateway<State, ConnectorData, F, Req, Resp, Context, FlowOutput>,
                     > = F::get_payout_gateway(ExecutionPath::ShadowUnifiedConnectorService);
@@ -555,21 +561,20 @@ where
                         )
                         .await
                         .attach_printable("Gateway execution failed");
-                    // Send comparison data asynchronously
                     match ucs_shadow_result {
                         Ok(ucs_router_data) => {
-                            // Send comparison data asynchronously
                             if let Some(comparison_service_config) =
                                 state_clone.get_comparison_service_config()
                             {
                                 let request_id = state_clone.get_request_id_str();
                                 let _ =
-                                    helpers::serialize_router_data_and_send_to_comparison_service(
+                                    helpers::serialize_router_data_with_config_and_send_to_comparison_service(
                                         &state_clone,
                                         direct_router_data_clone.get_router_data().clone(),
                                         ucs_router_data.get_router_data().clone(),
                                         comparison_service_config,
                                         request_id,
+                                        connector_config_header,
                                     )
                                     .await;
                             };

--- a/crates/hyperswitch_interfaces/src/helpers.rs
+++ b/crates/hyperswitch_interfaces/src/helpers.rs
@@ -29,6 +29,9 @@ pub struct ComparisonData {
     pub hyperswitch_data: hyperswitch_masking::Secret<serde_json::Value>,
     /// Unified Connector Service router data
     pub unified_connector_service_data: hyperswitch_masking::Secret<serde_json::Value>,
+    /// Connector-specific config snapshot for parity comparison
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub connector_config_header: Option<String>,
 }
 
 /// Trait to get comparison service configuration
@@ -45,6 +48,35 @@ pub async fn serialize_router_data_and_send_to_comparison_service<F, RouterDReq,
     unified_connector_service_router_data: router_data::RouterData<F, RouterDReq, RouterDResp>,
     comparison_service_config: types::ComparisonServiceConfig,
     request_id: Option<String>,
+) -> common_utils_errors::CustomResult<(), errors::HttpClientError>
+where
+    F: Send + Clone + Sync + 'static,
+    RouterDReq: Send + Sync + Clone + 'static + serde::Serialize,
+    RouterDResp: Send + Sync + Clone + 'static + serde::Serialize,
+{
+    serialize_router_data_with_config_and_send_to_comparison_service(
+        state,
+        hyperswitch_router_data,
+        unified_connector_service_router_data,
+        comparison_service_config,
+        request_id,
+        None,
+    )
+    .await
+}
+
+/// Serialize router data with an optional connector config snapshot and send to comparison service
+pub async fn serialize_router_data_with_config_and_send_to_comparison_service<
+    F,
+    RouterDReq,
+    RouterDResp,
+>(
+    state: &dyn api_client::ApiClientWrapper,
+    hyperswitch_router_data: router_data::RouterData<F, RouterDReq, RouterDResp>,
+    unified_connector_service_router_data: router_data::RouterData<F, RouterDReq, RouterDResp>,
+    comparison_service_config: types::ComparisonServiceConfig,
+    request_id: Option<String>,
+    connector_config_header: Option<String>,
 ) -> common_utils_errors::CustomResult<(), errors::HttpClientError>
 where
     F: Send + Clone + Sync + 'static,
@@ -74,6 +106,7 @@ where
     let comparison_data = ComparisonData {
         hyperswitch_data,
         unified_connector_service_data,
+        connector_config_header,
     };
     let _ = send_comparison_data(
         state,

--- a/crates/router/src/core/payments/gateway/context.rs
+++ b/crates/router/src/core/payments/gateway/context.rs
@@ -106,9 +106,34 @@ impl GatewayContext for RouterGatewayContext {
         self.execution_path
     }
 
-    /// Get the execution mode (Primary, Shadow, etc.)
     fn execution_mode(&self) -> ExecutionMode {
         self.execution_mode
+    }
+
+    #[cfg(feature = "v1")]
+    fn connector_config_header(&self) -> Option<String> {
+        use common_utils::ext_traits::ValueExt;
+        use hyperswitch_domain_models::router_data::ConnectorAuthType;
+        use hyperswitch_masking::ExposeInterface;
+
+        let connector_name = self.merchant_connector_account.get_connector_name()?;
+        let auth_type: ConnectorAuthType = self
+            .merchant_connector_account
+            .get_connector_account_details()
+            .parse_value("ConnectorAuthType")
+            .ok()?;
+        let metadata = self.merchant_connector_account.get_metadata();
+        let metadata_value = metadata
+            .as_ref()
+            .and_then(|m| serde_json::to_value(m.clone().expose()).ok());
+
+        crate::core::unified_connector_service::connector_config::build_connector_config_header(
+            &connector_name,
+            &auth_type,
+            metadata_value.as_ref(),
+        )
+        .ok()
+        .flatten()
     }
 }
 impl RouterGatewayContext {

--- a/crates/router/src/core/refunds.rs
+++ b/crates/router/src/core/refunds.rs
@@ -612,6 +612,36 @@ async fn execute_refund_execute_via_direct(
     Ok(refund_router_data_res)
 }
 
+#[cfg(feature = "v1")]
+fn build_connector_config_header_from_mca(
+    merchant_connector_account: &MerchantConnectorAccountType,
+) -> Option<serde_json::Value> {
+    use common_utils::ext_traits::ValueExt;
+    use hyperswitch_domain_models::router_data::ConnectorAuthType;
+    use hyperswitch_masking::ExposeInterface;
+
+    let connector_name = merchant_connector_account.get_connector_name()?;
+    let auth_type: ConnectorAuthType = merchant_connector_account
+        .get_connector_account_details()
+        .parse_value("ConnectorAuthType")
+        .ok()?;
+    let metadata = merchant_connector_account.get_metadata();
+    let metadata_value = metadata
+        .as_ref()
+        .and_then(|m| serde_json::to_value(m.clone().expose()).ok());
+
+    let config_string =
+        unified_connector_service::connector_config::build_connector_config_header(
+            &connector_name,
+            &auth_type,
+            metadata_value.as_ref(),
+        )
+        .ok()
+        .flatten()?;
+
+    serde_json::from_str(&config_string).ok()
+}
+
 /// Execute refund via Direct connector with UCS shadow comparison
 async fn execute_refund_execute_via_direct_with_ucs_shadow(
     state: &SessionState,
@@ -638,6 +668,10 @@ async fn execute_refund_execute_via_direct_with_ucs_shadow(
     let ucs_platform = platform.clone();
     let ucs_state = state.clone();
 
+    let connector_config_header = build_connector_config_header_from_mca(
+        &merchant_connector_account,
+    );
+
     // Clone direct result for comparison (if successful)
     let direct_router_data_for_comparison = direct_result.as_ref().ok().cloned();
 
@@ -656,10 +690,11 @@ async fn execute_refund_execute_via_direct_with_ucs_shadow(
                 match (ucs_result, direct_router_data_for_comparison) {
                     (Ok(ucs_router_data), Some(direct_router_data)) => {
                         Box::pin(
-                            unified_connector_service::serialize_router_data_and_send_to_comparison_service(
+                            unified_connector_service::serialize_router_data_with_config_and_send_to_comparison_service(
                                 &ucs_state,
                                 direct_router_data,
-                                ucs_router_data
+                                ucs_router_data,
+                                connector_config_header,
                             )
                         ).await
                             .inspect_err(|e| {
@@ -1207,6 +1242,9 @@ async fn execute_refund_sync_via_direct_with_ucs_shadow(
     let state = state.clone();
     let processor = processor.clone();
     let merchant_connector_account = merchant_connector_account.clone();
+    let connector_config_header = build_connector_config_header_from_mca(
+        &merchant_connector_account,
+    );
     let direct_router_data_for_comparison = direct_result.as_ref().ok().cloned();
 
     tokio::spawn(
@@ -1224,10 +1262,11 @@ async fn execute_refund_sync_via_direct_with_ucs_shadow(
                 match (ucs_result, direct_router_data_for_comparison) {
                     (Ok(ucs_router_data), Some(direct_router_data)) => {
                         Box::pin(
-                            unified_connector_service::serialize_router_data_and_send_to_comparison_service(
+                            unified_connector_service::serialize_router_data_with_config_and_send_to_comparison_service(
                                 &state,
                                 direct_router_data,
-                                ucs_router_data
+                                ucs_router_data,
+                                connector_config_header,
                             )
                         ).await
                             .inspect_err(|e| {

--- a/crates/router/src/core/unified_connector_service.rs
+++ b/crates/router/src/core/unified_connector_service.rs
@@ -2837,6 +2837,8 @@ where
 pub struct ComparisonData {
     pub hyperswitch_data: Secret<serde_json::Value>,
     pub unified_connector_service_data: Secret<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub connector_config_header: Option<serde_json::Value>,
 }
 
 /// Generic function to serialize router data and send comparison to external service
@@ -2846,6 +2848,32 @@ pub async fn serialize_router_data_and_send_to_comparison_service<F, RouterDReq,
     state: &SessionState,
     hyperswitch_router_data: RouterData<F, RouterDReq, RouterDResp>,
     unified_connector_service_router_data: RouterData<F, RouterDReq, RouterDResp>,
+) -> RouterResult<()>
+where
+    F: Send + Clone + Sync + 'static,
+    RouterDReq: Send + Sync + Clone + 'static + serde::Serialize,
+    RouterDResp: Send + Sync + Clone + 'static + serde::Serialize,
+{
+    serialize_router_data_with_config_and_send_to_comparison_service(
+        state,
+        hyperswitch_router_data,
+        unified_connector_service_router_data,
+        None,
+    )
+    .await
+}
+
+/// Serialize router data with an optional connector config snapshot and send to comparison service
+#[cfg(feature = "v1")]
+pub async fn serialize_router_data_with_config_and_send_to_comparison_service<
+    F,
+    RouterDReq,
+    RouterDResp,
+>(
+    state: &SessionState,
+    hyperswitch_router_data: RouterData<F, RouterDReq, RouterDResp>,
+    unified_connector_service_router_data: RouterData<F, RouterDReq, RouterDResp>,
+    connector_config_header: Option<serde_json::Value>,
 ) -> RouterResult<()>
 where
     F: Send + Clone + Sync + 'static,
@@ -2875,6 +2903,7 @@ where
     let comparison_data = ComparisonData {
         hyperswitch_data,
         unified_connector_service_data,
+        connector_config_header,
     };
     let _ = send_comparison_data(state, comparison_data, connector_name, sub_flow_name)
         .await
@@ -3125,4 +3154,35 @@ pub async fn call_unified_connector_service_for_refund_sync(
     ))
     .await
     .map(|(router_data, _flow_response)| router_data)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use hyperswitch_masking::Secret;
+
+    #[test]
+    fn comparison_data_serializes_connector_config_header_when_present() {
+        let config = serde_json::json!({"config": {"api_version": "2023-10-16"}});
+        let data = ComparisonData {
+            hyperswitch_data: Secret::new(serde_json::json!({"key": "hs"})),
+            unified_connector_service_data: Secret::new(serde_json::json!({"key": "ucs"})),
+            connector_config_header: Some(config.clone()),
+        };
+
+        let serialized = serde_json::to_value(&data).expect("serialization must succeed");
+        assert_eq!(serialized["connector_config_header"], config);
+    }
+
+    #[test]
+    fn comparison_data_omits_connector_config_header_when_none() {
+        let data = ComparisonData {
+            hyperswitch_data: Secret::new(serde_json::json!({"key": "hs"})),
+            unified_connector_service_data: Secret::new(serde_json::json!({"key": "ucs"})),
+            connector_config_header: None,
+        };
+
+        let serialized = serde_json::to_value(&data).expect("serialization must succeed");
+        assert!(serialized.get("connector_config_header").is_none());
+    }
 }


### PR DESCRIPTION
## Summary

Thread the actual `connector_config_header` value from `build_connector_config_header` through to all shadow-mode comparison service callers that previously passed `None`.

**Depends on:** #11848

### Changes

- **`helpers.rs`**: Add `connector_config_header: Option<String>` to `ComparisonData` with `skip_serializing_if`. Add `serialize_router_data_with_config_and_send_to_comparison_service` variant (delegate pattern matching #11848).
- **`gateway.rs`**: Add `connector_config_header()` to `GatewayContext` trait (default `None`). Update payment and payout shadow paths to extract config from context and pass to `with_config` variant.
- **`context.rs`**: Implement `connector_config_header()` on `RouterGatewayContext` — builds the header from MCA's connector name, auth type, and metadata via `build_connector_config_header`.
- **`refunds.rs`**: Add `build_connector_config_header_from_mca` helper. Update refund execute (L659) and refund sync (L1227) shadow paths to build config header before spawn and pass as `serde_json::Value` to the `with_config` variant.

### Validation

- `cargo check -p router --features v1 --lib` — compiles clean, no warnings
- `cargo test -p router --features v1 --lib connector_config` — 2/2 pass (PRI-33 tests)

### Scope

Shadow-mode comparison paths only — no live-traffic impact.

Closes: PRI-49