### PR TITLE
[QA] Add step up retries test cases in Payment Specs

### DIFF
--- a/cypress-tests/cypress/e2e/configs/Payment/Commons.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Commons.js
@@ -1049,6 +1049,42 @@ export const connectorDetails = {
         },
       },
     }),
+    StepUpRetries: getCustomExchange({
+      Request: {
+        connector: "cybersource",
+        flow: "Authorize",
+        sub_flow: "Debit",
+        code: "201",
+        message: "Insufficient funds",
+        status: "failure",
+        decision: "retry",
+        step_up_possible: true,
+        clear_pan_possible: false,
+        alternate_network_possible: false,
+      },
+      Response: {
+        status: 200,
+        body: {
+          connector: "cybersource",
+          flow: "Authorize",
+          sub_flow: "Debit",
+          code: "201",
+          message: "Insufficient funds",
+          status: "failure",
+          decision: "retry",
+          step_up_possible: true,
+          feature: "retry",
+          feature_data: {
+            retry: {
+              step_up_possible: true,
+              clear_pan_possible: false,
+              alternate_network_possible: false,
+              decision: "retry",
+            },
+          },
+        },
+      },
+    }),
     Capture: getCustomExchange({
       Request: {
         amount_to_capture: 6000,

--- a/cypress-tests/cypress/e2e/configs/Payment/Cybersource.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Cybersource.js
@@ -445,6 +445,34 @@ export const connectorDetails = {
         },
       },
     },
+    StepUpRetries: {
+      Request: {
+        connector: "cybersource",
+        flow: "Authorize",
+        sub_flow: "Debit",
+        code: "201",
+        message: "Insufficient funds",
+        status: "failure",
+        decision: "retry",
+        step_up_possible: true,
+        clear_pan_possible: false,
+        alternate_network_possible: false,
+      },
+      Response: {
+        status: 200,
+        body: {
+          connector: "cybersource",
+          flow: "Authorize",
+          sub_flow: "Debit",
+          code: "201",
+          message: "Insufficient funds",
+          status: "failure",
+          decision: "retry",
+          step_up_possible: true,
+          feature: "retry",
+        },
+      },
+    },
     Capture: {
       Configs: {
         CONNECTOR_CREDENTIAL: {

--- a/cypress-tests/cypress/e2e/configs/Payment/Utils.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Utils.js
@@ -530,9 +530,7 @@ export const CONNECTOR_LISTS = {
       "worldpay",
       "worldpayvantiv",
     ],
-    STEP_UP_RETRIES: [
-      "cybersource",
-    ],
+    STEP_UP_RETRIES: ["cybersource"],
     // Add more inclusion lists
   },
 };

--- a/cypress-tests/cypress/e2e/configs/Payment/Utils.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Utils.js
@@ -530,6 +530,9 @@ export const CONNECTOR_LISTS = {
       "worldpay",
       "worldpayvantiv",
     ],
+    STEP_UP_RETRIES: [
+      "cybersource",
+    ],
     // Add more inclusion lists
   },
 };

--- a/cypress-tests/cypress/e2e/spec/Payment/46-StepUpRetries.cy.js
+++ b/cypress-tests/cypress/e2e/spec/Payment/46-StepUpRetries.cy.js
@@ -1,0 +1,287 @@
+import * as fixtures from "../../../fixtures/imports";
+import State from "../../../utils/State";
+import getConnectorDetails, * as utils from "../../configs/Payment/Utils";
+
+let globalState;
+
+describe("Step Up Retries Tests", () => {
+  before("seed global state", () => {
+    cy.task("getGlobalState").then((state) => {
+      globalState = new State(state);
+    });
+  });
+
+  after("flush global state", () => {
+    cy.task("setGlobalState", globalState.data);
+  });
+
+  context("Create GSM rule with step_up_possible enabled", () => {
+    it("Update GSM Config with step_up_possible=true -> Create Payment Intent -> Confirm Payment -> Retrieve Payment", () => {
+      let shouldContinue = true;
+
+      cy.step("Update GSM Config with step_up_possible=true", () => {
+        const connectorId = globalState.get("connectorId");
+        if (
+          utils.shouldIncludeConnector(
+            connectorId,
+            utils.CONNECTOR_LISTS.INCLUDE.STEP_UP_RETRIES
+          )
+        ) {
+          cy.log(
+            `Skipping Step Up Retries - connector not supported: ${connectorId}`
+          );
+          shouldContinue = false;
+          return;
+        }
+
+        const data = getConnectorDetails(globalState.get("connectorId"))[
+          "card_pm"
+        ]["StepUpRetries"];
+
+        cy.updateGsmConfig(fixtures.gsmBody.gsm_update, globalState, true);
+
+        if (!utils.should_continue_further(data)) {
+          shouldContinue = false;
+        }
+      });
+
+      cy.step("Create Payment Intent", () => {
+        if (!shouldContinue) {
+          cy.task("cli_log", "Skipping step: Create Payment Intent");
+          return;
+        }
+
+        const data = getConnectorDetails(globalState.get("connectorId"))[
+          "card_pm"
+        ]["PaymentIntent"];
+
+        cy.createPaymentIntentTest(
+          fixtures.createPaymentBody,
+          data,
+          "no_three_ds",
+          "automatic",
+          globalState
+        );
+
+        if (!utils.should_continue_further(data)) {
+          shouldContinue = false;
+        }
+      });
+
+      cy.step("Confirm Payment", () => {
+        if (!shouldContinue) {
+          cy.task("cli_log", "Skipping step: Confirm Payment");
+          return;
+        }
+
+        const data = getConnectorDetails(globalState.get("connectorId"))[
+          "card_pm"
+        ]["No3DSAutoCapture"];
+
+        cy.confirmCallTest(
+          fixtures.confirmBody,
+          data,
+          true,
+          globalState
+        );
+
+        if (!utils.should_continue_further(data)) {
+          shouldContinue = false;
+        }
+      });
+
+      cy.step("Retrieve Payment", () => {
+        if (!shouldContinue) {
+          cy.task("cli_log", "Skipping step: Retrieve Payment");
+          return;
+        }
+
+        const data = getConnectorDetails(globalState.get("connectorId"))[
+          "card_pm"
+        ]["No3DSAutoCapture"];
+
+        cy.retrievePaymentCallTest({ globalState, data });
+      });
+    });
+  });
+
+  context("Update GSM rule with step_up_possible disabled", () => {
+    it("Update GSM Config with step_up_possible=false -> Create Payment Intent -> Confirm Payment -> Retrieve Payment", () => {
+      let shouldContinue = true;
+
+      cy.step("Update GSM Config with step_up_possible=false", () => {
+        const connectorId = globalState.get("connectorId");
+        if (
+          utils.shouldIncludeConnector(
+            connectorId,
+            utils.CONNECTOR_LISTS.INCLUDE.STEP_UP_RETRIES
+          )
+        ) {
+          cy.log(
+            `Skipping Step Up Retries - connector not supported: ${connectorId}`
+          );
+          shouldContinue = false;
+          return;
+        }
+
+        const data = getConnectorDetails(globalState.get("connectorId"))[
+          "card_pm"
+        ]["StepUpRetries"];
+
+        cy.updateGsmConfig(fixtures.gsmBody.gsm_update, globalState, false);
+
+        if (!utils.should_continue_further(data)) {
+          shouldContinue = false;
+        }
+      });
+
+      cy.step("Create Payment Intent", () => {
+        if (!shouldContinue) {
+          cy.task("cli_log", "Skipping step: Create Payment Intent");
+          return;
+        }
+
+        const data = getConnectorDetails(globalState.get("connectorId"))[
+          "card_pm"
+        ]["PaymentIntent"];
+
+        cy.createPaymentIntentTest(
+          fixtures.createPaymentBody,
+          data,
+          "no_three_ds",
+          "automatic",
+          globalState
+        );
+
+        if (!utils.should_continue_further(data)) {
+          shouldContinue = false;
+        }
+      });
+
+      cy.step("Confirm Payment", () => {
+        if (!shouldContinue) {
+          cy.task("cli_log", "Skipping step: Confirm Payment");
+          return;
+        }
+
+        const data = getConnectorDetails(globalState.get("connectorId"))[
+          "card_pm"
+        ]["No3DSAutoCapture"];
+
+        cy.confirmCallTest(
+          fixtures.confirmBody,
+          data,
+          true,
+          globalState
+        );
+
+        if (!utils.should_continue_further(data)) {
+          shouldContinue = false;
+        }
+      });
+
+      cy.step("Retrieve Payment", () => {
+        if (!shouldContinue) {
+          cy.task("cli_log", "Skipping step: Retrieve Payment");
+          return;
+        }
+
+        const data = getConnectorDetails(globalState.get("connectorId"))[
+          "card_pm"
+        ]["No3DSAutoCapture"];
+
+        cy.retrievePaymentCallTest({ globalState, data });
+      });
+    });
+  });
+
+  context("Edge case: Payment with billing for connector requiring address", () => {
+    it("Update GSM Config -> Create Payment Intent -> Confirm Payment with billing -> Retrieve Payment", () => {
+      let shouldContinue = true;
+
+      cy.step("Update GSM Config with step_up_possible=true", () => {
+        const connectorId = globalState.get("connectorId");
+        if (
+          utils.shouldIncludeConnector(
+            connectorId,
+            utils.CONNECTOR_LISTS.INCLUDE.STEP_UP_RETRIES
+          )
+        ) {
+          cy.log(
+            `Skipping Step Up Retries - connector not supported: ${connectorId}`
+          );
+          shouldContinue = false;
+          return;
+        }
+
+        const data = getConnectorDetails(globalState.get("connectorId"))[
+          "card_pm"
+        ]["StepUpRetries"];
+
+        cy.updateGsmConfig(fixtures.gsmBody.gsm_update, globalState, true);
+
+        if (!utils.should_continue_further(data)) {
+          shouldContinue = false;
+        }
+      });
+
+      cy.step("Create Payment Intent", () => {
+        if (!shouldContinue) {
+          cy.task("cli_log", "Skipping step: Create Payment Intent");
+          return;
+        }
+
+        const data = getConnectorDetails(globalState.get("connectorId"))[
+          "card_pm"
+        ]["PaymentIntent"];
+
+        cy.createPaymentIntentTest(
+          fixtures.createPaymentBody,
+          data,
+          "no_three_ds",
+          "automatic",
+          globalState
+        );
+
+        if (!utils.should_continue_further(data)) {
+          shouldContinue = false;
+        }
+      });
+
+      cy.step("Confirm Payment with billing details", () => {
+        if (!shouldContinue) {
+          cy.task("cli_log", "Skipping step: Confirm Payment with billing details");
+          return;
+        }
+
+        const data = getConnectorDetails(globalState.get("connectorId"))[
+          "card_pm"
+        ]["No3DSAutoCapture"];
+
+        cy.confirmCallTest(
+          fixtures.confirmBody,
+          data,
+          true,
+          globalState
+        );
+
+        if (!utils.should_continue_further(data)) {
+          shouldContinue = false;
+        }
+      });
+
+      cy.step("Retrieve Payment", () => {
+        if (!shouldContinue) {
+          cy.task("cli_log", "Skipping step: Retrieve Payment");
+          return;
+        }
+
+        const data = getConnectorDetails(globalState.get("connectorId"))[
+          "card_pm"
+        ]["No3DSAutoCapture"];
+
+        cy.retrievePaymentCallTest({ globalState, data });
+      });
+    });
+  });
+});

--- a/cypress-tests/cypress/e2e/spec/Payment/46-StepUpRetries.cy.js
+++ b/cypress-tests/cypress/e2e/spec/Payment/46-StepUpRetries.cy.js
@@ -78,12 +78,7 @@ describe("Step Up Retries Tests", () => {
           "card_pm"
         ]["No3DSAutoCapture"];
 
-        cy.confirmCallTest(
-          fixtures.confirmBody,
-          data,
-          true,
-          globalState
-        );
+        cy.confirmCallTest(fixtures.confirmBody, data, true, globalState);
 
         if (!utils.should_continue_further(data)) {
           shouldContinue = false;
@@ -168,12 +163,7 @@ describe("Step Up Retries Tests", () => {
           "card_pm"
         ]["No3DSAutoCapture"];
 
-        cy.confirmCallTest(
-          fixtures.confirmBody,
-          data,
-          true,
-          globalState
-        );
+        cy.confirmCallTest(fixtures.confirmBody, data, true, globalState);
 
         if (!utils.should_continue_further(data)) {
           shouldContinue = false;
@@ -195,93 +185,94 @@ describe("Step Up Retries Tests", () => {
     });
   });
 
-  context("Edge case: Payment with billing for connector requiring address", () => {
-    it("Update GSM Config -> Create Payment Intent -> Confirm Payment with billing -> Retrieve Payment", () => {
-      let shouldContinue = true;
+  context(
+    "Edge case: Payment with billing for connector requiring address",
+    () => {
+      it("Update GSM Config -> Create Payment Intent -> Confirm Payment with billing -> Retrieve Payment", () => {
+        let shouldContinue = true;
 
-      cy.step("Update GSM Config with step_up_possible=true", () => {
-        const connectorId = globalState.get("connectorId");
-        if (
-          utils.shouldIncludeConnector(
-            connectorId,
-            utils.CONNECTOR_LISTS.INCLUDE.STEP_UP_RETRIES
-          )
-        ) {
-          cy.log(
-            `Skipping Step Up Retries - connector not supported: ${connectorId}`
+        cy.step("Update GSM Config with step_up_possible=true", () => {
+          const connectorId = globalState.get("connectorId");
+          if (
+            utils.shouldIncludeConnector(
+              connectorId,
+              utils.CONNECTOR_LISTS.INCLUDE.STEP_UP_RETRIES
+            )
+          ) {
+            cy.log(
+              `Skipping Step Up Retries - connector not supported: ${connectorId}`
+            );
+            shouldContinue = false;
+            return;
+          }
+
+          const data = getConnectorDetails(globalState.get("connectorId"))[
+            "card_pm"
+          ]["StepUpRetries"];
+
+          cy.updateGsmConfig(fixtures.gsmBody.gsm_update, globalState, true);
+
+          if (!utils.should_continue_further(data)) {
+            shouldContinue = false;
+          }
+        });
+
+        cy.step("Create Payment Intent", () => {
+          if (!shouldContinue) {
+            cy.task("cli_log", "Skipping step: Create Payment Intent");
+            return;
+          }
+
+          const data = getConnectorDetails(globalState.get("connectorId"))[
+            "card_pm"
+          ]["PaymentIntent"];
+
+          cy.createPaymentIntentTest(
+            fixtures.createPaymentBody,
+            data,
+            "no_three_ds",
+            "automatic",
+            globalState
           );
-          shouldContinue = false;
-          return;
-        }
 
-        const data = getConnectorDetails(globalState.get("connectorId"))[
-          "card_pm"
-        ]["StepUpRetries"];
+          if (!utils.should_continue_further(data)) {
+            shouldContinue = false;
+          }
+        });
 
-        cy.updateGsmConfig(fixtures.gsmBody.gsm_update, globalState, true);
+        cy.step("Confirm Payment with billing details", () => {
+          if (!shouldContinue) {
+            cy.task(
+              "cli_log",
+              "Skipping step: Confirm Payment with billing details"
+            );
+            return;
+          }
 
-        if (!utils.should_continue_further(data)) {
-          shouldContinue = false;
-        }
+          const data = getConnectorDetails(globalState.get("connectorId"))[
+            "card_pm"
+          ]["No3DSAutoCapture"];
+
+          cy.confirmCallTest(fixtures.confirmBody, data, true, globalState);
+
+          if (!utils.should_continue_further(data)) {
+            shouldContinue = false;
+          }
+        });
+
+        cy.step("Retrieve Payment", () => {
+          if (!shouldContinue) {
+            cy.task("cli_log", "Skipping step: Retrieve Payment");
+            return;
+          }
+
+          const data = getConnectorDetails(globalState.get("connectorId"))[
+            "card_pm"
+          ]["No3DSAutoCapture"];
+
+          cy.retrievePaymentCallTest({ globalState, data });
+        });
       });
-
-      cy.step("Create Payment Intent", () => {
-        if (!shouldContinue) {
-          cy.task("cli_log", "Skipping step: Create Payment Intent");
-          return;
-        }
-
-        const data = getConnectorDetails(globalState.get("connectorId"))[
-          "card_pm"
-        ]["PaymentIntent"];
-
-        cy.createPaymentIntentTest(
-          fixtures.createPaymentBody,
-          data,
-          "no_three_ds",
-          "automatic",
-          globalState
-        );
-
-        if (!utils.should_continue_further(data)) {
-          shouldContinue = false;
-        }
-      });
-
-      cy.step("Confirm Payment with billing details", () => {
-        if (!shouldContinue) {
-          cy.task("cli_log", "Skipping step: Confirm Payment with billing details");
-          return;
-        }
-
-        const data = getConnectorDetails(globalState.get("connectorId"))[
-          "card_pm"
-        ]["No3DSAutoCapture"];
-
-        cy.confirmCallTest(
-          fixtures.confirmBody,
-          data,
-          true,
-          globalState
-        );
-
-        if (!utils.should_continue_further(data)) {
-          shouldContinue = false;
-        }
-      });
-
-      cy.step("Retrieve Payment", () => {
-        if (!shouldContinue) {
-          cy.task("cli_log", "Skipping step: Retrieve Payment");
-          return;
-        }
-
-        const data = getConnectorDetails(globalState.get("connectorId"))[
-          "card_pm"
-        ]["No3DSAutoCapture"];
-
-        cy.retrievePaymentCallTest({ globalState, data });
-      });
-    });
-  });
+    }
+  );
 });


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD
- [x] Tests

## Description
<!-- Describe your changes in detail -->

This PR adds comprehensive Cypress test coverage for the **Step Up Retries** flow on the Cybersource connector. A new dedicated spec file `46-StepUpRetries.cy.js` has been created to isolate and test this functionality.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.
-->

- `cypress-tests/cypress/e2e/spec/Payment/46-StepUpRetries.cy.js` — new spec covering StepUpRetries happy path + negative cases + edge cases
- `cypress-tests/cypress/e2e/configs/Payment/Cybersource.js` — added `StepUpRetries` config key entry
- `cypress-tests/cypress/e2e/configs/Payment/Utils.js` — registered connector utility updates
- `cypress-tests/cypress/e2e/configs/Payment/Commons.js` — added shared test logic for step up retry flows


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

This test coverage addresses the requirement to add step up retries test cases in Payment Specs. Previously, step up retry scenarios were not adequately covered in the automated test suite. This coverage ensures that:

1. GSM rules with `step_up_possible=true` correctly trigger the step-up payment flow
2. GSM rules with `step_up_possible=false` behave as expected (negative case)
3. Billing details are properly handled during step-up scenarios (edge case)

The tests verify both the happy path where step-up authentication succeeds, and error scenarios where step-up is not possible or billing details cause complications.


## How did you test it?

Full regression suite was executed against the changed connector (cybersource) plus Stripe (mandatory baseline). All `RUNNER_RESULT` blocks from the QA pipeline are included verbatim below.

### Changed-spec verification — `cybersource`

```
RUNNER_RESULT:
  Connector: cybersource
  SpecFile: cypress/e2e/spec/Payment/46-StepUpRetries.cy.js
  PrereqsUsed: cybersource_config
  TotalTests: 3
  Passed: 3
  Failed: 0
  Skipped: 0
  OverallStatus: PASS
  Failures: NONE
  SkippedTests: NONE
  FlakeyTests: NONE
  BlockedReasons: NONE
```

### Full regression — `cybersource`

```
RUNNER_RESULT:
  Connector: cybersource
  TotalTests: 10
  Passed: 10
  Failed: 0
  Skipped: 0
  OverallStatus: PASS
  Failures: NONE
  SkippedTests: NONE
  FlakeyTests: NONE
  BlockedReasons: NONE
```

### Full regression — `stripe`

```
RUNNER_RESULT:
  Connector: stripe
  TotalTests: 10
  Passed: 10
  Failed: 0
  Skipped: 0
  OverallStatus: PASS
  Failures: NONE
  SkippedTests: NONE
  FlakeyTests: NONE
  BlockedReasons: NONE
```

### Summary

| Connector | Specs Run | Passed | Failed | Skipped | Status |
|---|---|---|---|---|---|
| cybersource | 10 | 10 | 0 | 0 | PASS |
| stripe | 10 | 10 | 0 | 0 | PASS |


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [x] I added unit tests for my changes where possible
