### PR TITLE
test(cypress): mit_category in MIT payments for checkout connector

### DIFF
--- a/cypress-tests/cypress/e2e/configs/Payment/Checkout.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Checkout.js
@@ -130,7 +130,9 @@ export const connectorDetails = {
       },
     },
     MITManualCapture: {
-      Request: {},
+      Request: {
+        mit_category: "installment",
+      },
       Response: {
         status: 200,
         body: {
@@ -585,7 +587,9 @@ export const connectorDetails = {
       },
     },
     MITAutoCapture: {
-      Request: {},
+      Request: {
+        mit_category: "installment",
+      },
       Response: {
         status: 200,
         body: {


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD
- [x] Tests

## Description

Modified `cypress/e2e/configs/Payment/Checkout.js` to add `mit_category: "installment"` to both `MITAutoCapture.Request` and `MITManualCapture.Request` sections. Existing MIT specs (11, 12, 20, 21) automatically pick up the new field via the `for..in reqData` loop in commands.js.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

**Changed files:**

- `cypress/e2e/configs/Payment/Checkout.js` — added `mit_category: "installment"` to `MITAutoCapture.Request` and `MITManualCapture.Request` entries

No API, database, or configuration changes outside the Cypress test config.

## Motivation and Context

Update the MIT payment request flow to include the `mit_category` field with the value `Installment`, and verify that the system processes the request successfully without any behavioral changes, ensuring the response structure, status, and downstream handling remain consistent with existing MIT flows for the checkout connector.

- QA ticket: #11877
- Parent pipeline issue: QAAAA-11

## How did you test it?

Full regression suite was executed against the changed connector(s). All `RUNNER_RESULT` blocks from the QA pipeline are included verbatim below.

### Changed-spec verification — checkout

```
RUNNER_RESULT:
  Connector: checkout
  TotalTests: 63
  Passed: 63
  Failed: 0
  Skipped: 0
  OverallStatus: PASS
```

### Full regression — checkout

```
RUNNER_RESULT:
  Connector: checkout
  TotalTests: 63
  Passed: 63
  Failed: 0
  Skipped: 0
  OverallStatus: PASS
```

### Summary

| Connector | Specs Run | Passed | Failed | Skipped | Status |
|---|---|---|---|---|---|
| checkout | 63 | 63 | 0 | 0 | PASS |

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [x] I added unit tests for my changes where possible

---

Closes #11877
Related: QAAAA-11
