### PR TITLE
fix(connector): [AuthorizeDotNet] merchant_requires_action for review

### DIFF
--- a/crates/hyperswitch_connectors/src/connectors/authorizedotnet/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/authorizedotnet/transformers.rs
@@ -1354,7 +1354,7 @@ fn get_payment_status(
             enums::AttemptStatus::Failure
         }
         AuthorizedotnetPaymentStatus::RequiresAction => enums::AttemptStatus::AuthenticationPending,
-        AuthorizedotnetPaymentStatus::HeldForReview => enums::AttemptStatus::Pending,
+        AuthorizedotnetPaymentStatus::HeldForReview => enums::AttemptStatus::Unresolved,
     }
 }
 
@@ -1936,6 +1936,8 @@ pub enum SyncStatus {
     GeneralError,
     #[serde(rename = "FDSPendingReview")]
     FDSPendingReview,
+    #[serde(rename = "FDSAuthorizedPendingReview")]
+    FDSAuthorizedPendingReview,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -1987,9 +1989,12 @@ impl From<SyncStatus> for enums::AttemptStatus {
             SyncStatus::Voided => Self::Voided,
             SyncStatus::CouldNotVoid => Self::VoidFailed,
             SyncStatus::GeneralError => Self::Failure,
-            SyncStatus::RefundSettledSuccessfully
-            | SyncStatus::RefundPendingSettlement
-            | SyncStatus::FDSPendingReview => Self::Pending,
+            SyncStatus::RefundSettledSuccessfully | SyncStatus::RefundPendingSettlement => {
+                Self::Pending
+            }
+            SyncStatus::FDSPendingReview | SyncStatus::FDSAuthorizedPendingReview => {
+                Self::Unresolved
+            }
         }
     }
 }

--- a/crates/hyperswitch_connectors/src/connectors/authorizedotnet/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/authorizedotnet/transformers.rs
@@ -1990,7 +1990,7 @@ impl From<SyncStatus> for enums::AttemptStatus {
             SyncStatus::CouldNotVoid => Self::VoidFailed,
             SyncStatus::GeneralError => Self::Failure,
             SyncStatus::RefundSettledSuccessfully | SyncStatus::RefundPendingSettlement => {
-                Self::Pending
+                Self::Charged
             }
             SyncStatus::FDSPendingReview | SyncStatus::FDSAuthorizedPendingReview => {
                 Self::Unresolved


### PR DESCRIPTION


## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->

Authroizedotnet has feature to configure fraud detection which needs merchant to manually review in authorizedotnet dashboard and approve the payments before settlements

- Previously we were making this as Pending and Psync would throw error due to not handling this case

There are status which requires merchant Action (HeldForReview) in AuthorizeDotNet eg

   - FDSPendingReview: The transaction was identified as suspicious by the fraud filters and is being held for manual review. It has not yet been authorized by the payment processor. The merchant must manually approve or decline the transaction in the Merchant Interface.

  -  FDSAuthorizedPendingReview: The transaction has been authorized by the card issuer but is being held by the Authorize.net fraud tools for manual review before being captured for settlement. If the merchant approves it, it proceeds to settlement; if declined, the authorization is typically reversed/voided.



<img width="1618" height="993" alt="Screenshot 2026-04-21 at 1 30 51 PM" src="https://github.com/user-attachments/assets/31cdafa0-415c-4e8e-9c8e-7ffbcf60a4bb" />

### set a rule for amount greater then certain amount which would require manual review

<img width="1355" height="893" alt="Screenshot 2026-04-21 at 1 20 58 PM" src="https://github.com/user-attachments/assets/91b2aefd-3aa1-4796-b6c2-8aa261467f95" />


### make a payment 

<details>
 <summary> Payment results in merchant requires action</summary>

```json
{
    "amount": 9999999,
    "customer_id": "hello_world",
    "currency": "USD",
    "confirm": true,
    "capture_method": "automatic",
    "payment_method": "card",
    "payment_method_type": "debit",
    "authentication_type": "no_three_ds",


    "setup_future_usage": "off_session",
    "customer_acceptance": {
        "acceptance_type": "online",
        "accepted_at": "1963-05-03T04:07:52.723Z",
        "online": {
            "ip_address": "127.0.0.1",
            "user_agent": "amet irure esse"
        }
    },
    "metadata":{
        "hello_world":"value",
        "userdefined":true,
        "user_valuee":"abcd"
    },
    "email": "hello@gmail.com",
    "description": "hellow world",
    "connector": [
        "authorizedotnet"
    ],
    "billing": {
        "address": {
            "zip": "560095",
            "country": "US",
            "first_name": "Sakil",
            "last_name": "Mostak",
            "line1": "Fasdf",
            "line2": "Fasdf",
            "city": "Fasdf"
        }
    },
    "payment_method_data": {
        "card": {
            "card_number": "4111111111111111",
            "card_exp_month": "12",
            "card_exp_year": "2029",
            "card_holder_name": "Nithin Doe",
            "card_cvc": "123",
            "card_network": "Visa"
        }
    }
}
```

## response

```json

{
    "payment_id": "pay_6igiTbVTmN2MpBt32s3Z",
    "merchant_id": "merchant_1776758355",
    "status": "requires_merchant_action",
    "amount": 9999999,
    "net_amount": 9999999,
    "shipping_cost": null,
    "amount_capturable": 9999999,
    "amount_received": null,
    "processor_merchant_id": "merchant_1776758355",
    "initiator": null,
    "sdk_authorization": "cHJvZmlsZV9pZD1wcm9faVpIRnlKdmlvOGlWMFYzazBkOVMscHVibGlzaGFibGVfa2V5PXBrX2Rldl83NWExOWM1ZmJjMjY0NGUzODc1Yzc4OTY5ZmRiMmExMyxjbGllbnRfc2VjcmV0PXBheV82aWdpVGJWVG1OMk1wQnQzMnMzWl9zZWNyZXRfbEVaNmRlaFFxYUR6d1hvWVNEdjIsY3VzdG9tZXJfaWQ9aGVsbG9fd29ybGQsY2xpZW50X3Nlc3Npb25faWQ9Y2xpZW50X3Nlc3NfTGdTVHlWU1ZYYjlteVdFNG9OOUkscGF5bWVudF9pZD1wYXlfNmlnaVRiVlRtTjJNcEJ0MzJzM1o=",
    "connector": "authorizedotnet",
    "state_metadata": null,
    "client_secret": "pay_6igiTbVTmN2MpBt32s3Z_secret_lEZ6dehQqaDzwXoYSDv2",
    "created": "2026-04-21T08:00:33.142Z",
    "modified_at": "2026-04-21T08:00:33.713Z",
    "currency": "USD",
    "customer_id": "hello_world",
    "customer": {
        "id": "hello_world",
        "name": null,
        "email": "hello@gmail.com",
        "phone": null,
        "phone_country_code": null,
        "customer_document_details": null
    },
    "description": "hellow world",
    "refunds": null,
    "disputes": null,
    "mandate_id": null,
    "mandate_data": null,
    "setup_future_usage": "off_session",
    "off_session": null,
    "capture_on": null,
    "capture_method": "automatic",
    "payment_method": "card",
    "payment_method_data": {
        "card": {
            "last4": "1111",
            "card_type": null,
            "card_network": null,
            "card_issuer": null,
            "card_issuing_country": null,
            "card_isin": "411111",
            "card_extended_bin": null,
            "card_exp_month": "12",
            "card_exp_year": "2029",
            "card_holder_name": "Nithin Doe",
            "payment_checks": {
                "description": "The street address and postal code matched.",
                "avs_result_code": "Y"
            },
            "authentication_data": null,
            "auth_code": null
        },
        "billing": null
    },
    "payment_token": null,
    "shipping": null,
    "billing": {
        "address": {
            "city": "Fasdf",
            "country": "US",
            "line1": "Fasdf",
            "line2": "Fasdf",
            "line3": null,
            "zip": "560095",
            "state": null,
            "first_name": "Sakil",
            "last_name": "Mostak",
            "origin_zip": null
        },
        "phone": null,
        "email": null
    },
    "order_details": null,
    "email": "hello@gmail.com",
    "name": null,
    "phone": null,
    "return_url": null,
    "authentication_type": "no_three_ds",
    "statement_descriptor_name": null,
    "statement_descriptor_suffix": null,
    "next_action": null,
    "cancellation_reason": null,
    "error_code": null,
    "error_message": null,
    "unified_code": null,
    "unified_message": null,
    "error_details": null,
    "payment_experience": null,
    "payment_method_type": "debit",
    "connector_label": null,
    "business_country": null,
    "business_label": "default",
    "business_sub_label": null,
    "allowed_payment_method_types": null,
    "manual_retry_allowed": null,
    "connector_transaction_id": "120081439708",
    "frm_message": null,
    "metadata": {
        "hello_world": "value",
        "user_valuee": "abcd",
        "userdefined": true
    },
    "connector_metadata": null,
    "connector_response_metadata": null,
    "feature_metadata": {
        "redirect_response": null,
        "search_tags": null,
        "apple_pay_recurring_details": null,
        "pix_additional_details": null,
        "boleto_additional_details": null,
        "pix_automatico_additional_details": null
    },
    "reference_id": "120081439708",
    "payment_link": null,
    "profile_id": "pro_iZHFyJvio8iV0V3k0d9S",
    "surcharge_details": null,
    "attempt_count": 1,
    "merchant_decision": null,
    "merchant_connector_id": "mca_JOWZmVV0vwHnOG9i0naT",
    "incremental_authorization_allowed": false,
    "authorization_count": null,
    "incremental_authorizations": null,
    "external_authentication_details": null,
    "external_3ds_authentication_attempted": false,
    "expires_on": "2026-04-21T08:15:33.142Z",
    "fingerprint": null,
    "browser_info": null,
    "payment_channel": null,
    "payment_method_id": "pm_eIlGj9zi25RNtHqQ9yQ3",
    "network_transaction_id": "WNAO0LPML6ASCXLKYC2UBZH",
    "payment_method_status": "inactive",
    "updated": "2026-04-21T08:00:33.713Z",
    "split_payments": null,
    "frm_metadata": null,
    "extended_authorization_applied": null,
    "extended_authorization_last_applied_at": null,
    "request_extended_authorization": null,
    "capture_before": null,
    "merchant_order_reference_id": null,
    "order_tax_amount": null,
    "connector_mandate_id": null,
    "card_discovery": "manual",
    "force_3ds_challenge": false,
    "force_3ds_challenge_trigger": false,
    "issuer_error_code": null,
    "issuer_error_message": null,
    "is_iframe_redirection_enabled": null,
    "whole_connector_response": null,
    "enable_partial_authorization": null,
    "enable_overcapture": null,
    "is_overcapture_enabled": null,
    "network_details": null,
    "is_stored_credential": null,
    "mit_category": null,
    "billing_descriptor": null,
    "tokenization": null,
    "partner_merchant_identifier_details": null,
    "payment_method_tokenization_details": {
        "payment_method_id": "pm_eIlGj9zi25RNtHqQ9yQ3",
        "payment_method_status": "inactive",
        "psp_tokenization": false,
        "network_tokenization": false,
        "network_transaction_id": "WNAO0LPML6ASCXLKYC2UBZH",
        "is_eligible_for_mit_payment": true
    },
    "installment_options": null,
    "installment_data": null
}
```

```sh
 INFO hyperswitch_connectors::connectors::authorizedotnet: connector_response: AuthorizedotnetSyncResponse { transaction: Some(SyncTransactionResponse { transaction_id: "120081439839", transaction_status: FDSAuthorizedPendingReview }), messages: ResponseMessages { result_code: Ok, message: [ResponseMessage { code: "I00001", text: "Successful." }] } }
```

</details>

2. Go to Authorize Dashboard and Approve the payment

<details><summary>Psync</summary>

```json
{
    "payment_id": "pay_6igiTbVTmN2MpBt32s3Z",
    "merchant_id": "merchant_1776758355",
    "status": "succeeded",
    "amount": 9999999,
    "net_amount": 9999999,
    "shipping_cost": null,
    "amount_capturable": 0,
    "amount_received": 9999999,
    "processor_merchant_id": "merchant_1776758355",
    "initiator": null,
    "sdk_authorization": "cHJvZmlsZV9pZD1wcm9faVpIRnlKdmlvOGlWMFYzazBkOVMscHVibGlzaGFibGVfa2V5PXBrX2Rldl83NWExOWM1ZmJjMjY0NGUzODc1Yzc4OTY5ZmRiMmExMyxjbGllbnRfc2VjcmV0PXBheV82aWdpVGJWVG1OMk1wQnQzMnMzWl9zZWNyZXRfbEVaNmRlaFFxYUR6d1hvWVNEdjIsY3VzdG9tZXJfaWQ9aGVsbG9fd29ybGQscGF5bWVudF9pZD1wYXlfNmlnaVRiVlRtTjJNcEJ0MzJzM1o=",
    "connector": "authorizedotnet",
    "state_metadata": null,
    "client_secret": "pay_6igiTbVTmN2MpBt32s3Z_secret_lEZ6dehQqaDzwXoYSDv2",
    "created": "2026-04-21T08:00:33.142Z",
    "modified_at": "2026-04-21T08:01:49.410Z",
    "currency": "USD",
    "customer_id": "hello_world",
    "customer": {
        "id": "hello_world",
        "name": null,
        "email": "hello@gmail.com",
        "phone": null,
        "phone_country_code": null,
        "customer_document_details": null
    },
    "description": "hellow world",
    "refunds": null,
    "disputes": null,
    "mandate_id": null,
    "mandate_data": null,
    "setup_future_usage": "off_session",
    "off_session": null,
    "capture_on": null,
    "capture_method": "automatic",
    "payment_method": "card",
    "payment_method_data": {
        "card": {
            "last4": "1111",
            "card_type": null,
            "card_network": null,
            "card_issuer": null,
            "card_issuing_country": null,
            "card_isin": "411111",
            "card_extended_bin": null,
            "card_exp_month": "12",
            "card_exp_year": "2029",
            "card_holder_name": "Nithin Doe",
            "payment_checks": {
                "description": "The street address and postal code matched.",
                "avs_result_code": "Y"
            },
            "authentication_data": null,
            "auth_code": null
        },
        "billing": null
    },
    "payment_token": null,
    "shipping": null,
    "billing": {
        "address": {
            "city": "Fasdf",
            "country": "US",
            "line1": "Fasdf",
            "line2": "Fasdf",
            "line3": null,
            "zip": "560095",
            "state": null,
            "first_name": "Sakil",
            "last_name": "Mostak",
            "origin_zip": null
        },
        "phone": null,
        "email": null
    },
    "order_details": null,
    "email": "hello@gmail.com",
    "name": null,
    "phone": null,
    "return_url": null,
    "authentication_type": "no_three_ds",
    "statement_descriptor_name": null,
    "statement_descriptor_suffix": null,
    "next_action": null,
    "cancellation_reason": null,
    "error_code": null,
    "error_message": null,
    "unified_code": null,
    "unified_message": null,
    "error_details": null,
    "payment_experience": null,
    "payment_method_type": "debit",
    "connector_label": null,
    "business_country": null,
    "business_label": "default",
    "business_sub_label": null,
    "allowed_payment_method_types": null,
    "manual_retry_allowed": null,
    "connector_transaction_id": "120081439708",
    "frm_message": null,
    "metadata": {
        "hello_world": "value",
        "user_valuee": "abcd",
        "userdefined": true
    },
    "connector_metadata": null,
    "connector_response_metadata": null,
    "feature_metadata": {
        "redirect_response": null,
        "search_tags": null,
        "apple_pay_recurring_details": null,
        "pix_additional_details": null,
        "boleto_additional_details": null,
        "pix_automatico_additional_details": null
    },
    "reference_id": "120081439708",
    "payment_link": null,
    "profile_id": "pro_iZHFyJvio8iV0V3k0d9S",
    "surcharge_details": null,
    "attempt_count": 1,
    "merchant_decision": null,
    "merchant_connector_id": "mca_JOWZmVV0vwHnOG9i0naT",
    "incremental_authorization_allowed": false,
    "authorization_count": null,
    "incremental_authorizations": null,
    "external_authentication_details": null,
    "external_3ds_authentication_attempted": false,
    "expires_on": "2026-04-21T08:15:33.142Z",
    "fingerprint": null,
    "browser_info": null,
    "payment_channel": null,
    "payment_method_id": "pm_eIlGj9zi25RNtHqQ9yQ3",
    "network_transaction_id": "WNAO0LPML6ASCXLKYC2UBZH",
    "payment_method_status": "inactive",
    "updated": "2026-04-21T08:01:49.410Z",
    "split_payments": null,
    "frm_metadata": null,
    "extended_authorization_applied": null,
    "extended_authorization_last_applied_at": null,
    "request_extended_authorization": null,
    "capture_before": null,
    "merchant_order_reference_id": null,
    "order_tax_amount": null,
    "connector_mandate_id": null,
    "card_discovery": "manual",
    "force_3ds_challenge": false,
    "force_3ds_challenge_trigger": false,
    "issuer_error_code": null,
    "issuer_error_message": null,
    "is_iframe_redirection_enabled": null,
    "whole_connector_response": null,
    "enable_partial_authorization": null,
    "enable_overcapture": null,
    "is_overcapture_enabled": null,
    "network_details": null,
    "is_stored_credential": null,
    "mit_category": null,
    "billing_descriptor": null,
    "tokenization": null,
    "partner_merchant_identifier_details": null,
    "payment_method_tokenization_details": {
        "payment_method_id": "pm_eIlGj9zi25RNtHqQ9yQ3",
        "payment_method_status": "inactive",
        "psp_tokenization": false,
        "network_tokenization": false,
        "network_transaction_id": "WNAO0LPML6ASCXLKYC2UBZH",
        "is_eligible_for_mit_payment": true
    },
    "installment_options": null,
    "installment_data": null
}
```

</details>





### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
