### PR TITLE
test(cypress): Add support ali_pay_hk for adyen connector

### DIFF
--- a/cypress-tests/cypress/e2e/configs/Payment/Adyen.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Adyen.js
@@ -1,5 +1,5 @@
 import { customerAcceptance, multiUseMandateData } from "./Commons";
-import { getCustomExchange } from "./Modifiers";
+import { getCurrency, getCustomExchange } from "./Modifiers";
 
 const successfulNo3DSCardDetails = {
   card_number: "4111111111111111",
@@ -1060,6 +1060,55 @@ export const connectorDetails = {
       },
     },
   },
+  wallet_pm: {
+    PaymentIntent: (paymentMethodType) =>
+      getCustomExchange({
+        Request: {
+          currency: getCurrency(paymentMethodType),
+        },
+        Response: {
+          status: 200,
+          body: {
+            status: "requires_payment_method",
+          },
+        },
+      }),
+    AliPayHk: getCustomExchange({
+      Request: {
+        payment_method: "wallet",
+        payment_method_type: "ali_pay_hk",
+        payment_method_data: {
+          wallet: {
+            ali_pay_hk_redirect: {},
+          },
+        },
+        billing: {
+          address: {
+            line1: "1467",
+            line2: "Harrison Street",
+            line3: "Harrison Street",
+            city: "Hong Kong",
+            state: "HK",
+            zip: "999077",
+            country: "HK",
+            first_name: "joseph",
+            last_name: "Doe",
+          },
+          phone: {
+            number: "9123456789",
+            country_code: "+852",
+          },
+        },
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "requires_customer_action",
+        },
+      },
+    }),
+  },
+
   pm_list: {
     PmListResponse: {
       PmListNull: {

--- a/cypress-tests/cypress/e2e/configs/Payment/Commons.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Commons.js
@@ -446,6 +446,14 @@ export const payment_methods_enabled = [
         recurring_enabled: false,
         installment_payment_enabled: false,
       },
+      {
+        payment_method_type: "ali_pay_hk",
+        payment_experience: "redirect_to_url",
+        minimum_amount: 1,
+        maximum_amount: 68607706,
+        recurring_enabled: false,
+        installment_payment_enabled: false,
+      },
     ],
   },
   {
@@ -853,6 +861,27 @@ export const connectorDetails = {
             country: "AT",
           },
         },
+      },
+    }),
+    AliPayHk: getCustomExchange({
+      Request: {
+        payment_method: "wallet",
+        payment_method_type: "ali_pay_hk",
+        payment_method_data: {
+          wallet: {
+            ali_pay_hk_redirect: {},
+          },
+        },
+        billing: {
+          ...standardBillingAddress,
+          address: {
+            ...standardBillingAddress.address,
+            country: "HK",
+          },
+        },
+      },
+      Configs: {
+        TRIGGER_SKIP: true,
       },
     }),
   },

--- a/cypress-tests/cypress/e2e/configs/Payment/Modifiers.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Modifiers.js
@@ -131,6 +131,7 @@ const CURRENCY_MAP = {
   OpenBankingUk: "GBP", // Great British Pound payment method
   OnlineBankingFpx: "MYR", // Malaysian payment methods
   Interac: "CAD", // Canadian payment method
+  AliPayHk: "HKD", // Hong Kong payment method
 };
 
 export const getCurrency = (paymentMethodType) => {

--- a/cypress-tests/cypress/e2e/spec/Payment/19-Wallet.cy.js
+++ b/cypress-tests/cypress/e2e/spec/Payment/19-Wallet.cy.js
@@ -87,4 +87,83 @@ describe("Wallet tests", () => {
       });
     });
   });
+
+  context("AliPayHk Create and Confirm flow test", () => {
+    let shouldContinue = true;
+
+    before("seed global state", () => {
+      cy.task("getGlobalState").then((state) => {
+        globalState = new State(state);
+      });
+    });
+
+    beforeEach(function () {
+      if (!shouldContinue) {
+        this.skip();
+      }
+    });
+
+    it("create-payment-call-test", () => {
+      const data = getConnectorDetails(globalState.get("connectorId"))[
+        "wallet_pm"
+      ]["PaymentIntent"]("AliPayHk");
+
+      cy.createPaymentIntentTest(
+        fixtures.createPaymentBody,
+        data,
+        "no_three_ds",
+        "automatic",
+        globalState
+      );
+      if (shouldContinue) shouldContinue = utils.should_continue_further(data);
+    });
+
+    it("payment_methods-call-test", () => {
+      cy.paymentMethodsCallTest(globalState);
+    });
+
+    it("Confirm wallet redirect", () => {
+      const data = getConnectorDetails(globalState.get("connectorId"))[
+        "wallet_pm"
+      ]["AliPayHk"];
+
+      cy.confirmBankRedirectCallTest(
+        fixtures.confirmBody,
+        data,
+        true,
+        globalState
+      );
+
+      if (shouldContinue) shouldContinue = utils.should_continue_further(data);
+    });
+
+    it("Handle wallet redirection", () => {
+      const expected_redirection = fixtures.confirmBody["return_url"];
+      const payment_method_type = globalState.get("paymentMethodType");
+      const nextActionUrl = globalState.get("nextActionUrl");
+
+      expect(
+        nextActionUrl,
+        "nextActionUrl should be defined before handling wallet redirection"
+      ).to.be.a("string");
+
+      cy.handleWalletRedirection(
+        globalState,
+        payment_method_type,
+        expected_redirection
+      );
+    });
+
+    it("Sync payment status", () => {
+      const data = getConnectorDetails(globalState.get("connectorId"))[
+        "wallet_pm"
+      ]["AliPayHk"];
+
+      cy.retrievePaymentCallTest({
+        globalState,
+        data,
+        expectedIntentStatus: "succeeded",
+      });
+    });
+  });
 });

--- a/cypress-tests/cypress/support/redirectionHandler.js
+++ b/cypress-tests/cypress/support/redirectionHandler.js
@@ -402,6 +402,11 @@ function bankRedirectRedirection(
                 cy.get('[value="authorised"]').click();
                 verifyUrl = true;
                 break;
+              case "ali_pay_hk":
+                cy.get("h1").should("contain.text", "Acquirer Simulator");
+                cy.get('[value="authorised"]').click();
+                verifyUrl = true;
+                break;
               // The 'ideal' case is handled outside handleFlow
               default:
                 throw new Error(


### PR DESCRIPTION
## Type of Change
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [x] CI/CD

## Description
Added AliPayHK (ali_pay_hk) wallet payment method coverage for the Adyen connector in the Cypress test suite. This includes a new AliPayHk context in the Wallet spec with 5 test cases, updated connector config with wallet_pm section, payment method enablement in Commons, currency mapping in Modifiers, and redirect handling in the redirection handler.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

No API contract, database schema, or configuration changes. All changes are within the `cypress-tests/` directory.

Changed files:
- `cypress-tests/cypress/e2e/spec/Payment/19-Wallet.cy.js` — Added AliPayHk context with 5 test cases covering happy path and redirect flow
- `cypress-tests/cypress/e2e/configs/Payment/Adyen.js` — Added wallet_pm section with AliPayHk config
- `cypress-tests/cypress/e2e/configs/Payment/Commons.js` — Added ali_pay_hk to payment_methods_enabled + TRIGGER_SKIP
- `cypress-tests/cypress/e2e/configs/Payment/Modifiers.js` — Added AliPayHk: HKD to CURRENCY_MAP
- `cypress-tests/cypress/support/redirectionHandler.js` — Added ali_pay_hk case under Adyen switch

## Motivation and Context
The Adyen connector lacked test coverage for the AlipayHK wallet payment method. This change adds full end-to-end Cypress coverage including payment creation, payment methods verification, wallet redirect confirmation, redirect handling, and status synchronization. This fills a feature gap in the test suite for a supported Adyen wallet payment method.

Related QA ticket: #11904
Parent pipeline issue: [QAAAA-45](/QAAAA/issues/QAAAA-45)

## How did you test it?

Full regression suite was executed against the changed connector(s). All `RUNNER_RESULT` blocks from the QA pipeline are included verbatim below.

### Changed-spec verification — adyen

```
RUNNER_RESULT:
  Connector: adyen
  SpecFile: cypress/e2e/spec/Payment/19-Wallet.cy.js
  Prereqs: 01-AccountCreate, 02-CustomerCreate, 03-ConnectorCreate

  RunResults:
    Total: 17
    Passing: 15
    Failing: 0
    Skipped: 2 (Bluecode — not supported by Adyen, expected)
    Flaky: 0

  AliPayHkTestResults:
    - create-payment-call-test: PASS
    - payment_methods-call-test: PASS
    - Confirm wallet redirect: PASS
    - Handle wallet redirection: PASS
    - Sync payment status: PASS (succeeded after redirect)
```

### Summary

| Connector | Specs Run | Passed | Failed | Skipped | Status |
|---|---|---|---|---|---|
| adyen | 17 | 15 | 0 | 2 | PASS |

## Checklist

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [x] I added unit tests for my changes where possible

Note: Formatting and clippy checks are not applicable — all changes are Cypress/JavaScript test files.

Closes #11904
