### PR TITLE
feat(apple_pay): thread device_manufacturer_identifier from decrypted token to payment data

### DIFF
--- a/api-reference/v1/openapi_spec_v1.json
+++ b/api-reference/v1/openapi_spec_v1.json
@@ -9882,6 +9882,11 @@
           },
           "payment_data": {
             "$ref": "#/components/schemas/ApplePayCryptogramData"
+          },
+          "device_manufacturer_identifier": {
+            "type": "string",
+            "description": "Device manufacturer identifier from the decrypted Apple Pay token",
+            "nullable": true
           }
         }
       },

--- a/api-reference/v2/openapi_spec_v2.json
+++ b/api-reference/v2/openapi_spec_v2.json
@@ -6361,6 +6361,11 @@
           },
           "payment_data": {
             "$ref": "#/components/schemas/ApplePayCryptogramData"
+          },
+          "device_manufacturer_identifier": {
+            "type": "string",
+            "description": "Device manufacturer identifier from the decrypted Apple Pay token",
+            "nullable": true
           }
         }
       },

--- a/crates/common_types/src/payments.rs
+++ b/crates/common_types/src/payments.rs
@@ -768,6 +768,9 @@ pub struct ApplePayPredecryptData {
     #[schema(value_type = ApplePayCryptogramData)]
     #[smithy(value_type = "ApplePayCryptogramData")]
     pub payment_data: ApplePayCryptogramData,
+    /// Device manufacturer identifier from the decrypted Apple Pay token
+    #[schema(value_type = Option<String>)]
+    pub device_manufacturer_identifier: Option<Secret<String>>,
 }
 
 #[derive(

--- a/crates/hyperswitch_domain_models/src/router_data.rs
+++ b/crates/hyperswitch_domain_models/src/router_data.rs
@@ -500,6 +500,7 @@ impl TryFrom<ApplePayPredecryptDataInternal> for common_payment_types::ApplePayP
             application_expiration_month,
             application_expiration_year,
             payment_data: data.payment_data.into(),
+            device_manufacturer_identifier: Some(data.device_manufacturer_identifier),
         })
     }
 }

--- a/crates/router/src/compatibility/stripe/setup_intents/types.rs
+++ b/crates/router/src/compatibility/stripe/setup_intents/types.rs
@@ -87,7 +87,7 @@ pub struct StripePaymentMethodData {
 #[serde(rename_all = "snake_case")]
 pub enum StripePaymentMethodDetails {
     Card(StripeCard),
-    Wallet(StripeWallet),
+    Wallet(Box<StripeWallet>),
 }
 
 impl From<StripeCard> for payments::Card {
@@ -122,7 +122,7 @@ impl From<StripePaymentMethodDetails> for payments::PaymentMethodData {
         match item {
             StripePaymentMethodDetails::Card(card) => Self::Card(payments::Card::from(card)),
             StripePaymentMethodDetails::Wallet(wallet) => {
-                Self::Wallet(payments::WalletData::from(wallet))
+                Self::Wallet(payments::WalletData::from(*wallet))
             }
         }
     }


### PR DESCRIPTION
## Description

Apple Pay's decrypted payment token contains a `deviceManufacturerIdentifier` field that identifies the device/issuer involved in the tokenized card transaction. PayPal's `/v2/checkout/orders` Apple Pay `decrypted_token` path requires this as `device_manufacturer_id`.

`ApplePayPredecryptData` in HS did not carry `device_manufacturer_identifier`, so this value was never forwarded to UCS. The UCS PayPal connector (juspay/hyperswitch-prism#1159) had to hardcode the value to `"040010030273"` (Apple's standard identifier). That value works in sandbox but can cause failures or silent card-network downgrades in production where PayPal validates the field against the actual token.

This PR is the HS-side half of the fix. The companion UCS PR (juspay/hyperswitch-prism#1159) consumes the field once it is available.

## Changes

### `crates/common_types/src/payments.rs`
- Added `device_manufacturer_identifier: Option<Secret<String>>` to `ApplePayPredecryptData`
- Marked as optional since older tokens or non-Apple devices may not include it

### `crates/hyperswitch_domain_models/src/router_data.rs`
- Mapped `device_manufacturer_identifier` from `ApplePayPredecryptDataInternal` → `ApplePayPredecryptData` in the `TryFrom` impl
- Uses `Some(data.device_manufacturer_identifier)` — the internal struct always has the field after decryption, wrapped in `Option` in the public type for forward compatibility

## How it fits into the full flow

```
Apple Pay encrypted token (from browser/device)
  → HS Router decrypts using PPC cert
      → ApplePayPredecryptDataInternal (contains device_manufacturer_identifier)
          → TryFrom → ApplePayPredecryptData  ← this PR adds the field here
              → sent to UCS via proto (ApplePayDecryptedData.device_manufacturer_identifier)
                  → UCS PayPal transformer uses real value instead of hardcoded fallback
```

## Impact

- **Connectors affected:** PayPal Apple Pay (primary), any future UCS connector using the `decrypted_token` Apple Pay path
- **Severity:** Production blocker for PayPal Apple Pay — an incorrect `device_manufacturer_id` can cause payment failures or silent downgrades at PayPal
- **Sandbox:** Unaffected — PayPal sandbox accepts the hardcoded fallback value, so existing tests continue to pass

## Related

- Fixes juspay/hyperswitch-prism#1149
- Companion UCS PR: juspay/hyperswitch-prism#1159 (consumes this field in the PayPal transformer)
- Related routing bug fix (separate PR): #12565