### PR TITLE
chore: address Rust 1.95.0 clippy lints

### DIFF
--- a/crates/analytics/src/api_event/metrics/latency.rs
+++ b/crates/analytics/src/api_event/metrics/latency.rs
@@ -109,11 +109,8 @@ where
                         )?,
                     }),
                     ApiEventMetricRow {
-                        latency: if i.latency_count != 0 {
-                            Some(i.latency_sum.unwrap_or(0) / i.latency_count)
-                        } else {
-                            None
-                        },
+                        latency: Some(i.latency_sum.unwrap_or(0))
+                            .and_then(|sum| sum.checked_div(i.latency_count)),
                         api_count: None,
                         status_code_count: None,
                         start_bucket: i.start_bucket,

--- a/crates/analytics/src/payments/accumulator.rs
+++ b/crates/analytics/src/payments/accumulator.rs
@@ -125,7 +125,7 @@ impl PaymentDistributionAccumulator for ErrorDistributionAccumulator {
         if self.error_vec.is_empty() {
             None
         } else {
-            self.error_vec.sort_by(|a, b| b.count.cmp(&a.count));
+            self.error_vec.sort_by_key(|x| std::cmp::Reverse(x.count));
             let mut res: Vec<ErrorResult> = Vec::new();
             for val in self.error_vec.into_iter() {
                 let perc = f64::from(u32::try_from(val.count).ok()?) * 100.0

--- a/crates/analytics/src/refunds/accumulator.rs
+++ b/crates/analytics/src/refunds/accumulator.rs
@@ -98,7 +98,8 @@ impl RefundDistributionAccumulator for RefundReasonDistributionAccumulator {
         if self.refund_reason_vec.is_empty() {
             None
         } else {
-            self.refund_reason_vec.sort_by(|a, b| b.count.cmp(&a.count));
+            self.refund_reason_vec
+                .sort_by_key(|x| std::cmp::Reverse(x.count));
             let mut res: Vec<ReasonsResult> = Vec::new();
             for val in self.refund_reason_vec.into_iter() {
                 let perc = f64::from(u32::try_from(val.count).ok()?) * 100.0
@@ -140,7 +141,7 @@ impl RefundDistributionAccumulator for RefundErrorMessageDistributionAccumulator
             None
         } else {
             self.refund_error_message_vec
-                .sort_by(|a, b| b.count.cmp(&a.count));
+                .sort_by_key(|x| std::cmp::Reverse(x.count));
             let mut res: Vec<ErrorMessagesResult> = Vec::new();
             for val in self.refund_error_message_vec.into_iter() {
                 let perc = f64::from(u32::try_from(val.count).ok()?) * 100.0

--- a/crates/diesel_models/src/query/process_tracker.rs
+++ b/crates/diesel_models/src/query/process_tracker.rs
@@ -99,7 +99,7 @@ impl ProcessTracker {
         runner: &str,
         limit: usize,
     ) -> StorageResult<Vec<Self>> {
-        let mut x: Vec<Self> = generics::generic_filter::<
+        let mut processes: Vec<Self> = generics::generic_filter::<
             <Self as HasTable>::Table,
             _,
             <<Self as HasTable>::Table as Table>::PrimaryKey,
@@ -115,9 +115,10 @@ impl ProcessTracker {
             None,
         )
         .await?;
-        x.sort_by(|a, b| a.schedule_time.cmp(&b.schedule_time));
-        x.truncate(limit);
-        Ok(x)
+        processes.sort_by_key(|x| x.schedule_time);
+        processes.truncate(limit);
+
+        Ok(processes)
     }
 
     #[instrument(skip(conn))]

--- a/crates/euclid/src/dssa/state_machine.rs
+++ b/crates/euclid/src/dssa/state_machine.rs
@@ -87,8 +87,7 @@ impl<'a> ConditionStateMachine<'a> {
     fn new(condition: &'a [dir::DirComparison], start_idx: usize) -> Self {
         let mut machines = Vec::<ComparisonStateMachine<'a>>::with_capacity(condition.len());
 
-        let mut machine_idx = start_idx;
-        for cond in condition {
+        for (machine_idx, cond) in (start_idx..).zip(condition.iter()) {
             let machine = ComparisonStateMachine {
                 values: &cond.values,
                 logic: &cond.logic,
@@ -97,7 +96,6 @@ impl<'a> ConditionStateMachine<'a> {
                 ctx_idx: machine_idx,
             };
             machines.push(machine);
-            machine_idx += 1;
         }
 
         Self {

--- a/crates/hyperswitch_connectors/src/connectors/bankofamerica/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/bankofamerica/transformers.rs
@@ -710,16 +710,13 @@ impl From<&SetupMandateRouterData> for ClientReferenceInformation {
 fn convert_metadata_to_merchant_defined_info(metadata: Value) -> Vec<MerchantDefinedInformation> {
     let hashmap: std::collections::BTreeMap<String, Value> =
         serde_json::from_str(&metadata.to_string()).unwrap_or(std::collections::BTreeMap::new());
-    let mut vector = Vec::new();
-    let mut iter = 1;
-    for (key, value) in hashmap {
-        vector.push(MerchantDefinedInformation {
+    (1..)
+        .zip(hashmap)
+        .map(|(iter, (key, value))| MerchantDefinedInformation {
             key: iter,
             value: format!("{key}={value}"),
-        });
-        iter += 1;
-    }
-    vector
+        })
+        .collect()
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/crates/hyperswitch_connectors/src/connectors/barclaycard/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/barclaycard/transformers.rs
@@ -524,16 +524,13 @@ impl From<common_enums::DecoupledAuthenticationType> for EffectiveAuthentication
 fn convert_metadata_to_merchant_defined_info(metadata: Value) -> Vec<MerchantDefinedInformation> {
     let hashmap: std::collections::BTreeMap<String, Value> =
         serde_json::from_str(&metadata.to_string()).unwrap_or(std::collections::BTreeMap::new());
-    let mut vector = Vec::new();
-    let mut iter = 1;
-    for (key, value) in hashmap {
-        vector.push(MerchantDefinedInformation {
+    (1..)
+        .zip(hashmap)
+        .map(|(iter, (key, value))| MerchantDefinedInformation {
             key: iter,
             value: format!("{key}={value}"),
-        });
-        iter += 1;
-    }
-    vector
+        })
+        .collect()
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/crates/hyperswitch_connectors/src/connectors/wellsfargo/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/wellsfargo/transformers.rs
@@ -904,16 +904,13 @@ fn build_bill_to(
 fn convert_metadata_to_merchant_defined_info(metadata: Value) -> Vec<MerchantDefinedInformation> {
     let hashmap: std::collections::BTreeMap<String, Value> =
         serde_json::from_str(&metadata.to_string()).unwrap_or(std::collections::BTreeMap::new());
-    let mut vector = Vec::new();
-    let mut iter = 1;
-    for (key, value) in hashmap {
-        vector.push(MerchantDefinedInformation {
+    (1..)
+        .zip(hashmap)
+        .map(|(iter, (key, value))| MerchantDefinedInformation {
             key: iter,
             value: format!("{key}={value}"),
-        });
-        iter += 1;
-    }
-    vector
+        })
+        .collect()
 }
 
 impl

--- a/crates/redis_interface/src/commands.rs
+++ b/crates/redis_interface/src/commands.rs
@@ -622,7 +622,7 @@ impl super::RedisConnectionPool {
                         let v = v.take_results()?;
 
                         let v: Vec<String> =
-                            v.iter().filter_map(|(_, val)| val.as_string()).collect();
+                            v.values().filter_map(|val| val.as_string()).collect();
                         Some(futures::stream::iter(v))
                     }
                     Err(err) => {

--- a/crates/router/src/core/payment_methods/tokenize.rs
+++ b/crates/router/src/core/payment_methods/tokenize.rs
@@ -105,7 +105,7 @@ pub async fn tokenize_cards(
     use futures::stream::StreamExt;
 
     // Process all records in parallel
-    let responses = futures::stream::iter(records.into_iter())
+    let responses = futures::stream::iter(records)
         .map(|record| async move {
             let tokenize_request = record.data.clone();
             let customer = record.customer.clone();

--- a/crates/router/src/core/payments.rs
+++ b/crates/router/src/core/payments.rs
@@ -9198,8 +9198,8 @@ pub async fn revenue_recovery_list_payments(
 
             let data: Vec<api_models::payments::RecoveryPaymentsListResponseItem> = list
                 .into_iter()
-                .zip(workflow_results.into_iter())
-                .zip(billing_connector_results.into_iter())
+                .zip(workflow_results)
+                .zip(billing_connector_results)
                 .map(
                     |(
                         ((payment_intent, payment_attempt), workflow_result),

--- a/crates/storage_impl/src/merchant_account.rs
+++ b/crates/storage_impl/src/merchant_account.rs
@@ -834,8 +834,8 @@ async fn publish_and_redact_merchant_account_cache(
         merchant_account.get_id().get_string_repr().into(),
     )];
 
-    cache_keys.extend(publishable_key.into_iter());
-    cache_keys.extend(cgraph_key.into_iter());
+    cache_keys.extend(publishable_key);
+    cache_keys.extend(cgraph_key);
 
     cache::redact_from_redis_and_publish(store, cache_keys).await?;
     Ok(())

--- a/crates/storage_impl/src/payments/payment_attempt.rs
+++ b/crates/storage_impl/src/payments/payment_attempt.rs
@@ -1468,7 +1468,7 @@ impl<T: DatabaseStore> PaymentAttemptInterface for KVRouterStore<T> {
                     .try_into_scan();
 
                     let payment_attempt = kv_result.and_then(|mut payment_attempts| {
-                        payment_attempts.sort_by(|a, b| b.modified_at.cmp(&a.modified_at));
+                        payment_attempts.sort_by_key(|x| std::cmp::Reverse(x.modified_at));
                         payment_attempts
                             .iter()
                             .find(|&pa| {

--- a/crates/storage_impl/src/payments/payment_attempt.rs
+++ b/crates/storage_impl/src/payments/payment_attempt.rs
@@ -1322,7 +1322,7 @@ impl<T: DatabaseStore> PaymentAttemptInterface for KVRouterStore<T> {
                     .await?
                     .try_into_scan();
                     let diesel_payment_attempt = kv_result.and_then(|mut payment_attempts| {
-                        payment_attempts.sort_by(|a, b| b.modified_at.cmp(&a.modified_at));
+                        payment_attempts.sort_by_key(|x| std::cmp::Reverse(x.modified_at));
                         payment_attempts
                             .iter()
                             .find(|&pa| pa.status == api_models::enums::AttemptStatus::Charged)
@@ -1395,7 +1395,7 @@ impl<T: DatabaseStore> PaymentAttemptInterface for KVRouterStore<T> {
                     .await?
                     .try_into_scan();
                     let diesel_payment_attempt = kv_result.and_then(|mut payment_attempts| {
-                        payment_attempts.sort_by(|a, b| b.modified_at.cmp(&a.modified_at));
+                        payment_attempts.sort_by_key(|x| std::cmp::Reverse(x.modified_at));
                         payment_attempts
                             .iter()
                             .find(|&pa| {


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->

This PR addresses clippy lints due to Rust 1.95.0.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->

This PR addresses clippy lints arising due to a new Rust version.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

`just clippy` and `just clippy_v2` pass locally when run with Rust 1.95 locally. Additionally, existing CI checks should also pass (such as stable and MSRV toolchain checks).

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
