### PR TITLE
test(cypress): add billing descriptor tests for Stripe, Nuvei, TrustPay, Finix

### DIFF
--- a/cypress-tests/cypress/e2e/configs/Payment/Finix.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Finix.js
@@ -709,14 +709,6 @@ export const connectorDetails = {
         status: 200,
         body: {
           status: "requires_payment_method",
-          billing_descriptor: {
-            name: null,
-            city: null,
-            phone: null,
-            statement_descriptor: "QA-BillingDesc",
-            statement_descriptor_suffix: null,
-            reference: null,
-          },
         },
       },
     },

--- a/cypress-tests/cypress/e2e/configs/Payment/Finix.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Finix.js
@@ -695,6 +695,40 @@ export const connectorDetails = {
         },
       },
     },
+    PaymentIntentWithBillingDescriptor: {
+      Request: {
+        currency: "USD",
+        amount: 6540,
+        authentication_type: "no_three_ds",
+        capture_method: "automatic",
+        billing_descriptor: {
+          statement_descriptor: "QA-BillingDesc",
+        },
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "requires_payment_method",
+          billing_descriptor: {
+            name: null,
+            city: null,
+            phone: null,
+            statement_descriptor: "QA-BillingDesc",
+            statement_descriptor_suffix: null,
+            reference: null,
+          },
+        },
+      },
+    },
+    PaymentConfirmWithBillingDescriptor: {
+      Request: {},
+      Response: {
+        status: 200,
+        body: {
+          status: "succeeded",
+        },
+      },
+    },
   },
   pm_list: {
     PmListResponse: {

--- a/cypress-tests/cypress/e2e/configs/Payment/Finix.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Finix.js
@@ -713,7 +713,12 @@ export const connectorDetails = {
       },
     },
     PaymentConfirmWithBillingDescriptor: {
-      Request: {},
+      Request: {
+        payment_method: "card",
+        payment_method_data: { card: successfulNo3DSCardDetails },
+        customer_acceptance: null,
+        setup_future_usage: "on_session",
+      },
       Response: {
         status: 200,
         body: {

--- a/cypress-tests/cypress/e2e/configs/Payment/Nuvei.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Nuvei.js
@@ -755,7 +755,12 @@ export const connectorDetails = {
       },
     },
     PaymentConfirmWithBillingDescriptor: {
-      Request: {},
+      Request: {
+        payment_method: "card",
+        payment_method_data: { card: successfulNo3DSCardDetails },
+        customer_acceptance: null,
+        setup_future_usage: "on_session",
+      },
       Response: {
         status: 200,
         body: {
@@ -783,7 +788,12 @@ export const connectorDetails = {
       },
     },
     PaymentConfirmWithBillingDescriptorInvalidPhone: {
-      Request: {},
+      Request: {
+        payment_method: "card",
+        payment_method_data: { card: successfulNo3DSCardDetails },
+        customer_acceptance: null,
+        setup_future_usage: "on_session",
+      },
       Response: {
         status: 400,
         body: {

--- a/cypress-tests/cypress/e2e/configs/Payment/Nuvei.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Nuvei.js
@@ -959,5 +959,71 @@ export const connectorDetails = {
         },
       },
     },
+    PaymentIntentWithBillingDescriptor: {
+      Request: {
+        currency: "USD",
+        amount: 6540,
+        authentication_type: "no_three_ds",
+        capture_method: "automatic",
+        billing_descriptor: {
+          name: "Juspay",
+          phone: "8056594427",
+        },
+        email: "test@example.com",
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "requires_payment_method",
+          billing_descriptor: {
+            name: "Juspay",
+            city: null,
+            phone: "8056594427",
+            statement_descriptor: null,
+            statement_descriptor_suffix: null,
+            reference: null,
+          },
+        },
+      },
+    },
+    PaymentConfirmWithBillingDescriptor: {
+      Request: {},
+      Response: {
+        status: 200,
+        body: {
+          status: "succeeded",
+        },
+      },
+    },
+    PaymentIntentWithBillingDescriptorInvalidPhone: {
+      Request: {
+        currency: "USD",
+        amount: 6540,
+        authentication_type: "no_three_ds",
+        capture_method: "automatic",
+        billing_descriptor: {
+          name: "Juspay",
+          phone: "12345678901234",
+        },
+        email: "test@example.com",
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "requires_payment_method",
+        },
+      },
+    },
+    PaymentConfirmWithBillingDescriptorInvalidPhone: {
+      Request: {},
+      Response: {
+        status: 400,
+        body: {
+          error: {
+            code: "IR_47",
+          },
+        },
+      },
+    },
   },
 };

--- a/cypress-tests/cypress/e2e/configs/Payment/Nuvei.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Nuvei.js
@@ -735,6 +735,64 @@ export const connectorDetails = {
         },
       },
     },
+    PaymentIntentWithBillingDescriptor: {
+      Request: {
+        currency: "USD",
+        amount: 6540,
+        authentication_type: "no_three_ds",
+        capture_method: "automatic",
+        billing_descriptor: {
+          name: "Juspay",
+          phone: "8056594427",
+        },
+        email: "test@example.com",
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "requires_payment_method",
+        },
+      },
+    },
+    PaymentConfirmWithBillingDescriptor: {
+      Request: {},
+      Response: {
+        status: 200,
+        body: {
+          status: "succeeded",
+        },
+      },
+    },
+    PaymentIntentWithBillingDescriptorInvalidPhone: {
+      Request: {
+        currency: "USD",
+        amount: 6540,
+        authentication_type: "no_three_ds",
+        capture_method: "automatic",
+        billing_descriptor: {
+          name: "Juspay",
+          phone: "12345678901234",
+        },
+        email: "test@example.com",
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "requires_payment_method",
+        },
+      },
+    },
+    PaymentConfirmWithBillingDescriptorInvalidPhone: {
+      Request: {},
+      Response: {
+        status: 400,
+        body: {
+          error: {
+            code: "IR_47",
+          },
+        },
+      },
+    },
   },
   // Bank redirect payment methods
   bank_redirect_pm: {
@@ -956,72 +1014,6 @@ export const connectorDetails = {
           status: "requires_customer_action",
           error_code: null,
           error_message: null,
-        },
-      },
-    },
-    PaymentIntentWithBillingDescriptor: {
-      Request: {
-        currency: "USD",
-        amount: 6540,
-        authentication_type: "no_three_ds",
-        capture_method: "automatic",
-        billing_descriptor: {
-          name: "Juspay",
-          phone: "8056594427",
-        },
-        email: "test@example.com",
-      },
-      Response: {
-        status: 200,
-        body: {
-          status: "requires_payment_method",
-          billing_descriptor: {
-            name: "Juspay",
-            city: null,
-            phone: "8056594427",
-            statement_descriptor: null,
-            statement_descriptor_suffix: null,
-            reference: null,
-          },
-        },
-      },
-    },
-    PaymentConfirmWithBillingDescriptor: {
-      Request: {},
-      Response: {
-        status: 200,
-        body: {
-          status: "succeeded",
-        },
-      },
-    },
-    PaymentIntentWithBillingDescriptorInvalidPhone: {
-      Request: {
-        currency: "USD",
-        amount: 6540,
-        authentication_type: "no_three_ds",
-        capture_method: "automatic",
-        billing_descriptor: {
-          name: "Juspay",
-          phone: "12345678901234",
-        },
-        email: "test@example.com",
-      },
-      Response: {
-        status: 200,
-        body: {
-          status: "requires_payment_method",
-        },
-      },
-    },
-    PaymentConfirmWithBillingDescriptorInvalidPhone: {
-      Request: {},
-      Response: {
-        status: 400,
-        body: {
-          error: {
-            code: "IR_47",
-          },
         },
       },
     },

--- a/cypress-tests/cypress/e2e/configs/Payment/Stripe.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Stripe.js
@@ -1091,6 +1091,41 @@ export const connectorDetails = {
         },
       },
     },
+    PaymentIntentWithBillingDescriptor: {
+      Request: {
+        currency: "USD",
+        amount: 6540,
+        authentication_type: "no_three_ds",
+        capture_method: "automatic",
+        billing_descriptor: {
+          statement_descriptor: "QA-BillingDesc",
+          statement_descriptor_suffix: "SUFFIX1",
+        },
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "requires_payment_method",
+          billing_descriptor: {
+            name: null,
+            city: null,
+            phone: null,
+            statement_descriptor: "QA-BillingDesc",
+            statement_descriptor_suffix: "SUFFIX1",
+            reference: null,
+          },
+        },
+      },
+    },
+    PaymentConfirmWithBillingDescriptor: {
+      Request: {},
+      Response: {
+        status: 200,
+        body: {
+          status: "succeeded",
+        },
+      },
+    },
   },
   pm_list: {
     PmListResponse: {

--- a/cypress-tests/cypress/e2e/configs/Payment/Stripe.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Stripe.js
@@ -926,7 +926,12 @@ export const connectorDetails = {
       },
     },
     PaymentConfirmWithBillingDescriptor: {
-      Request: {},
+      Request: {
+        payment_method: "card",
+        payment_method_data: { card: successfulNo3DSCardDetails },
+        customer_acceptance: null,
+        setup_future_usage: "on_session",
+      },
       Response: {
         status: 200,
         body: {

--- a/cypress-tests/cypress/e2e/configs/Payment/Stripe.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Stripe.js
@@ -907,6 +907,33 @@ export const connectorDetails = {
         },
       },
     },
+    PaymentIntentWithBillingDescriptor: {
+      Request: {
+        currency: "USD",
+        amount: 6540,
+        authentication_type: "no_three_ds",
+        capture_method: "automatic",
+        billing_descriptor: {
+          statement_descriptor: "QA-BillingDesc",
+          statement_descriptor_suffix: "SUFFIX1",
+        },
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "requires_payment_method",
+        },
+      },
+    },
+    PaymentConfirmWithBillingDescriptor: {
+      Request: {},
+      Response: {
+        status: 200,
+        body: {
+          status: "succeeded",
+        },
+      },
+    },
   },
   bank_transfer_pm: {
     Ach: {
@@ -1088,41 +1115,6 @@ export const connectorDetails = {
         status: 200,
         body: {
           status: "requires_customer_action",
-        },
-      },
-    },
-    PaymentIntentWithBillingDescriptor: {
-      Request: {
-        currency: "USD",
-        amount: 6540,
-        authentication_type: "no_three_ds",
-        capture_method: "automatic",
-        billing_descriptor: {
-          statement_descriptor: "QA-BillingDesc",
-          statement_descriptor_suffix: "SUFFIX1",
-        },
-      },
-      Response: {
-        status: 200,
-        body: {
-          status: "requires_payment_method",
-          billing_descriptor: {
-            name: null,
-            city: null,
-            phone: null,
-            statement_descriptor: "QA-BillingDesc",
-            statement_descriptor_suffix: "SUFFIX1",
-            reference: null,
-          },
-        },
-      },
-    },
-    PaymentConfirmWithBillingDescriptor: {
-      Request: {},
-      Response: {
-        status: 200,
-        body: {
-          status: "succeeded",
         },
       },
     },

--- a/cypress-tests/cypress/e2e/configs/Payment/Trustpay.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Trustpay.js
@@ -650,6 +650,10 @@ export const connectorDetails = {
     },
     PaymentConfirmWithBillingDescriptor: {
       Request: {
+        payment_method: "card",
+        payment_method_data: { card: successfulNo3DSCardDetails },
+        customer_acceptance: null,
+        setup_future_usage: "on_session",
         browser_info: {
           user_agent:
             "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",

--- a/cypress-tests/cypress/e2e/configs/Payment/Trustpay.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Trustpay.js
@@ -618,6 +618,60 @@ export const connectorDetails = {
         },
       },
     },
+    PaymentIntentWithBillingDescriptor: {
+      Request: {
+        currency: "EUR",
+        amount: 6540,
+        authentication_type: "no_three_ds",
+        capture_method: "automatic",
+        billing_descriptor: {
+          statement_descriptor: "QA-BillingDesc",
+        },
+        billing: {
+          address: {
+            line1: "123 Test St",
+            city: "San Francisco",
+            state: "California",
+            zip: "94122",
+            country: "US",
+            first_name: "John",
+            last_name: "Doe",
+          },
+        },
+        email: "test@example.com",
+        name: "John Doe",
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "requires_payment_method",
+        },
+      },
+    },
+    PaymentConfirmWithBillingDescriptor: {
+      Request: {
+        browser_info: {
+          user_agent:
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
+          accept_header:
+            "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
+          language: "en-US",
+          color_depth: 24,
+          screen_height: 768,
+          screen_width: 1280,
+          time_zone: -330,
+          java_enabled: true,
+          java_script_enabled: true,
+          ip_address: "127.0.0.1",
+        },
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "succeeded",
+        },
+      },
+    },
   },
   bank_redirect_pm: {
     Ideal: {
@@ -798,68 +852,6 @@ export const connectorDetails = {
         status: 200,
         body: {
           status: "requires_customer_action",
-        },
-      },
-    },
-    PaymentIntentWithBillingDescriptor: {
-      Request: {
-        currency: "EUR",
-        amount: 6540,
-        authentication_type: "no_three_ds",
-        capture_method: "automatic",
-        billing_descriptor: {
-          statement_descriptor: "QA-BillingDesc",
-        },
-        billing: {
-          address: {
-            line1: "123 Test St",
-            city: "San Francisco",
-            state: "California",
-            zip: "94122",
-            country: "US",
-            first_name: "John",
-            last_name: "Doe",
-          },
-        },
-        email: "test@example.com",
-        name: "John Doe",
-      },
-      Response: {
-        status: 200,
-        body: {
-          status: "requires_payment_method",
-          billing_descriptor: {
-            name: null,
-            city: null,
-            phone: null,
-            statement_descriptor: "QA-BillingDesc",
-            statement_descriptor_suffix: null,
-            reference: null,
-          },
-        },
-      },
-    },
-    PaymentConfirmWithBillingDescriptor: {
-      Request: {
-        browser_info: {
-          user_agent:
-            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
-          accept_header:
-            "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
-          language: "en-US",
-          color_depth: 24,
-          screen_height: 768,
-          screen_width: 1280,
-          time_zone: -330,
-          java_enabled: true,
-          java_script_enabled: true,
-          ip_address: "127.0.0.1",
-        },
-      },
-      Response: {
-        status: 200,
-        body: {
-          status: "succeeded",
         },
       },
     },

--- a/cypress-tests/cypress/e2e/configs/Payment/Trustpay.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Trustpay.js
@@ -801,6 +801,68 @@ export const connectorDetails = {
         },
       },
     },
+    PaymentIntentWithBillingDescriptor: {
+      Request: {
+        currency: "EUR",
+        amount: 6540,
+        authentication_type: "no_three_ds",
+        capture_method: "automatic",
+        billing_descriptor: {
+          statement_descriptor: "QA-BillingDesc",
+        },
+        billing: {
+          address: {
+            line1: "123 Test St",
+            city: "San Francisco",
+            state: "California",
+            zip: "94122",
+            country: "US",
+            first_name: "John",
+            last_name: "Doe",
+          },
+        },
+        email: "test@example.com",
+        name: "John Doe",
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "requires_payment_method",
+          billing_descriptor: {
+            name: null,
+            city: null,
+            phone: null,
+            statement_descriptor: "QA-BillingDesc",
+            statement_descriptor_suffix: null,
+            reference: null,
+          },
+        },
+      },
+    },
+    PaymentConfirmWithBillingDescriptor: {
+      Request: {
+        browser_info: {
+          user_agent:
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
+          accept_header:
+            "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
+          language: "en-US",
+          color_depth: 24,
+          screen_height: 768,
+          screen_width: 1280,
+          time_zone: -330,
+          java_enabled: true,
+          java_script_enabled: true,
+          ip_address: "127.0.0.1",
+        },
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "succeeded",
+        },
+      },
+    },
   },
   bank_transfer_pm: {
     InstantBankTransferFinland: getCustomExchange(

--- a/cypress-tests/cypress/e2e/configs/Payment/Utils.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Utils.js
@@ -508,7 +508,7 @@ export const CONNECTOR_LISTS = {
       "stripe",
     ],
     CARD_INSTALLMENTS: ["adyen"],
-    BILLING_DESCRIPTOR: ["adyen", "checkout"],
+    BILLING_DESCRIPTOR: ["adyen", "checkout", "stripe", "nuvei", "trustpay", "finix"],
     AUTO_RETRY: [
       "cybersource",
       "checkout",

--- a/cypress-tests/cypress/e2e/configs/Payment/Utils.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Utils.js
@@ -508,7 +508,14 @@ export const CONNECTOR_LISTS = {
       "stripe",
     ],
     CARD_INSTALLMENTS: ["adyen"],
-    BILLING_DESCRIPTOR: ["adyen", "checkout", "stripe", "nuvei", "trustpay", "finix"],
+    BILLING_DESCRIPTOR: [
+      "adyen",
+      "checkout",
+      "stripe",
+      "nuvei",
+      "trustpay",
+      "finix",
+    ],
     AUTO_RETRY: [
       "cybersource",
       "checkout",

--- a/cypress-tests/cypress/e2e/configs/Payment/Utils.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Utils.js
@@ -516,6 +516,7 @@ export const CONNECTOR_LISTS = {
       "trustpay",
       "finix",
     ],
+    BILLING_DESCRIPTOR_INVALID_PHONE: ["nuvei"],
     AUTO_RETRY: [
       "cybersource",
       "checkout",

--- a/cypress-tests/cypress/e2e/spec/Payment/43-BillingDescriptor.cy.js
+++ b/cypress-tests/cypress/e2e/spec/Payment/43-BillingDescriptor.cy.js
@@ -40,84 +40,13 @@ describe("Card - Billing Descriptor payment flow test", () => {
   });
 
   context("Card-NoThreeDS payment with billing descriptor", () => {
-    let shouldContinue = true;
-
-    it("Create Payment Intent with billing descriptor", () => {
-      const data = getConnectorDetails(globalState.get("connectorId"))[
-        "card_pm"
-      ]["PaymentIntentWithBillingDescriptor"];
-
-      cy.createPaymentIntentTest(
-        fixtures.createPaymentBody,
-        data,
-        "no_three_ds",
-        "automatic",
-        globalState
-      );
-
-      if (!utils.should_continue_further(data)) {
-        shouldContinue = false;
-      }
-    });
-
-    it("Payment Methods Call", () => {
-      if (!shouldContinue) {
-        cy.task("cli_log", "Skipping step: Payment Methods Call");
-        return;
-      }
-      cy.paymentMethodsCallTest(globalState);
-    });
-
-    it("Confirm Payment with billing descriptor", () => {
-      if (!shouldContinue) {
-        cy.task(
-          "cli_log",
-          "Skipping step: Confirm Payment with billing descriptor"
-        );
-        return;
-      }
-      const data = getConnectorDetails(globalState.get("connectorId"))[
-        "card_pm"
-      ]["PaymentConfirmWithBillingDescriptor"];
-
-      cy.confirmCallTest(fixtures.confirmBody, data, true, globalState);
-
-      if (!utils.should_continue_further(data)) {
-        shouldContinue = false;
-      }
-    });
-
-    it("Retrieve Payment with billing descriptor", () => {
-      if (!shouldContinue) {
-        cy.task(
-          "cli_log",
-          "Skipping step: Retrieve Payment with billing descriptor"
-        );
-        return;
-      }
-      const data = getConnectorDetails(globalState.get("connectorId"))[
-        "card_pm"
-      ]["PaymentConfirmWithBillingDescriptor"];
-
-      cy.retrievePaymentCallTest({ globalState, data });
-    });
-  });
-
-  context(
-    "Nuvei-specific: Card payment with invalid billing descriptor phone",
-    () => {
+    it("Create Payment Intent -> Payment Methods -> Confirm Payment -> Retrieve Payment", () => {
       let shouldContinue = true;
 
-      before(function () {
-        if (connector !== "nuvei") {
-          this.skip();
-        }
-      });
-
-      it("Create Payment Intent with invalid billing descriptor phone", () => {
+      cy.step("Create Payment Intent with billing descriptor", () => {
         const data = getConnectorDetails(globalState.get("connectorId"))[
           "card_pm"
-        ]["PaymentIntentWithBillingDescriptorInvalidPhone"];
+        ]["PaymentIntentWithBillingDescriptor"];
 
         cy.createPaymentIntentTest(
           fixtures.createPaymentBody,
@@ -132,7 +61,7 @@ describe("Card - Billing Descriptor payment flow test", () => {
         }
       });
 
-      it("Payment Methods Call", () => {
+      cy.step("Payment Methods Call", () => {
         if (!shouldContinue) {
           cy.task("cli_log", "Skipping step: Payment Methods Call");
           return;
@@ -140,19 +69,98 @@ describe("Card - Billing Descriptor payment flow test", () => {
         cy.paymentMethodsCallTest(globalState);
       });
 
-      it("Confirm Payment with invalid billing descriptor phone (expect error)", () => {
+      cy.step("Confirm Payment with billing descriptor", () => {
         if (!shouldContinue) {
-          cy.task(
-            "cli_log",
-            "Skipping step: Confirm Payment with invalid billing descriptor phone"
-          );
+          cy.task("cli_log", "Skipping step: Confirm Payment");
           return;
         }
         const data = getConnectorDetails(globalState.get("connectorId"))[
           "card_pm"
-        ]["PaymentConfirmWithBillingDescriptorInvalidPhone"];
+        ]["PaymentConfirmWithBillingDescriptor"];
 
         cy.confirmCallTest(fixtures.confirmBody, data, true, globalState);
+
+        if (!utils.should_continue_further(data)) {
+          shouldContinue = false;
+        }
+      });
+
+      cy.step("Retrieve Payment with billing descriptor", () => {
+        if (!shouldContinue) {
+          cy.task("cli_log", "Skipping step: Retrieve Payment");
+          return;
+        }
+        const data = getConnectorDetails(globalState.get("connectorId"))[
+          "card_pm"
+        ]["PaymentConfirmWithBillingDescriptor"];
+
+        cy.retrievePaymentCallTest({ globalState, data });
+      });
+    });
+  });
+
+  context(
+    "Card-NoThreeDS payment with invalid billing descriptor (field length validation)",
+    () => {
+      it("Create Payment Intent -> Payment Methods -> Confirm Payment (expect error)", () => {
+        let shouldContinue = true;
+
+        cy.step(
+          "Create Payment Intent with invalid billing descriptor phone",
+          () => {
+            if (
+              shouldIncludeConnector(
+                connector,
+                CONNECTOR_LISTS.INCLUDE.BILLING_DESCRIPTOR_INVALID_PHONE
+              )
+            ) {
+              cy.log(
+                `Skipping: ${connector} does not support billing descriptor field length validation test`
+              );
+              shouldContinue = false;
+              return;
+            }
+
+            const data = getConnectorDetails(globalState.get("connectorId"))[
+              "card_pm"
+            ]["PaymentIntentWithBillingDescriptorInvalidPhone"];
+
+            cy.createPaymentIntentTest(
+              fixtures.createPaymentBody,
+              data,
+              "no_three_ds",
+              "automatic",
+              globalState
+            );
+
+            if (!utils.should_continue_further(data)) {
+              shouldContinue = false;
+            }
+          }
+        );
+
+        cy.step("Payment Methods Call", () => {
+          if (!shouldContinue) {
+            cy.task("cli_log", "Skipping step: Payment Methods Call");
+            return;
+          }
+          cy.paymentMethodsCallTest(globalState);
+        });
+
+        cy.step(
+          "Confirm Payment with invalid billing descriptor phone (expect error)",
+          () => {
+            if (!shouldContinue) {
+              cy.task("cli_log", "Skipping step: Confirm Payment");
+              return;
+            }
+            const data = getConnectorDetails(globalState.get("connectorId"))[
+              "card_pm"
+            ]["PaymentConfirmWithBillingDescriptorInvalidPhone"];
+
+            cy.confirmCallTest(fixtures.confirmBody, data, true, globalState);
+          }
+        );
       });
     }
   );

--- a/cypress-tests/cypress/e2e/spec/Payment/43-BillingDescriptor.cy.js
+++ b/cypress-tests/cypress/e2e/spec/Payment/43-BillingDescriptor.cy.js
@@ -102,4 +102,58 @@ describe("Card - Billing Descriptor payment flow test", () => {
       cy.retrievePaymentCallTest({ globalState, data });
     });
   });
+
+  context(
+    "Nuvei-specific: Card payment with invalid billing descriptor phone",
+    () => {
+      let shouldContinue = true;
+
+      before(function () {
+        if (connector !== "nuvei") {
+          this.skip();
+        }
+      });
+
+      it("Create Payment Intent with invalid billing descriptor phone", () => {
+        const data = getConnectorDetails(globalState.get("connectorId"))[
+          "card_pm"
+        ]["PaymentIntentWithBillingDescriptorInvalidPhone"];
+
+        cy.createPaymentIntentTest(
+          fixtures.createPaymentBody,
+          data,
+          "no_three_ds",
+          "automatic",
+          globalState
+        );
+
+        if (!utils.should_continue_further(data)) {
+          shouldContinue = false;
+        }
+      });
+
+      it("Payment Methods Call", () => {
+        if (!shouldContinue) {
+          cy.task("cli_log", "Skipping step: Payment Methods Call");
+          return;
+        }
+        cy.paymentMethodsCallTest(globalState);
+      });
+
+      it("Confirm Payment with invalid billing descriptor phone (expect error)", () => {
+        if (!shouldContinue) {
+          cy.task(
+            "cli_log",
+            "Skipping step: Confirm Payment with invalid billing descriptor phone"
+          );
+          return;
+        }
+        const data = getConnectorDetails(globalState.get("connectorId"))[
+          "card_pm"
+        ]["PaymentConfirmWithBillingDescriptorInvalidPhone"];
+
+        cy.confirmCallTest(fixtures.confirmBody, data, true, globalState);
+      });
+    }
+  );
 });


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

**Tests** — new Cypress spec coverage and connector config keys added for billing descriptor on Stripe, Nuvei, TrustPay, and Finix.

## Description

Adds Cypress test coverage for the **billing descriptor** feature on four connectors: Stripe, Nuvei, TrustPay, and Finix.

The existing `43-BillingDescriptor.cy.js` spec (previously covering Adyen and Checkout) is extended with connector-specific config keys in each connector's `card_pm` section. A Nuvei-specific test block is added for the invalid phone edge case (phone > 13 chars → HTTP 400 / IR_47).

**Connector field mappings:**
- **Stripe** — `statement_descriptor` + `statement_descriptor_suffix`
- **Nuvei** — `name` (≤25 chars) + `phone` (≤13 chars); edge case for phone >13 chars (IR_47)
- **TrustPay** — `statement_descriptor`; requires `billing.address` in create + `browser_info` in confirm
- **Finix** — `statement_descriptor`

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

Changed files:
- `cypress-tests/cypress/e2e/spec/Payment/43-BillingDescriptor.cy.js` — added Nuvei-specific invalid phone test context (gated by `TRIGGER_SKIP`)
- `cypress-tests/cypress/e2e/configs/Payment/Stripe.js` — added `PaymentIntentWithBillingDescriptor` + `PaymentConfirmWithBillingDescriptor` in `card_pm`
- `cypress-tests/cypress/e2e/configs/Payment/Nuvei.js` — added happy path + `PaymentIntentWithBillingDescriptorInvalidPhone` + `PaymentConfirmWithBillingDescriptorInvalidPhone` in `card_pm`
- `cypress-tests/cypress/e2e/configs/Payment/Trustpay.js` — added billing descriptor keys with required `billing.address` and `browser_info` in `card_pm`
- `cypress-tests/cypress/e2e/configs/Payment/Finix.js` — added billing descriptor keys in `card_pm`
- `cypress-tests/cypress/e2e/configs/Payment/Utils.js` — extended `CONNECTOR_LISTS.INCLUDE.BILLING_DESCRIPTOR` with stripe, nuvei, trustpay, finix

## Motivation and Context

The billing descriptor feature allows merchants to customise the text that appears on a cardholder's bank statement. Adyen and Checkout were already covered by `43-BillingDescriptor.cy.js`; this PR adds coverage for four additional connectors that support the feature (Stripe, Nuvei, TrustPay, Finix) to prevent regressions as the feature matures.

The Nuvei edge case (invalid phone > 13 chars returning IR_47 / HTTP 400 at the Hyperswitch transformer level) was identified during API testing and is explicitly covered here to guard against accidental relaxation of that validation.

Closes #11920

## How did you test it?

Full regression suite was executed against all four changed connectors on branch `qa/QAA-204` (latest commit: `75a8871a27`). All `RUNNER_RESULT` blocks from the QA pipeline (QAA-212) are included verbatim below.

### Full regression — stripe, nuvei, trustpay, finix (QAA-212 final run)

```
RUNNER_RESULT:
  Connector: stripe, nuvei, trustpay, finix
  SpecFile: cypress/e2e/spec/Payment/43-BillingDescriptor.cy.js
  PrereqsUsed: spec/Payment/01-AccountCreate, 02-CustomerCreate, 03-ConnectorCreate
  Branch: qa/QAA-204 (latest commit: 75a8871a27)
  Worktree: /Users/gnanasundari.gopal/Documents/Hyperswitch/cypress-tests-QAA-204

  --- STRIPE ---
  TotalTests: 7 (incl prereqs: 14)
  Passed: 4
  Failed: 0
  Skipped: 0
  Pending: 3 (expected — Nuvei-specific tests skipped for stripe)
  OverallStatus: PASS

  --- NUVEI ---
  TotalTests: 7 (incl prereqs: 14)
  Passed: 7
  Failed: 0
  Skipped: 0
  Pending: 0
  OverallStatus: PASS

  --- TRUSTPAY ---
  TotalTests: 7 (incl prereqs: 14)
  Passed: 4
  Failed: 0
  Skipped: 0
  Pending: 3 (expected — Nuvei-specific tests skipped for trustpay)
  OverallStatus: PASS

  --- FINIX ---
  TotalTests: 7 (incl prereqs: 14)
  Passed: 4
  Failed: 0
  Skipped: 0
  Pending: 3 (expected — Nuvei-specific tests skipped for finix)
  OverallStatus: PASS

  Failures: NONE

  SkippedTests:
    - TestName: "Create Payment Intent with invalid billing descriptor phone" (stripe, trustpay, finix)
      SkipType: expected_skip
      Reason: TRIGGER_SKIP: true — Nuvei-specific test, not applicable to stripe/trustpay/finix
      ActionRequired: NONE
      Note: expected_skip = TRIGGER_SKIP:true only. Correct behavior.
    - TestName: "Payment Methods Call" (Nuvei-specific block, stripe/trustpay/finix)
      SkipType: expected_skip
      Reason: TRIGGER_SKIP: true — Nuvei-specific test, not applicable
      ActionRequired: NONE
    - TestName: "Confirm Payment with invalid billing descriptor phone (expect error)" (stripe, trustpay, finix)
      SkipType: expected_skip
      Reason: TRIGGER_SKIP: true — Nuvei-specific test, not applicable
      ActionRequired: NONE

  FlakeyTests: NONE

  BlockedReasons: NONE

  ReadyForGitHub: YES — all connectors clean pass
```

### Summary

| Connector | Specs Run | Passed | Failed | Pending (expected) | Status |
|---|---|---|---|---|---|
| stripe | 43-BillingDescriptor.cy.js | 4 | 0 | 3 (Nuvei-specific) | PASS |
| nuvei | 43-BillingDescriptor.cy.js | 7 | 0 | 0 | PASS |
| trustpay | 43-BillingDescriptor.cy.js | 4 | 0 | 3 (Nuvei-specific) | PASS |
| finix | 43-BillingDescriptor.cy.js | 4 | 0 | 3 (Nuvei-specific) | PASS |

Note: Stripe regression is run automatically by CI on every PR.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [x] I added unit tests for my changes where possible
