### PR TITLE
feat(connector): Add AVS/CVV validation for Zift

### DIFF
--- a/crates/hyperswitch_connectors/src/connectors/zift/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/zift/transformers.rs
@@ -4,7 +4,10 @@ use common_utils::types::StringMinorUnit;
 use error_stack::ResultExt;
 use hyperswitch_domain_models::{
     payment_method_data::PaymentMethodData,
-    router_data::{ConnectorAuthType, ErrorResponse, RouterData},
+    router_data::{
+        AdditionalPaymentMethodConnectorResponse, ConnectorAuthType, ConnectorResponseData,
+        ErrorResponse, RouterData,
+    },
     router_flow_types::{refunds::Execute, PSync},
     router_request_types::{
         PaymentsAuthorizeData, PaymentsSyncData, ResponseId, SetupMandateRequestData,
@@ -408,6 +411,10 @@ pub struct ZiftAuthPaymentsResponse {
     pub transaction_id: Option<i64>,
     pub transaction_code: Option<String>,
     pub token: Option<String>,
+    #[serde(rename = "avsResponseCode")]
+    pub avs_response: Option<String>,
+    #[serde(rename = "cscResponseCode")]
+    pub csc_response: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -512,6 +519,25 @@ impl<F>
                 }
             })?;
 
+            let connector_response_data =
+                if item.response.avs_response.is_some() || item.response.csc_response.is_some() {
+                    let payment_checks = serde_json::json!({
+                        "avs_result": item.response.avs_response,
+                        "card_validation_result": item.response.csc_response,
+                    });
+                    Some(ConnectorResponseData::with_additional_payment_method_data(
+                        AdditionalPaymentMethodConnectorResponse::Card {
+                            authentication_data: None,
+                            payment_checks: Some(payment_checks),
+                            card_network: None,
+                            domestic_network: None,
+                            auth_code: None,
+                        },
+                    ))
+                } else {
+                    None
+                };
+
             Ok(Self {
                 status,
                 response: Ok(PaymentsResponseData::TransactionResponse {
@@ -525,6 +551,7 @@ impl<F>
                     authentication_data: None,
                     charges: None,
                 }),
+                connector_response: connector_response_data,
                 ..item.data
             })
         } else {


### PR DESCRIPTION
## Summary

Add AVS (Address Verification Service) and CVV (Card Verification Value) validation support for **Zift** connector using `AdditionalPaymentMethodConnectorResponse::Card` pattern with `payment_checks` field.

This PR was split from #11770 for easier per-connector review.

## Changes Made

### Response Struct Field Mapping
- Fixed serde renames on `ZiftAuthPaymentsResponse`:
  - `avsResponseCode` (Zift API field) -> `avs_response`
  - `cscResponseCode` (Zift API field) -> `csc_response`

### Standardized `payment_checks` Keys
- `avs_result` — standardized AVS response code
- `card_validation_result` — standardized CVV/CSC response code

Removed connector-specific raw field names (`avs_response`, `csc_response`) from `payment_checks` to align with hyperswitch standardized naming across connectors.

## Implementation

Uses the pattern:
- `AdditionalPaymentMethodConnectorResponse::Card { payment_checks: ... }`
- `ConnectorResponseData::with_additional_payment_method_data()`

Only populates `payment_checks` when `avs_response` or `csc_response` is present (`is_some()` check).

## Testing

### Test Payment Request
```json
POST /payments
{
  "amount": 100,
  "currency": "USD",
  "confirm": true,
  "connector": ["zift"],
  "customer_id": "test_customer",
  "payment_method": "card",
  "payment_method_type": "credit",
  "payment_method_data": {
    "card": {
      "card_number": "4242424242424242",
      "card_exp_month": "12",
      "card_exp_year": "27",
      "card_holder_name": "Test User",
      "card_cvc": "123"
    }
  },
  "billing": {
    "address": {
      "line1": "123 Test St",
      "city": "Test City",
      "state": "CA",
      "zip": "12345",
      "country": "US"
    }
  }
}
```

### Raw Connector Response (Zift Sandbox)
```json
{
  "responseCode": "A01",
  "responseMessage": "Approved",
  "transactionId": 8620475312,
  "transactionCode": "pay_BveRDFv2uJ1bOC6Af3se_1",
  "token": "VC10000000000011764242",
  "avsResponseCode": "",
  "cscResponseCode": "M"
}
```

### Final Payment Response
```json
{
  "status": "succeeded",
  "connector": "zift",
  "payment_method_data": {
    "card": {
      "payment_checks": {
        "avs_result": "",
        "card_validation_result": "M"
      }
    }
  }
}
```

### Results
- Payment status: `succeeded`
- Connector transaction ID: `8620475312`
- AVS result: `""` (empty string — Zift sandbox returns empty AVS for standard test cards)
- CVV/CSC result: `"M"` (match)
- `payment_checks` correctly populated with standardized field names

## Breaking Changes

None — purely additive changes to existing response handling. No changes to request structure or existing response fields.