### PR TITLE
test(cypress): refund for fiservcommercehub and dwolla

### DIFF
--- a/cypress-tests/cypress/e2e/configs/Payment/Dwolla.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Dwolla.js
@@ -1,0 +1,148 @@
+import { getCustomExchange } from "./Modifiers";
+
+export const connectorDetails = {
+  multi_credential_config: {},
+  card_pm: {
+    PaymentIntent: {
+      Request: {
+        currency: "USD",
+        customer_acceptance: null,
+        setup_future_usage: "on_session",
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "requires_payment_method",
+        },
+      },
+    },
+    No3DSAutoCapture: getCustomExchange({
+      Configs: {
+        ASSERT_BILLING_NOT_NULL: false,
+      },
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: {
+            card_number: "4111111111111111",
+            card_exp_month: "08",
+            card_exp_year: "30",
+            card_holder_name: "joseph Doe",
+            card_cvc: "999",
+          },
+        },
+        currency: "USD",
+        customer_acceptance: null,
+        setup_future_usage: "on_session",
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "succeeded",
+          billing: null,
+        },
+      },
+    }),
+    No3DSManualCapture: getCustomExchange({
+      Configs: {
+        ASSERT_BILLING_NOT_NULL: false,
+      },
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: {
+            card_number: "4111111111111111",
+            card_exp_month: "08",
+            card_exp_year: "30",
+            card_holder_name: "joseph Doe",
+            card_cvc: "999",
+          },
+        },
+        currency: "USD",
+        customer_acceptance: null,
+        setup_future_usage: "on_session",
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "requires_capture",
+          billing: null,
+        },
+      },
+    }),
+    Capture: getCustomExchange({
+      Request: {
+        amount_to_capture: 6000,
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "succeeded",
+        },
+      },
+    }),
+    PartialCapture: getCustomExchange({
+      Request: {
+        amount_to_capture: 2000,
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "partially_captured",
+        },
+      },
+    }),
+    Refund: getCustomExchange({
+      Request: {
+        amount: 6000,
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "succeeded",
+        },
+      },
+    }),
+    PartialRefund: getCustomExchange({
+      Request: {
+        amount: 2000,
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "succeeded",
+        },
+      },
+    }),
+    manualPaymentRefund: getCustomExchange({
+      Request: {
+        amount: 6000,
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "succeeded",
+        },
+      },
+    }),
+    manualPaymentPartialRefund: getCustomExchange({
+      Request: {
+        amount: 2000,
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "succeeded",
+        },
+      },
+    }),
+    SyncRefund: getCustomExchange({
+      Response: {
+        status: 200,
+        body: {
+          status: "succeeded",
+        },
+      },
+    }),
+  },
+};

--- a/cypress-tests/cypress/e2e/configs/Payment/Fiservcommercehub.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Fiservcommercehub.js
@@ -1,0 +1,144 @@
+import { getCustomExchange } from "./Modifiers";
+
+const cardDetails = {
+  card_number: "4111111111111111",
+  card_exp_month: "08",
+  card_exp_year: "30",
+  card_holder_name: "joseph Doe",
+  card_cvc: "999",
+};
+
+export const connectorDetails = {
+  multi_credential_config: {},
+  card_pm: {
+    PaymentIntent: {
+      Request: {
+        currency: "USD",
+        customer_acceptance: null,
+        setup_future_usage: "on_session",
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "requires_payment_method",
+        },
+      },
+    },
+    No3DSAutoCapture: getCustomExchange({
+      Configs: {
+        ASSERT_BILLING_NOT_NULL: false,
+      },
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: cardDetails,
+        },
+        currency: "USD",
+        customer_acceptance: null,
+        setup_future_usage: "on_session",
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "succeeded",
+          billing: null,
+        },
+      },
+    }),
+    No3DSManualCapture: getCustomExchange({
+      Configs: {
+        ASSERT_BILLING_NOT_NULL: false,
+      },
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: cardDetails,
+        },
+        currency: "USD",
+        customer_acceptance: null,
+        setup_future_usage: "on_session",
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "requires_capture",
+          billing: null,
+        },
+      },
+    }),
+    Capture: getCustomExchange({
+      Request: {
+        amount_to_capture: 6000,
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "succeeded",
+        },
+      },
+    }),
+    PartialCapture: getCustomExchange({
+      Request: {
+        amount_to_capture: 2000,
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "partially_captured",
+        },
+      },
+    }),
+    Refund: getCustomExchange({
+      Request: {
+        amount: 6000,
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "succeeded",
+        },
+      },
+    }),
+    PartialRefund: getCustomExchange({
+      Request: {
+        amount: 2000,
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "succeeded",
+        },
+      },
+    }),
+    manualPaymentRefund: getCustomExchange({
+      Request: {
+        amount: 6000,
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "succeeded",
+        },
+      },
+    }),
+    manualPaymentPartialRefund: getCustomExchange({
+      Request: {
+        amount: 2000,
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "succeeded",
+        },
+      },
+    }),
+    SyncRefund: getCustomExchange({
+      Response: {
+        status: 200,
+        body: {
+          status: "succeeded",
+        },
+      },
+    }),
+  },
+};


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [x] Tests
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->

This PR fixes the Cypress test configurations for `fiservcommercehub` and `dwolla` connectors to enable refund test coverage. Previously these connectors were skipped due to missing `TRIGGER_SKIP` removal and incorrect response body assertions.

### Changes Made:
- Removed `TRIGGER_SKIP: true` flags that were blocking refund test execution
- Added `multi_credential_config: {}` to connector configs
- Added `billing: null` to response body assertions for `No3DSAutoCapture` and `No3DSManualCapture`

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

No additional changes beyond the Cypress test configuration files.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

This change enables automated refund test coverage for two connectors that were previously skipped in the test suite. The connectors `fiservcommercehub` and `dwolla` now have proper Cypress configurations allowing refund flows to be tested.

Related to: [TESA-44](/TESA/issues/TESA-44)
Closes #11954

Previous PR that introduced the issue: https://github.com/juspay/hyperswitch/pull/11949

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

Full regression verification was performed against both connectors. All tests passed.

```
GATE_PASSED:
ConnectorRegressions:
  - fiservcommercehub: PASS
  - dwolla: PASS
```

### Summary

| Connector | Status |
|-----------|--------|
| fiservcommercehub | PASS |
| dwolla | PASS |

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [x] I added unit tests for my changes where possible
