### PR TITLE
feat(connector): [Checkout] add network token payment support (CIT + MIT NTID)

### DIFF
--- a/crates/hyperswitch_connectors/src/connectors/checkout/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/checkout/transformers.rs
@@ -904,19 +904,18 @@ impl TryFrom<&CheckoutRouterData<&PaymentsAuthorizeRouterData>> for PaymentsRequ
                     _ => CheckoutPaymentType::Unscheduled,
                 };
 
-                let payment_source =
-                    PaymentSource::NetworkToken(Box::new(NetworkTokenSource {
-                        source_type: "network_token".to_string(),
-                        token: cards::CardNumber::from(token_data.network_token),
-                        expiry_month: token_data.token_exp_month,
-                        expiry_year: token_data.token_exp_year,
-                        token_type,
-                        cryptogram: None,
-                        eci: token_data.eci,
-                        stored: Some(true),
-                        store_for_future_use: None,
-                        billing_address: billing_details,
-                    }));
+                let payment_source = PaymentSource::NetworkToken(Box::new(NetworkTokenSource {
+                    source_type: "network_token".to_string(),
+                    token: cards::CardNumber::from(token_data.network_token),
+                    expiry_month: token_data.token_exp_month,
+                    expiry_year: token_data.token_exp_year,
+                    token_type,
+                    cryptogram: None,
+                    eci: token_data.eci,
+                    stored: Some(true),
+                    store_for_future_use: None,
+                    billing_address: billing_details,
+                }));
 
                 Ok((payment_source, previous_id, Some(true), p_type, None))
             }

--- a/crates/hyperswitch_connectors/src/connectors/checkout/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/checkout/transformers.rs
@@ -261,6 +261,7 @@ pub enum PaymentSource {
     MandatePayment(MandateSource),
     GooglePayPredecrypt(Box<GooglePayPredecrypt>),
     DecryptedWalletToken(DecryptedWalletToken),
+    NetworkToken(Box<NetworkTokenSource>),
 }
 
 #[derive(Debug, Serialize)]
@@ -271,6 +272,22 @@ pub struct DecryptedWalletToken {
     token_type: String,
     expiry_month: Secret<String>,
     expiry_year: Secret<String>,
+    pub billing_address: Option<CheckoutAddress>,
+}
+
+#[skip_serializing_none]
+#[derive(Debug, Serialize)]
+pub struct NetworkTokenSource {
+    #[serde(rename = "type")]
+    pub source_type: String,
+    pub token: cards::CardNumber,
+    pub expiry_month: Secret<String>,
+    pub expiry_year: Secret<String>,
+    pub token_type: String,
+    pub cryptogram: Option<Secret<String>>,
+    pub eci: Option<String>,
+    pub stored: Option<bool>,
+    pub store_for_future_use: Option<bool>,
     pub billing_address: Option<CheckoutAddress>,
 }
 
@@ -817,6 +834,91 @@ impl TryFrom<&CheckoutRouterData<&PaymentsAuthorizeRouterData>> for PaymentsRequ
                     p_type,
                     store_for_future_use,
                 ))
+            }
+            PaymentMethodData::NetworkToken(token_data) => {
+                let token_type = match token_data.card_network {
+                    Some(enums::CardNetwork::Visa) => Ok("vts".to_string()),
+                    Some(enums::CardNetwork::Mastercard) => Ok("mdes".to_string()),
+                    _ => Err(errors::ConnectorError::NotImplemented(
+                        "Network token for this card network".to_string(),
+                    )),
+                }?;
+
+                #[cfg(feature = "v1")]
+                let (token, expiry_month, expiry_year, cryptogram) = (
+                    token_data.token_number,
+                    token_data.token_exp_month,
+                    token_data.token_exp_year,
+                    token_data.token_cryptogram,
+                );
+                #[cfg(feature = "v2")]
+                let (token, expiry_month, expiry_year, cryptogram) = (
+                    token_data.network_token,
+                    token_data.network_token_exp_month,
+                    token_data.network_token_exp_year,
+                    token_data.cryptogram,
+                );
+
+                let payment_source = PaymentSource::NetworkToken(Box::new(NetworkTokenSource {
+                    source_type: "network_token".to_string(),
+                    token: cards::CardNumber::from(token),
+                    expiry_month,
+                    expiry_year,
+                    token_type,
+                    cryptogram,
+                    eci: token_data.eci,
+                    stored: None,
+                    store_for_future_use,
+                    billing_address: billing_details,
+                }));
+
+                Ok((
+                    payment_source,
+                    None,
+                    None,
+                    payment_type,
+                    store_for_future_use,
+                ))
+            }
+            PaymentMethodData::NetworkTokenDetailsForNetworkTransactionId(token_data) => {
+                let token_type = match token_data.card_network {
+                    Some(enums::CardNetwork::Visa) => Ok("vts".to_string()),
+                    Some(enums::CardNetwork::Mastercard) => Ok("mdes".to_string()),
+                    _ => Err(errors::ConnectorError::NotImplemented(
+                        "Network token for this card network".to_string(),
+                    )),
+                }?;
+
+                let previous_id = Some(
+                    item.router_data
+                        .request
+                        .get_optional_network_transaction_id()
+                        .ok_or_else(utils::missing_field_err("network_transaction_id"))
+                        .attach_printable("Checkout unable to find NTID for MIT")?,
+                );
+
+                let p_type = match item.router_data.request.mit_category {
+                    Some(MitCategory::Installment) => CheckoutPaymentType::Installment,
+                    Some(MitCategory::Recurring) => CheckoutPaymentType::Recurring,
+                    Some(MitCategory::Unscheduled) | None => CheckoutPaymentType::Unscheduled,
+                    _ => CheckoutPaymentType::Unscheduled,
+                };
+
+                let payment_source =
+                    PaymentSource::NetworkToken(Box::new(NetworkTokenSource {
+                        source_type: "network_token".to_string(),
+                        token: cards::CardNumber::from(token_data.network_token),
+                        expiry_month: token_data.token_exp_month,
+                        expiry_year: token_data.token_exp_year,
+                        token_type,
+                        cryptogram: None,
+                        eci: token_data.eci,
+                        stored: Some(true),
+                        store_for_future_use: None,
+                        billing_address: billing_details,
+                    }));
+
+                Ok((payment_source, previous_id, Some(true), p_type, None))
             }
             _ => Err(errors::ConnectorError::NotImplemented(
                 utils::get_unimplemented_payment_method_error_message("checkout"),


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Adds end-to-end support for **raw network token (NT) payments** through the Checkout connector, covering both the Customer-Initiated Transaction (CIT) path and the Merchant-Initiated Transaction (MIT) path that reuses a previously stored Network Transaction ID (NTID).

### What's added

1. **CIT — raw NT → /payments**
   - New `PaymentSource::NetworkToken(NetworkTokenSource)` variant on the Checkout `PaymentsRequest` payload.
   - Handler for `PaymentMethodData::NetworkToken(...)` that maps `card_network` → Checkout `token_type` (`vts` / `mdes`) and forwards the NT, expiry, cryptogram and ECI exactly as supplied by the merchant.
   - `source.stored = None` for first-use (Checkout default), `store_for_future_use` honoured from the request.
   - The Checkout `scheme_id` returned in the response is mapped to `network_transaction_id` on the Hyperswitch response, so the merchant can persist it for future MITs without Hyperswitch having to vault the PAN.

2. **MIT — NT + NTID → /payments** *(this commit)*
   - New `PaymentMethodData::NetworkTokenDetailsForNetworkTransactionId(...)` arm in `checkout/transformers.rs`.
   - Builds the same `NetworkToken` source but with `stored = true` (Visa/MC stored-credential signalling), no cryptogram (not required for MITs), and forwards the saved NTID as `previous_payment_id`.
   - Sets `merchant_initiated = true` and maps `mit_category` → `payment_type` (`Recurring` / `Installment` / `Unscheduled`).
   - Routes through the existing `network_transaction_id_supported_connectors` list (Checkout already enabled).

### What's intentionally NOT done

- The PAN/network token is **not stored** by Hyperswitch. `long_lived_token = false` for Checkout, so the connector token is only used for the in-flight payment and never persisted in `payment_methods.metadata`.
- No mandate/payment-method record is created for these flows. Merchants are expected to retain the NT in their own vault and the NTID returned by Hyperswitch.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [x] This PR modifies application configuration/environment variables — `config/development.toml` enables Checkout for the network-token tokenization flow.

Files touched:

- `crates/hyperswitch_connectors/src/connectors/checkout.rs`
- `crates/hyperswitch_connectors/src/connectors/checkout/transformers.rs`
- `crates/router/src/core/payment_methods.rs`
- `crates/router/src/core/payments/tokenization.rs`
- `config/development.toml`
- `docs/design/network_token_storage_for_raw_nt_payments.md`

## Motivation and Context

Merchants who already provision their own network tokens (via Visa VTS / Mastercard MDES) need a way to push them through Hyperswitch → Checkout without going through the existing card-detail or wallet-decrypt paths. They also need to be able to perform downstream MITs against those tokens using the NTID returned on the original CIT, without Hyperswitch storing card data on their behalf.

Before this change, both `PaymentMethodData::NetworkToken(_)` and `PaymentMethodData::NetworkTokenDetailsForNetworkTransactionId(_)` fell into Checkout's `unimplemented` arm, so neither flow was usable.

## How did you test it?

End-to-end against the Checkout sandbox via a local router build (`cargo build -p router --features v1`) on the `test_nt_merchant` merchant.

### CIT — raw NT (Visa, 4242…)

```jsonc
POST /payments
{
  "amount": 1000, "currency": "USD",
  "confirm": true, "setup_future_usage": "off_session",
  "payment_method": "network_token", "payment_method_type": "network_token",
  "payment_method_data": {
    "network_token": {
      "network_token": "4242424242424242",
      "token_exp_month": "10", "token_exp_year": "2030",
      "token_cryptogram": "AgAAAAAAAIR8CQrXcIhbQAAAAAA=",
      "card_network": "Visa"
    }
  },
  "routing": { "type": "single", "data": { "connector": "checkout", ... } }
}
```

Result:

| Field | Value |
| --- | --- |
| `payment_id` | `pay_4ZL1PTAh58rHPmNeJxLI` |
| `status` | `succeeded` |
| `connector` | `checkout` |
| `connector_transaction_id` | `pay_7bhrhsabskaydnci52g32q6omu` |
| **`network_transaction_id`** | **`347901256248576`** |

### MIT — NT + saved NTID

```jsonc
POST /payments
{
  "amount": 2000, "currency": "USD",
  "confirm": true, "off_session": true,
  "payment_method": "card", "payment_method_type": "credit",
  "payment_type": "recurring_mandate", "mit_category": "recurring",
  "recurring_details": {
    "type": "network_transaction_id_and_network_token_details",
    "data": {
      "network_token": "4242424242424242",
      "token_exp_month": "10", "token_exp_year": "2030",
      "card_network": "Visa", "eci": "06",
      "network_transaction_id": "347901256248576"
    }
  },
  "routing": { "type": "single", "data": { "connector": "checkout", ... } }
}
```

Result:

| Field | Value |
| --- | --- |
| `payment_id` | `pay_UgXiI9vCKjzYANr3N9SZ` |
| `status` | `succeeded` |
| `connector_transaction_id` | `pay_dn2tarabiuoyjl6yv6xaqmeqny` |
| `network_transaction_id` | `347901256248576` |
| **`is_stored_credential`** | **`true`** |
| `mit_category` | `Recurring` |
| `off_session` | `true` |

`cargo check -p router --features v1` is clean (only pre-existing upstream-crate warnings).

## Checklist

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
