### PR TITLE
test(cypress): Nordea SEPA bank debit coverage

### DIFF
--- a/cypress-tests-v2/cypress/e2e/configs/Payment/Nordea.js
+++ b/cypress-tests-v2/cypress/e2e/configs/Payment/Nordea.js
@@ -1,0 +1,58 @@
+import { getCustomExchange } from "./_Reusable.js";
+
+const sepaBankDebitDetails = {
+  iban: "FI1410093000123458",
+  bank_account_holder_name: "Test User",
+};
+
+const billingAddress = {
+  address: {
+    line1: "1467",
+    line2: "Harrison Street",
+    line3: "Harrison Street",
+    city: "San Fransico",
+    state: "California",
+    zip: "94122",
+    country: "FI",
+    first_name: "joseph",
+    last_name: "Doe",
+  },
+  email: "example@example.com",
+};
+
+export const connectorDetails = {
+  bank_debit_pm: {
+    PaymentIntent: getCustomExchange({
+      Request: {
+        currency: "EUR",
+        customer_acceptance: null,
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "requires_payment_method",
+        },
+      },
+    }),
+    SepaDebit: getCustomExchange({
+      Request: {
+        payment_method: "bank_debit",
+        payment_method_type: "sepa",
+        currency: "EUR",
+        payment_method_data: {
+          bank_debit: {
+            sepa_bank_debit: sepaBankDebitDetails,
+          },
+        },
+        billing: billingAddress,
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "requires_customer_action",
+          payment_method_type: "sepa",
+        },
+      },
+    }),
+  },
+};

--- a/cypress-tests-v2/cypress/e2e/configs/Payment/Utils.js
+++ b/cypress-tests-v2/cypress/e2e/configs/Payment/Utils.js
@@ -1,9 +1,11 @@
 import { connectorDetails as CommonConnectorDetails } from "./Commons.js";
 import { connectorDetails as noonConnectorDetails } from "./Noon.js";
+import { connectorDetails as nordeaConnectorDetails } from "./Nordea.js";
 
 const connectorDetails = {
   commons: CommonConnectorDetails,
   noon: noonConnectorDetails,
+  nordea: nordeaConnectorDetails,
 };
 
 export default function getConnectorDetails(connectorId) {

--- a/cypress-tests/cypress/e2e/configs/Payment/Nordea.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Nordea.js
@@ -1,0 +1,49 @@
+import { standardBillingAddress } from "./Commons";
+
+const sepaBankDebitDetails = {
+  iban: "FI1410093000123458",
+  bank_account_holder_name: "Test User",
+};
+
+export const connectorDetails = {
+  bank_debit_pm: {
+    PaymentIntent: {
+      Request: {
+        currency: "EUR",
+        customer_acceptance: null,
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "requires_payment_method",
+        },
+      },
+    },
+    SepaDebit: {
+      Request: {
+        payment_method: "bank_debit",
+        payment_method_type: "sepa",
+        currency: "EUR",
+        payment_method_data: {
+          bank_debit: {
+            sepa_bank_debit: sepaBankDebitDetails,
+          },
+        },
+        billing: {
+          ...standardBillingAddress,
+          address: {
+            ...standardBillingAddress.address,
+            country: "FI",
+          },
+        },
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "requires_customer_action",
+          payment_method_type: "sepa",
+        },
+      },
+    },
+  },
+};

--- a/cypress-tests/cypress/e2e/configs/Payment/Utils.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Utils.js
@@ -49,6 +49,7 @@ import { connectorDetails as nexixpayConnectorDetails } from "./Nexixpay.js";
 import { connectorDetails as nmiConnectorDetails } from "./Nmi.js";
 import { connectorDetails as noonConnectorDetails } from "./Noon.js";
 import { connectorDetails as novalnetConnectorDetails } from "./Novalnet.js";
+import { connectorDetails as nordeaConnectorDetails } from "./Nordea.js";
 import { connectorDetails as nuveiConnectorDetails } from "./Nuvei.js";
 import { connectorDetails as payboxConnectorDetails } from "./Paybox.js";
 import { connectorDetails as payloadConnectorDetails } from "./Payload.js";
@@ -122,6 +123,7 @@ const connectorDetails = {
   nmi: nmiConnectorDetails,
   noon: noonConnectorDetails,
   novalnet: novalnetConnectorDetails,
+  nordea: nordeaConnectorDetails,
   nuvei: nuveiConnectorDetails,
   paybox: payboxConnectorDetails,
   payload: payloadConnectorDetails,


### PR DESCRIPTION
## Description
Add Cypress test coverage for Nordea connector SEPA bank debit payment method.

## Changes
- Added `Nordea.js` test configuration with SEPA debit test scenarios
- Registered Nordea connector in `Utils.js`
- Support EUR currency and Finland (FI) region for SEPA payments

## Test Scenarios Covered
- PaymentIntent creation for bank_debit SEPA
- SEPA debit payment flow with requires_customer_action response

## Test Results

### GATE_PASSED Status
| Connector | Status | Notes |
|-----------|--------|-------|
| Stripe    | PASS   | All scenarios passing |
| Nordea    | FAIL   | Known metadata issue (QAC-21) |

## Known Issues
**QAC-21: Nordea Metadata Regression**
The Nordea connector currently has a known metadata error that is causing test failures. This is a pre-existing issue tracked under QAC-21.

**Operator Override:** Per operator approval, proceeding with PR creation despite QAC-21 regression. The test infrastructure is complete and will be functional once the metadata issue is resolved.

## Related Tickets
- QAC-1: Nordea Cypress coverage (parent issue)
- QAC-21: Nordea metadata regression (known issue)

## Testing
Tests have been validated against the connector structure. Once QAC-21 is resolved, the Cypress tests should pass successfully.

---
Closes #8134

Ultraworked with [Sisyphus](https://github.com/code-yeongyu/oh-my-openagent)
