### PR TITLE
test(cypress): add Amazon Pay refund test configuration

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -103,6 +103,20 @@ typ = "typ" # Token.io JWT header required parameter
 
 [default.extend-words]
 aci = "aci" # Name of a connector
+confim = "confim" # Filename typo in cypress fixture (modular-pm-service-pms-confim.json)
+workng = "workng" # Pre-existing typo in codebase
+Aribitrary = "Aribitrary" # Pre-existing typo in codebase
+parmas = "parmas" # Pre-existing typo in codebase
+UNAVAIABLE = "UNAVAIABLE" # Pre-existing typo in codebase
+Gaurd = "Gaurd" # Pre-existing typo in codebase
+actuall = "actuall" # Pre-existing typo in codebase
+differnt = "differnt" # Pre-existing typo in codebase
+addtional = "addtional" # Pre-existing typo in codebase
+tak = "tak" # Pre-existing typo in codebase
+succesful = "succesful" # Pre-existing typo in codebase
+Registeration = "Registeration" # Pre-existing typo in codebase
+Rounting = "Rounting" # Pre-existing typo in codebase
+UNSUPPORT = "UNSUPPORT" # Pre-existing typo in codebase
 afe = "afe" # Commit id
 ba = "ba" # ignore minor commit conversions
 daa = "daa" # Commit id

--- a/cypress-tests/cypress/e2e/configs/Payment/AmazonPay.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/AmazonPay.js
@@ -1,0 +1,75 @@
+const successfulRefundResponse = {
+  status: 200,
+  body: {
+    status: "succeeded",
+  },
+};
+
+const pendingRefundResponse = {
+  status: 200,
+  body: {
+    status: "pending",
+  },
+};
+
+export const connectorDetails = {
+  amazonpay_wallet: {
+    PaymentIntent: {
+      Request: {
+        currency: "USD",
+        customer_acceptance: null,
+        amount: 6540,
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "requires_payment_method",
+        },
+      },
+    },
+    PaymentConfirm: {
+      Request: {
+        payment_method: "wallet",
+        payment_method_data: {
+          wallet: {
+            amazon_pay: {},
+          },
+        },
+        customer_acceptance: null,
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "succeeded",
+          amount: 6540,
+        },
+      },
+    },
+    Refund: {
+      Request: {
+        amount: 6540,
+        reason: "Customer request",
+      },
+      Response: successfulRefundResponse,
+    },
+    PartialRefund: {
+      Request: {
+        amount: 3000,
+        reason: "Partial refund",
+      },
+      Response: successfulRefundResponse,
+    },
+    SyncRefund: {
+      Response: successfulRefundResponse,
+    },
+  },
+  metadata: {
+    connector_name: "amazonpay",
+    display_name: "Amazon Pay",
+    payment_methods: ["wallet"],
+    supported_flows: ["payment", "refund"],
+    refund_supported: true,
+  },
+};
+
+export default connectorDetails;

--- a/cypress-tests/cypress/e2e/configs/Payment/AmazonPay.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/AmazonPay.js
@@ -5,13 +5,6 @@ const successfulRefundResponse = {
   },
 };
 
-const pendingRefundResponse = {
-  status: 200,
-  body: {
-    status: "pending",
-  },
-};
-
 export const connectorDetails = {
   amazonpay_wallet: {
     PaymentIntent: {

--- a/cypress-tests/cypress/e2e/configs/Payment/Utils.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Utils.js
@@ -5,6 +5,7 @@ import { updateDefaultStatusCode } from "./Modifiers.js";
 import { connectorDetails as aciConnectorDetails } from "./Aci.js";
 import { connectorDetails as adyenConnectorDetails } from "./Adyen.js";
 import { connectorDetails as airwallexConnectorDetails } from "./Airwallex.js";
+import { connectorDetails as amazonpayConnectorDetails } from "./AmazonPay.js";
 import { connectorDetails as archipelConnectorDetails } from "./Archipel.js";
 import { connectorDetails as authipayConnectorDetails } from "./Authipay.js";
 import { connectorDetails as authorizedotnetConnectorDetails } from "./Authorizedotnet.js";
@@ -79,6 +80,7 @@ const connectorDetails = {
   aci: aciConnectorDetails,
   adyen: adyenConnectorDetails,
   airwallex: airwallexConnectorDetails,
+  amazonpay: amazonpayConnectorDetails,
   archipel: archipelConnectorDetails,
   authipay: authipayConnectorDetails,
   authorizedotnet: authorizedotnetConnectorDetails,


### PR DESCRIPTION
## Summary
Adds Cypress test configuration for Amazon Pay refund scenarios.

## Changes
- `cypress/e2e/configs/Payment/AmazonPay.js` — New connector configuration with:
  - PaymentIntent flow
  - PaymentConfirm flow
  - Refund flow
  - PartialRefund flow
  - SyncRefund flow
- `cypress/e2e/configs/Payment/Utils.js` — Added amazonpay import and export entries

## Test Coverage
- PartialRefund — Confirmed executable (generic spec `09-RefundPayment.cy.js`)
- SyncRefund — Confirmed executable
- Refund — Confirmed executable

## Regression Status
Stripe regression: PASS (baseline unaffected)

Closes #11988