### PR TITLE
test(cypress): Add test coverage for 3DS Routing Region (UAS) in payment flow

### DIFF
--- a/cypress-tests/cypress/e2e/configs/Payment/Stripe.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Stripe.js
@@ -907,6 +907,46 @@ export const connectorDetails = {
         },
       },
     },
+    three_ds_uas_routing: {
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulThreeDSTestCardDetails,
+        },
+        authentication_type: "three_ds",
+        routing: {
+          threeds_routing_region: "UAS",
+        },
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "requires_customer_action",
+          authentication_type: "three_ds",
+        },
+      },
+    },
+    three_ds_uas_routing_manual_capture: {
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulThreeDSTestCardDetails,
+        },
+        authentication_type: "three_ds",
+        capture_method: "manual",
+        routing: {
+          threeds_routing_region: "UAS",
+        },
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "requires_customer_action",
+          authentication_type: "three_ds",
+          capture_method: "manual",
+        },
+      },
+    },
     PaymentIntentWithBillingDescriptor: {
       Request: {
         currency: "USD",

--- a/cypress-tests/cypress/e2e/spec/Payment/48-ThreeDSRoutingRegionUAS.cy.js
+++ b/cypress-tests/cypress/e2e/spec/Payment/48-ThreeDSRoutingRegionUAS.cy.js
@@ -1,0 +1,114 @@
+import * as fixtures from "../../../fixtures/imports";
+import State from "../../../utils/State";
+import getConnectorDetails, * as utils from "../../configs/Payment/Utils";
+
+let globalState;
+
+describe("Card - 3DS Routing Region (UAS) payment flow test", () => {
+  before("seed global state", function () {
+    let skip = false;
+
+    cy.task("getGlobalState")
+      .then((state) => {
+        globalState = new State(state);
+        const connectorId = globalState.get("connectorId");
+
+        if (
+          utils.shouldIncludeConnector(
+            connectorId,
+            utils.CONNECTOR_LISTS.EXCLUDE.THREE_DS
+          )
+        ) {
+          skip = true;
+          return;
+        }
+      })
+      .then(() => {
+        if (skip) {
+          this.skip();
+        }
+      });
+  });
+
+  after("flush global state", () => {
+    cy.task("setGlobalState", globalState.data);
+  });
+
+  context(
+    "Card-3DS-UAS-Routing payment flow test Create, Confirm and Retrieve",
+    () => {
+      it("create confirm payment with 3DS UAS routing -> retrieve payment", () => {
+        let shouldContinue = true;
+
+        cy.step("create and confirm payment with 3DS UAS routing", () => {
+          const data = getConnectorDetails(globalState.get("connectorId"))[
+            "card_pm"
+          ]["three_ds_uas_routing"];
+
+          cy.createConfirmPaymentTest(
+            fixtures.createConfirmPaymentBody,
+            data,
+            "three_ds",
+            "automatic",
+            globalState
+          );
+
+          if (!utils.should_continue_further(data)) {
+            shouldContinue = false;
+          }
+        });
+
+        cy.step("retrieve payment", () => {
+          if (!shouldContinue) {
+            cy.task("cli_log", "Skipping step: retrieve payment");
+            return;
+          }
+          cy.retrievePaymentCallTest({ globalState });
+        });
+      });
+    }
+  );
+
+  context(
+    "Card-3DS-UAS-Routing with manual capture flow test",
+    () => {
+      it("create confirm capture payment with 3DS UAS routing", () => {
+        let shouldContinue = true;
+
+        cy.step("create and confirm payment with manual capture", () => {
+          const data = getConnectorDetails(globalState.get("connectorId"))[
+            "card_pm"
+          ]["three_ds_uas_routing_manual_capture"];
+
+          cy.createConfirmPaymentTest(
+            fixtures.createConfirmPaymentBody,
+            data,
+            "three_ds",
+            "manual",
+            globalState
+          );
+
+          if (!utils.should_continue_further(data)) {
+            shouldContinue = false;
+          }
+        });
+
+        cy.step("capture payment", () => {
+          if (!shouldContinue) {
+            cy.task("cli_log", "Skipping step: capture payment");
+            return;
+          }
+          cy.capturePaymentCallTest({ globalState });
+        });
+
+        cy.step("retrieve payment after capture", () => {
+          if (!shouldContinue) {
+            cy.task("cli_log", "Skipping step: retrieve payment after capture");
+            return;
+          }
+          cy.retrievePaymentCallTest({ globalState });
+        });
+      });
+    }
+  );
+});

--- a/cypress-tests/cypress/e2e/spec/Payment/48-ThreeDSRoutingRegionUAS.cy.js
+++ b/cypress-tests/cypress/e2e/spec/Payment/48-ThreeDSRoutingRegionUAS.cy.js
@@ -69,46 +69,43 @@ describe("Card - 3DS Routing Region (UAS) payment flow test", () => {
     }
   );
 
-  context(
-    "Card-3DS-UAS-Routing with manual capture flow test",
-    () => {
-      it("create confirm capture payment with 3DS UAS routing", () => {
-        let shouldContinue = true;
+  context("Card-3DS-UAS-Routing with manual capture flow test", () => {
+    it("create confirm capture payment with 3DS UAS routing", () => {
+      let shouldContinue = true;
 
-        cy.step("create and confirm payment with manual capture", () => {
-          const data = getConnectorDetails(globalState.get("connectorId"))[
-            "card_pm"
-          ]["three_ds_uas_routing_manual_capture"];
+      cy.step("create and confirm payment with manual capture", () => {
+        const data = getConnectorDetails(globalState.get("connectorId"))[
+          "card_pm"
+        ]["three_ds_uas_routing_manual_capture"];
 
-          cy.createConfirmPaymentTest(
-            fixtures.createConfirmPaymentBody,
-            data,
-            "three_ds",
-            "manual",
-            globalState
-          );
+        cy.createConfirmPaymentTest(
+          fixtures.createConfirmPaymentBody,
+          data,
+          "three_ds",
+          "manual",
+          globalState
+        );
 
-          if (!utils.should_continue_further(data)) {
-            shouldContinue = false;
-          }
-        });
-
-        cy.step("capture payment", () => {
-          if (!shouldContinue) {
-            cy.task("cli_log", "Skipping step: capture payment");
-            return;
-          }
-          cy.capturePaymentCallTest({ globalState });
-        });
-
-        cy.step("retrieve payment after capture", () => {
-          if (!shouldContinue) {
-            cy.task("cli_log", "Skipping step: retrieve payment after capture");
-            return;
-          }
-          cy.retrievePaymentCallTest({ globalState });
-        });
+        if (!utils.should_continue_further(data)) {
+          shouldContinue = false;
+        }
       });
-    }
-  );
+
+      cy.step("capture payment", () => {
+        if (!shouldContinue) {
+          cy.task("cli_log", "Skipping step: capture payment");
+          return;
+        }
+        cy.capturePaymentCallTest({ globalState });
+      });
+
+      cy.step("retrieve payment after capture", () => {
+        if (!shouldContinue) {
+          cy.task("cli_log", "Skipping step: retrieve payment after capture");
+          return;
+        }
+        cy.retrievePaymentCallTest({ globalState });
+      });
+    });
+  });
 });


### PR DESCRIPTION
## What changed
- Added Cypress spec `48-ThreeDSRoutingRegionUAS.cy.js` with 2 test cases:
  - 3DS UAS routing with automatic capture (happy path)
  - 3DS UAS routing with manual capture (edge case)
- Updated `Stripe.js` connector config with `three_ds_uas_routing` configurations
- Validates routing region configuration for Unified Authentication Service during 3DS flows

## Why
Adds test coverage for the 3DS Routing Region (UAS) feature which defines the routing region used by the Unified Authentication Service during 3DS authentication flows.

## How did you test it?
```
RUNNER_RESULT:
  Connector: stripe
  SpecFile: cypress/e2e/spec/Payment/48-ThreeDSRoutingRegionUAS.cy.js
  PrereqsRun:
    - 01-AccountCreate: PASS
    - 02-CustomerCreate: PASS
    - 03-ConnectorCreate: PASS
  TestResults:
    - Test: "create confirm payment with 3DS UAS routing -> retrieve payment"
      Status: PASS
    - Test: "create confirm capture payment with 3DS UAS routing"
      Status: PASS
  Summary:
    Total: 2
    Passing: 2
    Failing: 0
    Skipped: 0
  Result: PASS
```

## Gate
```
GATE_PASSED:
  StripeRegression: PASS
  ConnectorRegressions:
    - Connector: stripe
      Result: PASS
  AllChecksPassed: YES
  ReadyForGitHubAgent: YES
```