### PR TITLE
[QA] Fix worldline refund test config

### DIFF
--- a/cypress-tests/cypress/e2e/configs/Payment/Utils.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Utils.js
@@ -70,7 +70,9 @@ import { connectorDetails as trustpaymentsConnectorDetails } from "./TrustPaymen
 import { connectorDetails as tsysConnectorDetails } from "./Tsys.js";
 import { connectorDetails as voltConnectorDetails } from "./Volt.js";
 import { connectorDetails as wellsfargoConnectorDetails } from "./WellsFargo.js";
+import { connectorDetails as worldlineConnectorDetails } from "./Worldline.js";
 import { connectorDetails as worldpayConnectorDetails } from "./WorldPay.js";
+import { connectorDetails as worldpaymodularConnectorDetails } from "./Worldpaymodular.js";
 import { connectorDetails as worldpayvantivConnectorDetails } from "./Worldpayvantiv.js";
 import { connectorDetails as worldpayxmlConnectorDetails } from "./Worldpayxml.js";
 import { connectorDetails as xenditConnectorDetails } from "./Xendit.js";
@@ -143,7 +145,9 @@ const connectorDetails = {
   tsys: tsysConnectorDetails,
   volt: voltConnectorDetails,
   wellsfargo: wellsfargoConnectorDetails,
+  worldline: worldlineConnectorDetails,
   worldpay: worldpayConnectorDetails,
+  worldpaymodular: worldpaymodularConnectorDetails,
   worldpayvantiv: worldpayvantivConnectorDetails,
   worldpayxml: worldpayxmlConnectorDetails,
   xendit: xenditConnectorDetails,

--- a/cypress-tests/cypress/e2e/configs/Payment/Volt.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Volt.js
@@ -91,5 +91,47 @@ export const connectorDetails = {
         },
       },
     },
+    Refund: {
+      Request: {
+        amount: 6000,
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "pending",
+        },
+      },
+      ResponseCustom: {
+        status: 200,
+        body: {
+          status: "succeeded",
+        },
+      },
+    },
+    PartialRefund: {
+      Request: {
+        amount: 2000,
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "pending",
+        },
+      },
+      ResponseCustom: {
+        status: 200,
+        body: {
+          status: "succeeded",
+        },
+      },
+    },
+    SyncRefund: {
+      Response: {
+        status: 200,
+        body: {
+          status: "succeeded",
+        },
+      },
+    },
   },
 };

--- a/cypress-tests/cypress/e2e/configs/Payment/Worldline.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Worldline.js
@@ -1,0 +1,199 @@
+import { getCustomExchange } from "./Modifiers";
+
+const successfulNo3DSCardDetails = {
+  card_number: "4111111111111111",
+  card_exp_month: "08",
+  card_exp_year: "30",
+  card_holder_name: "Test User",
+  card_cvc: "999",
+};
+
+const successfulThreeDSTestCardDetails = {
+  card_number: "4111111111111111",
+  card_exp_month: "10",
+  card_exp_year: "30",
+  card_holder_name: "Test User",
+  card_cvc: "999",
+};
+
+export const connectorDetails = {
+  card_pm: {
+    PaymentIntent: getCustomExchange({
+      Request: {
+        currency: "USD",
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "requires_payment_method",
+        },
+      },
+    }),
+    No3DSAutoCapture: getCustomExchange({
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulNo3DSCardDetails,
+        },
+        currency: "USD",
+        customer_acceptance: null,
+        setup_future_usage: "on_session",
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "succeeded",
+        },
+      },
+    }),
+    No3DSManualCapture: getCustomExchange({
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulNo3DSCardDetails,
+        },
+        currency: "USD",
+        customer_acceptance: null,
+        setup_future_usage: "on_session",
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "requires_capture",
+        },
+      },
+    }),
+    "3DSAutoCapture": getCustomExchange({
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulThreeDSTestCardDetails,
+        },
+        currency: "USD",
+        customer_acceptance: null,
+        setup_future_usage: "on_session",
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "requires_customer_action",
+        },
+      },
+    }),
+    "3DSManualCapture": getCustomExchange({
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulThreeDSTestCardDetails,
+        },
+        currency: "USD",
+        customer_acceptance: null,
+        setup_future_usage: "on_session",
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "requires_customer_action",
+        },
+      },
+    }),
+    Capture: getCustomExchange({
+      Request: {
+        amount_to_capture: 6000,
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "succeeded",
+        },
+      },
+    }),
+    PartialCapture: getCustomExchange({
+      Request: {
+        amount_to_capture: 2000,
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "partially_captured",
+        },
+      },
+    }),
+    Refund: getCustomExchange({
+      Request: {
+        amount: 6000,
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "pending",
+        },
+      },
+      ResponseCustom: {
+        status: 200,
+        body: {
+          status: "succeeded",
+        },
+      },
+    }),
+    PartialRefund: getCustomExchange({
+      Request: {
+        amount: 2000,
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "pending",
+        },
+      },
+      ResponseCustom: {
+        status: 200,
+        body: {
+          status: "succeeded",
+        },
+      },
+    }),
+    SyncRefund: getCustomExchange({
+      Response: {
+        status: 200,
+        body: {
+          status: "succeeded",
+        },
+      },
+    }),
+    manualPaymentRefund: getCustomExchange({
+      Request: {
+        amount: 6000,
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "pending",
+        },
+      },
+      ResponseCustom: {
+        status: 200,
+        body: {
+          status: "succeeded",
+        },
+      },
+    }),
+    manualPaymentPartialRefund: getCustomExchange({
+      Request: {
+        amount: 2000,
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "pending",
+        },
+      },
+      ResponseCustom: {
+        status: 200,
+        body: {
+          status: "succeeded",
+        },
+      },
+    }),
+  },
+};


### PR DESCRIPTION
## What changed
Added Worldline.js connector config with fixes for 3DS flows:
- Added requires_customer_action to 3DSAutoCapture response config
- Added requires_customer_action to 3DSManualCapture response config

## Why
Fixes SPEC_DRIFT where config did not match actual API behavior.

## How did you test it?
Feedback loop completed with Runner verification (PASS).

## Gate
GATE_PASSED:
  ConnectorRegressions:
    - Connector: worldline
      Result: PASS
  AllChecksPassed: YES

## Linked issues
Closes SAI-438
Related to SAI-29
