### PR TITLE
feat(ucs): default to shadow mode when no rollout config is present

### DIFF
--- a/crates/router/src/core/payments/helpers.rs
+++ b/crates/router/src/core/payments/helpers.rs
@@ -2523,14 +2523,17 @@ fn create_proxy_override(
 // Helper function to execute rollout logic or return default
 impl From<RolloutConfig> for RolloutExecutionResult {
     fn from(config: RolloutConfig) -> Self {
-        // Validate both rollout_percent bounds and execution_mode
         let is_valid_percent = (0.0..=1.0).contains(&config.rollout_percent);
-        let is_valid_execution_mode =
-            !matches!(config.execution_mode, ExecutionMode::NotApplicable);
 
-        match (is_valid_percent, is_valid_execution_mode) {
-            (true, true) => {
-                // Calculate probability to determine if request should execute
+        match is_valid_percent {
+            false => {
+                logger::warn!(
+                    is_valid_percent = is_valid_percent,
+                    "Invalid rollout percent in rollout config. Defaulting to should_execute false."
+                );
+                Self::default()
+            }
+            true => {
                 let sampled_value: f64 = rand::thread_rng().gen_range(0.0..1.0);
                 let should_execute = sampled_value < config.rollout_percent;
 
@@ -2547,7 +2550,6 @@ impl From<RolloutConfig> for RolloutExecutionResult {
                         let proxy_override =
                             create_proxy_override(config.http_url, config.https_url);
                         logger::info!(
-                            should_execute = should_execute,
                             execution_mode = ?config.execution_mode,
                             "Rollout will be executed with proxy override"
                         );
@@ -2559,36 +2561,12 @@ impl From<RolloutConfig> for RolloutExecutionResult {
                     }
                     false => {
                         logger::info!(
-                            should_execute = should_execute,
                             execution_mode = ?config.execution_mode,
                             "Rollout will not be executed"
                         );
                         Self::default()
                     }
                 }
-            }
-            (true, false) => {
-                logger::warn!(
-                is_valid_percent = is_valid_percent,
-                is_valid_execution_mode = is_valid_execution_mode,
-                "Invalid execution mode in rollout config. Defaulting to NotApplicable and should execute false."
-            );
-                Self::default()
-            }
-            (false, true) => {
-                logger::warn!(
-                is_valid_percent = is_valid_percent,
-                "Invalid rollout percent in rollout config. Defaulting to should execute false."
-            );
-                Self::default()
-            }
-            (false, false) => {
-                logger::warn!(
-                is_valid_percent = is_valid_percent,
-                is_valid_execution_mode = is_valid_execution_mode,
-                "Invalid rollout percent and execution mode in rollout config. Defaulting to should execute false and NotApplicable."
-            );
-                Self::default()
             }
         }
     }

--- a/crates/router/src/core/unified_connector_service.rs
+++ b/crates/router/src/core/unified_connector_service.rs
@@ -392,12 +392,14 @@ where
             | CallConnectorAction::HandleResponseWithoutBuildRequest
             | CallConnectorAction::Avoid
             | CallConnectorAction::StatusUpdate { .. } => {
-                // UCS is enabled, call decide function
-                decide_execution_path(
-                    connector_integration_type,
-                    previous_gateway,
-                    rollout_result.execution_mode,
-                )?
+                // If a rollout config key exists use its execution mode,
+                // otherwise default to Shadow so all traffic mirrors through UCS.
+                let execution_mode = if rollout_result.should_execute {
+                    rollout_result.execution_mode
+                } else {
+                    ExecutionMode::Shadow
+                };
+                decide_execution_path(connector_integration_type, previous_gateway, execution_mode)?
             }
         }
     };


### PR DESCRIPTION
## Summary

- When no per-merchant rollout config key exists for a payment, UCS now defaults to **Shadow mode** instead of skipping entirely. This means all traffic automatically mirrors through UCS alongside the legacy connector without affecting payment outcomes.
- Removed the `is_valid_execution_mode` check that previously rejected `NotApplicable` as an invalid rollout config value. It is now a valid explicit value, allowing merchants to intentionally opt out of UCS.
- Per-merchant rollout config still takes full precedence when present (`shadow`, `primary`, or `not_applicable`).

## Execution Mode Decision Logic

```
Rollout config key present?
├─ YES → use execution_mode from rollout config
└─ NO  → ExecutionMode::Shadow (default)
```

## Test plan

- [x] No rollout config → defaults to Shadow mode
- [x] Rollout config `shadow` → explicit shadow mode
- [x] Rollout config `not_applicable` → UCS skipped, legacy only
- [x] Invalid rollout percent → falls back to Shadow default

## Testing

**Setup:** Merchant `test_ucs_cutover_001`, Connector `adyen`, Profile `pro_r9goBf89oYu6zS3C4eQ1`

**How routing is verified:** Each scenario produces a specific log line confirming which execution path was chosen:
- No config → `"No rollout config found at any precedence level, using default execution mode"`
- Config found → `"Rollout execution decision made"` with `execution_mode=<mode>`
- Invalid percent → `"Invalid rollout percent in rollout config. Defaulting to should_execute false."`

---

### Scenario 1 — No rollout config → defaults to Shadow

No config set. Falls back to `ExecutionMode::Shadow`.

```bash
# Make payment (no rollout config set)
curl -s "http://localhost:8080/payments" \
  -H "api-key: dev_K2aE9v8DCu9KHsxg2lPIHNms1Hjd3S7C1fjW422I7vWqk9IP5zCeGVuyJpmP1dZx" \
  -H "Content-Type: application/json" \
  -d "{\"amount\":100,\"currency\":\"USD\",\"confirm\":true,\"profile_id\":\"pro_r9goBf89oYu6zS3C4eQ1\",\"capture_method\":\"automatic\",\"authentication_type\":\"no_three_ds\",\"payment_method\":\"card\",\"payment_method_type\":\"credit\",\"payment_method_data\":{\"card\":{\"card_number\":\"4000020951595057\",\"card_exp_month\":\"12\",\"card_exp_year\":\"2030\",\"card_cvc\":\"861\"}},\"billing\":{\"address\":{\"line1\":\"1467\",\"city\":\"pune\",\"state\":\"maharashtra\",\"zip\":\"12345\",\"country\":\"US\",\"first_name\":\"joseph\",\"last_name\":\"Doe\"}}}"
```

**Result:** `{"payment_id":"pay_venEJvKGUGWgdBjGreQm","status":"failed","connector":"adyen","error_code":"2","error_message":"Refused","connector_transaction_id":"TXF528P65DPFMZ65"}`

---

### Scenario 2 — Rollout config `shadow` → explicit shadow mode

```bash
# Set config
curl -s -X POST "http://localhost:8080/configs/" \
  -H "api-key: test_admin" -H "Content-Type: application/json" \
  -d "{\"key\":\"ucs_rollout_config_test_ucs_cutover_001_adyen_Execute\",\"value\":\"{\\\"rollout_percent\\\":1.0,\\\"http_url\\\":\\\"http://localhost:8081\\\",\\\"https_url\\\":\\\"http://localhost:8081\\\",\\\"execution_mode\\\":\\\"shadow\\\"}\"}"

# Make payment
curl -s "http://localhost:8080/payments" \
  -H "api-key: dev_K2aE9v8DCu9KHsxg2lPIHNms1Hjd3S7C1fjW422I7vWqk9IP5zCeGVuyJpmP1dZx" \
  -H "Content-Type: application/json" \
  -d "{\"amount\":100,\"currency\":\"USD\",\"confirm\":true,\"profile_id\":\"pro_r9goBf89oYu6zS3C4eQ1\",\"capture_method\":\"automatic\",\"authentication_type\":\"no_three_ds\",\"payment_method\":\"card\",\"payment_method_type\":\"credit\",\"payment_method_data\":{\"card\":{\"card_number\":\"4000020951595057\",\"card_exp_month\":\"12\",\"card_exp_year\":\"2030\",\"card_cvc\":\"861\"}},\"billing\":{\"address\":{\"line1\":\"1467\",\"city\":\"pune\",\"state\":\"maharashtra\",\"zip\":\"12345\",\"country\":\"US\",\"first_name\":\"joseph\",\"last_name\":\"Doe\"}}}"
```

**Result:** `{"payment_id":"pay_Le1iffTvTlFmHIRB2bs6","status":"failed","connector":"adyen","error_code":"2","error_message":"Refused","connector_transaction_id":"FXVSHKHT5FXH9275"}`

---

### Scenario 3 — Rollout config `not_applicable` → UCS skipped

```bash
# Set config
curl -s -X POST "http://localhost:8080/configs/ucs_rollout_config_test_ucs_cutover_001_adyen_Execute" \
  -H "api-key: test_admin" -H "Content-Type: application/json" \
  -d "{\"key\":\"ucs_rollout_config_test_ucs_cutover_001_adyen_Execute\",\"value\":\"{\\\"rollout_percent\\\":1.0,\\\"http_url\\\":\\\"http://localhost:8081\\\",\\\"https_url\\\":\\\"http://localhost:8081\\\",\\\"execution_mode\\\":\\\"not_applicable\\\"}\"}"

# Make payment
curl -s "http://localhost:8080/payments" \
  -H "api-key: dev_K2aE9v8DCu9KHsxg2lPIHNms1Hjd3S7C1fjW422I7vWqk9IP5zCeGVuyJpmP1dZx" \
  -H "Content-Type: application/json" \
  -d "{\"amount\":100,\"currency\":\"USD\",\"confirm\":true,\"profile_id\":\"pro_r9goBf89oYu6zS3C4eQ1\",\"capture_method\":\"automatic\",\"authentication_type\":\"no_three_ds\",\"payment_method\":\"card\",\"payment_method_type\":\"credit\",\"payment_method_data\":{\"card\":{\"card_number\":\"4000020951595057\",\"card_exp_month\":\"12\",\"card_exp_year\":\"2030\",\"card_cvc\":\"861\"}},\"billing\":{\"address\":{\"line1\":\"1467\",\"city\":\"pune\",\"state\":\"maharashtra\",\"zip\":\"12345\",\"country\":\"US\",\"first_name\":\"joseph\",\"last_name\":\"Doe\"}}}"
```

**Result:** `{"payment_id":"pay_vOVXMAE1lrwvDAE6hEf1","status":"failed","connector":"adyen","error_code":"2","error_message":"Refused","connector_transaction_id":"L2D58HNT5WW5KG75"}`

---

### Scenario 4 — Invalid rollout percent → falls back to Shadow

```bash
# Set invalid config
curl -s -X POST "http://localhost:8080/configs/ucs_rollout_config_test_ucs_cutover_001_adyen_Execute" \
  -H "api-key: test_admin" -H "Content-Type: application/json" \
  -d "{\"key\":\"ucs_rollout_config_test_ucs_cutover_001_adyen_Execute\",\"value\":\"{\\\"rollout_percent\\\":2.5,\\\"http_url\\\":\\\"http://localhost:8081\\\",\\\"https_url\\\":\\\"http://localhost:8081\\\",\\\"execution_mode\\\":\\\"shadow\\\"}\"}"

# Make payment
curl -s "http://localhost:8080/payments" \
  -H "api-key: dev_K2aE9v8DCu9KHsxg2lPIHNms1Hjd3S7C1fjW422I7vWqk9IP5zCeGVuyJpmP1dZx" \
  -H "Content-Type: application/json" \
  -d "{\"amount\":100,\"currency\":\"USD\",\"confirm\":true,\"profile_id\":\"pro_r9goBf89oYu6zS3C4eQ1\",\"capture_method\":\"automatic\",\"authentication_type\":\"no_three_ds\",\"payment_method\":\"card\",\"payment_method_type\":\"credit\",\"payment_method_data\":{\"card\":{\"card_number\":\"4000020951595057\",\"card_exp_month\":\"12\",\"card_exp_year\":\"2030\",\"card_cvc\":\"861\"}},\"billing\":{\"address\":{\"line1\":\"1467\",\"city\":\"pune\",\"state\":\"maharashtra\",\"zip\":\"12345\",\"country\":\"US\",\"first_name\":\"joseph\",\"last_name\":\"Doe\"}}}"
```

**Result:** `{"payment_id":"pay_BvSZWDiplPQjUoGYCE2t","status":"failed","connector":"adyen","error_code":"2","error_message":"Refused","connector_transaction_id":"RB66CT5JGPCJS975"}`