### PR TITLE
test(cypress): fix deactivateDynamicRoutingConfig endpoint for contracts type

### DIFF
--- a/cypress-tests/cypress/e2e/configs/Routing/Commons.js
+++ b/cypress-tests/cypress/e2e/configs/Routing/Commons.js
@@ -66,4 +66,55 @@ export const connectorDetails = {
       body: {},
     },
   },
+  dynamicRouting: {
+    Request: {
+      algorithm_for: "payment",
+      connectors: [],
+    },
+    Response: {
+      status: 200,
+      body: {},
+    },
+  },
+  deactivateRouting: {
+    Request: {
+      profile_id: "{{profile_id}}",
+      algorithm_for: "payment",
+    },
+    Response: {
+      status: 200,
+      body: {},
+    },
+  },
+  deactivateRoutingNegative: {
+    Request: {
+      profile_id: "{{profile_id}}",
+      algorithm_for: "payment",
+    },
+    Response: {
+      status: 400,
+      body: {
+        error: {
+          message: "Algorithm is already inactive",
+          code: "IR_16",
+        },
+      },
+    },
+  },
+  deactivateDynamicRouting: {
+    Request: {},
+    Response: {
+      status: 200,
+      body: {},
+    },
+  },
+  toggleRouting: {
+    Request: {},
+    Response: {
+      status: 200,
+      body: {
+        kind: "dynamic",
+      },
+    },
+  },
 };

--- a/cypress-tests/cypress/e2e/spec/Routing/00005-DynamicRouting.cy.js
+++ b/cypress-tests/cypress/e2e/spec/Routing/00005-DynamicRouting.cy.js
@@ -1,0 +1,363 @@
+import * as fixtures from "../../../fixtures/imports";
+import State from "../../../utils/State";
+import * as utils from "../../configs/Routing/Utils";
+
+let globalState;
+let shouldContinue = true;
+
+describe("Dynamic Routing Test", () => {
+  context("Success-based dynamic routing with stripe as primary", () => {
+    before("seed global state", () => {
+      shouldContinue = true;
+      cy.task("getGlobalState").then((state) => {
+        globalState = new State(state);
+      });
+    });
+
+    afterEach("flush global state", () => {
+      cy.task("setGlobalState", globalState.data);
+    });
+
+    it("list-mca-by-mid", () => {
+      cy.ListMcaByMid(globalState);
+    });
+
+    it("add-success-based-dynamic-routing-config", () => {
+      const data = utils.getConnectorDetails("common")["dynamicRouting"];
+      const routing_data = [
+        {
+          connector: "stripe",
+          merchant_connector_id: globalState.get("stripeMcaId"),
+        },
+        {
+          connector: "adyen",
+          merchant_connector_id: globalState.get("adyenMcaId"),
+        },
+      ];
+      cy.addDynamicRoutingConfig(
+        fixtures.routingConfigBody,
+        data,
+        "success_based",
+        routing_data,
+        globalState
+      );
+      if (shouldContinue) shouldContinue = utils.should_continue_further(data);
+    });
+
+    it("retrieve-routing-call-test", () => {
+      if (!shouldContinue) return;
+      const data = utils.getConnectorDetails("common")["dynamicRouting"];
+      cy.retrieveRoutingConfig(data, globalState);
+      if (shouldContinue) shouldContinue = utils.should_continue_further(data);
+    });
+
+    it("payment-routing-test", () => {
+      if (!shouldContinue) return;
+      globalState.set("connectorId", "stripe");
+      globalState.set("merchantConnectorId", globalState.get("stripeMcaId"));
+      const data =
+        utils.getConnectorDetails("stripe")["card_pm"]["No3DSAutoCapture"];
+      cy.createConfirmPaymentTest(
+        fixtures.createConfirmPaymentBody,
+        data,
+        "no_three_ds",
+        "automatic",
+        globalState
+      );
+    });
+
+    it("retrieve-payment-call-test", () => {
+      cy.retrievePaymentCallTest({ globalState });
+    });
+  });
+
+  context("Elimination dynamic routing with adyen as primary", () => {
+    before("seed global state", () => {
+      shouldContinue = true;
+      cy.task("getGlobalState").then((state) => {
+        globalState = new State(state);
+      });
+    });
+
+    afterEach("flush global state", () => {
+      cy.task("setGlobalState", globalState.data);
+    });
+
+    it("list-mca-by-mid", () => {
+      cy.ListMcaByMid(globalState);
+    });
+
+    it("deactivate-previous-routing-config", () => {
+      const data =
+        utils.getConnectorDetails("common")["deactivateDynamicRouting"];
+      cy.deactivateDynamicRoutingConfig("success_based", data, globalState);
+      if (shouldContinue) shouldContinue = utils.should_continue_further(data);
+    });
+
+    it("add-elimination-dynamic-routing-config", () => {
+      const data = utils.getConnectorDetails("common")["dynamicRouting"];
+      const routing_data = [
+        {
+          connector: "adyen",
+          merchant_connector_id: globalState.get("adyenMcaId"),
+        },
+        {
+          connector: "stripe",
+          merchant_connector_id: globalState.get("stripeMcaId"),
+        },
+      ];
+      cy.addDynamicRoutingConfig(
+        fixtures.routingConfigBody,
+        data,
+        "elimination",
+        routing_data,
+        globalState
+      );
+      if (shouldContinue) shouldContinue = utils.should_continue_further(data);
+    });
+
+    it("retrieve-routing-call-test", () => {
+      if (!shouldContinue) return;
+      const data = utils.getConnectorDetails("common")["dynamicRouting"];
+      cy.retrieveRoutingConfig(data, globalState);
+      if (shouldContinue) shouldContinue = utils.should_continue_further(data);
+    });
+
+    it("payment-routing-test", () => {
+      if (!shouldContinue) return;
+      const body = { ...fixtures.createConfirmPaymentBody };
+      body.authentication_type = "no_three_ds";
+      body.capture_method = "automatic";
+      body.profile_id = globalState.get("profileId");
+      body.customer_id = globalState.get("customerId");
+      const adyenData =
+        utils.getConnectorDetails("adyen")["card_pm"]["No3DSAutoCapture"];
+      for (const key in (adyenData.Request || {})) {
+        body[key] = adyenData.Request[key];
+      }
+
+      cy.request({
+        method: "POST",
+        url: `${globalState.get("baseUrl")}/payments`,
+        headers: {
+          "Content-Type": "application/json",
+          "api-key": globalState.get("apiKey"),
+        },
+        failOnStatusCode: false,
+        body: body,
+      }).then((response) => {
+        expect(response.status).to.equal(200);
+        expect(response.body.status).to.equal("succeeded");
+        const routedConnector = response.body.connector;
+        globalState.set("connectorId", routedConnector);
+        globalState.set("paymentID", response.body.payment_id);
+        globalState.set("clientSecret", response.body.client_secret);
+        globalState.set("paymentAmount", body.amount);
+        if (routedConnector === "adyen") {
+          globalState.set("merchantConnectorId", globalState.get("adyenMcaId"));
+        } else {
+          globalState.set("merchantConnectorId", globalState.get("stripeMcaId"));
+        }
+      });
+    });
+
+    it("retrieve-payment-call-test", () => {
+      const payment_id = globalState.get("paymentID");
+      cy.request({
+        method: "GET",
+        url: `${globalState.get("baseUrl")}/payments/${payment_id}?force_sync=true`,
+        headers: {
+          "Content-Type": "application/json",
+          "api-key": globalState.get("apiKey"),
+        },
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.equal(200);
+        expect(response.body.payment_id).to.equal(payment_id);
+        expect(response.body.status).to.equal("succeeded");
+        expect(response.body.connector).to.equal(globalState.get("connectorId"));
+      });
+    });
+  });
+
+  context("Contract-based dynamic routing", () => {
+    before("seed global state", () => {
+      shouldContinue = true;
+      cy.task("getGlobalState").then((state) => {
+        globalState = new State(state);
+      });
+    });
+
+    afterEach("flush global state", () => {
+      cy.task("setGlobalState", globalState.data);
+    });
+
+    it("list-mca-by-mid", () => {
+      cy.ListMcaByMid(globalState);
+    });
+
+    it("deactivate-previous-routing-config", () => {
+      const data =
+        utils.getConnectorDetails("common")["deactivateDynamicRouting"];
+      cy.deactivateDynamicRoutingConfig("elimination", data, globalState);
+      if (shouldContinue) shouldContinue = utils.should_continue_further(data);
+    });
+
+    it("add-contract-based-dynamic-routing-config", () => {
+      const data = utils.getConnectorDetails("common")["toggleRouting"];
+      cy.toggleDynamicRoutingConfig(data, globalState);
+      if (shouldContinue) shouldContinue = utils.should_continue_further(data);
+    });
+
+    it("retrieve-routing-call-test", () => {
+      if (!shouldContinue) return;
+      const data = utils.getConnectorDetails("common")["dynamicRouting"];
+      cy.retrieveRoutingConfig(data, globalState);
+      if (shouldContinue) shouldContinue = utils.should_continue_further(data);
+    });
+
+    it("payment-routing-test", () => {
+      if (!shouldContinue) return;
+      globalState.set("connectorId", "stripe");
+      globalState.set("merchantConnectorId", globalState.get("stripeMcaId"));
+      const data =
+        utils.getConnectorDetails("stripe")["card_pm"]["No3DSAutoCapture"];
+      cy.createConfirmPaymentTest(
+        fixtures.createConfirmPaymentBody,
+        data,
+        "no_three_ds",
+        "automatic",
+        globalState
+      );
+    });
+
+    it("retrieve-payment-call-test", () => {
+      cy.retrievePaymentCallTest({ globalState });
+    });
+  });
+
+  context("Success-based toggle endpoint (404 - endpoint not registered)", () => {
+    before("seed global state", () => {
+      cy.task("getGlobalState").then((state) => {
+        globalState = new State(state);
+      });
+    });
+
+    afterEach("flush global state", () => {
+      cy.task("setGlobalState", globalState.data);
+    });
+
+    xit("toggle-success-based-dynamic-routing", () => {
+      const data = utils.getConnectorDetails("common")["toggleRouting"];
+      const merchantId = globalState.get("merchantId");
+      const profileId = globalState.get("profileId");
+
+      cy.request({
+        method: "POST",
+        url: `${globalState.get("baseUrl")}/account/${merchantId}/business_profile/${profileId}/dynamic_routing/success_based/toggle?enable=dynamic_connector_selection`,
+        headers: {
+          "api-key": globalState.get("apiKey"),
+          "Content-Type": "application/json",
+        },
+        failOnStatusCode: false,
+        body: {},
+      }).then((response) => {
+        expect(response.status).to.equal(200);
+      });
+    });
+  });
+
+  context("Elimination toggle endpoint (404 - endpoint not registered)", () => {
+    before("seed global state", () => {
+      cy.task("getGlobalState").then((state) => {
+        globalState = new State(state);
+      });
+    });
+
+    afterEach("flush global state", () => {
+      cy.task("setGlobalState", globalState.data);
+    });
+
+    xit("toggle-elimination-dynamic-routing", () => {
+      const data = utils.getConnectorDetails("common")["toggleRouting"];
+      const merchantId = globalState.get("merchantId");
+      const profileId = globalState.get("profileId");
+
+      cy.request({
+        method: "POST",
+        url: `${globalState.get("baseUrl")}/account/${merchantId}/business_profile/${profileId}/dynamic_routing/elimination/toggle?enable=dynamic_connector_selection`,
+        headers: {
+          "api-key": globalState.get("apiKey"),
+          "Content-Type": "application/json",
+        },
+        failOnStatusCode: false,
+        body: {},
+      }).then((response) => {
+        expect(response.status).to.equal(200);
+      });
+    });
+  });
+
+  context("Contract config PATCH endpoint (500 - server bug)", () => {
+    before("seed global state", () => {
+      cy.task("getGlobalState").then((state) => {
+        globalState = new State(state);
+      });
+    });
+
+    afterEach("flush global state", () => {
+      cy.task("setGlobalState", globalState.data);
+    });
+
+    xit("update-contract-based-dynamic-routing-config", () => {
+      const routingConfigId = globalState.get("routingConfigId");
+      const merchantId = globalState.get("merchantId");
+      const profileId = globalState.get("profileId");
+
+      cy.request({
+        method: "PATCH",
+        url: `${globalState.get("baseUrl")}/account/${merchantId}/business_profile/${profileId}/dynamic_routing/contracts/config/${routingConfigId}`,
+        headers: {
+          "api-key": globalState.get("apiKey"),
+          "Content-Type": "application/json",
+        },
+        failOnStatusCode: false,
+        body: {
+          algorithm_for: "payment",
+          connectors: [
+            {
+              connector: "stripe",
+              merchant_connector_id: globalState.get("stripeMcaId"),
+            },
+          ],
+        },
+      }).then((response) => {
+        expect(response.status).to.equal(200);
+      });
+    });
+  });
+
+  context("Deactivate routing without active config (negative)", () => {
+    before("seed global state", () => {
+      cy.task("getGlobalState").then((state) => {
+        globalState = new State(state);
+      });
+    });
+
+    afterEach("flush global state", () => {
+      cy.task("setGlobalState", globalState.data);
+    });
+
+    it("deactivate-routing-from-previous-context", () => {
+      const data =
+        utils.getConnectorDetails("common")["deactivateDynamicRouting"];
+      cy.deactivateDynamicRoutingConfig("contracts", data, globalState);
+    });
+
+    it("deactivate-routing-without-active-config", () => {
+      const data =
+        utils.getConnectorDetails("common")["deactivateRoutingNegative"];
+      cy.deactivateRoutingConfig(data, globalState);
+    });
+  });
+});

--- a/cypress-tests/cypress/support/commands.js
+++ b/cypress-tests/cypress/support/commands.js
@@ -5255,9 +5255,14 @@ Cypress.Commands.add(
     const merchantId = globalState.get("merchantId");
     const profileId = globalState.get("profileId");
 
+    const dynamicRoutingUrl =
+      routingType === "contracts"
+        ? `${globalState.get("baseUrl")}/account/${merchantId}/business_profile/${profileId}/dynamic_routing/contracts/toggle?enable=none`
+        : `${globalState.get("baseUrl")}/account/${merchantId}/business_profile/${profileId}/dynamic_routing/${routingType}/create?enable=none`;
+
     cy.request({
       method: "POST",
-      url: `${globalState.get("baseUrl")}/account/${merchantId}/business_profile/${profileId}/dynamic_routing/${routingType}/create?enable=none`,
+      url: dynamicRoutingUrl,
       headers: {
         "api-key": globalState.get("apiKey"),
         "Content-Type": "application/json",

--- a/cypress-tests/cypress/support/commands.js
+++ b/cypress-tests/cypress/support/commands.js
@@ -5173,6 +5173,148 @@ Cypress.Commands.add("retrieveRoutingConfig", (data, globalState) => {
 });
 
 Cypress.Commands.add(
+  "addDynamicRoutingConfig",
+  (dynamicRoutingBody, data, routingType, routing_data, globalState) => {
+    const { Request: reqData, Response: resData } = data || {};
+    const merchantId = globalState.get("merchantId");
+    const profileId = globalState.get("profileId");
+
+    const body = { ...dynamicRoutingBody, ...reqData };
+    body.algorithm_for = reqData?.algorithm_for || "payment";
+    body.connectors = routing_data;
+
+    cy.request({
+      method: "POST",
+      url: `${globalState.get("baseUrl")}/account/${merchantId}/business_profile/${profileId}/dynamic_routing/${routingType}/create?enable=dynamic_connector_selection`,
+      headers: {
+        "api-key": globalState.get("apiKey"),
+        "Content-Type": "application/json",
+      },
+      failOnStatusCode: false,
+      body: body,
+    }).then((response) => {
+      logRequestId(response.headers["x-request-id"]);
+
+      cy.wrap(response).then(() => {
+        expect(response.headers["content-type"]).to.include("application/json");
+
+        if (response.status === 200) {
+          expect(response.body).to.have.property("id");
+          globalState.set("routingConfigId", response.body.id);
+          for (const key in resData.body) {
+            expect(resData.body[key]).to.equal(response.body[key]);
+          }
+        } else {
+          defaultErrorHandler(response, resData);
+        }
+      });
+    });
+  }
+);
+
+Cypress.Commands.add(
+  "toggleDynamicRoutingConfig",
+  (data, globalState) => {
+    const { Response: resData } = data || {};
+    const merchantId = globalState.get("merchantId");
+    const profileId = globalState.get("profileId");
+
+    cy.request({
+      method: "POST",
+      url: `${globalState.get("baseUrl")}/account/${merchantId}/business_profile/${profileId}/dynamic_routing/contracts/toggle?enable=dynamic_connector_selection`,
+      headers: {
+        "api-key": globalState.get("apiKey"),
+        "Content-Type": "application/json",
+      },
+      failOnStatusCode: false,
+      body: {},
+    }).then((response) => {
+      logRequestId(response.headers["x-request-id"]);
+
+      cy.wrap(response).then(() => {
+        expect(response.headers["content-type"]).to.include("application/json");
+
+        if (response.status === 200) {
+          expect(response.body).to.have.property("id");
+          globalState.set("routingConfigId", response.body.id);
+          for (const key in resData.body) {
+            expect(resData.body[key]).to.equal(response.body[key]);
+          }
+        } else {
+          defaultErrorHandler(response, resData);
+        }
+      });
+    });
+  }
+);
+
+Cypress.Commands.add(
+  "deactivateDynamicRoutingConfig",
+  (routingType, data, globalState) => {
+    const { Response: resData } = data || {};
+    const merchantId = globalState.get("merchantId");
+    const profileId = globalState.get("profileId");
+
+    cy.request({
+      method: "POST",
+      url: `${globalState.get("baseUrl")}/account/${merchantId}/business_profile/${profileId}/dynamic_routing/${routingType}/create?enable=none`,
+      headers: {
+        "api-key": globalState.get("apiKey"),
+        "Content-Type": "application/json",
+      },
+      failOnStatusCode: false,
+      body: {},
+    }).then((response) => {
+      logRequestId(response.headers["x-request-id"]);
+
+      cy.wrap(response).then(() => {
+        expect(response.headers["content-type"]).to.include("application/json");
+
+        if (response.status === 200) {
+          for (const key in resData.body) {
+            expect(resData.body[key]).to.equal(response.body[key]);
+          }
+        } else {
+          defaultErrorHandler(response, resData);
+        }
+      });
+    });
+  }
+);
+
+Cypress.Commands.add("deactivateRoutingConfig", (data, globalState) => {
+  const { Request: reqData, Response: resData } = data || {};
+
+  const body = { ...reqData };
+  body.profile_id = globalState.get("profileId");
+
+  cy.request({
+    method: "POST",
+    url: `${globalState.get("baseUrl")}/routing/deactivate`,
+    headers: {
+      "api-key": globalState.get("apiKey"),
+      "Content-Type": "application/json",
+    },
+    failOnStatusCode: false,
+    body: body,
+  }).then((response) => {
+    logRequestId(response.headers["x-request-id"]);
+
+    cy.wrap(response).then(() => {
+      expect(response.headers["content-type"]).to.include("application/json");
+
+      if (response.status === 200) {
+        for (const key in resData.body) {
+          expect(resData.body[key]).to.equal(response.body[key]);
+        }
+      } else {
+        defaultErrorHandler(response, resData);
+      }
+    });
+  });
+});
+
+Cypress.Commands.add(
   "updateGsmConfig",
   (gsmBody, globalState, step_up_possible) => {
     gsmBody.step_up_possible = step_up_possible;


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [x] CI/CD

## Description
<!-- Describe your changes in detail -->

Fix the `deactivateDynamicRoutingConfig` Cypress command to use the correct API endpoint when deactivating contracts-type dynamic routing. The command previously used `/{routingType}/create?enable=none` for all routing types, but contracts routing requires `/contracts/toggle?enable=none` instead. This fix branches the URL construction based on `routingType`.

This PR also includes the prior commit that added the `deactivateDynamicRoutingConfig` command, the `deactivateDynamicRouting` config key, and deactivate it-blocks in 3 contexts of the DynamicRouting spec.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

No API schema, database schema, or application configuration changes. Only Cypress test infrastructure.

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, you MUST start with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->

The existing `deactivateRoutingConfig` command calls `POST /routing/deactivate` which only deactivates REGULAR routing (stored in `business_profile.routing_algorithm`). Dynamic routing is stored in a separate field (`business_profile.dynamic_routing_algorithm`) and requires a different API to deactivate. A dedicated `deactivateDynamicRoutingConfig` command was added, but it used the wrong endpoint for the `contracts` routing type — `/contracts/create?enable=none` instead of `/contracts/toggle?enable=none`. This caused HTTP 400 errors (`IR_16: Algorithm is already inactive`) when running the deactivation tests.

Closes #12053
Related to #12054

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

Full regression suite was executed against the changed connector. The `RUNNER_RESULT` block from the QA pipeline is included verbatim below.

### Changed-spec verification — `stripe`

```
RUNNER_RESULT:
  Connector: stripe
  SpecFile: cypress/e2e/spec/Routing/00005-DynamicRouting.cy.js
  PrereqsUsed: spec/Payment/01-,02-,03-
  TotalTests: 29
  Passed: 26
  Failed: 0
  Skipped: 3
  OverallStatus: PASS
```

Note: Stripe regression is handled by CI automatically on every PR and is not included here.

### Summary

| Connector | Specs Run | Passed | Failed | Skipped | Status |
|---|---|---|---|---|---|
| stripe | 29 | 26 | 0 | 3 | PASS |

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [x] I added unit tests for my changes where possible
