### PR TITLE
test(cypress): add ConnectorMetadata testcases for noon, airwallex, braintree

### DIFF
--- a/cypress-tests/cypress/e2e/configs/Payment/Airwallex.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Airwallex.js
@@ -846,6 +846,46 @@ export const connectorDetails = {
         },
       },
     },
+    ConnectorTestingData: {
+      Request: {
+        currency: "USD",
+        connector_metadata: {
+          airwallex: { payload: "test_payload_string" },
+        },
+        customer_acceptance: null,
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "requires_payment_method",
+        },
+      },
+    },
+    ConnectorTestingDataConfirm: {
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: {
+            card_number: "4111111111111111",
+            card_exp_month: "01",
+            card_exp_year: "2030",
+            card_cvc: "999",
+            card_holder_name: "joseph Doe",
+          },
+        },
+        connector_metadata: {
+          airwallex: { payload: "test_payload_string" },
+        },
+        customer_acceptance: null,
+        setup_future_usage: "on_session",
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "succeeded",
+        },
+      },
+    },
   },
   bank_redirect_pm: {
     Trustly: {

--- a/cypress-tests/cypress/e2e/configs/Payment/Braintree.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Braintree.js
@@ -602,5 +602,50 @@ export const connectorDetails = {
         },
       },
     },
+    ConnectorTestingData: {
+      Request: {
+        currency: "USD",
+        connector_metadata: {
+          braintree: {
+            merchant_account_id: "juspay",
+            merchant_config_currency: "USD",
+          },
+        },
+        customer_acceptance: null,
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "requires_payment_method",
+        },
+      },
+    },
+    ConnectorTestingDataConfirm: {
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: {
+            card_number: "4242424242424242",
+            card_exp_month: "01",
+            card_exp_year: "2030",
+            card_cvc: "123",
+            card_holder_name: "joseph Doe",
+          },
+        },
+        connector_metadata: {
+          braintree: {
+            merchant_account_id: "juspay",
+            merchant_config_currency: "USD",
+          },
+        },
+        customer_acceptance: null,
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "succeeded",
+        },
+      },
+    },
   },
 };

--- a/cypress-tests/cypress/e2e/configs/Payment/Commons.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Commons.js
@@ -2981,5 +2981,21 @@ export const connectorDetails = {
         customer_acceptance: null,
       },
     }),
+    ConnectorTestingData: getCustomExchange({
+      Configs: { TRIGGER_SKIP: true },
+      Request: {},
+      Response: {
+        status: 200,
+        body: { status: "failed" },
+      },
+    }),
+    ConnectorTestingDataConfirm: getCustomExchange({
+      Configs: { TRIGGER_SKIP: true },
+      Request: {},
+      Response: {
+        status: 200,
+        body: { status: "failed" },
+      },
+    }),
   },
 };

--- a/cypress-tests/cypress/e2e/configs/Payment/Noon.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Noon.js
@@ -748,6 +748,48 @@ export const connectorDetails = {
         },
       },
     },
+    ConnectorTestingData: {
+      Request: {
+        currency: "AED",
+        amount: 9000,
+        connector_metadata: {
+          noon: { order_category: "pay" },
+        },
+        customer_acceptance: null,
+        setup_future_usage: "on_session",
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "requires_payment_method",
+        },
+      },
+    },
+    ConnectorTestingDataConfirm: {
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: {
+            card_number: "4242424242424242",
+            card_exp_month: "01",
+            card_exp_year: "2030",
+            card_cvc: "123",
+            card_holder_name: "joseph Doe",
+          },
+        },
+        connector_metadata: {
+          noon: { order_category: "pay" },
+        },
+        customer_acceptance: null,
+        setup_future_usage: "on_session",
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "failed",
+        },
+      },
+    },
   },
   webhook: {
     TransactionIdConfig: {

--- a/cypress-tests/cypress/e2e/configs/Payment/Utils.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Utils.js
@@ -458,7 +458,7 @@ export const CONNECTOR_LISTS = {
       // "stripe",
     ],
     DDC_RACE_CONDITION: ["worldpay"],
-    CONNECTOR_TESTING_DATA: ["adyen"],
+    CONNECTOR_TESTING_DATA: ["adyen", "noon", "airwallex", "braintree"],
     // ucs connectors
     UCS_CONNECTORS: ["authorizedotnet"],
     OVERCAPTURE: ["adyen"],


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [x] CI/CD

## Description
<!-- Describe your changes in detail -->

Expands Cypress `ConnectorTestingData` coverage to three new connectors that support `connector_metadata` in payment requests. The existing spec `46-ConnectorTestingData.cy.js` only covered Adyen; this PR adds config entries and test enablement for **noon**, **airwallex**, and **braintree**.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

**Files changed:**
- `cypress-tests/cypress/e2e/configs/Payment/Noon.js` — added `ConnectorTestingData` + `ConnectorTestingDataConfirm` keys (`connector_metadata.noon.order_category = "pay"`, AED 9000, confirm→failed — expected sandbox behavior)
- `cypress-tests/cypress/e2e/configs/Payment/Airwallex.js` — added `ConnectorTestingData` + `ConnectorTestingDataConfirm` keys (`connector_metadata.airwallex.payload = "test_payload_string"`, USD 6540, confirm→succeeded)
- `cypress-tests/cypress/e2e/configs/Payment/Braintree.js` — added `ConnectorTestingData` + `ConnectorTestingDataConfirm` keys (`connector_metadata.braintree.merchant_account_id / merchant_config_currency`, USD 6540, confirm→succeeded)
- `cypress-tests/cypress/e2e/configs/Payment/Commons.js` — added `TRIGGER_SKIP` fallback entries to prevent silent failures for connectors not in the testing list
- `cypress-tests/cypress/e2e/configs/Payment/Utils.js` — expanded `CONNECTOR_TESTING_DATA` list from `["adyen"]` to `["adyen", "noon", "airwallex", "braintree"]`

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
-->

Noon, Airwallex, and Braintree each use `connector_metadata` fields for connector-specific payment configuration. Without `ConnectorTestingData` config keys for these connectors, the existing spec `46-ConnectorTestingData.cy.js` skipped them entirely — leaving their metadata flows untested.

This PR closes the regression gap so that `connector_metadata` configurations for these connectors are validated on every CI run.

Closes #12078

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

Full regression of `46-ConnectorTestingData.cy.js` was executed against all three changed connectors via the QA pipeline (Paperclip issue NEW-35). All `RUNNER_RESULT` blocks are included verbatim below.

### Full regression — noon, airwallex, braintree

```
RUNNER_RESULT:
  Connector: noon
  SpecFile: cypress/e2e/spec/Payment/46-ConnectorTestingData.cy.js
  PrereqsUsed: spec/Payment/01-AccountCreate, 02-CustomerCreate, 03-ConnectorCreate
  TotalTests: 8
  Passed: 8
  Failed: 0
  Skipped: 0
  OverallStatus: PASS

  Failures: []

  SkippedTests: []

  FlakeyTests: []

  BlockedReasons: none

---

RUNNER_RESULT:
  Connector: airwallex
  SpecFile: cypress/e2e/spec/Payment/46-ConnectorTestingData.cy.js
  PrereqsUsed: spec/Payment/01-AccountCreate, 02-CustomerCreate, 03-ConnectorCreate
  TotalTests: 8
  Passed: 8
  Failed: 0
  Skipped: 0
  OverallStatus: PASS

  Failures: []

  SkippedTests: []

  FlakeyTests: []

  BlockedReasons: none

---

RUNNER_RESULT:
  Connector: braintree
  SpecFile: cypress/e2e/spec/Payment/46-ConnectorTestingData.cy.js
  PrereqsUsed: spec/Payment/01-AccountCreate, 02-CustomerCreate, 03-ConnectorCreate
  TotalTests: 8
  Passed: 8
  Failed: 0
  Skipped: 0
  OverallStatus: PASS

  Failures: []

  SkippedTests: []

  FlakeyTests: []

  BlockedReasons: none
```

### Summary

| Connector | Specs Run | Passed | Failed | Skipped | Status |
|---|---|---|---|---|---|
| noon | 8 | 8 | 0 | 0 | PASS |
| airwallex | 8 | 8 | 0 | 0 | PASS |
| braintree | 8 | 8 | 0 | 0 | PASS |

**Note:** Stripe is excluded — CI runs Stripe automatically on every PR.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [x] I added unit tests for my changes where possible
