### PR TITLE
fix(authorizedotnet): use actual error text in CreateConnectorCustomer error message

### DIFF
--- a/crates/hyperswitch_connectors/src/connectors/authorizedotnet/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/authorizedotnet/transformers.rs
@@ -672,7 +672,7 @@ impl<F, T> TryFrom<ResponseRouterData<F, AuthorizedotnetCustomerResponse, T, Pay
                     });
                     Ok(Self {
                         response,
-                        status: enums::AttemptStatus::PaymentMethodAwaited,
+                        status: enums::AttemptStatus::Failure,
                         ..item.data
                     })
                 }

--- a/crates/hyperswitch_connectors/src/connectors/authorizedotnet/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/authorizedotnet/transformers.rs
@@ -659,7 +659,7 @@ impl<F, T> TryFrom<ResponseRouterData<F, AuthorizedotnetCustomerResponse, T, Pay
                         .join(" ");
                     let response = Err(ErrorResponse {
                         code: error_code,
-                        message: item.response.messages.result_code.to_string(),
+                        message: error_reason.clone(),
                         reason: Some(error_reason),
                         status_code: item.http_code,
                         attempt_status: None,
@@ -672,7 +672,7 @@ impl<F, T> TryFrom<ResponseRouterData<F, AuthorizedotnetCustomerResponse, T, Pay
                     });
                     Ok(Self {
                         response,
-                        status: enums::AttemptStatus::Failure,
+                        status: enums::AttemptStatus::PaymentMethodAwaited,
                         ..item.data
                     })
                 }


### PR DESCRIPTION
## Summary

Fix two parity diffs in `CreateConnectorCustomer` error path for AuthorizeDotNet: use actual connector error text instead of literal `"Error"`, and return `PaymentMethodAwaited` instead of `Failure` since customer creation is a pre-payment step.

## Linked PRD

Closes juspay/hyperswitch-cloud#15708

## Understanding Summary

- **Connector**: authorizedotnet
- **Flow**: CreateConnectorCustomer
- **Root cause**: `ResultCode` enum `.to_string()` produces `"Error"` literal instead of the actual error message text; `AttemptStatus::Failure` is semantically wrong for a pre-payment step failure.

### Oracle Behavior (UCS)
- `message` = actual connector error text (e.g. "User authentication failed due to invalid authentication values.")
- `status` = `payment_method_awaited`

### Divergence in hyperswitch
- `message` = `"Error"` (from `ResultCode::Error.to_string()`)
- `status` = `Failure`

## Implementation

### Change 1: Line 662
```rust
// Before:
message: item.response.messages.result_code.to_string(),
// After:
message: error_reason.clone(),
```

### Change 2: Line 675
```rust
// Before:
status: enums::AttemptStatus::Failure,
// After:
status: enums::AttemptStatus::PaymentMethodAwaited,
```

## Build Tail

Pre-existing build failures in `diesel_models` and `api_models` crates (confirmed identical on `main`). No new errors introduced by this change.

## Acceptance Criteria

- [x] Change is scoped to exactly 2 lines in 1 file
- [x] `error_reason.clone()` provides actual error text before ownership moves to `reason`
- [x] `PaymentMethodAwaited` is a valid `AttemptStatus` variant (confirmed via grep)
- [x] No proto/domain-type changes needed
- [ ] Shadow-replay produces zero diff (CTO gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)