### PR TITLE
fix(connector): map globalpay brand_reference to network_txn_id

### DIFF
--- a/crates/hyperswitch_connectors/src/connectors/globalpay/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/globalpay/transformers.rs
@@ -441,7 +441,13 @@ impl<F, T> TryFrom<ResponseRouterData<F, GlobalpayPaymentsResponse, T, PaymentsR
                 redirection_data: Box::new(redirection_data),
                 mandate_reference: Box::new(mandate_reference),
                 connector_metadata: None,
-                network_txn_id: None,
+                network_txn_id: item
+                    .response
+                    .payment_method
+                    .as_ref()
+                    .and_then(|pm| pm.card.as_ref())
+                    .and_then(|card| card.brand_reference.as_ref())
+                    .map(|id| id.clone().expose()),
                 connector_response_reference_id: item.response.reference.clone(),
                 incremental_authorization_allowed: None,
                 authentication_data: None,


### PR DESCRIPTION
## Summary

Extract `network_txn_id` from `payment_method.card.brand_reference` in the globalpay psync response transformer. Previously hardcoded to `None`, causing a parity diff with UCS.

## Linked Issues

Fixes #12104
Refs juspay/hyperswitch-cloud#15765

## Understanding Summary

- **Connector:** globalpay
- **Flow:** psync (payment sync)
- **Field:** `response.Ok.TransactionResponse.network_txn_id`
- **Root cause:** `network_txn_id: None` hardcoded at line 444 of `globalpay/transformers.rs`
- **Oracle (UCS):** correctly maps `payment_method.card.brand_reference` → `network_txn_id`
- **HS (before):** returns `null` for `network_txn_id`
- **HS (after):** extracts `brand_reference` from the Card struct via the existing payment_method option chain

## Implementation

Single change in `crates/hyperswitch_connectors/src/connectors/globalpay/transformers.rs`:

```rust
// FROM:
network_txn_id: None,

// TO:
network_txn_id: item
    .response
    .payment_method
    .as_ref()
    .and_then(|pm| pm.card.as_ref())
    .and_then(|card| card.brand_reference.as_ref())
    .map(|id| id.clone().expose()),
```

## Build Tail

`cargo check -p hyperswitch_connectors` has pre-existing failures in `diesel_models` (54 errors, unrelated to this change). Verified by running on clean `main` — identical errors. The globalpay transformer change is type-safe: `Option<Secret<String>>` → `.clone().expose()` → `Option<String>` matches the `network_txn_id` field type.

## Acceptance Criteria

- [x] Change matches PRD specification exactly
- [x] Only PRD-named file modified (1 file, 7 insertions, 1 deletion)
- [x] Pre-existing build issues on main confirmed (not caused by this change)
- [x] `ExposeInterface` already imported (line 27)
- [ ] Shadow-replay produces zero diff (CTO gate)