### PR TITLE
parity(ucs): pass connector_metadata through from gRPC response

### DIFF
--- a/crates/hyperswitch_interfaces/src/unified_connector_service/transformers.rs
+++ b/crates/hyperswitch_interfaces/src/unified_connector_service/transformers.rs
@@ -299,7 +299,9 @@ impl ForeignTryFrom<(payments_grpc::PaymentServiceGetResponse, AttemptStatus)>
                             .transpose()?,
                     ),
                     mandate_reference: Box::new(response.mandate_reference.map(hyperswitch_domain_models::router_response_types::MandateReference::foreign_try_from).transpose()?),
-                    connector_metadata: None,
+                    connector_metadata: response
+                        .metadata
+                        .and_then(|m| serde_json::from_str(&m.expose()).ok()),
                     network_txn_id: response.network_transaction_id.clone(),
                     connector_response_reference_id: response.merchant_transaction_id,
                     incremental_authorization_allowed: response.incremental_authorization_allowed,


### PR DESCRIPTION
## Summary
The UCS response handler hardcoded `connector_metadata: None` when converting gRPC `PaymentServiceGetResponse` to `PaymentsResponseData`, discarding the `metadata` field that connectors populate. This caused all UCS-routed flows to return `connector_metadata: null` in the response, diverging from the non-UCS path.

Refs #15798

## Understanding Summary
- **Connector**: forte (but fix is cross-cutting for all connectors)
- **Flow**: PSync
- **Field**: `response.Ok.TransactionResponse.connector_metadata`
- **Root cause**: `crates/hyperswitch_interfaces/src/unified_connector_service/transformers.rs` line 302 set `connector_metadata: None` instead of extracting the gRPC `metadata` field (protobuf tag 21)
- Both the hyperswitch oracle and the prism UCS forte transformers already correctly populate `connector_metadata` — the issue was solely in the gRPC-to-domain conversion layer

## Implementation Plan
- **File**: `crates/hyperswitch_interfaces/src/unified_connector_service/transformers.rs`
- **Change**: Replace `connector_metadata: None` with extraction from `response.metadata` — deserialize `Secret<String>` to `serde_json::Value` via `serde_json::from_str`
- **Fallback**: If `metadata` is `None` or fails to parse, result is `None` (no regression)

## Acceptance Criteria
- [x] Formatter passes
- [x] Only PRD-named file modified (`git diff --stat` shows 1 file, 3 insertions, 1 deletion)
- [ ] Build passes (pre-existing `diesel_models` workspace errors on `main` prevent local full build — CI will validate)
- [ ] Shadow-replay produces zero diff (CTO gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)