### PR TITLE
parity(helcim): serialize preauth_transaction_id as String in connector_metadata

### DIFF
--- a/crates/hyperswitch_connectors/src/connectors/helcim.rs
+++ b/crates/hyperswitch_connectors/src/connectors/helcim.rs
@@ -88,7 +88,7 @@ impl Helcim {
         connector_meta: Option<&serde_json::Value>,
     ) -> CustomResult<Option<String>, errors::ConnectorError> {
         let meta: helcim::HelcimMetaData = to_connector_meta(connector_meta.cloned())?;
-        Ok(Some(meta.preauth_transaction_id.to_string()))
+        Ok(Some(meta.preauth_transaction_id))
     }
 }
 

--- a/crates/hyperswitch_connectors/src/connectors/helcim/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/helcim/transformers.rs
@@ -412,7 +412,7 @@ impl<F>
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct HelcimMetaData {
-    pub preauth_transaction_id: u64,
+    pub preauth_transaction_id: String,
 }
 
 impl TryFrom<PaymentsResponseRouterData<HelcimPaymentsResponse>> for PaymentsAuthorizeRouterData {
@@ -430,7 +430,7 @@ impl TryFrom<PaymentsResponseRouterData<HelcimPaymentsResponse>> for PaymentsAut
         };
         let connector_metadata = if !item.data.request.is_auto_capture()? {
             Some(serde_json::json!(HelcimMetaData {
-                preauth_transaction_id: item.response.transaction_id,
+                preauth_transaction_id: item.response.transaction_id.to_string(),
             }))
         } else {
             None


### PR DESCRIPTION
## Summary

Change `HelcimMetaData.preauth_transaction_id` from `u64` to `String` so `connector_metadata` serializes the field as a JSON string, matching UCS behavior.

Refs juspay/hyperswitch-cloud#15802

## Understanding Summary

- **Connector**: helcim
- **Flow**: PaymentsAuthorize (manual capture path)
- **Field path**: `response.Ok.TransactionResponse.connector_metadata.preauth_transaction_id`
- **Root cause**: `HelcimMetaData.preauth_transaction_id` was typed `u64`; `serde_json::json!()` serialized it as a JSON number. UCS serializes the same value as a JSON string.

### Oracle (hyperswitch) before fix
`preauth_transaction_id: u64` → JSON number (e.g. `47672462`)

### UCS behavior
`preauth_transaction_id` → JSON string (e.g. `"47672462"`)

### Fix applied
1. Changed `HelcimMetaData.preauth_transaction_id` type from `u64` to `String`
2. Added `.to_string()` at the assignment site (`item.response.transaction_id.to_string()`)
3. Removed redundant `.to_string()` in `Helcim::connector_transaction_id()` (already a `String`)

## Changes

| File | Change |
|------|--------|
| `helcim/transformers.rs:415` | `preauth_transaction_id: u64` → `String` |
| `helcim/transformers.rs:433` | Added `.to_string()` on assignment |
| `helcim.rs:91` | Removed redundant `.to_string()` |

## Verification

- `cargo check -p hyperswitch_connectors` — zero helcim-related errors (pre-existing errors in `diesel_models` are unrelated)
- `git diff --stat` confirms only 2 helcim files touched

## Acceptance Criteria
- [x] Build passes (no helcim errors)
- [x] Only PRD-scoped files changed
- [ ] Shadow-replay produces zero diff (CTO gate)