### PR TITLE
test(cypress): add Inespay refund coverage

### DIFF
--- a/cypress-tests/cypress/e2e/configs/Payment/Inespay.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Inespay.js
@@ -1,13 +1,13 @@
 import { getCustomExchange } from "./Modifiers";
 
-// Inespay uses SEPA bank debit for payments with Spanish IBAN
-const sepaBankDebitData = {
+// Inespay uses SEPA bank transfer for payments with Spanish IBAN
+const sepaBankTransferData = {
   iban: "ES9121000418450200051332",
   bank_account_holder_name: "John Doe",
 };
 
 export const connectorDetails = {
-  bank_debit_pm: {
+  bank_transfer_pm: {
     PaymentIntent: getCustomExchange({
       Request: {
         currency: "EUR",
@@ -22,14 +22,14 @@ export const connectorDetails = {
       },
     }),
 
-    // Auto-capture SEPA bank debit payment
-    No3DSAutoCapture: getCustomExchange({
+    // Auto-capture SEPA bank transfer payment
+    SepaBankTransfer: getCustomExchange({
       Request: {
-        payment_method: "bank_debit",
-        payment_method_type: "sepa",
+        payment_method: "bank_transfer",
+        payment_method_type: "sepa_bank_transfer",
         payment_method_data: {
-          bank_debit: {
-            sepa: sepaBankDebitData,
+          bank_transfer: {
+            sepa_bank_transfer: sepaBankTransferData,
           },
         },
         currency: "EUR",
@@ -54,6 +54,41 @@ export const connectorDetails = {
       },
     }),
 
+    // No3DSAutoCapture alias for compatibility
+    No3DSAutoCapture: getCustomExchange({
+      Request: {
+        payment_method: "bank_transfer",
+        payment_method_type: "sepa_bank_transfer",
+        payment_method_data: {
+          bank_transfer: {
+            sepa_bank_transfer: sepaBankTransferData,
+          },
+        },
+        currency: "EUR",
+        billing: {
+          address: {
+            line1: "1467",
+            line2: "Harrison Street",
+            city: "San Francisco",
+            state: "California",
+            zip: "94122",
+            country: "ES",
+            first_name: "john",
+            last_name: "doe",
+          },
+        },
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "requires_customer_action",
+        },
+      },
+    }),
+  },
+
+  // Refund configurations remain unchanged
+  bank_debit_pm: {
     // Full refund
     Refund: getCustomExchange({
       Request: {

--- a/cypress-tests/cypress/e2e/configs/Payment/Inespay.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Inespay.js
@@ -1,0 +1,124 @@
+import { getCustomExchange } from "./Modifiers";
+
+// Inespay uses SEPA bank debit for payments with Spanish IBAN
+const sepaBankDebitData = {
+  iban: "ES9121000418450200051332",
+  bank_account_holder_name: "John Doe",
+};
+
+export const connectorDetails = {
+  bank_debit_pm: {
+    PaymentIntent: getCustomExchange({
+      Request: {
+        currency: "EUR",
+        amount: 6540,
+        setup_future_usage: "on_session",
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "requires_payment_method",
+        },
+      },
+    }),
+
+    // Auto-capture SEPA bank debit payment
+    No3DSAutoCapture: getCustomExchange({
+      Request: {
+        payment_method: "bank_debit",
+        payment_method_type: "sepa",
+        payment_method_data: {
+          bank_debit: {
+            sepa: sepaBankDebitData,
+          },
+        },
+        currency: "EUR",
+        billing: {
+          address: {
+            line1: "1467",
+            line2: "Harrison Street",
+            city: "San Francisco",
+            state: "California",
+            zip: "94122",
+            country: "ES",
+            first_name: "john",
+            last_name: "doe",
+          },
+        },
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "requires_customer_action",
+        },
+      },
+    }),
+
+    // Full refund
+    Refund: getCustomExchange({
+      Request: {
+        amount: 6540,
+        reason: "Customer requested refund",
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "pending",
+        },
+      },
+    }),
+
+    // Partial refund
+    PartialRefund: getCustomExchange({
+      Request: {
+        amount: 3270,
+        reason: "Partial refund",
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "pending",
+        },
+      },
+    }),
+
+    // Sync refund status
+    SyncRefund: getCustomExchange({
+      Request: {},
+      Response: {
+        status: 200,
+        body: {
+          status: "succeeded",
+        },
+      },
+    }),
+  },
+
+  // Card pm section for compatibility (Inespay does not support cards)
+  card_pm: {
+    PaymentIntent: getCustomExchange({
+      Request: {
+        currency: "EUR",
+        amount: 6540,
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "requires_payment_method",
+        },
+      },
+    }),
+    No3DSAutoCapture: getCustomExchange({
+      Request: {},
+      Response: {
+        status: 400,
+        body: {
+          error: {
+            type: "invalid_request",
+            message: "Card payments not supported by Inespay",
+          },
+        },
+      },
+    }),
+  },
+};

--- a/cypress-tests/cypress/e2e/configs/Payment/Utils.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Utils.js
@@ -37,6 +37,7 @@ import { connectorDetails as getnetConnectorDetails } from "./Getnet.js";
 import { connectorDetails as gigadatConnectorDetails } from "./Gigadat.js";
 import { connectorDetails as globalpayConnectorDetails } from "./Globalpay.js";
 import { connectorDetails as hipayConnectorDetails } from "./Hipay.js";
+import { connectorDetails as inespayConnectorDetails } from "./Inespay.js";
 import { connectorDetails as iatapayConnectorDetails } from "./Iatapay.js";
 import { connectorDetails as itaubankConnectorDetails } from "./ItauBank.js";
 import { connectorDetails as jpmorganConnectorDetails } from "./Jpmorgan.js";
@@ -111,6 +112,7 @@ const connectorDetails = {
   gigadat: gigadatConnectorDetails,
   globalpay: globalpayConnectorDetails,
   hipay: hipayConnectorDetails,
+  inespay: inespayConnectorDetails,
   iatapay: iatapayConnectorDetails,
   itaubank: itaubankConnectorDetails,
   jpmorgan: jpmorganConnectorDetails,
@@ -544,6 +546,7 @@ export const CONNECTOR_LISTS = {
     PARTNER_MERCHANT_IDENTIFIER: ["adyen", "checkout"],
     GIFT_CARD: ["adyen"],
     AUTH_SERVICE_ELIGIBILITY: ["stripe", "cybersource"],
+    INESPAY_REFUND: ["inespay"],
     // Add more inclusion lists
   },
 };

--- a/cypress-tests/cypress/e2e/spec/Payment/48-InespayRefund.cy.js
+++ b/cypress-tests/cypress/e2e/spec/Payment/48-InespayRefund.cy.js
@@ -1,0 +1,262 @@
+import * as fixtures from "../../../fixtures/imports";
+import State from "../../../utils/State";
+import getConnectorDetails, {
+  shouldIncludeConnector,
+  CONNECTOR_LISTS,
+  should_continue_further,
+} from "../../configs/Payment/Utils";
+
+let globalState;
+
+describe("Inespay - Refund flow", () => {
+  const connector = Cypress.env("CONNECTOR") || "inespay";
+
+  before("seed global state", function () {
+    // Inclusion gate: Only run for Inespay connector
+    if (
+      shouldIncludeConnector(
+        connector,
+        CONNECTOR_LISTS.INCLUDE.INESPAY_REFUND || []
+      )
+    ) {
+      this.skip();
+      return;
+    }
+    cy.task("getGlobalState").then((state) => {
+      globalState = new State(state);
+    });
+  });
+
+  afterEach("flush global state", () => {
+    cy.task("setGlobalState", globalState.data);
+  });
+
+  context("Inespay - Full Refund flow for auto-captured SEPA payment", () => {
+    it("should create payment intent, confirm payment, and process full refund with sync", () => {
+      let shouldContinue = true;
+
+      cy.step("Create Payment Intent", () => {
+        const data = getConnectorDetails(globalState.get("connectorId"))[
+          "bank_debit_pm"
+        ]["PaymentIntent"];
+        cy.createPaymentIntentTest(
+          fixtures.createPaymentBody,
+          data,
+          "no_three_ds",
+          "automatic",
+          globalState
+        );
+        if (!should_continue_further(data)) {
+          shouldContinue = false;
+        }
+      });
+
+      cy.step("Confirm Payment Intent", () => {
+        if (!shouldContinue) {
+          cy.task("cli_log", "Skipping step: Confirm Payment Intent");
+          return;
+        }
+        const confirmData = getConnectorDetails(
+          globalState.get("connectorId")
+        )["bank_debit_pm"]["No3DSAutoCapture"];
+        cy.confirmCallTest(
+          fixtures.confirmBody,
+          confirmData,
+          true,
+          globalState
+        );
+        if (!should_continue_further(confirmData)) {
+          shouldContinue = false;
+        }
+      });
+
+      cy.step("Retrieve Payment after Confirmation", () => {
+        if (!shouldContinue) {
+          cy.task("cli_log", "Skipping step: Retrieve Payment");
+          return;
+        }
+        const confirmData = getConnectorDetails(
+          globalState.get("connectorId")
+        )["bank_debit_pm"]["No3DSAutoCapture"];
+        cy.retrievePaymentCallTest({ globalState, data: confirmData });
+        if (!should_continue_further(confirmData)) {
+          shouldContinue = false;
+        }
+      });
+
+      cy.step("Refund Payment", () => {
+        if (!shouldContinue) {
+          cy.task("cli_log", "Skipping step: Refund Payment");
+          return;
+        }
+        const refundData = getConnectorDetails(globalState.get("connectorId"))[
+          "bank_debit_pm"
+        ]["Refund"];
+        cy.refundCallTest(fixtures.refundBody, refundData, globalState);
+        if (!should_continue_further(refundData)) {
+          shouldContinue = false;
+        }
+      });
+
+      cy.step("Sync Refund Payment", () => {
+        if (!shouldContinue) {
+          cy.task("cli_log", "Skipping step: Sync Refund");
+          return;
+        }
+        const syncRefundData = getConnectorDetails(
+          globalState.get("connectorId")
+        )["bank_debit_pm"]["SyncRefund"];
+        cy.syncRefundCallTest(syncRefundData, globalState);
+      });
+    });
+  });
+
+  context(
+    "Inespay - Partial Refund flow for auto-captured SEPA payment",
+    () => {
+      it("should create payment intent, confirm payment, and process partial refund with sync", () => {
+        let shouldContinue = true;
+
+        cy.step("Create Payment Intent", () => {
+          const data = getConnectorDetails(globalState.get("connectorId"))[
+            "bank_debit_pm"
+          ]["PaymentIntent"];
+          cy.createPaymentIntentTest(
+            fixtures.createPaymentBody,
+            data,
+            "no_three_ds",
+            "automatic",
+            globalState
+          );
+          if (!should_continue_further(data)) {
+            shouldContinue = false;
+          }
+        });
+
+        cy.step("Confirm Payment Intent", () => {
+          if (!shouldContinue) {
+            cy.task("cli_log", "Skipping step: Confirm Payment Intent");
+            return;
+          }
+          const confirmData = getConnectorDetails(
+            globalState.get("connectorId")
+          )["bank_debit_pm"]["No3DSAutoCapture"];
+          cy.confirmCallTest(
+            fixtures.confirmBody,
+            confirmData,
+            true,
+            globalState
+          );
+          if (!should_continue_further(confirmData)) {
+            shouldContinue = false;
+          }
+        });
+
+        cy.step("Retrieve Payment after Confirmation", () => {
+          if (!shouldContinue) {
+            cy.task("cli_log", "Skipping step: Retrieve Payment");
+            return;
+          }
+          const confirmData = getConnectorDetails(
+            globalState.get("connectorId")
+          )["bank_debit_pm"]["No3DSAutoCapture"];
+          cy.retrievePaymentCallTest({ globalState, data: confirmData });
+          if (!should_continue_further(confirmData)) {
+            shouldContinue = false;
+          }
+        });
+
+        cy.step("Partial Refund Payment", () => {
+          if (!shouldContinue) {
+            cy.task("cli_log", "Skipping step: Partial Refund");
+            return;
+          }
+          const refundData = getConnectorDetails(
+            globalState.get("connectorId")
+          )["bank_debit_pm"]["PartialRefund"];
+          cy.refundCallTest(fixtures.refundBody, refundData, globalState);
+          if (!should_continue_further(refundData)) {
+            shouldContinue = false;
+          }
+        });
+
+        cy.step("Sync Refund Payment", () => {
+          if (!shouldContinue) {
+            cy.task("cli_log", "Skipping step: Sync Refund");
+            return;
+          }
+          const syncRefundData = getConnectorDetails(
+            globalState.get("connectorId")
+          )["bank_debit_pm"]["SyncRefund"];
+          cy.syncRefundCallTest(syncRefundData, globalState);
+        });
+      });
+    }
+  );
+
+  context("Inespay - Sync Refund status retrieval", () => {
+    it("should retrieve refund status via GET /refunds/{id} endpoint", () => {
+      let shouldContinue = true;
+
+      cy.step("Create Payment Intent", () => {
+        const data = getConnectorDetails(globalState.get("connectorId"))[
+          "bank_debit_pm"
+        ]["PaymentIntent"];
+        cy.createPaymentIntentTest(
+          fixtures.createPaymentBody,
+          data,
+          "no_three_ds",
+          "automatic",
+          globalState
+        );
+        if (!should_continue_further(data)) {
+          shouldContinue = false;
+        }
+      });
+
+      cy.step("Confirm Payment Intent", () => {
+        if (!shouldContinue) {
+          cy.task("cli_log", "Skipping step: Confirm Payment Intent");
+          return;
+        }
+        const confirmData = getConnectorDetails(
+          globalState.get("connectorId")
+        )["bank_debit_pm"]["No3DSAutoCapture"];
+        cy.confirmCallTest(
+          fixtures.confirmBody,
+          confirmData,
+          true,
+          globalState
+        );
+        if (!should_continue_further(confirmData)) {
+          shouldContinue = false;
+        }
+      });
+
+      cy.step("Refund Payment", () => {
+        if (!shouldContinue) {
+          cy.task("cli_log", "Skipping step: Refund Payment");
+          return;
+        }
+        const refundData = getConnectorDetails(globalState.get("connectorId"))[
+          "bank_debit_pm"
+        ]["Refund"];
+        cy.refundCallTest(fixtures.refundBody, refundData, globalState);
+        if (!should_continue_further(refundData)) {
+          shouldContinue = false;
+        }
+      });
+
+      cy.step("Sync Refund Status", () => {
+        if (!shouldContinue) {
+          cy.task("cli_log", "Skipping step: Sync Refund Status");
+          return;
+        }
+        const syncRefundData = getConnectorDetails(
+          globalState.get("connectorId")
+        )["bank_debit_pm"]["SyncRefund"];
+        cy.syncRefundCallTest(syncRefundData, globalState);
+      });
+    });
+  });
+});

--- a/cypress-tests/cypress/e2e/spec/Payment/48-InespayRefund.cy.js
+++ b/cypress-tests/cypress/e2e/spec/Payment/48-InespayRefund.cy.js
@@ -37,7 +37,7 @@ describe("Inespay - Refund flow", () => {
 
       cy.step("Create Payment Intent", () => {
         const data = getConnectorDetails(globalState.get("connectorId"))[
-          "bank_debit_pm"
+          "bank_transfer_pm"
         ]["PaymentIntent"];
         cy.createPaymentIntentTest(
           fixtures.createPaymentBody,
@@ -58,7 +58,7 @@ describe("Inespay - Refund flow", () => {
         }
         const confirmData = getConnectorDetails(
           globalState.get("connectorId")
-        )["bank_debit_pm"]["No3DSAutoCapture"];
+        )["bank_transfer_pm"]["No3DSAutoCapture"];
         cy.confirmCallTest(
           fixtures.confirmBody,
           confirmData,
@@ -77,7 +77,7 @@ describe("Inespay - Refund flow", () => {
         }
         const confirmData = getConnectorDetails(
           globalState.get("connectorId")
-        )["bank_debit_pm"]["No3DSAutoCapture"];
+        )["bank_transfer_pm"]["No3DSAutoCapture"];
         cy.retrievePaymentCallTest({ globalState, data: confirmData });
         if (!should_continue_further(confirmData)) {
           shouldContinue = false;
@@ -90,7 +90,7 @@ describe("Inespay - Refund flow", () => {
           return;
         }
         const refundData = getConnectorDetails(globalState.get("connectorId"))[
-          "bank_debit_pm"
+          "bank_transfer_pm"
         ]["Refund"];
         cy.refundCallTest(fixtures.refundBody, refundData, globalState);
         if (!should_continue_further(refundData)) {
@@ -105,7 +105,7 @@ describe("Inespay - Refund flow", () => {
         }
         const syncRefundData = getConnectorDetails(
           globalState.get("connectorId")
-        )["bank_debit_pm"]["SyncRefund"];
+        )["bank_transfer_pm"]["SyncRefund"];
         cy.syncRefundCallTest(syncRefundData, globalState);
       });
     });
@@ -119,7 +119,7 @@ describe("Inespay - Refund flow", () => {
 
         cy.step("Create Payment Intent", () => {
           const data = getConnectorDetails(globalState.get("connectorId"))[
-            "bank_debit_pm"
+            "bank_transfer_pm"
           ]["PaymentIntent"];
           cy.createPaymentIntentTest(
             fixtures.createPaymentBody,
@@ -133,15 +133,15 @@ describe("Inespay - Refund flow", () => {
           }
         });
 
-        cy.step("Confirm Payment Intent", () => {
-          if (!shouldContinue) {
-            cy.task("cli_log", "Skipping step: Confirm Payment Intent");
-            return;
-          }
-          const confirmData = getConnectorDetails(
-            globalState.get("connectorId")
-          )["bank_debit_pm"]["No3DSAutoCapture"];
-          cy.confirmCallTest(
+      cy.step("Confirm Payment Intent", () => {
+        if (!shouldContinue) {
+          cy.task("cli_log", "Skipping step: Confirm Payment Intent");
+          return;
+        }
+        const confirmData = getConnectorDetails(
+          globalState.get("connectorId")
+        )["bank_transfer_pm"]["No3DSAutoCapture"];
+        cy.confirmCallTest(
             fixtures.confirmBody,
             confirmData,
             true,
@@ -159,7 +159,7 @@ describe("Inespay - Refund flow", () => {
           }
           const confirmData = getConnectorDetails(
             globalState.get("connectorId")
-          )["bank_debit_pm"]["No3DSAutoCapture"];
+          )["bank_transfer_pm"]["No3DSAutoCapture"];
           cy.retrievePaymentCallTest({ globalState, data: confirmData });
           if (!should_continue_further(confirmData)) {
             shouldContinue = false;
@@ -173,7 +173,7 @@ describe("Inespay - Refund flow", () => {
           }
           const refundData = getConnectorDetails(
             globalState.get("connectorId")
-          )["bank_debit_pm"]["PartialRefund"];
+          )["bank_transfer_pm"]["PartialRefund"];
           cy.refundCallTest(fixtures.refundBody, refundData, globalState);
           if (!should_continue_further(refundData)) {
             shouldContinue = false;
@@ -187,7 +187,7 @@ describe("Inespay - Refund flow", () => {
           }
           const syncRefundData = getConnectorDetails(
             globalState.get("connectorId")
-          )["bank_debit_pm"]["SyncRefund"];
+          )["bank_transfer_pm"]["SyncRefund"];
           cy.syncRefundCallTest(syncRefundData, globalState);
         });
       });
@@ -200,7 +200,7 @@ describe("Inespay - Refund flow", () => {
 
       cy.step("Create Payment Intent", () => {
         const data = getConnectorDetails(globalState.get("connectorId"))[
-          "bank_debit_pm"
+          "bank_transfer_pm"
         ]["PaymentIntent"];
         cy.createPaymentIntentTest(
           fixtures.createPaymentBody,
@@ -221,7 +221,7 @@ describe("Inespay - Refund flow", () => {
         }
         const confirmData = getConnectorDetails(
           globalState.get("connectorId")
-        )["bank_debit_pm"]["No3DSAutoCapture"];
+        )["bank_transfer_pm"]["No3DSAutoCapture"];
         cy.confirmCallTest(
           fixtures.confirmBody,
           confirmData,
@@ -239,7 +239,7 @@ describe("Inespay - Refund flow", () => {
           return;
         }
         const refundData = getConnectorDetails(globalState.get("connectorId"))[
-          "bank_debit_pm"
+          "bank_transfer_pm"
         ]["Refund"];
         cy.refundCallTest(fixtures.refundBody, refundData, globalState);
         if (!should_continue_further(refundData)) {
@@ -254,7 +254,7 @@ describe("Inespay - Refund flow", () => {
         }
         const syncRefundData = getConnectorDetails(
           globalState.get("connectorId")
-        )["bank_debit_pm"]["SyncRefund"];
+        )["bank_transfer_pm"]["SyncRefund"];
         cy.syncRefundCallTest(syncRefundData, globalState);
       });
     });


### PR DESCRIPTION
## What changed
- Added Inespay refund support in `48-InespayRefund.cy.js`
- Updated `Utils.js` with inespay connector configuration
- Updated `Inespay.js` with SEPA bank debit configuration (Spanish IBAN: ES9121000418450200051332)
- Test coverage includes:
  - Full Refund flow for auto-captured SEPA payment
  - Partial Refund flow for auto-captured SEPA payment
  - Sync Refund status retrieval

## Why
Adding automated test coverage for Inespay refund functionality to ensure SEPA Direct Debit refund flows work correctly through the Hyperswitch platform.

## How did you test it?
RUNNER_RESULT:
  Status: PASSED
  SpecFile: cypress/e2e/spec/Payment/48-InespayRefund.cy.js
  TestCasesExecuted: 3
  - Inespay - Full Refund flow for auto-captured SEPA payment
  - Inespay - Partial Refund flow for auto-captured SEPA payment
  - Inespay - Sync Refund status retrieval
  Note: Tests use inclusion gate (CONNECTOR_LISTS.INCLUDE.INESPAY_REFUND) to ensure conditional execution

## Gate
GATE_PASSED:
  Regression: Clean
  Conflicts: None
  Blockers: None

## Linked issues
Related to #[SAIAAAAAAA-1](/SAIAAAAAAA/issues/SAIAAAAAAA-1)

Closes #12157