### PR TITLE
feat(ucs): read default execution mode from config table

### DIFF
--- a/crates/router/src/consts.rs
+++ b/crates/router/src/consts.rs
@@ -330,6 +330,9 @@ pub const PSD2_COUNTRIES: [Country; 27] = [
 // Rollout percentage config prefix
 pub const UCS_ROLLOUT_PERCENT_CONFIG_PREFIX: &str = "ucs_rollout_config";
 
+// Global default execution mode config key — used when no merchant/connector rollout config is found
+pub const UCS_DEFAULT_EXECUTION_MODE_KEY: &str = "ucs_rollout_config_default";
+
 // UCS feature enabled config
 pub const UCS_ENABLED: &str = "ucs_enabled";
 

--- a/crates/router/src/consts.rs
+++ b/crates/router/src/consts.rs
@@ -392,6 +392,8 @@ pub mod superposition {
     pub const PAYOUT_TRACKER_MAPPING: &str = "payout_tracker_mapping";
     /// client session validation enabled configuration key
     pub const CLIENT_SESSION_VALIDATION_ENABLED: &str = "client_session_validation_enabled";
+    /// UCS default execution mode configuration key
+    pub const UCS_DEFAULT_EXECUTION_MODE: &str = "ucs_rollout_config_default";
 }
 
 #[cfg(test)]

--- a/crates/router/src/core/configs/dimension_config.rs
+++ b/crates/router/src/core/configs/dimension_config.rs
@@ -398,3 +398,26 @@ impl DatabaseBackedConfig for MaxAutoPayoutRetries {
             })
     }
 }
+
+/// UCS global default execution mode config.
+/// Resolved via: Superposition → DB (`ucs_rollout_config_default`) → `"not_applicable"`.
+/// Output is a raw JSON string — parsed to `DefaultExecutionConfig` at the call site.
+pub struct UcsDefaultExecutionMode;
+
+impl external_services::superposition::Config for UcsDefaultExecutionMode {
+    type Output = String;
+    type TargetingKey = id_type::PaymentId;
+    const SUPERPOSITION_KEY: &'static str =
+        crate::consts::superposition::UCS_DEFAULT_EXECUTION_MODE;
+    fn default_value() -> Self::Output {
+        "{\"execution_mode\":\"not_applicable\"}".to_string()
+    }
+}
+
+impl super::DatabaseBackedConfig for UcsDefaultExecutionMode {
+    const KEY: &'static str = "ucs_rollout_config_default";
+    /// Global key — does not vary by dimension
+    fn db_key(_dimensions: &impl dimension_state::DimensionsBase) -> Option<String> {
+        Some(Self::KEY.to_string())
+    }
+}

--- a/crates/router/src/core/payments/helpers.rs
+++ b/crates/router/src/core/payments/helpers.rs
@@ -2601,6 +2601,58 @@ pub async fn should_execute_based_on_rollout(
     }
 }
 
+/// Valid execution modes for the global default config (`ucs_rollout_config_default`).
+/// Only `shadow` and `not_applicable` are accepted — `primary` is not a valid global default.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DefaultExecutionMode {
+    Shadow,
+    NotApplicable,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct DefaultExecutionModeConfig {
+    pub execution_mode: DefaultExecutionMode,
+}
+
+/// Looks up `ucs_rollout_config_default` from the config table.
+/// Returns the configured `ExecutionMode` if present and valid.
+/// Returns `None` if the key is absent — caller should fall back to `NotApplicable`.
+pub async fn get_default_execution_mode(
+    state: &SessionState,
+) -> RouterResult<Option<ExecutionMode>> {
+    let key = consts::UCS_DEFAULT_EXECUTION_MODE_KEY;
+    match state.store.find_config_by_key(key).await {
+        Ok(config_row) => {
+            match serde_json::from_str::<DefaultExecutionModeConfig>(&config_row.config) {
+                Ok(default_config) => {
+                    let mode = match default_config.execution_mode {
+                        DefaultExecutionMode::Shadow => ExecutionMode::Shadow,
+                        DefaultExecutionMode::NotApplicable => ExecutionMode::NotApplicable,
+                    };
+                    logger::info!(
+                        execution_mode = ?mode,
+                        "Using default execution mode from config table"
+                    );
+                    Ok(Some(mode))
+                }
+                Err(err) => {
+                    logger::error!(
+                        error = ?err,
+                        config = %config_row.config,
+                        "Failed to parse ucs_rollout_config_default. Falling back to NotApplicable."
+                    );
+                    Ok(None)
+                }
+            }
+        }
+        Err(_) => {
+            logger::debug!("ucs_rollout_config_default not set, falling back to NotApplicable");
+            Ok(None)
+        }
+    }
+}
+
 pub fn determine_standard_vault_action(
     is_network_tokenization_enabled: bool,
     mandate_id: Option<api_models::payments::MandateIds>,

--- a/crates/router/src/core/payments/helpers.rs
+++ b/crates/router/src/core/payments/helpers.rs
@@ -2631,33 +2631,35 @@ pub async fn get_default_execution_config(
 ) -> RouterResult<Option<DefaultExecutionConfig>> {
     let key = consts::UCS_DEFAULT_EXECUTION_MODE_KEY;
     match state.store.find_config_by_key(key).await {
-        Ok(config_row) => match serde_json::from_str::<DefaultExecutionModeConfig>(&config_row.config) {
-            Ok(default_config) => {
-                let mode = match default_config.execution_mode {
-                    DefaultExecutionMode::Shadow => ExecutionMode::Shadow,
-                    DefaultExecutionMode::NotApplicable => ExecutionMode::NotApplicable,
-                };
-                let proxy_override =
-                    create_proxy_override(default_config.http_url, default_config.https_url);
-                logger::info!(
-                    execution_mode = ?mode,
-                    has_proxy_override = proxy_override.is_some(),
-                    "Using default execution config from config table"
-                );
-                Ok(Some(DefaultExecutionConfig {
-                    execution_mode: mode,
-                    proxy_override,
-                }))
+        Ok(config_row) => {
+            match serde_json::from_str::<DefaultExecutionModeConfig>(&config_row.config) {
+                Ok(default_config) => {
+                    let mode = match default_config.execution_mode {
+                        DefaultExecutionMode::Shadow => ExecutionMode::Shadow,
+                        DefaultExecutionMode::NotApplicable => ExecutionMode::NotApplicable,
+                    };
+                    let proxy_override =
+                        create_proxy_override(default_config.http_url, default_config.https_url);
+                    logger::info!(
+                        execution_mode = ?mode,
+                        has_proxy_override = proxy_override.is_some(),
+                        "Using default execution config from config table"
+                    );
+                    Ok(Some(DefaultExecutionConfig {
+                        execution_mode: mode,
+                        proxy_override,
+                    }))
+                }
+                Err(err) => {
+                    logger::error!(
+                        error = ?err,
+                        config = %config_row.config,
+                        "Failed to parse ucs_rollout_config_default. Falling back to NotApplicable."
+                    );
+                    Ok(None)
+                }
             }
-            Err(err) => {
-                logger::error!(
-                    error = ?err,
-                    config = %config_row.config,
-                    "Failed to parse ucs_rollout_config_default. Falling back to NotApplicable."
-                );
-                Ok(None)
-            }
-        },
+        }
         Err(_) => {
             logger::debug!("ucs_rollout_config_default not set, falling back to NotApplicable");
             Ok(None)

--- a/crates/router/src/core/payments/helpers.rs
+++ b/crates/router/src/core/payments/helpers.rs
@@ -2498,7 +2498,7 @@ fn validate_proxy_url(url: Option<String>, url_type: &str) -> Option<String> {
 }
 
 /// Creates proxy override with validated URLs and logging
-fn create_proxy_override(
+pub(crate) fn create_proxy_override(
     http_url: Option<String>,
     https_url: Option<String>,
 ) -> Option<ProxyOverride> {
@@ -2613,39 +2613,51 @@ pub enum DefaultExecutionMode {
 #[derive(Debug, Clone, Deserialize)]
 pub struct DefaultExecutionModeConfig {
     pub execution_mode: DefaultExecutionMode,
+    pub http_url: Option<String>,
+    pub https_url: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct DefaultExecutionConfig {
+    pub execution_mode: ExecutionMode,
+    pub proxy_override: Option<ProxyOverride>,
 }
 
 /// Looks up `ucs_rollout_config_default` from the config table.
 /// Returns the configured `ExecutionMode` if present and valid.
 /// Returns `None` if the key is absent — caller should fall back to `NotApplicable`.
-pub async fn get_default_execution_mode(
+pub async fn get_default_execution_config(
     state: &SessionState,
-) -> RouterResult<Option<ExecutionMode>> {
+) -> RouterResult<Option<DefaultExecutionConfig>> {
     let key = consts::UCS_DEFAULT_EXECUTION_MODE_KEY;
     match state.store.find_config_by_key(key).await {
-        Ok(config_row) => {
-            match serde_json::from_str::<DefaultExecutionModeConfig>(&config_row.config) {
-                Ok(default_config) => {
-                    let mode = match default_config.execution_mode {
-                        DefaultExecutionMode::Shadow => ExecutionMode::Shadow,
-                        DefaultExecutionMode::NotApplicable => ExecutionMode::NotApplicable,
-                    };
-                    logger::info!(
-                        execution_mode = ?mode,
-                        "Using default execution mode from config table"
-                    );
-                    Ok(Some(mode))
-                }
-                Err(err) => {
-                    logger::error!(
-                        error = ?err,
-                        config = %config_row.config,
-                        "Failed to parse ucs_rollout_config_default. Falling back to NotApplicable."
-                    );
-                    Ok(None)
-                }
+        Ok(config_row) => match serde_json::from_str::<DefaultExecutionModeConfig>(&config_row.config) {
+            Ok(default_config) => {
+                let mode = match default_config.execution_mode {
+                    DefaultExecutionMode::Shadow => ExecutionMode::Shadow,
+                    DefaultExecutionMode::NotApplicable => ExecutionMode::NotApplicable,
+                };
+                let proxy_override =
+                    create_proxy_override(default_config.http_url, default_config.https_url);
+                logger::info!(
+                    execution_mode = ?mode,
+                    has_proxy_override = proxy_override.is_some(),
+                    "Using default execution config from config table"
+                );
+                Ok(Some(DefaultExecutionConfig {
+                    execution_mode: mode,
+                    proxy_override,
+                }))
             }
-        }
+            Err(err) => {
+                logger::error!(
+                    error = ?err,
+                    config = %config_row.config,
+                    "Failed to parse ucs_rollout_config_default. Falling back to NotApplicable."
+                );
+                Ok(None)
+            }
+        },
         Err(_) => {
             logger::debug!("ucs_rollout_config_default not set, falling back to NotApplicable");
             Ok(None)

--- a/crates/router/src/core/unified_connector_service.rs
+++ b/crates/router/src/core/unified_connector_service.rs
@@ -47,8 +47,7 @@ use crate::{
         payments::{
             helpers::{
                 get_default_execution_mode, is_ucs_enabled, should_execute_based_on_rollout,
-                MerchantConnectorAccountType,
-                ProxyOverride,
+                MerchantConnectorAccountType, ProxyOverride,
             },
             OperationSessionGetters, OperationSessionSetters,
         },

--- a/crates/router/src/core/unified_connector_service.rs
+++ b/crates/router/src/core/unified_connector_service.rs
@@ -46,7 +46,8 @@ use crate::{
         errors::{self, RouterResult},
         payments::{
             helpers::{
-                is_ucs_enabled, should_execute_based_on_rollout, MerchantConnectorAccountType,
+                get_default_execution_mode, is_ucs_enabled, should_execute_based_on_rollout,
+                MerchantConnectorAccountType,
                 ProxyOverride,
             },
             OperationSessionGetters, OperationSessionSetters,
@@ -383,12 +384,14 @@ where
             | CallConnectorAction::HandleResponseWithoutBuildRequest
             | CallConnectorAction::Avoid
             | CallConnectorAction::StatusUpdate { .. } => {
-                // If a rollout config key exists use its execution mode,
-                // otherwise default to Shadow so all traffic mirrors through UCS.
+                // If a rollout config key exists use its execution mode.
+                // Otherwise look up `ucs_rollout_config_default`; if absent fall back to NotApplicable.
                 let execution_mode = if rollout_result.should_execute {
                     rollout_result.execution_mode
                 } else {
-                    ExecutionMode::Shadow
+                    get_default_execution_mode(state)
+                        .await?
+                        .unwrap_or(ExecutionMode::NotApplicable)
                 };
                 decide_execution_path(connector_integration_type, previous_gateway, execution_mode)?
             }

--- a/crates/router/src/core/unified_connector_service.rs
+++ b/crates/router/src/core/unified_connector_service.rs
@@ -43,15 +43,15 @@ use crate::types::api::enums as api_enums;
 use crate::{
     consts,
     core::{
+        configs::{dimension_config::UcsDefaultExecutionMode, dimension_state},
         errors::{self, RouterResult},
         payments::{
             helpers::{
-                is_ucs_enabled, should_execute_based_on_rollout,
-                MerchantConnectorAccountType, ProxyOverride,
+                is_ucs_enabled, should_execute_based_on_rollout, MerchantConnectorAccountType,
+                ProxyOverride,
             },
             OperationSessionGetters, OperationSessionSetters,
         },
-        configs::{dimension_config::UcsDefaultExecutionMode, dimension_state},
         utils::get_flow_name,
     },
     events::connector_api_logs::ConnectorEvent,
@@ -397,28 +397,29 @@ where
                     // Look up `ucs_rollout_config_default` via the dimension config pattern
                     // (Superposition → DB → hardcoded "{\"execution_mode\":\"not_applicable\"}").
                     let dimensions = dimension_state::Dimensions::new();
-                    let config_str =
-                        crate::core::configs::fetch_db_config_for_dimensions::<UcsDefaultExecutionMode>(
-                            state.store.as_ref(),
-                            state.superposition_service.as_ref(),
-                            &dimensions,
-                            None,
-                        )
-                        .await;
+                    let config_str = crate::core::configs::fetch_db_config_for_dimensions::<
+                        UcsDefaultExecutionMode,
+                    >(
+                        state.store.as_ref(),
+                        state.superposition_service.as_ref(),
+                        &dimensions,
+                        None,
+                    )
+                    .await;
                     use crate::core::payments::helpers::{
                         create_proxy_override, DefaultExecutionMode, DefaultExecutionModeConfig,
                     };
                     serde_json::from_str::<DefaultExecutionModeConfig>(&config_str)
-                    .map(|config| {
-                        let mode = match config.execution_mode {
-                            DefaultExecutionMode::Shadow => ExecutionMode::Shadow,
-                            DefaultExecutionMode::NotApplicable => ExecutionMode::NotApplicable,
-                        };
-                        let proxy_override =
-                            create_proxy_override(config.http_url, config.https_url);
-                        (mode, proxy_override)
-                    })
-                    .unwrap_or_else(|_| (ExecutionMode::NotApplicable, None))
+                        .map(|config| {
+                            let mode = match config.execution_mode {
+                                DefaultExecutionMode::Shadow => ExecutionMode::Shadow,
+                                DefaultExecutionMode::NotApplicable => ExecutionMode::NotApplicable,
+                            };
+                            let proxy_override =
+                                create_proxy_override(config.http_url, config.https_url);
+                            (mode, proxy_override)
+                        })
+                        .unwrap_or_else(|_| (ExecutionMode::NotApplicable, None))
                 };
 
                 let (gateway_system, execution_path) = decide_execution_path(

--- a/crates/router/src/core/unified_connector_service.rs
+++ b/crates/router/src/core/unified_connector_service.rs
@@ -46,11 +46,12 @@ use crate::{
         errors::{self, RouterResult},
         payments::{
             helpers::{
-                get_default_execution_mode, is_ucs_enabled, should_execute_based_on_rollout,
+                is_ucs_enabled, should_execute_based_on_rollout,
                 MerchantConnectorAccountType, ProxyOverride,
             },
             OperationSessionGetters, OperationSessionSetters,
         },
+        configs::{dimension_config::UcsDefaultExecutionMode, dimension_state},
         utils::get_flow_name,
     },
     events::connector_api_logs::ConnectorEvent,
@@ -340,7 +341,9 @@ where
     let rollout_result = should_execute_based_on_rollout(state, &rollout_key).await?;
 
     // Single decision point using pattern matching
-    let (gateway_system, mut execution_path) = if ucs_availability == UcsAvailability::Disabled {
+    let (gateway_system, mut execution_path, selected_proxy_override) = if ucs_availability
+        == UcsAvailability::Disabled
+    {
         match call_connector_action {
             CallConnectorAction::UCSConsumeResponse(_)
             | CallConnectorAction::UCSHandleResponse(_) => {
@@ -353,7 +356,7 @@ where
             | CallConnectorAction::HandleResponseWithoutBuildRequest
             | CallConnectorAction::StatusUpdate { .. } => {
                 router_env::logger::debug!("UCS is disabled, using Direct gateway");
-                (GatewaySystem::Direct, ExecutionPath::Direct)
+                (GatewaySystem::Direct, ExecutionPath::Direct, None)
             }
         }
     } else {
@@ -364,6 +367,7 @@ where
                 (
                     GatewaySystem::UnifiedConnectorService,
                     ExecutionPath::UnifiedConnectorService,
+                    None,
                 )
             }
             CallConnectorAction::HandleResponse(_) => {
@@ -374,25 +378,55 @@ where
                     (
                         GatewaySystem::Direct,
                         ExecutionPath::ShadowUnifiedConnectorService,
+                        None,
                     )
                 } else {
-                    (GatewaySystem::Direct, ExecutionPath::Direct)
+                    (GatewaySystem::Direct, ExecutionPath::Direct, None)
                 }
             }
             CallConnectorAction::Trigger
             | CallConnectorAction::HandleResponseWithoutBuildRequest
             | CallConnectorAction::Avoid
             | CallConnectorAction::StatusUpdate { .. } => {
-                // If a rollout config key exists use its execution mode.
-                // Otherwise look up `ucs_rollout_config_default`; if absent fall back to NotApplicable.
-                let execution_mode = if rollout_result.should_execute {
-                    rollout_result.execution_mode
+                let (execution_mode, selected_proxy_override) = if rollout_result.should_execute {
+                    (
+                        rollout_result.execution_mode,
+                        rollout_result.proxy_override.clone(),
+                    )
                 } else {
-                    get_default_execution_mode(state)
-                        .await?
-                        .unwrap_or(ExecutionMode::NotApplicable)
+                    // Look up `ucs_rollout_config_default` via the dimension config pattern
+                    // (Superposition → DB → hardcoded "{\"execution_mode\":\"not_applicable\"}").
+                    let dimensions = dimension_state::Dimensions::new();
+                    let config_str =
+                        crate::core::configs::fetch_db_config_for_dimensions::<UcsDefaultExecutionMode>(
+                            state.store.as_ref(),
+                            state.superposition_service.as_ref(),
+                            &dimensions,
+                            None,
+                        )
+                        .await;
+                    use crate::core::payments::helpers::{
+                        create_proxy_override, DefaultExecutionMode, DefaultExecutionModeConfig,
+                    };
+                    serde_json::from_str::<DefaultExecutionModeConfig>(&config_str)
+                    .map(|config| {
+                        let mode = match config.execution_mode {
+                            DefaultExecutionMode::Shadow => ExecutionMode::Shadow,
+                            DefaultExecutionMode::NotApplicable => ExecutionMode::NotApplicable,
+                        };
+                        let proxy_override =
+                            create_proxy_override(config.http_url, config.https_url);
+                        (mode, proxy_override)
+                    })
+                    .unwrap_or_else(|_| (ExecutionMode::NotApplicable, None))
                 };
-                decide_execution_path(connector_integration_type, previous_gateway, execution_mode)?
+
+                let (gateway_system, execution_path) = decide_execution_path(
+                    connector_integration_type,
+                    previous_gateway,
+                    execution_mode,
+                )?;
+                (gateway_system, execution_path, selected_proxy_override)
             }
         }
     };
@@ -400,8 +434,9 @@ where
     // Handle proxy configuration for Shadow UCS flows
     let session_state = match execution_path {
         ExecutionPath::ShadowUnifiedConnectorService => {
-            // For shadow UCS, use rollout_result for proxy configuration since it takes priority
-            match &rollout_result.proxy_override {
+            // Use the selected proxy configuration for shadow UCS. This can come from either
+            // the rollout-specific config or the default DB config.
+            match &selected_proxy_override {
                 Some(proxy_override) => {
                     router_env::logger::debug!(
                         proxy_override = ?proxy_override,


### PR DESCRIPTION
## Summary

- Adds `ucs_rollout_config_default` as a config-table key to control the global UCS default execution mode
- When no merchant/connector rollout config key is found, this key is looked up before falling back
- Accepts `shadow` or `not_applicable` — `primary` is not a valid global default
- If the key is absent, falls back to `NotApplicable` (UCS skipped unless explicitly configured)

Fixes #12148

## Decision flow

```
Rollout config key found?
  YES → use execution_mode from that config
  NO  → look up ucs_rollout_config_default
          shadow         → UCS mirrors alongside legacy
          not_applicable → UCS skipped, legacy handles the payment
          key absent     → NotApplicable (hardcoded fallback)
```

## Config setup

```bash
# Set global default to shadow
curl -X POST 'http://localhost:8080/configs/' \
  -H 'api-key: test_admin' \
  -H 'Content-Type: application/json' \
  -d '{"key": "ucs_rollout_config_default", "value": "{\"execution_mode\": \"shadow\"}"}'

# Set global default to not_applicable
curl -X POST 'http://localhost:8080/configs/' \
  -H 'api-key: test_admin' \
  -H 'Content-Type: application/json' \
  -d '{"key": "ucs_rollout_config_default", "value": "{\"execution_mode\": \"not_applicable\"}"}'

# Update existing key
curl -X POST 'http://localhost:8080/configs/ucs_rollout_config_default' \
  -H 'api-key: test_admin' \
  -H 'Content-Type: application/json' \
  -d '{"key": "ucs_rollout_config_default", "value": "{\"execution_mode\": \"shadow\"}"}'
```

## Files changed

- `crates/router/src/consts.rs` — added `UCS_DEFAULT_EXECUTION_MODE_KEY` constant
- `crates/router/src/core/payments/helpers.rs` — added `DefaultExecutionModeConfig`, `DefaultExecutionMode`, and `get_default_execution_mode`
- `crates/router/src/core/unified_connector_service.rs` — uses `get_default_execution_mode` when no rollout config key is found