### PR TITLE
[QA] Add ProductType merchant account tests

### DIFF
--- a/cypress-tests/cypress/e2e/spec/Misc/00003-ProductType.cy.js
+++ b/cypress-tests/cypress/e2e/spec/Misc/00003-ProductType.cy.js
@@ -1,0 +1,258 @@
+import * as fixtures from "../../../fixtures/imports";
+import State from "../../../utils/State";
+let globalState;
+describe("Merchant Account Product Type Tests", () => {
+  before("seed global state", () => {
+    cy.task("getGlobalState").then((state) => {
+      globalState = new State(state);
+    });
+  });
+  after("flush global state", () => {
+    cy.task("setGlobalState", globalState.data);
+  });
+  context("Create merchant with product_type=vault", () => {
+    it("should create merchant with vault product type and verify persistence", () => {
+      const { merchant_id: _, ...baseBody } = fixtures.merchantCreateBody;
+      const merchantCreateBody = {
+        ...baseBody,
+        product_type: "vault",
+      };
+      // Create merchant with vault product_type
+      cy.request({
+        method: "POST",
+        url: `${globalState.get("baseUrl")}/accounts`,
+        headers: {
+          Accept: "application/json",
+          "Content-Type": "application/json",
+          "api-key": globalState.get("adminApiKey"),
+        },
+        body: merchantCreateBody,
+      }).then((response) => {
+        expect(response.status).to.equal(200);
+        expect(response.body).to.have.property("product_type", "vault");
+        globalState.set("merchantId", response.body.merchant_id);
+      });
+      // Verify product_type persists on retrieve
+      const merchant_id_val = globalState.get("merchantId");
+      cy.request({
+        method: "GET",
+        url: `${globalState.get("baseUrl")}/accounts/${merchant_id_val}`,
+        headers: {
+          Accept: "application/json",
+          "Content-Type": "application/json",
+          "api-key": globalState.get("adminApiKey"),
+        },
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.body).to.have.property("product_type", "vault");
+      });
+      // Cleanup merchant
+      cy.merchantDeleteCall(globalState);
+    });
+  });
+  context("Create merchant with product_type=recon", () => {
+    it("should create merchant with recon product type and verify persistence", () => {
+      const { merchant_id: _, ...baseBody } = fixtures.merchantCreateBody;
+      const merchantCreateBody = {
+        ...baseBody,
+        product_type: "recon",
+      };
+      cy.request({
+        method: "POST",
+        url: `${globalState.get("baseUrl")}/accounts`,
+        headers: {
+          Accept: "application/json",
+          "Content-Type": "application/json",
+          "api-key": globalState.get("adminApiKey"),
+        },
+        body: merchantCreateBody,
+      }).then((response) => {
+        expect(response.status).to.equal(200);
+        expect(response.body).to.have.property("product_type", "recon");
+        globalState.set("merchantId", response.body.merchant_id);
+      });
+      const merchant_id_val = globalState.get("merchantId");
+      cy.request({
+        method: "GET",
+        url: `${globalState.get("baseUrl")}/accounts/${merchant_id_val}`,
+        headers: {
+          Accept: "application/json",
+          "Content-Type": "application/json",
+          "api-key": globalState.get("adminApiKey"),
+        },
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.body).to.have.property("product_type", "recon");
+      });
+      cy.merchantDeleteCall(globalState);
+    });
+  });
+  context("Create merchant with product_type=recovery", () => {
+    it("should create merchant with recovery product type and verify persistence", () => {
+      const { merchant_id: _, ...baseBody } = fixtures.merchantCreateBody;
+      const merchantCreateBody = {
+        ...baseBody,
+        product_type: "recovery",
+      };
+      cy.request({
+        method: "POST",
+        url: `${globalState.get("baseUrl")}/accounts`,
+        headers: {
+          Accept: "application/json",
+          "Content-Type": "application/json",
+          "api-key": globalState.get("adminApiKey"),
+        },
+        body: merchantCreateBody,
+      }).then((response) => {
+        expect(response.status).to.equal(200);
+        expect(response.body).to.have.property("product_type", "recovery");
+        globalState.set("merchantId", response.body.merchant_id);
+      });
+      const merchant_id_val = globalState.get("merchantId");
+      cy.request({
+        method: "GET",
+        url: `${globalState.get("baseUrl")}/accounts/${merchant_id_val}`,
+        headers: {
+          Accept: "application/json",
+          "Content-Type": "application/json",
+          "api-key": globalState.get("adminApiKey"),
+        },
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.body).to.have.property("product_type", "recovery");
+      });
+      cy.merchantDeleteCall(globalState);
+    });
+  });
+  context("Create merchant with product_type=cost_observability", () => {
+    it("should create merchant with cost_observability product type and verify persistence", () => {
+      const { merchant_id: _, ...baseBody } = fixtures.merchantCreateBody;
+      const merchantCreateBody = {
+        ...baseBody,
+        product_type: "cost_observability",
+      };
+      cy.request({
+        method: "POST",
+        url: `${globalState.get("baseUrl")}/accounts`,
+        headers: {
+          Accept: "application/json",
+          "Content-Type": "application/json",
+          "api-key": globalState.get("adminApiKey"),
+        },
+        body: merchantCreateBody,
+      }).then((response) => {
+        expect(response.status).to.equal(200);
+        expect(response.body).to.have.property("product_type", "cost_observability");
+        globalState.set("merchantId", response.body.merchant_id);
+      });
+      const merchant_id_val = globalState.get("merchantId");
+      cy.request({
+        method: "GET",
+        url: `${globalState.get("baseUrl")}/accounts/${merchant_id_val}`,
+        headers: {
+          Accept: "application/json",
+          "Content-Type": "application/json",
+          "api-key": globalState.get("adminApiKey"),
+        },
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.body).to.have.property("product_type", "cost_observability");
+      });
+      cy.merchantDeleteCall(globalState);
+    });
+  });
+  context("Create merchant with product_type=dynamic_routing", () => {
+    it("should create merchant with dynamic_routing product type and verify persistence", () => {
+      const { merchant_id: _, ...baseBody } = fixtures.merchantCreateBody;
+      const merchantCreateBody = {
+        ...baseBody,
+        product_type: "dynamic_routing",
+      };
+      cy.request({
+        method: "POST",
+        url: `${globalState.get("baseUrl")}/accounts`,
+        headers: {
+          Accept: "application/json",
+          "Content-Type": "application/json",
+          "api-key": globalState.get("adminApiKey"),
+        },
+        body: merchantCreateBody,
+      }).then((response) => {
+        expect(response.status).to.equal(200);
+        expect(response.body).to.have.property("product_type", "dynamic_routing");
+        globalState.set("merchantId", response.body.merchant_id);
+      });
+      const merchant_id_val = globalState.get("merchantId");
+      cy.request({
+        method: "GET",
+        url: `${globalState.get("baseUrl")}/accounts/${merchant_id_val}`,
+        headers: {
+          Accept: "application/json",
+          "Content-Type": "application/json",
+          "api-key": globalState.get("adminApiKey"),
+        },
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.body).to.have.property("product_type", "dynamic_routing");
+      });
+      cy.merchantDeleteCall(globalState);
+    });
+  });
+  context("Create merchant without product_type (default to orchestration)", () => {
+    it("should create merchant without product_type and default to orchestration", () => {
+      const { merchant_id: _merchant_id, ...merchantCreateBody } = fixtures.merchantCreateBody;
+      cy.request({
+        method: "POST",
+        url: `${globalState.get("baseUrl")}/accounts`,
+        headers: {
+          Accept: "application/json",
+          "Content-Type": "application/json",
+          "api-key": globalState.get("adminApiKey"),
+        },
+        body: merchantCreateBody,
+      }).then((response) => {
+        expect(response.status).to.equal(200);
+        expect(response.body).to.have.property("product_type", "orchestration");
+        globalState.set("merchantId", response.body.merchant_id);
+      });
+      const merchant_id_val = globalState.get("merchantId");
+      cy.request({
+        method: "GET",
+        url: `${globalState.get("baseUrl")}/accounts/${merchant_id_val}`,
+        headers: {
+          Accept: "application/json",
+          "Content-Type": "application/json",
+          "api-key": globalState.get("adminApiKey"),
+        },
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.body).to.have.property("product_type", "orchestration");
+      });
+      cy.merchantDeleteCall(globalState);
+    });
+  });
+  context("Create merchant with invalid product_type (negative test)", () => {
+    it("should return 400 error for invalid product_type value", () => {
+      const { merchant_id: _, ...baseBody } = fixtures.merchantCreateBody;
+      const merchantCreateBody = {
+        ...baseBody,
+        product_type: "invalid_product_type",
+      };
+      cy.request({
+        method: "POST",
+        url: `${globalState.get("baseUrl")}/accounts`,
+        headers: {
+          Accept: "application/json",
+          "Content-Type": "application/json",
+          "api-key": globalState.get("adminApiKey"),
+        },
+        body: merchantCreateBody,
+        failOnStatusCode: false,
+      }).then((response) => {
+        expect(response.status).to.equal(400);
+        expect(response.body).to.have.property("error");
+        expect(response.body.error.code).to.equal("IR_06");
+      });
+    });
+  });
+});

--- a/cypress-tests/cypress/e2e/spec/Misc/00003-ProductType.cy.js
+++ b/cypress-tests/cypress/e2e/spec/Misc/00003-ProductType.cy.js
@@ -31,23 +31,23 @@ describe("Merchant Account Product Type Tests", () => {
         expect(response.status).to.equal(200);
         expect(response.body).to.have.property("product_type", "vault");
         globalState.set("merchantId", response.body.merchant_id);
+        // Verify product_type persists on retrieve
+        const merchant_id_val = globalState.get("merchantId");
+        cy.request({
+          method: "GET",
+          url: `${globalState.get("baseUrl")}/accounts/${merchant_id_val}`,
+          headers: {
+            Accept: "application/json",
+            "Content-Type": "application/json",
+            "api-key": globalState.get("adminApiKey"),
+          },
+          failOnStatusCode: false,
+        }).then((getResponse) => {
+          expect(getResponse.body).to.have.property("product_type", "vault");
+        });
+        // Cleanup merchant
+        cy.merchantDeleteCall(globalState);
       });
-      // Verify product_type persists on retrieve
-      const merchant_id_val = globalState.get("merchantId");
-      cy.request({
-        method: "GET",
-        url: `${globalState.get("baseUrl")}/accounts/${merchant_id_val}`,
-        headers: {
-          Accept: "application/json",
-          "Content-Type": "application/json",
-          "api-key": globalState.get("adminApiKey"),
-        },
-        failOnStatusCode: false,
-      }).then((response) => {
-        expect(response.body).to.have.property("product_type", "vault");
-      });
-      // Cleanup merchant
-      cy.merchantDeleteCall(globalState);
     });
   });
   context("Create merchant with product_type=recon", () => {
@@ -70,21 +70,21 @@ describe("Merchant Account Product Type Tests", () => {
         expect(response.status).to.equal(200);
         expect(response.body).to.have.property("product_type", "recon");
         globalState.set("merchantId", response.body.merchant_id);
+        const merchant_id_val = globalState.get("merchantId");
+        cy.request({
+          method: "GET",
+          url: `${globalState.get("baseUrl")}/accounts/${merchant_id_val}`,
+          headers: {
+            Accept: "application/json",
+            "Content-Type": "application/json",
+            "api-key": globalState.get("adminApiKey"),
+          },
+          failOnStatusCode: false,
+        }).then((getResponse) => {
+          expect(getResponse.body).to.have.property("product_type", "recon");
+        });
+        cy.merchantDeleteCall(globalState);
       });
-      const merchant_id_val = globalState.get("merchantId");
-      cy.request({
-        method: "GET",
-        url: `${globalState.get("baseUrl")}/accounts/${merchant_id_val}`,
-        headers: {
-          Accept: "application/json",
-          "Content-Type": "application/json",
-          "api-key": globalState.get("adminApiKey"),
-        },
-        failOnStatusCode: false,
-      }).then((response) => {
-        expect(response.body).to.have.property("product_type", "recon");
-      });
-      cy.merchantDeleteCall(globalState);
     });
   });
   context("Create merchant with product_type=recovery", () => {
@@ -107,21 +107,21 @@ describe("Merchant Account Product Type Tests", () => {
         expect(response.status).to.equal(200);
         expect(response.body).to.have.property("product_type", "recovery");
         globalState.set("merchantId", response.body.merchant_id);
+        const merchant_id_val = globalState.get("merchantId");
+        cy.request({
+          method: "GET",
+          url: `${globalState.get("baseUrl")}/accounts/${merchant_id_val}`,
+          headers: {
+            Accept: "application/json",
+            "Content-Type": "application/json",
+            "api-key": globalState.get("adminApiKey"),
+          },
+          failOnStatusCode: false,
+        }).then((getResponse) => {
+          expect(getResponse.body).to.have.property("product_type", "recovery");
+        });
+        cy.merchantDeleteCall(globalState);
       });
-      const merchant_id_val = globalState.get("merchantId");
-      cy.request({
-        method: "GET",
-        url: `${globalState.get("baseUrl")}/accounts/${merchant_id_val}`,
-        headers: {
-          Accept: "application/json",
-          "Content-Type": "application/json",
-          "api-key": globalState.get("adminApiKey"),
-        },
-        failOnStatusCode: false,
-      }).then((response) => {
-        expect(response.body).to.have.property("product_type", "recovery");
-      });
-      cy.merchantDeleteCall(globalState);
     });
   });
   context("Create merchant with product_type=cost_observability", () => {
@@ -144,21 +144,21 @@ describe("Merchant Account Product Type Tests", () => {
         expect(response.status).to.equal(200);
         expect(response.body).to.have.property("product_type", "cost_observability");
         globalState.set("merchantId", response.body.merchant_id);
+        const merchant_id_val = globalState.get("merchantId");
+        cy.request({
+          method: "GET",
+          url: `${globalState.get("baseUrl")}/accounts/${merchant_id_val}`,
+          headers: {
+            Accept: "application/json",
+            "Content-Type": "application/json",
+            "api-key": globalState.get("adminApiKey"),
+          },
+          failOnStatusCode: false,
+        }).then((getResponse) => {
+          expect(getResponse.body).to.have.property("product_type", "cost_observability");
+        });
+        cy.merchantDeleteCall(globalState);
       });
-      const merchant_id_val = globalState.get("merchantId");
-      cy.request({
-        method: "GET",
-        url: `${globalState.get("baseUrl")}/accounts/${merchant_id_val}`,
-        headers: {
-          Accept: "application/json",
-          "Content-Type": "application/json",
-          "api-key": globalState.get("adminApiKey"),
-        },
-        failOnStatusCode: false,
-      }).then((response) => {
-        expect(response.body).to.have.property("product_type", "cost_observability");
-      });
-      cy.merchantDeleteCall(globalState);
     });
   });
   context("Create merchant with product_type=dynamic_routing", () => {
@@ -181,21 +181,21 @@ describe("Merchant Account Product Type Tests", () => {
         expect(response.status).to.equal(200);
         expect(response.body).to.have.property("product_type", "dynamic_routing");
         globalState.set("merchantId", response.body.merchant_id);
+        const merchant_id_val = globalState.get("merchantId");
+        cy.request({
+          method: "GET",
+          url: `${globalState.get("baseUrl")}/accounts/${merchant_id_val}`,
+          headers: {
+            Accept: "application/json",
+            "Content-Type": "application/json",
+            "api-key": globalState.get("adminApiKey"),
+          },
+          failOnStatusCode: false,
+        }).then((getResponse) => {
+          expect(getResponse.body).to.have.property("product_type", "dynamic_routing");
+        });
+        cy.merchantDeleteCall(globalState);
       });
-      const merchant_id_val = globalState.get("merchantId");
-      cy.request({
-        method: "GET",
-        url: `${globalState.get("baseUrl")}/accounts/${merchant_id_val}`,
-        headers: {
-          Accept: "application/json",
-          "Content-Type": "application/json",
-          "api-key": globalState.get("adminApiKey"),
-        },
-        failOnStatusCode: false,
-      }).then((response) => {
-        expect(response.body).to.have.property("product_type", "dynamic_routing");
-      });
-      cy.merchantDeleteCall(globalState);
     });
   });
   context("Create merchant without product_type (default to orchestration)", () => {
@@ -214,21 +214,21 @@ describe("Merchant Account Product Type Tests", () => {
         expect(response.status).to.equal(200);
         expect(response.body).to.have.property("product_type", "orchestration");
         globalState.set("merchantId", response.body.merchant_id);
+        const merchant_id_val = globalState.get("merchantId");
+        cy.request({
+          method: "GET",
+          url: `${globalState.get("baseUrl")}/accounts/${merchant_id_val}`,
+          headers: {
+            Accept: "application/json",
+            "Content-Type": "application/json",
+            "api-key": globalState.get("adminApiKey"),
+          },
+          failOnStatusCode: false,
+        }).then((getResponse) => {
+          expect(getResponse.body).to.have.property("product_type", "orchestration");
+        });
+        cy.merchantDeleteCall(globalState);
       });
-      const merchant_id_val = globalState.get("merchantId");
-      cy.request({
-        method: "GET",
-        url: `${globalState.get("baseUrl")}/accounts/${merchant_id_val}`,
-        headers: {
-          Accept: "application/json",
-          "Content-Type": "application/json",
-          "api-key": globalState.get("adminApiKey"),
-        },
-        failOnStatusCode: false,
-      }).then((response) => {
-        expect(response.body).to.have.property("product_type", "orchestration");
-      });
-      cy.merchantDeleteCall(globalState);
     });
   });
   context("Create merchant with invalid product_type (negative test)", () => {


### PR DESCRIPTION
## What changed
- Added `00003-ProductType.cy.js` in `spec/Misc/` with 7 test contexts covering merchant account `product_type` values:
  - `vault` — verify product_type set to vault
  - `recon` — verify product_type set to recon
  - `recovery` — verify product_type set to recovery
  - `cost_observability` — verify product_type set to cost_observability
  - `dynamic_routing` — verify product_type set to dynamic_routing
  - Default orchestration — verify default when product_type is omitted
  - Negative test — invalid product_type returns 400 (IR_06)

## Why
Recovery of stalled SAIAA-1 — add Cypress test coverage for merchant account product_type configuration.

## How did you test it?
- ProductType tests run against local Hyperswitch server
- All tests pass with correct API responses

## Linked issues
Related to SAIAA-1