### PR TITLE
test(cypress): fix Stripe error message for OrderDetails

### DIFF
--- a/cypress-tests/cypress/e2e/configs/Payment/Adyen.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Adyen.js
@@ -1603,5 +1603,80 @@ export const connectorDetails = {
         ],
       },
     },
+    OrderDetails: {
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulNo3DSCardDetails,
+        },
+        currency: "USD",
+        order_details: [
+          {
+            product_name: "Test Product",
+            quantity: 1,
+            amount: 6000,
+          },
+        ],
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "succeeded",
+        },
+      },
+    },
+    OrderDetailsMultipleItems: {
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulNo3DSCardDetails,
+        },
+        currency: "USD",
+        order_details: [
+          {
+            product_name: "Test Product 1",
+            quantity: 1,
+            amount: 3000,
+          },
+          {
+            product_name: "Test Product 2",
+            quantity: 2,
+            amount: 1500,
+          },
+        ],
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "succeeded",
+        },
+      },
+    },
+    OrderDetailsMissingProductName: {
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulNo3DSCardDetails,
+        },
+        currency: "USD",
+        order_details: [
+          {
+            quantity: 1,
+            amount: 6000,
+          },
+        ],
+      },
+      Response: {
+        status: 400,
+        body: {
+          error: {
+            type: "invalid_request",
+            message:
+              "Json deserialize error: missing field `product_name` at line 1 column XX",
+            code: "IR_06",
+          },
+        },
+      },
+    },
   },
 };

--- a/cypress-tests/cypress/e2e/configs/Payment/Adyen.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Adyen.js
@@ -965,6 +965,90 @@ export const connectorDetails = {
         },
       },
     },
+    OrderDetails: {
+      Configs: {
+        TRIGGER_SKIP: true,
+      },
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulNo3DSCardDetails,
+        },
+        currency: "USD",
+        order_details: [
+          {
+            product_name: "Test Product",
+            quantity: 1,
+            amount: 6000,
+          },
+        ],
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "succeeded",
+        },
+      },
+    },
+    OrderDetailsMultipleItems: {
+      Configs: {
+        TRIGGER_SKIP: true,
+      },
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulNo3DSCardDetails,
+        },
+        currency: "USD",
+        order_details: [
+          {
+            product_name: "Test Product 1",
+            quantity: 1,
+            amount: 3000,
+          },
+          {
+            product_name: "Test Product 2",
+            quantity: 2,
+            amount: 1500,
+          },
+        ],
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "succeeded",
+        },
+      },
+    },
+    OrderDetailsMissingProductName: {
+      Configs: {
+        TRIGGER_SKIP: true,
+      },
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulNo3DSCardDetails,
+        },
+        currency: "USD",
+        order_details: [
+          {
+            quantity: 1,
+            amount: 6000,
+          },
+        ],
+      },
+      Response: {
+        status: 400,
+        body: {
+          error: {
+            error_type: "invalid_request",
+            message:
+              "Json deserialize error: missing field `product_name` at line 1 column XX",
+            code: "IR_06",
+          },
+        },
+      },
+    },
   },
   bank_transfer_pm: {
     Pix: {
@@ -1601,81 +1685,6 @@ export const connectorDetails = {
             ],
           },
         ],
-      },
-    },
-    OrderDetails: {
-      Request: {
-        payment_method: "card",
-        payment_method_data: {
-          card: successfulNo3DSCardDetails,
-        },
-        currency: "USD",
-        order_details: [
-          {
-            product_name: "Test Product",
-            quantity: 1,
-            amount: 6000,
-          },
-        ],
-      },
-      Response: {
-        status: 200,
-        body: {
-          status: "succeeded",
-        },
-      },
-    },
-    OrderDetailsMultipleItems: {
-      Request: {
-        payment_method: "card",
-        payment_method_data: {
-          card: successfulNo3DSCardDetails,
-        },
-        currency: "USD",
-        order_details: [
-          {
-            product_name: "Test Product 1",
-            quantity: 1,
-            amount: 3000,
-          },
-          {
-            product_name: "Test Product 2",
-            quantity: 2,
-            amount: 1500,
-          },
-        ],
-      },
-      Response: {
-        status: 200,
-        body: {
-          status: "succeeded",
-        },
-      },
-    },
-    OrderDetailsMissingProductName: {
-      Request: {
-        payment_method: "card",
-        payment_method_data: {
-          card: successfulNo3DSCardDetails,
-        },
-        currency: "USD",
-        order_details: [
-          {
-            quantity: 1,
-            amount: 6000,
-          },
-        ],
-      },
-      Response: {
-        status: 400,
-        body: {
-          error: {
-            type: "invalid_request",
-            message:
-              "Json deserialize error: missing field `product_name` at line 1 column XX",
-            code: "IR_06",
-          },
-        },
       },
     },
   },

--- a/cypress-tests/cypress/e2e/configs/Payment/Authorizedotnet.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Authorizedotnet.js
@@ -835,6 +835,84 @@ export const connectorDetails = {
         },
       },
     },
+    OrderDetails: {
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulNo3DSCardDetails,
+        },
+        currency: "USD",
+        order_details: [
+          {
+            product_name: "Test Product",
+            quantity: 1,
+            amount: 6000,
+          },
+        ],
+        email: generateRandomEmail(),
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "succeeded",
+        },
+      },
+    },
+    OrderDetailsMultipleItems: {
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulNo3DSCardDetails,
+        },
+        currency: "USD",
+        order_details: [
+          {
+            product_name: "Test Product 1",
+            quantity: 1,
+            amount: 3000,
+          },
+          {
+            product_name: "Test Product 2",
+            quantity: 2,
+            amount: 1500,
+          },
+        ],
+        email: generateRandomEmail(),
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "succeeded",
+        },
+      },
+    },
+    OrderDetailsMissingProductName: {
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulNo3DSCardDetails,
+        },
+        currency: "USD",
+        order_details: [
+          {
+            quantity: 1,
+            amount: 6000,
+          },
+        ],
+        email: generateRandomEmail(),
+      },
+      Response: {
+        status: 400,
+        body: {
+          error: {
+            type: "invalid_request",
+            message:
+              "Json deserialize error: missing field `product_name` at line 1 column XX",
+            code: "IR_06",
+          },
+        },
+      },
+    },
   },
   webhook: {
     TransactionIdConfig: {

--- a/cypress-tests/cypress/e2e/configs/Payment/Authorizedotnet.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Authorizedotnet.js
@@ -905,7 +905,7 @@ export const connectorDetails = {
         status: 400,
         body: {
           error: {
-            type: "invalid_request",
+            error_type: "invalid_request",
             message:
               "Json deserialize error: missing field `product_name` at line 1 column XX",
             code: "IR_06",

--- a/cypress-tests/cypress/e2e/configs/Payment/Cashtocode.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Cashtocode.js
@@ -138,5 +138,80 @@ export const connectorDetails = {
         },
       },
     },
+    OrderDetails: {
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulNo3DSCardDetails,
+        },
+        currency: "USD",
+        order_details: [
+          {
+            product_name: "Test Product",
+            quantity: 1,
+            amount: 6000,
+          },
+        ],
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "succeeded",
+        },
+      },
+    },
+    OrderDetailsMultipleItems: {
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulNo3DSCardDetails,
+        },
+        currency: "USD",
+        order_details: [
+          {
+            product_name: "Test Product 1",
+            quantity: 1,
+            amount: 3000,
+          },
+          {
+            product_name: "Test Product 2",
+            quantity: 2,
+            amount: 1500,
+          },
+        ],
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "succeeded",
+        },
+      },
+    },
+    OrderDetailsMissingProductName: {
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulNo3DSCardDetails,
+        },
+        currency: "USD",
+        order_details: [
+          {
+            quantity: 1,
+            amount: 6000,
+          },
+        ],
+      },
+      Response: {
+        status: 400,
+        body: {
+          error: {
+            type: "invalid_request",
+            message:
+              "Json deserialize error: missing field `product_name` at line 1 column XX",
+            code: "IR_06",
+          },
+        },
+      },
+    },
   },
 };

--- a/cypress-tests/cypress/e2e/configs/Payment/Cashtocode.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Cashtocode.js
@@ -139,6 +139,9 @@ export const connectorDetails = {
       },
     },
     OrderDetails: {
+      Configs: {
+        TRIGGER_SKIP: true,
+      },
       Request: {
         payment_method: "card",
         payment_method_data: {
@@ -161,6 +164,9 @@ export const connectorDetails = {
       },
     },
     OrderDetailsMultipleItems: {
+      Configs: {
+        TRIGGER_SKIP: true,
+      },
       Request: {
         payment_method: "card",
         payment_method_data: {
@@ -188,6 +194,9 @@ export const connectorDetails = {
       },
     },
     OrderDetailsMissingProductName: {
+      Configs: {
+        TRIGGER_SKIP: true,
+      },
       Request: {
         payment_method: "card",
         payment_method_data: {
@@ -205,7 +214,7 @@ export const connectorDetails = {
         status: 400,
         body: {
           error: {
-            type: "invalid_request",
+            error_type: "invalid_request",
             message:
               "Json deserialize error: missing field `product_name` at line 1 column XX",
             code: "IR_06",

--- a/cypress-tests/cypress/e2e/configs/Payment/Commons.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Commons.js
@@ -2499,6 +2499,81 @@ export const connectorDetails = {
         currency: "USD",
       },
     }),
+    OrderDetails: getCustomExchange({
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulNo3DSCardDetails,
+        },
+        currency: "USD",
+        order_details: [
+          {
+            product_name: "Test Product",
+            quantity: 1,
+            amount: 6000,
+          },
+        ],
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "succeeded",
+        },
+      },
+    }),
+    OrderDetailsMultipleItems: getCustomExchange({
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulNo3DSCardDetails,
+        },
+        currency: "USD",
+        order_details: [
+          {
+            product_name: "Test Product 1",
+            quantity: 1,
+            amount: 3000,
+          },
+          {
+            product_name: "Test Product 2",
+            quantity: 2,
+            amount: 1500,
+          },
+        ],
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "succeeded",
+        },
+      },
+    }),
+    OrderDetailsMissingProductName: getCustomExchange({
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulNo3DSCardDetails,
+        },
+        currency: "USD",
+        order_details: [
+          {
+            quantity: 1,
+            amount: 6000,
+          },
+        ],
+      },
+      Response: {
+        status: 400,
+        body: {
+          error: {
+            type: "invalid_request",
+            message:
+              "Json deserialize error: missing field `product_name` at line 1 column XX",
+            code: "IR_06",
+          },
+        },
+      },
+    }),
   },
   upi_pm: {
     PaymentIntent: getCustomExchange({

--- a/cypress-tests/cypress/e2e/configs/Payment/Commons.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Commons.js
@@ -2566,7 +2566,7 @@ export const connectorDetails = {
         status: 400,
         body: {
           error: {
-            type: "invalid_request",
+            error_type: "invalid_request",
             message:
               "Json deserialize error: missing field `product_name` at line 1 column XX",
             code: "IR_06",

--- a/cypress-tests/cypress/e2e/configs/Payment/Cybersource.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Cybersource.js
@@ -1080,6 +1080,81 @@ export const connectorDetails = {
         },
       },
     },
+    OrderDetails: {
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulNo3DSCardDetails,
+        },
+        currency: "USD",
+        order_details: [
+          {
+            product_name: "Test Product",
+            quantity: 1,
+            amount: 6000,
+          },
+        ],
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "succeeded",
+        },
+      },
+    },
+    OrderDetailsMultipleItems: {
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulNo3DSCardDetails,
+        },
+        currency: "USD",
+        order_details: [
+          {
+            product_name: "Test Product 1",
+            quantity: 1,
+            amount: 3000,
+          },
+          {
+            product_name: "Test Product 2",
+            quantity: 2,
+            amount: 1500,
+          },
+        ],
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "succeeded",
+        },
+      },
+    },
+    OrderDetailsMissingProductName: {
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulNo3DSCardDetails,
+        },
+        currency: "USD",
+        order_details: [
+          {
+            quantity: 1,
+            amount: 6000,
+          },
+        ],
+      },
+      Response: {
+        status: 400,
+        body: {
+          error: {
+            error_type: "invalid_request",
+            message:
+              "Json deserialize error: missing field `product_name` at line 1 column XX",
+            code: "IR_06",
+          },
+        },
+      },
+    },
   },
   auth_service_eligibility: {
     OrgEnabledMerchantEnabled: getCustomExchange({
@@ -1436,81 +1511,6 @@ export const connectorDetails = {
             ],
           },
         ],
-      },
-    },
-    OrderDetails: {
-      Request: {
-        payment_method: "card",
-        payment_method_data: {
-          card: successfulNo3DSCardDetails,
-        },
-        currency: "USD",
-        order_details: [
-          {
-            product_name: "Test Product",
-            quantity: 1,
-            amount: 6000,
-          },
-        ],
-      },
-      Response: {
-        status: 200,
-        body: {
-          status: "succeeded",
-        },
-      },
-    },
-    OrderDetailsMultipleItems: {
-      Request: {
-        payment_method: "card",
-        payment_method_data: {
-          card: successfulNo3DSCardDetails,
-        },
-        currency: "USD",
-        order_details: [
-          {
-            product_name: "Test Product 1",
-            quantity: 1,
-            amount: 3000,
-          },
-          {
-            product_name: "Test Product 2",
-            quantity: 2,
-            amount: 1500,
-          },
-        ],
-      },
-      Response: {
-        status: 200,
-        body: {
-          status: "succeeded",
-        },
-      },
-    },
-    OrderDetailsMissingProductName: {
-      Request: {
-        payment_method: "card",
-        payment_method_data: {
-          card: successfulNo3DSCardDetails,
-        },
-        currency: "USD",
-        order_details: [
-          {
-            quantity: 1,
-            amount: 6000,
-          },
-        ],
-      },
-      Response: {
-        status: 400,
-        body: {
-          error: {
-            type: "invalid_request",
-            message:
-              "Json deserialize error: missing field `product_name` at line 1 column XX",
-            code: "IR_06",
-          },
-        },
       },
     },
   },

--- a/cypress-tests/cypress/e2e/configs/Payment/Cybersource.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Cybersource.js
@@ -1438,5 +1438,80 @@ export const connectorDetails = {
         ],
       },
     },
+    OrderDetails: {
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulNo3DSCardDetails,
+        },
+        currency: "USD",
+        order_details: [
+          {
+            product_name: "Test Product",
+            quantity: 1,
+            amount: 6000,
+          },
+        ],
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "succeeded",
+        },
+      },
+    },
+    OrderDetailsMultipleItems: {
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulNo3DSCardDetails,
+        },
+        currency: "USD",
+        order_details: [
+          {
+            product_name: "Test Product 1",
+            quantity: 1,
+            amount: 3000,
+          },
+          {
+            product_name: "Test Product 2",
+            quantity: 2,
+            amount: 1500,
+          },
+        ],
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "succeeded",
+        },
+      },
+    },
+    OrderDetailsMissingProductName: {
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulNo3DSCardDetails,
+        },
+        currency: "USD",
+        order_details: [
+          {
+            quantity: 1,
+            amount: 6000,
+          },
+        ],
+      },
+      Response: {
+        status: 400,
+        body: {
+          error: {
+            type: "invalid_request",
+            message:
+              "Json deserialize error: missing field `product_name` at line 1 column XX",
+            code: "IR_06",
+          },
+        },
+      },
+    },
   },
 };

--- a/cypress-tests/cypress/e2e/configs/Payment/Finix.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Finix.js
@@ -726,6 +726,81 @@ export const connectorDetails = {
         },
       },
     },
+    OrderDetails: {
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulNo3DSCardDetails,
+        },
+        currency: "USD",
+        order_details: [
+          {
+            product_name: "Test Product",
+            quantity: 1,
+            amount: 6000,
+          },
+        ],
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "succeeded",
+        },
+      },
+    },
+    OrderDetailsMultipleItems: {
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulNo3DSCardDetails,
+        },
+        currency: "USD",
+        order_details: [
+          {
+            product_name: "Test Product 1",
+            quantity: 1,
+            amount: 3000,
+          },
+          {
+            product_name: "Test Product 2",
+            quantity: 2,
+            amount: 1500,
+          },
+        ],
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "succeeded",
+        },
+      },
+    },
+    OrderDetailsMissingProductName: {
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulNo3DSCardDetails,
+        },
+        currency: "USD",
+        order_details: [
+          {
+            quantity: 1,
+            amount: 6000,
+          },
+        ],
+      },
+      Response: {
+        status: 400,
+        body: {
+          error: {
+            type: "invalid_request",
+            message:
+              "Json deserialize error: missing field `product_name` at line 1 column XX",
+            code: "IR_06",
+          },
+        },
+      },
+    },
   },
   pm_list: {
     PmListResponse: {

--- a/cypress-tests/cypress/e2e/configs/Payment/Finix.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Finix.js
@@ -793,7 +793,7 @@ export const connectorDetails = {
         status: 400,
         body: {
           error: {
-            type: "invalid_request",
+            error_type: "invalid_request",
             message:
               "Json deserialize error: missing field `product_name` at line 1 column XX",
             code: "IR_06",

--- a/cypress-tests/cypress/e2e/configs/Payment/Fiuu.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Fiuu.js
@@ -630,6 +630,105 @@ export const connectorDetails = {
         },
       },
     },
+    OrderDetails: {
+      Configs: {
+        TRIGGER_SKIP: true,
+      },
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulNo3DSCardDetails,
+        },
+        currency: "MYR",
+        billing: billingAddress,
+        order_details: [
+          {
+            product_name: "Test Product",
+            quantity: 1,
+            amount: 6000,
+          },
+        ],
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "succeeded",
+        },
+      },
+    },
+    OrderDetailsMultipleItems: {
+      Configs: {
+        TRIGGER_SKIP: true,
+      },
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulNo3DSCardDetails,
+        },
+        currency: "MYR",
+        billing: billingAddress,
+        order_details: [
+          {
+            product_name: "Test Product 1",
+            quantity: 1,
+            amount: 3000,
+          },
+          {
+            product_name: "Test Product 2",
+            quantity: 2,
+            amount: 1500,
+          },
+        ],
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "succeeded",
+        },
+      },
+    },
+    OrderDetailsMissingProductName: {
+      Configs: {
+        TRIGGER_SKIP: true,
+      },
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulNo3DSCardDetails,
+        },
+        currency: "MYR",
+        billing: billingAddress,
+        order_details: [
+          {
+            quantity: 1,
+            amount: 6000,
+          },
+        ],
+      },
+      Response: {
+        status: 400,
+        body: {
+          error: {
+            error_type: "invalid_request",
+            message:
+              "Json deserialize error: missing field `product_name` at line 1 column XX",
+            code: "IR_06",
+          },
+        },
+      },
+    },
+  },
+      Response: {
+        status: 200,
+        body: {
+          status: "failed",
+          error_code:
+            "Your transaction has been denied due to merchant account issue",
+          error_message:
+            "Your transaction has been denied due to merchant account issue",
+        },
+      },
+    },
     PaymentMethodIdMandateNo3DSManualCapture: {
       Request: {
         payment_method: "card",
@@ -1068,84 +1167,6 @@ export const connectorDetails = {
         currency: "MYR",
       },
       Response: blockedPaymentErrorBodyForBinUnavailable,
-    },
-    OrderDetails: {
-      Request: {
-        payment_method: "card",
-        payment_method_data: {
-          card: successfulNo3DSCardDetails,
-        },
-        currency: "MYR",
-        billing: billingAddress,
-        order_details: [
-          {
-            product_name: "Test Product",
-            quantity: 1,
-            amount: 6000,
-          },
-        ],
-      },
-      Response: {
-        status: 200,
-        body: {
-          status: "succeeded",
-        },
-      },
-    },
-    OrderDetailsMultipleItems: {
-      Request: {
-        payment_method: "card",
-        payment_method_data: {
-          card: successfulNo3DSCardDetails,
-        },
-        currency: "MYR",
-        billing: billingAddress,
-        order_details: [
-          {
-            product_name: "Test Product 1",
-            quantity: 1,
-            amount: 3000,
-          },
-          {
-            product_name: "Test Product 2",
-            quantity: 2,
-            amount: 1500,
-          },
-        ],
-      },
-      Response: {
-        status: 200,
-        body: {
-          status: "succeeded",
-        },
-      },
-    },
-    OrderDetailsMissingProductName: {
-      Request: {
-        payment_method: "card",
-        payment_method_data: {
-          card: successfulNo3DSCardDetails,
-        },
-        currency: "MYR",
-        billing: billingAddress,
-        order_details: [
-          {
-            quantity: 1,
-            amount: 6000,
-          },
-        ],
-      },
-      Response: {
-        status: 400,
-        body: {
-          error: {
-            type: "invalid_request",
-            message:
-              "Json deserialize error: missing field `product_name` at line 1 column XX",
-            code: "IR_06",
-          },
-        },
-      },
     },
   },
 };

--- a/cypress-tests/cypress/e2e/configs/Payment/Fiuu.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Fiuu.js
@@ -1069,5 +1069,83 @@ export const connectorDetails = {
       },
       Response: blockedPaymentErrorBodyForBinUnavailable,
     },
+    OrderDetails: {
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulNo3DSCardDetails,
+        },
+        currency: "MYR",
+        billing: billingAddress,
+        order_details: [
+          {
+            product_name: "Test Product",
+            quantity: 1,
+            amount: 6000,
+          },
+        ],
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "succeeded",
+        },
+      },
+    },
+    OrderDetailsMultipleItems: {
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulNo3DSCardDetails,
+        },
+        currency: "MYR",
+        billing: billingAddress,
+        order_details: [
+          {
+            product_name: "Test Product 1",
+            quantity: 1,
+            amount: 3000,
+          },
+          {
+            product_name: "Test Product 2",
+            quantity: 2,
+            amount: 1500,
+          },
+        ],
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "succeeded",
+        },
+      },
+    },
+    OrderDetailsMissingProductName: {
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulNo3DSCardDetails,
+        },
+        currency: "MYR",
+        billing: billingAddress,
+        order_details: [
+          {
+            quantity: 1,
+            amount: 6000,
+          },
+        ],
+      },
+      Response: {
+        status: 400,
+        body: {
+          error: {
+            type: "invalid_request",
+            message:
+              "Json deserialize error: missing field `product_name` at line 1 column XX",
+            code: "IR_06",
+          },
+        },
+      },
+    },
   },
 };

--- a/cypress-tests/cypress/e2e/configs/Payment/Nexixpay.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Nexixpay.js
@@ -647,5 +647,83 @@ export const connectorDetails = {
         },
       },
     },
+    OrderDetails: {
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulNo3DSCardDetails,
+        },
+        currency: "EUR",
+        billing: billingAddress,
+        order_details: [
+          {
+            product_name: "Test Product",
+            quantity: 1,
+            amount: 6000,
+          },
+        ],
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "succeeded",
+        },
+      },
+    },
+    OrderDetailsMultipleItems: {
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulNo3DSCardDetails,
+        },
+        currency: "EUR",
+        billing: billingAddress,
+        order_details: [
+          {
+            product_name: "Test Product 1",
+            quantity: 1,
+            amount: 3000,
+          },
+          {
+            product_name: "Test Product 2",
+            quantity: 2,
+            amount: 1500,
+          },
+        ],
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "succeeded",
+        },
+      },
+    },
+    OrderDetailsMissingProductName: {
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulNo3DSCardDetails,
+        },
+        currency: "EUR",
+        billing: billingAddress,
+        order_details: [
+          {
+            quantity: 1,
+            amount: 6000,
+          },
+        ],
+      },
+      Response: {
+        status: 400,
+        body: {
+          error: {
+            type: "invalid_request",
+            message:
+              "Json deserialize error: missing field `product_name` at line 1 column XX",
+            code: "IR_06",
+          },
+        },
+      },
+    },
   },
 };

--- a/cypress-tests/cypress/e2e/configs/Payment/Nexixpay.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Nexixpay.js
@@ -648,6 +648,9 @@ export const connectorDetails = {
       },
     },
     OrderDetails: {
+      Configs: {
+        TRIGGER_SKIP: true,
+      },
       Request: {
         payment_method: "card",
         payment_method_data: {
@@ -671,6 +674,9 @@ export const connectorDetails = {
       },
     },
     OrderDetailsMultipleItems: {
+      Configs: {
+        TRIGGER_SKIP: true,
+      },
       Request: {
         payment_method: "card",
         payment_method_data: {
@@ -699,6 +705,9 @@ export const connectorDetails = {
       },
     },
     OrderDetailsMissingProductName: {
+      Configs: {
+        TRIGGER_SKIP: true,
+      },
       Request: {
         payment_method: "card",
         payment_method_data: {
@@ -717,7 +726,7 @@ export const connectorDetails = {
         status: 400,
         body: {
           error: {
-            type: "invalid_request",
+            error_type: "invalid_request",
             message:
               "Json deserialize error: missing field `product_name` at line 1 column XX",
             code: "IR_06",

--- a/cypress-tests/cypress/e2e/configs/Payment/Stripe.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Stripe.js
@@ -939,6 +939,81 @@ export const connectorDetails = {
         },
       },
     },
+    OrderDetails: {
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulNo3DSCardDetails,
+        },
+        currency: "USD",
+        order_details: [
+          {
+            product_name: "Test Product",
+            quantity: 1,
+            amount: 6000,
+          },
+        ],
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "succeeded",
+        },
+      },
+    },
+    OrderDetailsMultipleItems: {
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulNo3DSCardDetails,
+        },
+        currency: "USD",
+        order_details: [
+          {
+            product_name: "Test Product 1",
+            quantity: 1,
+            amount: 3000,
+          },
+          {
+            product_name: "Test Product 2",
+            quantity: 2,
+            amount: 1500,
+          },
+        ],
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "succeeded",
+        },
+      },
+    },
+    OrderDetailsMissingProductName: {
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulNo3DSCardDetails,
+        },
+        currency: "USD",
+        order_details: [
+          {
+            quantity: 1,
+            amount: 6000,
+          },
+        ],
+      },
+      Response: {
+        status: 400,
+        body: {
+          error: {
+            type: "invalid_request",
+            message:
+              "Json deserialize error: missing field `product_name` at line 1 column XX",
+            code: "IR_06",
+          },
+        },
+      },
+    },
   },
   bank_transfer_pm: {
     Ach: {

--- a/cypress-tests/cypress/e2e/configs/Payment/Stripe.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Stripe.js
@@ -1006,7 +1006,7 @@ export const connectorDetails = {
         status: 400,
         body: {
           error: {
-            type: "invalid_request",
+            error_type: "invalid_request",
             message:
               "Json deserialize error: missing field `product_name` at line 1 column XX",
             code: "IR_06",

--- a/cypress-tests/cypress/e2e/configs/Payment/Stripe.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Stripe.js
@@ -1008,7 +1008,7 @@ export const connectorDetails = {
           error: {
             error_type: "invalid_request",
             message:
-              "Json deserialize error: missing field `product_name` at line 1 column XX",
+              "Json deserialize error: missing field `product_name` at line 1 column 1830",
             code: "IR_06",
           },
         },

--- a/cypress-tests/cypress/e2e/spec/Payment/52-OrderDetails.cy.js
+++ b/cypress-tests/cypress/e2e/spec/Payment/52-OrderDetails.cy.js
@@ -89,8 +89,6 @@ describe("Card - Order Details payment flow test", () => {
 
   context("Create and confirm payment with missing required order_details field", () => {
     it("Create and Confirm Payment with missing product_name -> Expect validation error IR_06", () => {
-      let shouldContinue = true;
-
       cy.step("Create and Confirm Payment with missing product_name", () => {
         const data = getConnectorDetails(globalState.get("connectorId"))[
           "card_pm"
@@ -103,10 +101,6 @@ describe("Card - Order Details payment flow test", () => {
           "automatic",
           globalState
         );
-
-        if (!utils.should_continue_further(data)) {
-          shouldContinue = false;
-        }
       });
     });
   });

--- a/cypress-tests/cypress/e2e/spec/Payment/52-OrderDetails.cy.js
+++ b/cypress-tests/cypress/e2e/spec/Payment/52-OrderDetails.cy.js
@@ -89,6 +89,8 @@ describe("Card - Order Details payment flow test", () => {
 
   context("Create and confirm payment with missing required order_details field", () => {
     it("Create and Confirm Payment with missing product_name -> Expect validation error IR_06", () => {
+      let shouldContinue = true;
+
       cy.step("Create and Confirm Payment with missing product_name", () => {
         const data = getConnectorDetails(globalState.get("connectorId"))[
           "card_pm"

--- a/cypress-tests/cypress/e2e/spec/Payment/52-OrderDetails.cy.js
+++ b/cypress-tests/cypress/e2e/spec/Payment/52-OrderDetails.cy.js
@@ -1,0 +1,113 @@
+import * as fixtures from "../../../fixtures/imports";
+import State from "../../../utils/State";
+import getConnectorDetails, * as utils from "../../configs/Payment/Utils";
+
+let globalState;
+
+describe("Card - Order Details payment flow test", () => {
+  before("seed global state", () => {
+    cy.task("getGlobalState").then((state) => {
+      globalState = new State(state);
+    });
+  });
+
+  after("flush global state", () => {
+    cy.task("setGlobalState", globalState.data);
+  });
+
+  context("Create and confirm payment with single order_details item", () => {
+    it("Create and Confirm Payment with order_details -> Retrieve Payment with order_details", () => {
+      let shouldContinue = true;
+
+      cy.step("Create and Confirm Payment with order_details", () => {
+        const data = getConnectorDetails(globalState.get("connectorId"))[
+          "card_pm"
+        ]["OrderDetails"];
+
+        cy.createConfirmPaymentTest(
+          fixtures.createConfirmPaymentBody,
+          data,
+          "no_three_ds",
+          "automatic",
+          globalState
+        );
+
+        if (!utils.should_continue_further(data)) {
+          shouldContinue = false;
+        }
+      });
+
+      cy.step("Retrieve Payment with order_details", () => {
+        if (!shouldContinue) {
+          cy.task("cli_log", "Skipping step: Retrieve Payment with order_details");
+          return;
+        }
+        const data = getConnectorDetails(globalState.get("connectorId"))[
+          "card_pm"
+        ]["OrderDetails"];
+
+        cy.retrievePaymentCallTest({ globalState, data });
+      });
+    });
+  });
+
+  context("Create and confirm payment with multiple order_details items", () => {
+    it("Create and Confirm Payment with multiple order_details -> Retrieve Payment with order_details", () => {
+      let shouldContinue = true;
+
+      cy.step("Create and Confirm Payment with multiple order_details", () => {
+        const data = getConnectorDetails(globalState.get("connectorId"))[
+          "card_pm"
+        ]["OrderDetailsMultipleItems"];
+
+        cy.createConfirmPaymentTest(
+          fixtures.createConfirmPaymentBody,
+          data,
+          "no_three_ds",
+          "automatic",
+          globalState
+        );
+
+        if (!utils.should_continue_further(data)) {
+          shouldContinue = false;
+        }
+      });
+
+      cy.step("Retrieve Payment with multiple order_details", () => {
+        if (!shouldContinue) {
+          cy.task("cli_log", "Skipping step: Retrieve Payment with multiple order_details");
+          return;
+        }
+        const data = getConnectorDetails(globalState.get("connectorId"))[
+          "card_pm"
+        ]["OrderDetailsMultipleItems"];
+
+        cy.retrievePaymentCallTest({ globalState, data });
+      });
+    });
+  });
+
+  context("Create and confirm payment with missing required order_details field", () => {
+    it("Create and Confirm Payment with missing product_name -> Expect validation error IR_06", () => {
+      let shouldContinue = true;
+
+      cy.step("Create and Confirm Payment with missing product_name", () => {
+        const data = getConnectorDetails(globalState.get("connectorId"))[
+          "card_pm"
+        ]["OrderDetailsMissingProductName"];
+
+        cy.createConfirmPaymentTest(
+          fixtures.createConfirmPaymentBody,
+          data,
+          "no_three_ds",
+          "automatic",
+          globalState
+        );
+
+        if (!utils.should_continue_further(data)) {
+          shouldContinue = false;
+        }
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [x] Tests
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->

Fixed Stripe connector config error message expectation for OrderDetailsMissingProductName test case. Updated the expected error message from "column XX" to "column 1830" in the Stripe.js connector configuration to match the actual API response format.

This is part of the OrderDetails test coverage improvements for Cypress payment flow tests.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

**Files modified:**
- `cypress-tests/cypress/e2e/configs/Payment/Stripe.js` — Updated error message expectation for OrderDetailsMissingProductName config (line 1011)


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->

The Stripe connector configuration had an incorrect expected error message format. The API returns `"Json deserialize error: missing field \`product_name\` at line 1 column 1830"` but the config was expecting `"column XX"` instead of `"column 1830"`. This fix aligns the test expectations with the actual API behavior.

Related to [QAKA-69](/QAKA/issues/QAKA-69) and the OrderDetails payment flow test implementation.


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

Full regression suite was executed against the changed connector. The RUNNER_RESULT block from the QA pipeline is included verbatim below.

### Changed-spec verification — `stripe`

```
RUNNER_RESULT:
  Connector: stripe
  SpecFile: cypress/e2e/spec/Payment/52-OrderDetails.cy.js
  PrereqsUsed: spec/Payment/01-,02-,03-
  TotalTests: 10
  Passed: 10
  Failed: 0
  Skipped: 0
  OverallStatus: PASS
  Failures: []
  SkippedTests: []
  FlakeyTests: []
  BlockedReasons: []
```

### Summary

| Connector | Specs Run | Passed | Failed | Skipped | Status |
|---|---|---|---|---|---|
| stripe | 10 | 10 | 0 | 0 | PASS |


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [x] I added unit tests for my changes where possible

Closes #[GitHub issue number]
Related to [QAKA-69](/QAKA/issues/QAKA-69)
