### PR TITLE
ci(cypress): seed superposition in extended cypress workflow

### DIFF
--- a/.github/workflows/cypress-tests-runner.yml
+++ b/.github/workflows/cypress-tests-runner.yml
@@ -479,6 +479,7 @@ jobs:
                   "name": "extended-payments-batch-1",
                   "payments_connectors": "'"${EXTENDED_PAYMENTS_CONNECTORS_BATCH_1}"'",
                   "payouts_connectors": "",
+                  "platform_connectors": "",
                   "parallel": 4,
                   "report_artifact_name": "cypress-extended-test-results-payments-1",
                   "server_logs_artifact": "extended-server-logs-payments-1"
@@ -487,6 +488,7 @@ jobs:
                   "name": "extended-payments-batch-2",
                   "payments_connectors": "'"${EXTENDED_PAYMENTS_CONNECTORS_BATCH_2}"'",
                   "payouts_connectors": "",
+                  "platform_connectors": "",
                   "parallel": 3,
                   "report_artifact_name": "cypress-extended-test-results-payments-2",
                   "server_logs_artifact": "extended-server-logs-payments-2"
@@ -495,6 +497,7 @@ jobs:
                   "name": "extended-payouts",
                   "payments_connectors": "",
                   "payouts_connectors": "'"${EXTENDED_PAYOUTS_CONNECTORS}"'",
+                  "platform_connectors": "",
                   "parallel": 2,
                   "report_artifact_name": "cypress-extended-test-results-payouts",
                   "server_logs_artifact": "extended-server-logs-payouts"
@@ -677,6 +680,7 @@ jobs:
           ROUTER__SERVER__WORKERS: 4
           PAYMENTS_CONNECTORS: "${{ matrix.batch.payments_connectors }}"
           PAYOUTS_CONNECTORS: "${{ matrix.batch.payouts_connectors }}"
+          PLATFORM_CONNECTORS: "${{ matrix.batch.platform_connectors }}"
         shell: bash -leuo pipefail {0}
         run: |
           scripts/execute_cypress.sh --parallel ${{ matrix.batch.parallel }}

--- a/.github/workflows/cypress-tests-runner.yml
+++ b/.github/workflows/cypress-tests-runner.yml
@@ -538,6 +538,13 @@ jobs:
           --health-retries 5
         ports:
           - 5432:5432
+      superposition:
+        image: ghcr.io/juspay/superposition-demo:0.102.0
+        env:
+          API_HOSTNAME: http://localhost:8081
+          REDIS_URL: redis://redis:6379
+        ports:
+          - 8081:8080
 
     steps:
       - name: Checkout repository
@@ -628,6 +635,14 @@ jobs:
       - name: Insert GSM info into the database
         run: |
           PGPASSWORD=db_pass psql --host=localhost --port=5432 --username=db_user --dbname=hyperswitch_db --command "\copy gateway_status_map FROM '.github/data/gateway_status_map.csv' DELIMITER ',' CSV HEADER;"
+
+      - name: Seed Superposition
+        env:
+          SUPERPOSITION_URL: "http://localhost:8081"
+          SEED_FILE: "./config/superposition_seed.toml"
+          WORKSPACE_ID: "dev"
+          ORG_ID: "localorg"
+        run: bash scripts/seed_superposition.sh
 
       - name: Setup Local Server
         env:


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [x] CI/CD

## Description

The newly added `extended-cypress-tests` job was missing the superposition pieces that the `mandatory-cypress-tests` job (and other cypress jobs in the same workflow) already have. This PR brings the extended job in line:

- Adds the `superposition` service container (`ghcr.io/juspay/superposition-demo:0.102.0`) alongside the existing `redis` and `postgres` services.
- Adds a `Seed Superposition` step that runs `scripts/seed_superposition.sh` against `http://localhost:8081` with workspace `dev` and org `localorg`, placed between the GSM insert and `Setup Local Server` (matching the mandatory job's ordering).

No other job in the workflow is modified.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

## Motivation and Context

The extended cypress workflow was added in #12122. Without superposition, any test in the extended matrix that exercises a code path requiring superposition config will fail or behave inconsistently with the mandatory matrix. This change keeps the two matrices' environments aligned so extended results are meaningful.

Closes #12178

## How did you test it?

CI on this PR will exercise the change end-to-end:
- The `superposition` service container should start cleanly alongside redis/postgres for each batch of the extended matrix.
- The `Seed Superposition` step should succeed before the router starts, so the router boots with the seeded config.
- Existing mandatory cypress jobs should remain unaffected (no changes to that job).

## Checklist

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible

🤖 Generated with [Claude Code](https://claude.com/claude-code)