### PR TITLE
ci(cypress): disable alpha connector and extended cypress tests

### DIFF
--- a/.github/workflows/cypress-tests-runner.yml
+++ b/.github/workflows/cypress-tests-runner.yml
@@ -460,9 +460,7 @@ jobs:
 
   prepare-extended-matrix:
     name: Prepare Extended Connectors matrix to run cypress tests
-    if: |
-      github.event_name == 'merge_group' ||
-      (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'S-test-ready'))
+    if: false
     runs-on: ubuntu-latest
     outputs:
       extended-matrix: ${{ steps.set-extended-matrix.outputs.matrix }}
@@ -507,6 +505,7 @@ jobs:
   extended-cypress-tests:
     name: Run extended Cypress tests
     needs: [build-hyperswitch, prepare-extended-matrix]
+    if: false
     runs-on: hyperswitch-runners
     strategy:
       fail-fast: false
@@ -941,8 +940,7 @@ jobs:
   runner_alpha:
     name: Run optional Cypress tests for alpha connectors
     needs: build-hyperswitch
-    if: |
-      github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'S-test-ready')
+    if: false
     runs-on: hyperswitch-runners
     env:
       # Use `sccache` for caching compilation artifacts


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [x] CI/CD

## Description
<!-- Describe your changes in detail -->

Disables the alpha connector Cypress tests and the extended Cypress tests in the `Run Cypress tests` workflow.

Specifically, in `.github/workflows/cypress-tests-runner.yml`:
- `prepare-extended-matrix`: set `if: false` (was gated on `merge_group` / `S-test-ready` label).
- `extended-cypress-tests`: added `if: false` (previously always ran for the matrix).
- `runner_alpha`: set `if: false` (was gated on `S-test-ready` label).

This mirrors the same `if: false` pattern already used by the disabled `prepare-optional-matrix` and `runner-optional-connectors` jobs in this file. The `extended-cypress-tests-consolidated-result` job is intentionally left as-is because its existing logic already treats a `skipped` upstream as a pass, so it will continue to report green.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

Skip the alpha connector tests and the extended payments/payouts Cypress test batches on PRs and merge groups to reduce CI runtime and runner load. The mandatory Cypress tests and the v2 Cypress run are unaffected and remain gating.

Closes #12238

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

Workflow-only change. To be verified on this PR:
- The `Run extended Cypress tests` matrix and the `Run optional Cypress tests for alpha connectors` job appear as skipped in the Actions run.
- The `Run mandatory Cypress tests` jobs and `Run Cypress tests on v2 ...` job still execute when the `S-test-ready` label is applied.
- The `Extended Cypress Tests — Consolidated Result` job still completes successfully (handles a skipped upstream).

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible