### PR TITLE
fix(router): add missing `permissions` field in `ClientAuthenticationToken` request

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2232,7 +2232,7 @@ dependencies = [
 [[package]]
 name = "config_patch_derive"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?rev=59d3a57e08727945362d916585a90935a375ef3b#59d3a57e08727945362d916585a90935a375ef3b"
+source = "git+https://github.com/juspay/connector-service?rev=bdc981d8123632258baff4ccaac2e109f1f9a35f#bdc981d8123632258baff4ccaac2e109f1f9a35f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3948,7 +3948,7 @@ checksum = "32619942b8be646939eaf3db0602b39f5229b74575b67efc897811ded1db4e57"
 [[package]]
 name = "grpc-api-types"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?rev=59d3a57e08727945362d916585a90935a375ef3b#59d3a57e08727945362d916585a90935a375ef3b"
+source = "git+https://github.com/juspay/connector-service?rev=bdc981d8123632258baff4ccaac2e109f1f9a35f#bdc981d8123632258baff4ccaac2e109f1f9a35f"
 dependencies = [
  "axum 0.8.4",
  "error-stack 0.5.0",
@@ -8116,7 +8116,7 @@ dependencies = [
 [[package]]
 name = "rust-grpc-client"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?rev=59d3a57e08727945362d916585a90935a375ef3b#59d3a57e08727945362d916585a90935a375ef3b"
+source = "git+https://github.com/juspay/connector-service?rev=bdc981d8123632258baff4ccaac2e109f1f9a35f#bdc981d8123632258baff4ccaac2e109f1f9a35f"
 dependencies = [
  "grpc-api-types",
 ]
@@ -10944,7 +10944,7 @@ checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
 [[package]]
 name = "ucs_cards"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?rev=59d3a57e08727945362d916585a90935a375ef3b#59d3a57e08727945362d916585a90935a375ef3b"
+source = "git+https://github.com/juspay/connector-service?rev=bdc981d8123632258baff4ccaac2e109f1f9a35f#bdc981d8123632258baff4ccaac2e109f1f9a35f"
 dependencies = [
  "bytes 1.10.1",
  "error-stack 0.4.1",
@@ -10960,7 +10960,7 @@ dependencies = [
 [[package]]
 name = "ucs_common_enums"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?rev=59d3a57e08727945362d916585a90935a375ef3b#59d3a57e08727945362d916585a90935a375ef3b"
+source = "git+https://github.com/juspay/connector-service?rev=bdc981d8123632258baff4ccaac2e109f1f9a35f#bdc981d8123632258baff4ccaac2e109f1f9a35f"
 dependencies = [
  "serde",
  "strum 0.26.3",
@@ -10971,7 +10971,7 @@ dependencies = [
 [[package]]
 name = "ucs_common_utils"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?rev=59d3a57e08727945362d916585a90935a375ef3b#59d3a57e08727945362d916585a90935a375ef3b"
+source = "git+https://github.com/juspay/connector-service?rev=bdc981d8123632258baff4ccaac2e109f1f9a35f#bdc981d8123632258baff4ccaac2e109f1f9a35f"
 dependencies = [
  "anyhow",
  "base64 0.21.7",

--- a/crates/external_services/Cargo.toml
+++ b/crates/external_services/Cargo.toml
@@ -74,7 +74,7 @@ http = "0.2.12"
 url = { version = "2.5.4", features = ["serde"] }
 quick-xml = { version = "0.31.0", features = ["serialize"] }
 
-unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "59d3a57e08727945362d916585a90935a375ef3b", package = "rust-grpc-client" }
+unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "bdc981d8123632258baff4ccaac2e109f1f9a35f", package = "rust-grpc-client" }
 open-feature = { version = "0.2.5", optional = true }
 superposition_provider = { version = "0.102.0", optional = true}
 superposition_types = "0.102.0"

--- a/crates/hyperswitch_interfaces/Cargo.toml
+++ b/crates/hyperswitch_interfaces/Cargo.toml
@@ -31,7 +31,7 @@ thiserror = "1.0.69"
 time = "0.3.41"
 url = { version = "2.5.4", features = ["serde"] }
 
-unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "59d3a57e08727945362d916585a90935a375ef3b", package = "rust-grpc-client" }
+unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "bdc981d8123632258baff4ccaac2e109f1f9a35f", package = "rust-grpc-client" }
 tokio = { version = "1.45.1", features = ["macros", "rt-multi-thread"] }
 
 # First party crates

--- a/crates/router/Cargo.toml
+++ b/crates/router/Cargo.toml
@@ -89,8 +89,8 @@ ring = "0.17.14"
 rust_decimal = { version = "1.37.1", features = ["serde-with-float", "serde-with-str"] }
 rust-i18n = { git = "https://github.com/kashif-m/rust-i18n", rev = "f2d8096aaaff7a87a847c35a5394c269f75e077a" }
 
-unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "59d3a57e08727945362d916585a90935a375ef3b", package = "rust-grpc-client" }
-unified-connector-service-cards = { git = "https://github.com/juspay/connector-service", rev = "59d3a57e08727945362d916585a90935a375ef3b", package = "ucs_cards" }
+unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "bdc981d8123632258baff4ccaac2e109f1f9a35f", package = "rust-grpc-client" }
+unified-connector-service-cards = { git = "https://github.com/juspay/connector-service", rev = "bdc981d8123632258baff4ccaac2e109f1f9a35f", package = "ucs_cards" }
 rustc-hash = "1.1.0"
 rustls = "0.22"
 rustls-pemfile = "2"

--- a/crates/router/src/core/unified_connector_service/transformers.rs
+++ b/crates/router/src/core/unified_connector_service/transformers.rs
@@ -2034,6 +2034,10 @@ impl transformers::ForeignTryFrom<&RouterData<Session, PaymentsSessionData, Paym
             domain_context: Some(
                 payments_grpc::merchant_authentication_service_create_client_authentication_token_request::DomainContext::Payment(payment_sdk_session_context),
             ),
+            // Permissions are not passed from Hyperswitch to UCS.
+            // Connector-specific permissions (e.g., "PMT_POST_Create_Single" for GlobalPay)
+            // are handled by the connector's JavaScript transformer with a default fallback.
+            permissions: None
         })
     }
 }
@@ -5821,6 +5825,11 @@ impl transformers::ForeignTryFrom<&RouterData<RSync, RefundsData, RefundsRespons
             test_mode: router_data.test_mode,
             payment_method_type,
             connector_feature_data: None,
+            connector_refund_id: router_data.request.connector_refund_id.clone().ok_or(
+                error_stack::Report::new(UnifiedConnectorServiceError::MissingRequiredField {
+                    field_name: "connector_refund_id",
+                }),
+            )?,
         })
     }
 }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->

This PR fixes a compilation error introduced by the prism proto change in https://github.com/juspay/hyperswitch-prism/pull/1090.

The proto added a `permissions` field to `MerchantAuthenticationServiceCreateClientAuthenticationTokenRequest`, but the router code referenced an undefined `values` variable instead of properly handling the field.

**Fix:** Set `permissions: None` as connector-specific permissions (e.g., `"PMT_POST_Create_Single"` for GlobalPay) are handled by the connector's JavaScript transformer with a default fallback, not passed from Hyperswitch.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->

The compilation was failing with:

errorE0063: missing field `permissions` in initializer of `MerchantAuthenticationServiceCreateClientAuthenticationTokenRequest`
The code incorrectly referenced an undefined `values` variable instead of properly handling the new permissions field.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

No testing required, this is a compilation fix post UCS bump. The logic maintains the existing behavior where permissions are handled by the connector's JavaScript transformer.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `just clippy && just clippy_v2`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
