### PR TITLE
fix(router): Use read replica for OLAP flows

### DIFF
--- a/crates/router/src/connection.rs
+++ b/crates/router/src/connection.rs
@@ -1,8 +1,7 @@
 use bb8::PooledConnection;
 use diesel::PgConnection;
 use error_stack::ResultExt;
-use storage_impl::errors as storage_errors;
-use storage_impl::ReadPreference;
+use storage_impl::{errors as storage_errors, ReadPreference};
 
 use crate::errors;
 

--- a/crates/router/src/connection.rs
+++ b/crates/router/src/connection.rs
@@ -2,6 +2,7 @@ use bb8::PooledConnection;
 use diesel::PgConnection;
 use error_stack::ResultExt;
 use storage_impl::errors as storage_errors;
+use storage_impl::ReadPreference;
 
 use crate::errors;
 
@@ -28,20 +29,10 @@ pub async fn pg_connection_read<T: storage_impl::DatabaseStore>(
     PooledConnection<'_, async_bb8_diesel::ConnectionManager<PgConnection>>,
     storage_errors::StorageError,
 > {
-    // If only OLAP is enabled get replica pool.
-    #[cfg(all(feature = "olap", not(feature = "oltp")))]
-    let pool = store.get_replica_pool();
-
-    // If either one of these are true we need to get master pool.
-    //  1. Only OLTP is enabled.
-    //  2. Both OLAP and OLTP is enabled.
-    //  3. Both OLAP and OLTP is disabled.
-    #[cfg(any(
-        all(not(feature = "olap"), feature = "oltp"),
-        all(feature = "olap", feature = "oltp"),
-        all(not(feature = "olap"), not(feature = "oltp"))
-    ))]
-    let pool = store.get_master_pool();
+    let pool = match store.get_read_preference() {
+        ReadPreference::ReplicaDB => store.get_replica_pool(),
+        ReadPreference::MasterDB => store.get_master_pool(),
+    };
 
     pool.get()
         .await
@@ -54,20 +45,10 @@ pub async fn pg_accounts_connection_read<T: storage_impl::DatabaseStore>(
     PooledConnection<'_, async_bb8_diesel::ConnectionManager<PgConnection>>,
     storage_errors::StorageError,
 > {
-    // If only OLAP is enabled get replica pool.
-    #[cfg(all(feature = "olap", not(feature = "oltp")))]
-    let pool = store.get_accounts_replica_pool();
-
-    // If either one of these are true we need to get master pool.
-    //  1. Only OLTP is enabled.
-    //  2. Both OLAP and OLTP is enabled.
-    //  3. Both OLAP and OLTP is disabled.
-    #[cfg(any(
-        all(not(feature = "olap"), feature = "oltp"),
-        all(feature = "olap", feature = "oltp"),
-        all(not(feature = "olap"), not(feature = "oltp"))
-    ))]
-    let pool = store.get_accounts_master_pool();
+    let pool = match store.get_read_preference() {
+        ReadPreference::ReplicaDB => store.get_accounts_replica_pool(),
+        ReadPreference::MasterDB => store.get_accounts_master_pool(),
+    };
 
     pool.get()
         .await

--- a/crates/router/src/db.rs
+++ b/crates/router/src/db.rs
@@ -158,6 +158,8 @@ pub trait StorageInterface:
         -> Box<dyn subscriptions::state::SubscriptionStorageInterface>;
     fn get_cache_store(&self) -> Box<dyn RedisConnInterface + Send + Sync + 'static>;
     fn set_key_manager_state(&mut self, key_manager_state: KeyManagerState);
+
+    fn set_read_preference(&mut self, preference: storage_impl::ReadPreference);
 }
 
 #[async_trait::async_trait]
@@ -225,6 +227,10 @@ impl StorageInterface for Store {
         #[cfg(feature = "kv_store")]
         self.router_store.set_key_manager_state(key_manager_state);
     }
+
+    fn set_read_preference(&mut self, preference: storage_impl::ReadPreference) {
+        self.router_store.set_read_preference(preference);
+    }
 }
 
 #[async_trait::async_trait]
@@ -256,6 +262,8 @@ impl StorageInterface for MockDb {
     fn set_key_manager_state(&mut self, key_manager_state: KeyManagerState) {
         self.key_manager_state = Some(key_manager_state);
     }
+
+    fn set_read_preference(&mut self, _preference: storage_impl::ReadPreference) {}
 }
 
 #[async_trait::async_trait]

--- a/crates/router/src/db/kafka_store.rs
+++ b/crates/router/src/db/kafka_store.rs
@@ -3354,6 +3354,10 @@ impl StorageInterface for KafkaStore {
     fn set_key_manager_state(&mut self, key_manager_state: KeyManagerState) {
         self.diesel_store.set_key_manager_state(key_manager_state);
     }
+
+    fn set_read_preference(&mut self, preference: storage_impl::ReadPreference) {
+        self.diesel_store.set_read_preference(preference);
+    }
 }
 
 impl GlobalStorageInterface for KafkaStore {

--- a/crates/router/src/routes/app.rs
+++ b/crates/router/src/routes/app.rs
@@ -164,6 +164,22 @@ impl SessionState {
     pub fn set_store(&mut self, store: Box<dyn StorageInterface>) {
         self.store = store;
     }
+
+    /// Consumes the SessionState and sets the read preference based on flow.
+    /// This is called automatically by server_wrap for all routes.
+    pub fn with_flow(mut self, flow: impl router_env::types::FlowMetric) -> Self {
+        use storage_impl::ReadPreference;
+
+        let flow_str = flow.to_string();
+        let preference = flow_str
+            .parse::<router_env::logger::types::Flow>()
+            .map(|f| ReadPreference::from_flow(&f))
+            .unwrap_or(ReadPreference::MasterDB);
+
+        self.store.set_read_preference(preference);
+        self
+    }
+
     pub fn get_req_state(&self) -> ReqState {
         ReqState {
             event_context: events::EventContext::new(self.event_handler.clone()),

--- a/crates/router/src/services/api.rs
+++ b/crates/router/src/services/api.rs
@@ -236,6 +236,10 @@ where
             .switch()
         })?;
     session_state.add_request_id(request_id.clone());
+
+    // Inject flow into session_state for automatic read preference routing
+    session_state = session_state.with_flow(flow.clone());
+
     let mut request_state = session_state.get_req_state();
 
     request_state.event_context.record_info(request_id.clone());

--- a/crates/router_env/src/logger/types.rs
+++ b/crates/router_env/src/logger/types.rs
@@ -50,7 +50,7 @@ pub enum Tag {
 }
 
 /// API Flow
-#[derive(Debug, Display, Clone, PartialEq, Eq)]
+#[derive(Debug, Display, Clone, PartialEq, Eq, EnumString)]
 pub enum Flow {
     /// Health check
     HealthCheck,

--- a/crates/storage_impl/src/connection.rs
+++ b/crates/storage_impl/src/connection.rs
@@ -26,20 +26,10 @@ pub async fn pg_connection_read<T: crate::DatabaseStore>(
     PooledConnection<'_, async_bb8_diesel::ConnectionManager<PgConnection>>,
     crate::errors::StorageError,
 > {
-    // If only OLAP is enabled get replica pool.
-    #[cfg(all(feature = "olap", not(feature = "oltp")))]
-    let pool = store.get_replica_pool();
-
-    // If either one of these are true we need to get master pool.
-    //  1. Only OLTP is enabled.
-    //  2. Both OLAP and OLTP is enabled.
-    //  3. Both OLAP and OLTP is disabled.
-    #[cfg(any(
-        all(not(feature = "olap"), feature = "oltp"),
-        all(feature = "olap", feature = "oltp"),
-        all(not(feature = "olap"), not(feature = "oltp"))
-    ))]
-    let pool = store.get_master_pool();
+    let pool = match store.get_read_preference() {
+        crate::database::store::ReadPreference::ReplicaDB => store.get_replica_pool(),
+        crate::database::store::ReadPreference::MasterDB => store.get_master_pool(),
+    };
 
     pool.get()
         .await

--- a/crates/storage_impl/src/database/store.rs
+++ b/crates/storage_impl/src/database/store.rs
@@ -15,6 +15,376 @@ use crate::{
 pub type PgPool = bb8::Pool<async_bb8_diesel::ConnectionManager<PgConnection>>;
 pub type PgPooledConn = async_bb8_diesel::Connection<PgConnection>;
 
+/// Indicates whether a read operation should use the master database
+/// or can tolerate eventual consistency from a read replica.
+///
+/// - `MasterDB` (default): Always reads from the master database.
+///   Use this for OLTP operations that require up-to-date data, such as
+///   payment confirm, capture, or any read-after-write scenario.
+/// - `ReplicaDB`: Reads from the replica pool when available.
+///   Use this for OLAP operations like listing, filtering, or analytics
+///   where slight staleness is acceptable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ReadPreference {
+    #[default]
+    MasterDB,
+    ReplicaDB,
+}
+
+impl ReadPreference {
+    /// Creates a ReadPreference from a Flow.
+    /// OLAP flows (list, filter) use ReplicaDB.
+    /// All other flows default to MasterDB.
+    pub fn from_flow(flow: &router_env::logger::types::Flow) -> Self {
+        use router_env::logger::types::Flow;
+
+        match flow {
+            Flow::PaymentsList
+            | Flow::PaymentsFilters
+            | Flow::PaymentsAggregate
+            | Flow::PaymentAttemptsList
+            | Flow::RefundsList
+            | Flow::RefundsFilters
+            | Flow::RefundsAggregate
+            | Flow::DisputesList
+            | Flow::DisputesFilters
+            | Flow::CustomersList
+            | Flow::CustomersListWithConstraints
+            | Flow::MandatesList
+            | Flow::PaymentMethodsList
+            | Flow::CustomerPaymentMethodsList
+            | Flow::MerchantAccountList
+            | Flow::MerchantConnectorsList
+            | Flow::ApiKeyList
+            | Flow::ListBlocklist => ReadPreference::ReplicaDB,
+
+            Flow::HealthCheck
+            | Flow::DeepHealthCheck
+            | Flow::OidcDiscovery
+            | Flow::OidcJwks
+            | Flow::OidcAuthorize
+            | Flow::OidcToken
+            | Flow::OrganizationCreate
+            | Flow::OrganizationRetrieve
+            | Flow::OrganizationUpdate
+            | Flow::MerchantsAccountCreate
+            | Flow::MerchantsAccountRetrieve
+            | Flow::MerchantsAccountUpdate
+            | Flow::MerchantsAccountDelete
+            | Flow::MerchantConnectorsCreate
+            | Flow::MerchantConnectorsRetrieve
+            | Flow::MerchantConnectorsUpdate
+            | Flow::MerchantConnectorsDelete
+            | Flow::MerchantTransferKey
+            | Flow::MerchantConnectorWebhookRegister
+            | Flow::MerchantConnectorWebhookList
+            | Flow::ConfigKeyCreate
+            | Flow::ConfigKeyFetch
+            | Flow::EnablePlatformAccount
+            | Flow::ConfigKeyUpdate
+            | Flow::ConfigKeyDelete
+            | Flow::CustomersCreate
+            | Flow::CustomersRetrieve
+            | Flow::CustomersUpdate
+            | Flow::CustomersDelete
+            | Flow::CustomersGetMandates
+            | Flow::EphemeralKeyCreate
+            | Flow::EphemeralKeyDelete
+            | Flow::MandatesRetrieve
+            | Flow::MandatesRevoke
+            | Flow::PaymentMethodsCreate
+            | Flow::PaymentMethodsMigrate
+            | Flow::PaymentMethodsBatchUpdate
+            | Flow::PaymentMethodsBatchRetrieve
+            | Flow::PaymentMethodSave
+            | Flow::PaymentMethodGetTokenDetails
+            | Flow::GetPaymentMethodTokenData
+            | Flow::ListCountriesCurrencies
+            | Flow::PaymentMethodCollectLink
+            | Flow::PaymentMethodsRetrieve
+            | Flow::PaymentMethodsRetrieveOlap
+            | Flow::PaymentMethodsUpdate
+            | Flow::PaymentMethodsDelete
+            | Flow::NetworkTokenStatusCheck
+            | Flow::NetworkTokenEligibilityCheck
+            | Flow::DefaultPaymentMethodsSet
+            | Flow::PaymentsCreate
+            | Flow::PaymentsRetrieve
+            | Flow::PaymentsRetrieveForceSync
+            | Flow::PaymentsRetrieveUsingMerchantReferenceId
+            | Flow::PaymentsUpdate
+            | Flow::PaymentsConfirm
+            | Flow::PaymentsCapture
+            | Flow::PaymentsCancel
+            | Flow::PaymentsCancelPostCapture
+            | Flow::PaymentsApprove
+            | Flow::PaymentsReject
+            | Flow::PaymentsSessionToken
+            | Flow::PaymentsStart
+            | Flow::PaymentsCreateIntent
+            | Flow::PaymentsGetIntent
+            | Flow::PaymentsUpdateIntent
+            | Flow::PaymentsConfirmIntent
+            | Flow::PaymentsCreateAndConfirmIntent
+            | Flow::PayoutsCreate
+            | Flow::PayoutsRetrieve
+            | Flow::PayoutsUpdate
+            | Flow::PayoutsConfirm
+            | Flow::PayoutsCancel
+            | Flow::PayoutsFulfill
+            | Flow::PayoutsList
+            | Flow::PayoutsFilter
+            | Flow::PayoutsAccounts
+            | Flow::PayoutLinkInitiate
+            | Flow::PaymentsRedirect
+            | Flow::PaymentsCompleteAuthorize
+            | Flow::RefundsCreate
+            | Flow::RefundsRetrieve
+            | Flow::RefundsRetrieveForceSync
+            | Flow::RefundsUpdate
+            | Flow::RetrieveForexFlow
+            | Flow::RoutingCreateConfig
+            | Flow::RoutingLinkConfig
+            | Flow::RoutingUnlinkConfig
+            | Flow::RoutingRetrieveConfig
+            | Flow::RoutingRetrieveActiveConfig
+            | Flow::RoutingRetrieveDefaultConfig
+            | Flow::RoutingRetrieveDictionary
+            | Flow::DecisionEngineRuleMigration
+            | Flow::RoutingUpdateConfig
+            | Flow::RoutingUpdateDefaultConfig
+            | Flow::RoutingDeleteConfig
+            | Flow::CreateSubscription
+            | Flow::GetSubscriptionItemsForSubscription
+            | Flow::ConfirmSubscription
+            | Flow::CreateAndConfirmSubscription
+            | Flow::GetSubscription
+            | Flow::UpdateSubscription
+            | Flow::GetSubscriptionEstimate
+            | Flow::PauseSubscription
+            | Flow::ResumeSubscription
+            | Flow::CancelSubscription
+            | Flow::CreateDynamicRoutingConfig
+            | Flow::ToggleDynamicRouting
+            | Flow::UpdateDynamicRoutingConfigs
+            | Flow::AddCardIssuer
+            | Flow::UpdateCardIssuer
+            | Flow::DeleteCardIssuer
+            | Flow::ListCardIssuers
+            | Flow::AddToBlocklist
+            | Flow::DeleteFromBlocklist
+            | Flow::ToggleBlocklistGuard
+            | Flow::IncomingWebhookReceive
+            | Flow::RecoveryIncomingWebhookReceive
+            | Flow::ValidatePaymentMethod
+            | Flow::ApiKeyCreate
+            | Flow::ApiKeyRetrieve
+            | Flow::ApiKeyUpdate
+            | Flow::ApiKeyRevoke
+            | Flow::DisputesRetrieve
+            | Flow::CardsInfo
+            | Flow::CreateFile
+            | Flow::DeleteFile
+            | Flow::RetrieveFile
+            | Flow::DisputesEvidenceSubmit
+            | Flow::CreateConfigKey
+            | Flow::AttachDisputeEvidence
+            | Flow::DeleteDisputeEvidence
+            | Flow::DisputesAggregate
+            | Flow::RetrieveDisputeEvidence
+            | Flow::CacheInvalidate
+            | Flow::PaymentLinkRetrieve
+            | Flow::PaymentLinkInitiate
+            | Flow::PaymentSecureLinkInitiate
+            | Flow::PaymentLinkList
+            | Flow::PaymentLinkStatus
+            | Flow::ProfileCreate
+            | Flow::ProfileUpdate
+            | Flow::ProfileRetrieve
+            | Flow::ProfileDelete
+            | Flow::ProfileList
+            | Flow::Verification
+            | Flow::RustLockerMigration
+            | Flow::GsmRuleCreate
+            | Flow::GsmRuleRetrieve
+            | Flow::GsmRuleUpdate
+            | Flow::ApplePayCertificatesMigration
+            | Flow::GsmRuleDelete
+            | Flow::GetDataFromHyperswitchAiFlow
+            | Flow::ListAllChatInteractions
+            | Flow::UserSignUp
+            | Flow::UserSignUpWithMerchantId
+            | Flow::ConvertOrganizationToPlatform
+            | Flow::UserSignIn
+            | Flow::UserTransferKey
+            | Flow::UserConnectAccount
+            | Flow::DecisionManagerUpsertConfig
+            | Flow::DecisionManagerDeleteConfig
+            | Flow::DecisionManagerRetrieveConfig
+            | Flow::FrmFulfillment
+            | Flow::FeatureMatrix
+            | Flow::ChangePassword
+            | Flow::Signout
+            | Flow::SetDashboardMetadata
+            | Flow::GetMultipleDashboardMetadata
+            | Flow::VerifyPaymentConnector
+            | Flow::InternalUserSignup
+            | Flow::TenantUserCreate
+            | Flow::SwitchOrg
+            | Flow::SwitchMerchantV2
+            | Flow::SwitchProfile
+            | Flow::GetAuthorizationInfo
+            | Flow::GetRolesInfo
+            | Flow::GetParentGroupInfo
+            | Flow::ListRolesV2
+            | Flow::ListInvitableRolesAtEntityLevel
+            | Flow::ListUpdatableRolesAtEntityLevel
+            | Flow::GetRole
+            | Flow::GetRoleV2
+            | Flow::GetRoleFromToken
+            | Flow::GetRoleFromTokenV2
+            | Flow::GetParentGroupsInfoForRoleFromToken
+            | Flow::UpdateUserRole
+            | Flow::UserMerchantAccountCreate
+            | Flow::CreatePlatformAccount
+            | Flow::UserOrgMerchantCreate
+            | Flow::GenerateSampleData
+            | Flow::DeleteSampleData
+            | Flow::GetUserDetails
+            | Flow::GetUserRoleDetails
+            | Flow::PmAuthLinkTokenCreate
+            | Flow::PmAuthExchangeToken
+            | Flow::ForgotPassword
+            | Flow::ResetPassword
+            | Flow::RotatePassword
+            | Flow::InviteMultipleUser
+            | Flow::ReInviteUser
+            | Flow::AcceptInviteFromEmail
+            | Flow::DeleteUserRole
+            | Flow::PaymentsIncrementalAuthorization
+            | Flow::PaymentsExtendAuthorization
+            | Flow::GetActionUrl
+            | Flow::SyncOnboardingStatus
+            | Flow::ResetTrackingId
+            | Flow::VerifyEmail
+            | Flow::VerifyEmailRequest
+            | Flow::UpdateUserAccountDetails
+            | Flow::AcceptInvitationsV2
+            | Flow::AcceptInvitationsPreAuth
+            | Flow::PaymentsExternalAuthentication
+            | Flow::PaymentsAuthorize
+            | Flow::CreateRole
+            | Flow::CreateRoleV2
+            | Flow::UpdateRole
+            | Flow::UserFromEmail
+            | Flow::TotpBegin
+            | Flow::TotpReset
+            | Flow::TotpVerify
+            | Flow::TotpUpdate
+            | Flow::RecoveryCodeVerify
+            | Flow::RecoveryCodesGenerate
+            | Flow::TerminateTwoFactorAuth
+            | Flow::TwoFactorAuthStatus
+            | Flow::CreateUserAuthenticationMethod
+            | Flow::UpdateUserAuthenticationMethod
+            | Flow::ListUserAuthenticationMethods
+            | Flow::GetSsoAuthUrl
+            | Flow::SignInWithSso
+            | Flow::AuthSelect
+            | Flow::ListOrgForUser
+            | Flow::ListMerchantsForUserInOrg
+            | Flow::ListProfileForUserInOrgAndMerchant
+            | Flow::ListUsersInLineage
+            | Flow::ListInvitationsForUser
+            | Flow::GetThemeUsingLineage
+            | Flow::GetThemeUsingThemeId
+            | Flow::UploadFileToThemeStorage
+            | Flow::CreateTheme
+            | Flow::UpdateTheme
+            | Flow::DeleteTheme
+            | Flow::CreateUserTheme
+            | Flow::UpdateUserTheme
+            | Flow::DeleteUserTheme
+            | Flow::UploadFileToUserThemeStorage
+            | Flow::GetUserThemeUsingThemeId
+            | Flow::ListAllThemesInLineage
+            | Flow::GetUserThemeUsingLineage
+            | Flow::GetUserThemeConfigVersion
+            | Flow::WebhookEventInitialDeliveryAttemptList
+            | Flow::WebhookEventDeliveryAttemptList
+            | Flow::WebhookEventDeliveryRetry
+            | Flow::RetrievePollStatus
+            | Flow::ToggleExtendedCardInfo
+            | Flow::ToggleConnectorAgnosticMit
+            | Flow::GetExtendedCardInfo
+            | Flow::RefundsManualUpdate
+            | Flow::PaymentsManualUpdate
+            | Flow::PayoutsManualUpdate
+            | Flow::SessionUpdateTaxCalculation
+            | Flow::ProxyConfirmIntent
+            | Flow::PaymentsPostSessionTokens
+            | Flow::PaymentsUpdateMetadata
+            | Flow::PaymentStartRedirection
+            | Flow::VolumeSplitOnRoutingType
+            | Flow::RoutingEvaluateRule
+            | Flow::Relay
+            | Flow::RelayRetrieve
+            | Flow::TokenizeCard
+            | Flow::TokenizeCardUsingPaymentMethodId
+            | Flow::TokenizeCardBatch
+            | Flow::IncomingRelayWebhookReceive
+            | Flow::HypersenseTokenRequest
+            | Flow::HypersenseVerifyToken
+            | Flow::HypersenseSignoutToken
+            | Flow::PaymentMethodSessionCreate
+            | Flow::PaymentMethodSessionRetrieve
+            | Flow::PaymentMethodSessionUpdate
+            | Flow::PaymentMethodSessionUpdateSavedPaymentMethod
+            | Flow::PaymentMethodSessionDeleteSavedPaymentMethod
+            | Flow::PaymentMethodSessionConfirm
+            | Flow::CardsInfoCreate
+            | Flow::CardsInfoUpdate
+            | Flow::CardsInfoMigrate
+            | Flow::TotalPaymentMethodCount
+            | Flow::RevenueRecoveryRetrieve
+            | Flow::RevenueRecoveryResume
+            | Flow::TokenizationCreate
+            | Flow::TokenizationRetrieve
+            | Flow::CloneConnector
+            | Flow::AuthenticationCreate
+            | Flow::AuthenticationEligibility
+            | Flow::AuthenticationSync
+            | Flow::AuthenticationSyncPostUpdate
+            | Flow::AuthenticationAuthenticate
+            | Flow::AuthenticationSessionToken
+            | Flow::AuthenticationEligibilityCheck
+            | Flow::AuthenticationRetrieveEligibilityCheck
+            | Flow::Proxy
+            | Flow::ProfileAcquirerCreate
+            | Flow::ProfileAcquirerUpdate
+            | Flow::ThreeDsDecisionRuleExecute
+            | Flow::IncomingNetworkTokenWebhookReceive
+            | Flow::DecisionEngineDecideGatewayCall
+            | Flow::DecisionEngineGatewayFeedbackCall
+            | Flow::RecoveryPaymentsCreate
+            | Flow::TokenizationDelete
+            | Flow::RecoveryDataBackfill
+            | Flow::RevenueRecoveryRedis
+            | Flow::PaymentMethodBalanceCheck
+            | Flow::PaymentsSubmitEligibility
+            | Flow::ApplyPaymentMethodData
+            | Flow::PayoutsAggregate
+            | Flow::GetEmbeddedToken
+            | Flow::EmbeddedTokenInfo
+            | Flow::GetSuperpositionSdkConfig
+            | Flow::GetUserDetailsInternal
+            | Flow::ListUsersInternal
+            | Flow::ListMembersForEntity
+            | Flow::AuthorizeUserToken => ReadPreference::MasterDB,
+        }
+    }
+}
+
 #[async_trait::async_trait]
 pub trait DatabaseStore: Clone + Send + Sync {
     type Config: Send;
@@ -28,6 +398,13 @@ pub trait DatabaseStore: Clone + Send + Sync {
     fn get_replica_pool(&self) -> &PgPool;
     fn get_accounts_master_pool(&self) -> &PgPool;
     fn get_accounts_replica_pool(&self) -> &PgPool;
+
+    /// Returns the current read preference for this store instance.
+    /// The default implementation returns `MasterDB`, which is the
+    /// safe default for OLTP operations.
+    fn get_read_preference(&self) -> ReadPreference {
+        ReadPreference::MasterDB
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/crates/storage_impl/src/kv_router_store.rs
+++ b/crates/storage_impl/src/kv_router_store.rs
@@ -19,7 +19,7 @@ use serde::de;
 pub use crate::database::store::Store;
 pub use crate::{database::store::DatabaseStore, mock_db::MockDb};
 use crate::{
-    database::store::PgPool,
+    database::store::{PgPool, ReadPreference},
     diesel_error_to_data_error,
     errors::{self, RedisErrorExt, StorageResult},
     lookup::ReverseLookupInterface,
@@ -145,6 +145,10 @@ where
     fn get_accounts_replica_pool(&self) -> &PgPool {
         self.router_store.get_accounts_replica_pool()
     }
+
+    fn get_read_preference(&self) -> ReadPreference {
+        self.router_store.get_read_preference()
+    }
 }
 
 impl<T: DatabaseStore> RedisConnInterface for KVRouterStore<T> {
@@ -173,6 +177,10 @@ impl<T: DatabaseStore> KVRouterStore<T> {
             soft_kill_mode: soft_kill.unwrap_or(false),
             key_manager_state,
         }
+    }
+
+    pub fn set_read_preference(&mut self, preference: ReadPreference) {
+        self.router_store.set_read_preference(preference);
     }
 
     pub fn master_key(&self) -> &StrongSecret<Vec<u8>> {

--- a/crates/storage_impl/src/lib.rs
+++ b/crates/storage_impl/src/lib.rs
@@ -34,6 +34,7 @@ pub mod payments;
 #[cfg(feature = "payouts")]
 pub mod payouts;
 pub mod platform_wrapper;
+
 pub mod redis;
 pub mod refund;
 mod reverse_lookup;
@@ -50,7 +51,10 @@ use redis_interface::{errors::RedisError, RedisConnectionPool, SaddReply};
 
 #[cfg(not(feature = "payouts"))]
 pub use crate::database::store::Store;
-pub use crate::{database::store::DatabaseStore, errors::StorageError};
+pub use crate::{
+    database::store::{DatabaseStore, ReadPreference},
+    errors::StorageError,
+};
 
 #[derive(Debug, Clone)]
 pub struct RouterStore<T: DatabaseStore> {
@@ -59,6 +63,7 @@ pub struct RouterStore<T: DatabaseStore> {
     master_encryption_key: StrongSecret<Vec<u8>>,
     pub request_id: Option<String>,
     key_manager_state: Option<KeyManagerState>,
+    read_preference: ReadPreference,
 }
 
 impl<T: DatabaseStore> RouterStore<T> {
@@ -129,6 +134,10 @@ where
     fn get_accounts_replica_pool(&self) -> &PgPool {
         self.db_store.get_accounts_replica_pool()
     }
+
+    fn get_read_preference(&self) -> ReadPreference {
+        self.read_preference
+    }
 }
 
 impl<T: DatabaseStore> RedisConnInterface for RouterStore<T> {
@@ -167,7 +176,12 @@ impl<T: DatabaseStore> RouterStore<T> {
             master_encryption_key: encryption_key,
             request_id: None,
             key_manager_state,
+            read_preference: ReadPreference::MasterDB,
         })
+    }
+
+    pub fn set_read_preference(&mut self, preference: ReadPreference) {
+        self.read_preference = preference;
     }
 
     pub async fn cache_store(
@@ -303,6 +317,7 @@ impl<T: DatabaseStore> RouterStore<T> {
             master_encryption_key: encryption_key,
             request_id: None,
             key_manager_state,
+            read_preference: ReadPreference::MasterDB,
         })
     }
 }

--- a/crates/storage_impl/src/utils.rs
+++ b/crates/storage_impl/src/utils.rs
@@ -3,6 +3,7 @@ use diesel::PgConnection;
 use error_stack::ResultExt;
 
 use crate::{
+    database::store::ReadPreference,
     errors::{RedisErrorExt, StorageError},
     metrics, DatabaseStore,
 };
@@ -13,20 +14,10 @@ pub async fn pg_connection_read<T: DatabaseStore>(
     PooledConnection<'_, async_bb8_diesel::ConnectionManager<PgConnection>>,
     StorageError,
 > {
-    // If only OLAP is enabled get replica pool.
-    #[cfg(all(feature = "olap", not(feature = "oltp")))]
-    let pool = store.get_replica_pool();
-
-    // If either one of these are true we need to get master pool.
-    //  1. Only OLTP is enabled.
-    //  2. Both OLAP and OLTP is enabled.
-    //  3. Both OLAP and OLTP is disabled.
-    #[cfg(any(
-        all(not(feature = "olap"), feature = "oltp"),
-        all(feature = "olap", feature = "oltp"),
-        all(not(feature = "olap"), not(feature = "oltp"))
-    ))]
-    let pool = store.get_master_pool();
+    let pool = match store.get_read_preference() {
+        ReadPreference::ReplicaDB => store.get_replica_pool(),
+        ReadPreference::MasterDB => store.get_master_pool(),
+    };
 
     pool.get()
         .await
@@ -53,20 +44,10 @@ pub async fn pg_accounts_connection_read<T: DatabaseStore>(
     PooledConnection<'_, async_bb8_diesel::ConnectionManager<PgConnection>>,
     StorageError,
 > {
-    // If only OLAP is enabled get replica pool.
-    #[cfg(all(feature = "olap", not(feature = "oltp")))]
-    let pool = store.get_accounts_replica_pool();
-
-    // If either one of these are true we need to get master pool.
-    //  1. Only OLTP is enabled.
-    //  2. Both OLAP and OLTP is enabled.
-    //  3. Both OLAP and OLTP is disabled.
-    #[cfg(any(
-        all(not(feature = "olap"), feature = "oltp"),
-        all(feature = "olap", feature = "oltp"),
-        all(not(feature = "olap"), not(feature = "oltp"))
-    ))]
-    let pool = store.get_accounts_master_pool();
+    let pool = match store.get_read_preference() {
+        ReadPreference::ReplicaDB => store.get_accounts_replica_pool(),
+        ReadPreference::MasterDB => store.get_accounts_master_pool(),
+    };
 
     pool.get()
         .await


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
- Added `Flow` based read replica selection mechanism

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->
This pull request introduces a new mechanism for dynamically routing database read operations to either the master or replica pools based on the API flow. The main goal is to improve scalability and performance by leveraging read replicas for OLAP (analytical/listing) operations while ensuring OLTP (transactional) operations continue to use the master database for consistency. The changes include the introduction of a `ReadPreference` enum, its integration into store interfaces, and automatic flow-based routing.

Key changes:

**Dynamic Read Preference Routing**

* Added a `ReadPreference` enum to `storage_impl` that distinguishes between `MasterDB` (default, for OLTP) and `ReplicaDB` (for OLAP), with documentation and a helper to derive the preference from the API flow (`Flow`).
* Updated the `DatabaseStore` trait to include a `get_read_preference` method, defaulting to `MasterDB`.
* Refactored connection acquisition functions (e.g., `pg_connection_read`, `pg_accounts_connection_read`) to select the appropriate pool based on the current `ReadPreference` rather than compile-time feature flags. [[1]](diffhunk://#diff-cf01df95334768fac09fac65cc5ca1ad41abb9fc04db58faf961666655819c5bL31-R35) [[2]](diffhunk://#diff-cf01df95334768fac09fac65cc5ca1ad41abb9fc04db58faf961666655819c5bL57-R51) [[3]](diffhunk://#diff-745cf3c6d0e17c284d4d397eabd37ddd1597dac57caa77c9811840310931e160L29-R32)

**API Flow Integration**

* Enhanced the `Flow` enum with `EnumString` to support parsing from string representations, enabling runtime determination of flow type.
* Added a `with_flow` method to `SessionState` that sets the store's read preference automatically based on the current API flow, ensuring all routes use the correct pool without manual intervention.
* Updated API service logic to inject the flow into session state for every request, activating the new routing behavior.

**Store Interface and Implementation Updates**

* Extended the `StorageInterface` trait and its implementations (`Store`, `MockDb`, `KafkaStore`) to support setting the read preference, propagating it to underlying store layers as needed. [[1]](diffhunk://#diff-bf6f377ee0a9d9fdb4400defde7b877547ece8e57149635ab900657fef6c51f7R161-R162) [[2]](diffhunk://#diff-bf6f377ee0a9d9fdb4400defde7b877547ece8e57149635ab900657fef6c51f7R230-R233) [[3]](diffhunk://#diff-bf6f377ee0a9d9fdb4400defde7b877547ece8e57149635ab900657fef6c51f7R265-R266) [[4]](diffhunk://#diff-14d0eacc78cacac3f0a204117cd79568b260e86e5ab9960ea7f49a360bd169a5R3357-R3360)

These changes collectively enable safer and more efficient use of database replicas for read-heavy operations while maintaining consistency guarantees for critical writes and read-after-write scenarios.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
Closes #12257 

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Manually verified that payments filter calls are going to replica DB

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
