### PR TITLE
test(cypress): add PayPal wallet coverage for paypal connector

### DIFF
--- a/cypress-tests/cypress/e2e/configs/Payment/Commons.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Commons.js
@@ -1103,6 +1103,24 @@ export const connectorDetails = {
         TRIGGER_SKIP: true,
       },
     }),
+    PayPal: getCustomExchange({
+      Request: {
+        payment_method: "wallet",
+        payment_method_type: "paypal",
+        billing: standardBillingAddress,
+        payment_method_data: {
+          wallet: {
+            paypal_redirect: {},
+          },
+        },
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "requires_customer_action",
+        },
+      },
+    }),
   },
   pay_later_pm: {
     PaymentIntent: (paymentMethodType) =>

--- a/cypress-tests/cypress/e2e/configs/Payment/Modifiers.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Modifiers.js
@@ -132,6 +132,7 @@ const CURRENCY_MAP = {
   OnlineBankingFpx: "MYR", // Malaysian payment methods
   Interac: "CAD", // Canadian payment method
   AliPayHk: "HKD", // Hong Kong payment method
+  PayPal: "USD", // PayPal wallet
 };
 
 export const getCurrency = (paymentMethodType) => {

--- a/cypress-tests/cypress/e2e/configs/Payment/Paypal.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Paypal.js
@@ -934,6 +934,37 @@ export const connectorDetails = {
       },
     },
   },
+  wallet_pm: {
+    PaymentIntent: (paymentMethodType) =>
+      getCustomExchange({
+        Request: {
+          currency: paymentMethodType === "PayPal" ? "USD" : "EUR",
+        },
+        Response: {
+          status: 200,
+          body: {
+            status: "requires_payment_method",
+          },
+        },
+      }),
+    PayPal: {
+      Request: {
+        payment_method: "wallet",
+        payment_method_type: "paypal",
+        payment_method_data: {
+          wallet: {
+            paypal_redirect: {},
+          },
+        },
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "requires_customer_action",
+        },
+      },
+    },
+  },
   webhook: {
     TransactionIdConfig: {
       path: "resource.supplementary_data.related_ids.order_id",

--- a/cypress-tests/cypress/e2e/configs/Payment/Paypal.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Paypal.js
@@ -1,4 +1,5 @@
 import { getCustomExchange } from "./Modifiers";
+import { standardBillingAddress } from "./Commons";
 
 const successfulNo3DSCardDetails = {
   card_number: "4012000033330026",
@@ -951,6 +952,8 @@ export const connectorDetails = {
       Request: {
         payment_method: "wallet",
         payment_method_type: "paypal",
+        authentication_type: "no_three_ds",
+        billing: standardBillingAddress,
         payment_method_data: {
           wallet: {
             paypal_redirect: {},

--- a/cypress-tests/cypress/e2e/spec/Payment/19-Wallet.cy.js
+++ b/cypress-tests/cypress/e2e/spec/Payment/19-Wallet.cy.js
@@ -166,4 +166,83 @@ describe("Wallet tests", () => {
       });
     });
   });
+
+  context("PayPal Create and Confirm flow test", () => {
+    let shouldContinue = true;
+
+    before("seed global state", () => {
+      cy.task("getGlobalState").then((state) => {
+        globalState = new State(state);
+      });
+    });
+
+    beforeEach(function () {
+      if (!shouldContinue) {
+        this.skip();
+      }
+    });
+
+    it("create-payment-call-test", () => {
+      const data = getConnectorDetails(globalState.get("connectorId"))[
+        "wallet_pm"
+      ]["PaymentIntent"]("PayPal");
+
+      cy.createPaymentIntentTest(
+        fixtures.createPaymentBody,
+        data,
+        "no_three_ds",
+        "automatic",
+        globalState
+      );
+      if (shouldContinue) shouldContinue = utils.should_continue_further(data);
+    });
+
+    it("payment_methods-call-test", () => {
+      cy.paymentMethodsCallTest(globalState);
+    });
+
+    it("Confirm PayPal wallet redirect", () => {
+      const data = getConnectorDetails(globalState.get("connectorId"))[
+        "wallet_pm"
+      ]["PayPal"];
+
+      cy.confirmBankRedirectCallTest(
+        fixtures.confirmBody,
+        data,
+        true,
+        globalState
+      );
+
+      if (shouldContinue) shouldContinue = utils.should_continue_further(data);
+    });
+
+    it("Handle wallet redirection", () => {
+      const expected_redirection = fixtures.confirmBody["return_url"];
+      const payment_method_type = globalState.get("paymentMethodType");
+      const nextActionUrl = globalState.get("nextActionUrl");
+
+      expect(
+        nextActionUrl,
+        "nextActionUrl should be defined before handling wallet redirection"
+      ).to.be.a("string");
+
+      cy.handleWalletRedirection(
+        globalState,
+        payment_method_type,
+        expected_redirection
+      );
+    });
+
+    it("Sync payment status", () => {
+      const data = getConnectorDetails(globalState.get("connectorId"))[
+        "wallet_pm"
+      ]["PayPal"];
+
+      cy.retrievePaymentCallTest({
+        globalState,
+        data,
+        expectedIntentStatus: "requires_customer_action",
+      });
+    });
+  });
 });


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD
- [x] Tests

## Description
<!-- Describe your changes in detail -->

Added Cypress test coverage for PayPal wallet flow on the PayPal connector. This includes the complete happy path covering payment creation, confirmation, redirect handling, and status synchronization.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

- `cypress-tests/cypress/e2e/spec/Payment/19-Wallet.cy.js` — new spec covering PayPal wallet happy path (Create, Confirm, Handle redirect, Sync status)
- `cypress-tests/cypress/e2e/configs/Payment/Paypal.js` — added `wallet_pm` section with `PaymentIntent` and `PayPal` config keys; added `billing: standardBillingAddress` and `authentication_type: "no_three_ds"`
- `cypress-tests/cypress/e2e/configs/Payment/Commons.js` — registered PayPal wallet in commons
- `cypress-tests/cypress/e2e/configs/Payment/Modifiers.js` — added modifier for PayPal wallet

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->

This coverage was added to fill a gap in wallet payment testing for the PayPal connector. The PayPal wallet flow was not previously covered by automated Cypress tests.

Parent issue: BAR-54

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

Full regression suite was executed against the changed connector(s). Runner results from the QA pipeline are included below.

### Regression summary — `paypal`

| Connector | Specs Run | Passed | Failed | Skipped | Status |
|---|---|---|---|---|---|
| paypal | 4 | 4 | 0 | 0 | PASS |

All connector regressions passed. The CI will run Stripe regression automatically on PR merge.

## Linked issues

Closes #12266
Related to #12266

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [x] I added unit tests for my changes where possible
