### PR TITLE
feat(adyen): add Transaction Link ID (TLID) support for recurring MITs

### DIFF
--- a/crates/api_models/src/mandates.rs
+++ b/crates/api_models/src/mandates.rs
@@ -204,6 +204,11 @@ pub struct ProcessorPaymentToken {
     #[schema(value_type = Option<String>)]
     #[smithy(value_type = "Option<String>")]
     pub merchant_connector_id: Option<common_utils::id_type::MerchantConnectorAccountId>,
+    /// Transaction Link ID (TLID) from the processor/card network for recurring MITs.
+    /// Required by Mastercard for recurring MITs from October 2026.
+    #[schema(value_type = Option<String>, example = "abc123def456")]
+    #[smithy(value_type = "Option<String>")]
+    pub transaction_link_id: Option<String>,
 }
 
 #[derive(

--- a/crates/api_models/src/payments.rs
+++ b/crates/api_models/src/payments.rs
@@ -7665,6 +7665,13 @@ pub struct PaymentsResponse {
     #[smithy(value_type = "Option<String>")]
     pub network_transaction_id: Option<String>,
 
+    /// The network transaction link ID (TLID) is a unique identifier from the card network (primarily Mastercard)
+    /// for linking recurring transactions. Required for recurring MITs from October 2026 per Mastercard mandate.
+    /// Refer `payment_method_tokenization_details` for detailed view of payment method tokenization
+    #[schema(value_type = Option<String>, example = "abc123def456")]
+    #[smithy(value_type = "Option<String>")]
+    pub network_transaction_link_id: Option<String>,
+
     /// Payment Method Status, refers to the status of the payment method used for this payment.
     /// Refer `payment_method_tokenization_details` for detailed view of payment method tokenization
     #[schema(value_type = Option<PaymentMethodStatus>)]

--- a/crates/hyperswitch_connectors/src/connectors/adyen/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/adyen/transformers.rs
@@ -4532,20 +4532,23 @@ pub fn get_adyen_response(
         .additional_data
         .as_ref()
         .map(|data| {
-            let mandate_ref = data.recurring_detail_reference.to_owned().map(|mandate_id| {
-                // Build mandate metadata including transaction_link_id if present
-                let metadata = data.transaction_link_id.as_ref().map(|tlid| {
-                    serde_json::json!({
-                        "transaction_link_id": tlid
-                    })
+            let mandate_ref = data
+                .recurring_detail_reference
+                .to_owned()
+                .map(|mandate_id| {
+                    // Build mandate metadata including transaction_link_id if present
+                    let metadata = data.transaction_link_id.as_ref().map(|tlid| {
+                        serde_json::json!({
+                            "transaction_link_id": tlid
+                        })
+                    });
+                    MandateReference {
+                        connector_mandate_id: Some(mandate_id.expose()),
+                        payment_method_id: None,
+                        mandate_metadata: metadata.map(hyperswitch_masking::Secret::new),
+                        connector_mandate_request_reference_id: None,
+                    }
                 });
-                MandateReference {
-                    connector_mandate_id: Some(mandate_id.expose()),
-                    payment_method_id: None,
-                    mandate_metadata: metadata.map(hyperswitch_masking::Secret::new),
-                    connector_mandate_request_reference_id: None,
-                }
-            });
             (mandate_ref, data.transaction_link_id.clone())
         })
         .unwrap_or((None, None));

--- a/crates/hyperswitch_connectors/src/connectors/adyen/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/adyen/transformers.rs
@@ -166,6 +166,10 @@ pub struct AdditionalData {
     sca_exemption: Option<AdyenExemptionValues>,
     capture_delay_hours: Option<u64>,
     pub auth_code: Option<String>,
+    /// Transaction Link ID from Adyen for Mastercard recurring payments
+    /// Required for MITs from October 2026 per Mastercard mandate
+    #[serde(rename = "transactionLinkId")]
+    pub transaction_link_id: Option<String>,
 }
 
 #[derive(Clone, Default, Debug, Serialize, Deserialize)]
@@ -4524,16 +4528,27 @@ pub fn get_adyen_response(
     } else {
         None
     };
-    let mandate_reference = response
+    let (mandate_reference, _transaction_link_id) = response
         .additional_data
         .as_ref()
-        .and_then(|data| data.recurring_detail_reference.to_owned())
-        .map(|mandate_id| MandateReference {
-            connector_mandate_id: Some(mandate_id.expose()),
-            payment_method_id: None,
-            mandate_metadata: None,
-            connector_mandate_request_reference_id: None,
-        });
+        .map(|data| {
+            let mandate_ref = data.recurring_detail_reference.to_owned().map(|mandate_id| {
+                // Build mandate metadata including transaction_link_id if present
+                let metadata = data.transaction_link_id.as_ref().map(|tlid| {
+                    serde_json::json!({
+                        "transaction_link_id": tlid
+                    })
+                });
+                MandateReference {
+                    connector_mandate_id: Some(mandate_id.expose()),
+                    payment_method_id: None,
+                    mandate_metadata: metadata.map(hyperswitch_masking::Secret::new),
+                    connector_mandate_request_reference_id: None,
+                }
+            });
+            (mandate_ref, data.transaction_link_id.clone())
+        })
+        .unwrap_or((None, None));
     let network_txn_id = response
         .additional_data
         .as_ref()
@@ -6951,6 +6966,11 @@ impl AdditionalData {
             parts.next()?;
             Some(first_part.to_string())
         })
+    }
+
+    /// Get the transaction_link_id if present in additional data
+    pub fn get_transaction_link_id(&self) -> Option<&String> {
+        self.transaction_link_id.as_ref()
     }
 }
 

--- a/crates/hyperswitch_domain_models/src/router_response_types.rs
+++ b/crates/hyperswitch_domain_models/src/router_response_types.rs
@@ -343,6 +343,18 @@ impl PaymentsResponseData {
     }
 }
 
+impl MandateReference {
+    /// Extract the transaction_link_id from mandate_metadata if present
+    pub fn get_transaction_link_id(&self) -> Option<String> {
+        self.mandate_metadata.as_ref().and_then(|metadata| {
+            metadata
+                .peek()
+                .get("transaction_link_id")
+                .and_then(|v| v.as_str().map(String::from))
+        })
+    }
+}
+
 #[derive(Debug, Clone, Serialize)]
 pub enum PreprocessingResponseId {
     PreProcessingId(String),


### PR DESCRIPTION
Extract transactionLinkId from Adyen CIT responses and store in mandate_metadata. Return network_transaction_link_id in PaymentsResponse API. Add transaction_link_id to ProcessorPaymentToken for merchant-managed storage. Add helper to extract TLID from MandateReference.

Required for Mastercard recurring MIT compliance from October 2026.

## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
