### PR TITLE
fix(ci): resolve pre-existing spell check failures

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -118,6 +118,7 @@ requestor = "requestor" #Used in external 3ds flows
 substituters = "substituters" # Present in `flake.nix`
 unsuccess = "unsuccess" # Used in cryptopay request
 automatico = "automatico" # Pix Automático (Portuguese for Automatic) - payment method name
+UNSUPPORT = "UNSUPPORT" # PayPal API error code strings (UNSUPPORT_ENTITY, UNSUPPORT_INSTALLMENT, etc.)
 
 [files]
 extend-exclude = [

--- a/crates/euclid/src/dssa/graph.rs
+++ b/crates/euclid/src/dssa/graph.rs
@@ -879,7 +879,7 @@ mod test {
                 cgraph::Relation::Positive,
                 cgraph::Strength::Strong,
             ))
-            .expect("Memoization not workng");
+            .expect("Memoization not working");
         matches!(_answer, Ok(()));
     }
 

--- a/crates/euclid/src/frontend/dir.rs
+++ b/crates/euclid/src/frontend/dir.rs
@@ -193,7 +193,7 @@ pub enum DirKeyKind {
     CryptoType,
     #[strum(
         serialize = "metadata",
-        detailed_message = "Aribitrary Key and value pair",
+        detailed_message = "Arbitrary Key and value pair",
         props(Category = "Metadata")
     )]
     #[serde(rename = "metadata")]

--- a/crates/hyperswitch_connectors/src/connectors/worldpaymodular/transformers/response.rs
+++ b/crates/hyperswitch_connectors/src/connectors/worldpaymodular/transformers/response.rs
@@ -67,7 +67,7 @@ pub struct WroldpayModularActualPsyncResponseObj {
     pub value: super::PaymentValue,
 }
 
-// Sent for settlement plays totally differnt role in worldpaymodular in webhooks and psync
+// Sent for settlement plays totally different role in worldpaymodular in webhooks and psync
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum WorldpayModularPsyncObjResponse {

--- a/crates/router/src/core/payment_methods.rs
+++ b/crates/router/src/core/payment_methods.rs
@@ -3991,7 +3991,7 @@ pub async fn get_external_vault_token(
         .ok_or(errors::ApiErrorResponse::InternalServerError)
         .attach_printable("Missing vault token data")?;
 
-    let decrypted_addtional_payment_method_data = payment_method
+    let decrypted_additional_payment_method_data = payment_method
         .payment_method_data
         .clone()
         .map(Encryptable::into_inner)
@@ -3999,7 +3999,7 @@ pub async fn get_external_vault_token(
         .attach_printable("Failed to convert payment method data")?;
 
     convert_from_saved_payment_method_data(
-        decrypted_addtional_payment_method_data,
+        decrypted_additional_payment_method_data,
         external_vault_token_data,
         vault_token,
     )

--- a/crates/router/src/core/payouts/helpers.rs
+++ b/crates/router/src/core/payouts/helpers.rs
@@ -271,11 +271,11 @@ impl SourceBankDataOperation {
     ) -> RouterResult<Option<String>> {
         match source_bank_data {
             Some(source_bank_data) => {
-                let sourc_bank_data_token = Self::get_source_bank_data_token();
+                let source_bank_data_token = Self::get_source_bank_data_token();
 
                 let lookup_key = vault::Vault::store_payout_method_data_in_locker(
                     state,
-                    Some(sourc_bank_data_token),
+                    Some(source_bank_data_token),
                     &api::PayoutMethodData::BankTransfer(source_bank_data),
                     customer_id,
                     merchant_key_store,

--- a/crates/router/src/middleware.rs
+++ b/crates/router/src/middleware.rs
@@ -308,7 +308,7 @@ where
             let locale_param =
                 serde_qs::from_str::<LocaleQueryParam>(query_params).map_err(|error| {
                     actix_web::error::ErrorBadRequest(format!(
-                        "Could not convert query params to locale query parmas: {error:?}",
+                        "Could not convert query params to locale query params: {error:?}",
                     ))
                 })?;
             let accept_language_header = req.headers().get(http::header::ACCEPT_LANGUAGE);


### PR DESCRIPTION
## Summary

Fix pre-existing typos that cause the spell check CI job to fail on all PRs.

### Changes
- **`.typos.toml`**: Add `UNSUPPORT` to dictionary (PayPal API error code constants like `UNSUPPORT_ENTITY`, `UNSUPPORT_INSTALLMENT`)
- **`payment_methods.rs`**: Rename local variable `addtional` → `additional`
- **`payouts/helpers.rs`**: Rename local variable `sourc` → `source`
- **`worldpaymodular/response.rs`**: Fix comment typo `differnt` → `different`
- **`middleware.rs`**: Fix error message typo `parmas` → `params`
- **`euclid/dir.rs`**: Fix attribute typo `Aribitrary` → `Arbitrary`
- **`euclid/graph.rs`**: Fix test message typo `workng` → `working`

## Motivation

The spell check job on `main` currently fails, which means every PR inherits this failure regardless of its own changes. This unblocks 6+ approved PRs waiting to merge.

## Test plan
- [ ] Spell check CI passes on this PR
- [ ] No compilation errors (only comment/string/variable-name fixes)