### PR TITLE
[QA] Add billing descriptor test cases for Nuvei

### DIFF
--- a/cypress-tests/cypress/e2e/configs/Payment/Nuvei.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Nuvei.js
@@ -735,6 +735,79 @@ export const connectorDetails = {
         },
       },
     },
+    // Billing descriptor test cases
+    BillingDescriptorNo3DSAutoCapture: {
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulNo3DSCardDetails,
+        },
+        billing_descriptor: {
+          name: "Test Merchant",
+          phone: "1234567890",
+        },
+        amount: 11500,
+        currency: "USD",
+        customer_acceptance: null,
+        setup_future_usage: "on_session",
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "succeeded",
+          payment_method: "card",
+          attempt_count: 1,
+        },
+      },
+    },
+    BillingDescriptorInvalidPhone: {
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulNo3DSCardDetails,
+        },
+        billing_descriptor: {
+          name: "Test Merchant",
+          phone: "12345678901234", // Exceeds 13 chars
+        },
+        amount: 11500,
+        currency: "USD",
+        customer_acceptance: null,
+        setup_future_usage: "on_session",
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "succeeded",
+          payment_method: "card",
+          attempt_count: 1,
+        },
+      },
+    },
+    BillingDescriptorEmptyDescriptor: {
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulNo3DSCardDetails,
+        },
+        billing_descriptor: {
+          name: "",
+          phone: "",
+        },
+        amount: 11500,
+        currency: "USD",
+        customer_acceptance: null,
+        setup_future_usage: "on_session",
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "succeeded",
+          payment_method: "card",
+          attempt_count: 1,
+        },
+      },
+    },
   },
   // Bank redirect payment methods
   bank_redirect_pm: {

--- a/cypress-tests/cypress/e2e/spec/Payment/46-NuveiBillingDescriptor.cy.js
+++ b/cypress-tests/cypress/e2e/spec/Payment/46-NuveiBillingDescriptor.cy.js
@@ -1,0 +1,188 @@
+import * as fixtures from "../../../fixtures/imports";
+import State from "../../../utils/State";
+import getConnectorDetails, * as utils from "../../configs/Payment/Utils";
+
+let globalState;
+
+describe("Nuvei - Billing Descriptor Tests", () => {
+  before("seed global state", () => {
+    cy.task("getGlobalState").then((state) => {
+      globalState = new State(state);
+    });
+  });
+
+  after("flush global state", () => {
+    cy.task("setGlobalState", globalState.data);
+  });
+
+  context("Billing Descriptor - Happy Path with Auto Capture", () => {
+    it("Create Payment Intent -> Confirm Payment with billing_descriptor -> Retrieve Payment", () => {
+      let shouldContinue = true;
+
+      cy.step("Create Payment Intent", () => {
+        const data = getConnectorDetails(globalState.get("connectorId"))[
+          "card_pm"
+        ]["PaymentIntent"];
+
+        cy.createPaymentIntentTest(
+          fixtures.createPaymentBody,
+          data,
+          "no_three_ds",
+          "automatic",
+          globalState
+        );
+
+        if (!utils.should_continue_further(data)) {
+          shouldContinue = false;
+        }
+      });
+
+      cy.step("Confirm Payment with billing_descriptor", () => {
+        if (!shouldContinue) {
+          cy.task("cli_log", "Skipping step: Confirm Payment with billing_descriptor");
+          return;
+        }
+        const confirmData = getConnectorDetails(globalState.get("connectorId"))[
+          "card_pm"
+        ]["BillingDescriptorNo3DSAutoCapture"];
+
+        cy.confirmCallTest(
+          fixtures.confirmBody,
+          confirmData,
+          true,
+          globalState
+        );
+
+        if (!utils.should_continue_further(confirmData)) {
+          shouldContinue = false;
+        }
+      });
+
+      cy.step("Retrieve Payment", () => {
+        if (!shouldContinue) {
+          cy.task("cli_log", "Skipping step: Retrieve Payment");
+          return;
+        }
+        const confirmData = getConnectorDetails(globalState.get("connectorId"))[
+          "card_pm"
+        ]["BillingDescriptorNo3DSAutoCapture"];
+
+        cy.retrievePaymentCallTest({ globalState, data: confirmData });
+      });
+    });
+  });
+
+  context("Billing Descriptor - Invalid Phone (Exceeds 13 chars)", () => {
+    it("Create Payment Intent -> Confirm Payment with invalid billing_descriptor phone -> Payment fails with billing descriptor error", () => {
+      let shouldContinue = true;
+
+      cy.step("Create Payment Intent", () => {
+        const data = getConnectorDetails(globalState.get("connectorId"))[
+          "card_pm"
+        ]["PaymentIntent"];
+
+        cy.createPaymentIntentTest(
+          fixtures.createPaymentBody,
+          data,
+          "no_three_ds",
+          "automatic",
+          globalState
+        );
+
+        if (!utils.should_continue_further(data)) {
+          shouldContinue = false;
+        }
+      });
+
+      cy.step("Confirm Payment with invalid billing_descriptor phone", () => {
+        if (!shouldContinue) {
+          cy.task("cli_log", "Skipping step: Confirm Payment with invalid billing_descriptor phone");
+          return;
+        }
+        const confirmData = getConnectorDetails(globalState.get("connectorId"))[
+          "card_pm"
+        ]["BillingDescriptorInvalidPhone"];
+
+        cy.confirmCallTest(
+          fixtures.confirmBody,
+          confirmData,
+          true,
+          globalState
+        );
+
+        if (!utils.should_continue_further(confirmData)) {
+          shouldContinue = false;
+        }
+      });
+
+      cy.step("Validate payment failed with billing descriptor error", () => {
+        if (!shouldContinue) {
+          cy.task("cli_log", "Skipping step: Validate payment failed with billing descriptor error");
+          return;
+        }
+        const confirmData = getConnectorDetails(globalState.get("connectorId"))[
+          "card_pm"
+        ]["BillingDescriptorInvalidPhone"];
+
+        cy.retrievePaymentCallTest({ globalState, data: confirmData });
+      });
+    });
+  });
+
+  context("Billing Descriptor - Empty Descriptor", () => {
+    it("Create Payment Intent -> Confirm Payment with empty billing_descriptor -> Payment succeeds with empty descriptor", () => {
+      let shouldContinue = true;
+
+      cy.step("Create Payment Intent", () => {
+        const data = getConnectorDetails(globalState.get("connectorId"))[
+          "card_pm"
+        ]["PaymentIntent"];
+
+        cy.createPaymentIntentTest(
+          fixtures.createPaymentBody,
+          data,
+          "no_three_ds",
+          "automatic",
+          globalState
+        );
+
+        if (!utils.should_continue_further(data)) {
+          shouldContinue = false;
+        }
+      });
+
+      cy.step("Confirm Payment with empty billing_descriptor", () => {
+        if (!shouldContinue) {
+          cy.task("cli_log", "Skipping step: Confirm Payment with empty billing_descriptor");
+          return;
+        }
+        const confirmData = getConnectorDetails(globalState.get("connectorId"))[
+          "card_pm"
+        ]["BillingDescriptorEmptyDescriptor"];
+
+        cy.confirmCallTest(
+          fixtures.confirmBody,
+          confirmData,
+          true,
+          globalState
+        );
+
+        if (!utils.should_continue_further(confirmData)) {
+          shouldContinue = false;
+        }
+      });
+
+      cy.step("Retrieve Payment with empty billing_descriptor", () => {
+        if (!shouldContinue) {
+          cy.task("cli_log", "Skipping step: Retrieve Payment with empty billing_descriptor");
+          return;
+        }
+        const confirmData = getConnectorDetails(globalState.get("connectorId"))[
+          "card_pm"
+        ]["BillingDescriptorEmptyDescriptor"];
+
+        cy.retrievePaymentCallTest({ globalState, data: confirmData });
+      });
+    });
+  });
+});

--- a/cypress-tests/package-lock.json
+++ b/cypress-tests/package-lock.json
@@ -10,8 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "cors": "^2.8.5",
-        "express": "^5.1.0",
-        "fsevents": "2.3.3"
+        "express": "^5.1.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.33.0",


### PR DESCRIPTION
## What changed
- Added new Cypress spec `cypress/e2e/spec/Payment/46-NuveiBillingDescriptor.cy.js` covering Nuvei billing descriptor flows.
- Modified `cypress/e2e/configs/Payment/Nuvei.js` (+73 lines) to support the new test scenarios.

## Why
- QAA-87

## How did you test it
- Runner executed 10/10 tests successfully:
  - 01-AccountCreate.cy.js (3/3 pass)
  - 02-CustomerCreate.cy.js (1/1 pass)
  - 03-ConnectorCreate.cy.js (3/3 pass)
  - 46-NuveiBillingDescriptor.cy.js (3/3 pass)

## Gate
```
GATE_PASSED:
  ConnectorRegressions:
    - Connector: nuvei
      Result: PASS
      TestsRun: 10
      Passed: 10
      Failed: 0
      Specs:
        - 01-AccountCreate.cy.js (3/3 pass)
        - 02-CustomerCreate.cy.js (1/1 pass)
        - 03-ConnectorCreate.cy.js (3/3 pass)
        - 46-NuveiBillingDescriptor.cy.js (3/3 pass)
  AllChecksPassed: YES
  ReadyForGitHubAgent: YES
```