### PR TITLE
test(cypress): add billing descriptor coverage for finix

### DIFF
--- a/cypress-tests/cypress/e2e/configs/Payment/Finix.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Finix.js
@@ -727,6 +727,42 @@ export const connectorDetails = {
         },
       },
     },
+    PaymentIntentWithBillingDescriptorExtraFields: {
+      Request: {
+        currency: "USD",
+        amount: 6540,
+        authentication_type: "no_three_ds",
+        capture_method: "automatic",
+        billing_descriptor: {
+          name: "Juspay",
+          city: "San Francisco",
+          phone: "8056594427",
+          statement_descriptor: "QA-BillingDesc",
+          statement_descriptor_suffix: "SUFFIX1",
+          reference: "ref-qa-001",
+        },
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "requires_payment_method",
+        },
+      },
+    },
+    PaymentConfirmWithBillingDescriptorExtraFields: {
+      Request: {
+        payment_method: "card",
+        payment_method_data: { card: successfulNo3DSCardDetails },
+        customer_acceptance: null,
+        setup_future_usage: "on_session",
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "succeeded",
+        },
+      },
+    },
     external_three_ds: {
       Request: {
         payment_method: "card",

--- a/cypress-tests/cypress/e2e/configs/Payment/Utils.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Utils.js
@@ -525,6 +525,7 @@ export const CONNECTOR_LISTS = {
       "finix",
     ],
     BILLING_DESCRIPTOR_INVALID_PHONE: ["nuvei"],
+    BILLING_DESCRIPTOR_EXTRA_FIELDS: ["adyen", "checkout", "stripe", "trustpay"],
     FEATURE_METADATA: ["bankofamerica"],
     AUTO_RETRY: [
       "cybersource",

--- a/cypress-tests/cypress/e2e/configs/Payment/Utils.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Utils.js
@@ -525,7 +525,12 @@ export const CONNECTOR_LISTS = {
       "finix",
     ],
     BILLING_DESCRIPTOR_INVALID_PHONE: ["nuvei"],
-    BILLING_DESCRIPTOR_EXTRA_FIELDS: ["adyen", "checkout", "stripe", "trustpay"],
+    BILLING_DESCRIPTOR_EXTRA_FIELDS: [
+      "adyen",
+      "checkout",
+      "stripe",
+      "trustpay",
+    ],
     FEATURE_METADATA: ["bankofamerica"],
     AUTO_RETRY: [
       "cybersource",

--- a/cypress-tests/cypress/e2e/spec/Payment/43-BillingDescriptor.cy.js
+++ b/cypress-tests/cypress/e2e/spec/Payment/43-BillingDescriptor.cy.js
@@ -100,6 +100,88 @@ describe("Card - Billing Descriptor payment flow test", () => {
   });
 
   context(
+    "Card-NoThreeDS payment with extra billing descriptor fields silently dropped (edge case)",
+    () => {
+      it("Create Payment Intent with extra fields -> Payment Methods -> Confirm Payment -> Retrieve Payment", () => {
+        let shouldContinue = true;
+
+        cy.step(
+          "Create Payment Intent with extra billing descriptor fields",
+          () => {
+            if (
+              shouldIncludeConnector(
+                connector,
+                CONNECTOR_LISTS.INCLUDE.BILLING_DESCRIPTOR_EXTRA_FIELDS
+              )
+            ) {
+              cy.log(
+                `Skipping: ${connector} supports extra billing descriptor fields natively`
+              );
+              shouldContinue = false;
+              return;
+            }
+
+            const data = getConnectorDetails(globalState.get("connectorId"))[
+              "card_pm"
+            ]["PaymentIntentWithBillingDescriptorExtraFields"];
+
+            cy.createPaymentIntentTest(
+              fixtures.createPaymentBody,
+              data,
+              "no_three_ds",
+              "automatic",
+              globalState
+            );
+
+            if (!utils.should_continue_further(data)) {
+              shouldContinue = false;
+            }
+          }
+        );
+
+        cy.step("Payment Methods Call", () => {
+          if (!shouldContinue) {
+            cy.task("cli_log", "Skipping step: Payment Methods Call");
+            return;
+          }
+          cy.paymentMethodsCallTest(globalState);
+        });
+
+        cy.step("Confirm Payment with extra billing descriptor fields", () => {
+          if (!shouldContinue) {
+            cy.task("cli_log", "Skipping step: Confirm Payment");
+            return;
+          }
+          const data = getConnectorDetails(globalState.get("connectorId"))[
+            "card_pm"
+          ]["PaymentConfirmWithBillingDescriptorExtraFields"];
+
+          cy.confirmCallTest(fixtures.confirmBody, data, true, globalState);
+
+          if (!utils.should_continue_further(data)) {
+            shouldContinue = false;
+          }
+        });
+
+        cy.step(
+          "Retrieve Payment with extra billing descriptor fields (silently dropped)",
+          () => {
+            if (!shouldContinue) {
+              cy.task("cli_log", "Skipping step: Retrieve Payment");
+              return;
+            }
+            const data = getConnectorDetails(globalState.get("connectorId"))[
+              "card_pm"
+            ]["PaymentConfirmWithBillingDescriptorExtraFields"];
+
+            cy.retrievePaymentCallTest({ globalState, data });
+          }
+        );
+      });
+    }
+  );
+
+  context(
     "Card-NoThreeDS payment with invalid billing descriptor (field length validation)",
     () => {
       it("Create Payment Intent -> Payment Methods -> Confirm Payment (expect error)", () => {


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD
- [x] Tests

## Description
<!-- Describe your changes in detail -->

This PR adds Cypress test coverage for the billing descriptor feature on the **Finix** connector. Three test contexts are covered: the happy path with a standard billing descriptor, an edge case where extra billing descriptor fields are silently dropped, and an invalid billing descriptor phone validation scenario. The Finix connector configuration is extended with the necessary request/response definitions for each scenario.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->

- `cypress-tests/cypress/e2e/spec/Payment/43-BillingDescriptor.cy.js` — new spec covering Billing Descriptor happy path + extra-fields edge case + invalid-phone negative case
- `cypress-tests/cypress/e2e/configs/Payment/Finix.js` — added `PaymentIntentWithBillingDescriptor`, `PaymentConfirmWithBillingDescriptor`, `PaymentIntentWithBillingDescriptorExtraFields`, `PaymentConfirmWithBillingDescriptorExtraFields` config entries
- `cypress-tests/cypress/e2e/configs/Payment/Utils.js` — registered Finix in `CONNECTOR_LISTS.INCLUDE.BILLING_DESCRIPTOR`

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->

The Finix connector lacked automated regression coverage for billing descriptors. This PR fills that gap so future connector or platform changes affecting billing descriptor passthrough do not silently regress Finix behavior. The tests were generated via the internal QA pipeline (QAA-47) after validation confirmed the feature is in scope for Finix.

Parent pipeline issue: [QAA-47](/QAA/issues/QAA-47)

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

Full regression suite was executed against the changed connector(s). All `RUNNER_RESULT` blocks from the QA pipeline are included verbatim below.

### Changed-spec verification — `finix`

```
RUNNER_RESULT:
  Connector: finix
  SpecFile: cypress/e2e/spec/Payment/43-BillingDescriptor.cy.js
  PrereqsUsed: spec/Payment/01-AccountCreate,02-CustomerCreate,03-ConnectorCreate
  TotalTests: 9
  Passed: 9
  Failed: 0
  Skipped: 0
  OverallStatus: PASS

  Failures: []

  SkippedTests: []

  FlakeyTests: []

  BlockedReasons: []
```

### Summary

| Connector | Specs Run | Passed | Failed | Skipped | Status |
|---|---|---|---|---|---|
| finix | 9 | 9 | 0 | 0 | PASS |

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [x] I added unit tests for my changes where possible

## Linked issues

Closes #12313
Related to [QAA-47](/QAA/issues/QAA-47)
