### PR TITLE
feat(gigadat): add method to retrieve billing phone number without plus sign

### DIFF
--- a/crates/hyperswitch_connectors/src/connectors/gigadat/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/gigadat/transformers.rs
@@ -111,7 +111,7 @@ impl TryFrom<&GigadatRouterData<&PaymentsAuthorizeRouterData>> for GigadatCpiReq
                 let router_data = item.router_data;
                 let name = router_data.get_billing_full_name()?;
                 let email = router_data.get_billing_email()?;
-                let mobile = router_data.get_billing_phone_number()?;
+                let mobile = router_data.get_billing_phone_number_without_plus()?;
                 let currency = item.router_data.request.currency;
                 let sandbox = match item.router_data.test_mode {
                     Some(true) => true,
@@ -474,7 +474,7 @@ impl TryFrom<&GigadatRouterData<&PayoutsRouterData<PoQuote>>> for GigadatPayoutQ
                 let router_data = item.router_data;
                 let name = router_data.get_billing_full_name()?;
                 let email = interac_data.email;
-                let mobile = router_data.get_billing_phone_number()?;
+                let mobile = router_data.get_billing_phone_number_without_plus()?;
                 let currency = item.router_data.request.destination_currency;
 
                 let user_ip = router_data.request.get_browser_info()?.get_ip_address()?;

--- a/crates/hyperswitch_connectors/src/utils.rs
+++ b/crates/hyperswitch_connectors/src/utils.rs
@@ -562,6 +562,7 @@ pub trait RouterData {
     fn get_billing_city(&self) -> Result<String, Error>;
     fn get_billing_email(&self) -> Result<Email, Error>;
     fn get_billing_phone_number(&self) -> Result<Secret<String>, Error>;
+    fn get_billing_phone_number_without_plus(&self) -> Result<Secret<String>, Error>;
     fn to_connector_meta<T>(&self) -> Result<T, Error>
     where
         T: serde::de::DeserializeOwned;
@@ -914,6 +915,11 @@ impl<Flow, Request, Response> RouterData
             .map(|phone_details| phone_details.get_number_with_country_code())
             .transpose()?
             .ok_or_else(missing_field_err("payment_method_data.billing.phone"))
+    }
+
+    fn get_billing_phone_number_without_plus(&self) -> Result<Secret<String>, Error> {
+        self.get_billing_phone_number()
+            .map(|phone| Secret::new(phone.peek().trim_start_matches('+').to_string()))
     }
 
     fn get_optional_billing_line1(&self) -> Option<Secret<String>> {


### PR DESCRIPTION


## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
Main pr - https://github.com/juspay/hyperswitch/pull/12322


fix(gigadat): strip leading + from billing phone number
The get_billing_phone_number utility combines the country code and number (e.g. +12132432423), but Gigadat expects the phone number without a leading +.
Changes:
- Added get_billing_phone_number_without_plus to the RouterData utils trait and its implementation, which strips the + prefix from the result of get_billing_phone_number
- Updated both Gigadat transformer call sites to use the new helper instead of inline stripping logic

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
Make a gigadat payment
```
curl --location 'http://localhost:8080/payments' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: dev_lUiFUi59u5ccmsmfoYmGW96jQ39mMmUsO3fgzJ5CVLjsiQTxU9tYNl6iFlfrfNDC' \
--data-raw '{
    "amount": 100,
    "currency": "CAD",
    "confirm": true,
    "capture_method": "automatic",
    "customer_id": "aaaa",
    "profile_id": "pro_RhxF9bcun42ECJglUbt5",
    "authentication_type": "three_ds",
    "payment_method": "bank_redirect",
    "payment_method_type": "interac",
    "payment_method_data": {
        "bank_redirect": {
            "interac": {}
        }
    },
    "billing": {
        "address": {
            "line1": "Singapore Changi Airport. 2nd flr",
            "line2": "",
            "line3": "",
            "city": "Downtown Core",
            "state": "Central Indiana America",
            "zip": "039393",
            "country": "CA",
            "first_name": "Swangi",
            "last_name": "Kumari"
        },
        "phone": {
            "number": "8056594427",
            "country_code": "+91"
        },
        "email": "etransfer@orderdeposi1t.com"
    },
    "browser_info": {
        "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Safari/537.36",
        "accept_header": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8",
        "language": "nl-NL",
        "color_depth": 24,
        "screen_height": 723,
        "screen_width": 1536,
        "time_zone": 0,
        "java_enabled": true,
        "java_script_enabled": true,
        "ip_address": "127.0.0.1"
    }
}
'
```

Raw connector request of connector, even if we pass + in HS request, we will not pass that to connector
```
"{
  "userId": "aaaa",
  "site": "https://google.com/",
  "userIp": "127.0.0.1",
  "currency": "CAD",
  "amount": 1.0,
  "transactionId": "pay_TvrATmihzzwbhloN924F_1",
  "type": "CPI",
  "sandbox": false,
  "name": "Swangi Kumari",
  "email": "etransfer@orderdeposi1t.com",
  "mobile": "918056594427"
}
```

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
