### PR TITLE
fix(router): Treat ApplePay session Response as an opaque object

### DIFF
--- a/api-reference/v1/openapi_spec_v1.json
+++ b/api-reference/v1/openapi_spec_v1.json
@@ -9952,7 +9952,7 @@
             "$ref": "#/components/schemas/ThirdPartySdkSessionResponse"
           },
           {
-            "$ref": "#/components/schemas/NoThirdPartySdkSessionResponse"
+            "description": "We get this session response, when there is no involvement of third party sdk\nThis is the common response most of the times"
           },
           {
             "$ref": "#/components/schemas/NullObject"
@@ -26238,74 +26238,6 @@
           "invoke_upi_intent_sdk",
           "invoke_upi_qr_flow"
         ]
-      },
-      "NoThirdPartySdkSessionResponse": {
-        "type": "object",
-        "required": [
-          "epoch_timestamp",
-          "expires_at",
-          "merchant_session_identifier",
-          "nonce",
-          "merchant_identifier",
-          "domain_name",
-          "display_name",
-          "signature",
-          "operational_analytics_identifier",
-          "retries",
-          "psp_id"
-        ],
-        "properties": {
-          "epoch_timestamp": {
-            "type": "integer",
-            "format": "int64",
-            "description": "Timestamp at which session is requested",
-            "minimum": 0
-          },
-          "expires_at": {
-            "type": "integer",
-            "format": "int64",
-            "description": "Timestamp at which session expires",
-            "minimum": 0
-          },
-          "merchant_session_identifier": {
-            "type": "string",
-            "description": "The identifier for the merchant session"
-          },
-          "nonce": {
-            "type": "string",
-            "description": "Apple pay generated unique ID (UUID) value"
-          },
-          "merchant_identifier": {
-            "type": "string",
-            "description": "The identifier for the merchant"
-          },
-          "domain_name": {
-            "type": "string",
-            "description": "The domain name of the merchant which is registered in Apple Pay"
-          },
-          "display_name": {
-            "type": "string",
-            "description": "The name to be displayed on Apple Pay button"
-          },
-          "signature": {
-            "type": "string",
-            "description": "A string which represents the properties of a payment"
-          },
-          "operational_analytics_identifier": {
-            "type": "string",
-            "description": "The identifier for the operational analytics"
-          },
-          "retries": {
-            "type": "integer",
-            "format": "int32",
-            "description": "The number of retries to get the session response",
-            "minimum": 0
-          },
-          "psp_id": {
-            "type": "string",
-            "description": "The identifier for the connector transaction"
-          }
-        }
       },
       "NoonData": {
         "type": "object",

--- a/api-reference/v2/openapi_spec_v2.json
+++ b/api-reference/v2/openapi_spec_v2.json
@@ -6450,7 +6450,7 @@
             "$ref": "#/components/schemas/ThirdPartySdkSessionResponse"
           },
           {
-            "$ref": "#/components/schemas/NoThirdPartySdkSessionResponse"
+            "description": "We get this session response, when there is no involvement of third party sdk\nThis is the common response most of the times"
           },
           {
             "$ref": "#/components/schemas/NullObject"
@@ -19287,74 +19287,6 @@
           "invoke_upi_intent_sdk",
           "invoke_upi_qr_flow"
         ]
-      },
-      "NoThirdPartySdkSessionResponse": {
-        "type": "object",
-        "required": [
-          "epoch_timestamp",
-          "expires_at",
-          "merchant_session_identifier",
-          "nonce",
-          "merchant_identifier",
-          "domain_name",
-          "display_name",
-          "signature",
-          "operational_analytics_identifier",
-          "retries",
-          "psp_id"
-        ],
-        "properties": {
-          "epoch_timestamp": {
-            "type": "integer",
-            "format": "int64",
-            "description": "Timestamp at which session is requested",
-            "minimum": 0
-          },
-          "expires_at": {
-            "type": "integer",
-            "format": "int64",
-            "description": "Timestamp at which session expires",
-            "minimum": 0
-          },
-          "merchant_session_identifier": {
-            "type": "string",
-            "description": "The identifier for the merchant session"
-          },
-          "nonce": {
-            "type": "string",
-            "description": "Apple pay generated unique ID (UUID) value"
-          },
-          "merchant_identifier": {
-            "type": "string",
-            "description": "The identifier for the merchant"
-          },
-          "domain_name": {
-            "type": "string",
-            "description": "The domain name of the merchant which is registered in Apple Pay"
-          },
-          "display_name": {
-            "type": "string",
-            "description": "The name to be displayed on Apple Pay button"
-          },
-          "signature": {
-            "type": "string",
-            "description": "A string which represents the properties of a payment"
-          },
-          "operational_analytics_identifier": {
-            "type": "string",
-            "description": "The identifier for the operational analytics"
-          },
-          "retries": {
-            "type": "integer",
-            "format": "int32",
-            "description": "The number of retries to get the session response",
-            "minimum": 0
-          },
-          "psp_id": {
-            "type": "string",
-            "description": "The identifier for the connector transaction"
-          }
-        }
       },
       "NoonData": {
         "type": "object",

--- a/crates/api_models/src/payments.rs
+++ b/crates/api_models/src/payments.rs
@@ -6662,7 +6662,7 @@ pub struct UrlDetails {
 pub struct AuthenticationForStartResponse {
     pub authentication: UrlDetails,
 }
-#[derive(Clone, Debug, Eq, PartialEq, serde::Serialize, ToSchema)]
+#[derive(Clone, Debug, PartialEq, serde::Serialize, ToSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum NextActionType {
     RedirectToUrl,
@@ -6677,9 +6677,7 @@ pub enum NextActionType {
     InvokeUpiQrFlow,
 }
 
-#[derive(
-    Clone, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize, ToSchema, SmithyModel,
-)]
+#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize, ToSchema, SmithyModel)]
 #[serde(tag = "type", rename_all = "snake_case")]
 #[smithy(namespace = "com.hyperswitch.smithy.types")]
 pub enum NextActionData {
@@ -10308,9 +10306,7 @@ pub struct GooglePayTokenizationParameters {
     pub stripe_version: Option<Secret<String>>,
 }
 
-#[derive(
-    Debug, Clone, Eq, PartialEq, serde::Serialize, serde::Deserialize, ToSchema, SmithyModel,
-)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, ToSchema, SmithyModel)]
 #[serde(tag = "wallet_name")]
 #[serde(rename_all = "snake_case")]
 #[smithy(namespace = "com.hyperswitch.smithy.types")]
@@ -10652,9 +10648,7 @@ pub struct OpenBankingSessionToken {
     pub open_banking_session_token: String,
 }
 
-#[derive(
-    Debug, Clone, Eq, PartialEq, serde::Serialize, serde::Deserialize, ToSchema, SmithyModel,
-)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, ToSchema, SmithyModel)]
 #[serde(rename_all = "lowercase")]
 #[smithy(namespace = "com.hyperswitch.smithy.types")]
 pub struct ApplepaySessionTokenResponse {
@@ -10718,9 +10712,7 @@ pub enum NextActionCall {
     EligibilityCheck,
 }
 
-#[derive(
-    Debug, Clone, Eq, PartialEq, serde::Serialize, serde::Deserialize, ToSchema, SmithyModel,
-)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, ToSchema, SmithyModel)]
 #[serde(untagged)]
 #[smithy(namespace = "com.hyperswitch.smithy.types")]
 pub enum ApplePaySessionResponse {
@@ -10729,52 +10721,10 @@ pub enum ApplePaySessionResponse {
     ThirdPartySdk(ThirdPartySdkSessionResponse),
     ///  We get this session response, when there is no involvement of third party sdk
     /// This is the common response most of the times
-    #[smithy(value_type = "NoThirdPartySdkSessionResponse")]
-    NoThirdPartySdk(NoThirdPartySdkSessionResponse),
+    NoThirdPartySdk(serde_json::Value),
     /// This is for the empty session response
     #[smithy(value_type = "smithy.api#Unit")]
     NoSessionResponse(NullObject),
-}
-
-#[derive(
-    Debug, Clone, Eq, PartialEq, serde::Serialize, ToSchema, serde::Deserialize, SmithyModel,
-)]
-#[serde(rename_all(deserialize = "camelCase"))]
-#[smithy(namespace = "com.hyperswitch.smithy.types")]
-pub struct NoThirdPartySdkSessionResponse {
-    /// Timestamp at which session is requested
-    #[smithy(value_type = "u64")]
-    pub epoch_timestamp: u64,
-    /// Timestamp at which session expires
-    #[smithy(value_type = "u64")]
-    pub expires_at: u64,
-    /// The identifier for the merchant session
-    #[smithy(value_type = "String")]
-    pub merchant_session_identifier: String,
-    /// Apple pay generated unique ID (UUID) value
-    #[smithy(value_type = "String")]
-    pub nonce: String,
-    /// The identifier for the merchant
-    #[smithy(value_type = "String")]
-    pub merchant_identifier: String,
-    /// The domain name of the merchant which is registered in Apple Pay
-    #[smithy(value_type = "String")]
-    pub domain_name: String,
-    /// The name to be displayed on Apple Pay button
-    #[smithy(value_type = "String")]
-    pub display_name: String,
-    /// A string which represents the properties of a payment
-    #[smithy(value_type = "String")]
-    pub signature: String,
-    /// The identifier for the operational analytics
-    #[smithy(value_type = "String")]
-    pub operational_analytics_identifier: String,
-    /// The number of retries to get the session response
-    #[smithy(value_type = "u8")]
-    pub retries: u8,
-    /// The identifier for the connector transaction
-    #[smithy(value_type = "String")]
-    pub psp_id: String,
 }
 
 #[derive(

--- a/crates/hyperswitch_connectors/src/connectors/bluesnap/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/bluesnap/transformers.rs
@@ -4,8 +4,7 @@ use api_models::{
     payments::{
         AmountInfo, ApplePayPaymentRequest, ApplePaySessionResponse,
         ApplepayCombinedSessionTokenData, ApplepaySessionTokenData, ApplepaySessionTokenMetadata,
-        ApplepaySessionTokenResponse, NextActionCall, NoThirdPartySdkSessionResponse,
-        SdkNextAction, SessionToken,
+        ApplepaySessionTokenResponse, NextActionCall, SdkNextAction, SessionToken,
     },
     webhooks::IncomingWebhookEvent,
 };
@@ -528,8 +527,8 @@ impl
             .decode(response.wallet_token.clone().expose())
             .change_context(errors::ConnectorError::ResponseHandlingFailed)?;
 
-        let session_response: NoThirdPartySdkSessionResponse = wallet_token
-            .parse_struct("NoThirdPartySdkSessionResponse")
+        let session_response: Value = wallet_token
+            .parse_struct("serde_json::Value")
             .change_context(errors::ConnectorError::ParsingFailed)?;
 
         let metadata = item.data.get_connector_meta()?.expose();

--- a/crates/openapi/src/openapi.rs
+++ b/crates/openapi/src/openapi.rs
@@ -628,7 +628,6 @@ Never share your secret api keys. Keep them guarded and secure.
         api_models::payments::ApplePaySessionResponse,
         api_models::payments::NullObject,
         api_models::payments::ThirdPartySdkSessionResponse,
-        api_models::payments::NoThirdPartySdkSessionResponse,
         api_models::payments::SecretInfoToInitiateSdk,
         api_models::payments::ApplePayPaymentRequest,
         api_models::payments::ApplePayBillingContactFields,

--- a/crates/openapi/src/openapi_v2.rs
+++ b/crates/openapi/src/openapi_v2.rs
@@ -551,7 +551,6 @@ Never share your secret api keys. Keep them guarded and secure.
         api_models::payments::HyperswitchVaultSessionDetails,
         api_models::payments::ApplePaySessionResponse,
         api_models::payments::ThirdPartySdkSessionResponse,
-        api_models::payments::NoThirdPartySdkSessionResponse,
         api_models::payments::SecretInfoToInitiateSdk,
         api_models::payments::ApplePayPaymentRequest,
         api_models::payments::ApplePayBillingContactFields,

--- a/crates/router/src/compatibility/stripe/payment_intents/types.rs
+++ b/crates/router/src/compatibility/stripe/payment_intents/types.rs
@@ -469,7 +469,7 @@ impl From<StripePaymentCancelRequest> for payments::PaymentsCancelRequest {
     }
 }
 
-#[derive(Default, Eq, PartialEq, Serialize, Debug)]
+#[derive(Default, PartialEq, Serialize, Debug)]
 pub struct StripePaymentIntentResponse {
     pub id: id_type::PaymentId,
     pub object: &'static str,
@@ -677,7 +677,7 @@ fn from_timestamp_to_datetime(
     }
 }
 
-#[derive(Default, Eq, PartialEq, Serialize)]
+#[derive(Default, PartialEq, Serialize)]
 pub struct StripePaymentIntentListResponse {
     pub object: String,
     pub url: String,
@@ -815,7 +815,7 @@ pub struct RedirectUrl {
     pub url: Option<String>,
 }
 
-#[derive(Eq, PartialEq, serde::Serialize, Debug)]
+#[derive(PartialEq, serde::Serialize, Debug)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum StripeNextAction {
     RedirectToUrl {

--- a/crates/router/src/compatibility/stripe/setup_intents/types.rs
+++ b/crates/router/src/compatibility/stripe/setup_intents/types.rs
@@ -365,7 +365,7 @@ pub struct RedirectUrl {
     pub url: Option<String>,
 }
 
-#[derive(Eq, PartialEq, serde::Serialize)]
+#[derive(PartialEq, serde::Serialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum StripeNextAction {
     RedirectToUrl {
@@ -505,7 +505,7 @@ pub(crate) fn into_stripe_next_action(
     })
 }
 
-#[derive(Default, Eq, PartialEq, Serialize)]
+#[derive(Default, PartialEq, Serialize)]
 pub struct StripeSetupIntentResponse {
     pub id: id_type::PaymentId,
     pub object: String,

--- a/crates/router/src/core/payments/flows/session_flow.rs
+++ b/crates/router/src/core/payments/flows/session_flow.rs
@@ -574,9 +574,9 @@ async fn create_applepay_session_token(
                         apple_pay_res
                             .map(|res| {
                                 let response: Result<
-                                    payment_types::NoThirdPartySdkSessionResponse,
+                                    serde_json::Value,
                                     Report<common_utils::errors::ParsingError>,
-                                > = res.response.parse_struct("NoThirdPartySdkSessionResponse");
+                                > = res.response.parse_struct("serde_json::Value");
 
                                 // logging the parsing failed error
                                 if let Err(error) = response.as_ref() {


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
This pull request removes the dedicated `NoThirdPartySdkSessionResponse` struct from both the API models and OpenAPI specifications, replacing it with a generic JSON value (`serde_json::Value`) for cases where there is no third-party SDK involvement in Apple Pay session responses. Additionally, it removes the `Eq` trait from several model structs and enums where it is not required, simplifying trait bounds and potentially improving performance.

The most important changes are:

### API Model and Type Changes

* Removed the `NoThirdPartySdkSessionResponse` struct from `api_models::payments` and replaced its usage in the `ApplePaySessionResponse::NoThirdPartySdk` variant with a generic `serde_json::Value`. This makes the response more flexible and decouples the API from a rigid schema for this case. [[1]](diffhunk://#diff-460b9de06d0bc282f72b2b826d1516d58aa4a4e67c0004bea409664a9e2fa375L10732-L10779) [[2]](diffhunk://#diff-460b9de06d0bc282f72b2b826d1516d58aa4a4e67c0004bea409664a9e2fa375L10721-R10715) [[3]](diffhunk://#diff-215c83cabf9c72d417fa6208f9a9b26c205489cd601e78820e0ac3914578410cL7-R7) [[4]](diffhunk://#diff-215c83cabf9c72d417fa6208f9a9b26c205489cd601e78820e0ac3914578410cL531-R531) [[5]](diffhunk://#diff-ab1e9e3cc76fd39cadbe537ad26e387b2d4344fd532220908acf9611f7f2d377L577-R579) [[6]](diffhunk://#diff-449ddbba20051c3e750e25f17452d490a28f78cfe4bcda279865a0365c6b29d8L631) [[7]](diffhunk://#diff-14b68b3dd92d1c9b635336dc0d2da22aa44d29b3bcefe23d59f82c604d8b0550L554)

* Updated all internal handling and deserialization of "no third-party SDK" session responses to use `serde_json::Value` instead of the removed struct. [[1]](diffhunk://#diff-215c83cabf9c72d417fa6208f9a9b26c205489cd601e78820e0ac3914578410cL531-R531) [[2]](diffhunk://#diff-ab1e9e3cc76fd39cadbe537ad26e387b2d4344fd532220908acf9611f7f2d377L577-R579)

### OpenAPI Specification Updates

* Removed the `NoThirdPartySdkSessionResponse` schema definition from both `openapi_spec_v1.json` and `openapi_spec_v2.json`. The API now documents this response as a generic description rather than a specific schema. [[1]](diffhunk://#diff-b6d18c391ea1980a2470ad0527a5da72c5124a2ae9544f90a760ad64f4da87dcL26242-L26309) [[2]](diffhunk://#diff-c4efcaac0e434b9d0089b1b3efc75e7e0cfea9f411942a44010e4a724e6b1db6L19291-L19358)
* Updated endpoints that previously referenced `NoThirdPartySdkSessionResponse` to use a descriptive message instead. [[1]](diffhunk://#diff-b6d18c391ea1980a2470ad0527a5da72c5124a2ae9544f90a760ad64f4da87dcL9955-R9955) [[2]](diffhunk://#diff-c4efcaac0e434b9d0089b1b3efc75e7e0cfea9f411942a44010e4a724e6b1db6L6453-R6453)

### Trait Bound Simplification

* Removed the `Eq` trait bound from several model structs and enums (e.g., `NextActionType`, `NextActionData`, `ApplePaySessionResponse`, and various Stripe compatibility types) where it was unnecessary, simplifying the codebase and reducing trait requirements. [[1]](diffhunk://#diff-460b9de06d0bc282f72b2b826d1516d58aa4a4e67c0004bea409664a9e2fa375L6665-R6665) [[2]](diffhunk://#diff-460b9de06d0bc282f72b2b826d1516d58aa4a4e67c0004bea409664a9e2fa375L6680-R6680) [[3]](diffhunk://#diff-460b9de06d0bc282f72b2b826d1516d58aa4a4e67c0004bea409664a9e2fa375L10311-R10309) [[4]](diffhunk://#diff-460b9de06d0bc282f72b2b826d1516d58aa4a4e67c0004bea409664a9e2fa375L10655-R10651) [[5]](diffhunk://#diff-b3a18db4870f5c320bcaeedfbdaeec5c2270e75850d20f47f4ef2adaeffeafe9L472-R472) [[6]](diffhunk://#diff-b3a18db4870f5c320bcaeedfbdaeec5c2270e75850d20f47f4ef2adaeffeafe9L680-R680) [[7]](diffhunk://#diff-b3a18db4870f5c320bcaeedfbdaeec5c2270e75850d20f47f4ef2adaeffeafe9L818-R818) [[8]](diffhunk://#diff-239289569b1836f19ea1653a2c071fd173d55472d799a276c6d9b95cf364989aL368-R368) [[9]](diffhunk://#diff-239289569b1836f19ea1653a2c071fd173d55472d799a276c6d9b95cf364989aL508-R508)

These changes collectively make the Apple Pay session response model more flexible, simplify the codebase, and keep the OpenAPI documentation in sync with the new approach.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
We’re not seeing Apple Pay in the session token in both Integ and Sandbox environments.

The error log:

Grafana Log: "extra": {
    "error": "Failed to parse struct: NoThirdPartySdkSessionResponse\n├╴
at crates/router/src/core/payments/flows/session_flow.rs:579:50\n
├╴Unable to parse NoThirdPartySdkSessionResponse from &[u8] {\"epochTimestamp\":*************, \"expiresAt\":*************, \"merchantSessionIdentifier\":\"S**98**4\", \"nonce\":\"5**6**2\", \"merchantIdentifier\":\"1**62**F\", \"domainName\":\"h**32**p\", \"displayName\":\"a**6**y\", \"signature\":\"3**4418**0\", \"operationalAnalyticsIdentifier\":\"a**71**F\", \"pspId\":\"1**62**F\"}\n│\n
╰─▶ missing field `retries` at line 1 column 4990\n    
╰╴at crates/router/src/core/payments/flows/session_flow.rs:579:50",
This issue is because apple pay has stopped send a field in the session token response, due to which the session token parsing is failing at our end.

On checking the official ApplePay merchant guide, it says that:

This is the opaque session object, and is used to start a session for Apple Pay on the Web. It is
important that this object is not inspected, parsed or modified in any way. Apple may update the
contents of this object from time to time with changes and enhancements.

In the code, we are violating this by explicitly parsing the session token response into a strict type:

<img width="689" height="143" alt="Image" src="https://github.com/user-attachments/assets/15af728b-7df3-4d33-846a-749c6e812516" />

We need to stop parsing this response into a strict type and treat it as serde_json::Value

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
