### PR TITLE
fix(split_payments): remove deny_unknown_fields from StripeSplitPayments

### DIFF
--- a/api-reference/v1/openapi_spec_v1.json
+++ b/api-reference/v1/openapi_spec_v1.json
@@ -41464,8 +41464,7 @@
             "example": "acct_1234567890",
             "nullable": true
           }
-        },
-        "additionalProperties": false
+        }
       },
       "StripeSplitRefundRequest": {
         "type": "object",

--- a/api-reference/v2/openapi_spec_v2.json
+++ b/api-reference/v2/openapi_spec_v2.json
@@ -30823,8 +30823,7 @@
             "example": "acct_1234567890",
             "nullable": true
           }
-        },
-        "additionalProperties": false
+        }
       },
       "StripeSplitRefundRequest": {
         "type": "object",

--- a/crates/common_types/src/payments.rs
+++ b/crates/common_types/src/payments.rs
@@ -75,7 +75,6 @@ impl_to_sql_from_sql_json!(SplitPaymentsRequest);
     SmithyModel,
 )]
 #[diesel(sql_type = Jsonb)]
-#[serde(deny_unknown_fields)]
 #[smithy(namespace = "com.hyperswitch.smithy.types")]
 /// Fee information for Split Payments to be charged on the payment being collected for Stripe
 pub struct StripeSplitPaymentRequest {


### PR DESCRIPTION
## Summary

Removes #[serde(deny_unknown_fields)] from StripeSplitPaymentRequest to allow backward compatibility when new fields like  are present in the database but the older code doesn't recognize them.

Fixes #12412

## Context

A new field  was added to the  struct. However, the struct had  enabled, which caused deserialization failures when older application instances tried to read records from the database that contained this new field.

This caused SEV1 5xx errors in production during staggered deployment because:
- Newer code wrote records with the new  field to the database
- Older running instances couldn't deserialize these records due to 

## Why This Fix

Removing  allows forward compatibility - older code will ignore unknown fields instead of failing deserialization. This is essential for zero-downtime deployments where database records may contain fields from newer code versions.

## Testing

This issue can only be reproduced during staggered deployment scenarios where:
1. Newer code writes records with new fields to the database
2. Older code attempts to read those records

This cannot be tested locally as it requires a multi-version deployment environment. The fix will be validated during the next staggered deployment.

## Type of Change
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD