### PR TITLE
fix(split_payments): remove deny_unknown_fields from StripeSplitPayments

### DIFF
--- a/api-reference/v1/openapi_spec_v1.json
+++ b/api-reference/v1/openapi_spec_v1.json
@@ -38038,8 +38038,7 @@
             "type": "string",
             "description": "Identifier for the reseller's account where the funds were transferred"
           }
-        },
-        "additionalProperties": false
+        }
       },
       "StripeSplitRefundRequest": {
         "type": "object",

--- a/api-reference/v2/openapi_spec_v2.json
+++ b/api-reference/v2/openapi_spec_v2.json
@@ -27307,8 +27307,7 @@
             "type": "string",
             "description": "Identifier for the reseller's account where the funds were transferred"
           }
-        },
-        "additionalProperties": false
+        }
       },
       "StripeSplitRefundRequest": {
         "type": "object",

--- a/crates/common_types/src/payments.rs
+++ b/crates/common_types/src/payments.rs
@@ -66,7 +66,6 @@ impl_to_sql_from_sql_json!(SplitPaymentsRequest);
     SmithyModel,
 )]
 #[diesel(sql_type = Jsonb)]
-#[serde(deny_unknown_fields)]
 #[smithy(namespace = "com.hyperswitch.smithy.types")]
 /// Fee information for Split Payments to be charged on the payment being collected for Stripe
 pub struct StripeSplitPaymentRequest {


### PR DESCRIPTION
## Summary

Removes #[serde(deny_unknown_fields)] from StripeSplitPaymentRequest to allow backward compatibility when new fields like `on_behalf_of` are present in the database but the older code doesn't recognize them.

Fixes #12412

## Context

This fix addresses the SEV1 incident where deserialization failed during staggered deployment. When newer code writes records with new fields to the database, older running instances couldn't deserialize them due to `deny_unknown_fields`.

## Deployment Strategy

This fix targets the current production version so it can be deployed immediately as a hotfix before proceeding with the newer version deployment.

## Type of Change
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD