### PR TITLE
parity(setup_mandate): map connector_response_reference_id from GRPC response

### DIFF
--- a/crates/router/src/core/unified_connector_service/transformers.rs
+++ b/crates/router/src/core/unified_connector_service/transformers.rs
@@ -2682,7 +2682,7 @@ impl
                     connector_metadata,
                     network_txn_id: response.network_transaction_id,
                     network_txn_link_id: None,
-                    connector_response_reference_id: None,
+                    connector_response_reference_id: Some(response.merchant_recurring_payment_id.clone()).filter(|s| !s.is_empty()),
                     incremental_authorization_allowed: response.incremental_authorization_allowed,
                     authentication_data: None,
                     charges: None,


### PR DESCRIPTION
## Verdict in one line
setup_mandate (all connectors via UCS): HS bridge was dropping `connector_response_reference_id` by hardcoding `None`. The proto response carries it as `merchant_recurring_payment_id`. Fix in HS UCS bridge.

## Decision trail
- HS direct path (`crates/hyperswitch_connectors/src/connectors/stripe/transformers.rs:L3761`):
  ```rust
  connector_response_reference_id: Some(item.response.id),
  ```
- HS UCS bridge (`crates/router/src/core/unified_connector_service/transformers.rs:L2685`):
  ```rust
  connector_response_reference_id: None,
  ```
- Prism proto mapping (`crates/types-traits/domain_types/src/types.rs:L9663`):
  ```rust
  merchant_recurring_payment_id: extract_connector_request_reference_id(&connector_response_reference_id),
  ```
- Connector doc: https://docs.stripe.com/api/setup_intents/object
  > The `id` field (string) is always present — unique identifier for the SetupIntent object.
- Conclusion: HS UCS bridge drops the value that Prism correctly provides in the GRPC response
- Fix direction: HS (UCS bridge)

## Raw evidence
- PRD issue: https://github.com/juspay/hyperswitch-cloud/issues/16337
- Expected RouterData field after fix: `connector_response_reference_id: Some("seti_xxx")`
- Pattern consistency: authorize flow uses `response.merchant_transaction_id` (L2357), charge flow uses `response.merchant_charge_id` (L2771)

## Diff
Single line: `None` → `Some(response.merchant_recurring_payment_id.clone()).filter(|s| !s.is_empty())`

## Verification
<details><summary>cargo check -p router (clean)</summary>

```
Finished `dev` profile [unoptimized + debuginfo] target(s) in 5m 35s
```
</details>
<details><summary>cargo clippy -p router -- -D warnings (pending — build passed)</summary>

Build clean; clippy run in progress (HS router crate is large).
</details>

## What this PR is NOT
- Field paths NOT touched: `amount_captured` (separate PR on hyperswitch-prism repo)
- Files NOT touched: connector-specific transformers, error path at L2634
- PRD `Out of scope` items: error path at L2634 (ErrorResponse variant — separate concern), other UCS flow bridges

## Acceptance Criteria
- [x] Build clean
- [x] Clippy pending (build verification complete)
- [ ] Shadow-replay produces zero diff for `connector_response_reference_id`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

Closes juspay/hyperswitch-cloud#16456
