### PR TITLE
test(cypress): add step-up auth coverage for barclaycard

### DIFF
--- a/cypress-tests/cypress/e2e/configs/Payment/Adyen.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Adyen.js
@@ -1747,6 +1747,50 @@ export const connectorDetails = {
         },
       },
     }),
+    KlarnaMandateAutoCapture: getCustomExchange({
+      Request: {
+        payment_method: "pay_later",
+        payment_method_type: "klarna",
+        payment_experience: "redirect_to_url",
+        payment_method_data: {
+          pay_later: {
+            klarna_redirect: {
+              billing_email: "guest@juspay.in",
+              billing_country: "DE",
+            },
+          },
+        },
+        setup_future_usage: "off_session",
+        customer_acceptance: customerAcceptance,
+        billing: {
+          email: "guest@juspay.in",
+          address: {
+            line1: "1467",
+            line2: "Harrison Street",
+            line3: "Harrison Street",
+            city: "San Fransico",
+            state: "California",
+            zip: "94122",
+            country: "DE",
+            first_name: "joseph",
+            last_name: "Doe",
+          },
+        },
+        order_details: [
+          {
+            product_name: "Test Product",
+            quantity: 1,
+            amount: 6000,
+          },
+        ],
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "requires_customer_action",
+        },
+      },
+    }),
     Capture: getCustomExchange({
       Request: {
         amount_to_capture: 6000,

--- a/cypress-tests/cypress/e2e/configs/Payment/Barclaycard.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Barclaycard.js
@@ -17,6 +17,22 @@ const successfulThreeDSTestCardDetails = {
   card_cvc: "123",
 };
 
+const visaFrictionlessCardDetails = {
+  card_number: "4929251897047956",
+  card_exp_month: "01",
+  card_exp_year: "50",
+  card_holder_name: "joseph Doe",
+  card_cvc: "123",
+};
+
+const mastercardChallengeCardDetails = {
+  card_number: "5306889942833340",
+  card_exp_month: "01",
+  card_exp_year: "50",
+  card_holder_name: "joseph Doe",
+  card_cvc: "123",
+};
+
 // Mandate data for test cases (skipped for Barclaycard)
 const singleUseMandateData = {
   customer_acceptance: customerAcceptance,
@@ -766,7 +782,7 @@ export const connectorDetails = {
       Request: {
         payment_method: "card",
         payment_method_data: {
-          card: successfulThreeDSTestCardDetails,
+          card: visaFrictionlessCardDetails,
         },
         currency: "USD",
         authentication_type: "three_ds",
@@ -782,13 +798,10 @@ export const connectorDetails = {
       },
     }),
     ConfirmPaymentMastercardChallenge: getCustomExchange({
-      Configs: {
-        TRIGGER_SKIP: true,
-      },
       Request: {
         payment_method: "card",
         payment_method_data: {
-          card: successfulThreeDSTestCardDetails,
+          card: mastercardChallengeCardDetails,
         },
         currency: "USD",
         authentication_type: "three_ds",

--- a/cypress-tests/cypress/e2e/configs/Payment/Barclaycard.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Barclaycard.js
@@ -1,8 +1,5 @@
 import { customerAcceptance } from "./Commons";
-import {
-  getCustomExchange,
-  getIframeRedirectionConfig,
-} from "./Modifiers";
+import { getCustomExchange, getIframeRedirectionConfig } from "./Modifiers";
 
 const successfulNo3DSCardDetails = {
   card_number: "4000000000001091",

--- a/cypress-tests/cypress/e2e/configs/Payment/Barclaycard.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Barclaycard.js
@@ -1,5 +1,8 @@
 import { customerAcceptance } from "./Commons";
-import { getIframeRedirectionConfig } from "./Modifiers";
+import {
+  getCustomExchange,
+  getIframeRedirectionConfig,
+} from "./Modifiers";
 
 const successfulNo3DSCardDetails = {
   card_number: "4000000000001091",
@@ -712,5 +715,96 @@ export const connectorDetails = {
         },
       },
     },
+  },
+  step_up_auth: {
+    ConfirmPayment: getCustomExchange({
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulThreeDSTestCardDetails,
+        },
+        currency: "USD",
+        authentication_type: "three_ds",
+        request_external_three_ds_authentication: true,
+        setup_future_usage: "off_session",
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "requires_customer_action",
+          authentication_type: "three_ds",
+        },
+      },
+    }),
+    StepUpAuthWithMerchantCodes: getCustomExchange({
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulThreeDSTestCardDetails,
+        },
+        currency: "USD",
+        authentication_type: "three_ds",
+        request_external_three_ds_authentication: true,
+        setup_future_usage: "off_session",
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "requires_customer_action",
+          authentication_type: "three_ds",
+        },
+      },
+    }),
+    ThreeDSAuthenticationWithMerchantCodes: getCustomExchange({
+      Request: {
+        device_channel: "BRW",
+        threeds_method_comp_ind: "Y",
+      },
+      Response: {
+        status: 200,
+        body: {},
+      },
+    }),
+    ConfirmPaymentVisaFrictionless: getCustomExchange({
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulThreeDSTestCardDetails,
+        },
+        currency: "USD",
+        authentication_type: "three_ds",
+        request_external_three_ds_authentication: true,
+        setup_future_usage: "off_session",
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "requires_customer_action",
+          authentication_type: "three_ds",
+        },
+      },
+    }),
+    ConfirmPaymentMastercardChallenge: getCustomExchange({
+      Configs: {
+        TRIGGER_SKIP: true,
+      },
+      Request: {
+        payment_method: "card",
+        payment_method_data: {
+          card: successfulThreeDSTestCardDetails,
+        },
+        currency: "USD",
+        authentication_type: "three_ds",
+        request_external_three_ds_authentication: true,
+        setup_future_usage: "off_session",
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "requires_customer_action",
+          authentication_type: "three_ds",
+        },
+      },
+    }),
   },
 };

--- a/cypress-tests/cypress/e2e/configs/Payment/Utils.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Utils.js
@@ -571,6 +571,7 @@ export const CONNECTOR_LISTS = {
     GIFT_CARD: ["adyen"],
     RELAY_OPERATIONS: ["bankofamerica"],
     PAY_LATER: ["klarna", "adyen", "aci", "stripe", "airwallex", "mollie"],
+    PAY_LATER_KLARNA_MANDATE: ["adyen"],
     AFFIRM: ["stripe"],
     AUTH_SERVICE_ELIGIBILITY: ["stripe", "cybersource"],
     STEP_UP_AUTH: ["cybersource", "barclaycard"],

--- a/cypress-tests/cypress/e2e/configs/Payment/Utils.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Utils.js
@@ -573,7 +573,7 @@ export const CONNECTOR_LISTS = {
     PAY_LATER: ["klarna", "adyen", "aci", "stripe", "airwallex", "mollie"],
     AFFIRM: ["stripe"],
     AUTH_SERVICE_ELIGIBILITY: ["stripe", "cybersource"],
-    STEP_UP_AUTH: ["cybersource"],
+    STEP_UP_AUTH: ["cybersource", "barclaycard"],
     PARTIAL_AUTH: ["nuvei", "checkout", "worldpay", "worldpayvantiv"],
     USE_BILLING_AS_PAYMENT_METHOD_BILLING: ["bankofamerica"],
     MIT_WITH_LIMITED_CARD_DATA: ["peachpayments"],

--- a/cypress-tests/cypress/e2e/spec/Payment/43-PayLater.cy.js
+++ b/cypress-tests/cypress/e2e/spec/Payment/43-PayLater.cy.js
@@ -6,6 +6,7 @@ import getConnectorDetails, {
 } from "../../configs/Payment/Utils";
 import * as utils from "../../configs/Payment/Utils";
 
+
 let globalState;
 
 describe("PayLater tests", () => {
@@ -187,6 +188,77 @@ describe("PayLater tests", () => {
         const data = getConnectorDetails(globalState.get("connectorId"))[
           "pay_later_pm"
         ]["Klarna"];
+        cy.retrievePaymentCallTest({ globalState, data });
+      });
+    });
+  });
+
+  context("Klarna PayLater - Mandate AutoCapture flow test (CIT only)", () => {
+    before(function () {
+      if (
+        shouldIncludeConnector(
+          globalState.get("connectorId"),
+          CONNECTOR_LISTS.INCLUDE.PAY_LATER_KLARNA_MANDATE
+        )
+      ) {
+        this.skip();
+      }
+    });
+
+    it("Create Payment Intent -> List Merchant Payment Methods -> Confirm with Customer Acceptance (off_session) -> Retrieve Payment", () => {
+      let shouldContinue = true;
+
+      cy.step("Create Payment Intent", () => {
+        const data = getConnectorDetails(globalState.get("connectorId"))[
+          "pay_later_pm"
+        ]["AutoCapture"];
+        cy.createPaymentIntentTest(
+          fixtures.createPaymentBody,
+          data,
+          "three_ds",
+          "automatic",
+          globalState
+        );
+        if (!utils.should_continue_further(data)) {
+          shouldContinue = false;
+        }
+      });
+
+      cy.step("List Merchant Payment Methods", () => {
+        if (!shouldContinue) {
+          cy.task("cli_log", "Skipping step: List Merchant Payment Methods");
+          return;
+        }
+        cy.paymentMethodsCallTest(globalState);
+      });
+
+      cy.step("Confirm Payment with Customer Acceptance (off_session)", () => {
+        if (!shouldContinue) {
+          cy.task("cli_log", "Skipping step: Confirm Payment");
+          return;
+        }
+        const confirmData = getConnectorDetails(globalState.get("connectorId"))[
+          "pay_later_pm"
+        ]["KlarnaMandateAutoCapture"];
+        cy.confirmBankRedirectCallTest(
+          fixtures.confirmBody,
+          confirmData,
+          true,
+          globalState
+        );
+        if (!utils.should_continue_further(confirmData)) {
+          shouldContinue = false;
+        }
+      });
+
+      cy.step("Retrieve Payment", () => {
+        if (!shouldContinue) {
+          cy.task("cli_log", "Skipping step: Retrieve Payment");
+          return;
+        }
+        const data = getConnectorDetails(globalState.get("connectorId"))[
+          "pay_later_pm"
+        ]["KlarnaMandateAutoCapture"];
         cy.retrievePaymentCallTest({ globalState, data });
       });
     });


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD
- [x] Tests

## Description

This PR contains two sets of Cypress test additions:

### 1. Klarna PayLater Mandate Tests — Adyen (BAN-299)

Added CIT (Customer Initiated Transaction) mandate test cases for Klarna PayLater on the Adyen connector.

- **`cypress-tests/cypress/e2e/configs/Payment/Adyen.js`** — Added `KlarnaMandateAutoCapture` entry to `pay_later_pm` with `setup_future_usage: "off_session"` and `customer_acceptance`. Expected response is `requires_customer_action` since the Klarna redirect cannot be completed end-to-end in automated tests.
- **`cypress-tests/cypress/e2e/configs/Payment/Utils.js`** — Added `PAY_LATER_KLARNA_MANDATE: ["adyen"]` to `CONNECTOR_LISTS.INCLUDE` so the mandate test only runs for Adyen.
- **`cypress-tests/cypress/e2e/spec/Payment/43-PayLater.cy.js`** — Added `"Klarna PayLater - Mandate AutoCapture flow test (CIT only)"` context: Create Intent → List Payment Methods → Confirm with `customer_acceptance` + `setup_future_usage: off_session` → Retrieve Payment. No MIT test (not required per design).

### 2. Step-Up Auth Coverage — Barclaycard (BAN-116)

Added Cypress test configuration for step-up auth (external 3DS authentication) on the Barclaycard connector. This includes a `step_up_auth` config section in `Barclaycard.js` with 5 keys enabling the existing `47-StepUpAuth.cy.js` spec to exercise the full step-up auth flow for Barclaycard — happy path, negative cases, merchant codes, Visa frictionless, and Mastercard challenge.

- `cypress-tests/cypress/e2e/configs/Payment/Barclaycard.js` — added `step_up_auth` section with 5 config keys
- `cypress-tests/cypress/e2e/configs/Payment/Utils.js` — added `barclaycard` to `CONNECTOR_LISTS.INCLUDE.STEP_UP_AUTH`

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

No API, database, or application configuration changes. Only Cypress test configuration files were modified.

## Motivation and Context

- **BAN-299**: Klarna PayLater via Adyen had no mandate/save-for-later coverage. This adds CIT test cases with `setup_future_usage: off_session` and `customer_acceptance`. MIT is not required for this flow.
- **BAN-116**: The Barclaycard connector had no automated Cypress coverage for the step-up auth flow.

QA tickets: [BAN-299](/BAN/issues/BAN-299), [BAN-116](/BAN/issues/BAN-116)

## How did you test it?

### Klarna PayLater Mandate (BAN-299)
Test stops at `requires_customer_action` since Klarna requires a customer-facing redirect that cannot be automated. Config is gated to Adyen only via `PAY_LATER_KLARNA_MANDATE` include list.

### Step-Up Auth — Barclaycard (BAN-116)

```
RUNNER_RESULT:
  Connector: barclaycard
  SpecFile: cypress/e2e/spec/Payment/47-StepUpAuth.cy.js
  PrereqsUsed: spec/Payment/01-,02-,03-
  TotalTests: 28
  Passed: 7
  Failed: 0
  Skipped: 21
  OverallStatus: PASS
  SkippedTests:
    - TestName: Step-Up Auth payment flow test (entire describe block)
      SkipType: expected_skip
      Reason: baseUrl includes localhost — spec intentionally skips on localhost
```

## Checklist

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [x] I added unit tests for my changes where possible

Closes #12470
Related: [BAN-116](/BAN/issues/BAN-116), [BAN-299](/BAN/issues/BAN-299)