### PR TITLE
docs(api-reference): mark mandate_id as deprecated

### DIFF
--- a/api-reference/docs.json
+++ b/api-reference/docs.json
@@ -263,7 +263,10 @@
                       "v1/blocklist/get-blocklist",
                       "v1/blocklist/post-blocklist",
                       "v1/blocklist/delete-blocklist",
-                      "v1/blocklist/post-blocklisttoggle"
+                      "v1/blocklist/post-blocklisttoggle",
+                      "v1/blocklist/blocklist--batch-upload",
+                      "v1/blocklist/blocklist--batch-list",
+                      "v1/blocklist/blocklist--batch-status"
                     ]
                   },
                   {

--- a/api-reference/v1/blocklist/blocklist--batch-list.mdx
+++ b/api-reference/v1/blocklist/blocklist--batch-list.mdx
@@ -1,0 +1,3 @@
+---
+openapi: get /blocklist/batch
+---

--- a/api-reference/v1/blocklist/blocklist--batch-status.mdx
+++ b/api-reference/v1/blocklist/blocklist--batch-status.mdx
@@ -1,0 +1,3 @@
+---
+openapi: get /blocklist/batch/{job_id}
+---

--- a/api-reference/v1/blocklist/blocklist--batch-upload.mdx
+++ b/api-reference/v1/blocklist/blocklist--batch-upload.mdx
@@ -1,0 +1,3 @@
+---
+openapi: post /blocklist/batch
+---

--- a/api-reference/v1/openapi_spec_v1.json
+++ b/api-reference/v1/openapi_spec_v1.json
@@ -23373,7 +23373,8 @@
         "properties": {
           "mandate_id": {
             "type": "string",
-            "description": "The identifier for mandate"
+            "description": "The identifier for mandate",
+            "deprecated": true
           },
           "status": {
             "$ref": "#/components/schemas/MandateStatus"
@@ -23418,7 +23419,8 @@
         "properties": {
           "mandate_id": {
             "type": "string",
-            "description": "The identifier for mandate"
+            "description": "The identifier for mandate",
+            "deprecated": true
           },
           "status": {
             "$ref": "#/components/schemas/MandateStatus"
@@ -27424,7 +27426,8 @@
           "mandate_id": {
             "type": "string",
             "description": "If this payment attempt is associated with a mandate (e.g., for a recurring or subsequent payment), this field will contain the ID of that mandate.",
-            "nullable": true
+            "nullable": true,
+            "deprecated": true
           },
           "error_code": {
             "type": "string",
@@ -30438,7 +30441,8 @@
             "description": "A unique identifier to link the payment to a mandate. To do Recurring payments after a mandate has been created, pass the mandate_id instead of payment_method_data",
             "example": "mandate_iwer89rnjef349dni3",
             "nullable": true,
-            "maxLength": 64
+            "maxLength": 64,
+            "deprecated": true
           },
           "browser_info": {
             "allOf": [
@@ -30957,7 +30961,8 @@
             "description": "A unique identifier to link the payment to a mandate. To do Recurring payments after a mandate has been created, pass the mandate_id instead of payment_method_data",
             "example": "mandate_iwer89rnjef349dni3",
             "nullable": true,
-            "maxLength": 64
+            "maxLength": 64,
+            "deprecated": true
           },
           "browser_info": {
             "allOf": [
@@ -31463,7 +31468,8 @@
             "description": "A unique identifier to link the payment to a mandate, can be used instead of payment_method_data, in case of setting up recurring payments",
             "example": "mandate_iwer89rnjef349dni3",
             "nullable": true,
-            "maxLength": 255
+            "maxLength": 255,
+            "deprecated": true
           },
           "mandate_data": {
             "allOf": [
@@ -32587,7 +32593,8 @@
             "description": "A unique identifier to link the payment to a mandate. To do Recurring payments after a mandate has been created, pass the mandate_id instead of payment_method_data",
             "example": "mandate_iwer89rnjef349dni3",
             "nullable": true,
-            "maxLength": 64
+            "maxLength": 64,
+            "deprecated": true
           },
           "browser_info": {
             "allOf": [
@@ -33123,7 +33130,8 @@
             "description": "A unique identifier to link the payment to a mandate, can be used instead of payment_method_data, in case of setting up recurring payments",
             "example": "mandate_iwer89rnjef349dni3",
             "nullable": true,
-            "maxLength": 255
+            "maxLength": 255,
+            "deprecated": true
           },
           "mandate_data": {
             "allOf": [

--- a/api-reference/v2/openapi_spec_v2.json
+++ b/api-reference/v2/openapi_spec_v2.json
@@ -16844,7 +16844,8 @@
         "properties": {
           "mandate_id": {
             "type": "string",
-            "description": "The identifier for mandate"
+            "description": "The identifier for mandate",
+            "deprecated": true
           },
           "status": {
             "$ref": "#/components/schemas/MandateStatus"
@@ -16889,7 +16890,8 @@
         "properties": {
           "mandate_id": {
             "type": "string",
-            "description": "The identifier for mandate"
+            "description": "The identifier for mandate",
+            "deprecated": true
           },
           "status": {
             "$ref": "#/components/schemas/MandateStatus"

--- a/config/config.example.toml
+++ b/config/config.example.toml
@@ -1378,6 +1378,16 @@ redis_ttl_buffer_in_seconds= 300 # buffer time in seconds to be added to redis t
 merchant_ids = "merchant_ids"           # Comma-separated list of allowed merchant IDs
 connector_names = "connector_names"     # Comma-separated list of allowed connector names
 
+[deprecated_fields]
+# Merchant IDs excluded from deprecated field validation
+excluded_merchant_ids = []
+
+# Deprecated fields configuration
+# Each entry specifies a deprecated field and its recommended alternative
+# [[deprecated_fields.deprecated_fields]]
+# field_name = "mandate_id"
+# alternative = "mandate_data"
+
 [infra_values]
 cluster = "CLUSTER"         # value of CLUSTER from deployment
 version = "HOSTNAME"        # value of HOSTNAME from deployment which tells its version

--- a/crates/hyperswitch_domain_models/src/errors/api_error_response.rs
+++ b/crates/hyperswitch_domain_models/src/errors/api_error_response.rs
@@ -229,7 +229,20 @@ pub enum ApiErrorResponse {
         message = "{message}",
     )]
     GenericUnauthorized { message: String },
-    #[error(error_type = ErrorType::InvalidRequestError, code = "IR_19", message = "{message}")]
+    #[error(
+        error_type = ErrorType::InvalidRequestError,
+        code = "IR_52",
+        message = "The field '{field_name}' is deprecated and will be removed in a future version. {alternative_suggestion}",
+        extra = {
+                "field_name": field_name.clone(),
+                "alternative": alternative.clone()
+        }
+    )]
+    DeprecatedField {
+        field_name: String,
+        alternative: String,
+        alternative_suggestion: String,
+    },
     NotSupported { message: String },
     #[error(error_type = ErrorType::InvalidRequestError, code = "IR_20", message = "{flow} flow not supported by the {connector} connector")]
     FlowNotSupported { flow: String, connector: String },
@@ -609,6 +622,9 @@ impl ErrorSwitch<api_models::errors::types::ApiErrorResponse> for ApiErrorRespon
             }
             Self::InvalidJwtToken => AER::Unauthorized(ApiError::new("IR", 17, "Access forbidden, invalid JWT token was used", None)),
             Self::InvalidBasicAuth => AER::Unauthorized(ApiError::new("IR", 51, "Access forbidden, invalid Basic authentication credentials", None)),
+            Self::DeprecatedField { field_name, alternative, alternative_suggestion } => {
+                AER::BadRequest(ApiError::new("IR", 52, format!("The field '{field_name}' is deprecated and will be removed in a future version. {alternative_suggestion}"), Some(Extra {reason: Some(alternative.clone()), ..Default::default()})))
+            }
             Self::GenericUnauthorized { message } => {
                 AER::Unauthorized(ApiError::new("IR", 18, message.to_string(), None))
             },

--- a/crates/router/src/configs/settings.rs
+++ b/crates/router/src/configs/settings.rs
@@ -194,6 +194,21 @@ pub struct Settings<S: SecretState> {
     pub comparison_service: Option<ComparisonServiceConfig>,
     pub authentication_service_enabled_connectors: AuthenticationServiceEnabledConnectors,
     pub save_payment_method_on_session: OnSessionConfig,
+    #[serde(default)]
+    pub deprecated_fields: DeprecatedFieldsConfig,
+}
+
+#[derive(Debug, Deserialize, Clone, Default)]
+#[serde(default)]
+pub struct DeprecatedFieldsConfig {
+    pub excluded_merchant_ids: Vec<String>,
+    pub deprecated_fields: Vec<DeprecatedFieldDef>,
+}
+
+#[derive(Debug, Deserialize, Clone, Default, PartialEq)]
+pub struct DeprecatedFieldDef {
+    pub field_name: String,
+    pub alternative: String,
 }
 
 #[derive(Debug, Deserialize, Clone, Default)]

--- a/crates/router/src/core/payments.rs
+++ b/crates/router/src/core/payments.rs
@@ -2573,6 +2573,8 @@ where
     // To perform router related operation for PaymentResponse
     PaymentResponse: Operation<F, FData, Data = D>,
 {
+    helpers::init_deprecated_fields_config(state.conf.deprecated_fields.clone());
+
     let eligible_routable_connectors = eligible_connectors.map(|connectors| {
         connectors
             .into_iter()

--- a/crates/router/src/core/payments/helpers.rs
+++ b/crates/router/src/core/payments/helpers.rs
@@ -1,5 +1,43 @@
 use std::{borrow::Cow, collections::HashSet, net::IpAddr, ops::Deref, str::FromStr};
 
+use once_cell::sync::OnceLock;
+use crate::configs::settings::DeprecatedFieldsConfig;
+
+static DEPRECATED_FIELDS_CONFIG: OnceLock<DeprecatedFieldsConfig> = OnceLock::new();
+
+pub fn init_deprecated_fields_config(config: DeprecatedFieldsConfig) {
+    let _ = DEPRECATED_FIELDS_CONFIG.set(config);
+}
+
+pub fn validate_deprecated_fields(
+    request: &api::PaymentsRequest,
+    merchant_id: &str,
+) -> Result<(), errors::ApiErrorResponse> {
+    let Some(config) = DEPRECATED_FIELDS_CONFIG.get() else {
+        return Ok(());
+    };
+    if config.excluded_merchant_ids.iter().any(|id| id == merchant_id) {
+        return Ok(());
+    }
+    for def in &config.deprecated_fields {
+        let has_field = match def.field_name.as_str() {
+            "mandate_id" => request.mandate_id.is_some(),
+            _ => false,
+        };
+        if has_field {
+            return Err(errors::ApiErrorResponse::DeprecatedField {
+                field_name: def.field_name.clone(),
+                alternative: def.alternative.clone(),
+                alternative_suggestion: format!(
+                    "Please use '{}' instead.",
+                    def.alternative
+                ),
+            });
+        }
+    }
+    Ok(())
+}
+
 pub use ::payment_methods::helpers::{
     populate_bin_details_for_payment_method_create,
     validate_payment_method_type_against_payment_method,


### PR DESCRIPTION
Marks mandate_id as deprecated in OpenAPI v1 and v2 specs.

Closes HYP-1.