### PR TITLE
fix(split_payments): remove deny_unknown_fields from StripeSplitPayments

### DIFF
--- a/crates/common_types/src/payments.rs
+++ b/crates/common_types/src/payments.rs
@@ -68,7 +68,6 @@ impl_to_sql_from_sql_json!(SplitPaymentsRequest);
     SmithyModel,
 )]
 #[diesel(sql_type = Jsonb)]
-#[serde(deny_unknown_fields)]
 #[smithy(namespace = "com.hyperswitch.smithy.types")]
 /// Fee information for Split Payments to be charged on the payment being collected for Stripe
 pub struct StripeSplitPaymentRequest {


### PR DESCRIPTION
## Summary

Removes #[serde(deny_unknown_fields)] from StripeSplitPaymentRequest to allow backward compatibility when new fields like `on_behalf_of` are present in the database but the older code doesn't recognize them.

Fixes #12412

## Context

This fix addresses the SEV1 incident where deserialization failed during staggered deployment. When newer code writes records with new fields to the database, older running instances couldn't deserialize them due to `deny_unknown_fields`.

Cherry-picked on top of 2026.04.02.0-hotfix7.10 for the redis_rs branch.

## Type of Change
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD