### PR TITLE
feat(analytics): add ClickHouse-backed payment intents aggregate endpoints

### DIFF
--- a/crates/analytics/src/lib.rs
+++ b/crates/analytics/src/lib.rs
@@ -35,7 +35,10 @@ pub use types::AnalyticsDomain;
 pub mod lambda_utils;
 pub mod utils;
 
-use std::{collections::HashSet, sync::Arc};
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
 
 use api_models::analytics::{
     active_payments::{ActivePaymentsMetrics, ActivePaymentsMetricsBucketIdentifier},
@@ -430,6 +433,23 @@ impl AnalyticsProvider {
             self,
         )
         .await
+    }
+
+    pub async fn get_intent_status_with_count(
+        &self,
+        auth: &AuthInfo,
+        time_range: &TimeRange,
+    ) -> types::MetricsResult<HashMap<common_enums::IntentStatus, i64>> {
+        match self {
+            Self::Clickhouse(ckh_pool)
+            | Self::CombinedCkh(_, ckh_pool)
+            | Self::CombinedSqlx(_, ckh_pool) => {
+                payment_intents::aggregate::get_intent_status_with_count(ckh_pool, auth, time_range)
+                    .await
+            }
+            Self::Sqlx(_) => Err(report!(MetricsError::NotImplemented)
+                .attach_printable("ClickHouse aggregate not available: analytics source is sqlx")),
+        }
     }
 
     pub async fn get_refund_metrics(
@@ -1131,6 +1151,7 @@ pub enum AnalyticsFlow {
     GetInfo,
     GetPaymentMetrics,
     GetPaymentIntentMetrics,
+    GetPaymentIntentsAggregate,
     GetRefundsMetrics,
     GetFrmMetrics,
     GetSdkMetrics,

--- a/crates/analytics/src/payment_intents.rs
+++ b/crates/analytics/src/payment_intents.rs
@@ -1,4 +1,5 @@
 pub mod accumulator;
+pub mod aggregate;
 mod core;
 pub mod filters;
 pub mod metrics;

--- a/crates/analytics/src/payment_intents/aggregate.rs
+++ b/crates/analytics/src/payment_intents/aggregate.rs
@@ -1,0 +1,82 @@
+use std::collections::HashMap;
+
+use common_enums::IntentStatus;
+use common_utils::{
+    errors::ParsingError,
+    types::{authentication::AuthInfo, TimeRange},
+};
+use error_stack::ResultExt;
+use router_env::logger;
+
+use crate::{
+    clickhouse::ClickhouseClient,
+    query::{Aggregate, QueryBuilder, QueryFilter},
+    types::{AnalyticsCollection, DBEnumWrapper, MetricsError, MetricsResult},
+};
+
+#[derive(Debug, serde::Deserialize, serde::Serialize)]
+pub struct IntentStatusCountRow {
+    pub status: DBEnumWrapper<IntentStatus>,
+    pub count: i64,
+}
+
+impl TryInto<IntentStatusCountRow> for serde_json::Value {
+    type Error = error_stack::Report<ParsingError>;
+
+    fn try_into(self) -> Result<IntentStatusCountRow, Self::Error> {
+        logger::debug!("Parsing IntentStatusCountRow from {:?}", self);
+        serde_json::from_value(self).change_context(ParsingError::StructParseFailure(
+            "Failed to parse IntentStatusCount in clickhouse results",
+        ))
+    }
+}
+
+pub async fn get_intent_status_with_count(
+    clickhouse_client: &ClickhouseClient,
+    auth: &AuthInfo,
+    time_range: &TimeRange,
+) -> MetricsResult<HashMap<IntentStatus, i64>> {
+    let mut query_builder =
+        QueryBuilder::<ClickhouseClient>::new(AnalyticsCollection::PaymentIntent);
+
+    query_builder
+        .add_select_column("status")
+        .attach_printable("Error adding select status")
+        .change_context(MetricsError::QueryBuildingError)?;
+
+    query_builder
+        .add_select_column(Aggregate::<String>::Sum {
+            field: "sign_flag".to_string(),
+            alias: Some("count"),
+        })
+        .change_context(MetricsError::QueryBuildingError)?;
+
+    auth.set_filter_clause(&mut query_builder)
+        .change_context(MetricsError::QueryBuildingError)?;
+
+    time_range
+        .set_filter_clause(&mut query_builder)
+        .change_context(MetricsError::QueryBuildingError)?;
+
+    query_builder
+        .add_group_by_clause("status")
+        .attach_printable("Error adding group by status")
+        .change_context(MetricsError::QueryBuildingError)?;
+
+    let rows: Vec<IntentStatusCountRow> = query_builder
+        .execute_query::<IntentStatusCountRow, _>(clickhouse_client)
+        .await
+        .change_context(MetricsError::QueryBuildingError)?
+        .change_context(MetricsError::QueryExecutionFailure)?;
+
+    let mut status_map: HashMap<IntentStatus, i64> = rows
+        .into_iter()
+        .map(|row| (row.status.0, row.count))
+        .collect();
+
+    for status in <IntentStatus as strum::IntoEnumIterator>::iter() {
+        status_map.entry(status).or_insert(0);
+    }
+
+    Ok(status_map)
+}

--- a/crates/router/src/analytics.rs
+++ b/crates/router/src/analytics.rs
@@ -57,16 +57,26 @@ pub mod routes {
             web::scope("/v2/analytics")
                 .app_data(web::Data::new(state))
                 .service(
-                    web::scope("/profile").service(
-                        web::resource("report/payments")
-                            .route(web::post().to(generate_profile_payment_report)),
-                    ),
+                    web::scope("/profile")
+                        .service(
+                            web::resource("report/payments")
+                                .route(web::post().to(generate_profile_payment_report)),
+                        )
+                        .service(
+                            web::resource("payment_intents/aggregate")
+                                .route(web::get().to(get_profile_payment_intent_aggregate)),
+                        ),
                 )
                 .service(
-                    web::scope("/merchant").service(
-                        web::resource("report/payments")
-                            .route(web::post().to(generate_merchant_payment_report)),
-                    ),
+                    web::scope("/merchant")
+                        .service(
+                            web::resource("report/payments")
+                                .route(web::post().to(generate_merchant_payment_report)),
+                        )
+                        .service(
+                            web::resource("payment_intents/aggregate")
+                                .route(web::get().to(get_merchant_payment_intent_aggregate)),
+                        ),
                 )
                 .service(
                     web::scope("/org").service(
@@ -203,6 +213,10 @@ pub mod routes {
                         .service(
                             web::resource("metrics/sankey")
                                 .route(web::post().to(get_merchant_sankey)),
+                        )
+                        .service(
+                            web::resource("payment_intents/aggregate")
+                                .route(web::get().to(get_merchant_payment_intent_aggregate)),
                         )
                         .service(
                             web::resource("metrics/auth_events/sankey")
@@ -454,6 +468,10 @@ pub mod routes {
                                 .service(
                                     web::resource("metrics/sankey")
                                         .route(web::post().to(get_profile_sankey)),
+                                )
+                                .service(
+                                    web::resource("payment_intents/aggregate")
+                                        .route(web::get().to(get_profile_payment_intent_aggregate)),
                                 )
                                 .service(
                                     web::resource("metrics/auth_events/sankey")
@@ -718,6 +736,81 @@ pub mod routes {
             },
             &auth::JWTAuth {
                 permission: Permission::MerchantAnalyticsRead,
+                allow_connected: true,
+                allow_platform: false,
+            },
+            api_locking::LockAction::NotApplicable,
+        ))
+        .await
+    }
+
+    pub async fn get_merchant_payment_intent_aggregate(
+        state: web::Data<AppState>,
+        req: actix_web::HttpRequest,
+        query: web::Query<TimeRange>,
+    ) -> impl Responder {
+        let flow = AnalyticsFlow::GetPaymentIntentsAggregate;
+        let payload = query.into_inner();
+        Box::pin(api::server_wrap(
+            flow,
+            state,
+            &req,
+            payload,
+            |state, auth: AuthenticationData, req, _| async move {
+                let auth_info = auth.platform.to_merchant_level_auth_info();
+                let status_with_count = state
+                    .pool
+                    .get_intent_status_with_count(&auth_info, &req)
+                    .await
+                    .change_context(AnalyticsError::UnknownError)?;
+                Ok(ApplicationResponse::Json(
+                    api_models::payments::PaymentsAggregateResponse { status_with_count },
+                ))
+            },
+            &auth::JWTAuth {
+                permission: Permission::MerchantPaymentRead,
+                allow_connected: true,
+                allow_platform: false,
+            },
+            api_locking::LockAction::NotApplicable,
+        ))
+        .await
+    }
+
+    pub async fn get_profile_payment_intent_aggregate(
+        state: web::Data<AppState>,
+        req: actix_web::HttpRequest,
+        query: web::Query<TimeRange>,
+    ) -> impl Responder {
+        let flow = AnalyticsFlow::GetPaymentIntentsAggregate;
+        let payload = query.into_inner();
+        Box::pin(api::server_wrap(
+            flow,
+            state,
+            &req,
+            payload,
+            |state, auth: AuthenticationData, req, _| async move {
+                #[cfg(feature = "v1")]
+                let profile_id = auth
+                    .profile
+                    .ok_or(report!(UserErrors::JwtProfileIdMissing))
+                    .change_context(AnalyticsError::AccessForbiddenError)?
+                    .get_id()
+                    .clone();
+                #[cfg(feature = "v2")]
+                let profile_id = auth.profile.get_id().clone();
+                let auth_info = auth.platform.to_profile_level_auth_info(profile_id);
+                let status_with_count = state
+                    .pool
+                    .get_intent_status_with_count(&auth_info, &req)
+                    .await
+                    .change_context(AnalyticsError::UnknownError)?;
+                Ok(ApplicationResponse::Json(
+                    api_models::payments::PaymentsAggregateResponse { status_with_count },
+                ))
+            },
+            &auth::JWTAuth {
+                permission: Permission::ProfilePaymentRead,
                 allow_connected: true,
                 allow_platform: false,
             },


### PR DESCRIPTION

## Type of Change

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Breaking change
- [ ] Refactor

---

## Description

Adds two ClickHouse-backed read endpoints under the analytics module that serve the same status-count aggregate as the existing Postgres-backed `/payments/aggregate` and `/payments/profile/aggregate`. The dashboard's payment-volume and status widgets run `GROUP BY status` over the `payment_intent` table in primary Postgres on every page load; routing those queries to ClickHouse offloads that read traffic from the OLTP DB.

Both new endpoints return the same `PaymentsAggregateResponse { status_with_count }` shape as the existing PG endpoints, so the dashboard can switch URLs without any other change.

---

## Key Changes

1. **Two new endpoints under the analytics module**
   - `GET /analytics/v1/payment_intents/aggregate` — merchant-level
   - `GET /analytics/v1/profile/payment_intents/aggregate` — profile-level

2. **No new APIs, schemas, migrations, or permissions**
   - Endpoints reuse `Permission::MerchantAnalyticsRead` / `Permission::ProfileAnalyticsRead`
   - ClickHouse `payment_intents` table already exists in the analytics ingestion path; no schema work needed

3. **Four-file change** — 185 insertions / 1 deletion
   - `crates/analytics/src/lib.rs` — `AnalyticsProvider::get_intent_status_with_count` (CH-only) + `AnalyticsFlow::GetPaymentIntentsAggregate`
   - `crates/analytics/src/payment_intents.rs` — expose new `aggregate` submodule
   - `crates/analytics/src/payment_intents/aggregate.rs` — CH query via the standard `QueryBuilder`
   - `crates/router/src/analytics.rs` — two handlers + two route registrations

---

## Motivation and Context

The dashboard's payment-volume and status widgets call `/payments/aggregate` and `/payments/profile/aggregate` on every page load. Each call runs `SELECT status, COUNT(*) FROM payment_intent WHERE ... GROUP BY status` on primary Postgres. For large merchants this scans millions of rows on the hot OLTP table and contends with the write path.

The aggregate query is read-only and OLAP-shaped, so it belongs on ClickHouse — which already ingests `payment_intents` via the same Kafka pipeline used by every other analytics endpoint. The new endpoints sit alongside the existing PG ones so the FE can migrate behind a feature flag and the PG endpoints can be deprecated in a follow-up.

---

## How did you test it?

```bash
curl --location 'http://localhost:9000/api/analytics/v2/payment_intents/aggregate?start_time=2026-03-31T18%3A30%3A00Z&end_time=2026-05-21T06%3A30%3A28Z' \
--header 'Accept: */*' \
--header 'Accept-Language: en-US,en;q=0.9' \
--header 'Connection: keep-alive' \
--header 'Content-Type: application/json' \
--header 'Referer: http://localhost:9000/dashboard/payments' \
--header 'Sec-Fetch-Dest: empty' \
--header 'Sec-Fetch-Mode: cors' \
--header 'Sec-Fetch-Site: same-origin' \
--header 'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.0.0 Safari/537.36' \
--header 'X-Merchant-Id: merchant_1765458359' \
--header 'X-Profile-Id: pro_KtJIJeLFCQ6RReKUUqUH' \
--header 'api-key: hyperswitch' \
--header 'authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoiZjZjNDI5MTYtYzBiNS00OTVhLThiYTAtNDBiNjAwMDNjZjIwIiwibWVyY2hhbnRfaWQiOiJtZXJjaGFudF8xNzY1NDU4MzU5Iiwicm9sZV9pZCI6Im9yZ19hZG1pbiIsImV4cCI6MTc3OTUxNTM2OSwib3JnX2lkIjoib3JnX0dMMG9Xa2lpSXRlU0NPWWRSclJvIiwicHJvZmlsZV9pZCI6InByb19LdEpJSmVMRkNRNlJSZUtVVXFVSCIsInRlbmFudF9pZCI6InB1YmxpYyJ9.RPpqGVOYABDV-X9DS0f36Xec3yRuFTfKcOA4Ce2Y_gs' \
--header 'sec-ch-ua: "Chromium";v="148", "Google Chrome";v="148", "Not/A)Brand";v="99"' \
--header 'sec-ch-ua-mobile: ?0' \
--header 'sec-ch-ua-platform: "macOS"'
```

- Resposne:
```json
{
    "status_with_count": {
        "requires_customer_action": 0,
        "cancelled_post_capture": 0,
        "succeeded": 4,
        "cancelled": 0,
        "processing": 0,
        "requires_capture": 0,
        "partially_captured_and_capturable": 0,
        "partially_captured_and_processing": 0,
        "conflicted": 0,
        "review": 0,
        "partially_authorized_and_requires_capture": 0,
        "partially_captured": 0,
        "requires_merchant_action": 0,
        "failed": 1,
        "requires_confirmation": 0,
        "expired": 0,
        "requires_payment_method": 2
    }
}
```

## Impact

- `payment_intent` aggregate queries can move off primary OLTP Postgres onto ClickHouse, freeing PG CPU for the write path.
- Existing `/payments/aggregate` and `/payments/profile/aggregate` endpoints are untouched — the dashboard migrates behind a feature flag.
- Deployments running `[analytics] source = "sqlx"` get a clear `Not Implemented` error from the new endpoints rather than a silent PG fallback. Old PG endpoints continue to serve those deployments unchanged.
- No new permissions, no schema changes, no migrations.


## Checklist

- [x] I formatted the code (`cargo +nightly fmt --all`)
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
