### PR TITLE
feat(cache): add in-memory cache support for organization

### DIFF
--- a/crates/diesel_models/src/organization.rs
+++ b/crates/diesel_models/src/organization.rs
@@ -1,4 +1,4 @@
-use common_utils::{id_type, pii};
+use common_utils::{custom_serde, id_type, pii};
 use diesel::{AsChangeset, Identifiable, Insertable, Queryable, Selectable};
 
 #[cfg(feature = "v1")]
@@ -11,7 +11,9 @@ pub trait OrganizationBridge {
     fn set_organization_name(&mut self, organization_name: String);
 }
 #[cfg(feature = "v1")]
-#[derive(Clone, Debug, Identifiable, Queryable, Selectable)]
+#[derive(
+    Clone, Debug, Identifiable, Queryable, Selectable, serde::Serialize, serde::Deserialize,
+)]
 #[diesel(
     table_name = organization,
     primary_key(org_id),
@@ -22,7 +24,9 @@ pub struct Organization {
     org_name: Option<String>,
     pub organization_details: Option<pii::SecretSerdeValue>,
     pub metadata: Option<pii::SecretSerdeValue>,
+    #[serde(with = "custom_serde::iso8601")]
     pub created_at: time::PrimitiveDateTime,
+    #[serde(with = "custom_serde::iso8601")]
     pub modified_at: time::PrimitiveDateTime,
     #[allow(dead_code)]
     id: Option<id_type::OrganizationId>,
@@ -34,7 +38,9 @@ pub struct Organization {
 }
 
 #[cfg(feature = "v2")]
-#[derive(Clone, Debug, Identifiable, Queryable, Selectable)]
+#[derive(
+    Clone, Debug, Identifiable, Queryable, Selectable, serde::Serialize, serde::Deserialize,
+)]
 #[diesel(
     table_name = organization,
     primary_key(id),
@@ -43,7 +49,9 @@ pub struct Organization {
 pub struct Organization {
     pub organization_details: Option<pii::SecretSerdeValue>,
     pub metadata: Option<pii::SecretSerdeValue>,
+    #[serde(with = "custom_serde::iso8601")]
     pub created_at: time::PrimitiveDateTime,
+    #[serde(with = "custom_serde::iso8601")]
     pub modified_at: time::PrimitiveDateTime,
     id: id_type::OrganizationId,
     organization_name: Option<String>,

--- a/crates/router/src/db/organization.rs
+++ b/crates/router/src/db/organization.rs
@@ -2,6 +2,8 @@ use common_utils::{errors::CustomResult, id_type};
 use diesel_models::{organization as storage, organization::OrganizationBridge};
 use error_stack::report;
 use router_env::{instrument, tracing};
+#[cfg(feature = "accounts_cache")]
+use storage_impl::redis::cache::{self, CacheKind, ACCOUNTS_CACHE};
 
 use crate::{connection, core::errors, services::Store};
 
@@ -43,10 +45,28 @@ impl OrganizationInterface for Store {
         &self,
         org_id: &id_type::OrganizationId,
     ) -> CustomResult<storage::Organization, errors::StorageError> {
-        let conn = connection::pg_accounts_connection_read(self).await?;
-        storage::Organization::find_by_org_id(&conn, org_id.to_owned())
+        let find_call = || async {
+            let conn = connection::pg_accounts_connection_read(self).await?;
+            storage::Organization::find_by_org_id(&conn, org_id.to_owned())
+                .await
+                .map_err(|error| report!(errors::StorageError::from(error)))
+        };
+
+        #[cfg(not(feature = "accounts_cache"))]
+        {
+            find_call().await
+        }
+
+        #[cfg(feature = "accounts_cache")]
+        {
+            cache::get_or_populate_in_memory(
+                self,
+                org_id.get_string_repr(),
+                find_call,
+                &ACCOUNTS_CACHE,
+            )
             .await
-            .map_err(|error| report!(errors::StorageError::from(error)))
+        }
     }
 
     #[instrument(skip_all)]
@@ -56,10 +76,26 @@ impl OrganizationInterface for Store {
         update: storage::OrganizationUpdate,
     ) -> CustomResult<storage::Organization, errors::StorageError> {
         let conn = connection::pg_accounts_connection_write(self).await?;
+        let update_call = || async {
+            storage::Organization::update_by_org_id(&conn, org_id.to_owned(), update)
+                .await
+                .map_err(|error| report!(errors::StorageError::from(error)))
+        };
 
-        storage::Organization::update_by_org_id(&conn, org_id.to_owned(), update)
+        #[cfg(not(feature = "accounts_cache"))]
+        {
+            update_call().await
+        }
+
+        #[cfg(feature = "accounts_cache")]
+        {
+            cache::publish_and_redact(
+                self,
+                CacheKind::Accounts(org_id.get_string_repr().into()),
+                update_call,
+            )
             .await
-            .map_err(|error| report!(errors::StorageError::from(error)))
+        }
     }
 }
 


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->

This PR adds in-memory cache support for the organization table. As with the other tables with cache support, the cache would be populated on retrieval, and invalidated on updates. And no action would be performed on the cache during organization creation (inserts).

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->

We are in the process of adding in-memory cache support to missing entities in the organization-merchant-profile hierarchy as well as other accounts related entities (organization, merchant account, merchant key store, API key, profile, merchant connector account).

As of opening this PR, organization and profile are the only 2 entities without cache support. This PR adds support for organization, support for profiles will be added in a different PR.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

Running the router service locally, and testing out the organization create, retrieve, update APIs with Postman.

1. Create organization using the API.
2. Retrieve organization using the API. This should populate Redis and in-memory cache.
   - Running `MONITOR` command against Redis before calling this API shows that a key was set with key being organization ID (if multi-tenancy is enabled, this key would also include the tenant's Redis key prefix) and value being the JSON serialized organization object.
     ![Screenshot from Redis CLI indicating GET and SET commands](https://github.com/user-attachments/assets/b3723b87-8e10-44a9-bb31-13ded0c8a5d5)
     In this screenshot, a `GET` call was performed first. Since the value was not available in Redis, a `SET` command was called later.
   - Since this is the first time the value is being cached, we should also see a log line displaying the `SELECT` query being run against the database.
     ![Screenshot of SELECT SQL query](https://github.com/user-attachments/assets/cb0b6690-6391-4b2d-ae7b-afcae961000c)
3. Further attempts to retrieve the organization would NOT display the database query, since the value would already be cached in Redis. Additionally, if there is only a single instance of the application running, retrieving the organization again won't reach Redis either, it would be directly returned from in-memory cache, this can be verified using the `MONITOR` command.
4. Update the organization using the API. This should invalidate the cache. Logs would indicate that the in-memory cache was invalidated. Note the "Received message on channel" and the "Done invalidating" logs in the screenshot.
   ![Screenshot of logs indicating invalidation of cache](https://github.com/user-attachments/assets/eaa8ba65-c4b0-483c-99cb-cf7c5305800b)
   The Redis `MONITOR` command also indicates that the key would be deleted.
   ![Screenshot from Redis indicating the DEL and PUBLISH commands](https://github.com/user-attachments/assets/93891251-d7ae-4b5d-a71a-b7d742c4196d)
5. The next attempt to retrieve the organization again would populate Redis and in-memory cache, by fetching the value from the database. This would be evident from the database query being printed in logs, as described in 2.

The same behavior would also be visible with v2 organization endpoints.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
