### PR TITLE
fix(routing): preserve routed_through in Apple Pay web-domain auto-retry flow

### DIFF
--- a/crates/router/src/core/payments/routing.rs
+++ b/crates/router/src/core/payments/routing.rs
@@ -1260,6 +1260,11 @@ where
                 .first()
                 .ok_or(errors::ApiErrorResponse::IncorrectPaymentMethodConfiguration)?;
 
+            routing_data.routed_through =
+                Some(first_connector.connector_data.connector_name.to_string());
+            routing_data.merchant_connector_id =
+                first_connector.connector_data.merchant_connector_id.clone();
+
             #[cfg(feature = "retry")]
             {
                 let should_do_retry = crate::core::payments::retry::config_should_call_gsm(
@@ -1300,17 +1305,6 @@ where
             }
 
             if connector_call_type.is_none() {
-                routing_data.routed_through = Some(
-                    first_connector
-                        .connector_data
-                        .connector_name
-                        .to_string()
-                        .clone(),
-                );
-
-                routing_data.merchant_connector_id =
-                    first_connector.connector_data.merchant_connector_id.clone();
-
                 crate::core::payments::helpers::override_setup_future_usage_to_on_session(
                     &*state.store,
                     payment_data,


### PR DESCRIPTION
## Summary
- [#11001](https://github.com/juspay/hyperswitch/pull/11001) moved the `routing_data.routed_through` / `merchant_connector_id` assignments inside the `if connector_call_type.is_none()` fallback branch of `try_pre_routing_connectors`. When Apple Pay web-domain is configured on 2+ connectors with auto-retry enabled, the Retryable branch fires and the fallback is skipped, leaving `routed_through = None`. Downstream `set_connector_in_payment_attempt` then writes `None` to `payment_attempt.connector` and the payment fails with `connector_name is missing`.
- Restore the pre-#11001 invariant by populating `routing_data` immediately after `first_connector` is unwrapped — before the Apple Pay retry block — so both the `Retryable` and `PreDetermined` paths leave routing data intact.
- Drops a redundant `.clone()` on the `to_string()` result that was present in the removed block.
- Cherry-pick of 07ab0c4c92 (merged via #12489 on `main`) onto `hotfix-2026.05.25.0`.

## Test plan
- [ ] Configure a merchant profile with two MCAs that have Apple Pay web-domain registered, with auto-retry (GSM) enabled.
- [ ] Submit an Apple Pay payment — confirm `payment_attempt.connector` is populated with the first connector's name (not `null`) and the payment succeeds instead of erroring with `connector_name is missing`.
- [ ] Repeat with a single Apple Pay MCA (PreDetermined path) to confirm no regression.
- [ ] `cargo check -p router --features v1,retry` passes (verified locally).

