### PR TITLE
fix(split_payments): remove deny_unknown_fields from StripeChargeResponseData

### DIFF
--- a/api-reference/v1/openapi_spec_v1.json
+++ b/api-reference/v1/openapi_spec_v1.json
@@ -41550,8 +41550,7 @@
             "example": "acct_1234567890",
             "nullable": true
           }
-        },
-        "additionalProperties": false
+        }
       },
       "StripeChargeType": {
         "type": "string",

--- a/api-reference/v2/openapi_spec_v2.json
+++ b/api-reference/v2/openapi_spec_v2.json
@@ -30943,8 +30943,7 @@
             "example": "acct_1234567890",
             "nullable": true
           }
-        },
-        "additionalProperties": false
+        }
       },
       "StripeChargeType": {
         "type": "string",

--- a/crates/common_types/src/payments.rs
+++ b/crates/common_types/src/payments.rs
@@ -355,7 +355,6 @@ pub type DecisionManagerResponse = DecisionManagerRecord;
     SmithyModel,
 )]
 #[diesel(sql_type = Jsonb)]
-#[serde(deny_unknown_fields)]
 #[smithy(namespace = "com.hyperswitch.smithy.types")]
 pub struct StripeChargeResponseData {
     /// Identifier for charge created for the payment


### PR DESCRIPTION
## Type of Change
- [x] Bugfix

## Description
Removes `#[serde(deny_unknown_fields)]` attribute from `StripeChargeResponseData` struct to prevent deserialization failures when payment data stored in DB contains additional fields like `on_behalf_of`.

### Problem
When retrieving payments with `charges` data that includes the `on_behalf_of` field, the system encounters an `InternalServerError`:
```
Error deserializing field 'charges': unknown field `on_behalf_of`, expected one of `charge_id`, `charge_type`, `application_fees`, `transfer_account_id`
```

### Solution
Remove `deny_unknown_fields` from `StripeChargeResponseData` to allow graceful deserialization of payment data with unknown fields.

## Related PRs
- Main PR: #12516 (same fix for main branch)

## Related Issue
Fixes #12515

## Checklist
- [x] I reviewed the submitted code