### PR TITLE
hotfix(2026.02.02.0-hotfix16-11): webhook scope + JWT auth for list payment methods

### DIFF
--- a/crates/router/src/core/payment_methods/cards.rs
+++ b/crates/router/src/core/payment_methods/cards.rs
@@ -2780,6 +2780,9 @@ fn get_val(str: String, val: &serde_json::Value) -> Option<String> {
 pub async fn list_payment_methods(
     state: routes::SessionState,
     platform: domain::Platform,
+    // Profile resolved during JWT authentication. Used as a fallback to determine
+    // the business profile when no client_secret is provided and payment_intent is unavailable.
+    auth_profile: Option<Profile>,
     mut req: api::PaymentMethodListRequest,
 ) -> errors::RouterResponse<api::PaymentMethodListResponse> {
     let db = &*state.store;
@@ -2899,24 +2902,34 @@ pub async fn list_payment_methods(
         .await
         .to_not_found_response(errors::ApiErrorResponse::MerchantAccountNotFound)?;
 
-    let profile_id = payment_intent
-        .as_ref()
-        .and_then(|payment_intent| payment_intent.profile_id.as_ref())
-        .get_required_value("profile_id")
-        .change_context(errors::ApiErrorResponse::GenericNotFoundError {
-            message: "Profile id not found".to_string(),
-        })?;
-    let business_profile = db
-        .find_business_profile_by_profile_id(platform.get_processor().get_key_store(), profile_id)
-        .await
-        .to_not_found_response(errors::ApiErrorResponse::ProfileNotFound {
-            id: profile_id.get_string_repr().to_owned(),
-        })?;
+    let (profile_id, business_profile) =
+        match payment_intent.as_ref().and_then(|pi| pi.profile_id.clone()) {
+            Some(profile_id) => {
+                let business_profile = db
+                    .find_business_profile_by_profile_id(
+                        platform.get_processor().get_key_store(),
+                        &profile_id,
+                    )
+                    .await
+                    .to_not_found_response(errors::ApiErrorResponse::ProfileNotFound {
+                        id: profile_id.get_string_repr().to_owned(),
+                    })?;
+                (profile_id, business_profile)
+            }
+            None => {
+                let profile =
+                    auth_profile.ok_or(errors::ApiErrorResponse::GenericNotFoundError {
+                        message: "Profile id not found".to_string(),
+                    })?;
+                let profile_id = profile.get_id().clone();
+                (profile_id, profile)
+            }
+        };
 
     // filter out payment connectors based on profile_id
     let filtered_mcas = all_mcas
         .clone()
-        .filter_based_on_profile_and_connector_type(profile_id, ConnectorType::PaymentProcessor);
+        .filter_based_on_profile_and_connector_type(&profile_id, ConnectorType::PaymentProcessor);
 
     logger::debug!(mca_before_filtering=?filtered_mcas);
 

--- a/crates/router/src/routes/payment_methods.rs
+++ b/crates/router/src/routes/payment_methods.rs
@@ -625,10 +625,20 @@ pub async fn list_payment_method_api(
         allow_platform_self_operation: true,
     };
 
-    let (auth, _) = match auth::check_client_secret_and_get_auth(req.headers(), &payload, api_auth)
-    {
-        Ok((auth, _auth_flow)) => (auth, _auth_flow),
-        Err(e) => return api::log_and_return_error_response(e),
+    let (auth_type, _auth_flow) = if auth::is_jwt_auth(req.headers()) {
+        let jwt_auth: Box<dyn auth::AuthenticateAndFetch<auth::AuthenticationData, _>> =
+            Box::new(auth::JWTAuth {
+                permission: Permission::MerchantPaymentRead,
+                allow_connected: true,
+                allow_platform: true,
+            });
+
+        (jwt_auth, api::AuthFlow::Merchant)
+    } else {
+        match auth::check_client_secret_and_get_auth(req.headers(), &payload, api_auth) {
+            Ok(auth) => auth,
+            Err(e) => return api::log_and_return_error_response(e),
+        }
     };
 
     Box::pin(api::server_wrap(
@@ -638,9 +648,9 @@ pub async fn list_payment_method_api(
         payload,
         |state, auth: auth::AuthenticationData, req, _| {
             // TODO (#7195): Fill platform_merchant_account in the client secret auth and pass it here.
-            cards::list_payment_methods(state, auth.platform, req)
+            cards::list_payment_methods(state, auth.platform, auth.profile, req)
         },
-        &*auth,
+        &*auth_type,
         api_locking::LockAction::NotApplicable,
     ))
     .await

--- a/crates/router/src/routes/webhook_events.rs
+++ b/crates/router/src/routes/webhook_events.rs
@@ -1,13 +1,15 @@
 use actix_web::{web, HttpRequest, Responder};
+use common_enums::EntityType;
+use error_stack::ResultExt;
 use router_env::{instrument, tracing, Flow};
 
 use crate::{
-    core::{api_locking, webhooks::webhook_events},
+    core::{api_locking, errors, webhooks::webhook_events},
     routes::AppState,
     services::{
         api,
         authentication::{self as auth, UserFromToken},
-        authorization::permissions::Permission,
+        authorization::{permissions::Permission, roles::RoleInfo},
     },
     types::api::webhook_events::{
         EventListConstraints, EventListRequestInternal, WebhookDeliveryAttemptListRequestInternal,
@@ -75,18 +77,34 @@ pub async fn list_initial_webhook_delivery_attempts_with_jwtauth(
         state,
         &req,
         request_internal,
-        |state, auth: UserFromToken, mut request_internal, _| {
-            let merchant_id = auth.merchant_id;
-            let profile_id = auth.profile_id;
+        |state, auth: UserFromToken, request_internal, _| async move {
+            let role_info = RoleInfo::from_role_id_org_id_tenant_id(
+                &state,
+                &auth.role_id,
+                &auth.org_id,
+                auth.tenant_id.as_ref().unwrap_or(&state.tenant.tenant_id),
+            )
+            .await
+            .change_context(errors::ApiErrorResponse::InternalServerError)
+            .attach_printable("Failed to fetch role info while listing webhook events")?;
 
-            request_internal.merchant_id = merchant_id;
-            request_internal.constraints.profile_id = Some(profile_id);
+            // Merchant-or-higher scopes search across all profiles in the merchant;
+            // profile-scoped users stay confined to their JWT's profile_id.
+            let request_internal = EventListRequestInternal {
+                merchant_id: auth.merchant_id,
+                constraints: EventListConstraints {
+                    profile_id: (role_info.get_entity_type() == EntityType::Profile)
+                        .then_some(auth.profile_id),
+                    ..request_internal.constraints
+                },
+            };
 
             webhook_events::list_initial_delivery_attempts(
                 state,
                 request_internal.merchant_id,
                 request_internal.constraints,
             )
+            .await
         },
         &auth::JWTAuth {
             permission: Permission::ProfileWebhookEventRead,


### PR DESCRIPTION
## Summary

Hotfix bundle picked onto `2026.02.02.0-hotfix16-hotfix`. Three PRs in scope:

- [#12432](https://github.com/juspay/hyperswitch/pull/12432) — `Hotfix/clickhouse aggregate payment intents`
- [#12214](https://github.com/juspay/hyperswitch/pull/12214) — `fix(webhooks): respect role scope when listing events so merchant users can search across profiles`
- [#11595](https://github.com/juspay/hyperswitch/pull/11595) — `feat(payment_methods): enable JWT auth for list payment methods API`

Tracker: #12524

## Cherry-picks

- **#12432** — already on this branch via `ffecf25e67` (shipped in `-hotfix16-10`). No fresh pick needed; a re-pick produces an empty commit.
- **#12214** — picked from merge `55d48b68`. Clean, no conflicts.
- **#11595** — picked from merge `2ba04177`. Conflict in `crates/router/src/routes/payment_methods.rs::list_payment_method_api` resolved by swapping `auth::check_sdk_auth_and_get_auth` → `auth::check_client_secret_and_get_auth` (the helper that exists on this hotfix branch; same return signature). JWT-aware structure from the PR is otherwise preserved verbatim. `cards.rs` auto-merged.

## Test plan

- [ ] Build the `router` crate against the hotfix workspace
- [ ] Smoke test `GET /payment_methods` with JWT, with publishable-key + client_secret, and with API key
- [ ] Smoke test webhook events listing as Merchant-scoped and Profile-scoped users (cross-profile visibility for merchant, isolation for profile)
- [ ] Sanity-check ClickHouse aggregate endpoints from #12432 still respond as expected