### PR TITLE
feat(ucs): send x-proxy-name header so UCS selects the proxy based on…

### DIFF
--- a/crates/common_utils/src/consts.rs
+++ b/crates/common_utils/src/consts.rs
@@ -178,6 +178,9 @@ pub const X_SUB_FLOW_NAME: &str = "x-sub-flow";
 /// Unified Connector Service Mode
 pub const X_UNIFIED_CONNECTOR_SERVICE_MODE: &str = "x-shadow-mode";
 
+/// Proxy name for UCS to select the proxy to route the request through
+pub const X_PROXY_NAME: &str = "x-proxy-name";
+
 /// Config Override Header for UCS
 pub const X_CONFIG_OVERRIDE: &str = "x-config-override";
 

--- a/crates/external_services/src/grpc_client.rs
+++ b/crates/external_services/src/grpc_client.rs
@@ -168,6 +168,8 @@ pub struct GrpcHeadersUcs {
     resource_id: Option<ucs_types::UcsResourceId>,
 
     shadow_mode: Option<bool>,
+    /// Proxy name for UCS to select the proxy to route the request through
+    proxy_name: Option<&'static str>,
     /// Config override as JSON string to pass to UCS
     config_override: Option<String>,
 }
@@ -181,6 +183,7 @@ pub type GrpcHeadersUcsBuilderInitial = GrpcHeadersUcsBuilder<(
     (),
     (),
     (Option<bool>,),
+    (Option<&'static str>,),
     (Option<String>,),
 )>;
 /// Type aliase for GrpcHeaders builder in intermediate stage
@@ -192,6 +195,7 @@ pub type GrpcHeadersUcsBuilderFinal = GrpcHeadersUcsBuilder<(
     (Option<ucs_types::UcsReferenceId>,),
     (Option<ucs_types::UcsResourceId>,),
     (Option<bool>,),
+    (Option<&'static str>,),
     (Option<String>,),
 )>;
 

--- a/crates/external_services/src/grpc_client/unified_connector_service.rs
+++ b/crates/external_services/src/grpc_client/unified_connector_service.rs
@@ -1170,6 +1170,7 @@ pub fn build_unified_connector_service_grpc_headers(
         merchant_reference_id,
         resource_id,
         shadow_mode,
+        proxy_name,
         config_override,
     } = grpc_headers;
 
@@ -1283,6 +1284,13 @@ pub fn build_unified_connector_service_grpc_headers(
                 common_utils_consts::X_UNIFIED_CONNECTOR_SERVICE_MODE,
                 &shadow_mode.to_string(),
             )?,
+        );
+    }
+
+    if let Some(proxy_name) = proxy_name {
+        metadata.append(
+            common_utils_consts::X_PROXY_NAME,
+            parse(common_utils_consts::X_PROXY_NAME, proxy_name)?,
         );
     }
 

--- a/crates/router/src/routes/app.rs
+++ b/crates/router/src/routes/app.rs
@@ -186,6 +186,12 @@ impl SessionState {
             ExecutionMode::Shadow => Some(true),
             ExecutionMode::NotApplicable => None,
         };
+        // UCS selects the proxy to route through based on this header
+        let proxy_name = match unified_connector_service_execution_mode {
+            ExecutionMode::Primary => Some("primary"),
+            ExecutionMode::Shadow => Some("shadow"),
+            ExecutionMode::NotApplicable => None,
+        };
         // For shadow mode, disable event publishing in UCS
         let config_override = match unified_connector_service_execution_mode {
             ExecutionMode::Shadow => Some(
@@ -202,6 +208,7 @@ impl SessionState {
             .tenant_id(tenant_id)
             .request_id(request_id)
             .shadow_mode(shadow_mode)
+            .proxy_name(proxy_name)
             .config_override(config_override)
     }
     #[cfg(all(feature = "revenue_recovery", feature = "v2"))]


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [x] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Hyperswitch now sends an `x-proxy-name` gRPC header to the Unified Connector Service (UCS) so that **Hyperswitch decides which proxy a UCS request is routed through**, instead of UCS deciding internally.

This is the companion change to connector-service PR [juspay/hyperswitch-prism#1238](https://github.com/juspay/hyperswitch-prism/pull/1238), which restructures UCS proxy config into a named proxy map (`[proxy.proxies.<name>]`) and makes UCS a pure `HashMap` lookup on `x-proxy-name` with zero routing logic.

The header is derived from the existing `ExecutionMode`, mirroring the existing `shadow_mode` plumbing:

| `ExecutionMode` | `x-proxy-name` sent |
|-----------------|---------------------|
| `Primary`       | `primary`           |
| `Shadow`        | `shadow`            |
| `NotApplicable` | *(header omitted)*  |

When the header is omitted, UCS falls back to its `primary` proxy, so the behaviour for non-shadow paths is unchanged. `x-shadow-mode` continues to be sent as-is — it is an orthogonal MITM-level signal and is not affected by this change.

### Changes

- Added `X_PROXY_NAME` (`x-proxy-name`) header constant in `common_utils`.
- Added a `proxy_name: Option<&'static str>` field to `GrpcHeadersUcs` (and the builder type aliases).
- `get_grpc_headers_ucs` derives `proxy_name` from `ExecutionMode`.
- `build_unified_connector_service_grpc_headers` appends the `x-proxy-name` header when present.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

## Motivation and Context

Previously UCS owned the proxy-routing decision (e.g. `shadow_mode → MITM, else → Squid`), which was hardcoded and not extensible — adding a new proxy required UCS code changes and leaked internal proxy implementation details into config. Moving the decision to Hyperswitch via `x-proxy-name` lets UCS stay a dumb lookup and makes adding new proxies a config-only change. See connector-service PR #1238 for the full rationale.

## How did you test it?

- `cargo check -p external_services -p router` passes.

**End-to-end against UCS on the `feat/config-based-squid-mitm` branch** (named proxy map pointed at two distinct local listeners — `primary → :9101`, `shadow → :9102` — so the proxy actually selected is directly observable). Sent the exact gRPC `Authorize` metadata HS emits and observed which proxy received the outbound `CONNECT api.stripe.com:443`:

| Case | header sent (= what HS emits) | proxy that received the request |
|------|-------------------------------|---------------------------------|
| current HS `main` | *(no `x-proxy-name`)* | **primary** — UCS fallback ✅ |
| this branch, `Primary` | `x-proxy-name: primary` | **primary** ✅ |
| this branch, `Shadow` | `x-proxy-name: shadow` | **shadow** ✅ |

Confirmed independently by UCS's own logs, e.g. for the primary case:

```
INFO external_services::service: Creating new proxy client for config:
  (Proxy { https_url: Some("http://127.0.0.1:9101") .. }, "primary")
```

So current HS `main` keeps working against the new UCS (no header → safe fallback to `primary`, no regression), and `x-proxy-name` routes to the correct named proxy.

<!-- SCREENSHOT: drag the proof image (proxy_test_proof.png) here -->

## Checklist

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
