### PR TITLE
parity(nmi/setup_mandate): remove unsupported shipping_details from NmiValidateRequest

### DIFF
--- a/crates/hyperswitch_connectors/src/connectors/nmi/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/nmi/transformers.rs
@@ -517,8 +517,6 @@ pub struct NmiValidateRequest {
     customer_vault: CustomerAction,
     #[serde(flatten)]
     billing_details: NmiBillingDetails,
-    #[serde(flatten)]
-    shipping_details: NmiShippingDetails,
 }
 
 #[derive(Debug, Serialize)]
@@ -1103,7 +1101,6 @@ impl TryFrom<&NmiRouterData<&SetupMandateRouterData>> for NmiValidateRequest {
             orderid: item.router_data.connector_request_reference_id.clone(),
             customer_vault: CustomerAction::AddCustomer,
             billing_details: item.get_billing_details(),
-            shipping_details: item.get_shipping_details(),
         })
     }
 }


### PR DESCRIPTION
## Verdict in one line
nmi/setup_mandate: HS was sending 8 unsupported shipping_* fields in the validate request. Per NMI docs, CreditCardValidateRequest does not include the Shipping component. Fix in HS.

## Decision trail
- HS reads (`crates/hyperswitch_connectors/src/connectors/nmi/transformers.rs:L510-L522`):
  ```rust
  pub struct NmiValidateRequest {
      // ...
      #[serde(flatten)]
      billing_details: NmiBillingDetails,
      #[serde(flatten)]
      shipping_details: NmiShippingDetails,  // ← not in NMI validate spec
  }
  ```
- Prism reads (`crates/integrations/connector-integration/src/connectors/nmi/transformers.rs:L1544-L1573`):
  ```rust
  pub struct NmiSetupMandateRequest {
      // billing fields only — no shipping component
      first_name, last_name, email, address1..country
  }
  ```
- Connector doc: https://docs.nmi.com/reference/transactions-processing
  > Shipping fields are NOT part of the CreditCardValidateRequest schema. The Shipping component is only included in Sale and Authorize transaction types.
- Conclusion: HS is divergent — sends unsupported shipping fields that NMI silently ignores
- Fix direction: HS

## Raw evidence
- PRD issue: https://github.com/juspay/hyperswitch-cloud/issues/16479
- Expected: shipping_firstname..shipping_country removed from validate request body
- `NmiValidateRequest` is only used by SetupMandate flow (confirmed via grep)
- `NmiShippingDetails` struct and `get_shipping_details()` helper are NOT modified — still used by Authorize/Sale flows

## Diff
2 hunks, 3 lines removed:
1. Remove `shipping_details: NmiShippingDetails` from `NmiValidateRequest` struct (L520-521)
2. Remove `shipping_details: item.get_shipping_details()` from `TryFrom` construction (L1106)

## Verification
<details><summary>cargo check --features "release" (clean)</summary>

```
Finished `dev` profile [unoptimized + debuginfo] target(s) in 5m 48s
```
</details>
<details><summary>cargo clippy --features "release" (clean)</summary>

```
Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.41s
```
</details>

Note: No existing NMI unit tests in the repo. Regression fixture test not applicable — this is a request-side field removal (not a response-parsing change), and the HS repo has no NMI transformer unit test infrastructure. Validation via shadow-replay producing zero diff for shipping_* fields.

## What this PR is NOT
- Field paths NOT touched: `email` (separate PRD #2)
- Files NOT touched: `nmi.rs` (connector impl), `NmiShippingDetails` struct, `get_shipping_details()` helper
- PRD `Out of scope` items: NmiShippingDetails struct (still used by Authorize/Sale), get_shipping_details() helper, email field mapping

## Acceptance Criteria
- [x] Build clean
- [x] Clippy clean
- [x] No existing NMI tests to regress
- [ ] Shadow-replay produces zero diff for shipping_* fields (verified by next regular cycle; not blocking merge)


---
Closes: juspay/hyperswitch-cloud#16479
