### PR TITLE
fix(hotfix16): drop missing JWTAuth fields + adapt ClickHouse aggregate handlers

### DIFF
--- a/crates/router/src/analytics.rs
+++ b/crates/router/src/analytics.rs
@@ -756,7 +756,12 @@ pub mod routes {
             &req,
             payload,
             |state, auth: AuthenticationData, req, _| async move {
-                let auth_info = auth.platform.to_merchant_level_auth_info();
+                let org_id = auth.platform.get_processor().get_account().get_org_id();
+                let merchant_id = auth.platform.get_processor().get_account().get_id();
+                let auth_info = AuthInfo::MerchantLevel {
+                    org_id: org_id.clone(),
+                    merchant_ids: vec![merchant_id.clone()],
+                };
                 let status_with_count = state
                     .pool
                     .get_intent_status_with_count(&auth_info, &req)
@@ -768,8 +773,6 @@ pub mod routes {
             },
             &auth::JWTAuth {
                 permission: Permission::MerchantPaymentRead,
-                allow_connected: true,
-                allow_platform: false,
             },
             api_locking::LockAction::NotApplicable,
         ))
@@ -789,6 +792,8 @@ pub mod routes {
             &req,
             payload,
             |state, auth: AuthenticationData, req, _| async move {
+                let org_id = auth.platform.get_processor().get_account().get_org_id();
+                let merchant_id = auth.platform.get_processor().get_account().get_id();
                 #[cfg(feature = "v1")]
                 let profile_id = auth
                     .profile
@@ -798,7 +803,11 @@ pub mod routes {
                     .clone();
                 #[cfg(feature = "v2")]
                 let profile_id = auth.profile.get_id().clone();
-                let auth_info = auth.platform.to_profile_level_auth_info(profile_id);
+                let auth_info = AuthInfo::ProfileLevel {
+                    org_id: org_id.clone(),
+                    merchant_id: merchant_id.clone(),
+                    profile_ids: vec![profile_id],
+                };
                 let status_with_count = state
                     .pool
                     .get_intent_status_with_count(&auth_info, &req)
@@ -810,8 +819,6 @@ pub mod routes {
             },
             &auth::JWTAuth {
                 permission: Permission::ProfilePaymentRead,
-                allow_connected: true,
-                allow_platform: false,
             },
             api_locking::LockAction::NotApplicable,
         ))

--- a/crates/router/src/routes/payment_methods.rs
+++ b/crates/router/src/routes/payment_methods.rs
@@ -629,8 +629,6 @@ pub async fn list_payment_method_api(
         let jwt_auth: Box<dyn auth::AuthenticateAndFetch<auth::AuthenticationData, _>> =
             Box::new(auth::JWTAuth {
                 permission: Permission::MerchantPaymentRead,
-                allow_connected: true,
-                allow_platform: true,
             });
 
         (jwt_auth, api::AuthFlow::Merchant)


### PR DESCRIPTION
## Summary

`2026.02.02.0-hotfix16-11` (tag just cut from PR #12523) does not compile. Two PRs that are on `main` were never backported to this hotfix line, and code on the branch references their APIs:

- [#11195](https://github.com/juspay/hyperswitch/pull/11195) `feat(platform): JWT Authentication for Platform Operations` — added `allow_connected: bool` / `allow_platform: bool` to `JWTAuth` (the branch-local struct still only carries `permission`).
- [#11635](https://github.com/juspay/hyperswitch/pull/11635) `feat(platform): modify queries to support analytics for connected merchant` — added `Platform::to_merchant_level_auth_info()` / `to_profile_level_auth_info()`.

## Build error before this fix

```
error[E0560]: struct \`JWTAuth\` has no field named \`allow_connected\`
   --> crates/router/src/routes/payment_methods.rs:632:17
error[E0560]: struct \`JWTAuth\` has no field named \`allow_platform\`
   --> crates/router/src/routes/payment_methods.rs:633:17
error[E0560]: struct \`JWTAuth\` has no field named \`allow_connected\`
   --> crates/router/src/analytics.rs:771:17
error[E0560]: struct \`JWTAuth\` has no field named \`allow_platform\`
   --> crates/router/src/analytics.rs:772:17
error[E0560]: struct \`JWTAuth\` has no field named \`allow_connected\`
   --> crates/router/src/analytics.rs:813:17
error[E0560]: struct \`JWTAuth\` has no field named \`allow_platform\`
   --> crates/router/src/analytics.rs:814:17
error[E0599]: no method named \`to_merchant_level_auth_info\` found for struct \`Platform\`
   --> crates/router/src/analytics.rs:759:47
error[E0599]: no method named \`to_profile_level_auth_info\` found for struct \`Platform\`
   --> crates/router/src/analytics.rs:801:47
error: could not compile \`router\` (lib) due to 8 previous errors
```

Source PRs that introduced the offending references on this branch:

- [#12432](https://github.com/juspay/hyperswitch/pull/12432) (shipped in `-hotfix16-10`) — added the two ClickHouse aggregate handlers in `analytics.rs` that call `Platform::to_*_level_auth_info()` and use the missing `JWTAuth` fields.
- [#12523](https://github.com/juspay/hyperswitch/pull/12523) (shipped in `-hotfix16-11`) — cherry-picked #11595, which adds the JWT branch in `list_payment_method_api` and uses the same missing `JWTAuth` fields.

## Approach

Surgical adapt, no upstream feature backport (a full port of #11195 + #11635 would be a feature-merge on a frozen tag line, not a hotfix).

**Commit 1 — `analytics.rs`:** Inline-construct `AuthInfo::MerchantLevel` and `AuthInfo::ProfileLevel` from `auth.platform.get_processor()` exactly like the sibling handlers already in the file ([analytics.rs:557](crates/router/src/analytics.rs#L557), [:669](crates/router/src/analytics.rs#L669)). Drop `allow_connected` / `allow_platform` from the two `JWTAuth` literals.

**Commit 2 — `payment_methods.rs`:** Drop `allow_connected` / `allow_platform` from the `JWTAuth` literal in `list_payment_method_api`. The JWT branch stays functional with the `permission` field that does exist on this branch's struct.

## Behavior

- **Standard / Platform merchants:** unchanged. Same response shape, same auth requirements.
- **Connected-merchant gating** introduced by #11195 + #11635 on main is **not available on this hotfix line** and is intentionally not introduced here. Coverage is consistent with the rest of `-hotfix16-*`.

## Test plan

- [ ] Docker build succeeds: `docker buildx build --build-arg BINARY=router --build-arg VERSION_FEATURE_SET=v1 --features release ...`
- [ ] `GET /payment_methods` works with JWT (no client_secret), with publishable-key + client_secret, and with API key
- [ ] `GET /analytics/v1/payment_intents/aggregate` returns `status_with_count` for a Standard merchant JWT
- [ ] `GET /analytics/v1/profile/payment_intents/aggregate` returns `status_with_count` for a profile-scoped JWT

Tracker: #12539