### PR TITLE
ci: add author-scoped PR size policy

### DIFF
--- a/.github/pr-size-policy.yml
+++ b/.github/pr-size-policy.yml
@@ -1,0 +1,24 @@
+# PR size policy for selected authors.
+#
+# This check applies only to the GitHub usernames listed under target_authors.
+# Usernames are matched case-insensitively.
+enabled: true
+
+# Size metric to enforce. Supported values:
+# - changed_lines: additions + deletions
+# - additions: added lines only
+# - changed_files: number of changed files
+metric: changed_lines
+
+# Maximum allowed value for the selected metric before an admin bypass is required.
+threshold: 1000
+
+# Add GitHub usernames here to opt authors into the PR size policy.
+target_authors: []
+
+bypass:
+  # Adding this label lets an oversized PR pass.
+  label: pr-size/bypass
+
+  # An APPROVED review from a member of this GitHub team also lets an oversized PR pass.
+  approving_team: hyperswitch-admins

--- a/.github/pr-size-policy.yml
+++ b/.github/pr-size-policy.yml
@@ -17,8 +17,7 @@ threshold: 1000
 target_authors: []
 
 bypass:
-  # Adding this label lets an oversized PR pass.
+  # Adding this label lets an oversized PR pass when the label was applied by
+  # a member of label_actor_team.
   label: pr-size/bypass
-
-  # An APPROVED review from a member of this GitHub team also lets an oversized PR pass.
-  approving_team: hyperswitch-admins
+  label_actor_team: hyperswitch-admins

--- a/.github/scripts/check_pr_size.sh
+++ b/.github/scripts/check_pr_size.sh
@@ -26,7 +26,7 @@ function load_policy() {
   metric="$(jq -r '.metric // "changed_lines"' <<< "${policy_json}")"
   threshold="$(jq -r '.threshold // empty' <<< "${policy_json}")"
   bypass_label="$(jq -r '.bypass.label // empty' <<< "${policy_json}")"
-  approving_team="$(jq -r '.bypass.approving_team // empty' <<< "${policy_json}")"
+  label_actor_team="$(jq -r '.bypass.label_actor_team // empty' <<< "${policy_json}")"
   target_authors="$(jq -r '.target_authors[]? | ascii_downcase' <<< "${policy_json}")"
 }
 
@@ -94,58 +94,47 @@ function has_bypass_label() {
     --jq '.labels[].name' | grep --fixed-strings --line-regexp --quiet "${bypass_label}"
 }
 
-function is_user_team_member() {
-  local username="${1}"
-  local team_slug="${2}"
-  local org_name="${REPOSITORY%%/*}"
-
+function latest_bypass_label_actor() {
   gh api \
     --header "Accept: application/vnd.github+json" \
     --header "X-GitHub-Api-Version: 2022-11-28" \
-    "/orgs/${org_name}/teams/${team_slug}/memberships/${username}" \
-    >/dev/null 2>&1
+    --paginate \
+    "/repos/${REPOSITORY}/issues/${PR_NUMBER}/timeline" \
+    | jq --raw-output --arg label "${bypass_label}" '.[] | select(.event == "labeled" and .label.name == $label) | .actor.login' \
+    | tail -n 1
 }
 
-function has_current_admin_approval() {
-  [[ -n "${approving_team}" ]] || return 1
+function is_active_team_member() {
+  local username="${1}"
+  local team_slug="${2}"
+  local org_name="${REPOSITORY%%/*}"
+  local membership_state
 
-  local head_sha
-  head_sha="$(gh api \
+  membership_state="$(gh api \
     --header "Accept: application/vnd.github+json" \
     --header "X-GitHub-Api-Version: 2022-11-28" \
-    "/repos/${REPOSITORY}/pulls/${PR_NUMBER}" \
-    --jq '.head.sha')"
+    "/orgs/${org_name}/teams/${team_slug}/memberships/${username}" \
+    --jq '.state' 2>/dev/null || true)"
 
-  local approved_reviewers
-  approved_reviewers="$(gh api \
-    --header "Accept: application/vnd.github+json" \
-    --header "X-GitHub-Api-Version: 2022-11-28" \
-    --paginate \
-    "/repos/${REPOSITORY}/pulls/${PR_NUMBER}/reviews" \
-    --jq '.[] | select(.user.login != null and (.state == "APPROVED" or .state == "CHANGES_REQUESTED" or .state == "DISMISSED")) | [.submitted_at, .user.login, .state, .commit_id] | @tsv' \
-    | sort \
-    | awk -F '\t' -v head_sha="${head_sha}" '{ state[$2] = $3; commit[$2] = $4 } END { for (user in state) if (state[user] == "APPROVED" && commit[user] == head_sha) print user }')"
-
-  while IFS= read -r reviewer; do
-    [[ -z "${reviewer}" ]] && continue
-    if is_user_team_member "${reviewer}" "${approving_team}"; then
-      return 0
-    fi
-  done <<< "${approved_reviewers}"
-
-  return 1
+  [[ "${membership_state}" == "active" ]]
 }
 
 function find_bypass_reason() {
   bypass_reason=""
 
-  if has_bypass_label; then
+  if ! has_bypass_label; then
+    return 1
+  fi
+
+  if [[ -z "${label_actor_team}" ]]; then
     bypass_reason="label '${bypass_label}'"
     return 0
   fi
 
-  if has_current_admin_approval; then
-    bypass_reason="current approval from '${approving_team}'"
+  local label_actor
+  label_actor="$(latest_bypass_label_actor)"
+  if [[ -n "${label_actor}" ]] && is_active_team_member "${label_actor}" "${label_actor_team}"; then
+    bypass_reason="label '${bypass_label}' applied by '${label_actor}' from '${label_actor_team}'"
     return 0
   fi
 
@@ -153,20 +142,11 @@ function find_bypass_reason() {
 }
 
 function bypass_instructions() {
-  local message=""
-
-  if [[ -n "${bypass_label}" ]]; then
-    message=" Add label '${bypass_label}'"
+  if [[ -n "${bypass_label}" && -n "${label_actor_team}" ]]; then
+    printf " Add label '%s' by a member of '%s'" "${bypass_label}" "${label_actor_team}"
+  elif [[ -n "${bypass_label}" ]]; then
+    printf " Add label '%s'" "${bypass_label}"
   fi
-  if [[ -n "${approving_team}" ]]; then
-    if [[ -n "${message}" ]]; then
-      message+=" or get a current APPROVED review from '${approving_team}'"
-    else
-      message=" Get a current APPROVED review from '${approving_team}'"
-    fi
-  fi
-
-  printf '%s' "${message}"
 }
 
 load_policy

--- a/.github/scripts/check_pr_size.sh
+++ b/.github/scripts/check_pr_size.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+POLICY_FILE="${PR_SIZE_POLICY_CONFIG:-.github/pr-size-policy.yml}"
+REPOSITORY="${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
+PR_NUMBER="${PR_NUMBER:?PR_NUMBER is required}"
+PR_AUTHOR="${PR_AUTHOR:?PR_AUTHOR is required}"
+
+for command in gh jq ruby; do
+  if ! command -v "${command}" >/dev/null 2>&1; then
+    echo "::error::Required command '${command}' is not installed"
+    exit 1
+  fi
+done
+
+if [[ ! -f "${POLICY_FILE}" ]]; then
+  echo "::error::PR size policy file not found: ${POLICY_FILE}"
+  exit 1
+fi
+
+policy_json="$(ruby -ryaml -rjson -e 'puts JSON.generate(YAML.load_file(ARGV.fetch(0)) || {})' "${POLICY_FILE}")"
+
+enabled="$(jq -r '.enabled // true' <<< "${policy_json}")"
+metric="$(jq -r '.metric // "changed_lines"' <<< "${policy_json}")"
+threshold="$(jq -r '.threshold // empty' <<< "${policy_json}")"
+bypass_label="$(jq -r '.bypass.label // empty' <<< "${policy_json}")"
+approving_team="$(jq -r '.bypass.approving_team // empty' <<< "${policy_json}")"
+target_authors="$(jq -r '.target_authors[]? | ascii_downcase' <<< "${policy_json}")"
+
+if [[ "${enabled}" != "true" ]]; then
+  echo "PR size policy is disabled"
+  exit 0
+fi
+
+if [[ -z "${threshold}" || ! "${threshold}" =~ ^[0-9]+$ ]]; then
+  echo "::error::PR size policy threshold must be a non-negative integer"
+  exit 1
+fi
+
+case "${metric}" in
+  changed_lines | additions | changed_files) ;;
+  *)
+    echo "::error::Unsupported PR size metric '${metric}'. Supported: changed_lines, additions, changed_files"
+    exit 1
+    ;;
+esac
+
+pr_author_lower="$(tr '[:upper:]' '[:lower:]' <<< "${PR_AUTHOR}")"
+if ! grep --fixed-strings --line-regexp --quiet "${pr_author_lower}" <<< "${target_authors}"; then
+  echo "PR author '${PR_AUTHOR}' is not covered by PR size policy"
+  exit 0
+fi
+
+has_bypass_label=false
+if [[ -n "${bypass_label}" ]]; then
+  if gh api \
+      --header "Accept: application/vnd.github+json" \
+      --header "X-GitHub-Api-Version: 2022-11-28" \
+      "/repos/${REPOSITORY}/issues/${PR_NUMBER}" \
+      --jq '.labels[].name' | grep --fixed-strings --line-regexp --quiet "${bypass_label}"; then
+    has_bypass_label=true
+  fi
+fi
+
+function is_user_team_member() {
+  local username="${1}"
+  local team_slug="${2}"
+  local org_name="${REPOSITORY%%/*}"
+
+  local status_code
+  status_code="$(
+    curl \
+      --location \
+      --silent \
+      --output /dev/null \
+      --write-out '%{http_code}' \
+      --header 'Accept: application/vnd.github+json' \
+      --header 'X-GitHub-Api-Version: 2022-11-28' \
+      --header "Authorization: Bearer ${GH_TOKEN}" \
+      "https://api.github.com/orgs/${org_name}/teams/${team_slug}/memberships/${username}"
+  )"
+
+  [[ "${status_code}" -eq 200 ]]
+}
+
+has_admin_approval=false
+if [[ -n "${approving_team}" ]]; then
+  approved_reviewers="$(gh api \
+    --header "Accept: application/vnd.github+json" \
+    --header "X-GitHub-Api-Version: 2022-11-28" \
+    --paginate \
+    "/repos/${REPOSITORY}/pulls/${PR_NUMBER}/reviews" \
+    --jq '.[] | select(.state == "APPROVED") | .user.login' | sort -u)"
+
+  while IFS= read -r reviewer; do
+    [[ -z "${reviewer}" ]] && continue
+    if is_user_team_member "${reviewer}" "${approving_team}"; then
+      has_admin_approval=true
+      break
+    fi
+  done <<< "${approved_reviewers}"
+fi
+
+additions=0
+deletions=0
+changed_files=0
+while IFS=$'\t' read -r file_additions file_deletions; do
+  [[ -z "${file_additions}" ]] && continue
+  additions=$((additions + file_additions))
+  deletions=$((deletions + file_deletions))
+  changed_files=$((changed_files + 1))
+done < <(
+  gh api \
+    --header "Accept: application/vnd.github+json" \
+    --header "X-GitHub-Api-Version: 2022-11-28" \
+    --paginate \
+    "/repos/${REPOSITORY}/pulls/${PR_NUMBER}/files" \
+    --jq '.[] | [.additions, .deletions] | @tsv'
+)
+
+changed_lines=$((additions + deletions))
+case "${metric}" in
+  changed_lines) size="${changed_lines}" ;;
+  additions) size="${additions}" ;;
+  changed_files) size="${changed_files}" ;;
+esac
+
+if [[ "${size}" -le "${threshold}" ]]; then
+  echo "PR size policy passed for '${PR_AUTHOR}': ${metric}=${size}, threshold=${threshold}"
+  echo "Totals: additions=${additions}, deletions=${deletions}, changed_files=${changed_files}"
+  exit 0
+fi
+
+if [[ "${has_bypass_label}" == "true" ]]; then
+  echo "PR size policy bypassed by label '${bypass_label}' for '${PR_AUTHOR}': ${metric}=${size}, threshold=${threshold}"
+  exit 0
+fi
+
+if [[ "${has_admin_approval}" == "true" ]]; then
+  echo "PR size policy bypassed by approval from '${approving_team}' for '${PR_AUTHOR}': ${metric}=${size}, threshold=${threshold}"
+  exit 0
+fi
+
+bypass_message=""
+if [[ -n "${bypass_label}" ]]; then
+  bypass_message=" Add label '${bypass_label}'"
+fi
+if [[ -n "${approving_team}" ]]; then
+  if [[ -n "${bypass_message}" ]]; then
+    bypass_message+=" or get an APPROVED review from '${approving_team}'"
+  else
+    bypass_message=" Get an APPROVED review from '${approving_team}'"
+  fi
+fi
+
+message="PR size policy failed for '${PR_AUTHOR}': ${metric}=${size}, threshold=${threshold}. Totals: additions=${additions}, deletions=${deletions}, changed_files=${changed_files}.${bypass_message} to bypass."
+echo "::error::${message}"
+exit 1

--- a/.github/scripts/check_pr_size.sh
+++ b/.github/scripts/check_pr_size.sh
@@ -19,112 +19,165 @@ if [[ ! -f "${POLICY_FILE}" ]]; then
   exit 1
 fi
 
-policy_json="$(ruby -ryaml -rjson -e 'puts JSON.generate(YAML.load_file(ARGV.fetch(0)) || {})' "${POLICY_FILE}")"
+function load_policy() {
+  policy_json="$(ruby -ryaml -rjson -e 'puts JSON.generate(YAML.load_file(ARGV.fetch(0)) || {})' "${POLICY_FILE}")"
 
-enabled="$(jq -r '.enabled // true' <<< "${policy_json}")"
-metric="$(jq -r '.metric // "changed_lines"' <<< "${policy_json}")"
-threshold="$(jq -r '.threshold // empty' <<< "${policy_json}")"
-bypass_label="$(jq -r '.bypass.label // empty' <<< "${policy_json}")"
-approving_team="$(jq -r '.bypass.approving_team // empty' <<< "${policy_json}")"
-target_authors="$(jq -r '.target_authors[]? | ascii_downcase' <<< "${policy_json}")"
+  enabled="$(jq -r '.enabled // true' <<< "${policy_json}")"
+  metric="$(jq -r '.metric // "changed_lines"' <<< "${policy_json}")"
+  threshold="$(jq -r '.threshold // empty' <<< "${policy_json}")"
+  bypass_label="$(jq -r '.bypass.label // empty' <<< "${policy_json}")"
+  approving_team="$(jq -r '.bypass.approving_team // empty' <<< "${policy_json}")"
+  target_authors="$(jq -r '.target_authors[]? | ascii_downcase' <<< "${policy_json}")"
+}
 
-if [[ "${enabled}" != "true" ]]; then
-  echo "PR size policy is disabled"
-  exit 0
-fi
+function validate_policy() {
+  if [[ "${enabled}" != "true" ]]; then
+    echo "PR size policy is disabled"
+    exit 0
+  fi
 
-if [[ -z "${threshold}" || ! "${threshold}" =~ ^[0-9]+$ ]]; then
-  echo "::error::PR size policy threshold must be a non-negative integer"
-  exit 1
-fi
-
-case "${metric}" in
-  changed_lines | additions | changed_files) ;;
-  *)
-    echo "::error::Unsupported PR size metric '${metric}'. Supported: changed_lines, additions, changed_files"
+  if [[ -z "${threshold}" || ! "${threshold}" =~ ^[0-9]+$ ]]; then
+    echo "::error::PR size policy threshold must be a non-negative integer"
     exit 1
-    ;;
-esac
+  fi
 
-pr_author_lower="$(tr '[:upper:]' '[:lower:]' <<< "${PR_AUTHOR}")"
-if ! grep --fixed-strings --line-regexp --quiet "${pr_author_lower}" <<< "${target_authors}"; then
-  echo "PR author '${PR_AUTHOR}' is not covered by PR size policy"
-  exit 0
-fi
+  case "${metric}" in
+    changed_lines | additions | changed_files) ;;
+    *)
+      echo "::error::Unsupported PR size metric '${metric}'. Supported: changed_lines, additions, changed_files"
+      exit 1
+      ;;
+  esac
+}
 
-has_bypass_label=false
-if [[ -n "${bypass_label}" ]]; then
-  if gh api \
+function author_is_targeted() {
+  local pr_author_lower
+  pr_author_lower="$(tr '[:upper:]' '[:lower:]' <<< "${PR_AUTHOR}")"
+
+  grep --fixed-strings --line-regexp --quiet "${pr_author_lower}" <<< "${target_authors}"
+}
+
+function measure_pr_size() {
+  additions=0
+  deletions=0
+  changed_files=0
+
+  while IFS=$'\t' read -r file_additions file_deletions; do
+    [[ -z "${file_additions}" ]] && continue
+    additions=$((additions + file_additions))
+    deletions=$((deletions + file_deletions))
+    changed_files=$((changed_files + 1))
+  done < <(
+    gh api \
       --header "Accept: application/vnd.github+json" \
       --header "X-GitHub-Api-Version: 2022-11-28" \
-      "/repos/${REPOSITORY}/issues/${PR_NUMBER}" \
-      --jq '.labels[].name' | grep --fixed-strings --line-regexp --quiet "${bypass_label}"; then
-    has_bypass_label=true
-  fi
-fi
+      --paginate \
+      "/repos/${REPOSITORY}/pulls/${PR_NUMBER}/files" \
+      --jq '.[] | [.additions, .deletions] | @tsv'
+  )
+
+  changed_lines=$((additions + deletions))
+  case "${metric}" in
+    changed_lines) size="${changed_lines}" ;;
+    additions) size="${additions}" ;;
+    changed_files) size="${changed_files}" ;;
+  esac
+}
+
+function has_bypass_label() {
+  [[ -n "${bypass_label}" ]] || return 1
+
+  gh api \
+    --header "Accept: application/vnd.github+json" \
+    --header "X-GitHub-Api-Version: 2022-11-28" \
+    "/repos/${REPOSITORY}/issues/${PR_NUMBER}" \
+    --jq '.labels[].name' | grep --fixed-strings --line-regexp --quiet "${bypass_label}"
+}
 
 function is_user_team_member() {
   local username="${1}"
   local team_slug="${2}"
   local org_name="${REPOSITORY%%/*}"
 
-  local status_code
-  status_code="$(
-    curl \
-      --location \
-      --silent \
-      --output /dev/null \
-      --write-out '%{http_code}' \
-      --header 'Accept: application/vnd.github+json' \
-      --header 'X-GitHub-Api-Version: 2022-11-28' \
-      --header "Authorization: Bearer ${GH_TOKEN}" \
-      "https://api.github.com/orgs/${org_name}/teams/${team_slug}/memberships/${username}"
-  )"
-
-  [[ "${status_code}" -eq 200 ]]
+  gh api \
+    --header "Accept: application/vnd.github+json" \
+    --header "X-GitHub-Api-Version: 2022-11-28" \
+    "/orgs/${org_name}/teams/${team_slug}/memberships/${username}" \
+    >/dev/null 2>&1
 }
 
-has_admin_approval=false
-if [[ -n "${approving_team}" ]]; then
+function has_current_admin_approval() {
+  [[ -n "${approving_team}" ]] || return 1
+
+  local head_sha
+  head_sha="$(gh api \
+    --header "Accept: application/vnd.github+json" \
+    --header "X-GitHub-Api-Version: 2022-11-28" \
+    "/repos/${REPOSITORY}/pulls/${PR_NUMBER}" \
+    --jq '.head.sha')"
+
+  local approved_reviewers
   approved_reviewers="$(gh api \
     --header "Accept: application/vnd.github+json" \
     --header "X-GitHub-Api-Version: 2022-11-28" \
     --paginate \
     "/repos/${REPOSITORY}/pulls/${PR_NUMBER}/reviews" \
-    --jq '.[] | select(.state == "APPROVED") | .user.login' | sort -u)"
+    --jq '.[] | select(.user.login != null and (.state == "APPROVED" or .state == "CHANGES_REQUESTED" or .state == "DISMISSED")) | [.submitted_at, .user.login, .state, .commit_id] | @tsv' \
+    | sort \
+    | awk -F '\t' -v head_sha="${head_sha}" '{ state[$2] = $3; commit[$2] = $4 } END { for (user in state) if (state[user] == "APPROVED" && commit[user] == head_sha) print user }')"
 
   while IFS= read -r reviewer; do
     [[ -z "${reviewer}" ]] && continue
     if is_user_team_member "${reviewer}" "${approving_team}"; then
-      has_admin_approval=true
-      break
+      return 0
     fi
   done <<< "${approved_reviewers}"
+
+  return 1
+}
+
+function find_bypass_reason() {
+  bypass_reason=""
+
+  if has_bypass_label; then
+    bypass_reason="label '${bypass_label}'"
+    return 0
+  fi
+
+  if has_current_admin_approval; then
+    bypass_reason="current approval from '${approving_team}'"
+    return 0
+  fi
+
+  return 1
+}
+
+function bypass_instructions() {
+  local message=""
+
+  if [[ -n "${bypass_label}" ]]; then
+    message=" Add label '${bypass_label}'"
+  fi
+  if [[ -n "${approving_team}" ]]; then
+    if [[ -n "${message}" ]]; then
+      message+=" or get a current APPROVED review from '${approving_team}'"
+    else
+      message=" Get a current APPROVED review from '${approving_team}'"
+    fi
+  fi
+
+  printf '%s' "${message}"
+}
+
+load_policy
+validate_policy
+
+if ! author_is_targeted; then
+  echo "PR author '${PR_AUTHOR}' is not covered by PR size policy"
+  exit 0
 fi
 
-additions=0
-deletions=0
-changed_files=0
-while IFS=$'\t' read -r file_additions file_deletions; do
-  [[ -z "${file_additions}" ]] && continue
-  additions=$((additions + file_additions))
-  deletions=$((deletions + file_deletions))
-  changed_files=$((changed_files + 1))
-done < <(
-  gh api \
-    --header "Accept: application/vnd.github+json" \
-    --header "X-GitHub-Api-Version: 2022-11-28" \
-    --paginate \
-    "/repos/${REPOSITORY}/pulls/${PR_NUMBER}/files" \
-    --jq '.[] | [.additions, .deletions] | @tsv'
-)
-
-changed_lines=$((additions + deletions))
-case "${metric}" in
-  changed_lines) size="${changed_lines}" ;;
-  additions) size="${additions}" ;;
-  changed_files) size="${changed_files}" ;;
-esac
+measure_pr_size
 
 if [[ "${size}" -le "${threshold}" ]]; then
   echo "PR size policy passed for '${PR_AUTHOR}': ${metric}=${size}, threshold=${threshold}"
@@ -132,28 +185,11 @@ if [[ "${size}" -le "${threshold}" ]]; then
   exit 0
 fi
 
-if [[ "${has_bypass_label}" == "true" ]]; then
-  echo "PR size policy bypassed by label '${bypass_label}' for '${PR_AUTHOR}': ${metric}=${size}, threshold=${threshold}"
+if find_bypass_reason; then
+  echo "PR size policy bypassed by ${bypass_reason} for '${PR_AUTHOR}': ${metric}=${size}, threshold=${threshold}"
   exit 0
 fi
 
-if [[ "${has_admin_approval}" == "true" ]]; then
-  echo "PR size policy bypassed by approval from '${approving_team}' for '${PR_AUTHOR}': ${metric}=${size}, threshold=${threshold}"
-  exit 0
-fi
-
-bypass_message=""
-if [[ -n "${bypass_label}" ]]; then
-  bypass_message=" Add label '${bypass_label}'"
-fi
-if [[ -n "${approving_team}" ]]; then
-  if [[ -n "${bypass_message}" ]]; then
-    bypass_message+=" or get an APPROVED review from '${approving_team}'"
-  else
-    bypass_message=" Get an APPROVED review from '${approving_team}'"
-  fi
-fi
-
-message="PR size policy failed for '${PR_AUTHOR}': ${metric}=${size}, threshold=${threshold}. Totals: additions=${additions}, deletions=${deletions}, changed_files=${changed_files}.${bypass_message} to bypass."
+message="PR size policy failed for '${PR_AUTHOR}': ${metric}=${size}, threshold=${threshold}. Totals: additions=${additions}, deletions=${deletions}, changed_files=${changed_files}.$(bypass_instructions) to bypass."
 echo "::error::${message}"
 exit 1

--- a/.github/workflows/pr-convention-checks.yml
+++ b/.github/workflows/pr-convention-checks.yml
@@ -14,6 +14,8 @@ on:
       - reopened
       - ready_for_review
       - synchronize
+      - labeled
+      - unlabeled
 
   merge_group:
     types:

--- a/.github/workflows/pr-convention-checks.yml
+++ b/.github/workflows/pr-convention-checks.yml
@@ -137,6 +137,8 @@ jobs:
 
     steps:
       - name: Checkout trusted base branch
+        # pull_request_target workflows must use trusted base-branch code only.
+        # The PR size script and policy are read from the base commit, not the PR head.
         uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.base.sha }}

--- a/.github/workflows/pr-convention-checks.yml
+++ b/.github/workflows/pr-convention-checks.yml
@@ -136,6 +136,8 @@ jobs:
     name: Verify PR size policy
     if: ${{ github.event_name == 'pull_request_target' }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout trusted base branch

--- a/.github/workflows/pr-convention-checks.yml
+++ b/.github/workflows/pr-convention-checks.yml
@@ -5,8 +5,8 @@ on:
   # context of the target repository.
   # Avoid checking out the head of the pull request or building code from the
   # pull request whenever this trigger is used.
-  # Since we do not have a checkout step in this workflow, this is an
-  # acceptable use of this trigger.
+  # Checkout only trusted base-branch code when files from the repository are
+  # required. Never checkout the pull request head in this workflow.
   pull_request_target:
     types:
       - opened
@@ -129,6 +129,34 @@ jobs:
               exit 1
             fi
           done <<< "${linked_issues}"
+
+  pr_size_policy_check:
+    name: Verify PR size policy
+    if: ${{ github.event_name == 'pull_request_target' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout trusted base branch
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          persist-credentials: false
+
+      - name: Generate GitHub app token
+        id: generate_app_token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.HYPERSWITCH_BOT_APP_ID }}
+          private-key: ${{ secrets.HYPERSWITCH_BOT_APP_PRIVATE_KEY }}
+          owner: ${{ github.event.repository.owner.login }}
+
+      - name: Verify PR size policy
+        shell: bash
+        env:
+          GH_TOKEN: ${{ steps.generate_app_token.outputs.token }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: .github/scripts/check_pr_size.sh
 
   pr_labeler:
     name: Attach suitable labels to PR


### PR DESCRIPTION
## Summary
- add a trusted PR size policy config for selected authors
- add a metadata-only evaluator script that enforces PR size thresholds
- wire the check into the existing PR convention workflow without checking out PR head code

## Notes
- `target_authors` is intentionally empty until maintainers choose the initial cohort.
- Oversized PRs can be bypassed with `pr-size/bypass` only when the label is applied by an active `hyperswitch-admins` member.

## Testing
- `bash -n .github/scripts/check_pr_size.sh`
- Ruby YAML parsing for `.github/pr-size-policy.yml` and `.github/workflows/pr-convention-checks.yml`
- Script no-op path for a non-target author
- Mocked targeted-author under-threshold path

Closes #12541