### PR TITLE
feat(airwallex): add shopper_name, shopper_email, billing to Atome

### DIFF
--- a/crates/hyperswitch_connectors/src/connectors/airwallex/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/airwallex/transformers.rs
@@ -391,7 +391,10 @@ pub struct AtomeData {
 
 #[derive(Debug, Serialize)]
 pub struct AtomeDetails {
+    shopper_name: Secret<String>,
+    shopper_email: Email,
     shopper_phone: Secret<String>,
+    billing: Option<Billing>,
 }
 
 #[derive(Debug, Serialize)]
@@ -786,6 +789,16 @@ fn get_paylater_details(
         PayLaterData::AtomeRedirect {} => {
             AirwallexPaymentMethod::PayLater(AirwallexPayLaterData::Atome(AtomeData {
                 atome: AtomeDetails {
+                    shopper_name: item.router_data.get_billing_full_name().map_err(|_| {
+                        errors::ConnectorError::MissingRequiredField {
+                            field_name: "shopper_name",
+                        }
+                    })?,
+                    shopper_email: item.router_data.get_billing_email().map_err(|_| {
+                        errors::ConnectorError::MissingRequiredField {
+                            field_name: "shopper_email",
+                        }
+                    })?,
                     shopper_phone: item
                         .router_data
                         .get_billing_phone()
@@ -796,6 +809,19 @@ fn get_paylater_details(
                         .map_err(|_| errors::ConnectorError::MissingRequiredField {
                             field_name: "country_code",
                         })?,
+                    billing: Some(Billing {
+                        date_of_birth: None,
+                        first_name: item.router_data.get_optional_billing_first_name(),
+                        last_name: item.router_data.get_optional_billing_last_name(),
+                        email: item.router_data.get_optional_billing_email(),
+                        phone_number: item.router_data.get_optional_billing_phone_number(),
+                        address: Some(AddressAirwallex {
+                            country_code: item.router_data.get_optional_billing_country(),
+                            city: item.router_data.get_optional_billing_city(),
+                            street: item.router_data.get_optional_billing_line1(),
+                            postcode: item.router_data.get_optional_billing_zip(),
+                        }),
+                    }),
                 },
                 payment_method_type: AirwallexPaymentType::Atome,
             }))


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

Curl
```
curl --location 'http://localhost:8080/payments' \
--header 'Content-Type: application/json' \
--header 'api-key: *' \
--data-raw '{
  "amount": 6540,
  "currency": "SGD",
  "confirm": true,
  "connector": ["airwallex"],
  "profile_id": "pro_htjBjTe8ilVYs3RNlq2X",
  "capture_method": "automatic",
  "authentication_type": "no_three_ds",
  "return_url": "https://google.com",
  "payment_method": "pay_later",
  "payment_method_type": "atome",
  "payment_method_data": {
    "pay_later": {
      "atome_redirect": {}
    }
  },
  "billing": {
    "address": {
      "first_name": "joseph",
      "last_name": "Doe",
      "city": "Singapore",
      "country": "SG",
      "zip": "94122"
    },
    "phone": {
      "number": "9123456789",
      "country_code": "+65"
    },
    "email": "guest@example.com"
  },
  "shipping": {
    "address": {
      "first_name": "joseph",
      "last_name": "Doe",
      "city": "Singapore",
      "country": "SG",
      "zip": "94122"
    },
    "phone": {
      "number": "9123456789",
      "country_code": "+65"
    }
  },
  "order_details": [
    {
      "product_name": "Apple iphone 15",
      "quantity": 1,
      "amount": 6540
    }
  ],
  "browser_info": {
    "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Safari/537.36",
    "accept_header": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8",
    "language": "en",
    "color_depth": 24,
    "screen_height": 723,
    "screen_width": 1536,
    "time_zone": 0,
    "java_enabled": true,
    "java_script_enabled": true,
    "ip_address": "128.0.0.1"
  }
}'
```

Response

```
{
    "payment_id": "pay_iqjOkp7jHxvJ4PcVXDti",
    "merchant_id": "merchant_1780339248",
    "status": "requires_customer_action",
    "amount": 6540,
    "net_amount": 6540,
    "shipping_cost": null,
    "amount_capturable": 6540,
    "amount_received": null,
    "processor_merchant_id": "merchant_1780339248",
    "initiator": null,
    "sdk_authorization": "cHJvZmlsZV9pZD1wcm9faHRqQmpUZThpbFZZczNSTmxxMlgscHVibGlzaGFibGVfa2V5PXBrX2Rldl9mMDczOWQ1ZGI2NWU0M2U4OGRkMDUyMjc0MDZmYTgwNixjbGllbnRfc2VjcmV0PXBheV9pcWpPa3A3akh4dko0UGNWWER0aV9zZWNyZXRfQXNLcmkyN1ZVcXFsVEhYSTJ2OEYsY2xpZW50X3Nlc3Npb25faWQ9Y2xpZW50X3Nlc3NfZU9qdTlXZ2JRN012cVRYV1l2VjYscGF5bWVudF9pZD1wYXlfaXFqT2twN2pIeHZKNFBjVlhEdGk=",
    "connector": "airwallex",
    "state_metadata": null,
    "client_secret": "pay_iqjOkp7jHxvJ4PcVXDti_secret_AsKri27VUqqlTHXI2v8F",
    "created": "2026-06-01T18:59:08.341Z",
    "modified_at": "2026-06-01T18:59:10.020Z",
    "currency": "SGD",
    "customer_id": null,
    "customer": null,
    "description": null,
    "refunds": null,
    "disputes": null,
    "mandate_id": null,
    "mandate_data": null,
    "setup_future_usage": null,
    "off_session": null,
    "capture_on": null,
    "capture_method": "automatic",
    "payment_method": "pay_later",
    "payment_method_data": {
        "pay_later": {
            "klarna_sdk": null
        },
        "billing": null
    },
    "payment_token": null,
    "shipping": {
        "address": {
            "city": "Singapore",
            "country": "SG",
            "line1": null,
            "line2": null,
            "line3": null,
            "zip": "94122",
            "state": null,
            "first_name": "joseph",
            "last_name": "Doe",
            "origin_zip": null
        },
        "phone": {
            "number": "9123456789",
            "country_code": "+65"
        },
        "email": null
    },
    "billing": {
        "address": {
            "city": "Singapore",
            "country": "SG",
            "line1": null,
            "line2": null,
            "line3": null,
            "zip": "94122",
            "state": null,
            "first_name": "joseph",
            "last_name": "Doe",
            "origin_zip": null
        },
        "phone": {
            "number": "9123456789",
            "country_code": "+65"
        },
        "email": "guest@example.com"
    },
    "order_details": [
        {
            "sku": null,
            "upc": null,
            "brand": null,
            "amount": 6540,
            "category": null,
            "quantity": 1,
            "tax_rate": null,
            "product_id": null,
            "description": null,
            "product_name": "Apple iphone 15",
            "product_type": null,
            "sub_category": null,
            "total_amount": null,
            "commodity_code": null,
            "unit_of_measure": null,
            "product_img_link": null,
            "product_tax_code": null,
            "total_tax_amount": null,
            "requires_shipping": null,
            "unit_discount_amount": null
        }
    ],
    "email": null,
    "name": null,
    "phone": null,
    "return_url": "https://google.com/",
    "authentication_type": "no_three_ds",
    "statement_descriptor_name": null,
    "statement_descriptor_suffix": null,
    "next_action": {
        "type": "redirect_to_url",
        "redirect_to_url": "http://localhost:8080/payments/redirect/pay_iqjOkp7jHxvJ4PcVXDti/merchant_1780339248/pay_iqjOkp7jHxvJ4PcVXDti_1"
    },
    "cancellation_reason": null,
    "error_code": null,
    "error_message": null,
    "unified_code": null,
    "unified_message": null,
    "error_details": null,
    "payment_experience": null,
    "payment_method_type": "atome",
    "connector_label": null,
    "business_country": null,
    "business_label": "default",
    "business_sub_label": null,
    "allowed_payment_method_types": null,
    "manual_retry_allowed": null,
    "connector_transaction_id": "int_hkdmj5z4fhj2t2cnj7v",
    "frm_message": null,
    "metadata": null,
    "connector_metadata": null,
    "connector_response_metadata": null,
    "feature_metadata": {
        "redirect_response": null,
        "search_tags": null,
        "apple_pay_recurring_details": null,
        "pix_additional_details": null,
        "boleto_additional_details": null,
        "pix_automatico_additional_details": null,
        "finix_additional_details": null
    },
    "reference_id": "int_hkdmj5z4fhj2t2cnj7v",
    "payment_link": null,
    "profile_id": "pro_htjBjTe8ilVYs3RNlq2X",
    "surcharge_details": null,
    "attempt_count": 1,
    "merchant_decision": null,
    "merchant_connector_id": "mca_NGn0meobtxsTNS31lsMg",
    "incremental_authorization_allowed": false,
    "authorization_count": null,
    "incremental_authorizations": null,
    "external_authentication_details": null,
    "external_3ds_authentication_attempted": false,
    "expires_on": "2026-06-01T19:14:08.341Z",
    "fingerprint": null,
    "browser_info": {
        "language": "en",
        "time_zone": 0,
        "ip_address": "128.0.0.1",
        "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Safari/537.36",
        "color_depth": 24,
        "java_enabled": true,
        "screen_width": 1536,
        "accept_header": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8",
        "screen_height": 723,
        "java_script_enabled": true
    },
    "payment_channel": null,
    "payment_method_id": null,
    "network_transaction_id": null,
    "network_transaction_link_id": null,
    "payment_method_status": null,
    "updated": "2026-06-01T18:59:10.020Z",
    "split_payments": null,
    "frm_metadata": null,
    "extended_authorization_applied": null,
    "extended_authorization_last_applied_at": null,
    "request_extended_authorization": null,
    "capture_before": null,
    "merchant_order_reference_id": null,
    "order_tax_amount": null,
    "connector_mandate_id": null,
    "card_discovery": null,
    "force_3ds_challenge": false,
    "force_3ds_challenge_trigger": false,
    "issuer_error_code": null,
    "issuer_error_message": null,
    "is_iframe_redirection_enabled": null,
    "whole_connector_response": null,
    "enable_partial_authorization": null,
    "enable_overcapture": null,
    "is_overcapture_enabled": null,
    "network_details": null,
    "is_stored_credential": null,
    "mit_category": null,
    "billing_descriptor": null,
    "tokenization": null,
    "partner_merchant_identifier_details": null,
    "payment_method_tokenization_details": null,
    "installment_options": null,
    "installment_data": null,
    "sender_payment_instrument_id": null
}
```


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
