### PR TITLE
refactor(authentication): logged error for acquirer details if not found in default bucket

### DIFF
--- a/crates/router/src/core/payments/helpers.rs
+++ b/crates/router/src/core/payments/helpers.rs
@@ -8489,19 +8489,24 @@ pub async fn get_payment_external_authentication_flow_during_confirm<F: Clone>(
                         })?;
 
                     let resolved = match profile_acquirer_id {
-                        Some(id) => business_profile
+                        Some(id) => Some(business_profile
                             .get_acquirer_details_for_profile_acquirer(id, network.clone())
                             .ok_or(errors::ApiErrorResponse::PreconditionFailed {
                                 message: format!("Acquirer configuration not found for network {:?} in bucket {:?}", network, id),
-                            })?,
+                            })?),
+                        // Ignoring this error as merchant can also configure acquirer details on authentication connector side as well.
                         None => business_profile
                             .get_default_acquirer_details_from_network(network.clone())
-                            .ok_or(errors::ApiErrorResponse::PreconditionFailed {
-                                message: format!("Acquirer configuration not found for network {:?} in default bucket", network),
-                            })?,
+                            .ok_or_else(|| {
+                                logger::error!(
+                                    "Acquirer configuration not found for network {:?}",
+                                    network
+                                )
+                            })
+                            .ok(),
                     };
 
-                    Some(authentication::types::AcquirerDetails {
+                    resolved.map(|resolved| authentication::types::AcquirerDetails {
                         acquirer_bin: resolved.acquirer_bin.unwrap_or_default(),
                         acquirer_merchant_id: resolved.acquirer_assigned_merchant_id.unwrap_or_default(),
                         acquirer_country_code: resolved.acquirer_country_code,

--- a/crates/router/src/core/unified_authentication_service.rs
+++ b/crates/router/src/core/unified_authentication_service.rs
@@ -1173,7 +1173,7 @@ pub async fn authentication_eligibility_core(
             let bucket_id = authentication.profile_acquirer_id.as_ref();
 
             let acquirer_details = match bucket_id {
-                Some(acquirer_id) => business_profile
+                Some(acquirer_id) => Some(business_profile
                     .get_acquirer_details_for_profile_acquirer(acquirer_id, card_network.clone())
                     .ok_or_else(|| {
                         error_stack::report!(ApiErrorResponse::GenericNotFoundError {
@@ -1186,17 +1186,13 @@ pub async fn authentication_eligibility_core(
                         .attach_printable(
                             "The requested profile acquirer bucket does not contain the required card network configuration",
                         )
-                    })?,
+                    })?),
+                // Ignoring this error as merchant can also configure acquirer details on authentication connector side as well.
                 None => business_profile
-                    .get_default_acquirer_details_from_network(card_network)
+                    .get_default_acquirer_details_from_network(card_network.clone())
                     .ok_or_else(|| {
-                        error_stack::report!(ApiErrorResponse::GenericNotFoundError {
-                            message: "Default Profile Acquirer configuration not found".to_string(),
-                        })
-                        .attach_printable(
-                            "No default acquirer configuration was found for the given card network",
-                        )
-                    })?,
+                        router_env::logger::error!("Default Acquirer configuration not found for network {}", card_network)
+                    }).ok(),
             };
 
             // If we resolved acquirer details from a bucket, persist them to the authentication record.
@@ -1204,9 +1200,9 @@ pub async fn authentication_eligibility_core(
             db.update_authentication_by_merchant_id_authentication_id(
                 authentication.clone(),
                 hyperswitch_domain_models::authentication::AuthenticationUpdate::AcquirerDetailsUpdate {
-                    acquirer_bin: acquirer_details.acquirer_bin.clone(),
-                    acquirer_merchant_id: acquirer_details.acquirer_assigned_merchant_id.clone(),
-                    acquirer_country_code: acquirer_details.acquirer_country_code.clone(),
+                    acquirer_bin: acquirer_details.as_ref().and_then(|d| d.acquirer_bin.clone()),
+                    acquirer_merchant_id: acquirer_details.as_ref().and_then(|d| d.acquirer_assigned_merchant_id.clone()),
+                    acquirer_country_code: acquirer_details.as_ref().and_then(|d| d.acquirer_country_code.clone()),
                 },
                 platform.get_processor().get_key_store(),
                 key_manager_state_ref,
@@ -1216,10 +1212,18 @@ pub async fn authentication_eligibility_core(
             .attach_printable("Failed to persist resolved acquirer details to authentication record")?;
 
             (
-                acquirer_details.acquirer_bin.clone(),
-                acquirer_details.acquirer_assigned_merchant_id.clone(),
-                acquirer_details.acquirer_country_code.clone(),
-                acquirer_details.merchant_name.clone(),
+                acquirer_details
+                    .as_ref()
+                    .and_then(|d| d.acquirer_bin.clone()),
+                acquirer_details
+                    .as_ref()
+                    .and_then(|d| d.acquirer_assigned_merchant_id.clone()),
+                acquirer_details
+                    .as_ref()
+                    .and_then(|d| d.acquirer_country_code.clone()),
+                acquirer_details
+                    .as_ref()
+                    .and_then(|d| d.merchant_name.clone()),
             )
         } else {
             (


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
 logged error for acquirer details if not found in default bucket

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


This pull request addresses an issue where missing default acquirer configuration in the business profile caused a hard failure during the authentication flow. 

Here is a summary of the changes made:

### Core Change: Making Default Acquirer Details Optional
Previously, if a payment or authentication request did not specify an acquirer bucket (`profile_acquirer_id`) and the system failed to find a default acquirer configuration for the card network, it would immediately return an API error (`ApiErrorResponse::PreconditionFailed` or `ApiErrorResponse::GenericNotFoundError`).

This PR updates the behavior to **ignore the error and proceed without acquirer details** when a default config is missing. 

### Why this change was made
A comment was added explaining the rationale: *"Ignoring this error as merchant can also configure acquirer details on authentication connector side as well."* 
Since the acquirer details are not strictly required from the business profile to continue the flow, throwing a hard error was preventing legitimate transactions from proceeding.

### Code Modifications
The changes touch two files, adapting them to handle the newly introduced `Option` type for acquirer details:

1. **`crates/router/src/core/payments/helpers.rs`**: 
   - Modified `get_payment_external_authentication_flow_during_confirm` to log an error instead of returning an `ApiErrorResponse` when `get_default_acquirer_details_from_network` fails.
   - Wrapped the resulting mapped `AcquirerDetails` inside an `Option`.

2. **`crates/router/src/core/unified_authentication_service.rs`**: 
   - Modified `authentication_eligibility_core` to similarly log an error and swallow the failure when default acquirer details are missing.
   - Refactored the database update call (`update_authentication_by_merchant_id_authentication_id`) and the return values to gracefully handle the fact that `acquirer_details` might be `None` by using `.as_ref().and_then(...)` when extracting properties like `acquirer_bin` and `acquirer_merchant_id`.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Update business profile for netcetera

```shell
curl --location 'localhost:8080/account/sahkal11111/business_profile/pro_UAbZAWMUa9i8zlmkXkBF' \
--header 'Content-Type: application/json' \
--header 'api-key: dev_Vlm8UhVgnhrqph2ecAxGQ9QljLdOLA28RNhf9Edxgl9QaBcjdtibSDiN7zcPVEE2' \
--data '
{
    "authentication_connector_details": {
        "authentication_connectors": ["netcetera"],
        "three_ds_requestor_url": "https://google.com"
    },
    "merchant_country_code": "004",
    "merchant_category_code": "5411"
}

'
```

Do payments Create

```shell
curl --location 'localhost:8080/payments' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: dev_Vlm8UhVgnhrqph2ecAxGQ9QljLdOLA28RNhf9Edxgl9QaBcjdtibSDiN7zcPVEE2' \
--data-raw '{
    "amount": 10,
    "currency": "EUR",
    "confirm": false,
    "capture_method": "automatic",
    "capture_on": "2022-09-10T10:11:12Z",
    "customer_id": "StripeCustomer",
    "email": "guest@example.com",
    "name": "John Doe",
    "phone": "999999999",
    "phone_country_code": "+65",
    "description": "Its my first payment request",
    "authentication_type": "three_ds",
    "return_url": "https://duck.com",
    "billing": {
        "address": {
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "city": "San Fransico",
            "state": "CA",
            "zip": "94122",
            "country": "US",
            "first_name": "PiX",
            "last_name": "Poddar"
        },
        "phone": {
            "number": "123456789",
            "country_code": "12"
        }
    },
    "shipping": {
        "address": {
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "city": "San Fransico",
            "state": "CA",
            "zip": "94122",
            "country": "US",
            "first_name": "PiX",
            "last_name": "Poddar"
        },
        "phone": {
            "number": "123456789",
            "country_code": "12"
        }
    }, 
    "request_external_three_ds_authentication": true,
    "statement_descriptor_name": "joseph",
    "statement_descriptor_suffix": "JS",
    "metadata": {
        "udf1": "value1",
        "new_customer": "true",
        "login_date": "2019-09-10T10:11:12Z"
    }
}'
```

Do payments Confirm

```shell
curl --location 'localhost:8080/payments/pay_saU0lQoZc1iTizITIyXG/confirm' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'sdk_authorization: cHJvZmlsZV9pZD1wcm9fdjBiR3B5akliakUxUmZDcmhzUGkscHVibGlzaGFibGVfa2V5PXBrX3NuZF83ZDFhZmMzYjZjMGE0NThjYTdlZTgyZDJiOWQ4ZTNiMCxjbGllbnRfc2VjcmV0PXBheV9Eb21JNjJNYTN2SU1mMTEyRk9JOV9zZWNyZXRfZUM2ekRPa3pqYXFaSEZQT0FsdW0scHJvZmlsZT1wcm9fdjBiR3B5akliakUxUmZDcmhzUGksY3VzdG9tZXJfaWQ9U3RyaXBlQ3VzdG9tZXIsY2xpZW50X3Nlc3Npb25faWQ9Y2xpZW50X3Nlc3NfS2tWaGcwaE1XWUJuZDNQU0dBWjQscGF5bWVudF9pZD1wYXlfRG9tSTYyTWEzdklNZjExMkZPSTk=' \
--header 'api-key: dev_Vlm8UhVgnhrqph2ecAxGQ9QljLdOLA28RNhf9Edxgl9QaBcjdtibSDiN7zcPVEE2' \
--data '{
    "browser_info": {
        "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Safari/537.36",
        "accept_header": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8",
        "language": "nl-NL",
        "color_depth": 24,
        "screen_height": 723,
        "screen_width": 1536,
        "time_zone": 0,
        "java_enabled": true,
        "java_script_enabled": true,
        "ip_address": "115.99.183.2"
    },
    "payment_method": "card",
    "payment_method_data": {
        "card": {  
            "card_number": "Card Number",   
            "card_exp_month": "09",
            "card_exp_year": "31",
            "card_holder_name": "Sahkal Poddar",
            "card_cvc": "013"
        }
    }
}'
```
Confirm Response
```shell
{
    "payment_id": "pay_saU0lQoZc1iTizITIyXG",
    "merchant_id": "sahkal11111",
    "status": "requires_customer_action",
    "amount": 10,
    "net_amount": 10,
    "shipping_cost": null,
    "amount_capturable": 0,
    "amount_received": null,
    "processor_merchant_id": "sahkal11111",
    "initiator": null,
    "sdk_authorization": "cHJvZmlsZV9pZD1wcm9fVUFiWkFXTVVhOWk4emxta1hrQkYscHVibGlzaGFibGVfa2V5PXBrX2Rldl9mYzMwYWYzNGNmZGE0NzJhOGY4ZjEzNzc3ZDI2ZDk0ZixjbGllbnRfc2VjcmV0PXBheV9zYVUwbFFvWmMxaVRpeklUSXlYR19zZWNyZXRfNDZKQk16T2RJUGxUTkJTRVFoa2EsY3VzdG9tZXJfaWQ9U3RyaXBlQ3VzdG9tZXIscGF5bWVudF9pZD1wYXlfc2FVMGxRb1pjMWlUaXpJVEl5WEc=",
    "connector": "cybersource",
    "state_metadata": null,
    "client_secret": "pay_saU0lQoZc1iTizITIyXG_secret_46JBMzOdIPlTNBSEQhka",
    "created": "2026-06-03T06:58:04.252Z",
    "modified_at": "2026-06-03T06:58:07.053Z",
    "currency": "EUR",
    "customer_id": "StripeCustomer",
    "customer": {
        "id": "StripeCustomer",
        "name": "John Doe",
        "email": "guest@example.com",
        "phone": "999999999",
        "phone_country_code": "+65",
        "customer_document_details": null
    },
    "description": "Its my first payment request",
    "refunds": null,
    "disputes": null,
    "mandate_id": null,
    "mandate_data": null,
    "setup_future_usage": null,
    "off_session": null,
    "capture_on": null,
    "capture_method": "automatic",
    "payment_method": "card",
    "payment_method_data": {
        "card": {
            "last4": "3340",
            "card_type": "DEBIT",
            "card_network": "Mastercard",
            "card_issuer": "MASTERCARD INTERNATIONAL",
            "card_issuing_country": "UNITED STATES",
            "card_isin": "530688",
            "card_extended_bin": null,
            "card_exp_month": "09",
            "card_exp_year": "31",
            "card_holder_name": "Sahkal Poddar",
            "payment_checks": null,
            "authentication_data": null,
            "auth_code": null
        },
        "billing": null
    },
    "payment_token": "token_vCe3G7P86kjfMiqlU37M",
    "shipping": {
        "address": {
            "city": "San Fransico",
            "country": "US",
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "zip": "94122",
            "state": "CA",
            "first_name": "PiX",
            "last_name": "Poddar",
            "origin_zip": null
        },
        "phone": {
            "number": "123456789",
            "country_code": "12"
        },
        "email": null
    },
    "billing": {
        "address": {
            "city": "San Fransico",
            "country": "US",
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "zip": "94122",
            "state": "CA",
            "first_name": "PiX",
            "last_name": "Poddar",
            "origin_zip": null
        },
        "phone": {
            "number": "123456789",
            "country_code": "12"
        },
        "email": null
    },
    "order_details": null,
    "email": "guest@example.com",
    "name": "John Doe",
    "phone": "999999999",
    "return_url": "https://duck.com/",
    "authentication_type": "three_ds",
    "statement_descriptor_name": "joseph",
    "statement_descriptor_suffix": "JS",
    "next_action": {
        "type": "three_ds_invoke",
        "three_ds_data": {
            "three_ds_authentication_url": "http://localhost:8080/payments/pay_saU0lQoZc1iTizITIyXG/3ds/authentication",
            "three_ds_authorize_url": "http://localhost:8080/payments/pay_saU0lQoZc1iTizITIyXG/sahkal11111/authorize/cybersource",
            "three_ds_method_details": {
                "three_ds_method_data_submission": true,
                "three_ds_method_data": "eyJ0aHJlZURTTWV0aG9kTm90aWZpY2F0aW9uVVJMIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS8zZHMtbWV0aG9kLW5vdGlmaWNhdGlvbi11cmwiLCJ0aHJlZURTU2VydmVyVHJhbnNJRCI6Ijg2YzZlMWY5LTE2NDMtNDA4Mi1hZDExLTZiNjEzMTRhZDUyOCJ9",
                "three_ds_method_url": "https://ndm-prev.3dss-non-prod.cloud.netcetera.com/acs/3ds-method",
                "three_ds_method_key": "threeDSMethodData",
                "consume_post_message_for_three_ds_method_completion": false
            },
            "poll_config": {
                "poll_id": "external_authentication_pay_saU0lQoZc1iTizITIyXG",
                "delay_in_secs": 2,
                "frequency": 5
            },
            "message_version": "2.3.1",
            "directory_server_id": "A000000004",
            "card_network": "Mastercard",
            "three_ds_connector": "netcetera"
        }
    },
    "cancellation_reason": null,
    "error_code": null,
    "error_message": null,
    "unified_code": null,
    "unified_message": null,
    "error_details": null,
    "payment_experience": null,
    "payment_method_type": "debit",
    "connector_label": null,
    "business_country": null,
    "business_label": "default",
    "business_sub_label": null,
    "allowed_payment_method_types": null,
    "manual_retry_allowed": null,
    "connector_transaction_id": null,
    "frm_message": null,
    "metadata": {
        "udf1": "value1",
        "login_date": "2019-09-10T10:11:12Z",
        "new_customer": "true"
    },
    "connector_metadata": null,
    "connector_response_metadata": null,
    "feature_metadata": null,
    "reference_id": null,
    "payment_link": null,
    "profile_id": "pro_UAbZAWMUa9i8zlmkXkBF",
    "surcharge_details": null,
    "attempt_count": 1,
    "merchant_decision": null,
    "merchant_connector_id": "mca_udCcfZsoQ48rarJx7HGW",
    "incremental_authorization_allowed": null,
    "authorization_count": null,
    "incremental_authorizations": null,
    "external_authentication_details": {
        "authentication_flow": null,
        "electronic_commerce_indicator": null,
        "status": "pending",
        "ds_transaction_id": "86c6e1f9-1643-4082-ad11-6b61314ad528",
        "version": "2.3.1",
        "error_code": null,
        "error_message": null
    },
    "external_3ds_authentication_attempted": true,
    "expires_on": "2026-06-03T07:13:04.252Z",
    "fingerprint": null,
    "browser_info": {
        "os_type": null,
        "referer": null,
        "language": "nl-NL",
        "time_zone": 0,
        "ip_address": "115.99.183.2",
        "os_version": null,
        "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Safari/537.36",
        "color_depth": 24,
        "device_model": null,
        "java_enabled": true,
        "screen_width": 1536,
        "accept_header": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8",
        "screen_height": 723,
        "accept_language": "en",
        "java_script_enabled": true
    },
    "payment_channel": null,
    "payment_method_id": null,
    "network_transaction_id": null,
    "network_transaction_link_id": null,
    "payment_method_status": null,
    "updated": "2026-06-03T06:58:07.053Z",
    "split_payments": null,
    "frm_metadata": null,
    "extended_authorization_applied": null,
    "extended_authorization_last_applied_at": null,
    "request_extended_authorization": null,
    "capture_before": null,
    "merchant_order_reference_id": null,
    "order_tax_amount": null,
    "connector_mandate_id": null,
    "card_discovery": "manual",
    "force_3ds_challenge": false,
    "force_3ds_challenge_trigger": false,
    "issuer_error_code": null,
    "issuer_error_message": null,
    "is_iframe_redirection_enabled": null,
    "whole_connector_response": null,
    "enable_partial_authorization": null,
    "enable_overcapture": null,
    "is_overcapture_enabled": null,
    "network_details": null,
    "is_stored_credential": null,
    "mit_category": null,
    "billing_descriptor": null,
    "tokenization": null,
    "partner_merchant_identifier_details": null,
    "payment_method_tokenization_details": null,
    "installment_options": null,
    "installment_data": null,
    "sender_payment_instrument_id": null
}
```
<img width="1710" height="497" alt="Screenshot 2026-06-03 at 12 31 17 PM" src="https://github.com/user-attachments/assets/cd3dce67-6ef0-445b-8755-c5d945118889" />
we are logging the error and moving ahead to complete the txns


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
