### PR TITLE
fix(ucs): correct Finix key mapping and pass wallet payment token to Authorize

### DIFF
--- a/crates/router/src/core/unified_connector_service.rs
+++ b/crates/router/src/core/unified_connector_service.rs
@@ -1269,6 +1269,17 @@ pub fn build_unified_connector_service_payment_method(
             }
         }
         hyperswitch_domain_models::payment_method_data::PaymentMethodData::Wallet(wallet_data) => {
+            // If a payment instrument token was returned from the tokenize step (e.g. Finix
+            // PI...), use it directly for the authorize rather than re-sending the raw wallet
+            // data.  This mirrors the same check in the Card branch above.
+            if let Some(PaymentMethodToken::Token(token)) = payment_method_token {
+                let token_payment_method = payments_grpc::TokenPaymentMethodType {
+                    token: Some(token.clone()),
+                };
+                return Ok(payments_grpc::PaymentMethod {
+                    payment_method: Some(PaymentMethod::Token(token_payment_method)),
+                });
+            }
             match wallet_data {
                 hyperswitch_domain_models::payment_method_data::WalletData::Mifinity(
                     mifinity_data,

--- a/crates/router/src/core/unified_connector_service/connector_config.rs
+++ b/crates/router/src/core/unified_connector_service/connector_config.rs
@@ -1330,8 +1330,8 @@ impl ForeignTryFrom<(Connector, &ConnectorAuthType, Option<&serde_json::Value>)>
                 } => Ok(Self::Finix {
                     finix_user_name: api_key.clone(),
                     finix_password: api_secret.clone(),
-                    merchant_identity_id: key1.clone(),
-                    merchant_id: key2.clone(),
+                    merchant_id: key1.clone(),
+                    merchant_identity_id: key2.clone(),
                 }),
                 _ => Err(err("Finix requires MultiAuthKey auth type")),
             },


### PR DESCRIPTION
## Summary

Two independent bug fixes discovered during end-to-end Apple Pay testing with the Finix connector via UCS.

---

## Bug Fix 1 — Finix: `key1`/`key2` fields swapped in `connector_config.rs`

**File:** `crates/router/src/core/unified_connector_service/connector_config.rs`

### Problem
The `Connector::Finix` arm in `ForeignTryFrom` was mapping:
- `key1` → `merchant_identity_id` (`IDq...`)
- `key2` → `merchant_id` (`MU...`)

This is backwards. The Finix API docs and UCS `transformers.rs` both confirm:
- `key1` = `merchant_id` (the `MU...` value used as `merchant` in `POST /transfers`)
- `key2` = `merchant_identity_id` (the `ID...` value)

With the wrong mapping, UCS was sending the Identity ID as the `merchant` field in `POST /transfers`, causing Finix to return HTTP 404 "merchant not found".

### Fix
Swapped the two field assignments so `key1 → merchant_id` and `key2 → merchant_identity_id`.

---

## Bug Fix 2 — Wallet flows: payment method token not passed to Authorize

**File:** `crates/router/src/core/unified_connector_service.rs`

### Problem
When a `Tokenize` step returns a payment instrument token (e.g. Finix `PI...`), the subsequent `Authorize` call was ignoring that token and re-sending the raw wallet data (e.g. raw `ApplePaySdk` payload). The `Card` branch already had the correct `PaymentMethodToken::Token` check, but the `Wallet` branch was missing it.

### Fix
Added a `PaymentMethodToken::Token` check at the top of the `Wallet` match arm. If a token is present, it returns `PaymentMethod::Token(token)` immediately — consistent with the Card branch.

---

## E2E Verification

Both fixes verified with a live Apple Pay flow against the Finix sandbox:

- **Payment ID:** `pay_nPaNuyCAuikY5Y3WXLyt`
- **Status:** `succeeded`
- **Finix Transfer ID:** `TRoWqs52gKVfzKw28Dnm9uSU` — confirmed `state: SUCCEEDED` via direct Finix API call
- **Finix Payment Instrument:** `PI4fh2q6Kby5S4F4rwFniPk3` — confirmed `type: "APPLE_PAY"`

**Tokenize (POST /payment_instruments):**
```
Request:  { "type": "APPLE_PAY", "identity": "...", "merchant_identity": "...", "third_party_token": "..." }
Response: { "id": "PI4fh2q6Kby5S4F4rwFniPk3", "type": "APPLE_PAY", "enabled": true }
```

**Authorize (POST /transfers):**
```
Request:  { "amount": 1000, "currency": "USD", "source": "PI4fh2q6Kby5S4F4rwFniPk3", "merchant": "MU3YACSJUhFGMGSbfMPL5xd7", ... }
Response: { "id": "TRoWqs52gKVfzKw28Dnm9uSU", "state": "SUCCEEDED" }
```

---

## Related
- Companion UCS PR: juspay/hyperswitch-prism#1424 (`feat/grace-finix-applepay`)