### PR TITLE
fix: remove skip_serializing_if for connector_customer_id in PaymentsResponse

### DIFF
--- a/api-reference/v1/openapi_spec_v1.json
+++ b/api-reference/v1/openapi_spec_v1.json
@@ -32183,7 +32183,8 @@
           "sender_payment_instrument_id": {
             "type": "string",
             "description": "A connector-specific identifier representing the stored payment instrument",
-            "nullable": true
+            "nullable": true,
+            "maxLength": 255
           }
         }
       },
@@ -33881,7 +33882,8 @@
           "sender_payment_instrument_id": {
             "type": "string",
             "description": "A connector-specific identifier representing the stored payment instrument",
-            "nullable": true
+            "nullable": true,
+            "maxLength": 255
           }
         }
       },

--- a/crates/api_models/src/payments.rs
+++ b/crates/api_models/src/payments.rs
@@ -7165,7 +7165,6 @@ pub struct PaymentsResponse {
 
     /// A unique identifier for a customer provided by the connector.
     #[schema(value_type = Option<String>, example = "cus_Rnm2pDKGyQi506")]
-    #[serde(skip_serializing_if = "Option::is_none")]
     #[smithy(value_type = "Option<String>")]
     pub connector_customer_id: Option<String>,
 
@@ -7651,6 +7650,11 @@ pub struct PaymentsResponse {
     pub installment_data: Option<common_types::payments::InstallmentData>,
 
     /// A connector-specific identifier representing the stored payment instrument
+    #[schema(
+        value_type = Option<String>,
+        max_length = 255
+    )]
+    #[smithy(value_type = "Option<String>")]
     pub sender_payment_instrument_id: Option<String>,
 }
 


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Removes the #[serde(skip_serializing_if = "Option::is_none")] attribute for connector_customer_id field in PaymentsResponse , ensuring the connector_customer_id field is always included in the serialized response (even when None)

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Zift:
Payments Request:

```

{
    "amount": 1000,
    "currency": "USD",
    "confirm": true, 
    "email": "guest@example.com",
    "name": "John Doe",
    "phone": "999999999",
    "phone_country_code": "+1",
    "description": "Its my first payment request",
    "authentication_type": "no_three_ds",
    "return_url": "https://duck.com",
    "payment_method": "card",
    "payment_method_type":"credit",
    "payment_method_data": {
        "card": {
            "card_number": "4111111111111111",
            "card_exp_month": "03",
            "card_exp_year": "2030",
            "card_holder_name": "joseph Doe",
            "card_cvc": "737"
        }
    },
    "billing": {
        "address": {
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "city": "San Fransico",
            "state": "California",
            "zip": "94122",
            "country": "US",
            "first_name": "sundari"
        }
    },
    "shipping": {
        "address": {
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "city": "San Fransico",
            "state": "California",
            "zip": "94122",
            "country": "US",
            "first_name": "sundari"
        }
    },
    "statement_descriptor_name": "joseph",
    "statement_descriptor_suffix": "JS",
    "metadata": {
        "udf1": "value1",
        "new_customer": "true",
        "login_date": "2019-09-10T10:11:12Z"
    },
    "browser_info": {
        "user_agent": "Mozilla\/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/70.0.3538.110 Safari\/537.36",
        "accept_header": "text\/html,application\/xhtml+xml,application\/xml;q=0.9,image\/webp,image\/apng,*\/*;q=0.8",
        "language": "nl-NL",
        "color_depth": 24,
        "screen_height": 723,
        "screen_width": 1536,
        "time_zone": 0,
        "java_enabled": true,
        "java_script_enabled": true,
        "ip_address": "128.0.0.1"
    }
}

```

Response(Look for connector_customer_id, earlier this was not returned since it was None):

```

{
    "payment_id": "pay_WHj9jYpTS9KGK4zLdZFe",
    "merchant_id": "merchant_1780560105",
    "status": "succeeded",
    "amount": 1000,
    "net_amount": 1000,
    "shipping_cost": null,
    "amount_capturable": 0,
    "amount_received": 1000,
    "processor_merchant_id": "merchant_1780560105",
    "initiator": null,
    "sdk_authorization": "cHJvZmlsZV9pZD1wcm9fcktQMHBZSGdjSktaNk44UUw3ODYscHVibGlzaGFibGVfa2V5PXBrX2Rldl80YzdiMWY3MWI0NjU0N2VjYmVlM2I0YWYyYzFmNGY4NSxjbGllbnRfc2VjcmV0PXBheV9XSGo5allwVFM5S0dLNHpMZFpGZV9zZWNyZXRfblJyOEE2Y3RzeXlWVnNmNFM3S0csY2xpZW50X3Nlc3Npb25faWQ9Y2xpZW50X3Nlc3NfYlBPZUhFQXd2WGViUFdiMk5zaHgscGF5bWVudF9pZD1wYXlfV0hqOWpZcFRTOUtHSzR6TGRaRmU=",
    "connector": "zift",
    "state_metadata": null,
    "client_secret": "pay_WHj9jYpTS9KGK4zLdZFe_secret_nRr8A6ctsyyVVsf4S7KG",
    "created": "2026-06-04T08:02:39.649Z",
    "modified_at": "2026-06-04T08:02:42.301Z",
    "connector_customer_id": null,
    "currency": "USD",
    "customer_id": null,
    "customer": {
        "id": null,
        "name": "John Doe",
        "email": "guest@example.com",
        "phone": "999999999",
        "phone_country_code": "+1",
        "customer_document_details": null
    },
    "description": "Its my first payment request",
    "refunds": null,
    "disputes": null,
    "mandate_id": null,
    "mandate_data": null,
    "setup_future_usage": null,
    "off_session": null,
    "capture_on": null,
    "capture_method": null,
    "payment_method": "card",
    "payment_method_data": {
        "card": {
            "last4": "1111",
            "card_type": "CREDIT",
            "card_network": "Visa",
            "card_issuer": "JP Morgan",
            "card_issuing_country": "INDIA",
            "card_isin": "411111",
            "card_extended_bin": null,
            "card_exp_month": "03",
            "card_exp_year": "2030",
            "card_holder_name": "joseph Doe",
            "payment_checks": null,
            "authentication_data": null,
            "auth_code": null
        },
        "billing": null
    },
    "payment_token": null,
    "shipping": {
        "address": {
            "city": "San Fransico",
            "country": "US",
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "zip": "94122",
            "state": "California",
            "first_name": "sundari",
            "last_name": null,
            "origin_zip": null
        },
        "phone": null,
        "email": null
    },
    "billing": {
        "address": {
            "city": "San Fransico",
            "country": "US",
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "zip": "94122",
            "state": "California",
            "first_name": "sundari",
            "last_name": null,
            "origin_zip": null
        },
        "phone": null,
        "email": null
    },
    "order_details": null,
    "email": "guest@example.com",
    "name": "John Doe",
    "phone": "999999999",
    "return_url": "https://duck.com/",
    "authentication_type": "no_three_ds",
    "statement_descriptor_name": "joseph",
    "statement_descriptor_suffix": "JS",
    "next_action": null,
    "cancellation_reason": null,
    "error_code": null,
    "error_message": null,
    "unified_code": null,
    "unified_message": null,
    "error_details": null,
    "payment_experience": null,
    "payment_method_type": "credit",
    "connector_label": null,
    "business_country": null,
    "business_label": "default",
    "business_sub_label": null,
    "allowed_payment_method_types": null,
    "manual_retry_allowed": null,
    "connector_transaction_id": "8621605072",
    "frm_message": null,
    "metadata": {
        "udf1": "value1",
        "login_date": "2019-09-10T10:11:12Z",
        "new_customer": "true"
    },
    "connector_metadata": null,
    "connector_response_metadata": null,
    "feature_metadata": {
        "redirect_response": null,
        "search_tags": null,
        "apple_pay_recurring_details": null,
        "pix_additional_details": null,
        "boleto_additional_details": null,
        "pix_automatico_additional_details": null,
        "finix_additional_details": null
    },
    "reference_id": "pay_WHj9jYpTS9KGK4zLdZFe_1",
    "payment_link": null,
    "profile_id": "pro_rKP0pYHgcJKZ6N8QL786",
    "surcharge_details": null,
    "attempt_count": 1,
    "merchant_decision": null,
    "merchant_connector_id": "mca_3r0lbemw1tgZVpKYDtLh",
    "incremental_authorization_allowed": false,
    "authorization_count": null,
    "incremental_authorizations": null,
    "external_authentication_details": null,
    "external_3ds_authentication_attempted": false,
    "expires_on": "2026-06-04T08:17:39.649Z",
    "fingerprint": null,
    "browser_info": {
        "language": "nl-NL",
        "time_zone": 0,
        "ip_address": "128.0.0.1",
        "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Safari/537.36",
        "color_depth": 24,
        "java_enabled": true,
        "screen_width": 1536,
        "accept_header": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8",
        "screen_height": 723,
        "java_script_enabled": true
    },
    "payment_channel": null,
    "payment_method_id": null,
    "network_transaction_id": null,
    "network_transaction_link_id": null,
    "payment_method_status": null,
    "updated": "2026-06-04T08:02:42.301Z",
    "split_payments": null,
    "frm_metadata": null,
    "extended_authorization_applied": null,
    "extended_authorization_last_applied_at": null,
    "request_extended_authorization": null,
    "capture_before": null,
    "merchant_order_reference_id": null,
    "order_tax_amount": null,
    "connector_mandate_id": null,
    "card_discovery": "manual",
    "force_3ds_challenge": false,
    "force_3ds_challenge_trigger": false,
    "issuer_error_code": null,
    "issuer_error_message": null,
    "is_iframe_redirection_enabled": null,
    "whole_connector_response": null,
    "enable_partial_authorization": null,
    "enable_overcapture": null,
    "is_overcapture_enabled": null,
    "network_details": null,
    "is_stored_credential": null,
    "mit_category": null,
    "billing_descriptor": null,
    "tokenization": null,
    "partner_merchant_identifier_details": null,
    "payment_method_tokenization_details": null,
    "installment_options": null,
    "installment_data": null,
    "sender_payment_instrument_id": null
}

```

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
