### PR TITLE
feat(refunds): add v1 refund reverse route

### DIFF
--- a/crates/api_models/src/events/refund.rs
+++ b/crates/api_models/src/events/refund.rs
@@ -6,7 +6,8 @@ use crate::refunds::{
 };
 #[cfg(feature = "v1")]
 use crate::refunds::{
-    RefundManualUpdateRequest, RefundRequest, RefundUpdateRequest, RefundsRetrieveRequest,
+    RefundManualUpdateRequest, RefundRequest, RefundReverseRequest, RefundUpdateRequest,
+    RefundsRetrieveRequest,
 };
 
 #[cfg(feature = "v1")]
@@ -64,6 +65,16 @@ impl ApiEventMetric for refunds::RefundsRetrieveRequest {
 
 #[cfg(feature = "v1")]
 impl ApiEventMetric for RefundUpdateRequest {
+    fn get_api_event_type(&self) -> Option<ApiEventsType> {
+        Some(ApiEventsType::Refund {
+            payment_id: None,
+            refund_id: self.refund_id.clone(),
+        })
+    }
+}
+
+#[cfg(feature = "v1")]
+impl ApiEventMetric for RefundReverseRequest {
     fn get_api_event_type(&self) -> Option<ApiEventsType> {
         Some(ApiEventsType::Refund {
             payment_id: None,

--- a/crates/api_models/src/refunds.rs
+++ b/crates/api_models/src/refunds.rs
@@ -214,6 +214,20 @@ pub struct RefundUpdateRequest {
     pub metadata: Option<pii::SecretSerdeValue>,
 }
 
+#[cfg(feature = "v1")]
+#[derive(Default, Debug, ToSchema, Clone, Deserialize, Serialize, SmithyModel)]
+#[serde(deny_unknown_fields)]
+#[smithy(namespace = "com.hyperswitch.smithy.types")]
+pub struct RefundReverseRequest {
+    #[serde(skip)]
+    pub refund_id: String,
+
+    /// Reason for reversing/voiding the refund at the connector.
+    #[schema(max_length = 255, example = "Void refund before settlement")]
+    #[smithy(value_type = "Option<String>")]
+    pub cancellation_reason: Option<String>,
+}
+
 #[cfg(feature = "v2")]
 #[derive(Default, Debug, ToSchema, Clone, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]

--- a/crates/external_services/Cargo.toml
+++ b/crates/external_services/Cargo.toml
@@ -16,9 +16,7 @@ superposition = ["dep:open-feature", "dep:superposition_provider"]
 v1 = ["hyperswitch_interfaces/v1", "common_utils/v1"]
 v2 = ["hyperswitch_interfaces/v2", "common_utils/v2"]
 revenue_recovery = [
-    "dep:prost",
     "dep:router_env",
-    "dep:tonic-prost",
     "tokio/macros",
     "tokio/rt-multi-thread",
     "dep:hyper-util",
@@ -26,9 +24,7 @@ revenue_recovery = [
     "dep:prost-types",
 ]
 dynamic_routing = [
-    "dep:prost",
     "dep:api_models",
-    "dep:tonic-prost",
     "tokio/macros",
     "tokio/rt-multi-thread",
     "dep:router_env",
@@ -57,12 +53,12 @@ thiserror = "1.0.69"
 serde_json = "1.0.140"
 serde_urlencoded = "0.7.1"
 vaultrs = { version = "0.7.4", optional = true }
-prost = { version = "0.14", optional = true }
+prost = "0.14"
 prost-types = { version = "0.14", optional = true }
 time = { version = "0.3.41", features = ["serde", "serde-well-known", "std"] }
 tokio = "1.48.0"
 tonic = "0.14"
-tonic-prost = { version = "0.14", optional = true }
+tonic-prost = "0.14"
 tonic-reflection = "0.14.0"
 tonic-types = "0.13.1"
 typed-builder = "0.21.2"

--- a/crates/external_services/src/grpc_client/unified_connector_service.rs
+++ b/crates/external_services/src/grpc_client/unified_connector_service.rs
@@ -31,8 +31,71 @@ pub type UnifiedConnectorServiceResult<T> = CustomResult<T, UnifiedConnectorServ
 pub struct UnifiedConnectorServiceClient {
     /// The Unified Connector Service Client
     pub client: PaymentServiceClient<tonic::transport::Channel>,
+    /// Raw channel used for UCS methods that may not be present in the pinned generated client yet.
+    pub refund_service_channel: tonic::transport::Channel,
     /// The Refund Service Client
     pub refund_client: RefundServiceClient<tonic::transport::Channel>,
+}
+
+/// Compatibility request for RefundService.Reverse until the pinned UCS client
+/// crate exposes the generated type.
+#[allow(missing_docs)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct RefundServiceReverseRequest {
+    #[prost(string, optional, tag = "1")]
+    pub merchant_refund_id: Option<String>,
+    #[prost(string, tag = "2")]
+    pub connector_transaction_id: String,
+    #[prost(string, tag = "3")]
+    pub connector_refund_id: String,
+    #[prost(string, optional, tag = "4")]
+    pub cancellation_reason: Option<String>,
+    #[prost(message, optional, tag = "5")]
+    pub browser_info: Option<payments_grpc::BrowserInformation>,
+    #[prost(message, optional, tag = "6")]
+    pub refund_metadata: Option<Secret<String>>,
+    #[prost(message, optional, tag = "7")]
+    pub state: Option<RefundReverseConnectorState>,
+    #[prost(bool, optional, tag = "8")]
+    pub test_mode: Option<bool>,
+    #[prost(enumeration = "payments_grpc::PaymentMethodType", optional, tag = "9")]
+    pub payment_method_type: Option<i32>,
+    #[prost(message, optional, tag = "10")]
+    pub connector_feature_data: Option<Secret<String>>,
+    #[prost(string, optional, tag = "11")]
+    pub merchant_request_id: Option<String>,
+    #[prost(string, optional, tag = "12")]
+    pub connector_order_id: Option<String>,
+}
+
+#[allow(missing_docs)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct RefundReverseConnectorState {
+    #[prost(message, optional, tag = "1")]
+    pub access_token: Option<payments_grpc::AccessToken>,
+    #[prost(string, optional, tag = "2")]
+    pub connector_customer_id: Option<String>,
+    #[prost(message, optional, tag = "3")]
+    pub state_metadata: Option<Secret<String>>,
+}
+
+#[allow(missing_docs)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct RefundReverseResponse {
+    #[prost(string, optional, tag = "1")]
+    pub merchant_refund_id: Option<String>,
+    #[prost(string, tag = "2")]
+    pub connector_refund_id: String,
+    #[prost(int32, tag = "3")]
+    pub status: i32,
+    #[prost(uint32, tag = "5")]
+    pub status_code: u32,
+    #[prost(message, optional, tag = "20")]
+    pub state: Option<RefundReverseConnectorState>,
+    #[prost(message, optional, tag = "21")]
+    pub raw_connector_response: Option<Secret<String>>,
+    #[prost(message, optional, tag = "22")]
+    pub raw_connector_request: Option<Secret<String>>,
 }
 
 /// Contains the Unified Connector Service Client config
@@ -124,23 +187,34 @@ impl UnifiedConnectorServiceClient {
 
                 let refund_client_result = timeout(
                     Duration::from_secs(unified_connector_service_client_config.connection_timeout),
-                    RefundServiceClient::connect(uri),
+                    RefundServiceClient::connect(uri.clone()),
                 )
                 .await;
 
-                match (payment_client_result, refund_client_result) {
-                    (Ok(Ok(client)), Ok(Ok(refund_client))) => {
+                let refund_service_channel_result = timeout(
+                    Duration::from_secs(unified_connector_service_client_config.connection_timeout),
+                    tonic::transport::Channel::builder(uri.clone()).connect(),
+                )
+                .await;
+
+                match (
+                    payment_client_result,
+                    refund_client_result,
+                    refund_service_channel_result,
+                ) {
+                    (Ok(Ok(client)), Ok(Ok(refund_client)), Ok(Ok(refund_service_channel))) => {
                         logger::info!("Successfully connected to Unified Connector Service");
                         Some(Self {
                             client,
+                            refund_service_channel,
                             refund_client,
                         })
                     }
-                    (Ok(Err(err)), _) | (_, Ok(Err(err))) => {
+                    (Ok(Err(err)), _, _) | (_, Ok(Err(err)), _) | (_, _, Ok(Err(err))) => {
                         logger::error!(error = ?err, "Failed to connect to Unified Connector Service");
                         None
                     }
-                    (Err(err), _) | (_, Err(err)) => {
+                    (Err(err), _, _) | (_, Err(err), _) | (_, _, Err(err)) => {
                         logger::error!(error = ?err, "Connection to Unified Connector Service timed out");
                         None
                     }
@@ -758,6 +832,48 @@ impl UnifiedConnectorServiceClient {
                     method="refund_sync",
                     connector_name=?connector_name,
                     "UCS refund sync gRPC call failed"
+                )
+            })
+    }
+
+    /// Performs Refund Reverse/Void
+    pub async fn refund_reverse(
+        &self,
+        refund_reverse_request: RefundServiceReverseRequest,
+        connector_auth_metadata: ConnectorAuthMetadata,
+        grpc_headers: GrpcHeadersUcs,
+    ) -> UnifiedConnectorServiceResult<tonic::Response<RefundReverseResponse>> {
+        let mut request = tonic::Request::new(refund_reverse_request);
+
+        let connector_name = connector_auth_metadata.connector_name.clone();
+        let metadata =
+            build_unified_connector_service_grpc_headers(connector_auth_metadata, grpc_headers)?;
+        *request.metadata_mut() = metadata;
+
+        let mut grpc = tonic::client::Grpc::new(self.refund_service_channel.clone());
+        grpc.ready()
+            .await
+            .change_context(UnifiedConnectorServiceError::RefundSyncFailure)
+            .inspect_err(|error| {
+                logger::error!(
+                    grpc_error=?error,
+                    method="refund_reverse",
+                    connector_name=?connector_name,
+                    "UCS refund reverse gRPC client not ready"
+                )
+            })?;
+
+        let path =
+            tonic::codegen::http::uri::PathAndQuery::from_static("/ucs.v2.RefundService/Reverse");
+        grpc.unary(request, path, tonic_prost::ProstCodec::default())
+            .await
+            .change_context(UnifiedConnectorServiceError::RefundSyncFailure)
+            .inspect_err(|error| {
+                logger::error!(
+                    grpc_error=?error,
+                    method="refund_reverse",
+                    connector_name=?connector_name,
+                    "UCS refund reverse gRPC call failed"
                 )
             })
     }

--- a/crates/router/src/core/refunds.rs
+++ b/crates/router/src/core/refunds.rs
@@ -7,6 +7,7 @@ use api_models::enums as api_enums;
 use common_enums::ExecutionMode;
 use common_utils::{
     ext_traits::{AsyncExt, StringExt},
+    pii,
     types::{ConnectorTransactionId, MinorUnit},
 };
 use diesel_models::{process_tracker::business_status, refund as diesel_refund};
@@ -19,12 +20,45 @@ use hyperswitch_interfaces::{
     consts as interfaces_consts,
     integrity::{CheckIntegrity, FlowIntegrity, GetIntegrityObject},
 };
+use hyperswitch_masking::{ExposeInterface, PeekInterface};
 use router_env::{instrument, tracing, tracing::Instrument};
 use scheduler::{
     consumer::types::process_data, errors as sch_errors, utils as process_tracker_utils,
 };
 #[cfg(feature = "olap")]
 use strum::IntoEnumIterator;
+
+fn build_refund_reverse_metadata(
+    existing_metadata: Option<pii::SecretSerdeValue>,
+    reverse_response: &unified_connector_service::RefundReverseUcsResponse,
+) -> pii::SecretSerdeValue {
+    let mut metadata = existing_metadata
+        .map(ExposeInterface::expose)
+        .unwrap_or_else(|| serde_json::json!({}));
+
+    if !metadata.is_object() {
+        metadata = serde_json::json!({
+            "previous_metadata": metadata,
+        });
+    }
+
+    let state_metadata = reverse_response
+        .state_metadata
+        .as_ref()
+        .and_then(|state_metadata| serde_json::from_str(state_metadata.peek()).ok())
+        .unwrap_or_else(|| {
+            serde_json::json!({
+                "connector_refund_id": reverse_response.connector_refund_id,
+                "status": reverse_response.status.to_string(),
+            })
+        });
+
+    if let Some(metadata_object) = metadata.as_object_mut() {
+        metadata_object.insert("state_metadata".to_string(), state_metadata);
+    }
+
+    pii::SecretSerdeValue::new(metadata)
+}
 
 use crate::{
     consts,
@@ -1291,6 +1325,208 @@ pub async fn refund_update_core(
         })?;
 
     Ok(services::ApplicationResponse::Json(response.foreign_into()))
+}
+
+pub async fn refund_reverse_core(
+    state: SessionState,
+    platform: domain::Platform,
+    req: refunds::RefundReverseRequest,
+) -> RouterResponse<refunds::RefundResponse> {
+    let db = state.store.as_ref();
+    let processor = platform.get_processor();
+    let processor_account = processor.get_account();
+    let storage_scheme = processor_account.storage_scheme;
+    let processor_merchant_id = processor_account.get_id();
+
+    let refund = db
+        .find_refund_by_processor_merchant_id_refund_id(
+            processor_merchant_id,
+            &req.refund_id,
+            storage_scheme,
+        )
+        .await
+        .to_not_found_response(errors::ApiErrorResponse::RefundNotFound)?;
+
+    utils::when(refund.refund_status != enums::RefundStatus::Success, || {
+        Err(report!(errors::ApiErrorResponse::PaymentUnexpectedState {
+            current_flow: "refund_reverse".into(),
+            field_name: "refund_status".into(),
+            current_value: refund.refund_status.to_string(),
+            states: "success".to_string(),
+        })
+        .attach_printable("refund reverse is only supported for successful refunds"))
+    })?;
+
+    let payment_intent = db
+        .find_payment_intent_by_payment_id_processor_merchant_id(
+            &refund.payment_id,
+            processor_merchant_id,
+            processor.get_key_store(),
+            storage_scheme,
+        )
+        .await
+        .to_not_found_response(errors::ApiErrorResponse::PaymentNotFound)?;
+
+    let payment_attempt = db
+        .find_payment_attempt_last_successful_or_partially_captured_attempt_by_payment_id_processor_merchant_id(
+            &refund.payment_id,
+            processor_merchant_id,
+            storage_scheme,
+            processor.get_key_store(),
+        )
+        .await
+        .to_not_found_response(errors::ApiErrorResponse::SuccessfulPaymentNotFound)?;
+
+    let connector_id = refund.connector.to_string();
+    let connector = api::ConnectorData::get_connector_by_name(
+        &state.conf.connectors,
+        &connector_id,
+        api::GetToken::Connector,
+        payment_attempt.merchant_connector_id.clone(),
+    )
+    .change_context(errors::ApiErrorResponse::InternalServerError)
+    .attach_printable("Failed to get the connector")?;
+
+    let profile_id = payment_intent
+        .profile_id
+        .as_ref()
+        .get_required_value("profile_id")
+        .change_context(errors::ApiErrorResponse::InternalServerError)
+        .attach_printable("profile_id is not set in payment_intent")?;
+
+    let merchant_connector_account = helpers::get_merchant_connector_account(
+        &state,
+        processor,
+        None,
+        profile_id,
+        &connector_id,
+        payment_attempt.merchant_connector_id.as_ref(),
+    )
+    .await?;
+
+    let currency = payment_attempt.currency.get_required_value("currency")?;
+    let mut router_data = core_utils::construct_refund_router_data::<api::RSync>(
+        &state,
+        &connector_id,
+        processor,
+        (payment_attempt.get_total_amount(), currency),
+        &payment_intent,
+        &payment_attempt,
+        &refund,
+        None,
+        &merchant_connector_account,
+    )
+    .await?;
+    router_data.request.reason = req
+        .cancellation_reason
+        .clone()
+        .or(router_data.request.reason.clone());
+
+    let (execution_path, updated_state) =
+        unified_connector_service::should_call_unified_connector_service(
+            &state,
+            processor,
+            &router_data,
+            None,
+            payments::CallConnectorAction::Trigger,
+            None,
+            common_enums::TransactionType::Payment,
+        )
+        .await?;
+
+    if !matches!(
+        execution_path,
+        common_enums::ExecutionPath::UnifiedConnectorService
+            | common_enums::ExecutionPath::ShadowUnifiedConnectorService
+    ) {
+        return Err(report!(errors::ApiErrorResponse::NotImplemented {
+            message: errors::NotImplementedMessage::Reason(
+                "refund reverse is supported only through Unified Connector Service".to_string(),
+            ),
+        }));
+    }
+
+    let execution_mode = match execution_path {
+        common_enums::ExecutionPath::UnifiedConnectorService => ExecutionMode::Primary,
+        common_enums::ExecutionPath::ShadowUnifiedConnectorService => ExecutionMode::Shadow,
+        common_enums::ExecutionPath::Direct => ExecutionMode::NotApplicable,
+    };
+
+    let lineage_ids = LineageIds::new(payment_intent.merchant_id.clone(), profile_id.clone());
+    let gateway_context = gateway_context::RouterGatewayContext {
+        creds_identifier: None,
+        processor: processor.clone(),
+        header_payload: HeaderPayload::default(),
+        lineage_ids,
+        merchant_connector_account: merchant_connector_account.clone(),
+        execution_path,
+        execution_mode,
+    };
+
+    let add_access_token_result = Box::pin(access_token::add_access_token(
+        &state,
+        &connector,
+        &router_data,
+        None,
+        &gateway_context,
+        None,
+    ))
+    .await?;
+
+    access_token::update_router_data_with_access_token_result(
+        &add_access_token_result,
+        &mut router_data,
+        &payments::CallConnectorAction::Trigger,
+    );
+
+    utils::when(
+        add_access_token_result.connector_supports_access_token
+            && router_data.access_token.is_none(),
+        || {
+            Err(report!(errors::ApiErrorResponse::InternalServerError)
+                .attach_printable("access token required for refund reverse but not available"))
+        },
+    )?;
+
+    let reverse_response =
+        unified_connector_service::call_unified_connector_service_for_refund_reverse(
+            &updated_state,
+            processor,
+            router_data,
+            execution_mode,
+            merchant_connector_account,
+        )
+        .await
+        .attach_printable(format!(
+            "UCS refund reverse failed for connector: {connector_id}, refund_id: {}",
+            refund.refund_id
+        ))?;
+
+    let metadata = build_refund_reverse_metadata(refund.metadata.clone(), &reverse_response);
+    let raw_connector_response = reverse_response.raw_connector_response.clone();
+
+    let response = db
+        .update_refund(
+            refund,
+            diesel_refund::RefundUpdate::MetadataAndReasonUpdate {
+                metadata: Some(metadata),
+                reason: req.cancellation_reason,
+                updated_by: storage_scheme.to_string(),
+            },
+            storage_scheme,
+        )
+        .await
+        .change_context(errors::ApiErrorResponse::InternalServerError)
+        .attach_printable_lazy(|| {
+            format!(
+                "Unable to update refund reverse metadata with refund_id: {}",
+                req.refund_id
+            )
+        })?;
+
+    Ok(services::ApplicationResponse::Json(
+        (response, raw_connector_response).foreign_into(),
+    ))
 }
 
 // ********************************************** VALIDATIONS **********************************************

--- a/crates/router/src/core/refunds.rs
+++ b/crates/router/src/core/refunds.rs
@@ -1339,11 +1339,7 @@ pub async fn refund_reverse_core(
     let processor_merchant_id = processor_account.get_id();
 
     let refund = db
-        .find_refund_by_processor_merchant_id_refund_id(
-            processor_merchant_id,
-            &req.refund_id,
-            storage_scheme,
-        )
+        .find_refund_by_merchant_id_refund_id(processor_merchant_id, &req.refund_id, storage_scheme)
         .await
         .to_not_found_response(errors::ApiErrorResponse::RefundNotFound)?;
 
@@ -1408,7 +1404,7 @@ pub async fn refund_reverse_core(
     let mut router_data = core_utils::construct_refund_router_data::<api::RSync>(
         &state,
         &connector_id,
-        processor,
+        &platform,
         (payment_attempt.get_total_amount(), currency),
         &payment_intent,
         &payment_attempt,
@@ -1430,7 +1426,6 @@ pub async fn refund_reverse_core(
             None,
             payments::CallConnectorAction::Trigger,
             None,
-            common_enums::TransactionType::Payment,
         )
         .await?;
 
@@ -1469,7 +1464,6 @@ pub async fn refund_reverse_core(
         &router_data,
         None,
         &gateway_context,
-        None,
     ))
     .await?;
 

--- a/crates/router/src/core/unified_connector_service.rs
+++ b/crates/router/src/core/unified_connector_service.rs
@@ -21,7 +21,10 @@ use diesel_models::types::FeatureMetadata;
 use error_stack::ResultExt;
 use external_services::{
     grpc_client::{
-        unified_connector_service::{ConnectorAuthMetadata, UnifiedConnectorServiceError},
+        unified_connector_service::{
+            ConnectorAuthMetadata, RefundReverseResponse, RefundServiceReverseRequest,
+            UnifiedConnectorServiceError,
+        },
         LineageIds,
     },
     http_client,
@@ -71,6 +74,14 @@ use crate::{
 };
 
 pub mod transformers;
+
+pub struct RefundReverseUcsResponse {
+    pub state_metadata: Option<Secret<String>>,
+    pub raw_connector_response: Option<Secret<String>>,
+    pub connector_refund_id: String,
+    pub status: common_enums::RefundStatus,
+}
+
 /// Returns Apple Pay data from payment method token when it has decrypt data,
 /// otherwise returns the original payment data.
 fn get_apple_pay_payment_data(
@@ -2836,4 +2847,83 @@ pub async fn call_unified_connector_service_for_refund_sync(
     ))
     .await
     .map(|(router_data, _flow_response)| router_data)
+}
+
+/// Execute UCS refund reverse request using RefundService.Reverse gRPC method.
+#[instrument(skip_all)]
+pub async fn call_unified_connector_service_for_refund_reverse(
+    state: &SessionState,
+    processor: &Processor,
+    router_data: RouterData<refunds::RSync, RefundsData, RefundsResponseData>,
+    execution_mode: ExecutionMode,
+    #[cfg(feature = "v1")] merchant_connector_account: MerchantConnectorAccountType,
+    #[cfg(feature = "v2")] merchant_connector_account: MerchantConnectorAccountTypeDetails,
+) -> RouterResult<RefundReverseUcsResponse> {
+    let ucs_client = get_ucs_client(state)?;
+
+    let connector_auth_metadata = build_unified_connector_service_auth_metadata(
+        merchant_connector_account,
+        processor,
+        router_data.connector.clone(),
+    )
+    .change_context(errors::ApiErrorResponse::InternalServerError)
+    .attach_printable("Failed to build UCS auth metadata for refund reverse")?;
+
+    let ucs_refund_reverse_request = RefundServiceReverseRequest::foreign_try_from(&router_data)
+        .change_context(errors::ApiErrorResponse::InternalServerError)
+        .attach_printable("Failed to transform router data to UCS refund reverse request")?;
+
+    let merchant_id = processor.get_account().get_id().clone();
+    let profile_id = id_type::ProfileId::from_str(merchant_id.get_string_repr())
+        .change_context(errors::ApiErrorResponse::InternalServerError)
+        .attach_printable("Failed to convert merchant_id to profile_id for UCS refund reverse")?;
+    let lineage_ids = LineageIds::new(merchant_id, profile_id);
+    let merchant_reference_id =
+        id_type::PaymentReferenceId::from_str(router_data.payment_id.as_str())
+            .inspect_err(|err| logger::warn!(error=?err, "Invalid PaymentId for UCS reference id"))
+            .ok()
+            .map(ucs_types::UcsReferenceId::Payment);
+    let resource_id = router_data
+        .refund_id
+        .as_ref()
+        .and_then(|refund_id| {
+            id_type::RefundReferenceId::try_from(Cow::Owned(refund_id.to_string()))
+                .inspect_err(
+                    |err| logger::warn!(error=?err, "Invalid RefundId for UCS resource id"),
+                )
+                .ok()
+        })
+        .map(ucs_types::UcsResourceId::Refund);
+
+    let grpc_headers = state
+        .get_grpc_headers_ucs(execution_mode)
+        .lineage_ids(lineage_ids)
+        .external_vault_proxy_metadata(None)
+        .merchant_reference_id(merchant_reference_id)
+        .resource_id(resource_id)
+        .build();
+
+    let grpc_response: RefundReverseResponse = ucs_client
+        .refund_reverse(
+            ucs_refund_reverse_request,
+            connector_auth_metadata,
+            grpc_headers,
+        )
+        .await
+        .change_context(errors::ApiErrorResponse::InternalServerError)
+        .attach_printable("UCS refund reverse execution failed")?
+        .into_inner();
+
+    let refund_status = payments_grpc::RefundStatus::try_from(grpc_response.status)
+        .unwrap_or(payments_grpc::RefundStatus::Unspecified);
+    let status = common_enums::RefundStatus::foreign_try_from(refund_status)
+        .change_context(errors::ApiErrorResponse::InternalServerError)
+        .attach_printable("Failed to transform UCS refund reverse status")?;
+
+    Ok(RefundReverseUcsResponse {
+        state_metadata: grpc_response.state.and_then(|state| state.state_metadata),
+        raw_connector_response: grpc_response.raw_connector_response,
+        connector_refund_id: grpc_response.connector_refund_id,
+        status,
+    })
 }

--- a/crates/router/src/core/unified_connector_service/transformers.rs
+++ b/crates/router/src/core/unified_connector_service/transformers.rs
@@ -16,7 +16,9 @@ use common_utils::{
 };
 use diesel_models::enums as storage_enums;
 use error_stack::{report, ResultExt};
-use external_services::grpc_client::unified_connector_service::UnifiedConnectorServiceError;
+use external_services::grpc_client::unified_connector_service::{
+    RefundReverseConnectorState, RefundServiceReverseRequest, UnifiedConnectorServiceError,
+};
 use hyperswitch_domain_models::{
     mandates::{MandateData, MandateDataType},
     router_data::{AccessToken, ErrorResponse, RouterData},
@@ -111,6 +113,20 @@ impl ForeignFrom<&AccessToken> for ConnectorState {
                 token_type: None,
             }),
             connector_customer_id: None,
+        }
+    }
+}
+
+impl ForeignFrom<&AccessToken> for RefundReverseConnectorState {
+    fn foreign_from(access_token: &AccessToken) -> Self {
+        Self {
+            access_token: Some(payments_grpc::AccessToken {
+                token: Some(access_token.token.clone().expose().into()),
+                expires_in_seconds: Some(access_token.expires),
+                token_type: None,
+            }),
+            connector_customer_id: None,
+            state_metadata: None,
         }
     }
 }
@@ -5708,6 +5724,70 @@ impl transformers::ForeignTryFrom<&RouterData<RSync, RefundsData, RefundsRespons
                 .map(|s| s.into()),
             test_mode: router_data.test_mode,
             payment_method_type,
+        })
+    }
+}
+
+impl transformers::ForeignTryFrom<&RouterData<RSync, RefundsData, RefundsResponseData>>
+    for RefundServiceReverseRequest
+{
+    type Error = error_stack::Report<UnifiedConnectorServiceError>;
+
+    fn foreign_try_from(
+        router_data: &RouterData<RSync, RefundsData, RefundsResponseData>,
+    ) -> Result<Self, Self::Error> {
+        let state = router_data
+            .access_token
+            .as_ref()
+            .map(RefundReverseConnectorState::foreign_from);
+
+        let payment_method_type = router_data
+            .payment_method_type
+            .map(payments_grpc::PaymentMethodType::foreign_try_from)
+            .transpose()?
+            .map(|payment_method_type| payment_method_type.into());
+
+        Ok(Self {
+            merchant_refund_id: Some(router_data.connector_request_reference_id.clone()),
+            connector_transaction_id: router_data.request.connector_transaction_id.clone(),
+            connector_refund_id: router_data.request.connector_refund_id.clone().ok_or(
+                UnifiedConnectorServiceError::RequestEncodingFailedWithReason(
+                    "Missing connector_refund_id for refund reverse operation".to_string(),
+                ),
+            )?,
+            cancellation_reason: router_data.request.reason.clone(),
+            browser_info: router_data
+                .request
+                .browser_info
+                .clone()
+                .map(payments_grpc::BrowserInformation::foreign_try_from)
+                .transpose()
+                .map_err(|_| {
+                    UnifiedConnectorServiceError::RequestEncodingFailedWithReason(
+                        "Failed to convert browser info".to_string(),
+                    )
+                })?,
+            refund_metadata: router_data
+                .request
+                .refund_connector_metadata
+                .as_ref()
+                .map(serde_json::to_string)
+                .transpose()
+                .change_context(UnifiedConnectorServiceError::RequestEncodingFailed)?
+                .map(|s| s.into()),
+            state,
+            test_mode: router_data.test_mode,
+            payment_method_type,
+            connector_feature_data: router_data
+                .request
+                .connector_metadata
+                .as_ref()
+                .map(serde_json::to_string)
+                .transpose()
+                .change_context(UnifiedConnectorServiceError::RequestEncodingFailed)?
+                .map(|s| s.into()),
+            merchant_request_id: Some(router_data.connector_request_reference_id.clone()),
+            connector_order_id: None,
         })
     }
 }

--- a/crates/router/src/routes/app.rs
+++ b/crates/router/src/routes/app.rs
@@ -1493,6 +1493,7 @@ impl Refunds {
             route = route
                 .service(web::resource("").route(web::post().to(refunds_create)))
                 .service(web::resource("/sync").route(web::post().to(refunds_retrieve_with_body)))
+                .service(web::resource("/{id}/reverse").route(web::post().to(refunds_reverse)))
                 .service(
                     web::resource("/{id}")
                         .route(web::get().to(refunds_retrieve))

--- a/crates/router/src/routes/refunds.rs
+++ b/crates/router/src/routes/refunds.rs
@@ -363,6 +363,37 @@ pub async fn refunds_update(
     .await
 }
 
+#[cfg(feature = "v1")]
+/// Refunds - Reverse
+///
+/// Reverse/void a previously successful refund before connector settlement.
+#[instrument(skip_all, fields(flow = ?Flow::RefundsUpdate))]
+pub async fn refunds_reverse(
+    state: web::Data<AppState>,
+    req: HttpRequest,
+    json_payload: web::Json<refunds::RefundReverseRequest>,
+    path: web::Path<String>,
+) -> HttpResponse {
+    let flow = Flow::RefundsUpdate;
+    let mut refund_reverse_req = json_payload.into_inner();
+    refund_reverse_req.refund_id = path.into_inner();
+    Box::pin(api::server_wrap(
+        flow,
+        state,
+        &req,
+        refund_reverse_req,
+        |state, auth: auth::AuthenticationData, req, _| {
+            refund_reverse_core(state, auth.platform, req)
+        },
+        &auth::HeaderAuth(auth::ApiKeyAuth {
+            allow_connected_scope_operation: true,
+            allow_platform_self_operation: false,
+        }),
+        api_locking::LockAction::NotApplicable,
+    ))
+    .await
+}
+
 #[cfg(feature = "v2")]
 #[instrument(skip_all, fields(flow = ?Flow::RefundsUpdate))]
 pub async fn refunds_metadata_update(

--- a/crates/router/src/types/api/refunds.rs
+++ b/crates/router/src/types/api/refunds.rs
@@ -1,11 +1,11 @@
-#[cfg(feature = "v1")]
-pub use api_models::refunds::RefundRequest;
 pub use api_models::refunds::{
     RefundListRequest, RefundListResponse, RefundResponse, RefundStatus, RefundType,
     RefundUpdateRequest, RefundsRetrieveBody, RefundsRetrieveRequest,
 };
 #[cfg(feature = "v2")]
 pub use api_models::refunds::{RefundMetadataUpdateRequest, RefundsCreateRequest};
+#[cfg(feature = "v1")]
+pub use api_models::refunds::{RefundRequest, RefundReverseRequest};
 pub use hyperswitch_domain_models::router_flow_types::refunds::{Execute, RSync};
 pub use hyperswitch_interfaces::api::refunds::{Refund, RefundExecute, RefundSync};
 


### PR DESCRIPTION
## Summary

- Adds v1 `POST /refunds/{id}/reverse` for refund void-after-refund routing through UCS.

- Preserves refund status and writes connector reverse state under refund metadata `state_metadata`.
- Adds a temporary UCS reverse compatibility shim because the pinned generated client does not expose `RefundService.Reverse` yet.



## Validation
- `cargo fmt --all`

- `cargo check -p router`


