### PR TITLE
fix(payment_attempt): fix incorrect value being serialized in payment attempt update flow

### DIFF
--- a/crates/storage_impl/src/payments/payment_attempt.rs
+++ b/crates/storage_impl/src/payments/payment_attempt.rs
@@ -1056,12 +1056,13 @@ impl<T: DatabaseStore> PaymentAttemptInterface for KVRouterStore<T> {
                     .convert()
                     .await
                     .change_context(errors::StorageError::EncryptionError)?;
-                let updated_payment_attempt_diesel = payment_attempt.to_storage_model();
+                let payment_attempt_update_diesel = payment_attempt.to_storage_model();
+                let updated_payment_attempt_diesel = payment_attempt_update_diesel
+                    .clone()
+                    .apply_changeset(source_payment_attempt_diesel.clone());
                 let updated_attempt = PaymentAttempt::convert_back(
                     key_manager_state,
-                    updated_payment_attempt_diesel
-                        .clone()
-                        .apply_changeset(source_payment_attempt_diesel.clone()),
+                    updated_payment_attempt_diesel.clone(),
                     merchant_key_store.key.get_inner(),
                     merchant_key_store.merchant_id.clone().into(),
                 )
@@ -1132,7 +1133,7 @@ impl<T: DatabaseStore> PaymentAttemptInterface for KVRouterStore<T> {
                 }
 
                 let mut query_gen_conn = pg_connection_write(self).await?;
-                let drainer_query = updated_payment_attempt_diesel
+                let drainer_query = payment_attempt_update_diesel
                     .generate_drainer_update_query(
                         &mut query_gen_conn,
                         &source_payment_attempt_diesel,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->

This PR fixes a bug introduced in #12449 where an incorrect value was being serialized in Redis (`PaymentAttemptUpdate` diesel model) instead of `PaymentAttempt` diesel model, during the payment attempt KV flow.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->

This PR fixes a bug.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

Ran router and drainer locally, enabled KV for a merchant, performed payment create and payment retrieve. Both API calls were successful, there were no deserialization errors during payment retrieve.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
