### PR TITLE
fix(cypress): correct parameter order in manualRefundStatusUpdateTest command

### DIFF
--- a/cypress-tests/cypress/e2e/spec/Payment/50-RefundWebhook.cy.js
+++ b/cypress-tests/cypress/e2e/spec/Payment/50-RefundWebhook.cy.js
@@ -128,8 +128,8 @@ describe("Refund Webhook Tests", () => {
       };
 
       cy.manualRefundStatusUpdateTest(
-        globalState,
-        refundManualUpdateRequestBody
+        refundManualUpdateRequestBody,
+        globalState
       );
     });
 

--- a/cypress-tests/cypress/support/commands.js
+++ b/cypress-tests/cypress/support/commands.js
@@ -7276,39 +7276,36 @@ Cypress.Commands.add(
   }
 );
 
-Cypress.Commands.add(
-  "manualRefundStatusUpdateTest",
-  (data, globalState) => {
-    const merchantId = globalState.get("merchantId");
-    const refundId = globalState.get("refundId");
-    const completeUrl = `${Cypress.env("BASEURL")}/refunds/${refundId}/manual-update`;
-    const adminApiKey = globalState.get("adminApiKey");
+Cypress.Commands.add("manualRefundStatusUpdateTest", (data, globalState) => {
+  const merchantId = globalState.get("merchantId");
+  const refundId = globalState.get("refundId");
+  const completeUrl = `${Cypress.env("BASEURL")}/refunds/${refundId}/manual-update`;
+  const adminApiKey = globalState.get("adminApiKey");
 
-    cy.request({
-      method: "PUT",
-      url: completeUrl,
-      headers: {
-        "Content-Type": "application/json",
-        "api-key": adminApiKey,
-        "X-Merchant-Id": merchantId,
-      },
-      body: data,
-      failOnStatusCode: false,
-    }).then((response) => {
-      logRequestId(response.headers["x-request-id"]);
+  cy.request({
+    method: "PUT",
+    url: completeUrl,
+    headers: {
+      "Content-Type": "application/json",
+      "api-key": adminApiKey,
+      "X-Merchant-Id": merchantId,
+    },
+    body: data,
+    failOnStatusCode: false,
+  }).then((response) => {
+    logRequestId(response.headers["x-request-id"]);
 
-      cy.wrap(response).then(() => {
-        if (response.status === 200) {
-          expect(response.status).to.eq(200);
-        } else {
-          throw new Error(
-            `Refund Manual Update Call Failed with error code "${response.body?.error?.code}" error message "${response.body?.error?.message}"`
-          );
-        }
-      });
+    cy.wrap(response).then(() => {
+      if (response.status === 200) {
+        expect(response.status).to.eq(200);
+      } else {
+        throw new Error(
+          `Refund Manual Update Call Failed with error code "${response.body?.error?.code}" error message "${response.body?.error?.message}"`
+        );
+      }
     });
-  }
-);
+  });
+});
 
 Cypress.Commands.add(
   "IncomingWebhookTest",

--- a/cypress-tests/cypress/support/commands.js
+++ b/cypress-tests/cypress/support/commands.js
@@ -7278,7 +7278,7 @@ Cypress.Commands.add(
 
 Cypress.Commands.add(
   "manualRefundStatusUpdateTest",
-  (globalState, refundManualUpdateRequestBody) => {
+  (data, globalState) => {
     const merchantId = globalState.get("merchantId");
     const refundId = globalState.get("refundId");
     const completeUrl = `${Cypress.env("BASEURL")}/refunds/${refundId}/manual-update`;
@@ -7292,7 +7292,7 @@ Cypress.Commands.add(
         "api-key": adminApiKey,
         "X-Merchant-Id": merchantId,
       },
-      body: refundManualUpdateRequestBody,
+      body: data,
       failOnStatusCode: false,
     }).then((response) => {
       logRequestId(response.headers["x-request-id"]);


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
The manualRefundStatusUpdateTest custom command had its parameters in the wrong order: (globalState, refundManualUpdateRequestBody), but all callers (including 47-RefundManualUpdate.cy.js) passed arguments as (data, globalState). This caused globalState to receive the plain request body object, resulting in TypeError: globalState.get is not a function.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
