### PR TITLE
ci: seed superposition in extended cypress tests

### DIFF
--- a/.github/workflows/cypress-tests-runner.yml
+++ b/.github/workflows/cypress-tests-runner.yml
@@ -545,6 +545,13 @@ jobs:
           --health-retries 5
         ports:
           - 5432:5432
+      superposition:
+        image: ghcr.io/juspay/superposition-demo:0.102.0
+        env:
+          API_HOSTNAME: http://localhost:8081
+          REDIS_URL: redis://redis:6379
+        ports:
+          - 8081:8080
 
     steps:
       - name: Checkout repository
@@ -635,6 +642,14 @@ jobs:
       - name: Insert GSM info into the database
         run: |
           PGPASSWORD=db_pass psql --host=localhost --port=5432 --username=db_user --dbname=hyperswitch_db --command "\copy gateway_status_map FROM '.github/data/gateway_status_map.csv' DELIMITER ',' CSV HEADER;"
+
+      - name: Seed Superposition
+        env:
+          SUPERPOSITION_URL: "http://localhost:8081"
+          SEED_FILE: "./config/superposition_seed.toml"
+          WORKSPACE_ID: "dev"
+          ORG_ID: "localorg"
+        run: bash scripts/seed_superposition.sh
 
       - name: Setup Local Server
         env:


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [x] CI/CD

## Description
<!-- Describe your changes in detail -->

Adds Superposition setup to the `extended-cypress-tests` job in `cypress-tests-runner.yml`.

The extended Cypress job configures `ROUTER__SUPERPOSITION__POLLING_INTERVAL`, but did not start the Superposition service or seed Superposition before starting the local router.

This PR adds the missing:

- `superposition` service
- `Seed Superposition` step before `Setup Local Server`

This matches the setup already used by the other Cypress jobs.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

Fixes #12178.

Extended Cypress tests can fail when the router starts without the expected Superposition configuration. Other Cypress jobs already start and seed Superposition before starting the router, but `extended-cypress-tests` was missing that setup.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

Tested manually.

- Confirmed `extended-cypress-tests` previously had `ROUTER__SUPERPOSITION__POLLING_INTERVAL` but no Superposition service or seed step.
- Confirmed the updated job now starts the Superposition service and runs `scripts/seed_superposition.sh` before `Setup Local Server`.
- Ran a regression check across Cypress jobs using `ROUTER__SUPERPOSITION__POLLING_INTERVAL` to confirm each has Superposition service + seed before server startup.
- Ran `git diff --check -- .github/workflows/cypress-tests-runner.yml`.
- Ran `actionlint` on `.github/workflows/cypress-tests-runner.yml`, ignoring existing disabled-job and custom-runner warnings.
- Ran `scripts/seed_superposition.sh` against a live local Superposition service and confirmed it completed successfully.

The full extended Cypress job was not run locally because it depends on GitHub Actions secrets, S3 connector credentials, and self-hosted runner context.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible