### PR TITLE
feat(connector): [TOKENIO] Add Integrity Check support for Authorize …

### DIFF
--- a/crates/hyperswitch_connectors/src/connectors/tokenio.rs
+++ b/crates/hyperswitch_connectors/src/connectors/tokenio.rs
@@ -425,10 +425,21 @@ impl ConnectorIntegration<Authorize, PaymentsAuthorizeData, PaymentsResponseData
             .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
         event_builder.map(|i| i.set_response_body(&response));
         router_env::logger::info!(connector_response=?response);
+
+        let integrity_object = utils::get_authorise_integrity_object(
+            &self.amount_convertor,
+            data.request.amount,
+            data.request.currency.to_string(),
+        )?;
+
         RouterData::try_from(ResponseRouterData {
             response,
             data: data.clone(),
             http_code: res.status_code,
+        })
+        .map(|mut router_data| {
+            router_data.request.integrity_object = Some(response_integrity_object);
+            router_data
         })
     }
 
@@ -524,10 +535,21 @@ impl ConnectorIntegration<PSync, PaymentsSyncData, PaymentsResponseData> for Tok
             .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
         event_builder.map(|i| i.set_response_body(&response));
         router_env::logger::info!(connector_response=?response);
+
+        let integrity_object = utils::get_sync_integrity_object(
+            &self.amount_convertor,
+            data.request.amount,
+            data.request.currency.to_string(),
+        )?;
+
         RouterData::try_from(ResponseRouterData {
             response,
             data: data.clone(),
             http_code: res.status_code,
+        })
+        .map(|mut router_data| {
+            router_data.request.integrity_object = Some(response_integrity_object);
+            router_data
         })
     }
 


### PR DESCRIPTION
## Type of Change
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
Added integrity check support for Authorize and PSync flows for the TokenIO connector.

Integrity check validates that the amount returned by the connector matches
the amount sent in the request. If there's a discrepancy, the payment is held
in a non-terminal state and returns IE_00.

Refund and RSync flows are not supported by TokenIO (returns FlowNotSupported),
so integrity checks were not added for those flows.

### Additional Changes
- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

## Motivation and Context
Closes #9227

## How did you test it?
- Ran `cargo check -p hyperswitch_connectors` — no errors
- Ran `cargo +nightly fmt --all` — no changes
- Ran `cargo clippy -p hyperswitch_connectors -- -D warnings` — no warnings

## Checklist
- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible