### PR TITLE
fix(ucs): convert NMI redirect-form amount to major units in reverse-map

### DIFF
--- a/crates/hyperswitch_interfaces/src/unified_connector_service/transformers.rs
+++ b/crates/hyperswitch_interfaces/src/unified_connector_service/transformers.rs
@@ -835,7 +835,11 @@ impl ForeignTryFrom<payments_grpc::RedirectForm> for RedirectForm {
                 }
                 .attach_printable("Failed to parse currency from UCS Nmi redirect form")?;
                 Ok(Self::Nmi {
-                    amount: amount_money.minor_amount.to_string(),
+                    amount: common_utils::types::MinorUnit::new(amount_money.minor_amount)
+                        .to_major_unit_as_f64(currency)
+                        .change_context(UnifiedConnectorServiceError::ParsingFailed)?
+                        .get_amount_as_f64()
+                        .to_string(),
                     currency,
                     public_key: hyperswitch_masking::Secret::new(
                         nmi.public_key


### PR DESCRIPTION
## What
The UCS reverse-map reconstructed the NMI 3DS redirect-form `amount` by stringifying `Money.minor_amount` directly — i.e. **minor** units — while native NMI emits the amount in **major** units. Result: the UCS-reconstructed RouterData diverged from native (e.g. native `"366.74"` vs reconstructed `"366"`/`"36674"`).

## Fix
Convert through the typed amount framework — `MinorUnit` → `FloatMajorUnit` via `to_major_unit_as_f64` — which is currency-aware (2-/3-/zero-decimal) and matches native's `to_currency_base_unit_asf64(..).to_string()` output byte-for-byte (`36674` → `"366.74"`, `6000` → `"60"`).

Paired with the UCS-side change in juspay/hyperswitch-prism#1479 (which sends the raw minor amount per the proto `Money` convention).

## Testing
- `cargo check -p hyperswitch_interfaces --features v1` — clean.
