### PR TITLE
test(cypress): add redirection handling for iatapay RealTimePayment DuitNow

### DIFF
--- a/cypress-tests/cypress/e2e/configs/Payment/Fiuu.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Fiuu.js
@@ -88,6 +88,9 @@ const requiredFields = {
 export const connectorDetails = {
   real_time_payment_pm: {
     DuitNow: {
+      Configs: {
+        TRIGGER_SKIP: true,
+      },
       Request: {
         payment_method: "real_time_payment",
         payment_method_type: "duit_now",

--- a/cypress-tests/cypress/e2e/configs/Payment/Fiuu.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Fiuu.js
@@ -89,7 +89,7 @@ export const connectorDetails = {
   real_time_payment_pm: {
     DuitNow: {
       Configs: {
-        TRIGGER_SKIP: true,
+        TRIGGER_SKIP: true, //Since fiuu follows a qr flow we are skipping the qr handling
       },
       Request: {
         payment_method: "real_time_payment",

--- a/cypress-tests/cypress/e2e/configs/Payment/Iatapay.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Iatapay.js
@@ -106,6 +106,23 @@ export const connectorDetails = {
         },
       },
     },
+    DuitNowRetrieve: {
+      Configs: {
+        CONNECTOR_CREDENTIAL: {
+          specName: ["realTimePayment"],
+          value: "connector_2",
+        },
+      },
+      Response: {
+        status: 200,
+        body: {
+          status: "succeeded",
+          amount: 6000,
+          amount_received: 6000,
+          amount_capturable: 0,
+        },
+      },
+    },
   },
   card_pm: {
     ZeroAuthMandate: {

--- a/cypress-tests/cypress/e2e/spec/Payment/31-RealTimePayment.cy.js
+++ b/cypress-tests/cypress/e2e/spec/Payment/31-RealTimePayment.cy.js
@@ -67,9 +67,25 @@ describe("Real Time Payment", () => {
     it("Retrieve Payment", () => {
       const data = getConnectorDetails(globalState.get("connectorId"))[
         "real_time_payment_pm"
-      ]["DuitNow"];
+      ]["DuitNowRetrieve"];
 
-      cy.retrievePaymentCallTest({ globalState, data });
+      cy.retrievePaymentCallTest({
+        globalState,
+        data,
+        expectedIntentStatus: "succeeded",
+      });
+    });
+
+    it("Sync Payment", () => {
+      const data = getConnectorDetails(globalState.get("connectorId"))[
+        "real_time_payment_pm"
+      ]["DuitNowRetrieve"];
+
+      cy.retrievePaymentCallTest({
+        globalState,
+        data,
+        expectedIntentStatus: "succeeded",
+      });
     });
   });
 });

--- a/cypress-tests/cypress/e2e/spec/Payment/31-RealTimePayment.cy.js
+++ b/cypress-tests/cypress/e2e/spec/Payment/31-RealTimePayment.cy.js
@@ -16,7 +16,7 @@ describe("Real Time Payment", () => {
   });
 
   context("DuitNow automatic capture flow", () => {
-    let shouldContinue = true; // variable that will be used to skip tests if a previous test fails
+    let shouldContinue = true;
 
     beforeEach(function () {
       if (!shouldContinue) {
@@ -57,6 +57,11 @@ describe("Real Time Payment", () => {
       );
 
       if (shouldContinue) shouldContinue = utils.should_continue_further(data);
+    });
+
+    it("Handle Redirection", () => {
+      const expected_redirection = fixtures.confirmBody["return_url"];
+      cy.handleRedirection(globalState, expected_redirection);
     });
 
     it("Retrieve Payment", () => {

--- a/cypress-tests/cypress/e2e/spec/Payment/31-RealTimePayment.cy.js
+++ b/cypress-tests/cypress/e2e/spec/Payment/31-RealTimePayment.cy.js
@@ -60,8 +60,11 @@ describe("Real Time Payment", () => {
     });
 
     it("Handle Redirection", () => {
-      const expected_redirection = fixtures.confirmBody["return_url"];
-      cy.handleRedirection(globalState, expected_redirection);
+      const connectorId = globalState.get("connectorId");
+      if (connectorId === "iatapay") {
+        const expected_redirection = fixtures.confirmBody["return_url"];
+        cy.handleRedirection(globalState, expected_redirection);
+      }
     });
 
     it("Retrieve Payment", () => {

--- a/cypress-tests/cypress/e2e/spec/Payment/31-RealTimePayment.cy.js
+++ b/cypress-tests/cypress/e2e/spec/Payment/31-RealTimePayment.cy.js
@@ -60,11 +60,8 @@ describe("Real Time Payment", () => {
     });
 
     it("Handle Redirection", () => {
-      const connectorId = globalState.get("connectorId");
-      if (connectorId === "iatapay") {
-        const expected_redirection = fixtures.confirmBody["return_url"];
-        cy.handleRedirection(globalState, expected_redirection);
-      }
+      const expected_redirection = fixtures.confirmBody["return_url"];
+      cy.handleRedirection(globalState, expected_redirection);
     });
 
     it("Retrieve Payment", () => {

--- a/cypress-tests/cypress/support/commands.js
+++ b/cypress-tests/cypress/support/commands.js
@@ -5336,9 +5336,6 @@ Cypress.Commands.add(
           ) {
             switch (response.body.payment_method_type) {
               case "duit_now":
-              case "fps":
-              case "prompt_pay":
-              case "viet_qr":
                 if (response.body.connector === "fiuu")
                   expect(response.body)
                     .to.have.property("next_action")

--- a/cypress-tests/cypress/support/commands.js
+++ b/cypress-tests/cypress/support/commands.js
@@ -5084,7 +5084,7 @@ Cypress.Commands.add(
       "three_ds",
       { redirectionUrl, expectedUrl },
       connectorId,
-      null
+      globalState.get("paymentMethodType")
     );
   }
 );

--- a/cypress-tests/cypress/support/commands.js
+++ b/cypress-tests/cypress/support/commands.js
@@ -5336,6 +5336,9 @@ Cypress.Commands.add(
           ) {
             switch (response.body.payment_method_type) {
               case "duit_now":
+              case "fps":
+              case "prompt_pay":
+              case "viet_qr":
                 if (response.body.connector === "fiuu")
                   expect(response.body)
                     .to.have.property("next_action")
@@ -5345,10 +5348,15 @@ Cypress.Commands.add(
                     response.body[key]
                   );
                 }
-                if (response.body.connector === "iatapay")
+                if (response.body.connector === "iatapay") {
                   expect(response.body)
                     .to.have.property("next_action")
                     .to.have.property("redirect_to_url");
+                  globalState.set(
+                    "nextActionUrl",
+                    response.body.next_action.redirect_to_url
+                  );
+                }
                 break;
 
               default:

--- a/cypress-tests/cypress/support/redirectionHandler.js
+++ b/cypress-tests/cypress/support/redirectionHandler.js
@@ -1994,6 +1994,26 @@ function threeDsRedirection(redirectionUrl, expectedUrl, connectorId) {
     return;
   }
 
+  if (connectorId === "iatapay") {
+    cy.log("Starting iatapay RealTimePayment redirection flow");
+
+    cy.get(".iatapay-button.iatapay-button--secondary", {
+      timeout: CONSTANTS.TIMEOUT,
+    })
+      .should("be.visible")
+      .click();
+
+    cy.log("Clicked Simulate button");
+
+    cy.url({ timeout: CONSTANTS.TIMEOUT }).should(
+      "include",
+      expectedUrl.hostname
+    );
+
+    verifyReturnUrl(redirectionUrl, expectedUrl, true);
+    return;
+  }
+
   // Special handling for Airwallex which uses multiple domains in 3DS flow
   // Handle separately to avoid nested cy.origin() calls
   if (connectorId === "airwallex") {

--- a/cypress-tests/cypress/support/redirectionHandler.js
+++ b/cypress-tests/cypress/support/redirectionHandler.js
@@ -61,7 +61,8 @@ export function handleRedirection(
       threeDsRedirection(
         urls.redirectionUrl,
         urls.expectedUrl,
-        resolvedConnectorId
+        resolvedConnectorId,
+        paymentMethodType
       );
       break;
     case "upi":
@@ -1924,7 +1925,12 @@ function bankRedirectRedirection(
   });
 }
 
-function threeDsRedirection(redirectionUrl, expectedUrl, connectorId) {
+function threeDsRedirection(
+  redirectionUrl,
+  expectedUrl,
+  connectorId,
+  paymentMethodType
+) {
   let responseContentType = null;
 
   // First check what type of response we get from the redirect URL

--- a/cypress-tests/cypress/support/redirectionHandler.js
+++ b/cypress-tests/cypress/support/redirectionHandler.js
@@ -1994,8 +1994,8 @@ function threeDsRedirection(redirectionUrl, expectedUrl, connectorId) {
     return;
   }
 
-  if (connectorId === "iatapay") {
-    cy.log("Starting iatapay RealTimePayment redirection flow");
+  if (connectorId === "iatapay" && paymentMethodType === "duit_now") {
+    cy.log("Starting iatapay RealTimePayment redirection flow for DuitNow");
 
     cy.get(".iatapay-button.iatapay-button--secondary", {
       timeout: CONSTANTS.TIMEOUT,


### PR DESCRIPTION
## Type of Change
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [x] Other (Cypress test coverage)

## Description
Adds redirection handling for iatapay RealTimePayment DuitNow flow:

1. **31-RealTimePayment.cy.js**: Adds "Handle Redirection" step after Confirm DuitNow
2. **commands.js**: Stores `nextActionUrl` for iatapay RealTimePayment (required for handleRedirection)
3. **redirectionHandler.js**: Adds iatapay-specific handler that clicks the Simulate button (`.iatapay-button--secondary`) on the sandbox page

## Motivation and Context
The DuitNow flow for iatapay reaches `requires_customer_action` with a redirect URL. Previously the test skipped the redirection step entirely. This change ensures the full payment flow is tested end-to-end.

## Related Issues
- Closes #12645 (partial — DuitNow only; Fps/PromptPay/VietQr tracked in linked issue)

## How did you test it?
Ran locally against iatapay sandbox: Create Payment Intent -> Payment Methods Call -> Confirm DuitNow -> Handle Redirection (click Simulate) -> Retrieve Payment.

## Checklist
- [x] I formatted the code with Prettier
- [x] I reviewed submitted code
- [x] I added unit tests for my changes where possible
