### PR TITLE
feat(dlocal,ucs): GCash Recurring + customer document plumbing to UCS (counterpart of prism #1459)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2264,7 +2264,7 @@ dependencies = [
 [[package]]
 name = "config_patch_derive"
 version = "0.1.0"
-source = "git+https://github.com/juspay/hyperswitch-prism?rev=90ff39981d44e51babfd4eccf18fa8ffbe49d4a2#90ff39981d44e51babfd4eccf18fa8ffbe49d4a2"
+source = "git+https://github.com/juspay/hyperswitch-prism?tag=2026.06.10.0#1044ccf1d636eed98e70fbf06acc18ecc78d5be8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3981,7 +3981,7 @@ checksum = "32619942b8be646939eaf3db0602b39f5229b74575b67efc897811ded1db4e57"
 [[package]]
 name = "grpc-api-types"
 version = "0.1.0"
-source = "git+https://github.com/juspay/hyperswitch-prism?rev=90ff39981d44e51babfd4eccf18fa8ffbe49d4a2#90ff39981d44e51babfd4eccf18fa8ffbe49d4a2"
+source = "git+https://github.com/juspay/hyperswitch-prism?tag=2026.06.10.0#1044ccf1d636eed98e70fbf06acc18ecc78d5be8"
 dependencies = [
  "axum 0.8.4",
  "bytes 1.10.1",
@@ -8184,7 +8184,7 @@ dependencies = [
 [[package]]
 name = "rust-grpc-client"
 version = "0.1.0"
-source = "git+https://github.com/juspay/hyperswitch-prism?rev=90ff39981d44e51babfd4eccf18fa8ffbe49d4a2#90ff39981d44e51babfd4eccf18fa8ffbe49d4a2"
+source = "git+https://github.com/juspay/hyperswitch-prism?tag=2026.06.10.0#1044ccf1d636eed98e70fbf06acc18ecc78d5be8"
 dependencies = [
  "grpc-api-types",
 ]
@@ -11018,7 +11018,7 @@ checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
 [[package]]
 name = "ucs_cards"
 version = "0.1.0"
-source = "git+https://github.com/juspay/hyperswitch-prism?rev=90ff39981d44e51babfd4eccf18fa8ffbe49d4a2#90ff39981d44e51babfd4eccf18fa8ffbe49d4a2"
+source = "git+https://github.com/juspay/hyperswitch-prism?tag=2026.06.10.0#1044ccf1d636eed98e70fbf06acc18ecc78d5be8"
 dependencies = [
  "bytes 1.10.1",
  "error-stack 0.4.1",
@@ -11034,7 +11034,7 @@ dependencies = [
 [[package]]
 name = "ucs_common_enums"
 version = "0.1.0"
-source = "git+https://github.com/juspay/hyperswitch-prism?rev=90ff39981d44e51babfd4eccf18fa8ffbe49d4a2#90ff39981d44e51babfd4eccf18fa8ffbe49d4a2"
+source = "git+https://github.com/juspay/hyperswitch-prism?tag=2026.06.10.0#1044ccf1d636eed98e70fbf06acc18ecc78d5be8"
 dependencies = [
  "serde",
  "strum 0.26.3",
@@ -11045,7 +11045,7 @@ dependencies = [
 [[package]]
 name = "ucs_common_utils"
 version = "0.1.0"
-source = "git+https://github.com/juspay/hyperswitch-prism?rev=90ff39981d44e51babfd4eccf18fa8ffbe49d4a2#90ff39981d44e51babfd4eccf18fa8ffbe49d4a2"
+source = "git+https://github.com/juspay/hyperswitch-prism?tag=2026.06.10.0#1044ccf1d636eed98e70fbf06acc18ecc78d5be8"
 dependencies = [
  "anyhow",
  "base64 0.21.7",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2264,7 +2264,7 @@ dependencies = [
 [[package]]
 name = "config_patch_derive"
 version = "0.1.0"
-source = "git+https://github.com/juspay/hyperswitch-prism?rev=b5da6133e497d3fe6146691262f438cfcf99d58e#b5da6133e497d3fe6146691262f438cfcf99d58e"
+source = "git+https://github.com/juspay/hyperswitch-prism?rev=90ff39981d44e51babfd4eccf18fa8ffbe49d4a2#90ff39981d44e51babfd4eccf18fa8ffbe49d4a2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3981,7 +3981,7 @@ checksum = "32619942b8be646939eaf3db0602b39f5229b74575b67efc897811ded1db4e57"
 [[package]]
 name = "grpc-api-types"
 version = "0.1.0"
-source = "git+https://github.com/juspay/hyperswitch-prism?rev=b5da6133e497d3fe6146691262f438cfcf99d58e#b5da6133e497d3fe6146691262f438cfcf99d58e"
+source = "git+https://github.com/juspay/hyperswitch-prism?rev=90ff39981d44e51babfd4eccf18fa8ffbe49d4a2#90ff39981d44e51babfd4eccf18fa8ffbe49d4a2"
 dependencies = [
  "axum 0.8.4",
  "bytes 1.10.1",
@@ -8184,7 +8184,7 @@ dependencies = [
 [[package]]
 name = "rust-grpc-client"
 version = "0.1.0"
-source = "git+https://github.com/juspay/hyperswitch-prism?rev=b5da6133e497d3fe6146691262f438cfcf99d58e#b5da6133e497d3fe6146691262f438cfcf99d58e"
+source = "git+https://github.com/juspay/hyperswitch-prism?rev=90ff39981d44e51babfd4eccf18fa8ffbe49d4a2#90ff39981d44e51babfd4eccf18fa8ffbe49d4a2"
 dependencies = [
  "grpc-api-types",
 ]
@@ -11018,7 +11018,7 @@ checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
 [[package]]
 name = "ucs_cards"
 version = "0.1.0"
-source = "git+https://github.com/juspay/hyperswitch-prism?rev=b5da6133e497d3fe6146691262f438cfcf99d58e#b5da6133e497d3fe6146691262f438cfcf99d58e"
+source = "git+https://github.com/juspay/hyperswitch-prism?rev=90ff39981d44e51babfd4eccf18fa8ffbe49d4a2#90ff39981d44e51babfd4eccf18fa8ffbe49d4a2"
 dependencies = [
  "bytes 1.10.1",
  "error-stack 0.4.1",
@@ -11034,7 +11034,7 @@ dependencies = [
 [[package]]
 name = "ucs_common_enums"
 version = "0.1.0"
-source = "git+https://github.com/juspay/hyperswitch-prism?rev=b5da6133e497d3fe6146691262f438cfcf99d58e#b5da6133e497d3fe6146691262f438cfcf99d58e"
+source = "git+https://github.com/juspay/hyperswitch-prism?rev=90ff39981d44e51babfd4eccf18fa8ffbe49d4a2#90ff39981d44e51babfd4eccf18fa8ffbe49d4a2"
 dependencies = [
  "serde",
  "strum 0.26.3",
@@ -11045,7 +11045,7 @@ dependencies = [
 [[package]]
 name = "ucs_common_utils"
 version = "0.1.0"
-source = "git+https://github.com/juspay/hyperswitch-prism?rev=b5da6133e497d3fe6146691262f438cfcf99d58e#b5da6133e497d3fe6146691262f438cfcf99d58e"
+source = "git+https://github.com/juspay/hyperswitch-prism?rev=90ff39981d44e51babfd4eccf18fa8ffbe49d4a2#90ff39981d44e51babfd4eccf18fa8ffbe49d4a2"
 dependencies = [
  "anyhow",
  "base64 0.21.7",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2264,7 +2264,7 @@ dependencies = [
 [[package]]
 name = "config_patch_derive"
 version = "0.1.0"
-source = "git+https://github.com/juspay/hyperswitch-prism?rev=1b83744ff6a8ed86b24a98867a8bdae8bd7d8001#1b83744ff6a8ed86b24a98867a8bdae8bd7d8001"
+source = "git+https://github.com/juspay/hyperswitch-prism?rev=b5da6133e497d3fe6146691262f438cfcf99d58e#b5da6133e497d3fe6146691262f438cfcf99d58e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3981,7 +3981,7 @@ checksum = "32619942b8be646939eaf3db0602b39f5229b74575b67efc897811ded1db4e57"
 [[package]]
 name = "grpc-api-types"
 version = "0.1.0"
-source = "git+https://github.com/juspay/hyperswitch-prism?rev=1b83744ff6a8ed86b24a98867a8bdae8bd7d8001#1b83744ff6a8ed86b24a98867a8bdae8bd7d8001"
+source = "git+https://github.com/juspay/hyperswitch-prism?rev=b5da6133e497d3fe6146691262f438cfcf99d58e#b5da6133e497d3fe6146691262f438cfcf99d58e"
 dependencies = [
  "axum 0.8.4",
  "bytes 1.10.1",
@@ -8184,7 +8184,7 @@ dependencies = [
 [[package]]
 name = "rust-grpc-client"
 version = "0.1.0"
-source = "git+https://github.com/juspay/hyperswitch-prism?rev=1b83744ff6a8ed86b24a98867a8bdae8bd7d8001#1b83744ff6a8ed86b24a98867a8bdae8bd7d8001"
+source = "git+https://github.com/juspay/hyperswitch-prism?rev=b5da6133e497d3fe6146691262f438cfcf99d58e#b5da6133e497d3fe6146691262f438cfcf99d58e"
 dependencies = [
  "grpc-api-types",
 ]
@@ -11018,7 +11018,7 @@ checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
 [[package]]
 name = "ucs_cards"
 version = "0.1.0"
-source = "git+https://github.com/juspay/hyperswitch-prism?rev=1b83744ff6a8ed86b24a98867a8bdae8bd7d8001#1b83744ff6a8ed86b24a98867a8bdae8bd7d8001"
+source = "git+https://github.com/juspay/hyperswitch-prism?rev=b5da6133e497d3fe6146691262f438cfcf99d58e#b5da6133e497d3fe6146691262f438cfcf99d58e"
 dependencies = [
  "bytes 1.10.1",
  "error-stack 0.4.1",
@@ -11034,7 +11034,7 @@ dependencies = [
 [[package]]
 name = "ucs_common_enums"
 version = "0.1.0"
-source = "git+https://github.com/juspay/hyperswitch-prism?rev=1b83744ff6a8ed86b24a98867a8bdae8bd7d8001#1b83744ff6a8ed86b24a98867a8bdae8bd7d8001"
+source = "git+https://github.com/juspay/hyperswitch-prism?rev=b5da6133e497d3fe6146691262f438cfcf99d58e#b5da6133e497d3fe6146691262f438cfcf99d58e"
 dependencies = [
  "serde",
  "strum 0.26.3",
@@ -11045,7 +11045,7 @@ dependencies = [
 [[package]]
 name = "ucs_common_utils"
 version = "0.1.0"
-source = "git+https://github.com/juspay/hyperswitch-prism?rev=1b83744ff6a8ed86b24a98867a8bdae8bd7d8001#1b83744ff6a8ed86b24a98867a8bdae8bd7d8001"
+source = "git+https://github.com/juspay/hyperswitch-prism?rev=b5da6133e497d3fe6146691262f438cfcf99d58e#b5da6133e497d3fe6146691262f438cfcf99d58e"
 dependencies = [
  "anyhow",
  "base64 0.21.7",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2264,7 +2264,7 @@ dependencies = [
 [[package]]
 name = "config_patch_derive"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.05.25.0#7707061b2d360f943ff59d169ed605ca91a99fc6"
+source = "git+https://github.com/juspay/hyperswitch-prism?rev=1b83744ff6a8ed86b24a98867a8bdae8bd7d8001#1b83744ff6a8ed86b24a98867a8bdae8bd7d8001"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3981,7 +3981,7 @@ checksum = "32619942b8be646939eaf3db0602b39f5229b74575b67efc897811ded1db4e57"
 [[package]]
 name = "grpc-api-types"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.05.25.0#7707061b2d360f943ff59d169ed605ca91a99fc6"
+source = "git+https://github.com/juspay/hyperswitch-prism?rev=1b83744ff6a8ed86b24a98867a8bdae8bd7d8001#1b83744ff6a8ed86b24a98867a8bdae8bd7d8001"
 dependencies = [
  "axum 0.8.4",
  "bytes 1.10.1",
@@ -8184,7 +8184,7 @@ dependencies = [
 [[package]]
 name = "rust-grpc-client"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.05.25.0#7707061b2d360f943ff59d169ed605ca91a99fc6"
+source = "git+https://github.com/juspay/hyperswitch-prism?rev=1b83744ff6a8ed86b24a98867a8bdae8bd7d8001#1b83744ff6a8ed86b24a98867a8bdae8bd7d8001"
 dependencies = [
  "grpc-api-types",
 ]
@@ -11018,7 +11018,7 @@ checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
 [[package]]
 name = "ucs_cards"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.05.25.0#7707061b2d360f943ff59d169ed605ca91a99fc6"
+source = "git+https://github.com/juspay/hyperswitch-prism?rev=1b83744ff6a8ed86b24a98867a8bdae8bd7d8001#1b83744ff6a8ed86b24a98867a8bdae8bd7d8001"
 dependencies = [
  "bytes 1.10.1",
  "error-stack 0.4.1",
@@ -11034,7 +11034,7 @@ dependencies = [
 [[package]]
 name = "ucs_common_enums"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.05.25.0#7707061b2d360f943ff59d169ed605ca91a99fc6"
+source = "git+https://github.com/juspay/hyperswitch-prism?rev=1b83744ff6a8ed86b24a98867a8bdae8bd7d8001#1b83744ff6a8ed86b24a98867a8bdae8bd7d8001"
 dependencies = [
  "serde",
  "strum 0.26.3",
@@ -11045,7 +11045,7 @@ dependencies = [
 [[package]]
 name = "ucs_common_utils"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.05.25.0#7707061b2d360f943ff59d169ed605ca91a99fc6"
+source = "git+https://github.com/juspay/hyperswitch-prism?rev=1b83744ff6a8ed86b24a98867a8bdae8bd7d8001#1b83744ff6a8ed86b24a98867a8bdae8bd7d8001"
 dependencies = [
  "anyhow",
  "base64 0.21.7",

--- a/crates/api_models/src/payments.rs
+++ b/crates/api_models/src/payments.rs
@@ -4799,8 +4799,8 @@ impl DocumentDetails {
         match self.document_type {
             DocumentKind::Cpf => (Some(self.document_number.clone()), None),
             DocumentKind::Cnpj => (None, Some(self.document_number.clone())),
-            // Not a Brazilian CPF/CNPJ — no split applies.
-            DocumentKind::Other => (None, None),
+            // Not a Brazilian CPF/CNPJ (Other / Philippine PSN) — no split applies.
+            DocumentKind::Other | DocumentKind::Psn => (None, None),
         }
     }
 }

--- a/crates/api_models/src/payments.rs
+++ b/crates/api_models/src/payments.rs
@@ -4799,6 +4799,8 @@ impl DocumentDetails {
         match self.document_type {
             DocumentKind::Cpf => (Some(self.document_number.clone()), None),
             DocumentKind::Cnpj => (None, Some(self.document_number.clone())),
+            // Not a Brazilian CPF/CNPJ — no split applies.
+            DocumentKind::Other => (None, None),
         }
     }
 }

--- a/crates/api_models/src/payments.rs
+++ b/crates/api_models/src/payments.rs
@@ -4800,7 +4800,7 @@ impl DocumentDetails {
             DocumentKind::Cpf => (Some(self.document_number.clone()), None),
             DocumentKind::Cnpj => (None, Some(self.document_number.clone())),
             // Not a Brazilian CPF/CNPJ (Other / Philippine PSN) — no split applies.
-            DocumentKind::Other | DocumentKind::Psn => (None, None),
+            DocumentKind::Psn | DocumentKind::Other => (None, None),
         }
     }
 }

--- a/crates/common_types/src/customers.rs
+++ b/crates/common_types/src/customers.rs
@@ -52,6 +52,10 @@ pub enum DocumentKind {
     Cpf,
     /// Cadastro Nacional da Pessoa Jurídica - The Brazilian business identifier.
     Cnpj,
+    /// Generic / non-Brazilian national document (e.g. the Philippine PSN required by
+    /// dLocal for GCash). Carried through to the connector without a Brazil-specific
+    /// checksum; the connector/PSP validates the value per country.
+    Other,
 }
 
 impl DocumentKind {
@@ -63,6 +67,9 @@ impl DocumentKind {
         match self {
             Self::Cpf => self.validate_cpf(doc_number),
             Self::Cnpj => self.validate_cnpj(doc_number),
+            // Non-Brazilian documents are passed through; the connector/PSP validates
+            // them per country (e.g. dLocal validates the Philippine PSN server-side).
+            Self::Other => Ok(()),
         }
     }
 

--- a/crates/common_types/src/customers.rs
+++ b/crates/common_types/src/customers.rs
@@ -52,12 +52,13 @@ pub enum DocumentKind {
     Cpf,
     /// Cadastro Nacional da Pessoa Jurídica - The Brazilian business identifier.
     Cnpj,
-    /// Generic / other non-Brazilian national document. Carried through to the connector
-    /// without a Brazil-specific checksum; the connector/PSP validates the value per country.
-    Other,
     /// Philippine PhilSys Number (PSN) — a randomly-generated 12-digit national ID,
     /// required by dLocal for GCash.
     Psn,
+    /// Generic / other non-Brazilian national document. Carried through to the connector
+    /// without a Brazil-specific checksum; the connector/PSP validates the value per country.
+    /// Kept last as the catch-all.
+    Other,
 }
 
 impl DocumentKind {

--- a/crates/common_types/src/customers.rs
+++ b/crates/common_types/src/customers.rs
@@ -52,10 +52,12 @@ pub enum DocumentKind {
     Cpf,
     /// Cadastro Nacional da Pessoa Jurídica - The Brazilian business identifier.
     Cnpj,
-    /// Generic / non-Brazilian national document (e.g. the Philippine PSN required by
-    /// dLocal for GCash). Carried through to the connector without a Brazil-specific
-    /// checksum; the connector/PSP validates the value per country.
+    /// Generic / other non-Brazilian national document. Carried through to the connector
+    /// without a Brazil-specific checksum; the connector/PSP validates the value per country.
     Other,
+    /// Philippine PhilSys Number (PSN) — a randomly-generated 12-digit national ID,
+    /// required by dLocal for GCash.
+    Psn,
 }
 
 impl DocumentKind {
@@ -67,9 +69,25 @@ impl DocumentKind {
         match self {
             Self::Cpf => self.validate_cpf(doc_number),
             Self::Cnpj => self.validate_cnpj(doc_number),
-            // Non-Brazilian documents are passed through; the connector/PSP validates
-            // them per country (e.g. dLocal validates the Philippine PSN server-side).
+            Self::Psn => self.validate_psn(doc_number),
+            // Other non-Brazilian documents are passed through; the connector/PSP
+            // validates them per country.
             Self::Other => Ok(()),
+        }
+    }
+
+    /// The Philippine PhilSys Number (PSN) is a randomly-generated 12-digit national ID
+    /// with no checksum; validate that it is exactly 12 numeric digits.
+    fn validate_psn(
+        self,
+        doc_number: &str,
+    ) -> common_utils::errors::CustomResult<(), ValidationError> {
+        if doc_number.len() == 12 && doc_number.bytes().all(|b| b.is_ascii_digit()) {
+            Ok(())
+        } else {
+            Err(error_stack::Report::new(ValidationError::InvalidValue {
+                message: "Invalid PSN: expected exactly 12 digits".to_string(),
+            }))
         }
     }
 

--- a/crates/external_services/Cargo.toml
+++ b/crates/external_services/Cargo.toml
@@ -74,7 +74,7 @@ http = "0.2.12"
 url = { version = "2.5.4", features = ["serde"] }
 quick-xml = { version = "0.31.0", features = ["serialize"] }
 
-unified-connector-service-client = { git = "https://github.com/juspay/hyperswitch-prism", rev = "90ff39981d44e51babfd4eccf18fa8ffbe49d4a2", package = "rust-grpc-client" }
+unified-connector-service-client = { git = "https://github.com/juspay/hyperswitch-prism", tag = "2026.06.10.0", package = "rust-grpc-client" }
 open-feature = { version = "0.2.5", optional = true }
 superposition_provider = { version = "0.102.0", optional = true}
 superposition_types = "0.102.0"

--- a/crates/external_services/Cargo.toml
+++ b/crates/external_services/Cargo.toml
@@ -74,7 +74,7 @@ http = "0.2.12"
 url = { version = "2.5.4", features = ["serde"] }
 quick-xml = { version = "0.31.0", features = ["serialize"] }
 
-unified-connector-service-client = { git = "https://github.com/juspay/hyperswitch-prism", rev = "1b83744ff6a8ed86b24a98867a8bdae8bd7d8001", package = "rust-grpc-client" }
+unified-connector-service-client = { git = "https://github.com/juspay/hyperswitch-prism", rev = "b5da6133e497d3fe6146691262f438cfcf99d58e", package = "rust-grpc-client" }
 open-feature = { version = "0.2.5", optional = true }
 superposition_provider = { version = "0.102.0", optional = true}
 superposition_types = "0.102.0"

--- a/crates/external_services/Cargo.toml
+++ b/crates/external_services/Cargo.toml
@@ -74,7 +74,7 @@ http = "0.2.12"
 url = { version = "2.5.4", features = ["serde"] }
 quick-xml = { version = "0.31.0", features = ["serialize"] }
 
-unified-connector-service-client = { git = "https://github.com/juspay/hyperswitch-prism", rev = "b5da6133e497d3fe6146691262f438cfcf99d58e", package = "rust-grpc-client" }
+unified-connector-service-client = { git = "https://github.com/juspay/hyperswitch-prism", rev = "90ff39981d44e51babfd4eccf18fa8ffbe49d4a2", package = "rust-grpc-client" }
 open-feature = { version = "0.2.5", optional = true }
 superposition_provider = { version = "0.102.0", optional = true}
 superposition_types = "0.102.0"

--- a/crates/external_services/Cargo.toml
+++ b/crates/external_services/Cargo.toml
@@ -74,7 +74,7 @@ http = "0.2.12"
 url = { version = "2.5.4", features = ["serde"] }
 quick-xml = { version = "0.31.0", features = ["serialize"] }
 
-unified-connector-service-client = { git = "https://github.com/juspay/connector-service", tag = "2026.05.25.0", package = "rust-grpc-client" }
+unified-connector-service-client = { git = "https://github.com/juspay/hyperswitch-prism", rev = "1b83744ff6a8ed86b24a98867a8bdae8bd7d8001", package = "rust-grpc-client" }
 open-feature = { version = "0.2.5", optional = true }
 superposition_provider = { version = "0.102.0", optional = true}
 superposition_types = "0.102.0"

--- a/crates/external_services/src/grpc_client/unified_connector_service.rs
+++ b/crates/external_services/src/grpc_client/unified_connector_service.rs
@@ -659,9 +659,9 @@ impl UnifiedConnectorServiceClient {
 
         *request.metadata_mut() = metadata;
 
-        self.payment_service_client
-            .clone()
-            .authorize(request)
+        // Box the authorize future: the merged UCS proto request types are large enough
+        // to trip clippy::large_futures when this is awaited inline.
+        Box::pin(self.payment_service_client.clone().authorize(request))
             .await
             .map_err(|error| {
                 error_stack::Report::new(UnifiedConnectorServiceError::from_grpc_error(

--- a/crates/hyperswitch_connectors/src/connectors/santander/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/santander/transformers.rs
@@ -675,8 +675,9 @@ impl
                 SantanderDocumentKind::Cnpj,
                 Some(customer_document_details.document_number),
             ),
-            // Santander is Brazil-only (CPF/CNPJ); `Other` is not expected here.
-            common_types::customers::DocumentKind::Other => (
+            // Santander is Brazil-only (CPF/CNPJ); `Other`/`Psn` are not expected here.
+            common_types::customers::DocumentKind::Other
+            | common_types::customers::DocumentKind::Psn => (
                 SantanderDocumentKind::Cpf,
                 Some(customer_document_details.document_number),
             ),
@@ -823,8 +824,9 @@ impl
             common_types::customers::DocumentKind::Cnpj => {
                 (None, Some(customer_document_details.document_number))
             }
-            // Santander is Brazil-only (CPF/CNPJ); `Other` is not expected here.
-            common_types::customers::DocumentKind::Other => {
+            // Santander is Brazil-only (CPF/CNPJ); `Other`/`Psn` are not expected here.
+            common_types::customers::DocumentKind::Other
+            | common_types::customers::DocumentKind::Psn => {
                 (Some(customer_document_details.document_number), None)
             }
         };
@@ -1295,8 +1297,9 @@ impl From<common_types::customers::DocumentKind> for SantanderDocumentKind {
         match item {
             common_types::customers::DocumentKind::Cnpj => Self::Cnpj,
             common_types::customers::DocumentKind::Cpf => Self::Cpf,
-            // Santander is Brazil-only (CPF/CNPJ); `Other` is not expected here.
-            common_types::customers::DocumentKind::Other => Self::Cpf,
+            // Santander is Brazil-only (CPF/CNPJ); `Other`/`Psn` are not expected here.
+            common_types::customers::DocumentKind::Other
+            | common_types::customers::DocumentKind::Psn => Self::Cpf,
         }
     }
 }
@@ -2353,8 +2356,9 @@ impl
                 common_types::customers::DocumentKind::Cnpj => {
                     (None, Some(details.document_number.clone()))
                 }
-                // Santander is Brazil-only (CPF/CNPJ); `Other` is not expected here.
-                common_types::customers::DocumentKind::Other => {
+                // Santander is Brazil-only (CPF/CNPJ); `Other`/`Psn` are not expected here.
+                common_types::customers::DocumentKind::Other
+                | common_types::customers::DocumentKind::Psn => {
                     (Some(details.document_number.clone()), None)
                 }
             })
@@ -2628,8 +2632,9 @@ impl TryFrom<&PaymentsPushNotificationRouterData> for SantanderPixAutomaticSolic
             common_types::customers::DocumentKind::Cnpj => {
                 (None, Some(customer_document_details.document_number))
             }
-            // Santander is Brazil-only (CPF/CNPJ); `Other` is not expected here.
-            common_types::customers::DocumentKind::Other => {
+            // Santander is Brazil-only (CPF/CNPJ); `Other`/`Psn` are not expected here.
+            common_types::customers::DocumentKind::Other
+            | common_types::customers::DocumentKind::Psn => {
                 (Some(customer_document_details.document_number), None)
             }
         };

--- a/crates/hyperswitch_connectors/src/connectors/santander/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/santander/transformers.rs
@@ -675,6 +675,11 @@ impl
                 SantanderDocumentKind::Cnpj,
                 Some(customer_document_details.document_number),
             ),
+            // Santander is Brazil-only (CPF/CNPJ); `Other` is not expected here.
+            common_types::customers::DocumentKind::Other => (
+                SantanderDocumentKind::Cpf,
+                Some(customer_document_details.document_number),
+            ),
         };
 
         let order_id = value
@@ -817,6 +822,10 @@ impl
             }
             common_types::customers::DocumentKind::Cnpj => {
                 (None, Some(customer_document_details.document_number))
+            }
+            // Santander is Brazil-only (CPF/CNPJ); `Other` is not expected here.
+            common_types::customers::DocumentKind::Other => {
+                (Some(customer_document_details.document_number), None)
             }
         };
 
@@ -1286,6 +1295,8 @@ impl From<common_types::customers::DocumentKind> for SantanderDocumentKind {
         match item {
             common_types::customers::DocumentKind::Cnpj => Self::Cnpj,
             common_types::customers::DocumentKind::Cpf => Self::Cpf,
+            // Santander is Brazil-only (CPF/CNPJ); `Other` is not expected here.
+            common_types::customers::DocumentKind::Other => Self::Cpf,
         }
     }
 }
@@ -2342,6 +2353,10 @@ impl
                 common_types::customers::DocumentKind::Cnpj => {
                     (None, Some(details.document_number.clone()))
                 }
+                // Santander is Brazil-only (CPF/CNPJ); `Other` is not expected here.
+                common_types::customers::DocumentKind::Other => {
+                    (Some(details.document_number.clone()), None)
+                }
             })
             .ok_or(errors::ConnectorError::MissingRequiredField {
                 field_name: "customer.document_details",
@@ -2612,6 +2627,10 @@ impl TryFrom<&PaymentsPushNotificationRouterData> for SantanderPixAutomaticSolic
             }
             common_types::customers::DocumentKind::Cnpj => {
                 (None, Some(customer_document_details.document_number))
+            }
+            // Santander is Brazil-only (CPF/CNPJ); `Other` is not expected here.
+            common_types::customers::DocumentKind::Other => {
+                (Some(customer_document_details.document_number), None)
             }
         };
 

--- a/crates/hyperswitch_connectors/src/connectors/santander/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/santander/transformers.rs
@@ -676,8 +676,8 @@ impl
                 Some(customer_document_details.document_number),
             ),
             // Santander is Brazil-only (CPF/CNPJ); `Other`/`Psn` are not expected here.
-            common_types::customers::DocumentKind::Other
-            | common_types::customers::DocumentKind::Psn => (
+            common_types::customers::DocumentKind::Psn
+            | common_types::customers::DocumentKind::Other => (
                 SantanderDocumentKind::Cpf,
                 Some(customer_document_details.document_number),
             ),
@@ -825,8 +825,8 @@ impl
                 (None, Some(customer_document_details.document_number))
             }
             // Santander is Brazil-only (CPF/CNPJ); `Other`/`Psn` are not expected here.
-            common_types::customers::DocumentKind::Other
-            | common_types::customers::DocumentKind::Psn => {
+            common_types::customers::DocumentKind::Psn
+            | common_types::customers::DocumentKind::Other => {
                 (Some(customer_document_details.document_number), None)
             }
         };
@@ -1298,8 +1298,8 @@ impl From<common_types::customers::DocumentKind> for SantanderDocumentKind {
             common_types::customers::DocumentKind::Cnpj => Self::Cnpj,
             common_types::customers::DocumentKind::Cpf => Self::Cpf,
             // Santander is Brazil-only (CPF/CNPJ); `Other`/`Psn` are not expected here.
-            common_types::customers::DocumentKind::Other
-            | common_types::customers::DocumentKind::Psn => Self::Cpf,
+            common_types::customers::DocumentKind::Psn
+            | common_types::customers::DocumentKind::Other => Self::Cpf,
         }
     }
 }
@@ -2357,8 +2357,8 @@ impl
                     (None, Some(details.document_number.clone()))
                 }
                 // Santander is Brazil-only (CPF/CNPJ); `Other`/`Psn` are not expected here.
-                common_types::customers::DocumentKind::Other
-                | common_types::customers::DocumentKind::Psn => {
+                common_types::customers::DocumentKind::Psn
+                | common_types::customers::DocumentKind::Other => {
                     (Some(details.document_number.clone()), None)
                 }
             })
@@ -2633,8 +2633,8 @@ impl TryFrom<&PaymentsPushNotificationRouterData> for SantanderPixAutomaticSolic
                 (None, Some(customer_document_details.document_number))
             }
             // Santander is Brazil-only (CPF/CNPJ); `Other`/`Psn` are not expected here.
-            common_types::customers::DocumentKind::Other
-            | common_types::customers::DocumentKind::Psn => {
+            common_types::customers::DocumentKind::Psn
+            | common_types::customers::DocumentKind::Other => {
                 (Some(customer_document_details.document_number), None)
             }
         };

--- a/crates/hyperswitch_interfaces/Cargo.toml
+++ b/crates/hyperswitch_interfaces/Cargo.toml
@@ -33,7 +33,7 @@ time = "0.3.41"
 tonic = "0.14"
 url = { version = "2.5.4", features = ["serde"] }
 
-unified-connector-service-client = { git = "https://github.com/juspay/connector-service", tag = "2026.05.25.0", package = "rust-grpc-client" }
+unified-connector-service-client = { git = "https://github.com/juspay/hyperswitch-prism", rev = "1b83744ff6a8ed86b24a98867a8bdae8bd7d8001", package = "rust-grpc-client" }
 tokio = { version = "1.45.1", features = ["macros", "rt-multi-thread"] }
 
 # First party crates

--- a/crates/hyperswitch_interfaces/Cargo.toml
+++ b/crates/hyperswitch_interfaces/Cargo.toml
@@ -33,7 +33,7 @@ time = "0.3.41"
 tonic = "0.14"
 url = { version = "2.5.4", features = ["serde"] }
 
-unified-connector-service-client = { git = "https://github.com/juspay/hyperswitch-prism", rev = "1b83744ff6a8ed86b24a98867a8bdae8bd7d8001", package = "rust-grpc-client" }
+unified-connector-service-client = { git = "https://github.com/juspay/hyperswitch-prism", rev = "b5da6133e497d3fe6146691262f438cfcf99d58e", package = "rust-grpc-client" }
 tokio = { version = "1.45.1", features = ["macros", "rt-multi-thread"] }
 
 # First party crates

--- a/crates/hyperswitch_interfaces/Cargo.toml
+++ b/crates/hyperswitch_interfaces/Cargo.toml
@@ -33,7 +33,7 @@ time = "0.3.41"
 tonic = "0.14"
 url = { version = "2.5.4", features = ["serde"] }
 
-unified-connector-service-client = { git = "https://github.com/juspay/hyperswitch-prism", rev = "b5da6133e497d3fe6146691262f438cfcf99d58e", package = "rust-grpc-client" }
+unified-connector-service-client = { git = "https://github.com/juspay/hyperswitch-prism", rev = "90ff39981d44e51babfd4eccf18fa8ffbe49d4a2", package = "rust-grpc-client" }
 tokio = { version = "1.45.1", features = ["macros", "rt-multi-thread"] }
 
 # First party crates

--- a/crates/hyperswitch_interfaces/Cargo.toml
+++ b/crates/hyperswitch_interfaces/Cargo.toml
@@ -33,7 +33,7 @@ time = "0.3.41"
 tonic = "0.14"
 url = { version = "2.5.4", features = ["serde"] }
 
-unified-connector-service-client = { git = "https://github.com/juspay/hyperswitch-prism", rev = "90ff39981d44e51babfd4eccf18fa8ffbe49d4a2", package = "rust-grpc-client" }
+unified-connector-service-client = { git = "https://github.com/juspay/hyperswitch-prism", tag = "2026.06.10.0", package = "rust-grpc-client" }
 tokio = { version = "1.45.1", features = ["macros", "rt-multi-thread"] }
 
 # First party crates

--- a/crates/router/Cargo.toml
+++ b/crates/router/Cargo.toml
@@ -91,8 +91,8 @@ ring = "0.17.14"
 rust_decimal = { version = "1.37.1", features = ["serde-with-float", "serde-with-str"] }
 rust-i18n = { git = "https://github.com/kashif-m/rust-i18n", rev = "f2d8096aaaff7a87a847c35a5394c269f75e077a" }
 
-unified-connector-service-client = { git = "https://github.com/juspay/connector-service", tag = "2026.05.25.0", package = "rust-grpc-client" }
-unified-connector-service-cards = { git = "https://github.com/juspay/connector-service", tag = "2026.05.25.0", package = "ucs_cards" }
+unified-connector-service-client = { git = "https://github.com/juspay/hyperswitch-prism", rev = "1b83744ff6a8ed86b24a98867a8bdae8bd7d8001", package = "rust-grpc-client" }
+unified-connector-service-cards = { git = "https://github.com/juspay/hyperswitch-prism", rev = "1b83744ff6a8ed86b24a98867a8bdae8bd7d8001", package = "ucs_cards" }
 rustc-hash = "1.1.0"
 rustls = "0.22"
 rustls-pemfile = "2"

--- a/crates/router/Cargo.toml
+++ b/crates/router/Cargo.toml
@@ -91,8 +91,8 @@ ring = "0.17.14"
 rust_decimal = { version = "1.37.1", features = ["serde-with-float", "serde-with-str"] }
 rust-i18n = { git = "https://github.com/kashif-m/rust-i18n", rev = "f2d8096aaaff7a87a847c35a5394c269f75e077a" }
 
-unified-connector-service-client = { git = "https://github.com/juspay/hyperswitch-prism", rev = "90ff39981d44e51babfd4eccf18fa8ffbe49d4a2", package = "rust-grpc-client" }
-unified-connector-service-cards = { git = "https://github.com/juspay/hyperswitch-prism", rev = "90ff39981d44e51babfd4eccf18fa8ffbe49d4a2", package = "ucs_cards" }
+unified-connector-service-client = { git = "https://github.com/juspay/hyperswitch-prism", tag = "2026.06.10.0", package = "rust-grpc-client" }
+unified-connector-service-cards = { git = "https://github.com/juspay/hyperswitch-prism", tag = "2026.06.10.0", package = "ucs_cards" }
 rustc-hash = "1.1.0"
 rustls = "0.22"
 rustls-pemfile = "2"

--- a/crates/router/Cargo.toml
+++ b/crates/router/Cargo.toml
@@ -91,8 +91,8 @@ ring = "0.17.14"
 rust_decimal = { version = "1.37.1", features = ["serde-with-float", "serde-with-str"] }
 rust-i18n = { git = "https://github.com/kashif-m/rust-i18n", rev = "f2d8096aaaff7a87a847c35a5394c269f75e077a" }
 
-unified-connector-service-client = { git = "https://github.com/juspay/hyperswitch-prism", rev = "1b83744ff6a8ed86b24a98867a8bdae8bd7d8001", package = "rust-grpc-client" }
-unified-connector-service-cards = { git = "https://github.com/juspay/hyperswitch-prism", rev = "1b83744ff6a8ed86b24a98867a8bdae8bd7d8001", package = "ucs_cards" }
+unified-connector-service-client = { git = "https://github.com/juspay/hyperswitch-prism", rev = "b5da6133e497d3fe6146691262f438cfcf99d58e", package = "rust-grpc-client" }
+unified-connector-service-cards = { git = "https://github.com/juspay/hyperswitch-prism", rev = "b5da6133e497d3fe6146691262f438cfcf99d58e", package = "ucs_cards" }
 rustc-hash = "1.1.0"
 rustls = "0.22"
 rustls-pemfile = "2"

--- a/crates/router/Cargo.toml
+++ b/crates/router/Cargo.toml
@@ -91,8 +91,8 @@ ring = "0.17.14"
 rust_decimal = { version = "1.37.1", features = ["serde-with-float", "serde-with-str"] }
 rust-i18n = { git = "https://github.com/kashif-m/rust-i18n", rev = "f2d8096aaaff7a87a847c35a5394c269f75e077a" }
 
-unified-connector-service-client = { git = "https://github.com/juspay/hyperswitch-prism", rev = "b5da6133e497d3fe6146691262f438cfcf99d58e", package = "rust-grpc-client" }
-unified-connector-service-cards = { git = "https://github.com/juspay/hyperswitch-prism", rev = "b5da6133e497d3fe6146691262f438cfcf99d58e", package = "ucs_cards" }
+unified-connector-service-client = { git = "https://github.com/juspay/hyperswitch-prism", rev = "90ff39981d44e51babfd4eccf18fa8ffbe49d4a2", package = "rust-grpc-client" }
+unified-connector-service-cards = { git = "https://github.com/juspay/hyperswitch-prism", rev = "90ff39981d44e51babfd4eccf18fa8ffbe49d4a2", package = "ucs_cards" }
 rustc-hash = "1.1.0"
 rustls = "0.22"
 rustls-pemfile = "2"

--- a/crates/router/src/core/unified_connector_service.rs
+++ b/crates/router/src/core/unified_connector_service.rs
@@ -1435,6 +1435,13 @@ pub fn build_unified_connector_service_payment_method(
                         })),
                     })
                 }
+                hyperswitch_domain_models::payment_method_data::WalletData::GcashRedirect(_) => {
+                    Ok(payments_grpc::PaymentMethod {
+                        payment_method: Some(PaymentMethod::GcashRedirect(
+                            payments_grpc::GcashRedirectWallet {},
+                        )),
+                    })
+                }
                 _ => Err(UnifiedConnectorServiceError::NotImplemented(format!(
                     "Unimplemented payment method subtype: {payment_method_type:?}"
                 ))
@@ -1603,6 +1610,7 @@ pub fn build_unified_connector_service_payment_method(
                                 social_security_number: boleto_data
                                     .social_security_number
                                     .map(|ssn| ssn.expose()),
+                                expiration_date: boleto_data.due_date.clone(),
                             },
                         )),
                     })

--- a/crates/router/src/core/unified_connector_service/transformers.rs
+++ b/crates/router/src/core/unified_connector_service/transformers.rs
@@ -196,6 +196,9 @@ impl
             return_url: router_data.request.router_return_url.clone(),
             test_mode: router_data.test_mode,
             customer: Some(payments_grpc::Customer {
+                first_name: None,
+                last_name: None,
+                salutation: None,
                 name: None,
                 email: None,
                 id: router_data
@@ -301,6 +304,9 @@ impl
                 router_data.request.request_incremental_authorization,
             ),
             customer: Some(payments_grpc::Customer {
+                first_name: None,
+                last_name: None,
+                salutation: None,
                 name: router_data
                     .request
                     .customer_name
@@ -521,6 +527,9 @@ impl
                 router_data.request.request_incremental_authorization,
             ),
             customer: Some(payments_grpc::Customer {
+                first_name: None,
+                last_name: None,
+                salutation: None,
                 name: None,
                 email: router_data
                     .request
@@ -759,6 +768,8 @@ impl transformers::ForeignTryFrom<&RouterData<PSync, PaymentsSyncData, PaymentsR
             ),
             metadata: None,
             test_mode: router_data.test_mode,
+            // Placeholder; payment_method_type is not currently threaded into sync.
+            payment_method_type: None,
             payment_experience: router_data
                 .request
                 .payment_experience
@@ -891,6 +902,9 @@ impl
                 }),
             payment_method,
             customer: Some(payments_grpc::Customer {
+                first_name: None,
+                last_name: None,
+                salutation: None,
                 name: None,
                 email: router_data
                     .request
@@ -981,6 +995,9 @@ impl
                 }),
             payment_method,
             customer: Some(payments_grpc::Customer {
+                first_name: None,
+                last_name: None,
+                salutation: None,
                 name: None,
                 email: router_data
                     .request
@@ -1072,6 +1089,9 @@ impl
             }),
             payment_method: Some(payment_method),
             customer: Some(payments_grpc::Customer {
+                first_name: None,
+                last_name: None,
+                salutation: None,
                 name: router_data
                     .request
                     .customer_name
@@ -1258,6 +1278,9 @@ impl
             enrolled_for_3ds: Some(false),
             request_incremental_authorization: Some(false),
             customer: Some(payments_grpc::Customer {
+                first_name: None,
+                last_name: None,
+                salutation: None,
                 name: None,
                 email: router_data
                     .request
@@ -1411,6 +1434,9 @@ impl
                 .order_tax_amount
                 .map(|order_tax_amount| order_tax_amount.get_amount_as_i64()),
             customer: Some(payments_grpc::Customer {
+                first_name: None,
+                last_name: None,
+                salutation: None,
                 name: router_data
                     .request
                     .customer_name
@@ -1579,6 +1605,9 @@ impl
                 router_data.request.request_incremental_authorization,
             ),
             customer: Some(payments_grpc::Customer {
+                first_name: None,
+                last_name: None,
+                salutation: None,
                 name: router_data
                     .request
                     .customer_name
@@ -1725,6 +1754,9 @@ impl
             }),
             payment_method: Some(payment_method),
             customer: Some(payments_grpc::Customer {
+                first_name: None,
+                last_name: None,
+                salutation: None,
                 name: router_data
                     .request
                     .customer_name
@@ -2003,6 +2035,9 @@ impl
             l2_l3_data: None,
             customer_document_details: to_grpc_customer_document_details(router_data),
             customer: Some(payments_grpc::Customer {
+                first_name: None,
+                last_name: None,
+                salutation: None,
                 name: router_data
                     .request
                     .customer_name
@@ -2063,6 +2098,9 @@ impl transformers::ForeignTryFrom<&RouterData<Session, PaymentsSessionData, Paym
                 .map(|payment_method_type| payment_method_type.into()),
             country_alpha2_code: country,
             customer: Some(payments_grpc::Customer {
+                first_name: None,
+                last_name: None,
+                salutation: None,
                 name: router_data
                     .request
                     .customer_name
@@ -6222,6 +6260,10 @@ impl ForeignFrom<&router_request_types::CustomerDetails> for payments_grpc::Cust
             email: customer.email.clone().map(|e| e.expose().expose().into()),
             phone_number: customer.phone.clone().map(|s| s.expose()),
             phone_country_code: customer.phone_country_code.clone(),
+            // CustomerDetails does not carry these proto fields; placeholders for now.
+            first_name: None,
+            last_name: None,
+            salutation: None,
             // Payout CustomerDetails does not carry an identification document.
             customer_document_details: None,
         }

--- a/crates/router/src/core/unified_connector_service/transformers.rs
+++ b/crates/router/src/core/unified_connector_service/transformers.rs
@@ -83,6 +83,40 @@ pub fn build_upi_wait_screen_data(
         .attach_printable("Failed to serialize WaitScreenInstructions to JSON value")
 }
 
+/// Maps the optional customer identification document on a `RouterData` to the
+/// gRPC `CustomerDocumentDetails` sent to the Unified Connector Service.
+///
+/// `document_type` is encoded as the `DocumentKind` enum's `i32` discriminant
+/// (Cpf -> CPF, Cnpj -> CNPJ); `document_number` is passed through as a masked
+/// secret. Returns `None` when no document is present on the source data.
+fn to_grpc_customer_document_details<F, Req, Res>(
+    router_data: &RouterData<F, Req, Res>,
+) -> Option<payments_grpc::CustomerDocumentDetails> {
+    router_data
+        .customer_document_details
+        .as_ref()
+        .map(|details| {
+            let document_type = match details.document_type {
+                common_types::customers::DocumentKind::Cpf => {
+                    i32::from(payments_grpc::DocumentKind::Cpf)
+                }
+                common_types::customers::DocumentKind::Cnpj => {
+                    i32::from(payments_grpc::DocumentKind::Cnpj)
+                }
+                // Non-Brazilian document (e.g. Philippine PSN). Carried as the proto
+                // OTHER type; UCS keeps it and forwards document_number as-is, validated
+                // by the connector per country.
+                common_types::customers::DocumentKind::Other => {
+                    i32::from(payments_grpc::DocumentKind::Other)
+                }
+            };
+            payments_grpc::CustomerDocumentDetails {
+                document_type,
+                document_number: Some(details.document_number.clone()),
+            }
+        })
+}
+
 impl transformers::ForeignTryFrom<&payments_grpc::AccessToken> for AccessToken {
     type Error = error_stack::Report<UnifiedConnectorServiceError>;
 
@@ -171,7 +205,12 @@ impl
                 connector_customer_id: router_data.connector_customer.clone(),
                 phone_number: None,
                 phone_country_code: None,
+                customer_document_details: to_grpc_customer_document_details(router_data),
             }),
+            state: router_data
+                .access_token
+                .as_ref()
+                .map(ConnectorState::foreign_from),
         })
     }
 }
@@ -280,6 +319,7 @@ impl
                 connector_customer_id: router_data.connector_customer.clone(),
                 phone_number: None,
                 phone_country_code: None,
+                customer_document_details: to_grpc_customer_document_details(router_data),
             }),
             browser_info,
             session_token: router_data.session_token.clone(),
@@ -491,6 +531,7 @@ impl
                 connector_customer_id: router_data.connector_customer.clone(),
                 phone_number: None,
                 phone_country_code: None,
+                customer_document_details: to_grpc_customer_document_details(router_data),
             }),
             browser_info,
             session_token: router_data.session_token.clone(),
@@ -860,6 +901,7 @@ impl
                 connector_customer_id: router_data.connector_customer.clone(),
                 phone_number: None,
                 phone_country_code: None,
+                customer_document_details: to_grpc_customer_document_details(router_data),
             }),
             address: Some(address),
             authentication_data,
@@ -949,6 +991,7 @@ impl
                 connector_customer_id: router_data.connector_customer.clone(),
                 phone_number: None,
                 phone_country_code: None,
+                customer_document_details: to_grpc_customer_document_details(router_data),
             }),
             address: Some(address),
             authentication_data: None,
@@ -1043,6 +1086,7 @@ impl
                 connector_customer_id: router_data.connector_customer.clone(),
                 phone_number: None,
                 phone_country_code: None,
+                customer_document_details: to_grpc_customer_document_details(router_data),
             }),
             address: Some(address),
             enrolled_for_3ds: router_data.request.enrolled_for_3ds,
@@ -1224,6 +1268,7 @@ impl
                 connector_customer_id: router_data.connector_customer.clone(),
                 phone_number: None,
                 phone_country_code: None,
+                customer_document_details: to_grpc_customer_document_details(router_data),
             }),
             browser_info,
             locale: None,
@@ -1384,6 +1429,7 @@ impl
                 connector_customer_id: router_data.connector_customer.clone(),
                 phone_number: None,
                 phone_country_code: None,
+                customer_document_details: to_grpc_customer_document_details(router_data),
             }),
             capture_method: capture_method.map(|capture_method| capture_method.into()),
             webhook_url: router_data.request.webhook_url.clone(),
@@ -1551,6 +1597,7 @@ impl
                 connector_customer_id: router_data.connector_customer.clone(),
                 phone_number: None,
                 phone_country_code: None,
+                customer_document_details: to_grpc_customer_document_details(router_data),
             }),
             browser_info,
             locale: None,
@@ -1696,6 +1743,7 @@ impl
                 connector_customer_id: router_data.connector_customer.clone(),
                 phone_number: None,
                 phone_country_code: None,
+                customer_document_details: to_grpc_customer_document_details(router_data),
             }),
             address: Some(address),
             auth_type: auth_type.into(),
@@ -1953,6 +2001,7 @@ impl
                 .transpose()?
                 .map(|currency| currency.into()),
             l2_l3_data: None,
+            customer_document_details: to_grpc_customer_document_details(router_data),
             customer: Some(payments_grpc::Customer {
                 name: router_data
                     .request
@@ -1971,6 +2020,7 @@ impl
                 connector_customer_id: router_data.connector_customer.clone(),
                 phone_number: None,
                 phone_country_code: None,
+                customer_document_details: to_grpc_customer_document_details(router_data),
             }),
         })
     }
@@ -2030,6 +2080,7 @@ impl transformers::ForeignTryFrom<&RouterData<Session, PaymentsSessionData, Paym
                 connector_customer_id: router_data.connector_customer.clone(),
                 phone_number: None,
                 phone_country_code: None,
+                customer_document_details: to_grpc_customer_document_details(router_data),
             }),
             return_url: None,
             metadata: None,
@@ -6171,6 +6222,8 @@ impl ForeignFrom<&router_request_types::CustomerDetails> for payments_grpc::Cust
             email: customer.email.clone().map(|e| e.expose().expose().into()),
             phone_number: customer.phone.clone().map(|s| s.expose()),
             phone_country_code: customer.phone_country_code.clone(),
+            // Payout CustomerDetails does not carry an identification document.
+            customer_document_details: None,
         }
     }
 }

--- a/crates/router/src/core/unified_connector_service/transformers.rs
+++ b/crates/router/src/core/unified_connector_service/transformers.rs
@@ -103,11 +103,16 @@ fn to_grpc_customer_document_details<F, Req, Res>(
                 common_types::customers::DocumentKind::Cnpj => {
                     i32::from(payments_grpc::DocumentKind::Cnpj)
                 }
-                // Non-Brazilian document (e.g. Philippine PSN). Carried as the proto
-                // OTHER type; UCS keeps it and forwards document_number as-is, validated
-                // by the connector per country.
+                // Generic non-Brazilian document. Carried as the proto OTHER type; UCS
+                // keeps it and forwards document_number as-is, validated by the connector
+                // per country.
                 common_types::customers::DocumentKind::Other => {
                     i32::from(payments_grpc::DocumentKind::Other)
+                }
+                // Philippine PhilSys Number — mapped to the dedicated proto PSN type so the
+                // connector (dLocal/GCash) can validate it as a 12-digit national ID.
+                common_types::customers::DocumentKind::Psn => {
+                    i32::from(payments_grpc::DocumentKind::Psn)
                 }
             };
             payments_grpc::CustomerDocumentDetails {

--- a/crates/router/src/core/unified_connector_service/transformers.rs
+++ b/crates/router/src/core/unified_connector_service/transformers.rs
@@ -103,16 +103,16 @@ fn to_grpc_customer_document_details<F, Req, Res>(
                 common_types::customers::DocumentKind::Cnpj => {
                     i32::from(payments_grpc::DocumentKind::Cnpj)
                 }
+                // Philippine PhilSys Number — mapped to the dedicated proto PSN type so the
+                // connector (dLocal/GCash) can validate it as a 12-digit national ID.
+                common_types::customers::DocumentKind::Psn => {
+                    i32::from(payments_grpc::DocumentKind::Psn)
+                }
                 // Generic non-Brazilian document. Carried as the proto OTHER type; UCS
                 // keeps it and forwards document_number as-is, validated by the connector
                 // per country.
                 common_types::customers::DocumentKind::Other => {
                     i32::from(payments_grpc::DocumentKind::Other)
-                }
-                // Philippine PhilSys Number — mapped to the dedicated proto PSN type so the
-                // connector (dLocal/GCash) can validate it as a 12-digit national ID.
-                common_types::customers::DocumentKind::Psn => {
-                    i32::from(payments_grpc::DocumentKind::Psn)
                 }
             };
             payments_grpc::CustomerDocumentDetails {


### PR DESCRIPTION
## Summary

HyperSwitch-side counterpart to prism **[#1459](https://github.com/juspay/hyperswitch-prism/pull/1459)** — the changes the orchestrator needs to drive dLocal **GCash (incl. Recurring CIT/MIT)** and the APM redirect methods through the Unified Connector Service.

## Changes

- **`DocumentKind::Other`** (`common_types`) — a non‑Brazilian national document (e.g. the Philippine PSN dLocal requires for GCash). `validate()` passes it through unchanged (the connector/PSP validates per country); exhaustive match arms added in `api_models` and the Brazil‑only `santander` connector.
- **UCS client** (`router::core::unified_connector_service`):
  - send `customer_document_details` to UCS (maps `DocumentKind` → proto `DocumentKind`; `Other` → `OTHER`).
  - map the `GcashRedirect` wallet in the payment‑method encoder.
  - forward the boleto due/expiration date.
- **Pin** the UCS client crates to `hyperswitch-prism` released nightly tag **`2026.06.10.0`** (prism [#1459](https://github.com/juspay/hyperswitch-prism/pull/1459) merged) — the proto contract (`DocumentKind` Cpf/Cnpj/Psn/Other, `customer_document_details`, `GcashRedirect`).

## Validation

- `cargo +nightly fmt --all --check` ✅
- `cargo clippy` (router + changed crates) ✅
- Build ✅
- End‑to‑end **HS → UCS → dLocal** verified live (GCash one‑time, GCash Recurring CIT + MIT, all 10 APM redirect methods). Real grpcurl runs + responses are attached on prism [1459](https://github.com/juspay/hyperswitch-prism/pull/1459).

<details>
<summary><b>Working examples — GCash Recurring CIT + MIT (HS API, masked)</b></summary>

**CIT — enroll + charge** (`setup_future_usage: off_session` + `amount > 0` → Authorize with `RG` + `wallet.save`):
```bash
curl -s localhost:8080/payments -H 'api-key: $API_KEY' -H 'content-type: application/json' -d '{
  "amount": 6540, "currency": "PHP", "confirm": true, "capture_method": "automatic",
  "authentication_type": "no_three_ds", "setup_future_usage": "off_session",
  "customer_id": "customer123",
  "customer": {"id":"customer123","name":"Juan Dela Cruz","email":"customer@example.com",
    "phone":"9171234567","phone_country_code":"+63",
    "document_details":{"document_type":"other","document_number":"************"}},
  "routing": {"type":"single","data":"dlocal"},
  "payment_method": "wallet", "payment_method_type": "gcash",
  "payment_method_data": {"wallet":{"gcash_redirect":{}}},
  "billing": {"address":{"line1":"123 Rizal Ave","city":"Manila","state":"Metro Manila",
    "zip":"1000","country":"PH","first_name":"Juan","last_name":"Dela Cruz"},
    "phone":{"number":"9171234567","country_code":"+63"}},
  "customer_acceptance": {"acceptance_type":"online","accepted_at":"2026-01-01T00:00:00Z",
    "online":{"ip_address":"125.0.0.1","user_agent":"Mozilla/5.0"}},
  "return_url": "https://example.com/return"
}'
# -> status: requires_customer_action  (+ dLocal redirect)
# after redirect, the dLocal IPN settles it:
#    source_verified: true, status: CHARGED, connector_mandate_id persisted (active) -> succeeded
```

**MIT — recurring charge with the stored token** (no `payment_method_data`, no redirect):
```bash
curl -s localhost:8080/payments -H 'api-key: $API_KEY' -H 'content-type: application/json' -d '{
  "amount": 6540, "currency": "PHP", "confirm": true, "capture_method": "automatic",
  "customer_id": "customer123", "off_session": true,
  "recurring_details": {"type":"payment_method_id","data":"pm_xxxxxxxxxxxxxxxxxxxx"},
  "routing": {"type":"single","data":"dlocal"},
  "merchant_order_reference_id": "gcash_rg_mit_001"
}'
# -> RepeatPayment -> UCS RecurringPaymentService/Charge -> dLocal RG token replay
#    sync status: requires_customer_action (AuthenticationPending; dLocal settles GCash async)
```
</details>

<details>
<summary><b>Proof — end‑to‑end chain + MIT webhook <code>CHARGED</code> after ~8s (live run)</b></summary>

```
CIT   POST /payments  off_session, amt>0       -> Authorize -> dLocal RG+wallet.save -> requires_customer_action
CIT   IPN  /webhooks/{MID}/{MCA}               -> UCS EventService: source_verified=true, CHARGED,
                                                  connector_mandate_id persisted (status: active) -> succeeded
MIT   POST /payments  recurring_details+off_session -> RepeatPayment -> UCS RecurringPaymentService/Charge
        20:52:37  -> dLocal 200 PENDING(100)                          (sync = AuthenticationPending)
        ...~8.1s (off_session; no shopper)...
        20:52:45  -> IPN -> UCS EventService: PAYMENT_INTENT_SUCCESS, status CHARGED, status_code 200,
                          source_verified: true, error: {} (empty), mandate_reference.connector_mandate_id present
                   -> HS: succeeded
```
Δt(MIT charge → CHARGED webhook) ≈ **8.1s**.
</details>

> The deployed `grpc-server` must be built from the same prism release (the connector transformers + webhook handler live there); this PR pins only the **proto contract** (nightly tag `2026.06.10.0`) and adds the HS‑side plumbing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

