### PR TITLE
feat(redis_interface): redis metrics addition

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7702,6 +7702,7 @@ dependencies = [
  "fred",
  "futures 0.3.31",
  "redis",
+ "router_env",
  "serde",
  "thiserror 1.0.69",
  "tokio 1.48.0",

--- a/crates/drainer/Cargo.toml
+++ b/crates/drainer/Cargo.toml
@@ -13,8 +13,8 @@ release = ["vergen", "external_services/aws_kms"]
 vergen = ["router_env/vergen"]
 v1 = ["diesel_models/v1", "external_services/v1", "hyperswitch_interfaces/v1", "common_utils/v1"]
 v2 = ["diesel_models/v2", "external_services/v2", "hyperswitch_interfaces/v2", "common_utils/v2"]
-fred     = ["redis_interface/fred"]
-redis-rs = ["redis_interface/redis-rs"]
+fred     = ["redis_interface/fred",     "redis_interface/metrics"]
+redis-rs = ["redis_interface/redis-rs", "redis_interface/metrics"]
 
 [dependencies]
 actix-web = "4.11.0"

--- a/crates/redis_interface/Cargo.toml
+++ b/crates/redis_interface/Cargo.toml
@@ -1,4 +1,4 @@
-crates/redis_interface/Cargo.toml[package]
+[package]
 name = "redis_interface"
 description = "A user-friendly interface to Redis"
 version = "0.1.0"

--- a/crates/redis_interface/Cargo.toml
+++ b/crates/redis_interface/Cargo.toml
@@ -12,6 +12,7 @@ default = ["redis-rs"]
 fred = ["dep:fred"]
 redis-rs = ["dep:redis"]
 multitenancy_fallback = []
+metrics = ["dep:router_env"]
 
 [dependencies]
 error-stack = "0.4.1"
@@ -32,7 +33,7 @@ fred = { version = "8.0.6", optional = true, features = [
 
 # First party crates
 common_utils = { version = "0.1.0", path = "../common_utils", features = ["async_ext"] }
-router_env = { version = "0.1.0", path = "../router_env" }
+router_env = { version = "0.1.0", path = "../router_env", optional = true }
 
 [dev-dependencies]
 tokio = { version = "1.48.0", features = ["macros", "rt-multi-thread"] }

--- a/crates/redis_interface/Cargo.toml
+++ b/crates/redis_interface/Cargo.toml
@@ -1,4 +1,4 @@
-[package]
+crates/redis_interface/Cargo.toml[package]
 name = "redis_interface"
 description = "A user-friendly interface to Redis"
 version = "0.1.0"
@@ -32,6 +32,7 @@ fred = { version = "8.0.6", optional = true, features = [
 
 # First party crates
 common_utils = { version = "0.1.0", path = "../common_utils", features = ["async_ext"] }
+router_env = { version = "0.1.0", path = "../router_env" }
 
 [dev-dependencies]
 tokio = { version = "1.48.0", features = ["macros", "rt-multi-thread"] }

--- a/crates/redis_interface/src/lib.rs
+++ b/crates/redis_interface/src/lib.rs
@@ -21,6 +21,7 @@ compile_error!("Features \"fred\" and \"redis-rs\" are mutually exclusive — en
 
 pub mod constant;
 pub mod errors;
+pub mod metrics;
 pub mod types;
 
 #[cfg(feature = "fred")]

--- a/crates/redis_interface/src/lib.rs
+++ b/crates/redis_interface/src/lib.rs
@@ -21,7 +21,7 @@ compile_error!("Features \"fred\" and \"redis-rs\" are mutually exclusive — en
 
 pub mod constant;
 pub mod errors;
-pub mod metrics;
+pub(crate) mod metrics;
 pub mod types;
 
 #[cfg(feature = "fred")]

--- a/crates/redis_interface/src/metrics.rs
+++ b/crates/redis_interface/src/metrics.rs
@@ -1,13 +1,18 @@
-use router_env::{counter_metric, global_meter, histogram_metric_f64};
+//! OpenTelemetry metrics for Redis operations, gated behind the `metrics` feature.
 
-global_meter!(GLOBAL_METER, "ROUTER_API");
+#[cfg(feature = "metrics")]
+use router_env::{global_meter, histogram_metric_f64};
 
-counter_metric!(REDIS_CALLS_COUNT, GLOBAL_METER);
+#[cfg(feature = "metrics")]
+global_meter!(GLOBAL_METER, "REDIS");
+
+// The histogram's `_count` series carries the call count, so no separate counter is needed.
+#[cfg(feature = "metrics")]
 histogram_metric_f64!(REDIS_CALL_TIME, GLOBAL_METER);
 
 /// The Redis operation being performed, used as the `operation` metric label.
 #[derive(Debug)]
-pub enum RedisOperation {
+pub(crate) enum RedisOperation {
     SetKey,
     SetKeyWithoutModifyingTtl,
     SetKeyWithExpiry,
@@ -49,9 +54,10 @@ pub enum RedisOperation {
     EvaluateRedisScript,
 }
 
-/// Time a Redis future and record call-count + latency, tagged by operation.
+/// Times a Redis future and records its latency, tagged by operation.
+#[cfg(feature = "metrics")]
 #[inline]
-pub async fn track_redis_call<Fut, U>(operation: RedisOperation, future: Fut) -> U
+pub(crate) async fn track_redis_call<Fut, U>(operation: RedisOperation, future: Fut) -> U
 where
     Fut: std::future::Future<Output = U>,
 {
@@ -66,9 +72,17 @@ where
     );
 
     let attributes = router_env::metric_attributes!(("operation", format!("{operation:?}")));
-
-    REDIS_CALLS_COUNT.add(1, attributes);
     REDIS_CALL_TIME.record(time_elapsed.as_secs_f64(), attributes);
 
     output
+}
+
+/// No-op pass-through when the `metrics` feature is disabled.
+#[cfg(not(feature = "metrics"))]
+#[inline]
+pub(crate) async fn track_redis_call<Fut, U>(_operation: RedisOperation, future: Fut) -> U
+where
+    Fut: std::future::Future<Output = U>,
+{
+    future.await
 }

--- a/crates/redis_interface/src/metrics.rs
+++ b/crates/redis_interface/src/metrics.rs
@@ -6,7 +6,6 @@ use router_env::{global_meter, histogram_metric_f64};
 #[cfg(feature = "metrics")]
 global_meter!(GLOBAL_METER, "REDIS");
 
-// The histogram's `_count` series carries the call count, so no separate counter is needed.
 #[cfg(feature = "metrics")]
 histogram_metric_f64!(REDIS_CALL_TIME, GLOBAL_METER);
 
@@ -55,7 +54,6 @@ pub(crate) enum RedisOperation {
 }
 
 /// Times a Redis future and records its latency, tagged by operation.
-#[cfg(feature = "metrics")]
 #[inline]
 pub(crate) async fn track_redis_call<Fut, U>(operation: RedisOperation, future: Fut) -> U
 where
@@ -65,24 +63,17 @@ where
     let output = future.await;
     let time_elapsed = start.elapsed();
 
-    router_env::logger::debug!(
+    tracing::debug!(
         redis_operation = ?operation,
         execution_time = ?time_elapsed,
         "Redis operation executed"
     );
 
-    let attributes = router_env::metric_attributes!(("operation", format!("{operation:?}")));
-    REDIS_CALL_TIME.record(time_elapsed.as_secs_f64(), attributes);
+    #[cfg(feature = "metrics")]
+    {
+        let attributes = router_env::metric_attributes!(("operation", format!("{operation:?}")));
+        REDIS_CALL_TIME.record(time_elapsed.as_secs_f64(), attributes);
+    }
 
     output
-}
-
-/// No-op pass-through when the `metrics` feature is disabled.
-#[cfg(not(feature = "metrics"))]
-#[inline]
-pub(crate) async fn track_redis_call<Fut, U>(_operation: RedisOperation, future: Fut) -> U
-where
-    Fut: std::future::Future<Output = U>,
-{
-    future.await
 }

--- a/crates/redis_interface/src/metrics.rs
+++ b/crates/redis_interface/src/metrics.rs
@@ -1,9 +1,3 @@
-//! OpenTelemetry metrics for Redis operations.
-//!
-//! Mirrors the `track_database_call` pattern in `diesel_models`: every Redis
-//! command routes its future through [`track_redis_call`], which records a
-//! call-count counter and a latency histogram tagged by [`RedisOperation`].
-
 use router_env::{counter_metric, global_meter, histogram_metric_f64};
 
 global_meter!(GLOBAL_METER, "ROUTER_API");

--- a/crates/redis_interface/src/metrics.rs
+++ b/crates/redis_interface/src/metrics.rs
@@ -12,11 +12,6 @@ counter_metric!(REDIS_CALLS_COUNT, GLOBAL_METER);
 histogram_metric_f64!(REDIS_CALL_TIME, GLOBAL_METER);
 
 /// The Redis operation being performed, used as the `operation` metric label.
-///
-/// One variant per command function that directly issues a Redis call; shared
-/// by both the `redis_rs` and `fred` backends. Pure delegating wrappers (e.g.
-/// `serialize_and_set_key` → `set_key`) reuse the inner call's variant and have
-/// none of their own to avoid double counting.
 #[derive(Debug)]
 pub enum RedisOperation {
     SetKey,

--- a/crates/redis_interface/src/metrics.rs
+++ b/crates/redis_interface/src/metrics.rs
@@ -1,0 +1,85 @@
+//! OpenTelemetry metrics for Redis operations.
+//!
+//! Mirrors the `track_database_call` pattern in `diesel_models`: every Redis
+//! command routes its future through [`track_redis_call`], which records a
+//! call-count counter and a latency histogram tagged by [`RedisOperation`].
+
+use router_env::{counter_metric, global_meter, histogram_metric_f64};
+
+global_meter!(GLOBAL_METER, "ROUTER_API");
+
+counter_metric!(REDIS_CALLS_COUNT, GLOBAL_METER);
+histogram_metric_f64!(REDIS_CALL_TIME, GLOBAL_METER);
+
+/// The Redis operation being performed, used as the `operation` metric label.
+///
+/// One variant per command function that directly issues a Redis call; shared
+/// by both the `redis_rs` and `fred` backends. Pure delegating wrappers (e.g.
+/// `serialize_and_set_key` → `set_key`) reuse the inner call's variant and have
+/// none of their own to avoid double counting.
+#[derive(Debug)]
+pub enum RedisOperation {
+    SetKey,
+    SetKeyWithoutModifyingTtl,
+    SetKeyWithExpiry,
+    SerializeAndSetKeyWithExpiry,
+    SetMultipleKeysIfNotExist,
+    SetKeyIfNotExistsWithExpiry,
+    SetKeyIfNotExistsAndGetValue,
+    GetKey,
+    GetMultipleKeys,
+    Exists,
+    DeleteKey,
+    SetExpiry,
+    SetExpireAt,
+    GetTtl,
+    SetHashFields,
+    SetHashFieldIfNotExist,
+    IncrementFieldsInHash,
+    GetHashField,
+    GetHashFields,
+    Hscan,
+    Scan,
+    Sadd,
+    StreamAppendEntry,
+    StreamDeleteEntries,
+    StreamTrimEntries,
+    StreamAcknowledgeEntries,
+    StreamGetLength,
+    StreamReadEntries,
+    StreamReadWithOptions,
+    AppendElementsToList,
+    GetListElements,
+    GetListLength,
+    LpopListElements,
+    ConsumerGroupCreate,
+    ConsumerGroupDestroy,
+    ConsumerGroupDeleteConsumer,
+    ConsumerGroupSetLastId,
+    ConsumerGroupSetMessageOwner,
+    EvaluateRedisScript,
+}
+
+/// Time a Redis future and record call-count + latency, tagged by operation.
+#[inline]
+pub async fn track_redis_call<Fut, U>(operation: RedisOperation, future: Fut) -> U
+where
+    Fut: std::future::Future<Output = U>,
+{
+    let start = std::time::Instant::now();
+    let output = future.await;
+    let time_elapsed = start.elapsed();
+
+    router_env::logger::debug!(
+        redis_operation = ?operation,
+        execution_time = ?time_elapsed,
+        "Redis operation executed"
+    );
+
+    let attributes = router_env::metric_attributes!(("operation", format!("{operation:?}")));
+
+    REDIS_CALLS_COUNT.add(1, attributes);
+    REDIS_CALL_TIME.record(time_elapsed.as_secs_f64(), attributes);
+
+    output
+}

--- a/crates/redis_interface/src/module/fred/commands.rs
+++ b/crates/redis_interface/src/module/fred/commands.rs
@@ -255,10 +255,7 @@ impl super::RedisConnectionPool {
             keys.iter().map(|key| key.tenant_aware_key(self)).collect();
 
         let futures = tenant_aware_keys.iter().map(|redis_key| {
-            track_redis_call(
-                RedisOperation::GetMultipleKeys,
-                self.pool.get::<Option<V>, _>(redis_key),
-            )
+            track_redis_call(RedisOperation::GetKey, self.pool.get::<Option<V>, _>(redis_key))
         });
 
         let results = futures::future::try_join_all(futures)

--- a/crates/redis_interface/src/module/fred/commands.rs
+++ b/crates/redis_interface/src/module/fred/commands.rs
@@ -255,7 +255,10 @@ impl super::RedisConnectionPool {
             keys.iter().map(|key| key.tenant_aware_key(self)).collect();
 
         let futures = tenant_aware_keys.iter().map(|redis_key| {
-            track_redis_call(RedisOperation::GetKey, self.pool.get::<Option<V>, _>(redis_key))
+            track_redis_call(
+                RedisOperation::GetKey,
+                self.pool.get::<Option<V>, _>(redis_key),
+            )
         });
 
         let results = futures::future::try_join_all(futures)

--- a/crates/redis_interface/src/module/fred/commands.rs
+++ b/crates/redis_interface/src/module/fred/commands.rs
@@ -24,6 +24,7 @@ use tracing::instrument;
 
 use crate::{
     errors,
+    metrics::{track_redis_call, RedisOperation},
     types::{
         DelReply, HsetnxReply, MsetnxReply, RedisEntryId, RedisKey, SaddReply, SetGetReply,
         SetnxReply, StreamEntries, StreamReadResult, StreamTrimConfig,
@@ -45,16 +46,18 @@ impl super::RedisConnectionPool {
         V: TryInto<RedisValue> + Debug + Send + Sync,
         V::Error: Into<fred::error::RedisError> + Send + Sync,
     {
-        self.pool
-            .set(
+        track_redis_call(
+            RedisOperation::SetKey,
+            self.pool.set(
                 key.tenant_aware_key(self),
                 value,
                 Some(Expiration::EX(self.config.default_ttl.into())),
                 None,
                 false,
-            )
-            .await
-            .change_context(errors::RedisError::SetFailed)
+            ),
+        )
+        .await
+        .change_context(errors::RedisError::SetFailed)
     }
 
     pub async fn set_key_without_modifying_ttl<V>(
@@ -66,16 +69,18 @@ impl super::RedisConnectionPool {
         V: TryInto<RedisValue> + Debug + Send + Sync,
         V::Error: Into<fred::error::RedisError> + Send + Sync,
     {
-        self.pool
-            .set(
+        track_redis_call(
+            RedisOperation::SetKeyWithoutModifyingTtl,
+            self.pool.set(
                 key.tenant_aware_key(self),
                 value,
                 Some(Expiration::KEEPTTL),
                 None,
                 false,
-            )
-            .await
-            .change_context(errors::RedisError::SetFailed)
+            ),
+        )
+        .await
+        .change_context(errors::RedisError::SetFailed)
     }
 
     pub async fn set_multiple_keys_if_not_exist<K, V>(
@@ -95,10 +100,12 @@ impl super::RedisConnectionPool {
             .change_context(errors::RedisError::SetFailed)
             .attach_printable("Failed to convert key-value pairs to fred::types::RedisMap")?;
 
-        self.pool
-            .msetnx(map)
-            .await
-            .change_context(errors::RedisError::SetFailed)
+        track_redis_call(
+            RedisOperation::SetMultipleKeysIfNotExist,
+            self.pool.msetnx(map),
+        )
+        .await
+        .change_context(errors::RedisError::SetFailed)
     }
 
     #[instrument(level = "DEBUG", skip(self))]
@@ -165,16 +172,18 @@ impl super::RedisConnectionPool {
             .encode_to_vec()
             .change_context(errors::RedisError::JsonSerializationFailed)?;
 
-        self.pool
-            .set(
+        track_redis_call(
+            RedisOperation::SerializeAndSetKeyWithExpiry,
+            self.pool.set(
                 key.tenant_aware_key(self),
                 serialized.as_slice(),
                 Some(Expiration::EX(seconds)),
                 None,
                 false,
-            )
-            .await
-            .change_context(errors::RedisError::SetExFailed)
+            ),
+        )
+        .await
+        .change_context(errors::RedisError::SetExFailed)
     }
 
     #[instrument(level = "DEBUG", skip(self))]
@@ -182,11 +191,12 @@ impl super::RedisConnectionPool {
     where
         V: FromRedis + Unpin + Send + 'static,
     {
-        match self
-            .pool
-            .get(key.tenant_aware_key(self))
-            .await
-            .change_context(errors::RedisError::GetFailed)
+        match track_redis_call(
+            RedisOperation::GetKey,
+            self.pool.get(key.tenant_aware_key(self)),
+        )
+        .await
+        .change_context(errors::RedisError::GetFailed)
         {
             Ok(v) => Ok(v),
             Err(_err) => {
@@ -197,10 +207,12 @@ impl super::RedisConnectionPool {
 
                 #[cfg(feature = "multitenancy_fallback")]
                 {
-                    self.pool
-                        .get(key.tenant_unaware_key(self))
-                        .await
-                        .change_context(errors::RedisError::GetFailed)
+                    track_redis_call(
+                        RedisOperation::GetKey,
+                        self.pool.get(key.tenant_unaware_key(self)),
+                    )
+                    .await
+                    .change_context(errors::RedisError::GetFailed)
                 }
             }
         }
@@ -220,10 +232,12 @@ impl super::RedisConnectionPool {
 
         let tenant_aware_keys: Vec<String> =
             keys.iter().map(|key| key.tenant_aware_key(self)).collect();
-        self.pool
-            .mget(tenant_aware_keys)
-            .await
-            .change_context(errors::RedisError::GetFailed)
+        track_redis_call(
+            RedisOperation::GetMultipleKeys,
+            self.pool.mget(tenant_aware_keys),
+        )
+        .await
+        .change_context(errors::RedisError::GetFailed)
     }
 
     #[instrument(level = "DEBUG", skip(self))]
@@ -240,9 +254,12 @@ impl super::RedisConnectionPool {
         let tenant_aware_keys: Vec<String> =
             keys.iter().map(|key| key.tenant_aware_key(self)).collect();
 
-        let futures = tenant_aware_keys
-            .iter()
-            .map(|redis_key| self.pool.get::<Option<V>, _>(redis_key));
+        let futures = tenant_aware_keys.iter().map(|redis_key| {
+            track_redis_call(
+                RedisOperation::GetMultipleKeys,
+                self.pool.get::<Option<V>, _>(redis_key),
+            )
+        });
 
         let results = futures::future::try_join_all(futures)
             .await
@@ -308,11 +325,12 @@ impl super::RedisConnectionPool {
     where
         V: Into<MultipleKeys> + Unpin + Send + 'static,
     {
-        match self
-            .pool
-            .exists(key.tenant_aware_key(self))
-            .await
-            .change_context(errors::RedisError::GetFailed)
+        match track_redis_call(
+            RedisOperation::Exists,
+            self.pool.exists(key.tenant_aware_key(self)),
+        )
+        .await
+        .change_context(errors::RedisError::GetFailed)
         {
             Ok(v) => Ok(v),
             Err(_err) => {
@@ -323,10 +341,12 @@ impl super::RedisConnectionPool {
 
                 #[cfg(feature = "multitenancy_fallback")]
                 {
-                    self.pool
-                        .exists(key.tenant_unaware_key(self))
-                        .await
-                        .change_context(errors::RedisError::GetFailed)
+                    track_redis_call(
+                        RedisOperation::Exists,
+                        self.pool.exists(key.tenant_unaware_key(self)),
+                    )
+                    .await
+                    .change_context(errors::RedisError::GetFailed)
                 }
             }
         }
@@ -383,11 +403,12 @@ impl super::RedisConnectionPool {
 
     #[instrument(level = "DEBUG", skip(self))]
     pub async fn delete_key(&self, key: &RedisKey) -> CustomResult<DelReply, errors::RedisError> {
-        match self
-            .pool
-            .del(key.tenant_aware_key(self))
-            .await
-            .change_context(errors::RedisError::DeleteFailed)
+        match track_redis_call(
+            RedisOperation::DeleteKey,
+            self.pool.del(key.tenant_aware_key(self)),
+        )
+        .await
+        .change_context(errors::RedisError::DeleteFailed)
         {
             Ok(v) => Ok(v),
             Err(_err) => {
@@ -398,10 +419,12 @@ impl super::RedisConnectionPool {
 
                 #[cfg(feature = "multitenancy_fallback")]
                 {
-                    self.pool
-                        .del(key.tenant_unaware_key(self))
-                        .await
-                        .change_context(errors::RedisError::DeleteFailed)
+                    track_redis_call(
+                        RedisOperation::DeleteKey,
+                        self.pool.del(key.tenant_unaware_key(self)),
+                    )
+                    .await
+                    .change_context(errors::RedisError::DeleteFailed)
                 }
             }
         }
@@ -432,16 +455,18 @@ impl super::RedisConnectionPool {
         V: TryInto<RedisValue> + Debug + Send + Sync,
         V::Error: Into<fred::error::RedisError> + Send + Sync,
     {
-        self.pool
-            .set(
+        track_redis_call(
+            RedisOperation::SetKeyWithExpiry,
+            self.pool.set(
                 key.tenant_aware_key(self),
                 value,
                 Some(Expiration::EX(seconds)),
                 None,
                 false,
-            )
-            .await
-            .change_context(errors::RedisError::SetExFailed)
+            ),
+        )
+        .await
+        .change_context(errors::RedisError::SetExFailed)
     }
 
     #[instrument(level = "DEBUG", skip(self))]
@@ -455,8 +480,9 @@ impl super::RedisConnectionPool {
         V: TryInto<RedisValue> + Debug + Send + Sync,
         V::Error: Into<fred::error::RedisError> + Send + Sync,
     {
-        self.pool
-            .set(
+        track_redis_call(
+            RedisOperation::SetKeyIfNotExistsWithExpiry,
+            self.pool.set(
                 key.tenant_aware_key(self),
                 value,
                 Some(Expiration::EX(
@@ -464,9 +490,10 @@ impl super::RedisConnectionPool {
                 )),
                 Some(SetOptions::NX),
                 false,
-            )
-            .await
-            .change_context(errors::RedisError::SetFailed)
+            ),
+        )
+        .await
+        .change_context(errors::RedisError::SetFailed)
     }
 
     #[instrument(level = "DEBUG", skip(self))]
@@ -475,10 +502,12 @@ impl super::RedisConnectionPool {
         key: &RedisKey,
         seconds: i64,
     ) -> CustomResult<(), errors::RedisError> {
-        self.pool
-            .expire(key.tenant_aware_key(self), seconds)
-            .await
-            .change_context(errors::RedisError::SetExpiryFailed)
+        track_redis_call(
+            RedisOperation::SetExpiry,
+            self.pool.expire(key.tenant_aware_key(self), seconds),
+        )
+        .await
+        .change_context(errors::RedisError::SetExpiryFailed)
     }
 
     #[instrument(level = "DEBUG", skip(self))]
@@ -487,18 +516,22 @@ impl super::RedisConnectionPool {
         key: &RedisKey,
         timestamp: i64,
     ) -> CustomResult<(), errors::RedisError> {
-        self.pool
-            .expire_at(key.tenant_aware_key(self), timestamp)
-            .await
-            .change_context(errors::RedisError::SetExpiryFailed)
+        track_redis_call(
+            RedisOperation::SetExpireAt,
+            self.pool.expire_at(key.tenant_aware_key(self), timestamp),
+        )
+        .await
+        .change_context(errors::RedisError::SetExpiryFailed)
     }
 
     #[instrument(level = "DEBUG", skip(self))]
     pub async fn get_ttl(&self, key: &RedisKey) -> CustomResult<i64, errors::RedisError> {
-        self.pool
-            .ttl(key.tenant_aware_key(self))
-            .await
-            .change_context(errors::RedisError::GetFailed)
+        track_redis_call(
+            RedisOperation::GetTtl,
+            self.pool.ttl(key.tenant_aware_key(self)),
+        )
+        .await
+        .change_context(errors::RedisError::GetFailed)
     }
 
     #[instrument(level = "DEBUG", skip(self))]
@@ -521,11 +554,12 @@ impl super::RedisConnectionPool {
             .change_context(errors::RedisError::SetHashFailed)
             .attach_printable("Failed to convert field pairs to fred::types::RedisMap")?;
 
-        let output: Result<(), _> = self
-            .pool
-            .hset(key.tenant_aware_key(self), map)
-            .await
-            .change_context(errors::RedisError::SetHashFailed);
+        let output: Result<(), _> = track_redis_call(
+            RedisOperation::SetHashFields,
+            self.pool.hset(key.tenant_aware_key(self), map),
+        )
+        .await
+        .change_context(errors::RedisError::SetHashFailed);
         // setting expiry for the key
         output
             .async_and_then(|_| {
@@ -546,11 +580,12 @@ impl super::RedisConnectionPool {
         V: TryInto<RedisValue> + Debug + Send + Sync,
         V::Error: Into<fred::error::RedisError> + Send + Sync,
     {
-        let output: Result<HsetnxReply, _> = self
-            .pool
-            .hsetnx(key.tenant_aware_key(self), field, value)
-            .await
-            .change_context(errors::RedisError::SetHashFieldFailed);
+        let output: Result<HsetnxReply, _> = track_redis_call(
+            RedisOperation::SetHashFieldIfNotExist,
+            self.pool.hsetnx(key.tenant_aware_key(self), field, value),
+        )
+        .await
+        .change_context(errors::RedisError::SetHashFieldFailed);
 
         output
             .async_and_then(|inner| async {
@@ -612,10 +647,13 @@ impl super::RedisConnectionPool {
         let mut values_after_increment = Vec::with_capacity(fields_to_increment.len());
         for (field, increment) in fields_to_increment {
             values_after_increment.push(
-                self.pool
-                    .hincrby(key.tenant_aware_key(self), field.to_string(), *increment)
-                    .await
-                    .change_context(errors::RedisError::IncrementHashFieldFailed)?,
+                track_redis_call(
+                    RedisOperation::IncrementFieldsInHash,
+                    self.pool
+                        .hincrby(key.tenant_aware_key(self), field.to_string(), *increment),
+                )
+                .await
+                .change_context(errors::RedisError::IncrementHashFieldFailed)?,
             )
         }
 
@@ -631,28 +669,30 @@ impl super::RedisConnectionPool {
     ) -> CustomResult<Vec<String>, errors::RedisError> {
         use futures::StreamExt;
 
-        Ok(self
-            .pool
-            .next()
-            .hscan::<&str, &str>(&key.tenant_aware_key(self), pattern, count)
-            .filter_map(|value| async move {
-                match value {
-                    Ok(mut v) => {
-                        let v = v.take_results()?;
+        Ok(track_redis_call(
+            RedisOperation::Hscan,
+            self.pool
+                .next()
+                .hscan::<&str, &str>(&key.tenant_aware_key(self), pattern, count)
+                .filter_map(|value| async move {
+                    match value {
+                        Ok(mut v) => {
+                            let v = v.take_results()?;
 
-                        let v: Vec<String> =
-                            v.values().filter_map(|val| val.as_string()).collect();
-                        Some(futures::stream::iter(v))
+                            let v: Vec<String> =
+                                v.values().filter_map(|val| val.as_string()).collect();
+                            Some(futures::stream::iter(v))
+                        }
+                        Err(err) => {
+                            tracing::error!(redis_err=?err, "Redis error while executing hscan command");
+                            None
+                        }
                     }
-                    Err(err) => {
-                        tracing::error!(redis_err=?err, "Redis error while executing hscan command");
-                        None
-                    }
-                }
-            })
-            .flatten()
-            .collect::<Vec<_>>()
-            .await)
+                })
+                .flatten()
+                .collect::<Vec<_>>(),
+        )
+        .await)
     }
 
     #[instrument(level = "DEBUG", skip(self))]
@@ -666,27 +706,29 @@ impl super::RedisConnectionPool {
 
         let fred_scan_type = scan_type.map(fred::types::ScanType::from);
 
-        Ok(self
-            .pool
-            .next()
-            .scan(pattern.tenant_aware_key(self), count, fred_scan_type)
-            .filter_map(|value| async move {
-                match value {
-                    Ok(mut v) => {
-                        let v = v.take_results()?;
-                        let v: Vec<String> =
-                            v.into_iter().filter_map(|val| val.into_string()).collect();
-                        Some(futures::stream::iter(v))
+        Ok(track_redis_call(
+            RedisOperation::Scan,
+            self.pool
+                .next()
+                .scan(pattern.tenant_aware_key(self), count, fred_scan_type)
+                .filter_map(|value| async move {
+                    match value {
+                        Ok(mut v) => {
+                            let v = v.take_results()?;
+                            let v: Vec<String> =
+                                v.into_iter().filter_map(|val| val.into_string()).collect();
+                            Some(futures::stream::iter(v))
+                        }
+                        Err(err) => {
+                            tracing::error!(redis_err=?err, "Redis error while executing scan command");
+                            None
+                        }
                     }
-                    Err(err) => {
-                        tracing::error!(redis_err=?err, "Redis error while executing scan command");
-                        None
-                    }
-                }
-            })
-            .flatten()
-            .collect::<Vec<_>>()
-            .await)
+                })
+                .flatten()
+                .collect::<Vec<_>>(),
+        )
+        .await)
     }
 
     #[instrument(level = "DEBUG", skip(self))]
@@ -718,20 +760,23 @@ impl super::RedisConnectionPool {
     where
         V: FromRedis + Unpin + Send + 'static,
     {
-        match self
-            .pool
-            .hget(key.tenant_aware_key(self), field)
-            .await
-            .change_context(errors::RedisError::GetHashFieldFailed)
+        match track_redis_call(
+            RedisOperation::GetHashField,
+            self.pool.hget(key.tenant_aware_key(self), field),
+        )
+        .await
+        .change_context(errors::RedisError::GetHashFieldFailed)
         {
             Ok(v) => Ok(v),
             Err(_err) => {
                 #[cfg(feature = "multitenancy_fallback")]
                 {
-                    self.pool
-                        .hget(key.tenant_unaware_key(self), field)
-                        .await
-                        .change_context(errors::RedisError::GetHashFieldFailed)
+                    track_redis_call(
+                        RedisOperation::GetHashField,
+                        self.pool.hget(key.tenant_unaware_key(self), field),
+                    )
+                    .await
+                    .change_context(errors::RedisError::GetHashFieldFailed)
                 }
 
                 #[cfg(not(feature = "multitenancy_fallback"))]
@@ -747,20 +792,23 @@ impl super::RedisConnectionPool {
     where
         V: FromRedis + Unpin + Send + 'static,
     {
-        match self
-            .pool
-            .hgetall(key.tenant_aware_key(self))
-            .await
-            .change_context(errors::RedisError::GetHashFieldFailed)
+        match track_redis_call(
+            RedisOperation::GetHashFields,
+            self.pool.hgetall(key.tenant_aware_key(self)),
+        )
+        .await
+        .change_context(errors::RedisError::GetHashFieldFailed)
         {
             Ok(v) => Ok(v),
             Err(_err) => {
                 #[cfg(feature = "multitenancy_fallback")]
                 {
-                    self.pool
-                        .hgetall(key.tenant_unaware_key(self))
-                        .await
-                        .change_context(errors::RedisError::GetHashFieldFailed)
+                    track_redis_call(
+                        RedisOperation::GetHashFields,
+                        self.pool.hgetall(key.tenant_unaware_key(self)),
+                    )
+                    .await
+                    .change_context(errors::RedisError::GetHashFieldFailed)
                 }
 
                 #[cfg(not(feature = "multitenancy_fallback"))]
@@ -802,10 +850,12 @@ impl super::RedisConnectionPool {
         V: TryInto<MultipleValues> + Debug + Send,
         V::Error: Into<fred::error::RedisError> + Send,
     {
-        self.pool
-            .sadd(key.tenant_aware_key(self), members)
-            .await
-            .change_context(errors::RedisError::SetAddMembersFailed)
+        track_redis_call(
+            RedisOperation::Sadd,
+            self.pool.sadd(key.tenant_aware_key(self), members),
+        )
+        .await
+        .change_context(errors::RedisError::SetAddMembersFailed)
     }
 
     #[instrument(level = "DEBUG", skip(self))]
@@ -830,16 +880,18 @@ impl super::RedisConnectionPool {
                 "Failed to convert field pairs to fred::types::MultipleOrderedPairs",
             )?;
 
-        self.pool
-            .xadd(
+        track_redis_call(
+            RedisOperation::StreamAppendEntry,
+            self.pool.xadd(
                 stream.tenant_aware_key(self),
                 false,
                 None,
                 entry_id,
                 fred_fields,
-            )
-            .await
-            .change_context(errors::RedisError::StreamAppendFailed)
+            ),
+        )
+        .await
+        .change_context(errors::RedisError::StreamAppendFailed)
     }
 
     #[instrument(level = "DEBUG", skip(self))]
@@ -849,10 +901,12 @@ impl super::RedisConnectionPool {
         ids: Vec<String>,
     ) -> CustomResult<usize, errors::RedisError> {
         let fred_ids: MultipleStrings = ids.into();
-        self.pool
-            .xdel(stream.tenant_aware_key(self), fred_ids)
-            .await
-            .change_context(errors::RedisError::StreamDeleteFailed)
+        track_redis_call(
+            RedisOperation::StreamDeleteEntries,
+            self.pool.xdel(stream.tenant_aware_key(self), fred_ids),
+        )
+        .await
+        .change_context(errors::RedisError::StreamDeleteFailed)
     }
 
     #[instrument(level = "DEBUG", skip(self))]
@@ -864,10 +918,12 @@ impl super::RedisConnectionPool {
         let xcap = fred::types::XCap::try_from(config)
             .change_context(errors::RedisError::StreamTrimFailed)
             .attach_printable("Failed to convert StreamTrimConfig to fred::types::XCap")?;
-        self.pool
-            .xtrim(stream.tenant_aware_key(self), xcap)
-            .await
-            .change_context(errors::RedisError::StreamTrimFailed)
+        track_redis_call(
+            RedisOperation::StreamTrimEntries,
+            self.pool.xtrim(stream.tenant_aware_key(self), xcap),
+        )
+        .await
+        .change_context(errors::RedisError::StreamTrimFailed)
     }
 
     #[instrument(level = "DEBUG", skip(self))]
@@ -878,10 +934,13 @@ impl super::RedisConnectionPool {
         ids: Vec<String>,
     ) -> CustomResult<usize, errors::RedisError> {
         let fred_ids: MultipleIDs = ids.into();
-        self.pool
-            .xack(stream.tenant_aware_key(self), group, fred_ids)
-            .await
-            .change_context(errors::RedisError::StreamAcknowledgeFailed)
+        track_redis_call(
+            RedisOperation::StreamAcknowledgeEntries,
+            self.pool
+                .xack(stream.tenant_aware_key(self), group, fred_ids),
+        )
+        .await
+        .change_context(errors::RedisError::StreamAcknowledgeFailed)
     }
 
     #[instrument(level = "DEBUG", skip(self))]
@@ -889,10 +948,12 @@ impl super::RedisConnectionPool {
         &self,
         stream: &RedisKey,
     ) -> CustomResult<usize, errors::RedisError> {
-        self.pool
-            .xlen(stream.tenant_aware_key(self))
-            .await
-            .change_context(errors::RedisError::GetLengthFailed)
+        track_redis_call(
+            RedisOperation::StreamGetLength,
+            self.pool.xlen(stream.tenant_aware_key(self)),
+        )
+        .await
+        .change_context(errors::RedisError::GetLengthFailed)
     }
 
     fn get_keys_with_prefix(&self, streams: &[RedisKey]) -> MultipleKeys {
@@ -909,21 +970,22 @@ impl super::RedisConnectionPool {
     ) -> CustomResult<StreamReadResult, errors::RedisError> {
         let strms = self.get_keys_with_prefix(streams);
         let ids: MultipleIDs = ids.into();
-        let reply: XReadResponse<String, String, String, String> = self
-            .pool
-            .xread_map(
+        let reply: XReadResponse<String, String, String, String> = track_redis_call(
+            RedisOperation::StreamReadEntries,
+            self.pool.xread_map(
                 Some(read_count.unwrap_or(self.config.default_stream_read_count)),
                 None,
                 strms,
                 ids,
-            )
-            .await
-            .map_err(|err| match err.kind() {
-                RedisErrorKind::NotFound | RedisErrorKind::Parse => {
-                    report!(err).change_context(errors::RedisError::StreamEmptyOrNotAvailable)
-                }
-                _ => report!(err).change_context(errors::RedisError::StreamReadFailed),
-            })?;
+            ),
+        )
+        .await
+        .map_err(|err| match err.kind() {
+            RedisErrorKind::NotFound | RedisErrorKind::Parse => {
+                report!(err).change_context(errors::RedisError::StreamEmptyOrNotAvailable)
+            }
+            _ => report!(err).change_context(errors::RedisError::StreamReadFailed),
+        })?;
 
         Ok(reply
             .into_iter()
@@ -964,11 +1026,27 @@ impl super::RedisConnectionPool {
 
         let reply: XReadResponse<String, String, String, Option<String>> = match group {
             Some((group_name, consumer_name)) => {
-                self.pool
-                    .xreadgroup_map(group_name, consumer_name, count, block, false, strms, ids)
-                    .await
+                track_redis_call(
+                    RedisOperation::StreamReadWithOptions,
+                    self.pool.xreadgroup_map(
+                        group_name,
+                        consumer_name,
+                        count,
+                        block,
+                        false,
+                        strms,
+                        ids,
+                    ),
+                )
+                .await
             }
-            None => self.pool.xread_map(count, block, strms, ids).await,
+            None => {
+                track_redis_call(
+                    RedisOperation::StreamReadWithOptions,
+                    self.pool.xread_map(count, block, strms, ids),
+                )
+                .await
+            }
         }
         .map_err(|err| match err.kind() {
             RedisErrorKind::NotFound | RedisErrorKind::Parse => {
@@ -1016,10 +1094,12 @@ impl super::RedisConnectionPool {
         V: TryInto<MultipleValues> + Debug + Send,
         V::Error: Into<fred::error::RedisError> + Send,
     {
-        self.pool
-            .rpush(key.tenant_aware_key(self), elements)
-            .await
-            .change_context(errors::RedisError::AppendElementsToListFailed)
+        track_redis_call(
+            RedisOperation::AppendElementsToList,
+            self.pool.rpush(key.tenant_aware_key(self), elements),
+        )
+        .await
+        .change_context(errors::RedisError::AppendElementsToListFailed)
     }
 
     #[instrument(level = "DEBUG", skip(self))]
@@ -1029,18 +1109,22 @@ impl super::RedisConnectionPool {
         start: i64,
         stop: i64,
     ) -> CustomResult<Vec<String>, errors::RedisError> {
-        self.pool
-            .lrange(key.tenant_aware_key(self), start, stop)
-            .await
-            .change_context(errors::RedisError::GetListElementsFailed)
+        track_redis_call(
+            RedisOperation::GetListElements,
+            self.pool.lrange(key.tenant_aware_key(self), start, stop),
+        )
+        .await
+        .change_context(errors::RedisError::GetListElementsFailed)
     }
 
     #[instrument(level = "DEBUG", skip(self))]
     pub async fn get_list_length(&self, key: &RedisKey) -> CustomResult<usize, errors::RedisError> {
-        self.pool
-            .llen(key.tenant_aware_key(self))
-            .await
-            .change_context(errors::RedisError::GetListLengthFailed)
+        track_redis_call(
+            RedisOperation::GetListLength,
+            self.pool.llen(key.tenant_aware_key(self)),
+        )
+        .await
+        .change_context(errors::RedisError::GetListLengthFailed)
     }
 
     #[instrument(level = "DEBUG", skip(self))]
@@ -1049,10 +1133,12 @@ impl super::RedisConnectionPool {
         key: &RedisKey,
         count: Option<usize>,
     ) -> CustomResult<Vec<String>, errors::RedisError> {
-        self.pool
-            .lpop(key.tenant_aware_key(self), count)
-            .await
-            .change_context(errors::RedisError::PopListElementsFailed)
+        track_redis_call(
+            RedisOperation::LpopListElements,
+            self.pool.lpop(key.tenant_aware_key(self), count),
+        )
+        .await
+        .change_context(errors::RedisError::PopListElementsFailed)
     }
 
     //                                              Consumer Group API
@@ -1072,10 +1158,13 @@ impl super::RedisConnectionPool {
             Err(errors::RedisError::InvalidRedisEntryId)?;
         }
 
-        self.pool
-            .xgroup_create(stream.tenant_aware_key(self), group, id, true)
-            .await
-            .change_context(errors::RedisError::ConsumerGroupCreateFailed)
+        track_redis_call(
+            RedisOperation::ConsumerGroupCreate,
+            self.pool
+                .xgroup_create(stream.tenant_aware_key(self), group, id, true),
+        )
+        .await
+        .change_context(errors::RedisError::ConsumerGroupCreateFailed)
     }
 
     #[instrument(level = "DEBUG", skip(self))]
@@ -1084,11 +1173,13 @@ impl super::RedisConnectionPool {
         stream: &RedisKey,
         group: &str,
     ) -> CustomResult<crate::types::ConsumerGroupDestroyReply, errors::RedisError> {
-        let reply: crate::types::ConsumerGroupDestroyReply = self
-            .pool
-            .xgroup_destroy(stream.tenant_aware_key(self), group)
-            .await
-            .change_context(errors::RedisError::ConsumerGroupDestroyFailed)?;
+        let reply: crate::types::ConsumerGroupDestroyReply = track_redis_call(
+            RedisOperation::ConsumerGroupDestroy,
+            self.pool
+                .xgroup_destroy(stream.tenant_aware_key(self), group),
+        )
+        .await
+        .change_context(errors::RedisError::ConsumerGroupDestroyFailed)?;
         Ok(reply)
     }
 
@@ -1100,10 +1191,13 @@ impl super::RedisConnectionPool {
         group: &str,
         consumer: &str,
     ) -> CustomResult<usize, errors::RedisError> {
-        self.pool
-            .xgroup_delconsumer(stream.tenant_aware_key(self), group, consumer)
-            .await
-            .change_context(errors::RedisError::ConsumerGroupRemoveConsumerFailed)
+        track_redis_call(
+            RedisOperation::ConsumerGroupDeleteConsumer,
+            self.pool
+                .xgroup_delconsumer(stream.tenant_aware_key(self), group, consumer),
+        )
+        .await
+        .change_context(errors::RedisError::ConsumerGroupRemoveConsumerFailed)
     }
 
     #[instrument(level = "DEBUG", skip(self))]
@@ -1114,10 +1208,13 @@ impl super::RedisConnectionPool {
         id: &RedisEntryId,
     ) -> CustomResult<String, errors::RedisError> {
         let id_str = id.to_stream_id();
-        self.pool
-            .xgroup_setid::<(), _, _, _>(stream.tenant_aware_key(self), group, &id_str)
-            .await
-            .change_context(errors::RedisError::ConsumerGroupSetIdFailed)?;
+        track_redis_call(
+            RedisOperation::ConsumerGroupSetLastId,
+            self.pool
+                .xgroup_setid::<(), _, _, _>(stream.tenant_aware_key(self), group, &id_str),
+        )
+        .await
+        .change_context(errors::RedisError::ConsumerGroupSetIdFailed)?;
         Ok(id_str)
     }
 
@@ -1134,8 +1231,9 @@ impl super::RedisConnectionPool {
         R: FromRedis + Unpin + Send + 'static,
     {
         let fred_ids: MultipleIDs = ids.into();
-        self.pool
-            .xclaim(
+        track_redis_call(
+            RedisOperation::ConsumerGroupSetMessageOwner,
+            self.pool.xclaim(
                 stream.tenant_aware_key(self),
                 group,
                 consumer,
@@ -1146,9 +1244,10 @@ impl super::RedisConnectionPool {
                 None,
                 false,
                 false,
-            )
-            .await
-            .change_context(errors::RedisError::ConsumerGroupClaimFailed)
+            ),
+        )
+        .await
+        .change_context(errors::RedisError::ConsumerGroupClaimFailed)
     }
 
     #[instrument(level = "DEBUG", skip(self))]
@@ -1163,11 +1262,12 @@ impl super::RedisConnectionPool {
         V::Error: Into<fred::error::RedisError> + Send + Sync,
         T: serde::de::DeserializeOwned + FromRedis,
     {
-        let val: T = self
-            .pool
-            .eval(lua_script, key, values)
-            .await
-            .change_context(errors::RedisError::IncrementHashFieldFailed)?;
+        let val: T = track_redis_call(
+            RedisOperation::EvaluateRedisScript,
+            self.pool.eval(lua_script, key, values),
+        )
+        .await
+        .change_context(errors::RedisError::IncrementHashFieldFailed)?;
         Ok(val)
     }
 
@@ -1236,11 +1336,11 @@ impl super::RedisConnectionPool {
             .attach_printable("Failed to queue get command")?;
 
         // Execute transaction
-        let mut results: Vec<RedisValue> = trx
-            .exec(true)
-            .await
-            .change_context(errors::RedisError::SetFailed)
-            .attach_printable("Failed to execute the redis transaction")?;
+        let mut results: Vec<RedisValue> =
+            track_redis_call(RedisOperation::SetKeyIfNotExistsAndGetValue, trx.exec(true))
+                .await
+                .change_context(errors::RedisError::SetFailed)
+                .attach_printable("Failed to execute the redis transaction")?;
 
         let msg = "Got unexpected number of results from transaction";
         let get_result = results

--- a/crates/redis_interface/src/module/redis_rs/commands.rs
+++ b/crates/redis_interface/src/module/redis_rs/commands.rs
@@ -243,11 +243,14 @@ impl super::RedisConnectionPool {
         let tenant_aware_keys: Vec<String> =
             keys.iter().map(|key| key.tenant_aware_key(self)).collect();
 
-        let futures = tenant_aware_keys.iter().map(|redis_key| {
-            let mut conn = self.pool.clone();
-            let key = redis_key.clone();
-            async move { track_redis_call(RedisOperation::GetKey, conn.get::<_, Option<V>>(&key)).await }
-        });
+        let futures =
+            tenant_aware_keys.iter().map(|redis_key| {
+                let mut conn = self.pool.clone();
+                let key = redis_key.clone();
+                async move {
+                    track_redis_call(RedisOperation::GetKey, conn.get::<_, Option<V>>(&key)).await
+                }
+            });
 
         let results = futures::future::try_join_all(futures)
             .await

--- a/crates/redis_interface/src/module/redis_rs/commands.rs
+++ b/crates/redis_interface/src/module/redis_rs/commands.rs
@@ -246,13 +246,7 @@ impl super::RedisConnectionPool {
         let futures = tenant_aware_keys.iter().map(|redis_key| {
             let mut conn = self.pool.clone();
             let key = redis_key.clone();
-            async move {
-                track_redis_call(
-                    RedisOperation::GetMultipleKeys,
-                    conn.get::<_, Option<V>>(&key),
-                )
-                .await
-            }
+            async move { track_redis_call(RedisOperation::GetKey, conn.get::<_, Option<V>>(&key)).await }
         });
 
         let results = futures::future::try_join_all(futures)
@@ -602,15 +596,8 @@ impl super::RedisConnectionPool {
 
         // Only set expiry if the field was actually set
         if matches!(result, HsetnxReply::KeySet) {
-            track_redis_call(
-                RedisOperation::SetHashFieldIfNotExist,
-                conn.expire::<_, ()>(
-                    key.tenant_aware_key(self),
-                    ttl.unwrap_or(self.config.default_hash_ttl).into(),
-                ),
-            )
-            .await
-            .change_context(errors::RedisError::SetExpiryFailed)?;
+            self.set_expiry(key, ttl.unwrap_or(self.config.default_hash_ttl).into())
+                .await?;
         }
 
         Ok(result)

--- a/crates/redis_interface/src/module/redis_rs/commands.rs
+++ b/crates/redis_interface/src/module/redis_rs/commands.rs
@@ -25,6 +25,7 @@ use crate::{
         REDIS_COMMAND_GET, REDIS_COMMAND_HSCAN, REDIS_COMMAND_SCAN, REDIS_COMMAND_SET,
     },
     errors,
+    metrics::{track_redis_call, RedisOperation},
     types::{
         DelReply, HsetnxReply, MsetnxReply, RedisEntryId, RedisKey, SaddReply, SetGetReply,
         SetnxReply, StreamEntries, StreamReadResult, StreamTrimConfig,
@@ -50,10 +51,12 @@ impl super::RedisConnectionPool {
         let mut conn = self.pool.clone();
         let options = SetOptions::default()
             .with_expiration(SetExpiry::EX(u64::from(self.config.default_ttl)));
-        let _: Option<String> = conn
-            .set_options(key.tenant_aware_key(self), value, options)
-            .await
-            .change_context(errors::RedisError::SetFailed)?;
+        let _: Option<String> = track_redis_call(
+            RedisOperation::SetKey,
+            conn.set_options(key.tenant_aware_key(self), value, options),
+        )
+        .await
+        .change_context(errors::RedisError::SetFailed)?;
         Ok(())
     }
 
@@ -67,10 +70,12 @@ impl super::RedisConnectionPool {
     {
         let mut conn = self.pool.clone();
         let options = SetOptions::default().with_expiration(SetExpiry::KEEPTTL);
-        let _: Option<String> = conn
-            .set_options(key.tenant_aware_key(self), value, options)
-            .await
-            .change_context(errors::RedisError::SetFailed)?;
+        let _: Option<String> = track_redis_call(
+            RedisOperation::SetKeyWithoutModifyingTtl,
+            conn.set_options(key.tenant_aware_key(self), value, options),
+        )
+        .await
+        .change_context(errors::RedisError::SetFailed)?;
         Ok(())
     }
 
@@ -83,9 +88,12 @@ impl super::RedisConnectionPool {
         V: redis::ToRedisArgs + Debug + Send + Sync,
     {
         let mut conn = self.pool.clone();
-        conn.mset_nx(key_value_pairs)
-            .await
-            .change_context(errors::RedisError::SetFailed)
+        track_redis_call(
+            RedisOperation::SetMultipleKeysIfNotExist,
+            conn.mset_nx(key_value_pairs),
+        )
+        .await
+        .change_context(errors::RedisError::SetFailed)
     }
 
     #[instrument(level = "DEBUG", skip(self))]
@@ -156,10 +164,12 @@ impl super::RedisConnectionPool {
         let options = SetOptions::default().with_expiration(SetExpiry::EX(
             u64::try_from(seconds).change_context(errors::RedisError::SetExFailed)?,
         ));
-        let _: Option<String> = conn
-            .set_options(key.tenant_aware_key(self), serialized.as_slice(), options)
-            .await
-            .change_context(errors::RedisError::SetExFailed)?;
+        let _: Option<String> = track_redis_call(
+            RedisOperation::SerializeAndSetKeyWithExpiry,
+            conn.set_options(key.tenant_aware_key(self), serialized.as_slice(), options),
+        )
+        .await
+        .change_context(errors::RedisError::SetExFailed)?;
         Ok(())
     }
 
@@ -169,10 +179,12 @@ impl super::RedisConnectionPool {
         V: FromRedisValue + Send + 'static,
     {
         let mut conn = self.pool.clone();
-        match conn
-            .get::<_, V>(key.tenant_aware_key(self))
-            .await
-            .change_context(errors::RedisError::GetFailed)
+        match track_redis_call(
+            RedisOperation::GetKey,
+            conn.get::<_, V>(key.tenant_aware_key(self)),
+        )
+        .await
+        .change_context(errors::RedisError::GetFailed)
         {
             Ok(v) => Ok(v),
             Err(_err) => {
@@ -183,9 +195,12 @@ impl super::RedisConnectionPool {
 
                 #[cfg(feature = "multitenancy_fallback")]
                 {
-                    conn.get::<_, V>(key.tenant_unaware_key(self))
-                        .await
-                        .change_context(errors::RedisError::GetFailed)
+                    track_redis_call(
+                        RedisOperation::GetKey,
+                        conn.get::<_, V>(key.tenant_unaware_key(self)),
+                    )
+                    .await
+                    .change_context(errors::RedisError::GetFailed)
                 }
             }
         }
@@ -206,9 +221,12 @@ impl super::RedisConnectionPool {
         let tenant_aware_keys: Vec<String> =
             keys.iter().map(|key| key.tenant_aware_key(self)).collect();
         let mut conn = self.pool.clone();
-        conn.mget(&tenant_aware_keys)
-            .await
-            .change_context(errors::RedisError::GetFailed)
+        track_redis_call(
+            RedisOperation::GetMultipleKeys,
+            conn.mget(&tenant_aware_keys),
+        )
+        .await
+        .change_context(errors::RedisError::GetFailed)
     }
 
     #[instrument(level = "DEBUG", skip(self))]
@@ -228,7 +246,13 @@ impl super::RedisConnectionPool {
         let futures = tenant_aware_keys.iter().map(|redis_key| {
             let mut conn = self.pool.clone();
             let key = redis_key.clone();
-            async move { conn.get::<_, Option<V>>(&key).await }
+            async move {
+                track_redis_call(
+                    RedisOperation::GetMultipleKeys,
+                    conn.get::<_, Option<V>>(&key),
+                )
+                .await
+            }
         });
 
         let results = futures::future::try_join_all(futures)
@@ -296,10 +320,12 @@ impl super::RedisConnectionPool {
         V: Send + 'static,
     {
         let mut conn = self.pool.clone();
-        match conn
-            .exists::<_, bool>(key.tenant_aware_key(self))
-            .await
-            .change_context(errors::RedisError::GetFailed)
+        match track_redis_call(
+            RedisOperation::Exists,
+            conn.exists::<_, bool>(key.tenant_aware_key(self)),
+        )
+        .await
+        .change_context(errors::RedisError::GetFailed)
         {
             Ok(v) => Ok(v),
             Err(_err) => {
@@ -310,9 +336,12 @@ impl super::RedisConnectionPool {
 
                 #[cfg(feature = "multitenancy_fallback")]
                 {
-                    conn.exists::<_, bool>(key.tenant_unaware_key(self))
-                        .await
-                        .change_context(errors::RedisError::GetFailed)
+                    track_redis_call(
+                        RedisOperation::Exists,
+                        conn.exists::<_, bool>(key.tenant_unaware_key(self)),
+                    )
+                    .await
+                    .change_context(errors::RedisError::GetFailed)
                 }
             }
         }
@@ -370,10 +399,12 @@ impl super::RedisConnectionPool {
         let mut conn = self.pool.clone();
         // Redis DEL returns the number of keys that were deleted.
         // 0 means the key did not exist (not an error).
-        let deleted_count: usize = conn
-            .del(key.tenant_aware_key(self))
-            .await
-            .change_context(errors::RedisError::DeleteFailed)?;
+        let deleted_count: usize = track_redis_call(
+            RedisOperation::DeleteKey,
+            conn.del(key.tenant_aware_key(self)),
+        )
+        .await
+        .change_context(errors::RedisError::DeleteFailed)?;
 
         let reply = if deleted_count > 0 {
             DelReply::KeyDeleted
@@ -389,10 +420,12 @@ impl super::RedisConnectionPool {
 
             #[cfg(feature = "multitenancy_fallback")]
             {
-                let fallback_count: usize = conn
-                    .del(key.tenant_unaware_key(self))
-                    .await
-                    .change_context(errors::RedisError::DeleteFailed)?;
+                let fallback_count: usize = track_redis_call(
+                    RedisOperation::DeleteKey,
+                    conn.del(key.tenant_unaware_key(self)),
+                )
+                .await
+                .change_context(errors::RedisError::DeleteFailed)?;
                 if fallback_count > 0 {
                     DelReply::KeyDeleted
                 } else {
@@ -432,10 +465,12 @@ impl super::RedisConnectionPool {
         let options = SetOptions::default().with_expiration(SetExpiry::EX(
             u64::try_from(seconds).change_context(errors::RedisError::SetExFailed)?,
         ));
-        let _: Option<String> = conn
-            .set_options(key.tenant_aware_key(self), value, options)
-            .await
-            .change_context(errors::RedisError::SetExFailed)?;
+        let _: Option<String> = track_redis_call(
+            RedisOperation::SetKeyWithExpiry,
+            conn.set_options(key.tenant_aware_key(self), value, options),
+        )
+        .await
+        .change_context(errors::RedisError::SetExFailed)?;
         Ok(())
     }
 
@@ -456,10 +491,12 @@ impl super::RedisConnectionPool {
             .with_expiration(SetExpiry::EX(
                 u64::try_from(ttl).change_context(errors::RedisError::SetFailed)?,
             ));
-        let result: Option<String> = conn
-            .set_options(key.tenant_aware_key(self), value, options)
-            .await
-            .change_context(errors::RedisError::SetFailed)?;
+        let result: Option<String> = track_redis_call(
+            RedisOperation::SetKeyIfNotExistsWithExpiry,
+            conn.set_options(key.tenant_aware_key(self), value, options),
+        )
+        .await
+        .change_context(errors::RedisError::SetFailed)?;
 
         // SET NX returns OK on success, nil if key already exists
         let reply = if result.is_some() {
@@ -477,9 +514,12 @@ impl super::RedisConnectionPool {
         seconds: i64,
     ) -> CustomResult<(), errors::RedisError> {
         let mut conn = self.pool.clone();
-        conn.expire::<_, ()>(key.tenant_aware_key(self), seconds)
-            .await
-            .change_context(errors::RedisError::SetExpiryFailed)
+        track_redis_call(
+            RedisOperation::SetExpiry,
+            conn.expire::<_, ()>(key.tenant_aware_key(self), seconds),
+        )
+        .await
+        .change_context(errors::RedisError::SetExpiryFailed)
     }
 
     #[instrument(level = "DEBUG", skip(self))]
@@ -489,17 +529,23 @@ impl super::RedisConnectionPool {
         timestamp: i64,
     ) -> CustomResult<(), errors::RedisError> {
         let mut conn = self.pool.clone();
-        conn.expire_at::<_, ()>(key.tenant_aware_key(self), timestamp)
-            .await
-            .change_context(errors::RedisError::SetExpiryFailed)
+        track_redis_call(
+            RedisOperation::SetExpireAt,
+            conn.expire_at::<_, ()>(key.tenant_aware_key(self), timestamp),
+        )
+        .await
+        .change_context(errors::RedisError::SetExpiryFailed)
     }
 
     #[instrument(level = "DEBUG", skip(self))]
     pub async fn get_ttl(&self, key: &RedisKey) -> CustomResult<i64, errors::RedisError> {
         let mut conn = self.pool.clone();
-        conn.ttl::<_, i64>(key.tenant_aware_key(self))
-            .await
-            .change_context(errors::RedisError::GetFailed)
+        track_redis_call(
+            RedisOperation::GetTtl,
+            conn.ttl::<_, i64>(key.tenant_aware_key(self)),
+        )
+        .await
+        .change_context(errors::RedisError::GetFailed)
     }
 
     // ─── Hash Commands ───────────────────────────────────────────────────────
@@ -516,15 +562,20 @@ impl super::RedisConnectionPool {
         V: redis::ToRedisArgs + Debug + Send + Sync,
     {
         let mut conn = self.pool.clone();
-        let _: () = conn
-            .hset_multiple(key.tenant_aware_key(self), &field_value_pairs)
-            .await
-            .change_context(errors::RedisError::SetHashFailed)?;
+        let _: () = track_redis_call(
+            RedisOperation::SetHashFields,
+            conn.hset_multiple(key.tenant_aware_key(self), &field_value_pairs),
+        )
+        .await
+        .change_context(errors::RedisError::SetHashFailed)?;
 
         // setting expiry for the key — reuse the same connection
-        conn.expire::<_, ()>(
-            key.tenant_aware_key(self),
-            ttl.unwrap_or(self.config.default_hash_ttl.into()),
+        track_redis_call(
+            RedisOperation::SetHashFields,
+            conn.expire::<_, ()>(
+                key.tenant_aware_key(self),
+                ttl.unwrap_or(self.config.default_hash_ttl.into()),
+            ),
         )
         .await
         .change_context(errors::RedisError::SetExpiryFailed)
@@ -542,16 +593,21 @@ impl super::RedisConnectionPool {
         V: redis::ToRedisArgs + ToSingleRedisArg + Debug + Send + Sync,
     {
         let mut conn = self.pool.clone();
-        let result: HsetnxReply = conn
-            .hset_nx::<_, _, _, HsetnxReply>(key.tenant_aware_key(self), field, value)
-            .await
-            .change_context(errors::RedisError::SetHashFieldFailed)?;
+        let result: HsetnxReply = track_redis_call(
+            RedisOperation::SetHashFieldIfNotExist,
+            conn.hset_nx::<_, _, _, HsetnxReply>(key.tenant_aware_key(self), field, value),
+        )
+        .await
+        .change_context(errors::RedisError::SetHashFieldFailed)?;
 
         // Only set expiry if the field was actually set
         if matches!(result, HsetnxReply::KeySet) {
-            conn.expire::<_, ()>(
-                key.tenant_aware_key(self),
-                ttl.unwrap_or(self.config.default_hash_ttl).into(),
+            track_redis_call(
+                RedisOperation::SetHashFieldIfNotExist,
+                conn.expire::<_, ()>(
+                    key.tenant_aware_key(self),
+                    ttl.unwrap_or(self.config.default_hash_ttl).into(),
+                ),
             )
             .await
             .change_context(errors::RedisError::SetExpiryFailed)?;
@@ -612,10 +668,13 @@ impl super::RedisConnectionPool {
         let mut values_after_increment = Vec::with_capacity(fields_to_increment.len());
         for (field, increment) in fields_to_increment {
             values_after_increment.push(
-                conn.hincr::<_, _, _, usize>(
-                    key.tenant_aware_key(self),
-                    field.to_string(),
-                    *increment,
+                track_redis_call(
+                    RedisOperation::IncrementFieldsInHash,
+                    conn.hincr::<_, _, _, usize>(
+                        key.tenant_aware_key(self),
+                        field.to_string(),
+                        *increment,
+                    ),
                 )
                 .await
                 .change_context(errors::RedisError::IncrementHashFieldFailed)?,
@@ -662,10 +721,10 @@ impl super::RedisConnectionPool {
             }
 
             // HSCAN returns: [cursor, [field1, value1, field2, value2, ...]]
-            let reply: (u64, Vec<redis::Value>) = command
-                .query_async(&mut conn)
-                .await
-                .change_context(errors::RedisError::GetHashFieldFailed)?;
+            let reply: (u64, Vec<redis::Value>) =
+                track_redis_call(RedisOperation::Hscan, command.query_async(&mut conn))
+                    .await
+                    .change_context(errors::RedisError::GetHashFieldFailed)?;
 
             cursor = reply.0;
 
@@ -723,10 +782,10 @@ impl super::RedisConnectionPool {
                 command.arg(REDIS_ARG_TYPE).arg(scan_type_value.as_ref());
             }
 
-            let reply: (u64, Vec<String>) = command
-                .query_async(&mut conn)
-                .await
-                .change_context(errors::RedisError::GetFailed)?;
+            let reply: (u64, Vec<String>) =
+                track_redis_call(RedisOperation::Scan, command.query_async(&mut conn))
+                    .await
+                    .change_context(errors::RedisError::GetFailed)?;
 
             cursor = reply.0;
             results.extend(reply.1);
@@ -769,18 +828,23 @@ impl super::RedisConnectionPool {
         V: FromRedisValue + Send + 'static,
     {
         let mut conn = self.pool.clone();
-        match conn
-            .hget::<_, _, V>(key.tenant_aware_key(self), field)
-            .await
-            .change_context(errors::RedisError::GetHashFieldFailed)
+        match track_redis_call(
+            RedisOperation::GetHashField,
+            conn.hget::<_, _, V>(key.tenant_aware_key(self), field),
+        )
+        .await
+        .change_context(errors::RedisError::GetHashFieldFailed)
         {
             Ok(v) => Ok(v),
             Err(_err) => {
                 #[cfg(feature = "multitenancy_fallback")]
                 {
-                    conn.hget::<_, _, V>(key.tenant_unaware_key(self), field)
-                        .await
-                        .change_context(errors::RedisError::GetHashFieldFailed)
+                    track_redis_call(
+                        RedisOperation::GetHashField,
+                        conn.hget::<_, _, V>(key.tenant_unaware_key(self), field),
+                    )
+                    .await
+                    .change_context(errors::RedisError::GetHashFieldFailed)
                 }
 
                 #[cfg(not(feature = "multitenancy_fallback"))]
@@ -797,18 +861,23 @@ impl super::RedisConnectionPool {
         V: FromRedisValue + Send + 'static,
     {
         let mut conn = self.pool.clone();
-        match conn
-            .hgetall::<_, V>(key.tenant_aware_key(self))
-            .await
-            .change_context(errors::RedisError::GetHashFieldFailed)
+        match track_redis_call(
+            RedisOperation::GetHashFields,
+            conn.hgetall::<_, V>(key.tenant_aware_key(self)),
+        )
+        .await
+        .change_context(errors::RedisError::GetHashFieldFailed)
         {
             Ok(v) => Ok(v),
             Err(_err) => {
                 #[cfg(feature = "multitenancy_fallback")]
                 {
-                    conn.hgetall::<_, V>(key.tenant_unaware_key(self))
-                        .await
-                        .change_context(errors::RedisError::GetHashFieldFailed)
+                    track_redis_call(
+                        RedisOperation::GetHashFields,
+                        conn.hgetall::<_, V>(key.tenant_unaware_key(self)),
+                    )
+                    .await
+                    .change_context(errors::RedisError::GetHashFieldFailed)
                 }
 
                 #[cfg(not(feature = "multitenancy_fallback"))]
@@ -852,9 +921,12 @@ impl super::RedisConnectionPool {
         V: redis::ToRedisArgs + Debug + Send + Sync,
     {
         let mut conn = self.pool.clone();
-        conn.sadd::<_, _, SaddReply>(key.tenant_aware_key(self), members)
-            .await
-            .change_context(errors::RedisError::SetAddMembersFailed)
+        track_redis_call(
+            RedisOperation::Sadd,
+            conn.sadd::<_, _, SaddReply>(key.tenant_aware_key(self), members),
+        )
+        .await
+        .change_context(errors::RedisError::SetAddMembersFailed)
     }
 
     // ─── Stream Commands ─────────────────────────────────────────────────────
@@ -876,14 +948,16 @@ impl super::RedisConnectionPool {
             .collect();
 
         let mut conn = self.pool.clone();
-        let _: Option<String> = conn
-            .xadd_map(
+        let _: Option<String> = track_redis_call(
+            RedisOperation::StreamAppendEntry,
+            conn.xadd_map(
                 stream.tenant_aware_key(self),
                 entry_id.to_stream_id(),
                 &pairs,
-            )
-            .await
-            .change_context(errors::RedisError::StreamAppendFailed)?;
+            ),
+        )
+        .await
+        .change_context(errors::RedisError::StreamAppendFailed)?;
         Ok(())
     }
 
@@ -894,9 +968,12 @@ impl super::RedisConnectionPool {
         ids: Vec<String>,
     ) -> CustomResult<usize, errors::RedisError> {
         let mut conn = self.pool.clone();
-        conn.xdel(stream.tenant_aware_key(self), &ids)
-            .await
-            .change_context(errors::RedisError::StreamDeleteFailed)
+        track_redis_call(
+            RedisOperation::StreamDeleteEntries,
+            conn.xdel(stream.tenant_aware_key(self), &ids),
+        )
+        .await
+        .change_context(errors::RedisError::StreamDeleteFailed)
     }
 
     #[instrument(level = "DEBUG", skip(self))]
@@ -911,9 +988,12 @@ impl super::RedisConnectionPool {
             .to_trim_options()
             .change_context(errors::RedisError::StreamTrimFailed)?;
 
-        conn.xtrim_options(stream.tenant_aware_key(self), &options)
-            .await
-            .change_context(errors::RedisError::StreamTrimFailed)
+        track_redis_call(
+            RedisOperation::StreamTrimEntries,
+            conn.xtrim_options(stream.tenant_aware_key(self), &options),
+        )
+        .await
+        .change_context(errors::RedisError::StreamTrimFailed)
     }
 
     #[instrument(level = "DEBUG", skip(self))]
@@ -924,9 +1004,12 @@ impl super::RedisConnectionPool {
         ids: Vec<String>,
     ) -> CustomResult<usize, errors::RedisError> {
         let mut conn = self.pool.clone();
-        conn.xack(stream.tenant_aware_key(self), group, &ids)
-            .await
-            .change_context(errors::RedisError::StreamAcknowledgeFailed)
+        track_redis_call(
+            RedisOperation::StreamAcknowledgeEntries,
+            conn.xack(stream.tenant_aware_key(self), group, &ids),
+        )
+        .await
+        .change_context(errors::RedisError::StreamAcknowledgeFailed)
     }
 
     #[instrument(level = "DEBUG", skip(self))]
@@ -935,9 +1018,12 @@ impl super::RedisConnectionPool {
         stream: &RedisKey,
     ) -> CustomResult<usize, errors::RedisError> {
         let mut conn = self.pool.clone();
-        conn.xlen(stream.tenant_aware_key(self))
-            .await
-            .change_context(errors::RedisError::GetLengthFailed)
+        track_redis_call(
+            RedisOperation::StreamGetLength,
+            conn.xlen(stream.tenant_aware_key(self)),
+        )
+        .await
+        .change_context(errors::RedisError::GetLengthFailed)
     }
 
     /// Read entries from one or more streams using XREAD.
@@ -961,18 +1047,20 @@ impl super::RedisConnectionPool {
         let options = StreamReadOptions::default()
             .count(usize::try_from(count).change_context(errors::RedisError::StreamReadFailed)?);
 
-        let reply: redis::streams::StreamReadReply = conn
-            .xread_options(&stream_keys, &ids, &options)
-            .await
-            .map_err(|err| {
-                let kind = err.kind();
-                match kind {
-                    redis::ErrorKind::UnexpectedReturnType | redis::ErrorKind::Parse => {
-                        report!(err).change_context(errors::RedisError::StreamEmptyOrNotAvailable)
-                    }
-                    _ => report!(err).change_context(errors::RedisError::StreamReadFailed),
+        let reply: redis::streams::StreamReadReply = track_redis_call(
+            RedisOperation::StreamReadEntries,
+            conn.xread_options(&stream_keys, &ids, &options),
+        )
+        .await
+        .map_err(|err| {
+            let kind = err.kind();
+            match kind {
+                redis::ErrorKind::UnexpectedReturnType | redis::ErrorKind::Parse => {
+                    report!(err).change_context(errors::RedisError::StreamEmptyOrNotAvailable)
                 }
-            })?;
+                _ => report!(err).change_context(errors::RedisError::StreamReadFailed),
+            }
+        })?;
 
         Ok(reply
             .keys
@@ -1035,18 +1123,20 @@ impl super::RedisConnectionPool {
             options = options.group(group_name, consumer_name);
         }
 
-        let reply: redis::streams::StreamReadReply = conn
-            .xread_options(&stream_keys, &ids, &options)
-            .await
-            .map_err(|err| {
-                let kind = err.kind();
-                match kind {
-                    redis::ErrorKind::UnexpectedReturnType | redis::ErrorKind::Parse => {
-                        report!(err).change_context(errors::RedisError::StreamEmptyOrNotAvailable)
-                    }
-                    _ => report!(err).change_context(errors::RedisError::StreamReadFailed),
+        let reply: redis::streams::StreamReadReply = track_redis_call(
+            RedisOperation::StreamReadWithOptions,
+            conn.xread_options(&stream_keys, &ids, &options),
+        )
+        .await
+        .map_err(|err| {
+            let kind = err.kind();
+            match kind {
+                redis::ErrorKind::UnexpectedReturnType | redis::ErrorKind::Parse => {
+                    report!(err).change_context(errors::RedisError::StreamEmptyOrNotAvailable)
                 }
-            })?;
+                _ => report!(err).change_context(errors::RedisError::StreamReadFailed),
+            }
+        })?;
 
         Ok(reply
             .keys
@@ -1086,9 +1176,12 @@ impl super::RedisConnectionPool {
         V: redis::ToRedisArgs + Debug + Send + Sync,
     {
         let mut conn = self.pool.clone();
-        conn.rpush::<_, _, ()>(key.tenant_aware_key(self), elements)
-            .await
-            .change_context(errors::RedisError::AppendElementsToListFailed)
+        track_redis_call(
+            RedisOperation::AppendElementsToList,
+            conn.rpush::<_, _, ()>(key.tenant_aware_key(self), elements),
+        )
+        .await
+        .change_context(errors::RedisError::AppendElementsToListFailed)
     }
 
     #[instrument(level = "DEBUG", skip(self))]
@@ -1099,10 +1192,13 @@ impl super::RedisConnectionPool {
         stop: i64,
     ) -> CustomResult<Vec<String>, errors::RedisError> {
         let mut conn = self.pool.clone();
-        conn.lrange::<_, Vec<String>>(
-            key.tenant_aware_key(self),
-            isize::try_from(start).change_context(errors::RedisError::GetListElementsFailed)?,
-            isize::try_from(stop).change_context(errors::RedisError::GetListElementsFailed)?,
+        track_redis_call(
+            RedisOperation::GetListElements,
+            conn.lrange::<_, Vec<String>>(
+                key.tenant_aware_key(self),
+                isize::try_from(start).change_context(errors::RedisError::GetListElementsFailed)?,
+                isize::try_from(stop).change_context(errors::RedisError::GetListElementsFailed)?,
+            ),
         )
         .await
         .change_context(errors::RedisError::GetListElementsFailed)
@@ -1111,9 +1207,12 @@ impl super::RedisConnectionPool {
     #[instrument(level = "DEBUG", skip(self))]
     pub async fn get_list_length(&self, key: &RedisKey) -> CustomResult<usize, errors::RedisError> {
         let mut conn = self.pool.clone();
-        conn.llen::<_, usize>(key.tenant_aware_key(self))
-            .await
-            .change_context(errors::RedisError::GetListLengthFailed)
+        track_redis_call(
+            RedisOperation::GetListLength,
+            conn.llen::<_, usize>(key.tenant_aware_key(self)),
+        )
+        .await
+        .change_context(errors::RedisError::GetListLengthFailed)
     }
 
     #[instrument(level = "DEBUG", skip(self))]
@@ -1124,9 +1223,12 @@ impl super::RedisConnectionPool {
     ) -> CustomResult<Vec<String>, errors::RedisError> {
         let mut conn = self.pool.clone();
         let non_zero_count = count.and_then(std::num::NonZeroUsize::new);
-        conn.lpop::<_, Vec<String>>(key.tenant_aware_key(self), non_zero_count)
-            .await
-            .change_context(errors::RedisError::PopListElementsFailed)
+        track_redis_call(
+            RedisOperation::LpopListElements,
+            conn.lpop::<_, Vec<String>>(key.tenant_aware_key(self), non_zero_count),
+        )
+        .await
+        .change_context(errors::RedisError::PopListElementsFailed)
     }
 
     //                                              Consumer Group API
@@ -1146,10 +1248,12 @@ impl super::RedisConnectionPool {
         }
 
         let mut conn = self.pool.clone();
-        let _: () = conn
-            .xgroup_create_mkstream(stream.tenant_aware_key(self), group, id.to_stream_id())
-            .await
-            .change_context(errors::RedisError::ConsumerGroupCreateFailed)?;
+        let _: () = track_redis_call(
+            RedisOperation::ConsumerGroupCreate,
+            conn.xgroup_create_mkstream(stream.tenant_aware_key(self), group, id.to_stream_id()),
+        )
+        .await
+        .change_context(errors::RedisError::ConsumerGroupCreateFailed)?;
         Ok(())
     }
 
@@ -1160,10 +1264,12 @@ impl super::RedisConnectionPool {
         group: &str,
     ) -> CustomResult<crate::types::ConsumerGroupDestroyReply, errors::RedisError> {
         let mut conn = self.pool.clone();
-        let reply: crate::types::ConsumerGroupDestroyReply = conn
-            .xgroup_destroy(stream.tenant_aware_key(self), group)
-            .await
-            .change_context(errors::RedisError::ConsumerGroupDestroyFailed)?;
+        let reply: crate::types::ConsumerGroupDestroyReply = track_redis_call(
+            RedisOperation::ConsumerGroupDestroy,
+            conn.xgroup_destroy(stream.tenant_aware_key(self), group),
+        )
+        .await
+        .change_context(errors::RedisError::ConsumerGroupDestroyFailed)?;
         Ok(reply)
     }
 
@@ -1176,9 +1282,12 @@ impl super::RedisConnectionPool {
         consumer: &str,
     ) -> CustomResult<usize, errors::RedisError> {
         let mut conn = self.pool.clone();
-        conn.xgroup_delconsumer(stream.tenant_aware_key(self), group, consumer)
-            .await
-            .change_context(errors::RedisError::ConsumerGroupRemoveConsumerFailed)
+        track_redis_call(
+            RedisOperation::ConsumerGroupDeleteConsumer,
+            conn.xgroup_delconsumer(stream.tenant_aware_key(self), group, consumer),
+        )
+        .await
+        .change_context(errors::RedisError::ConsumerGroupRemoveConsumerFailed)
     }
 
     #[instrument(level = "DEBUG", skip(self))]
@@ -1189,10 +1298,12 @@ impl super::RedisConnectionPool {
         id: &RedisEntryId,
     ) -> CustomResult<String, errors::RedisError> {
         let mut conn = self.pool.clone();
-        let _: () = conn
-            .xgroup_setid(stream.tenant_aware_key(self), group, id.to_stream_id())
-            .await
-            .change_context(errors::RedisError::ConsumerGroupSetIdFailed)?;
+        let _: () = track_redis_call(
+            RedisOperation::ConsumerGroupSetLastId,
+            conn.xgroup_setid(stream.tenant_aware_key(self), group, id.to_stream_id()),
+        )
+        .await
+        .change_context(errors::RedisError::ConsumerGroupSetIdFailed)?;
         Ok(id.to_stream_id().to_string())
     }
 
@@ -1209,12 +1320,15 @@ impl super::RedisConnectionPool {
         R: FromRedisValue + Send + 'static,
     {
         let mut conn = self.pool.clone();
-        conn.xclaim(
-            stream.tenant_aware_key(self),
-            group,
-            consumer,
-            min_idle_time,
-            &ids,
+        track_redis_call(
+            RedisOperation::ConsumerGroupSetMessageOwner,
+            conn.xclaim(
+                stream.tenant_aware_key(self),
+                group,
+                consumer,
+                min_idle_time,
+                &ids,
+            ),
         )
         .await
         .change_context(errors::RedisError::ConsumerGroupClaimFailed)
@@ -1242,10 +1356,12 @@ impl super::RedisConnectionPool {
         }
         invocation.arg(values);
 
-        let val: T = invocation
-            .invoke_async(&mut conn)
-            .await
-            .change_context(errors::RedisError::ScriptExecutionFailed)?;
+        let val: T = track_redis_call(
+            RedisOperation::EvaluateRedisScript,
+            invocation.invoke_async(&mut conn),
+        )
+        .await
+        .change_context(errors::RedisError::ScriptExecutionFailed)?;
         Ok(val)
     }
 
@@ -1311,11 +1427,13 @@ impl super::RedisConnectionPool {
         // Execute the transaction.
         // Redis MULTI/EXEC guarantees results are returned in the same order
         // as the commands were queued: [SET result, GET result].
-        let results: Vec<redis::Value> = pipe
-            .query_async(&mut conn)
-            .await
-            .change_context(errors::RedisError::SetFailed)
-            .attach_printable("Failed to execute the redis transaction")?;
+        let results: Vec<redis::Value> = track_redis_call(
+            RedisOperation::SetKeyIfNotExistsAndGetValue,
+            pipe.query_async(&mut conn),
+        )
+        .await
+        .change_context(errors::RedisError::SetFailed)
+        .attach_printable("Failed to execute the redis transaction")?;
 
         let msg = "Got unexpected number of results from transaction";
         if results.len() < 2 {

--- a/crates/router/Cargo.toml
+++ b/crates/router/Cargo.toml
@@ -40,8 +40,8 @@ tokenization_v2 = ["api_models/tokenization_v2", "diesel_models/tokenization_v2"
 # The feature reduces the overhead of the router authenticating the merchant for every request, and trusts on `x-merchant-id` header to be present in the request.
 # This is named as partial-auth because the router will still try to authenticate if the `x-merchant-id` header is not present.
 partial-auth = []
-fred    = ["redis_interface/fred",     "storage_impl/fred",    "scheduler/fred"]
-redis-rs = ["redis_interface/redis-rs", "storage_impl/redis-rs", "scheduler/redis-rs"]
+fred    = ["redis_interface/fred",     "redis_interface/metrics", "storage_impl/fred",    "scheduler/fred"]
+redis-rs = ["redis_interface/redis-rs", "redis_interface/metrics", "storage_impl/redis-rs", "scheduler/redis-rs"]
 
 [dependencies]
 actix-cors = "0.6.5"


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Adds per-operation metrics to `redis_interface`. 
Function `track_redis_call(operation, future)` (times the call, logs op + duration) and a shared `RedisOperation` enum added for every Redis command in both backends (`redis_rs` + `fred`) is routed through it.

Two metrics are recorded on the `ROUTER_API` meter, labelled by `operation`:
- `REDIS_CALLS_COUNT` — counter → `router_REDIS_CALLS_COUNT_total{operation="..."}`
- `REDIS_CALL_TIME` — latency histogram → `router_REDIS_CALL_TIME_*{operation="..."}`

<img width="1593" height="745" alt="Screenshot 2026-06-09 at 2 52 46 PM" src="https://github.com/user-attachments/assets/e080b82c-1479-4a18-8717-8a94dd2e0b4a" />

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

## Motivation and Context

Redis interface had no metrics — it was a blind spot from monitoring perspective. This adds per-operation visibility, enabling call-rate/latency metrics for observability.


## How did you test it?

Logs
```bash
  2026-06-09T09:26:57.536773Z DEBUG redis_interface::metrics: Redis operation executed, redis_operation: GetMultipleKeys, execution_time: 743.333µs
    at crates/redis_interface/src/metrics.rs:62
    in redis_interface::module::redis_rs::commands::get_multiple_keys_with_mget with keys: [RedisKey("API_LOCK_merchant_1780945287_payments_pay_0e8x8tYElfG5sy3Des0b"), RedisKey("API_LOCK_merchant_1780945287_payments_wertyuiuhgfcvghjkjhgfdgyuijhgfcvbhj")]
    in redis_interface::module::redis_rs::commands::get_keys_by_mode with keys: [RedisKey("API_LOCK_merchant_1780945287_payments_pay_0e8x8tYElfG5sy3Des0b"), RedisKey("API_LOCK_merchant_1780945287_payments_wertyuiuhgfcvghjkjhgfdgyuijhgfcvbhj")]
    in redis_interface::module::redis_rs::commands::get_multiple_keys with keys: [RedisKey("API_LOCK_merchant_1780945287_payments_pay_0e8x8tYElfG5sy3Des0b"), RedisKey("API_LOCK_merchant_1780945287_payments_wertyuiuhgfcvghjkjhgfdgyuijhgfcvbhj")]
    in router::core::api_locking::free_lock_action
    in router::services::api::server_wrap_util with flow: PaymentsCreate, lock_action: HoldMultiple { inputs: [LockingInput { unique_locking_key: "pay_0e8x8tYElfG5sy3Des0b", api_identifier: Payments, override_lock_retries: None }, LockingInput { unique_locking_key: "wertyuiuhgfcvghjkjhgfdgyuijhgfcvbhj", api_identifier: Payments, override_lock_retries: None }] }, merchant_id: "merchant_1780945287"
    in router::services::api::server_wrap with flow: PaymentsCreate, lock_action: HoldMultiple { inputs: [LockingInput { unique_locking_key: "pay_0e8x8tYElfG5sy3Des0b", api_identifier: Payments, override_lock_retries: None }, LockingInput { unique_locking_key: "wertyuiuhgfcvghjkjhgfdgyuijhgfcvbhj", api_identifier: Payments, override_lock_retries: None }] }, request_method: "POST", request_url_path: "/payments"
    in router::routes::payments::payments_create with flow: PaymentsCreate, payment_id: "pay_0e8x8tYElfG5sy3Des0b"
    in router::middleware::ROOT_SPAN with flow: "UNKNOWN", tenant_id: "public", tenant_id: "public"
    in router_env::root_span::HTTP request with http.method: POST, http.route: /payments, http.flavor: 1.1, http.scheme: http, http.host: localhost:9080, http.client_ip: ::1, http.user_agent: PostmanRuntime/7.44.1, http.target: /payments, otel.name: POST /payments, otel.kind: "server", request_id: 019eabb4-d0ed-73d0-b1b7-129d393d784e, request_id: "019eabb4-d0ed-73d0-b1b7-1288d500a6a5", trace_id: 00000000000000000000000000000000

  2026-06-09T09:26:57.537574Z DEBUG redis_interface::metrics: Redis operation executed, redis_operation: DeleteKey, execution_time: 550.542µs
    at crates/redis_interface/src/metrics.rs:62
    in redis_interface::module::redis_rs::commands::delete_key with key: RedisKey("API_LOCK_merchant_1780945287_payments_pay_0e8x8tYElfG5sy3Des0b")
    in redis_interface::module::redis_rs::commands::delete_multiple_keys with keys: [RedisKey("API_LOCK_merchant_1780945287_payments_pay_0e8x8tYElfG5sy3Des0b"), RedisKey("API_LOCK_merchant_1780945287_payments_wertyuiuhgfcvghjkjhgfdgyuijhgfcvbhj")]
    in router::core::api_locking::free_lock_action
    in router::services::api::server_wrap_util with flow: PaymentsCreate, lock_action: HoldMultiple { inputs: [LockingInput { unique_locking_key: "pay_0e8x8tYElfG5sy3Des0b", api_identifier: Payments, override_lock_retries: None }, LockingInput { unique_locking_key: "wertyuiuhgfcvghjkjhgfdgyuijhgfcvbhj", api_identifier: Payments, override_lock_retries: None }] }, merchant_id: "merchant_1780945287"
    in router::services::api::server_wrap with flow: PaymentsCreate, lock_action: HoldMultiple { inputs: [LockingInput { unique_locking_key: "pay_0e8x8tYElfG5sy3Des0b", api_identifier: Payments, override_lock_retries: None }, LockingInput { unique_locking_key: "wertyuiuhgfcvghjkjhgfdgyuijhgfcvbhj", api_identifier: Payments, override_lock_retries: None }] }, request_method: "POST", request_url_path: "/payments"
    in router::routes::payments::payments_create with flow: PaymentsCreate, payment_id: "pay_0e8x8tYElfG5sy3Des0b"
    in router::middleware::ROOT_SPAN with flow: "UNKNOWN", tenant_id: "public", tenant_id: "public"
    in router_env::root_span::HTTP request with http.method: POST, http.route: /payments, http.flavor: 1.1, http.scheme: http, http.host: localhost:9080, http.client_ip: ::1, http.user_agent: PostmanRuntime/7.44.1, http.target: /payments, otel.name: POST /payments, otel.kind: "server", request_id: 019eabb4-d0ed-73d0-b1b7-129d393d784e, request_id: "019eabb4-d0ed-73d0-b1b7-1288d500a6a5", trace_id: 00000000000000000000000000000000

  2026-06-09T09:26:57.537657Z DEBUG redis_interface::metrics: Redis operation executed, redis_operation: DeleteKey, execution_time: 599.959µs
    at crates/redis_interface/src/metrics.rs:62
    in redis_interface::module::redis_rs::commands::delete_key with key: RedisKey("API_LOCK_merchant_1780945287_payments_wertyuiuhgfcvghjkjhgfdgyuijhgfcvbhj")
    in redis_interface::module::redis_rs::commands::delete_multiple_keys with keys: [RedisKey("API_LOCK_merchant_1780945287_payments_pay_0e8x8tYElfG5sy3Des0b"), RedisKey("API_LOCK_merchant_1780945287_payments_wertyuiuhgfcvghjkjhgfdgyuijhgfcvbhj")]
    in router::core::api_locking::free_lock_action
    in router::services::api::server_wrap_util with flow: PaymentsCreate, lock_action: HoldMultiple { inputs: [LockingInput { unique_locking_key: "pay_0e8x8tYElfG5sy3Des0b", api_identifier: Payments, override_lock_retries: None }, LockingInput { unique_locking_key: "wertyuiuhgfcvghjkjhgfdgyuijhgfcvbhj", api_identifier: Payments, override_lock_retries: None }] }, merchant_id: "merchant_1780945287"
    in router::services::api::server_wrap with flow: PaymentsCreate, lock_action: HoldMultiple { inputs: [LockingInput { unique_locking_key: "pay_0e8x8tYElfG5sy3Des0b", api_identifier: Payments, override_lock_retries: None }, LockingInput { unique_locking_key: "wertyuiuhgfcvghjkjhgfdgyuijhgfcvbhj", api_identifier: Payments, override_lock_retries: None }] }, request_method: "POST", request_url_path: "/payments"
    in router::routes::payments::payments_create with flow: PaymentsCreate, payment_id: "pay_0e8x8tYElfG5sy3Des0b"
    in router::middleware::ROOT_SPAN with flow: "UNKNOWN", tenant_id: "public", tenant_id: "public"
    in router_env::root_span::HTTP request with http.method: POST, http.route: /payments, http.flavor: 1.1, http.scheme: http, http.host: localhost:9080, http.client_ip: ::1, http.user_agent: PostmanRuntime/7.44.1, http.target: /payments, otel.name: POST /payments, otel.kind: "server", request_id: 019eabb4-d0ed-73d0-b1b7-129d393d784e, request_id: "019eabb4-d0ed-73d0-b1b7-1288d500a6a5", trace_id: 00000000000000000000000000000000
```


## Checklist

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
