### PR TITLE
fix(ucs): populate setup_mandate connector_response_reference_id from connector transaction id

### DIFF
--- a/crates/router/src/core/unified_connector_service/transformers.rs
+++ b/crates/router/src/core/unified_connector_service/transformers.rs
@@ -2707,7 +2707,7 @@ impl
                     connector_metadata,
                     network_txn_id: response.network_transaction_id,
                     network_txn_link_id: None,
-                    connector_response_reference_id: Some(response.merchant_recurring_payment_id.clone()),
+                    connector_response_reference_id: response.connector_recurring_payment_id.clone(),
                     incremental_authorization_allowed: response.incremental_authorization_allowed,
                     authentication_data: None,
                     charges: None,


### PR DESCRIPTION
## What
In the UCS response reconstruction for the **setup_mandate** (SetupRecurring) flow, `connector_response_reference_id` was left `null` — it was sourced from a field that is empty for some connectors (e.g. paypal). Native hyperswitch sets it to the connector transaction id, so the reconstructed RouterData diverged from native.

Example (paypal setup_mandate) — these are all the same connector transaction id, but only `connector_response_reference_id` was wrong:

| field | native | reconstructed (before) |
|---|---|---|
| `resource_id.ConnectorTransactionId` | `7e966890y1635844v` | `7e966890y1635844v` |
| `mandate_reference.connector_mandate_id` | `7e966890y1635844v` | `7e966890y1635844v` |
| `connector_response_reference_id` | `7e966890y1635844v` | **`null`** |

## Fix
Source `connector_response_reference_id` from `connector_recurring_payment_id` — the same id already used for `resource_id` — so it matches native.

`crates/router/src/core/unified_connector_service/transformers.rs` (setup_recurring success arm).

## Scope
Hyperswitch-side only (response reconstruction). **No connector-service / UCS changes.**
