### PR TITLE
fix(ucs): null amount_captured for setup_mandate response

### DIFF
--- a/crates/router/src/core/unified_connector_service.rs
+++ b/crates/router/src/core/unified_connector_service.rs
@@ -2131,10 +2131,8 @@ pub fn handle_unified_connector_service_response_for_payment_setup_recurring(
         status_code,
         connector_customer_id,
         connector_response,
-        amount_captured: response.captured_amount,
-        minor_amount_captured: response
-            .captured_amount
-            .map(common_utils::types::MinorUnit::new),
+        amount_captured: None,
+        minor_amount_captured: None,
     })
 }
 


### PR DESCRIPTION
## What
For the setup_mandate (SetupRecurring) flow, `amount_captured` / `minor_amount_captured` were read from the proto `captured_amount` field. setup_mandate is a zero-auth mandate registration and never captures an amount, so native leaves these null while the value came through as `0` — a shadow diff.

## Fix
Hardcode `amount_captured: None` and `minor_amount_captured: None` in the setup_recurring response handler (`crates/router/src/core/unified_connector_service.rs`).

Pairs with removal of the now-unused `captured_amount` field from `PaymentServiceSetupRecurringResponse` on the connector-service side. This change is independent of that — it simply stops reading the field — so it is safe with the current client tag and after the field is removed.

## Scope
Hyperswitch-side only. No SDK changes.
