### PR TITLE
fix(connector): [ADYEN] Remove PMT check in function get_shopper_email

### DIFF
--- a/crates/hyperswitch_connectors/src/connectors/adyen/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/adyen/transformers.rs
@@ -4004,13 +4004,8 @@ fn get_shopper_email(
     is_mandate_payment: bool,
 ) -> CustomResult<Option<Email>, errors::ConnectorError> {
     if is_mandate_payment {
-        let payment_method_type = item
-            .request
-            .payment_method_type
-            .as_ref()
-            .ok_or(errors::ConnectorError::MissingPaymentMethodType)?;
-        match payment_method_type {
-            storage_enums::PaymentMethodType::Paypal => Ok(Some(item.get_billing_email()?)),
+        match item.request.payment_method_type {
+            Some(storage_enums::PaymentMethodType::Paypal) => Ok(Some(item.get_billing_email()?)),
             _ => Ok(item.get_optional_billing_email()),
         }
     } else {


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Adyen's `get_shopper_email` returned MissingPaymentMethodType (surfaced as HE_00) for wallet mandate payments whenever payment_method_type was absent. This broke wallet setup_mandate/zero-auth payments to Adyen, because convert_setup_mandate_router_data_to_authorize_router_data populates payment_method_type as None.

The payment_method_type value was only ever used to special-case PayPal (force a billing email). This change removes the hard error and treats a missing type as a non-PayPal method.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
https://github.com/juspay/hyperswitch/issues/12665

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Payment Intent:
Request:
```
curl --location 'http://localhost:8080/payments' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: dev_2DFyxAB4YZs3ea0CPbKGazMtj5IViiwB6Y8mengP57lqgXtNPab6uughMxLcdDgV' \
--data '{
    "currency": "AUD",
    "amount": 0,
    "setup_future_usage": "off_session",
    "capture_method": "automatic",
    "customer": {
        "id": "cus_NgphORniZV2yAogIbcsS"
    },
    "return_url": "https://web.edge-uat.zurich.com.au/portfolio/policy/payment-setup/gdp/callback",
    "confirm": false
}'
```
Response:
```
{
    "payment_id": "pay_pLBfslEFDSTThY4l50Rj",
    "merchant_id": "merchant_1781011869",
    "status": "requires_payment_method",
    "amount": 0,
    "net_amount": 0,
    "shipping_cost": null,
    "amount_capturable": 0,
    "amount_received": null,
    "processor_merchant_id": "merchant_1781011869",
    "initiator": null,
    "sdk_authorization": "cHJvZmlsZV9pZD1wcm9fSW41QVhDelk3aGUxV0tQSDB0cjEscHVibGlzaGFibGVfa2V5PXBrX2Rldl81MmJmNDY2Mzk3ODM0OTI5YWZjZGZkMTcwNTMyOGFjOSxjbGllbnRfc2VjcmV0PXBheV9wTEJmc2xFRkRTVFRoWTRsNTBSal9zZWNyZXRfU2pYZWhpR1BQNXFMcWNyNFh0b24sY3VzdG9tZXJfaWQ9Y3VzX05ncGhPUm5pWlYyeUFvZ0liY3NTLGNsaWVudF9zZXNzaW9uX2lkPWNsaWVudF9zZXNzX1VSUzNMdkQweEY2VHJSbWtTUkVjLHBheW1lbnRfaWQ9cGF5X3BMQmZzbEVGRFNUVGhZNGw1MFJq",
    "connector": null,
    "state_metadata": null,
    "client_secret": "pay_pLBfslEFDSTThY4l50Rj_secret_SjXehiGPP5qLqcr4Xton",
    "created": "2026-06-09T13:51:36.862Z",
    "modified_at": "2026-06-09T13:51:36.879Z",
    "connector_customer_id": null,
    "currency": "AUD",
    "customer_id": "cus_NgphORniZV2yAogIbcsS",
    "customer": {
        "id": "cus_NgphORniZV2yAogIbcsS",
        "name": null,
        "email": null,
        "phone": null,
        "phone_country_code": null,
        "customer_document_details": null
    },
    "description": null,
    "refunds": null,
    "disputes": null,
    "mandate_id": null,
    "mandate_data": null,
    "setup_future_usage": "off_session",
    "off_session": null,
    "capture_on": null,
    "capture_method": "automatic",
    "payment_method": null,
    "payment_method_data": null,
    "payment_token": null,
    "shipping": null,
    "billing": null,
    "order_details": null,
    "email": null,
    "name": null,
    "phone": null,
    "return_url": "https://web.edge-uat.zurich.com.au/portfolio/policy/payment-setup/gdp/callback",
    "authentication_type": null,
    "statement_descriptor_name": null,
    "statement_descriptor_suffix": null,
    "next_action": null,
    "cancellation_reason": null,
    "error_code": null,
    "error_message": null,
    "unified_code": null,
    "unified_message": null,
    "error_details": null,
    "payment_experience": null,
    "payment_method_type": null,
    "connector_label": null,
    "business_country": null,
    "business_label": "default",
    "business_sub_label": null,
    "allowed_payment_method_types": null,
    "manual_retry_allowed": null,
    "connector_transaction_id": null,
    "frm_message": null,
    "metadata": null,
    "connector_metadata": null,
    "connector_response_metadata": null,
    "feature_metadata": null,
    "reference_id": null,
    "payment_link": null,
    "profile_id": "pro_In5AXCzY7he1WKPH0tr1",
    "surcharge_details": null,
    "attempt_count": 1,
    "merchant_decision": null,
    "merchant_connector_id": null,
    "incremental_authorization_allowed": null,
    "authorization_count": null,
    "incremental_authorizations": null,
    "external_authentication_details": null,
    "external_3ds_authentication_attempted": false,
    "expires_on": "2026-06-09T14:06:36.862Z",
    "fingerprint": null,
    "browser_info": null,
    "payment_channel": null,
    "payment_method_id": null,
    "network_transaction_id": null,
    "network_transaction_link_id": null,
    "payment_method_status": null,
    "updated": "2026-06-09T13:51:36.879Z",
    "split_payments": null,
    "frm_metadata": null,
    "extended_authorization_applied": null,
    "extended_authorization_last_applied_at": null,
    "request_extended_authorization": null,
    "capture_before": null,
    "merchant_order_reference_id": null,
    "order_tax_amount": null,
    "connector_mandate_id": null,
    "card_discovery": null,
    "force_3ds_challenge": false,
    "force_3ds_challenge_trigger": false,
    "issuer_error_code": null,
    "issuer_error_message": null,
    "is_iframe_redirection_enabled": null,
    "whole_connector_response": null,
    "enable_partial_authorization": null,
    "enable_overcapture": null,
    "is_overcapture_enabled": null,
    "network_details": null,
    "is_stored_credential": null,
    "mit_category": null,
    "billing_descriptor": null,
    "tokenization": null,
    "partner_merchant_identifier_details": null,
    "payment_method_tokenization_details": null,
    "installment_options": null,
    "installment_data": null,
    "sender_payment_instrument_id": null
}
```

Payment Confirm:
Request:
```
curl --location 'http://localhost:8080/payments/pay_pLBfslEFDSTThY4l50Rj/confirm' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: dev_2DFyxAB4YZs3ea0CPbKGazMtj5IViiwB6Y8mengP57lqgXtNPab6uughMxLcdDgV' \
--data '{
    "payment_type": "setup_mandate",
    "customer_acceptance": {
        "acceptance_type": "online",
        "accepted_at": "2026-06-05T11:11:00.860Z",
        "online": {
            "ip_address": null,
            "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.0.0 Safari/537.36 Edg/148.0.0.0"
        }
    },
    "payment_method": "wallet",
    "payment_method_type": "google_pay",
    "payment_method_data": {
        "wallet": {
            "google_pay": {
                "type": "CARD",
                "description": "NL Cla SC Optional: Visa •••• 1142",
                "info": {
                    "assurance_details": {
                        "account_verified": true,
                        "card_holder_authenticated": false
                    },
                    "card_details": "1142",
                    "card_funding_source": "CREDIT",
                    "card_network": "VISA"
                },
                "tokenization_data": {
                    "token": "REDACTED",
                    "type": "PAYMENT_GATEWAY"
                }
            }
        }
    },
    "browser_info": {
        "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.0.0 Safari/537.36",
        "accept_header": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8",
        "language": "en-GB",
        "color_depth": 24,
        "screen_height": 1117,
        "screen_width": 1728,
        "time_zone": -330,
        "java_enabled": true,
        "java_script_enabled": true,
        "device_model": "Macintosh",
        "os_type": "macOS",
        "os_version": "10.15.7"
    }
}'
```

Response:
```
{
    "payment_id": "pay_pLBfslEFDSTThY4l50Rj",
    "merchant_id": "merchant_1781011869",
    "status": "failed",
    "amount": 0,
    "net_amount": 0,
    "shipping_cost": null,
    "amount_capturable": 0,
    "amount_received": null,
    "processor_merchant_id": "merchant_1781011869",
    "initiator": null,
    "sdk_authorization": "cHJvZmlsZV9pZD1wcm9fSW41QVhDelk3aGUxV0tQSDB0cjEscHVibGlzaGFibGVfa2V5PXBrX2Rldl81MmJmNDY2Mzk3ODM0OTI5YWZjZGZkMTcwNTMyOGFjOSxjbGllbnRfc2VjcmV0PXBheV9wTEJmc2xFRkRTVFRoWTRsNTBSal9zZWNyZXRfU2pYZWhpR1BQNXFMcWNyNFh0b24sY3VzdG9tZXJfaWQ9Y3VzX05ncGhPUm5pWlYyeUFvZ0liY3NTLHBheW1lbnRfaWQ9cGF5X3BMQmZzbEVGRFNUVGhZNGw1MFJq",
    "connector": "adyen",
    "state_metadata": null,
    "client_secret": "pay_pLBfslEFDSTThY4l50Rj_secret_SjXehiGPP5qLqcr4Xton",
    "created": "2026-06-09T13:51:36.862Z",
    "modified_at": "2026-06-09T13:51:44.002Z",
    "connector_customer_id": null,
    "currency": "AUD",
    "customer_id": "cus_NgphORniZV2yAogIbcsS",
    "customer": {
        "id": "cus_NgphORniZV2yAogIbcsS",
        "name": null,
        "email": null,
        "phone": null,
        "phone_country_code": null,
        "customer_document_details": null
    },
    "description": null,
    "refunds": null,
    "disputes": null,
    "mandate_id": null,
    "mandate_data": null,
    "setup_future_usage": "off_session",
    "off_session": null,
    "capture_on": null,
    "capture_method": "automatic",
    "payment_method": "wallet",
    "payment_method_data": {
        "wallet": {
            "google_pay": {
                "last4": "1142",
                "card_network": "VISA",
                "type": "CARD",
                "card_exp_month": null,
                "card_exp_year": null,
                "auth_code": null,
                "email": null
            }
        },
        "billing": null
    },
    "payment_token": null,
    "shipping": null,
    "billing": null,
    "order_details": null,
    "email": null,
    "name": null,
    "phone": null,
    "return_url": "https://web.edge-uat.zurich.com.au/portfolio/policy/payment-setup/gdp/callback",
    "authentication_type": "three_ds",
    "statement_descriptor_name": null,
    "statement_descriptor_suffix": null,
    "next_action": null,
    "cancellation_reason": null,
    "error_code": "5_210",
    "error_message": "Google Pay token already used",
    "unified_code": "UE_9000",
    "unified_message": "Something went wrong",
    "error_details": {
        "unified_details": {
            "category": "UE_9000",
            "message": "Something went wrong",
            "standardised_code": null,
            "description": null,
            "user_guidance_message": null,
            "recommended_action": null
        },
        "issuer_details": null,
        "connector_details": {
            "code": "5_210",
            "message": "Google Pay token already used",
            "reason": "Google Pay token already used"
        }
    },
    "payment_experience": null,
    "payment_method_type": "google_pay",
    "connector_label": null,
    "business_country": null,
    "business_label": "default",
    "business_sub_label": null,
    "allowed_payment_method_types": null,
    "manual_retry_allowed": null,
    "connector_transaction_id": "FTF62NCBK94BT6V5",
    "frm_message": null,
    "metadata": null,
    "connector_metadata": null,
    "connector_response_metadata": null,
    "feature_metadata": {
        "redirect_response": null,
        "search_tags": null,
        "apple_pay_recurring_details": null,
        "pix_additional_details": null,
        "boleto_additional_details": null,
        "pix_automatico_additional_details": null,
        "finix_additional_details": null
    },
    "reference_id": null,
    "payment_link": null,
    "profile_id": "pro_In5AXCzY7he1WKPH0tr1",
    "surcharge_details": null,
    "attempt_count": 1,
    "merchant_decision": null,
    "merchant_connector_id": "mca_EUxcZ0A7MjF6GeLRQdqp",
    "incremental_authorization_allowed": false,
    "authorization_count": null,
    "incremental_authorizations": null,
    "external_authentication_details": null,
    "external_3ds_authentication_attempted": false,
    "expires_on": "2026-06-09T14:06:36.862Z",
    "fingerprint": null,
    "browser_info": {
        "os_type": "macOS",
        "referer": null,
        "language": "en-GB",
        "time_zone": -330,
        "ip_address": "::1",
        "os_version": "10.15.7",
        "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.0.0 Safari/537.36",
        "color_depth": 24,
        "device_model": "Macintosh",
        "java_enabled": true,
        "screen_width": 1728,
        "accept_header": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8",
        "screen_height": 1117,
        "accept_language": "en",
        "java_script_enabled": true
    },
    "payment_channel": null,
    "payment_method_id": null,
    "network_transaction_id": null,
    "network_transaction_link_id": null,
    "payment_method_status": null,
    "updated": "2026-06-09T13:51:44.002Z",
    "split_payments": null,
    "frm_metadata": null,
    "extended_authorization_applied": null,
    "extended_authorization_last_applied_at": null,
    "request_extended_authorization": null,
    "capture_before": null,
    "merchant_order_reference_id": null,
    "order_tax_amount": null,
    "connector_mandate_id": null,
    "card_discovery": null,
    "force_3ds_challenge": false,
    "force_3ds_challenge_trigger": false,
    "issuer_error_code": null,
    "issuer_error_message": null,
    "is_iframe_redirection_enabled": null,
    "whole_connector_response": null,
    "enable_partial_authorization": null,
    "enable_overcapture": null,
    "is_overcapture_enabled": null,
    "network_details": {
        "network_advice_code": null
    },
    "is_stored_credential": null,
    "mit_category": null,
    "billing_descriptor": null,
    "tokenization": null,
    "partner_merchant_identifier_details": null,
    "payment_method_tokenization_details": null,
    "installment_options": null,
    "installment_data": null,
    "sender_payment_instrument_id": null
}
```
Note: The above payment is failing because I am reusing the google pay token while testing in my local. But before this fix the payment was failing at hyperswitch with the error `ConnectorError::MissingPaymentMethodType`
The above error was recreated in local as well on latest main with above same requests.
<img width="998" height="128" alt="image" src="https://github.com/user-attachments/assets/799a8320-5a9d-4da2-8b10-09a8e4a71ee4" />

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
