### PR TITLE
fix(unified_connector_service): populate connector_response in payment capture readback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2264,7 +2264,7 @@ dependencies = [
 [[package]]
 name = "config_patch_derive"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?rev=660bed60ec166e3f4e134431ca13e5ac318538fc#660bed60ec166e3f4e134431ca13e5ac318538fc"
+source = "git+https://github.com/juspay/connector-service?tag=2026.06.12.1#f0f87879f730320cbf67b4a18ce741720e32e9bb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3981,7 +3981,7 @@ checksum = "32619942b8be646939eaf3db0602b39f5229b74575b67efc897811ded1db4e57"
 [[package]]
 name = "grpc-api-types"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?rev=660bed60ec166e3f4e134431ca13e5ac318538fc#660bed60ec166e3f4e134431ca13e5ac318538fc"
+source = "git+https://github.com/juspay/connector-service?tag=2026.06.12.1#f0f87879f730320cbf67b4a18ce741720e32e9bb"
 dependencies = [
  "axum 0.8.4",
  "bytes 1.10.1",
@@ -8175,7 +8175,7 @@ dependencies = [
 [[package]]
 name = "rust-grpc-client"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?rev=660bed60ec166e3f4e134431ca13e5ac318538fc#660bed60ec166e3f4e134431ca13e5ac318538fc"
+source = "git+https://github.com/juspay/connector-service?tag=2026.06.12.1#f0f87879f730320cbf67b4a18ce741720e32e9bb"
 dependencies = [
  "grpc-api-types",
 ]
@@ -11009,7 +11009,7 @@ checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
 [[package]]
 name = "ucs_cards"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?rev=660bed60ec166e3f4e134431ca13e5ac318538fc#660bed60ec166e3f4e134431ca13e5ac318538fc"
+source = "git+https://github.com/juspay/connector-service?tag=2026.06.12.1#f0f87879f730320cbf67b4a18ce741720e32e9bb"
 dependencies = [
  "bytes 1.10.1",
  "error-stack 0.4.1",
@@ -11025,7 +11025,7 @@ dependencies = [
 [[package]]
 name = "ucs_common_enums"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?rev=660bed60ec166e3f4e134431ca13e5ac318538fc#660bed60ec166e3f4e134431ca13e5ac318538fc"
+source = "git+https://github.com/juspay/connector-service?tag=2026.06.12.1#f0f87879f730320cbf67b4a18ce741720e32e9bb"
 dependencies = [
  "serde",
  "strum 0.26.3",
@@ -11036,7 +11036,7 @@ dependencies = [
 [[package]]
 name = "ucs_common_utils"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?rev=660bed60ec166e3f4e134431ca13e5ac318538fc#660bed60ec166e3f4e134431ca13e5ac318538fc"
+source = "git+https://github.com/juspay/connector-service?tag=2026.06.12.1#f0f87879f730320cbf67b4a18ce741720e32e9bb"
 dependencies = [
  "anyhow",
  "base64 0.21.7",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2264,7 +2264,7 @@ dependencies = [
 [[package]]
 name = "config_patch_derive"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.06.10.0#1044ccf1d636eed98e70fbf06acc18ecc78d5be8"
+source = "git+https://github.com/juspay/connector-service?rev=660bed60ec166e3f4e134431ca13e5ac318538fc#660bed60ec166e3f4e134431ca13e5ac318538fc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3981,7 +3981,7 @@ checksum = "32619942b8be646939eaf3db0602b39f5229b74575b67efc897811ded1db4e57"
 [[package]]
 name = "grpc-api-types"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.06.10.0#1044ccf1d636eed98e70fbf06acc18ecc78d5be8"
+source = "git+https://github.com/juspay/connector-service?rev=660bed60ec166e3f4e134431ca13e5ac318538fc#660bed60ec166e3f4e134431ca13e5ac318538fc"
 dependencies = [
  "axum 0.8.4",
  "bytes 1.10.1",
@@ -8175,7 +8175,7 @@ dependencies = [
 [[package]]
 name = "rust-grpc-client"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.06.10.0#1044ccf1d636eed98e70fbf06acc18ecc78d5be8"
+source = "git+https://github.com/juspay/connector-service?rev=660bed60ec166e3f4e134431ca13e5ac318538fc#660bed60ec166e3f4e134431ca13e5ac318538fc"
 dependencies = [
  "grpc-api-types",
 ]
@@ -11009,7 +11009,7 @@ checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
 [[package]]
 name = "ucs_cards"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.06.10.0#1044ccf1d636eed98e70fbf06acc18ecc78d5be8"
+source = "git+https://github.com/juspay/connector-service?rev=660bed60ec166e3f4e134431ca13e5ac318538fc#660bed60ec166e3f4e134431ca13e5ac318538fc"
 dependencies = [
  "bytes 1.10.1",
  "error-stack 0.4.1",
@@ -11025,7 +11025,7 @@ dependencies = [
 [[package]]
 name = "ucs_common_enums"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.06.10.0#1044ccf1d636eed98e70fbf06acc18ecc78d5be8"
+source = "git+https://github.com/juspay/connector-service?rev=660bed60ec166e3f4e134431ca13e5ac318538fc#660bed60ec166e3f4e134431ca13e5ac318538fc"
 dependencies = [
  "serde",
  "strum 0.26.3",
@@ -11036,7 +11036,7 @@ dependencies = [
 [[package]]
 name = "ucs_common_utils"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.06.10.0#1044ccf1d636eed98e70fbf06acc18ecc78d5be8"
+source = "git+https://github.com/juspay/connector-service?rev=660bed60ec166e3f4e134431ca13e5ac318538fc#660bed60ec166e3f4e134431ca13e5ac318538fc"
 dependencies = [
  "anyhow",
  "base64 0.21.7",

--- a/crates/external_services/Cargo.toml
+++ b/crates/external_services/Cargo.toml
@@ -74,7 +74,7 @@ http = "0.2.12"
 url = { version = "2.5.4", features = ["serde"] }
 quick-xml = { version = "0.31.0", features = ["serialize"] }
 
-unified-connector-service-client = { git = "https://github.com/juspay/connector-service", tag = "2026.06.10.0", package = "rust-grpc-client" }
+unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "660bed60ec166e3f4e134431ca13e5ac318538fc", package = "rust-grpc-client" }
 open-feature = { version = "0.2.5", optional = true }
 superposition_provider = { version = "0.102.0", optional = true}
 superposition_types = "0.102.0"

--- a/crates/external_services/Cargo.toml
+++ b/crates/external_services/Cargo.toml
@@ -74,7 +74,7 @@ http = "0.2.12"
 url = { version = "2.5.4", features = ["serde"] }
 quick-xml = { version = "0.31.0", features = ["serialize"] }
 
-unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "660bed60ec166e3f4e134431ca13e5ac318538fc", package = "rust-grpc-client" }
+unified-connector-service-client = { git = "https://github.com/juspay/connector-service", tag = "2026.06.12.1", package = "rust-grpc-client" }
 open-feature = { version = "0.2.5", optional = true }
 superposition_provider = { version = "0.102.0", optional = true}
 superposition_types = "0.102.0"

--- a/crates/hyperswitch_interfaces/Cargo.toml
+++ b/crates/hyperswitch_interfaces/Cargo.toml
@@ -33,7 +33,7 @@ time = "0.3.41"
 tonic = "0.14"
 url = { version = "2.5.4", features = ["serde"] }
 
-unified-connector-service-client = { git = "https://github.com/juspay/connector-service", tag = "2026.06.10.0", package = "rust-grpc-client" }
+unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "660bed60ec166e3f4e134431ca13e5ac318538fc", package = "rust-grpc-client" }
 tokio = { version = "1.45.1", features = ["macros", "rt-multi-thread"] }
 
 # First party crates

--- a/crates/hyperswitch_interfaces/Cargo.toml
+++ b/crates/hyperswitch_interfaces/Cargo.toml
@@ -33,7 +33,7 @@ time = "0.3.41"
 tonic = "0.14"
 url = { version = "2.5.4", features = ["serde"] }
 
-unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "660bed60ec166e3f4e134431ca13e5ac318538fc", package = "rust-grpc-client" }
+unified-connector-service-client = { git = "https://github.com/juspay/connector-service", tag = "2026.06.12.1", package = "rust-grpc-client" }
 tokio = { version = "1.45.1", features = ["macros", "rt-multi-thread"] }
 
 # First party crates

--- a/crates/router/Cargo.toml
+++ b/crates/router/Cargo.toml
@@ -91,8 +91,8 @@ ring = "0.17.14"
 rust_decimal = { version = "1.37.1", features = ["serde-with-float", "serde-with-str"] }
 rust-i18n = { git = "https://github.com/kashif-m/rust-i18n", rev = "f2d8096aaaff7a87a847c35a5394c269f75e077a" }
 
-unified-connector-service-client = { git = "https://github.com/juspay/connector-service", tag = "2026.06.10.0", package = "rust-grpc-client" }
-unified-connector-service-cards = { git = "https://github.com/juspay/connector-service", tag = "2026.06.10.0", package = "ucs_cards" }
+unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "660bed60ec166e3f4e134431ca13e5ac318538fc", package = "rust-grpc-client" }
+unified-connector-service-cards = { git = "https://github.com/juspay/connector-service", rev = "660bed60ec166e3f4e134431ca13e5ac318538fc", package = "ucs_cards" }
 rustc-hash = "1.1.0"
 rustls = "0.22"
 rustls-pemfile = "2"

--- a/crates/router/Cargo.toml
+++ b/crates/router/Cargo.toml
@@ -91,8 +91,8 @@ ring = "0.17.14"
 rust_decimal = { version = "1.37.1", features = ["serde-with-float", "serde-with-str"] }
 rust-i18n = { git = "https://github.com/kashif-m/rust-i18n", rev = "f2d8096aaaff7a87a847c35a5394c269f75e077a" }
 
-unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "660bed60ec166e3f4e134431ca13e5ac318538fc", package = "rust-grpc-client" }
-unified-connector-service-cards = { git = "https://github.com/juspay/connector-service", rev = "660bed60ec166e3f4e134431ca13e5ac318538fc", package = "ucs_cards" }
+unified-connector-service-client = { git = "https://github.com/juspay/connector-service", tag = "2026.06.12.1", package = "rust-grpc-client" }
+unified-connector-service-cards = { git = "https://github.com/juspay/connector-service", tag = "2026.06.12.1", package = "ucs_cards" }
 rustc-hash = "1.1.0"
 rustls = "0.22"
 rustls-pemfile = "2"

--- a/crates/router/src/core/payments/access_token.rs
+++ b/crates/router/src/core/payments/access_token.rs
@@ -402,6 +402,7 @@ async fn fetch_access_token_from_ucs(
             metadata: None,
             connector_feature_data: None,
             test_mode,
+            merchant_request_id: None,
         };
 
     let response = client

--- a/crates/router/src/core/payments/gateway/capture_gateway.rs
+++ b/crates/router/src/core/payments/gateway/capture_gateway.rs
@@ -167,14 +167,14 @@ where
 
                 let payment_capture_response = response.into_inner();
 
-                let (router_data_response, status_code) =
+                let ucs_data =
                     unified_connector_service::handle_unified_connector_service_response_for_payment_capture(
                         payment_capture_response.clone(),
                         router_data.status,
                     )
                     .attach_printable("Failed to deserialize UCS response")?;
 
-                let router_data_response = match router_data_response {
+                let router_data_response = match ucs_data.router_data_response {
                     Ok((response, status)) => {
                         router_data.status = status;
                         Ok(response)
@@ -192,7 +192,11 @@ where
                 router_data.minor_amount_captured = payment_capture_response
                     .captured_amount
                     .map(MinorUnit::new);
-                router_data.connector_http_status_code = Some(status_code);
+                router_data.connector_http_status_code = Some(ucs_data.status_code);
+
+                ucs_data.connector_response.map(|connector_response| {
+                    router_data.connector_response = Some(connector_response);
+                });
 
                 Ok((router_data, (), payment_capture_response))
             },

--- a/crates/router/src/core/unified_connector_service.rs
+++ b/crates/router/src/core/unified_connector_service.rs
@@ -58,8 +58,8 @@ use crate::{
     types::{
         api::enums as api_enums,
         transformers::{ForeignFrom, ForeignTryFrom},
-        UcsPaymentAuthorizeResponseData, UcsPaymentSetupRecurringResponseData,
-        UcsRecurringPaymentChargeResponseData,
+        UcsPaymentAuthorizeResponseData, UcsPaymentCaptureResponseData,
+        UcsPaymentSetupRecurringResponseData, UcsRecurringPaymentChargeResponseData,
     },
 };
 
@@ -2203,16 +2203,23 @@ pub fn handle_unified_connector_service_response_for_payment_pre_authenticate(
 pub fn handle_unified_connector_service_response_for_payment_capture(
     response: payments_grpc::PaymentServiceCaptureResponse,
     prev_status: AttemptStatus,
-) -> UnifiedConnectorServiceResult {
+) -> CustomResult<UcsPaymentCaptureResponseData, UnifiedConnectorServiceError> {
     let status_code = transformers::convert_connector_service_status_code(response.status_code)?;
 
     let router_data_response =
         Result::<(PaymentsResponseData, AttemptStatus), ErrorResponse>::foreign_try_from((
-            response,
+            response.clone(),
             prev_status,
         ))?;
 
-    Ok((router_data_response, status_code))
+    let connector_response =
+        extract_connector_response_from_ucs(response.connector_response.as_ref());
+
+    Ok(UcsPaymentCaptureResponseData {
+        router_data_response,
+        status_code,
+        connector_response,
+    })
 }
 
 pub fn handle_unified_connector_service_response_for_payment_setup_recurring(

--- a/crates/router/src/core/unified_connector_service/transformers.rs
+++ b/crates/router/src/core/unified_connector_service/transformers.rs
@@ -834,6 +834,8 @@ impl
             }),
             metadata: None,
             browser_info: None,
+            customer: None,
+            address: None,
         };
 
         Ok(Self {
@@ -1201,6 +1203,7 @@ impl transformers::ForeignTryFrom<&RouterData<Capture, PaymentsCaptureData, Paym
             test_mode: router_data.test_mode,
             merchant_order_id: router_data.request.merchant_order_reference_id.clone(),
             merchant_request_id: None,
+            order_tax_amount: None,
         })
     }
 }
@@ -5927,6 +5930,7 @@ impl transformers::ForeignTryFrom<&RouterData<Execute, RefundsData, RefundsRespo
                 .map(|id| id.get_string_repr().to_string()),
             merchant_request_id: None,
             connector_order_id: None,
+            payment_method: None,
         })
     }
 }
@@ -6281,6 +6285,7 @@ impl
             metadata: None,
             connector_feature_data: None,
             test_mode: router_data.test_mode,
+            merchant_request_id: None,
         })
     }
 }

--- a/crates/router/src/core/unified_connector_service/transformers.rs
+++ b/crates/router/src/core/unified_connector_service/transformers.rs
@@ -826,6 +826,7 @@ impl
                 field_name: "amount"
             }
         ))?;
+        let address = payments_grpc::PaymentAddress::foreign_try_from(router_data.address.clone())?;
 
         let payment_session_context = payments_grpc::PaymentSessionContext {
             amount: Some(payments_grpc::Money {
@@ -834,8 +835,19 @@ impl
             }),
             metadata: None,
             browser_info: None,
-            customer: None,
-            address: None,
+            customer: Some(payments_grpc::Customer {
+                first_name: None,
+                last_name: None,
+                salutation: None,
+                name: None,
+                email: None,
+                id: None,
+                connector_customer_id: router_data.connector_customer.clone(),
+                phone_number: None,
+                phone_country_code: None,
+                customer_document_details: to_grpc_customer_document_details(router_data),
+            }),
+            address: Some(address),
         };
 
         Ok(Self {

--- a/crates/router/src/types.rs
+++ b/crates/router/src/types.rs
@@ -790,6 +790,13 @@ pub struct UcsPaymentSetupRecurringResponseData {
     pub minor_amount_captured: Option<MinorUnit>,
 }
 
+pub struct UcsPaymentCaptureResponseData {
+    pub router_data_response:
+        Result<(PaymentsResponseData, common_enums::AttemptStatus), ErrorResponse>,
+    pub status_code: u16,
+    pub connector_response: Option<ConnectorResponseData>,
+}
+
 #[cfg(feature = "payouts")]
 pub struct UcsPayoutCreateResponseData {
     pub router_data_response: Result<PayoutsResponseData, ErrorResponse>,


### PR DESCRIPTION
## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

When a payment capture is routed through the unified connector service, the additional connector response details (AVS result, authorization code, card network) returned by the connector were dropped: `router_data.connector_response` was never populated on the capture path, while the authorize path already wires it.

**Why it was there:** two gaps — the `PaymentServiceCaptureResponse` proto had no `connector_response` field (authorize/get/setup_recurring responses all carry one), and even apart from that, `handle_unified_connector_service_response_for_payment_capture` / `capture_gateway` never extracted or assigned it.

**How it was resolved:** the proto gained an optional `connector_response` field on the connector-service side (juspay/hyperswitch-prism#1499). This PR consumes it following the existing authorize pattern:
- new `UcsPaymentCaptureResponseData` struct in `crates/router/src/types.rs` (mirrors `UcsPaymentAuthorizeResponseData`),
- the capture handler in `unified_connector_service.rs` extracts `connector_response` via `extract_connector_response_from_ucs` and returns the struct,
- `capture_gateway.rs` assigns it onto `router_data`, same idiom as `authorize_gateway.rs`.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

`unified-connector-service-client` / `unified-connector-service-cards` are bumped to the connector-service release tag `2026.06.12.1`, which carries the new capture `connector_response` proto field (juspay/hyperswitch-prism#1499, merged). New optional request fields added upstream between tags (`merchant_request_id`, `PaymentSessionContext.customer`/`address`, capture `order_tax_amount`, refund `payment_method`) are initialized as absent, preserving current behavior.

## Motivation and Context

Shadow-mode validation of hyperswitch vs UCS flagged a RouterData diff on capture: `connector_response` was an object on the native connector path but `null` on the UCS path (observed on Finix manual capture). With this change the UCS path produces identical RouterData.

## How did you test it?

- `cargo check -p router` passes against the pinned client revision.
- Ran the Finix manual-capture Cypress suite with UCS in shadow mode: the `connector_response` RouterData diff resolves; remaining capture fields already matched.

## Checklist

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
