### PR TITLE
fix(connector): [Peachpayments] Add 5xx Error Response Structure

### DIFF
--- a/crates/hyperswitch_connectors/src/connectors/peachpayments.rs
+++ b/crates/hyperswitch_connectors/src/connectors/peachpayments.rs
@@ -38,6 +38,7 @@ use hyperswitch_interfaces::{
         ConnectorValidation,
     },
     configs::Connectors,
+    consts::{NO_ERROR_CODE, NO_ERROR_MESSAGE},
     errors,
     events::connector_api_logs::ConnectorEvent,
     types::{self, Response},
@@ -469,27 +470,66 @@ impl ConnectorIntegration<Capture, PaymentsCaptureData, PaymentsResponseData> fo
         res: Response,
         event_builder: Option<&mut ConnectorEvent>,
     ) -> CustomResult<ErrorResponse, errors::ConnectorError> {
-        let response: peachpayments::PeachpaymentsErrorResponse = res
+        let response: peachpayments::Peachpayments5xxErrorResponse = res
             .response
-            .parse_struct("PeachpaymentsErrorResponse")
+            .parse_struct("Peachpayments5xxErrorResponse")
             .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
 
         event_builder.map(|i| i.set_response_body(&response));
         router_env::logger::info!(connector_response=?response);
 
-        Ok(ErrorResponse {
-            status_code: res.status_code,
-            code: response.error_ref.clone(),
-            message: response.message.clone(),
-            reason: Some(response.message.clone()),
-            attempt_status: Some(enums::AttemptStatus::Authorized),
-            connector_transaction_id: None,
-            connector_response_reference_id: None,
-            network_advice_code: None,
-            network_decline_code: None,
-            network_error_message: None,
-            connector_metadata: None,
-        })
+        match response {
+            peachpayments::Peachpayments5xxErrorResponse::Standard(error_response) => {
+                Ok(ErrorResponse {
+                    status_code: res.status_code,
+                    code: error_response.error_ref.clone(),
+                    message: error_response.message.clone(),
+                    reason: Some(error_response.message.clone()),
+                    attempt_status: Some(enums::AttemptStatus::Authorized),
+                    connector_transaction_id: None,
+                    connector_response_reference_id: None,
+                    network_advice_code: None,
+                    network_decline_code: None,
+                    network_error_message: None,
+                    connector_metadata: None,
+                })
+            }
+            peachpayments::Peachpayments5xxErrorResponse::Detailed(decline_response) => {
+                let (code, message, reason) = match &decline_response.response.response_code {
+                    Some(peachpayments::ResponseCode::Text(text)) => {
+                        (text.clone(), text.clone(), Some(text.clone()))
+                    }
+                    Some(peachpayments::ResponseCode::Structured {
+                        value,
+                        description,
+                        explanation,
+                        ..
+                    }) => (value.clone(), description.clone(), explanation.clone()),
+                    None => (
+                        NO_ERROR_CODE.to_string(),
+                        NO_ERROR_MESSAGE.to_string(),
+                        None,
+                    ),
+                };
+                Ok(ErrorResponse {
+                    status_code: res.status_code,
+                    code,
+                    message,
+                    reason,
+                    attempt_status: Some(enums::AttemptStatus::Authorized),
+                    connector_transaction_id: Some(
+                        decline_response.response.transaction_id.clone(),
+                    ),
+                    connector_response_reference_id: Some(
+                        decline_response.response.reference_id.clone(),
+                    ),
+                    network_advice_code: None,
+                    network_decline_code: None,
+                    network_error_message: None,
+                    connector_metadata: None,
+                })
+            }
+        }
     }
 }
 
@@ -830,8 +870,12 @@ impl webhooks::IncomingWebhook for Peachpayments {
                                 Ok(api_models::webhooks::IncomingWebhookEvent::PaymentIntentSuccess)
                             }
                         }
+                        // `FailedRetry` is returned by PeachPayments for 5xx capture failures.
+                        // In this state, the transaction remains retryable and Capture/Void
+                        // operations can be re-attempted.
                         peachpayments::PeachpaymentsPaymentStatus::Authorized
-                        | peachpayments::PeachpaymentsPaymentStatus::Approved => {
+                        | peachpayments::PeachpaymentsPaymentStatus::Approved
+                        | peachpayments::PeachpaymentsPaymentStatus::FailedRetry => {
                             Ok(api_models::webhooks::IncomingWebhookEvent::PaymentIntentAuthorizationSuccess)
                         }
                         peachpayments::PeachpaymentsPaymentStatus::Pending => {

--- a/crates/hyperswitch_connectors/src/connectors/peachpayments/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/peachpayments/transformers.rs
@@ -808,6 +808,7 @@ pub enum PeachpaymentsPaymentStatus {
     Reversed,
     ThreedsRequired,
     Voided,
+    FailedRetry,
 }
 
 impl From<PeachpaymentsPaymentStatus> for common_enums::AttemptStatus {
@@ -816,7 +817,8 @@ impl From<PeachpaymentsPaymentStatus> for common_enums::AttemptStatus {
             // PENDING means authorized but not yet captured - requires confirmation
             PeachpaymentsPaymentStatus::Pending
             | PeachpaymentsPaymentStatus::Authorized
-            | PeachpaymentsPaymentStatus::Approved => Self::Authorized,
+            | PeachpaymentsPaymentStatus::Approved
+            | PeachpaymentsPaymentStatus::FailedRetry => Self::Authorized,
             PeachpaymentsPaymentStatus::Declined | PeachpaymentsPaymentStatus::Failed => {
                 Self::Failure
             }
@@ -1001,6 +1003,8 @@ pub enum ResponseCode {
         description: String,
         terminal_outcome_string: Option<String>,
         receipt_string: Option<String>,
+        iso_code_description: Option<String>,
+        explanation: Option<String>,
     },
 }
 
@@ -1275,13 +1279,15 @@ pub struct PeachpaymentsErrorResponse {
     pub message: String,
 }
 
-impl TryFrom<ErrorResponse> for PeachpaymentsErrorResponse {
-    type Error = error_stack::Report<errors::ConnectorError>;
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum Peachpayments5xxErrorResponse {
+    Standard(PeachpaymentsErrorResponse),
+    Detailed(PeachpaymentsDetailedDeclineResponse),
+}
 
-    fn try_from(error_response: ErrorResponse) -> Result<Self, Self::Error> {
-        Ok(Self {
-            error_ref: error_response.code,
-            message: error_response.message,
-        })
-    }
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PeachpaymentsDetailedDeclineResponse {
+    #[serde(flatten)]
+    pub response: PeachpaymentsCaptureResponse,
 }

--- a/crates/hyperswitch_connectors/src/connectors/peachpayments/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/peachpayments/transformers.rs
@@ -811,23 +811,29 @@ pub enum PeachpaymentsPaymentStatus {
     FailedRetry,
 }
 
-impl From<PeachpaymentsPaymentStatus> for common_enums::AttemptStatus {
-    fn from(item: PeachpaymentsPaymentStatus) -> Self {
+impl TryFrom<PeachpaymentsPaymentStatus> for common_enums::AttemptStatus {
+    type Error = errors::ConnectorError;
+
+    fn try_from(item: PeachpaymentsPaymentStatus) -> Result<Self, errors::ConnectorError> {
         match item {
             // PENDING means authorized but not yet captured - requires confirmation
             PeachpaymentsPaymentStatus::Pending
             | PeachpaymentsPaymentStatus::Authorized
-            | PeachpaymentsPaymentStatus::Approved
-            | PeachpaymentsPaymentStatus::FailedRetry => Self::Authorized,
+            | PeachpaymentsPaymentStatus::Approved => Ok(Self::Authorized),
             PeachpaymentsPaymentStatus::Declined | PeachpaymentsPaymentStatus::Failed => {
-                Self::Failure
+                Ok(Self::Failure)
             }
             PeachpaymentsPaymentStatus::Voided | PeachpaymentsPaymentStatus::Reversed => {
-                Self::Voided
+                Ok(Self::Voided)
             }
-            PeachpaymentsPaymentStatus::ThreedsRequired => Self::AuthenticationPending,
+            PeachpaymentsPaymentStatus::ThreedsRequired => Ok(Self::AuthenticationPending),
             PeachpaymentsPaymentStatus::ApprovedConfirmed
-            | PeachpaymentsPaymentStatus::Successful => Self::Charged,
+            | PeachpaymentsPaymentStatus::Successful => Ok(Self::Charged),
+            PeachpaymentsPaymentStatus::FailedRetry => Err(
+                errors::ConnectorError::UnexpectedResponseError(bytes::Bytes::from(
+                    "Received FailedRetry status from PeachPayments in 2xx response",
+                )),
+            ),
         }
     }
 }
@@ -1078,7 +1084,7 @@ pub fn get_peachpayments_response(
     ),
     errors::ConnectorError,
 > {
-    let status = common_enums::AttemptStatus::from(response.transaction_result);
+    let status = common_enums::AttemptStatus::try_from(response.transaction_result)?;
     let payments_response = if utils::is_payment_failure(status) {
         Err(ErrorResponse {
             code: get_error_code(response.response_code.as_ref()),
@@ -1127,7 +1133,7 @@ pub fn get_webhook_response(
     let transaction = response
         .transaction
         .ok_or(errors::ConnectorError::WebhookResourceObjectNotFound)?;
-    let status = common_enums::AttemptStatus::from(transaction.transaction_result);
+    let status = common_enums::AttemptStatus::try_from(transaction.transaction_result)?;
     let webhook_response = if utils::is_payment_failure(status) {
         Err(ErrorResponse {
             code: get_error_code(transaction.response_code.as_ref()),
@@ -1195,7 +1201,7 @@ impl<F, T> TryFrom<ResponseRouterData<F, PeachpaymentsCaptureResponse, T, Paymen
     fn try_from(
         item: ResponseRouterData<F, PeachpaymentsCaptureResponse, T, PaymentsResponseData>,
     ) -> Result<Self, Self::Error> {
-        let status = common_enums::AttemptStatus::from(item.response.transaction_result);
+        let status = common_enums::AttemptStatus::try_from(item.response.transaction_result)?;
 
         // Check if it's an error response
         let response = if utils::is_payment_failure(status) {


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->

Added 5xx error response structure for Capture in peachpayments.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

Not able to test as can't reproduce 5xx error from peachpayments connector end.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
