### PR TITLE
fix(connectors): graceful response deserialization for worldpay

### DIFF
--- a/crates/hyperswitch_connectors/src/connectors/worldpay.rs
+++ b/crates/hyperswitch_connectors/src/connectors/worldpay.rs
@@ -68,7 +68,7 @@ use requests::{
     WorldpayCompleteAuthorizationRequest, WorldpayPartialRequest, WorldpayPaymentsRequest,
 };
 use response::{
-    EventType, ResponseIdStr, WorldpayErrorResponse, WorldpayEventResponse,
+    EventType, PaymentOutcome, ResponseIdStr, WorldpayErrorResponse, WorldpayEventResponse,
     WorldpayPaymentsResponse, WorldpayWebhookEventType, WorldpayWebhookTransactionId,
     WP_CORRELATION_ID,
 };
@@ -1027,9 +1027,22 @@ impl ConnectorIntegration<Execute, RefundsData, RefundsResponseData> for Worldpa
                         .and_then(|header_value| header_value.to_str().ok())
                         .map(|id| id.to_string())
                 });
+                let refund_status = match response.outcome {
+                    PaymentOutcome::Unknown => {
+                        router_env::logger::warn!(
+                            "Unknown PaymentOutcome from Worldpay refund, preserving existing status"
+                        );
+                        data.response
+                            .as_ref()
+                            .ok()
+                            .map(|r| r.refund_status)
+                            .unwrap_or(enums::RefundStatus::Pending)
+                    }
+                    _ => enums::RefundStatus::from(response.outcome.clone()),
+                };
                 Ok(RefundExecuteRouterData {
                     response: Ok(RefundsResponseData {
-                        refund_status: enums::RefundStatus::from(response.outcome.clone()),
+                        refund_status,
                         connector_refund_id: ResponseIdStr::foreign_try_from((
                             response,
                             optional_correlation_id,

--- a/crates/hyperswitch_connectors/src/connectors/worldpay/payout_response.rs
+++ b/crates/hyperswitch_connectors/src/connectors/worldpay/payout_response.rs
@@ -13,4 +13,6 @@ pub enum PayoutOutcome {
     Refused,
     Error,
     QueryRequired,
+    #[serde(other)]
+    Unknown,
 }

--- a/crates/hyperswitch_connectors/src/connectors/worldpay/payout_transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/worldpay/payout_transformers.rs
@@ -169,6 +169,7 @@ impl From<PayoutOutcome> for enums::PayoutStatus {
             PayoutOutcome::RequestReceived => Self::Initiated,
             PayoutOutcome::Error | PayoutOutcome::Refused => Self::Failed,
             PayoutOutcome::QueryRequired => Self::Pending,
+            PayoutOutcome::Unknown => Self::Pending,
         }
     }
 }
@@ -180,9 +181,19 @@ impl TryFrom<PayoutsResponseRouterData<PoFulfill, WorldpayPayoutResponse>>
     fn try_from(
         item: PayoutsResponseRouterData<PoFulfill, WorldpayPayoutResponse>,
     ) -> Result<Self, Self::Error> {
+        let status = match item.response.outcome {
+            PayoutOutcome::Unknown => {
+                router_env::logger::warn!(
+                    "Unknown PayoutOutcome from Worldpay, preserving existing status: {:?}",
+                    item.data.status
+                );
+                item.data.status
+            }
+            _ => enums::PayoutStatus::from(item.response.outcome.clone()),
+        };
         Ok(Self {
             response: Ok(PayoutsResponseData {
-                status: Some(enums::PayoutStatus::from(item.response.outcome.clone())),
+                status: Some(status),
                 connector_payout_id: None,
                 payout_eligible: None,
                 should_add_next_step_to_process_tracker: false,

--- a/crates/hyperswitch_connectors/src/connectors/worldpay/response.rs
+++ b/crates/hyperswitch_connectors/src/connectors/worldpay/response.rs
@@ -28,19 +28,22 @@ pub enum WorldpayPaymentResponseFields {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AuthorizedResponse {
-    pub payment_instrument: PaymentsResPaymentInstrument,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub issuer: Option<Issuer>,
+    pub payment_instrument: Option<Secret<serde_json::Value>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub scheme: Option<PaymentsResponseScheme>,
+    pub issuer: Option<Secret<serde_json::Value>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub scheme: Option<Secret<serde_json::Value>>,
     #[serde(rename = "_links", skip_serializing_if = "Option::is_none")]
     pub links: Option<SelfLink>,
-    #[serde(rename = "_actions")]
-    pub actions: Option<ActionLinks>,
+    #[serde(rename = "_actions", skip_serializing_if = "Option::is_none")]
+    pub actions: Option<Secret<serde_json::Value>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
-    pub risk_factors: Option<Vec<RiskFactorsInner>>,
-    pub fraud: Option<Fraud>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub risk_factors: Option<Secret<serde_json::Value>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fraud: Option<Secret<serde_json::Value>>,
     /// Mandate's token
     pub token: Option<MandateToken>,
     /// Network transaction ID
@@ -48,29 +51,24 @@ pub struct AuthorizedResponse {
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct MandateToken {
-    pub href: Secret<String>,
-    pub token_id: String,
-    pub token_expiry_date_time: String,
-}
-
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct FraudHighRiskResponse {
-    pub score: f32,
-    pub reason: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub score: Option<Secret<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<Secret<serde_json::Value>>,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RefusedResponse {
     pub refusal_description: String,
-    // Access Worldpay returns a raw response code in the refusalCode field (if enabled) containing the unmodified response code received either directly from the card scheme for Worldpay-acquired transactions, or from third party acquirers.
     pub refusal_code: String,
-    pub risk_factors: Option<Vec<RiskFactorsInner>>,
-    pub fraud: Option<Fraud>,
-    #[serde(rename = "threeDS")]
-    pub three_ds: Option<ThreeDsResponse>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub risk_factors: Option<Secret<serde_json::Value>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fraud: Option<Secret<serde_json::Value>>,
+    #[serde(rename = "threeDS", skip_serializing_if = "Option::is_none")]
+    pub three_ds: Option<Secret<serde_json::Value>>,
     pub advice: Option<Advice>,
 }
 
@@ -81,23 +79,12 @@ pub struct Advice {
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct ThreeDsResponse {
-    pub outcome: String,
-    pub issuer_response: IssuerResponse,
-}
-
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 pub struct ThreeDsChallengedResponse {
-    pub authentication: AuthenticationResponse,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub authentication: Option<Secret<serde_json::Value>>,
     pub challenge: ThreeDsChallenge,
     #[serde(rename = "_actions")]
     pub actions: CompleteThreeDsActionLink,
-}
-
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-pub struct AuthenticationResponse {
-    pub version: String,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -112,13 +99,6 @@ pub struct ThreeDsChallenge {
 pub struct CompleteThreeDsActionLink {
     #[serde(rename = "complete3dsChallenge")]
     pub complete_three_ds_challenge: ActionLink,
-}
-
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "lowercase")]
-pub enum IssuerResponse {
-    Challenged,
-    Frictionless,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -161,6 +141,8 @@ pub enum PaymentOutcome {
     ThreeDsChallenged,
     #[serde(alias = "3dsUnavailable")]
     ThreeDsUnavailable,
+    #[serde(other)]
+    Unknown,
 }
 
 impl std::fmt::Display for PaymentOutcome {
@@ -177,6 +159,7 @@ impl std::fmt::Display for PaymentOutcome {
             Self::SentForPartialRefund => write!(f, "sentForPartialRefund"),
             Self::ThreeDsChallenged => write!(f, "3dsChallenged"),
             Self::ThreeDsUnavailable => write!(f, "3dsUnavailable"),
+            Self::Unknown => write!(f, "unknown"),
         }
     }
 }
@@ -193,33 +176,9 @@ pub struct SelfLinkInner {
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct ActionLinks {
-    supply_3ds_device_data: Option<ActionLink>,
-    settle_payment: Option<ActionLink>,
-    partially_settle_payment: Option<ActionLink>,
-    refund_payment: Option<ActionLink>,
-    partially_refund_payment: Option<ActionLink>,
-    cancel_payment: Option<ActionLink>,
-}
-
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct ActionLink {
     pub href: String,
     pub method: String,
-}
-
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-pub struct Fraud {
-    pub outcome: FraudOutcome,
-    pub score: f32,
-}
-
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub enum FraudOutcome {
-    LowRisk,
-    HighRisk,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -306,97 +265,12 @@ pub struct ResponseIdStr {
     pub id: String,
 }
 
-#[derive(Clone, Debug, PartialEq, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct Issuer {
-    pub authorization_code: Secret<String>,
-}
-
-impl Issuer {
-    pub fn new(code: String) -> Self {
-        Self {
-            authorization_code: Secret::new(code),
-        }
-    }
-}
-
-#[derive(Clone, Debug, PartialEq, Default, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct PaymentsResPaymentInstrument {
-    #[serde(rename = "type")]
-    pub payment_instrument_type: String,
-    pub card_bin: Option<String>,
-    pub last_four: Option<String>,
-    pub expiry_date: Option<ExpiryDate>,
-    pub card_brand: Option<String>,
-    pub funding_type: Option<String>,
-    pub category: Option<String>,
-    pub issuer_name: Option<String>,
-    pub payment_account_reference: Option<String>,
-}
-
-#[derive(Clone, Debug, PartialEq, Default, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct RiskFactorsInner {
-    #[serde(rename = "type")]
-    pub risk_type: RiskType,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub detail: Option<Detail>,
-    pub risk: Risk,
-}
-
-impl RiskFactorsInner {
-    pub fn new(risk_type: RiskType, risk: Risk) -> Self {
-        Self {
-            risk_type,
-            detail: None,
-            risk,
-        }
-    }
-}
-
-#[derive(
-    Clone, Copy, Default, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize,
-)]
-#[serde(rename_all = "camelCase")]
-pub enum RiskType {
-    #[default]
-    Avs,
-    Cvc,
-    RiskProfile,
-}
-
-#[derive(
-    Clone, Copy, Default, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize,
-)]
-#[serde(rename_all = "lowercase")]
-pub enum Detail {
-    #[default]
-    Address,
-    Postcode,
-}
-
-#[derive(
-    Clone, Copy, Default, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize,
-)]
-#[serde(rename_all = "camelCase")]
-pub enum Risk {
-    #[default]
-    NotChecked,
-    NotMatched,
-    NotSupplied,
-    VerificationFailed,
-}
-
-#[derive(Clone, Debug, PartialEq, Default, Serialize, Deserialize)]
-pub struct PaymentsResponseScheme {
-    pub reference: String,
-}
-
-impl PaymentsResponseScheme {
-    pub fn new(reference: String) -> Self {
-        Self { reference }
-    }
+pub struct MandateToken {
+    pub href: Secret<String>,
+    pub token_id: String,
+    pub token_expiry_date_time: String,
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq)]

--- a/crates/hyperswitch_connectors/src/connectors/worldpay/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/worldpay/transformers.rs
@@ -627,6 +627,7 @@ impl From<PaymentOutcome> for enums::AttemptStatus {
             }
             PaymentOutcome::Refused | PaymentOutcome::FraudHighRisk => Self::Failure,
             PaymentOutcome::ThreeDsUnavailable => Self::AuthenticationFailed,
+            PaymentOutcome::Unknown => Self::Pending,
         }
     }
 }
@@ -643,7 +644,8 @@ impl From<PaymentOutcome> for enums::RefundStatus {
             | PaymentOutcome::ThreeDsAuthenticationFailed
             | PaymentOutcome::ThreeDsChallenged
             | PaymentOutcome::SentForCancellation
-            | PaymentOutcome::ThreeDsUnavailable => Self::Failure,
+            | PaymentOutcome::ThreeDsUnavailable
+            | PaymentOutcome::Unknown => Self::Failure,
         }
     }
 }
@@ -782,10 +784,18 @@ impl<F, T>
             PaymentOutcome::FraudHighRisk => Some("Transaction marked as high risk".to_string()),
             _ => None,
         };
-        let status = if amount == 0 && worldpay_status == PaymentOutcome::Authorized {
-            enums::AttemptStatus::Charged
-        } else {
-            enums::AttemptStatus::from(worldpay_status.clone())
+        let status = match worldpay_status {
+            PaymentOutcome::Unknown => {
+                router_env::logger::warn!(
+                    "Unknown PaymentOutcome from Worldpay, preserving existing status: {:?}",
+                    router_data.data.status
+                );
+                router_data.data.status
+            }
+            _ if amount == 0 && worldpay_status == PaymentOutcome::Authorized => {
+                enums::AttemptStatus::Charged
+            }
+            _ => enums::AttemptStatus::from(worldpay_status.clone()),
         };
         let response = match (optional_error_message, error) {
             (None, None) => Ok(PaymentsResponseData::TransactionResponse {


### PR DESCRIPTION
## Summary
This PR applies "graceful response deserialization" fixes to the Worldpay connector to prevent production SEV-1/SEV-2 incidents caused by unexpected connector API changes.

### Changes Applied

**Fix 1 — No `#[serde(deny_unknown_fields)]` on response structs**
No `#[serde(deny_unknown_fields)]` attributes were present on Worldpay response structs.

**Fix 2 — Catch-all variants on business-logic enums**
- Added `#[serde(other)] Unknown` to `PaymentOutcome` enum (used in authorization, capture, void, refund flows)
- Added `#[serde(other)] Unknown` to `PayoutOutcome` enum (used in payout fulfill flow)
- In `transformers.rs`: When `PaymentOutcome::Unknown` is encountered during payment handling, logs a warning and preserves the existing `AttemptStatus` from `router_data.data.status` (never writes `Unknown` to DB)
- In `payout_transformers.rs`: When `PayoutOutcome::Unknown` is encountered, logs a warning and preserves the existing payout status
- In `worldpay.rs` refund execute handler: When `PaymentOutcome::Unknown` is encountered, logs a warning and preserves the existing `RefundStatus`
- `EventType::Unknown` already existed with `#[serde(other)]`

**Fix 3 — Unused fields made opaque optional types**
- `AuthorizedResponse.payment_instrument` → `Option<Secret<serde_json::Value>>`
- `AuthorizedResponse.issuer` → `Option<Secret<serde_json::Value>>`
- `AuthorizedResponse.scheme` → `Option<Secret<serde_json::Value>>`
- `AuthorizedResponse.actions` → `Option<Secret<serde_json::Value>>`
- `AuthorizedResponse.risk_factors` → `Option<Secret<serde_json::Value>>`
- `AuthorizedResponse.fraud` → `Option<Secret<serde_json::Value>>`
- `RefusedResponse.risk_factors` → `Option<Secret<serde_json::Value>>`
- `RefusedResponse.fraud` → `Option<Secret<serde_json::Value>>`
- `RefusedResponse.three_ds` → `Option<Secret<serde_json::Value>>`
- `FraudHighRiskResponse.score` → `Option<Secret<String>>`
- `FraudHighRiskResponse.reason` → `Option<Secret<serde_json::Value>>`
- `ThreeDsChallengedResponse.authentication` → `Option<Secret<serde_json::Value>>`

**Removed unused response structs/enums (not referenced in business logic):**
- `Issuer`, `PaymentsResPaymentInstrument`, `PaymentsResponseScheme`
- `RiskFactorsInner`, `RiskType`, `Detail`, `Risk`
- `Fraud`, `FraudOutcome`
- `ThreeDsResponse`, `IssuerResponse`, `AuthenticationResponse`
- `ActionLinks`

Relates to HYP-39