### PR TITLE
fix(connectors): graceful response deserialization for stripe_test

### DIFF
--- a/crates/hyperswitch_connectors/src/connectors/dummyconnector/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/dummyconnector/transformers.rs
@@ -257,6 +257,8 @@ pub enum DummyConnectorPaymentStatus {
     Failed,
     #[default]
     Processing,
+    #[serde(other)]
+    Unknown,
 }
 
 impl From<DummyConnectorPaymentStatus> for AttemptStatus {
@@ -265,6 +267,7 @@ impl From<DummyConnectorPaymentStatus> for AttemptStatus {
             DummyConnectorPaymentStatus::Succeeded => Self::Charged,
             DummyConnectorPaymentStatus::Failed => Self::Failure,
             DummyConnectorPaymentStatus::Processing => Self::AuthenticationPending,
+            DummyConnectorPaymentStatus::Unknown => Self::AuthenticationPending,
         }
     }
 }
@@ -273,10 +276,10 @@ impl From<DummyConnectorPaymentStatus> for AttemptStatus {
 pub struct PaymentsResponse {
     status: DummyConnectorPaymentStatus,
     id: String,
-    amount: MinorUnit,
-    currency: Currency,
-    created: String,
-    payment_method_type: PaymentMethodType,
+    amount: Option<Secret<String>>,
+    currency: Option<Secret<String>>,
+    created: Option<Secret<String>>,
+    payment_method_type: Option<Secret<String>>,
     next_action: Option<DummyConnectorNextAction>,
 }
 
@@ -367,6 +370,8 @@ pub enum DummyRefundStatus {
     Failed,
     #[default]
     Processing,
+    #[serde(other)]
+    Unknown,
 }
 
 impl From<DummyRefundStatus> for RefundStatus {
@@ -375,7 +380,7 @@ impl From<DummyRefundStatus> for RefundStatus {
             DummyRefundStatus::Succeeded => Self::Success,
             DummyRefundStatus::Failed => Self::Failure,
             DummyRefundStatus::Processing => Self::Pending,
-            //TODO: Review mapping
+            DummyRefundStatus::Unknown => Self::Pending,
         }
     }
 }
@@ -384,10 +389,10 @@ impl From<DummyRefundStatus> for RefundStatus {
 pub struct RefundResponse {
     id: String,
     status: DummyRefundStatus,
-    currency: Currency,
-    created: String,
-    payment_amount: MinorUnit,
-    refund_amount: MinorUnit,
+    currency: Option<Secret<String>>,
+    created: Option<Secret<String>>,
+    payment_amount: Option<Secret<String>>,
+    refund_amount: Option<Secret<String>>,
 }
 
 impl TryFrom<RefundsResponseRouterData<Execute, RefundResponse>> for RefundsRouterData<Execute> {


### PR DESCRIPTION
## Summary

Applies graceful response deserialization fixes to the `stripe_test` dummy connector (`dummyconnector`) to prevent SEV-1/SEV-2 incidents when the upstream mock server introduces unexpected fields or enum variants.

### Changes

**Fix 1 — Remove `#[serde(deny_unknown_fields)]`**
- No response structs in `dummyconnector` had this attribute; nothing to remove.

**Fix 2 — Catch-all variants on enums used in business logic**
- `DummyConnectorPaymentStatus`: added `#[serde(other)] Unknown` variant; mapped to `AttemptStatus::AuthenticationPending` (preserves existing state).
- `DummyRefundStatus`: added `#[serde(other)] Unknown` variant; mapped to `RefundStatus::Pending` (preserves existing state).

**Fix 3 — Opaque optional types for fields not used in business logic**
- `PaymentsResponse`: changed `amount`, `currency`, `created`, `payment_method_type` from strict types to `Option<Secret<String>>`.
- `RefundResponse`: changed `currency`, `created`, `payment_amount`, `refund_amount` from strict types to `Option<Secret<String>>`.
- These fields are deserialized from the connector response but never consumed in the `TryFrom` impls that write payment/refund state.

### Checklist
- [x] No `#[serde(deny_unknown_fields)]` on response structs
- [x] Business-logic enums have `#[serde(other)] Unknown` with safe fallbacks
- [x] Unused response fields use `Option<Secret<String>>`
- [x] Compilation verified against pre-existing repo baseline