### PR TITLE
fix(connectors): graceful response deserialization for finix

### DIFF
--- a/crates/hyperswitch_connectors/src/connectors/bankofamerica/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/bankofamerica/transformers.rs
@@ -1377,6 +1377,7 @@ fn map_boa_attempt_status(
 pub enum BankOfAmericaPaymentsResponse {
     ClientReferenceInformation(Box<BankOfAmericaClientReferenceResponse>),
     ErrorInformation(Box<BankOfAmericaErrorInformationResponse>),
+    Unknown(serde_json::Value),
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -1384,6 +1385,7 @@ pub enum BankOfAmericaPaymentsResponse {
 pub enum BankOfAmericaSetupMandatesResponse {
     ClientReferenceInformation(Box<BankOfAmericaClientReferenceResponse>),
     ErrorInformation(Box<BankOfAmericaErrorInformationResponse>),
+    Unknown(serde_json::Value),
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -1741,6 +1743,12 @@ impl TryFrom<PaymentsResponseRouterData<BankOfAmericaPaymentsResponse>>
                     Some(enums::AttemptStatus::Failure),
                 ))
             }
+            BankOfAmericaPaymentsResponse::Unknown(_) => {
+                logger::warn!(
+                    "Unknown BankOfAmericaPaymentsResponse variant received in authorize"
+                );
+                Ok(item.data)
+            }
         }
     }
 }
@@ -1795,6 +1803,12 @@ impl TryFrom<PaymentsCaptureResponseRouterData<BankOfAmericaPaymentsResponse>>
             BankOfAmericaPaymentsResponse::ErrorInformation(ref error_response) => {
                 Ok(map_error_response(&error_response.clone(), item, None))
             }
+            BankOfAmericaPaymentsResponse::Unknown(_) => {
+                logger::warn!(
+                    "Unknown BankOfAmericaPaymentsResponse variant received in capture"
+                );
+                Ok(item.data)
+            }
         }
     }
 }
@@ -1819,6 +1833,12 @@ impl TryFrom<PaymentsCancelResponseRouterData<BankOfAmericaPaymentsResponse>>
             }
             BankOfAmericaPaymentsResponse::ErrorInformation(ref error_response) => {
                 Ok(map_error_response(&error_response.clone(), item, None))
+            }
+            BankOfAmericaPaymentsResponse::Unknown(_) => {
+                logger::warn!(
+                    "Unknown BankOfAmericaPaymentsResponse variant received in cancel"
+                );
+                Ok(item.data)
             }
         }
     }

--- a/crates/hyperswitch_connectors/src/connectors/bankofamerica/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/bankofamerica/transformers.rs
@@ -1323,7 +1323,8 @@ pub enum BankofamericaPaymentStatus {
     PendingReview,
     Accepted,
     Cancelled,
-    //PartialAuthorized, not being consumed yet.
+    #[serde(other)]
+    Unknown,
 }
 
 fn map_boa_attempt_status(
@@ -1364,6 +1365,10 @@ fn map_boa_attempt_status(
         BankofamericaPaymentStatus::PendingReview
         | BankofamericaPaymentStatus::Challenge
         | BankofamericaPaymentStatus::Accepted => enums::AttemptStatus::Pending,
+        BankofamericaPaymentStatus::Unknown => {
+            logger::warn!("Unknown BankofamericaPaymentStatus variant received");
+            enums::AttemptStatus::Pending
+        }
     }
 }
 
@@ -2098,6 +2103,10 @@ impl From<BankOfAmericaRefundResponse> for enums::RefundStatus {
                     Self::Pending
                 }
             }
+            BankofamericaRefundStatus::Unknown => {
+                logger::warn!("Unknown BankofamericaRefundStatus variant received");
+                Self::Pending
+            }
         }
     }
 }
@@ -2152,6 +2161,8 @@ pub enum BankofamericaRefundStatus {
     Cancelled,
     #[serde(rename = "201")]
     TwoZeroOne,
+    #[serde(other)]
+    Unknown,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -2199,6 +2210,10 @@ impl TryFrom<RefundsResponseRouterData<RSync, BankOfAmericaRsyncResponse>>
                         } else {
                             enums::RefundStatus::Pending
                         }
+                    }
+                    BankofamericaRefundStatus::Unknown => {
+                        logger::warn!("Unknown BankofamericaRefundStatus variant received in refund sync");
+                        enums::RefundStatus::Pending
                     }
                 };
                 if utils::is_refund_failure(refund_status) {

--- a/crates/hyperswitch_connectors/src/connectors/bankofamerica/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/bankofamerica/transformers.rs
@@ -1804,9 +1804,7 @@ impl TryFrom<PaymentsCaptureResponseRouterData<BankOfAmericaPaymentsResponse>>
                 Ok(map_error_response(&error_response.clone(), item, None))
             }
             BankOfAmericaPaymentsResponse::Unknown(_) => {
-                logger::warn!(
-                    "Unknown BankOfAmericaPaymentsResponse variant received in capture"
-                );
+                logger::warn!("Unknown BankOfAmericaPaymentsResponse variant received in capture");
                 Ok(item.data)
             }
         }
@@ -1835,9 +1833,7 @@ impl TryFrom<PaymentsCancelResponseRouterData<BankOfAmericaPaymentsResponse>>
                 Ok(map_error_response(&error_response.clone(), item, None))
             }
             BankOfAmericaPaymentsResponse::Unknown(_) => {
-                logger::warn!(
-                    "Unknown BankOfAmericaPaymentsResponse variant received in cancel"
-                );
+                logger::warn!("Unknown BankOfAmericaPaymentsResponse variant received in cancel");
                 Ok(item.data)
             }
         }
@@ -2232,7 +2228,9 @@ impl TryFrom<RefundsResponseRouterData<RSync, BankOfAmericaRsyncResponse>>
                         }
                     }
                     BankofamericaRefundStatus::Unknown => {
-                        logger::warn!("Unknown BankofamericaRefundStatus variant received in refund sync");
+                        logger::warn!(
+                            "Unknown BankofamericaRefundStatus variant received in refund sync"
+                        );
                         enums::RefundStatus::Pending
                     }
                 };

--- a/crates/hyperswitch_connectors/src/connectors/checkout/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/checkout/transformers.rs
@@ -1112,6 +1112,8 @@ pub enum CheckoutPaymentStatus {
     Refunded,
     Canceled,
     Expired,
+    #[serde(other)]
+    Unknown,
 }
 
 impl TryFrom<CheckoutWebhookEventType> for CheckoutPaymentStatus {
@@ -1173,6 +1175,10 @@ fn get_attempt_status_cap(
         CheckoutPaymentStatus::Pending => AttemptStatus::AuthenticationPending,
         CheckoutPaymentStatus::RetryScheduled => AttemptStatus::Pending,
         CheckoutPaymentStatus::Voided => AttemptStatus::Voided,
+        CheckoutPaymentStatus::Unknown => {
+            router_env::logger::warn!("Unknown CheckoutPaymentStatus received in get_attempt_status_cap, preserving existing state");
+            AttemptStatus::AuthenticationPending
+        }
     }
 }
 
@@ -1200,6 +1206,10 @@ fn get_attempt_status_intent(
         CheckoutPaymentStatus::Pending => AttemptStatus::AuthenticationPending,
         CheckoutPaymentStatus::RetryScheduled => AttemptStatus::Pending,
         CheckoutPaymentStatus::Voided => AttemptStatus::Voided,
+        CheckoutPaymentStatus::Unknown => {
+            router_env::logger::warn!("Unknown CheckoutPaymentStatus received in get_attempt_status_intent, preserving existing state");
+            AttemptStatus::AuthenticationPending
+        }
     }
 }
 
@@ -1229,6 +1239,10 @@ fn get_attempt_status_bal(item: (CheckoutPaymentStatus, Option<Balances>)) -> At
             AttemptStatus::Pending
         }
         CheckoutPaymentStatus::Voided => AttemptStatus::Voided,
+        CheckoutPaymentStatus::Unknown => {
+            router_env::logger::warn!("Unknown CheckoutPaymentStatus received in get_attempt_status_bal, preserving existing state");
+            AttemptStatus::AuthenticationPending
+        }
     }
 }
 
@@ -1867,6 +1881,8 @@ pub enum ActionType {
     Return,
     #[serde(rename = "Card Verification")]
     CardVerification,
+    #[serde(other)]
+    Unknown,
 }
 
 #[derive(Deserialize, Debug, Serialize)]
@@ -1942,6 +1958,8 @@ impl utils::MultipleCaptureSyncResponse for Box<PaymentsResponse> {
 pub enum CheckoutRedirectResponseStatus {
     Success,
     Failure,
+    #[serde(other)]
+    Unknown,
 }
 
 #[derive(Debug, Clone, serde::Deserialize, Eq, PartialEq)]
@@ -1988,6 +2006,10 @@ impl From<CheckoutRedirectResponseStatus> for AttemptStatus {
         match item {
             CheckoutRedirectResponseStatus::Success => Self::AuthenticationSuccessful,
             CheckoutRedirectResponseStatus::Failure => Self::Failure,
+            CheckoutRedirectResponseStatus::Unknown => {
+                router_env::logger::warn!("Unknown CheckoutRedirectResponseStatus received");
+                Self::Failure
+            }
         }
     }
 }
@@ -2114,6 +2136,30 @@ pub enum CheckoutDisputeTransactionType {
     DisputeArbitrationWon,
     DisputeWon,
     DisputeLost,
+    #[serde(other)]
+    Unknown,
+}
+
+impl From<CheckoutDisputeTransactionType> for api_models::enums::DisputeStage {
+    fn from(code: CheckoutDisputeTransactionType) -> Self {
+        match code {
+            CheckoutDisputeTransactionType::DisputeArbitrationLost
+            | CheckoutDisputeTransactionType::DisputeArbitrationWon => Self::PreArbitration,
+            CheckoutDisputeTransactionType::DisputeReceived
+            | CheckoutDisputeTransactionType::DisputeExpired
+            | CheckoutDisputeTransactionType::DisputeAccepted
+            | CheckoutDisputeTransactionType::DisputeCanceled
+            | CheckoutDisputeTransactionType::DisputeEvidenceSubmitted
+            | CheckoutDisputeTransactionType::DisputeEvidenceAcknowledgedByScheme
+            | CheckoutDisputeTransactionType::DisputeEvidenceRequired
+            | CheckoutDisputeTransactionType::DisputeWon
+            | CheckoutDisputeTransactionType::DisputeLost => Self::Dispute,
+            CheckoutDisputeTransactionType::Unknown => {
+                router_env::logger::warn!("Unknown CheckoutDisputeTransactionType received, defaulting to Dispute");
+                Self::Dispute
+            }
+        }
+    }
 }
 
 impl From<CheckoutWebhookEventType> for api_models::webhooks::IncomingWebhookEvent {

--- a/crates/hyperswitch_connectors/src/connectors/checkout/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/checkout/transformers.rs
@@ -2155,7 +2155,9 @@ impl From<CheckoutDisputeTransactionType> for api_models::enums::DisputeStage {
             | CheckoutDisputeTransactionType::DisputeWon
             | CheckoutDisputeTransactionType::DisputeLost => Self::Dispute,
             CheckoutDisputeTransactionType::Unknown => {
-                router_env::logger::warn!("Unknown CheckoutDisputeTransactionType received, defaulting to Dispute");
+                router_env::logger::warn!(
+                    "Unknown CheckoutDisputeTransactionType received, defaulting to Dispute"
+                );
                 Self::Dispute
             }
         }

--- a/crates/hyperswitch_connectors/src/connectors/cybersource.rs
+++ b/crates/hyperswitch_connectors/src/connectors/cybersource.rs
@@ -486,6 +486,12 @@ impl ConnectorIntegration<SetupMandate, SetupMandateRequestData, PaymentsRespons
             Some(reason) => match reason {
                 transformers::Reason::SystemError => Some(enums::AttemptStatus::Failure),
                 transformers::Reason::ServerTimeout | transformers::Reason::ServiceTimeout => None,
+                transformers::Reason::Unknown => {
+                    router_env::logger::warn!(
+                        "Received unknown reason from cybersource 5xx error response"
+                    );
+                    None
+                }
             },
             None => None,
         };
@@ -1324,6 +1330,12 @@ impl ConnectorIntegration<Authorize, PaymentsAuthorizeData, PaymentsResponseData
             Some(reason) => match reason {
                 transformers::Reason::SystemError => Some(enums::AttemptStatus::Failure),
                 transformers::Reason::ServerTimeout | transformers::Reason::ServiceTimeout => None,
+                transformers::Reason::Unknown => {
+                    router_env::logger::warn!(
+                        "Received unknown reason from cybersource 5xx error response"
+                    );
+                    None
+                }
             },
             None => None,
         };
@@ -1448,6 +1460,12 @@ impl ConnectorIntegration<Authorize, PaymentsAuthorizeData, PaymentsResponseData
             Some(reason) => match reason {
                 transformers::Reason::SystemError => Some(enums::AttemptStatus::Failure),
                 transformers::Reason::ServerTimeout | transformers::Reason::ServiceTimeout => None,
+                transformers::Reason::Unknown => {
+                    router_env::logger::warn!(
+                        "Received unknown reason from cybersource 5xx error response"
+                    );
+                    None
+                }
             },
             None => None,
         };
@@ -1567,6 +1585,12 @@ impl ConnectorIntegration<PoFulfill, PayoutsData, PayoutsResponseData> for Cyber
             Some(reason) => match reason {
                 transformers::Reason::SystemError => Some(enums::AttemptStatus::Failure),
                 transformers::Reason::ServerTimeout | transformers::Reason::ServiceTimeout => None,
+                transformers::Reason::Unknown => {
+                    router_env::logger::warn!(
+                        "Received unknown reason from cybersource 5xx error response"
+                    );
+                    None
+                }
             },
             None => None,
         };
@@ -1694,6 +1718,12 @@ impl ConnectorIntegration<CompleteAuthorize, CompleteAuthorizeData, PaymentsResp
             Some(reason) => match reason {
                 transformers::Reason::SystemError => Some(enums::AttemptStatus::Failure),
                 transformers::Reason::ServerTimeout | transformers::Reason::ServiceTimeout => None,
+                transformers::Reason::Unknown => {
+                    router_env::logger::warn!(
+                        "Received unknown reason from cybersource 5xx error response"
+                    );
+                    None
+                }
             },
             None => None,
         };

--- a/crates/hyperswitch_connectors/src/connectors/finix/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/finix/transformers.rs
@@ -822,7 +822,9 @@ impl FinixWebhookBody {
                     FinixDisputeState::LOST => Ok(IncomingWebhookEvent::DisputeLost),
                     FinixDisputeState::WON => Ok(IncomingWebhookEvent::DisputeWon),
                     FinixDisputeState::Unknown => {
-                        router_env::logger::warn!("Received unknown Finix dispute state in webhook");
+                        router_env::logger::warn!(
+                            "Received unknown Finix dispute state in webhook"
+                        );
                         Ok(IncomingWebhookEvent::EventNotSupported)
                     }
                 }

--- a/crates/hyperswitch_connectors/src/connectors/finix/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/finix/transformers.rs
@@ -821,6 +821,10 @@ impl FinixWebhookBody {
                     FinixDisputeState::INQUIRY => Ok(IncomingWebhookEvent::DisputeChallenged),
                     FinixDisputeState::LOST => Ok(IncomingWebhookEvent::DisputeLost),
                     FinixDisputeState::WON => Ok(IncomingWebhookEvent::DisputeWon),
+                    FinixDisputeState::Unknown => {
+                        router_env::logger::warn!("Received unknown Finix dispute state in webhook");
+                        Ok(IncomingWebhookEvent::EventNotSupported)
+                    }
                 }
             }
         }

--- a/crates/hyperswitch_connectors/src/connectors/finix/transformers/response.rs
+++ b/crates/hyperswitch_connectors/src/connectors/finix/transformers/response.rs
@@ -1,7 +1,6 @@
-use std::collections::HashMap;
-
 use common_enums::Currency;
 use common_utils::types::MinorUnit;
+use hyperswitch_masking::Secret;
 use serde::{Deserialize, Serialize};
 use strum::Display;
 use time::PrimitiveDateTime;
@@ -23,11 +22,10 @@ pub struct FinixPaymentsResponse {
     pub messages: Option<Vec<String>>,
     pub failure_message: Option<String>,
     pub transfer: Option<String>,
-    pub tags: FinixTags,
+    pub tags: Option<Secret<serde_json::Value>>,
     #[serde(rename = "type")]
     pub payment_type: Option<FinixPaymentType>,
-    // pub trace_id: String,
-    pub three_d_secure: Option<FinixThreeDSecure>,
+    pub three_d_secure: Option<Secret<serde_json::Value>>,
     pub address_verification: Option<String>,
     pub network_details: Option<FinixNetworkDetails>,
 }
@@ -63,26 +61,26 @@ pub struct FinixIdentityResponse {
     pub id: String,
     pub created_at: Option<String>,
     pub updated_at: Option<String>,
-    pub application: Option<String>,
-    pub entity: Option<HashMap<String, serde_json::Value>>,
-    pub tags: Option<FinixTags>,
+    pub application: Option<Secret<String>>,
+    pub entity: Option<Secret<serde_json::Value>>,
+    pub tags: Option<Secret<serde_json::Value>>,
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct FinixInstrumentResponse {
     pub id: String,
-    pub created_at: String,
-    pub updated_at: String,
-    pub application: String,
-    pub created_via: Option<String>,
-    pub identity: Option<String>,
+    pub created_at: Option<String>,
+    pub updated_at: Option<String>,
+    pub application: Option<Secret<String>>,
+    pub created_via: Option<Secret<String>>,
+    pub identity: Option<Secret<String>>,
     #[serde(rename = "type")]
-    pub instrument_type: FinixPaymentInstrumentType,
-    pub tags: Option<FinixTags>,
-    pub card_type: Option<FinixCardType>,
+    pub instrument_type: Option<Secret<String>>,
+    pub tags: Option<Secret<serde_json::Value>>,
+    pub card_type: Option<Secret<String>>,
     pub card_brand: Option<String>,
     pub fingerprint: Option<String>,
-    pub address: Option<FinixAddress>,
+    pub address: Option<Secret<serde_json::Value>>,
     pub address_verification: Option<String>,
     pub disabled_code: Option<String>,
     pub disabled_message: Option<String>,
@@ -120,6 +118,8 @@ pub enum FinixDisputeState {
     PENDING,
     LOST,
     WON,
+    #[serde(other)]
+    Unknown,
 }
 #[derive(Clone, Debug, Serialize, Deserialize)]
 

--- a/crates/hyperswitch_connectors/src/connectors/worldpaymodular/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/worldpaymodular/transformers.rs
@@ -323,6 +323,7 @@ impl From<PaymentOutcome> for enums::AttemptStatus {
             PaymentOutcome::SentForSettlement => Self::Charged,
             PaymentOutcome::SentForRefund => Self::AutoRefunded,
             PaymentOutcome::SentForCancellation => Self::Voided,
+            PaymentOutcome::Unknown => Self::Pending,
         }
     }
 }

--- a/crates/hyperswitch_connectors/src/connectors/worldpaymodular/transformers/response.rs
+++ b/crates/hyperswitch_connectors/src/connectors/worldpaymodular/transformers/response.rs
@@ -9,15 +9,14 @@ use crate::utils::ForeignTryFrom;
 #[serde(rename_all = "camelCase")]
 pub struct WorldpaymodularPaymentsResponse {
     pub outcome: PaymentOutcome,
-    /// Any risk factors which have been identified for the authorization. This section will not appear if no risks are identified.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub risk_factors: Option<Vec<RiskFactorsInner>>,
+    pub risk_factors: Option<Secret<serde_json::Value>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub issuer: Option<Issuer>,
+    pub issuer: Option<Secret<serde_json::Value>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub scheme: Option<PaymentsResponseScheme>,
+    pub scheme: Option<Secret<serde_json::Value>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub payment_instrument: Option<PaymentsResPaymentInstrument>,
+    pub payment_instrument: Option<Secret<serde_json::Value>>,
     #[serde(rename = "_links")]
     pub links: PaymentLinks,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -44,6 +43,8 @@ pub enum PaymentOutcome {
     SentForRefund,
     #[serde(alias = "Sent for Cancellation")]
     SentForCancellation,
+    #[serde(other)]
+    Unknown,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]

--- a/crates/hyperswitch_connectors/src/connectors/worldpaymodular/transformers/response.rs
+++ b/crates/hyperswitch_connectors/src/connectors/worldpaymodular/transformers/response.rs
@@ -48,17 +48,11 @@ pub enum PaymentOutcome {
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-pub enum RefundOutcome {
-    #[serde(alias = "Sent for Refund")]
-    SentForRefund,
-}
-
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct WorldpaymodularEventResponse {
     pub last_event: EventType,
     #[serde(rename = "_links", skip_serializing_if = "Option::is_none")]
-    pub links: Option<EventLinks>,
+    pub links: Option<Secret<serde_json::Value>>,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -149,12 +143,6 @@ pub struct PaymentLinks {
     pub reverse_event: Option<PaymentLink>,
     #[serde(rename = "tokens:token", skip_serializing_if = "Option::is_none")]
     pub token: Option<SecretPaymentLink>,
-}
-
-#[derive(Clone, Debug, PartialEq, Default, Serialize, Deserialize)]
-pub struct EventLinks {
-    #[serde(rename = "payments:events", skip_serializing_if = "Option::is_none")]
-    pub events: Option<String>,
 }
 
 impl PaymentLinks {
@@ -273,115 +261,6 @@ impl ForeignTryFrom<Option<PaymentLinks>> for ResponseId {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Default, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct Issuer {
-    pub authorization_code: Secret<String>,
-}
-
-impl Issuer {
-    pub fn new(code: String) -> Self {
-        Self {
-            authorization_code: Secret::new(code),
-        }
-    }
-}
-
-#[derive(Clone, Debug, PartialEq, Default, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct PaymentsResPaymentInstrument {
-    #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
-    pub payment_instrument_type: Option<String>,
-    pub card_bin: Option<String>,
-    pub last_four: Option<String>,
-    pub category: Option<String>,
-    // pub expiry_date: Option<ExpiryDate>,
-    pub card_brand: Option<String>,
-    pub funding_type: Option<String>,
-    pub issuer_name: Option<String>,
-    pub payment_account_reference: Option<String>,
-}
-
-impl PaymentsResPaymentInstrument {
-    pub fn new() -> Self {
-        Self {
-            payment_instrument_type: None,
-            card_bin: None,
-            last_four: None,
-            category: None,
-            // expiry_date: None,
-            card_brand: None,
-            funding_type: None,
-            issuer_name: None,
-            payment_account_reference: None,
-        }
-    }
-}
-
-#[derive(Clone, Debug, PartialEq, Default, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct RiskFactorsInner {
-    #[serde(rename = "type")]
-    pub risk_type: RiskType,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub detail: Option<Detail>,
-    pub risk: Risk,
-}
-
-impl RiskFactorsInner {
-    pub fn new(risk_type: RiskType, risk: Risk) -> Self {
-        Self {
-            risk_type,
-            detail: None,
-            risk,
-        }
-    }
-}
-
-#[derive(
-    Clone, Copy, Default, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize,
-)]
-#[serde(rename_all = "camelCase")]
-pub enum RiskType {
-    #[default]
-    Avs,
-    Cvc,
-    RiskProfile,
-}
-
-#[derive(
-    Clone, Copy, Default, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize,
-)]
-#[serde(rename_all = "camelCase")]
-pub enum Detail {
-    #[default]
-    Address,
-    Postcode,
-}
-
-#[derive(
-    Clone, Copy, Default, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize,
-)]
-#[serde(rename_all = "camelCase")]
-pub enum Risk {
-    #[default]
-    NotChecked,
-    NotMatched,
-    NotSupplied,
-    VerificationFailed,
-}
-
-#[derive(Clone, Debug, PartialEq, Default, Serialize, Deserialize)]
-pub struct PaymentsResponseScheme {
-    pub reference: String,
-}
-
-impl PaymentsResponseScheme {
-    pub fn new(reference: String) -> Self {
-        Self { reference }
-    }
-}
-
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct WorldpaymodularErrorResponse {
@@ -428,18 +307,4 @@ pub struct WorldpaymodularWebhookEventType {
     pub event_id: String,
     pub event_timestamp: String,
     pub event_details: EventDetails,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-#[serde(rename_all = "camelCase")]
-pub enum WorldpaymodularWebhookStatus {
-    SentForSettlement,
-    Authorized,
-    SentForAuthorization,
-    Cancelled,
-    Error,
-    Expired,
-    Refused,
-    SentForRefund,
-    RefundFailed,
 }


### PR DESCRIPTION
## Summary
This PR applies the three standard graceful response deserialization fixes to the Finix connector:

### Fix 1 — Removed deny_unknown_fields
- No `#[serde(deny_unknown_fields)]` existed on any response structs in this connector

### Fix 2 — Added catch-all variant to response enums used in business logic
- Added `#[serde(other)] Unknown` variant to `FinixDisputeState`
- Updated webhook match arms to return `EventNotSupported` and log a warning for unknown dispute states

### Fix 3 — Made unused response fields opaque optional types
- `tags` (HashMap/FinixTags) → `Option<Secret<serde_json::Value>>` in `FinixPaymentsResponse`, `FinixIdentityResponse`, `FinixInstrumentResponse`
- `entity` (HashMap) → `Option<Secret<serde_json::Value>>` in `FinixIdentityResponse`
- `three_d_secure` (nested struct) → `Option<Secret<serde_json::Value>>` in `FinixPaymentsResponse`
- `instrument_type` (enum) → `Option<Secret<String>>` in `FinixInstrumentResponse`
- `card_type` (enum) → `Option<Secret<String>>` in `FinixInstrumentResponse`
- `address` (nested struct) → `Option<Secret<serde_json::Value>>` in `FinixInstrumentResponse`
- `created_at`, `updated_at`, `application`, `created_via`, `identity` → made optional and/or wrapped in `Secret<String>` as needed

## Files Changed
- `crates/hyperswitch_connectors/src/connectors/finix/transformers/response.rs`
- `crates/hyperswitch_connectors/src/connectors/finix/transformers.rs`