### PR TITLE
fix(connectors): graceful response deserialization for paybox

### DIFF
--- a/crates/hyperswitch_connectors/src/connectors/authorizedotnet/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/authorizedotnet/transformers.rs
@@ -2248,6 +2248,7 @@ impl From<AuthorizedotnetWebhookEvent> for SyncStatus {
             AuthorizedotnetWebhookEvent::PriorAuthCapture => Self::SettledSuccessfully,
             AuthorizedotnetWebhookEvent::VoidCreated => Self::Voided,
             AuthorizedotnetWebhookEvent::RefundCreated => Self::RefundSettledSuccessfully,
+            AuthorizedotnetWebhookEvent::Unknown => Self::GeneralError,
         }
     }
 }

--- a/crates/hyperswitch_connectors/src/connectors/paybox/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/paybox/transformers.rs
@@ -857,7 +857,9 @@ impl From<PayboxStatus> for common_enums::RefundStatus {
             | PayboxStatus::Captured
             | PayboxStatus::Rejected => Self::Failure,
             PayboxStatus::Unknown => {
-                router_env::logger::warn!("Received unknown paybox refund status, preserving as failure");
+                router_env::logger::warn!(
+                    "Received unknown paybox refund status, preserving as failure"
+                );
                 Self::Failure
             }
         }
@@ -871,7 +873,9 @@ impl From<PayboxStatus> for enums::AttemptStatus {
             PayboxStatus::Captured | PayboxStatus::Refunded => Self::Charged,
             PayboxStatus::Rejected => Self::Failure,
             PayboxStatus::Unknown => {
-                router_env::logger::warn!("Received unknown paybox payment status, preserving as pending");
+                router_env::logger::warn!(
+                    "Received unknown paybox payment status, preserving as pending"
+                );
                 Self::Pending
             }
         }

--- a/crates/hyperswitch_connectors/src/connectors/paybox/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/paybox/transformers.rs
@@ -610,6 +610,9 @@ pub enum PayboxStatus {
 
     #[serde(rename = "Refusé")]
     Rejected,
+
+    #[serde(other)]
+    Unknown,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -853,6 +856,10 @@ impl From<PayboxStatus> for common_enums::RefundStatus {
             | PayboxStatus::Authorised
             | PayboxStatus::Captured
             | PayboxStatus::Rejected => Self::Failure,
+            PayboxStatus::Unknown => {
+                router_env::logger::warn!("Received unknown paybox refund status, preserving as failure");
+                Self::Failure
+            }
         }
     }
 }
@@ -863,6 +870,10 @@ impl From<PayboxStatus> for enums::AttemptStatus {
             PayboxStatus::Authorised => Self::Authorized,
             PayboxStatus::Captured | PayboxStatus::Refunded => Self::Charged,
             PayboxStatus::Rejected => Self::Failure,
+            PayboxStatus::Unknown => {
+                router_env::logger::warn!("Received unknown paybox payment status, preserving as pending");
+                Self::Pending
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
This PR applies graceful response deserialization fixes to the Paybox connector to prevent production SEV incidents caused by unexpected API changes.

### Changes Made
- **Fix 2 (Catch-all enum variant)**: Added `#[serde(other)] Unknown` variant to `PayboxStatus` enum, which is used in business logic for both payment status and refund status mapping.
- Added warning logs and safe defaults for the Unknown variant:
  - `From<PayboxStatus> for AttemptStatus`: Maps Unknown → `AttemptStatus::Pending` with warning log
  - `From<PayboxStatus> for RefundStatus`: Maps Unknown → `RefundStatus::Failure` with warning log

### Why
Previously, if Paybox added a new status value (e.g., a new transaction state), our serde deserialization would fail with `HE_00` (`server_not_available`). With the catch-all variant, unknown statuses are gracefully handled without hard failures.

### Notes
- Fix 1 (deny_unknown_fields): Not applicable — no response structs in the Paybox connector had `#[serde(deny_unknown_fields)]`.
- Fix 3 (opaque optional types): Not applicable — all fields on response structs are actively used in business logic (`TryFrom` implementations).