### PR TITLE
fix(connectors): graceful response deserialization for zift

### DIFF
--- a/crates/hyperswitch_connectors/src/connectors/zift/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/zift/transformers.rs
@@ -91,6 +91,8 @@ pub enum PaymentRequestType {
     #[serde(rename = "sale-auth")]
     Auth,
     Capture,
+    #[serde(other)]
+    Unknown,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
@@ -396,8 +398,8 @@ impl ResponseCodeExt for String {
 pub struct ZiftErrorResponse {
     pub response_code: String,
     pub response_message: String,
-    pub failure_code: String,
-    pub failure_message: String,
+    pub failure_code: Option<Secret<String>>,
+    pub failure_message: Option<Secret<String>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -657,6 +659,8 @@ pub enum TransactionStatus {
     Cancelled,
     #[serde(rename = "R")]
     InRebill,
+    #[serde(other)]
+    Unknown,
 }
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -702,6 +706,13 @@ impl TryFrom<ResponseRouterData<PSync, ZiftSyncResponse, PaymentsSyncData, Payme
     fn try_from(
         item: ResponseRouterData<PSync, ZiftSyncResponse, PaymentsSyncData, PaymentsResponseData>,
     ) -> Result<Self, Self::Error> {
+        if item.response.transaction_status == TransactionStatus::Unknown {
+            router_env::logger::warn!(
+                "Received unknown transaction status from Zift; preserving existing status"
+            );
+            return Ok(item.data);
+        }
+
         let attempt_status = match item.response.transaction_type {
             // Sale transactions
             PaymentRequestType::Sale => match item.response.transaction_status {
@@ -710,6 +721,7 @@ impl TryFrom<ResponseRouterData<PSync, ZiftSyncResponse, PaymentsSyncData, Payme
                     common_enums::AttemptStatus::Pending
                 }
                 TransactionStatus::Cancelled => common_enums::AttemptStatus::Failure,
+                TransactionStatus::Unknown => unreachable!(),
             },
 
             // Auth transactions (sale-auth)
@@ -719,6 +731,7 @@ impl TryFrom<ResponseRouterData<PSync, ZiftSyncResponse, PaymentsSyncData, Payme
                     common_enums::AttemptStatus::Pending
                 }
                 TransactionStatus::Cancelled => common_enums::AttemptStatus::Failure,
+                TransactionStatus::Unknown => unreachable!(),
             },
 
             // Capture transactions
@@ -728,7 +741,15 @@ impl TryFrom<ResponseRouterData<PSync, ZiftSyncResponse, PaymentsSyncData, Payme
                     common_enums::AttemptStatus::CaptureInitiated
                 }
                 TransactionStatus::Cancelled => common_enums::AttemptStatus::CaptureFailed,
+                TransactionStatus::Unknown => unreachable!(),
             },
+
+            PaymentRequestType::Unknown => {
+                router_env::logger::warn!(
+                    "Received unknown transaction type from Zift; preserving existing status"
+                );
+                return Ok(item.data);
+            }
         };
         let response = if attempt_status == common_enums::AttemptStatus::Failure {
             Err(ErrorResponse {


### PR DESCRIPTION
## Summary

Apply the three standard graceful response deserialization fixes to the **Zift** connector.

### Fix 1 — Remove `#[serde(deny_unknown_fields)]` from response structs
No `#[serde(deny_unknown_fields)]` attributes existed on response structs in the Zift connector; nothing to remove.

### Fix 2 — Add `#[serde(other)] Unknown` catch-all to response enums

Added `Unknown` variant to enums used in business logic:

- **`TransactionStatus`** — matched in PSync `TryFrom`. On `Unknown`, logs a warning and returns `Ok(item.data)` (preserves existing payment status).
- **`PaymentRequestType`** — matched in PSync `TryFrom`. On `Unknown`, logs a warning and returns `Ok(item.data)` (preserves existing payment status).

Nested match arms use `TransactionStatus::Unknown => unreachable!()` because the outer check handles `Unknown` early.

### Fix 3 — Unused fields → opaque optional types

- `ZiftErrorResponse.failure_code`: `String` → `Option<Secret<String>>`
- `ZiftErrorResponse.failure_message`: `String` → `Option<Secret<String>>`

These fields are not consumed in `build_error_response`; making them opaque optional prevents hard failures when Zift adds new error field shapes.

### Testing

No Zift-specific compiler errors. Full workspace clippy is blocked by pre-existing `diesel_models`/`common_utils` issues unrelated to this change.

Resolves HYP-43.