### PR TITLE
test(cypress): exclude nexixpay from connector-agnostic NTID tests

### DIFF
--- a/cypress-tests/cypress/e2e/configs/Payment/Utils.js
+++ b/cypress-tests/cypress/e2e/configs/Payment/Utils.js
@@ -447,6 +447,7 @@ export const CONNECTOR_LISTS = {
       "jpmorgan",
       "loonio",
       "nexinets",
+      "nexixpay",
       "noon",
       "novalnet",
       "payload",


### PR DESCRIPTION
Closes #12750

nexixpay does not support network transaction ID flows:
- NotImplemented error thrown for NetworkMandateId/NetworkTokenWithNTI
- network_txn_id hardcoded to None in all response paths
- CardDetailsForNetworkTransactionId payment method not supported
