### PR TITLE
fix(ucs): populate authorize integrity_object on the UCS gateway path

### DIFF
--- a/crates/router/src/core/payments/gateway/authorize_gateway.rs
+++ b/crates/router/src/core/payments/gateway/authorize_gateway.rs
@@ -4,7 +4,10 @@ use async_trait::async_trait;
 use common_enums::{CallConnectorAction, ExecutionPath};
 use common_utils::{errors::CustomResult, id_type, request::Request, ucs_types};
 use error_stack::ResultExt;
-use hyperswitch_domain_models::{router_data::RouterData, router_flow_types as domain};
+use hyperswitch_domain_models::{
+    router_data::RouterData, router_flow_types as domain,
+    router_request_types::AuthoriseIntegrityObject,
+};
 use hyperswitch_interfaces::{
     api::gateway as payment_gateway,
     connector_integration_interface::{BoxedConnectorIntegrationInterface, RouterDataConversion},
@@ -341,6 +344,11 @@ where
                         }
                     };
                     router_data.response = router_data_response;
+
+                    router_data.request.integrity_object = Some(AuthoriseIntegrityObject {
+                        amount: router_data.request.minor_amount,
+                        currency: router_data.request.currency,
+                    });
 
                     router_data.amount_captured = payment_authorize_response.captured_amount;
                     router_data.minor_amount_captured = payment_authorize_response


### PR DESCRIPTION
## Type of Change
- [x] Bugfix

## Description

On the **UCS (unified connector service) gateway** authorize path, the reconstructed
`RouterData` never gets `request.integrity_object` populated, while the **direct connector**
flow does (each connector sets it in `handle_response` — e.g. stripe builds it from the
response amount/currency and assigns `router_data.request.integrity_object = Some(..)`).

Because `PaymentsAuthorizeData::get_response_integrity_object()` simply returns the
`integrity_object` field, leaving it `None` means **the amount-integrity check is silently
skipped for UCS-routed payments** (the `CheckIntegrity` match takes the `None` branch and does
no comparison). It also surfaces as an `integrity_object: null` divergence when comparing
HS-native vs UCS-reconstructed `RouterData`:

```diff
-    "integrity_object": { "amount": 6500, "currency": "EUR" },
+    "integrity_object": null,
```

### Root cause
`crates/router/src/core/payments/gateway/authorize_gateway.rs` applies the UCS authorize
response to `router_data` (status, response, captured amounts, raw response, etc.) but does not
set `request.integrity_object`. The UCS reverse-map
(`handle_unified_connector_service_response_for_payment_authorize`) doesn't carry it either.

### Fix
Set the authorize integrity object from the request amount/currency right after the UCS response
is applied, mirroring the direct flow (in the common authorize case `response.amount ==
request.minor_amount`):

```rust
router_data.request.integrity_object = Some(AuthoriseIntegrityObject {
    amount: router_data.request.minor_amount,
    currency: router_data.request.currency,
});
```

> A fully faithful version would thread the connector's *response* amount through the UCS proto
> response and use that (so a connector amount mismatch is actually caught on the UCS path too).
> Raising as a **draft** to align on whether the request-amount approach is acceptable for now or
> the proto should carry the response amount.

## Motivation and Context
Restores amount-integrity parity between direct and UCS-routed payments, and removes a
false-looking diff in UCS shadow-validation runs.

## How did you test it?
Local shadow run (HS direct vs UCS) for a stripe bank-redirect authorize: confirmed the
native path emits `integrity_object: {amount, currency}` while the UCS path emitted `null` before
this change; with the change the UCS path populates the same object.
