### PR TITLE
fix(connector): [Paypal] make order status optional in PSync to handle declined captures

### DIFF
--- a/crates/hyperswitch_connectors/src/connectors/paypal/transformers.rs
+++ b/crates/hyperswitch_connectors/src/connectors/paypal/transformers.rs
@@ -2226,7 +2226,12 @@ pub enum AuthenticationStatus {
 pub struct PaypalOrdersResponse {
     id: String,
     intent: PaypalPaymentIntent,
-    status: PaypalOrderStatus,
+    // PayPal can omit the top-level order `status` in some Orders v2 responses (observed in PSync
+    // for an order whose only capture was `DECLINED`). This field is kept optional so the response
+    // still deserializes when it is absent. The attempt status is not derived from this field
+    // anyway: for orders it is taken from the capture/authorization status inside `purchase_units`
+    // (see `TryFrom<ResponseRouterData<F, PaypalOrdersResponse, ..>>`).
+    status: Option<PaypalOrderStatus>,
     purchase_units: Vec<PurchaseUnitItem>,
     payment_source: Option<PaymentSourceItemResponse>,
     payer: Option<Payer>,
@@ -2417,6 +2422,9 @@ where
             _ => None,
         }
         .ok_or(errors::ConnectorError::ResponseDeserializationFailed)?;
+        // Derive the attempt status from the capture/authorization status rather than the
+        // top-level order `status`, which PayPal may omit (e.g. a declined capture). For example a
+        // `DECLINED` capture maps to `AttemptStatus::Failure` and is handled by the branch below.
         let status = payment_collection_item.status.clone();
         let status = storage_enums::AttemptStatus::from(status);
 
@@ -3834,7 +3842,7 @@ impl TryFrom<(PaypalRedirectsWebhooks, PaypalWebhookEventType)> for PaypalOrders
         Ok(Self {
             id: webhook_body.id,
             intent: webhook_body.intent,
-            status: PaypalOrderStatus::try_from(webhook_event)?,
+            status: Some(PaypalOrderStatus::try_from(webhook_event)?),
             purchase_units: webhook_body.purchase_units,
             payment_source: None,
             payer: webhook_body.payer,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
PayPal PSync was failing with `HE_00 / Something went wrong` for orders where the top-level order `status` field is absent from PayPal's Orders v2 response. This occurs for orders whose only capture is `DECLINED`, as PayPal returns the order resource without a settled order-level `status`.

`PaypalSyncResponse` is an untagged enum, and every variant previously required a `status` field. As a result, payloads that otherwise matched the `PaypalOrdersResponse` structure but omitted `status` failed deserialization with:

```text
data did not match any variant of untagged enum PaypalSyncResponse
```

This is a **missing field** issue rather than an **unknown enum value** issue. Therefore, the correct fix is to make the field optional instead of introducing a new enum variant.

The top-level order `status` is not used in the orders conversion flow. The attempt status is derived from the capture or authorization status within `purchase_units`. For example:

```text
captures[0].status = DECLINED → AttemptStatus::Failure
```

This status then flows through the existing `is_payment_failure` path to construct the appropriate error response.

### Changes

* Changed `PaypalOrdersResponse.status` from `PaypalOrderStatus` to `Option<PaypalOrderStatus>`.


### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
https://github.com/juspay/hyperswitch-cloud/issues/16812

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Did sanity as we are unable to recreate this scenario in local
Request:
```
curl --location 'http://localhost:8080/payments/pay_QRNeZVkyQIuJpY0TpX5H?force_sync=true&expand_captures=true&expand_attempts=true' \
--header 'Accept: application/json' \
--header 'api-key: dev_K98hR9ahCaxcUjLpSZyuw5IrHsfWElw8CBQZ719NpPueMwkIk0Fhvf2TKzTcGygt'
```
Response: 
```
{
    "payment_id": "pay_QRNeZVkyQIuJpY0TpX5H",
    "merchant_id": "merchant_1781608067",
    "status": "succeeded",
    "amount": 6540,
    "net_amount": 6540,
    "shipping_cost": null,
    "amount_capturable": 0,
    "amount_received": 6540,
    "processor_merchant_id": "merchant_1781608067",
    "initiator": null,
    "sdk_authorization": "cHJvZmlsZV9pZD1wcm9fcE9hZ2RtRDR5RzREeGpvekJkSTEscHVibGlzaGFibGVfa2V5PXBrX2Rldl82Y2E0Y2E0NWRhOGE0ZGE4OTg4MGY2YWRjMTMwZDI4YSxjbGllbnRfc2VjcmV0PXBheV9RUk5lWlZreVFJdUpwWTBUcFg1SF9zZWNyZXRfcnRTaUlDTkt2bnY3OVJJalBDSUcsY3VzdG9tZXJfaWQ9dGVzdGVyLHBheW1lbnRfaWQ9cGF5X1FSTmVaVmt5UUl1SnBZMFRwWDVI",
    "connector": "paypal",
    "state_metadata": null,
    "client_secret": "pay_QRNeZVkyQIuJpY0TpX5H_secret_rtSiICNKvnv79RIjPCIG",
    "created": "2026-06-16T11:11:08.104Z",
    "modified_at": "2026-06-16T11:12:50.337Z",
    "connector_customer_id": null,
    "currency": "USD",
    "customer_id": "tester",
    "customer": {
        "id": "tester",
        "name": "John Doe",
        "email": "guest@example.com",
        "phone": null,
        "phone_country_code": null,
        "customer_document_details": null
    },
    "description": null,
    "refunds": null,
    "disputes": null,
    "attempts": [
        {
            "attempt_id": "pay_QRNeZVkyQIuJpY0TpX5H_1",
            "status": "pending",
            "amount": 6540,
            "order_tax_amount": null,
            "currency": "USD",
            "connector": "paypal",
            "error_message": null,
            "payment_method": "card",
            "connector_transaction_id": "1E483126CL492315F",
            "capture_method": null,
            "authentication_type": "no_three_ds",
            "created_at": "2026-06-16T11:11:08.105Z",
            "modified_at": "2026-06-16T11:11:12.723Z",
            "cancellation_reason": null,
            "mandate_id": null,
            "error_code": null,
            "payment_token": null,
            "connector_metadata": {
                "order_id": null,
                "capture_id": "629976774R9839103",
                "psync_flow": "CAPTURE",
                "next_action": null,
                "authorize_id": null,
                "incremental_authorization_id": null
            },
            "payment_experience": null,
            "payment_method_type": "debit",
            "reference_id": "pay_QRNeZVkyQIuJpY0TpX5H_1",
            "unified_code": null,
            "unified_message": null,
            "client_source": null,
            "client_version": null,
            "error_details": null
        }
    ],
    "mandate_id": null,
    "mandate_data": null,
    "setup_future_usage": "off_session",
    "off_session": null,
    "capture_on": null,
    "capture_method": null,
    "payment_method": "card",
    "payment_method_data": {
        "card": {
            "last4": "1111",
            "card_type": null,
            "card_network": null,
            "card_issuer": null,
            "card_issuing_country": null,
            "card_isin": "411111",
            "card_extended_bin": null,
            "card_exp_month": "04",
            "card_exp_year": "27",
            "card_holder_name": "John Doe",
            "payment_checks": null,
            "authentication_data": null,
            "auth_code": null
        },
        "billing": null
    },
    "payment_token": null,
    "shipping": null,
    "billing": {
        "address": {
            "city": "San Fransico",
            "country": "US",
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "zip": "94122",
            "state": "California",
            "first_name": "john",
            "last_name": "doe",
            "origin_zip": null
        },
        "phone": null,
        "email": null
    },
    "order_details": null,
    "email": "guest@example.com",
    "name": "John Doe",
    "phone": null,
    "return_url": null,
    "authentication_type": "no_three_ds",
    "statement_descriptor_name": null,
    "statement_descriptor_suffix": null,
    "next_action": null,
    "cancellation_reason": null,
    "error_code": null,
    "error_message": null,
    "unified_code": null,
    "unified_message": null,
    "error_details": null,
    "payment_experience": null,
    "payment_method_type": "debit",
    "connector_label": null,
    "business_country": null,
    "business_label": "default",
    "business_sub_label": null,
    "allowed_payment_method_types": null,
    "manual_retry_allowed": null,
    "connector_transaction_id": "1E483126CL492315F",
    "frm_message": null,
    "metadata": null,
    "connector_metadata": null,
    "connector_response_metadata": null,
    "feature_metadata": {
        "redirect_response": null,
        "search_tags": null,
        "apple_pay_recurring_details": null,
        "pix_additional_details": null,
        "boleto_additional_details": null,
        "pix_automatico_additional_details": null,
        "finix_additional_details": null
    },
    "reference_id": "pay_QRNeZVkyQIuJpY0TpX5H_1",
    "payment_link": null,
    "profile_id": "pro_pOagdmD4yG4DxjozBdI1",
    "surcharge_details": null,
    "attempt_count": 1,
    "merchant_decision": null,
    "merchant_connector_id": "mca_S73e2EBEjQAhkKSy2Qqh",
    "incremental_authorization_allowed": false,
    "authorization_count": null,
    "incremental_authorizations": null,
    "external_authentication_details": null,
    "external_3ds_authentication_attempted": false,
    "expires_on": "2026-06-16T11:26:08.104Z",
    "fingerprint": null,
    "browser_info": {
        "language": "en-US",
        "time_zone": -330,
        "ip_address": "129.0.0.1",
        "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
        "color_depth": 32,
        "java_enabled": true,
        "screen_width": 1728,
        "accept_header": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8",
        "screen_height": 1117,
        "java_script_enabled": true
    },
    "payment_channel": null,
    "payment_method_id": "pm_aOY4HTh3NXgyfL49R0gO",
    "network_transaction_id": null,
    "network_transaction_link_id": null,
    "payment_method_status": "active",
    "updated": "2026-06-16T11:12:50.337Z",
    "split_payments": null,
    "frm_metadata": null,
    "extended_authorization_applied": null,
    "extended_authorization_last_applied_at": null,
    "request_extended_authorization": null,
    "capture_before": null,
    "merchant_order_reference_id": null,
    "order_tax_amount": null,
    "connector_mandate_id": "3x773013um3122446",
    "card_discovery": "manual",
    "force_3ds_challenge": false,
    "force_3ds_challenge_trigger": false,
    "issuer_error_code": null,
    "issuer_error_message": null,
    "is_iframe_redirection_enabled": null,
    "whole_connector_response": null,
    "enable_partial_authorization": null,
    "enable_overcapture": null,
    "is_overcapture_enabled": null,
    "network_details": null,
    "is_stored_credential": null,
    "mit_category": null,
    "billing_descriptor": null,
    "tokenization": null,
    "partner_merchant_identifier_details": null,
    "payment_method_tokenization_details": {
        "payment_method_id": "pm_aOY4HTh3NXgyfL49R0gO",
        "payment_method_status": "active",
        "psp_tokenization": true,
        "network_tokenization": false,
        "network_transaction_id": null,
        "network_transaction_link_id": null,
        "is_eligible_for_mit_payment": true
    },
    "installment_options": null,
    "installment_data": null,
    "sender_payment_instrument_id": null
}
```

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
