### PR TITLE
fix(relay): Remove raw connector response population logic for unreferenced refunds

### DIFF
--- a/crates/router/src/core/relay.rs
+++ b/crates/router/src/core/relay.rs
@@ -8,8 +8,8 @@ use common_utils::{
     self, fp_utils,
     id_type::{self, GenerateId},
 };
-use router_env::tracing::instrument;
 use error_stack::ResultExt;
+use router_env::tracing::{self, instrument};
 use hyperswitch_connectors::connector_relay::RelayConnectors;
 use hyperswitch_domain_models::relay;
 use hyperswitch_interfaces::{

--- a/crates/router/src/core/relay.rs
+++ b/crates/router/src/core/relay.rs
@@ -8,6 +8,7 @@ use common_utils::{
     self, fp_utils,
     id_type::{self, GenerateId},
 };
+use router_env::tracing::instrument;
 use error_stack::ResultExt;
 use hyperswitch_connectors::connector_relay::RelayConnectors;
 use hyperswitch_domain_models::relay;

--- a/crates/router/src/core/relay.rs
+++ b/crates/router/src/core/relay.rs
@@ -1126,7 +1126,7 @@ async fn process_unreferenced_refund(
                 status: relay_status,
                 error_code: connector_resp.error_code,
                 error_message: connector_resp.error_message,
-                response_data: connector_resp.raw_response,
+                response_data: None,
             };
             (bytes, relay_update)
         }

--- a/crates/router/src/core/relay.rs
+++ b/crates/router/src/core/relay.rs
@@ -994,6 +994,7 @@ pub async fn sync_relay_refund_with_gateway(
     Ok(relay_response)
 }
 
+#[instrument(skip_all)]
 async fn process_unreferenced_refund(
     state: &SessionState,
     platform: &domain::Platform,

--- a/crates/router/src/core/relay.rs
+++ b/crates/router/src/core/relay.rs
@@ -8,7 +8,6 @@ use common_utils::{
     self, fp_utils,
     id_type::{self, GenerateId},
 };
-use router_env::tracing::instrument;
 use error_stack::ResultExt;
 use hyperswitch_connectors::connector_relay::RelayConnectors;
 use hyperswitch_domain_models::relay;
@@ -17,6 +16,7 @@ use hyperswitch_interfaces::{
     relay::{ConnectorRelayIntegration, UnreferencedRefundRouterData},
 };
 use hyperswitch_masking::Secret;
+use router_env::tracing::instrument;
 
 use super::errors::{self, ConnectorErrorExt, RouterResponse, RouterResult, StorageErrorExt};
 use crate::{

--- a/crates/router/src/core/relay.rs
+++ b/crates/router/src/core/relay.rs
@@ -9,7 +9,6 @@ use common_utils::{
     id_type::{self, GenerateId},
 };
 use error_stack::ResultExt;
-use router_env::tracing::{self, instrument};
 use hyperswitch_connectors::connector_relay::RelayConnectors;
 use hyperswitch_domain_models::relay;
 use hyperswitch_interfaces::{
@@ -17,7 +16,7 @@ use hyperswitch_interfaces::{
     relay::{ConnectorRelayIntegration, UnreferencedRefundRouterData},
 };
 use hyperswitch_masking::Secret;
-use router_env::tracing::instrument;
+use router_env::tracing::{self, instrument};
 
 use super::errors::{self, ConnectorErrorExt, RouterResponse, RouterResult, StorageErrorExt};
 use crate::{


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
The raw connector response contains connector authentication details, which could potentially expose sensitive credentials. Therefore, we removed storing the raw connector response in the relay response_data column. 

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
```
curl --location 'http://localhost:8080/relay/unreferenced_refund' \
--header 'Accept: application/json' \
--header 'Content-Type: application/json' \
--header 'X-Profile-Id: pro_OGLiyjG7xQV4mQsJg5gW' \
--header 'api-key:{{}}' \
--data '{
        "amount": 1000,
        "currency": "USD",
        "connector_id": "mca_KcAExAwgsADVEKKUSydK",
        "customer_id": "cus_xxx",
        "connector_resource_id": "cnx_123",
        "recipient_payment_method_data": {
            "card": {
                "card_number": "6011000990139424",
                "card_exp_month": "03",
                "card_exp_year": "30"
                
                
            }
        }   
    }'
```

<img width="770" height="389" alt="Screenshot 2026-06-16 at 9 09 17 PM" src="https://github.com/user-attachments/assets/d08a413d-708f-439e-b8de-3e47cf05cfa9" />


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
