### PR TITLE
feat(core): send adyen_split_payment to UCS for Adyen splits (#16710)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2264,7 +2264,7 @@ dependencies = [
 [[package]]
 name = "config_patch_derive"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?rev=8dfe03d9cb3ab5303ace7370bc700d2b3ff12cc5#8dfe03d9cb3ab5303ace7370bc700d2b3ff12cc5"
+source = "git+https://github.com/juspay/connector-service?rev=bc84585262b41e5c9549d15ad12781ff2e5d254f#bc84585262b41e5c9549d15ad12781ff2e5d254f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3981,7 +3981,7 @@ checksum = "32619942b8be646939eaf3db0602b39f5229b74575b67efc897811ded1db4e57"
 [[package]]
 name = "grpc-api-types"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?rev=8dfe03d9cb3ab5303ace7370bc700d2b3ff12cc5#8dfe03d9cb3ab5303ace7370bc700d2b3ff12cc5"
+source = "git+https://github.com/juspay/connector-service?rev=bc84585262b41e5c9549d15ad12781ff2e5d254f#bc84585262b41e5c9549d15ad12781ff2e5d254f"
 dependencies = [
  "axum 0.8.4",
  "bytes 1.10.1",
@@ -8176,7 +8176,7 @@ dependencies = [
 [[package]]
 name = "rust-grpc-client"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?rev=8dfe03d9cb3ab5303ace7370bc700d2b3ff12cc5#8dfe03d9cb3ab5303ace7370bc700d2b3ff12cc5"
+source = "git+https://github.com/juspay/connector-service?rev=bc84585262b41e5c9549d15ad12781ff2e5d254f#bc84585262b41e5c9549d15ad12781ff2e5d254f"
 dependencies = [
  "grpc-api-types",
 ]
@@ -11010,7 +11010,7 @@ checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
 [[package]]
 name = "ucs_cards"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?rev=8dfe03d9cb3ab5303ace7370bc700d2b3ff12cc5#8dfe03d9cb3ab5303ace7370bc700d2b3ff12cc5"
+source = "git+https://github.com/juspay/connector-service?rev=bc84585262b41e5c9549d15ad12781ff2e5d254f#bc84585262b41e5c9549d15ad12781ff2e5d254f"
 dependencies = [
  "bytes 1.10.1",
  "error-stack 0.4.1",
@@ -11026,7 +11026,7 @@ dependencies = [
 [[package]]
 name = "ucs_common_enums"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?rev=8dfe03d9cb3ab5303ace7370bc700d2b3ff12cc5#8dfe03d9cb3ab5303ace7370bc700d2b3ff12cc5"
+source = "git+https://github.com/juspay/connector-service?rev=bc84585262b41e5c9549d15ad12781ff2e5d254f#bc84585262b41e5c9549d15ad12781ff2e5d254f"
 dependencies = [
  "serde",
  "strum 0.26.3",
@@ -11037,7 +11037,7 @@ dependencies = [
 [[package]]
 name = "ucs_common_utils"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?rev=8dfe03d9cb3ab5303ace7370bc700d2b3ff12cc5#8dfe03d9cb3ab5303ace7370bc700d2b3ff12cc5"
+source = "git+https://github.com/juspay/connector-service?rev=bc84585262b41e5c9549d15ad12781ff2e5d254f#bc84585262b41e5c9549d15ad12781ff2e5d254f"
 dependencies = [
  "anyhow",
  "base64 0.21.7",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2264,7 +2264,7 @@ dependencies = [
 [[package]]
 name = "config_patch_derive"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.06.12.1#f0f87879f730320cbf67b4a18ce741720e32e9bb"
+source = "git+https://github.com/juspay/connector-service?rev=8dfe03d9cb3ab5303ace7370bc700d2b3ff12cc5#8dfe03d9cb3ab5303ace7370bc700d2b3ff12cc5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3981,7 +3981,7 @@ checksum = "32619942b8be646939eaf3db0602b39f5229b74575b67efc897811ded1db4e57"
 [[package]]
 name = "grpc-api-types"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.06.12.1#f0f87879f730320cbf67b4a18ce741720e32e9bb"
+source = "git+https://github.com/juspay/connector-service?rev=8dfe03d9cb3ab5303ace7370bc700d2b3ff12cc5#8dfe03d9cb3ab5303ace7370bc700d2b3ff12cc5"
 dependencies = [
  "axum 0.8.4",
  "bytes 1.10.1",
@@ -8176,7 +8176,7 @@ dependencies = [
 [[package]]
 name = "rust-grpc-client"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.06.12.1#f0f87879f730320cbf67b4a18ce741720e32e9bb"
+source = "git+https://github.com/juspay/connector-service?rev=8dfe03d9cb3ab5303ace7370bc700d2b3ff12cc5#8dfe03d9cb3ab5303ace7370bc700d2b3ff12cc5"
 dependencies = [
  "grpc-api-types",
 ]
@@ -11010,7 +11010,7 @@ checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
 [[package]]
 name = "ucs_cards"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.06.12.1#f0f87879f730320cbf67b4a18ce741720e32e9bb"
+source = "git+https://github.com/juspay/connector-service?rev=8dfe03d9cb3ab5303ace7370bc700d2b3ff12cc5#8dfe03d9cb3ab5303ace7370bc700d2b3ff12cc5"
 dependencies = [
  "bytes 1.10.1",
  "error-stack 0.4.1",
@@ -11026,7 +11026,7 @@ dependencies = [
 [[package]]
 name = "ucs_common_enums"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.06.12.1#f0f87879f730320cbf67b4a18ce741720e32e9bb"
+source = "git+https://github.com/juspay/connector-service?rev=8dfe03d9cb3ab5303ace7370bc700d2b3ff12cc5#8dfe03d9cb3ab5303ace7370bc700d2b3ff12cc5"
 dependencies = [
  "serde",
  "strum 0.26.3",
@@ -11037,7 +11037,7 @@ dependencies = [
 [[package]]
 name = "ucs_common_utils"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.06.12.1#f0f87879f730320cbf67b4a18ce741720e32e9bb"
+source = "git+https://github.com/juspay/connector-service?rev=8dfe03d9cb3ab5303ace7370bc700d2b3ff12cc5#8dfe03d9cb3ab5303ace7370bc700d2b3ff12cc5"
 dependencies = [
  "anyhow",
  "base64 0.21.7",

--- a/crates/external_services/Cargo.toml
+++ b/crates/external_services/Cargo.toml
@@ -74,7 +74,7 @@ http = "0.2.12"
 url = { version = "2.5.4", features = ["serde"] }
 quick-xml = { version = "0.31.0", features = ["serialize"] }
 
-unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "8dfe03d9cb3ab5303ace7370bc700d2b3ff12cc5", package = "rust-grpc-client" }
+unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "bc84585262b41e5c9549d15ad12781ff2e5d254f", package = "rust-grpc-client" }
 open-feature = { version = "0.2.5", optional = true }
 superposition_provider = { version = "0.102.0", optional = true}
 superposition_types = "0.102.0"

--- a/crates/external_services/Cargo.toml
+++ b/crates/external_services/Cargo.toml
@@ -74,7 +74,7 @@ http = "0.2.12"
 url = { version = "2.5.4", features = ["serde"] }
 quick-xml = { version = "0.31.0", features = ["serialize"] }
 
-unified-connector-service-client = { git = "https://github.com/juspay/connector-service", tag = "2026.06.12.1", package = "rust-grpc-client" }
+unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "8dfe03d9cb3ab5303ace7370bc700d2b3ff12cc5", package = "rust-grpc-client" }
 open-feature = { version = "0.2.5", optional = true }
 superposition_provider = { version = "0.102.0", optional = true}
 superposition_types = "0.102.0"

--- a/crates/hyperswitch_interfaces/Cargo.toml
+++ b/crates/hyperswitch_interfaces/Cargo.toml
@@ -33,7 +33,7 @@ time = "0.3.41"
 tonic = "0.14"
 url = { version = "2.5.4", features = ["serde"] }
 
-unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "8dfe03d9cb3ab5303ace7370bc700d2b3ff12cc5", package = "rust-grpc-client" }
+unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "bc84585262b41e5c9549d15ad12781ff2e5d254f", package = "rust-grpc-client" }
 tokio = { version = "1.45.1", features = ["macros", "rt-multi-thread"] }
 
 # First party crates

--- a/crates/hyperswitch_interfaces/Cargo.toml
+++ b/crates/hyperswitch_interfaces/Cargo.toml
@@ -33,7 +33,7 @@ time = "0.3.41"
 tonic = "0.14"
 url = { version = "2.5.4", features = ["serde"] }
 
-unified-connector-service-client = { git = "https://github.com/juspay/connector-service", tag = "2026.06.12.1", package = "rust-grpc-client" }
+unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "8dfe03d9cb3ab5303ace7370bc700d2b3ff12cc5", package = "rust-grpc-client" }
 tokio = { version = "1.45.1", features = ["macros", "rt-multi-thread"] }
 
 # First party crates

--- a/crates/router/Cargo.toml
+++ b/crates/router/Cargo.toml
@@ -91,8 +91,8 @@ ring = "0.17.14"
 rust_decimal = { version = "1.37.1", features = ["serde-with-float", "serde-with-str"] }
 rust-i18n = { git = "https://github.com/kashif-m/rust-i18n", rev = "f2d8096aaaff7a87a847c35a5394c269f75e077a" }
 
-unified-connector-service-client = { git = "https://github.com/juspay/connector-service", tag = "2026.06.12.1", package = "rust-grpc-client" }
-unified-connector-service-cards = { git = "https://github.com/juspay/connector-service", tag = "2026.06.12.1", package = "ucs_cards" }
+unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "8dfe03d9cb3ab5303ace7370bc700d2b3ff12cc5", package = "rust-grpc-client" }
+unified-connector-service-cards = { git = "https://github.com/juspay/connector-service", rev = "8dfe03d9cb3ab5303ace7370bc700d2b3ff12cc5", package = "ucs_cards" }
 rustc-hash = "1.1.0"
 rustls = "0.22"
 rustls-pemfile = "2"

--- a/crates/router/Cargo.toml
+++ b/crates/router/Cargo.toml
@@ -91,8 +91,8 @@ ring = "0.17.14"
 rust_decimal = { version = "1.37.1", features = ["serde-with-float", "serde-with-str"] }
 rust-i18n = { git = "https://github.com/kashif-m/rust-i18n", rev = "f2d8096aaaff7a87a847c35a5394c269f75e077a" }
 
-unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "8dfe03d9cb3ab5303ace7370bc700d2b3ff12cc5", package = "rust-grpc-client" }
-unified-connector-service-cards = { git = "https://github.com/juspay/connector-service", rev = "8dfe03d9cb3ab5303ace7370bc700d2b3ff12cc5", package = "ucs_cards" }
+unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "bc84585262b41e5c9549d15ad12781ff2e5d254f", package = "rust-grpc-client" }
+unified-connector-service-cards = { git = "https://github.com/juspay/connector-service", rev = "bc84585262b41e5c9549d15ad12781ff2e5d254f", package = "ucs_cards" }
 rustc-hash = "1.1.0"
 rustls = "0.22"
 rustls-pemfile = "2"

--- a/crates/router/src/core/unified_connector_service/transformers.rs
+++ b/crates/router/src/core/unified_connector_service/transformers.rs
@@ -402,6 +402,25 @@ impl
                 .map(Into::into),
             l2_l3_data: None,
             merchant_request_id: None,
+            partner_merchant_identifier_details: router_data
+                .request
+                .partner_merchant_identifier_details
+                .as_ref()
+                .map(|details| payments_grpc::PartnerMerchantIdentifierDetails {
+                    partner_details: details.partner_details.as_ref().map(|p| {
+                        payments_grpc::PartnerApplicationDetails {
+                            name: p.name.clone(),
+                            version: p.version.clone(),
+                            integrator: p.integrator.clone(),
+                        }
+                    }),
+                    merchant_details: details.merchant_details.as_ref().map(|m| {
+                        payments_grpc::MerchantApplicationDetails {
+                            name: m.name.clone(),
+                            version: m.version.clone(),
+                        }
+                    }),
+                }),
         })
     }
 }
@@ -598,6 +617,7 @@ impl
             l2_l3_data: None,
             connector_order_id: None,
             merchant_request_id: None,
+            partner_merchant_identifier_details: None,
         })
     }
 }
@@ -1363,6 +1383,7 @@ impl
             connector_order_id: None,
             l2_l3_data: None,
             merchant_request_id: None,
+            partner_merchant_identifier_details: None,
         })
     }
 }
@@ -1547,6 +1568,7 @@ impl
             connector_order_id: None,
             l2_l3_data: None,
             merchant_request_id: None,
+            partner_merchant_identifier_details: None,
         })
     }
 }
@@ -1711,6 +1733,7 @@ impl
             connector_order_id: None,
             l2_l3_data: None,
             merchant_request_id: None,
+            partner_merchant_identifier_details: None,
         })
     }
 }

--- a/crates/router/src/core/unified_connector_service/transformers.rs
+++ b/crates/router/src/core/unified_connector_service/transformers.rs
@@ -421,6 +421,25 @@ impl
                         }
                     }),
                 }),
+            adyen_split_payment: match router_data.request.split_payments.as_ref() {
+                Some(common_types::payments::SplitPaymentsRequest::AdyenSplitPayment(
+                    adyen_split,
+                )) => Some(payments_grpc::AdyenSplitData {
+                    store: adyen_split.store.clone(),
+                    split_items: adyen_split
+                        .split_items
+                        .iter()
+                        .map(|item| payments_grpc::AdyenSplitItem {
+                            amount: item.amount.map(|a| a.get_amount_as_i64()),
+                            split_type: item.split_type.to_string(),
+                            account: item.account.clone(),
+                            reference: item.reference.clone(),
+                            description: item.description.clone(),
+                        })
+                        .collect(),
+                }),
+                _ => None,
+            },
         })
     }
 }
@@ -618,6 +637,7 @@ impl
             connector_order_id: None,
             merchant_request_id: None,
             partner_merchant_identifier_details: None,
+            adyen_split_payment: None,
         })
     }
 }
@@ -1384,6 +1404,7 @@ impl
             l2_l3_data: None,
             merchant_request_id: None,
             partner_merchant_identifier_details: None,
+            adyen_split_payment: None,
         })
     }
 }
@@ -1569,6 +1590,7 @@ impl
             l2_l3_data: None,
             merchant_request_id: None,
             partner_merchant_identifier_details: None,
+            adyen_split_payment: None,
         })
     }
 }
@@ -1734,6 +1756,7 @@ impl
             l2_l3_data: None,
             merchant_request_id: None,
             partner_merchant_identifier_details: None,
+            adyen_split_payment: None,
         })
     }
 }


### PR DESCRIPTION
## What & why

Client-side half of shadow-validation issue **#16710** (`adyen` / `authorize`). The Direct path emitted Adyen `splits` while the shadow UCS path did not:

```
body.keyDiff.splits = {"hyperswitch":true,"ucs":false}
```

UCS now carries structured Adyen split data over the proto. This PR maps `request.split_payments` (`SplitPaymentsRequest::AdyenSplitPayment`) into the new `payments_grpc::AdyenSplitData` when building the UCS authorize request, and bumps the connector-service rev-pin to the proto that adds the field.

## Changes
- **rev-pin** `8dfe03d` → `bc8458526` (adds `adyen_split_payment`, field 47) across all 4 `connector-service` deps (external_services, hyperswitch_interfaces, router ×2).
- Map `AdyenSplitPayment` → `AdyenSplitData` / `AdyenSplitItem` in `unified_connector_service/transformers.rs` (`None` on the other authorize construction sites).

## Proof (local shadow validation service, `:9100`)

**Before** (issue): `body.keyDiff.splits = {"hyperswitch":true,"ucs":false}`

**After** (router rebuilt against rev `bc8458526` + prism splits change, re-fired adyen/authorize; request id `019ed211-12da-7262-8837-6a51a6134566`):

```json
"bodyComparison": { "keyDiff": {}, "valueDiff": {}, "typeDiff": {} }
```

## Notes
- **Draft**: rev-pins a branch commit. Flip to a CalVer tag once the prism proto change merges and the nightly tag job runs.
- Pairs with hyperswitch-prism **#1539** (proto + connector + domain). Stacked on **#12786** (applicationInfo client + rev-pin); base is that branch so the diff here is splits-only.
- No credentials / local config (`config/development.toml`) included.
