### PR TITLE
feat(core): send stripe_split_payment to UCS for Stripe-Account on capture (#16719)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2264,7 +2264,7 @@ dependencies = [
 [[package]]
 name = "config_patch_derive"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?rev=18502e58738ed3a0b56bc90fc0de1c9317c88ff9#18502e58738ed3a0b56bc90fc0de1c9317c88ff9"
+source = "git+https://github.com/juspay/connector-service?rev=1c429a62f5dc29b1aec0ada154c7e1cfda40d480#1c429a62f5dc29b1aec0ada154c7e1cfda40d480"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3981,7 +3981,7 @@ checksum = "32619942b8be646939eaf3db0602b39f5229b74575b67efc897811ded1db4e57"
 [[package]]
 name = "grpc-api-types"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?rev=18502e58738ed3a0b56bc90fc0de1c9317c88ff9#18502e58738ed3a0b56bc90fc0de1c9317c88ff9"
+source = "git+https://github.com/juspay/connector-service?rev=1c429a62f5dc29b1aec0ada154c7e1cfda40d480#1c429a62f5dc29b1aec0ada154c7e1cfda40d480"
 dependencies = [
  "axum 0.8.4",
  "bytes 1.10.1",
@@ -8176,7 +8176,7 @@ dependencies = [
 [[package]]
 name = "rust-grpc-client"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?rev=18502e58738ed3a0b56bc90fc0de1c9317c88ff9#18502e58738ed3a0b56bc90fc0de1c9317c88ff9"
+source = "git+https://github.com/juspay/connector-service?rev=1c429a62f5dc29b1aec0ada154c7e1cfda40d480#1c429a62f5dc29b1aec0ada154c7e1cfda40d480"
 dependencies = [
  "grpc-api-types",
 ]
@@ -11010,7 +11010,7 @@ checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
 [[package]]
 name = "ucs_cards"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?rev=18502e58738ed3a0b56bc90fc0de1c9317c88ff9#18502e58738ed3a0b56bc90fc0de1c9317c88ff9"
+source = "git+https://github.com/juspay/connector-service?rev=1c429a62f5dc29b1aec0ada154c7e1cfda40d480#1c429a62f5dc29b1aec0ada154c7e1cfda40d480"
 dependencies = [
  "bytes 1.10.1",
  "error-stack 0.4.1",
@@ -11026,7 +11026,7 @@ dependencies = [
 [[package]]
 name = "ucs_common_enums"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?rev=18502e58738ed3a0b56bc90fc0de1c9317c88ff9#18502e58738ed3a0b56bc90fc0de1c9317c88ff9"
+source = "git+https://github.com/juspay/connector-service?rev=1c429a62f5dc29b1aec0ada154c7e1cfda40d480#1c429a62f5dc29b1aec0ada154c7e1cfda40d480"
 dependencies = [
  "serde",
  "strum 0.26.3",
@@ -11037,7 +11037,7 @@ dependencies = [
 [[package]]
 name = "ucs_common_utils"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?rev=18502e58738ed3a0b56bc90fc0de1c9317c88ff9#18502e58738ed3a0b56bc90fc0de1c9317c88ff9"
+source = "git+https://github.com/juspay/connector-service?rev=1c429a62f5dc29b1aec0ada154c7e1cfda40d480#1c429a62f5dc29b1aec0ada154c7e1cfda40d480"
 dependencies = [
  "anyhow",
  "base64 0.21.7",

--- a/crates/external_services/Cargo.toml
+++ b/crates/external_services/Cargo.toml
@@ -74,7 +74,7 @@ http = "0.2.12"
 url = { version = "2.5.4", features = ["serde"] }
 quick-xml = { version = "0.31.0", features = ["serialize"] }
 
-unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "18502e58738ed3a0b56bc90fc0de1c9317c88ff9", package = "rust-grpc-client" }
+unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "1c429a62f5dc29b1aec0ada154c7e1cfda40d480", package = "rust-grpc-client" }
 open-feature = { version = "0.2.5", optional = true }
 superposition_provider = { version = "0.102.0", optional = true}
 superposition_types = "0.102.0"

--- a/crates/hyperswitch_interfaces/Cargo.toml
+++ b/crates/hyperswitch_interfaces/Cargo.toml
@@ -33,7 +33,7 @@ time = "0.3.41"
 tonic = "0.14"
 url = { version = "2.5.4", features = ["serde"] }
 
-unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "18502e58738ed3a0b56bc90fc0de1c9317c88ff9", package = "rust-grpc-client" }
+unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "1c429a62f5dc29b1aec0ada154c7e1cfda40d480", package = "rust-grpc-client" }
 tokio = { version = "1.45.1", features = ["macros", "rt-multi-thread"] }
 
 # First party crates

--- a/crates/router/Cargo.toml
+++ b/crates/router/Cargo.toml
@@ -91,8 +91,8 @@ ring = "0.17.14"
 rust_decimal = { version = "1.37.1", features = ["serde-with-float", "serde-with-str"] }
 rust-i18n = { git = "https://github.com/kashif-m/rust-i18n", rev = "f2d8096aaaff7a87a847c35a5394c269f75e077a" }
 
-unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "18502e58738ed3a0b56bc90fc0de1c9317c88ff9", package = "rust-grpc-client" }
-unified-connector-service-cards = { git = "https://github.com/juspay/connector-service", rev = "18502e58738ed3a0b56bc90fc0de1c9317c88ff9", package = "ucs_cards" }
+unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "1c429a62f5dc29b1aec0ada154c7e1cfda40d480", package = "rust-grpc-client" }
+unified-connector-service-cards = { git = "https://github.com/juspay/connector-service", rev = "1c429a62f5dc29b1aec0ada154c7e1cfda40d480", package = "ucs_cards" }
 rustc-hash = "1.1.0"
 rustls = "0.22"
 rustls-pemfile = "2"

--- a/crates/router/src/core/unified_connector_service/transformers.rs
+++ b/crates/router/src/core/unified_connector_service/transformers.rs
@@ -1287,6 +1287,9 @@ impl transformers::ForeignTryFrom<&RouterData<Capture, PaymentsCaptureData, Paym
             merchant_order_id: router_data.request.merchant_order_reference_id.clone(),
             merchant_request_id: None,
             order_tax_amount: None,
+            stripe_split_payment: build_stripe_split_payment(
+                router_data.request.split_payments.as_ref(),
+            ),
         })
     }
 }


### PR DESCRIPTION
## What

Forward Stripe Connect `split_payments` to UCS on the **capture** flow, so the
UCS path emits the `Stripe-Account` header for direct charges — matching the
Direct gateway. Continuation of #12797 (#16718, authorize / customer-create /
tokenize) for the capture flow.

Resolves the production shadow-validation diff juspay/hyperswitch-cloud#16719
(merchant `yucca`, connector `stripe`, flow `capture`):

```
header.keyDiff.stripe-account={"hyperswitch":true,"ucs":false}
```

## Changes

- `unified_connector_service/transformers.rs`: set `stripe_split_payment` on
  `PaymentServiceCaptureRequest` via the existing `build_stripe_split_payment`
  helper (read from `PaymentsCaptureData.split_payments`), mirroring the
  authorize / complete-authorize builders.
- Rev-pin the 4 `connector-service` deps to the prism proto commit that adds
  `stripe_split_payment` to `PaymentServiceCaptureRequest`
  (`18502e58…` → `1c429a62…`).

> **Draft**: depends on prism PR juspay/hyperswitch-prism#1546. The `rev` pin is
> a temporary proto-branch commit; flip it to a CalVer tag once the prism PR
> merges and the nightly tag job runs, then mark ready.

## Proof

**Before** (production #16719): `header.keyDiff.stripe-account={"hyperswitch":true,"ucs":false}`

**After** (local shadow repro via validation service `:9100`, stripe/capture,
x-request-id `019ed29c-d8af-7601-a277-8d1a3f53c9ac`):

```
headerComparison.keyDiff: { "x-merchant-id": {"hyperswitch":false,"ucs":true} }  # ignore-listed only; stripe-account GONE
bodyComparison.keyDiff:   {}
methodComparison: POST == POST
```

Both Direct and UCS now send identical `Stripe-Account: acct_…` on the capture
request.

_No credentials included; `config/development.toml` excluded._
