### PR TITLE
fix(router): send raw card expiry month in UCS payment-method request (#16726)

### DIFF
--- a/crates/router/src/core/unified_connector_service.rs
+++ b/crates/router/src/core/unified_connector_service.rs
@@ -21,7 +21,6 @@ use external_services::grpc_client::{
     unified_connector_service::{ConnectorAuthMetadata, UnifiedConnectorServiceError},
     LineageIds,
 };
-use hyperswitch_connectors::utils::CardData;
 #[cfg(feature = "v2")]
 use hyperswitch_domain_models::merchant_connector_account::MerchantConnectorAccountTypeDetails;
 use hyperswitch_domain_models::{
@@ -765,14 +764,12 @@ pub fn build_unified_connector_service_payment_method(
                     })
                 }
                 _ => {
-                    let card_exp_month = card
-                        .get_card_expiry_month_2_digit()
-                        .attach_printable("Failed to extract 2-digit expiry month from card")
-                        .change_context(UnifiedConnectorServiceError::InvalidDataFormat {
-                            field_name: "card_exp_month",
-                        })?
-                        .peek()
-                        .to_string();
+                    // Forward the expiry month exactly as the cardholder provided it, mirroring
+                    // the Direct gateway (which uses the raw value) and the card expiry year sent
+                    // raw below. Pre-padding to two digits here diverged the UCS request from
+                    // Direct for connectors that format the expiry from the raw month
+                    // (e.g. authorizedotnet sent "2030-03" via UCS vs "2030-3" via Direct).
+                    let card_exp_month = card.card_exp_month.peek().to_string();
 
                     let card_network = card
                         .card_network


### PR DESCRIPTION
## Summary

Resolves shadow-validation diff [`hyperswitch-cloud#16726`](https://github.com/juspay/hyperswitch-cloud/issues/16726) (connector `authorizedotnet`, flow `authorize`).

In shadow mode the UCS (prism) outbound request to Authorize.net diverged from the Direct request on the card expiry month:

```
body.valueDiff.createTransactionRequest.transactionRequest.payment.creditCard.expirationDate
  = { "hyperswitch": "2030-3", "ucs": "2030-03" }
```

### Root cause

`build_unified_connector_service_payment_method` (the UCS client that builds the gRPC `CardDetails`) zero-padded the expiry month to two digits via `get_card_expiry_month_2_digit()`:

```rust
let card_exp_month = card.get_card_expiry_month_2_digit()? /* "3" -> "03" */ .peek().to_string();
```

But the **Direct** gateway and **every** connector transformer (both Direct and the prism/UCS side) format the `expirationDate` from the *raw*, cardholder-supplied month. For a single-digit input month (`"3"`), Authorize.net's transformer produces `format!("{year}-{month}")`:
- Direct: raw `"3"` → `"2030-3"`
- UCS: pre-padded `"03"` → `"2030-03"`

The padding in the client is the only place the month is altered; the adjacent expiry **year** is already forwarded raw. So the proto card was not a faithful copy of the domain card.

### Fix

Forward the expiry month exactly as provided, mirroring the raw year on the next line:

```rust
let card_exp_month = card.card_exp_month.peek().to_string();
```

### Blast-radius check (safe)

The only connectors whose **Direct** transformer pads the month internally are `redsys`, `tesouro`, `worldpayxml`:
- **redsys** — its prism transformer *also* calls `get_card_expiry_month_2_digit()`, so it re-pads the now-raw proto value → unchanged.
- **tesouro** — not implemented in prism (no UCS path).
- **worldpayxml** — only a payout connector in prism (a different proto path, `CardPayout`), not the payment card builder touched here.

All other connectors format from the raw month in Direct, so sending the raw month over UCS brings them into parity (and fixes this class of diff).

## Verification (local shadow stack)

Reproduced with an authorizedotnet authorize, single-digit input month `card_exp_month="3"`:

**Before** — validation service `bodyComparison.valueDiff`:
```json
{ "createTransactionRequest.transactionRequest.payment.creditCard.expirationDate":
  { "hyperswitch": "2030-3", "ucs": "2030-03" } }
```

**After** (rebuilt router, re-fired) — `diff_result_authorize:authorizedotnet:019ed3f6-21e1-7a63-8206-1e362a4b8280`:
```json
bodyComparison.keyDiff   = {}
bodyComparison.valueDiff = {}
bodyComparison.typeDiff  = {}
```
Both Direct and UCS now send `expirationDate = "2030-3"`. (Only the benign, ignore-listed `x-merchant-id` header remains.) The `create_connector_customer` flow was already clean (it carries no card).
