### PR TITLE
feat(ucs): map split_payments to UCS gRPC on capture for Stripe Connect (#16719)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2264,7 +2264,7 @@ dependencies = [
 [[package]]
 name = "config_patch_derive"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.06.23.1#2a748b69578e5d61c4586b30aabddad0ed7fd88a"
+source = "git+https://github.com/juspay/connector-service?rev=c457ea2b9c2b22b2baa48e3557928dbcfe3dd746#c457ea2b9c2b22b2baa48e3557928dbcfe3dd746"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3981,7 +3981,7 @@ checksum = "32619942b8be646939eaf3db0602b39f5229b74575b67efc897811ded1db4e57"
 [[package]]
 name = "grpc-api-types"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.06.23.1#2a748b69578e5d61c4586b30aabddad0ed7fd88a"
+source = "git+https://github.com/juspay/connector-service?rev=c457ea2b9c2b22b2baa48e3557928dbcfe3dd746#c457ea2b9c2b22b2baa48e3557928dbcfe3dd746"
 dependencies = [
  "axum 0.8.4",
  "bytes 1.10.1",
@@ -8176,7 +8176,7 @@ dependencies = [
 [[package]]
 name = "rust-grpc-client"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.06.23.1#2a748b69578e5d61c4586b30aabddad0ed7fd88a"
+source = "git+https://github.com/juspay/connector-service?rev=c457ea2b9c2b22b2baa48e3557928dbcfe3dd746#c457ea2b9c2b22b2baa48e3557928dbcfe3dd746"
 dependencies = [
  "grpc-api-types",
 ]
@@ -11010,7 +11010,7 @@ checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
 [[package]]
 name = "ucs_cards"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.06.23.1#2a748b69578e5d61c4586b30aabddad0ed7fd88a"
+source = "git+https://github.com/juspay/connector-service?rev=c457ea2b9c2b22b2baa48e3557928dbcfe3dd746#c457ea2b9c2b22b2baa48e3557928dbcfe3dd746"
 dependencies = [
  "bytes 1.10.1",
  "error-stack 0.4.1",
@@ -11026,7 +11026,7 @@ dependencies = [
 [[package]]
 name = "ucs_common_enums"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.06.23.1#2a748b69578e5d61c4586b30aabddad0ed7fd88a"
+source = "git+https://github.com/juspay/connector-service?rev=c457ea2b9c2b22b2baa48e3557928dbcfe3dd746#c457ea2b9c2b22b2baa48e3557928dbcfe3dd746"
 dependencies = [
  "serde",
  "strum 0.26.3",
@@ -11037,7 +11037,7 @@ dependencies = [
 [[package]]
 name = "ucs_common_utils"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.06.23.1#2a748b69578e5d61c4586b30aabddad0ed7fd88a"
+source = "git+https://github.com/juspay/connector-service?rev=c457ea2b9c2b22b2baa48e3557928dbcfe3dd746#c457ea2b9c2b22b2baa48e3557928dbcfe3dd746"
 dependencies = [
  "anyhow",
  "base64 0.21.7",

--- a/crates/external_services/Cargo.toml
+++ b/crates/external_services/Cargo.toml
@@ -80,7 +80,7 @@ http = "0.2.12"
 url = { version = "2.5.4", features = ["serde"] }
 quick-xml = { version = "0.31.0", features = ["serialize"] }
 
-unified-connector-service-client = { git = "https://github.com/juspay/connector-service", tag = "2026.06.23.1", package = "rust-grpc-client" }
+unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "c457ea2b9c2b22b2baa48e3557928dbcfe3dd746", package = "rust-grpc-client" }
 open-feature = { version = "0.2.5", optional = true }
 superposition_provider = { version = "0.102.0", optional = true }
 superposition_types = "0.102.0"

--- a/crates/hyperswitch_interfaces/Cargo.toml
+++ b/crates/hyperswitch_interfaces/Cargo.toml
@@ -33,7 +33,7 @@ time = "0.3.41"
 tonic = "0.14"
 url = { version = "2.5.4", features = ["serde"] }
 
-unified-connector-service-client = { git = "https://github.com/juspay/connector-service", tag = "2026.06.23.1", package = "rust-grpc-client" }
+unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "c457ea2b9c2b22b2baa48e3557928dbcfe3dd746", package = "rust-grpc-client" }
 tokio = { version = "1.45.1", features = ["macros", "rt-multi-thread"] }
 
 # First party crates

--- a/crates/router/Cargo.toml
+++ b/crates/router/Cargo.toml
@@ -91,8 +91,8 @@ ring = "0.17.14"
 rust_decimal = { version = "1.37.1", features = ["serde-with-float", "serde-with-str"] }
 rust-i18n = { git = "https://github.com/kashif-m/rust-i18n", rev = "f2d8096aaaff7a87a847c35a5394c269f75e077a" }
 
-unified-connector-service-client = { git = "https://github.com/juspay/connector-service", tag = "2026.06.23.1", package = "rust-grpc-client" }
-unified-connector-service-cards = { git = "https://github.com/juspay/connector-service", tag = "2026.06.23.1", package = "ucs_cards" }
+unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "c457ea2b9c2b22b2baa48e3557928dbcfe3dd746", package = "rust-grpc-client" }
+unified-connector-service-cards = { git = "https://github.com/juspay/connector-service", rev = "c457ea2b9c2b22b2baa48e3557928dbcfe3dd746", package = "ucs_cards" }
 rustc-hash = "1.1.0"
 rustls = "0.22"
 rustls-pemfile = "2"

--- a/crates/router/src/core/unified_connector_service/transformers.rs
+++ b/crates/router/src/core/unified_connector_service/transformers.rs
@@ -1222,6 +1222,11 @@ impl transformers::ForeignTryFrom<&RouterData<Capture, PaymentsCaptureData, Paym
             .map(ConnectorState::foreign_from);
 
         Ok(Self {
+            split_payments: router_data
+                .request
+                .split_payments
+                .as_ref()
+                .map(payments_grpc::SplitPaymentsDetails::foreign_from),
             connector_transaction_id,
             merchant_capture_id: Some(router_data.connector_request_reference_id.clone()),
             amount_to_capture: Some(payments_grpc::Money {


### PR DESCRIPTION
## Summary

Maps the payment's `split_payments` (Stripe Connect) to the UCS gRPC contract on the
**capture** flow, so the shadow (UCS) capture request emits the `Stripe-Account` header for
Connect **Direct** charges — matching HS-native behaviour.

**Shadow-validation diff (yucca / stripe / capture):**
`header.keyDiff.stripe-account = {"hyperswitch": true, "ucs": false}`

HS routes the capture onto the connected account via `Stripe-Account`; UCS dropped the header
because `split_payments` was never threaded through the gRPC contract → behavioural divergence
(money-movement routing), not a benign signature/timestamp diff.

## Layer category

Proto-category, cross-repo (UCS + HS) — same family as #16718 (authorize). This HS PR adds the
HS->UCS **mapping** for the capture flow; the proto + domain + L3 header builder live in the UCS PR.

## Changes

- `core/unified_connector_service/transformers.rs`: populate `split_payments` from
  `router_data.request.split_payments` in the `PaymentServiceCaptureRequest` mapping
  (`impl ForeignTryFrom<RouterData<Capture, PaymentsCaptureData, _>>`), via
  `payments_grpc::SplitPaymentsDetails::foreign_from` — mirroring the already-merged
  authorize/customer/token/repeat mappings.
- Bump the UCS gRPC dep (`unified-connector-service-{client,cards}`) tag -> `rev` to the UCS PR
  head in the three Cargo.tomls + `Cargo.lock`, so CI compiles against the new capture proto field.

## Dependency

Depends on UCS PR juspay/connector-service#1550 (which stacks on #16718's #1549). The `rev` pin is
**interim** — once #1550 merges to `main`, move the pin back to a release `tag`/main commit.

## Verification

Reproduced locally on the stack (`repro_16719.py`, using a real Stripe test connected account
`acct_1TjBkeDfqJC9T9K6`): before -> VS `diff_result_capture:stripe` header keyDiff
`stripe-account {hs:true, ucs:false}`; after -> keyDiff `{}`, raw HS & UCS capture requests carry an
identical `Stripe-Account: acct_1TjBkeDfqJC9T9K6` (diff -> no_diff). UCS-side local checks pass
(composite parity test, `domain_types` clippy, test compile).

Closes #12804

Shadow-validation diff tracked at internal tracking issue (closed) — referenced here so
the validation board surfaces this PR. (Plain cross-reference, not a closing keyword: the HS
`pr-convention-checks` linked-issue gate requires every `closingIssuesReferences` entry to be an
OPEN issue, and the cloud tracking issue is already closed; the same-repo `Closes #12804` above
satisfies that gate.)
