### PR TITLE
feat(ucs): map split_refunds to UCS gRPC for Stripe Connect refund routing (#16723)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1550,7 +1550,7 @@ dependencies = [
  "bitflags 2.9.0",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "log 0.4.27",
  "prettyplease",
  "proc-macro2",
@@ -2264,7 +2264,7 @@ dependencies = [
 [[package]]
 name = "config_patch_derive"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.06.12.2#131ee8aec3d67d05c2826ceb6e6ff7e35d16050a"
+source = "git+https://github.com/juspay/connector-service?rev=6fd9852a54d0939e9be292a92b8f1aab2d39fde8#6fd9852a54d0939e9be292a92b8f1aab2d39fde8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3981,7 +3981,7 @@ checksum = "32619942b8be646939eaf3db0602b39f5229b74575b67efc897811ded1db4e57"
 [[package]]
 name = "grpc-api-types"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.06.12.2#131ee8aec3d67d05c2826ceb6e6ff7e35d16050a"
+source = "git+https://github.com/juspay/connector-service?rev=6fd9852a54d0939e9be292a92b8f1aab2d39fde8#6fd9852a54d0939e9be292a92b8f1aab2d39fde8"
 dependencies = [
  "axum 0.8.4",
  "bytes 1.10.1",
@@ -7156,8 +7156,8 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.4.1",
- "itertools 0.10.5",
+ "heck 0.5.0",
+ "itertools 0.11.0",
  "log 0.4.27",
  "multimap",
  "petgraph",
@@ -7178,7 +7178,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn 2.0.101",
@@ -7191,7 +7191,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn 2.0.101",
@@ -8176,7 +8176,7 @@ dependencies = [
 [[package]]
 name = "rust-grpc-client"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.06.12.2#131ee8aec3d67d05c2826ceb6e6ff7e35d16050a"
+source = "git+https://github.com/juspay/connector-service?rev=6fd9852a54d0939e9be292a92b8f1aab2d39fde8#6fd9852a54d0939e9be292a92b8f1aab2d39fde8"
 dependencies = [
  "grpc-api-types",
 ]
@@ -11010,7 +11010,7 @@ checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
 [[package]]
 name = "ucs_cards"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.06.12.2#131ee8aec3d67d05c2826ceb6e6ff7e35d16050a"
+source = "git+https://github.com/juspay/connector-service?rev=6fd9852a54d0939e9be292a92b8f1aab2d39fde8#6fd9852a54d0939e9be292a92b8f1aab2d39fde8"
 dependencies = [
  "bytes 1.10.1",
  "error-stack 0.4.1",
@@ -11026,7 +11026,7 @@ dependencies = [
 [[package]]
 name = "ucs_common_enums"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.06.12.2#131ee8aec3d67d05c2826ceb6e6ff7e35d16050a"
+source = "git+https://github.com/juspay/connector-service?rev=6fd9852a54d0939e9be292a92b8f1aab2d39fde8#6fd9852a54d0939e9be292a92b8f1aab2d39fde8"
 dependencies = [
  "serde",
  "strum 0.26.3",
@@ -11037,7 +11037,7 @@ dependencies = [
 [[package]]
 name = "ucs_common_utils"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.06.12.2#131ee8aec3d67d05c2826ceb6e6ff7e35d16050a"
+source = "git+https://github.com/juspay/connector-service?rev=6fd9852a54d0939e9be292a92b8f1aab2d39fde8#6fd9852a54d0939e9be292a92b8f1aab2d39fde8"
 dependencies = [
  "anyhow",
  "base64 0.21.7",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1550,7 +1550,7 @@ dependencies = [
  "bitflags 2.9.0",
  "cexpr",
  "clang-sys",
- "itertools 0.11.0",
+ "itertools 0.10.5",
  "log 0.4.27",
  "prettyplease",
  "proc-macro2",
@@ -2264,7 +2264,7 @@ dependencies = [
 [[package]]
 name = "config_patch_derive"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?rev=eb7dfd7855d290e743a91a279e7dfddc15c67675#eb7dfd7855d290e743a91a279e7dfddc15c67675"
+source = "git+https://github.com/juspay/connector-service?rev=4dc2c036c1169237d673c4bdc0bfaeb0026f3a95#4dc2c036c1169237d673c4bdc0bfaeb0026f3a95"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3981,7 +3981,7 @@ checksum = "32619942b8be646939eaf3db0602b39f5229b74575b67efc897811ded1db4e57"
 [[package]]
 name = "grpc-api-types"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?rev=eb7dfd7855d290e743a91a279e7dfddc15c67675#eb7dfd7855d290e743a91a279e7dfddc15c67675"
+source = "git+https://github.com/juspay/connector-service?rev=4dc2c036c1169237d673c4bdc0bfaeb0026f3a95#4dc2c036c1169237d673c4bdc0bfaeb0026f3a95"
 dependencies = [
  "axum 0.8.4",
  "bytes 1.10.1",
@@ -7156,8 +7156,8 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.5.0",
- "itertools 0.11.0",
+ "heck 0.4.1",
+ "itertools 0.10.5",
  "log 0.4.27",
  "multimap",
  "petgraph",
@@ -7178,7 +7178,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.11.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.101",
@@ -7191,7 +7191,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.11.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.101",
@@ -8176,7 +8176,7 @@ dependencies = [
 [[package]]
 name = "rust-grpc-client"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?rev=eb7dfd7855d290e743a91a279e7dfddc15c67675#eb7dfd7855d290e743a91a279e7dfddc15c67675"
+source = "git+https://github.com/juspay/connector-service?rev=4dc2c036c1169237d673c4bdc0bfaeb0026f3a95#4dc2c036c1169237d673c4bdc0bfaeb0026f3a95"
 dependencies = [
  "grpc-api-types",
 ]
@@ -11010,7 +11010,7 @@ checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
 [[package]]
 name = "ucs_cards"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?rev=eb7dfd7855d290e743a91a279e7dfddc15c67675#eb7dfd7855d290e743a91a279e7dfddc15c67675"
+source = "git+https://github.com/juspay/connector-service?rev=4dc2c036c1169237d673c4bdc0bfaeb0026f3a95#4dc2c036c1169237d673c4bdc0bfaeb0026f3a95"
 dependencies = [
  "bytes 1.10.1",
  "error-stack 0.4.1",
@@ -11026,7 +11026,7 @@ dependencies = [
 [[package]]
 name = "ucs_common_enums"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?rev=eb7dfd7855d290e743a91a279e7dfddc15c67675#eb7dfd7855d290e743a91a279e7dfddc15c67675"
+source = "git+https://github.com/juspay/connector-service?rev=4dc2c036c1169237d673c4bdc0bfaeb0026f3a95#4dc2c036c1169237d673c4bdc0bfaeb0026f3a95"
 dependencies = [
  "serde",
  "strum 0.26.3",
@@ -11037,7 +11037,7 @@ dependencies = [
 [[package]]
 name = "ucs_common_utils"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?rev=eb7dfd7855d290e743a91a279e7dfddc15c67675#eb7dfd7855d290e743a91a279e7dfddc15c67675"
+source = "git+https://github.com/juspay/connector-service?rev=4dc2c036c1169237d673c4bdc0bfaeb0026f3a95#4dc2c036c1169237d673c4bdc0bfaeb0026f3a95"
 dependencies = [
  "anyhow",
  "base64 0.21.7",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2264,7 +2264,7 @@ dependencies = [
 [[package]]
 name = "config_patch_derive"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?rev=6fd9852a54d0939e9be292a92b8f1aab2d39fde8#6fd9852a54d0939e9be292a92b8f1aab2d39fde8"
+source = "git+https://github.com/juspay/connector-service?rev=eb7dfd7855d290e743a91a279e7dfddc15c67675#eb7dfd7855d290e743a91a279e7dfddc15c67675"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3981,7 +3981,7 @@ checksum = "32619942b8be646939eaf3db0602b39f5229b74575b67efc897811ded1db4e57"
 [[package]]
 name = "grpc-api-types"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?rev=6fd9852a54d0939e9be292a92b8f1aab2d39fde8#6fd9852a54d0939e9be292a92b8f1aab2d39fde8"
+source = "git+https://github.com/juspay/connector-service?rev=eb7dfd7855d290e743a91a279e7dfddc15c67675#eb7dfd7855d290e743a91a279e7dfddc15c67675"
 dependencies = [
  "axum 0.8.4",
  "bytes 1.10.1",
@@ -8176,7 +8176,7 @@ dependencies = [
 [[package]]
 name = "rust-grpc-client"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?rev=6fd9852a54d0939e9be292a92b8f1aab2d39fde8#6fd9852a54d0939e9be292a92b8f1aab2d39fde8"
+source = "git+https://github.com/juspay/connector-service?rev=eb7dfd7855d290e743a91a279e7dfddc15c67675#eb7dfd7855d290e743a91a279e7dfddc15c67675"
 dependencies = [
  "grpc-api-types",
 ]
@@ -11010,7 +11010,7 @@ checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
 [[package]]
 name = "ucs_cards"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?rev=6fd9852a54d0939e9be292a92b8f1aab2d39fde8#6fd9852a54d0939e9be292a92b8f1aab2d39fde8"
+source = "git+https://github.com/juspay/connector-service?rev=eb7dfd7855d290e743a91a279e7dfddc15c67675#eb7dfd7855d290e743a91a279e7dfddc15c67675"
 dependencies = [
  "bytes 1.10.1",
  "error-stack 0.4.1",
@@ -11026,7 +11026,7 @@ dependencies = [
 [[package]]
 name = "ucs_common_enums"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?rev=6fd9852a54d0939e9be292a92b8f1aab2d39fde8#6fd9852a54d0939e9be292a92b8f1aab2d39fde8"
+source = "git+https://github.com/juspay/connector-service?rev=eb7dfd7855d290e743a91a279e7dfddc15c67675#eb7dfd7855d290e743a91a279e7dfddc15c67675"
 dependencies = [
  "serde",
  "strum 0.26.3",
@@ -11037,7 +11037,7 @@ dependencies = [
 [[package]]
 name = "ucs_common_utils"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?rev=6fd9852a54d0939e9be292a92b8f1aab2d39fde8#6fd9852a54d0939e9be292a92b8f1aab2d39fde8"
+source = "git+https://github.com/juspay/connector-service?rev=eb7dfd7855d290e743a91a279e7dfddc15c67675#eb7dfd7855d290e743a91a279e7dfddc15c67675"
 dependencies = [
  "anyhow",
  "base64 0.21.7",

--- a/crates/external_services/Cargo.toml
+++ b/crates/external_services/Cargo.toml
@@ -80,7 +80,7 @@ http = "0.2.12"
 url = { version = "2.5.4", features = ["serde"] }
 quick-xml = { version = "0.31.0", features = ["serialize"] }
 
-unified-connector-service-client = { git = "https://github.com/juspay/connector-service", tag = "2026.06.12.2", package = "rust-grpc-client" }
+unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "6fd9852a54d0939e9be292a92b8f1aab2d39fde8", package = "rust-grpc-client" }
 open-feature = { version = "0.2.5", optional = true }
 superposition_provider = { version = "0.102.0", optional = true }
 superposition_types = "0.102.0"

--- a/crates/external_services/Cargo.toml
+++ b/crates/external_services/Cargo.toml
@@ -80,7 +80,7 @@ http = "0.2.12"
 url = { version = "2.5.4", features = ["serde"] }
 quick-xml = { version = "0.31.0", features = ["serialize"] }
 
-unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "eb7dfd7855d290e743a91a279e7dfddc15c67675", package = "rust-grpc-client" }
+unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "4dc2c036c1169237d673c4bdc0bfaeb0026f3a95", package = "rust-grpc-client" }
 open-feature = { version = "0.2.5", optional = true }
 superposition_provider = { version = "0.102.0", optional = true }
 superposition_types = "0.102.0"

--- a/crates/external_services/Cargo.toml
+++ b/crates/external_services/Cargo.toml
@@ -80,7 +80,7 @@ http = "0.2.12"
 url = { version = "2.5.4", features = ["serde"] }
 quick-xml = { version = "0.31.0", features = ["serialize"] }
 
-unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "6fd9852a54d0939e9be292a92b8f1aab2d39fde8", package = "rust-grpc-client" }
+unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "eb7dfd7855d290e743a91a279e7dfddc15c67675", package = "rust-grpc-client" }
 open-feature = { version = "0.2.5", optional = true }
 superposition_provider = { version = "0.102.0", optional = true }
 superposition_types = "0.102.0"

--- a/crates/hyperswitch_interfaces/Cargo.toml
+++ b/crates/hyperswitch_interfaces/Cargo.toml
@@ -33,7 +33,7 @@ time = "0.3.41"
 tonic = "0.14"
 url = { version = "2.5.4", features = ["serde"] }
 
-unified-connector-service-client = { git = "https://github.com/juspay/connector-service", tag = "2026.06.12.2", package = "rust-grpc-client" }
+unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "6fd9852a54d0939e9be292a92b8f1aab2d39fde8", package = "rust-grpc-client" }
 tokio = { version = "1.45.1", features = ["macros", "rt-multi-thread"] }
 
 # First party crates

--- a/crates/hyperswitch_interfaces/Cargo.toml
+++ b/crates/hyperswitch_interfaces/Cargo.toml
@@ -33,7 +33,7 @@ time = "0.3.41"
 tonic = "0.14"
 url = { version = "2.5.4", features = ["serde"] }
 
-unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "6fd9852a54d0939e9be292a92b8f1aab2d39fde8", package = "rust-grpc-client" }
+unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "eb7dfd7855d290e743a91a279e7dfddc15c67675", package = "rust-grpc-client" }
 tokio = { version = "1.45.1", features = ["macros", "rt-multi-thread"] }
 
 # First party crates

--- a/crates/hyperswitch_interfaces/Cargo.toml
+++ b/crates/hyperswitch_interfaces/Cargo.toml
@@ -33,7 +33,7 @@ time = "0.3.41"
 tonic = "0.14"
 url = { version = "2.5.4", features = ["serde"] }
 
-unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "eb7dfd7855d290e743a91a279e7dfddc15c67675", package = "rust-grpc-client" }
+unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "4dc2c036c1169237d673c4bdc0bfaeb0026f3a95", package = "rust-grpc-client" }
 tokio = { version = "1.45.1", features = ["macros", "rt-multi-thread"] }
 
 # First party crates

--- a/crates/router/Cargo.toml
+++ b/crates/router/Cargo.toml
@@ -91,8 +91,8 @@ ring = "0.17.14"
 rust_decimal = { version = "1.37.1", features = ["serde-with-float", "serde-with-str"] }
 rust-i18n = { git = "https://github.com/kashif-m/rust-i18n", rev = "f2d8096aaaff7a87a847c35a5394c269f75e077a" }
 
-unified-connector-service-client = { git = "https://github.com/juspay/connector-service", tag = "2026.06.12.2", package = "rust-grpc-client" }
-unified-connector-service-cards = { git = "https://github.com/juspay/connector-service", tag = "2026.06.12.2", package = "ucs_cards" }
+unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "6fd9852a54d0939e9be292a92b8f1aab2d39fde8", package = "rust-grpc-client" }
+unified-connector-service-cards = { git = "https://github.com/juspay/connector-service", rev = "6fd9852a54d0939e9be292a92b8f1aab2d39fde8", package = "ucs_cards" }
 rustc-hash = "1.1.0"
 rustls = "0.22"
 rustls-pemfile = "2"

--- a/crates/router/Cargo.toml
+++ b/crates/router/Cargo.toml
@@ -91,8 +91,8 @@ ring = "0.17.14"
 rust_decimal = { version = "1.37.1", features = ["serde-with-float", "serde-with-str"] }
 rust-i18n = { git = "https://github.com/kashif-m/rust-i18n", rev = "f2d8096aaaff7a87a847c35a5394c269f75e077a" }
 
-unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "6fd9852a54d0939e9be292a92b8f1aab2d39fde8", package = "rust-grpc-client" }
-unified-connector-service-cards = { git = "https://github.com/juspay/connector-service", rev = "6fd9852a54d0939e9be292a92b8f1aab2d39fde8", package = "ucs_cards" }
+unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "eb7dfd7855d290e743a91a279e7dfddc15c67675", package = "rust-grpc-client" }
+unified-connector-service-cards = { git = "https://github.com/juspay/connector-service", rev = "eb7dfd7855d290e743a91a279e7dfddc15c67675", package = "ucs_cards" }
 rustc-hash = "1.1.0"
 rustls = "0.22"
 rustls-pemfile = "2"

--- a/crates/router/Cargo.toml
+++ b/crates/router/Cargo.toml
@@ -91,8 +91,8 @@ ring = "0.17.14"
 rust_decimal = { version = "1.37.1", features = ["serde-with-float", "serde-with-str"] }
 rust-i18n = { git = "https://github.com/kashif-m/rust-i18n", rev = "f2d8096aaaff7a87a847c35a5394c269f75e077a" }
 
-unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "eb7dfd7855d290e743a91a279e7dfddc15c67675", package = "rust-grpc-client" }
-unified-connector-service-cards = { git = "https://github.com/juspay/connector-service", rev = "eb7dfd7855d290e743a91a279e7dfddc15c67675", package = "ucs_cards" }
+unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "4dc2c036c1169237d673c4bdc0bfaeb0026f3a95", package = "rust-grpc-client" }
+unified-connector-service-cards = { git = "https://github.com/juspay/connector-service", rev = "4dc2c036c1169237d673c4bdc0bfaeb0026f3a95", package = "ucs_cards" }
 rustc-hash = "1.1.0"
 rustls = "0.22"
 rustls-pemfile = "2"

--- a/crates/router/src/core/unified_connector_service/transformers.rs
+++ b/crates/router/src/core/unified_connector_service/transformers.rs
@@ -1263,6 +1263,9 @@ impl transformers::ForeignTryFrom<&RouterData<Capture, PaymentsCaptureData, Paym
             merchant_order_id: router_data.request.merchant_order_reference_id.clone(),
             merchant_request_id: None,
             order_tax_amount: None,
+            split_payments: build_unified_connector_service_split_payments(
+                router_data.request.split_payments.as_ref(),
+            ),
         })
     }
 }

--- a/crates/router/src/core/unified_connector_service/transformers.rs
+++ b/crates/router/src/core/unified_connector_service/transformers.rs
@@ -84,6 +84,42 @@ pub fn build_upi_wait_screen_data(
         .attach_printable("Failed to serialize WaitScreenInstructions to JSON value")
 }
 
+/// Convert the domain `SplitPaymentsRequest` into the gRPC `SplitPaymentsRequest`.
+/// Only the Stripe Connect variant is represented in the UCS contract today; the
+/// Adyen / Xendit variants have no gRPC mapping yet and are dropped (None).
+fn build_unified_connector_service_split_payments(
+    split: Option<&common_types::payments::SplitPaymentsRequest>,
+) -> Option<payments_grpc::SplitPaymentsRequest> {
+    match split? {
+        common_types::payments::SplitPaymentsRequest::StripeSplitPayment(stripe) => {
+            let charge_type = match &stripe.charge_type {
+                common_enums::PaymentChargeType::Stripe(charge) => match charge {
+                    common_enums::StripeChargeType::Destination => {
+                        payments_grpc::StripeChargeType::Destination
+                    }
+                    common_enums::StripeChargeType::Direct => {
+                        payments_grpc::StripeChargeType::Direct
+                    }
+                },
+            };
+            Some(payments_grpc::SplitPaymentsRequest {
+                split_payment: Some(
+                    payments_grpc::split_payments_request::SplitPayment::StripeSplitPayment(
+                        payments_grpc::StripeSplitPaymentRequest {
+                            charge_type: charge_type as i32,
+                            application_fees: stripe
+                                .application_fees
+                                .map(MinorUnit::get_amount_as_i64),
+                            transfer_account_id: stripe.transfer_account_id.clone(),
+                        },
+                    ),
+                ),
+            })
+        }
+        _ => None,
+    }
+}
+
 impl ForeignFrom<common_types::customers::DocumentKind> for payments_grpc::DocumentKind {
     fn foreign_from(document_kind: common_types::customers::DocumentKind) -> Self {
         match document_kind {
@@ -182,6 +218,9 @@ impl
         let address = payments_grpc::PaymentAddress::foreign_try_from(router_data.address.clone())?;
 
         Ok(Self {
+            split_payments: build_unified_connector_service_split_payments(
+                router_data.request.split_payments.as_ref(),
+            ),
             merchant_payment_method_id: Some(router_data.connector_request_reference_id.clone()),
             amount: router_data
                 .request
@@ -292,6 +331,9 @@ impl
             .map(ConnectorState::foreign_from);
 
         Ok(Self {
+            split_payments: build_unified_connector_service_split_payments(
+                router_data.request.split_payments.as_ref(),
+            ),
             amount: Some(payments_grpc::Money {
                 minor_amount: router_data.request.minor_amount.get_amount_as_i64(),
                 currency: currency.into(),
@@ -515,6 +557,7 @@ impl
             .map(ConnectorState::foreign_from);
 
         Ok(Self {
+            split_payments: None,
             amount: Some(payments_grpc::Money {
                 minor_amount: router_data.request.minor_amount.get_amount_as_i64(),
                 currency: currency.into(),
@@ -673,6 +716,9 @@ impl
         let address = payments_grpc::PaymentAddress::foreign_try_from(router_data.address.clone())?;
 
         Ok(Self {
+            split_payments: build_unified_connector_service_split_payments(
+                router_data.request.split_payments.as_ref(),
+            ),
             merchant_customer_id: router_data
                 .customer_id
                 .as_ref()
@@ -1288,6 +1334,7 @@ impl
             .transpose()?;
 
         Ok(Self {
+            split_payments: None,
             amount: Some(payments_grpc::Money {
                 minor_amount: router_data.request.minor_amount.get_amount_as_i64(),
                 currency: currency.into(),
@@ -1437,6 +1484,9 @@ impl
             .map(ConnectorState::foreign_from);
 
         Ok(Self {
+            split_payments: build_unified_connector_service_split_payments(
+                router_data.request.split_payments.as_ref(),
+            ),
             amount: Some(payments_grpc::Money {
                 minor_amount: router_data.request.minor_amount.get_amount_as_i64(),
                 currency: currency.into(),
@@ -1613,6 +1663,7 @@ impl
             .transpose()?;
 
         Ok(Self {
+            split_payments: None,
             amount: Some(payments_grpc::Money {
                 minor_amount: router_data.request.minor_amount.get_amount_as_i64(),
                 currency: currency.into(),

--- a/crates/router/src/core/unified_connector_service/transformers.rs
+++ b/crates/router/src/core/unified_connector_service/transformers.rs
@@ -120,6 +120,61 @@ fn build_unified_connector_service_split_payments(
     }
 }
 
+/// Map the domain split-refund routing (Stripe Connect) into the UCS gRPC
+/// `SplitRefundsRequest` so UCS can refund the charge and emit the `Stripe-Account`
+/// header (Direct charges) instead of refunding the payment_intent. Non-Stripe split
+/// refunds (Adyen/Xendit) are routed via their own request bodies and yield None here.
+fn build_unified_connector_service_split_refunds(
+    split: Option<&router_request_types::SplitRefundsRequest>,
+) -> Option<payments_grpc::SplitRefundsRequest> {
+    match split? {
+        router_request_types::SplitRefundsRequest::StripeSplitRefund(stripe) => {
+            let charge_type = match &stripe.charge_type {
+                common_enums::PaymentChargeType::Stripe(charge) => match charge {
+                    common_enums::StripeChargeType::Destination => {
+                        payments_grpc::StripeChargeType::Destination
+                    }
+                    common_enums::StripeChargeType::Direct => {
+                        payments_grpc::StripeChargeType::Direct
+                    }
+                },
+            };
+            let options = match &stripe.options {
+                router_request_types::ChargeRefundsOptions::Destination(d) => {
+                    payments_grpc::charge_refunds_options::Options::Destination(
+                        payments_grpc::DestinationChargeRefund {
+                            revert_platform_fee: d.revert_platform_fee,
+                            revert_transfer: d.revert_transfer,
+                        },
+                    )
+                }
+                router_request_types::ChargeRefundsOptions::Direct(d) => {
+                    payments_grpc::charge_refunds_options::Options::Direct(
+                        payments_grpc::DirectChargeRefund {
+                            revert_platform_fee: d.revert_platform_fee,
+                        },
+                    )
+                }
+            };
+            Some(payments_grpc::SplitRefundsRequest {
+                split_refund: Some(
+                    payments_grpc::split_refunds_request::SplitRefund::StripeSplitRefund(
+                        payments_grpc::StripeSplitRefundRequest {
+                            charge_id: stripe.charge_id.clone(),
+                            transfer_account_id: stripe.transfer_account_id.clone(),
+                            charge_type: charge_type as i32,
+                            options: Some(payments_grpc::ChargeRefundsOptions {
+                                options: Some(options),
+                            }),
+                        },
+                    ),
+                ),
+            })
+        }
+        _ => None,
+    }
+}
+
 impl ForeignFrom<common_types::customers::DocumentKind> for payments_grpc::DocumentKind {
     fn foreign_from(document_kind: common_types::customers::DocumentKind) -> Self {
         match document_kind {
@@ -6006,6 +6061,9 @@ impl transformers::ForeignTryFrom<&RouterData<Execute, RefundsData, RefundsRespo
             merchant_request_id: None,
             connector_order_id: None,
             payment_method: None,
+            split_refunds: build_unified_connector_service_split_refunds(
+                router_data.request.split_refunds.as_ref(),
+            ),
         })
     }
 }

--- a/crates/router/src/core/unified_connector_service/transformers.rs
+++ b/crates/router/src/core/unified_connector_service/transformers.rs
@@ -106,7 +106,7 @@ fn build_unified_connector_service_split_payments(
                 split_payment: Some(
                     payments_grpc::split_payments_request::SplitPayment::StripeSplitPayment(
                         payments_grpc::StripeSplitPaymentRequest {
-                            charge_type: charge_type as i32,
+                            charge_type: i32::from(charge_type),
                             application_fees: stripe
                                 .application_fees
                                 .map(MinorUnit::get_amount_as_i64),
@@ -162,7 +162,7 @@ fn build_unified_connector_service_split_refunds(
                         payments_grpc::StripeSplitRefundRequest {
                             charge_id: stripe.charge_id.clone(),
                             transfer_account_id: stripe.transfer_account_id.clone(),
-                            charge_type: charge_type as i32,
+                            charge_type: i32::from(charge_type),
                             options: Some(payments_grpc::ChargeRefundsOptions {
                                 options: Some(options),
                             }),


### PR DESCRIPTION
## What

Refund-flow variant of the Stripe Connect split family (#12802 authorize/MIT, #12805 capture). Closes the shadow-validation diff in an internal issue (merchant `yucca`, stripe / refund):

```
header.keyDiff.stripe-account       = {hyperswitch:true, ucs:false}
body.keyDiff.charge                 = {hyperswitch:true, ucs:false}
body.keyDiff.payment_intent         = {hyperswitch:false, ucs:true}
body.keyDiff.refund_application_fee = {hyperswitch:true, ucs:false}
```

For Stripe Connect **Direct** charges, a refund must be issued against the **charge** (`Stripe-Account` header + `refund_application_fee`), not the `payment_intent`. HS's native stripe connector does this from `split_refunds`, but the HS→UCS gRPC mapping never forwarded `refund.split_refunds`, so on the shadow path UCS fell back to the `payment_intent` form and dropped the header.

## Changes

- `build_unified_connector_service_split_refunds` + populate `PaymentServiceRefundRequest.split_refunds` in the Execute refund mapping.
- bump the UCS gRPC client dep (`rust-grpc-client` / `ucs_cards`) to the connector-service PR head that adds the `split_refunds` proto field; refresh `Cargo.lock`.

**No HS connector transformer changes** — HS is the reference; the fix is carrying `split_refunds` to UCS so UCS matches HS.

## Depends on

UCS PR juspay/connector-service#1552 (adds `SplitRefundsRequest` + `PaymentServiceRefundRequest.split_refunds = 20` proto/domain). The `rev` pin is **interim** — it must move back to a `tag`/main commit once #1552 merges to main. Merge #1552 first, then this.

## Verification (local shadow stack, before→after)

Auto-capture Direct split payment (real Stripe test connected acct `acct_1TjBkeDfqJC9T9K6`) → refund with `split_refunds`:

- **before**: 4-field diff above (`stripe-account`/`charge`/`refund_application_fee` only on HS; UCS sends `payment_intent`).
- **after**: VS `diff_result_refund:stripe` → `headerComparison.keyDiff {}` and `bodyComparison.keyDiff {}`. Raw HS and UCS requests are **byte-identical** (`POST /v1/refunds`, header `stripe-account: acct_1TjBkeDfqJC9T9K6`, body `charge=ch_…&refund_application_fee=true&amount=6000&metadata…`).

Closes #12808
