### PR TITLE
build(docker): switch base images from Docker Hub to AWS ECR Public Gallery

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:bookworm as builder
+FROM public.ecr.aws/docker/library/rust:bookworm as builder
 
 ARG EXTRA_FEATURES=""
 ARG VERSION_FEATURE_SET="v1"
@@ -40,7 +40,7 @@ RUN cargo build \
 
 
 
-FROM debian:bookworm
+FROM public.ecr.aws/docker/library/debian:bookworm
 
 # Placing config and binary executable in different directories
 ARG CONFIG_DIR=/local/config

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/docker/library/rust:bookworm as builder
+FROM public.ecr.aws/docker/library/rust:trixie as builder
 
 ARG EXTRA_FEATURES=""
 ARG VERSION_FEATURE_SET="v1"
@@ -40,7 +40,7 @@ RUN cargo build \
 
 
 
-FROM public.ecr.aws/docker/library/debian:bookworm
+FROM public.ecr.aws/docker/library/debian:trixie
 
 # Placing config and binary executable in different directories
 ARG CONFIG_DIR=/local/config


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Switch Dockerfile base images from Docker Hub to the AWS ECR Public Gallery equivalents to mitigate Docker Hub rate limiting.

rust:bookworm → public.ecr.aws/docker/library/rust:trixie
debian:bookworm → public.ecr.aws/docker/library/debian:trixie

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
2. `crates/router/src/configs`
3. `loadtest/config`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
