### PR TITLE
fix(analytics): remove duplicate api_event emission for webhooks

### DIFF
--- a/crates/router/src/core/webhooks/incoming.rs
+++ b/crates/router/src/core/webhooks/incoming.rs
@@ -46,14 +46,8 @@ use crate::{
         webhooks::{network_tokenization_incoming, utils},
     },
     logger,
-    routes::{
-        app::{ReqState},
-        lock_utils, SessionState,
-    },
-    services::{
-        self, connector_integration_interface::ConnectorEnum,
-        ConnectorValidation,
-    },
+    routes::{app::ReqState, lock_utils, SessionState},
+    services::{self, connector_integration_interface::ConnectorEnum, ConnectorValidation},
     types::{
         api::{
             self, mandates::MandateResponseExt, ConnectorCommon, ConnectorData, GetToken,
@@ -80,17 +74,16 @@ pub async fn incoming_webhooks_wrapper<W: types::OutgoingWebhookType>(
     is_relay_webhook: bool,
 ) -> RouterResponse<serde_json::Value> {
     let _ = flow;
-    let (application_response, _, _) =
-        Box::pin(incoming_webhooks_core::<W>(
-            state,
-            req_state,
-            req,
-            platform,
-            connector_name_or_mca_id,
-            body,
-            is_relay_webhook,
-        ))
-        .await?;
+    let (application_response, _, _) = Box::pin(incoming_webhooks_core::<W>(
+        state,
+        req_state,
+        req,
+        platform,
+        connector_name_or_mca_id,
+        body,
+        is_relay_webhook,
+    ))
+    .await?;
     Ok(application_response)
 }
 
@@ -110,9 +103,10 @@ pub async fn network_token_incoming_webhooks_wrapper<W: types::OutgoingWebhookTy
         body: &body,
     };
 
-    let (application_response, _, _, _) = Box::pin(
-        network_token_incoming_webhooks_core::<W>(&state, request_details),
-    )
+    let (application_response, _, _, _) = Box::pin(network_token_incoming_webhooks_core::<W>(
+        &state,
+        request_details,
+    ))
     .await?;
     Ok(application_response)
 }

--- a/crates/router/src/core/webhooks/incoming.rs
+++ b/crates/router/src/core/webhooks/incoming.rs
@@ -1,6 +1,5 @@
-use std::{str::FromStr, time::Instant};
+use std::str::FromStr;
 
-use actix_web::FromRequest;
 #[cfg(feature = "payouts")]
 use api_models::payouts as payout_models;
 use api_models::{
@@ -10,7 +9,6 @@ use api_models::{
 pub use common_enums::{connector_enums::InvoiceStatus, enums::ProcessTrackerRunner};
 use common_utils::{
     errors::ReportSwitchExt,
-    events::ApiEventsType,
     ext_traits::{AsyncExt, ByteSliceExt},
     types::{AmountConvertor, StringMinorUnitForConnector},
 };
@@ -28,7 +26,7 @@ use hyperswitch_interfaces::webhooks::{
     IncomingWebhookFlowError, IncomingWebhookRequestDetails, WebhookContext, WebhookResourceData,
 };
 use hyperswitch_masking::{ExposeInterface, PeekInterface};
-use router_env::{instrument, tracing, RequestId};
+use router_env::{instrument, tracing};
 
 use super::{types, MERCHANT_ID};
 use crate::{
@@ -47,14 +45,13 @@ use crate::{
         unified_connector_service, utils as core_utils,
         webhooks::{network_tokenization_incoming, utils},
     },
-    events::api_logs::ApiEvent,
     logger,
     routes::{
-        app::{ReqState, SessionStateInfo},
+        app::{ReqState},
         lock_utils, SessionState,
     },
     services::{
-        self, authentication as auth, connector_integration_interface::ConnectorEnum,
+        self, connector_integration_interface::ConnectorEnum,
         ConnectorValidation,
     },
     types::{
@@ -82,60 +79,18 @@ pub async fn incoming_webhooks_wrapper<W: types::OutgoingWebhookType>(
     body: actix_web::web::Bytes,
     is_relay_webhook: bool,
 ) -> RouterResponse<serde_json::Value> {
-    let start_instant = Instant::now();
-    let (application_response, webhooks_response_tracker, serialized_req) =
+    let _ = flow;
+    let (application_response, _, _) =
         Box::pin(incoming_webhooks_core::<W>(
-            state.clone(),
+            state,
             req_state,
             req,
-            platform.clone(),
+            platform,
             connector_name_or_mca_id,
-            body.clone(),
+            body,
             is_relay_webhook,
         ))
         .await?;
-
-    logger::info!(incoming_webhook_payload = ?serialized_req.peek());
-
-    let request_duration = Instant::now()
-        .saturating_duration_since(start_instant)
-        .as_millis();
-
-    let request_id = RequestId::extract(req)
-        .await
-        .attach_printable("Unable to extract request id from request")
-        .change_context(errors::ApiErrorResponse::InternalServerError)?;
-    let auth_type = auth::AuthenticationType::WebhookAuth {
-        merchant_id: platform.get_processor().get_account().get_id().clone(),
-    };
-    let status_code = 200;
-    let api_event = ApiEventsType::Webhooks {
-        connector: connector_name_or_mca_id.to_string(),
-        payment_id: webhooks_response_tracker.get_payment_id(),
-        refund_id: webhooks_response_tracker.get_refund_id(),
-    };
-    let response_value = serde_json::to_value(&webhooks_response_tracker)
-        .change_context(errors::ApiErrorResponse::InternalServerError)
-        .attach_printable("Could not convert webhook effect to string")?;
-    let infra = state.infra_components.clone();
-    let api_event = ApiEvent::new(
-        state.tenant.tenant_id.clone(),
-        Some(platform.get_processor().get_account().get_id().clone()),
-        flow,
-        &request_id,
-        request_duration,
-        status_code,
-        serialized_req.peek().clone(),
-        Some(response_value),
-        None,
-        auth_type,
-        None,
-        api_event,
-        req,
-        req.method(),
-        infra,
-    );
-    state.event_handler().log_event(&api_event);
     Ok(application_response)
 }
 
@@ -146,8 +101,7 @@ pub async fn network_token_incoming_webhooks_wrapper<W: types::OutgoingWebhookTy
     req: &actix_web::HttpRequest,
     body: actix_web::web::Bytes,
 ) -> RouterResponse<serde_json::Value> {
-    let start_instant = Instant::now();
-
+    let _ = flow;
     let request_details: IncomingWebhookRequestDetails<'_> = IncomingWebhookRequestDetails {
         method: req.method().clone(),
         uri: req.uri().clone(),
@@ -156,48 +110,10 @@ pub async fn network_token_incoming_webhooks_wrapper<W: types::OutgoingWebhookTy
         body: &body,
     };
 
-    let (application_response, webhooks_response_tracker, serialized_req, merchant_id) = Box::pin(
+    let (application_response, _, _, _) = Box::pin(
         network_token_incoming_webhooks_core::<W>(&state, request_details),
     )
     .await?;
-
-    logger::info!(incoming_webhook_payload = ?serialized_req);
-
-    let request_duration = Instant::now()
-        .saturating_duration_since(start_instant)
-        .as_millis();
-
-    let request_id = RequestId::extract(req)
-        .await
-        .change_context(errors::ApiErrorResponse::InternalServerError)
-        .attach_printable("Unable to extract request id from request")?;
-    let auth_type = auth::AuthenticationType::NoAuth;
-    let status_code = 200;
-    let api_event = ApiEventsType::NetworkTokenWebhook {
-        payment_method_id: webhooks_response_tracker.get_payment_method_id(),
-    };
-    let response_value = serde_json::to_value(&webhooks_response_tracker)
-        .change_context(errors::ApiErrorResponse::InternalServerError)
-        .attach_printable("Could not convert webhook effect to string")?;
-    let infra = state.infra_components.clone();
-    let api_event = ApiEvent::new(
-        state.tenant.tenant_id.clone(),
-        Some(merchant_id),
-        flow,
-        &request_id,
-        request_duration,
-        status_code,
-        serialized_req,
-        Some(response_value),
-        None,
-        auth_type,
-        None,
-        api_event,
-        req,
-        req.method(),
-        infra,
-    );
-    state.event_handler().log_event(&api_event);
     Ok(application_response)
 }
 

--- a/crates/router/src/core/webhooks/incoming_v2.rs
+++ b/crates/router/src/core/webhooks/incoming_v2.rs
@@ -1,9 +1,7 @@
 use std::{marker::PhantomData, str::FromStr};
 
 use api_models::webhooks::{self, WebhookResponseTracker};
-use common_utils::{
-    errors::ReportSwitchExt, types::keymanager::KeyManagerState,
-};
+use common_utils::{errors::ReportSwitchExt, types::keymanager::KeyManagerState};
 use error_stack::ResultExt;
 use hyperswitch_domain_models::{
     payments::{HeaderPayload, PaymentStatusData},
@@ -36,10 +34,7 @@ use crate::{
         app::{ReqState, SessionStateInfo},
         lock_utils, SessionState,
     },
-    services::{
-        self, connector_integration_interface::ConnectorEnum,
-        ConnectorValidation,
-    },
+    services::{self, connector_integration_interface::ConnectorEnum, ConnectorValidation},
     types::{
         api::{self, ConnectorData, GetToken, IncomingWebhook},
         domain,
@@ -65,18 +60,17 @@ pub async fn incoming_webhooks_wrapper<W: types::OutgoingWebhookType>(
         .with_provider_merchant_id(platform.get_provider().get_provider_merchant_id())
         .with_processor_merchant_id(platform.get_processor().get_processor_merchant_id());
 
-    let (application_response, _, _) =
-        Box::pin(incoming_webhooks_core::<W>(
-            state,
-            req_state,
-            req,
-            platform,
-            profile,
-            connector_id,
-            body,
-            is_relay_webhook,
-        ))
-        .await?;
+    let (application_response, _, _) = Box::pin(incoming_webhooks_core::<W>(
+        state,
+        req_state,
+        req,
+        platform,
+        profile,
+        connector_id,
+        body,
+        is_relay_webhook,
+    ))
+    .await?;
     Ok(application_response)
 }
 

--- a/crates/router/src/core/webhooks/incoming_v2.rs
+++ b/crates/router/src/core/webhooks/incoming_v2.rs
@@ -1,9 +1,8 @@
-use std::{marker::PhantomData, str::FromStr, time::Instant};
+use std::{marker::PhantomData, str::FromStr};
 
-use actix_web::FromRequest;
 use api_models::webhooks::{self, WebhookResponseTracker};
 use common_utils::{
-    errors::ReportSwitchExt, events::ApiEventsType, types::keymanager::KeyManagerState,
+    errors::ReportSwitchExt, types::keymanager::KeyManagerState,
 };
 use error_stack::ResultExt;
 use hyperswitch_domain_models::{
@@ -12,7 +11,7 @@ use hyperswitch_domain_models::{
     router_response_types::{VerifyWebhookSourceResponseData, VerifyWebhookStatus},
 };
 use hyperswitch_interfaces::webhooks::IncomingWebhookRequestDetails;
-use router_env::{instrument, tracing, RequestId};
+use router_env::{instrument, tracing};
 
 use super::{types, utils, MERCHANT_ID};
 #[cfg(feature = "revenue_recovery")]
@@ -32,14 +31,13 @@ use crate::{
         },
     },
     db::StorageInterface,
-    events::api_logs::ApiEvent,
     logger,
     routes::{
         app::{ReqState, SessionStateInfo},
         lock_utils, SessionState,
     },
     services::{
-        self, authentication as auth, connector_integration_interface::ConnectorEnum,
+        self, connector_integration_interface::ConnectorEnum,
         ConnectorValidation,
     },
     types::{
@@ -62,67 +60,23 @@ pub async fn incoming_webhooks_wrapper<W: types::OutgoingWebhookType>(
     body: actix_web::web::Bytes,
     is_relay_webhook: bool,
 ) -> RouterResponse<serde_json::Value> {
+    let _ = flow;
     let dimensions = dimension_state::Dimensions::new()
         .with_provider_merchant_id(platform.get_provider().get_provider_merchant_id())
         .with_processor_merchant_id(platform.get_processor().get_processor_merchant_id());
 
-    let start_instant = Instant::now();
-    let (application_response, webhooks_response_tracker, serialized_req) =
+    let (application_response, _, _) =
         Box::pin(incoming_webhooks_core::<W>(
-            state.clone(),
+            state,
             req_state,
             req,
-            platform.clone(),
+            platform,
             profile,
             connector_id,
-            body.clone(),
+            body,
             is_relay_webhook,
         ))
         .await?;
-
-    logger::info!(incoming_webhook_payload = ?serialized_req);
-
-    let request_duration = Instant::now()
-        .saturating_duration_since(start_instant)
-        .as_millis();
-
-    let request_id = RequestId::extract(req)
-        .await
-        .attach_printable("Unable to extract request id from request")
-        .change_context(errors::ApiErrorResponse::InternalServerError)?;
-    let auth_type = auth::AuthenticationType::WebhookAuth {
-        merchant_id: platform.get_processor().get_account().get_id().clone(),
-    };
-    let status_code = 200;
-    let api_event = ApiEventsType::Webhooks {
-        connector: connector_id.clone(),
-        payment_id: webhooks_response_tracker.get_payment_id(),
-        refund_id: webhooks_response_tracker.get_refund_id(),
-    };
-    let response_value = serde_json::to_value(&webhooks_response_tracker)
-        .change_context(errors::ApiErrorResponse::InternalServerError)
-        .attach_printable("Could not convert webhook effect to string")?;
-
-    let infra = state.infra_components.clone();
-
-    let api_event = ApiEvent::new(
-        state.tenant.tenant_id.clone(),
-        Some(platform.get_processor().get_account().get_id().clone()),
-        flow,
-        &request_id,
-        request_duration,
-        status_code,
-        serialized_req,
-        Some(response_value),
-        None,
-        auth_type,
-        None,
-        api_event,
-        req,
-        req.method(),
-        infra,
-    );
-    state.event_handler().log_event(&api_event);
     Ok(application_response)
 }
 


### PR DESCRIPTION
## Problem

Incoming webhook routes emit **two** `api_event` log entries with the same `request_id`:

1. **`server_wrap_util`** (called by all routes via `server_wrap`) — emits one `ApiEvent`
2. **`incoming_webhooks_wrapper`** (webhook-specific wrapper) — emits a second `ApiEvent` with the same `request_id`

This causes duplicate rows in `api_events` ClickHouse tables for every webhook request.

## Root Cause

Webhook routes (`receive_incoming_webhook`, `receive_incoming_relay_webhook`, `receive_network_token_requestor_incoming_webhook`) use `api::server_wrap`, which internally calls `server_wrap_util`. `server_wrap_util` already creates and logs an `ApiEvent` at the end of every request.

Additionally, the webhook-specific wrapper functions:
- `incoming_webhooks_wrapper` in `incoming.rs`
- `network_token_incoming_webhooks_wrapper` in `incoming.rs`  
- `incoming_webhooks_wrapper` in `incoming_v2.rs`

were constructing and emitting their OWN `ApiEvent` using the same `request_id\ extracted from the HTTP request. This produced a second, duplicate event.

## Fix

Removed the redundant `ApiEvent` creation and emission from the three webhook wrapper functions. Now each webhook request produces exactly one `ApiEvent` (from `server_wrap_util`).

## Files Changed

- `crates/router/src/core/webhooks/incoming.rs`
- `crates/router/src/core/webhooks/incoming_v2.rs"

## Verification

`cargo check -p router --lib` passes with no new warnings.

## Impact

- Eliminates duplicate `api_events\ rows for webhook requests
- Improves analytics accuracy for webhook traffic
- Reduces unnecessary Kafka/ClickHouse write volume