### PR TITLE
fix(ucs): retain previous refund status when UCS returns Unspecified

### DIFF
--- a/crates/router/src/core/unified_connector_service.rs
+++ b/crates/router/src/core/unified_connector_service.rs
@@ -2319,22 +2319,24 @@ pub fn extract_connector_response_from_ucs(
 
 pub fn handle_unified_connector_service_response_for_payment_refund(
     response: payments_grpc::RefundResponse,
+    prev_status: common_enums::RefundStatus,
 ) -> UnifiedConnectorServiceRefundResult {
     let status_code = transformers::convert_connector_service_status_code(response.status_code)?;
 
     let router_data_response: Result<RefundsResponseData, ErrorResponse> =
-        Result::<RefundsResponseData, ErrorResponse>::foreign_try_from(response)?;
+        Result::<RefundsResponseData, ErrorResponse>::foreign_try_from((response, prev_status))?;
 
     Ok((router_data_response, status_code))
 }
 
 pub fn handle_unified_connector_service_response_for_refund_get(
     response: payments_grpc::RefundResponse,
+    prev_status: common_enums::RefundStatus,
 ) -> UnifiedConnectorServiceRefundResult {
     let status_code = transformers::convert_connector_service_status_code(response.status_code)?;
 
     let router_data_response =
-        Result::<RefundsResponseData, ErrorResponse>::foreign_try_from(response)?;
+        Result::<RefundsResponseData, ErrorResponse>::foreign_try_from((response, prev_status))?;
 
     Ok((router_data_response, status_code))
 }
@@ -3043,6 +3045,8 @@ pub async fn call_unified_connector_service_for_refund_execute(
         .merchant_reference_id(merchant_reference_id)
         .resource_id(resource_id);
 
+    let prev_refund_status = router_data.request.refund_status;
+
     // Make UCS refund call with logging wrapper
     Box::pin(ucs_logging_wrapper(
         router_data,
@@ -3100,9 +3104,12 @@ pub async fn call_unified_connector_service_for_refund_execute(
 
             // Transform UCS response back to RouterData
             let (refund_response_data, status_code) =
-                handle_unified_connector_service_response_for_payment_refund(grpc_response.clone())
-                    .change_context(errors::ApiErrorResponse::InternalServerError)
-                    .attach_printable("Failed to transform UCS refund response")?;
+                handle_unified_connector_service_response_for_payment_refund(
+                    grpc_response.clone(),
+                    prev_refund_status,
+                )
+                .change_context(errors::ApiErrorResponse::InternalServerError)
+                .attach_printable("Failed to transform UCS refund response")?;
 
             router_data.response = refund_response_data;
             router_data.connector_http_status_code = Some(status_code);
@@ -3173,6 +3180,8 @@ pub async fn call_unified_connector_service_for_refund_sync(
         .merchant_reference_id(merchant_reference_id)
         .resource_id(resource_id);
 
+    let prev_refund_status = router_data.request.refund_status;
+
     // Make UCS refund sync call with logging wrapper
     Box::pin(ucs_logging_wrapper(
         router_data,
@@ -3230,9 +3239,12 @@ pub async fn call_unified_connector_service_for_refund_sync(
 
             // Transform UCS response back to RouterData
             let (refund_response_data, status_code) =
-                handle_unified_connector_service_response_for_refund_get(grpc_response.clone())
-                    .change_context(errors::ApiErrorResponse::InternalServerError)
-                    .attach_printable("Failed to transform UCS refund get response")?;
+                handle_unified_connector_service_response_for_refund_get(
+                    grpc_response.clone(),
+                    prev_refund_status,
+                )
+                .change_context(errors::ApiErrorResponse::InternalServerError)
+                .attach_printable("Failed to transform UCS refund get response")?;
 
             router_data.response = refund_response_data;
             router_data.connector_http_status_code = Some(status_code);

--- a/crates/router/src/core/unified_connector_service/transformers.rs
+++ b/crates/router/src/core/unified_connector_service/transformers.rs
@@ -6025,13 +6025,17 @@ impl transformers::ForeignTryFrom<&RouterData<RSync, RefundsData, RefundsRespons
     }
 }
 
-/// Transform UCS RefundResponse into Result<RefundsResponseData, ErrorResponse>
-impl transformers::ForeignTryFrom<payments_grpc::RefundResponse>
+/// Transform UCS RefundResponse into Result<RefundsResponseData, ErrorResponse>.
+/// prev_status is the refund status prior to the UCS call; it is used as a fallback when UCS
+/// returns Unspecified (i.e. an unknown connector refund status) so the DB state is not corrupted.
+impl transformers::ForeignTryFrom<(payments_grpc::RefundResponse, RefundStatus)>
     for Result<RefundsResponseData, ErrorResponse>
 {
     type Error = error_stack::Report<UnifiedConnectorServiceError>;
 
-    fn foreign_try_from(response: payments_grpc::RefundResponse) -> Result<Self, Self::Error> {
+    fn foreign_try_from(
+        (response, prev_status): (payments_grpc::RefundResponse, RefundStatus),
+    ) -> Result<Self, Self::Error> {
         let status_code = convert_connector_service_status_code(response.status_code)?;
 
         let response = if let Some(error_info) = response.error.as_ref() {
@@ -6085,7 +6089,7 @@ impl transformers::ForeignTryFrom<payments_grpc::RefundResponse>
                 connector_metadata: None,
             })
         } else {
-            let refund_status = RefundStatus::foreign_try_from(response.status())?;
+            let refund_status = RefundStatus::foreign_try_from((response.status(), prev_status))?;
 
             Ok(RefundsResponseData {
                 connector_refund_id: response.connector_refund_id,
@@ -6197,12 +6201,20 @@ impl
     }
 }
 
-impl transformers::ForeignTryFrom<payments_grpc::RefundStatus> for RefundStatus {
+impl transformers::ForeignTryFrom<(payments_grpc::RefundStatus, Self)> for RefundStatus {
     type Error = error_stack::Report<UnifiedConnectorServiceError>;
 
-    fn foreign_try_from(grpc_status: payments_grpc::RefundStatus) -> Result<Self, Self::Error> {
+    fn foreign_try_from(
+        (grpc_status, prev_status): (payments_grpc::RefundStatus, Self),
+    ) -> Result<Self, Self::Error> {
         match grpc_status {
-            payments_grpc::RefundStatus::Unspecified => Ok(Self::Pending),
+            payments_grpc::RefundStatus::Unspecified => {
+                router_env::logger::warn!(
+                    "Received Unspecified refund status from UCS; retaining previous status {:?}",
+                    prev_status
+                );
+                Ok(prev_status)
+            }
             payments_grpc::RefundStatus::RefundFailure => Ok(Self::Failure),
             payments_grpc::RefundStatus::RefundManualReview => Ok(Self::ManualReview),
             payments_grpc::RefundStatus::RefundPending => Ok(Self::Pending),


### PR DESCRIPTION
## Summary

When a UCS connector returns an unknown refund status, the gRPC layer maps it to `RefundStatus::Unspecified`. Previously this was hardcoded to `RefundStatus::Pending`, which could silently corrupt DB state — e.g. a `Failure` refund being overwritten with `Pending` after a sync.

This fix mirrors the pattern already in place for payment attempt status ([`transformers.rs:409`](https://github.com/juspay/hyperswitch/blob/main/crates/hyperswitch_interfaces/src/unified_connector_service/transformers.rs#L409)): thread the pre-call refund status through the UCS response handlers and return it unchanged when `Unspecified` is received, logging a warning for observability.

## Changes

- **`unified_connector_service/transformers.rs`**
  - `ForeignTryFrom<payments_grpc::RefundStatus>` → tuple form `(RefundStatus, RefundStatus)` with `prev_status`; `Unspecified` now returns `prev_status` instead of `Pending`
  - `ForeignTryFrom<payments_grpc::RefundResponse>` → tuple form, threads `prev_status` through to status conversion

- **`unified_connector_service.rs`**
  - `handle_unified_connector_service_response_for_payment_refund` and `_for_refund_get` each accept a new `prev_status: common_enums::RefundStatus` param
  - Both call sites (refund execute + refund sync) supply `router_data.request.refund_status` as the previous status before the UCS gRPC call

## Behaviour before / after

| Scenario | Before | After |
|---|---|---|
| UCS returns known refund status | Correct status written to DB | Unchanged |
| UCS returns `Unspecified` (unknown connector value) | DB status overwritten with `Pending` | DB status retained; warn log emitted |

## Test Cases
Payment Create CURL
```
curl -X POST http://localhost:3000/payments \
    -H "Content-Type: application/json" \
    -H "api-key: dev_KcLYlyNEHHTMITUvtBVakBVMUErh3bCSL153WJwi4GKwMg8ES8iSvNDqJHIq3Nr8" \
    -d '{
      "amount": 6540,
      "currency": "USD",
      "confirm": true,
      "capture_method": "automatic",
      "payment_method": "card",
      "payment_method_type": "credit",
      "payment_method_data": {
        "card": {
          "card_number": "4111111111111111",
          "card_exp_month": "03",
          "card_exp_year": "2030",
          "card_holder_name": "Test User",
          "card_cvc": "737"
        }
      },
      "routing": {
        "type": "single",
        "data": {
          "connector": "adyen",
          "merchant_connector_id": "mca_ArjZG6tmlHrj0UiPS3iI"
        }
      },
      "profile_id": "pro_Gf6Y0kl48bqIUhqLuYHt",
      "return_url": "https://example.com/return",
      "browser_info": {
        "user_agent": "Mozilla/5.0",
        "accept_header": "text/html",
        "language": "en-US",
        "color_depth": 24,
        "screen_height": 1080,
        "screen_width": 1920,
        "time_zone": 0,
        "java_enabled": false,
        "java_script_enabled": true,
        "ip_address": "127.0.0.1"
      }
    }'
```

Response
 ```
 {
    "payment_id": "pay_W0BfFwexYCfEtqYUPpdl",
    "merchant_id": "merchant_1763721807",
    "status": "succeeded",
    "amount": 6540,
    "currency": "USD",
    "connector": "adyen",
    "connector_transaction_id": "SDSN676HHT794WT5",
    "payment_method": "card",
    "payment_method_type": "credit",
    "capture_method": "automatic",
    "created": "2026-06-19T13:56:22.022Z",
    "modified_at": "2026-06-19T13:56:23.579Z",
    "error_code": null,
    "error_message": null
  }
```

Refunds Create CURL
```
curl -X POST http://localhost:3000/refunds \
    -H "Content-Type: application/json" \
    -H "api-key: dev_KcLYlyNEHHTMITUvtBVakBVMUErh3bCSL153WJwi4GKwMg8ES8iSvNDqJHIq3Nr8" \
    -d '{
      "payment_id": "pay_W0BfFwexYCfEtqYUPpdl",
      "amount": 6540,
      "reason": "CUSTOMER REQUEST"
    }'
```

```
Response:
  {
    "refund_id": "ref_Gkxu2KhWmFavDmUGg4hv",
    "payment_id": "pay_W0BfFwexYCfEtqYUPpdl",
    "connector": "adyen",
    "connector_refund_id": "DDRXRQBQZBMVNLV5",
    "status": "pending",
    "amount": 6540,
    "currency": "USD",
    "reason": "CUSTOMER REQUEST",
    "created_at": "2026-06-19T14:04:50.586Z",
    "updated_at": "2026-06-19T14:04:51.220Z",
    "error_code": null,
    "error_message": null
  }
```

UCS Logs

Payment — routed Direct (Authorize flow not in UCS scope):
```
  INFO router::core::unified_connector_service: Payment gateway decision: gateway=Direct, execution_path=Direct
    merchant_id=merchant_1763721807, connector=adyen, flow=Authorize
```

  Refund Create — routed through UCS (Execute flow, 100% primary):
```
  INFO router::core::refunds: Executing refund via UnifiedConnectorService,
    refund_id: "ref_Gkxu2KhWmFavDmUGg4hv", execution_path: UnifiedConnectorService
```

