### PR TITLE
fix(connector): add payconex to ucs_only_connectors in env_specific config

### DIFF
--- a/config/deployments/env_specific.toml
+++ b/config/deployments/env_specific.toml
@@ -409,7 +409,7 @@ connector_names = "connector_names"     # Comma-separated list of allowed connec
 [grpc_client.unified_connector_service]
 base_url = "http://localhost:8000"      # Unified Connector Service Base URL
 connection_timeout = 10                 # Connection Timeout Duration in Seconds
-ucs_only_connectors = "imerchantsolutions, paytm, phonepe, hyperpg, revolv3, fiservcommercehub, absa_sanlam, interpayments"    # Comma-separated list of connectors that use UCS only
+ucs_only_connectors = "imerchantsolutions, paytm, phonepe, hyperpg, revolv3, fiservcommercehub, absa_sanlam, interpayments, payconex"    # Comma-separated list of connectors that use UCS only
 ucs_psync_disabled_connectors = "cashtocode, trustly"    # Comma-separated list of connectors to disable UCS PSync call
 
 [revenue_recovery]


### PR DESCRIPTION
## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

PayConex is a **UCS-only connector** — its native Hyperswitch connector is a stub (`PAYCONEX_SUPPORTED_PAYMENT_METHODS = SupportedPaymentMethods::new()`, every flow returns `NotImplemented`). It only works when routed through the Unified Connector Service (UCS), which requires its name to be present in `grpc_client.unified_connector_service.ucs_only_connectors`.

Deployed environments build their effective config by merging `config/deployments/env_specific.toml` over the per-environment file. That override file was **missing `payconex`** from `ucs_only_connectors`, so in deployed environments `determine_connector_integration_type` returned `DirectandUCSConnector` instead of `UcsConnector`, the gateway decision fell back to `Direct`, and the native stub rejected the card:

```
HTTP 400 BadRequest — "Payment method type not supported" / reason: "card is not supported by payconex"
```

The request never reached UCS. It worked locally only because `RUN_ENV=development` reads `config/development.toml`, which already lists `payconex`.

#12608 (which introduced PayConex) added `payconex` to `development.toml`, `integration_test.toml`, `sandbox.toml`, and `production.toml`, but not to `env_specific.toml`. This PR closes that gap.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [x] This PR modifies application configuration/environment variables

`config/deployments/env_specific.toml` — added `payconex` to `ucs_only_connectors`.

## Motivation and Context

Closes #12855

PayConex payments are unusable in all deployed environments (integration_test / sandbox / production) without this entry, because the connector has no native implementation and must be routed via UCS.

## How did you test it?

Diagnosed from a failing integration request (Grafana request id `019ee39c-8322-7333-90eb-9d999d54a42b`): logs show `Using DirectandUCSConnector - not in ucs_only_list` → `gateway=Direct` → `400 "card is not supported by payconex"`, confirming the request never reached UCS. Adding `payconex` to `ucs_only_connectors` makes `determine_connector_integration_type` return `UcsConnector`, forcing the UCS path — identical to the working local behavior, where `development.toml` already contains the entry. This mirrors the same entry already present in `integration_test.toml`, `sandbox.toml`, and `production.toml`.

## Checklist

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
