### PR TITLE
feat(unified_connector_service): send auth_type on repeat payment to UCS (novalnet enforce_3d)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2264,7 +2264,7 @@ dependencies = [
 [[package]]
 name = "config_patch_derive"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.07.02.1#a070ef74a8d36aeca23f8e90d4d8bb0cc4db77ca"
+source = "git+https://github.com/juspay/connector-service?rev=e5bab57ad052ca4ebfb574b21f66de87cda84dbd#e5bab57ad052ca4ebfb574b21f66de87cda84dbd"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3982,7 +3982,7 @@ checksum = "32619942b8be646939eaf3db0602b39f5229b74575b67efc897811ded1db4e57"
 [[package]]
 name = "grpc-api-types"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.07.02.1#a070ef74a8d36aeca23f8e90d4d8bb0cc4db77ca"
+source = "git+https://github.com/juspay/connector-service?rev=e5bab57ad052ca4ebfb574b21f66de87cda84dbd#e5bab57ad052ca4ebfb574b21f66de87cda84dbd"
 dependencies = [
  "axum 0.8.4",
  "bytes 1.10.1",
@@ -6836,7 +6836,7 @@ dependencies = [
  "regex-cache",
  "serde",
  "serde_derive",
- "strum 0.26.3",
+ "strum 0.25.0",
  "thiserror 1.0.69",
 ]
 
@@ -8178,7 +8178,7 @@ dependencies = [
 [[package]]
 name = "rust-grpc-client"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.07.02.1#a070ef74a8d36aeca23f8e90d4d8bb0cc4db77ca"
+source = "git+https://github.com/juspay/connector-service?rev=e5bab57ad052ca4ebfb574b21f66de87cda84dbd#e5bab57ad052ca4ebfb574b21f66de87cda84dbd"
 dependencies = [
  "grpc-api-types",
 ]
@@ -11012,7 +11012,7 @@ checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
 [[package]]
 name = "ucs_cards"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.07.02.1#a070ef74a8d36aeca23f8e90d4d8bb0cc4db77ca"
+source = "git+https://github.com/juspay/connector-service?rev=e5bab57ad052ca4ebfb574b21f66de87cda84dbd#e5bab57ad052ca4ebfb574b21f66de87cda84dbd"
 dependencies = [
  "bytes 1.10.1",
  "error-stack 0.4.1",
@@ -11028,7 +11028,7 @@ dependencies = [
 [[package]]
 name = "ucs_common_enums"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.07.02.1#a070ef74a8d36aeca23f8e90d4d8bb0cc4db77ca"
+source = "git+https://github.com/juspay/connector-service?rev=e5bab57ad052ca4ebfb574b21f66de87cda84dbd#e5bab57ad052ca4ebfb574b21f66de87cda84dbd"
 dependencies = [
  "serde",
  "strum 0.26.3",
@@ -11039,7 +11039,7 @@ dependencies = [
 [[package]]
 name = "ucs_common_utils"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.07.02.1#a070ef74a8d36aeca23f8e90d4d8bb0cc4db77ca"
+source = "git+https://github.com/juspay/connector-service?rev=e5bab57ad052ca4ebfb574b21f66de87cda84dbd#e5bab57ad052ca4ebfb574b21f66de87cda84dbd"
 dependencies = [
  "anyhow",
  "base64 0.21.7",

--- a/crates/external_services/Cargo.toml
+++ b/crates/external_services/Cargo.toml
@@ -82,7 +82,7 @@ http = "0.2.12"
 url = { version = "2.5.4", features = ["serde"] }
 quick-xml = { version = "0.31.0", features = ["serialize"] }
 
-unified-connector-service-client = { git = "https://github.com/juspay/connector-service", tag = "2026.07.02.1", package = "rust-grpc-client" }
+unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "e5bab57ad052ca4ebfb574b21f66de87cda84dbd", package = "rust-grpc-client" }
 open-feature = { version = "0.2.5", optional = true }
 superposition_provider = { version = "0.114.0", optional = true}
 superposition_types = "0.114.0"

--- a/crates/external_services/src/grpc_client/unified_connector_service.rs
+++ b/crates/external_services/src/grpc_client/unified_connector_service.rs
@@ -818,9 +818,7 @@ impl UnifiedConnectorServiceClient {
             build_unified_connector_service_grpc_headers(connector_auth_metadata, grpc_headers)?;
         *request.metadata_mut() = metadata;
 
-        self.payment_service_client
-            .clone()
-            .setup_recurring(request)
+        Box::pin(self.payment_service_client.clone().setup_recurring(request))
             .await
             .map_err(|error| {
                 error_stack::Report::new(UnifiedConnectorServiceError::from_grpc_error(

--- a/crates/hyperswitch_interfaces/Cargo.toml
+++ b/crates/hyperswitch_interfaces/Cargo.toml
@@ -33,7 +33,7 @@ time = "0.3.41"
 tonic = "0.14"
 url = { version = "2.5.4", features = ["serde"] }
 
-unified-connector-service-client = { git = "https://github.com/juspay/connector-service", tag = "2026.07.02.1", package = "rust-grpc-client" }
+unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "e5bab57ad052ca4ebfb574b21f66de87cda84dbd", package = "rust-grpc-client" }
 tokio = { version = "1.45.1", features = ["macros", "rt-multi-thread"] }
 
 # First party crates

--- a/crates/hyperswitch_interfaces/src/unified_connector_service/transformers.rs
+++ b/crates/hyperswitch_interfaces/src/unified_connector_service/transformers.rs
@@ -970,6 +970,12 @@ impl ForeignTryFrom<payments_grpc::RedirectForm> for RedirectForm {
                 )
                 .into(),
             ),
+            Some(payments_grpc::redirect_form::FormType::HostedIframe(_)) => Err(
+                UnifiedConnectorServiceError::RequestEncodingFailedWithReason(
+                    "Hosted iframe form type is not implemented".to_string(),
+                )
+                .into(),
+            ),
             Some(payments_grpc::redirect_form::FormType::Braintree(braintree)) => {
                 Ok(Self::Braintree {
                     client_token: braintree.client_token,

--- a/crates/router/Cargo.toml
+++ b/crates/router/Cargo.toml
@@ -91,8 +91,8 @@ ring = "0.17.14"
 rust_decimal = { version = "1.37.1", features = ["serde-with-float", "serde-with-str"] }
 rust-i18n = { git = "https://github.com/kashif-m/rust-i18n", rev = "f2d8096aaaff7a87a847c35a5394c269f75e077a" }
 
-unified-connector-service-client = { git = "https://github.com/juspay/connector-service", tag = "2026.07.02.1", package = "rust-grpc-client" }
-unified-connector-service-cards = { git = "https://github.com/juspay/connector-service", tag = "2026.07.02.1", package = "ucs_cards" }
+unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "e5bab57ad052ca4ebfb574b21f66de87cda84dbd", package = "rust-grpc-client" }
+unified-connector-service-cards = { git = "https://github.com/juspay/connector-service", rev = "e5bab57ad052ca4ebfb574b21f66de87cda84dbd", package = "ucs_cards" }
 rustc-hash = "1.1.0"
 rustls = "0.22"
 rustls-pemfile = "2"

--- a/crates/router/src/core/unified_connector_service/transformers.rs
+++ b/crates/router/src/core/unified_connector_service/transformers.rs
@@ -1054,6 +1054,7 @@ impl
                 .transpose()?,
             connector_feature_data: None,
             capture_method: capture_method.map(|capture_method| capture_method.into()),
+            webhook_url: None,
         })
     }
 }
@@ -1238,6 +1239,7 @@ impl
             connector_feature_data: None,
             capture_method: capture_method.map(|capture_method| capture_method.into()),
             description: router_data.description.clone(),
+            merchant_transaction_id: None,
         })
     }
 }
@@ -2146,6 +2148,9 @@ impl
             browser_info,
             test_mode: router_data.test_mode,
             payment_method_type,
+            auth_type: Some(
+                payments_grpc::AuthenticationType::foreign_try_from(router_data.auth_type)?.into(),
+            ),
             state,
             return_url: router_data.request.router_return_url.clone(),
             description: router_data.description.clone(),
@@ -5763,6 +5768,14 @@ impl transformers::ForeignTryFrom<&MandateData> for payments_grpc::SetupMandateD
                                                 dt.assume_utc().unix_timestamp()
                                             },
                                         ),
+                                        initial_billing_amount: None,
+                                        external_subscription_id: None,
+                                        status: None,
+                                        next_billing_date: None,
+                                        billing_cycle: None,
+                                        description: None,
+                                        mandate_status: payments_grpc::MandateStatus::default()
+                                            .into(),
                                     },
                                 ),
                             ),
@@ -5799,6 +5812,14 @@ impl transformers::ForeignTryFrom<&MandateData> for payments_grpc::SetupMandateD
                                                     dt.assume_utc().unix_timestamp()
                                                 },
                                             ),
+                                            initial_billing_amount: None,
+                                            external_subscription_id: None,
+                                            status: None,
+                                            next_billing_date: None,
+                                            billing_cycle: None,
+                                            description: None,
+                                            mandate_status:
+                                                payments_grpc::MandateStatus::default().into(),
                                         },
                                     ),
                                 )


### PR DESCRIPTION
## What

Populate the new `auth_type` field on the UCS repeat/MIT request
(`RecurringPaymentServiceChargeRequest`) from `router_data.auth_type`, in the
HS → UCS mapping. This lets UCS rebuild an MIT request whose auth-type–dependent
fields (e.g. Novalnet's `enforce_3d`) match Hyperswitch's.

Also bumps the `unified-connector-service-{client,cards}` git pin to the paired
UCS PR head so CI compiles against the proto that adds the field.

## Why — shadow-validation diff

Closes #12865
Fixes an internal validation-diff issue (linked via the Development sidebar).
connector=`novalnet`, flow=`repeat_payment`, merchant=`bu_de_getolo`:

```
body.typeDiff.transaction.enforce_3d = {"hyperswitch":"number","ucs":"null"}
```

The repeat charge request to UCS carried no auth type, so the UCS server defaulted
`PaymentFlowData.auth_type` to `NoThreeDs`. The MIT attempt was
`authentication_type=three_ds`, so Hyperswitch built `enforce_3d = Some(1)` (a
number) while UCS built `None` (null) → diff.

**Layer category:** proto + HS→UCS mapping (cross-repo).

## Cross-repo dependency

Depends on UCS PR **juspay/connector-service#1585**, which adds
`optional AuthenticationType auth_type = 36;` to `RecurringPaymentServiceChargeRequest`
and honours it in the domain conversion (Novalnet's L3 transformer already maps
`auth_type → enforce_3d`).

⚠️ The `unified-connector-service-{client,cards}` deps are pinned by **`rev`** to
that UCS PR's head commit (`e5bab57ad052ca4ebfb574b21f66de87cda84dbd`) as an
**interim** measure so CI sees the new proto field. Once the UCS PR merges to
`main`, this `rev` pin must move back to a released `tag`. (Merge UCS first, then
this PR.)

## Repro & verification (local shadow stack on `main`)

`prod-fixes/repro_16914.py`: CIT no-3DS off_session card payment (saves a reusable
PM) → MIT with `recurring_details(payment_method_id)` and
`authentication_type=three_ds` → HS routes the repeat to UCS over gRPC; MITM
mirrors both built requests to the validation service.

| | `transaction.enforce_3d` typeDiff |
|---|---|
| **before** | `{"hyperswitch":"number","ucs":"null"}` (diff) |
| **after** (this PR + UCS#1585) | keyDiff `{}` / typeDiff `{}` → **no_diff** |

Verified end-to-end on the local stack: HS built against the UCS PR's proto
(`auth_type` field 36), UCS rebuilt with the matching domain mapping. The
`enforce_3d` diff disappears with no new diffs.


## Update (2026-07-06 CI re-verification)

Rebased onto current `main` and re-bumped the UCS `rev` pin (both PRs were stale after
several days of unrelated upstream churn). Also fixed an unrelated required-check
regression surfaced by this rebase: `crates/external_services/src/grpc_client/unified_connector_service.rs`'s
`payment_setup_recurring` future crossed clippy's `large_futures` size threshold once the
UCS proto crate grew (pre-existing borderline size, tipped over by this PR's field
addition) — `Box::pin`'d that call per clippy's own suggestion. Verified clean with
`just clippy`, `just clippy_v2`, `cargo check --features release,v2,redis-rs` and
`...,fred`, and `cargo fmt --all -- --check` locally before pushing.

All required checks are green. The non-required, repo-wide `Spell check` remains red
(pre-existing, unrelated to this diff).
