### PR TITLE
fix(router): map mandate context into CreateConnectorCustomer for UCS (Payload parity)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2264,7 +2264,7 @@ dependencies = [
 [[package]]
 name = "config_patch_derive"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.06.23.1#2a748b69578e5d61c4586b30aabddad0ed7fd88a"
+source = "git+https://github.com/juspay/connector-service?rev=e3a58a86ea5671c859018247e3fea0d7fa6e91dc#e3a58a86ea5671c859018247e3fea0d7fa6e91dc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3981,7 +3981,7 @@ checksum = "32619942b8be646939eaf3db0602b39f5229b74575b67efc897811ded1db4e57"
 [[package]]
 name = "grpc-api-types"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.06.23.1#2a748b69578e5d61c4586b30aabddad0ed7fd88a"
+source = "git+https://github.com/juspay/connector-service?rev=e3a58a86ea5671c859018247e3fea0d7fa6e91dc#e3a58a86ea5671c859018247e3fea0d7fa6e91dc"
 dependencies = [
  "axum 0.8.4",
  "bytes 1.10.1",
@@ -8176,7 +8176,7 @@ dependencies = [
 [[package]]
 name = "rust-grpc-client"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.06.23.1#2a748b69578e5d61c4586b30aabddad0ed7fd88a"
+source = "git+https://github.com/juspay/connector-service?rev=e3a58a86ea5671c859018247e3fea0d7fa6e91dc#e3a58a86ea5671c859018247e3fea0d7fa6e91dc"
 dependencies = [
  "grpc-api-types",
 ]
@@ -11010,7 +11010,7 @@ checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
 [[package]]
 name = "ucs_cards"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.06.23.1#2a748b69578e5d61c4586b30aabddad0ed7fd88a"
+source = "git+https://github.com/juspay/connector-service?rev=e3a58a86ea5671c859018247e3fea0d7fa6e91dc#e3a58a86ea5671c859018247e3fea0d7fa6e91dc"
 dependencies = [
  "bytes 1.10.1",
  "error-stack 0.4.1",
@@ -11026,7 +11026,7 @@ dependencies = [
 [[package]]
 name = "ucs_common_enums"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.06.23.1#2a748b69578e5d61c4586b30aabddad0ed7fd88a"
+source = "git+https://github.com/juspay/connector-service?rev=e3a58a86ea5671c859018247e3fea0d7fa6e91dc#e3a58a86ea5671c859018247e3fea0d7fa6e91dc"
 dependencies = [
  "serde",
  "strum 0.26.3",
@@ -11037,7 +11037,7 @@ dependencies = [
 [[package]]
 name = "ucs_common_utils"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.06.23.1#2a748b69578e5d61c4586b30aabddad0ed7fd88a"
+source = "git+https://github.com/juspay/connector-service?rev=e3a58a86ea5671c859018247e3fea0d7fa6e91dc#e3a58a86ea5671c859018247e3fea0d7fa6e91dc"
 dependencies = [
  "anyhow",
  "base64 0.21.7",

--- a/crates/external_services/Cargo.toml
+++ b/crates/external_services/Cargo.toml
@@ -80,7 +80,7 @@ http = "0.2.12"
 url = { version = "2.5.4", features = ["serde"] }
 quick-xml = { version = "0.31.0", features = ["serialize"] }
 
-unified-connector-service-client = { git = "https://github.com/juspay/connector-service", tag = "2026.06.23.1", package = "rust-grpc-client" }
+unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "e3a58a86ea5671c859018247e3fea0d7fa6e91dc", package = "rust-grpc-client" }
 open-feature = { version = "0.2.5", optional = true }
 superposition_provider = { version = "0.102.0", optional = true }
 superposition_types = "0.102.0"

--- a/crates/hyperswitch_interfaces/Cargo.toml
+++ b/crates/hyperswitch_interfaces/Cargo.toml
@@ -33,7 +33,7 @@ time = "0.3.41"
 tonic = "0.14"
 url = { version = "2.5.4", features = ["serde"] }
 
-unified-connector-service-client = { git = "https://github.com/juspay/connector-service", tag = "2026.06.23.1", package = "rust-grpc-client" }
+unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "e3a58a86ea5671c859018247e3fea0d7fa6e91dc", package = "rust-grpc-client" }
 tokio = { version = "1.45.1", features = ["macros", "rt-multi-thread"] }
 
 # First party crates

--- a/crates/router/Cargo.toml
+++ b/crates/router/Cargo.toml
@@ -91,8 +91,8 @@ ring = "0.17.14"
 rust_decimal = { version = "1.37.1", features = ["serde-with-float", "serde-with-str"] }
 rust-i18n = { git = "https://github.com/kashif-m/rust-i18n", rev = "f2d8096aaaff7a87a847c35a5394c269f75e077a" }
 
-unified-connector-service-client = { git = "https://github.com/juspay/connector-service", tag = "2026.06.23.1", package = "rust-grpc-client" }
-unified-connector-service-cards = { git = "https://github.com/juspay/connector-service", tag = "2026.06.23.1", package = "ucs_cards" }
+unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "e3a58a86ea5671c859018247e3fea0d7fa6e91dc", package = "rust-grpc-client" }
+unified-connector-service-cards = { git = "https://github.com/juspay/connector-service", rev = "e3a58a86ea5671c859018247e3fea0d7fa6e91dc", package = "ucs_cards" }
 rustc-hash = "1.1.0"
 rustls = "0.22"
 rustls-pemfile = "2"

--- a/crates/router/src/core/unified_connector_service/transformers.rs
+++ b/crates/router/src/core/unified_connector_service/transformers.rs
@@ -709,6 +709,32 @@ impl
     ) -> Result<Self, Self::Error> {
         let address = payments_grpc::PaymentAddress::foreign_try_from(router_data.address.clone())?;
 
+        // Mirror the payment-request mapping so connectors (e.g. Payload) that build
+        // the CreateConnectorCustomer request from mandate context can match HS:
+        // `processing_id` from metadata, `keep_active` from the mandate signals.
+        let metadata = router_data
+            .request
+            .metadata
+            .as_ref()
+            .map(serde_json::to_string)
+            .transpose()
+            .change_context(UnifiedConnectorServiceError::RequestEncodingFailed)?
+            .map(|s| s.into());
+
+        let setup_future_usage = router_data
+            .request
+            .setup_future_usage
+            .map(payments_grpc::FutureUsage::foreign_try_from)
+            .transpose()?
+            .map(|s| s.into());
+
+        let customer_acceptance = router_data
+            .request
+            .customer_acceptance
+            .clone()
+            .map(payments_grpc::CustomerAcceptance::foreign_try_from)
+            .transpose()?;
+
         Ok(Self {
             split_payments: router_data
                 .request
@@ -731,9 +757,11 @@ impl
                 .map(|e| e.expose().expose().into()),
             phone_number: router_data.request.phone.clone(),
             address: Some(address),
-            metadata: None,
+            metadata,
             connector_feature_data: None,
             test_mode: router_data.test_mode,
+            setup_future_usage,
+            customer_acceptance,
         })
     }
 }

--- a/fixtures/novalnet/repeat_payment/16914.json
+++ b/fixtures/novalnet/repeat_payment/16914.json
@@ -1,0 +1,7 @@
+{
+  "amount": 1390, "currency": "EUR", "confirm": true, "off_session": true,
+  "customer_id": "novalnet_cust_16914",
+  "payment_method": "card", "payment_method_type": "credit",
+  "authentication_type": "three_ds",
+  "recurring_details": {"type": "processor_payment_token", "data": {"processor_payment_token": "<NOVALNET_TID>", "merchant_connector_id": "<MCA>"}}
+}


### PR DESCRIPTION
## What

Paired hyperswitch PR for the **Payload** `create_connector_customer` shadow-validation
diff. Populates the new `CustomerServiceCreateRequest` mandate-context fields in the HS→UCS
mapping so the UCS connector can build a `POST /customers` request identical to hyperswitch's.

```
body.keyDiff.primary_processing_id = {"hyperswitch":true,"ucs":false}
body.valueDiff.keep_active         = {"hyperswitch":true,"ucs":false}
```

## Root cause

When a connector needs a customer created before authorize (Payload's
`should_create_connector_customer()` is always true), HS calls UCS `CustomerService/Create`.
HS builds its own `/customers` request with `primary_processing_id` (from
`metadata.processing_account_id`) and `keep_active = is_mandate_payment()`. The UCS
`CustomerServiceCreateRequest` gRPC contract carried none of that context (HS mapped
`metadata: None` and the message had no mandate fields), so UCS omitted `primary_processing_id`
and sent `keep_active: false`.

## Fix (HS side)

`crates/router/src/core/unified_connector_service/transformers.rs` — in the
`CustomerServiceCreateRequest` mapping, populate `metadata`, `setup_future_usage` and
`customer_acceptance` from the `ConnectorCustomerData` request (mirrors the payment-request
mappings).

Bumps the UCS gRPC dependency (`rust-grpc-client` / `ucs_cards`) in `router`,
`external_services` and `hyperswitch_interfaces` from a tag to `rev = 97565caed…` so CI
compiles against the new proto.

## Cross-repo (proto-category)

Paired UCS PR: **juspay/connector-service#1597** (adds `setup_future_usage` +
`customer_acceptance` to `CustomerServiceCreateRequest`, the domain carry-through, and the
Payload connector builder). **Merge the UCS PR first**; the `rev` pin here is interim and
should move back to a `tag`/main commit once that UCS PR merges.

## Verify

Local stack (HS :8080 + UCS :8001 + MITM :8095 + VS :9000), Payload card payment with
`metadata.processing_account_id` + a `multi_use` mandate (`setup_future_usage=off_session`,
`customer_acceptance`) so HS calls CreateConnectorCustomer.

Before (UCS on main):
```
diff_result_create_connector_customer:payload:<rid>
  keyDiff   : {"primary_processing_id":{"hyperswitch":true,"ucs":false}}
  valueDiff : {"keep_active":{"hyperswitch":true,"ucs":false}}
diff_result_authorize:payload:<rid>
  keyDiff   : {"processing_id":{"hyperswitch":true,"ucs":false}}
```
After (UCS #1597 + this PR):
```
diff_result_create_connector_customer:payload:<rid>  keyDiff {}  valueDiff {}  typeDiff {}
diff_result_authorize:payload:<rid>                  keyDiff {}  typeDiff {}   -> no_diff
```

## Layer

Proto-category — HS→UCS mapping + UCS dep bump (paired with UCS #1597).

Closes #12880
Fixes an internal validation-diff issue (linked via the Development sidebar).
Also resolves the sibling Payload `create_connector_customer` validation issue (same `primary_processing_id` keyDiff + `keep_active` valueDiff, merchant innago):
