### PR TITLE
refactor(configs): allow config retrieve API to be called with internal API key or admin API key

### DIFF
--- a/crates/router/src/routes/configs.rs
+++ b/crates/router/src/routes/configs.rs
@@ -48,7 +48,7 @@ pub async fn config_key_retrieve(
         &req,
         &key,
         |state, _, key, _| configs::read_config(state, key),
-        &ADMIN_API_AUTH,
+        &auth::InternalApiKeyAuth(ADMIN_API_AUTH),
         api_locking::LockAction::NotApplicable,
     )
     .await

--- a/crates/router/src/services/authentication.rs
+++ b/crates/router/src/services/authentication.rs
@@ -201,6 +201,7 @@ pub enum AuthenticationType {
         merchant_id: id_type::MerchantId,
         profile_id: id_type::ProfileId,
     },
+    InternalApiKey,
     NoAuth,
 }
 
@@ -235,6 +236,7 @@ impl AuthenticationType {
             | Self::EmbeddedJwt { merchant_id, .. }
             | Self::SdkAuthorization { merchant_id, .. } => Some(merchant_id),
             Self::AdminApiKey
+            | Self::InternalApiKey
             | Self::OrganizationJwt { .. }
             | Self::BasicAuth { .. }
             | Self::UserJwt { .. }
@@ -2760,6 +2762,47 @@ where
                     profile_id: Some(validated_data.profile.get_id().clone()),
                 },
             )),
+            None => self.0.authenticate_and_fetch(request_headers, state).await,
+        }
+    }
+}
+
+pub struct InternalApiKeyAuth<F>(pub F);
+
+#[async_trait]
+impl<A, F> AuthenticateAndFetch<(), A> for InternalApiKeyAuth<F>
+where
+    A: SessionStateInfo + Sync + Send,
+    F: AuthenticateAndFetch<(), A> + Sync + Send,
+{
+    async fn authenticate_and_fetch(
+        &self,
+        request_headers: &HeaderMap,
+        state: &A,
+    ) -> RouterResult<((), AuthenticationType)> {
+        if !state.conf().internal_merchant_id_profile_id_auth.enabled {
+            return self.0.authenticate_and_fetch(request_headers, state).await;
+        }
+
+        let internal_api_key = HeaderMapStruct::new(request_headers)
+            .get_header_value_by_key(headers::X_INTERNAL_API_KEY)
+            .map(|s| s.to_string());
+
+        match internal_api_key {
+            Some(key) => {
+                if key
+                    == *state
+                        .conf()
+                        .internal_merchant_id_profile_id_auth
+                        .internal_api_key
+                        .peek()
+                {
+                    Ok(((), AuthenticationType::InternalApiKey))
+                } else {
+                    Err(errors::ApiErrorResponse::Unauthorized)
+                        .attach_printable("Internal API key authentication failed")
+                }
+            }
             None => self.0.authenticate_and_fetch(request_headers, state).await,
         }
     }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

This PR updates the config retrieve endpoint (both v1 and v2) to also allow internal API key authentication alongside the existing admin API key authentication. This is being done so as to allow other internal systems to make use of Hyperswitch's config setup to retrieve configs. In this case, the internal system that requires this is our card vault (see juspay/hyperswitch-card-vault#171).

### Additional Changes

- [x] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

This PR updates the config retrieve endpoint to allow internal API key authentication alongside the existing admin API key authentication.

## Motivation and Context

This allows other internal systems such as our card vault to make use of Hyperswitch's config setup to retrieve runtime configs. See juspay/hyperswitch-card-vault#171.

## How did you test it?

- Enable internal API key authentication by setting `internal_merchant_id_profile_id_auth.enabled` to `true` in the config file.
- Create a config (`POST /configs/` endpoint) using admin API key.
  - If the internal API key is used here instead of the admin API key, the request would fail with an unauthenticated error.
- Retrieve the created config using either the admin API key, or the internal API key (from `internal_merchant_id_profile_id_auth.internal_api_key` field in the config file), both should succeed. Providing neither of them causes the API to fail with an unauthenticated error.
  - The internal API key can be used with the config retrieve endpoint like so:
    ```shell
    curl --location 'http://localhost:8080/configs/locker.use_read_replica' \
      --header 'Content-Type: application/json' \
      --header 'Accept: application/json' \
      --header 'X-Internal-Api-Key: ********'
    ```

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
