### PR TITLE
feat(core): added sdk authorisation support to sdk configs

### DIFF
--- a/crates/api_models/src/superposition_sdk_config.rs
+++ b/crates/api_models/src/superposition_sdk_config.rs
@@ -1,8 +1,16 @@
 use common_utils::events::ApiEventMetric;
+use hyperswitch_masking::Secret;
 use serde_json::{Map, Value};
 use superposition_types::Config;
 
 use crate::enums as api_enums;
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct SdkConfigRequest {
+    pub client_secret: Option<Secret<String>>,
+}
+
+impl ApiEventMetric for SdkConfigRequest {}
 
 #[derive(Debug, Clone, Copy, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]

--- a/crates/router/src/lib.rs
+++ b/crates/router/src/lib.rs
@@ -93,8 +93,6 @@ pub mod headers {
     pub const X_CLIENT_SECRET: &str = "X-Client-Secret";
     pub const X_CUSTOMER_ID: &str = "X-Customer-Id";
     pub const X_CONNECTED_MERCHANT_ID: &str = "x-connected-merchant-id";
-    pub const CLIENT_SECRET: &str = "client-secret";
-    pub const SDK_AUTHORIZATION: &str = "sdk-authorization";
     // Header value for X_CONNECTOR_HTTP_STATUS_CODE differs by version.
     // Constant name is kept the same for consistency across versions.
     #[cfg(feature = "v1")]

--- a/crates/router/src/routes/superposition_sdk_config.rs
+++ b/crates/router/src/routes/superposition_sdk_config.rs
@@ -1,7 +1,9 @@
 use actix_web::{web, HttpRequest, HttpResponse};
+#[cfg(feature = "v1")]
 use error_stack::ResultExt;
 #[cfg(feature = "v1")]
 use hyperswitch_domain_models::sdk_auth::SdkAuthorization;
+use hyperswitch_masking::PeekInterface;
 use router_env::{instrument, tracing, Flow};
 
 use super::app::AppState;
@@ -9,17 +11,16 @@ use super::app::AppState;
 use crate::core::{payments, superposition_sdk_config};
 use crate::{
     core::{api_locking, errors},
-    headers::{CLIENT_SECRET, SDK_AUTHORIZATION},
+    headers::AUTHORIZATION,
     services::{api, authentication as auth},
 };
 
 #[cfg(feature = "v1")]
-fn get_payment_id_from_headers(
+fn get_payment_id_from_headers_or_payload(
     headers: &actix_web::http::header::HeaderMap,
+    json_payload: &api_models::superposition_sdk_config::SdkConfigRequest,
 ) -> error_stack::Result<common_utils::id_type::PaymentId, errors::ApiErrorResponse> {
-    if let Some(sdk_auth_val) =
-        auth::get_header_value_by_key(SDK_AUTHORIZATION.to_string(), headers)?
-    {
+    if let Some(sdk_auth_val) = auth::get_header_value_by_key(AUTHORIZATION.to_string(), headers)? {
         let sdk_auth = SdkAuthorization::decode(sdk_auth_val)
             .change_context(errors::ApiErrorResponse::Unauthorized)?;
         sdk_auth.payment_id.ok_or_else(|| {
@@ -28,15 +29,17 @@ fn get_payment_id_from_headers(
             })
         })
     } else {
-        let client_secret = auth::get_header_value_by_key(CLIENT_SECRET.to_string(), headers)?
+        let client_secret = json_payload
+            .client_secret
+            .as_ref()
+            .map(|cs| cs.peek())
             .ok_or_else(|| {
                 error_stack::report!(errors::ApiErrorResponse::MissingRequiredField {
-                    field_name: CLIENT_SECRET,
+                    field_name: "client_secret",
                 })
-            })?
-            .to_string();
+            })?;
 
-        let payment_id_str = payments::helpers::get_payment_id_from_client_secret(&client_secret)?;
+        let payment_id_str = payments::helpers::get_payment_id_from_client_secret(client_secret)?;
         common_utils::id_type::PaymentId::wrap(payment_id_str).change_context(
             errors::ApiErrorResponse::InvalidDataValue {
                 field_name: "payment_id",
@@ -51,14 +54,27 @@ pub async fn get_sdk_config(
     state: web::Data<AppState>,
     req: HttpRequest,
     path: web::Path<String>,
+    json_payload: web::Query<api_models::superposition_sdk_config::SdkConfigRequest>,
 ) -> HttpResponse {
     let flow = Flow::GetSuperpositionSdkConfig;
     let _platform = path.into_inner();
+    let payload = json_payload.into_inner();
 
-    let payment_id = match get_payment_id_from_headers(req.headers()) {
+    let payment_id = match get_payment_id_from_headers_or_payload(req.headers(), &payload) {
         Ok(payment_id) => payment_id,
         Err(err) => return api::log_and_return_error_response(err),
     };
+
+    let api_auth = auth::ApiKeyAuth {
+        allow_connected_scope_operation: true,
+        allow_platform_self_operation: true,
+    };
+
+    let (auth_type, _auth_flow) =
+        match auth::check_sdk_auth_and_get_auth(req.headers(), &payload, api_auth) {
+            Ok(auth) => auth,
+            Err(e) => return api::log_and_return_error_response(e),
+        };
 
     Box::pin(api::server_wrap(
         flow,
@@ -72,10 +88,7 @@ pub async fn get_sdk_config(
                 payment_id.clone(),
             )
         },
-        &auth::HeaderAuth(auth::PublishableKeyAuth {
-            allow_connected_scope_operation: true,
-            allow_platform_self_operation: false,
-        }),
+        &*auth_type,
         api_locking::LockAction::NotApplicable,
     ))
     .await

--- a/crates/router/src/services/authentication.rs
+++ b/crates/router/src/services/authentication.rs
@@ -5756,7 +5756,9 @@ impl ClientSecretFetch for api_models::authentication::AuthenticationSessionToke
 
 impl ClientSecretFetch for api_models::superposition_sdk_config::SdkConfigRequest {
     fn get_client_secret(&self) -> Option<&String> {
-        self.client_secret.as_ref().map(|cs| cs.peek())
+        self.client_secret
+            .as_ref()
+            .map(|client_secret| client_secret.peek())
     }
 }
 

--- a/crates/router/src/services/authentication.rs
+++ b/crates/router/src/services/authentication.rs
@@ -5754,6 +5754,12 @@ impl ClientSecretFetch for api_models::authentication::AuthenticationSessionToke
     }
 }
 
+impl ClientSecretFetch for api_models::superposition_sdk_config::SdkConfigRequest {
+    fn get_client_secret(&self) -> Option<&String> {
+        self.client_secret.as_ref().map(|cs| cs.peek())
+    }
+}
+
 pub fn get_auth_type_and_flow<A: SessionStateInfo + Sync + Send>(
     headers: &HeaderMap,
     api_auth: ApiKeyAuth,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
Currently sdk config api doesn't support sdk authorization like the other api's for example PML.
To unify the behavior we are making this change. 

### Additional Changes

- [x] This PR modifies the API contract

### 1. **New Request Payload Struct**
- **Added `SdkConfigRequest`** in `crates/api_models/src/superposition_sdk_config.rs` containing an optional `client_secret` field wrapped in a `Secret<String>`.
- Implemented the `ApiEventMetric` trait for `SdkConfigRequest`.

### 2. **Header Constants Cleanup**
- **Removed custom header constants** `CLIENT_SECRET` and `SDK_AUTHORIZATION` from `crates/router/src/lib.rs`. The standard `AUTHORIZATION` header and the new query/payload fields are used instead.

### 3. **Refactored SDK Config Handler**
- **Updated route signature**: `get_sdk_config` in `crates/router/src/routes/superposition_sdk_config.rs` now accepts query parameters mapped to `json_payload: web::Query<SdkConfigRequest>`.
- **Payment ID extraction**: Refactored the extraction logic from `get_payment_id_from_headers` to `get_payment_id_from_headers_or_payload`. It now checks the standard `AUTHORIZATION` header for SDK authorization. If that is absent, it retrieves the `client_secret` from the query parameters rather than a custom `client-secret` HTTP header.
- **Dynamic Authentication Handling**:
  - Replaced the previously hardcoded publishable key authentication with standard SDK authorization checks.
  - Introduced `auth::check_sdk_auth_and_get_auth` to dynamically resolve the authorization type (`auth_type`) based on headers and payload, and passed `&*auth_type` to `api::server_wrap`.

### 4. **Authentication Trait Implementation**
- Implemented the `ClientSecretFetch` trait for `api_models::superposition_sdk_config::SdkConfigRequest` in `crates/router/src/services/authentication.rs` to allow the authentication flows to extract and verify the `client_secret` from the request payload.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Do payments Create

```shell
curl --location 'localhost:8080/payments' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--header 'api-key: dev_ncosNoSPIWtqqfX9kJt0MQSllcS5aRjXREp3xK1JZVdAHkGdMM2RbYfyWMHMKFuG' \
--data-raw '{
    "amount": 5677,
    "currency": "USD",
    "confirm": false,
    "setup_future_usage": "off_session",
    "capture_method": "automatic",
    "capture_on": "2022-09-10T10:11:12Z",
    "customer_id": "StripeCustomer",
    "email": "guest@example.com",
    "name": "John Doe",
    "phone": "999999999",
    "phone_country_code": "+65",
    "description": "Its my first payment request",
    "authentication_type": "three_ds",
    "return_url": "https://duck.com",
    "billing": {
        "address": {
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "city": "San Fransico",
            "state": "CA",
            "zip": "94122",
            "country": "US",
            "first_name": "PiX",
            "last_name": "Poddar"
        },
        "phone": {
            "number": "123456789",
            "country_code": "12"
        }
    },
    "shipping": {
        "address": {
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "city": "San Fransico",
            "state": "CA",
            "zip": "94122",
            "country": "US",
            "first_name": "PiX",
            "last_name": "Poddar"
        },
        "phone": {
            "number": "123456789",
            "country_code": "12"
        }
    },
    "request_external_three_ds_authentication": true,
    "statement_descriptor_name": "joseph",
    "statement_descriptor_suffix": "JS",
    "metadata": {
        "udf1": "value1",
        "new_customer": "true",
        "login_date": "2019-09-10T10:11:12Z"
    }
}'
```

Do sdk config call using both variant

Publishable key auth
```
curl --location 'https://13a2-2402-e280-3d17-2d4-b5ea-1ebf-a2c5-dc55.ngrok-free.app/v1/sdk/configs/web/sdk_config.json?client_secret=pay_O1eLWZEDVdvAhAqKFxSM_secret_T5pfinNN93S3RlPi8gvR' \
--header 'api-key: pk_dev_e9feb0ec450a4b9c808a2fbc449de81e' \
--data ''
```

SdkAuthorisation auth

```shell
curl --location 'https://13a2-2402-e280-3d17-2d4-b5ea-1ebf-a2c5-dc55.ngrok-free.app/v1/sdk/configs/web/sdk_config.json' \
--header 'authorization: cHJvZmlsZV9pZD1wcm9fVkE2QWZsWEpzOVlQZ1IxT2FEVjEscHVibGlzaGFibGVfa2V5PXBrX2Rldl9lOWZlYjBlYzQ1MGE0YjljODA4YTJmYmM0NDlkZTgxZSxjbGllbnRfc2VjcmV0PXBheV9PMWVMV1pFRFZkdkFoQXFLRnhTTV9zZWNyZXRfVDVwZmluTk45M1MzUmxQaThndlIsY3VzdG9tZXJfaWQ9U3RyaXBlQ3VzdG9tZXIsY2xpZW50X3Nlc3Npb25faWQ9Y2xpZW50X3Nlc3NfR2tRVWNXWGVsNFUwMUxrYnJ6SkMscGF5bWVudF9pZD1wYXlfTzFlTFdaRURWZHZBaEFxS0Z4U00=' \
--data ''
```


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [x] I added unit tests for my changes where possible
