### PR TITLE
fix(ucs): map network_txn_link_id in adyen authorize UCS shadow response

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1550,7 +1550,7 @@ dependencies = [
  "bitflags 2.9.0",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "log 0.4.27",
  "prettyplease",
  "proc-macro2",
@@ -2264,7 +2264,7 @@ dependencies = [
 [[package]]
 name = "config_patch_derive"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.06.12.2#131ee8aec3d67d05c2826ceb6e6ff7e35d16050a"
+source = "git+https://github.com/juspay/connector-service?tag=2026.06.18.0#da8d57ea9656070346b3d957ce0856fd41591a0d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3981,7 +3981,7 @@ checksum = "32619942b8be646939eaf3db0602b39f5229b74575b67efc897811ded1db4e57"
 [[package]]
 name = "grpc-api-types"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.06.12.2#131ee8aec3d67d05c2826ceb6e6ff7e35d16050a"
+source = "git+https://github.com/juspay/connector-service?tag=2026.06.18.0#da8d57ea9656070346b3d957ce0856fd41591a0d"
 dependencies = [
  "axum 0.8.4",
  "bytes 1.10.1",
@@ -7156,8 +7156,8 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.4.1",
- "itertools 0.10.5",
+ "heck 0.5.0",
+ "itertools 0.11.0",
  "log 0.4.27",
  "multimap",
  "petgraph",
@@ -7178,7 +7178,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn 2.0.101",
@@ -7191,7 +7191,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn 2.0.101",
@@ -8176,7 +8176,7 @@ dependencies = [
 [[package]]
 name = "rust-grpc-client"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.06.12.2#131ee8aec3d67d05c2826ceb6e6ff7e35d16050a"
+source = "git+https://github.com/juspay/connector-service?tag=2026.06.18.0#da8d57ea9656070346b3d957ce0856fd41591a0d"
 dependencies = [
  "grpc-api-types",
 ]
@@ -11010,7 +11010,7 @@ checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
 [[package]]
 name = "ucs_cards"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.06.12.2#131ee8aec3d67d05c2826ceb6e6ff7e35d16050a"
+source = "git+https://github.com/juspay/connector-service?tag=2026.06.18.0#da8d57ea9656070346b3d957ce0856fd41591a0d"
 dependencies = [
  "bytes 1.10.1",
  "error-stack 0.4.1",
@@ -11026,7 +11026,7 @@ dependencies = [
 [[package]]
 name = "ucs_common_enums"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.06.12.2#131ee8aec3d67d05c2826ceb6e6ff7e35d16050a"
+source = "git+https://github.com/juspay/connector-service?tag=2026.06.18.0#da8d57ea9656070346b3d957ce0856fd41591a0d"
 dependencies = [
  "serde",
  "strum 0.26.3",
@@ -11037,7 +11037,7 @@ dependencies = [
 [[package]]
 name = "ucs_common_utils"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.06.12.2#131ee8aec3d67d05c2826ceb6e6ff7e35d16050a"
+source = "git+https://github.com/juspay/connector-service?tag=2026.06.18.0#da8d57ea9656070346b3d957ce0856fd41591a0d"
 dependencies = [
  "anyhow",
  "base64 0.21.7",

--- a/crates/external_services/Cargo.toml
+++ b/crates/external_services/Cargo.toml
@@ -80,7 +80,7 @@ http = "0.2.12"
 url = { version = "2.5.4", features = ["serde"] }
 quick-xml = { version = "0.31.0", features = ["serialize"] }
 
-unified-connector-service-client = { git = "https://github.com/juspay/connector-service", tag = "2026.06.12.2", package = "rust-grpc-client" }
+unified-connector-service-client = { git = "https://github.com/juspay/connector-service", tag = "2026.06.18.0", package = "rust-grpc-client" }
 open-feature = { version = "0.2.5", optional = true }
 superposition_provider = { version = "0.102.0", optional = true }
 superposition_types = "0.102.0"

--- a/crates/hyperswitch_interfaces/Cargo.toml
+++ b/crates/hyperswitch_interfaces/Cargo.toml
@@ -33,7 +33,7 @@ time = "0.3.41"
 tonic = "0.14"
 url = { version = "2.5.4", features = ["serde"] }
 
-unified-connector-service-client = { git = "https://github.com/juspay/connector-service", tag = "2026.06.12.2", package = "rust-grpc-client" }
+unified-connector-service-client = { git = "https://github.com/juspay/connector-service", tag = "2026.06.18.0", package = "rust-grpc-client" }
 tokio = { version = "1.45.1", features = ["macros", "rt-multi-thread"] }
 
 # First party crates

--- a/crates/router/Cargo.toml
+++ b/crates/router/Cargo.toml
@@ -91,8 +91,8 @@ ring = "0.17.14"
 rust_decimal = { version = "1.37.1", features = ["serde-with-float", "serde-with-str"] }
 rust-i18n = { git = "https://github.com/kashif-m/rust-i18n", rev = "f2d8096aaaff7a87a847c35a5394c269f75e077a" }
 
-unified-connector-service-client = { git = "https://github.com/juspay/connector-service", tag = "2026.06.12.2", package = "rust-grpc-client" }
-unified-connector-service-cards = { git = "https://github.com/juspay/connector-service", tag = "2026.06.12.2", package = "ucs_cards" }
+unified-connector-service-client = { git = "https://github.com/juspay/connector-service", tag = "2026.06.18.0", package = "rust-grpc-client" }
+unified-connector-service-cards = { git = "https://github.com/juspay/connector-service", tag = "2026.06.18.0", package = "ucs_cards" }
 rustc-hash = "1.1.0"
 rustls = "0.22"
 rustls-pemfile = "2"

--- a/crates/router/src/core/unified_connector_service/transformers.rs
+++ b/crates/router/src/core/unified_connector_service/transformers.rs
@@ -2516,7 +2516,7 @@ impl
                     mandate_reference: Box::new(response.mandate_reference.map(hyperswitch_domain_models::router_response_types::MandateReference::foreign_try_from).transpose()?),
                     connector_metadata,
                     network_txn_id: response.network_transaction_id.clone(),
-                    network_txn_link_id: None,
+                    network_txn_link_id: response.network_txn_link_id.clone(),
                     connector_response_reference_id: response.merchant_transaction_id.clone(),
                     incremental_authorization_allowed: response.incremental_authorization_allowed,
                     authentication_data: None,


### PR DESCRIPTION
## What

Adyen returns `additionalData.transactionLinkId` on card-on-file / recurring
(`UnscheduledCardOnFile`) authorizations. HS-native parses it into
`PaymentsResponseData::TransactionResponse.network_txn_link_id` (a `String`), but the
**UCS shadow path** reconstructed it as `null`: the
`PaymentServiceAuthorizeResponse -> PaymentsResponseData` mapping in
`router/src/core/unified_connector_service/transformers.rs` hardcoded
`network_txn_link_id: None`.

This surfaced as the shadow-validation router-data diff:

```
router.typeDiff:response.Ok.TransactionResponse.network_txn_link_id
  { hyperswitch: "string", ucs: "null" }
```

## Fix

UCS already builds this field and exposes it over gRPC — `network_txn_link_id = 19` was
added to `PaymentServiceAuthorizeResponse` and populated in the authorize builder by
juspay/connector-service#1509. HS simply never read it on the authorize flow.

- Map `network_txn_link_id: response.network_txn_link_id.clone()` in the authorize
  response mapping (was `None`).
- Bump the pinned UCS gRPC client tag `2026.06.12.2` → `2026.06.18.0` (earliest tag
  containing #1509, so the proto field exists) in `crates/router/Cargo.toml`,
  `crates/external_services/Cargo.toml`, `crates/hyperswitch_interfaces/Cargo.toml` +
  `Cargo.lock`.

No connector transformer is touched (HS is the ground truth); the sync (`PSync`) path
already maps this field — this brings authorize to parity.

## Category

HS→UCS gRPC mapping (response side). UCS side already merged (#1509), so this is an
HS-only change.

## Repro & verification (local shadow stack, HS:8080 + UCS:8001 + MITM + VS)

Adyen card-on-file authorize (`setup_future_usage: off_session` + `customer_id`) so
Adyen returns `transactionLinkId`. Read the **router-data** comparison from the
validation service:
`GET :9000/validation-service/api/router-data/requests/router_data_adyen_Authorize_<rid>_<payment_id>`.

**Before:**
```json
"comparison_results": { "typeDiff": {
  "response.Ok.TransactionResponse.network_txn_link_id": { "hyperswitch": "string", "ucs": "null" } } }
```

**After (this PR):**
```json
"comparison_metadata": { "comparison_performed": true, "comparison_status": "success", "differences_found": false }
```
Both sides now carry the same value (e.g. `network_txn_link_id = "CtTkrXXRVvZ5bsPUWGcAmC"`),
no new diffs. Verified locally: `cargo build` (v1), `cargo check --no-default-features
--features "release,v2,redis-rs"` (v2), `cargo clippy --bin router -D warnings`, `cargo fmt --check`.

Closes #12891
Fixes an internal validation-diff issue (linked via the Development sidebar).