### PR TITLE
fix(ucs): send authentication_data on cybersource setup_mandate (#16922)

### DIFF
--- a/crates/router/src/core/unified_connector_service/transformers.rs
+++ b/crates/router/src/core/unified_connector_service/transformers.rs
@@ -2047,6 +2047,13 @@ impl
             .as_ref()
             .map(ConnectorState::foreign_from);
 
+        let authentication_data = router_data
+            .request
+            .authentication_data
+            .clone()
+            .map(payments_grpc::AuthenticationData::foreign_try_from)
+            .transpose()?;
+
         Ok(Self {
             mit_category: None,
             merchant_recurring_payment_id: router_data.connector_request_reference_id.clone(),
@@ -2082,7 +2089,7 @@ impl
             address: Some(address),
             auth_type: auth_type.into(),
             enrolled_for_3ds: false,
-            authentication_data: None,
+            authentication_data,
             metadata: router_data
                 .request
                 .metadata


### PR DESCRIPTION
## What

Client half of the **cybersource / setup_mandate** shadow-validation diff (juspay/hyperswitch-cloud#16922):
```
body.keyDiff.consumerAuthenticationInformation = {"hyperswitch": true, "ucs": false}
```

The UCS client built `PaymentServiceSetupRecurringRequest` with `authentication_data: None` hardcoded, so the connector-service (prism) never received the 3DS data for a setup_mandate even though the proto field exists. The Direct gateway does send it, hence the diff.

## Fix

Map `router_data.request.authentication_data` into the request in the `SetupMandate → PaymentServiceSetupRecurringRequest` builder, mirroring the existing `PaymentServiceAuthorizeRequest` builders.

**No proto / rev change** — `authentication_data` already exists on `PaymentServiceSetupRecurringRequest` in the currently-pinned connector-service tag (`2026.06.12.2`); this is pure client mapping.

## Pairs with

Prism PR juspay/hyperswitch-prism#1605 (server-side mapping + cybersource transformer). Draft until that merges.

## Verification

End-to-end at the outbound-cybersource-body level (via prism + mitm), `authentication_data` set on the request:
- BEFORE: UCS body missing `consumerAuthenticationInformation` → `keyDiff = {consumerAuthenticationInformation: {hyperswitch:true, ucs:false}}`
- AFTER (this + prism #1605): `consumerAuthenticationInformation` present → `keyDiff = {}` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
