### PR TITLE
feat(analytics): connector_events source/destination/execution_mode + UCS event ingestion

### DIFF
--- a/crates/analytics/docs/clickhouse/scripts/connector_events.sql
+++ b/crates/analytics/docs/clickhouse/scripts/connector_events.sql
@@ -14,7 +14,9 @@ CREATE TABLE connector_events_queue
     `method` LowCardinality(String),
     `dispute_id` Nullable(String),
     `refund_id` Nullable(String),
-    `payout_id` Nullable(String)
+    `payout_id` Nullable(String),
+    `destination` LowCardinality(Nullable(String)),
+    `execution_mode` LowCardinality(Nullable(String))
 )
 ENGINE = Kafka
 SETTINGS kafka_broker_list = 'kafka0:29092', kafka_topic_list = 'hyperswitch-outgoing-connector-events', kafka_group_name = 'hyper', kafka_format = 'JSONEachRow', kafka_handle_error_mode = 'stream';
@@ -57,6 +59,9 @@ CREATE TABLE connector_events (
     `dispute_id` Nullable(String),
     `refund_id` Nullable(String),
     `payout_id` Nullable(String),
+    `destination` LowCardinality(Nullable(String)),
+    `execution_mode` LowCardinality(Nullable(String)),
+    `source` LowCardinality(Nullable(String)),
     INDEX flowIndex flow TYPE bloom_filter GRANULARITY 1,
     INDEX connectorIndex connector_name TYPE bloom_filter GRANULARITY 1,
     INDEX statusIndex status_code TYPE bloom_filter GRANULARITY 1
@@ -87,6 +92,9 @@ CREATE TABLE connector_events_audit (
     `method` LowCardinality(String),
     `dispute_id` Nullable(String),
     `refund_id` Nullable(String),
+    `destination` LowCardinality(Nullable(String)),
+    `execution_mode` LowCardinality(Nullable(String)),
+    `source` LowCardinality(Nullable(String)),
     INDEX flowIndex flow TYPE bloom_filter GRANULARITY 1,
     INDEX connectorIndex connector_name TYPE bloom_filter GRANULARITY 1,
     INDEX statusIndex status_code TYPE bloom_filter GRANULARITY 1
@@ -109,6 +117,9 @@ CREATE TABLE connector_events_payout_audit (
     `inserted_at` DateTime DEFAULT now() CODEC(T64, LZ4),
     `latency` UInt128,
     `method` LowCardinality(String),
+    `destination` LowCardinality(Nullable(String)),
+    `execution_mode` LowCardinality(Nullable(String)),
+    `source` LowCardinality(Nullable(String)),
     INDEX flowIndex flow TYPE bloom_filter GRANULARITY 1,
     INDEX connectorIndex connector_name TYPE bloom_filter GRANULARITY 1,
     INDEX statusIndex status_code TYPE bloom_filter GRANULARITY 1
@@ -132,7 +143,10 @@ CREATE MATERIALIZED VIEW connector_events_audit_mv TO connector_events_audit (
     `latency` UInt128,
     `method` LowCardinality(String),
     `refund_id` Nullable(String),
-    `dispute_id` Nullable(String)
+    `dispute_id` Nullable(String),
+    `destination` LowCardinality(Nullable(String)),
+    `execution_mode` LowCardinality(Nullable(String)),
+    `source` LowCardinality(Nullable(String))
 ) AS
 SELECT
     merchant_id,
@@ -150,7 +164,10 @@ SELECT
     latency,
     method,
     refund_id,
-    dispute_id
+    dispute_id,
+    destination,
+    execution_mode,
+    'hyperswitch' AS source
 FROM
     connector_events_queue
 WHERE
@@ -171,7 +188,10 @@ CREATE MATERIALIZED VIEW connector_events_payout_audit_mv TO connector_events_pa
     `created_at` DateTime64(3),
     `inserted_at` DateTime DEFAULT now() CODEC(T64, LZ4),
     `latency` UInt128,
-    `method` LowCardinality(String)
+    `method` LowCardinality(String),
+    `destination` LowCardinality(Nullable(String)),
+    `execution_mode` LowCardinality(Nullable(String)),
+    `source` LowCardinality(Nullable(String))
 ) AS
 SELECT
     merchant_id,
@@ -187,7 +207,10 @@ SELECT
     created_at,
     now64() AS inserted_at,
     latency,
-    method
+    method,
+    destination,
+    execution_mode,
+    'hyperswitch' AS source
 FROM
     connector_events_queue
 WHERE
@@ -211,7 +234,10 @@ CREATE MATERIALIZED VIEW connector_events_mv TO connector_events (
     `method` LowCardinality(String),
     `refund_id` Nullable(String),
     `dispute_id` Nullable(String),
-    `payout_id` Nullable(String)
+    `payout_id` Nullable(String),
+    `destination` LowCardinality(Nullable(String)),
+    `execution_mode` LowCardinality(Nullable(String)),
+    `source` LowCardinality(Nullable(String))
 ) AS
 SELECT
     merchant_id,
@@ -230,8 +256,147 @@ SELECT
     method,
     refund_id,
     dispute_id,
-    payout_id
+    payout_id,
+    destination,
+    execution_mode,
+    'hyperswitch' AS source
 FROM
     connector_events_queue
 WHERE
     length(_error) = 0;
+
+-- Kafka consumer for the UCS connector-events topic; maps UCS's native field
+-- shape onto the shared connector_events tables (source = unified_connector_service).
+
+CREATE TABLE unified_connector_service_connector_events_queue
+(
+    `request_id` String,
+    `timestamp` Int64,
+    `flow_type` LowCardinality(String),
+    `connector` LowCardinality(String),
+    `url` Nullable(String),
+    `method` Nullable(String),
+    `stage` LowCardinality(String),
+    `execution_mode` LowCardinality(Nullable(String)),
+    `latency_ms` Nullable(UInt64),
+    `status_code` Nullable(Int32),
+    `request_data` Nullable(String),
+    `response_data` Nullable(String),
+    `error` Nullable(String),
+    `reference_id` Nullable(String),
+    `resource_id` Nullable(String),
+    `lineage_merchant_id` Nullable(String)
+)
+ENGINE = Kafka
+SETTINGS kafka_broker_list = 'kafka0:29092', kafka_topic_list = 'unified-connector-service-connector-events', kafka_group_name = 'hyper', kafka_format = 'JSONEachRow', kafka_handle_error_mode = 'stream';
+
+CREATE MATERIALIZED VIEW unified_connector_service_connector_events_parse_errors (
+    `topic` String,
+    `partition` Int64,
+    `offset` Int64,
+    `raw` String,
+    `error` String
+) ENGINE = MergeTree
+ORDER BY
+    (topic, partition, offset) SETTINGS index_granularity = 8192 AS
+SELECT
+    _topic AS topic,
+    _partition AS partition,
+    _offset AS offset,
+    _raw_message AS raw,
+    _error AS error
+FROM
+    unified_connector_service_connector_events_queue
+WHERE
+    length(_error) > 0;
+
+CREATE MATERIALIZED VIEW unified_connector_service_connector_events_mv TO connector_events (
+    `merchant_id` String,
+    `payment_id` Nullable(String),
+    `connector_name` LowCardinality(String),
+    `request_id` String,
+    `flow` LowCardinality(String),
+    `request` String,
+    `response` Nullable(String),
+    `masked_response` Nullable(String),
+    `error` Nullable(String),
+    `status_code` UInt32,
+    `created_at` DateTime64(3),
+    `inserted_at` DateTime DEFAULT now() CODEC(T64, LZ4),
+    `latency` UInt128,
+    `method` LowCardinality(String),
+    `refund_id` Nullable(String),
+    `payout_id` Nullable(String),
+    `destination` LowCardinality(Nullable(String)),
+    `execution_mode` LowCardinality(Nullable(String)),
+    `source` LowCardinality(Nullable(String))
+) AS
+SELECT
+    ifNull(lineage_merchant_id, '') AS merchant_id,
+    reference_id AS payment_id,
+    connector AS connector_name,
+    request_id,
+    flow_type AS flow,
+    ifNull(request_data, '') AS request,
+    response_data AS response,
+    response_data AS masked_response,
+    error,
+    toUInt32(ifNull(status_code, 0)) AS status_code,
+    fromUnixTimestamp64Milli(timestamp) AS created_at,
+    now64() AS inserted_at,
+    toUInt128(ifNull(latency_ms, 0)) AS latency,
+    ifNull(method, '') AS method,
+    resource_id AS refund_id,
+    CAST(NULL AS Nullable(String)) AS payout_id,
+    'connector' AS destination,
+    execution_mode,
+    'unified_connector_service' AS source
+FROM
+    unified_connector_service_connector_events_queue
+WHERE
+    length(_error) = 0;
+
+CREATE MATERIALIZED VIEW unified_connector_service_connector_events_audit_mv TO connector_events_audit (
+    `merchant_id` String,
+    `payment_id` String,
+    `connector_name` LowCardinality(String),
+    `request_id` String,
+    `flow` LowCardinality(String),
+    `request` String,
+    `response` Nullable(String),
+    `masked_response` Nullable(String),
+    `error` Nullable(String),
+    `status_code` UInt32,
+    `created_at` DateTime64(3),
+    `inserted_at` DateTime DEFAULT now() CODEC(T64, LZ4),
+    `latency` UInt128,
+    `method` LowCardinality(String),
+    `refund_id` Nullable(String),
+    `destination` LowCardinality(Nullable(String)),
+    `execution_mode` LowCardinality(Nullable(String)),
+    `source` LowCardinality(Nullable(String))
+) AS
+SELECT
+    ifNull(lineage_merchant_id, '') AS merchant_id,
+    reference_id AS payment_id,
+    connector AS connector_name,
+    request_id,
+    flow_type AS flow,
+    ifNull(request_data, '') AS request,
+    response_data AS response,
+    response_data AS masked_response,
+    error,
+    toUInt32(ifNull(status_code, 0)) AS status_code,
+    fromUnixTimestamp64Milli(timestamp) AS created_at,
+    now64() AS inserted_at,
+    toUInt128(ifNull(latency_ms, 0)) AS latency,
+    ifNull(method, '') AS method,
+    resource_id AS refund_id,
+    'connector' AS destination,
+    execution_mode,
+    'unified_connector_service' AS source
+FROM
+    unified_connector_service_connector_events_queue
+WHERE
+    (length(_error) = 0)
+    AND (reference_id IS NOT NULL);


### PR DESCRIPTION
## What

ClickHouse ingestion (stage 2) for the connector-event analytics tagging — the consumer side that matches the producer changes in juspay/hyperswitch#12714 (HS) and juspay/hyperswitch-prism#1501 (UCS).

Two parts:

1. **`connector_events`** gains three dimensions — `source`, `destination`, `execution_mode` — across the queue table, the three target tables (`connector_events`, `connector_events_audit`, `connector_events_payout_audit`) and the three materialized views.
2. **New UCS ingestion**: UCS emits the same audit event from its own Kafka topics in its native field shape. New Kafka-engine tables + MVs map that shape onto the shared `connector_events` tables, and a new `ucs_api_events` table captures the inbound gRPC-request stream.

## The three dimensions

| column | meaning | how it's set |
|---|---|---|
| `source` | which service emitted the row (`hyperswitch` / `unified_connector_service`) | **stamped in the MV**, per topic — not in the payload |
| `destination` | call target (`connector` / `unified_connector_service`) | from the HS payload; constant `connector` for UCS connector calls; `null` for `ucs_api_events` |
| `execution_mode` | `primary` (live) / `shadow` (mirror) | from the payload |

All three are `LowCardinality(Nullable(String))` — Nullable, no backfill; pre-migration rows read `NULL`.

## UCS field mapping

UCS emits a different (native) field shape; the UCS MVs translate it onto the `connector_events` columns:

| target column | UCS field |
|---|---|
| `merchant_id` | `lineage_merchant_id` |
| `payment_id` | `reference_id` |
| `refund_id` | `resource_id` |
| `connector_name` | `connector` |
| `flow` | `flow_type` |
| `request` | `request_data` |
| `masked_response` | `response_data` |
| `created_at` | `timestamp` (ms → `fromUnixTimestamp64Milli`) |
| `latency` | `latency_ms` |

`reference_id` carries the payment id for all UCS flows (HS sends it as `UcsReferenceId::Payment`), so UCS rows key into the payment-id audit table the same way HS rows do.

## Files

- `scripts/connector_events.sql` — 3 columns added to the HS pipeline (`source='hyperswitch'`), plus the UCS→`connector_events` queue + MVs (`source='unified_connector_service'`, `destination='connector'`).
- `scripts/ucs_api_events.sql` — new pipeline for the UCS inbound gRPC stream (`destination=null`).

## Notes for review / deploy

- **Topic names** in the Kafka-engine tables are the fresh-init convention names; actual per-env topics are set by hyperswitch-infra. The UCS api-events topic is the one new topic to provision; UCS connector events reuse the existing UCS topic.
- These scripts are CREATE-only (fresh-init). The live-cluster column adds / new tables are applied out-of-band per environment.
- This is the **read/ingest** schema; it does not require the producer PRs to be merged first, but the dimensions only populate once those deploy.

## Companion

- Producer (HS): juspay/hyperswitch#12714
- Producer (UCS): juspay/hyperswitch-prism#1501