### PR TITLE
feat(analytics): surface connector-event dimensions + ucs_api_events read API

### DIFF
--- a/crates/analytics/src/clickhouse.rs
+++ b/crates/analytics/src/clickhouse.rs
@@ -153,6 +153,8 @@ impl AnalyticsDataSource for ClickhouseClient {
             | AnalyticsCollection::ApiPayoutEvents
             | AnalyticsCollection::ConnectorEvents
             | AnalyticsCollection::ConnectorPayoutEvents
+            | AnalyticsCollection::PrismConnectorEvents
+            | AnalyticsCollection::PrismConnectorPayoutEvents
             | AnalyticsCollection::RoutingEvents
             | AnalyticsCollection::ApiEventsAnalytics
             | AnalyticsCollection::OutgoingWebhookEvent
@@ -484,6 +486,10 @@ impl ToSql<ClickhouseClient> for AnalyticsCollection {
             Self::PaymentIntentSessionized => Ok("sessionizer_payment_intents".to_string()),
             Self::ConnectorEvents => Ok("connector_events_audit".to_string()),
             Self::ConnectorPayoutEvents => Ok("connector_events_payout_audit".to_string()),
+            Self::PrismConnectorEvents => Ok("prism_connector_events_audit".to_string()),
+            Self::PrismConnectorPayoutEvents => {
+                Ok("prism_connector_events_payout_audit".to_string())
+            }
             Self::OutgoingWebhookEvent => Ok("outgoing_webhook_events_audit".to_string()),
             Self::OutgoingWebhookPayoutEvent => {
                 Ok("outgoing_webhook_events_payout_audit".to_string())

--- a/crates/analytics/src/connector_events.rs
+++ b/crates/analytics/src/connector_events.rs
@@ -2,4 +2,4 @@ mod core;
 pub mod events;
 pub trait ConnectorEventAnalytics: events::ConnectorEventLogAnalytics {}
 
-pub use self::core::connector_events_core;
+pub use self::core::{connector_events_core, prism_connector_events_core};

--- a/crates/analytics/src/connector_events.rs
+++ b/crates/analytics/src/connector_events.rs
@@ -2,4 +2,15 @@ mod core;
 pub mod events;
 pub trait ConnectorEventAnalytics: events::ConnectorEventLogAnalytics {}
 
-pub use self::core::{connector_events_core, prism_connector_events_core};
+pub use self::core::connector_events_core;
+
+/// Which set of physical connector-event tables a query targets.
+#[derive(Debug, Clone, Copy)]
+pub enum ConnectorEventSource {
+    /// Native Hyperswitch connector events
+    /// (`connector_events_audit` / `connector_events_payout_audit`).
+    Hyperswitch,
+    /// UCS/Prism-emitted connector events
+    /// (`prism_connector_events_audit` / `prism_connector_events_payout_audit`).
+    Prism,
+}

--- a/crates/analytics/src/connector_events/core.rs
+++ b/crates/analytics/src/connector_events/core.rs
@@ -2,30 +2,17 @@ use api_models::analytics::connector_events::ConnectorEventsRequest;
 use common_utils::errors::ReportSwitchExt;
 use error_stack::ResultExt;
 
-use super::events::{get_connector_events, ConnectorEventsResult};
+use super::{
+    events::{get_connector_events, ConnectorEventsResult},
+    ConnectorEventSource,
+};
 use crate::{errors::AnalyticsResult, types::FiltersError, AnalyticsProvider};
 
 pub async fn connector_events_core(
     pool: &AnalyticsProvider,
     req: ConnectorEventsRequest,
     merchant_id: &common_utils::id_type::MerchantId,
-) -> AnalyticsResult<Vec<ConnectorEventsResult>> {
-    connector_events_core_inner(pool, req, merchant_id, false).await
-}
-
-pub async fn prism_connector_events_core(
-    pool: &AnalyticsProvider,
-    req: ConnectorEventsRequest,
-    merchant_id: &common_utils::id_type::MerchantId,
-) -> AnalyticsResult<Vec<ConnectorEventsResult>> {
-    connector_events_core_inner(pool, req, merchant_id, true).await
-}
-
-async fn connector_events_core_inner(
-    pool: &AnalyticsProvider,
-    req: ConnectorEventsRequest,
-    merchant_id: &common_utils::id_type::MerchantId,
-    use_prism_tables: bool,
+    source: ConnectorEventSource,
 ) -> AnalyticsResult<Vec<ConnectorEventsResult>> {
     let data = match pool {
         AnalyticsProvider::Sqlx(_) => Err(FiltersError::NotImplemented(
@@ -35,7 +22,7 @@ async fn connector_events_core_inner(
         AnalyticsProvider::Clickhouse(ckh_pool)
         | AnalyticsProvider::CombinedSqlx(_, ckh_pool)
         | AnalyticsProvider::CombinedCkh(_, ckh_pool) => {
-            get_connector_events(merchant_id, req, ckh_pool, use_prism_tables).await
+            get_connector_events(merchant_id, req, ckh_pool, source).await
         }
     }
     .switch()?;

--- a/crates/analytics/src/connector_events/core.rs
+++ b/crates/analytics/src/connector_events/core.rs
@@ -10,6 +10,23 @@ pub async fn connector_events_core(
     req: ConnectorEventsRequest,
     merchant_id: &common_utils::id_type::MerchantId,
 ) -> AnalyticsResult<Vec<ConnectorEventsResult>> {
+    connector_events_core_inner(pool, req, merchant_id, false).await
+}
+
+pub async fn prism_connector_events_core(
+    pool: &AnalyticsProvider,
+    req: ConnectorEventsRequest,
+    merchant_id: &common_utils::id_type::MerchantId,
+) -> AnalyticsResult<Vec<ConnectorEventsResult>> {
+    connector_events_core_inner(pool, req, merchant_id, true).await
+}
+
+async fn connector_events_core_inner(
+    pool: &AnalyticsProvider,
+    req: ConnectorEventsRequest,
+    merchant_id: &common_utils::id_type::MerchantId,
+    use_prism_tables: bool,
+) -> AnalyticsResult<Vec<ConnectorEventsResult>> {
     let data = match pool {
         AnalyticsProvider::Sqlx(_) => Err(FiltersError::NotImplemented(
             "Connector Events not implemented for SQLX",
@@ -18,7 +35,7 @@ pub async fn connector_events_core(
         AnalyticsProvider::Clickhouse(ckh_pool)
         | AnalyticsProvider::CombinedSqlx(_, ckh_pool)
         | AnalyticsProvider::CombinedCkh(_, ckh_pool) => {
-            get_connector_events(merchant_id, req, ckh_pool).await
+            get_connector_events(merchant_id, req, ckh_pool, use_prism_tables).await
         }
     }
     .switch()?;

--- a/crates/analytics/src/connector_events/events.rs
+++ b/crates/analytics/src/connector_events/events.rs
@@ -71,6 +71,7 @@ pub struct ConnectorEventsResult {
     pub payout_id: Option<String>,
     pub connector_name: Option<String>,
     pub request_id: Option<String>,
+    pub url: Option<String>,
     pub flow: String,
     pub request: String,
     #[serde(rename = "masked_response")]

--- a/crates/analytics/src/connector_events/events.rs
+++ b/crates/analytics/src/connector_events/events.rs
@@ -13,6 +13,7 @@ pub async fn get_connector_events<T>(
     merchant_id: &common_utils::id_type::MerchantId,
     query_param: ConnectorEventsRequest,
     pool: &T,
+    use_prism_tables: bool,
 ) -> FiltersResult<Vec<ConnectorEventsResult>>
 where
     T: AnalyticsDataSource + ConnectorEventLogAnalytics,
@@ -22,10 +23,13 @@ where
     Aggregate<&'static str>: ToSql<T>,
     Window<&'static str>: ToSql<T>,
 {
-    let mut query_builder: QueryBuilder<T> = match query_param.payment_id {
-        Some(_) => QueryBuilder::new(AnalyticsCollection::PrismConnectorEvents),
-        None => QueryBuilder::new(AnalyticsCollection::PrismConnectorPayoutEvents),
-    };
+    let mut query_builder: QueryBuilder<T> =
+        match (use_prism_tables, query_param.payment_id.as_ref()) {
+            (true, Some(_)) => QueryBuilder::new(AnalyticsCollection::PrismConnectorEvents),
+            (true, None) => QueryBuilder::new(AnalyticsCollection::PrismConnectorPayoutEvents),
+            (false, Some(_)) => QueryBuilder::new(AnalyticsCollection::ConnectorEvents),
+            (false, None) => QueryBuilder::new(AnalyticsCollection::ConnectorPayoutEvents),
+        };
     query_builder.add_select_column("*").switch()?;
 
     query_builder
@@ -79,8 +83,8 @@ pub struct ConnectorEventsResult {
     pub error: Option<String>,
     pub status_code: u16,
     pub latency: Option<u128>,
-    pub source: Option<String>,
-    pub destination: Option<String>,
+    pub tenant_id: Option<String>,
+    pub service_name: Option<String>,
     pub execution_mode: Option<String>,
     #[serde(with = "common_utils::custom_serde::iso8601")]
     pub created_at: PrimitiveDateTime,

--- a/crates/analytics/src/connector_events/events.rs
+++ b/crates/analytics/src/connector_events/events.rs
@@ -78,6 +78,9 @@ pub struct ConnectorEventsResult {
     pub error: Option<String>,
     pub status_code: u16,
     pub latency: Option<u128>,
+    pub source: Option<String>,
+    pub destination: Option<String>,
+    pub execution_mode: Option<String>,
     #[serde(with = "common_utils::custom_serde::iso8601")]
     pub created_at: PrimitiveDateTime,
     pub method: Option<String>,

--- a/crates/analytics/src/connector_events/events.rs
+++ b/crates/analytics/src/connector_events/events.rs
@@ -83,7 +83,6 @@ pub struct ConnectorEventsResult {
     pub payout_id: Option<String>,
     pub connector_name: Option<String>,
     pub request_id: Option<String>,
-    pub url: Option<String>,
     pub flow: String,
     pub request: String,
     #[serde(rename = "masked_response")]
@@ -91,9 +90,6 @@ pub struct ConnectorEventsResult {
     pub error: Option<String>,
     pub status_code: u16,
     pub latency: Option<u128>,
-    pub tenant_id: Option<String>,
-    pub service_name: Option<String>,
-    pub execution_mode: Option<String>,
     #[serde(with = "common_utils::custom_serde::iso8601")]
     pub created_at: PrimitiveDateTime,
     pub method: Option<String>,

--- a/crates/analytics/src/connector_events/events.rs
+++ b/crates/analytics/src/connector_events/events.rs
@@ -23,8 +23,8 @@ where
     Window<&'static str>: ToSql<T>,
 {
     let mut query_builder: QueryBuilder<T> = match query_param.payment_id {
-        Some(_) => QueryBuilder::new(AnalyticsCollection::ConnectorEvents),
-        None => QueryBuilder::new(AnalyticsCollection::ConnectorPayoutEvents),
+        Some(_) => QueryBuilder::new(AnalyticsCollection::PrismConnectorEvents),
+        None => QueryBuilder::new(AnalyticsCollection::PrismConnectorPayoutEvents),
     };
     query_builder.add_select_column("*").switch()?;
 

--- a/crates/analytics/src/connector_events/events.rs
+++ b/crates/analytics/src/connector_events/events.rs
@@ -3,6 +3,7 @@ use common_utils::errors::ReportSwitchExt;
 use error_stack::ResultExt;
 use time::PrimitiveDateTime;
 
+use super::ConnectorEventSource;
 use crate::{
     query::{Aggregate, GroupByClause, QueryBuilder, ToSql, Window},
     types::{AnalyticsCollection, AnalyticsDataSource, FiltersError, FiltersResult, LoadRow},
@@ -13,7 +14,7 @@ pub async fn get_connector_events<T>(
     merchant_id: &common_utils::id_type::MerchantId,
     query_param: ConnectorEventsRequest,
     pool: &T,
-    use_prism_tables: bool,
+    source: ConnectorEventSource,
 ) -> FiltersResult<Vec<ConnectorEventsResult>>
 where
     T: AnalyticsDataSource + ConnectorEventLogAnalytics,
@@ -23,13 +24,20 @@ where
     Aggregate<&'static str>: ToSql<T>,
     Window<&'static str>: ToSql<T>,
 {
-    let mut query_builder: QueryBuilder<T> =
-        match (use_prism_tables, query_param.payment_id.as_ref()) {
-            (true, Some(_)) => QueryBuilder::new(AnalyticsCollection::PrismConnectorEvents),
-            (true, None) => QueryBuilder::new(AnalyticsCollection::PrismConnectorPayoutEvents),
-            (false, Some(_)) => QueryBuilder::new(AnalyticsCollection::ConnectorEvents),
-            (false, None) => QueryBuilder::new(AnalyticsCollection::ConnectorPayoutEvents),
-        };
+    let mut query_builder: QueryBuilder<T> = match (source, query_param.payment_id.as_ref()) {
+        (ConnectorEventSource::Prism, Some(_)) => {
+            QueryBuilder::new(AnalyticsCollection::PrismConnectorEvents)
+        }
+        (ConnectorEventSource::Prism, None) => {
+            QueryBuilder::new(AnalyticsCollection::PrismConnectorPayoutEvents)
+        }
+        (ConnectorEventSource::Hyperswitch, Some(_)) => {
+            QueryBuilder::new(AnalyticsCollection::ConnectorEvents)
+        }
+        (ConnectorEventSource::Hyperswitch, None) => {
+            QueryBuilder::new(AnalyticsCollection::ConnectorPayoutEvents)
+        }
+    };
     query_builder.add_select_column("*").switch()?;
 
     query_builder

--- a/crates/analytics/src/lib.rs
+++ b/crates/analytics/src/lib.rs
@@ -1173,6 +1173,7 @@ pub enum AnalyticsFlow {
     GetApiEventMetrics,
     GetApiEventFilters,
     GetConnectorEvents,
+    GetPrismConnectorEvents,
     GetOutgoingWebhookEvents,
     GetGlobalSearchResults,
     GetSearchResults,

--- a/crates/analytics/src/sqlx.rs
+++ b/crates/analytics/src/sqlx.rs
@@ -1467,6 +1467,12 @@ impl ToSql<SqlxClient> for AnalyticsCollection {
                 .attach_printable("ConnectorEvents table is not implemented for Sqlx"))?,
             Self::ConnectorPayoutEvents => Err(error_stack::report!(ParsingError::UnknownError)
                 .attach_printable("ConnectorPayoutEvents table is not implemented for Sqlx"))?,
+            Self::PrismConnectorEvents => Err(error_stack::report!(ParsingError::UnknownError)
+                .attach_printable("PrismConnectorEvents table is not implemented for Sqlx"))?,
+            Self::PrismConnectorPayoutEvents => Err(error_stack::report!(
+                ParsingError::UnknownError
+            )
+            .attach_printable("PrismConnectorPayoutEvents table is not implemented for Sqlx"))?,
             Self::ApiEventsAnalytics => Err(error_stack::report!(ParsingError::UnknownError)
                 .attach_printable("ApiEvents table is not implemented for Sqlx"))?,
             Self::ActivePaymentsAnalytics => Err(error_stack::report!(ParsingError::UnknownError)

--- a/crates/analytics/src/types.rs
+++ b/crates/analytics/src/types.rs
@@ -39,6 +39,8 @@ pub enum AnalyticsCollection {
     PaymentIntentSessionized,
     ConnectorEvents,
     ConnectorPayoutEvents,
+    PrismConnectorEvents,
+    PrismConnectorPayoutEvents,
     OutgoingWebhookEvent,
     OutgoingWebhookPayoutEvent,
     Authentications,

--- a/crates/router/src/analytics.rs
+++ b/crates/router/src/analytics.rs
@@ -9,7 +9,7 @@ pub mod routes {
     use actix_web::{web, Responder, Scope};
     use analytics::{
         api_event::api_events_core,
-        connector_events::{connector_events_core, prism_connector_events_core},
+        connector_events::{connector_events_core, ConnectorEventSource},
         enums::AuthInfo,
         errors::AnalyticsError,
         lambda_utils::invoke_lambda,
@@ -3424,18 +3424,19 @@ pub mod routes {
         .await
     }
 
-    pub async fn get_profile_connector_events(
+    async fn connector_event_logs(
         state: web::Data<AppState>,
         req: actix_web::HttpRequest,
         json_payload: web::Query<api_models::analytics::connector_events::ConnectorEventsRequest>,
+        flow: AnalyticsFlow,
+        source: ConnectorEventSource,
     ) -> impl Responder {
-        let flow = AnalyticsFlow::GetConnectorEvents;
         Box::pin(api::server_wrap(
             flow,
             state,
             &req,
             json_payload.into_inner(),
-            |state, auth: AuthenticationData, req, _| async move {
+            move |state, auth: AuthenticationData, req, _| async move {
                 #[cfg(feature = "v1")]
                 let profile_id = auth.profile.map(|profile| profile.get_id().clone());
                 #[cfg(feature = "v2")]
@@ -3453,6 +3454,7 @@ pub mod routes {
                     &state.pool,
                     req,
                     auth.platform.get_processor().get_account().get_id(),
+                    source,
                 )
                 .await
                 .map(ApplicationResponse::Json)
@@ -3467,46 +3469,33 @@ pub mod routes {
         .await
     }
 
+    pub async fn get_profile_connector_events(
+        state: web::Data<AppState>,
+        req: actix_web::HttpRequest,
+        json_payload: web::Query<api_models::analytics::connector_events::ConnectorEventsRequest>,
+    ) -> impl Responder {
+        connector_event_logs(
+            state,
+            req,
+            json_payload,
+            AnalyticsFlow::GetConnectorEvents,
+            ConnectorEventSource::Hyperswitch,
+        )
+        .await
+    }
+
     pub async fn get_profile_prism_connector_events(
         state: web::Data<AppState>,
         req: actix_web::HttpRequest,
         json_payload: web::Query<api_models::analytics::connector_events::ConnectorEventsRequest>,
     ) -> impl Responder {
-        let flow = AnalyticsFlow::GetPrismConnectorEvents;
-        Box::pin(api::server_wrap(
-            flow,
+        connector_event_logs(
             state,
-            &req,
-            json_payload.into_inner(),
-            |state, auth: AuthenticationData, req, _| async move {
-                #[cfg(feature = "v1")]
-                let profile_id = auth.profile.map(|profile| profile.get_id().clone());
-                #[cfg(feature = "v2")]
-                let profile_id = Some(auth.profile.get_id().clone());
-                utils::check_if_profile_id_is_present_in_intent_table(
-                    req.payment_id.clone(),
-                    req.payout_id.clone(),
-                    &state,
-                    auth.platform.get_processor(),
-                    profile_id,
-                )
-                .await
-                .change_context(AnalyticsError::AccessForbiddenError)?;
-                prism_connector_events_core(
-                    &state.pool,
-                    req,
-                    auth.platform.get_processor().get_account().get_id(),
-                )
-                .await
-                .map(ApplicationResponse::Json)
-            },
-            &auth::JWTAuth {
-                permission: Permission::ProfileAnalyticsRead,
-                allow_connected: true,
-                allow_platform: false,
-            },
-            api_locking::LockAction::NotApplicable,
-        ))
+            req,
+            json_payload,
+            AnalyticsFlow::GetPrismConnectorEvents,
+            ConnectorEventSource::Prism,
+        )
         .await
     }
 

--- a/crates/router/src/analytics.rs
+++ b/crates/router/src/analytics.rs
@@ -8,10 +8,16 @@ pub mod routes {
 
     use actix_web::{web, Responder, Scope};
     use analytics::{
-        api_event::api_events_core, connector_events::connector_events_core, enums::AuthInfo,
-        errors::AnalyticsError, lambda_utils::invoke_lambda, opensearch::OpenSearchError,
-        outgoing_webhook_event::outgoing_webhook_events_core, routing_events::routing_events_core,
-        sdk_events::sdk_events_core, AnalyticsFlow,
+        api_event::api_events_core,
+        connector_events::{connector_events_core, prism_connector_events_core},
+        enums::AuthInfo,
+        errors::AnalyticsError,
+        lambda_utils::invoke_lambda,
+        opensearch::OpenSearchError,
+        outgoing_webhook_event::outgoing_webhook_events_core,
+        routing_events::routing_events_core,
+        sdk_events::sdk_events_core,
+        AnalyticsFlow,
     };
     use api_models::analytics::{
         api_event::QueryType,
@@ -173,6 +179,10 @@ pub mod routes {
                         .service(
                             web::resource("connector_event_logs")
                                 .route(web::get().to(get_profile_connector_events)),
+                        )
+                        .service(
+                            web::resource("prism_connector_event_logs")
+                                .route(web::get().to(get_profile_prism_connector_events)),
                         )
                         .service(
                             web::resource("routing_event_logs")
@@ -427,6 +437,10 @@ pub mod routes {
                                 .service(
                                     web::resource("connector_event_logs")
                                         .route(web::get().to(get_profile_connector_events)),
+                                )
+                                .service(
+                                    web::resource("prism_connector_event_logs")
+                                        .route(web::get().to(get_profile_prism_connector_events)),
                                 )
                                 .service(
                                     web::resource("routing_event_logs")
@@ -3436,6 +3450,49 @@ pub mod routes {
                 .await
                 .change_context(AnalyticsError::AccessForbiddenError)?;
                 connector_events_core(
+                    &state.pool,
+                    req,
+                    auth.platform.get_processor().get_account().get_id(),
+                )
+                .await
+                .map(ApplicationResponse::Json)
+            },
+            &auth::JWTAuth {
+                permission: Permission::ProfileAnalyticsRead,
+                allow_connected: true,
+                allow_platform: false,
+            },
+            api_locking::LockAction::NotApplicable,
+        ))
+        .await
+    }
+
+    pub async fn get_profile_prism_connector_events(
+        state: web::Data<AppState>,
+        req: actix_web::HttpRequest,
+        json_payload: web::Query<api_models::analytics::connector_events::ConnectorEventsRequest>,
+    ) -> impl Responder {
+        let flow = AnalyticsFlow::GetPrismConnectorEvents;
+        Box::pin(api::server_wrap(
+            flow,
+            state,
+            &req,
+            json_payload.into_inner(),
+            |state, auth: AuthenticationData, req, _| async move {
+                #[cfg(feature = "v1")]
+                let profile_id = auth.profile.map(|profile| profile.get_id().clone());
+                #[cfg(feature = "v2")]
+                let profile_id = Some(auth.profile.get_id().clone());
+                utils::check_if_profile_id_is_present_in_intent_table(
+                    req.payment_id.clone(),
+                    req.payout_id.clone(),
+                    &state,
+                    auth.platform.get_processor(),
+                    profile_id,
+                )
+                .await
+                .change_context(AnalyticsError::AccessForbiddenError)?;
+                prism_connector_events_core(
                     &state.pool,
                     req,
                     auth.platform.get_processor().get_account().get_id(),


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->

Analytics read side for the UCS/prism connector-event stream. Adds a new profile endpoint that serves connector events from the prism audit tables, mirroring the existing `connector_event_logs`.

- New **`prism_connector_event_logs`** endpoint (v1 + v2, profile scope, JWT `ProfileAnalyticsRead`) returning `Vec<ConnectorEventsResult>` — the same response shape as `connector_event_logs`, so the existing Control Center renderer can be reused.
- Table selection by flow via `AnalyticsCollection::PrismConnectorEvents{,Payout}` → `prism_connector_events_audit` (payment/refund) and `prism_connector_events_payout_audit` (payout).
- **Refactor:** de-duplicated the connector-event read path — one shared core parameterised by a `ConnectorEventSource` enum, instead of copy-pasted handlers for the HS and prism sources.
- **Refactor:** dropped the unused prism-only dimensions from `ConnectorEventsResult` (they remain ClickHouse columns; `SELECT *` with no `deny_unknown_fields` tolerates the extra columns).
- ClickHouse-only (the Sqlx arm returns not-implemented), same as `connector_events`.

### Additional Changes

- [x] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

<!-- New read endpoint `…/analytics/{v1,v2}/profile/prism_connector_event_logs`; no config or schema changes in this PR (the ClickHouse DDL is the companion #12896). -->

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
-->

Connector calls made by the UCS (Unified Connector Service) are emitted to a separate prism stream and land in dedicated ClickHouse tables. They are not visible through the existing `connector_event_logs` endpoint. This adds the read API so Control Center can surface UCS connector request/response logs alongside the native ones, per payment / refund / payout.

Companion PRs:
- Ingestion (ClickHouse DDL): juspay/hyperswitch#12896
- Producers: juspay/hyperswitch#12714 (HS) · juspay/hyperswitch-prism#1501 (UCS)

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

Tested manually, end-to-end, against a local ClickHouse seeded with the `prism_connector_events_audit` schema:

- Ran the router on this branch (`--features olap`) with analytics `source = "clickhouse"` pointed at the local ClickHouse.
- Created a real payment (so the endpoint's `payment_intent` profile guard passes), seeded matching connector-event rows, and called the endpoint with a dashboard JWT (`ProfileAnalyticsRead`).
- Both flows return `200` with `Vec<ConnectorEventsResult>`.

**Payment**
```
GET /analytics/v1/profile/prism_connector_event_logs?type=Payment&payment_id=<payment_id>
```
<img width="1231" height="491" alt="image" src="https://github.com/user-attachments/assets/a8797ce1-86c4-47c3-b7dc-8246bb00518a" />


**Refund**
```
GET /analytics/v1/profile/prism_connector_event_logs?payment_id=<payment_id>&refund_id=<refund_id>
```
<img width="1231" height="491" alt="image" src="https://github.com/user-attachments/assets/a8797ce1-86c4-47c3-b7dc-8246bb00518a" />

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible