### PR TITLE
fix(ucs): map minor_amount_captured from capture response instead of re-deriving

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2274,7 +2274,7 @@ dependencies = [
 [[package]]
 name = "config_patch_derive"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.07.17.0#b406d5ee29e92680c85a4417a8e0b69e5a51d10b"
+source = "git+https://github.com/juspay/connector-service?rev=b292660a5f00ffefb2f4c30bb8b075f4c52d345d#b292660a5f00ffefb2f4c30bb8b075f4c52d345d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4141,7 +4141,7 @@ checksum = "32619942b8be646939eaf3db0602b39f5229b74575b67efc897811ded1db4e57"
 [[package]]
 name = "grpc-api-types"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.07.17.0#b406d5ee29e92680c85a4417a8e0b69e5a51d10b"
+source = "git+https://github.com/juspay/connector-service?rev=b292660a5f00ffefb2f4c30bb8b075f4c52d345d#b292660a5f00ffefb2f4c30bb8b075f4c52d345d"
 dependencies = [
  "axum 0.8.4",
  "bytes 1.10.1",
@@ -7093,7 +7093,7 @@ dependencies = [
  "regex-cache",
  "serde",
  "serde_derive",
- "strum 0.26.3",
+ "strum 0.25.0",
  "thiserror 1.0.69",
 ]
 
@@ -8443,7 +8443,7 @@ dependencies = [
 [[package]]
 name = "rust-grpc-client"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.07.17.0#b406d5ee29e92680c85a4417a8e0b69e5a51d10b"
+source = "git+https://github.com/juspay/connector-service?rev=b292660a5f00ffefb2f4c30bb8b075f4c52d345d#b292660a5f00ffefb2f4c30bb8b075f4c52d345d"
 dependencies = [
  "grpc-api-types",
 ]
@@ -11297,7 +11297,7 @@ checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
 [[package]]
 name = "ucs_cards"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.07.17.0#b406d5ee29e92680c85a4417a8e0b69e5a51d10b"
+source = "git+https://github.com/juspay/connector-service?rev=b292660a5f00ffefb2f4c30bb8b075f4c52d345d#b292660a5f00ffefb2f4c30bb8b075f4c52d345d"
 dependencies = [
  "bytes 1.10.1",
  "error-stack 0.4.1",
@@ -11313,7 +11313,7 @@ dependencies = [
 [[package]]
 name = "ucs_common_enums"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.07.17.0#b406d5ee29e92680c85a4417a8e0b69e5a51d10b"
+source = "git+https://github.com/juspay/connector-service?rev=b292660a5f00ffefb2f4c30bb8b075f4c52d345d#b292660a5f00ffefb2f4c30bb8b075f4c52d345d"
 dependencies = [
  "serde",
  "strum 0.26.3",
@@ -11324,7 +11324,7 @@ dependencies = [
 [[package]]
 name = "ucs_common_utils"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.07.17.0#b406d5ee29e92680c85a4417a8e0b69e5a51d10b"
+source = "git+https://github.com/juspay/connector-service?rev=b292660a5f00ffefb2f4c30bb8b075f4c52d345d#b292660a5f00ffefb2f4c30bb8b075f4c52d345d"
 dependencies = [
  "anyhow",
  "base64 0.21.7",

--- a/crates/external_services/Cargo.toml
+++ b/crates/external_services/Cargo.toml
@@ -84,7 +84,7 @@ http = "0.2.12"
 url = { version = "2.5.4", features = ["serde"] }
 quick-xml = { version = "0.31.0", features = ["serialize"] }
 
-unified-connector-service-client = { git = "https://github.com/juspay/connector-service", tag = "2026.07.17.0", package = "rust-grpc-client" }
+unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "b292660a5f00ffefb2f4c30bb8b075f4c52d345d", package = "rust-grpc-client" }
 open-feature = { version = "0.2.5", optional = true }
 bytes = { version = "1.10.1", optional = true }
 superposition_provider = { version = "0.115.2", optional = true }

--- a/crates/hyperswitch_interfaces/Cargo.toml
+++ b/crates/hyperswitch_interfaces/Cargo.toml
@@ -33,7 +33,7 @@ time = "0.3.41"
 tonic = "0.14"
 url = { version = "2.5.4", features = ["serde"] }
 
-unified-connector-service-client = { git = "https://github.com/juspay/connector-service", tag = "2026.07.17.0", package = "rust-grpc-client" }
+unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "b292660a5f00ffefb2f4c30bb8b075f4c52d345d", package = "rust-grpc-client" }
 tokio = { version = "1.45.1", features = ["macros", "rt-multi-thread"] }
 
 # First party crates

--- a/crates/router/Cargo.toml
+++ b/crates/router/Cargo.toml
@@ -92,8 +92,8 @@ ring = "0.17.14"
 rust_decimal = { version = "1.37.1", features = ["serde-with-float", "serde-with-str"] }
 rust-i18n = { git = "https://github.com/kashif-m/rust-i18n", rev = "f2d8096aaaff7a87a847c35a5394c269f75e077a" }
 
-unified-connector-service-client = { git = "https://github.com/juspay/connector-service", tag = "2026.07.17.0", package = "rust-grpc-client" }
-unified-connector-service-cards = { git = "https://github.com/juspay/connector-service", tag = "2026.07.17.0", package = "ucs_cards" }
+unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "b292660a5f00ffefb2f4c30bb8b075f4c52d345d", package = "rust-grpc-client" }
+unified-connector-service-cards = { git = "https://github.com/juspay/connector-service", rev = "b292660a5f00ffefb2f4c30bb8b075f4c52d345d", package = "ucs_cards" }
 rustc-hash = "1.1.0"
 rustls = "0.22"
 rustls-pemfile = "2"

--- a/crates/router/src/core/payments/gateway/capture_gateway.rs
+++ b/crates/router/src/core/payments/gateway/capture_gateway.rs
@@ -176,7 +176,7 @@ where
                 router_data.response = router_data_response;
                 router_data.amount_captured = payment_capture_response.captured_amount;
                 router_data.minor_amount_captured = payment_capture_response
-                    .captured_amount
+                    .minor_amount_captured
                     .map(MinorUnit::new);
                 router_data.connector_http_status_code = Some(ucs_data.status_code);
 

--- a/crates/router/src/core/unified_connector_service/transformers.rs
+++ b/crates/router/src/core/unified_connector_service/transformers.rs
@@ -2364,6 +2364,13 @@ impl
                 .billing_descriptor
                 .as_ref()
                 .map(payments_grpc::BillingDescriptor::foreign_from),
+            payment_channel: router_data
+                .request
+                .payment_channel
+                .as_ref()
+                .map(payments_grpc::PaymentChannel::foreign_try_from)
+                .transpose()?
+                .map(|payment_channel| payment_channel.into()),
             mit_category: router_data
                 .request
                 .mit_category


### PR DESCRIPTION
Closes #12980

---
**Re-detection — also fixes internal tracking issues / #17118, #20698** (paypal / `capture`, signature `router.typeDiff:minor_amount_captured`).
Same paypal-capture `minor_amount_captured` family as #16970/#16995/#17051/#17052/#20698.
This PR (`capture_gateway.rs` maps the gRPC `minor_amount_captured` instead of re-deriving
from `captured_amount`; rev-pins connector-service) resolves it. Re-verified GREEN locally
on latest main — see proof comment.

**Depends on connector-service PR #1606** (adds `minor_amount_captured` as proto field 18 on
`PaymentServiceCaptureResponse`). The `rev = "..."` pin on `unified-connector-service-client`
/ `unified-connector-service-cards` in the three Cargo.tomls is **interim** — once #1606 merges
to `connector-service` main, this pin should move back to a `tag`/main commit.

Verified locally: fresh capture repro against the rebased UCS branch shows
`differences_found: false` with `minor_amount_captured: null` and `amount_captured: 6000`
identical on both the native HS and UCS-shadow sides (previously UCS diverged with
`minor_amount_captured: 6000`).
