### PR TITLE
feat(ucs): map split charges onto PSync charges response for Stripe Connect

### DIFF
--- a/crates/hyperswitch_interfaces/src/unified_connector_service/transformers.rs
+++ b/crates/hyperswitch_interfaces/src/unified_connector_service/transformers.rs
@@ -246,6 +246,47 @@ pub struct ConnectorErrorInner {
     pub network_error_message: Option<String>,
 }
 
+/// Map the UCS gRPC split response (connected-account / split-payment charge
+/// details returned on sync) back into the hyperswitch `ConnectorChargeResponseData`
+/// so the `charges` field on the synced payment matches the direct (non-UCS) path.
+fn convert_connector_charge_response(
+    splits: payments_grpc::ConnectorSplitResponseData,
+) -> Option<common_types::payments::ConnectorChargeResponseData> {
+    use payments_grpc::connector_split_response_data::SplitResponseType;
+
+    match splits.split_response_type? {
+        SplitResponseType::StripeSplitResponse(stripe) => {
+            let charge_type = match stripe.charge_type() {
+                payments_grpc::PaymentChargeType::StripeDestination => {
+                    common_enums::PaymentChargeType::Stripe(
+                        common_enums::StripeChargeType::Destination,
+                    )
+                }
+                // STRIPE_DIRECT and the unspecified default both map to Direct.
+                _ => {
+                    common_enums::PaymentChargeType::Stripe(common_enums::StripeChargeType::Direct)
+                }
+            };
+            Some(
+                common_types::payments::ConnectorChargeResponseData::StripeSplitPayment(
+                    common_types::payments::StripeChargeResponseData {
+                        charge_id: stripe.charge_id,
+                        charge_type,
+                        application_fees: stripe
+                            .application_fees
+                            .map(common_utils::types::MinorUnit::new),
+                        transfer_account_id: stripe.transfer_account_id,
+                        on_behalf_of: stripe.on_behalf_of,
+                    },
+                ),
+            )
+        }
+        // Adyen split-charge response mapping is not yet wired on the UCS shadow
+        // path; falls back to None (matches prior behavior, no regression).
+        SplitResponseType::AdyenSplitResponse(_) => None,
+    }
+}
+
 impl ForeignTryFrom<(payments_grpc::PaymentServiceGetResponse, AttemptStatus)>
     for Result<(PaymentsResponseData, AttemptStatus), ErrorResponse>
 {
@@ -336,7 +377,7 @@ impl ForeignTryFrom<(payments_grpc::PaymentServiceGetResponse, AttemptStatus)>
                     connector_response_reference_id: response.merchant_transaction_id,
                     incremental_authorization_allowed: response.incremental_authorization_allowed,
                     authentication_data: None,
-                    charges: None,
+                    charges: response.splits.and_then(convert_connector_charge_response),
                 },
                 status,
             ))


### PR DESCRIPTION
## What

On the unified-connector-service (UCS) shadow path, the PSync response builder in
`hyperswitch_interfaces` (`unified_connector_service/transformers.rs`,
`PaymentServiceGetResponse -> PaymentsResponseData::TransactionResponse`) hardcoded
`charges: None`. UCS already returns the connected-account split-charge details in the
gRPC `PaymentServiceGetResponse.splits` field (`ConnectorSplitResponseData`), and the
request side already forwards `split_payments` on PSync — but HS dropped the response,
so a synced **Stripe Connect** split payment had `charges = null` on the UCS path while
the direct connector path returned the full charge object.

This maps the gRPC `splits` back into `ConnectorChargeResponseData` so the synced
`charges` field matches the direct path.

**Layer:** HS→UCS mapping (HS-only). UCS needs no change — it already populates
`splits` (field 32) on `PaymentServiceGetResponse` for stripe psync, and the HS PSync
request already forwards `split_payments`. The router-side response builders
(authorize/capture/void) already map `splits -> charges`; this closes the remaining
PSync gap.

## Shadow-validation diff (before)

```
result_type: router_diff   (stripe / PSync / merchant yucca)
comparison_results.typeDiff:
  response.Ok.TransactionResponse.charges = { hyperswitch: object, ucs: null }
```
HS native built `charges.stripe_split_payment{charge_id, charge_type:direct,
application_fees, transfer_account_id}` from the synced PaymentIntent's `latest_charge`;
the UCS-shadow router data had `charges = null`.

## Repro

Stripe Connect Direct split, manual-capture authorize then force-sync:

```
POST /payments  {amount, capture_method:"manual", payment_method:"card",
  split_payments:{stripe_split_payment:{charge_type:"direct",
    application_fees:100, transfer_account_id:"acct_..."}}, ...}
GET  /payments/{id}?force_sync=true        # PSync -> UCS shadow
```
(enroll `ucs_rollout_config_{mid}_stripe_card_PSync`). Full script: `repro_16969.py`.

## Verify (local stack, latest main + this change)

`GET :9000/validation-service/api/router-data/requests/router_data_stripe_PSync_<rid>_<pid>`

| | before | after |
|---|---|---|
| `differences_found` | `true` | **`false`** |
| `typeDiff` | `{charges: {hs:object, ucs:null}}` | **`{}`** |
| UCS `charges` | `null` | **`{stripe_split_payment{charge_id:ch_…, charge_type:direct, application_fees:100, transfer_account_id:acct_…}}`** |

UCS `charges` is now byte-identical to HS native; no new diffs.

Closes #12911
Fixes an internal validation-diff issue (linked via the Development sidebar).
