### PR TITLE
fix(ucs): map charges on stripe repeat_payment response (#16965)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2264,7 +2264,7 @@ dependencies = [
 [[package]]
 name = "config_patch_derive"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.06.23.1#2a748b69578e5d61c4586b30aabddad0ed7fd88a"
+source = "git+https://github.com/juspay/connector-service?rev=33ca5a55a406f3a23da5539017f7941285bfb255#33ca5a55a406f3a23da5539017f7941285bfb255"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3981,7 +3981,7 @@ checksum = "32619942b8be646939eaf3db0602b39f5229b74575b67efc897811ded1db4e57"
 [[package]]
 name = "grpc-api-types"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.06.23.1#2a748b69578e5d61c4586b30aabddad0ed7fd88a"
+source = "git+https://github.com/juspay/connector-service?rev=33ca5a55a406f3a23da5539017f7941285bfb255#33ca5a55a406f3a23da5539017f7941285bfb255"
 dependencies = [
  "axum 0.8.4",
  "bytes 1.10.1",
@@ -8176,7 +8176,7 @@ dependencies = [
 [[package]]
 name = "rust-grpc-client"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.06.23.1#2a748b69578e5d61c4586b30aabddad0ed7fd88a"
+source = "git+https://github.com/juspay/connector-service?rev=33ca5a55a406f3a23da5539017f7941285bfb255#33ca5a55a406f3a23da5539017f7941285bfb255"
 dependencies = [
  "grpc-api-types",
 ]
@@ -11010,7 +11010,7 @@ checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
 [[package]]
 name = "ucs_cards"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.06.23.1#2a748b69578e5d61c4586b30aabddad0ed7fd88a"
+source = "git+https://github.com/juspay/connector-service?rev=33ca5a55a406f3a23da5539017f7941285bfb255#33ca5a55a406f3a23da5539017f7941285bfb255"
 dependencies = [
  "bytes 1.10.1",
  "error-stack 0.4.1",
@@ -11026,7 +11026,7 @@ dependencies = [
 [[package]]
 name = "ucs_common_enums"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.06.23.1#2a748b69578e5d61c4586b30aabddad0ed7fd88a"
+source = "git+https://github.com/juspay/connector-service?rev=33ca5a55a406f3a23da5539017f7941285bfb255#33ca5a55a406f3a23da5539017f7941285bfb255"
 dependencies = [
  "serde",
  "strum 0.26.3",
@@ -11037,7 +11037,7 @@ dependencies = [
 [[package]]
 name = "ucs_common_utils"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.06.23.1#2a748b69578e5d61c4586b30aabddad0ed7fd88a"
+source = "git+https://github.com/juspay/connector-service?rev=33ca5a55a406f3a23da5539017f7941285bfb255#33ca5a55a406f3a23da5539017f7941285bfb255"
 dependencies = [
  "anyhow",
  "base64 0.21.7",

--- a/crates/external_services/Cargo.toml
+++ b/crates/external_services/Cargo.toml
@@ -80,7 +80,7 @@ http = "0.2.12"
 url = { version = "2.5.4", features = ["serde"] }
 quick-xml = { version = "0.31.0", features = ["serialize"] }
 
-unified-connector-service-client = { git = "https://github.com/juspay/connector-service", tag = "2026.06.23.1", package = "rust-grpc-client" }
+unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "33ca5a55a406f3a23da5539017f7941285bfb255", package = "rust-grpc-client" }
 open-feature = { version = "0.2.5", optional = true }
 superposition_provider = { version = "0.102.0", optional = true }
 superposition_types = "0.102.0"

--- a/crates/hyperswitch_interfaces/Cargo.toml
+++ b/crates/hyperswitch_interfaces/Cargo.toml
@@ -33,7 +33,7 @@ time = "0.3.41"
 tonic = "0.14"
 url = { version = "2.5.4", features = ["serde"] }
 
-unified-connector-service-client = { git = "https://github.com/juspay/connector-service", tag = "2026.06.23.1", package = "rust-grpc-client" }
+unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "33ca5a55a406f3a23da5539017f7941285bfb255", package = "rust-grpc-client" }
 tokio = { version = "1.45.1", features = ["macros", "rt-multi-thread"] }
 
 # First party crates

--- a/crates/router/Cargo.toml
+++ b/crates/router/Cargo.toml
@@ -91,8 +91,8 @@ ring = "0.17.14"
 rust_decimal = { version = "1.37.1", features = ["serde-with-float", "serde-with-str"] }
 rust-i18n = { git = "https://github.com/kashif-m/rust-i18n", rev = "f2d8096aaaff7a87a847c35a5394c269f75e077a" }
 
-unified-connector-service-client = { git = "https://github.com/juspay/connector-service", tag = "2026.06.23.1", package = "rust-grpc-client" }
-unified-connector-service-cards = { git = "https://github.com/juspay/connector-service", tag = "2026.06.23.1", package = "ucs_cards" }
+unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "33ca5a55a406f3a23da5539017f7941285bfb255", package = "rust-grpc-client" }
+unified-connector-service-cards = { git = "https://github.com/juspay/connector-service", rev = "33ca5a55a406f3a23da5539017f7941285bfb255", package = "ucs_cards" }
 rustc-hash = "1.1.0"
 rustls = "0.22"
 rustls-pemfile = "2"

--- a/crates/router/src/core/unified_connector_service/transformers.rs
+++ b/crates/router/src/core/unified_connector_service/transformers.rs
@@ -3028,7 +3028,7 @@ impl
                     connector_response_reference_id: response.merchant_charge_id.clone(),
                     incremental_authorization_allowed: response.incremental_authorization_allowed,
                     authentication_data: None,
-                    charges: None,
+                    charges: response.splits.map(common_types::payments::ConnectorChargeResponseData::foreign_try_from).transpose()?,
                 },
                 status,
             ))


### PR DESCRIPTION
## What

Maps `charges` on the Stripe **repeat_payment** response from the UCS gRPC `RecurringPaymentServiceChargeResponse`, instead of hardcoding `None`. Mirrors the Authorize/Capture response mappings.

Related: juspay/hyperswitch-cloud#16965
Depends on: juspay/hyperswitch-prism#1607 (adds `splits` to `RecurringPaymentServiceChargeResponse`).

> **Draft** until the prism PR merges and a CalVer tag is cut — then flip the `rev` pin (currently `33ca5a55…`) to that tag and undraft.

## Root cause

For a split (Stripe Connect) merchant on repeat_payment, the recurring response mapping in `unified_connector_service/transformers.rs` set `charges: None`, dropping the Stripe charge response data and producing:

```
router.typeDiff:response.Ok.TransactionResponse.charges  ->  {hyperswitch:"object", ucs:"null"}
```

## Changes
- `unified_connector_service/transformers.rs`: `charges: response.splits.map(ConnectorChargeResponseData::foreign_try_from).transpose()?` (was `None`).
- Rev-pin all 4 `connector-service` deps to the prism branch rev that adds `splits = 16`.

## Verification

Local shadow run on this build (req `019ef51b…`, sub-flow `Authorize`, both `charged`):
- **BEFORE** (prod #16965): `typeDiff { response.Ok.TransactionResponse.charges: {object, null} }`
- **AFTER** (local): `keyDiff:{}, valueDiff:{}` — `charges` typeDiff gone (remaining `request.integrity_object` is unrelated/out of scope). Both sides emit `StripeSplitPayment{charge_id: ch_repro16965, charge_type: direct, transfer_account_id: acct_repro16965}`.

See prism PR for full detail.
