### PR TITLE
feat(ucs): map mandate_metadata from UCS MandateReference response (#16966)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2264,7 +2264,7 @@ dependencies = [
 [[package]]
 name = "config_patch_derive"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.06.23.1#2a748b69578e5d61c4586b30aabddad0ed7fd88a"
+source = "git+https://github.com/juspay/connector-service?rev=49ee61a8950b89483fffa5547084c7a9dece44f5#49ee61a8950b89483fffa5547084c7a9dece44f5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3981,7 +3981,7 @@ checksum = "32619942b8be646939eaf3db0602b39f5229b74575b67efc897811ded1db4e57"
 [[package]]
 name = "grpc-api-types"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.06.23.1#2a748b69578e5d61c4586b30aabddad0ed7fd88a"
+source = "git+https://github.com/juspay/connector-service?rev=49ee61a8950b89483fffa5547084c7a9dece44f5#49ee61a8950b89483fffa5547084c7a9dece44f5"
 dependencies = [
  "axum 0.8.4",
  "bytes 1.10.1",
@@ -8176,7 +8176,7 @@ dependencies = [
 [[package]]
 name = "rust-grpc-client"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.06.23.1#2a748b69578e5d61c4586b30aabddad0ed7fd88a"
+source = "git+https://github.com/juspay/connector-service?rev=49ee61a8950b89483fffa5547084c7a9dece44f5#49ee61a8950b89483fffa5547084c7a9dece44f5"
 dependencies = [
  "grpc-api-types",
 ]
@@ -11010,7 +11010,7 @@ checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
 [[package]]
 name = "ucs_cards"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.06.23.1#2a748b69578e5d61c4586b30aabddad0ed7fd88a"
+source = "git+https://github.com/juspay/connector-service?rev=49ee61a8950b89483fffa5547084c7a9dece44f5#49ee61a8950b89483fffa5547084c7a9dece44f5"
 dependencies = [
  "bytes 1.10.1",
  "error-stack 0.4.1",
@@ -11026,7 +11026,7 @@ dependencies = [
 [[package]]
 name = "ucs_common_enums"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.06.23.1#2a748b69578e5d61c4586b30aabddad0ed7fd88a"
+source = "git+https://github.com/juspay/connector-service?rev=49ee61a8950b89483fffa5547084c7a9dece44f5#49ee61a8950b89483fffa5547084c7a9dece44f5"
 dependencies = [
  "serde",
  "strum 0.26.3",
@@ -11037,7 +11037,7 @@ dependencies = [
 [[package]]
 name = "ucs_common_utils"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.06.23.1#2a748b69578e5d61c4586b30aabddad0ed7fd88a"
+source = "git+https://github.com/juspay/connector-service?rev=49ee61a8950b89483fffa5547084c7a9dece44f5#49ee61a8950b89483fffa5547084c7a9dece44f5"
 dependencies = [
  "anyhow",
  "base64 0.21.7",

--- a/crates/external_services/Cargo.toml
+++ b/crates/external_services/Cargo.toml
@@ -80,7 +80,7 @@ http = "0.2.12"
 url = { version = "2.5.4", features = ["serde"] }
 quick-xml = { version = "0.31.0", features = ["serialize"] }
 
-unified-connector-service-client = { git = "https://github.com/juspay/connector-service", tag = "2026.06.23.1", package = "rust-grpc-client" }
+unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "49ee61a8950b89483fffa5547084c7a9dece44f5", package = "rust-grpc-client" }
 open-feature = { version = "0.2.5", optional = true }
 superposition_provider = { version = "0.102.0", optional = true }
 superposition_types = "0.102.0"

--- a/crates/hyperswitch_interfaces/Cargo.toml
+++ b/crates/hyperswitch_interfaces/Cargo.toml
@@ -33,7 +33,7 @@ time = "0.3.41"
 tonic = "0.14"
 url = { version = "2.5.4", features = ["serde"] }
 
-unified-connector-service-client = { git = "https://github.com/juspay/connector-service", tag = "2026.06.23.1", package = "rust-grpc-client" }
+unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "49ee61a8950b89483fffa5547084c7a9dece44f5", package = "rust-grpc-client" }
 tokio = { version = "1.45.1", features = ["macros", "rt-multi-thread"] }
 
 # First party crates

--- a/crates/hyperswitch_interfaces/src/unified_connector_service/transformers.rs
+++ b/crates/hyperswitch_interfaces/src/unified_connector_service/transformers.rs
@@ -365,9 +365,7 @@ impl ForeignTryFrom<payments_grpc::MandateReference>
                             .map(hyperswitch_masking::Secret::new)
                     })
                     .transpose()
-                    .change_context(
-                        UnifiedConnectorServiceError::ResponseDeserializationFailed,
-                    )
+                    .change_context(UnifiedConnectorServiceError::ResponseDeserializationFailed)
                     .attach_printable("Failed to deserialize mandate_metadata from UCS")?,
                 connector_mandate_request_reference_id: connector_mandate_id
                     .connector_mandate_request_reference_id,

--- a/crates/hyperswitch_interfaces/src/unified_connector_service/transformers.rs
+++ b/crates/hyperswitch_interfaces/src/unified_connector_service/transformers.rs
@@ -358,7 +358,17 @@ impl ForeignTryFrom<payments_grpc::MandateReference>
             )) => Ok(Self {
                 connector_mandate_id: connector_mandate_id.connector_mandate_id,
                 payment_method_id: connector_mandate_id.payment_method_id,
-                mandate_metadata: None,
+                mandate_metadata: value
+                    .mandate_metadata
+                    .map(|metadata| {
+                        serde_json::from_str(&metadata.expose())
+                            .map(hyperswitch_masking::Secret::new)
+                    })
+                    .transpose()
+                    .change_context(
+                        UnifiedConnectorServiceError::ResponseDeserializationFailed,
+                    )
+                    .attach_printable("Failed to deserialize mandate_metadata from UCS")?,
                 connector_mandate_request_reference_id: connector_mandate_id
                     .connector_mandate_request_reference_id,
             }),

--- a/crates/router/Cargo.toml
+++ b/crates/router/Cargo.toml
@@ -91,8 +91,8 @@ ring = "0.17.14"
 rust_decimal = { version = "1.37.1", features = ["serde-with-float", "serde-with-str"] }
 rust-i18n = { git = "https://github.com/kashif-m/rust-i18n", rev = "f2d8096aaaff7a87a847c35a5394c269f75e077a" }
 
-unified-connector-service-client = { git = "https://github.com/juspay/connector-service", tag = "2026.06.23.1", package = "rust-grpc-client" }
-unified-connector-service-cards = { git = "https://github.com/juspay/connector-service", tag = "2026.06.23.1", package = "ucs_cards" }
+unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "49ee61a8950b89483fffa5547084c7a9dece44f5", package = "rust-grpc-client" }
+unified-connector-service-cards = { git = "https://github.com/juspay/connector-service", rev = "49ee61a8950b89483fffa5547084c7a9dece44f5", package = "ucs_cards" }
 rustc-hash = "1.1.0"
 rustls = "0.22"
 rustls-pemfile = "2"

--- a/crates/router/src/core/unified_connector_service/transformers.rs
+++ b/crates/router/src/core/unified_connector_service/transformers.rs
@@ -1964,6 +1964,7 @@ impl
             Some(mandate) => match &mandate.mandate_reference_id {
                 Some(mandates::MandateReferenceId::ConnectorMandateId(connector_mandate_id)) => {
                     Some(payments_grpc::MandateReference {
+                        mandate_metadata: None,
                         mandate_id_type: Some(
                             payments_grpc::mandate_reference::MandateIdType::ConnectorMandateId(
                                 payments_grpc::ConnectorMandateReferenceId {
@@ -1979,6 +1980,7 @@ impl
                 }
                 Some(mandates::MandateReferenceId::NetworkMandateId(network_mandate_id)) => {
                     Some(payments_grpc::MandateReference {
+                        mandate_metadata: None,
                         mandate_id_type: Some(
                             payments_grpc::mandate_reference::MandateIdType::NetworkMandateId(
                                 network_mandate_id.network_transaction_id.clone(),
@@ -1988,6 +1990,7 @@ impl
                 }
                 Some(mandates::MandateReferenceId::NetworkTokenWithNTI(network_token_with_nti)) => {
                     Some(payments_grpc::MandateReference {
+                        mandate_metadata: None,
                         mandate_id_type: Some(
                             payments_grpc::mandate_reference::MandateIdType::NetworkTokenWithNti(
                                 payments_grpc::NetworkTokenWithNti {


### PR DESCRIPTION
## What

Paired hyperswitch (router) side of the fix for shadow-validation `router_diff`
**#16966** — yucca / stripe / repeat_payment:

```
router.typeDiff:response.Ok.TransactionResponse.mandate_reference.mandate_metadata
```
(hyperswitch=`object`, ucs=`null`)

Proto/connector change: **juspay/hyperswitch-prism#1608**.

## Changes

- `hyperswitch_interfaces` UCS client: map `mandate_metadata` from the proto
  `MandateReference` into `router_response_types::MandateReference` (was
  hardcoded `None`), so the UCS path matches the Direct Stripe gateway.
- `router` UCS request builder: set `mandate_metadata: None` on the three
  request-side `MandateReference` constructions (new proto field).
- Rev-pin the four `connector-service` deps to the prism branch SHA
  `49ee61a8950b89483fffa5547084c7a9dece44f5`.

## Draft

Draft until prism#1608 merges and a CalVer tag is cut; then flip `rev` → `tag`
and undraft.

## Verification

Built and verified end-to-end on the local shadow stack. Repeat-payment fired
with Stripe split-payment data; router-data comparison for the Authorize
sub-flow, x-request-id `019ef547-3f98-7b00-a7f2-d51a86ec34ff`:

**After:** `keyDiff {}`, `valueDiff {}`; `mandate_reference.mandate_metadata`
**no longer** in `typeDiff` (UCS now emits it matching Direct). Remaining
`request.integrity_object` (benign) and `response...charges` (separate sibling
#16965) are out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
