### PR TITLE
fix(core): map MandateReference.mandate_metadata from UCS response (#16967)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2264,7 +2264,7 @@ dependencies = [
 [[package]]
 name = "config_patch_derive"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.07.02.1#a070ef74a8d36aeca23f8e90d4d8bb0cc4db77ca"
+source = "git+https://github.com/juspay/connector-service?rev=1aa8d40d8e4e2d93de8b20ded4afb12d53669046#1aa8d40d8e4e2d93de8b20ded4afb12d53669046"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3982,7 +3982,7 @@ checksum = "32619942b8be646939eaf3db0602b39f5229b74575b67efc897811ded1db4e57"
 [[package]]
 name = "grpc-api-types"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.07.02.1#a070ef74a8d36aeca23f8e90d4d8bb0cc4db77ca"
+source = "git+https://github.com/juspay/connector-service?rev=1aa8d40d8e4e2d93de8b20ded4afb12d53669046#1aa8d40d8e4e2d93de8b20ded4afb12d53669046"
 dependencies = [
  "axum 0.8.4",
  "bytes 1.10.1",
@@ -6836,7 +6836,7 @@ dependencies = [
  "regex-cache",
  "serde",
  "serde_derive",
- "strum 0.26.3",
+ "strum 0.25.0",
  "thiserror 1.0.69",
 ]
 
@@ -8178,7 +8178,7 @@ dependencies = [
 [[package]]
 name = "rust-grpc-client"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.07.02.1#a070ef74a8d36aeca23f8e90d4d8bb0cc4db77ca"
+source = "git+https://github.com/juspay/connector-service?rev=1aa8d40d8e4e2d93de8b20ded4afb12d53669046#1aa8d40d8e4e2d93de8b20ded4afb12d53669046"
 dependencies = [
  "grpc-api-types",
 ]
@@ -11012,7 +11012,7 @@ checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
 [[package]]
 name = "ucs_cards"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.07.02.1#a070ef74a8d36aeca23f8e90d4d8bb0cc4db77ca"
+source = "git+https://github.com/juspay/connector-service?rev=1aa8d40d8e4e2d93de8b20ded4afb12d53669046#1aa8d40d8e4e2d93de8b20ded4afb12d53669046"
 dependencies = [
  "bytes 1.10.1",
  "error-stack 0.4.1",
@@ -11028,7 +11028,7 @@ dependencies = [
 [[package]]
 name = "ucs_common_enums"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.07.02.1#a070ef74a8d36aeca23f8e90d4d8bb0cc4db77ca"
+source = "git+https://github.com/juspay/connector-service?rev=1aa8d40d8e4e2d93de8b20ded4afb12d53669046#1aa8d40d8e4e2d93de8b20ded4afb12d53669046"
 dependencies = [
  "serde",
  "strum 0.26.3",
@@ -11039,7 +11039,7 @@ dependencies = [
 [[package]]
 name = "ucs_common_utils"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.07.02.1#a070ef74a8d36aeca23f8e90d4d8bb0cc4db77ca"
+source = "git+https://github.com/juspay/connector-service?rev=1aa8d40d8e4e2d93de8b20ded4afb12d53669046#1aa8d40d8e4e2d93de8b20ded4afb12d53669046"
 dependencies = [
  "anyhow",
  "base64 0.21.7",

--- a/crates/external_services/Cargo.toml
+++ b/crates/external_services/Cargo.toml
@@ -82,7 +82,7 @@ http = "0.2.12"
 url = { version = "2.5.4", features = ["serde"] }
 quick-xml = { version = "0.31.0", features = ["serialize"] }
 
-unified-connector-service-client = { git = "https://github.com/juspay/connector-service", tag = "2026.07.02.1", package = "rust-grpc-client" }
+unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "1aa8d40d8e4e2d93de8b20ded4afb12d53669046", package = "rust-grpc-client" }
 open-feature = { version = "0.2.5", optional = true }
 superposition_provider = { version = "0.114.0", optional = true}
 superposition_types = "0.114.0"

--- a/crates/hyperswitch_interfaces/Cargo.toml
+++ b/crates/hyperswitch_interfaces/Cargo.toml
@@ -33,7 +33,7 @@ time = "0.3.41"
 tonic = "0.14"
 url = { version = "2.5.4", features = ["serde"] }
 
-unified-connector-service-client = { git = "https://github.com/juspay/connector-service", tag = "2026.07.02.1", package = "rust-grpc-client" }
+unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "1aa8d40d8e4e2d93de8b20ded4afb12d53669046", package = "rust-grpc-client" }
 tokio = { version = "1.45.1", features = ["macros", "rt-multi-thread"] }
 
 # First party crates

--- a/crates/hyperswitch_interfaces/src/unified_connector_service/transformers.rs
+++ b/crates/hyperswitch_interfaces/src/unified_connector_service/transformers.rs
@@ -519,7 +519,10 @@ impl ForeignTryFrom<payments_grpc::MandateReference>
             )) => Ok(Self {
                 connector_mandate_id: connector_mandate_id.connector_mandate_id,
                 payment_method_id: connector_mandate_id.payment_method_id,
-                mandate_metadata: None,
+                mandate_metadata: connector_mandate_id
+                    .mandate_metadata
+                    .and_then(|s| serde_json::from_str::<serde_json::Value>(&s).ok())
+                    .map(hyperswitch_masking::Secret::new),
                 connector_mandate_request_reference_id: connector_mandate_id
                     .connector_mandate_request_reference_id,
             }),
@@ -1297,5 +1300,69 @@ impl ErrorSwitch<ConnectorError> for UnifiedConnectorServiceError {
             | Self::PayoutEnrollDisburseAccountFailure
             | Self::NotifyConnectorFailure => ConnectorError::ResponseHandlingFailed,
         }
+    }
+}
+
+#[cfg(test)]
+mod mandate_metadata_tests {
+    use hyperswitch_masking::PeekInterface;
+
+    use super::*;
+
+    // Regression test for #16967 / #20158: the UCS -> HS mandate_reference mapping must
+    // carry `mandate_metadata` through instead of hardcoding `None`, or the connector's
+    // split-payment routing info gets silently dropped on the shadow (UCS) path.
+    #[test]
+    fn mandate_metadata_is_parsed_from_ucs_response() {
+        let proto = payments_grpc::MandateReference {
+            mandate_id_type: Some(payments_grpc::mandate_reference::MandateIdType::ConnectorMandateId(
+                payments_grpc::ConnectorMandateReferenceId {
+                    connector_mandate_id: Some("pm_123".to_string()),
+                    payment_method_id: Some("pm_123".to_string()),
+                    connector_mandate_request_reference_id: None,
+                    mandate_metadata: Some(
+                        r#"{"transfer_account_id":"acct_1TjBkeDfqJC9T9K6","charge_type":"direct","application_fees":100,"on_behalf_of":null}"#
+                            .to_string(),
+                    ),
+                },
+            )),
+        };
+
+        let domain =
+            hyperswitch_domain_models::router_response_types::MandateReference::foreign_try_from(
+                proto,
+            )
+            .expect("conversion should succeed");
+
+        let metadata = domain
+            .mandate_metadata
+            .expect("mandate_metadata must be populated, not dropped as None");
+        let metadata_str = serde_json::to_string(metadata.peek()).unwrap();
+        assert!(metadata_str.contains("acct_1TjBkeDfqJC9T9K6"));
+        assert!(metadata_str.contains("100"));
+    }
+
+    #[test]
+    fn missing_mandate_metadata_maps_to_none() {
+        let proto = payments_grpc::MandateReference {
+            mandate_id_type: Some(
+                payments_grpc::mandate_reference::MandateIdType::ConnectorMandateId(
+                    payments_grpc::ConnectorMandateReferenceId {
+                        connector_mandate_id: Some("pm_456".to_string()),
+                        payment_method_id: None,
+                        connector_mandate_request_reference_id: None,
+                        mandate_metadata: None,
+                    },
+                ),
+            ),
+        };
+
+        let domain =
+            hyperswitch_domain_models::router_response_types::MandateReference::foreign_try_from(
+                proto,
+            )
+            .expect("conversion should succeed");
+
+        assert!(domain.mandate_metadata.is_none());
     }
 }

--- a/crates/router/Cargo.toml
+++ b/crates/router/Cargo.toml
@@ -91,8 +91,8 @@ ring = "0.17.14"
 rust_decimal = { version = "1.37.1", features = ["serde-with-float", "serde-with-str"] }
 rust-i18n = { git = "https://github.com/kashif-m/rust-i18n", rev = "f2d8096aaaff7a87a847c35a5394c269f75e077a" }
 
-unified-connector-service-client = { git = "https://github.com/juspay/connector-service", tag = "2026.07.02.1", package = "rust-grpc-client" }
-unified-connector-service-cards = { git = "https://github.com/juspay/connector-service", tag = "2026.07.02.1", package = "ucs_cards" }
+unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "1aa8d40d8e4e2d93de8b20ded4afb12d53669046", package = "rust-grpc-client" }
+unified-connector-service-cards = { git = "https://github.com/juspay/connector-service", rev = "1aa8d40d8e4e2d93de8b20ded4afb12d53669046", package = "ucs_cards" }
 rustc-hash = "1.1.0"
 rustls = "0.22"
 rustls-pemfile = "2"

--- a/crates/router/src/core/unified_connector_service/transformers.rs
+++ b/crates/router/src/core/unified_connector_service/transformers.rs
@@ -841,6 +841,7 @@ impl ForeignFrom<&mandates::ConnectorMandateReferenceId>
         Self {
             connector_mandate_id: value.get_connector_mandate_id(),
             payment_method_id: value.get_payment_method_id(),
+            mandate_metadata: None,
             connector_mandate_request_reference_id: value
                 .get_connector_mandate_request_reference_id(),
         }
@@ -876,6 +877,7 @@ impl ForeignFrom<&RouterData<PSync, PaymentsSyncData, PaymentsResponseData>>
         Some(payments_grpc::ConnectorMandateReferenceId {
             connector_mandate_id,
             payment_method_id,
+            mandate_metadata: None,
             connector_mandate_request_reference_id,
         })
     }
@@ -2026,6 +2028,7 @@ impl
                                     connector_mandate_id: connector_mandate_id
                                         .get_connector_mandate_id(),
                                     payment_method_id: connector_mandate_id.get_payment_method_id(),
+                                    mandate_metadata: None,
                                     connector_mandate_request_reference_id: connector_mandate_id
                                         .get_connector_mandate_request_reference_id(),
                                 },


### PR DESCRIPTION


Closes #12981

---

## Re-detection — also Fixes #17069 (parent #17067)

The `stripe` / `repeat_payment` shadow diff
`router.typeDiff:response.Ok.TransactionResponse.mandate_reference.mandate_metadata`
`{hyperswitch:"object", ucs:"null"}` was re-detected in prod as #17069 (child of parent #17067),
12 occurrences. Same family / root cause as #16966/#16967 — this PR fixes it on the repeat path too
(`generate_repeat_payment_response` threads `m.mandate_metadata` into `ConnectorMandateReferenceId`).

- Live prod re-detection (Grafana, validation-service `VS_48`): req `019efd2e-5884-7b73-b8bb-66732b32f129`
  (2026-06-25 05:08 UTC, stripe, repeat→Authorize sub-flow) — paired with the `charges` diff (#17068),
  `mandate_metadata {hyperswitch:object, ucs:null}`, still firing as of 2026-06-25.
- Re-detection is a **stale prod build** (`2026.06.17.0-dirty-aef0be919`) that predates this fix:
  on `main`, proto `ConnectorMandateReferenceId` has no `mandate_metadata` slot, so the diff persists
  until this PR merges and prod rebuilds.

Fixes #17069

Also fixes an internal issue (stripe authorize / create_connector_customer sub-flow, same `mandate_reference.mandate_metadata` typeDiff family as above — closed by the same response-side mapping).


---

**Re-detection (#20165):** `stripe` / `authorize` (+`payment_method_token` sub-flow), same
`router.typeDiff:response.Ok.TransactionResponse.mandate_reference.mandate_metadata`
{hs:object, ucs:null}. 9th+ duplicate sighting since 2026-06-24 (after #16967, #16966, #16993,
#17050, #18238, #19863, #20158, #20172, #20177). Re-verified live on current `main` — diff still
reproduces. No new PR needed; this fix (paired with juspay/connector-service#1611, which was
rebased today to clear a stale-CI failure) already covers it. Still needs a human review approval
to merge.
