### PR TITLE
fix(ucs): drop empty connector_response_reference_id in setup_recurring response (novalnet setup_mandate)

### DIFF
--- a/crates/router/src/core/unified_connector_service/transformers.rs
+++ b/crates/router/src/core/unified_connector_service/transformers.rs
@@ -2909,7 +2909,8 @@ impl
                     connector_metadata,
                     network_txn_id: response.network_transaction_id,
                     network_txn_link_id: None,
-                    connector_response_reference_id: Some(response.merchant_recurring_payment_id.clone()),
+                    connector_response_reference_id: Some(response.merchant_recurring_payment_id.clone())
+                        .filter(|s| !s.is_empty()),
                     incremental_authorization_allowed: response.incremental_authorization_allowed,
                     authentication_data: None,
                     charges: response.splits.map(common_types::payments::ConnectorChargeResponseData::foreign_try_from).transpose()?,


### PR DESCRIPTION
## Summary

```
router.typeDiff: response.Ok.TransactionResponse.connector_response_reference_id
  { hyperswitch: null, ucs: string }   (16 occurrences, prod, merchant bu_de_getolo)
```

## Root cause

In the UCS client mapping for `PaymentServiceSetupRecurringResponse` (`unified_connector_service/transformers.rs`), the **success** branch set:

```rust
connector_response_reference_id: Some(response.merchant_recurring_payment_id.clone()),
```

`merchant_recurring_payment_id` is a **non-optional** proto `String`. On the prism (UCS) side it is populated by `generate_setup_mandate_response` via `extract_connector_request_reference_id(&connector_response_reference_id)`, which is `unwrap_or_default()` — i.e. it becomes `""` whenever the connector returns no transaction id.

For novalnet's `setup_mandate` 3DS-redirect response there is no `tid`, so the native (Direct) integration sets `connector_response_reference_id: transaction_id` → `None`, while the UCS path produced `Some("")` → a JSON string. Hence the `null` (Direct) vs `string` (UCS) type diff.

The **error** branch of this very function already guards against this with `.filter(|s| !s.is_empty())`; the success branch simply omitted it.

## Fix

Filter out the empty string so it maps to `None`, matching Direct and the error branch. One line; no proto/prism change required.

## Verification (local shadow stack)

Reproduced the prod diff and verified the fix via the validation service router-data comparison (VS_48 = diff, VS_46 = no diff):

**BEFORE** (`x-request-id 019ef5dd-f73d-7852-90ee-ad039daa3bd2`):
```
VS_48  typeDiff: {"response.Ok.TransactionResponse.connector_response_reference_id":
                  {"hyperswitch":"null","ucs":"string"}}
       keyDiff: {}  valueDiff: {}
```

**AFTER** (`x-request-id 019ef5e8-e4b9-7ca0-a7c0-7c36edf8bef5`, fixed router binary):
```
VS_46  Router data comparison completed successfully - no differences found
       total_key_differences: 0, total_value_differences: 0, total_type_differences: 0
       (hyperswitch_data_keys: 56, ucs_data_keys: 56)
```

Both runs were the same novalnet `setup_mandate` 3DS-redirect payment (status `requires_customer_action`, no `tid`).

> Note: internal tracking issue is the same shadow-validation diff
> (`router.typeDiff: response.Ok.TransactionResponse.connector_response_reference_id`,
> novalnet / setup_mandate, `{hyperswitch: null, ucs: string}`) re-observed on prod
> (samples `019ef34b-…`, `019ef374-…`, `019ef37b-…`; VS_48). It is fixed by this same
> one-line guard — cross-linked so the validation board surfaces it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

### Re-detection (internal tracking issue / #17060)

This exact diff was re-surfaced by the prod validation board as **hyperswitch-cloud#17059** (parent)
/ **#17060** (`router.typeDiff:response.Ok.TransactionResponse.connector_response_reference_id`,
novalnet / setup_mandate, 3 occurrences, first/last seen 2026-06-23). Grafana (prod Loki,
`namespace=validation-service`) confirms all three sample request ids
(`019ef34b-fae7-7cc2-85d0-bb803209bed8`, `019ef374-bbe9-7fb3-acd0-cf31e7549b15`,
`019ef37b-2394-7083-bc0b-da5f41e88d98`) produced the identical `VS_48`
`{"connector_response_reference_id":{"hyperswitch":"null","ucs":"string"}}` (total_type=1, 56 keys
both sides). The connector-service gRPC log for `019ef37b` shows novalnet returning HTTP 200
`status SUCCESS` with **`transaction.tid: null`** and a 3DS `redirect_url` — exactly the no-tid
redirect path this one-line empty-string guard fixes. No new PR; this same fix resolves the
re-detection.

Closes #12982
