### PR TITLE
feat(payments): support hyperswitch self-hosted vault for repeat-customer payments

### DIFF
--- a/api-reference/v1/openapi_spec_v1.json
+++ b/api-reference/v1/openapi_spec_v1.json
@@ -16522,6 +16522,11 @@
             "type": "string",
             "description": "The CVC number for the card",
             "nullable": true
+          },
+          "card_cvc_token": {
+            "type": "string",
+            "description": "Token referencing a CVC vaulted in the hyperswitch (self-hosted) vault. Used by the\nself-hosted default-vault repeat-customer flow, where the card is referenced by the\ntop-level `payment_token` and the freshly-tokenized CVC arrives as this token; the server\nresolves it to the raw CVC. Not used by the external vault proxy flow.",
+            "nullable": true
           }
         }
       },
@@ -29975,7 +29980,7 @@
             ],
             "properties": {
               "vault_card_token_data": {
-                "$ref": "#/components/schemas/CardToken"
+                "$ref": "#/components/schemas/VaultCardToken"
               }
             }
           }
@@ -44608,6 +44613,25 @@
         "description": "Represents a value in the DSL",
         "discriminator": {
           "propertyName": "type"
+        }
+      },
+      "VaultCardToken": {
+        "type": "object",
+        "description": "Card token data carried by the external vault proxy `vault_card_token_data` variant. Its\n`card_cvc` is a vault token detokenized on the wire by the external vault (e.g. VGS). Kept as a\ndistinct type from [`CardToken`] so the self-hosted `card_cvc_token` field does not leak into\nthe proxy contract.",
+        "required": [
+          "card_holder_name"
+        ],
+        "properties": {
+          "card_holder_name": {
+            "type": "string",
+            "description": "The card holder's name",
+            "example": "John Test"
+          },
+          "card_cvc": {
+            "type": "string",
+            "description": "The CVC number for the card (a vault token for the external vault proxy flow)",
+            "nullable": true
+          }
         }
       },
       "VaultDetails": {

--- a/api-reference/v2/openapi_spec_v2.json
+++ b/api-reference/v2/openapi_spec_v2.json
@@ -10871,6 +10871,11 @@
             "type": "string",
             "description": "The CVC number for the card",
             "nullable": true
+          },
+          "card_cvc_token": {
+            "type": "string",
+            "description": "Token referencing a CVC vaulted in the hyperswitch (self-hosted) vault. Used by the\nself-hosted default-vault repeat-customer flow, where the card is referenced by the\ntop-level `payment_token` and the freshly-tokenized CVC arrives as this token; the server\nresolves it to the raw CVC. Not used by the external vault proxy flow.",
+            "nullable": true
           }
         }
       },
@@ -22019,7 +22024,7 @@
             ],
             "properties": {
               "vault_card_token_data": {
-                "$ref": "#/components/schemas/CardToken"
+                "$ref": "#/components/schemas/VaultCardToken"
               }
             }
           }
@@ -32505,6 +32510,25 @@
         "description": "Represents a value in the DSL",
         "discriminator": {
           "propertyName": "type"
+        }
+      },
+      "VaultCardToken": {
+        "type": "object",
+        "description": "Card token data carried by the external vault proxy `vault_card_token_data` variant. Its\n`card_cvc` is a vault token detokenized on the wire by the external vault (e.g. VGS). Kept as a\ndistinct type from [`CardToken`] so the self-hosted `card_cvc_token` field does not leak into\nthe proxy contract.",
+        "required": [
+          "card_holder_name"
+        ],
+        "properties": {
+          "card_holder_name": {
+            "type": "string",
+            "description": "The card holder's name",
+            "example": "John Test"
+          },
+          "card_cvc": {
+            "type": "string",
+            "description": "The CVC number for the card (a vault token for the external vault proxy flow)",
+            "nullable": true
+          }
         }
       },
       "VaultDetails": {

--- a/crates/api_models/src/payments.rs
+++ b/crates/api_models/src/payments.rs
@@ -2701,6 +2701,43 @@ pub struct CardToken {
     #[schema(value_type = Option<String>)]
     #[smithy(value_type = "Option<String>")]
     pub card_cvc: Option<Secret<String>>,
+
+    /// Token referencing a CVC vaulted in the hyperswitch (self-hosted) vault. Used by the
+    /// self-hosted default-vault repeat-customer flow, where the card is referenced by the
+    /// top-level `payment_token` and the freshly-tokenized CVC arrives as this token; the server
+    /// resolves it to the raw CVC. Not used by the external vault proxy flow.
+    #[schema(value_type = Option<String>)]
+    #[smithy(value_type = "Option<String>")]
+    pub card_cvc_token: Option<Secret<String>>,
+}
+
+/// Card token data carried by the external vault proxy `vault_card_token_data` variant. Its
+/// `card_cvc` is a vault token detokenized on the wire by the external vault (e.g. VGS). Kept as a
+/// distinct type from [`CardToken`] so the self-hosted `card_cvc_token` field does not leak into
+/// the proxy contract.
+#[derive(
+    Eq,
+    PartialEq,
+    Debug,
+    serde::Deserialize,
+    serde::Serialize,
+    Clone,
+    ToSchema,
+    Default,
+    SmithyModel,
+)]
+#[serde(rename_all = "snake_case")]
+#[smithy(namespace = "com.hyperswitch.smithy.types")]
+pub struct VaultCardToken {
+    /// The card holder's name
+    #[schema(value_type = String, example = "John Test")]
+    #[smithy(value_type = "Option<String>")]
+    pub card_holder_name: Option<Secret<String>>,
+
+    /// The CVC number for the card (a vault token for the external vault proxy flow)
+    #[schema(value_type = Option<String>)]
+    #[smithy(value_type = "Option<String>")]
+    pub card_cvc: Option<Secret<String>>,
 }
 
 #[derive(
@@ -3499,14 +3536,15 @@ pub enum PaymentMethodData {
     /// Vault card data used for external vault proxy payments.
     /// When this variant is used, the payment will be routed through the external vault proxy flow.
     #[schema(title = "VaultDataCard")]
-    #[serde(rename = "vault_data_card")]
+    #[serde(rename = "vault_data_card", alias = "vault_card")]
     ProxyCard(Box<ProxyCardData>),
     /// Vault card token data used for external vault proxy payments with an already-saved card.
     /// The top-level `payment_token` resolves to a stored payment method whose external vault
     /// tokens are retrieved from the modular PM service; this variant carries the CVC / card
     /// holder name to combine with those tokens. Routed through the external vault proxy flow.
     #[schema(title = "VaultCardTokenData")]
-    VaultCardTokenData(CardToken),
+    #[serde(rename = "vault_card_token_data", alias = "vault_card_token")]
+    VaultCardTokenData(VaultCardToken),
 }
 
 pub trait GetAddressFromPaymentMethodData {

--- a/crates/hyperswitch_domain_models/src/payment_method_data.rs
+++ b/crates/hyperswitch_domain_models/src/payment_method_data.rs
@@ -1435,6 +1435,10 @@ pub struct CardToken {
 
     /// The CVC number for the card
     pub card_cvc: Option<Secret<String>>,
+
+    /// Token referencing a CVC vaulted in the hyperswitch (self-hosted) vault, resolved by the
+    /// server to the raw CVC for the self-hosted default-vault repeat-customer flow.
+    pub card_cvc_token: Option<Secret<String>>,
 }
 
 #[derive(serde::Deserialize, serde::Serialize, Debug, Clone, Eq, PartialEq)]
@@ -2856,10 +2860,12 @@ impl From<api_models::payments::CardToken> for CardToken {
         let api_models::payments::CardToken {
             card_holder_name,
             card_cvc,
+            card_cvc_token,
         } = value;
         Self {
             card_holder_name,
             card_cvc,
+            card_cvc_token,
         }
     }
 }

--- a/crates/openapi/src/openapi.rs
+++ b/crates/openapi/src/openapi.rs
@@ -627,6 +627,7 @@ Never share your secret api keys. Keep them guarded and secure.
         api_models::payments::Card,
         api_models::payments::CardRedirectData,
         api_models::payments::CardToken,
+        api_models::payments::VaultCardToken,
         api_models::payments::PaymentsRequest,
         api_models::payments::PaymentsCreateRequest,
         api_models::payments::PaymentsUpdateRequest,

--- a/crates/openapi/src/openapi_v2.rs
+++ b/crates/openapi/src/openapi_v2.rs
@@ -532,6 +532,7 @@ Never share your secret api keys. Keep them guarded and secure.
         api_models::payments::Card,
         api_models::payments::CardRedirectData,
         api_models::payments::CardToken,
+        api_models::payments::VaultCardToken,
         api_models::payments::ConnectorTokenDetails,
         api_models::payments::PaymentsRequest,
         api_models::payments::PaymentsResponse,

--- a/crates/router/src/core/payment_methods.rs
+++ b/crates/router/src/core/payment_methods.rs
@@ -2406,7 +2406,7 @@ impl PaymentMethodResolver {
                     Some(
                         vault::insert_cvc_using_payment_token(
                             state,
-                            &existing_pm.id,
+                            existing_pm.id.get_string_repr(),
                             cvc,
                             intent_fulfillment_time,
                             platform.get_provider().get_key_store(),
@@ -2658,7 +2658,7 @@ async fn execute_payment_method_create(
                 .async_map(|cvc| {
                     vault::insert_cvc_using_payment_token(
                         state,
-                        &payment_method.id,
+                        payment_method.id.get_string_repr(),
                         cvc,
                         intent_fulfillment_time,
                         platform.get_provider().get_key_store(),
@@ -2829,7 +2829,7 @@ pub async fn create_generic_volatile_payment_method(
                 .async_map(|cvc| {
                     vault::insert_cvc_using_payment_token(
                         state,
-                        &domain_payment_method.id,
+                        domain_payment_method.id.get_string_repr(),
                         cvc,
                         intent_fulfillment_time,
                         platform.get_provider().get_key_store(),
@@ -6357,20 +6357,28 @@ pub async fn payment_methods_session_retrieve(
     Ok(services::ApplicationResponse::Json(response))
 }
 
-/// Stores `card_cvc` and `card_holder_name` as a `TemporaryCardToken` in Redis under `token`.
+/// Stores `card_cvc` as an encrypted CVC under `pm_token_{token}_hyperswitch_cvc` — the same
+/// `_hyperswitch_cvc` mechanism used by the first-time flow — so CVC retrieval (router-side
+/// `retrieve_and_delete_cvc_from_payment_token`) resolves it consistently. The card holder name is
+/// not vaulted with the CVC token; it is carried by the saved payment method itself.
 #[cfg(feature = "v2")]
 async fn store_cvc_and_card_holder_name_as_payment_token_in_redis(
     state: &SessionState,
     token: &str,
     card_cvc: Option<Secret<String>>,
-    card_holder_name: Option<Secret<String>>,
+    _card_holder_name: Option<Secret<String>>,
+    key_store: &domain::MerchantKeyStore,
 ) -> RouterResult<()> {
-    let redis_token_data =
-        storage::PaymentTokenData::temporary_card_token(card_cvc, card_holder_name);
-    let intent_fulfillment_time = common_utils::consts::DEFAULT_INTENT_FULFILLMENT_TIME;
-    pm_routes::ParentPaymentMethodToken::create_key_for_token(&token.to_string())
-        .insert(intent_fulfillment_time, redis_token_data, state)
+    if let Some(card_cvc) = card_cvc {
+        vault::insert_cvc_using_payment_token(
+            state,
+            token,
+            card_cvc,
+            common_utils::consts::DEFAULT_INTENT_FULFILLMENT_TIME,
+            key_store,
+        )
         .await?;
+    }
     Ok(())
 }
 
@@ -6480,6 +6488,7 @@ pub async fn payment_methods_session_update_payment_method(
                 &parent_payment_method_token,
                 card_cvc,
                 card_holder_name,
+                platform.get_provider().get_key_store(),
             )
             .await?;
 
@@ -6541,6 +6550,7 @@ pub async fn payment_methods_session_update_payment_method(
                     &pm_token,
                     card_cvc,
                     card_holder_name,
+                    platform.get_provider().get_key_store(),
                 )
                 .await?;
             }
@@ -7174,7 +7184,7 @@ impl<'a> pm_types::PaymentMethodUpdateHandler<'a> {
             .async_map(|cvc| {
                 vault::insert_cvc_using_payment_token(
                     self.state,
-                    self.payment_method.get_id(),
+                    self.payment_method.get_id().get_string_repr(),
                     cvc,
                     common_utils::consts::DEFAULT_INTENT_FULFILLMENT_TIME,
                     self.platform.get_provider().get_key_store(),

--- a/crates/router/src/core/payment_methods/vault.rs
+++ b/crates/router/src/core/payment_methods/vault.rs
@@ -1,5 +1,5 @@
 use common_enums::PaymentMethodType;
-#[cfg(feature = "v2")]
+#[cfg(any(feature = "v1", feature = "v2"))]
 use common_utils::encryption::Encryption;
 use common_utils::{
     crypto::{DecodeMessage, EncodeMessage, GcmAes256},
@@ -41,6 +41,10 @@ use crate::{
     },
     utils::{ConnectorResponseExt, StringExt},
 };
+// `pm_cards` and `OptionExt` are imported for v2 via the larger v2-only `use` block below; the v1
+// build needs them for `retrieve_and_delete_cvc_from_payment_token` (self-hosted vault CVC retrieval).
+#[cfg(feature = "v1")]
+use crate::{core::payment_methods::cards as pm_cards, utils::ext_traits::OptionExt};
 #[cfg(feature = "v2")]
 use crate::{
     core::{
@@ -2329,7 +2333,7 @@ pub struct TemporaryVaultCvc {
 #[instrument(skip_all)]
 pub async fn insert_cvc_using_payment_token(
     state: &routes::SessionState,
-    payment_method_id: &id_type::GlobalPaymentMethodId,
+    token: &str,
     card_cvc: hyperswitch_masking::Secret<String>,
     fulfillment_time: i64,
     key_store: &domain::MerchantKeyStore,
@@ -2340,10 +2344,7 @@ pub async fn insert_cvc_using_payment_token(
         .change_context(errors::ApiErrorResponse::InternalServerError)
         .attach_printable("Failed to get redis connection")?;
 
-    let key = format!(
-        "pm_token_{}_hyperswitch_cvc",
-        payment_method_id.get_string_repr()
-    );
+    let key = format!("pm_token_{token}_hyperswitch_cvc");
 
     let payload_to_be_encrypted = TemporaryVaultCvc { card_cvc };
 
@@ -2378,7 +2379,7 @@ pub async fn insert_cvc_using_payment_token(
     Ok(card_token_cvc_storage)
 }
 
-#[cfg(feature = "v2")]
+#[cfg(any(feature = "v1", feature = "v2"))]
 #[instrument(skip_all)]
 pub async fn retrieve_and_delete_cvc_from_payment_token(
     state: &routes::SessionState,

--- a/crates/router/src/core/payment_methods/vault.rs
+++ b/crates/router/src/core/payment_methods/vault.rs
@@ -2413,7 +2413,7 @@ pub async fn retrieve_and_delete_cvc_from_payment_token(
     );
 
     // delete key after retrieving the cvc
-    redis_conn.delete_key(&key.into()).await.map_err(|err| {
+    let _ = redis_conn.delete_key(&key.into()).await.map_err(|err| {
         logger::error!("Failed to delete token from redis: {:?}", err);
     });
 

--- a/crates/router/src/core/payments/operations/payment_confirm.rs
+++ b/crates/router/src/core/payments/operations/payment_confirm.rs
@@ -1243,16 +1243,20 @@ impl<F: Clone + Send + Sync> Domain<F, api::PaymentsRequest, PaymentData<F>> for
             if let Some(payment_method_ref) = self.get_payment_method_reference(req) {
                 let payment_method_ref_to_use = match req.payment_token.as_deref() {
                     Some(payment_token) if payment_token == payment_method_ref => {
-                        let token_data = helpers::retrieve_payment_token_data(
+                        // Best-effort: resolve the token to its stored payment_method_id. A
+                        // self-hosted vault token minted by the modular PM service is not present in
+                        // the legacy redis token store (different key), so a miss/error here is not
+                        // fatal — fall back to using the reference as-is and let the modular fetch
+                        // resolve it, instead of failing the payment with "token invalid or expired".
+                        match helpers::retrieve_payment_token_data(
                             state,
                             payment_method_ref.to_string(),
                             req.payment_method,
                         )
-                        .await?;
-
-                        match token_data {
-                            storage::PaymentTokenData::Permanent(card_token_data)
-                            | storage::PaymentTokenData::PermanentCard(card_token_data) => {
+                        .await
+                        {
+                            Ok(storage::PaymentTokenData::Permanent(card_token_data))
+                            | Ok(storage::PaymentTokenData::PermanentCard(card_token_data)) => {
                                 card_token_data
                                     .payment_method_id
                                     .as_deref()
@@ -2359,6 +2363,23 @@ impl PaymentConfirm {
             Some(domain::PaymentMethodData::CardToken(token)) => Some(token),
             _ => None,
         };
+        // Self-hosted (default) vault repeat-customer flow: the saved card is referenced by the
+        // top-level `payment_token`, while the freshly-tokenized CVC arrives as `card_cvc_token`
+        // (minted by the modular PM service and stored in redis keyed by that token). Resolve it to
+        // the raw CVC here so the modular fetch below receives a usable card. `take()` consumes the
+        // token so it is not carried any further.
+        if let Some(token) = card_token_data.as_mut() {
+            if let Some(card_cvc_token) = token.card_cvc_token.take() {
+                let resolved_cvc =
+                    crate::core::payment_methods::vault::retrieve_and_delete_cvc_from_payment_token(
+                        state,
+                        card_cvc_token.peek(),
+                        platform.get_provider().get_key_store(),
+                    )
+                    .await?;
+                token.card_cvc = Some(resolved_cvc);
+            }
+        }
         if let Some(card_cvc) = req.card_cvc.clone() {
             if let Some(card_token_data) = card_token_data.as_mut() {
                 card_token_data.card_cvc = Some(card_cvc);
@@ -2366,6 +2387,7 @@ impl PaymentConfirm {
                 card_token_data = Some(domain::CardToken {
                     card_holder_name: None,
                     card_cvc: Some(card_cvc),
+                    card_cvc_token: None,
                 });
             }
         }

--- a/crates/router/src/core/payments/operations/payment_confirm_external_vault_proxy.rs
+++ b/crates/router/src/core/payments/operations/payment_confirm_external_vault_proxy.rs
@@ -555,6 +555,7 @@ impl<F: Clone + Send + Sync> Domain<F, PaymentsRequest, PaymentData<F>>
                     Some(domain::CardToken {
                         card_cvc: token_data.card_cvc.clone(),
                         card_holder_name: token_data.card_holder_name.clone(),
+                        card_cvc_token: None,
                     })
                 }
                 _ => None,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->

Supports the **hyperswitch self-hosted (default) vault** for repeat-customer card payments. When a merchant has **no external vault** configured (the PCI/SaaS setup, where the payment server can handle card data), card data is tokenized via the modular PM service and the payment is confirmed through the **normal payments core** — not the external vault proxy flow. The `vault_card_data` / `vault_card_token_data` shapes continue to route to the proxy core untouched; the self-hosted case uses the normal `payment_token` + `card_token` shapes.

Pieces:

1. **API types**
   - Add an optional `card_cvc_token` to `CardToken` (the self-hosted repeat flow references the saved card by the top-level `payment_token` and carries the freshly-tokenized CVC as this token).
   - Split the external-vault-proxy `vault_card_token_data` payload into its own `VaultCardToken` type (identical fields) so the new field does not leak into the proxy contract.

2. **Confirm flow** (`payment_confirm.rs`)
   - Resolve a modular-minted `payment_token` **best-effort**: a redis miss is no longer fatal — fall back to using the reference as-is and let the modular fetch resolve it (instead of failing with "token invalid or expired").
   - Resolve `card_cvc_token` → raw CVC in the modular-fetch path and attach it to the card.

3. **CVC storage alignment** (`vault.rs`, `payment_methods.rs`)
   - `update-saved-payment-method` now stores the CVC via the shared `_hyperswitch_cvc` mechanism (`insert_cvc_using_payment_token`) instead of a `TemporaryCardToken`, so the **store and retrieve sides use the same key**.
   - `retrieve_and_delete_cvc_from_payment_token` is made available to v1; `insert_cvc_using_payment_token` takes a `&str` key so the minted token can reuse it.

### Additional Changes

- [x] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
-->

For merchants on the default hyperswitch vault (no external vault), there was no working repeat-customer path: a saved-card confirm using a modular-minted `payment_token` failed token resolution, and there was no way to carry a freshly-tokenized CVC for the saved card. This adds that path while keeping the external-vault proxy flow and `payments_core` cleanly separated (the self-hosted case never enters the proxy core).

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually?
-->
**Setup used**
- Profile (external vault disabled, modular enabled): `pro_bsOCSNWEF35YqCmzlsiY`
- Connector: `checkout` · Card: `4111 1111 1111 1111` exp `03/2031` cvc `737`
- Services: v1 router `:8080`, modular/v2 `:3030`, UCS `:8000`

> Note: the profile must have `external_vault_connector_details = null` (clearing it is what makes
> the session return the hyperswitch/internal vault rather than an external vault).

---

## A. First-time customer (fresh card)

### 1. Create customer  ·  `POST :3030/v1/customers`

```bash
curl --location 'http://localhost:3030/v1/customers' \
--header 'Content-Type: application/json' \
--header 'x-profile-id: pro_bsOCSNWEF35YqCmzlsiY' \
--header 'Authorization: api-key=dev_fvKtG0E9nMjG5rslWtI0ChxR9AmjVtYAUosc4vjht1RIXL4ZabnjSUTPQnqIbwvx' \
--data-raw '{
  "merchant_reference_id": "selfhost_doc_001",
  "name": "Doc Tester",
  "email": "doc@example.com",
  "phone": "9999999999",
  "phone_country_code": "+1"
}'
```

Response:
```json
{
  "id": "0a_cus_019ef61ff18a7e32bc8023eba5210f36",
  "merchant_reference_id": "selfhost_doc_001",
  "name": "Doc Tester",
  "email": "doc@example.com"
}
```

### 2. Create payment intent  ·  `POST :8080/payments`

```bash
curl --location 'http://localhost:8080/payments' \
--header 'Content-Type: application/json' \
--header 'api-key: dev_fvKtG0E9nMjG5rslWtI0ChxR9AmjVtYAUosc4vjht1RIXL4ZabnjSUTPQnqIbwvx' \
--data-raw '{
  "amount": 1000,
  "currency": "USD",
  "profile_id": "pro_bsOCSNWEF35YqCmzlsiY",
  "confirm": false,
  "capture_method": "automatic",
  "customer_id": "0a_cus_019ef622a3a477d08282c4aa810979a2",
  "setup_future_usage": "off_session",
  "authentication_type": "no_three_ds",
  "return_url": "https://google.com"
}'
```

Response (key fields):
```json
{
  "payment_id": "pay_iYTG3iUipdTQ99k4omiP",
  "status": "requires_payment_method",
  "amount": 1000,
  "currency": "USD",
  "customer_id": "0a_cus_019ef61ff18a7e32bc8023eba5210f36",
  "client_secret": "pay_iYTG3iUipdTQ99k4omiP_secret_zBA0cNzh2ZNY2fXT1h7i"
}
```

> The create response also returns `sdk_authorization` (used as the `Authorization` for `/client`).

### 3. Session tokens  ·  `POST :8080/payments/session_tokens`

```bash
curl --location 'http://localhost:8080/payments/session_tokens' \
--header 'Content-Type: application/json' \
--header 'api-key: pk_dev_851f0ff229564c419cdc0df5ecb34e38' \
--data-raw '{
  "payment_id": "pay_Iv7HwmzVijlYyoRvQdhV",
  "client_secret": "pay_iYTG3iUipdTQ99k4omiP_secret_zBA0cNzh2ZNY2fXT1h7i",
  "wallets": []
}'
```

Response (`vault_details` shows the hyperswitch/internal vault + the PM-session SDK auth):
```json
{
  "payment_id": "pay_iYTG3iUipdTQ99k4omiP",
  "vault_details": {
    "vault_type": "hyperswitch",
    "vault_data": {
      "sdk_authorization": "cHJvZmlsZV9pZD1wcm9fYnNPQ1NOV0VGMzVZcUNtemxzaVkscHVibGlzaGFibGVfa2V5PXBrX2Rldl84NTFmMGZmMjI5NTY0YzQxOWNkYzBkZjVlY2IzNGUzOCxjbGllbnRfc2VjcmV0PWNzXzAxOWVmNjFmZjI3ZjcyYjM5NmYzMWY4MTY2ZGJjNzkxLGN1c3RvbWVyX2lkPTBhX2N1c18wMTllZjYxZmYxOGE3ZTMyYmM4MDIzZWJhNTIxMGYzNixwYXltZW50X21ldGhvZF9zZXNzaW9uX2lkPTBhX3Btc18wMTllZjYxZmYyN2U3NGIzYjIyYjI1OTdmZjEyMzQwYg=="
    }
  }
}
```

### 4. Tokenize the card  ·  `POST :3030/v1/payment-method-sessions/{pms_id}/confirm`

The `pms_id` and `Authorization` come from the `sdk_authorization` above (it base64-decodes to `...,payment_method_session_id=<pms_id>`).

```bash
curl --location 'http://localhost:3030/v1/payment-method-sessions/{pms_id}/confirm' \
--header 'x-profile-id: pro_bsOCSNWEF35YqCmzlsiY' \
--header 'Authorization: <sdk_authorization from session_tokens vault_details>' \
--header 'Content-Type: application/json' \
--header 'Authorization: api-key=dev_BjzZ0Dh2oPuRhIJpUE5HUBbf5RNqmto83jBw5PQUwwb61mkqDEZEfnU5HbfCyQ8m' \
--data-raw '{
  "payment_method_type": "card",
  "payment_method_subtype": "credit",
  "payment_method_data": {
    "card": {
      "card_number": "4111111111111111",
      "card_exp_month": "03",
      "card_exp_year": "2031",
      "card_network": "Visa",
      "card_holder_name": "joseph Doe",
      "card_cvc": "737"
    }
  },
  "customer_acceptance": {
    "acceptance_type": "offline",
    "accepted_at": "1963-05-03T04:07:52.723Z",
    "online": {
      "ip_address": "125.0.0.1",
      "user_agent": "x"
    }
  }
}'
```

Response (the saved-card token is `associated_payment_methods[0].payment_method_token.data`):
```json
{
  "id": "0a_pms_019ef61ff27e74b3b22b2597ff12340b",
  "customer_id": "0a_cus_019ef61ff18a7e32bc8023eba5210f36",
  "associated_payment_methods": [
    {
      "payment_method_token": {
        "type": "payment_method_session_token",
        "data": "token_rStI8jVSX7pBXxbOu1xO"
      }
    }
  ],
  "card_cvc_token_storage": {
    "is_stored": true,
    "expires_at": "2026-06-23T20:30:49.542Z"
  },
  "associated_token_id": null,
  "storage_type": "persistent"
}
```

### 5. Confirm — `payment_token` only  ·  `POST :8080/payments/{payment_id}/confirm`

```bash
curl --location 'http://localhost:8080/payments/pay_iYTG3iUipdTQ99k4omiP/confirm' \
--header 'Content-Type: application/json' \
--header 'api-key: dev_fvKtG0E9nMjG5rslWtI0ChxR9AmjVtYAUosc4vjht1RIXL4ZabnjSUTPQnqIbwvx' \
--data-raw '{
  "payment_method": "card",
  "payment_method_type": "credit",
  "connector": [
    "checkout"
  ],
  "payment_token": "token_rStI8jVSX7pBXxbOu1xO",
  "customer_acceptance": {
    "acceptance_type": "offline",
    "accepted_at": "1963-05-03T04:07:52.723Z",
    "online": {
      "ip_address": "125.0.0.1",
      "user_agent": "x"
    }
  },
  "billing": {
    "address": {
      "line1": "1467",
      "city": "SF",
      "state": "California",
      "zip": "94122",
      "country": "US",
      "first_name": "joseph",
      "last_name": "Doe"
    },
    "email": "guest@example.com",
    "phone": {
      "number": "9123456789",
      "country_code": "+1"
    }
  },
  "browser_info": {
    "ip_address": "129.0.0.1",
    "user_agent": "Mozilla/5.0",
    "accept_header": "text/html",
    "language": "en-US",
    "color_depth": 32,
    "screen_height": 1117,
    "screen_width": 1728,
    "time_zone": -330,
    "java_enabled": true,
    "java_script_enabled": true
  }
}'
```

Response (key fields):
```json
{
  "payment_id": "pay_iYTG3iUipdTQ99k4omiP",
  "status": "succeeded",
  "amount": 1000,
  "currency": "USD",
  "customer_id": "0a_cus_019ef61ff18a7e32bc8023eba5210f36",
  "connector": "checkout",
  "payment_method": "card",
  "payment_method_type": "credit",
  "payment_method_id": "0a_pm_019ef61ff2e57da197d0ddd6393627db",
  "connector_transaction_id": "pay_kpyfc2ybebmyvmwl52zmzy2pxu",
  "client_secret": "pay_iYTG3iUipdTQ99k4omiP_secret_zBA0cNzh2ZNY2fXT1h7i",
  "setup_future_usage": "off_session",
  "error_code": null,
  "error_message": null
}
```


---

## B. Repeat customer (saved card + fresh CVC)

### 6. Create payment intent  ·  `POST :8080/payments`

```bash
curl --location 'http://localhost:8080/payments' \
--header 'Content-Type: application/json' \
--header 'api-key: dev_fvKtG0E9nMjG5rslWtI0ChxR9AmjVtYAUosc4vjht1RIXL4ZabnjSUTPQnqIbwvx' \
--data-raw '{
  "amount": 1000,
  "currency": "USD",
  "profile_id": "pro_bsOCSNWEF35YqCmzlsiY",
  "confirm": false,
  "capture_method": "automatic",
  "customer_id": "0a_cus_019ef61ff18a7e32bc8023eba5210f36",
  "authentication_type": "no_three_ds",
  "return_url": "https://google.com"
}'
```

Response (key fields):
```json
{
  "payment_id": "pay_frAZXRzDlrcPsj4G49ly",
  "status": "requires_payment_method",
  "customer_id": "0a_cus_019ef61ff18a7e32bc8023eba5210f36",
  "client_secret": "pay_frAZXRzDlrcPsj4G49ly_secret_YIzDrDoHCvUxOZ7tSDG1"
}
```

### 7. List saved methods  ·  `GET :8080/payments/{payment_id}/client`

`Authorization` = the `sdk_authorization` from the create response.

```bash
curl --location 'http://localhost:8080/payments/pay_frAZXRzDlrcPsj4G49ly/client' \
--header 'Authorization: <sdk_authorization from the payment-create response>' \
--header 'api-key: dev_fvKtG0E9nMjG5rslWtI0ChxR9AmjVtYAUosc4vjht1RIXL4ZabnjSUTPQnqIbwvx'
```

Response (take `payment_token` of the saved card):
```json
{
  "customer_payment_methods": [
    {
      "payment_token": "token_fVZo2LRZv7uBiGSw1YTw",
      "payment_method": "card",
      "payment_method_type": "credit",
      "requires_cvv": true,
      "payment_method_data": {
        "card": {
          "scheme": null,
          "last4_digits": "1111",
          "card_network": null
        }
      }
    }
  ]
}
```

### 8. Session tokens  ·  `POST :8080/payments/session_tokens`

```bash
curl --location 'http://localhost:8080/payments/session_tokens' \
--header 'Content-Type: application/json' \
--header 'api-key: pk_dev_851f0ff229564c419cdc0df5ecb34e38' \
--data-raw '{
  "payment_id": "pay_frAZXRzDlrcPsj4G49ly",
  "client_secret": "pay_frAZXRzDlrcPsj4G49ly_secret_YIzDrDoHCvUxOZ7tSDG1",
  "wallets": []
}'
```

Response:
```json
{
  "payment_id": "pay_frAZXRzDlrcPsj4G49ly",
  "vault_details": {
    "vault_type": "hyperswitch",
    "vault_data": {
      "sdk_authorization": "cHJvZmlsZV9pZD1wcm9fYnNPQ1NOV0VGMzVZcUNtemxzaVkscHVibGlzaGFibGVfa2V5PXBrX2Rldl84NTFmMGZmMjI5NTY0YzQxOWNkYzBkZjVlY2IzNGUzOCxjbGllbnRfc2VjcmV0PWNzXzAxOWVmNjIwNmU2NTdlODM5YjQ4MTU4YTE1MGUwNTk3LGN1c3RvbWVyX2lkPTBhX2N1c18wMTllZjYxZmYxOGE3ZTMyYmM4MDIzZWJhNTIxMGYzNixwYXltZW50X21ldGhvZF9zZXNzaW9uX2lkPTBhX3Btc18wMTllZjYyMDZlNjU3ZTgzOWI0ODE1NzIyNmNmYTIyZg=="
    }
  }
}
```

### 9. Tokenize the fresh CVC  ·  `PUT :3030/v1/payment-method-sessions/{pms_id}/update-saved-payment-method`

Mints the `card_cvc_token`. `pms_id`/`Authorization` from the session-token SDK auth above.

```bash
curl --location --request PUT 'http://localhost:3030/v1/payment-method-sessions/{pms_id}/update-saved-payment-method' \
--header 'x-profile-id: pro_bsOCSNWEF35YqCmzlsiY' \
--header 'Authorization: <sdk_authorization from session_tokens vault_details>' \
--header 'Content-Type: application/json' \
--header 'Authorization: api-key=dev_BjzZ0Dh2oPuRhIJpUE5HUBbf5RNqmto83jBw5PQUwwb61mkqDEZEfnU5HbfCyQ8m' \
--data-raw '{
  "payment_method_data": {
    "card": {
      "card_cvc": "123"
    }
  }
}'
```

Response (the `card_cvc_token` is `associated_payment_methods[0].payment_method_token.data`):
```json
{
  "id": "0a_pms_019ef6206e657e839b48157226cfa22f",
  "customer_id": "0a_cus_019ef61ff18a7e32bc8023eba5210f36",
  "associated_payment_methods": [
    {
      "payment_method_token": {
        "type": "payment_method_session_token",
        "data": "token_fGJZRD6ZQWOQbLfVlUHv"
      }
    }
  ],
  "card_cvc_token_storage": null,
  "associated_token_id": null,
  "storage_type": "persistent"
}
```

### 10. Confirm — `payment_token` + `card_cvc_token`  ·  `POST :8080/payments/{payment_id}/confirm`

```bash
curl --location 'http://localhost:8080/payments/pay_frAZXRzDlrcPsj4G49ly/confirm' \
--header 'Content-Type: application/json' \
--header 'api-key: dev_fvKtG0E9nMjG5rslWtI0ChxR9AmjVtYAUosc4vjht1RIXL4ZabnjSUTPQnqIbwvx' \
--data-raw '{
  "payment_method": "card",
  "payment_method_type": "credit",
  "connector": [
    "checkout"
  ],
  "payment_token": "token_fVZo2LRZv7uBiGSw1YTw",
  "payment_method_data": {
    "card_token": {
      "card_cvc_token": "token_fGJZRD6ZQWOQbLfVlUHv"
    }
  },
  "customer_acceptance": {
    "acceptance_type": "offline",
    "accepted_at": "1963-05-03T04:07:52.723Z",
    "online": {
      "ip_address": "125.0.0.1",
      "user_agent": "x"
    }
  },
  "billing": {
    "address": {
      "line1": "1467",
      "city": "SF",
      "state": "California",
      "zip": "94122",
      "country": "US",
      "first_name": "joseph",
      "last_name": "Doe"
    },
    "email": "guest@example.com",
    "phone": {
      "number": "9123456789",
      "country_code": "+1"
    }
  },
  "browser_info": {
    "ip_address": "129.0.0.1",
    "user_agent": "Mozilla/5.0",
    "accept_header": "text/html",
    "language": "en-US",
    "color_depth": 32,
    "screen_height": 1117,
    "screen_width": 1728,
    "time_zone": -330,
    "java_enabled": true,
    "java_script_enabled": true
  }
}'
```

Response (key fields):
```json
{
  "payment_id": "pay_frAZXRzDlrcPsj4G49ly",
  "status": "succeeded",
  "amount": 1000,
  "currency": "USD",
  "customer_id": "0a_cus_019ef61ff18a7e32bc8023eba5210f36",
  "connector": "checkout",
  "payment_method": "card",
  "payment_method_type": "credit",
  "payment_method_id": "0a_pm_019ef61ff2e57da197d0ddd6393627db",
  "connector_transaction_id": "pay_egmpl4qb3isi3bfs7r5k3exvia",
  "client_secret": "pay_frAZXRzDlrcPsj4G49ly_secret_YIzDrDoHCvUxOZ7tSDG1",
  "setup_future_usage": null,
  "error_code": null,
  "error_message": null
}
```



## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
