### PR TITLE
fix(router): use UCS connector_metadata for redsys pre_authenticate readback (shadow parity #16979)

### DIFF
--- a/crates/router/src/core/payments/flows/authorize_flow.rs
+++ b/crates/router/src/core/payments/flows/authorize_flow.rs
@@ -1470,7 +1470,7 @@ fn transform_response_for_pre_authenticate_flow(
                 resource_id,
                 redirection_data,
                 mandate_reference,
-                connector_metadata: _,
+                connector_metadata: ucs_connector_metadata,
                 network_txn_id,
                 network_txn_link_id,
                 connector_response_reference_id,
@@ -1513,19 +1513,30 @@ fn transform_response_for_pre_authenticate_flow(
                                         .map(|v| v == "true")
                                         .unwrap_or(true),
                                 };
-                            // Set connector_metadata with invoke data, clear redirection_data
-                            (serde_json::to_value(&invoke_data).ok(), Box::new(None))
+                            // Prefer the connector_metadata UCS already mapped from
+                            // connector_feature_data (it mirrors hyperswitch's native
+                            // `RedsysThreeDsInvokeData`); fall back to deriving it from the
+                            // 3DS-method form_fields for older UCS builds. Clear redirection_data
+                            // so the `invoke_hidden_iframe` next_action is generated.
+                            (
+                                ucs_connector_metadata
+                                    .clone()
+                                    .or_else(|| serde_json::to_value(&invoke_data).ok()),
+                                Box::new(None),
+                            )
                         } else {
-                            // 3DS exempt or challenge - keep redirection_data, no special connector_metadata
-                            (None, redirection_data)
+                            // 3DS exempt or challenge - keep redirection_data and the
+                            // connector_metadata UCS mapped from connector_feature_data.
+                            (ucs_connector_metadata.clone(), redirection_data)
                         }
                     } else {
                         // Not a Form type redirect
-                        (None, redirection_data)
+                        (ucs_connector_metadata.clone(), redirection_data)
                     }
                 } else {
-                    // No redirection data
-                    (None, redirection_data)
+                    // No redirection data (3DS exempt): keep the connector_metadata UCS mapped
+                    // from connector_feature_data so it matches hyperswitch's native response.
+                    (ucs_connector_metadata.clone(), redirection_data)
                 };
 
             Ok(


### PR DESCRIPTION
## Issue
Shadow validation — `redsys / pre_authenticate` (juspay/hyperswitch-cloud#16979, child #16982).

`transform_response_for_pre_authenticate_flow` (UCS pre_authenticate readback, redsys arm) **discarded** the `connector_metadata` that the UCS readback had already mapped from the gRPC `connector_feature_data` (`connector_metadata: _`), re-deriving it **only** from `redirection_data.form_fields`. On the redsys **3DS-exempt** path there is no form, so `connector_metadata` collapsed to `null` while hyperswitch's native gateway produces an object → router-data `typeDiff response.Ok.TransactionResponse.connector_metadata {hyperswitch:"object", ucs:"null"}`.

## Fix
Bind the readback `connector_metadata` (`ucs_connector_metadata`) and prefer it:
- **3DS-method/invoke** path: use the UCS-mapped metadata (it mirrors native `RedsysThreeDsInvokeData`); fall back to deriving from `form_fields` for older UCS builds. Still clear `redirection_data` so the `invoke_hidden_iframe` next_action is generated.
- **3DS-exempt / non-invoke** paths: pass the UCS-mapped metadata through (was hardcoded `None`).

Functionally unchanged for the invoke iframe decision (`should_continue_*` parses the same `PaymentsConnectorThreeDsInvokeData`); only the previously-dropped exempt metadata is now preserved.

Pairs with **juspay/hyperswitch-prism#1616**, which makes the UCS redsys transformer populate `connector_feature_data` (+ `resource_id`, `authentication_data`). Merge that first; without it this PR is a safe no-op (old UCS sends no `connector_feature_data`, so the invoke fallback path is used and exempt stays `None` as today).

## Verification (local shadow stack, router-data comparison)
- **BEFORE** (clean `main`, req `019ef60b-d8e1-7950-9a61-b1566da6553c`): `VS_48` →
  `typeDiff {resource_id: object/string, connector_metadata: object/null}`
- **AFTER** (prism#1616 + this PR, req `019ef621-6db3-7db3-99a7-bc1b22ee4f8e`, reconfirmed ×3): `VS_46` →
  `Router data comparison completed successfully - no differences found`.

Part of #16979 (#16982). Also covers re-detection #17044 (`connector_metadata` typeDiff).