### PR TITLE
fix(core): map split_payments on UCS capture request to rebuild charges (#16992)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2264,7 +2264,7 @@ dependencies = [
 [[package]]
 name = "config_patch_derive"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?rev=a4c63ec8d6e43c6c3f25c48e60ffbb33c5ef6dcf#a4c63ec8d6e43c6c3f25c48e60ffbb33c5ef6dcf"
+source = "git+https://github.com/juspay/connector-service?rev=7cfdd9041e4c0d2bd00789df0459e1175f14d72d#7cfdd9041e4c0d2bd00789df0459e1175f14d72d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3981,7 +3981,7 @@ checksum = "32619942b8be646939eaf3db0602b39f5229b74575b67efc897811ded1db4e57"
 [[package]]
 name = "grpc-api-types"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?rev=a4c63ec8d6e43c6c3f25c48e60ffbb33c5ef6dcf#a4c63ec8d6e43c6c3f25c48e60ffbb33c5ef6dcf"
+source = "git+https://github.com/juspay/connector-service?rev=7cfdd9041e4c0d2bd00789df0459e1175f14d72d#7cfdd9041e4c0d2bd00789df0459e1175f14d72d"
 dependencies = [
  "axum 0.8.4",
  "bytes 1.10.1",
@@ -8176,7 +8176,7 @@ dependencies = [
 [[package]]
 name = "rust-grpc-client"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?rev=a4c63ec8d6e43c6c3f25c48e60ffbb33c5ef6dcf#a4c63ec8d6e43c6c3f25c48e60ffbb33c5ef6dcf"
+source = "git+https://github.com/juspay/connector-service?rev=7cfdd9041e4c0d2bd00789df0459e1175f14d72d#7cfdd9041e4c0d2bd00789df0459e1175f14d72d"
 dependencies = [
  "grpc-api-types",
 ]
@@ -11010,7 +11010,7 @@ checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
 [[package]]
 name = "ucs_cards"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?rev=a4c63ec8d6e43c6c3f25c48e60ffbb33c5ef6dcf#a4c63ec8d6e43c6c3f25c48e60ffbb33c5ef6dcf"
+source = "git+https://github.com/juspay/connector-service?rev=7cfdd9041e4c0d2bd00789df0459e1175f14d72d#7cfdd9041e4c0d2bd00789df0459e1175f14d72d"
 dependencies = [
  "bytes 1.10.1",
  "error-stack 0.4.1",
@@ -11026,7 +11026,7 @@ dependencies = [
 [[package]]
 name = "ucs_common_enums"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?rev=a4c63ec8d6e43c6c3f25c48e60ffbb33c5ef6dcf#a4c63ec8d6e43c6c3f25c48e60ffbb33c5ef6dcf"
+source = "git+https://github.com/juspay/connector-service?rev=7cfdd9041e4c0d2bd00789df0459e1175f14d72d#7cfdd9041e4c0d2bd00789df0459e1175f14d72d"
 dependencies = [
  "serde",
  "strum 0.26.3",
@@ -11037,7 +11037,7 @@ dependencies = [
 [[package]]
 name = "ucs_common_utils"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?rev=a4c63ec8d6e43c6c3f25c48e60ffbb33c5ef6dcf#a4c63ec8d6e43c6c3f25c48e60ffbb33c5ef6dcf"
+source = "git+https://github.com/juspay/connector-service?rev=7cfdd9041e4c0d2bd00789df0459e1175f14d72d#7cfdd9041e4c0d2bd00789df0459e1175f14d72d"
 dependencies = [
  "anyhow",
  "base64 0.21.7",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2264,7 +2264,7 @@ dependencies = [
 [[package]]
 name = "config_patch_derive"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.06.23.1#2a748b69578e5d61c4586b30aabddad0ed7fd88a"
+source = "git+https://github.com/juspay/connector-service?rev=a4c63ec8d6e43c6c3f25c48e60ffbb33c5ef6dcf#a4c63ec8d6e43c6c3f25c48e60ffbb33c5ef6dcf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3981,7 +3981,7 @@ checksum = "32619942b8be646939eaf3db0602b39f5229b74575b67efc897811ded1db4e57"
 [[package]]
 name = "grpc-api-types"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.06.23.1#2a748b69578e5d61c4586b30aabddad0ed7fd88a"
+source = "git+https://github.com/juspay/connector-service?rev=a4c63ec8d6e43c6c3f25c48e60ffbb33c5ef6dcf#a4c63ec8d6e43c6c3f25c48e60ffbb33c5ef6dcf"
 dependencies = [
  "axum 0.8.4",
  "bytes 1.10.1",
@@ -8176,7 +8176,7 @@ dependencies = [
 [[package]]
 name = "rust-grpc-client"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.06.23.1#2a748b69578e5d61c4586b30aabddad0ed7fd88a"
+source = "git+https://github.com/juspay/connector-service?rev=a4c63ec8d6e43c6c3f25c48e60ffbb33c5ef6dcf#a4c63ec8d6e43c6c3f25c48e60ffbb33c5ef6dcf"
 dependencies = [
  "grpc-api-types",
 ]
@@ -11010,7 +11010,7 @@ checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
 [[package]]
 name = "ucs_cards"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.06.23.1#2a748b69578e5d61c4586b30aabddad0ed7fd88a"
+source = "git+https://github.com/juspay/connector-service?rev=a4c63ec8d6e43c6c3f25c48e60ffbb33c5ef6dcf#a4c63ec8d6e43c6c3f25c48e60ffbb33c5ef6dcf"
 dependencies = [
  "bytes 1.10.1",
  "error-stack 0.4.1",
@@ -11026,7 +11026,7 @@ dependencies = [
 [[package]]
 name = "ucs_common_enums"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.06.23.1#2a748b69578e5d61c4586b30aabddad0ed7fd88a"
+source = "git+https://github.com/juspay/connector-service?rev=a4c63ec8d6e43c6c3f25c48e60ffbb33c5ef6dcf#a4c63ec8d6e43c6c3f25c48e60ffbb33c5ef6dcf"
 dependencies = [
  "serde",
  "strum 0.26.3",
@@ -11037,7 +11037,7 @@ dependencies = [
 [[package]]
 name = "ucs_common_utils"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.06.23.1#2a748b69578e5d61c4586b30aabddad0ed7fd88a"
+source = "git+https://github.com/juspay/connector-service?rev=a4c63ec8d6e43c6c3f25c48e60ffbb33c5ef6dcf#a4c63ec8d6e43c6c3f25c48e60ffbb33c5ef6dcf"
 dependencies = [
  "anyhow",
  "base64 0.21.7",

--- a/crates/external_services/Cargo.toml
+++ b/crates/external_services/Cargo.toml
@@ -80,7 +80,7 @@ http = "0.2.12"
 url = { version = "2.5.4", features = ["serde"] }
 quick-xml = { version = "0.31.0", features = ["serialize"] }
 
-unified-connector-service-client = { git = "https://github.com/juspay/connector-service", tag = "2026.06.23.1", package = "rust-grpc-client" }
+unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "a4c63ec8d6e43c6c3f25c48e60ffbb33c5ef6dcf", package = "rust-grpc-client" }
 open-feature = { version = "0.2.5", optional = true }
 superposition_provider = { version = "0.102.0", optional = true }
 superposition_types = "0.102.0"

--- a/crates/external_services/Cargo.toml
+++ b/crates/external_services/Cargo.toml
@@ -80,7 +80,7 @@ http = "0.2.12"
 url = { version = "2.5.4", features = ["serde"] }
 quick-xml = { version = "0.31.0", features = ["serialize"] }
 
-unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "a4c63ec8d6e43c6c3f25c48e60ffbb33c5ef6dcf", package = "rust-grpc-client" }
+unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "7cfdd9041e4c0d2bd00789df0459e1175f14d72d", package = "rust-grpc-client" }
 open-feature = { version = "0.2.5", optional = true }
 superposition_provider = { version = "0.102.0", optional = true }
 superposition_types = "0.102.0"

--- a/crates/hyperswitch_interfaces/Cargo.toml
+++ b/crates/hyperswitch_interfaces/Cargo.toml
@@ -33,7 +33,7 @@ time = "0.3.41"
 tonic = "0.14"
 url = { version = "2.5.4", features = ["serde"] }
 
-unified-connector-service-client = { git = "https://github.com/juspay/connector-service", tag = "2026.06.23.1", package = "rust-grpc-client" }
+unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "a4c63ec8d6e43c6c3f25c48e60ffbb33c5ef6dcf", package = "rust-grpc-client" }
 tokio = { version = "1.45.1", features = ["macros", "rt-multi-thread"] }
 
 # First party crates

--- a/crates/hyperswitch_interfaces/Cargo.toml
+++ b/crates/hyperswitch_interfaces/Cargo.toml
@@ -33,7 +33,7 @@ time = "0.3.41"
 tonic = "0.14"
 url = { version = "2.5.4", features = ["serde"] }
 
-unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "a4c63ec8d6e43c6c3f25c48e60ffbb33c5ef6dcf", package = "rust-grpc-client" }
+unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "7cfdd9041e4c0d2bd00789df0459e1175f14d72d", package = "rust-grpc-client" }
 tokio = { version = "1.45.1", features = ["macros", "rt-multi-thread"] }
 
 # First party crates

--- a/crates/router/Cargo.toml
+++ b/crates/router/Cargo.toml
@@ -91,8 +91,8 @@ ring = "0.17.14"
 rust_decimal = { version = "1.37.1", features = ["serde-with-float", "serde-with-str"] }
 rust-i18n = { git = "https://github.com/kashif-m/rust-i18n", rev = "f2d8096aaaff7a87a847c35a5394c269f75e077a" }
 
-unified-connector-service-client = { git = "https://github.com/juspay/connector-service", tag = "2026.06.23.1", package = "rust-grpc-client" }
-unified-connector-service-cards = { git = "https://github.com/juspay/connector-service", tag = "2026.06.23.1", package = "ucs_cards" }
+unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "a4c63ec8d6e43c6c3f25c48e60ffbb33c5ef6dcf", package = "rust-grpc-client" }
+unified-connector-service-cards = { git = "https://github.com/juspay/connector-service", rev = "a4c63ec8d6e43c6c3f25c48e60ffbb33c5ef6dcf", package = "ucs_cards" }
 rustc-hash = "1.1.0"
 rustls = "0.22"
 rustls-pemfile = "2"

--- a/crates/router/Cargo.toml
+++ b/crates/router/Cargo.toml
@@ -91,8 +91,8 @@ ring = "0.17.14"
 rust_decimal = { version = "1.37.1", features = ["serde-with-float", "serde-with-str"] }
 rust-i18n = { git = "https://github.com/kashif-m/rust-i18n", rev = "f2d8096aaaff7a87a847c35a5394c269f75e077a" }
 
-unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "a4c63ec8d6e43c6c3f25c48e60ffbb33c5ef6dcf", package = "rust-grpc-client" }
-unified-connector-service-cards = { git = "https://github.com/juspay/connector-service", rev = "a4c63ec8d6e43c6c3f25c48e60ffbb33c5ef6dcf", package = "ucs_cards" }
+unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "7cfdd9041e4c0d2bd00789df0459e1175f14d72d", package = "rust-grpc-client" }
+unified-connector-service-cards = { git = "https://github.com/juspay/connector-service", rev = "7cfdd9041e4c0d2bd00789df0459e1175f14d72d", package = "ucs_cards" }
 rustc-hash = "1.1.0"
 rustls = "0.22"
 rustls-pemfile = "2"

--- a/crates/router/src/core/unified_connector_service/transformers.rs
+++ b/crates/router/src/core/unified_connector_service/transformers.rs
@@ -6401,6 +6401,11 @@ impl transformers::ForeignTryFrom<&RouterData<api::Void, PaymentsCancelData, Pay
             test_mode: router_data.test_mode,
             merchant_order_id: router_data.request.merchant_order_reference_id.clone(),
             merchant_request_id: None,
+            split_payments: router_data
+                .request
+                .split_payments
+                .as_ref()
+                .map(payments_grpc::SplitPaymentsDetails::foreign_from),
         })
     }
 }
@@ -6444,6 +6449,7 @@ impl
             metadata: None,
             state,
             test_mode: router_data.test_mode,
+            split_payments: None,
         })
     }
 }

--- a/crates/router/src/core/unified_connector_service/transformers.rs
+++ b/crates/router/src/core/unified_connector_service/transformers.rs
@@ -1260,6 +1260,11 @@ impl transformers::ForeignTryFrom<&RouterData<Capture, PaymentsCaptureData, Paym
             merchant_order_id: router_data.request.merchant_order_reference_id.clone(),
             merchant_request_id: None,
             order_tax_amount: None,
+            split_payments: router_data
+                .request
+                .split_payments
+                .as_ref()
+                .map(payments_grpc::SplitPaymentsDetails::foreign_from),
         })
     }
 }


### PR DESCRIPTION
## Problem

Shadow-validation diff (cloud #16992), connector **stripe**, flow **capture**, merchant `yucca`:

```
router.typeDiff: response.Ok.TransactionResponse.charges   { hyperswitch: object, ucs: null }
```

On a split-payment capture, native HS rebuilds the Stripe charge object from the capture
request's `split_payments`. The UCS-shadow path emitted `charges = null` because the HS→UCS
gRPC capture-request builder
(`PaymentServiceCaptureRequest::foreign_try_from(&RouterData<Capture, …>)`) dropped
`split_payments` — the gRPC `PaymentServiceCaptureRequest` proto had no such field, so UCS
received `split_payments = None`, could not run `construct_charge_response`, and returned no
split charge. The capture **response** path already carries `splits`/`charges` on both ends;
only the **request** side was missing it.

## Fix

- Map `router_data.request.split_payments` into `PaymentServiceCaptureRequest`
  (mirrors the existing authorize / get request builders). HS already populates
  `PaymentsCaptureData.split_payments` from the payment intent, so no other HS change is needed.
- Bump the UCS gRPC client pin (3 Cargo.tomls + lockfile) to the connector-service PR that adds
  `split_payments` to the capture contract.

**Depends on UCS PR juspay/connector-service#1615** (`split_payments = 14` on
`PaymentServiceCaptureRequest`). The `rev` pin is interim — move it back to a `tag`/main commit
once that UCS PR merges (reviewers merge UCS first, then HS).

## Verification

- Direct UCS gRPC capture against a fresh Stripe PI: with `split_payments` in the capture
  request the response now carries
  `splits{ stripeSplitResponse{ chargeId, chargeType: STRIPE_DESTINATION, applicationFees, transferAccountId } }`
  (→ HS `charges = object`); without it the field is absent (→ `charges = null`). Both return
  `status: CHARGED, capturedAmount: 6000` — only the `charges`/`splits` field flips, i.e. exactly
  the diverging field.
- HS compiles against the new UCS rev: `cargo build` (v1) and
  `cargo check --no-default-features --features "release,v2,redis-rs"` (v2) both pass;
  `cargo fmt`/`cargo clippy -p router` clean.

(The runtime shadow diff cannot reach `no_diff` for Stripe capture locally because Stripe capture
is not idempotent — the primary HS capture finalizes the PI first, so the shadow UCS capture sees
"already captured". Hence the direct-gRPC verification of the actual fixed field.)

Closes #12923
Fixes an internal validation-diff issue (linked via the Development sidebar).

---
**Re-detection (#17049):** parent #17048 — `unknown / stripe / capture`, signature `router.typeDiff:response.Ok.TransactionResponse.charges` ({hs:object, ucs:null}), occurrences 2, sample req `019ef32e-b7d5-74b2-b4ac-b869a6b2ceca`. Grafana RCA: identical to #16992 on the stale prod build `2026.06.17.0` (predates this fix). Same root cause and fix; no new PR.

---
**Void extension (#17000).** Same split_payments request plumbing, now also for the **void (cancel)** flow. The shadow validation flagged `router.typeDiff:response.Ok.TransactionResponse.mandate_reference.mandate_metadata` ({hs:object, ucs:null}) on `yucca / stripe / void`. Root cause is identical to capture: the void response is built by the same shared `TryFrom<ResponseRouterData<PaymentIntentResponse,…>>` impl (which computes `mandate_metadata` from `request.get_split_payment_data()`), and `PaymentVoidData` impls `SplitPaymentData` — but the void **request** carried no `split_payments`, so UCS returned `null` while HS-native built the object. This adds `PaymentServiceVoidRequest.split_payments` (=13) / `CompositeVoidRequest.split_payments` (=15) and threads them into `PaymentVoidData` + the composite void transformer (UCS), and maps `PaymentsCancelData.split_payments` on the HS→UCS void request (HS).

The response-side `mandate_metadata` mapping itself is flow-generic and lives in juspay/connector-service#1611 / juspay/hyperswitch#12919 (the #16967 PRs); this PR provides the void-request prerequisite, so the union of the two PR sets closes the diff (exactly as capture = this PR + #1611/#12919).

**Verified** via direct UCS gRPC `PaymentService.Void` A/B (void is terminal → shadow can't reach no_diff; same approach as the capture verify): WITH `split_payments` → `mandate_metadata = {"transfer_account_id":"acct_1TjBkeDfqJC9T9K6","charge_type":"destination","application_fees":100,"on_behalf_of":null}` (byte-identical to HS); WITHOUT → absent. (`prod-fixes/verify_17000.py`)


---
**Re-detection (#20176):** `gimme / stripe / capture`, signature `router.typeDiff:response.Ok.TransactionResponse.charges` ({hs:object, ucs:null}), occurrences 44. Same root cause and fix as #16992/#17049; no new PR.
