### PR TITLE
fix(router): send webhook_url on redsys pre_authenticate UCS request (shadow parity #16982)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2264,7 +2264,7 @@ dependencies = [
 [[package]]
 name = "config_patch_derive"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.06.23.1#2a748b69578e5d61c4586b30aabddad0ed7fd88a"
+source = "git+https://github.com/juspay/connector-service?rev=ade76c2b590657677062bb12e9928cae282e92fe#ade76c2b590657677062bb12e9928cae282e92fe"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3981,7 +3981,7 @@ checksum = "32619942b8be646939eaf3db0602b39f5229b74575b67efc897811ded1db4e57"
 [[package]]
 name = "grpc-api-types"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.06.23.1#2a748b69578e5d61c4586b30aabddad0ed7fd88a"
+source = "git+https://github.com/juspay/connector-service?rev=ade76c2b590657677062bb12e9928cae282e92fe#ade76c2b590657677062bb12e9928cae282e92fe"
 dependencies = [
  "axum 0.8.4",
  "bytes 1.10.1",
@@ -8176,7 +8176,7 @@ dependencies = [
 [[package]]
 name = "rust-grpc-client"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.06.23.1#2a748b69578e5d61c4586b30aabddad0ed7fd88a"
+source = "git+https://github.com/juspay/connector-service?rev=ade76c2b590657677062bb12e9928cae282e92fe#ade76c2b590657677062bb12e9928cae282e92fe"
 dependencies = [
  "grpc-api-types",
 ]
@@ -11010,7 +11010,7 @@ checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
 [[package]]
 name = "ucs_cards"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.06.23.1#2a748b69578e5d61c4586b30aabddad0ed7fd88a"
+source = "git+https://github.com/juspay/connector-service?rev=ade76c2b590657677062bb12e9928cae282e92fe#ade76c2b590657677062bb12e9928cae282e92fe"
 dependencies = [
  "bytes 1.10.1",
  "error-stack 0.4.1",
@@ -11026,7 +11026,7 @@ dependencies = [
 [[package]]
 name = "ucs_common_enums"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.06.23.1#2a748b69578e5d61c4586b30aabddad0ed7fd88a"
+source = "git+https://github.com/juspay/connector-service?rev=ade76c2b590657677062bb12e9928cae282e92fe#ade76c2b590657677062bb12e9928cae282e92fe"
 dependencies = [
  "serde",
  "strum 0.26.3",
@@ -11037,7 +11037,7 @@ dependencies = [
 [[package]]
 name = "ucs_common_utils"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.06.23.1#2a748b69578e5d61c4586b30aabddad0ed7fd88a"
+source = "git+https://github.com/juspay/connector-service?rev=ade76c2b590657677062bb12e9928cae282e92fe#ade76c2b590657677062bb12e9928cae282e92fe"
 dependencies = [
  "anyhow",
  "base64 0.21.7",

--- a/crates/external_services/Cargo.toml
+++ b/crates/external_services/Cargo.toml
@@ -80,7 +80,7 @@ http = "0.2.12"
 url = { version = "2.5.4", features = ["serde"] }
 quick-xml = { version = "0.31.0", features = ["serialize"] }
 
-unified-connector-service-client = { git = "https://github.com/juspay/connector-service", tag = "2026.06.23.1", package = "rust-grpc-client" }
+unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "ade76c2b590657677062bb12e9928cae282e92fe", package = "rust-grpc-client" }
 open-feature = { version = "0.2.5", optional = true }
 superposition_provider = { version = "0.102.0", optional = true }
 superposition_types = "0.102.0"

--- a/crates/hyperswitch_interfaces/Cargo.toml
+++ b/crates/hyperswitch_interfaces/Cargo.toml
@@ -33,7 +33,7 @@ time = "0.3.41"
 tonic = "0.14"
 url = { version = "2.5.4", features = ["serde"] }
 
-unified-connector-service-client = { git = "https://github.com/juspay/connector-service", tag = "2026.06.23.1", package = "rust-grpc-client" }
+unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "ade76c2b590657677062bb12e9928cae282e92fe", package = "rust-grpc-client" }
 tokio = { version = "1.45.1", features = ["macros", "rt-multi-thread"] }
 
 # First party crates

--- a/crates/router/Cargo.toml
+++ b/crates/router/Cargo.toml
@@ -91,8 +91,8 @@ ring = "0.17.14"
 rust_decimal = { version = "1.37.1", features = ["serde-with-float", "serde-with-str"] }
 rust-i18n = { git = "https://github.com/kashif-m/rust-i18n", rev = "f2d8096aaaff7a87a847c35a5394c269f75e077a" }
 
-unified-connector-service-client = { git = "https://github.com/juspay/connector-service", tag = "2026.06.23.1", package = "rust-grpc-client" }
-unified-connector-service-cards = { git = "https://github.com/juspay/connector-service", tag = "2026.06.23.1", package = "ucs_cards" }
+unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "ade76c2b590657677062bb12e9928cae282e92fe", package = "rust-grpc-client" }
+unified-connector-service-cards = { git = "https://github.com/juspay/connector-service", rev = "ade76c2b590657677062bb12e9928cae282e92fe", package = "ucs_cards" }
 rustc-hash = "1.1.0"
 rustls = "0.22"
 rustls-pemfile = "2"

--- a/crates/router/src/core/unified_connector_service/transformers.rs
+++ b/crates/router/src/core/unified_connector_service/transformers.rs
@@ -1177,6 +1177,7 @@ impl
             metadata,
             return_url: router_data.request.router_return_url.clone(),
             continue_redirection_url: router_data.request.complete_authorize_url.clone(),
+            webhook_url: router_data.request.webhook_url.clone(),
             state: None,
             browser_info: router_data
                 .request


### PR DESCRIPTION
## Issue
Shadow validation — `redsys / pre_authenticate` (juspay/hyperswitch-cloud#16982).

```
router.valueDiff: response.Ok.TransactionResponse.connector_metadata.three_ds_method_data
```

On the redsys 3DS-method (invoke) path, `three_ds_method_data` embeds a `threeDSMethodNotificationURL`. The native gateway builds it from the merchant `webhook_url` (`get_webhook_url()`), but the UCS gRPC `PaymentMethodAuthenticationServicePreAuthenticateRequest` never sent a webhook URL, so prism fell back to `continue_redirection_url` → the two base64 blobs differ.

## Fix
Set `webhook_url` on the PreAuthenticate gRPC request from `router_data.request.webhook_url` — the same field native redsys reads via `get_webhook_url()`. Paired with **juspay/hyperswitch-prism#1618**, which adds `webhook_url` (proto field 15) to the request and makes the redsys transformer use it for the 3DS method notification URL.

Rev-pins the `connector-service` deps to the proto branch carrying the new field
(`rust-grpc-client` / `ucs_cards`). Flip to a CalVer tag once the prism PR merges and the nightly tag job runs, then undraft.

## Verification
Redsys sandbox returns only the 3DS-exempt path, so the invoke-path `three_ds_method_data` value is not locally reproducible (same constraint as #1616). `cargo build -p router` succeeds against the rev-pinned proto.

**Runtime proof (local shadow stack, req `019ef664-ca84-7433-8af0-7d7707340ea2`):** the outgoing PreAuthenticate gRPC request now contains
`"webhook_url":"http://localhost:8080/webhooks/redsys_repro_4224/mca_1Dc7BJnWmf9AM1I7W72H"` — the `/webhooks/<mid>/<mca_id>` family the native gateway uses (prod RCA showed native `/api/webhooks/bu_es/mca_ox5UaUXMQooZ8rh63uqa` vs UCS `/redirect/complete/redsys`). The same exempt-path payment shows only the unrelated pre-existing `resource_id`/`connector_metadata` typeDiffs and **no new diff** → no regression. On the invoke path prism now builds `threeDSMethodNotificationURL` from this `webhook_url`, producing the identical base64 blob.

Part of #16982.
