### PR TITLE
fix(ucs): map PSync connector_metadata from UCS response (nexixpay shadow parity)

### DIFF
--- a/crates/hyperswitch_interfaces/src/unified_connector_service/transformers.rs
+++ b/crates/hyperswitch_interfaces/src/unified_connector_service/transformers.rs
@@ -330,7 +330,9 @@ impl ForeignTryFrom<(payments_grpc::PaymentServiceGetResponse, AttemptStatus)>
                             .transpose()?,
                     ),
                     mandate_reference: Box::new(response.mandate_reference.map(hyperswitch_domain_models::router_response_types::MandateReference::foreign_try_from).transpose()?),
-                    connector_metadata: None,
+                    connector_metadata: response
+                        .metadata
+                        .and_then(|m| serde_json::from_str(&m.expose()).ok()),
                     network_txn_id: response.network_transaction_id.clone(),
                     network_txn_link_id: response.network_txn_link_id.clone(),
                     connector_response_reference_id: response.merchant_transaction_id,


### PR DESCRIPTION
## What

Paired hyperswitch-side change for the nexixpay **PSync** `connector_metadata` shadow-validation diff (juspay/hyperswitch-cloud#16984; parent #16983).

The UCS client mapping `PaymentServiceGetResponse → PaymentsResponseData::TransactionResponse` (PSync) hardcoded `connector_metadata: None`, so shadow-mode router-data always showed `null` for `connector_metadata` while native hyperswitch surfaced an object → a router-data **typeDiff**.

## Change

`crates/hyperswitch_interfaces/src/unified_connector_service/transformers.rs` — read `connector_metadata` back from the proto `metadata` field (which prism now serializes the connector metadata into on the sync response):

```rust
connector_metadata: response
    .metadata
    .and_then(|m| serde_json::from_str(&m.expose()).ok()),
```

**No proto change / dependency `rev` bump** — `metadata` already exists on `PaymentServiceGetResponse`. The change is backward-compatible: when prism does not populate `metadata`, this yields `None` (prior behavior).

## Pairs with

hyperswitch-prism#1619 (nexixpay PSync `resource_id` + `connector_metadata`, and the prism domain→proto serialization into `metadata`). Both are needed end-to-end for #16984; merge prism first.

## Verification

End-to-end on the local shadow stack with real nexixpay sandbox — see the before/after in hyperswitch-prism#1619:
- BEFORE (`019ef687-4822-…`): `typeDiff connector_metadata { hyperswitch: object, ucs: null }` (+ resource_id valueDiff).
- AFTER (`019ef68e-a6ce-…`): `VS_46` no differences (0/0/0, 56 keys both sides).

Fixes juspay/hyperswitch-cloud#16984
