### PR TITLE
fix(ucs): thread connector_mandate_request_reference_id into PSync GET request (#16985)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2264,7 +2264,7 @@ dependencies = [
 [[package]]
 name = "config_patch_derive"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.06.23.1#2a748b69578e5d61c4586b30aabddad0ed7fd88a"
+source = "git+https://github.com/juspay/connector-service?rev=5c0e2fb3deb2202e8dd7da8a2b53c5de94c40c7e#5c0e2fb3deb2202e8dd7da8a2b53c5de94c40c7e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3981,7 +3981,7 @@ checksum = "32619942b8be646939eaf3db0602b39f5229b74575b67efc897811ded1db4e57"
 [[package]]
 name = "grpc-api-types"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.06.23.1#2a748b69578e5d61c4586b30aabddad0ed7fd88a"
+source = "git+https://github.com/juspay/connector-service?rev=5c0e2fb3deb2202e8dd7da8a2b53c5de94c40c7e#5c0e2fb3deb2202e8dd7da8a2b53c5de94c40c7e"
 dependencies = [
  "axum 0.8.4",
  "bytes 1.10.1",
@@ -8176,7 +8176,7 @@ dependencies = [
 [[package]]
 name = "rust-grpc-client"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.06.23.1#2a748b69578e5d61c4586b30aabddad0ed7fd88a"
+source = "git+https://github.com/juspay/connector-service?rev=5c0e2fb3deb2202e8dd7da8a2b53c5de94c40c7e#5c0e2fb3deb2202e8dd7da8a2b53c5de94c40c7e"
 dependencies = [
  "grpc-api-types",
 ]
@@ -11010,7 +11010,7 @@ checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
 [[package]]
 name = "ucs_cards"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.06.23.1#2a748b69578e5d61c4586b30aabddad0ed7fd88a"
+source = "git+https://github.com/juspay/connector-service?rev=5c0e2fb3deb2202e8dd7da8a2b53c5de94c40c7e#5c0e2fb3deb2202e8dd7da8a2b53c5de94c40c7e"
 dependencies = [
  "bytes 1.10.1",
  "error-stack 0.4.1",
@@ -11026,7 +11026,7 @@ dependencies = [
 [[package]]
 name = "ucs_common_enums"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.06.23.1#2a748b69578e5d61c4586b30aabddad0ed7fd88a"
+source = "git+https://github.com/juspay/connector-service?rev=5c0e2fb3deb2202e8dd7da8a2b53c5de94c40c7e#5c0e2fb3deb2202e8dd7da8a2b53c5de94c40c7e"
 dependencies = [
  "serde",
  "strum 0.26.3",
@@ -11037,7 +11037,7 @@ dependencies = [
 [[package]]
 name = "ucs_common_utils"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.06.23.1#2a748b69578e5d61c4586b30aabddad0ed7fd88a"
+source = "git+https://github.com/juspay/connector-service?rev=5c0e2fb3deb2202e8dd7da8a2b53c5de94c40c7e#5c0e2fb3deb2202e8dd7da8a2b53c5de94c40c7e"
 dependencies = [
  "anyhow",
  "base64 0.21.7",

--- a/crates/external_services/Cargo.toml
+++ b/crates/external_services/Cargo.toml
@@ -80,7 +80,7 @@ http = "0.2.12"
 url = { version = "2.5.4", features = ["serde"] }
 quick-xml = { version = "0.31.0", features = ["serialize"] }
 
-unified-connector-service-client = { git = "https://github.com/juspay/connector-service", tag = "2026.06.23.1", package = "rust-grpc-client" }
+unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "5c0e2fb3deb2202e8dd7da8a2b53c5de94c40c7e", package = "rust-grpc-client" }
 open-feature = { version = "0.2.5", optional = true }
 superposition_provider = { version = "0.102.0", optional = true }
 superposition_types = "0.102.0"

--- a/crates/hyperswitch_interfaces/Cargo.toml
+++ b/crates/hyperswitch_interfaces/Cargo.toml
@@ -33,7 +33,7 @@ time = "0.3.41"
 tonic = "0.14"
 url = { version = "2.5.4", features = ["serde"] }
 
-unified-connector-service-client = { git = "https://github.com/juspay/connector-service", tag = "2026.06.23.1", package = "rust-grpc-client" }
+unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "5c0e2fb3deb2202e8dd7da8a2b53c5de94c40c7e", package = "rust-grpc-client" }
 tokio = { version = "1.45.1", features = ["macros", "rt-multi-thread"] }
 
 # First party crates

--- a/crates/router/Cargo.toml
+++ b/crates/router/Cargo.toml
@@ -91,8 +91,8 @@ ring = "0.17.14"
 rust_decimal = { version = "1.37.1", features = ["serde-with-float", "serde-with-str"] }
 rust-i18n = { git = "https://github.com/kashif-m/rust-i18n", rev = "f2d8096aaaff7a87a847c35a5394c269f75e077a" }
 
-unified-connector-service-client = { git = "https://github.com/juspay/connector-service", tag = "2026.06.23.1", package = "rust-grpc-client" }
-unified-connector-service-cards = { git = "https://github.com/juspay/connector-service", tag = "2026.06.23.1", package = "ucs_cards" }
+unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "5c0e2fb3deb2202e8dd7da8a2b53c5de94c40c7e", package = "rust-grpc-client" }
+unified-connector-service-cards = { git = "https://github.com/juspay/connector-service", rev = "5c0e2fb3deb2202e8dd7da8a2b53c5de94c40c7e", package = "ucs_cards" }
 rustc-hash = "1.1.0"
 rustls = "0.22"
 rustls-pemfile = "2"

--- a/crates/router/src/core/unified_connector_service/transformers.rs
+++ b/crates/router/src/core/unified_connector_service/transformers.rs
@@ -826,6 +826,12 @@ impl transformers::ForeignTryFrom<&RouterData<PSync, PaymentsSyncData, PaymentsR
                 .map(payments_grpc::PaymentMethodType::foreign_try_from)
                 .transpose()?
                 .map(|payment_method_type| payment_method_type.into()),
+            // Thread the stored connector_mandate_request_reference_id so prism can
+            // surface response.mandate_reference on sync for off-session mandate
+            // setups, matching the native gateway (#16985).
+            connector_mandate_request_reference_id: router_data
+                .connector_mandate_request_reference_id
+                .clone(),
         })
     }
 }


### PR DESCRIPTION
## What

Client side of #16985 — nexixpay / PSync `router.typeDiff:response.Ok.TransactionResponse.mandate_reference` (hyperswitch `object` vs ucs `null`).

For off-session mandate setups the native gateway builds `response.mandate_reference` on PSync from the stored `connector_mandate_request_reference_id`. The UCS `PaymentServiceGetRequest` did not carry that value, so prism emitted `mandate_reference: null`.

This sets `connector_mandate_request_reference_id` on the `PaymentServiceGetRequest` from `RouterData.connector_mandate_request_reference_id`, so prism can surface the mandate reference (matching native).

## Pairs with

connector-service / prism: juspay/hyperswitch-prism#1623 (adds proto field 18 + `PaymentsSyncData` thread + nexixpay PSync transformer).

Rev-pinned (`external_services`, `hyperswitch_interfaces`, `router` ×2) to that branch. **Draft** until #1623 merges and a CalVer tag is cut — then flip `rev` → `tag` and undraft.

## Proof

See juspay/hyperswitch-prism#1623 for the full before/after. Verified locally end-to-end: BEFORE req `019ef6b8` had the `mandate_reference` typeDiff (object vs null); AFTER req `019ef6cb` the UCS gRPC response carries `mandate_reference.ConnectorMandateId.connector_mandate_id = "6CI2T4iq7uI2WuzWMh"` (== stored `connector_mandate_request_reference_id`) and the field is no longer in the diff.

Fixes #16985
