### PR TITLE
fix(ucs): redsys psync error-path parity — status + connector_transaction_id (#16987)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2264,7 +2264,7 @@ dependencies = [
 [[package]]
 name = "config_patch_derive"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.06.23.1#2a748b69578e5d61c4586b30aabddad0ed7fd88a"
+source = "git+https://github.com/juspay/connector-service?rev=c5c71dabbb1e39df509b421aab0ab8ebe41b65bd#c5c71dabbb1e39df509b421aab0ab8ebe41b65bd"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3981,7 +3981,7 @@ checksum = "32619942b8be646939eaf3db0602b39f5229b74575b67efc897811ded1db4e57"
 [[package]]
 name = "grpc-api-types"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.06.23.1#2a748b69578e5d61c4586b30aabddad0ed7fd88a"
+source = "git+https://github.com/juspay/connector-service?rev=c5c71dabbb1e39df509b421aab0ab8ebe41b65bd#c5c71dabbb1e39df509b421aab0ab8ebe41b65bd"
 dependencies = [
  "axum 0.8.4",
  "bytes 1.10.1",
@@ -8176,7 +8176,7 @@ dependencies = [
 [[package]]
 name = "rust-grpc-client"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.06.23.1#2a748b69578e5d61c4586b30aabddad0ed7fd88a"
+source = "git+https://github.com/juspay/connector-service?rev=c5c71dabbb1e39df509b421aab0ab8ebe41b65bd#c5c71dabbb1e39df509b421aab0ab8ebe41b65bd"
 dependencies = [
  "grpc-api-types",
 ]
@@ -11010,7 +11010,7 @@ checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
 [[package]]
 name = "ucs_cards"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.06.23.1#2a748b69578e5d61c4586b30aabddad0ed7fd88a"
+source = "git+https://github.com/juspay/connector-service?rev=c5c71dabbb1e39df509b421aab0ab8ebe41b65bd#c5c71dabbb1e39df509b421aab0ab8ebe41b65bd"
 dependencies = [
  "bytes 1.10.1",
  "error-stack 0.4.1",
@@ -11026,7 +11026,7 @@ dependencies = [
 [[package]]
 name = "ucs_common_enums"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.06.23.1#2a748b69578e5d61c4586b30aabddad0ed7fd88a"
+source = "git+https://github.com/juspay/connector-service?rev=c5c71dabbb1e39df509b421aab0ab8ebe41b65bd#c5c71dabbb1e39df509b421aab0ab8ebe41b65bd"
 dependencies = [
  "serde",
  "strum 0.26.3",
@@ -11037,7 +11037,7 @@ dependencies = [
 [[package]]
 name = "ucs_common_utils"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.06.23.1#2a748b69578e5d61c4586b30aabddad0ed7fd88a"
+source = "git+https://github.com/juspay/connector-service?rev=c5c71dabbb1e39df509b421aab0ab8ebe41b65bd#c5c71dabbb1e39df509b421aab0ab8ebe41b65bd"
 dependencies = [
  "anyhow",
  "base64 0.21.7",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2264,7 +2264,7 @@ dependencies = [
 [[package]]
 name = "config_patch_derive"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?rev=c5c71dabbb1e39df509b421aab0ab8ebe41b65bd#c5c71dabbb1e39df509b421aab0ab8ebe41b65bd"
+source = "git+https://github.com/juspay/connector-service?rev=ab9cff70b#ab9cff70bc08ff60165ccad219157c0fa581bc7c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3981,7 +3981,7 @@ checksum = "32619942b8be646939eaf3db0602b39f5229b74575b67efc897811ded1db4e57"
 [[package]]
 name = "grpc-api-types"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?rev=c5c71dabbb1e39df509b421aab0ab8ebe41b65bd#c5c71dabbb1e39df509b421aab0ab8ebe41b65bd"
+source = "git+https://github.com/juspay/connector-service?rev=ab9cff70b#ab9cff70bc08ff60165ccad219157c0fa581bc7c"
 dependencies = [
  "axum 0.8.4",
  "bytes 1.10.1",
@@ -8176,7 +8176,7 @@ dependencies = [
 [[package]]
 name = "rust-grpc-client"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?rev=c5c71dabbb1e39df509b421aab0ab8ebe41b65bd#c5c71dabbb1e39df509b421aab0ab8ebe41b65bd"
+source = "git+https://github.com/juspay/connector-service?rev=ab9cff70b#ab9cff70bc08ff60165ccad219157c0fa581bc7c"
 dependencies = [
  "grpc-api-types",
 ]
@@ -11010,7 +11010,7 @@ checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
 [[package]]
 name = "ucs_cards"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?rev=c5c71dabbb1e39df509b421aab0ab8ebe41b65bd#c5c71dabbb1e39df509b421aab0ab8ebe41b65bd"
+source = "git+https://github.com/juspay/connector-service?rev=ab9cff70b#ab9cff70bc08ff60165ccad219157c0fa581bc7c"
 dependencies = [
  "bytes 1.10.1",
  "error-stack 0.4.1",
@@ -11026,7 +11026,7 @@ dependencies = [
 [[package]]
 name = "ucs_common_enums"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?rev=c5c71dabbb1e39df509b421aab0ab8ebe41b65bd#c5c71dabbb1e39df509b421aab0ab8ebe41b65bd"
+source = "git+https://github.com/juspay/connector-service?rev=ab9cff70b#ab9cff70bc08ff60165ccad219157c0fa581bc7c"
 dependencies = [
  "serde",
  "strum 0.26.3",
@@ -11037,7 +11037,7 @@ dependencies = [
 [[package]]
 name = "ucs_common_utils"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?rev=c5c71dabbb1e39df509b421aab0ab8ebe41b65bd#c5c71dabbb1e39df509b421aab0ab8ebe41b65bd"
+source = "git+https://github.com/juspay/connector-service?rev=ab9cff70b#ab9cff70bc08ff60165ccad219157c0fa581bc7c"
 dependencies = [
  "anyhow",
  "base64 0.21.7",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1550,7 +1550,7 @@ dependencies = [
  "bitflags 2.9.0",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "log 0.4.27",
  "prettyplease",
  "proc-macro2",
@@ -2264,7 +2264,7 @@ dependencies = [
 [[package]]
 name = "config_patch_derive"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?rev=ab9cff70b#ab9cff70bc08ff60165ccad219157c0fa581bc7c"
+source = "git+https://github.com/juspay/connector-service?rev=8f77f0b428985ecd4736248ca865144bcbe79dc3#8f77f0b428985ecd4736248ca865144bcbe79dc3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3981,7 +3981,7 @@ checksum = "32619942b8be646939eaf3db0602b39f5229b74575b67efc897811ded1db4e57"
 [[package]]
 name = "grpc-api-types"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?rev=ab9cff70b#ab9cff70bc08ff60165ccad219157c0fa581bc7c"
+source = "git+https://github.com/juspay/connector-service?rev=8f77f0b428985ecd4736248ca865144bcbe79dc3#8f77f0b428985ecd4736248ca865144bcbe79dc3"
 dependencies = [
  "axum 0.8.4",
  "bytes 1.10.1",
@@ -7156,8 +7156,8 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.4.1",
- "itertools 0.10.5",
+ "heck 0.5.0",
+ "itertools 0.11.0",
  "log 0.4.27",
  "multimap",
  "petgraph",
@@ -7178,7 +7178,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn 2.0.101",
@@ -7191,7 +7191,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn 2.0.101",
@@ -8176,7 +8176,7 @@ dependencies = [
 [[package]]
 name = "rust-grpc-client"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?rev=ab9cff70b#ab9cff70bc08ff60165ccad219157c0fa581bc7c"
+source = "git+https://github.com/juspay/connector-service?rev=8f77f0b428985ecd4736248ca865144bcbe79dc3#8f77f0b428985ecd4736248ca865144bcbe79dc3"
 dependencies = [
  "grpc-api-types",
 ]
@@ -11010,7 +11010,7 @@ checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
 [[package]]
 name = "ucs_cards"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?rev=ab9cff70b#ab9cff70bc08ff60165ccad219157c0fa581bc7c"
+source = "git+https://github.com/juspay/connector-service?rev=8f77f0b428985ecd4736248ca865144bcbe79dc3#8f77f0b428985ecd4736248ca865144bcbe79dc3"
 dependencies = [
  "bytes 1.10.1",
  "error-stack 0.4.1",
@@ -11026,7 +11026,7 @@ dependencies = [
 [[package]]
 name = "ucs_common_enums"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?rev=ab9cff70b#ab9cff70bc08ff60165ccad219157c0fa581bc7c"
+source = "git+https://github.com/juspay/connector-service?rev=8f77f0b428985ecd4736248ca865144bcbe79dc3#8f77f0b428985ecd4736248ca865144bcbe79dc3"
 dependencies = [
  "serde",
  "strum 0.26.3",
@@ -11037,7 +11037,7 @@ dependencies = [
 [[package]]
 name = "ucs_common_utils"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?rev=ab9cff70b#ab9cff70bc08ff60165ccad219157c0fa581bc7c"
+source = "git+https://github.com/juspay/connector-service?rev=8f77f0b428985ecd4736248ca865144bcbe79dc3#8f77f0b428985ecd4736248ca865144bcbe79dc3"
 dependencies = [
  "anyhow",
  "base64 0.21.7",

--- a/crates/external_services/Cargo.toml
+++ b/crates/external_services/Cargo.toml
@@ -80,7 +80,7 @@ http = "0.2.12"
 url = { version = "2.5.4", features = ["serde"] }
 quick-xml = { version = "0.31.0", features = ["serialize"] }
 
-unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "ab9cff70b", package = "rust-grpc-client" }
+unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "8f77f0b428985ecd4736248ca865144bcbe79dc3", package = "rust-grpc-client" }
 open-feature = { version = "0.2.5", optional = true }
 superposition_provider = { version = "0.102.0", optional = true }
 superposition_types = "0.102.0"

--- a/crates/external_services/Cargo.toml
+++ b/crates/external_services/Cargo.toml
@@ -80,7 +80,7 @@ http = "0.2.12"
 url = { version = "2.5.4", features = ["serde"] }
 quick-xml = { version = "0.31.0", features = ["serialize"] }
 
-unified-connector-service-client = { git = "https://github.com/juspay/connector-service", tag = "2026.06.23.1", package = "rust-grpc-client" }
+unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "c5c71dabbb1e39df509b421aab0ab8ebe41b65bd", package = "rust-grpc-client" }
 open-feature = { version = "0.2.5", optional = true }
 superposition_provider = { version = "0.102.0", optional = true }
 superposition_types = "0.102.0"

--- a/crates/external_services/Cargo.toml
+++ b/crates/external_services/Cargo.toml
@@ -80,7 +80,7 @@ http = "0.2.12"
 url = { version = "2.5.4", features = ["serde"] }
 quick-xml = { version = "0.31.0", features = ["serialize"] }
 
-unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "c5c71dabbb1e39df509b421aab0ab8ebe41b65bd", package = "rust-grpc-client" }
+unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "ab9cff70b", package = "rust-grpc-client" }
 open-feature = { version = "0.2.5", optional = true }
 superposition_provider = { version = "0.102.0", optional = true }
 superposition_types = "0.102.0"

--- a/crates/hyperswitch_interfaces/Cargo.toml
+++ b/crates/hyperswitch_interfaces/Cargo.toml
@@ -33,7 +33,7 @@ time = "0.3.41"
 tonic = "0.14"
 url = { version = "2.5.4", features = ["serde"] }
 
-unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "c5c71dabbb1e39df509b421aab0ab8ebe41b65bd", package = "rust-grpc-client" }
+unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "ab9cff70b", package = "rust-grpc-client" }
 tokio = { version = "1.45.1", features = ["macros", "rt-multi-thread"] }
 
 # First party crates

--- a/crates/hyperswitch_interfaces/Cargo.toml
+++ b/crates/hyperswitch_interfaces/Cargo.toml
@@ -33,7 +33,7 @@ time = "0.3.41"
 tonic = "0.14"
 url = { version = "2.5.4", features = ["serde"] }
 
-unified-connector-service-client = { git = "https://github.com/juspay/connector-service", tag = "2026.06.23.1", package = "rust-grpc-client" }
+unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "c5c71dabbb1e39df509b421aab0ab8ebe41b65bd", package = "rust-grpc-client" }
 tokio = { version = "1.45.1", features = ["macros", "rt-multi-thread"] }
 
 # First party crates

--- a/crates/hyperswitch_interfaces/Cargo.toml
+++ b/crates/hyperswitch_interfaces/Cargo.toml
@@ -33,7 +33,7 @@ time = "0.3.41"
 tonic = "0.14"
 url = { version = "2.5.4", features = ["serde"] }
 
-unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "ab9cff70b", package = "rust-grpc-client" }
+unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "8f77f0b428985ecd4736248ca865144bcbe79dc3", package = "rust-grpc-client" }
 tokio = { version = "1.45.1", features = ["macros", "rt-multi-thread"] }
 
 # First party crates

--- a/crates/hyperswitch_interfaces/src/unified_connector_service/transformers.rs
+++ b/crates/hyperswitch_interfaces/src/unified_connector_service/transformers.rs
@@ -277,8 +277,7 @@ impl ForeignTryFrom<(payments_grpc::PaymentServiceGetResponse, AttemptStatus)>
             let attempt_status = match response.status() {
                 payments_grpc::PaymentStatus::Unspecified => None,
                 _ => {
-                    let mapped =
-                        AttemptStatus::foreign_try_from((response.status(), prev_status))?;
+                    let mapped = AttemptStatus::foreign_try_from((response.status(), prev_status))?;
                     (mapped != prev_status).then_some(mapped)
                 }
             };

--- a/crates/hyperswitch_interfaces/src/unified_connector_service/transformers.rs
+++ b/crates/hyperswitch_interfaces/src/unified_connector_service/transformers.rs
@@ -269,12 +269,18 @@ impl ForeignTryFrom<(payments_grpc::PaymentServiceGetResponse, AttemptStatus)>
         let response = if let Some(error_code) =
             connector_details.and_then(|details| details.code.clone())
         {
+            // Only surface an attempt_status when the connector's sync actually moves
+            // the status. On an errored sync that leaves the status unchanged (e.g.
+            // Redsys xml0024 while still authentication_pending) the native gateway
+            // keeps attempt_status None and preserves the prior status, so mirror that
+            // by leaving it None — the caller then retains prev_status.
             let attempt_status = match response.status() {
                 payments_grpc::PaymentStatus::Unspecified => None,
-                _ => Some(AttemptStatus::foreign_try_from((
-                    response.status(),
-                    prev_status,
-                ))?),
+                _ => {
+                    let mapped =
+                        AttemptStatus::foreign_try_from((response.status(), prev_status))?;
+                    (mapped != prev_status).then_some(mapped)
+                }
             };
 
             Err(ErrorResponse {
@@ -291,8 +297,16 @@ impl ForeignTryFrom<(payments_grpc::PaymentServiceGetResponse, AttemptStatus)>
                 reason: connector_details.as_ref().and_then(|cd| cd.reason.clone()),
                 status_code,
                 attempt_status,
-                connector_transaction_id: connector_transaction_id.get_optional_response_id(),
-                connector_response_reference_id: response.merchant_transaction_id,
+                // The proto carries a non-optional connector_transaction_id, so an
+                // absent id arrives as "" — treat empty as None to match the native
+                // gateway (which leaves connector_transaction_id None on sync errors).
+                connector_transaction_id: connector_transaction_id
+                    .get_optional_response_id()
+                    .filter(|id| !id.is_empty()),
+                // The native gateway does not echo the merchant's own reference back as
+                // the connector response reference on a sync error, so leave it None for
+                // parity (the merchant_transaction_id here is the caller-supplied ref).
+                connector_response_reference_id: None,
                 network_decline_code: response.error.as_ref().and_then(|error| {
                     error.issuer_details.as_ref().and_then(|id| {
                         id.network_details

--- a/crates/router/Cargo.toml
+++ b/crates/router/Cargo.toml
@@ -91,8 +91,8 @@ ring = "0.17.14"
 rust_decimal = { version = "1.37.1", features = ["serde-with-float", "serde-with-str"] }
 rust-i18n = { git = "https://github.com/kashif-m/rust-i18n", rev = "f2d8096aaaff7a87a847c35a5394c269f75e077a" }
 
-unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "c5c71dabbb1e39df509b421aab0ab8ebe41b65bd", package = "rust-grpc-client" }
-unified-connector-service-cards = { git = "https://github.com/juspay/connector-service", rev = "c5c71dabbb1e39df509b421aab0ab8ebe41b65bd", package = "ucs_cards" }
+unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "ab9cff70b", package = "rust-grpc-client" }
+unified-connector-service-cards = { git = "https://github.com/juspay/connector-service", rev = "ab9cff70b", package = "ucs_cards" }
 rustc-hash = "1.1.0"
 rustls = "0.22"
 rustls-pemfile = "2"

--- a/crates/router/Cargo.toml
+++ b/crates/router/Cargo.toml
@@ -91,8 +91,8 @@ ring = "0.17.14"
 rust_decimal = { version = "1.37.1", features = ["serde-with-float", "serde-with-str"] }
 rust-i18n = { git = "https://github.com/kashif-m/rust-i18n", rev = "f2d8096aaaff7a87a847c35a5394c269f75e077a" }
 
-unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "ab9cff70b", package = "rust-grpc-client" }
-unified-connector-service-cards = { git = "https://github.com/juspay/connector-service", rev = "ab9cff70b", package = "ucs_cards" }
+unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "8f77f0b428985ecd4736248ca865144bcbe79dc3", package = "rust-grpc-client" }
+unified-connector-service-cards = { git = "https://github.com/juspay/connector-service", rev = "8f77f0b428985ecd4736248ca865144bcbe79dc3", package = "ucs_cards" }
 rustc-hash = "1.1.0"
 rustls = "0.22"
 rustls-pemfile = "2"

--- a/crates/router/Cargo.toml
+++ b/crates/router/Cargo.toml
@@ -91,8 +91,8 @@ ring = "0.17.14"
 rust_decimal = { version = "1.37.1", features = ["serde-with-float", "serde-with-str"] }
 rust-i18n = { git = "https://github.com/kashif-m/rust-i18n", rev = "f2d8096aaaff7a87a847c35a5394c269f75e077a" }
 
-unified-connector-service-client = { git = "https://github.com/juspay/connector-service", tag = "2026.06.23.1", package = "rust-grpc-client" }
-unified-connector-service-cards = { git = "https://github.com/juspay/connector-service", tag = "2026.06.23.1", package = "ucs_cards" }
+unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "c5c71dabbb1e39df509b421aab0ab8ebe41b65bd", package = "rust-grpc-client" }
+unified-connector-service-cards = { git = "https://github.com/juspay/connector-service", rev = "c5c71dabbb1e39df509b421aab0ab8ebe41b65bd", package = "ucs_cards" }
 rustc-hash = "1.1.0"
 rustls = "0.22"
 rustls-pemfile = "2"

--- a/crates/router/src/core/unified_connector_service/transformers.rs
+++ b/crates/router/src/core/unified_connector_service/transformers.rs
@@ -834,7 +834,7 @@ impl transformers::ForeignTryFrom<&RouterData<PSync, PaymentsSyncData, PaymentsR
     }
 }
 
-impl transformers::ForeignFrom<AttemptStatus> for payments_grpc::PaymentStatus {
+impl ForeignFrom<AttemptStatus> for payments_grpc::PaymentStatus {
     fn foreign_from(status: AttemptStatus) -> Self {
         match status {
             AttemptStatus::Started => Self::Started,

--- a/crates/router/src/core/unified_connector_service/transformers.rs
+++ b/crates/router/src/core/unified_connector_service/transformers.rs
@@ -826,7 +826,48 @@ impl transformers::ForeignTryFrom<&RouterData<PSync, PaymentsSyncData, PaymentsR
                 .map(payments_grpc::PaymentMethodType::foreign_try_from)
                 .transpose()?
                 .map(|payment_method_type| payment_method_type.into()),
+            // Send the current attempt status so connectors that preserve the prior
+            // status on sync (e.g. Redsys on an errored consultaOperaciones) keep the
+            // real status instead of defaulting to PENDING on the UCS side.
+            status: Some(payments_grpc::PaymentStatus::foreign_from(router_data.status).into()),
         })
+    }
+}
+
+impl transformers::ForeignFrom<AttemptStatus> for payments_grpc::PaymentStatus {
+    fn foreign_from(status: AttemptStatus) -> Self {
+        match status {
+            AttemptStatus::Started => Self::Started,
+            AttemptStatus::AuthenticationFailed => Self::AuthenticationFailed,
+            AttemptStatus::RouterDeclined => Self::RouterDeclined,
+            AttemptStatus::AuthenticationPending => Self::AuthenticationPending,
+            AttemptStatus::AuthenticationSuccessful => Self::AuthenticationSuccessful,
+            AttemptStatus::Authorized => Self::Authorized,
+            AttemptStatus::AuthorizationFailed => Self::AuthorizationFailed,
+            AttemptStatus::Charged => Self::Charged,
+            AttemptStatus::Authorizing => Self::Authorizing,
+            AttemptStatus::CodInitiated => Self::CodInitiated,
+            AttemptStatus::Voided => Self::Voided,
+            AttemptStatus::VoidedPostCharge => Self::VoidedPostCapture,
+            AttemptStatus::VoidInitiated => Self::VoidInitiated,
+            AttemptStatus::CaptureInitiated => Self::CaptureInitiated,
+            AttemptStatus::CaptureFailed => Self::CaptureFailed,
+            AttemptStatus::VoidFailed => Self::VoidFailed,
+            AttemptStatus::AutoRefunded => Self::AutoRefunded,
+            AttemptStatus::PartialCharged => Self::PartialCharged,
+            AttemptStatus::PartiallyAuthorized => Self::PartiallyAuthorized,
+            AttemptStatus::PartialChargedAndChargeable => Self::PartialChargedAndChargeable,
+            AttemptStatus::Unresolved => Self::Unresolved,
+            AttemptStatus::Pending => Self::Pending,
+            AttemptStatus::Failure => Self::Failure,
+            AttemptStatus::IntegrityFailure => Self::Failure,
+            AttemptStatus::PaymentMethodAwaited => Self::PaymentMethodAwaited,
+            AttemptStatus::ConfirmationAwaited => Self::ConfirmationAwaited,
+            AttemptStatus::DeviceDataCollectionPending => Self::DeviceDataCollectionPending,
+            AttemptStatus::Expired => Self::Expired,
+            // No dedicated proto variant — leave Unspecified so the UCS side keeps its default.
+            AttemptStatus::CaptureReview => Self::Unspecified,
+        }
     }
 }
 


### PR DESCRIPTION
## What

Hyperswitch (router / UCS-client) half of the Redsys `psync` shadow-validation parity fix
(internal tracking issue, children #16988 + #16989). Pairs with prism PR
juspay/hyperswitch-prism#1624 (proto field + read).

On an errored Redsys `consultaOperaciones` sync (`xml0024` while still `authentication_pending`),
the UCS-built `RouterData` diverged from the native gateway on two fields:

- **#16988 `response.Err.connector_transaction_id`** (`null` vs `string`): the proto carries a
  non-optional `connector_transaction_id`, so an absent id arrives as `""`; the decoder mapped
  `""` → `Some("")`. Native leaves it `None`.
- **#16989 `status`** (`authentication_pending` vs `pending`): the GET request carried no attempt
  status, so prism defaulted to `Pending` and the error branch preserved that wrong value.

## Change

`crates/router/src/core/unified_connector_service/transformers.rs`
- Populate `PaymentServiceGetRequest.status` from `router_data.status` (uses the new proto field).
- Add `ForeignFrom<AttemptStatus> for payments_grpc::PaymentStatus`.

`crates/hyperswitch_interfaces/src/unified_connector_service/transformers.rs` (Get error decode)
- `connector_transaction_id`: treat empty string as `None` (#16988).
- `attempt_status`: only surface it when the sync actually moves the status; on an errored sync
  that leaves the status unchanged, keep it `None` so the caller retains `prev_status` — matching
  the native gateway (avoids a `response.Err.attempt_status` regression).
- `connector_response_reference_id`: `None` on the error branch (native does not echo the
  caller-supplied merchant reference back on a sync error).

Rev-pins the 4 `connector-service` deps to the prism branch commit (will become a CalVer tag once
the prism PR merges — this PR stays draft until then).

## Proof

**Before (prod, req `019ef455-70bc-76b2-ab73-ee1aed417ee1`, VS_48):**
```
valueDiff: { "status": { hyperswitch:"authentication_pending", ucs:"pending" } }              # #16989
typeDiff:  { "response.Err.connector_transaction_id": { hyperswitch:"null", ucs:"string" } }   # #16988
```

**After (local shadow repro, redsys 3DS authorize → force_sync PSync with synthetic `xml0024`):**
```
VS_46 Router data comparison completed - no differences found
keyDiff {} valueDiff {} typeDiff {}   (hyperswitch_status = ucs_status = authentication_pending)
```

Closes #12984
