### PR TITLE
fix(ucs): forward webhook_url on PreAuthenticate request for redsys 3DS parity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1550,7 +1550,7 @@ dependencies = [
  "bitflags 2.9.0",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "log 0.4.27",
  "prettyplease",
  "proc-macro2",
@@ -2264,7 +2264,7 @@ dependencies = [
 [[package]]
 name = "config_patch_derive"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.06.23.1#2a748b69578e5d61c4586b30aabddad0ed7fd88a"
+source = "git+https://github.com/juspay/connector-service?rev=d29837cdde69fb26aac326cff669f4f7995d3957#d29837cdde69fb26aac326cff669f4f7995d3957"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3981,7 +3981,7 @@ checksum = "32619942b8be646939eaf3db0602b39f5229b74575b67efc897811ded1db4e57"
 [[package]]
 name = "grpc-api-types"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.06.23.1#2a748b69578e5d61c4586b30aabddad0ed7fd88a"
+source = "git+https://github.com/juspay/connector-service?rev=d29837cdde69fb26aac326cff669f4f7995d3957#d29837cdde69fb26aac326cff669f4f7995d3957"
 dependencies = [
  "axum 0.8.4",
  "bytes 1.10.1",
@@ -7156,8 +7156,8 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.4.1",
- "itertools 0.10.5",
+ "heck 0.5.0",
+ "itertools 0.11.0",
  "log 0.4.27",
  "multimap",
  "petgraph",
@@ -7178,7 +7178,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn 2.0.101",
@@ -7191,7 +7191,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn 2.0.101",
@@ -8176,7 +8176,7 @@ dependencies = [
 [[package]]
 name = "rust-grpc-client"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.06.23.1#2a748b69578e5d61c4586b30aabddad0ed7fd88a"
+source = "git+https://github.com/juspay/connector-service?rev=d29837cdde69fb26aac326cff669f4f7995d3957#d29837cdde69fb26aac326cff669f4f7995d3957"
 dependencies = [
  "grpc-api-types",
 ]
@@ -11010,7 +11010,7 @@ checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
 [[package]]
 name = "ucs_cards"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.06.23.1#2a748b69578e5d61c4586b30aabddad0ed7fd88a"
+source = "git+https://github.com/juspay/connector-service?rev=d29837cdde69fb26aac326cff669f4f7995d3957#d29837cdde69fb26aac326cff669f4f7995d3957"
 dependencies = [
  "bytes 1.10.1",
  "error-stack 0.4.1",
@@ -11026,7 +11026,7 @@ dependencies = [
 [[package]]
 name = "ucs_common_enums"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.06.23.1#2a748b69578e5d61c4586b30aabddad0ed7fd88a"
+source = "git+https://github.com/juspay/connector-service?rev=d29837cdde69fb26aac326cff669f4f7995d3957#d29837cdde69fb26aac326cff669f4f7995d3957"
 dependencies = [
  "serde",
  "strum 0.26.3",
@@ -11037,7 +11037,7 @@ dependencies = [
 [[package]]
 name = "ucs_common_utils"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?tag=2026.06.23.1#2a748b69578e5d61c4586b30aabddad0ed7fd88a"
+source = "git+https://github.com/juspay/connector-service?rev=d29837cdde69fb26aac326cff669f4f7995d3957#d29837cdde69fb26aac326cff669f4f7995d3957"
 dependencies = [
  "anyhow",
  "base64 0.21.7",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2264,7 +2264,7 @@ dependencies = [
 [[package]]
 name = "config_patch_derive"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?rev=d29837cdde69fb26aac326cff669f4f7995d3957#d29837cdde69fb26aac326cff669f4f7995d3957"
+source = "git+https://github.com/juspay/connector-service?rev=8c30000437dfc4a70536119cce8781ad6d270b58#8c30000437dfc4a70536119cce8781ad6d270b58"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3981,7 +3981,7 @@ checksum = "32619942b8be646939eaf3db0602b39f5229b74575b67efc897811ded1db4e57"
 [[package]]
 name = "grpc-api-types"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?rev=d29837cdde69fb26aac326cff669f4f7995d3957#d29837cdde69fb26aac326cff669f4f7995d3957"
+source = "git+https://github.com/juspay/connector-service?rev=8c30000437dfc4a70536119cce8781ad6d270b58#8c30000437dfc4a70536119cce8781ad6d270b58"
 dependencies = [
  "axum 0.8.4",
  "bytes 1.10.1",
@@ -8176,7 +8176,7 @@ dependencies = [
 [[package]]
 name = "rust-grpc-client"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?rev=d29837cdde69fb26aac326cff669f4f7995d3957#d29837cdde69fb26aac326cff669f4f7995d3957"
+source = "git+https://github.com/juspay/connector-service?rev=8c30000437dfc4a70536119cce8781ad6d270b58#8c30000437dfc4a70536119cce8781ad6d270b58"
 dependencies = [
  "grpc-api-types",
 ]
@@ -11010,7 +11010,7 @@ checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
 [[package]]
 name = "ucs_cards"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?rev=d29837cdde69fb26aac326cff669f4f7995d3957#d29837cdde69fb26aac326cff669f4f7995d3957"
+source = "git+https://github.com/juspay/connector-service?rev=8c30000437dfc4a70536119cce8781ad6d270b58#8c30000437dfc4a70536119cce8781ad6d270b58"
 dependencies = [
  "bytes 1.10.1",
  "error-stack 0.4.1",
@@ -11026,7 +11026,7 @@ dependencies = [
 [[package]]
 name = "ucs_common_enums"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?rev=d29837cdde69fb26aac326cff669f4f7995d3957#d29837cdde69fb26aac326cff669f4f7995d3957"
+source = "git+https://github.com/juspay/connector-service?rev=8c30000437dfc4a70536119cce8781ad6d270b58#8c30000437dfc4a70536119cce8781ad6d270b58"
 dependencies = [
  "serde",
  "strum 0.26.3",
@@ -11037,7 +11037,7 @@ dependencies = [
 [[package]]
 name = "ucs_common_utils"
 version = "0.1.0"
-source = "git+https://github.com/juspay/connector-service?rev=d29837cdde69fb26aac326cff669f4f7995d3957#d29837cdde69fb26aac326cff669f4f7995d3957"
+source = "git+https://github.com/juspay/connector-service?rev=8c30000437dfc4a70536119cce8781ad6d270b58#8c30000437dfc4a70536119cce8781ad6d270b58"
 dependencies = [
  "anyhow",
  "base64 0.21.7",

--- a/crates/external_services/Cargo.toml
+++ b/crates/external_services/Cargo.toml
@@ -80,7 +80,7 @@ http = "0.2.12"
 url = { version = "2.5.4", features = ["serde"] }
 quick-xml = { version = "0.31.0", features = ["serialize"] }
 
-unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "d29837cdde69fb26aac326cff669f4f7995d3957", package = "rust-grpc-client" }
+unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "8c30000437dfc4a70536119cce8781ad6d270b58", package = "rust-grpc-client" }
 open-feature = { version = "0.2.5", optional = true }
 superposition_provider = { version = "0.102.0", optional = true }
 superposition_types = "0.102.0"

--- a/crates/external_services/Cargo.toml
+++ b/crates/external_services/Cargo.toml
@@ -80,7 +80,7 @@ http = "0.2.12"
 url = { version = "2.5.4", features = ["serde"] }
 quick-xml = { version = "0.31.0", features = ["serialize"] }
 
-unified-connector-service-client = { git = "https://github.com/juspay/connector-service", tag = "2026.06.23.1", package = "rust-grpc-client" }
+unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "d29837cdde69fb26aac326cff669f4f7995d3957", package = "rust-grpc-client" }
 open-feature = { version = "0.2.5", optional = true }
 superposition_provider = { version = "0.102.0", optional = true }
 superposition_types = "0.102.0"

--- a/crates/hyperswitch_interfaces/Cargo.toml
+++ b/crates/hyperswitch_interfaces/Cargo.toml
@@ -33,7 +33,7 @@ time = "0.3.41"
 tonic = "0.14"
 url = { version = "2.5.4", features = ["serde"] }
 
-unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "d29837cdde69fb26aac326cff669f4f7995d3957", package = "rust-grpc-client" }
+unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "8c30000437dfc4a70536119cce8781ad6d270b58", package = "rust-grpc-client" }
 tokio = { version = "1.45.1", features = ["macros", "rt-multi-thread"] }
 
 # First party crates

--- a/crates/hyperswitch_interfaces/Cargo.toml
+++ b/crates/hyperswitch_interfaces/Cargo.toml
@@ -33,7 +33,7 @@ time = "0.3.41"
 tonic = "0.14"
 url = { version = "2.5.4", features = ["serde"] }
 
-unified-connector-service-client = { git = "https://github.com/juspay/connector-service", tag = "2026.06.23.1", package = "rust-grpc-client" }
+unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "d29837cdde69fb26aac326cff669f4f7995d3957", package = "rust-grpc-client" }
 tokio = { version = "1.45.1", features = ["macros", "rt-multi-thread"] }
 
 # First party crates

--- a/crates/router/Cargo.toml
+++ b/crates/router/Cargo.toml
@@ -91,8 +91,8 @@ ring = "0.17.14"
 rust_decimal = { version = "1.37.1", features = ["serde-with-float", "serde-with-str"] }
 rust-i18n = { git = "https://github.com/kashif-m/rust-i18n", rev = "f2d8096aaaff7a87a847c35a5394c269f75e077a" }
 
-unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "d29837cdde69fb26aac326cff669f4f7995d3957", package = "rust-grpc-client" }
-unified-connector-service-cards = { git = "https://github.com/juspay/connector-service", rev = "d29837cdde69fb26aac326cff669f4f7995d3957", package = "ucs_cards" }
+unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "8c30000437dfc4a70536119cce8781ad6d270b58", package = "rust-grpc-client" }
+unified-connector-service-cards = { git = "https://github.com/juspay/connector-service", rev = "8c30000437dfc4a70536119cce8781ad6d270b58", package = "ucs_cards" }
 rustc-hash = "1.1.0"
 rustls = "0.22"
 rustls-pemfile = "2"

--- a/crates/router/Cargo.toml
+++ b/crates/router/Cargo.toml
@@ -91,8 +91,8 @@ ring = "0.17.14"
 rust_decimal = { version = "1.37.1", features = ["serde-with-float", "serde-with-str"] }
 rust-i18n = { git = "https://github.com/kashif-m/rust-i18n", rev = "f2d8096aaaff7a87a847c35a5394c269f75e077a" }
 
-unified-connector-service-client = { git = "https://github.com/juspay/connector-service", tag = "2026.06.23.1", package = "rust-grpc-client" }
-unified-connector-service-cards = { git = "https://github.com/juspay/connector-service", tag = "2026.06.23.1", package = "ucs_cards" }
+unified-connector-service-client = { git = "https://github.com/juspay/connector-service", rev = "d29837cdde69fb26aac326cff669f4f7995d3957", package = "rust-grpc-client" }
+unified-connector-service-cards = { git = "https://github.com/juspay/connector-service", rev = "d29837cdde69fb26aac326cff669f4f7995d3957", package = "ucs_cards" }
 rustc-hash = "1.1.0"
 rustls = "0.22"
 rustls-pemfile = "2"

--- a/crates/router/src/core/unified_connector_service/transformers.rs
+++ b/crates/router/src/core/unified_connector_service/transformers.rs
@@ -1177,6 +1177,7 @@ impl
             metadata,
             return_url: router_data.request.router_return_url.clone(),
             continue_redirection_url: router_data.request.complete_authorize_url.clone(),
+            webhook_url: router_data.request.webhook_url.clone(),
             state: None,
             browser_info: router_data
                 .request


### PR DESCRIPTION
## What

HS→UCS mapping: forward `webhook_url` on the **PreAuthenticate** gRPC request so UCS's redsys
`build_threeds_invoke_response` can build the 3DS-method notification URL from the same source
HS-native redsys uses. Pairs with UCS PR juspay/connector-service#1626 (adds `webhook_url` to the
`PaymentMethodAuthenticationServicePreAuthenticateRequest` proto + domain + redsys transformer).

## Diff signature (shadow-validation)

```
router.valueDiff:response.Ok.TransactionResponse.connector_metadata.three_ds_method_data
```
connector=redsys, flow=pre_authenticate, merchant=bu_es (org zurich_insurance).

## Root cause

`three_ds_method_data` = base64(JSON{`threeDSMethodNotificationURL`, `threeDSServerTransID`}).
HS-native redsys builds the notification URL from `request.get_webhook_url()` (= `webhook_url`).
UCS redsys `build_threeds_invoke_response` used `continue_redirection_url`, which the HS→UCS
PreAuthenticate mapping populates from `complete_authorize_url`. `webhook_url ≠ complete_authorize_url`
→ different base64 payload → `valueDiff`. The HS `ThreedsInvokeRequest` and UCS
`RedsysThreedsInvokeRequest` structs are byte-identical (`rename_all = "camelCase"`, same field
order), so once both sides use the same URL the base64 is byte-identical.

## Fix (PROTO category — spans both repos)

- **UCS** juspay/connector-service#1626: add `optional string webhook_url = 15` to the
  `PaymentMethodAuthenticationServicePreAuthenticateRequest` proto; add `webhook_url: Option<Url>`
  to domain `PaymentsPreAuthenticateData` + map it in `types.rs`; redsys uses `webhook_url`
  (falls back to `continue_redirection_url`); threaded through the composite service.
- **HS** (this PR): `webhook_url: router_data.request.webhook_url.clone()` on the PreAuthenticate
  gRPC request in `router/src/core/unified_connector_service/transformers.rs`, plus the UCS dep
  `rev` bump to #1626's head commit in `crates/router/Cargo.toml`,
  `crates/external_services/Cargo.toml`, `crates/hyperswitch_interfaces/Cargo.toml` + `Cargo.lock`.

**Depends on UCS PR #1626** — the `rev` pin is interim and must move back to a `tag`/main commit
once that UCS PR merges to main (reviewers merge UCS first, then HS).

## Verify (before → after)

Live redsys 3DS shadow is not locally reproducible (real ACS + redsys sandbox + prod merchant
creds). Verified by source-parity: a Python-simulated serde of the two structs shows the base64
**differs** before (URL = `complete_authorize_url`) and is **byte-identical** after
(URL = `webhook_url`) ⇒ `valueDiff → no_diff`. Local checks green: `cargo build` for router,
V2-features compilation check, clippy, fmt.

## Links

Closes #12935
